### PR TITLE
feat(gpu): an unusable GPU marks the server worker unhealthy, not just logs (sc-16260)

### DIFF
--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -709,6 +709,41 @@ fn person_readiness_reflects_live_worker_capabilities() {
     assert_eq!(readiness["segment"]["ready"], json!(false));
 }
 
+/// sc-16260: an `unhealthy` worker is heartbeating, so it is NOT offline — but it has withdrawn
+/// every capability it serves and will claim nothing. Readiness must exclude it, or the UI ungates
+/// Replace Person on a host whose GPU cannot be initialized.
+///
+/// Pinned against a worker that still advertises the capability, which is what makes this a real
+/// gate rather than a restatement of the capability check: the SAME advertisement reads ready when
+/// idle and not-ready when unhealthy.
+#[test]
+fn person_readiness_excludes_an_unhealthy_worker() {
+    let advertised = vec![
+        WorkerCapability::PersonDetect,
+        WorkerCapability::PersonTrack,
+    ];
+
+    let idle = vec![readiness_worker(
+        "gpu",
+        WorkerStatus::Idle,
+        advertised.clone(),
+    )];
+    assert_eq!(
+        person_readiness_from_workers(&idle)["detect"]["ready"],
+        json!(true),
+        "control: the identical advertisement must read ready while the worker is idle"
+    );
+
+    let unhealthy = vec![readiness_worker("gpu", WorkerStatus::Unhealthy, advertised)];
+    let readiness = person_readiness_from_workers(&unhealthy);
+    assert_eq!(
+        readiness["detect"]["ready"],
+        json!(false),
+        "an unhealthy worker cannot run person detection, whatever its registration still says"
+    );
+    assert_eq!(readiness["track"]["ready"], json!(false));
+}
+
 #[tokio::test]
 async fn create_image_job_rejects_over_length_negative_prompt() {
     // sc-8884 (F-082): negativePrompt now shares the prompt char cap.

--- a/apps/rust-api/src/tests/support.rs
+++ b/apps/rust-api/src/tests/support.rs
@@ -137,6 +137,7 @@ pub(crate) fn readiness_worker(
         capabilities,
         loaded_models: Vec::new(),
         utilization: None,
+        status_reason: None,
         registered_at: "2026-05-21T00:00:00Z".to_owned(),
         last_seen_at: "2026-05-21T00:00:00Z".to_owned(),
         extra: Default::default(),

--- a/apps/rust-api/src/workers.rs
+++ b/apps/rust-api/src/workers.rs
@@ -25,10 +25,22 @@ pub(crate) async fn list_workers(
 /// dependency, whether real detection/tracking/segmentation/replacement (and the
 /// procedural previews) can actually run, so the UI can gate Replace Person and
 /// explain why an action is unavailable (sc-1484).
+///
+/// `Unhealthy` is excluded alongside `Offline` (sc-16260): such a worker is heartbeating, so it is
+/// not offline, but its accelerator is unusable and it will claim nothing. Counting it would
+/// report Replace Person as ready on a host whose GPU cannot be initialized — the same misleading
+/// state on the API side that `appHelpers::isActiveWorker` removes on the web side. In practice a
+/// candle worker also withholds these capabilities when it goes unhealthy, so this is the backstop
+/// for the case where it cannot.
 pub(crate) fn person_readiness_from_workers(workers: &[WorkerSnapshot]) -> Value {
     let live: Vec<&WorkerSnapshot> = workers
         .iter()
-        .filter(|worker| worker.status != WorkerStatus::Offline)
+        .filter(|worker| {
+            !matches!(
+                worker.status,
+                WorkerStatus::Offline | WorkerStatus::Unhealthy
+            )
+        })
         .collect();
     let entry = |capability: WorkerCapability| {
         let cap = capability.as_str();
@@ -176,6 +188,7 @@ pub(crate) async fn heartbeat_worker(
             current_job_id: payload.current_job_id,
             loaded_models: payload.loaded_models,
             utilization: payload.utilization,
+            status_reason: payload.status_reason,
         })
     })
     .await?;

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -76,6 +76,7 @@ import {
 } from "./simple/uiMode.js";
 import {
   buildLocalJobStack,
+  canWorkerTakeWork,
   isActiveWorker,
   isAudioGenerationJob,
   isImageGenerationJob,
@@ -1322,7 +1323,11 @@ export function App() {
   // server's GET /api/v1/capabilities/person (person_readiness_from_workers); the
   // worker SSE handlers keep `workers` current, so this never goes stale.
   const personReadiness = useMemo(() => {
-    const live = workers.filter((worker) => worker.status !== "offline");
+    // sc-16260: `canWorkerTakeWork`, not a bare non-offline check — an unhealthy worker is alive
+    // but cannot run anything, and counting it here would ungate Replace Person on a host whose
+    // GPU failed its startup probe. Keeps this in step with the server's
+    // `person_readiness_from_workers`, which the comment above promises it mirrors.
+    const live = workers.filter(canWorkerTakeWork);
     const ready = (capability) => live.some((worker) => (worker.capabilities ?? []).includes(capability));
     return {
       detect: { capability: "person_detect", ready: ready("person_detect") },

--- a/apps/web/src/App.queue.test.jsx
+++ b/apps/web/src/App.queue.test.jsx
@@ -5,6 +5,7 @@ import { App } from "./main.jsx";
 import { QueueScreen } from "./screens/QueueScreen.jsx";
 import { qualityChoices, GPU_REQUIRED_JOB_TYPES, errorStatuses } from "./jobTypes.js";
 import { withAppContext, FakeEventSource, response, settle } from "./main.testSupport.jsx";
+import { isActiveWorker, isPlaceholderOnlyGpuWorker } from "./appHelpers.js";
 
 describe("SceneWorks app shell", () => {
   let container;
@@ -419,6 +420,204 @@ describe("SceneWorks app shell", () => {
     expect(container.textContent).toContain("Waiting for model download Qwen Image Edit to finish.");
     expect(container.textContent).toContain("Waiting for dependency job-dependency to finish.");
     expect(container.textContent).toContain("Warm: z_image_turbo");
+  });
+
+  // Exactly what `with_candle_capabilities` leaves behind when the CUDA probe fails: the bare
+  // nvidia descriptor PLUS the `candle` lane marker. The marker is what keeps this worker out of
+  // `isPlaceholderOnlyGpuWorker`, so its card still renders.
+  const WITHHELD_CAPABILITIES = ["placeholder", "gpu", "nvidia", "candle"];
+
+  it("names the host-side remedy when the GPU worker withheld its capabilities (sc-16260)", async () => {
+    // The server/Docker lane's unusable-GPU state, end to end through the UI. The worker is
+    // registered and heartbeating, but its startup CUDA probe failed, so it advertises only the
+    // bare nvidia descriptor set and reports `unhealthy` with the host-side remedy attached.
+    //
+    // Before sc-16260 this exact shape rendered as a "Ready" GPU card next to
+    // "Blocked: no active worker supports image generate." — both true, neither useful. The
+    // remedy has to reach the screen, because on a headless/Docker host there is no setup screen
+    // and the operator's only other source is container logs.
+    const REMEDY =
+      "The NVIDIA kernel driver and the CUDA driver library on this machine are different " +
+      "versions, so SceneWorks can't use the GPU. Reboot, then reopen SceneWorks.";
+    const RAW_WORKERS = [
+      {
+        id: "gpu-0",
+        gpuId: "0",
+        gpuName: "Fixture GPU 0",
+        status: "unhealthy",
+        statusReason: REMEDY,
+        capabilities: WITHHELD_CAPABILITIES,
+        loadedModels: [],
+      },
+    ];
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Project 1" },
+            createPlaceholderJob: (event) => event.preventDefault(),
+            filteredJobs: [
+              {
+                id: "job-stalled",
+                type: "image_generate",
+                status: "queued",
+                stage: "queued",
+                progress: 0,
+                projectId: "project-1",
+                projectName: "Project 1",
+                requestedGpu: "auto",
+                payload: { prompt: "mist", model: "z_image_turbo" },
+                attempts: 1,
+              },
+            ],
+            gpuOptions: ["auto", "0"],
+            jobAction: () => {},
+            jobPrompt: "Placeholder generation",
+            projectFilter: "all",
+            projects: [{ id: "project-1", name: "Project 1" }],
+            requestedGpu: "auto",
+            setJobPrompt: () => {},
+            setProjectFilter: () => {},
+            setRequestedGpu: () => {},
+            // Piped through App.jsx's OWN `visibleWorkers` filter rather than injected raw.
+            // That filter is where this whole feature nearly died: it drops `!isActiveWorker`
+            // AND `isPlaceholderOnlyGpuWorker` workers, and an early version of sc-16260 tripped
+            // both — so every string asserted below was unreachable in the real app while a
+            // hand-injected `visibleWorkers` kept the test green.
+            visibleWorkers: RAW_WORKERS.filter(
+              (worker) => isActiveWorker(worker) && !isPlaceholderOnlyGpuWorker(worker),
+            ),
+          },
+          <QueueScreen />,
+        ),
+      );
+    });
+
+    // The card must not claim the worker is ready, and must carry the remedy.
+    expect(container.textContent).toContain("GPU unavailable");
+    expect(container.textContent).not.toContain("Ready");
+    expect(container.textContent).toContain(REMEDY);
+    // The stalled job explains itself with the same remedy rather than the bare capability miss.
+    expect(container.textContent).toContain("this machine's GPU is unavailable");
+    expect(container.textContent).not.toContain("Blocked: no active worker supports image generate.");
+  });
+
+  it("scopes the unusable-GPU remedy to jobs and GPUs it actually explains (sc-16260)", async () => {
+    // A wrong remedy is worse than a vague one, so the branch is scoped twice:
+    //   * a queued `model_download` does not need the GPU — blaming the driver would send an
+    //     operator off to fix something unrelated to why it is stuck;
+    //   * a job pinned to gpu 1 is not explained by gpu 0 being unhealthy.
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Project 1" },
+            createPlaceholderJob: (event) => event.preventDefault(),
+            filteredJobs: [
+              {
+                id: "job-download",
+                type: "model_download",
+                status: "queued",
+                stage: "queued",
+                progress: 0,
+                projectId: null,
+                projectName: null,
+                requestedGpu: "auto",
+                payload: { modelId: "sdxl", modelName: "SDXL" },
+                attempts: 1,
+              },
+              {
+                id: "job-pinned-elsewhere",
+                type: "image_generate",
+                status: "queued",
+                stage: "queued",
+                progress: 0,
+                projectId: "project-1",
+                projectName: "Project 1",
+                requestedGpu: "1",
+                payload: { prompt: "mist", model: "z_image_turbo" },
+                attempts: 1,
+              },
+            ],
+            gpuOptions: ["auto", "0", "1"],
+            jobAction: () => {},
+            jobPrompt: "Placeholder generation",
+            projectFilter: "all",
+            projects: [{ id: "project-1", name: "Project 1" }],
+            requestedGpu: "auto",
+            setJobPrompt: () => {},
+            setProjectFilter: () => {},
+            setRequestedGpu: () => {},
+            visibleWorkers: [
+              {
+                id: "gpu-0",
+                gpuId: "0",
+                gpuName: "Fixture GPU 0",
+                status: "unhealthy",
+                statusReason: "REMEDY-FOR-GPU-ZERO",
+                capabilities: ["placeholder", "gpu", "nvidia"],
+                loadedModels: [],
+              },
+            ],
+          },
+          <QueueScreen />,
+        ),
+      );
+    });
+
+    // The remedy still renders on gpu 0's own card — it is true of that worker.
+    expect(container.textContent).toContain("REMEDY-FOR-GPU-ZERO");
+    // But neither queued job may be explained by it.
+    expect(container.textContent).toContain("Blocked: no active worker supports model download.");
+    expect(container.textContent).toContain("Blocked: no active worker can run image generate on GPU 1.");
+    expect(container.textContent).not.toContain("so model download cannot run");
+    expect(container.textContent).not.toContain("so image generate cannot run");
+  });
+
+  it("does not surface a stale remedy once the worker recovers (sc-16260)", async () => {
+    // The recovery direction. `statusReason` is cleared by the store on the first healthy
+    // heartbeat, but the UI must not depend on that: a reason left on a non-unhealthy worker is
+    // stale by definition and telling an operator to reboot an already-fixed host is worse than
+    // saying nothing.
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        withAppContext(
+          {
+            activeProject: { id: "project-1", name: "Project 1" },
+            createPlaceholderJob: (event) => event.preventDefault(),
+            filteredJobs: [],
+            gpuOptions: ["auto", "0"],
+            jobAction: () => {},
+            jobPrompt: "Placeholder generation",
+            projectFilter: "all",
+            projects: [{ id: "project-1", name: "Project 1" }],
+            requestedGpu: "auto",
+            setJobPrompt: () => {},
+            setProjectFilter: () => {},
+            setRequestedGpu: () => {},
+            visibleWorkers: [
+              {
+                id: "gpu-0",
+                gpuId: "0",
+                gpuName: "Fixture GPU 0",
+                status: "idle",
+                statusReason: "reboot onto the staged driver",
+                capabilities: ["placeholder", "gpu", "image_generate", "candle"],
+                loadedModels: [],
+              },
+            ],
+          },
+          <QueueScreen />,
+        ),
+      );
+    });
+
+    expect(container.textContent).toContain("Ready");
+    expect(container.textContent).not.toContain("reboot onto the staged driver");
+    expect(container.textContent).not.toContain("GPU unavailable");
   });
 
   it("clears completed queue items scoped to the active project filter (issue #1556)", async () => {

--- a/apps/web/src/appHelpers.js
+++ b/apps/web/src/appHelpers.js
@@ -15,8 +15,23 @@ import {
 } from "./sorters.js";
 import { DEFAULT_ACCENT, isAccentId } from "./accents.js";
 
+/// A worker that is PRESENT — i.e. still heartbeating. This drives what gets RENDERED
+/// (`visibleWorkers` in App.jsx), so an `unhealthy` worker deliberately counts as active
+/// (sc-16260): it is registered, alive, and carrying the one message that explains why the queue
+/// is stalled. Filtering it here would delete its card and leave the Queue screen claiming "No GPU
+/// workers registered" about a worker that is very much registered.
+///
+/// "Present" is NOT "can take work" — for that, see `canWorkerTakeWork`.
 export function isActiveWorker(worker) {
   return worker.status !== "offline";
+}
+
+/// A worker that can actually be given work: present AND not reporting an unusable accelerator
+/// (sc-16260). Capability-readiness gates use this rather than [`isActiveWorker`], so a workflow
+/// is never reported ready on a machine whose GPU cannot be initialized. Mirrors the API's
+/// `person_readiness_from_workers`, which excludes the same two statuses.
+export function canWorkerTakeWork(worker) {
+  return worker.status !== "offline" && worker.status !== "unhealthy";
 }
 
 export function hasCapability(worker, capability) {

--- a/apps/web/src/appHelpers.test.js
+++ b/apps/web/src/appHelpers.test.js
@@ -5,6 +5,7 @@ import {
   failedJobNotice,
   generatedResultAssetCount,
   hasCapability,
+  canWorkerTakeWork,
   isActiveWorker,
   isAudioGenerationJob,
   isImageGenerationJob,
@@ -28,7 +29,37 @@ import { DEFAULT_ACCENT } from "./accents.js";
 describe("worker classification", () => {
   it("treats any non-offline worker as active", () => {
     expect(isActiveWorker({ status: "idle" })).toBe(true);
+    expect(isActiveWorker({ status: "busy" })).toBe(true);
     expect(isActiveWorker({ status: "offline" })).toBe(false);
+    // sc-16260: an UNHEALTHY worker is still active. This predicate drives what gets rendered, and
+    // that worker is registered, heartbeating, and carrying the only message explaining why the
+    // queue is stalled — filtering it here would delete its card and make the Queue screen claim
+    // "No GPU workers registered" about a worker that plainly is.
+    expect(isActiveWorker({ status: "unhealthy" })).toBe(true);
+  });
+
+  it("separates 'present' from 'can take work' (sc-16260)", () => {
+    // The readiness gates need the stricter question. An unhealthy worker is present but has
+    // withdrawn every capability it serves, so counting it would ungate a workflow on a machine
+    // whose GPU cannot be initialized. Mirrors the API's `person_readiness_from_workers`.
+    expect(canWorkerTakeWork({ status: "idle" })).toBe(true);
+    expect(canWorkerTakeWork({ status: "busy" })).toBe(true);
+    expect(canWorkerTakeWork({ status: "offline" })).toBe(false);
+    expect(canWorkerTakeWork({ status: "unhealthy" })).toBe(false);
+    // The two predicates must actually differ on the unhealthy case, or one of them is redundant
+    // and the split has silently collapsed.
+    expect(isActiveWorker({ status: "unhealthy" })).not.toBe(canWorkerTakeWork({ status: "unhealthy" }));
+  });
+
+  it("keeps an unhealthy candle worker out of the placeholder-only filter (sc-16260)", () => {
+    // The withheld set keeps the `candle` lane marker precisely so this returns false: App.jsx
+    // drops placeholder-only workers from `visibleWorkers`, so without the marker the unhealthy
+    // worker's card — and its remedy — would never render.
+    expect(
+      isPlaceholderOnlyGpuWorker({ capabilities: ["placeholder", "gpu", "nvidia", "candle"] }),
+    ).toBe(false);
+    // Without the marker it IS placeholder-only, which is what would have hidden it.
+    expect(isPlaceholderOnlyGpuWorker({ capabilities: ["placeholder", "gpu", "nvidia"] })).toBe(true);
   });
 
   it("checks capabilities defensively", () => {

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -84,6 +84,28 @@ function jobWaitingMessage(job, workers, jobs) {
   }
   const candidates = workers.filter((worker) => workerCanClaim(job, worker));
   if (!candidates.length) {
+    // sc-16260: an unusable GPU is the most likely reason a candle host has NO eligible worker —
+    // the worker withheld its capabilities on purpose, so "no active worker supports image
+    // generate" is technically true and completely unhelpful. When an unhealthy worker is
+    // registered, lead with the host-side remedy it reported. Checked before the requested-GPU
+    // branch: a job pinned to the very GPU that failed its probe deserves the reason, not a
+    // restatement of the pin.
+    //
+    // Scoped twice, because a wrong remedy is worse than a vague one:
+    //   * NOT for utility work. A queued `model_download` does not need the GPU, so blaming the
+    //     driver for it would send an operator to fix something unrelated to why it is stuck.
+    //   * When the job pins a GPU, only THAT GPU's worker may explain it — on a multi-GPU host,
+    //     gpu 0 being unhealthy says nothing about a job pinned to gpu 1.
+    const pinned = job.requestedGpu && job.requestedGpu !== "auto" ? job.requestedGpu : null;
+    const unhealthy = NON_GPU_JOB_TYPES.has(job.type)
+      ? null
+      : workers
+          .filter((worker) => pinned === null || worker.gpuId === pinned)
+          .map(workerHealthReason)
+          .find(Boolean);
+    if (unhealthy) {
+      return `Blocked: this machine's GPU is unavailable, so ${formatJobType(job.type)} cannot run.\n\n${unhealthy}`;
+    }
     if (job.requestedGpu && job.requestedGpu !== "auto") {
       return `Blocked: no active worker can run ${formatJobType(job.type)} on GPU ${job.requestedGpu}.`;
     }
@@ -108,7 +130,24 @@ function workerStatusLine(worker) {
   if (worker.status === "busy") {
     return `Busy${worker.currentJobId ? ` with ${worker.currentJobId}` : ""}`;
   }
+  // sc-16260: a worker whose GPU failed its startup probe has withdrawn every capability it
+  // serves, so it will never claim anything. It still heartbeats, so without this it renders the
+  // raw enum next to a card that otherwise looks perfectly healthy.
+  if (worker.status === "unhealthy") {
+    return "GPU unavailable";
+  }
   return worker.status === "idle" ? "Ready" : worker.status;
+}
+
+/// sc-16260: the host-side remedy an `unhealthy` worker reports, or `null`. The API only sets
+/// `statusReason` alongside the unhealthy status, but this checks both so a stale reason left on a
+/// recovered worker can never surface as a live warning.
+function workerHealthReason(worker) {
+  if (worker?.status !== "unhealthy") {
+    return null;
+  }
+  const reason = typeof worker.statusReason === "string" ? worker.statusReason.trim() : "";
+  return reason || "This worker's GPU could not be initialized, so it cannot run jobs.";
 }
 
 function isGpuWorker(worker) {
@@ -153,12 +192,22 @@ function WorkerCard({ worker }) {
   const freeMb = Number(utilization.memoryFreeMb);
   const usedMb = Number(utilization.memoryUsedMb);
   const totalMb = Number(utilization.memoryTotalMb);
+  const healthReason = workerHealthReason(worker);
   return (
     <div className="worker-card">
       <div className="worker-card-header">
         <strong>{worker.gpuName ?? `GPU ${worker.gpuId}`}</strong>
         <span>{workerStatusLine(worker)}</span>
       </div>
+      {/* sc-16260: the host-side remedy, on the card for the worker it applies to. `pre-wrap`
+          because the reason is the probe's two-part message — remedy, blank line, raw CUDA error
+          — and collapsing that runs them together (the same fix sc-16247 made on the setup
+          screen and the queue card). */}
+      {healthReason === null ? null : (
+        <p className="worker-card-health" role="status" style={{ whiteSpace: "pre-wrap" }}>
+          {healthReason}
+        </p>
+      )}
       <div className="worker-stat-grid">
         <span>
           <small>Available</small>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -13546,6 +13546,17 @@ details[open] > summary.lora-scope-group-heading::before,
   color: var(--accent);
 }
 
+/* sc-16260: the host-side remedy on a worker whose GPU failed its startup probe. It is the only
+   place that machine's operator is told what to fix, so it reads as a warning rather than as one
+   more stat. `pre-wrap` is set inline alongside this (the reason is a two-part message whose
+   blank line must survive), matching the sc-16247 fix on the setup screen. */
+.worker-card-health {
+  margin: 0;
+  color: var(--danger);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .worker-stat-grid {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -374,10 +374,21 @@ string_enum! {
 }
 
 string_enum! {
+    /// `idle` / `busy` / `offline` are the ordinary lifecycle: ready, running a job, gone.
+    ///
+    /// `unhealthy` (sc-16260) is different in kind — the worker process is alive and
+    /// heartbeating, but its accelerator is unusable, so it has withdrawn the capabilities it
+    /// would otherwise serve and can run nothing. The server/Docker lane has no setup screen to
+    /// refuse startup on, so this is the only place an operator can see WHY a queue is stalled;
+    /// [`WorkerSnapshot::status_reason`] carries the host-side remedy. Distinct from `offline`
+    /// on purpose: `offline` means "stopped heartbeating, may already be gone", and treating an
+    /// unusable-GPU worker as offline would hide a running container behind a message that says
+    /// the opposite of what is true.
     pub enum WorkerStatus {
         Idle => "idle",
         Busy => "busy",
         Offline => "offline",
+        Unhealthy => "unhealthy",
     }
 }
 
@@ -910,6 +921,11 @@ pub struct WorkerHeartbeatRequest {
     pub loaded_models: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub utilization: Option<WorkerUtilizationSnapshot>,
+    /// Why the worker is in [`WorkerStatus::Unhealthy`], as user-facing text (sc-16260).
+    /// `None` for every other status; the store clears the stored reason whenever a
+    /// heartbeat arrives without one, so a recovered worker doesn't keep a stale remedy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_reason: Option<String>,
     #[serde(flatten)]
     pub extra: ExtraFields,
 }
@@ -1164,6 +1180,11 @@ pub struct WorkerSnapshot {
     pub loaded_models: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub utilization: Option<WorkerUtilizationSnapshot>,
+    /// User-facing reason for a [`WorkerStatus::Unhealthy`] worker (sc-16260) — the host-side
+    /// remedy, so the Queue screen can explain a stalled queue without an operator reading
+    /// container logs. `None` for every healthy worker.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_reason: Option<String>,
     pub registered_at: String,
     pub last_seen_at: String,
     #[serde(flatten)]

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -361,6 +361,8 @@ pub struct WorkerHeartbeat {
     pub current_job_id: Option<String>,
     pub loaded_models: Vec<String>,
     pub utilization: Option<WorkerUtilizationSnapshot>,
+    /// Host-side remedy for a [`WorkerStatus::Unhealthy`] worker (sc-16260); `None` otherwise.
+    pub status_reason: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -487,6 +489,10 @@ impl JobsStore {
             ",
         )?;
         ensure_column(&transaction, "workers", "utilization_json", "text")?;
+        // sc-16260: why an `unhealthy` worker withdrew its capabilities — the host-side remedy,
+        // so the Queue screen can explain a stalled queue instead of leaving an operator to read
+        // container logs. Nullable and absent on every healthy worker.
+        ensure_column(&transaction, "workers", "status_reason", "text")?;
         // sc-2086: per-job peak GPU memory % and load %, written by the worker
         // along with progress so a completed row shows the peak the run reached.
         ensure_column(&transaction, "jobs", "peak_gpu_memory_pct", "real")?;
@@ -724,7 +730,11 @@ impl JobsStore {
             params![now],
         )?;
         transaction.execute(
-            "update workers set status = 'offline', current_job_id = null where status != 'offline'",
+            // sc-16260: `status_reason` is cleared alongside the status everywhere `offline` is
+            // written. It describes why an ALIVE worker withdrew its capabilities; on a worker we
+            // have just declared gone it is stale by construction, and `GET /api/v1/workers` would
+            // otherwise keep handing clients a host remedy for a worker that is no longer there.
+            "update workers set status = 'offline', current_job_id = null, status_reason = null              where status != 'offline'",
             [],
         )?;
         let updated_ids = interrupted_ids
@@ -1436,6 +1446,13 @@ impl JobsStore {
               gpu_id = excluded.gpu_id,
               gpu_name = excluded.gpu_name,
               status = case when workers.current_job_id is null then 'idle' else workers.status end,
+              -- A registration is the worker re-advertising what it can serve, so it also
+              -- retires any previous unhealthy reason (sc-16260): the recovery path re-registers
+              -- with the full capability set, and leaving the old remedy behind would tell an
+              -- operator to fix a host that is already fixed. An unhealthy worker re-asserts its
+              -- reason on the very next heartbeat, and its capabilities are withheld at
+              -- registration either way, so nothing routes to it during the gap.
+              status_reason = null,
               capabilities_json = excluded.capabilities_json,
               loaded_models_json = excluded.loaded_models_json,
               utilization_json = excluded.utilization_json,
@@ -1498,14 +1515,19 @@ impl JobsStore {
                    current_job_id = ?2,
                    loaded_models_json = ?3,
                    utilization_json = ?4,
-                   last_seen_at = ?5
-             where id = ?6
+                   status_reason = ?5,
+                   last_seen_at = ?6
+             where id = ?7
             ",
             params![
                 request.status.as_str(),
                 request.current_job_id,
                 dumps(&request.loaded_models)?,
                 optional_dumps(request.utilization.as_ref())?,
+                // Written unconditionally, so a worker that recovers clears its own reason on the
+                // very next heartbeat rather than carrying a stale remedy for a fixed host
+                // (sc-16260 AC 4). `None` on every non-unhealthy heartbeat.
+                request.status_reason,
                 now,
                 request.worker_id,
             ],
@@ -1593,6 +1615,7 @@ impl JobsStore {
                 update workers
                    set status = 'offline',
                        current_job_id = null,
+                       status_reason = null,
                        last_seen_at = ?1
                  where id in ({placeholders})
                 "
@@ -1671,6 +1694,7 @@ impl JobsStore {
             update workers
                set status = 'offline',
                    current_job_id = null,
+                   status_reason = null,
                    last_seen_at = ?1
              where id = ?2
             ",
@@ -3061,6 +3085,7 @@ fn row_to_worker(row: &Row<'_>) -> rusqlite::Result<WorkerSnapshot> {
                 .as_deref(),
         ),
         utilization: loads_optional(row.get::<_, Option<String>>("utilization_json")?.as_deref()),
+        status_reason: row.get("status_reason")?,
         registered_at: row.get("registered_at")?,
         last_seen_at: row.get("last_seen_at")?,
         extra: Default::default(),
@@ -3592,6 +3617,18 @@ fn is_apple_unified_gpu_id(gpu_id: &str) -> bool {
 }
 
 fn worker_supports_job(worker: &WorkerSnapshot, job: &JobSnapshot) -> bool {
+    // sc-16260: a worker that has declared itself unhealthy — its accelerator is unusable, so
+    // every job it claims is one it is certain to fail — is handed nothing at all. This is the
+    // BACKSTOP, not the primary gate: the worker also withholds the capabilities it can no
+    // longer serve (`with_candle_capabilities`), which is what keeps `image_generate` and
+    // friends queued for a host that gets fixed. Both exist because they fail differently — the
+    // capability half is what the web's queue explanation and tier pickers already read, while
+    // this half holds for any future unhealthy reason whose capability set we don't yet know to
+    // trim. Refuses EVERY job type, not just GPU ones: "I cannot run work" is the whole claim
+    // the status makes, and the CPU utility lane is a separate worker.
+    if worker.status == WorkerStatus::Unhealthy {
+        return false;
+    }
     if job_requires_gpu(&job.job_type) && worker.gpu_id.eq_ignore_ascii_case("cpu") {
         return false;
     }

--- a/crates/sceneworks-core/src/jobs_store/tests/candle_routing_tests.rs
+++ b/crates/sceneworks-core/src/jobs_store/tests/candle_routing_tests.rs
@@ -56,10 +56,16 @@ fn image_edit_job(payload: Value) -> JobSnapshot {
 /// A worker on a real CUDA gpu index advertising `capabilities` (string ids). The candle worker
 /// carries the `candle` marker; a synthetic generic descriptor does not.
 fn gpu_worker(capabilities: &[&str]) -> WorkerSnapshot {
+    gpu_worker_with_status(capabilities, "idle")
+}
+
+/// [`gpu_worker`] with an explicit status, so the sc-16260 unhealthy backstop can be exercised
+/// against a worker that is otherwise fully eligible.
+fn gpu_worker_with_status(capabilities: &[&str], status: &str) -> WorkerSnapshot {
     serde_json::from_value(json!({
         "id": "worker_1",
         "gpuId": "0",
-        "status": "idle",
+        "status": status,
         "capabilities": capabilities,
         "loadedModels": [],
         "registeredAt": "2026-06-12T00:00:00Z",
@@ -3170,4 +3176,116 @@ fn flux1_dev_control_pose_jobs_route_to_candle() {
     // flux_dev now HAS a candle pose lane (so it is not pose-rejected); schnell does not.
     assert!(model_has_candle_pose_lane("flux_dev"));
     assert!(!model_has_candle_pose_lane("flux_schnell"));
+}
+
+// ---------------------------------------------------------------------------
+// sc-16260: an unusable GPU must not be routed generation it is certain to fail.
+// ---------------------------------------------------------------------------
+
+/// CHARACTERIZATION of the routing consequence (sc-16260 AC 2), from the store's side.
+///
+/// It asserts pre-existing `worker_supports_job` behaviour against the two capability sets rather
+/// than any code this story added — the probe→withholding link itself is pinned by
+/// `an_unusable_gpu_withholds_every_candle_capability` in the worker crate. Its value here is that
+/// it fixes the OTHER end of the contract: it turns red if the withheld set ever becomes
+/// claimable, which is the assumption the whole design rests on and which lives in a different
+/// crate from the code that produces it.
+///
+/// The `healthy` side of each pair is the control: it proves the job is genuinely claimable by a
+/// full candle worker, so a `false` from the degraded worker means "withheld", not "this job was
+/// never routable here anyway".
+#[test]
+fn a_gpu_worker_that_withheld_its_candle_capabilities_is_routed_no_generation() {
+    // Exactly what `with_candle_capabilities` leaves behind when the probe fails, and exactly what
+    // a non-candle build advertises: no job capability at all.
+    const WITHHELD_CAPS: &[&str] = &["placeholder", "gpu", "nvidia"];
+    let degraded = gpu_worker(WITHHELD_CAPS);
+    let healthy = gpu_worker(CANDLE_CAPS);
+
+    for job in [
+        image_generate_job(json!({"model": "sdxl", "prompt": "a cat"})),
+        image_edit_job(json!({
+            "model": "z_image_edit",
+            "mode": "edit_image",
+            "sourceAssetId": "asset_1",
+        })),
+    ] {
+        assert!(
+            worker_supports_job(&healthy, &job),
+            "control: a healthy candle worker must claim {} — otherwise the assertion below is \
+             vacuous",
+            job.job_type.as_str()
+        );
+        assert!(
+            !worker_supports_job(&degraded, &job),
+            "a worker whose CUDA probe failed withheld its capabilities, so {} must stay QUEUED \
+             rather than be claimed and failed",
+            job.job_type.as_str()
+        );
+    }
+}
+
+/// THE BACKSTOP (sc-16260). Independent of the capability half: a worker that has declared itself
+/// `unhealthy` is handed nothing, even while still advertising the full candle set.
+///
+/// That combination is reachable in practice — registration and heartbeat are separate round trips,
+/// so a worker that goes unhealthy AFTER registering (or whose unhealthy reason is one whose
+/// capability impact we don't yet know how to trim) still has its advertisement on file. Pinned
+/// against the SAME capability set that the healthy control claims with, so deleting the status
+/// check in `worker_supports_job` turns this red rather than shifting it onto the capability gate.
+#[test]
+fn an_unhealthy_worker_is_routed_nothing_even_with_full_capabilities() {
+    let job = image_generate_job(json!({"model": "sdxl", "prompt": "a cat"}));
+
+    let idle = gpu_worker_with_status(CANDLE_CAPS, "idle");
+    assert!(
+        worker_supports_job(&idle, &job),
+        "control: the identical worker must claim this job when idle"
+    );
+
+    let unhealthy = gpu_worker_with_status(CANDLE_CAPS, "unhealthy");
+    assert!(
+        !worker_supports_job(&unhealthy, &job),
+        "an unhealthy worker must be routed nothing, even while its registration still advertises \
+         the capability"
+    );
+
+    // "I cannot run work" is the whole claim the status makes, so it holds for the non-GPU job
+    // types too — not just the ones that need an accelerator.
+    let download: JobSnapshot = serde_json::from_value(json!({
+        "id": "job_2",
+        "type": "model_download",
+        "status": "queued",
+        "payload": {"modelId": "sdxl_base"},
+        "result": {},
+        "requestedGpu": "auto",
+        "progress": 0,
+        "stage": "queued",
+        "message": "",
+        "attempts": 1,
+        "cancelRequested": false,
+        "createdAt": "2026-06-12T00:00:00Z",
+        "updatedAt": "2026-06-12T00:00:00Z",
+    }))
+    .expect("valid JobSnapshot");
+    const UTILITY_CAPS: &[&str] = &["gpu", "model_download", "candle"];
+    assert!(
+        worker_supports_job(&gpu_worker_with_status(UTILITY_CAPS, "idle"), &download),
+        "control: the identical worker must claim the download when idle"
+    );
+    assert!(
+        !worker_supports_job(
+            &gpu_worker_with_status(UTILITY_CAPS, "unhealthy"),
+            &download
+        ),
+        "an unhealthy worker must not claim utility work either"
+    );
+
+    // And the ordinary statuses are untouched — this must not have become a general status filter.
+    for status in ["idle", "busy"] {
+        assert!(
+            worker_supports_job(&gpu_worker_with_status(CANDLE_CAPS, status), &job),
+            "{status} routing must be unchanged by the unhealthy backstop"
+        );
+    }
 }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1933,6 +1933,7 @@ fn idle_heartbeat_interrupts_previous_heartbeated_job() {
             current_job_id: Some(created.id.clone()),
             loaded_models: Vec::new(),
             utilization: None,
+            status_reason: None,
         })
         .expect("busy heartbeat succeeds");
 
@@ -1943,6 +1944,7 @@ fn idle_heartbeat_interrupts_previous_heartbeated_job() {
             current_job_id: None,
             loaded_models: Vec::new(),
             utilization: None,
+            status_reason: None,
         })
         .expect("heartbeat succeeds");
     let job = store.get_job(&created.id).expect("job loads");
@@ -2208,6 +2210,7 @@ fn idle_heartbeat_does_not_interrupt_just_claimed_job() {
             current_job_id: None,
             loaded_models: Vec::new(),
             utilization: None,
+            status_reason: None,
         })
         .expect("heartbeat succeeds");
     let job = store.get_job(&created.id).expect("job loads");
@@ -2261,6 +2264,7 @@ fn heartbeat_only_refreshes_a_job_the_reporting_worker_owns() {
             current_job_id: Some(created.id.clone()),
             loaded_models: Vec::new(),
             utilization: None,
+            status_reason: None,
         })
         .expect("owner heartbeat succeeds");
     let baseline = store.get_job(&created.id).expect("job loads");
@@ -2280,6 +2284,7 @@ fn heartbeat_only_refreshes_a_job_the_reporting_worker_owns() {
             current_job_id: Some(created.id.clone()),
             loaded_models: Vec::new(),
             utilization: None,
+            status_reason: None,
         })
         .expect("non-owner heartbeat still returns the worker snapshot");
     let after_intruder = store.get_job(&created.id).expect("job loads");
@@ -2320,6 +2325,7 @@ fn heartbeat_only_refreshes_a_job_the_reporting_worker_owns() {
             current_job_id: Some(created.id.clone()),
             loaded_models: Vec::new(),
             utilization: None,
+            status_reason: None,
         })
         .expect("owner heartbeat succeeds");
     let owner_refreshed = store.get_job(&created.id).expect("job loads");
@@ -3428,6 +3434,73 @@ fn candle_required_does_not_fail_when_a_live_candle_worker_is_present() {
     assert_eq!(
         store.get_job(&job.id).expect("job loads").status,
         JobStatus::Queued
+    );
+}
+
+/// sc-16260: an UNHEALTHY candle worker must keep candle-eligible work QUEUED, not let the grace
+/// sweep terminally fail it.
+///
+/// This is the trap the capability-withholding design walks straight into. The withheld set drops
+/// every job capability, and if it dropped the `candle` LANE MARKER too, `fail_stranded_candle_jobs`
+/// would see no live candle worker, conclude candle is unavailable, and fail every queued
+/// candle-eligible job after the grace window with `candle_unavailable: ... confirm the candle
+/// worker is running` — a message that is both wrong (it IS running) and silent about the driver.
+/// `SCENEWORKS_CANDLE_REQUIRED=1` ships in docker-compose, the Dockerfile and the desktop, so that
+/// is the default path for exactly the lane this story targets: it would have converted "one job
+/// fails at a time with the real CUDA error" into "all of them fail at once with a misleading one".
+///
+/// Hence the marker survives the withholding, and this pins it from the store's side.
+#[test]
+fn an_unhealthy_candle_worker_keeps_stranded_jobs_queued() {
+    let store = store("candle-strand-unhealthy");
+    // Exactly what `with_candle_capabilities` advertises for an unusable GPU: the lane marker and
+    // no job capability at all.
+    register_gpu_worker(
+        &store,
+        "worker-candle",
+        "0",
+        vec![
+            WorkerCapability::Placeholder,
+            WorkerCapability::Gpu,
+            WorkerCapability::Unknown("nvidia".to_owned()),
+            WorkerCapability::Unknown("candle".to_owned()),
+        ],
+    );
+    store
+        .heartbeat_worker(WorkerHeartbeat {
+            worker_id: "worker-candle".to_owned(),
+            status: WorkerStatus::Unhealthy,
+            current_job_id: None,
+            loaded_models: Vec::new(),
+            utilization: None,
+            status_reason: Some("reboot onto the staged driver".to_owned()),
+        })
+        .expect("unhealthy heartbeat succeeds");
+
+    let job = job_of(
+        &store,
+        JobType::ImageGenerate,
+        json!({ "model": "z_image_turbo", "prompt": "p" }),
+    );
+    backdate_job_created_at(&store, &job.id);
+
+    let failed = store.fail_stranded_candle_jobs(true, 90).expect("sweep ok");
+    assert!(
+        failed.is_empty(),
+        "an unhealthy candle worker is still a candle host — its queued work must WAIT for the          driver to be fixed, not be failed as candle_unavailable: {failed:?}"
+    );
+    assert_eq!(
+        store.get_job(&job.id).expect("job loads").status,
+        JobStatus::Queued,
+        "the job must remain queued for a host that gets fixed"
+    );
+    // And the worker still claims nothing, so "queued" does not quietly become "claimed and failed".
+    assert!(
+        store
+            .claim_next_job("worker-candle")
+            .expect("claim query succeeds")
+            .is_none(),
+        "the unhealthy worker must not claim the job it is keeping queued"
     );
 }
 
@@ -7044,6 +7117,7 @@ fn long_lived_connection_survives_many_sequential_ops() {
                 current_job_id: Some(job.id.clone()),
                 loaded_models: Vec::new(),
                 utilization: None,
+                status_reason: None,
             })
             .expect("heartbeat ok");
 
@@ -7112,5 +7186,107 @@ fn long_lived_connection_survives_many_sequential_ops() {
     assert_eq!(
         journal_mode, "wal",
         "WAL journal mode persisted on the db file"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// sc-16260: `unhealthy` is a first-class worker state, persisted with its remedy.
+// ---------------------------------------------------------------------------
+
+/// The status half end-to-end through the store: an `unhealthy` heartbeat persists BOTH the status
+/// and the host-side reason, that worker is then routed nothing, and a later healthy heartbeat
+/// clears the reason so a repaired host stops advertising a fix it no longer needs (AC 4).
+///
+/// `register_image_worker` advertises `image_generate`, so the claim below is genuinely eligible on
+/// capability alone — which is what makes the refusal attributable to the status.
+#[test]
+fn an_unhealthy_heartbeat_persists_its_reason_stops_claims_and_clears_on_recovery() {
+    let store = store("unhealthy-worker");
+    register_image_worker(&store);
+    let created = store
+        .create_job(image_job(Map::new()))
+        .expect("job creates");
+
+    const REASON: &str =
+        "The NVIDIA kernel driver and the CUDA driver library on this machine are \
+                          different versions — reboot, then reopen SceneWorks.";
+    let worker = store
+        .heartbeat_worker(WorkerHeartbeat {
+            worker_id: "worker-1".to_owned(),
+            status: WorkerStatus::Unhealthy,
+            current_job_id: None,
+            loaded_models: Vec::new(),
+            utilization: None,
+            status_reason: Some(REASON.to_owned()),
+        })
+        .expect("unhealthy heartbeat succeeds");
+    assert_eq!(worker.status, WorkerStatus::Unhealthy);
+    assert_eq!(
+        worker.status_reason.as_deref(),
+        Some(REASON),
+        "the remedy must reach the snapshot the Queue screen renders"
+    );
+
+    assert!(
+        store
+            .claim_next_job("worker-1")
+            .expect("claim query succeeds")
+            .is_none(),
+        "an unhealthy worker must not be handed a job it is certain to fail"
+    );
+    assert_eq!(
+        store.get_job(&created.id).expect("job loads").status,
+        JobStatus::Queued,
+        "the job must remain QUEUED for a host that gets fixed, not be claimed and failed"
+    );
+
+    // Recovery: a plain idle heartbeat retires the reason, and the same job becomes claimable.
+    let worker = store
+        .heartbeat_worker(WorkerHeartbeat {
+            worker_id: "worker-1".to_owned(),
+            status: WorkerStatus::Idle,
+            current_job_id: None,
+            loaded_models: Vec::new(),
+            utilization: None,
+            status_reason: None,
+        })
+        .expect("idle heartbeat succeeds");
+    assert_eq!(worker.status, WorkerStatus::Idle);
+    assert_eq!(
+        worker.status_reason, None,
+        "a recovered worker must not keep telling operators to fix an already-fixed host"
+    );
+    let claimed = store
+        .claim_next_job("worker-1")
+        .expect("claim succeeds")
+        .expect("the recovered worker claims the still-queued job");
+    assert_eq!(claimed.id, created.id);
+}
+
+/// Re-registration is the recovery path the worker actually takes (`recheck_gpu_health` re-runs
+/// `discover_gpu` and re-registers with the full capability set), so it must retire the stored
+/// reason too — otherwise a worker that recovered across a restart would advertise everything while
+/// still displaying the old remedy.
+#[test]
+fn registering_retires_a_previous_unhealthy_reason() {
+    let store = store("unhealthy-reregister");
+    register_image_worker(&store);
+    store
+        .heartbeat_worker(WorkerHeartbeat {
+            worker_id: "worker-1".to_owned(),
+            status: WorkerStatus::Unhealthy,
+            current_job_id: None,
+            loaded_models: Vec::new(),
+            utilization: None,
+            status_reason: Some("reboot onto the staged driver".to_owned()),
+        })
+        .expect("unhealthy heartbeat succeeds");
+
+    register_image_worker(&store);
+    let worker = store.get_worker("worker-1").expect("worker loads");
+    assert_eq!(worker.status, WorkerStatus::Idle);
+    assert_eq!(
+        worker.status_reason, None,
+        "re-registering re-advertises what the worker can serve, so the old remedy must be retired"
     );
 }

--- a/crates/sceneworks-worker/src/cuda_preflight_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/cuda_preflight_gpu_smoke.rs
@@ -1,0 +1,69 @@
+//! Hardware-gated evidence for the sc-16260 recovery re-check (AC 4). `#[ignore]`d — run by hand on
+//! a real CUDA box.
+//!
+//! sc-16260 makes an unhealthy worker re-run [`crate::cuda_preflight`] on an interval instead of
+//! staying stranded until someone restarts the container. That is only worth having if a repeated
+//! IN-PROCESS probe actually re-reads driver state — a `cuInit` result the CUDA driver latches for
+//! the life of the process would make the re-check dead code no matter how correct the surrounding
+//! Rust is. That question cannot be answered by a unit test, and the failing side of it cannot be
+//! answered on a healthy box without damaging the driver install, so it is answered here with the
+//! one negative path that IS safely reproducible: `CUDA_VISIBLE_DEVICES`.
+//!
+//! ```text
+//! cargo test -p sceneworks-worker --features backend-candle --lib \
+//!   cuda_preflight_recovers_within_one_process -- --ignored --nocapture
+//! ```
+//!
+//! Single-threaded by construction: it mutates a process-global env var, so it must not run
+//! concurrently with anything else that touches CUDA. Pass `--test-threads=1` if combining it with
+//! other GPU tests.
+
+/// Does a probe that FAILED for lack of a visible device succeed again, in the same process, once
+/// the device is visible? That is exactly the shape the recovery re-check depends on.
+///
+/// `CUDA_VISIBLE_DEVICES=-1` is the story's own suggested negative path and the one sc-16247
+/// validated on this hardware (it surfaces as `CUDA_ERROR_NO_DEVICE`). Hiding the device is not a
+/// driver-stack mismatch, so this does not prove the 803 case recovers in-process — nothing safely
+/// can, and 803 needs a host reboot anyway, which restarts the container. What it DOES establish is
+/// the property the re-check is built on: a failed probe does not poison the process.
+#[test]
+#[ignore = "needs a real CUDA device; mutates CUDA_VISIBLE_DEVICES process-wide"]
+fn cuda_preflight_recovers_within_one_process() {
+    const VAR: &str = "CUDA_VISIBLE_DEVICES";
+    let original = std::env::var(VAR).ok();
+
+    // 1. Hide every device and probe. This must fail, or the rest proves nothing.
+    std::env::set_var(VAR, "-1");
+    let hidden = crate::cuda_preflight();
+    let hidden_error = hidden.expect_err("with every device hidden the probe must fail");
+    println!("[hidden] {hidden_error}");
+    assert!(
+        hidden_error.contains("CUDA_ERROR_NO_DEVICE")
+            || hidden_error.contains("CUDA_ERROR_INVALID_DEVICE"),
+        "hiding the devices must surface as a no-device class error, got: {hidden_error}"
+    );
+    assert!(
+        crate::cuda_failure_is_blocking(&hidden_error),
+        "a no-device failure is a definite host problem and must be treated as blocking"
+    );
+
+    // 2. Restore visibility and probe AGAIN in the same process — the recovery re-check's move.
+    match original.as_deref() {
+        Some(value) => std::env::set_var(VAR, value),
+        None => std::env::remove_var(VAR),
+    }
+    let recovered = crate::cuda_preflight();
+    println!("[restored] {recovered:?}");
+    assert!(
+        recovered.is_ok(),
+        "a failed probe must not poison the process — the sc-16260 recovery re-check depends on \
+         a later in-process probe seeing current driver state. Got: {recovered:?}"
+    );
+
+    // 3. And a repeat probe on a healthy device stays healthy, so the re-check cannot degrade a
+    //    worker by running (each probe builds and drops its own device).
+    assert!(
+        crate::cuda_preflight().is_ok(),
+        "repeated probes on a healthy device must keep succeeding"
+    );
+}

--- a/crates/sceneworks-worker/src/gpu.rs
+++ b/crates/sceneworks-worker/src/gpu.rs
@@ -12,7 +12,7 @@ fn extend_capabilities_unique(
     }
 }
 
-pub(crate) async fn discover_gpu(settings: &Settings) -> DiscoveredGpu {
+pub(crate) async fn discover_gpu(settings: &Settings, health: &GpuHealth) -> DiscoveredGpu {
     let requested_gpu_id = settings.gpu_id.as_str();
     if requested_gpu_id == "cpu" {
         return cpu_gpu();
@@ -52,8 +52,19 @@ pub(crate) async fn discover_gpu(settings: &Settings) -> DiscoveredGpu {
     // startup (`lib.rs`) BEFORE the job-claim loop, so every generation resolves against a populated
     // value; a worker that somehow never probed reads `None` and is treated as NVFP4-INELIGIBLE
     // (fail-safe: the tier falls back rather than routing an FP4 load at hardware that can't run it).
-    cache_compute_cap(compute_cap);
-    with_candle_capabilities(gpu, settings, compute_cap)
+    //
+    // Skipped while the GPU is UNUSABLE (sc-16260). `cache_compute_cap` is first-call-wins by
+    // design, and sc-16260 gave `discover_gpu` a second caller: the recovery re-check. Caching an
+    // unhealthy startup's probe would therefore be permanent — and on a host whose driver stack
+    // was still coming up, `nvidia-smi` can be unready too, so that permanent value would be the
+    // fail-safe `None`. The worker would recover, re-advertise everything, and still hide the
+    // NVFP4/ConvRot tiers for the rest of the process. Deferring means the recovery pass makes the
+    // first (and correct) call. An unhealthy worker publishing no cap is right anyway: it routes
+    // nothing, so there is no tier decision for it to inform.
+    if health.is_usable() {
+        cache_compute_cap(compute_cap);
+    }
+    with_candle_capabilities(gpu, settings, compute_cap, health)
 }
 
 /// Light up the Windows/CUDA candle SDXL lane on the discovered nvidia GPU (epic 3672, sc-3678).
@@ -68,19 +79,65 @@ pub(crate) async fn discover_gpu(settings: &Settings) -> DiscoveredGpu {
 ///
 /// All-targets signature so `discover_gpu` is uniform; a no-op everywhere except the Windows candle
 /// build with `backend_candle_enabled`, so production routing is unchanged until the lane is on.
+///
+/// **A failed startup CUDA preflight withholds this entire block (sc-16260).** `health` is the
+/// verdict of `preflight::cuda_preflight`, run once at GPU-worker startup by
+/// `crate::cuda_startup_health`. When the driver stack is unusable, every capability advertised
+/// below is one this worker is *certain* to fail — the generation would die at the first model
+/// load with the same `DriverError` the probe already saw. Withholding them degrades the worker
+/// so `jobs_store::worker_supports_job` refuses every generation job and the work stays QUEUED for
+/// a host that gets fixed instead of being claimed and failed one job at a time.
+///
+/// **The `candle` LANE MARKER is kept even when unhealthy — that is load-bearing, not an
+/// oversight.** The marker says "this host serves the candle lane", not "this worker can run your
+/// job", and two things read it that way:
+///
+///   * `jobs_store::fail_stranded_candle_jobs` treats "no live worker advertising `candle`" as
+///     candle being *unavailable* and TERMINALLY FAILS every queued candle-eligible job after the
+///     grace window — with a `candle_unavailable: ... confirm the candle worker is running`
+///     message that is both wrong (it is running) and silent about the driver. Since
+///     `SCENEWORKS_CANDLE_REQUIRED=1` ships in `docker-compose.yml`, `docker/rust.Dockerfile` and
+///     the desktop, dropping the marker would convert this story's "jobs wait for a fixed host"
+///     into "jobs fail en masse with a misleading error" — the exact opposite of AC 2.
+///   * `appHelpers::isPlaceholderOnlyGpuWorker` matches the bare `[placeholder, gpu, nvidia]`
+///     triple, and `App.jsx` filters those workers out of `visibleWorkers` entirely. Without the
+///     marker the Queue screen would render "No GPU workers registered" for a worker that is
+///     registered, heartbeating and reporting exactly why it cannot work — hiding the remedy this
+///     story exists to surface.
+///
+/// The marker routes nothing on its own: every candle branch in `worker_supports_job` falls
+/// through to the advertised-capability check, which now fails for every job type, and the
+/// `WorkerStatus::Unhealthy` backstop refuses the claim before that. So the marker buys the two
+/// behaviours above at no routing cost.
+///
+/// The routing consequence is deliberately paired with the visible one: the same verdict puts the
+/// worker in `WorkerStatus::Unhealthy` with the remedy attached, because a worker that silently
+/// advertises nothing while reporting "Ready" would leave an operator staring at a stalled queue.
 #[cfg_attr(
     not(all(not(target_os = "macos"), feature = "backend-candle")),
     allow(unused_mut, unused_variables)
 )]
-fn with_candle_capabilities(
+pub(crate) fn with_candle_capabilities(
     mut gpu: DiscoveredGpu,
     settings: &Settings,
     compute_cap: Option<f32>,
+    health: &GpuHealth,
 ) -> DiscoveredGpu {
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     if settings.backend_candle_enabled && gpu.capabilities.contains(&WorkerCapability::Gpu) {
         let derived = crate::engines::registry_capabilities(settings);
         if !derived.is_empty() {
+            // sc-16260: an unusable GPU advertises the lane marker and NOTHING ELSE. Every
+            // capability below names work this worker would be certain to fail — the generation
+            // would die at the first model load with the same `DriverError` the probe already saw
+            // — so none of them may be claimed. Returning here rather than filtering afterwards
+            // means a capability added below is withheld by construction, with no second list to
+            // keep in sync. See the doc comment for why the marker itself stays.
+            if !health.is_usable() {
+                gpu.capabilities
+                    .push(WorkerCapability::Unknown("candle".to_owned()));
+                return gpu;
+            }
             extend_capabilities_unique(&mut gpu.capabilities, derived);
             // Plain Image Edit (sc-5487, epic 5480): the distinct `image_edit` job type
             // (`mode == "edit_image"` + `sourceAssetId`, epic 2427) runs the bespoke candle edit lanes

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -324,6 +324,12 @@ mod sensenova_gpu_smoke;
 // hardware evidence backing `macOnly: false` / `candle_routed = true`.
 #[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
 mod sana_candle_gpu_smoke;
+// Hardware-gated evidence that a FAILED `cuda_preflight` does not poison the process (sc-16260 AC 4).
+// Test-only + candle-only; hides the devices with `CUDA_VISIBLE_DEVICES=-1`, probes (must fail),
+// restores visibility and probes again in the SAME process — the exact move `recheck_gpu_health`
+// makes. Without that property the recovery re-check would be dead code however correct its Rust.
+#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
+mod cuda_preflight_gpu_smoke;
 // Real-weight GPU smoke for the candle Qwen-Image-Edit lane (sc-13534). Test-only + candle-only; drives
 // the WORKER's `resolve_qwen_edit_candle_base` (the tier/gate reconciliation this story landed) + a
 // bespoke `runtime_cuda::providers::qwen_image::QwenEdit` load + render, proving the resolver lands on the
@@ -955,12 +961,16 @@ fn should_run_cuda_preflight(settings: &Settings) -> bool {
 /// level — so the container's logs name the host-side fix rather than leaving an operator to infer
 /// it from a stream of failed jobs.
 ///
-/// It deliberately does **not** abort the process. The worker's registration + capability
-/// advertisement is what the API routes on, and tearing the process down here would turn a
-/// diagnosable, self-healing state (reboot the host, the next probe passes) into a crash loop with
-/// its own message. Surfacing this as a first-class *unhealthy worker status* would be the better
-/// end state, but that needs a new `WorkerStatus` variant plus API and UI surface — genuinely
-/// separate work, recorded on sc-16247 rather than smuggled in here.
+/// **sc-16260 acts on the verdict instead of only logging it.** The returned [`GpuHealth`] is
+/// threaded into `discover_gpu`, which withholds every candle capability when the GPU is unusable,
+/// and into the worker loop, which reports `WorkerStatus::Unhealthy` carrying the same reason.
+/// Together those mean a driver-mismatch host leaves generation QUEUED with a visible explanation
+/// instead of claiming and failing every routed job forever.
+///
+/// It deliberately does **not** abort the process. Tearing the process down here would turn a
+/// diagnosable, recoverable state into a crash loop with its own message, and the worker still has
+/// a job to do while degraded: hold its registration, report why, and re-probe (see
+/// [`GPU_HEALTH_RECHECK`]) so a host fixed without restarting the container recovers on its own.
 ///
 /// Gated to the GPU worker by [`should_run_cuda_preflight`]: the CPU utility loops never touch
 /// CUDA, and probing from each of them would build a throwaway CUDA context per utility process.
@@ -980,24 +990,156 @@ fn should_run_cuda_preflight(settings: &Settings) -> bool {
 /// (`spawn_inprocess_utility_worker`). That pool is `cpu` by default and so skips the probe
 /// entirely, but `SCENEWORKS_RUST_WORKER_GPU_ID` can override it — and a GPU-id override there
 /// would otherwise stall the API's runtime thread during startup.
-async fn log_cuda_preflight_failure(settings: &Settings) {
+async fn cuda_startup_health(settings: &Settings) -> GpuHealth {
+    let health = probe_cuda_health(settings).await;
+    if let Some(reason) = health.reason() {
+        tracing::error!(
+            event = "cuda_preflight_failed",
+            gpuId = %settings.gpu_id,
+            reason = %reason,
+            "SceneWorks GPU worker cannot acquire a CUDA device; generation capabilities withheld"
+        );
+    }
+    health
+}
+
+/// Run the probe and classify the outcome, with no logging of its own — so the startup call
+/// ([`cuda_startup_health`]) can be loud exactly once while the recovery re-check
+/// ([`recheck_gpu_health`]) stays quiet about a failure it has already reported.
+///
+/// A lane that does not probe ([`should_run_cuda_preflight`]) reports [`GpuHealth::Usable`]: the
+/// CPU utility loops and the macOS `mlx` worker must behave precisely as they did before this
+/// existed, so "no probe ran" is deliberately indistinguishable from "the probe passed".
+///
+/// **Only a BLOCKING failure makes the worker unhealthy** — the severity split
+/// [`cuda_failure_is_blocking`] already draws for the desktop setup screen, applied here to the
+/// worker's own advertisement. That split exists because the two directions cost wildly different
+/// amounts, and this path is no different: over-reporting is the expensive one. A transient CUDA
+/// OOM — another process, or an orphaned worker from a crashed session, currently holding the GPU
+/// — is a real probe failure that says nothing about the driver stack. Treating it as unhealthy
+/// would strip every capability, hand the operator the GENERIC "check that nvidia-smi lists a
+/// supported GPU" text (no `CUDA_ERROR_*` token matches, so there is no specific remedy to give),
+/// and — with `SCENEWORKS_CANDLE_REQUIRED=1` — fail queued work over a condition that clears by
+/// itself. The desktop deliberately starts the app in that state; the worker must likewise stay
+/// advertising. A transient failure is logged and stepped over, and if a job does then run, the
+/// classified message from [`crate::classify_engine_error`] explains what happened.
+async fn probe_cuda_health(settings: &Settings) -> GpuHealth {
     if !should_run_cuda_preflight(settings) {
-        return;
+        return GpuHealth::Usable;
     }
     let probe = tokio::task::spawn_blocking(cuda_preflight).await;
     // A JoinError can only be a panic inside `cuda_preflight`, which already catches its own
-    // (see `preflight::cuda_preflight`) — report rather than propagate either way.
-    let reason = match probe {
-        Ok(Ok(())) => return,
-        Ok(Err(reason)) => reason,
-        Err(error) => format!("the CUDA preflight probe did not complete: {error}"),
+    // (see `preflight::cuda_preflight`) — report rather than propagate either way. It is NOT
+    // evidence of a driver-class fault, so it is folded into the same `Err` the classifier then
+    // routes down the advisory path.
+    let outcome = match probe {
+        Ok(result) => result,
+        Err(error) => Err(format!(
+            "the CUDA preflight probe did not complete: {error}"
+        )),
     };
-    tracing::error!(
-        event = "cuda_preflight_failed",
-        gpuId = %settings.gpu_id,
-        reason = %reason,
-        "SceneWorks GPU worker cannot acquire a CUDA device; generation jobs will fail"
-    );
+    classify_probe_outcome(outcome, &settings.gpu_id)
+}
+
+/// The probe outcome → health verdict decision, sync and GPU-free so the severity split is
+/// unit-testable on any machine (see `only_a_driver_class_probe_failure_makes_the_worker_unhealthy`).
+///
+/// Kept apart from [`probe_cuda_health`] deliberately: that function's only other job is running
+/// the probe, which needs real CUDA, and a rule this consequential — it decides whether a worker
+/// withdraws every capability it serves — must not be reachable only from hardware.
+fn classify_probe_outcome(probe: Result<(), String>, gpu_id: &str) -> GpuHealth {
+    let reason = match probe {
+        Ok(()) => return GpuHealth::Usable,
+        Err(reason) => reason,
+    };
+    if !cuda_failure_is_blocking(&reason) {
+        tracing::warn!(
+            event = "cuda_preflight_transient",
+            gpuId = %gpu_id,
+            reason = %reason,
+            "SceneWorks GPU probe failed for a reason that may clear on its own; keeping the \
+             worker's capabilities advertised"
+        );
+        return GpuHealth::Usable;
+    }
+    GpuHealth::Unusable { reason }
+}
+
+/// How often an UNHEALTHY worker re-runs the CUDA probe (sc-16260 AC 4).
+///
+/// The startup probe is a single sample, so without this a host repaired underneath a running
+/// container would stay stranded with its capabilities withheld until someone restarted it. Only
+/// an unhealthy worker re-probes; once the GPU is usable the loop stops entirely, so a healthy
+/// worker never pays for this and never builds a second CUDA context behind a running job.
+///
+/// **The transition is therefore ONE-WAY: unhealthy → healthy only.** A worker that starts healthy
+/// is never re-probed, so a driver that dies mid-life (an Xid, a device falling off the bus) leaves
+/// it reporting `idle` and claiming jobs, which then fail individually with the classified
+/// driver-error text from [`crate::classify_engine_error`] — i.e. exactly the pre-sc-16260
+/// behaviour, for that case only. Detecting mid-life GPU death is a different problem (it wants a
+/// signal from the failing job, not a poll) and is deliberately out of this story's scope.
+///
+/// A minute is chosen against what actually gets fixed on the other side. The dominant failure
+/// (`CUDA_ERROR_SYSTEM_DRIVER_MISMATCH`, GH #1966) needs a host reboot, which restarts the
+/// container anyway — the re-check cannot help there and is not meant to. What it does cover is
+/// the genuinely transient family: `CUDA_ERROR_SYSTEM_NOT_READY` while the driver/fabric is still
+/// initializing, a GPU briefly held by another process, or a device hot-attached to the container.
+/// Those clear on the order of seconds-to-minutes, so a minute recovers promptly without spinning
+/// `cuInit` against a wedged driver every poll turn.
+const GPU_HEALTH_RECHECK: Duration = Duration::from_secs(60);
+
+/// Re-run the CUDA probe for a worker that is currently unhealthy, and act on any change
+/// (sc-16260 AC 4).
+///
+/// On recovery this RE-REGISTERS. That is the load-bearing half: the capability set is what the
+/// API routes on, and it was frozen at the withheld set when the worker started, so simply
+/// flipping the status back to `idle` would leave a healthy worker advertising nothing and the
+/// queue still stalled. `register_worker` is an upsert on `worker_id`, so this restores the full
+/// candle set on the existing row and clears the stored reason; the next heartbeat reports `idle`.
+///
+/// Logging is asymmetric on purpose. Recovery is an event worth an `info` line. A failure
+/// IDENTICAL to the one already reported at startup is not — repeating it every minute would bury
+/// the loud line it was meant to make findable. A failure whose reason CHANGED is new information
+/// (`SYSTEM_NOT_READY` resolving into `NO_DEVICE` says the driver came up but the GPU did not),
+/// so that gets its own `warn`.
+async fn recheck_gpu_health(
+    api: &ApiClient,
+    settings: &Settings,
+    health: &mut GpuHealth,
+) -> WorkerResult<()> {
+    let previous = health.reason().map(str::to_owned);
+    let next = probe_cuda_health(settings).await;
+    let reason = next.reason().map(str::to_owned);
+    *health = next;
+    match reason {
+        None => {
+            tracing::info!(
+                event = "cuda_preflight_recovered",
+                gpuId = %settings.gpu_id,
+                "SceneWorks GPU worker re-acquired a CUDA device; re-advertising generation capabilities"
+            );
+            let gpu = discover_gpu(settings, health).await;
+            // A `Canceled` here means shutdown arrived during the re-registration backoff, not a
+            // recovery failure. Swallow it: propagating would exit `run_worker_loop` with `Err`,
+            // skipping the terminal `Offline` heartbeat that both other shutdown paths post and
+            // leaving the row reading `unhealthy` for the full 90 s stale window. The loop's own
+            // `shutdown_signal()` arm handles it one turn later, cleanly.
+            match register_worker_with_retry(api, settings, &gpu).await {
+                Ok(()) | Err(WorkerError::Canceled(_)) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Some(reason) if previous.as_deref() != Some(reason.as_str()) => {
+            tracing::warn!(
+                event = "cuda_preflight_changed",
+                gpuId = %settings.gpu_id,
+                reason = %reason,
+                "SceneWorks GPU worker still cannot acquire a CUDA device; the reason changed"
+            );
+        }
+        Some(_) => {}
+    }
+    Ok(())
 }
 
 pub async fn run_worker_loop(settings: Settings) -> WorkerResult<()> {
@@ -1022,14 +1164,26 @@ pub async fn run_worker_loop(settings: Settings) -> WorkerResult<()> {
     if settings.gpu_id == "mlx" {
         generator_cache::spawn_gpu_telemetry(settings.config_dir.clone());
     }
-    log_cuda_preflight_failure(&settings).await;
-    let gpu = discover_gpu(&settings).await;
+    // sc-16247 / sc-16260: probe the CUDA device ONCE before advertising anything, and let the
+    // verdict shape what this worker claims to be able to do. `discover_gpu` withholds the whole
+    // candle capability block on an unusable GPU, so the registration below advertises only the
+    // placeholder set and no generation job can route here.
+    let mut health = cuda_startup_health(&settings).await;
+    let gpu = discover_gpu(&settings, &health).await;
     let api = ApiClient::new(&settings);
     let http_client = crate::downloads::streaming_download_client();
     register_worker_with_retry(&api, &settings, &gpu).await?;
     let mut lock_failures = 0_u32;
     let mut idle_heartbeat = IdleHeartbeat::new(progress_report_interval(&settings));
+    // sc-16260 AC 4: the startup probe is one sample, so an unhealthy worker re-probes on an
+    // interval and re-advertises if the host is repaired underneath it. Seeded a full interval
+    // out — the startup probe just ran, and re-running it immediately would say nothing new.
+    let mut next_gpu_recheck = Instant::now() + GPU_HEALTH_RECHECK;
     loop {
+        if !health.is_usable() && Instant::now() >= next_gpu_recheck {
+            next_gpu_recheck = Instant::now() + GPU_HEALTH_RECHECK;
+            recheck_gpu_health(&api, &settings, &mut health).await?;
+        }
         // sc-8845 (F-043): shutdown is observed ONLY here, around the claim / idle-sleep phase —
         // NOT around full job execution. `poll_once` does no long GPU work (memory-sync, idle
         // heartbeat, the transactional claim POST, and the idle sleep), so racing it against
@@ -1041,7 +1195,7 @@ pub async fn run_worker_loop(settings: Settings) -> WorkerResult<()> {
         // work mid-write. Now a mid-job shutdown trips the job's cancel and posts a prompt terminal
         // `Canceled` (see `run_job_with_shutdown`).
         let claim = tokio::select! {
-            result = poll_once(&api, &settings, &mut idle_heartbeat) => result,
+            result = poll_once(&api, &settings, &mut idle_heartbeat, &health) => result,
             _ = shutdown_signal() => {
                 // Clean-idle shutdown: no job in flight, so the pre-existing Offline heartbeat +
                 // return is preserved exactly.
@@ -1236,6 +1390,7 @@ async fn poll_once(
     api: &ApiClient,
     settings: &Settings,
     idle_heartbeat: &mut IdleHeartbeat,
+    health: &GpuHealth,
 ) -> WorkerResult<Option<JobSnapshot>> {
     // sc-7824 (epic 7819): pick up a live GPU-memory-limit change here, before claiming the next
     // job, so a Settings slider move applies between jobs (not mid-flight) with no worker restart.
@@ -1244,9 +1399,31 @@ async fn poll_once(
         generator_cache::sync_gpu_memory_limit(&settings.config_dir);
     }
     if idle_heartbeat.should_send() {
-        heartbeat(api, settings, WorkerStatus::Idle, None).await?;
+        // sc-16260: an unusable GPU reports `unhealthy` + the host-side remedy here instead of
+        // `idle`. It keeps heartbeating on the same cadence — the process IS alive, it must stay
+        // out of the API's stale sweep, and it has to be able to recover — but `idle` on a worker
+        // that has withdrawn every capability it serves is the misleading state this story exists
+        // to remove: an operator would read "Ready" off a worker that will never claim anything.
+        match health.reason() {
+            None => heartbeat(api, settings, WorkerStatus::Idle, None).await?,
+            Some(reason) => {
+                heartbeat_with_reason(
+                    api,
+                    settings,
+                    WorkerStatus::Unhealthy,
+                    None,
+                    Some(reason.to_owned()),
+                )
+                .await?;
+            }
+        }
         idle_heartbeat.mark_sent();
     }
+    // The claim POST still goes out while unhealthy, deliberately. The store refuses it twice
+    // over (no advertised capability, plus the `Unhealthy` backstop in `worker_supports_job`), so
+    // this costs one cheap request per poll and keeps the loop shape identical — which is what
+    // makes recovery instant: the moment the re-probe passes and re-registration lands, the very
+    // next claim is served with no extra transition to get right.
     let claim: ClaimResponse = api
         .post_json(
             "/api/v1/jobs/claim",
@@ -1321,6 +1498,22 @@ pub(crate) async fn heartbeat(
     status: WorkerStatus,
     current_job_id: Option<&str>,
 ) -> WorkerResult<()> {
+    heartbeat_with_reason(api, settings, status, current_job_id, None).await
+}
+
+/// [`heartbeat`] plus the `status_reason` a [`WorkerStatus::Unhealthy`] worker carries
+/// (sc-16260) — the host-side remedy, so the Queue screen can explain a stalled queue.
+///
+/// Separate from [`heartbeat`] rather than an extra parameter on it: `heartbeat` has ~50 call
+/// sites, every one of which reports `Idle`/`Busy`/`Offline` and would have to pass `None`.
+/// Only the idle-poll path in [`poll_once`] ever has a reason to send.
+pub(crate) async fn heartbeat_with_reason(
+    api: &ApiClient,
+    settings: &Settings,
+    status: WorkerStatus,
+    current_job_id: Option<&str>,
+    status_reason: Option<String>,
+) -> WorkerResult<()> {
     // Capture the label before `status` is moved into the request, for the log line.
     let status_label = status.as_str().to_owned();
     let outcome: WorkerResult<WorkerSnapshot> = api
@@ -1331,6 +1524,7 @@ pub(crate) async fn heartbeat(
                 current_job_id: current_job_id.map(str::to_owned),
                 loaded_models: Vec::new(),
                 utilization: gpu_utilization(&settings.gpu_id).await,
+                status_reason,
                 extra: BTreeMap::new(),
             },
         )

--- a/crates/sceneworks-worker/src/preflight.rs
+++ b/crates/sceneworks-worker/src/preflight.rs
@@ -282,6 +282,45 @@ pub fn cuda_failure_is_blocking(message: &str) -> bool {
     cuda_driver_error_guidance(message).is_some() || message.contains(CUDA_DRIVER_LIBRARY_MISSING)
 }
 
+/// Whether this worker's accelerator is usable, as decided by the startup probe (sc-16260).
+///
+/// The server/Docker lane has no setup screen to refuse startup on, so the verdict has to travel
+/// *into* the worker's own behaviour instead: an [`Self::Unusable`] worker withholds the
+/// capabilities it can no longer serve (so generation stays queued for a host that gets fixed,
+/// rather than being claimed and failed one job at a time) and reports
+/// `WorkerStatus::Unhealthy` carrying [`Self::reason`] so an operator sees the host-side remedy
+/// without reading container logs.
+///
+/// [`Self::Usable`] covers both "the probe passed" and "this lane runs no probe" — the CPU
+/// utility loops, the macOS `mlx` worker (which has its own Metal gate on the desktop), and any
+/// build without the candle lane linked. Those must behave exactly as they did before this
+/// existed, so the absence of a probe is deliberately indistinguishable from a passing one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GpuHealth {
+    Usable,
+    Unusable {
+        /// The composed user-facing text from [`cuda_preflight`]: the host-side remedy chosen by
+        /// [`cuda_driver_error_guidance`], then the raw CUDA error. Reused verbatim rather than
+        /// re-authored, so the startup log, the worker status and a mid-job failure all name the
+        /// same fix.
+        reason: String,
+    },
+}
+
+impl GpuHealth {
+    /// The remedy text when unusable; `None` when the accelerator is fine.
+    pub(crate) fn reason(&self) -> Option<&str> {
+        match self {
+            Self::Usable => None,
+            Self::Unusable { reason } => Some(reason.as_str()),
+        }
+    }
+
+    pub(crate) fn is_usable(&self) -> bool {
+        matches!(self, Self::Usable)
+    }
+}
+
 /// No-op wherever the candle/CUDA lane isn't linked (macOS, and any off-Mac build without
 /// `backend-candle`): there is no CUDA runtime to probe, and the desktop keeps the lane
 /// dormant in that state anyway. Present on all targets so the `SCENEWORKS_GPU_CHECK`

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -2627,3 +2627,172 @@ fn cuda_preflight_runs_on_the_candle_gpu_worker_and_no_other_lane() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// sc-16260: an unusable GPU must change what the worker CLAIMS, not just what it logs.
+// ---------------------------------------------------------------------------
+
+/// The routing half of the story. sc-16247 shipped the loud startup log; a driver-mismatch host
+/// still registered, still advertised its full candle capability set, and so still claimed and
+/// failed every routed generation job. Withholding the capability block is what actually stops
+/// that: it degrades the worker to the `[placeholder, gpu, nvidia]` set a non-candle build
+/// advertises, which `jobs_store::worker_supports_job` refuses for every generation job, so the
+/// work stays QUEUED for a host that gets fixed.
+///
+/// Candle-gated because `with_candle_capabilities` is a no-op outside the candle lane — on a
+/// non-candle build BOTH sides would be the bare placeholder set and this test would pass with the
+/// health check ripped out entirely.
+///
+/// Asserts against the HEALTHY set rather than a hardcoded list, so this cannot rot into a false
+/// green as capabilities are added: whatever a healthy candle worker advertises, an unusable one
+/// must advertise none of it.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn an_unusable_gpu_withholds_every_candle_capability() {
+    use crate::gpu::with_candle_capabilities;
+    use sceneworks_core::contracts::WorkerCapability;
+
+    let mut settings = crate::Settings::from_env();
+    settings.backend_candle_enabled = true;
+    settings.gpu_id = "0".to_owned();
+    // sm_120, so the compute-cap-gated markers (`int8_convrot`, `nvfp4`) are in the healthy set
+    // too — they are advertised eligibility for a GPU this worker cannot reach, so they must be
+    // withheld as well.
+    let compute_cap = Some(12.0);
+    let descriptor = || crate::gpu::parse_nvidia_smi_gpus("0, Test GPU, 98304, 1024, 97280, 3")
+        .into_iter()
+        .next()
+        .expect("one parsed descriptor");
+
+    let healthy =
+        with_candle_capabilities(descriptor(), &settings, compute_cap, &crate::GpuHealth::Usable);
+    let unusable = with_candle_capabilities(
+        descriptor(),
+        &settings,
+        compute_cap,
+        &crate::GpuHealth::Unusable {
+            reason: "DriverError(CUDA_ERROR_SYSTEM_DRIVER_MISMATCH, \"...\")".to_owned(),
+        },
+    );
+
+    // The healthy worker must actually have gained something, or the comparison below is vacuous.
+    assert!(
+        healthy.capabilities.len() > unusable.capabilities.len(),
+        "a healthy candle worker must advertise MORE than an unusable one; healthy={:?}",
+        healthy.capabilities
+    );
+    assert!(
+        healthy.capabilities.contains(&WorkerCapability::ImageGenerate),
+        "the healthy baseline must include image_generate, else this test proves nothing"
+    );
+
+    // The withheld worker keeps the descriptor's own base set PLUS the `candle` lane marker, and
+    // nothing else. The marker is not a job capability — it says "this host serves the candle
+    // lane", which `fail_stranded_candle_jobs` needs in order to leave queued work WAITING instead
+    // of terminally failing it as `candle_unavailable`, and which keeps the worker out of the
+    // web's `isPlaceholderOnlyGpuWorker` filter so its card (and remedy) still render.
+    let marker = WorkerCapability::Unknown("candle".to_owned());
+    let mut expected = descriptor().capabilities;
+    expected.push(marker.clone());
+    assert_eq!(
+        unusable.capabilities, expected,
+        "an unusable GPU must advertise the bare nvidia descriptor plus the candle lane marker, \
+         and nothing else"
+    );
+    assert!(
+        healthy.capabilities.contains(&marker),
+        "the marker must be present on BOTH, or the unusable worker looks like a different lane"
+    );
+
+    // Every capability the healthy worker GAINED names work this GPU cannot do. The marker is the
+    // one deliberate exception, so exclude it explicitly rather than silently.
+    for gained in &healthy.capabilities {
+        if descriptor().capabilities.contains(gained) || *gained == marker {
+            continue;
+        }
+        assert!(
+            !unusable.capabilities.contains(gained),
+            "{gained:?} is served by the CUDA device the probe could not acquire, so an unusable \
+             GPU must not advertise it"
+        );
+    }
+}
+
+/// The verdict type's two consumers read it through these accessors — the capability gate asks
+/// `is_usable`, the heartbeat asks `reason` — so an inverted accessor would silently make an
+/// unhealthy worker advertise everything AND report `idle`.
+///
+/// Deliberately NOT candle-gated: `GpuHealth` is compiled on every target, and the parity lane
+/// (macOS / candle-off) is where most contributors run the suite.
+#[test]
+fn gpu_health_reports_usability_and_carries_the_remedy() {
+    assert!(crate::GpuHealth::Usable.is_usable());
+    assert_eq!(crate::GpuHealth::Usable.reason(), None);
+
+    let unusable = crate::GpuHealth::Unusable {
+        reason: "reboot onto the staged driver".to_owned(),
+    };
+    assert!(!unusable.is_usable());
+    assert_eq!(unusable.reason(), Some("reboot onto the staged driver"));
+}
+
+/// Which probe failures may withdraw a worker's capabilities — and AC 3, that the reason it then
+/// reports is the SHARED guidance rather than a second copy of that text.
+///
+/// Both halves run through the real `classify_probe_outcome`, not a value the test composed, so a
+/// future edit that hand-writes a status message or drops the severity check turns this red.
+///
+/// The severity split is the same one sc-16247 drew for the desktop setup screen, and it matters
+/// more here: a transient CUDA OOM (another process, or an orphaned worker from a crashed session,
+/// holding the GPU) says nothing about the driver stack. Treating it as unhealthy would strip every
+/// capability and — with `SCENEWORKS_CANDLE_REQUIRED=1` — fail queued work over a condition that
+/// clears by itself.
+#[test]
+fn only_a_driver_class_probe_failure_makes_the_worker_unhealthy() {
+    use crate::preflight::cuda_preflight_message;
+
+    let classify =
+        |underlying: &str| crate::classify_probe_outcome(Err(cuda_preflight_message(underlying)), "0");
+
+    // A clean probe is usable, obviously — but pin it so an inverted check can't pass the rest.
+    assert!(crate::classify_probe_outcome(Ok(()), "0").is_usable());
+
+    // DISQUALIFYING: the driver-class family this story exists for. The verbatim string from
+    // GH #1966.
+    let health = classify(
+        "DriverError(CUDA_ERROR_SYSTEM_DRIVER_MISMATCH, \"system has unsupported display driver / \
+         cuda driver combination\")",
+    );
+    assert!(
+        !health.is_usable(),
+        "a driver-stack mismatch must withdraw the worker's capabilities"
+    );
+    let reason = health.reason().expect("an unusable GPU carries a reason");
+    assert!(
+        reason.contains("reboot"),
+        "the reported reason must be the shared host-side remedy, got: {reason}"
+    );
+    assert!(
+        reason.contains("CUDA_ERROR_SYSTEM_DRIVER_MISMATCH"),
+        "the underlying CUDA error must survive into the reason for the logs, got: {reason}"
+    );
+
+    // NOT disqualifying: failures that may clear on their own. The worker keeps advertising and
+    // any job that does run reports the classified error itself.
+    for transient in [
+        "DriverError(CUDA_ERROR_OUT_OF_MEMORY, \"out of memory\")",
+        "cuda error: CUBLAS_STATUS_NOT_INITIALIZED",
+        "the CUDA preflight probe did not complete: task panicked",
+    ] {
+        let health = classify(transient);
+        assert!(
+            health.is_usable(),
+            "{transient:?} may be transient and must NOT strip the worker's capabilities"
+        );
+        assert_eq!(
+            health.reason(),
+            None,
+            "a worker that stays usable must report no unhealthy reason"
+        );
+    }
+}

--- a/tests/fixtures/rust_migration_contracts/job_protocol.json
+++ b/tests/fixtures/rust_migration_contracts/job_protocol.json
@@ -34,7 +34,7 @@
   "activeStatuses": ["preparing", "downloading", "loading_model", "running", "saving"],
   "terminalStatuses": ["completed", "failed", "canceled", "interrupted"],
   "nonGpuJobTypes": ["model_download", "model_import", "model_convert", "lora_import"],
-  "workerStatuses": ["idle", "busy", "offline"],
+  "workerStatuses": ["idle", "busy", "offline", "unhealthy"],
   "progressStages": [
     "queued",
     "preparing",


### PR DESCRIPTION
Closes the second half of [sc-16247](https://app.shortcut.com/trefry/story/16247)'s AC 5, tracked as **[sc-16260](https://app.shortcut.com/trefry/story/16260)** (epic 2273, GH issue #1966).

## The gap

[PR #2003](https://github.com/SceneWorks/SceneWorks/pull/2003) gave the server/Docker lane a real CUDA preflight and a loud `error`-level log at worker startup. It stopped there. On a driver-mismatch host the worker still registered, still advertised its full candle GPU capability set, and therefore **still claimed and failed every routed generation job, forever**. An operator gained one log line; queue behaviour was unchanged.

## The decision (AC 1)

The story offered two shapes. Neither is sufficient alone:

| shape | why not alone |
|---|---|
| New `WorkerStatus::Unhealthy` | **Stops nothing.** `worker_supports_job` never consulted status, and the claim is worker-initiated — the worker polls, the store hands it a job. |
| Withhold the GPU capabilities | **Makes the UI lie.** The Workers panel reads "Ready" for a worker that refuses everything, and the stalled job says "no active worker supports image generate". Both true, neither actionable — and a headless host has no setup screen to say otherwise. |

So **withholding is the mechanism, and the status is what makes it honest.** Full reasoning is recorded [on the story](https://app.shortcut.com/trefry/story/16260#activity-16279).

The capability gate turned out much cheaper than the story assumed: the withheld set is what a non-candle build already advertises, so `worker_supports_job`, the tier pickers and the person-workflow gates all already do the right thing with it.

## What landed

- **`discover_gpu` takes the probe verdict** and withholds the candle capability block when the GPU is unusable — generation stays **queued** for a host that gets fixed instead of being claimed and failed one job at a time.
- **`WorkerStatus::Unhealthy` + `status_reason`**, carrying the probe's composed message verbatim so `cuda_driver_error_guidance` stays the single source of the remedy across the startup log, the worker status, and a mid-job failure (**AC 3** — no second copy of that text).
- **`worker_supports_job` refuses an unhealthy worker outright**, as a backstop independent of the capability half.
- **Queue screen** renders the remedy on the worker's card and leads the stalled job's explanation with it — scoped to GPU-needing jobs and to the pinned GPU, so a queued `model_download` or a job pinned to a healthy GPU 1 is never blamed on gpu 0's driver.

### Two traps this design walks into, and why the code looks the way it does

**The `candle` lane marker deliberately survives the withholding.** `fail_stranded_candle_jobs` reads "no live worker advertising `candle`" as candle being *unavailable* and terminally fails every queued candle-eligible job after the grace window — with `candle_unavailable: … confirm the candle worker is running`, which is both wrong (it *is* running) and silent about the driver. `SCENEWORKS_CANDLE_REQUIRED=1` ships in `docker-compose.yml`, `docker/rust.Dockerfile` and the desktop, so that is the **default path for exactly the lane this story targets**. Dropping the marker would have converted "one job fails at a time with the real CUDA error" into "all of them fail at once with a misleading one". The marker also keeps the worker out of the web's `isPlaceholderOnlyGpuWorker` filter — without it the card, and the remedy, never render at all.

**Only a driver-class failure disqualifies a worker.** `cuda_failure_is_blocking` is the severity split sc-16247 drew for the setup screen, applied here to the worker's own advertisement. A transient CUDA OOM — another process, or an orphaned worker from a crashed session, holding the GPU — says nothing about the driver stack; treating it as unhealthy would strip every capability and, with `CANDLE_REQUIRED`, fail queued work over a condition that clears by itself.

### AC 4 — recovery, with hardware evidence

An unhealthy worker re-probes every 60 s and, on success, **re-registers with the full capability set** (flipping the status alone would leave a healthy worker advertising nothing and the queue still stalled). Only an unhealthy worker re-probes.

The re-check is only worth having if a repeated in-process probe re-reads driver state, so that was measured rather than assumed. `cuda_preflight_recovers_within_one_process` (hardware-gated): hiding the devices yields `CUDA_ERROR_NO_DEVICE`, and **restoring visibility + re-probing in the same process returns `Ok(())`** — a failed probe does not poison the process.

The transition is one-way by design, and documented as such: the dominant failure (803) needs a host reboot, which restarts the container anyway. The re-check covers the transient family — `SYSTEM_NOT_READY` during driver/fabric init, a GPU briefly held, a device attached to the container.

### Deliberately NOT done

`/api/v1/health` readiness is untouched. It answers "is the API serving", and its readiness block is about readiness-critical startup (sc-14788). Folding a GPU worker's driver fault into it would make a container orchestrator restart-loop the **API** over a **host** problem no restart can fix.

## Verification

On 2× RTX PRO 6000 Blackwell (driver 596.36, CUDA 12.9, MSVC 14.44, `CUDA_COMPUTE_CAP=120`):

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` — clean.
- **Candle lane** `clippy -p sceneworks-worker -p sceneworks-rust-api --all-targets --features backend-candle -- -D warnings` — clean, and the candle-gated tests **run**, not just typecheck.
- Full workspace `cargo test` — 30 binaries, 0 failures. `npm run check` — 138 pass.
- Web: 231 test files / 3405 tests; `vite build` clean.

**Nine mutations run, each confirmed to turn its own test red** — including re-introducing the two defects an adversarial review caught (below), and dropping the `candle` marker, which reproduces the verbatim `candle_unavailable` error.

## Adversarial review found two defects that are fixed here

Worth stating plainly, because both were shipped-looking and green:

1. **The entire UI half was dead code.** `App.jsx` builds `visibleWorkers` by filtering out `!isActiveWorker` *and* `isPlaceholderOnlyGpuWorker` — the first version tripped both, so a driver-mismatch host would have rendered *"No GPU workers registered"* about a worker that was registered and heartbeating. The web tests passed because they injected `visibleWorkers` directly, bypassing the one line where the bug lived. `isActiveWorker` now answers "is present" (rendering) and a new `canWorkerTakeWork` answers "can be given work" (readiness gates), and the queue test drives App.jsx's own filter.
2. **The stranded-candle sweep regression** described above.

## Known, pre-existing (not from this change)

The web suite is flaky under back-to-back full runs — ~20 tests across 5–6 full-App-mount files. Reproduced on a clean baseline with these changes stashed, so it is not introduced here, but CI may hit it. Raised separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
