### PR TITLE
fix(gpu): real CUDA device preflight + actionable driver-error text (sc-16247)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6362,6 +6362,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "tokio",
  "tracing",
  "windows-sys 0.59.0",
  "zip 2.4.2",

--- a/apps/desktop/Cargo.toml
+++ b/apps/desktop/Cargo.toml
@@ -54,6 +54,12 @@ sha2 = "0.10"
 # buffered whole in RAM (F-129, sc-8931). Already in the workspace lock (0.3.x), so no
 # new locked version is pulled; `alloc` is needed for the stream combinators.
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
+# Bound the one-shot CUDA device preflight (sc-16247): `cuInit` on a wedged NVIDIA driver can
+# block indefinitely rather than returning an error, and that probe gates `run_startup` — an
+# unbounded wait would leave the setup screen spinning forever with no message and no Retry.
+# Only `time` is needed; Tauri already runs on tokio, so this adds no runtime and no new locked
+# version (the workspace pins 1.40 for the API/worker).
+tokio = { version = "1.40", default-features = false, features = ["time"] }
 
 [target.'cfg(windows)'.dependencies]
 # Confine the API sidecar (and any child processes it spawns) to a kill-on-close Job

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -1254,18 +1254,11 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
     // CUDA runtime DLLs by name; prepend the bundled redist dir to the sidecar's
     // PATH so they resolve without a CUDA Toolkit on the machine (sc-5560). No-op on
     // a plain build — the resolver returns None when only the placeholder is staged.
-    #[cfg(target_os = "windows")]
-    if let Some(cuda_dir) = resolve_bundled_cuda_dir(app) {
-        let existing = std::env::var_os("PATH").unwrap_or_default();
-        let mut paths = vec![cuda_dir];
-        paths.extend(std::env::split_paths(&existing));
-        if let Ok(joined) = std::env::join_paths(paths) {
-            command = command.env("PATH", joined);
-        }
-    }
-    #[cfg(target_os = "linux")]
-    if let Some(runtime) = linux_candle_runtime() {
-        command = inject_linux_candle_runtime_env(command, &runtime);
+    // Shared with `cuda_device_preflight` so the probe's loader path can't drift from
+    // this one (sc-16247).
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    {
+        command = apply_candle_loader_env(app, command);
     }
     // LAN mode (epic 4484): hand the API the user's password as the access token so it
     // requires auth on the now-network-reachable bind. The server ALSO refuses any
@@ -2926,6 +2919,152 @@ async fn metal_preflight(app: &AppHandle) -> Result<(), String> {
     Err(message)
 }
 
+/// How long to wait for the one-shot CUDA probe before giving up on it.
+///
+/// The probe is ~0.25-0.5 s on a healthy box (measured on a 2x RTX PRO 6000 / driver 596.36
+/// box: ~519 ms cold, ~235 ms warm), so this is ~40x headroom. It exists because `cuInit` on a
+/// wedged driver — a TDR-recovering GPU, a stalled persistence daemon, exactly the sort of
+/// broken driver stack this probe is here to catch — can block indefinitely rather than
+/// returning an error. Without a bound, `run_startup` would never return and the setup screen
+/// would spin forever with no message and no Retry button.
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+const CUDA_PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Shown when the probe itself hangs — a distinct state from any CUDA error, because we never
+/// got one.
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+const CUDA_PREFLIGHT_TIMED_OUT: &str = "The NVIDIA driver on this machine did not respond when \
+    SceneWorks tried to initialize the GPU. This usually means the driver is wedged or still \
+    recovering. Reboot, then reopen SceneWorks. If it keeps happening, check that `nvidia-smi` \
+    returns promptly — if that hangs too, the driver stack needs attention before SceneWorks \
+    can use the GPU.";
+
+/// Apply the candle loader environment (the provisioned CUDA runtime) to a sidecar command.
+///
+/// The ONE seam for this. `spawn_api`, `supervise_candle_worker`, and `cuda_device_preflight`
+/// all need cudarc to resolve `cudart`/`cublas`/`cublasLt`/`curand`/`nvrtc` by name out of the
+/// first-run-provisioned `gpu-runtime` dir rather than a system CUDA Toolkit (sc-5560). Kept in
+/// one function because the probe MUST see the same loader path the worker will: if they drift,
+/// the probe fails for a reason that has nothing to do with the GPU and — before the severity
+/// split below — could have stranded users on the setup screen (the sc-10353 failure mode,
+/// where a Mac probe missing one env var blocked every fresh install).
+///
+/// Windows prepends the redist dir to `PATH` (the DLL search path); Linux uses the dynamic
+/// linker's `LD_LIBRARY_PATH` via [`inject_linux_candle_runtime_env`]. A no-op before
+/// provisioning completes, when the resolver returns `None`.
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+fn apply_candle_loader_env(app: &AppHandle, command: Command) -> Command {
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(cuda_dir) = resolve_bundled_cuda_dir(app) {
+            let existing = std::env::var_os("PATH").unwrap_or_default();
+            let mut paths = vec![cuda_dir];
+            paths.extend(std::env::split_paths(&existing));
+            if let Ok(joined) = std::env::join_paths(paths) {
+                return command.env("PATH", joined);
+            }
+        }
+        command
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let _ = app;
+        match linux_candle_runtime() {
+            Some(runtime) => inject_linux_candle_runtime_env(command, &runtime),
+            None => command,
+        }
+    }
+}
+
+/// CUDA **device-acquisition** preflight (sc-16247, GH #1966): the off-Mac twin of
+/// [`metal_preflight`], and a strictly deeper gate than the `nvidia-smi`
+/// [`cuda_preflight`] / [`linux_cuda_preflight`] above.
+///
+/// Those probe NVML and check a driver-version floor + compute-capability range; they never
+/// call `cuInit`, so they cannot see a CUDA driver-API initialization failure —
+/// `CUDA_ERROR_SYSTEM_DRIVER_MISMATCH` (803) and friends, where `nvcuda.dll`/`libcuda.so`
+/// and the loaded kernel module are different versions. NVML and CUDA version-check
+/// separately, so a host passes the first and still fails the second, and the failure lands
+/// mid-generation as a raw `DriverError(...)` on the user's Queue screen (GH #1966). This
+/// spawns the bundled `sceneworks-api` sidecar in its one-shot `SCENEWORKS_GPU_CHECK=1` mode,
+/// which acquires a real device and runs a real kernel — the same spawn context, and the same
+/// `runtime_cuda::media::default_device()` seam, the worker will use.
+///
+/// Deliberately runs AFTER GPU-runtime provisioning: the probe needs the downloaded CUDA
+/// runtime DLLs on its loader path to get as far as `cuInit`, so probing before provisioning
+/// would fail for a reason that has nothing to do with the driver.
+///
+/// ## Only a DEFINITE host problem blocks startup
+///
+/// `Err` here stops the app on the setup screen, so it is reserved for exit code 2 — the
+/// sidecar's "this is a driver-class condition and generation cannot work" verdict (see
+/// `gpu_check` / `cuda_failure_is_blocking`). Every other non-zero exit, and a timeout, is
+/// logged and stepped over, because the alternative is locking a user out of Library,
+/// Settings, and everything else over a state that may be transient: a CUDA OOM because
+/// another process (or an orphaned worker from a crashed session) currently holds the GPU
+/// would otherwise make the whole app unopenable. Those users still get the classified,
+/// actionable message from `classify_engine_error` if they start a generation.
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+async fn cuda_device_preflight(app: &AppHandle) -> Result<(), String> {
+    // Probe only the lane we are about to start. `candle_runtime_present` is the exact gate
+    // that decides whether `supervise_candle_worker` runs at all; when it is false the desktop
+    // keeps the candle lane dormant, there is no CUDA worker to protect, and a non-candle
+    // sidecar's `cuda_preflight` is a no-op anyway — so skip the spawn rather than pay for a
+    // process that cannot fail meaningfully.
+    if !candle_runtime_present(app) {
+        return Ok(());
+    }
+    let command = app
+        .shell()
+        .sidecar("sceneworks-api")
+        .map_err(|error| format!("locate api for GPU check: {error}"))?
+        .env("SCENEWORKS_GPU_CHECK", "1");
+    let command = apply_candle_loader_env(app, command);
+    let output = match tokio::time::timeout(CUDA_PREFLIGHT_TIMEOUT, command.output()).await {
+        Ok(Ok(output)) => output,
+        Ok(Err(error)) => {
+            // Couldn't even run the probe. Not evidence about the GPU — don't block on it.
+            log_candle_preflight_skip(&format!("GPU check could not be run: {error}"));
+            return Ok(());
+        }
+        Err(_elapsed) => {
+            // Dropping the future kills the child (tauri's Command owns it), so the wedged
+            // probe does not outlive this call. A hang IS strong evidence of a broken driver
+            // stack, and unlike a transient OOM it will not clear on its own — block on it.
+            return Err(CUDA_PREFLIGHT_TIMED_OUT.to_owned());
+        }
+    };
+    if output.status.code() == Some(0) {
+        return Ok(());
+    }
+    let message = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if output.status.code() == Some(2) && !message.is_empty() {
+        return Err(message);
+    }
+    // Exit 1 (probe failed, but possibly transient), or any other code / a crash with no
+    // reason printed. Record it and let the app start.
+    let detail = if message.is_empty() {
+        format!(
+            "GPU check exited with {:?} and printed no reason",
+            output.status.code()
+        )
+    } else {
+        message
+    };
+    log_candle_preflight_skip(&detail);
+    Ok(())
+}
+
+/// Record a non-blocking GPU-preflight outcome next to the candle worker's own log, which is
+/// where anyone diagnosing "why did generation fail" already looks.
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+fn log_candle_preflight_skip(detail: &str) {
+    append_log(
+        &logs_dir().join("candle-worker.log"),
+        &format!("[desktop] GPU preflight did not pass (continuing anyway): {detail}\n"),
+    );
+}
+
 async fn run_startup(app: AppHandle) {
     // Provide the builtin model catalog the rust-api/worker expect before they
     // start, so Model Manager is populated and native video resources resolve.
@@ -2994,6 +3133,20 @@ async fn run_startup(app: AppHandle) {
     // CI build path). The setup page renders this `error` event.
     #[cfg(target_os = "macos")]
     if let Err(error) = metal_preflight(&app).await {
+        emit(&app, "error", error, true);
+        return;
+    }
+    // CUDA device-acquisition preflight (sc-16247, GH #1966): the off-Mac sibling of the Metal
+    // probe above, and the second, deeper gate behind the `nvidia-smi` check near the top of this
+    // function. That check is NVML and stays exactly where it is — it catches no-GPU / too-old-
+    // driver / unsupported-architecture hosts before the multi-GB runtime download, which is its
+    // whole point. It cannot catch a `cuInit` failure, because NVML and the CUDA driver API
+    // version-check separately; GH #1966 was a host that passed the first and failed the second,
+    // and learned about it as a raw `DriverError(CUDA_ERROR_SYSTEM_DRIVER_MISMATCH, ...)` on the
+    // Queue screen mid-generation. Placed HERE, after provisioning, because the probe needs the
+    // downloaded CUDA runtime on its loader path to reach `cuInit` at all.
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    if let Err(error) = cuda_device_preflight(&app).await {
         emit(&app, "error", error, true);
         return;
     }

--- a/apps/desktop/ui/index.html
+++ b/apps/desktop/ui/index.html
@@ -34,6 +34,10 @@
         margin: 0 0 1.25rem;
         color: #9aa1ad;
         min-height: 1.4em;
+        /* Preflight failures are multi-paragraph: an actionable remedy, a blank line, then the
+           underlying driver error (sc-16247). Without pre-wrap the blank line collapses and the
+           whole thing renders as one unreadable run-on sentence. */
+        white-space: pre-wrap;
       }
       #status.error {
         color: #ff8888;

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -537,15 +537,42 @@ fn json_rejection_response(rejection: JsonRejection) -> Response {
 }
 
 /// Run this binary as a standalone worker process instead of the HTTP API.
-/// Apple-Silicon Metal preflight (sc-8411). Dispatched from `main` when
-/// `SCENEWORKS_GPU_CHECK=1`: a one-shot probe that the desktop spawns at startup —
-/// the macOS counterpart of the Windows `nvidia-smi` `cuda_preflight`. Reuses this
-/// binary because it already links MLX (the desktop crate does not), and runs the
-/// probe in the SAME process/spawn context the real worker uses, so it faithfully
-/// predicts whether the worker can acquire a Metal GPU. `Ok(())` when usable;
+/// One-shot GPU preflight (sc-8411 Metal, sc-16247 CUDA). Dispatched from `main` when
+/// `SCENEWORKS_GPU_CHECK=1`: a probe that the desktop spawns at startup. Reuses this
+/// binary because it already links the GPU backends (the desktop crate does not), and
+/// runs the probe in the SAME process/spawn context the real worker uses, so it
+/// faithfully predicts whether the worker can acquire a GPU. `Ok(())` when usable;
 /// `Err(message)` is the user-facing reason the desktop relays onto the setup screen.
-pub fn gpu_check() -> Result<(), String> {
-    sceneworks_worker::metal_preflight()
+///
+/// Exactly one of the two probes is ever live in a given build: `metal_preflight` is a
+/// no-op off-Mac, and `cuda_preflight` is a no-op on macOS and on any off-Mac build
+/// without `backend-candle`. Calling both keeps this dispatch platform-agnostic — the
+/// desktop decides *whether* to spawn the probe, not which one runs.
+pub fn gpu_check() -> Result<(), GpuCheckFailure> {
+    if let Err(message) = sceneworks_worker::metal_preflight() {
+        // Metal's contract is unchanged from sc-8411: any failure blocks startup.
+        return Err(GpuCheckFailure {
+            message,
+            blocking: true,
+        });
+    }
+    sceneworks_worker::cuda_preflight().map_err(|message| GpuCheckFailure {
+        blocking: sceneworks_worker::cuda_failure_is_blocking(&message),
+        message,
+    })
+}
+
+/// A failed [`gpu_check`], plus whether it should stop the app from starting.
+///
+/// `blocking` is the whole reason this isn't a bare `String`. The desktop can't make the call
+/// itself — it doesn't link the worker crate and so has no access to the CUDA error table — and
+/// getting it wrong is asymmetric: over-blocking locks the user out of the entire application
+/// over what may be a transient GPU state, while under-blocking costs one failed job that now
+/// carries an actionable message anyway. See `sceneworks_worker::cuda_failure_is_blocking`.
+/// Crosses the process boundary as an exit code (see `main.rs`), the message on stdout.
+pub struct GpuCheckFailure {
+    pub message: String,
+    pub blocking: bool,
 }
 
 /// Spawns the in-process CPU utility worker pool ([`sceneworks_worker::run_worker_loop`])

--- a/apps/rust-api/src/main.rs
+++ b/apps/rust-api/src/main.rs
@@ -10,12 +10,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // relays it onto the setup screen) and exit non-zero on failure, rather than
     // returning Err (whose Debug print would be noise). Checked before WORKER_ONLY so
     // the probe never starts a worker loop.
+    // Exit code carries the SEVERITY, stdout the reason (sc-16247): 0 = usable GPU, 2 = a
+    // definite host-side problem the desktop must stop on, 1 = the probe failed for a reason
+    // that may not be fatal (a transient CUDA OOM, an unrecognized error), which the desktop
+    // logs and steps over rather than locking the user out of the whole app. macOS keeps its
+    // sc-8411 contract: every Metal failure is blocking, so it always exits 2 here.
     if std::env::var("SCENEWORKS_GPU_CHECK").is_ok_and(|value| value.trim() == "1") {
         match sceneworks_rust_api::gpu_check() {
             Ok(()) => std::process::exit(0),
-            Err(message) => {
-                println!("{message}");
-                std::process::exit(1);
+            Err(failure) => {
+                println!("{}", failure.message);
+                std::process::exit(if failure.blocking { 2 } else { 1 });
             }
         }
     }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -14988,6 +14988,10 @@ details[open] > summary.lora-scope-group-heading::before,
   line-height: 1.45;
   color: var(--text-muted);
   overflow-wrap: anywhere;
+  /* A classified failure is an actionable remedy, a blank line, then the underlying engine
+     error (sc-16247). Without pre-wrap the paragraph break collapses and the remedy runs
+     straight into the raw `DriverError(...)` text. */
+  white-space: pre-wrap;
 }
 
 .worker-progress-card__message.error {

--- a/crates/sceneworks-worker/src/error.rs
+++ b/crates/sceneworks-worker/src/error.rs
@@ -79,12 +79,68 @@ pub(crate) fn task_join_error(label: &str, error: tokio::task::JoinError) -> Wor
 /// message text INTACT, rather than burying it in an opaque [`WorkerError::Engine`]. Everything else
 /// stays [`WorkerError::Engine`]. `context` prefixes the message so the origin (load vs generate)
 /// stays legible, matching the existing `format!("{context}: {error}")` seams.
+///
+/// ## Driver-class CUDA failures (sc-16247, GH #1966)
+///
+/// A CUDA driver/userspace version mismatch used to reach the user's screen verbatim: this
+/// function's message becomes `fail_job`'s failure detail (`lib.rs`), which `QueueScreen.jsx`
+/// renders as `job.error`, so GH #1966 read
+/// `candle krea_2_turbo load failed: backend op failed: DriverError(CUDA_ERROR_SYSTEM_DRIVER_MISMATCH,
+/// "system has unsupported display driver / cuda driver combination")` — with no hint that the fix
+/// is on the reporter's machine, not in ours. When the engine error carries a known `CUDA_ERROR_*`
+/// token, the actionable host-side remedy now LEADS the message and the raw error is appended for
+/// the logs. The token table is shared with [`crate::cuda_preflight`] so the same failure reads
+/// identically whether it is caught at startup or escapes into a running job; see
+/// [`crate::preflight::cuda_driver_error_guidance`] for why this matches on the string rather than
+/// downcasting.
+///
+/// Matched on the whole stringified error rather than only `Error::Backend`, because a provider is
+/// free to surface a driver failure as `Error::Msg` — the token is what identifies it, not the
+/// variant it arrived in.
+///
+/// These stay [`WorkerError::Engine`] deliberately. A driver mismatch is not an invalid payload,
+/// and the variant carries no behaviour to change: every non-test site that branches on a
+/// `WorkerError` variant during job completion special-cases only `Canceled` (`lib.rs`) — `Engine`
+/// and `InvalidPayload` both fall through to the identical `fail_job` call and terminate the job.
+/// There is no retry semantics attached to the distinction, so promoting the variant would add an
+/// unread distinction; the defect was the message, and the message is what changed.
 pub(crate) fn classify_engine_error(context: &str, error: gen_core::Error) -> WorkerError {
     match error {
         gen_core::Error::Unsupported(_) => {
             WorkerError::InvalidPayload(format!("{context}: {error}"))
         }
-        other => WorkerError::Engine(format!("{context}: {other}")),
+        other => {
+            let detail = other.to_string();
+            match crate::preflight::cuda_driver_error_guidance(&detail) {
+                Some(guidance) => WorkerError::Engine(format!(
+                    "{context}: {guidance}\n\nUnderlying CUDA error: {detail}"
+                )),
+                None => WorkerError::Engine(format!("{context}: {detail}")),
+            }
+        }
+    }
+}
+
+/// Prepend the actionable host-side remedy to a terminal job-failure detail when it describes a
+/// driver-class CUDA failure, leaving everything else untouched (sc-16247).
+///
+/// The backstop for [`classify_engine_error`]. AC3 of sc-16247 names that function, and the lane
+/// GH #1966 reported does route through it — but roughly 35 other load seams build
+/// `WorkerError::Engine(format!("… load failed: {error}"))` directly (`image_jobs/*_candle.rs`,
+/// `instantid.rs`, `training_jobs.rs`, …), and a host driver mismatch breaks all of them the same
+/// way. Converting 36 call sites would be a large mechanical churn across 20+ files for the same
+/// result; annotating once at the job-failure tail, where every terminal detail passes, covers
+/// them all.
+///
+/// **Idempotent**, because a detail that already came through `classify_engine_error` carries the
+/// guidance: if the remedy text is present the string is returned unchanged, so the message is
+/// never doubled.
+pub(crate) fn annotate_cuda_driver_failure(detail: &str) -> String {
+    match crate::preflight::cuda_driver_error_guidance(detail) {
+        Some(guidance) if !detail.contains(guidance) => {
+            format!("{guidance}\n\nUnderlying CUDA error: {detail}")
+        }
+        _ => detail.to_owned(),
     }
 }
 
@@ -139,6 +195,147 @@ mod tests {
         assert!(
             matches!(classified, WorkerError::Engine(_)),
             "a generic engine failure must stay WorkerError::Engine, got {classified:?}"
+        );
+    }
+
+    /// sc-16247 / GH #1966: the reported failure end-to-end. A Bazzite host whose kernel module
+    /// and `libcuda.so` were out of step raised `CUDA_ERROR_SYSTEM_DRIVER_MISMATCH` deep inside a
+    /// Krea 2 Turbo load; the load seam (`generator_cache::with_generator`) routes that through
+    /// here, and the resulting string is what `fail_job` stores and `QueueScreen.jsx` renders. It
+    /// must lead with the host-side remedy instead of a raw `DriverError(...)` dump. Injected at
+    /// the seam exactly as `crate::inference_runtime::load` would return it — no GPU needed.
+    #[test]
+    fn cuda_driver_mismatch_surfaces_the_host_side_remedy_not_a_raw_driver_error() {
+        let raw = "DriverError(CUDA_ERROR_SYSTEM_DRIVER_MISMATCH, \
+                   \"system has unsupported display driver / cuda driver combination\")";
+        let engine_error = gen_core::Error::backend(std::io::Error::other(raw));
+
+        let classified = classify_engine_error("candle krea_2_turbo load failed", engine_error);
+
+        let WorkerError::Engine(message) = classified else {
+            panic!("a driver-class CUDA failure stays WorkerError::Engine, got {classified:?}");
+        };
+        // The actionable part: the user must be told this is their machine's driver state and
+        // that a reboot is what fixes it. Asserting on the CONTENT, not merely that it changed.
+        assert!(
+            message.contains("kernel driver") && message.contains("reboot"),
+            "the message must name the host-side remedy, got: {message}"
+        );
+        // Bazzite/Silverblue is the reported environment and the reason a long uptime doesn't
+        // imply an up-to-date module, so the immutable-distro case is called out by name.
+        assert!(
+            message.contains("Bazzite"),
+            "the immutable-distro case must be covered, got: {message}"
+        );
+        // The raw driver error still has to reach the logs.
+        assert!(
+            message.contains("CUDA_ERROR_SYSTEM_DRIVER_MISMATCH"),
+            "the underlying CUDA error must be preserved, got: {message}"
+        );
+        // And the origin context must survive, as it does for every other classification.
+        assert!(
+            message.contains("candle krea_2_turbo load failed"),
+            "the load-vs-generate context must be preserved, got: {message}"
+        );
+    }
+
+    /// The rest of the driver-class family (sc-16247 AC 3) reaches the same treatment, and each
+    /// gets its OWN text — a shared fallback would pass a weaker version of this test.
+    #[test]
+    fn the_whole_driver_class_family_is_classified_with_distinct_messages() {
+        let mut seen = Vec::new();
+        for token in [
+            "CUDA_ERROR_SYSTEM_DRIVER_MISMATCH",
+            "CUDA_ERROR_INSUFFICIENT_DRIVER",
+            "CUDA_ERROR_SYSTEM_NOT_READY",
+            "CUDA_ERROR_NO_DEVICE",
+        ] {
+            let engine_error = gen_core::Error::backend(std::io::Error::other(format!(
+                "DriverError({token}, \"...\")"
+            )));
+            let classified = classify_engine_error("candle load failed", engine_error);
+            let WorkerError::Engine(message) = classified else {
+                panic!("{token} must stay WorkerError::Engine, got {classified:?}");
+            };
+            assert!(
+                message.contains(token),
+                "{token} must be preserved in the message for the logs, got: {message}"
+            );
+            // The rewrite must actually have happened. Without this the test passes on the
+            // ORIGINAL raw pass-through: each message would still be "distinct" below, purely
+            // because the embedded token differs. Requiring the separator pins the shape —
+            // guidance first, raw error after — rather than merely "the strings differ".
+            let (guidance, underlying) = message
+                .split_once("\n\nUnderlying CUDA error:")
+                .unwrap_or_else(|| {
+                    panic!("{token} was not rewritten with guidance + a preserved raw error: {message}")
+                });
+            assert!(
+                underlying.contains(token),
+                "{token} must appear in the preserved tail, not only the guidance: {message}"
+            );
+            let guidance = guidance.to_owned();
+            assert!(
+                !seen.contains(&guidance),
+                "{token} reuses another code's guidance; the family must not collapse"
+            );
+            seen.push(guidance);
+        }
+        assert_eq!(seen.len(), 4, "all four driver-class codes must be covered");
+    }
+
+    /// The job-failure-tail backstop (sc-16247) for the ~35 load seams that build
+    /// `WorkerError::Engine` directly instead of going through `classify_engine_error`. Must
+    /// annotate those, must leave unrelated failures alone, and must NOT double-annotate a detail
+    /// that already came through the classifier.
+    #[test]
+    fn the_job_failure_tail_annotates_unclassified_driver_errors_exactly_once() {
+        // A lane that bypassed `classify_engine_error` (e.g. `image_jobs/krea_edit_candle.rs`).
+        let raw = "Krea edit load failed: backend op failed: \
+                   DriverError(CUDA_ERROR_SYSTEM_DRIVER_MISMATCH, \"...\")";
+        let annotated = annotate_cuda_driver_failure(raw);
+        assert!(
+            annotated.contains("reboot") && annotated.contains(raw),
+            "a direct-construction lane must still get the remedy, got: {annotated}"
+        );
+
+        // Already classified: running it through the tail must change nothing.
+        let classified = classify_engine_error(
+            "candle krea_2_turbo load failed",
+            gen_core::Error::backend(std::io::Error::other(
+                "DriverError(CUDA_ERROR_SYSTEM_DRIVER_MISMATCH, \"...\")",
+            )),
+        )
+        .to_string();
+        assert_eq!(
+            annotate_cuda_driver_failure(&classified),
+            classified,
+            "an already-classified detail must not be annotated twice"
+        );
+
+        // Unrelated failures pass through byte-for-byte.
+        for untouched in ["disk full", "missing tensor: unet.x", ""] {
+            assert_eq!(annotate_cuda_driver_failure(untouched), untouched);
+        }
+    }
+
+    /// The negative control that keeps the rewrite honest: a CUDA OOM is a CUDA error but NOT a
+    /// driver-stack problem, so it must pass through with its original text. Without this, a
+    /// table that matched `CUDA_ERROR_` as a prefix would tell an out-of-VRAM user to reboot.
+    #[test]
+    fn a_cuda_oom_is_not_rewritten_as_a_driver_problem() {
+        let raw = "DriverError(CUDA_ERROR_OUT_OF_MEMORY, \"out of memory\")";
+        let engine_error = gen_core::Error::backend(std::io::Error::other(raw));
+
+        let classified = classify_engine_error("candle wan load failed", engine_error);
+
+        let WorkerError::Engine(message) = classified else {
+            panic!("a CUDA OOM stays WorkerError::Engine, got {classified:?}");
+        };
+        assert_eq!(
+            message,
+            format!("candle wan load failed: backend op failed: {raw}"),
+            "a non-driver CUDA failure must pass through untouched"
         );
     }
 }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -933,6 +933,73 @@ pub async fn run() -> WorkerResult<()> {
     run_worker_loop(settings).await
 }
 
+/// Which worker loops should run the startup CUDA probe: only a GPU worker on a candle-enabled
+/// build. Pure so the gate is testable without a GPU — every one of these three conditions is
+/// load-bearing, and inverting any of them is silent. `cpu` covers both the standalone utility
+/// pool and the API's in-process loops (`spawn_inprocess_utility_worker`); those must never build
+/// a CUDA context. `mlx` is the macOS GPU worker, which has its own Metal probe. And with the
+/// candle backend off there is nothing to probe for.
+fn should_run_cuda_preflight(settings: &Settings) -> bool {
+    settings.backend_candle_enabled && settings.gpu_id != "cpu" && settings.gpu_id != "mlx"
+}
+
+/// Server/Docker-lane CUDA preflight (sc-16247, GH #1966).
+///
+/// The desktop gets a real setup screen: `run_startup` runs `cuda_device_preflight` and refuses to
+/// start on an unusable GPU. The server/Docker lane has no such screen and, before this, no GPU
+/// preflight of ANY kind — `run_worker()` goes straight into the worker loop, so a driver-stack
+/// mismatch there surfaces exactly as GH #1966 described: first at the first model load, as a job
+/// failure, per job, forever.
+///
+/// This runs the same probe and logs the actionable reason ONCE at startup, loudly, at `error`
+/// level — so the container's logs name the host-side fix rather than leaving an operator to infer
+/// it from a stream of failed jobs.
+///
+/// It deliberately does **not** abort the process. The worker's registration + capability
+/// advertisement is what the API routes on, and tearing the process down here would turn a
+/// diagnosable, self-healing state (reboot the host, the next probe passes) into a crash loop with
+/// its own message. Surfacing this as a first-class *unhealthy worker status* would be the better
+/// end state, but that needs a new `WorkerStatus` variant plus API and UI surface — genuinely
+/// separate work, recorded on sc-16247 rather than smuggled in here.
+///
+/// Gated to the GPU worker by [`should_run_cuda_preflight`]: the CPU utility loops never touch
+/// CUDA, and probing from each of them would build a throwaway CUDA context per utility process.
+/// A no-op on every build without the candle lane linked, and on macOS.
+///
+/// The probe acquires device 0, which is faithful for the deployments that set
+/// `CUDA_VISIBLE_DEVICES`: under the `auto` supervisor each per-GPU child is spawned with
+/// `CUDA_VISIBLE_DEVICES=<its gpu id>` (`supervisor::child_environment`), so device 0 IS that
+/// child's own GPU. A server deployment that pins `SCENEWORKS_CANDLE_GPU_ID` without also setting
+/// `CUDA_VISIBLE_DEVICES` gets physical device 0 instead — but so does its generation, because
+/// `runtime_cuda::media::default_device()` is itself a hardcoded `new_cuda(0)`. The probe is
+/// therefore still testing the device that lane will use; it does not fix, and must not be read as
+/// endorsing, that pinning gap.
+///
+/// Runs on the blocking pool: `cuInit` plus the first kernel launch is ~0.25-0.5 s of synchronous
+/// driver work, and `run_worker_loop` is also called IN-PROCESS by the API's utility pool
+/// (`spawn_inprocess_utility_worker`). That pool is `cpu` by default and so skips the probe
+/// entirely, but `SCENEWORKS_RUST_WORKER_GPU_ID` can override it — and a GPU-id override there
+/// would otherwise stall the API's runtime thread during startup.
+async fn log_cuda_preflight_failure(settings: &Settings) {
+    if !should_run_cuda_preflight(settings) {
+        return;
+    }
+    let probe = tokio::task::spawn_blocking(cuda_preflight).await;
+    // A JoinError can only be a panic inside `cuda_preflight`, which already catches its own
+    // (see `preflight::cuda_preflight`) — report rather than propagate either way.
+    let reason = match probe {
+        Ok(Ok(())) => return,
+        Ok(Err(reason)) => reason,
+        Err(error) => format!("the CUDA preflight probe did not complete: {error}"),
+    };
+    tracing::error!(
+        event = "cuda_preflight_failed",
+        gpuId = %settings.gpu_id,
+        reason = %reason,
+        "SceneWorks GPU worker cannot acquire a CUDA device; generation jobs will fail"
+    );
+}
+
 pub async fn run_worker_loop(settings: Settings) -> WorkerResult<()> {
     // sc-4482 (epic 3720): log the resolved backend-neutral gen-core contract version at startup
     // so a pin skew that slips past the CI guard (`scripts/check-gen-core-skew.sh`) is
@@ -955,6 +1022,7 @@ pub async fn run_worker_loop(settings: Settings) -> WorkerResult<()> {
     if settings.gpu_id == "mlx" {
         generator_cache::spawn_gpu_telemetry(settings.config_dir.clone());
     }
+    log_cuda_preflight_failure(&settings).await;
     let gpu = discover_gpu(&settings).await;
     let api = ApiClient::new(&settings);
     let http_client = crate::downloads::streaming_download_client();
@@ -1565,7 +1633,14 @@ async fn run_utility_job(
         match error {
             WorkerError::Canceled(_) => {}
             error => {
-                let _ = fail_job(api, &job.id, message, Some(error.to_string())).await;
+                // sc-16247: this detail is what `QueueScreen` renders as `job.error`, so it is the
+                // last point before a raw `DriverError(...)` reaches the user. `classify_engine_error`
+                // already annotates the lanes that route through it (the reported krea_2_turbo path),
+                // but ~35 other load seams build `WorkerError::Engine` directly — a host driver
+                // problem hits all of them identically. Annotating here catches every one, and is a
+                // no-op when the guidance is already present.
+                let detail = annotate_cuda_driver_failure(&error.to_string());
+                let _ = fail_job(api, &job.id, message, Some(detail)).await;
                 tracing::error!(
                     event = "utility_job_failed",
                     jobId = %job.id,

--- a/crates/sceneworks-worker/src/preflight.rs
+++ b/crates/sceneworks-worker/src/preflight.rs
@@ -1,4 +1,4 @@
-//! Startup hardware preflight (sc-8411).
+//! Startup hardware preflight (sc-8411, sc-16247).
 //!
 //! On Apple Silicon the generation worker is MLX-only: every job eventually casts a
 //! tensor on the Metal GPU. If MLX can't materialize a default Metal device+stream —
@@ -9,6 +9,23 @@
 //! one-shot at startup (via the `SCENEWORKS_GPU_CHECK=1` sidecar mode) so an
 //! unusable-GPU machine gets a clear, actionable message on the setup screen BEFORE
 //! any model load — the macOS counterpart of the Windows `nvidia-smi` `cuda_preflight`.
+//!
+//! Off-Mac, [`cuda_preflight`] is the exact same idea for CUDA (sc-16247, GH #1966). The
+//! desktop's `nvidia-smi` preflight probes **NVML** (`libnvidia-ml.so` / `nvml.dll`) and
+//! checks a driver-version floor + compute-capability range. That is a genuinely useful
+//! pre-download gate, but it never calls `cuInit`, so it cannot see the class of failure
+//! where the CUDA **driver API** itself refuses to initialize — most notably
+//! `CUDA_ERROR_SYSTEM_DRIVER_MISMATCH` (803), raised when `libcuda.so`/`nvcuda.dll` and
+//! the loaded NVIDIA kernel module are different versions. Two libraries, two version
+//! checks: a host can pass the NVML probe and still fail `cuInit`, which is exactly what
+//! GH #1966 reported (a Bazzite box whose atomic image had staged a new driver while the
+//! running kernel still held the old module). [`cuda_preflight`] closes that gap by
+//! acquiring a real device and running a real kernel — the CUDA twin of the Metal probe's
+//! "the exact op that fails in the field".
+//!
+//! [`cuda_driver_error_guidance`] is the shared, GPU-free token → remedy table used by
+//! BOTH the probe above and [`crate::classify_engine_error`], so a driver-class CUDA
+//! failure reads the same whether it is caught at startup or escapes into a running job.
 
 /// User-facing message when MLX can't acquire a Metal GPU. Authored here (next to the
 /// MLX knowledge) and printed to stdout by the `SCENEWORKS_GPU_CHECK=1` probe so the
@@ -37,10 +54,432 @@ pub fn metal_preflight() -> Result<(), String> {
     }
 }
 
-/// Off-Mac the desktop uses its own CUDA preflight (`nvidia-smi`); there is no MLX to
-/// probe, so this is a no-op. Present on all targets so the `SCENEWORKS_GPU_CHECK`
-/// dispatch in the shared binary compiles everywhere.
+/// Off-Mac there is no MLX to probe, so this is a no-op; [`cuda_preflight`] is the
+/// off-Mac probe. Present on all targets so the `SCENEWORKS_GPU_CHECK` dispatch in the
+/// shared binary compiles everywhere.
 #[cfg(not(target_os = "macos"))]
 pub fn metal_preflight() -> Result<(), String> {
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// CUDA driver-error classification (sc-16247). Pure, GPU-free, all targets.
+// ---------------------------------------------------------------------------
+
+/// Fallback when CUDA is unusable for a reason with no specific remedy below.
+const CUDA_UNAVAILABLE: &str = "SceneWorks can't initialize the CUDA GPU on this machine. \
+Off-Mac generation is NVIDIA/CUDA-only — there is no CPU or AMD fallback. Check that \
+`nvidia-smi` lists a supported NVIDIA GPU and that the driver is installed and healthy, \
+then restart SceneWorks.";
+
+/// `CUDA_ERROR_SYSTEM_DRIVER_MISMATCH` (803) — GH #1966.
+const CUDA_DRIVER_MISMATCH: &str = "The NVIDIA kernel driver and the CUDA driver library on \
+this machine are different versions, so SceneWorks can't use the GPU. This almost always \
+means a driver update has been installed but the machine has not been rebooted onto it yet \
+— reboot, then reopen SceneWorks. On an immutable/atomic Linux distribution (Bazzite, \
+Silverblue, Bluefin, …) a driver update is staged into the NEXT boot, so a reboot is \
+required even if the app has been running for days. Note that `nvidia-smi` can still look \
+healthy in this state: it queries NVML, which version-checks separately from CUDA.";
+
+/// `CUDA_ERROR_INSUFFICIENT_DRIVER` (35).
+const CUDA_INSUFFICIENT_DRIVER: &str = "The installed NVIDIA driver is older than the CUDA \
+runtime SceneWorks ships, so the GPU can't be used. Update the NVIDIA driver — 576.02 or \
+newer on Windows, 575.51.03 or newer on Linux — then restart SceneWorks.";
+
+/// `CUDA_ERROR_SYSTEM_NOT_READY` (802).
+const CUDA_SYSTEM_NOT_READY: &str = "The NVIDIA driver stack on this machine isn't ready yet \
+— the driver or GPU fabric is still initializing. Wait until `nvidia-smi` lists your GPU and \
+try again; if it persists, reboot.";
+
+/// No CUDA driver library at all — `libcuda.so.1` / `nvcuda.dll` could not be loaded. Distinct
+/// from every code below, which all require a driver that at least loaded. The dominant cause
+/// is a container started without GPU access, where the NVIDIA container runtime never
+/// injected the driver.
+const CUDA_DRIVER_LIBRARY_MISSING: &str = "SceneWorks could not load the NVIDIA CUDA driver \
+library (`nvcuda.dll` on Windows, `libcuda.so.1` on Linux), so the GPU can't be used at all. \
+If you're running the container/server build, start it with GPU access — `docker run --gpus \
+all ...`, or `deploy.resources.reservations.devices` in Compose — and make sure the NVIDIA \
+Container Toolkit is installed on the host. Otherwise, install or repair the NVIDIA driver \
+and restart SceneWorks.";
+
+/// `CUDA_ERROR_NO_DEVICE` (100) / `CUDA_ERROR_INVALID_DEVICE` (101).
+const CUDA_NO_DEVICE: &str = "CUDA started, but no usable NVIDIA GPU is visible to SceneWorks. \
+Check that an NVIDIA GPU is present and enabled, that `CUDA_VISIBLE_DEVICES` isn't hiding it, \
+and — if you're running the container/server build — that the container was started with GPU \
+access (for example `docker run --gpus all`).";
+
+/// Map a stringified CUDA failure onto actionable host-side guidance, or `None` when it
+/// isn't a driver-class CUDA error at all.
+///
+/// **Matched on the stringified error, deliberately — not a typed downcast.**
+/// `gen_core::Error::Backend` is a `Box<dyn Error + Send + Sync>` because gen-core cannot
+/// name backend types (see `gen-core/src/error.rs`). Recovering the code would mean a
+/// downcast chain `gen_core` → `candle_core::Error::Cuda` → `cudarc::driver::DriverError`,
+/// which drags a candle dependency into this crate's error path and re-breaks on every
+/// candle/cudarc bump. The `CUDA_ERROR_*` token, by contrast, is a stable part of the
+/// rendered message on every path: `cudarc`'s `Display for DriverError` forwards to its
+/// `Debug`, which prints the `CUresult` variant name — e.g.
+/// `DriverError(CUDA_ERROR_SYSTEM_DRIVER_MISMATCH, "system has unsupported display driver /
+/// cuda driver combination")`. So this is version-stable, dependency-free, works on any
+/// target, and is unit-testable with no GPU — which is why it is also the *only* half of
+/// sc-16247 that a non-CUDA machine can verify.
+///
+/// Order matters only in that every token here is a distinct full identifier; none is a
+/// substring of another (`NO_DEVICE` is not a substring of `INVALID_DEVICE`).
+pub(crate) fn cuda_driver_error_guidance(message: &str) -> Option<&'static str> {
+    // Ordered most-specific first purely for readability; the tokens are disjoint.
+    const TABLE: &[(&str, &str)] = &[
+        ("CUDA_ERROR_SYSTEM_DRIVER_MISMATCH", CUDA_DRIVER_MISMATCH),
+        ("CUDA_ERROR_INSUFFICIENT_DRIVER", CUDA_INSUFFICIENT_DRIVER),
+        ("CUDA_ERROR_SYSTEM_NOT_READY", CUDA_SYSTEM_NOT_READY),
+        // Both "CUDA is up but there's nothing to run on" shapes. `cuInit` succeeding with
+        // zero visible devices surfaces as INVALID_DEVICE from `cuDeviceGet(_, 0)` (that is
+        // what `CUDA_VISIBLE_DEVICES=-1` produces), while a driver that enumerates nothing
+        // raises NO_DEVICE. Same remedy, so they share a message.
+        ("CUDA_ERROR_NO_DEVICE", CUDA_NO_DEVICE),
+        ("CUDA_ERROR_INVALID_DEVICE", CUDA_NO_DEVICE),
+    ];
+    TABLE
+        .iter()
+        .find(|(token, _)| message.contains(token))
+        .map(|(_, guidance)| *guidance)
+}
+
+// ---------------------------------------------------------------------------
+// CUDA device-acquisition preflight (sc-16247). Off-Mac candle builds only.
+// ---------------------------------------------------------------------------
+
+/// Verify this process can acquire a usable CUDA GPU **and run a kernel on it** — the
+/// off-Mac counterpart of [`metal_preflight`], and the deeper second gate behind the
+/// desktop's `nvidia-smi` check (which stays: it is the cheap pre-download gate for
+/// no-GPU / too-old-driver / unsupported-architecture hosts, and it runs before the
+/// multi-GB first-run runtime download; this probe needs that runtime present to run at
+/// all).
+///
+/// Goes through `runtime_cuda::media::default_device()` rather than `Device::new_cuda(0)`
+/// directly so the probe uses the *identical* device-acquisition seam every provider load
+/// uses, then runs the smallest op that forces real work: an H2D copy, a dtype-cast kernel
+/// (which also forces candle's PTX module load), and a D2H read that synchronizes. Any of
+/// those failing is what the field sees as `backend op failed: DriverError(...)` mid-load.
+///
+/// Probes device 0 only, which is the right scope for the failure class this exists to
+/// catch: a driver/userspace version mismatch is machine-wide, not per-GPU. Per-GPU
+/// health on a multi-GPU box remains the `auto` supervisor's concern.
+///
+/// **Panics are caught, and that is load-bearing, not defensive habit.** cudarc loads the
+/// CUDA driver library by `dlopen`/`LoadLibrary` at first use (`dynamic-loading`), and when
+/// no candidate resolves its `culib()` calls `panic_no_lib_found` — it does not return a
+/// `CUresult`. Missing symbols panic the same way. That is precisely the container-started-
+/// without-`--gpus` case, where `libcuda.so.1` is simply absent because the NVIDIA container
+/// runtime never injected it. Without [`std::panic::catch_unwind`] this function would abort
+/// its caller instead of reporting, which for the in-process server-lane call
+/// (`log_cuda_preflight_failure`) means killing the worker at startup over a condition it
+/// exists to *describe*. Unwinding across the FFI boundary is not a concern: the panic is
+/// raised in cudarc's own Rust code before any `extern "C"` call is made.
+///
+/// `Ok(())` when the GPU is usable; `Err(message)` is the user-facing reason, with the
+/// underlying CUDA error appended for the logs — the same shape `metal_preflight` returns,
+/// so the `SCENEWORKS_GPU_CHECK=1` sidecar relays either verbatim.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+pub fn cuda_preflight() -> Result<(), String> {
+    use runtime_cuda::media::candle_core::{DType, Tensor};
+
+    let probe = || -> Result<(), String> {
+        let device = runtime_cuda::media::default_device().map_err(|error| error.to_string())?;
+        // One closure so the three candle_core::Error tails share a single conversion.
+        let op = || -> Result<Vec<f32>, runtime_cuda::media::candle_core::Error> {
+            Tensor::new(&[1.0f32], &device)?
+                .to_dtype(DType::F16)?
+                .to_dtype(DType::F32)?
+                .to_vec1::<f32>()
+        };
+        op().map(|_| ()).map_err(|error| error.to_string())
+    };
+    match std::panic::catch_unwind(probe) {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(cuda_preflight_message(&error)),
+        // A panic here is the driver library itself being unloadable, which is its OWN
+        // failure mode — not "no device" and not "mismatched versions" — so it gets its own
+        // remedy rather than the generic fallback.
+        Err(payload) => Err(compose_preflight_message(
+            CUDA_DRIVER_LIBRARY_MISSING,
+            &panic_reason(payload.as_ref()),
+        )),
+    }
+}
+
+/// Render a caught panic payload as a one-line reason. `catch_unwind` hands back a
+/// `Box<dyn Any>`; the two shapes `panic!` ever produces are `&str` and `String`.
+///
+/// Compiled on all targets (with the same dead-code carve-out as
+/// [`cuda_preflight_message`]) so the container-without-GPU message contract is testable
+/// where the probe itself cannot be built.
+#[cfg_attr(
+    not(all(not(target_os = "macos"), feature = "backend-candle")),
+    allow(dead_code)
+)]
+fn panic_reason(payload: &(dyn std::any::Any + Send)) -> String {
+    let detail = payload
+        .downcast_ref::<&str>()
+        .map(|text| (*text).to_owned())
+        .or_else(|| payload.downcast_ref::<String>().cloned())
+        .unwrap_or_else(|| "no panic message".to_owned());
+    // Named so the logs make clear this was a hard failure inside the CUDA driver loader,
+    // not a returned CUresult. `panic_no_lib_found`'s own text names the libraries it tried.
+    format!("the CUDA driver library could not be loaded: {detail}")
+}
+
+/// Compose the probe's user-facing failure text: the specific host-side remedy when the
+/// error carries a known `CUDA_ERROR_*` token, the generic CUDA-unavailable message
+/// otherwise, always with the raw error appended so the logs keep the real cause.
+///
+/// Split out from [`cuda_preflight`] and compiled on all targets so the message assembly
+/// (including the no-device vs. driver-mismatch split, which must not collapse) is
+/// unit-tested on machines that cannot build the CUDA probe itself — which is the entire
+/// point: `npm run rust:check` on a Mac never compiles the probe, so this is where the
+/// message contract is actually verified.
+///
+/// That is also why it needs the dead-code carve-out: its only non-test caller is the
+/// candle-gated [`cuda_preflight`], so on a build without the candle lane it is reachable
+/// from the tests alone, and `-D warnings` would reject it.
+#[cfg_attr(
+    not(all(not(target_os = "macos"), feature = "backend-candle")),
+    allow(dead_code)
+)]
+pub(crate) fn cuda_preflight_message(underlying: &str) -> String {
+    let guidance = cuda_driver_error_guidance(underlying).unwrap_or(CUDA_UNAVAILABLE);
+    compose_preflight_message(guidance, underlying)
+}
+
+/// The one place the probe's two-part message shape is defined: actionable remedy first, raw
+/// error after a blank line. Shared so the caught-panic path (whose guidance is chosen by the
+/// failure mode, not by a `CUDA_ERROR_*` token) produces an identically-shaped message.
+pub(crate) fn compose_preflight_message(guidance: &str, underlying: &str) -> String {
+    format!("{guidance}\n\nUnderlying CUDA error: {underlying}")
+}
+
+/// Does this [`cuda_preflight`] failure describe a host condition that GENUINELY prevents
+/// generation, as opposed to one that might clear on its own?
+///
+/// This is the difference between "show the user a setup screen and refuse to start" and
+/// "log it and let the app run", and getting it wrong in the permissive direction costs one
+/// failed job while getting it wrong in the strict direction **locks the user out of the whole
+/// application** — Library, Settings, everything — over a condition that may not even involve
+/// the driver. So only the definite, non-transient host states qualify:
+///
+/// - any recognized driver-class `CUDA_ERROR_*` code (the family this story exists for), and
+/// - the CUDA driver library failing to load at all.
+///
+/// Everything else — a CUDA OOM because another process (or an orphaned worker from a crashed
+/// session) currently holds the GPU, a cuBLAS/cuRAND handle failing to initialize under that
+/// same pressure, or any error we do not recognize — is reported and stepped over. The user
+/// keeps a usable app, and if they do start a generation the classified message from
+/// [`crate::classify_engine_error`] tells them what happened.
+///
+/// Takes the COMPOSED message (guidance + underlying), which is what crosses the process
+/// boundary; the `CUDA_ERROR_*` token survives in its tail.
+pub fn cuda_failure_is_blocking(message: &str) -> bool {
+    cuda_driver_error_guidance(message).is_some() || message.contains(CUDA_DRIVER_LIBRARY_MISSING)
+}
+
+/// No-op wherever the candle/CUDA lane isn't linked (macOS, and any off-Mac build without
+/// `backend-candle`): there is no CUDA runtime to probe, and the desktop keeps the lane
+/// dormant in that state anyway. Present on all targets so the `SCENEWORKS_GPU_CHECK`
+/// dispatch in the shared binary compiles everywhere, exactly like [`metal_preflight`].
+#[cfg(not(all(not(target_os = "macos"), feature = "backend-candle")))]
+pub fn cuda_preflight() -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The literal text GH #1966 reported, as it reaches the worker: `gen_core::Error::Backend`
+    /// renders `backend op failed: {0}`, and cudarc's `Display for DriverError` forwards to its
+    /// `Debug`, which prints the `CUresult` variant name plus `cuGetErrorString`'s text.
+    const REPORTED_803: &str = "backend op failed: DriverError(CUDA_ERROR_SYSTEM_DRIVER_MISMATCH, \
+        \"system has unsupported display driver / cuda driver combination\")";
+
+    #[test]
+    fn the_reported_driver_mismatch_maps_to_the_reboot_remedy() {
+        let guidance = cuda_driver_error_guidance(REPORTED_803)
+            .expect("803 must be recognized as a CUDA error");
+        assert_eq!(
+            guidance, CUDA_DRIVER_MISMATCH,
+            "the exact string from GH #1966 must map to the driver-mismatch remedy"
+        );
+        // The remedy has to actually name the host-side action, not just restate the error.
+        assert!(
+            guidance.contains("reboot"),
+            "the 803 remedy must tell the user to reboot, got: {guidance}"
+        );
+    }
+
+    #[test]
+    fn every_driver_class_code_maps_to_its_own_remedy() {
+        // Pinned to DISTINCT expected values, so deleting an arm or collapsing two of them
+        // fails here rather than passing on a shared default.
+        for (token, expected) in [
+            ("CUDA_ERROR_SYSTEM_DRIVER_MISMATCH", CUDA_DRIVER_MISMATCH),
+            ("CUDA_ERROR_INSUFFICIENT_DRIVER", CUDA_INSUFFICIENT_DRIVER),
+            ("CUDA_ERROR_SYSTEM_NOT_READY", CUDA_SYSTEM_NOT_READY),
+            ("CUDA_ERROR_NO_DEVICE", CUDA_NO_DEVICE),
+            ("CUDA_ERROR_INVALID_DEVICE", CUDA_NO_DEVICE),
+        ] {
+            let rendered = format!("backend op failed: DriverError({token}, \"whatever\")");
+            assert_eq!(
+                cuda_driver_error_guidance(&rendered),
+                Some(expected),
+                "{token} must map to its own remedy"
+            );
+        }
+    }
+
+    /// The two failure shapes the story explicitly forbids collapsing: "this machine has no
+    /// CUDA device" and "this machine's CUDA driver stack is mismatched" want different
+    /// remedies, because the user actions are different (check the GPU/container flags vs.
+    /// reboot onto the staged driver).
+    #[test]
+    fn no_device_and_driver_mismatch_do_not_share_a_message() {
+        let no_device = cuda_driver_error_guidance("DriverError(CUDA_ERROR_NO_DEVICE, \"x\")")
+            .expect("no-device recognized");
+        let mismatch = cuda_driver_error_guidance(REPORTED_803).expect("mismatch recognized");
+        assert_ne!(
+            no_device, mismatch,
+            "the no-device and driver-mismatch remedies must stay distinct"
+        );
+        assert!(
+            no_device.contains("--gpus"),
+            "the no-device remedy must cover the container case, got: {no_device}"
+        );
+    }
+
+    #[test]
+    fn non_cuda_failures_are_not_claimed_as_driver_errors() {
+        // A CUDA OOM is a real CUDA error but NOT a driver-stack problem: rewriting it as
+        // "reboot your machine" would be actively misleading. Only the driver-class family
+        // may match.
+        for unrelated in [
+            "backend op failed: DriverError(CUDA_ERROR_OUT_OF_MEMORY, \"out of memory\")",
+            "missing tensor: unet.down_blocks.0",
+            "backend op failed: cuda error: an illegal memory access was encountered",
+            "",
+        ] {
+            assert_eq!(
+                cuda_driver_error_guidance(unrelated),
+                None,
+                "{unrelated:?} must not be classified as a driver-class CUDA failure"
+            );
+        }
+    }
+
+    #[test]
+    fn the_probe_message_keeps_the_underlying_error_for_the_logs() {
+        let message = cuda_preflight_message(REPORTED_803);
+        assert!(
+            message.starts_with(CUDA_DRIVER_MISMATCH),
+            "the actionable remedy must lead, got: {message}"
+        );
+        assert!(
+            message.contains(REPORTED_803),
+            "the raw CUDA error must be preserved for the logs, got: {message}"
+        );
+    }
+
+    /// The container-without-`--gpus` contract. cudarc loads the CUDA driver library lazily and
+    /// `panic!`s (`panic_no_lib_found`) when no candidate resolves — it does NOT return a
+    /// `CUresult`. `cuda_preflight` therefore wraps the probe in `catch_unwind`, and the
+    /// server-lane caller runs IN-PROCESS at worker startup, so without that wrapper a GPU-less
+    /// container would abort the worker instead of logging why. This pins the two halves that
+    /// make the wrapper work — the payload actually renders, and the composed message names the
+    /// container remedy — on any machine, with no CUDA and no panic of our own.
+    #[test]
+    fn a_missing_driver_library_reads_as_the_container_remedy() {
+        // Both payload shapes `panic!` can produce. cudarc's is a formatted String.
+        let from_string: Box<dyn std::any::Any + Send> =
+            Box::new(String::from("Unable to find lib: \"libcuda.so\""));
+        let from_str: Box<dyn std::any::Any + Send> = Box::new("boom");
+        assert!(
+            panic_reason(from_string.as_ref()).contains("libcuda.so"),
+            "a String payload must survive into the reason"
+        );
+        assert!(
+            panic_reason(from_str.as_ref()).contains("boom"),
+            "a &str payload must survive into the reason"
+        );
+
+        let message = compose_preflight_message(
+            CUDA_DRIVER_LIBRARY_MISSING,
+            &panic_reason(from_string.as_ref()),
+        );
+        assert!(
+            message.contains("--gpus"),
+            "the missing-driver-library remedy must name container GPU access, got: {message}"
+        );
+        assert!(
+            message.contains("libcuda.so"),
+            "the underlying loader failure must reach the logs, got: {message}"
+        );
+        // It must NOT be mistaken for the "GPU present but hidden" case: those have different
+        // remedies (install/expose the driver vs. check CUDA_VISIBLE_DEVICES).
+        assert_ne!(
+            CUDA_DRIVER_LIBRARY_MISSING, CUDA_NO_DEVICE,
+            "a missing driver library and a hidden device must not share a message"
+        );
+    }
+
+    /// The severity split that decides whether a probe failure STOPS THE APP or is merely logged
+    /// (sc-16247). Over-blocking is the expensive direction: it locks the user out of Library,
+    /// Settings and everything else, so only definite, non-transient host states may qualify.
+    #[test]
+    fn only_definite_host_problems_block_startup() {
+        // Blocks: the whole driver-class family, and no driver library at all.
+        for token in [
+            "CUDA_ERROR_SYSTEM_DRIVER_MISMATCH",
+            "CUDA_ERROR_INSUFFICIENT_DRIVER",
+            "CUDA_ERROR_SYSTEM_NOT_READY",
+            "CUDA_ERROR_NO_DEVICE",
+            "CUDA_ERROR_INVALID_DEVICE",
+        ] {
+            let composed = cuda_preflight_message(&format!("DriverError({token}, \"whatever\")"));
+            assert!(
+                cuda_failure_is_blocking(&composed),
+                "{token} is a definite host problem and must block startup"
+            );
+        }
+        let missing = compose_preflight_message(
+            CUDA_DRIVER_LIBRARY_MISSING,
+            "the CUDA driver library could not be loaded: Unable to find lib",
+        );
+        assert!(
+            cuda_failure_is_blocking(&missing),
+            "no CUDA driver library at all must block startup"
+        );
+
+        // Does NOT block: transient or unrecognized failures. A CUDA OOM is the motivating case —
+        // another process (or an orphaned worker from a crashed session) holding the GPU must not
+        // make the entire application unopenable.
+        for transient in [
+            "DriverError(CUDA_ERROR_OUT_OF_MEMORY, \"out of memory\")",
+            "cuda error: CUBLAS_STATUS_NOT_INITIALIZED",
+            "some brand new cudarc failure",
+        ] {
+            let composed = cuda_preflight_message(transient);
+            assert!(
+                !cuda_failure_is_blocking(&composed),
+                "{transient:?} may be transient and must NOT lock the user out of the app"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unrecognized_cuda_failure_still_gets_the_generic_requirement() {
+        let message = cuda_preflight_message("some brand new cudarc failure");
+        assert!(
+            message.starts_with(CUDA_UNAVAILABLE),
+            "an unmapped failure must still explain that CUDA is required, got: {message}"
+        );
+        assert!(message.contains("some brand new cudarc failure"));
+    }
 }

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -2583,3 +2583,47 @@ fn dense_te_declarations_only_appear_on_entries_with_packed_tiers() {
         );
     }
 }
+
+// sc-16247 (GH #1966): the startup CUDA probe must run on the candle GPU worker and NOWHERE else.
+// All three conditions are load-bearing and every one of them fails silently if inverted:
+//   * `cpu`  — the utility pool, INCLUDING the API's in-process loops (`spawn_inprocess_utility_worker`,
+//              2 by default), would each build and tear down a CUDA context on a lane that never
+//              touches CUDA;
+//   * `mlx`  — the macOS GPU worker, which has `metal_preflight` and no CUDA at all;
+//   * candle off — nothing to probe, and `cuda_preflight` is a compiled-out no-op anyway.
+// Inverting the whole predicate the other way makes the server-lane gate (AC5) dead code that
+// still compiles and still passes every other test.
+#[test]
+fn cuda_preflight_runs_on_the_candle_gpu_worker_and_no_other_lane() {
+    let gated = |candle: bool, gpu_id: &str| {
+        let mut settings = crate::Settings::from_env();
+        settings.backend_candle_enabled = candle;
+        settings.gpu_id = gpu_id.to_owned();
+        crate::should_run_cuda_preflight(&settings)
+    };
+
+    // The one lane that must probe: a candle build on a real GPU id (`auto` never reaches
+    // `run_worker_loop`, so the ids seen here are the per-GPU children's).
+    for gpu_id in ["0", "1"] {
+        assert!(
+            gated(true, gpu_id),
+            "the candle GPU worker on gpu {gpu_id} must run the CUDA preflight"
+        );
+    }
+
+    // Every lane that must NOT.
+    assert!(
+        !gated(true, "cpu"),
+        "the CPU utility pool must never build a CUDA context"
+    );
+    assert!(
+        !gated(true, "mlx"),
+        "the macOS MLX worker has its own Metal probe and no CUDA"
+    );
+    for gpu_id in ["0", "cpu", "mlx"] {
+        assert!(
+            !gated(false, gpu_id),
+            "with the candle backend disabled there is nothing to probe (gpu {gpu_id})"
+        );
+    }
+}


### PR DESCRIPTION
Closes the CUDA half of [#1966](https://github.com/SceneWorks/SceneWorks/issues/1966). Story: [sc-16247](https://app.shortcut.com/trefry/story/16247). [PR #1968](https://github.com/SceneWorks/SceneWorks/pull/1968) addressed only the Logs-tab UI half of that report and deferred this.

## The report

A user on Bazzite (`bazzite-dx-nvidia-gnome:testing`, RTX 3090 Ti, 2 days' uptime) hit this mid-generation:

```
candle krea_2_turbo load failed: backend op failed:
DriverError(CUDA_ERROR_SYSTEM_DRIVER_MISMATCH, "system has unsupported display driver / cuda driver combination")
```

CUDA 803 means the loaded NVIDIA kernel module and `libcuda.so` are out of step — a host-environment problem with no code-side fix. But it exposed two real defects in how we handle it.

## Defect 1 — the preflight probed the wrong API

`cuda_preflight` / `linux_cuda_preflight` shell out to `nvidia-smi`, which is **NVML**. It never calls `cuInit`. NVML and the CUDA driver API version-check separately, so a host can pass the NVML probe and still fail device acquisition — which is exactly what happened.

That check **stays where it is**: it is the cheap gate that catches no-GPU / too-old-driver / unsupported-architecture hosts *before* the multi-GB runtime download, and failing fast there is its whole point. `cuda_preflight` in `crates/sceneworks-worker/src/preflight.rs` is now a second, deeper gate that acquires a real device through the same `runtime_cuda::media::default_device()` seam every provider load uses, then runs an H2D copy → cast kernel → D2H sync. It is the CUDA twin of `metal_preflight`, invoked through the existing `SCENEWORKS_GPU_CHECK=1` sidecar, and placed **after** GPU-runtime provisioning — the probe needs those downloaded DLLs on its loader path to reach `cuInit` at all.

## Defect 2 — the raw driver error was what the user saw

`classify_engine_error` bucketed everything except `Unsupported` into opaque `WorkerError::Engine`, and that string is `fail_job`'s detail, which `QueueScreen` renders as `job.error`. Driver-class failures now lead with the host-side remedy and keep the underlying error for the logs. The family is covered, not just 803: `SYSTEM_DRIVER_MISMATCH` (803), `INSUFFICIENT_DRIVER` (35), `SYSTEM_NOT_READY` (802), `NO_DEVICE` (100) and `INVALID_DEVICE` (101).

Matched on the stringified `CUDA_ERROR_*` token rather than a typed downcast, per the story: `gen_core::Error::Backend` is a `Box<dyn Error>` *by design* (gen-core cannot name backend types), and cudarc's `Display for DriverError` forwards to its `Debug`, which prints the `CUresult` variant name. So this is version-stable, dependency-free, and unit-testable with no GPU.

## Three things that turned up while building it

**Only a definite host problem may block startup.** The first cut treated any probe failure as fatal. That would lock a user out of Library, Settings, and everything else over a state that may be transient — a CUDA OOM because another process (or an orphaned worker from a crashed session) currently holds the GPU would make the whole app unopenable. The verdict now crosses the process boundary as an exit code (2 = blocking, 1 = advisory); advisory failures are logged to `candle-worker.log` and the app starts. Those users still get the classified message if they run a generation.

**The desktop probe is bounded by a timeout.** `cuInit` on a wedged driver — a TDR-recovering GPU, a stalled persistence daemon, precisely what this probe exists to catch — can block indefinitely instead of returning an error. Unbounded, `run_startup` would never return and the setup screen would spin forever with no message and no Retry button.

**`cudarc` panics rather than returning an error when no CUDA driver library loads.** `culib()` calls `panic_no_lib_found`; missing symbols panic too. That is exactly the container-started-without-`--gpus` case, where the NVIDIA container runtime never injected `libcuda.so.1`. Since the server-lane call runs in-process, without `catch_unwind` this would have killed the worker at startup over a condition it exists to *describe*. Caught, and given its own remedy naming `--gpus all`.

## AC 5 — the server/Docker lane

Confirmed: it ran **no GPU preflight of any kind**. `run_worker()` goes straight into the worker loop, so a driver mismatch there surfaces as a job failure, per job, forever. It now logs the same actionable reason once at GPU-worker startup, at `error` level, on the blocking pool (the worker loop also runs in-process in the API, so blocking the runtime was a real hazard).

The **unhealthy-worker-status** half of that AC is [sc-16260](https://app.shortcut.com/trefry/story/16260) — it needs a new `WorkerStatus` variant plus API and UI surface, and the alternative (withholding capabilities so the router skips the worker) silently changes queued-vs-failed semantics. That is a deliberate decision, not a line in a preflight function.

## Also in here

- **The job-failure tail is annotated too.** ~35 load seams build `WorkerError::Engine(format!(...))` directly and bypass `classify_engine_error`; a host driver problem breaks all of them identically. Annotating once where every terminal detail passes covers them without a 36-call-site churn across 20+ files. Idempotent, so an already-classified detail is never doubled.
- **`white-space: pre-wrap`** on the setup screen's `#status` and the queue card's `__message`. Both were collapsing the paragraph break, running the remedy straight into the raw `DriverError(...)`.
- **One shared `apply_candle_loader_env`** for `spawn_api` and the probe. The probe MUST see the same loader path the worker will; a third hand-maintained copy is the sc-10353 failure mode waiting to happen.

## Verification

On this box (2× RTX PRO 6000 Blackwell, driver 596.36, CUDA 12.9):

| case | result |
|---|---|
| Healthy box | exit 0, **~235 ms warm / ~519 ms cold** — the startup cost the story asked me to record |
| `CUDA_VISIBLE_DEVICES=-1` | exit 1 → no-device message, `CUDA_ERROR_NO_DEVICE` |
| `CUDA_VISIBLE_DEVICES=99` | same |

Gates: `cargo fmt --all --check`; clippy on worker + rust-api + desktop and on `--features backend-candle`, all `-D warnings`; `cargo test` worker (526) + rust-api (679) + desktop (104); 15 new tests pass under both the default and candle feature sets; `npm run rust:check:neither`; web vitest 3400 tests / 231 files, lint, and production build.

Three mutations were run against the new tests — collapsing the no-device message onto the driver-mismatch one, reverting `classify_engine_error`, and forcing the guidance lookup to always miss. Each turned tests RED, so they are not false greens.

**Not reproduced:** a genuine 803. Faking it safely needs the Linux `LD_LIBRARY_PATH` trick, which does not apply on Windows, and I would not touch this box's real driver files. It is covered by unit tests against the verbatim string from the issue, and the mechanism is proven end-to-end by the `NO_DEVICE` run above, which exercises the same table and message assembly.

**Coverage gap to note:** `apps/desktop` is excluded from workspace `default-members` and `desktop-linux.yml` is `workflow_dispatch:`-only, so no automatic PR lane compiles the `#[cfg(target_os = "linux")]` desktop branch — on a story that is itself a Linux bug report. Dispatching that workflow by hand on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
