### PR TITLE
Clamp strict-pose jobs at 64 selections (sc-16075)

### DIFF
--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -429,6 +429,9 @@ async fn validate_and_canonicalize_merged_generation_payload(
         validate_raw_job_payload(state, &job_type, &merged)?;
     }
     if matches!(job_type, JobType::ImageGenerate | JobType::ImageEdit) {
+        if let Some(advanced) = merged.get("advanced").and_then(Value::as_object) {
+            validate_image_pose_count(advanced)?;
+        }
         crate::control_overlays::resolve_control_overlay_selection(
             state,
             project_id.as_deref(),

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -4009,6 +4009,7 @@ fn validate_image_job(payload: &ImageJobRequest) -> Result<(), ApiError> {
         ));
     }
     validate_prompt_extras(&payload.negative_prompt, &payload.advanced)?;
+    validate_image_pose_count(&payload.advanced)?;
     if payload.loras.len() > sceneworks_core::lora_family::MAX_JOB_LORAS {
         return Err(ApiError::bad_request(format!(
             "loras must contain at most {} entries",
@@ -4048,6 +4049,25 @@ fn validate_image_job(payload: &ImageJobRequest) -> Result<(), ApiError> {
         if payload.upscale.engine.trim().is_empty() {
             return Err(ApiError::bad_request("upscale.engine is required"));
         }
+    }
+    Ok(())
+}
+
+/// Bound strict-pose fan-out at the image-job creation boundary. Each `advanced.poses` entry
+/// renders one image, so this is an output-count contract rather than a JSON-size guard.
+///
+/// Existing stored jobs are immutable and remain readable. Retry/duplicate pass their merged
+/// payload through this same helper in `jobs.rs`, so a legacy over-limit job must be reduced before
+/// it can create new work instead of silently reproducing the old unbounded behavior.
+fn validate_image_pose_count(advanced: &JsonObject) -> Result<(), ApiError> {
+    let Some(poses) = advanced.get("poses").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    if poses.len() > sceneworks_core::image_request::MAX_JOB_POSES {
+        return Err(ApiError::bad_request(format!(
+            "advanced.poses must contain at most {} entries; each pose renders one image",
+            sceneworks_core::image_request::MAX_JOB_POSES
+        )));
     }
     Ok(())
 }

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -793,6 +793,128 @@ async fn create_image_job_rejects_oversized_advanced_object() {
 }
 
 #[tokio::test]
+async fn create_image_job_enforces_the_pose_output_ceiling() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let poses: Vec<Value> = (0..sceneworks_core::image_request::MAX_JOB_POSES)
+        .map(|index| json!({ "id": format!("pose-{index}"), "keypoints": [] }))
+        .collect();
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": "project-1",
+            "mode": "text_to_image",
+            "prompt": "mist over hills",
+            "count": 1,
+            "advanced": { "poses": poses },
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{body}");
+
+    let mut over = poses;
+    over.push(json!({ "id": "one-too-many", "keypoints": [] }));
+    let (status, error) = request(
+        app,
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": "project-1",
+            "mode": "text_to_image",
+            "prompt": "mist over hills",
+            "count": 1,
+            "advanced": { "poses": over },
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{error}");
+    assert_eq!(
+        error["detail"],
+        "advanced.poses must contain at most 64 entries; each pose renders one image"
+    );
+}
+
+/// Legacy over-limit payloads stay inspectable, but replaying them would create new unbounded work.
+/// Retry and duplicate therefore reject until the caller reduces `advanced.poses` to the current
+/// product ceiling. This makes the compatibility policy executable instead of an incidental side
+/// effect of which creation route happened to run.
+#[tokio::test]
+async fn legacy_over_limit_pose_job_is_readable_but_cannot_be_replayed() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let jobs_db_path = settings.jobs_db_path.clone();
+    let app = create_app(settings).expect("app creates");
+    let (status, created) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": "project-1",
+            "mode": "text_to_image",
+            "prompt": "legacy pose set",
+            "count": 1,
+            "advanced": { "poses": [{ "id": "pose-0", "keypoints": [] }] },
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{created}");
+    let job_id = created["id"].as_str().expect("job id");
+    let mut legacy_payload = created["payload"]
+        .as_object()
+        .cloned()
+        .expect("stored payload object");
+    let legacy_poses: Vec<Value> = (0..=sceneworks_core::image_request::MAX_JOB_POSES)
+        .map(|index| json!({ "id": format!("legacy-pose-{index}"), "keypoints": [] }))
+        .collect();
+    legacy_payload.insert("advanced".to_owned(), json!({ "poses": legacy_poses }));
+
+    let connection = rusqlite::Connection::open(jobs_db_path).expect("jobs db opens");
+    let updated = connection
+        .execute(
+            "update jobs set payload_json = ?1 where id = ?2",
+            rusqlite::params![Value::Object(legacy_payload).to_string(), job_id],
+        )
+        .expect("legacy payload writes");
+    assert_eq!(updated, 1);
+    drop(connection);
+
+    let (status, stored) = request(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/jobs/{job_id}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{stored}");
+    assert_eq!(
+        stored["payload"]["advanced"]["poses"]
+            .as_array()
+            .map(Vec::len),
+        Some(65)
+    );
+
+    for operation in ["retry", "duplicate"] {
+        let (status, error) = request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/jobs/{job_id}/{operation}"),
+            json!({ "payloadChanges": {} }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{operation}: {error}");
+        assert_eq!(
+            error["detail"],
+            "advanced.poses must contain at most 64 entries; each pose renders one image"
+        );
+    }
+
+    let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    assert_eq!(jobs.as_array().map(Vec::len), Some(1));
+}
+
+#[tokio::test]
 async fn create_video_job_rejects_over_length_negative_prompt() {
     // sc-8884 (F-082): the negative-prompt cap is shared by the video validator too.
     let temp_dir = tempfile::tempdir().expect("temp dir creates");

--- a/apps/web/src/components/PoseLibraryPicker.jsx
+++ b/apps/web/src/components/PoseLibraryPicker.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { usePoseLibrary } from "../poseLibrary.js";
+import { MAX_JOB_POSES } from "../poseSelection.js";
 
 // Multi-select gallery of OpenPose poses, grouped by category. Controlled: the parent
 // owns `selectedIds` (array) and gets toggles via `onToggle(id)` / `onClear()`. Shared
@@ -16,6 +17,7 @@ export function PoseLibraryPicker({ selectedIds = [], onToggle, onClear, loadUse
   // "standing" when present, else the first available category.
   const [activeCategory, setActiveCategory] = useState("standing");
   const selected = new Set(selectedIds);
+  const atPoseLimit = selected.size >= MAX_JOB_POSES;
 
   if (loading) {
     return <p className="muted">Loading pose library…</p>;
@@ -37,6 +39,11 @@ export function PoseLibraryPicker({ selectedIds = [], onToggle, onClear, loadUse
           Clear
         </button>
       ) : null}
+      {atPoseLimit ? (
+        <span className="field-hint" role="status">
+          Maximum of {MAX_JOB_POSES} poses per job. Deselect one to choose another.
+        </span>
+      ) : null}
     </div>
   );
 
@@ -44,14 +51,20 @@ export function PoseLibraryPicker({ selectedIds = [], onToggle, onClear, loadUse
   // layout leaves the .pose-thumb markup untouched so the shared call sites are unchanged.
   const renderThumb = (pose, showCheck = false) => {
     const isSelected = selected.has(pose.id);
+    const selectionDisabled = atPoseLimit && !isSelected;
     return (
       <button
         aria-label={`${isSelected ? "Deselect" : "Select"} pose ${pose.label}`}
         aria-pressed={isSelected}
         className={isSelected ? "pose-thumb selected" : "pose-thumb"}
+        disabled={selectionDisabled}
         key={pose.id}
         onClick={() => onToggle?.(pose.id)}
-        title={pose.label}
+        title={
+          selectionDisabled
+            ? `Maximum of ${MAX_JOB_POSES} poses per job. Deselect one to choose another.`
+            : pose.label
+        }
         type="button"
       >
         <img alt={pose.label} loading="lazy" src={pose.previewUrl ?? `/${pose.preview}`} />

--- a/apps/web/src/components/PoseLibraryPicker.test.jsx
+++ b/apps/web/src/components/PoseLibraryPicker.test.jsx
@@ -1,0 +1,71 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PoseLibraryPicker } from "./PoseLibraryPicker.jsx";
+
+const POSES = Array.from({ length: 65 }, (_, index) => ({
+  id: `pose-${index}`,
+  label: `Pose ${index}`,
+  category: "test",
+  keypoints: [],
+  preview: `pose-${index}.png`,
+}));
+
+vi.mock("../poseLibrary.js", () => ({
+  usePoseLibrary: () => ({
+    poses: POSES,
+    categories: ["test"],
+    loading: false,
+    error: null,
+  }),
+}));
+
+describe("PoseLibraryPicker pose-count ceiling", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("disables only new selections at the ceiling and explains how to continue", async () => {
+    const onToggle = vi.fn();
+    await act(async () => {
+      root.render(
+        <PoseLibraryPicker
+          onClear={vi.fn()}
+          onToggle={onToggle}
+          selectedIds={POSES.slice(0, 64).map((pose) => pose.id)}
+        />,
+      );
+    });
+    const sixtyFifth = container.querySelector('[aria-label="Select pose Pose 64"]');
+    expect(sixtyFifth).not.toBeNull();
+    expect(sixtyFifth.disabled).toBe(true);
+    expect(sixtyFifth.title).toContain("Maximum of 64 poses per job");
+    expect(container.querySelector('[role="status"]').textContent).toContain(
+      "Maximum of 64 poses per job. Deselect one to choose another.",
+    );
+    await act(async () => {
+      sixtyFifth.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onToggle).not.toHaveBeenCalled();
+
+    const selected = container.querySelector('[aria-label="Deselect pose Pose 0"]');
+    expect(selected.disabled).toBe(false);
+    await act(async () => {
+      selected.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onToggle).toHaveBeenCalledWith("pose-0");
+  });
+});

--- a/apps/web/src/poseSelection.js
+++ b/apps/web/src/poseSelection.js
@@ -1,0 +1,5 @@
+// Strict pose jobs render one image per selected pose. Keep that output fan-out at the Rust API's
+// product ceiling: eight ordinary maximum-size (8-image) batches. 64 still fits all 46 shipped
+// built-ins plus 18 user-created poses. `the_pose_cap_matches_the_request_and_web_validators` reads
+// this declaration and the Rust source so either side moving forces an explicit reconciliation.
+export const MAX_JOB_POSES = 64;

--- a/crates/sceneworks-core/src/image_request.rs
+++ b/crates/sceneworks-core/src/image_request.rs
@@ -63,6 +63,18 @@ const MIN_COUNT: u32 = 1;
 /// measured against.
 pub(crate) const MAX_COUNT: u32 = 8;
 
+/// The maximum number of strict poses one image-generation job may render.
+///
+/// A pose set is not ordinary batch metadata: every entry becomes a separate generated image and
+/// therefore a separate output artifact. Keep that fan-out finite at eight ordinary maximum-size
+/// batches. The resulting 64-pose ceiling still admits the complete shipped 46-pose library plus
+/// 18 user-created Key Point Library entries in one run, while preventing an accidentally huge
+/// library selection from becoming an effectively unbounded job.
+///
+/// This is the product/request contract. The workflow-share envelope derives its entry cap from
+/// this value, and the web's mechanically pinned twin is checked by a cross-file drift test.
+pub const MAX_JOB_POSES: usize = 8 * MAX_COUNT as usize;
+
 /// `defaults.count` from a resolved manifest entry, or `None` for the blanket [`DEFAULT_COUNT`].
 ///
 /// The fifth and last dead `defaults.*` key, and the widest: **29 of the 45** image models declare

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -2412,20 +2412,13 @@ const MAX_SHARE_PHASES: usize = 8;
 
 /// The most pose entries an envelope may carry.
 ///
-/// The one collection with NO upstream validator to inherit, and the review that added it said so:
-/// the pose lane renders one image per pose and nothing in the worker's `pose_entries` or in
-/// `apps/web/src` clamps how many a user may select. So the derivation is the library they are
-/// selected FROM — `apps/web/public/poses/index.json` ships 46 poses — and 64 clears an
-/// all-of-the-library selection with room for user-created Key Point Library entries on top.
-///
-/// Because there is no upstream ceiling, this cap can fire on OUR OWN WRITE SIDE: a user who
-/// selects 65 poses gets an envelope with no `advanced.poses` in it. That is why
-/// [`OMITTED_FIELDS`] exists and is emitted on the build side too — a 70-pose selection that is
-/// not recorded says so, instead of arriving as an absence indistinguishable from "no poses".
-/// Clamping the selection at the source is the better fix and is not this story's to make.
+/// Derived directly from [`crate::image_request::MAX_JOB_POSES`], the request contract enforced by
+/// the API and mirrored by the shared web picker. A valid newly submitted job therefore cannot
+/// first discover this limit when its workflow is embedded in an output image. The sanitizer still
+/// retains its over-cap omission marker for untrusted or legacy envelopes.
 ///
 /// This bounds the ENTRY count only; [`MAX_SHARE_POSE_SLOTS`] is what bounds the volume.
-const MAX_SHARE_POSES: usize = 64;
+const MAX_SHARE_POSES: usize = crate::image_request::MAX_JOB_POSES;
 
 /// The most coordinate SLOTS the whole `advanced.poses` array may carry, across every entry and
 /// field: a number, or a `null` standing in for one.
@@ -4031,6 +4024,8 @@ mod tests {
         // `the_phase_cap_matches_the_multi_phase_validators` in tests/workflow_share.rs, which can
         // read the file this crate cannot import.
         assert_eq!(MAX_SHARE_PHASES, 8);
+        assert_eq!(MAX_SHARE_POSES, crate::image_request::MAX_JOB_POSES);
+        assert_eq!(MAX_SHARE_POSES, 64);
         // The pose budget is 16 whole-body skeletons, and 16 is twice the payload-sanity ceiling on
         // images per job — the thing a pose set is the pose lane's version of. If that ceiling
         // moves, the budget is a decision to re-make, not a number to follow.

--- a/crates/sceneworks-core/tests/workflow_share.rs
+++ b/crates/sceneworks-core/tests/workflow_share.rs
@@ -1734,6 +1734,29 @@ fn the_phase_cap_matches_the_multi_phase_validators() {
     );
 }
 
+/// The share envelope inherits the pose-output ceiling from the Rust request contract, while the
+/// web must repeat the number because it cannot import Rust. Pin all three declarations together
+/// so a valid UI/API job can never first discover a stale limit when it is shared.
+#[test]
+fn the_pose_cap_matches_the_request_and_web_validators() {
+    let request = read_repo_file("crates/sceneworks-core/src/image_request.rs");
+    assert!(
+        request.contains("pub(crate) const MAX_COUNT: u32 = 8;")
+            && request.contains("pub const MAX_JOB_POSES: usize = 8 * MAX_COUNT as usize;"),
+        "the Rust pose-output ceiling moved; reconcile the API, share envelope, and web picker"
+    );
+    let share = read_repo_file("crates/sceneworks-core/src/workflow_share.rs");
+    assert!(
+        share.contains("const MAX_SHARE_POSES: usize = crate::image_request::MAX_JOB_POSES;"),
+        "the share envelope must derive its pose cap from image_request::MAX_JOB_POSES"
+    );
+    let web = read_repo_file("apps/web/src/poseSelection.js");
+    assert!(
+        web.contains("export const MAX_JOB_POSES = 64;"),
+        "the web pose picker moved; reconcile it with image_request::MAX_JOB_POSES and MAX_SHARE_POSES"
+    );
+}
+
 /// The bounds against REAL requests, not fixtures written to pass them.
 ///
 /// A cap is only correct if nothing legitimate touches it, and the failure mode of getting that

--- a/docs/workflow-share-envelope.md
+++ b/docs/workflow-share-envelope.md
@@ -543,10 +543,11 @@ adding them here for consistency — the inconsistency is the decision.
 ## Ceilings
 
 Two kinds of bound. Per-collection caps, each inherited from the validator that already limits the
-thing — where one exists. Two are not inherited: `MAX_SHARE_INPUTS` is a **shape** rather than a
-validator's number (it is `INPUT_KINDS.len()` — one entry per kind, and the kinds are closed), and
-`MAX_SHARE_POSES` has no upstream validator to inherit at all and is derived from the size of the
-shipped pose library instead. And one ceiling on the serialized envelope, checked after every
+thing. `MAX_SHARE_INPUTS` is a **shape** rather than a validator's number (it is
+`INPUT_KINDS.len()` — one entry per kind, and the kinds are closed). `MAX_SHARE_POSES` derives from
+the API/UI `MAX_JOB_POSES` output-count contract: every pose renders one image, so new jobs are
+stopped at selection or request validation rather than first losing poses in a shared file. And one
+ceiling on the serialized envelope, checked after every
 per-field rule has run. The second is what actually composes: per-field bounds did not, and each new
 measurement found a new way to spend what they left.
 


### PR DESCRIPTION
## Summary
- define a justified 64-pose output ceiling shared by Rust request validation and workflow sharing
- prevent new UI selections at the ceiling across all shared picker surfaces with explanatory copy
- reject oversized create, retry, and duplicate requests while keeping legacy stored jobs readable
- pin the web constant to the Rust/share contract with a drift regression

## Validation
- independent adversarial review: PASS (high confidence; no scope gaps)
- core workflow-share suite: 84 passed
- documentation pins: 27 passed
- full web suite: 232 files / 3,406 tests passed
- focused picker regression: passed
- API 64/65 boundary and legacy replay regressions: passed
- web lint and production build: passed
- cargo fmt and strict targeted clippy: passed
- post-rebase focused core/API/web checks: passed

## Compatibility
Existing stored jobs above 64 poses remain readable. Retry or duplicate returns HTTP 400 until the caller reduces advanced.poses to the current ceiling.

Shortcut: https://app.shortcut.com/trefry/story/16075