### PR TITLE
docs(core): replace stale engine line references (sc-16219)

### DIFF
--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -1040,10 +1040,12 @@ mod tests {
     /// must NOT invent one.
     ///
     /// **The backends now agree** — sc-12308 reconciled them, so the table is simply each
-    /// engine's cap rather than the stricter of two answers. Both reject an over-cap request
-    /// (candle `wan14b.rs:645` / `model_vace.rs:298` / `candle-gen-bernini/src/config.rs:164` /
-    /// `candle-gen-scail2/src/pipeline.rs:294` / `lib.rs`'s new `MAX_AREA_5B` check; mlx
-    /// `validate_impl` → `reject_over_area`), at these values.
+    /// engine's cap rather than the stricter of two answers. Both measure the same rendered,
+    /// lattice-aligned geometry and reject it when it exceeds that cap. The relevant validation
+    /// paths are candle's Wan `validate` methods, Bernini's `validate_bernini_geometry`, and
+    /// SCAIL-2's `reject_over_area`; mlx validation reaches `reject_over_area`,
+    /// `validate_bernini_geometry`, or SCAIL-2's `reject_unrenderable_geometry` →
+    /// `reject_over_area_dims`.
     ///
     /// Before that they disagreed three ways on one manifest entry, and the table had to carry
     /// the strictest: mlx T2V/VACE/bernini/scail2 were **uncapped**, mlx I2V/5B **silently
@@ -1052,7 +1054,7 @@ mod tests {
     /// values themselves were wrong too: the whole 14B family carried the TI2V-5B's 901,120.
     /// * `ltx_2_3` / `ltx_2_3_eros` / `svd` / `mochi_1` — no `maxPixels`-expressible area cap in
     ///   either backend, so no cap is declared. Not literally "no checks": candle-LTX caps
-    ///   **latent tokens** (`candle-gen-ltx/src/lib.rs:454`: `t_lat·h_lat·w_lat > 131_072`), which
+    ///   **latent tokens** through `config::max_latent_tokens` (`t_lat·h_lat·w_lat > 131_072`), which
     ///   is proportional to `frames × w × h`. That is a frames×area constraint and therefore
     ///   outside `maxPixels`' scope — `maxPixels` is a pure per-frame area budget with no frame
     ///   term, so no value of it could express this cap without either under- or over-constraining


### PR DESCRIPTION
## What does this PR do?

Updates the ENGINE_GEOMETRY area-cap documentation in crates/sceneworks-core/src/video_request.rs so it:

- removes drift-prone engine file:line citations, including the nearby candle-LTX citation;
- names stable candle and MLX validation helpers instead;
- records that both backends measure the same rendered, lattice-aligned geometry before rejecting over-cap requests;
- accurately describes MLX SCAIL-2 as reject_unrenderable_geometry reaching reject_over_area_dims.

## Related issue

Shortcut: https://app.shortcut.com/trefry/story/16219

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

- [ ] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (web UI, docs, shared crate)

Validation on the integrated latest main branch:

- focused assertion over the full ENGINE_GEOMETRY doc block: no remaining Rust file:line citations and all named helpers present
- cargo fmt --all -- --check
- cargo clippy -p sceneworks-core --all-targets -- -D warnings
- cargo test -p sceneworks-core shipped_manifest_matches_each_engines_real_geometry
- npm run check:rust-derived-docs
- npm run rust:build
- independent adversarial review: PASS (high confidence)

The broader npm run rust:check reached cargo test after derived-doc checks, formatting, and clippy passed, then stopped on the unrelated untouched Windows process-watcher test tests::server::parent_death_resolves_when_watched_parent_exits_windows (freshly spawned parent reads as dead). The exact isolated test fails identically. The build phase was run separately and passed.

No engine build or runtime validation is required for this comment-only change; the current host cannot run MLX.

## Checklist

- [ ] I ran npm run rust:check (if I touched Rust) and it passed
- [ ] I ran npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build (if I touched the web app)
- [ ] I ran npm run check (scaffold checks)
- [x] I updated documentation where relevant
- [x] All my commits are signed off (git commit -s)
- [x] My PR is focused on a single logical change