### PR TITLE
fix(memory-matrix): guard catalog-relative cell inventory (sc-15995)

### DIFF
--- a/docs/generated/calibration-cost-model.json
+++ b/docs/generated/calibration-cost-model.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "generatedFrom": {
-    "sceneWorksRevision": "source-tree:925d038c3a3d9318bf613f113277dada43cc9afec3dee0e5c013e0b85fdf5332",
+    "sceneWorksRevision": "source-tree:a02c9cb595001353d767cc419d3214759c4c5eab811380d2c5a044245f42ad06",
     "matrixRevision": "source-tree:25e2b4b7e5d474aa3c71cab87d5eb65bdbe6777a56a826319d97e0efbb802e2a",
     "inferenceRevision": "138778bdd0fb9e28a4047dce824c94262f4c0959",
     "sources": {
@@ -19,7 +19,7 @@
       },
       "matrixGenerator": {
         "path": "scripts/generate-memory-matrix.mjs",
-        "sha256": "8e36b9204430a7d8452ef3fd242e9d5dc933598a7fbed5234e6dda4f2471d705"
+        "sha256": "18b45a0229ada2a0d836708cad0e924e57fc348ed7fa161df8ccc67b89810423"
       },
       "sourceRevision": {
         "path": "scripts/lib/source-revision.mjs",

--- a/packages/schemas/memory-matrix.schema.json
+++ b/packages/schemas/memory-matrix.schema.json
@@ -284,6 +284,7 @@
       }
     },
     "cells": {
+      "description": "The 265-item floor is deliberately only a schema-level sanity check: 53 entries in this epic times the five normative rungs. JSON Schema cannot derive the real catalog cross-product of backend, tier, mode, overlay, and rung axes. Exact completeness is enforced before artifact writes by assertCellInventoryMatchesCatalog in scripts/generate-memory-matrix.mjs; do not replace 265 with today's generated cell count, because legitimate catalog drift changes that total.",
       "type": "array",
       "minItems": 265,
       "items": {

--- a/scripts/generate-memory-matrix.mjs
+++ b/scripts/generate-memory-matrix.mjs
@@ -272,6 +272,46 @@ export function assertCellOwnershipIsBackendScoped(cells, scope = buildStoryBack
 }
 
 /**
+ * Prove that the emitted cells still equal the catalog cross-product that was resolved for this run.
+ *
+ * This deliberately does NOT pin today's total. Tiers, modes, overlays, backends, and even catalog
+ * entries legitimately drift; their resolved axis sizes are the expectation. The schema's low
+ * `minItems` can only be a shape sanity check because JSON Schema cannot derive this cross-product.
+ * Keeping the exact check here also makes a dropped generation branch fail before either artifact is
+ * written.
+ */
+export function assertCellInventoryMatchesCatalog(cells, expectedByScope) {
+  const actualByScope = new Map();
+  const seenIds = new Set();
+
+  for (const cell of cells) {
+    if (seenIds.has(cell.id)) {
+      throw new Error(`${cell.id}: duplicate memory-matrix cell id`);
+    }
+    seenIds.add(cell.id);
+
+    const scope = `${cell.modelId}:${cell.backend}`;
+    if (!expectedByScope.has(scope)) {
+      throw new Error(`${cell.id}: emitted a cell for unexpected catalog scope ${scope}`);
+    }
+    actualByScope.set(scope, (actualByScope.get(scope) ?? 0) + 1);
+  }
+
+  for (const [scope, expected] of expectedByScope) {
+    if (!Number.isInteger(expected.cells) || expected.cells < 1) {
+      throw new Error(`${scope}: catalog axes resolved to no memory-matrix cells`);
+    }
+    const actual = actualByScope.get(scope) ?? 0;
+    if (actual !== expected.cells) {
+      throw new Error(
+        `${scope}: catalog cross-product expects ${expected.cells} cells ` +
+          `(${expected.tiers} tiers x ${expected.modes} modes x ${expected.overlays} overlays x ${expected.rungs} rungs), emitted ${actual}`,
+      );
+    }
+  }
+}
+
+/**
  * The reconcile the story originally pinned as an absolute epic story count ("100 -> ~147"), restated
  * relatively so it stops going stale every time a story is filed. Twin coverage is derived from what
  * the catalog advertises: every dual-backend entry needs a Candle twin, and an mlx-only entry must
@@ -1081,7 +1121,13 @@ function strategyStatus({
   return { state: "Missing", source: null, parameters: {} };
 }
 
-function validateMatrix(matrix, expectedIds, backendTierOverrides, rung4Survey) {
+function validateMatrix(
+  matrix,
+  expectedIds,
+  backendTierOverrides,
+  rung4Survey,
+  cellInventoryExpectations,
+) {
   const ids = matrix.models.map((model) => model.id);
   if (ids.length !== EXPECTED_IMAGE_COUNT) {
     throw new Error(`expected exactly ${EXPECTED_IMAGE_COUNT} image entries, found ${ids.length}`);
@@ -1115,6 +1161,7 @@ function validateMatrix(matrix, expectedIds, backendTierOverrides, rung4Survey) 
       );
     }
   }
+  assertCellInventoryMatchesCatalog(matrix.cells, cellInventoryExpectations);
   assertTwinCoverage(matrix.models);
   assertCellOwnershipIsBackendScoped(matrix.cells);
   assertRung4SurveyCoversEveryFamily(rung4Survey, matrix.models);
@@ -1169,7 +1216,7 @@ export const SOURCE_PATHS = Object.freeze({
   cargo: "Cargo.toml",
 });
 
-export async function buildMatrix({ sourceOverrides = {} } = {}) {
+export async function buildMatrix({ sourceOverrides = {}, cellFilter = null } = {}) {
   const sourcePaths = SOURCE_PATHS;
   const sourceEntries = Object.entries(sourcePaths);
   const sourceBodies = await Promise.all(
@@ -1243,6 +1290,26 @@ export async function buildMatrix({ sourceOverrides = {} } = {}) {
       };
     })
     .sort((left, right) => left.id.localeCompare(right.id));
+
+  // Resolve the complete catalog expectation in its own pass. Keeping this outside the emission loop
+  // is load-bearing: if a later regression skips an entire model/backend branch while emitting cells,
+  // the expected scope must survive so validation can report the loss.
+  const cellInventoryExpectations = new Map();
+  for (const modelSummary of models) {
+    const model = manifestById.get(modelSummary.id);
+    for (const backend of modelSummary.backends) {
+      const tiers = tiersFor(model, backend, backendTierOverrides);
+      const modes = modesFor(model);
+      const overlays = overlaysFor(model, backend);
+      cellInventoryExpectations.set(`${model.id}:${backend}`, {
+        tiers: tiers.length,
+        modes: modes.length,
+        overlays: overlays.length,
+        rungs: RUNGS.length,
+        cells: tiers.length * modes.length * overlays.length * RUNGS.length,
+      });
+    }
+  }
 
   const cells = [];
   for (const modelSummary of models) {
@@ -1361,7 +1428,7 @@ export async function buildMatrix({ sourceOverrides = {} } = {}) {
                     inference: pin,
                   }) === "current" && record.status === "complete",
               );
-              cells.push({
+              const cell = {
                 id: [model.id, provider, backend, tier, mode, overlay, rung].join(":"),
                 modelId: model.id,
                 resolvedRoute: provider,
@@ -1405,7 +1472,10 @@ export async function buildMatrix({ sourceOverrides = {} } = {}) {
                   strategyParameterVerification: status.strategyParameterVerification ?? [],
                   structural: status.structural ?? [],
                 },
-              });
+              };
+              // Mutation seam used by the inventory regression test. The CLI never supplies a filter;
+              // every production build emits the full catalog and validates it below before writing.
+              if (!cellFilter || cellFilter(cell)) cells.push(cell);
             }
           }
         }
@@ -1549,7 +1619,13 @@ export async function buildMatrix({ sourceOverrides = {} } = {}) {
     calibrationRuns,
     modelSlices,
   };
-  validateMatrix(matrix, expectedIds, backendTierOverrides, rung4Survey);
+  validateMatrix(
+    matrix,
+    expectedIds,
+    backendTierOverrides,
+    rung4Survey,
+    cellInventoryExpectations,
+  );
   return matrix;
 }
 

--- a/scripts/generate-memory-matrix.test.mjs
+++ b/scripts/generate-memory-matrix.test.mjs
@@ -8,6 +8,7 @@ import {
   MODEL_STORIES,
   SOURCE_PATHS,
   assertCellOwnershipIsBackendScoped,
+  assertCellInventoryMatchesCatalog,
   assertTwinCoverage,
   backendScopes,
   buildMatrix,
@@ -194,6 +195,73 @@ test("provenance is stamped once on the document, never per row", async () => {
   assert.ok(
     !JSON.stringify(matrix.cells).includes(matrix.generatedFrom.sceneWorksRevision),
     "no cell may embed the source revision under any other key either",
+  );
+});
+
+test("catalog-relative inventory guard rejects whole-scope loss without freezing today's total", async () => {
+  const matrix = await buildMatrix();
+  const candleCells = matrix.cells.filter((cell) => cell.backend === "candle");
+  assert.ok(candleCells.length > matrix.cells.length / 4, "mutation must drop a substantial fraction");
+  await assert.rejects(
+    buildMatrix({
+      // Preserve the bespoke tier-override scope so its older, narrower guard does not mask the new
+      // catalog-wide assertion. Every other Candle scope disappears from the real generator path.
+      cellFilter: (cell) => cell.backend !== "candle" || cell.modelId === "instantid_realvisxl",
+    }),
+    /:candle: catalog cross-product expects .* emitted 0/,
+  );
+
+  // The expectation moves with a legitimate new catalog scope; no committed 7,360-cell ratchet needs
+  // editing. The generator's separate 53-entry and ownership guards still decide whether that scope is
+  // part of this epic, while this guard checks only that an accepted scope emits its full cross-product.
+  const driftRungs = [
+    "resident",
+    "staged_residency",
+    "bounded_decode",
+    "bounded_attention",
+    "bounded_transformer_residency",
+  ];
+  const driftCells = driftRungs.map((rung) => ({
+    id: `future:future:mlx:bf16:text_to_image:none:${rung}`,
+    modelId: "future",
+    backend: "mlx",
+  }));
+  const driftExpectations = new Map([
+    ["future:mlx", { tiers: 1, modes: 1, overlays: 1, rungs: driftRungs.length, cells: driftRungs.length }],
+  ]);
+  assert.doesNotThrow(() => assertCellInventoryMatchesCatalog(driftCells, driftExpectations));
+});
+
+test("inventory guard rejects duplicate and unknown-scope cells", async () => {
+  const cells = [
+    {
+      id: "known:known:mlx:bf16:text_to_image:none:resident",
+      modelId: "known",
+      backend: "mlx",
+    },
+  ];
+  const expected = new Map([
+    ["known:mlx", { tiers: 1, modes: 1, overlays: 1, rungs: 1, cells: 1 }],
+  ]);
+
+  assert.throws(
+    () => assertCellInventoryMatchesCatalog([...cells, cells[0]], expected),
+    /duplicate memory-matrix cell id/,
+  );
+  assert.throws(
+    () =>
+      assertCellInventoryMatchesCatalog(
+        [
+          ...cells,
+          {
+            id: "other:other:mlx:bf16:text_to_image:none:resident",
+            modelId: "other",
+            backend: "mlx",
+          },
+        ],
+        expected,
+      ),
+    /unexpected catalog scope other:mlx/,
   );
 });
 


### PR DESCRIPTION
## Summary

- derive expected memory-matrix cells per current model/backend from tiers x modes x overlays x the five normative rungs
- validate emitted scope counts before either generated artifact can be written
- keep the schema 265-item floor only as a documented 53-entry x five-rung sanity check, never as the completeness guard
- reject duplicate ids and cells emitted outside an advertised catalog scope
- refresh calibration-cost-model provenance because the matrix generator is one of its semantic inputs

## Acceptance criteria

- Large-scale loss: the generator-path regression removes every Candle scope except the bespoke tier-override scope, dropping more than 25 percent of current cells, and the pre-write assertion rejects it.
- Mutation proof: disabling only the new count comparison makes that regression fail with Missing expected rejection; restoring it passes.
- Ordinary drift: expectations are derived from current catalog axes, and a synthetic added catalog scope passes without any committed total-count ratchet. Existing 53-entry and ownership guards remain unchanged and continue enforcing this epic scope.
- Rationale: schema and generator comments explain why 265 is only a sanity floor and why the current 7,360 total must not be frozen.
- Epic safety: no provider implementation, calibration row, model signoff, precision, geometry, selector, ownership, or backend behavior changes. The generated memory matrix is byte-unchanged.

## Validation

- node scripts/generate-memory-matrix.mjs --check
- npm run check (156 tests)
- uv run with pytest 9.0.2 and jsonschema 4.25.1: tests/test_memory_matrix.py --strict-markers (9 passed)
- git diff --check
- independent adversarial review: PASS, high confidence

Shortcut: https://app.shortcut.com/trefry/story/15995