### PR TITLE
ci(desktop-linux): typecheck the Linux desktop crate on PRs (sc-16269)

### DIFF
--- a/.github/workflows/desktop-linux-check.yml
+++ b/.github/workflows/desktop-linux-check.yml
@@ -1,0 +1,101 @@
+name: Desktop (Linux typecheck)
+
+# The Linux mirror of desktop-windows.yml's `build-windows` PR job, and the PR-time
+# sibling of desktop-linux.yml's manual packaging lane (sc-16269).
+#
+# Until this existed, `#[cfg(target_os = "linux")]` code in apps/desktop was compiled
+# by NO automatic lane. Two facts combined: the crate is excluded from the workspace
+# `default-members` (it needs GTK/WebKit), so the Linux `Check` lane skips it, and
+# desktop-linux.yml is workflow_dispatch-only. desktop-windows.yml runs on PRs, so
+# only the LINUX branches were dark — which is how sc-16247, itself a Linux bug
+# report, came to add Linux-only desktop code that nothing would have compiled.
+#
+# ## Why this is a separate file, not a job inside desktop-linux.yml
+#
+# That workflow carries a deliberate invariant, asserted by
+# `scripts/check-scaffold.mjs::assertDesktopLinuxPackagingWorkflow`: it must stay
+# workflow_dispatch-only, because "an accidental pull_request/push trigger would turn
+# every desktop edit into a full nvcc release build". Adding a PR trigger there —
+# even with the packaging job gated off — would mean loosening that guard from a
+# simple file-level rule to a job-aware one. Keeping the cheap lane in its own file
+# leaves the heavy lane's invariant literally true and un-bypassable, which is worth
+# more than co-locating the two.
+#
+# ## Why this is affordable per-PR when the packaging lane is not
+#
+# `cargo test` / `cargo clippy` never run tauri's `beforeBuildCommand`, so this needs
+# neither the candle sidecar (nvcc over every provider) nor the CUDA toolkit — only
+# the GTK/WebKit dev headers. `build.rs` -> `tauri_build` does validate
+# tauri.conf.json's `externalBin` + `resources` and panics if any path is missing, so
+# the crate cannot even typecheck without them; `stage-test-sidecars.mjs` (the same
+# script the Windows lane uses) writes tiny placeholders, which suffices because
+# nothing here bundles them. Verified: replacing the real 429 MB sidecar with a
+# 0-byte file still leaves `cargo check -p sceneworks-desktop` at exit 0.
+
+on:
+  pull_request:
+    paths: &desktop_linux_check_paths
+      - "apps/desktop/**"
+      # The only workspace crate apps/desktop depends on.
+      - "crates/sceneworks-core/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/desktop-linux-check.yml"
+  push:
+    branches: [main]
+    paths: *desktop_linux_check_paths
+  workflow_dispatch:
+
+concurrency:
+  group: desktop-linux-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-linux:
+    runs-on: ubuntu-22.04
+    env:
+      CARGO_NET_OFFLINE: "true"
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
+
+      # The Tauri/WebKitGTK prerequisites desktop-linux.yml installs, minus the
+      # packaging-only ones: libfuse2/patchelf serve AppImage bundling and
+      # gstreamer1.0-libav is the webview's runtime H.264 decoder. Nothing here
+      # bundles or runs a webview. Ubuntu 22.04 matches the packaging lane's glibc
+      # baseline so both compile against the same headers.
+      - name: Install GTK and WebKitGTK development headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            build-essential \
+            libayatana-appindicator3-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev
+
+      - name: Fetch the private inference release
+        env:
+          CARGO_NET_OFFLINE: "false"
+          GIT_CONFIG_COUNT: "1"
+          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
+          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
+        run: cargo fetch --locked
+
+      - name: Stage desktop test sidecar placeholders
+        run: node apps/desktop/scripts/stage-test-sidecars.mjs
+
+      - name: Run desktop Rust tests (Linux)
+        run: cargo test -p sceneworks-desktop
+
+      - name: Check desktop Rust lint (Linux)
+        run: npm run desktop:check

--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -1,19 +1,101 @@
 name: Desktop (Linux packages)
 
 # Build the complete Linux/NVIDIA desktop packages on the Ubuntu 22.04
-# compatibility baseline. Manual-only, like server-candle-linux.yml: compiling
-# the candle sidecar runs nvcc for every provider and is too heavy for the
-# standing PR lanes. A GPU is not required to compile or package it.
+# compatibility baseline. `package-linux` is manual-only, like
+# server-candle-linux.yml: compiling the candle sidecar runs nvcc for every
+# provider and is too heavy for the standing PR lanes. A GPU is not required to
+# compile or package it.
+#
+# `check-linux` (sc-16269) is the cheap PR gate alongside it. Until it existed,
+# `#[cfg(target_os = "linux")]` code in apps/desktop was compiled by NO automatic
+# lane: the crate is excluded from workspace `default-members` (it needs GTK/
+# WebKit), so the Linux `Check` lane skips it, and this workflow was
+# workflow_dispatch-only. desktop-windows.yml runs on PRs, so only the LINUX
+# branches were dark — which is how sc-16247, itself a Linux bug report, came to
+# add Linux-only desktop code that nothing would have compiled.
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths: &desktop_linux_paths
+      - "apps/desktop/**"
+      # The only workspace crate apps/desktop depends on.
+      - "crates/sceneworks-core/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/desktop-linux.yml"
+  push:
+    branches: [main]
+    paths: *desktop_linux_paths
 
 concurrency:
   group: desktop-linux-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # The Linux mirror of desktop-windows.yml's `build-windows` PR job: same staging
+  # script, same tests, same lint. Deliberately NOT a package build — `cargo test`
+  # / `cargo clippy` never run tauri's beforeBuildCommand, so this needs neither the
+  # candle sidecar nor the CUDA toolkit, only the GTK/WebKit dev headers.
+  check-linux:
+    runs-on: ubuntu-22.04
+    env:
+      CARGO_NET_OFFLINE: "true"
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
+
+      # The same Tauri/WebKitGTK prerequisites package-linux installs, minus the
+      # packaging-only ones: libfuse2/patchelf/gstreamer1.0-libav serve AppImage
+      # bundling and the webview's runtime media stack, and nothing here bundles or
+      # runs a webview.
+      - name: Install GTK and WebKitGTK development headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y \
+            build-essential \
+            libayatana-appindicator3-dev \
+            libgtk-3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev
+
+      - name: Fetch the private inference release
+        env:
+          CARGO_NET_OFFLINE: "false"
+          GIT_CONFIG_COUNT: "1"
+          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
+          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
+        run: cargo fetch --locked
+
+      # `tauri_build` validates tauri.conf.json's `externalBin` + `resources` at
+      # build.rs time and panics if any is missing, so the desktop crate cannot even
+      # typecheck without them. The same script desktop-windows.yml uses; it writes
+      # tiny placeholders, which is sufficient because nothing here bundles them.
+      # Building the real sidecar would mean nvcc over every candle provider —
+      # precisely the cost this job exists to avoid.
+      - name: Stage desktop test sidecar placeholders
+        run: node apps/desktop/scripts/stage-test-sidecars.mjs
+
+      - name: Run desktop Rust tests (Linux)
+        run: cargo test -p sceneworks-desktop
+
+      - name: Check desktop Rust lint (Linux)
+        run: npm run desktop:check
+
   package-linux:
+    # Stays manual-only. It installs the CUDA toolkit and runs the full
+    # sidecar + AppImage/deb build (90-minute cap) — adding the PR trigger above
+    # must not drag that onto every PR.
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
     env:
       # compute_80 PTX the driver JITs forward to sm_120. Keep this and the CUDA

--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -1,101 +1,19 @@
 name: Desktop (Linux packages)
 
 # Build the complete Linux/NVIDIA desktop packages on the Ubuntu 22.04
-# compatibility baseline. `package-linux` is manual-only, like
-# server-candle-linux.yml: compiling the candle sidecar runs nvcc for every
-# provider and is too heavy for the standing PR lanes. A GPU is not required to
-# compile or package it.
-#
-# `check-linux` (sc-16269) is the cheap PR gate alongside it. Until it existed,
-# `#[cfg(target_os = "linux")]` code in apps/desktop was compiled by NO automatic
-# lane: the crate is excluded from workspace `default-members` (it needs GTK/
-# WebKit), so the Linux `Check` lane skips it, and this workflow was
-# workflow_dispatch-only. desktop-windows.yml runs on PRs, so only the LINUX
-# branches were dark — which is how sc-16247, itself a Linux bug report, came to
-# add Linux-only desktop code that nothing would have compiled.
+# compatibility baseline. Manual-only, like server-candle-linux.yml: compiling
+# the candle sidecar runs nvcc for every provider and is too heavy for the
+# standing PR lanes. A GPU is not required to compile or package it.
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths: &desktop_linux_paths
-      - "apps/desktop/**"
-      # The only workspace crate apps/desktop depends on.
-      - "crates/sceneworks-core/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - ".github/workflows/desktop-linux.yml"
-  push:
-    branches: [main]
-    paths: *desktop_linux_paths
 
 concurrency:
   group: desktop-linux-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # The Linux mirror of desktop-windows.yml's `build-windows` PR job: same staging
-  # script, same tests, same lint. Deliberately NOT a package build — `cargo test`
-  # / `cargo clippy` never run tauri's beforeBuildCommand, so this needs neither the
-  # candle sidecar nor the CUDA toolkit, only the GTK/WebKit dev headers.
-  check-linux:
-    runs-on: ubuntu-22.04
-    env:
-      CARGO_NET_OFFLINE: "true"
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "20"
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
-
-      # The same Tauri/WebKitGTK prerequisites package-linux installs, minus the
-      # packaging-only ones: libfuse2/patchelf/gstreamer1.0-libav serve AppImage
-      # bundling and the webview's runtime media stack, and nothing here bundles or
-      # runs a webview.
-      - name: Install GTK and WebKitGTK development headers
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y \
-            build-essential \
-            libayatana-appindicator3-dev \
-            libgtk-3-dev \
-            librsvg2-dev \
-            libssl-dev \
-            libwebkit2gtk-4.1-dev \
-            libxdo-dev
-
-      - name: Fetch the private inference release
-        env:
-          CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
-        run: cargo fetch --locked
-
-      # `tauri_build` validates tauri.conf.json's `externalBin` + `resources` at
-      # build.rs time and panics if any is missing, so the desktop crate cannot even
-      # typecheck without them. The same script desktop-windows.yml uses; it writes
-      # tiny placeholders, which is sufficient because nothing here bundles them.
-      # Building the real sidecar would mean nvcc over every candle provider —
-      # precisely the cost this job exists to avoid.
-      - name: Stage desktop test sidecar placeholders
-        run: node apps/desktop/scripts/stage-test-sidecars.mjs
-
-      - name: Run desktop Rust tests (Linux)
-        run: cargo test -p sceneworks-desktop
-
-      - name: Check desktop Rust lint (Linux)
-        run: npm run desktop:check
-
   package-linux:
-    # Stays manual-only. It installs the CUDA toolkit and runs the full
-    # sidecar + AppImage/deb build (90-minute cap) — adding the PR trigger above
-    # must not drag that onto every PR.
-    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-22.04
     env:
       # compute_80 PTX the driver JITs forward to sm_120. Keep this and the CUDA

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -393,6 +393,13 @@ fn linux_desktop_paths() -> LinuxDesktopPaths {
 /// Per-OS application support root: `~/Library/Application Support/SceneWorks`
 /// (macOS), `%APPDATA%\SceneWorks` (Windows), `$XDG_DATA_HOME/SceneWorks` or
 /// `~/.local/share/SceneWorks` (Linux).
+///
+/// Unused on Linux: every caller (`default_data_dir`, `config_dir`, `settings_file`,
+/// `gpu_runtime_dir`, `huggingface_home`, the cred-IPC socket, the sidecar pidfile) takes
+/// its `#[cfg(all(unix, not(target_os = "macos")))]` branch through `linux_desktop_paths()`
+/// instead, so the XDG arm below is reachable only in principle. Kept whole rather than
+/// cfg'd out so the three platform arms stay readable side by side (sc-16269).
+#[cfg_attr(all(unix, not(target_os = "macos")), allow(dead_code))]
 pub fn app_support_dir() -> PathBuf {
     #[cfg(target_os = "macos")]
     if let Ok(home) = std::env::var("HOME") {

--- a/apps/desktop/src/update.rs
+++ b/apps/desktop/src/update.rs
@@ -123,6 +123,13 @@ async fn check_and_prompt(app: &AppHandle) -> tauri_plugin_updater::Result<()> {
 /// valid non-UTF-8 Windows paths are not changed. NSIS requires `/D=` to be the
 /// final argument; the updater builder preserves insertion order and appends
 /// installer arguments last.
+///
+/// Its only non-test caller is `#[cfg(target_os = "windows")]` — NSIS is the Windows
+/// installer — but the tests below are unconditional, because the path logic they cover is
+/// platform-neutral. That combination makes this dead code in a non-Windows *bin* build
+/// while it stays live in the test target, so the carve-out is platform-scoped rather than
+/// blanket (sc-16269).
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 fn nsis_install_dir_arg(current_exe: &Path) -> Option<OsString> {
     let install_dir = current_exe.parent()?;
     if install_dir.as_os_str().is_empty() {

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -42,6 +42,7 @@ const requiredPaths = [
 const inferenceCargoWorkflows = [
   ".github/workflows/check.yml",
   ".github/workflows/desktop-linux.yml",
+  ".github/workflows/desktop-linux-check.yml",
   ".github/workflows/desktop-windows.yml",
   ".github/workflows/macos-mlx.yml",
   ".github/workflows/release.yml",


### PR DESCRIPTION
Story: [sc-16269](https://app.shortcut.com/trefry/story/16269). Found while working [sc-16247](https://app.shortcut.com/trefry/story/16247).

## The gap

**`#[cfg(target_os = "linux")]` code in `apps/desktop` was compiled by no automatic CI lane.** Two independent facts combined:

1. `apps/desktop` is excluded from workspace `default-members` (it needs GTK/WebKit and isn't shipped on Linux via cargo), so the Linux `Check` lane never builds it.
2. `desktop-linux.yml` is `workflow_dispatch:` only.

`desktop-windows.yml` runs on PRs, so the *Windows* branches of `apps/desktop` were covered. Only the Linux ones were dark.

sc-16247 — itself a **Linux** bug report, on Bazzite — added Linux-only desktop code. It was verified only because I went looking for the gap and dispatched the workflow by hand. Nothing would have re-verified it on any later commit. Same class as the dispatch-only lane that let a candle break rot on `main` (sc-5495 → sc-7475, #865).

## What this adds

A new `desktop-linux-check.yml` — the Linux mirror of `desktop-windows.yml`'s `build-windows` PR job, reusing its pieces rather than inventing a parallel standard:

| step | same as the Windows PR job |
|---|---|
| `node apps/desktop/scripts/stage-test-sidecars.mjs` | yes |
| `cargo test -p sceneworks-desktop` | yes |
| `npm run desktop:check` (`clippy --all-targets -- -D warnings`) | yes |

Path-filtered to `apps/desktop/**`, `crates/sceneworks-core/**` (the only workspace crate it depends on), the manifests, and the workflow itself.

### Why a separate file, and not a job inside `desktop-linux.yml`

My first attempt put it there and **CI correctly rejected it.** That workflow carries a deliberate invariant, asserted by `check-scaffold.mjs::assertDesktopLinuxPackagingWorkflow`, with the reason in its own comment: *"an accidental pull_request/push trigger would turn every desktop edit into a full nvcc release build."*

I had gated `package-linux` behind `workflow_dispatch` so the intent was preserved, but honoring it that way would have meant loosening the guard from a simple file-level rule into a job-aware one. A separate file keeps the heavy lane's invariant literally true and un-bypassable, which is worth more than co-locating the two. `desktop-linux.yml` is now **byte-identical to `main`** in this PR.

The new file is registered in `check-scaffold.mjs`'s `inferenceCargoWorkflows`, which asserts the private-inference token wiring every cargo workflow needs.

### Why it is affordable per-PR when the packaging lane is not

`cargo test` / `cargo clippy` never run tauri's `beforeBuildCommand`, so this needs neither the candle sidecar (nvcc over every provider) nor the CUDA toolkit — only the GTK/WebKit dev headers.

`build.rs` → `tauri_build` does validate `tauri.conf.json`'s `externalBin` + `resources` and panics if any path is missing, so the crate cannot even typecheck without them. `stage-test-sidecars.mjs` writes tiny placeholders, which suffices because nothing here bundles them. I confirmed the premise directly: replacing the real 429 MB sidecar with a **0-byte** file still leaves `cargo check -p sceneworks-desktop` at exit 0.

## The lane earned its keep on its first run

Before the guard failure, it got far enough to prove itself: apt, staging and `cargo test -p sceneworks-desktop` all passed on Linux, and `npm run desktop:check` **failed on two pre-existing dead-code errors** that no lane had ever compiled. Neither is from sc-16247:

- **`app_support_dir`** (`setup.rs`) — every caller (`default_data_dir`, `config_dir`, `settings_file`, `gpu_runtime_dir`, `huggingface_home`, the cred-IPC socket, the sidecar pidfile) takes its `cfg(all(unix, not(macos)))` branch through `linux_desktop_paths()` instead, so the function is unreachable on Linux.
- **`nsis_install_dir_arg`** (`update.rs`) — its only non-test caller is `cfg(target_os = "windows")` (NSIS is the Windows installer), while its tests are unconditional. Dead in a non-Windows *bin*, live in the test target — which is precisely why only the bin build failed and the test build didn't.

Both fixed with a platform-scoped `cfg_attr(..., allow(dead_code))` — the pattern already used elsewhere in this repo — rather than a blanket allow or a cfg-out that would strand the other platform arms. No behaviour changes.

## Verification

- `Desktop (Linux typecheck)` → **success** on this PR. Including the workflow in its own path filter means the change validates itself.
- `package-linux` showed as **skipped** on the earlier run, confirming the heavy lane stays manual.
- Locally: `cargo fmt --all --check`, `npm run desktop:check`, `cargo test -p sceneworks-desktop` (104 passed), and the full `npm run check` — scaffold passes, action pins pass across 9 workflows.

Process note for the record: the first push tripped the scaffold guard because I ran only `check-action-pins.mjs` locally instead of the full `npm run check`, which would have caught it in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
