### PR TITLE
Replay shared pose selections in Image Studio (sc-16132)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2982,6 +2982,7 @@ export function App() {
     // The list the studio's own picker is built from, so a substitute chosen in the panel cannot be
     // a row the picker would drop on the next render (sc-15952).
     models: imageModels,
+    macCapabilities,
     catalogRevision,
     failedInstallJobIds,
     installModel: createModelDownloadJob,

--- a/apps/web/src/App.workflowDropLaunch.test.jsx
+++ b/apps/web/src/App.workflowDropLaunch.test.jsx
@@ -26,7 +26,7 @@ const MODEL = {
   defaults: { resolution: "1024x1024" },
   limits: { resolutions: ["1024x1024"] },
   loraCompatibility: {},
-  ui: {},
+  ui: { controlModes: ["pose"] },
 };
 
 const INSPECT_BODY = {
@@ -43,7 +43,7 @@ const INSPECT_BODY = {
     width: 1024,
     height: 1024,
     count: 1,
-    advanced: { steps: 28 },
+    advanced: { steps: 28, poses: [{ keypoints: [[0.25, 0.75]], face: [[0.5, 0.5]] }] },
   },
   resolution: {
     model: {
@@ -161,6 +161,8 @@ describe("App — a dropped workflow launches from either shell", () => {
       node.value.includes("a lighthouse in heavy fog"),
     );
     expect(prompt).toBeTruthy();
+    expect(document.body.querySelector('[aria-label="Deselect pose Shared workflow pose 1"]')).toBeTruthy();
+    expect(document.body.querySelector(".pose-thumb-placeholder")).toBeTruthy();
     expect(document.body.querySelector(".workflow-drop-modal")).toBeNull();
   });
 

--- a/apps/web/src/components/ControlPanel.jsx
+++ b/apps/web/src/components/ControlPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { PoseLibraryPicker } from "./PoseLibraryPicker.jsx";
 import { ImageEditSourcePickerField } from "./AssetPicker.jsx";
 import { ControlOverlayPicker } from "./ControlOverlayPicker.jsx";
@@ -35,6 +35,10 @@ export function ControlPanel({
   onTogglePose,
   onClearPoses,
   loadUserPoses,
+  extraPoses,
+  preferredPoseCategory,
+  revealPoseLibraryToken,
+  poseReplayOpen,
   poseBlockText,
   // Trained ControlNet overlay selection (sc-10165 B4). `controlOverlayBaseModel` is the backbone id
   // whose pose control rides a REGISTERED overlay (e.g. `krea_2_turbo`); `null` for the Fun-Union
@@ -63,6 +67,13 @@ export function ControlPanel({
   // the bespoke `.control-panel-toggle` header it used to draw is gone). Local-only state, matching
   // Advanced, which doesn't persist either.
   const [open, setOpen] = useState(false);
+  useEffect(() => {
+    if (revealPoseLibraryToken) {
+      setOpen(true);
+    } else if (poseReplayOpen === false) {
+      setOpen(false);
+    }
+  }, [revealPoseLibraryToken, poseReplayOpen]);
   if (!modes.length) {
     return null;
   }
@@ -117,10 +128,12 @@ export function ControlPanel({
             ) : null}
             <PoseLibraryPicker
               categoryFilter
+              extraPoses={extraPoses}
               loadUserPoses={loadUserPoses}
               onClear={onClearPoses}
               onToggle={onTogglePose}
               selectedIds={selectedPoseIds}
+              preferredCategory={preferredPoseCategory}
             />
             <p className="muted">
               Selecting poses generates one image per pose (overrides

--- a/apps/web/src/components/ControlPanel.test.jsx
+++ b/apps/web/src/components/ControlPanel.test.jsx
@@ -127,6 +127,17 @@ describe("ControlPanel (sc-8245 gating + toggle)", () => {
     expect(tabLabels()).toEqual([]);
   });
 
+  it("auto-opens for a shared-workflow pose launch", async () => {
+    await render(
+      <ControlPanel
+        {...baseProps({ revealPoseLibraryToken: "launch-poses" })}
+      />,
+    );
+    const head = container.querySelector(".control-panel .advanced-section-toggle");
+    expect(head.getAttribute("aria-expanded")).toBe("true");
+    expect(container.querySelector(".pose-library")).not.toBeNull();
+  });
+
   it("shows all three tabs when the backbone supports pose+canny+depth", async () => {
     await renderExpanded(<ControlPanel {...baseProps()} />);
     expect(tabLabels()).toEqual(["Pose", "Canny", "Depth"]);

--- a/apps/web/src/components/PoseLibraryPicker.jsx
+++ b/apps/web/src/components/PoseLibraryPicker.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { usePoseLibrary } from "../poseLibrary.js";
 import { MAX_JOB_POSES } from "../poseSelection.js";
 
@@ -11,18 +11,31 @@ import { MAX_JOB_POSES } from "../poseSelection.js";
 //   * `categoryFilter` — one category grid at a time behind a wrapping chip row (design
 //     handoff sc-8245 Fix 2). Selections still persist ACROSS categories; only the visible
 //     grid swaps. Used by the Image Studio Structure Control panel to cap the panel height.
-export function PoseLibraryPicker({ selectedIds = [], onToggle, onClear, loadUserPoses, categoryFilter = false }) {
-  const { poses, categories, loading, error } = usePoseLibrary({ loadUserPoses });
+export function PoseLibraryPicker({
+  selectedIds = [],
+  onToggle,
+  onClear,
+  loadUserPoses,
+  extraPoses,
+  categoryFilter = false,
+  preferredCategory = null,
+}) {
+  const { poses, categories, loading, error } = usePoseLibrary({ loadUserPoses, extraPoses });
   // Which chip's grid is shown (categoryFilter layout only). Default to the design's
   // "standing" when present, else the first available category.
-  const [activeCategory, setActiveCategory] = useState("standing");
+  const [activeCategory, setActiveCategory] = useState(preferredCategory ?? "standing");
+  useEffect(() => {
+    if (preferredCategory) {
+      setActiveCategory(preferredCategory);
+    }
+  }, [preferredCategory]);
   const selected = new Set(selectedIds);
   const atPoseLimit = selected.size >= MAX_JOB_POSES;
 
-  if (loading) {
+  if (loading && !poses.length) {
     return <p className="muted">Loading pose library…</p>;
   }
-  if (error) {
+  if (error && !poses.length) {
     return <p className="inline-warning">Pose library unavailable: {error}</p>;
   }
   if (!poses.length) {
@@ -67,7 +80,17 @@ export function PoseLibraryPicker({ selectedIds = [], onToggle, onClear, loadUse
         }
         type="button"
       >
-        <img alt={pose.label} loading="lazy" src={pose.previewUrl ?? `/${pose.preview}`} />
+        {pose.previewUrl || pose.preview ? (
+          <img alt={pose.label} loading="lazy" src={pose.previewUrl ?? `/${pose.preview}`} />
+        ) : (
+          <span
+            aria-label={`${pose.label} preview unavailable`}
+            className="pose-thumb-placeholder"
+            role="img"
+          >
+            {pose.source === "workflow" ? "Shared workflow pose" : "Preview unavailable"}
+          </span>
+        )}
         <span className="pose-thumb-label">{pose.label}</span>
         {showCheck && isSelected ? (
           <span aria-hidden="true" className="pose-thumb-check">
@@ -83,6 +106,9 @@ export function PoseLibraryPicker({ selectedIds = [], onToggle, onClear, loadUse
     // chip/heading read nicely without a hardcoded map (user categories degrade gracefully).
     const labelFor = (category) => {
       const sample = poses.find((pose) => pose.category === category);
+      if (sample?.source === "workflow") {
+        return category;
+      }
       return sample?.label?.replace(/\s*\d+$/, "").trim() || category;
     };
     const active = categories.includes(activeCategory) ? activeCategory : categories[0];
@@ -90,6 +116,8 @@ export function PoseLibraryPicker({ selectedIds = [], onToggle, onClear, loadUse
 
     return (
       <div className="pose-library category-filter">
+        {loading ? <p className="muted">Loading saved pose library…</p> : null}
+        {error ? <p className="inline-warning">Saved pose library unavailable: {error}</p> : null}
         {toolbar}
         <div className="pose-chip-row">
           {categories.map((category) => {
@@ -124,6 +152,8 @@ export function PoseLibraryPicker({ selectedIds = [], onToggle, onClear, loadUse
 
   return (
     <div className="pose-library">
+      {loading ? <p className="muted">Loading saved pose library…</p> : null}
+      {error ? <p className="inline-warning">Saved pose library unavailable: {error}</p> : null}
       {toolbar}
       {categories.map((category) => {
         const inCategory = poses.filter((pose) => pose.category === category);

--- a/apps/web/src/components/PoseLibraryPicker.live.test.jsx
+++ b/apps/web/src/components/PoseLibraryPicker.live.test.jsx
@@ -1,0 +1,61 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PoseLibraryPicker } from "./PoseLibraryPicker.jsx";
+
+describe("PoseLibraryPicker with the real pose-library hook", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("does not reload or loop when a parent rerenders without extra poses", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        poses: [
+          {
+            id: "standing-1",
+            label: "Standing 1",
+            category: "standing",
+            keypoints: [[0.5, 0.5]],
+            preview: "poses/standing-1.png",
+          },
+        ],
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const renderPicker = async (tick) => {
+      await act(async () => {
+        root.render(
+          <div data-tick={tick}>
+            <PoseLibraryPicker onToggle={vi.fn()} selectedIds={[]} />
+          </div>,
+        );
+      });
+      await act(async () => {});
+    };
+
+    await renderPicker(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[aria-label="Select pose Standing 1"]')).not.toBeNull();
+
+    await renderPicker(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(container.querySelector("[data-tick='2']")).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/PoseLibraryPicker.test.jsx
+++ b/apps/web/src/components/PoseLibraryPicker.test.jsx
@@ -4,6 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PoseLibraryPicker } from "./PoseLibraryPicker.jsx";
 
+const libraryMock = vi.hoisted(() => ({
+  state: { poses: [], categories: [], loading: false, error: null },
+}));
+
 const POSES = Array.from({ length: 65 }, (_, index) => ({
   id: `pose-${index}`,
   label: `Pose ${index}`,
@@ -13,12 +17,14 @@ const POSES = Array.from({ length: 65 }, (_, index) => ({
 }));
 
 vi.mock("../poseLibrary.js", () => ({
-  usePoseLibrary: () => ({
-    poses: POSES,
-    categories: ["test"],
-    loading: false,
-    error: null,
-  }),
+  usePoseLibrary: ({ extraPoses = [] } = {}) => {
+    const poses = [...libraryMock.state.poses, ...extraPoses];
+    return {
+      ...libraryMock.state,
+      poses,
+      categories: [...new Set(poses.map((pose) => pose.category))],
+    };
+  },
 }));
 
 describe("PoseLibraryPicker pose-count ceiling", () => {
@@ -30,6 +36,7 @@ describe("PoseLibraryPicker pose-count ceiling", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
+    libraryMock.state = { poses: POSES, categories: ["test"], loading: false, error: null };
   });
 
   afterEach(async () => {
@@ -67,5 +74,63 @@ describe("PoseLibraryPicker pose-count ceiling", () => {
       selected.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     expect(onToggle).toHaveBeenCalledWith("pose-0");
+  });
+
+  it.each([
+    ["loading", { loading: true, error: null }],
+    ["error", { loading: false, error: "offline" }],
+    ["empty", { loading: false, error: null }],
+  ])("keeps honest shared-workflow placeholders visible while the saved library is %s", async (_name, state) => {
+    libraryMock.state = { poses: [], categories: [], ...state };
+    const shared = {
+      id: "workflow:launch:0",
+      label: "Shared workflow pose 1",
+      category: "Shared workflow",
+      keypoints: [[1, 2]],
+      source: "workflow",
+    };
+    await act(async () => {
+      root.render(
+        <PoseLibraryPicker
+          extraPoses={[shared]}
+          onToggle={vi.fn()}
+          preferredCategory="Shared workflow"
+          selectedIds={[shared.id]}
+        />,
+      );
+    });
+
+    expect(container.querySelector('[aria-label="Shared workflow pose 1 preview unavailable"]')).not.toBeNull();
+    expect(container.textContent).toContain("Shared workflow pose");
+  });
+
+  it("opens the Shared workflow category and keeps all 65 selected legacy records deselectable", async () => {
+    libraryMock.state = { poses: [], categories: [], loading: false, error: null };
+    const shared = Array.from({ length: 65 }, (_, index) => ({
+      id: `workflow:legacy:${index}`,
+      label: `Shared workflow pose ${index + 1}`,
+      category: "Shared workflow",
+      keypoints: [[index, index]],
+      source: "workflow",
+    }));
+    const onToggle = vi.fn();
+    await act(async () => {
+      root.render(
+        <PoseLibraryPicker
+          categoryFilter
+          extraPoses={shared}
+          onToggle={onToggle}
+          preferredCategory="Shared workflow"
+          selectedIds={shared.map((pose) => pose.id)}
+        />,
+      );
+    });
+
+    expect(container.querySelector(".pose-category-name").textContent).toBe("Shared workflow");
+    expect(container.querySelectorAll(".pose-thumb")).toHaveLength(65);
+    const last = container.querySelector('[aria-label="Deselect pose Shared workflow pose 65"]');
+    expect(last.disabled).toBe(false);
+    await act(async () => last.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(onToggle).toHaveBeenCalledWith("workflow:legacy:64");
   });
 });

--- a/apps/web/src/components/WorkflowDropPanel.jsx
+++ b/apps/web/src/components/WorkflowDropPanel.jsx
@@ -60,15 +60,32 @@ export function WorkflowDropPanel({
   // The project's images, offered by the input pickers.
   assets = [],
 }) {
+  // `poseReplayIssue` is the live-catalog result. Keep the older missing-model inputs coherent for
+  // direct callers: before this field existed they expressed the same blocked state as required +
+  // no substitute + detail.
+  const poseReplayIssue =
+    missing.poseReplayIssue ??
+    (missing.poseSubstituteRequired && !missing.substituteModelId
+      ? (missing.poseSubstituteDetail ?? "")
+      : "");
   // Hooks run before the early returns below can skip them — a `return null` above a `useMemo` is
   // the hook-order violation React refuses at runtime.
   const draft = React.useMemo(
     () => ({
       report: offer?.share ? (offer.report ?? null) : null,
       substituteModelId: missing.substituteModelId ?? "",
+      substituteModelIssue: missing.poseSubstituteDetail ?? "",
+      poseReplayIssue,
       inputPicks: missing.inputPicks ?? {},
     }),
-    [offer?.share, offer?.report, missing.substituteModelId, missing.inputPicks],
+    [
+      offer?.share,
+      offer?.report,
+      missing.substituteModelId,
+      missing.poseSubstituteDetail,
+      poseReplayIssue,
+      missing.inputPicks,
+    ],
   );
   const validity = useValidation(workflowReplayValidation, draft, undefined);
   if (!offer) {
@@ -96,7 +113,15 @@ export function WorkflowDropPanel({
   }
 
   const resolutionLabel = workflowResolutionLabel(share);
-  const settings = workflowSettingRows(share, report);
+  const settings = workflowSettingRows(share, report).map((row) =>
+    row.key === "poses" && poseReplayIssue
+      ? {
+          ...row,
+          restored: false,
+          detail: poseReplayIssue,
+        }
+      : row,
+  );
   const batchCount = Number(share.count);
   const producer = share.producer ?? {};
   // A model this install cannot resolve is NOT prefilled — the studio keeps the model it is
@@ -160,7 +185,22 @@ export function WorkflowDropPanel({
         </div>
       ) : null}
 
-      <WorkflowResolutionReport report={report} share={share} />
+      <WorkflowResolutionReport
+        replayNotRestored={
+          poseReplayIssue
+            ? [
+                {
+                  kind: "advanced",
+                  key: "poses",
+                  title: "Setting — Poses",
+                  detail: poseReplayIssue,
+                },
+              ]
+            : []
+        }
+        report={report}
+        share={share}
+      />
 
       {/* The repairs, when there are any. Renders NOTHING for a fully-resolvable recipe with no
           input images — no empty container, no zero-state line — so a working case looks exactly
@@ -174,6 +214,8 @@ export function WorkflowDropPanel({
         onInstall={missing.onInstall}
         onPickInput={missing.onPickInput}
         onSubstituteModel={missing.onSubstituteModel}
+        poseSubstituteDetail={missing.poseSubstituteDetail}
+        poseSubstituteRequired={missing.poseSubstituteRequired}
         report={report}
         substituteModelId={missing.substituteModelId}
       />

--- a/apps/web/src/components/WorkflowDropPanel.test.jsx
+++ b/apps/web/src/components/WorkflowDropPanel.test.jsx
@@ -292,10 +292,10 @@ describe("WorkflowDropPanel — what will not be restored", () => {
     expect(settingRow("PiD decoder").querySelector(".workflow-drop-setting-mark")).toBeNull();
     expect(settingRow("Tile ControlNet").textContent).toContain("not restored");
     expect(settingRow("Poses").textContent).toContain("3 poses");
-    expect(settingRow("Poses").textContent).toContain("not restored");
+    expect(settingRow("Poses").querySelector(".workflow-drop-setting-mark")).toBeNull();
   });
 
-  it("folds them into the verdict, so a fully installed recipe still reads as lossy", async () => {
+  it("treats replayable poses as restored in an otherwise complete recipe", async () => {
     await render({
       offer: {
         share: share({ advanced: { steps: 28, poses: [{ keypoints: [] }] } }),
@@ -304,12 +304,10 @@ describe("WorkflowDropPanel — what will not be restored", () => {
       },
     });
 
-    // The report itself is clean — the model is installed and nothing was omitted — so without
-    // this clause the panel would say "Everything this recipe names is installed here." over a
-    // pose selection that is about to be dropped on the floor.
-    expect(document.body.textContent).toContain("1 setting will not be restored");
-    expect(document.querySelector(".workflow-req-verdict.ok")).toBeNull();
-    expect(document.body.textContent).toContain("Poses — 1 pose");
+    expect(document.body.textContent).toContain("Everything this recipe names is installed here.");
+    expect(document.querySelector(".workflow-req-verdict.ok")).not.toBeNull();
+    expect(settingRow("Poses").textContent).toContain("1 pose");
+    expect(settingRow("Poses").textContent).not.toContain("not restored");
   });
 
   it("says nothing extra when every setting in the file lands somewhere", async () => {
@@ -472,6 +470,106 @@ describe("WorkflowDropPanel — what it needs from the user", () => {
     // The "keeps the model it is already on" warning is now false, and must not be shown.
     expect(document.body.textContent).not.toContain("keeps the model it is already on");
   });
+
+  it("does not call poses restored when an unknown model has no pose-capable substitute", async () => {
+    const poseConstraint =
+      "This workflow includes poses, but no installed model can run pose control for it.";
+    await render({
+      offer: {
+        share: share({
+          model: "someones_private_model",
+          advanced: { poses: [{ keypoints: [[0.2, 0.8]] }] },
+        }),
+        report: report({
+          runnable: false,
+          model: { slug: "someones_private_model", state: "missing", detail: "Not installed." },
+        }),
+        error: "",
+      },
+      missing: {
+        models: [],
+        poseSubstituteRequired: true,
+        poseSubstituteDetail: poseConstraint,
+        substituteModelId: "",
+      },
+    });
+
+    const poseRow = [...document.querySelectorAll(".workflow-drop-settings li")].find((node) =>
+      node.textContent.startsWith("Poses"),
+    );
+    expect(poseRow.textContent).toContain("not restored");
+    expect(poseRow.querySelector(".workflow-drop-setting-mark").title).toBe(poseConstraint);
+    const picker = document.querySelector("#workflow-substitute-model");
+    expect(picker.disabled).toBe(true);
+    expect([...picker.options].map((option) => option.textContent)).toEqual([
+      "No pose-capable model available",
+    ]);
+    expect(document.body.textContent).toContain(poseConstraint);
+    expect(cta().disabled).toBe(true);
+  });
+
+  it("calls poses restored only after the user chooses an offered pose-capable substitute", async () => {
+    await render({
+      offer: {
+        share: share({
+          model: "private_pose_model",
+          advanced: { poses: [{ keypoints: [[0.2, 0.8]] }] },
+        }),
+        report: report({
+          runnable: false,
+          model: { slug: "private_pose_model", state: "missing", detail: "Not installed." },
+        }),
+        error: "",
+      },
+      missing: {
+        models: [{ id: "fun_union", name: "Fun Union" }],
+        poseSubstituteRequired: true,
+        poseSubstituteDetail:
+          "This workflow includes poses. Only installed models with pose control for this workflow are offered.",
+        substituteModelId: "fun_union",
+      },
+    });
+
+    const poseRow = [...document.querySelectorAll(".workflow-drop-settings li")].find((node) =>
+      node.textContent.startsWith("Poses"),
+    );
+    expect(poseRow.querySelector(".workflow-drop-setting-mark")).toBeNull();
+    expect(document.querySelector("#workflow-substitute-model").value).toBe("fun_union");
+    expect(cta().disabled).toBe(false);
+  });
+
+  it.each(["text_to_image", "character_image"])(
+    "marks poses unrestored and makes no everything-restored claim for an incompatible resolved %s model",
+    async (mode) => {
+      const capabilityError =
+        "Krea 2 Turbo is installed, but it cannot replay poses for this workflow mode.";
+      await render({
+        offer: {
+          share: share({
+            mode,
+            advanced: { poses: [{ keypoints: [[0.2, 0.8]] }] },
+          }),
+          report: report(),
+          error: "",
+        },
+        missing: {
+          poseReplayIssue: capabilityError,
+          poseSubstituteRequired: true,
+          poseSubstituteDetail: capabilityError,
+        },
+      });
+
+      const poseRow = [...document.querySelectorAll(".workflow-drop-settings li")].find((node) =>
+        node.textContent.startsWith("Poses"),
+      );
+      expect(poseRow.textContent).toContain("not restored");
+      expect(document.body.textContent).toContain(capabilityError);
+      expect(document.body.textContent).not.toContain(
+        "Everything this recipe names is installed here.",
+      );
+      expect(cta().disabled).toBe(true);
+    },
+  );
 
   it("blocks until every input image the recipe needs has been picked", async () => {
     const inputs = report({

--- a/apps/web/src/components/WorkflowMissingInputs.jsx
+++ b/apps/web/src/components/WorkflowMissingInputs.jsx
@@ -76,6 +76,8 @@ export function WorkflowMissingInputs({
   onInstall,
   substituteModelId = "",
   onSubstituteModel,
+  poseSubstituteRequired = false,
+  poseSubstituteDetail = "",
   inputPicks = {},
   onPickInput,
 }) {
@@ -111,11 +113,16 @@ export function WorkflowMissingInputs({
             Model to use instead
           </label>
           <select
+            disabled={poseSubstituteRequired && models.length === 0}
             id="workflow-substitute-model"
             onChange={(event) => onSubstituteModel?.(event.target.value)}
             value={substituteModelId}
           >
-            <option value="">Choose a model…</option>
+            <option value="">
+              {poseSubstituteRequired && models.length === 0
+                ? "No pose-capable model available"
+                : "Choose a model…"}
+            </option>
             {models.map((model) => (
               <option key={model.id} value={model.id}>
                 {model.name ?? model.id}
@@ -126,6 +133,9 @@ export function WorkflowMissingInputs({
             {report.model?.detail} Whichever you pick makes a different image from the one you
             were sent — nothing is chosen for you.
           </p>
+          {poseSubstituteDetail ? (
+            <p className="workflow-fix-detail">{poseSubstituteDetail}</p>
+          ) : null}
         </div>
       ) : null}
 

--- a/apps/web/src/components/WorkflowResolutionReport.jsx
+++ b/apps/web/src/components/WorkflowResolutionReport.jsx
@@ -65,8 +65,11 @@ function Row({ title, state, detail }) {
 
 // The verdict sentence. Two independent axes, so three sentences rather than a boolean: what this
 // install cannot RESOLVE, and what this studio cannot APPLY. A recipe can fail either alone.
-function verdictText({ report, blocking, notRestored }) {
+function verdictText({ report, blocking, notRestored, replayBlocked }) {
   const lost = `${notRestored.length} setting${notRestored.length === 1 ? "" : "s"} will not be restored`;
+  if (replayBlocked) {
+    return `This recipe cannot be replayed as configured on this install. ${lost[0].toUpperCase()}${lost.slice(1)}.`;
+  }
   if (!report.runnable) {
     const blocked = `${blocking.length} thing${blocking.length === 1 ? "" : "s"} in this recipe cannot be reproduced on this install.`;
     return notRestored.length ? `${blocked} ${lost[0].toUpperCase()}${lost.slice(1)}.` : blocked;
@@ -81,7 +84,7 @@ function verdictText({ report, blocking, notRestored }) {
   return `Everything this recipe names is installed here.${inputClause}`;
 }
 
-export function WorkflowResolutionReport({ report, share = null }) {
+export function WorkflowResolutionReport({ report, share = null, replayNotRestored = [] }) {
   if (!report) {
     return (
       <p className="workflow-req-empty">
@@ -91,7 +94,12 @@ export function WorkflowResolutionReport({ report, share = null }) {
     );
   }
   const blocking = workflowUnresolved(report);
-  const notRestored = workflowNotRestored(share, report);
+  const notRestored = [...workflowNotRestored(share, report)];
+  for (const entry of replayNotRestored) {
+    if (!notRestored.some((existing) => existing.kind === entry.kind && existing.key === entry.key)) {
+      notRestored.push(entry);
+    }
+  }
   const model = report.model ?? null;
   const loras = report.loras ?? [];
   // A resolved `stylePreset` is rendered by the not-restored list below instead — "Ready" would be
@@ -105,7 +113,12 @@ export function WorkflowResolutionReport({ report, share = null }) {
   return (
     <div className="workflow-req">
       <p className={clean ? "workflow-req-verdict ok" : "workflow-req-verdict warn"}>
-        {verdictText({ report, blocking, notRestored })}
+        {verdictText({
+          report,
+          blocking,
+          notRestored,
+          replayBlocked: replayNotRestored.length > 0,
+        })}
       </p>
       <ul className="workflow-req-list">
         {model ? (

--- a/apps/web/src/hooks/useWorkflowDrop.assetWorkflow.test.jsx
+++ b/apps/web/src/hooks/useWorkflowDrop.assetWorkflow.test.jsx
@@ -22,6 +22,7 @@ vi.mock("../api.js", async () => {
 });
 
 import { ApiError } from "../api.js";
+import { WorkflowDropPanel } from "../components/WorkflowDropPanel.jsx";
 import { useWorkflowDrop } from "./useWorkflowDrop.js";
 
 const IMPORTED_ASSET = { id: "asset_1", extra: { importedWorkflow: { sceneworksWorkflow: "image" } } };
@@ -79,9 +80,30 @@ describe("useWorkflowDrop — the imported-asset offer", () => {
     return null;
   }
 
+  function PanelHarness(props) {
+    hook = useWorkflowDrop(props);
+    return (
+      <WorkflowDropPanel
+        canImport
+        importState={hook.importState}
+        missing={hook.missing}
+        offer={hook.offer}
+        onDismiss={hook.dismiss}
+        onImport={hook.importImage}
+        onUse={hook.useWorkflow}
+      />
+    );
+  }
+
   const render = async (props) => {
     await act(async () =>
       root.render(<Harness enabled projectId="project_1" token="t" {...props} />),
+    );
+  };
+
+  const renderPanel = async (props) => {
+    await act(async () =>
+      root.render(<PanelHarness enabled projectId="project_1" token="t" {...props} />),
     );
   };
 
@@ -258,6 +280,244 @@ describe("useWorkflowDrop — the imported-asset offer", () => {
     await render({ launchRecipe, models: [] });
     await act(async () => hook.useWorkflow());
     expect(launchRecipe.mock.calls[0][0].recipe.model).toBeUndefined();
+  });
+
+  it("offers and keeps only pose-capable substitutes for a pose-bearing workflow", async () => {
+    const body = workflowBody({
+      model: { slug: "private_pose_model", state: "missing", detail: "Not installed." },
+    });
+    body.workflow.model = "private_pose_model";
+    body.workflow.advanced = { poses: [{ keypoints: [[0.3, 0.7]] }] };
+    fetchAssetWorkflow.mockResolvedValue(body);
+    const nonPose = { id: "z_image_turbo", name: "Z-Image Turbo", ui: {} };
+    const poseCapable = {
+      id: "fun_union",
+      name: "Fun Union",
+      ui: { controlModes: ["pose", "canny"] },
+    };
+    const launchRecipe = vi.fn().mockResolvedValue({ ok: true });
+    await render({ launchRecipe, models: [nonPose, poseCapable] });
+    await act(async () => hook.offerAssetWorkflow(IMPORTED_ASSET));
+
+    expect(hook.missing.models.map((model) => model.id)).toEqual(["fun_union"]);
+    expect(hook.missing.poseSubstituteRequired).toBe(true);
+    expect(hook.missing.poseSubstituteDetail).toContain("pose control");
+
+    await act(async () => hook.missing.onSubstituteModel("z_image_turbo"));
+    expect(hook.missing.substituteModelId).toBe("");
+    await act(async () => hook.missing.onSubstituteModel("fun_union"));
+    expect(hook.missing.substituteModelId).toBe("fun_union");
+    await act(async () => hook.useWorkflow());
+    expect(launchRecipe.mock.calls[0][0].recipe.model).toBe("fun_union");
+  });
+
+  it.each([
+    {
+      label: "text",
+      mode: "text_to_image",
+      model: {
+        id: "krea_2_turbo",
+        name: "Krea 2 Turbo",
+        capabilities: ["text_to_image"],
+        ui: { controlModes: ["canny"] },
+      },
+    },
+    {
+      label: "character",
+      mode: "character_image",
+      model: {
+        id: "krea_2_turbo",
+        name: "Krea 2 Turbo",
+        capabilities: ["character_image"],
+        ui: { poseLibrary: false },
+      },
+    },
+  ])(
+    "blocks a resolved $label model whose live catalog row cannot replay poses",
+    async ({ mode, model }) => {
+      const body = workflowBody({ model: RESOLVED_MODEL, runnable: true });
+      body.workflow.mode = mode;
+      body.workflow.advanced = { poses: [{ keypoints: [[0.3, 0.7]] }] };
+      fetchAssetWorkflow.mockResolvedValue(body);
+      const launchRecipe = vi.fn().mockResolvedValue({ ok: true });
+      await render({ launchRecipe, models: [model] });
+      await act(async () => hook.offerAssetWorkflow(IMPORTED_ASSET));
+
+      expect(hook.missing.poseReplayIssue).toMatch(/cannot replay poses/i);
+      expect(hook.missing.poseSubstituteRequired).toBe(true);
+      await act(async () => hook.useWorkflow());
+      expect(launchRecipe).not.toHaveBeenCalled();
+    },
+  );
+
+  it("blocks a resolved edit-only model even when it advertises strict pose control", async () => {
+    const body = workflowBody({ model: RESOLVED_MODEL, runnable: true });
+    body.workflow.advanced = { poses: [{ keypoints: [[0.3, 0.7]] }] };
+    fetchAssetWorkflow.mockResolvedValue(body);
+    const launchRecipe = vi.fn().mockResolvedValue({ ok: true });
+    await render({
+      launchRecipe,
+      models: [
+        {
+          id: "krea_2_turbo",
+          name: "Krea 2 Turbo",
+          capabilities: ["edit_image"],
+          ui: { controlModes: ["pose"] },
+        },
+      ],
+    });
+    await act(async () => hook.offerAssetWorkflow(IMPORTED_ASSET));
+
+    expect(hook.missing.poseReplayIssue).toMatch(/cannot replay poses/i);
+    await act(async () => hook.useWorkflow());
+    expect(launchRecipe).not.toHaveBeenCalled();
+  });
+
+  it("does not offer an edit-only pose-control model as a text pose substitute", async () => {
+    const body = workflowBody({
+      model: { slug: "private_pose_model", state: "missing", detail: "Not installed." },
+    });
+    body.workflow.model = "private_pose_model";
+    body.workflow.advanced = { poses: [{ keypoints: [[0.3, 0.7]] }] };
+    fetchAssetWorkflow.mockResolvedValue(body);
+    await render({
+      models: [
+        {
+          id: "edit_pose",
+          capabilities: ["edit_image"],
+          ui: { controlModes: ["pose"] },
+        },
+      ],
+    });
+    await act(async () => hook.offerAssetWorkflow(IMPORTED_ASSET));
+
+    expect(hook.missing.models).toEqual([]);
+    expect(hook.missing.poseReplayIssue).toMatch(/no installed model/i);
+  });
+
+  it("marks poses unrestored and refuses a resolved model whose pose feature is Mac-blocked", async () => {
+    const body = workflowBody({ model: RESOLVED_MODEL, runnable: true });
+    body.workflow.advanced = { poses: [{ keypoints: [[0.3, 0.7]] }] };
+    fetchAssetWorkflow.mockResolvedValue(body);
+    const launchRecipe = vi.fn().mockResolvedValue({ ok: true });
+    await renderPanel({
+      launchRecipe,
+      macCapabilities: { macGatingActive: true },
+      models: [
+        {
+          id: "krea_2_turbo",
+          capabilities: ["text_to_image"],
+          ui: { controlModes: ["pose"] },
+          macSupport: { supported: true, features: { pose: false } },
+        },
+      ],
+    });
+    await act(async () => hook.offerAssetWorkflow(IMPORTED_ASSET));
+
+    const poseRow = [...document.querySelectorAll(".workflow-drop-settings li")].find((node) =>
+      node.textContent.startsWith("Poses"),
+    );
+    expect(poseRow.textContent).toContain("not restored");
+    expect(document.querySelector(".workflow-drop-actions .primary").disabled).toBe(true);
+    await act(async () => hook.useWorkflow());
+    expect(launchRecipe).not.toHaveBeenCalled();
+  });
+
+  it("excludes a Mac-blocked pose substitute and refuses the unresolved replay", async () => {
+    const body = workflowBody({
+      model: { slug: "private_pose_model", state: "missing", detail: "Not installed." },
+    });
+    body.workflow.model = "private_pose_model";
+    body.workflow.advanced = { poses: [{ keypoints: [[0.3, 0.7]] }] };
+    fetchAssetWorkflow.mockResolvedValue(body);
+    const launchRecipe = vi.fn().mockResolvedValue({ ok: true });
+    await renderPanel({
+      launchRecipe,
+      macCapabilities: { macGatingActive: true },
+      models: [
+        {
+          id: "strict_pose",
+          capabilities: ["text_to_image"],
+          ui: { controlModes: ["pose"] },
+          macSupport: { supported: true, features: { pose: false } },
+        },
+      ],
+    });
+    await act(async () => hook.offerAssetWorkflow(IMPORTED_ASSET));
+
+    expect(hook.missing.models).toEqual([]);
+    expect(document.querySelector("#workflow-substitute-model").disabled).toBe(true);
+    expect(document.querySelector(".workflow-drop-actions .primary").disabled).toBe(true);
+    await act(async () => hook.useWorkflow());
+    expect(launchRecipe).not.toHaveBeenCalled();
+  });
+
+  it("blocks a resolved pose model that is absent from the live studio catalog", async () => {
+    const body = workflowBody({ model: RESOLVED_MODEL, runnable: true });
+    body.workflow.advanced = { poses: [{ keypoints: [[0.3, 0.7]] }] };
+    fetchAssetWorkflow.mockResolvedValue(body);
+    const launchRecipe = vi.fn().mockResolvedValue({ ok: true });
+    await render({ launchRecipe, models: [] });
+    await act(async () => hook.offerAssetWorkflow(IMPORTED_ASSET));
+
+    expect(hook.missing.poseReplayIssue).toMatch(/no longer available.*live model catalog/i);
+    await act(async () => hook.useWorkflow());
+    expect(launchRecipe).not.toHaveBeenCalled();
+  });
+
+  it("rechecks an explicit pose substitute against the live catalog at click time", async () => {
+    const body = workflowBody({
+      model: { slug: "private_pose_model", state: "missing", detail: "Not installed." },
+    });
+    body.workflow.model = "private_pose_model";
+    body.workflow.advanced = { poses: [{ keypoints: [[0.3, 0.7]] }] };
+    fetchAssetWorkflow.mockResolvedValue(body);
+    const launchRecipe = vi.fn().mockResolvedValue({ ok: true });
+    const compatible = {
+      id: "fun_union",
+      name: "Fun Union",
+      capabilities: ["text_to_image"],
+      ui: { controlModes: ["pose"] },
+    };
+    await render({ launchRecipe, models: [compatible] });
+    await act(async () => hook.offerAssetWorkflow(IMPORTED_ASSET));
+    await act(async () => hook.missing.onSubstituteModel("fun_union"));
+    expect(hook.missing.poseReplayIssue).toBe("");
+
+    // The catalog keeps the id but withdraws the capability before the user clicks. The original
+    // remains missing, so neither silently falling back nor trusting the stale pick is safe.
+    await render({
+      launchRecipe,
+      models: [{ ...compatible, ui: { controlModes: ["depth"] } }],
+    });
+    await act(async () => hook.useWorkflow());
+    expect(hook.offer.launchError).toMatch(/no longer available with pose control/i);
+    expect(launchRecipe).not.toHaveBeenCalled();
+  });
+
+  it("rechecks pose capability when an installable model resolves to an incompatible live row", async () => {
+    const body = workflowBody();
+    body.workflow.advanced = { poses: [{ keypoints: [[0.3, 0.7]] }] };
+    fetchAssetWorkflow.mockResolvedValueOnce(body);
+    const launchRecipe = vi.fn().mockResolvedValue({ ok: true });
+    const incompatible = {
+      id: "krea_2_turbo",
+      name: "Krea 2 Turbo",
+      capabilities: ["text_to_image"],
+      ui: { controlModes: ["depth"] },
+    };
+    await render({ catalogRevision: "missing", launchRecipe, models: [] });
+    await act(async () => hook.offerAssetWorkflow(IMPORTED_ASSET));
+
+    fetchAssetWorkflow.mockResolvedValueOnce(
+      workflowBody({ model: RESOLVED_MODEL, runnable: true }),
+    );
+    await render({ catalogRevision: "resolved", launchRecipe, models: [incompatible] });
+
+    expect(hook.offer.report.model.state).toBe("resolved");
+    expect(hook.missing.poseReplayIssue).toMatch(/cannot replay poses/i);
+    await act(async () => hook.useWorkflow());
+    expect(launchRecipe).not.toHaveBeenCalled();
   });
 
   it("carries the picked images to the launch, source and references apart", async () => {

--- a/apps/web/src/hooks/useWorkflowDrop.js
+++ b/apps/web/src/hooks/useWorkflowDrop.js
@@ -3,8 +3,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { fetchAssetWorkflow, inspectWorkflowFile, isAbortError } from "../api.js";
 import {
   keptSubstituteModelId,
+  workflowPoseReplayCapability,
   pickedReferenceAssetIds,
   pickedSourceAssetId,
+  workflowHasPoseSelection,
+  workflowSubstituteModels,
 } from "../workflowReplayValidation.js";
 import {
   looksLikeWorkflowCandidate,
@@ -86,6 +89,8 @@ export function useWorkflowDrop({
   // sc-15952. The installed models the studio would actually offer, so a substitute the user picked
   // is re-checked against the live list on every render rather than trusted once at pick time.
   models = [],
+  // The same live Mac/MLX gate Image Studio applies to its model picker and pose controls.
+  macCapabilities = null,
   // A cheap identity for "what this install has on disk", derived by App from the model and LoRA
   // catalogs. It changes when a download completes, because `useJobEvents` refetches both catalogs
   // on a completed `model_download` / `lora_download` — so re-resolution rides the app's existing
@@ -123,6 +128,30 @@ export function useWorkflowDrop({
   // The open offer, readable from an effect that must not re-run when it changes.
   const offerRef = useRef(null);
   offerRef.current = offer;
+
+  const hasPoseSelection = workflowHasPoseSelection(offer?.share);
+  const substituteModels = useMemo(
+    () =>
+      workflowSubstituteModels(
+        hasPoseSelection ? offer?.share : null,
+        models,
+        macCapabilities,
+      ),
+    [hasPoseSelection, offer?.share, models, macCapabilities],
+  );
+  const poseReplay = useMemo(
+    () =>
+      workflowPoseReplayCapability({
+        share: offer?.share,
+        report: offer?.report,
+        substituteModelId: fixes.substituteModelId,
+        models,
+        macCapabilities,
+      }),
+    [offer?.share, offer?.report, fixes.substituteModelId, models, macCapabilities],
+  );
+  const poseSubstituteRequired = hasPoseSelection && !poseReplay.ready;
+  const poseSubstituteDetail = poseReplay.issue;
 
   // Abandon whatever is running and take the next ticket. Every supersede goes through here so
   // there is one place that can forget to abort.
@@ -458,10 +487,26 @@ export function useWorkflowDrop({
     if (!current?.share || typeof launchRecipe !== "function") {
       return;
     }
+    // Defense in depth for a catalog/capability change at the click boundary. The panel's CTA is
+    // driven by the same result on render, but an imperative caller or a click racing a catalog
+    // refresh must not launch a pose recipe through a model that can no longer consume it.
+    const clickPoseReplay = workflowPoseReplayCapability({
+      share: current.share,
+      report: current.report,
+      substituteModelId: fixes.substituteModelId,
+      models,
+      macCapabilities,
+    });
+    if (!clickPoseReplay.ready) {
+      setOffer((existing) =>
+        existing ? { ...existing, launchError: clickPoseReplay.issue } : existing,
+      );
+      return;
+    }
     const recipe = recipeFromWorkflowShare(current.share, current.report, {
       // Re-checked here as well as in the panel: the catalog can change between the pick and the
       // click, and a substitute the studio's list no longer offers would seed a blank control.
-      substituteModelId: keptSubstituteModelId(fixes.substituteModelId, models),
+      substituteModelId: keptSubstituteModelId(fixes.substituteModelId, substituteModels),
       referenceAssetIds: pickedReferenceAssetIds(current.report, fixes.inputPicks),
     });
     const outcome = await launchRecipe({
@@ -479,7 +524,16 @@ export function useWorkflowDrop({
       return;
     }
     dismiss();
-  }, [offer, launchRecipe, dismiss, fixes.substituteModelId, fixes.inputPicks, models]);
+  }, [
+    offer,
+    launchRecipe,
+    dismiss,
+    fixes.substituteModelId,
+    fixes.inputPicks,
+    substituteModels,
+    models,
+    macCapabilities,
+  ]);
 
   // "Import the image too" — the ordinary upload path, which is what records
   // `extra.importedWorkflow` on the asset (sc-15949). The panel stays open on success so the
@@ -502,24 +556,30 @@ export function useWorkflowDrop({
   // drift out of step with each other.
   const missing = useMemo(
     () => ({
-      models,
+      models: substituteModels,
       installing: fixes.installing,
       installed: queued,
       installFailed,
       onInstall: installRequirement,
-      substituteModelId: keptSubstituteModelId(fixes.substituteModelId, models),
+      substituteModelId: keptSubstituteModelId(fixes.substituteModelId, substituteModels),
+      poseSubstituteRequired,
+      poseSubstituteDetail,
+      poseReplayIssue: poseReplay.issue,
       onSubstituteModel: chooseSubstituteModel,
       inputPicks: fixes.inputPicks,
       onPickInput: pickInput,
     }),
     [
-      models,
+      substituteModels,
       fixes,
       queued,
       installFailed,
       installRequirement,
       chooseSubstituteModel,
       pickInput,
+      poseSubstituteRequired,
+      poseSubstituteDetail,
+      poseReplay.issue,
     ],
   );
 

--- a/apps/web/src/poseLibrary.js
+++ b/apps/web/src/poseLibrary.js
@@ -16,6 +16,46 @@ export const GLOBAL_POSES_PROJECT_ID = "project_global_poses";
 //    create/trash poses). Optional + best-effort: any failure degrades to built-ins.
 // Selected poses' keypoints (+ optional hands/face) ride advanced.poses on a job.
 let builtinCache = null;
+const EMPTY_EXTRA_POSES = Object.freeze([]);
+
+export const WORKFLOW_POSE_CATEGORY = "Shared workflow";
+
+// Rehydrate sanitized shared-workflow coordinates as ordinary pose-library records. These
+// records deliberately live only in the Image Studio launch that created them: they are never
+// written to the builtin cache or the reserved user-pose project. Index-based ids preserve two
+// identical poses as two independently selectable outputs.
+export function workflowPoseRecords(poses, launchId) {
+  if (!Array.isArray(poses)) {
+    return [];
+  }
+  const launchKey = String(launchId ?? "unknown");
+  return poses.map((pose, index) => ({
+    id: `workflow:${launchKey}:${index}`,
+    label: `Shared workflow pose ${index + 1}`,
+    category: WORKFLOW_POSE_CATEGORY,
+    keypoints: pose?.keypoints ?? [],
+    ...(pose?.hands !== undefined ? { hands: pose.hands } : {}),
+    ...(pose?.face !== undefined ? { face: pose.face } : {}),
+    source: "workflow",
+  }));
+}
+
+// The ordinary request projection used for every library source. Keeping this beside the
+// transient adapter makes the lossless coordinates → picker record → request round trip explicit.
+export function poseRecordToPayload(pose) {
+  return {
+    id: pose.id,
+    keypoints: pose.keypoints,
+    ...(pose.hands !== undefined ? { hands: pose.hands } : {}),
+    ...(pose.face !== undefined ? { face: pose.face } : {}),
+  };
+}
+
+function libraryFromPoses(poses, { loading = false, error = "" } = {}) {
+  const categories = [...new Set(poses.map((pose) => pose.category).filter(Boolean))];
+  const byId = Object.fromEntries(poses.map((pose) => [pose.id, pose]));
+  return { poses, categories, byId, loading, error };
+}
 
 export function loadBuiltinPoses() {
   if (!builtinCache) {
@@ -76,7 +116,7 @@ export function poseAssetToRecord(asset) {
   };
 }
 
-export async function loadPoseLibrary({ loadUserPoses } = {}) {
+export async function loadPoseLibrary({ loadUserPoses, extraPoses = [] } = {}) {
   const builtin = await loadBuiltinPoses();
   let user = [];
   if (typeof loadUserPoses === "function") {
@@ -86,10 +126,8 @@ export async function loadPoseLibrary({ loadUserPoses } = {}) {
       user = []; // best-effort: never let user-pose fetch failures hide the built-ins
     }
   }
-  const poses = [...builtin, ...user];
-  const categories = [...new Set(poses.map((pose) => pose.category).filter(Boolean))];
-  const byId = Object.fromEntries(poses.map((pose) => [pose.id, pose]));
-  return { poses, categories, byId };
+  const poses = [...builtin, ...user, ...(Array.isArray(extraPoses) ? extraPoses : [])];
+  return libraryFromPoses(poses);
 }
 
 // A memoized fetcher for the user's saved poses (the reserved global project),
@@ -108,16 +146,28 @@ export function useUserPoseLoader() {
 }
 
 // `loadUserPoses` should be a memoized (useCallback) async fetcher or undefined.
-export function usePoseLibrary({ loadUserPoses } = {}) {
-  const [state, setState] = useState({ poses: [], categories: [], byId: {}, loading: true, error: "" });
+export function usePoseLibrary({ loadUserPoses, extraPoses = EMPTY_EXTRA_POSES } = {}) {
+  const [state, setState] = useState(() =>
+    libraryFromPoses(Array.isArray(extraPoses) ? extraPoses : [], { loading: true }),
+  );
   useEffect(() => {
     let active = true;
-    loadPoseLibrary({ loadUserPoses })
+    const transient = Array.isArray(extraPoses) ? extraPoses : [];
+    setState(libraryFromPoses(transient, { loading: true }));
+    loadPoseLibrary({ loadUserPoses, extraPoses: transient })
       .then((library) => active && setState({ ...library, loading: false, error: "" }))
-      .catch((error) => active && setState({ poses: [], categories: [], byId: {}, loading: false, error: String(error.message ?? error) }));
+      .catch((error) =>
+        active &&
+        setState(
+          libraryFromPoses(transient, {
+            loading: false,
+            error: String(error.message ?? error),
+          }),
+        ),
+      );
     return () => {
       active = false;
     };
-  }, [loadUserPoses]);
+  }, [loadUserPoses, extraPoses]);
   return state;
 }

--- a/apps/web/src/poseLibrary.test.js
+++ b/apps/web/src/poseLibrary.test.js
@@ -1,0 +1,74 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { poseRecordToPayload, usePoseLibrary, workflowPoseRecords } from "./poseLibrary.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("workflowPoseRecords", () => {
+  it("creates unique session-only picker records without losing duplicate coordinates", () => {
+    const pose = {
+      keypoints: [[0.1, 0.2, 0.9]],
+      hands: [[[0.3, 0.4]]],
+      face: [[0.5, 0.6]],
+    };
+    const records = workflowPoseRecords([pose, pose], "launch-7");
+
+    expect(records).toHaveLength(2);
+    expect(records.map((record) => record.id)).toEqual([
+      "workflow:launch-7:0",
+      "workflow:launch-7:1",
+    ]);
+    expect(records.map(({ keypoints, hands, face }) => ({ keypoints, hands, face }))).toEqual([
+      pose,
+      pose,
+    ]);
+    expect(records.every((record) => record.source === "workflow")).toBe(true);
+    expect(records.map(poseRecordToPayload)).toEqual([
+      { id: "workflow:launch-7:0", ...pose },
+      { id: "workflow:launch-7:1", ...pose },
+    ]);
+  });
+
+  it("does not truncate a legacy selection above the current 64-pose ceiling", () => {
+    const poses = Array.from({ length: 65 }, (_, index) => ({ keypoints: [[index, index + 1]] }));
+    const records = workflowPoseRecords(poses, "legacy");
+
+    expect(records).toHaveLength(65);
+    expect(records.at(-1)).toMatchObject({
+      id: "workflow:legacy:64",
+      keypoints: [[64, 65]],
+    });
+  });
+
+  it("returns no records for an omitted pose setting", () => {
+    expect(workflowPoseRecords(undefined, "launch-8")).toEqual([]);
+  });
+});
+
+describe("usePoseLibrary", () => {
+  it("does not reload on a parent rerender when no extra poses were supplied", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ poses: [] }) }));
+    vi.stubGlobal("fetch", fetchMock);
+    const container = document.createElement("div");
+    const root = createRoot(container);
+
+    function Probe({ tick }) {
+      const state = usePoseLibrary();
+      return React.createElement("output", null, `${tick}:${state.loading}`);
+    }
+
+    await act(async () => root.render(React.createElement(Probe, { tick: 1 })));
+    await act(async () => {});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await act(async () => root.render(React.createElement(Probe, { tick: 2 })));
+    await act(async () => {});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => root.unmount());
+  });
+});

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -46,7 +46,13 @@ import {
   validateCaption,
 } from "../ideogramCaption.js";
 import { buildImageJobRequest, composeImageJobPrompt } from "../imageJobRequest.js";
-import { usePoseLibrary, useUserPoseLoader } from "../poseLibrary.js";
+import {
+  usePoseLibrary,
+  useUserPoseLoader,
+  workflowPoseRecords,
+  poseRecordToPayload,
+  WORKFLOW_POSE_CATEGORY,
+} from "../poseLibrary.js";
 
 const PROMPT_SUGGESTION_POOL = [
   "Barista pouring espresso, morning light",
@@ -386,6 +392,7 @@ export function ImageStudio() {
   // assets, the worker disappears").
   const latestAssets = recentImageAssets ?? latestImageAssets;
   const launchRequest = studioLaunch;
+  const nonRecipeLaunchIdRef = useRef(null);
   const trackedLocalJobs = imageLocalJobs;
   const onCancelJob = (job) => jobAction(job, "cancel");
   const onLocalJobCreated = (job) => rememberLocalGenerationJob("image", job);
@@ -498,6 +505,8 @@ export function ImageStudio() {
   // Pose library: selected pose ids. When non-empty, the job carries advanced.poses
   // (one image per pose) instead of the normal variations count. Transient (not saved).
   const [selectedPoseIds, setSelectedPoseIds] = useState([]);
+  const [workflowPoses, setWorkflowPoses] = useState([]);
+  const [poseLibraryReplayOpen, setPoseLibraryReplayOpen] = useState(false);
   // Strict-control panel (epic 8236, sc-8245). The selected control type (pose / canny / depth),
   // gated to the backbone's `ui.controlModes`. Pose reuses `selectedPoseIds`; canny/depth use a
   // control-image asset + a preprocess-vs-passthrough toggle. `controlScale` (advanced.controlScale)
@@ -567,7 +576,7 @@ export function ImageStudio() {
   // User-created poses (reserved global project) join the built-in library in both
   // the picker and the id→keypoints resolver below, so saved poses can generate.
   const loadUserPoses = useUserPoseLoader();
-  const { byId: poseById } = usePoseLibrary({ loadUserPoses });
+  const { byId: poseById } = usePoseLibrary({ loadUserPoses, extraPoses: workflowPoses });
   const [upscaleEnabled, setUpscaleEnabled] = useState(saved.upscaleEnabled ?? false);
   const [upscaleFactor, setUpscaleFactor] = useState(saved.upscaleFactor ?? 2);
   const [upscaleEngine, setUpscaleEngine] = useState(saved.upscaleEngine ?? "real-esrgan");
@@ -668,6 +677,19 @@ export function ImageStudio() {
     }
     if (launchRequest.recipe) {
       return;
+    }
+    const freshLaunch = nonRecipeLaunchIdRef.current !== launchRequest.id;
+    nonRecipeLaunchIdRef.current = launchRequest.id;
+    if (freshLaunch) {
+      // A fresh non-recipe launch is a new intent entering this keep-alive studio. Workflow pose
+      // records belong to the recipe launch that created them; carrying them into a character/edit
+      // launch would silently submit advanced.poses (and its face-restoration opt-in) from the last
+      // workflow. The id guard prevents an equivalent context-object rerender from clearing poses
+      // the user picked while editing this same launch.
+      setSelectedPoseIds([]);
+      setWorkflowPoses([]);
+      setPoseLibraryReplayOpen(false);
+      setFaceRestore(false);
     }
     if (launchRequest.characterId) {
       setMode(launchRequest.mode ?? "character_image");
@@ -829,7 +851,7 @@ export function ImageStudio() {
       ? selectedPoseIds
           .map((id) => poseById[id])
           .filter(Boolean)
-          .map((pose) => ({ id: pose.id, keypoints: pose.keypoints }))
+          .map(poseRecordToPayload)
       : [];
   const controlActive = showControlPanel && Boolean(activeControlMode);
   const controlIsImageMode = controlActive && activeControlMode !== "pose";
@@ -1034,6 +1056,8 @@ export function ImageStudio() {
     setTrueCfgScale(typeof ui.variationStrength?.default === "number" ? ui.variationStrength.default : 4.0);
     setViewAngle("");
     setSelectedPoseIds([]);
+    setWorkflowPoses([]);
+    setPoseLibraryReplayOpen(false);
     // Re-gate the strict-control panel to the new backbone: snap the control type to a supported mode
     // (an unsupported pick — e.g. canny on a pose-only backbone — resets to the first supported one),
     // reset the control-scale to the model's manifest default, and clear a stale control image.
@@ -1554,7 +1578,10 @@ export function ImageStudio() {
     const resolutionFromRecipe = recipeResolution(recipe);
     const { loraIds, loraWeights: loraWeightMap } = recipeLoraSelection(recipe);
 
-    skipReferenceTuningReset.current = true;
+    // Arm the model-change reset skip only when this recipe actually changes the model. A
+    // same-model recipe never triggers that effect; leaving `true` behind would make the NEXT
+    // manual model switch consume a stale skip and retain this recipe's transient pose records.
+    skipReferenceTuningReset.current = Boolean(recipe.model && recipe.model !== model);
     // A recipe injects its own reference tuning below (setIpAdapterScale/…), so disarm the
     // fresh-mount declared-defaults resolver (sc-12034) — it must not overwrite the recipe values
     // once the catalog resolves, even on a late-catalog mount where `skip*` was already consumed.
@@ -1672,7 +1699,15 @@ export function ImageStudio() {
     setFaceRestore(rawSettings.faceRestore === true);
     setImg2imgStrength(replayNumber(rawSettings.strength, img2imgStrength));
     setTextStyleGain(replayNumber(rawSettings.textStyleGain, textStyleGain));
-    if (rawSettings.controlMode) {
+    const replayPoses = workflowPoseRecords(rawSettings.poses, launchRequest.id);
+    setWorkflowPoses(replayPoses);
+    setSelectedPoseIds(replayPoses.map((pose) => pose.id));
+    setPoseLibraryReplayOpen(replayPoses.length > 0);
+    if (replayPoses.length) {
+      // A shared pose selection is strict pose conditioning even when controlMode was omitted
+      // (pose is the worker default). Never strand replayed poses behind canny or depth.
+      setControlMode("pose");
+    } else if (rawSettings.controlMode) {
       setControlMode(rawSettings.controlMode);
     }
     setControlScale(replayNumber(rawSettings.controlScale, controlScale));
@@ -1683,7 +1718,6 @@ export function ImageStudio() {
     const restoredPhases = deserializePhases(rawSettings.phases ?? [], loraIds);
     setMultiPhasePhases(restoredPhases);
     setMultiPhaseEnabled(restoredPhases.length > 0);
-    setSelectedPoseIds([]);
     if (nextMode === "edit_image") {
       setSourceAssetId(launchRequest.sourceAssetId ?? launchRequest.assetId ?? settings.sourceAssetId ?? "");
       setFitMode(rawSettings.fitMode ?? settings.fitMode ?? "crop");
@@ -3201,11 +3235,16 @@ export function ImageStudio() {
                       {poseLibrary && macPoseBlock ? (
                         <p className="mac-gating-note">{macPoseBlock.text}</p>
                       ) : poseLibrary ? (
-                        <details className="pose-library-details">
+                        <details
+                          className="pose-library-details"
+                          onToggle={(event) => setPoseLibraryReplayOpen(event.currentTarget.open)}
+                          open={poseLibraryReplayOpen || undefined}
+                        >
                           <summary>
                             Pose library{selectedPoseIds.length ? ` · ${selectedPoseIds.length} selected` : ""}
                           </summary>
                           <PoseLibraryPicker
+                            extraPoses={workflowPoses}
                             loadUserPoses={loadUserPoses}
                             onClear={() => setSelectedPoseIds([])}
                             onToggle={(id) =>
@@ -3214,6 +3253,7 @@ export function ImageStudio() {
                               )
                             }
                             selectedIds={selectedPoseIds}
+                            preferredCategory={workflowPoses.length ? WORKFLOW_POSE_CATEGORY : null}
                           />
                           <label className="checkline">
                             <input checked={faceRestore} onChange={(event) => setFaceRestore(event.target.checked)} type="checkbox" />
@@ -3405,6 +3445,10 @@ export function ImageStudio() {
               }
               onClearPoses={() => setSelectedPoseIds([])}
               loadUserPoses={loadUserPoses}
+              extraPoses={workflowPoses}
+              preferredPoseCategory={workflowPoses.length ? WORKFLOW_POSE_CATEGORY : null}
+              revealPoseLibraryToken={workflowPoses.length ? launchRequest?.id : null}
+              poseReplayOpen={poseLibraryReplayOpen}
               poseBlockText={macPoseBlock ? macPoseBlock.text : null}
               controlImageAssetId={controlImageAssetId}
               onControlImageChange={setControlImageAssetId}

--- a/apps/web/src/screens/ImageStudio.recipeKnobs.test.jsx
+++ b/apps/web/src/screens/ImageStudio.recipeKnobs.test.jsx
@@ -348,6 +348,163 @@ describe("a replayed recipe reaches every allow-listed control", () => {
     expect(checkbox("Restore face").checked).toBe(true);
   });
 
+  it("replays shared pose records through the visible strict-pose picker and exact submit path", async () => {
+    seedOpenDisclosures({ model: OTHER_MODEL.id, controlMode: "depth", count: 7 });
+    const createImageJob = vi.fn(async () => ({ id: "job-pose-replay" }));
+    const recipe = everyKnobRecipe({
+      poses: [
+        {
+          keypoints: [[0.1, 0.2, 0.9]],
+          hands: [[[0.3, 0.4]]],
+          face: [[0.5, 0.6]],
+        },
+        { keypoints: [[0.7, 0.8]] },
+      ],
+    });
+    delete recipe.rawAdapterSettings.controlMode;
+    const studioLaunch = launch(recipe, { id: "shared-launch" });
+
+    await render(baseContext({ createImageJob, studioLaunch }));
+
+    // The launch switches models, but the model-default reset must not erase its selection.
+    expect(modelSelect().value).toBe(EVERY_LANE.id);
+    expect(document.body.querySelector(".control-panel .advanced-section-toggle").getAttribute("aria-expanded")).toBe("true");
+    expect(activeControlModeLabel()).toBe("Pose");
+    expect(document.body.querySelector(".pose-category-name").textContent).toBe("Shared workflow");
+    expect(document.body.querySelectorAll(".pose-thumb-placeholder")).toHaveLength(2);
+    expect(document.body.textContent).toContain("2 poses selected");
+
+    // Duplicates are independent records; removing the second leaves exactly the first payload.
+    await click(document.body.querySelector('[aria-label="Deselect pose Shared workflow pose 2"]'));
+    expect(document.body.textContent).toContain("1 pose selected");
+    await click(buttonByText("Generate"));
+
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.count).toBe(1);
+    expect(payload.advanced.faceRestore).toBe(true);
+    expect(payload.advanced).not.toHaveProperty("controlMode");
+    expect(payload.advanced.poses).toEqual([
+      {
+        id: "workflow:shared-launch:0",
+        keypoints: [[0.1, 0.2, 0.9]],
+        hands: [[[0.3, 0.4]]],
+        face: [[0.5, 0.6]],
+      },
+    ]);
+
+    // A subsequent user model change owns a safe reset; transient records do not leak globally.
+    await act(async () => {
+      modelSelect().value = OTHER_MODEL.id;
+      modelSelect().dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await act(async () => {});
+    expect(document.body.querySelector(".pose-thumb-placeholder")).toBeNull();
+  });
+
+  it("clears a prior shared-pose launch when the next recipe omits advanced.poses", async () => {
+    const first = everyKnobRecipe({ poses: [{ keypoints: [[1, 2]] }] });
+    await render(baseContext({ studioLaunch: launch(first, { id: "with-poses" }) }));
+    expect(document.body.querySelector(".pose-thumb-placeholder")).not.toBeNull();
+
+    const second = everyKnobRecipe();
+    const context = baseContext({ studioLaunch: launch(second, { id: "without-poses" }) });
+    await render(context);
+    expect(document.body.querySelector(".pose-thumb-placeholder")).toBeNull();
+  });
+
+  it("clears shared poses and face restoration at a same-model non-recipe launch boundary", async () => {
+    const reference = {
+      id: "asset_boundary_face",
+      type: "image",
+      projectId: "project_1",
+      displayName: "Boundary face",
+      status: {},
+      file: { path: "assets/images/boundary.png", mimeType: "image/png" },
+    };
+    const character = {
+      id: "char_boundary",
+      name: "Boundary",
+      looks: [],
+      approvedReferences: [{ assetId: reference.id, asset: reference }],
+    };
+    const poseModel = {
+      ...EVERY_LANE,
+      capabilities: ["text_to_image", "character_image"],
+      ui: { ...EVERY_LANE.ui, poseLibrary: true },
+    };
+    const recipe = everyKnobRecipe({
+      poses: [{ keypoints: [[0.2, 0.8]] }],
+      faceRestore: true,
+    });
+    recipe.mode = "character_image";
+    recipe.normalizedSettings = {
+      ...recipe.normalizedSettings,
+      characterId: character.id,
+    };
+    recipe.rawAdapterSettings.referenceAssetId = reference.id;
+    const createImageJob = vi.fn(async () => ({ id: "job-boundary" }));
+    const common = {
+      assets: [reference],
+      characters: [character],
+      createImageJob,
+      imageModels: [poseModel],
+      models: [poseModel, PID_CHECKPOINT],
+    };
+
+    await render(
+      baseContext({
+        ...common,
+        studioLaunch: launch(recipe, { id: "recipe-boundary" }),
+      }),
+    );
+    expect(document.body.querySelector(".pose-thumb-placeholder")).not.toBeNull();
+    expect(checkbox("Restore face").checked).toBe(true);
+
+    const characterLaunch = {
+      id: "character-boundary",
+      view: "Image",
+      mode: "character_image",
+      characterId: character.id,
+      referenceAssetId: reference.id,
+    };
+    await render(baseContext({ ...common, studioLaunch: characterLaunch }));
+
+    expect(document.body.querySelector(".pose-thumb-placeholder")).toBeNull();
+    expect(document.body.textContent).not.toContain("pose selected");
+    expect(checkbox("Restore face").checked).toBe(false);
+
+    // Re-rendering the same launch with a new context object is not a new boundary. A choice the
+    // user makes inside that launch must persist until a genuinely new launch id arrives.
+    await click(checkbox("Restore face"));
+    expect(checkbox("Restore face").checked).toBe(true);
+    await render(baseContext({ ...common, studioLaunch: { ...characterLaunch } }));
+    expect(checkbox("Restore face").checked).toBe(true);
+
+    await click(buttonByText("Generate"));
+    const payload = createImageJob.mock.calls[0][0];
+    expect(payload.advanced).not.toHaveProperty("poses");
+    expect(payload.advanced).not.toHaveProperty("faceRestore");
+  });
+
+  it("consumes no reset skip for a same-model recipe before a later manual model switch", async () => {
+    seedOpenDisclosures({ model: EVERY_LANE.id, controlMode: "pose" });
+    const recipe = everyKnobRecipe({ poses: [{ keypoints: [[0.4, 0.6]] }] });
+    await render(baseContext({ studioLaunch: launch(recipe, { id: "same-model-poses" }) }));
+
+    expect(document.body.querySelector(".pose-thumb-placeholder")).not.toBeNull();
+    expect(document.body.querySelector(".control-panel .advanced-section-toggle").getAttribute("aria-expanded")).toBe("true");
+
+    await act(async () => {
+      modelSelect().value = OTHER_MODEL.id;
+      modelSelect().dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await act(async () => {});
+
+    expect(document.body.querySelector(".pose-thumb-placeholder")).toBeNull();
+    expect(document.body.textContent).not.toContain("pose selected");
+    expect(document.body.querySelector(".control-panel .advanced-section-toggle").getAttribute("aria-expanded")).toBe("false");
+  });
+
   // Multi-phase denoise. A 3-phase schedule replaying as a single pass is a DIFFERENT image, not a
   // degraded one, so the schedule has to survive — including the `loras[].index` -> resolved-id
   // remap, which is the only genuinely new code on this path.

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -4532,6 +4532,20 @@ label {
   border-radius: var(--r-sm);
 }
 
+.pose-thumb-placeholder {
+  display: grid;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  place-items: center;
+  padding: 8px;
+  border-radius: var(--r-sm);
+  background: var(--surface-hover);
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.25;
+  text-align: center;
+}
+
 .pose-thumb-label {
   font-size: 10px;
   line-height: 1.2;

--- a/apps/web/src/workflowReplayValidation.js
+++ b/apps/web/src/workflowReplayValidation.js
@@ -28,13 +28,128 @@
 // will not carry, or where the missing piece is supplied. Nothing is silent either way.
 
 import { issue } from "./validation/issues.js";
+import { macModelBlock, macModelFeatureBlock } from "./macGating.js";
+import { imageModelServesMode, supportedControlModes } from "./modelEligibility.js";
 import { workflowInputSlots } from "./workflowShare.js";
+
+export function workflowHasPoseSelection(share) {
+  return Array.isArray(share?.advanced?.poses) && share.advanced.poses.length > 0;
+}
+
+// A substitute must expose the SAME visible pose lane Image Studio will render for the replay's
+// mode. A generic image model is not enough: text mode needs strict pose control, while character
+// mode needs the character pose library and a character-image engine.
+export function modelSupportsWorkflowPoseReplay(
+  model,
+  mode = "text_to_image",
+  macCapabilities = null,
+) {
+  if (
+    !model ||
+    macModelBlock(model, macCapabilities) ||
+    !imageModelServesMode(model, mode, macCapabilities) ||
+    macModelFeatureBlock(model, macCapabilities, "pose")
+  ) {
+    return false;
+  }
+  if (mode === "character_image") {
+    return Boolean(model.ui?.poseLibrary);
+  }
+  if (mode !== "text_to_image") {
+    return false;
+  }
+  return supportedControlModes(model).includes("pose");
+}
+
+export function workflowSubstituteModels(share, models = [], macCapabilities = null) {
+  if (!workflowHasPoseSelection(share)) {
+    return models;
+  }
+  return models.filter((model) =>
+    modelSupportsWorkflowPoseReplay(model, share?.mode, macCapabilities),
+  );
+}
+
+// Resolve the model that would ACTUALLY receive a pose-bearing replay against the live Image
+// Studio catalog. The server report proves that a catalog row resolved when the report was made;
+// it does not prove that the current row still exists or still exposes the pose lane. Catalogs can
+// change while the offer is open, so callers use this on every render and once more on click.
+//
+// An explicit replacement wins only when that exact current row remains compatible. Falling back
+// to the original after the user's choice disappears would be another silent substitution.
+export function workflowPoseReplayCapability({
+  share = null,
+  report = null,
+  substituteModelId = "",
+  models = [],
+  macCapabilities = null,
+} = {}) {
+  if (!workflowHasPoseSelection(share)) {
+    return { ready: true, issue: "", model: null };
+  }
+
+  const compatibleModels = workflowSubstituteModels(share, models, macCapabilities);
+  if (substituteModelId) {
+    const substitute = compatibleModels.find((model) => model.id === substituteModelId) ?? null;
+    if (substitute) {
+      return { ready: true, issue: "", model: substitute };
+    }
+    return {
+      ready: false,
+      issue:
+        "The model you chose is no longer available with pose control for this workflow mode. Poses will not be restored; choose a compatible model again.",
+      model: null,
+    };
+  }
+
+  const requirement = report?.model ?? null;
+  if (requirement?.state === "resolved") {
+    const catalogId = requirement.catalogId ?? requirement.slug ?? "";
+    const original =
+      models.find(
+        (model) =>
+          model.id === catalogId ||
+          (!requirement.catalogId && requirement.slug && model.id === requirement.slug),
+      ) ?? null;
+    const name = requirement.name ?? requirement.slug ?? "The resolved model";
+    if (!original) {
+      return {
+        ready: false,
+        issue: `${name} is no longer available in Image Studio's live model catalog. Poses will not be restored.`,
+        model: null,
+      };
+    }
+    if (!modelSupportsWorkflowPoseReplay(original, share?.mode, macCapabilities)) {
+      return {
+        ready: false,
+        issue: `${name} is installed, but it cannot replay poses for this workflow mode. Poses will not be restored.`,
+        model: original,
+      };
+    }
+    return { ready: true, issue: "", model: original };
+  }
+
+  return {
+    ready: false,
+    issue: compatibleModels.length
+      ? "This workflow includes poses. Choose an installed model with pose control for this workflow mode — nothing is substituted for you."
+      : "This workflow includes poses, but no installed model can run pose control for this workflow mode. Poses will not be restored.",
+    model: null,
+  };
+}
 
 export function workflowReplayValidation({
   report = null,
   // The model id the user chose in the substitute picker, or "" for "not chosen". NEVER defaulted
   // to anything: a default here would be the silent substitution the whole epic exists to prevent.
   substituteModelId = "",
+  // A mode/capability constraint from the live substitute catalog. When present it replaces the
+  // generic "choose a model" sentence so an empty filtered picker never points at an impossible
+  // next action.
+  substituteModelIssue = "",
+  // The live-catalog/capability result for a pose-bearing workflow. Unlike the server report this
+  // is recomputed in the browser whenever the studio catalog changes.
+  poseReplayIssue = "",
   // `{ [slotKey]: assetId }` from the input-image pickers.
   inputPicks = {},
 } = {}) {
@@ -53,17 +168,23 @@ export function workflowReplayValidation({
   }
 
   const model = report.model ?? null;
+  let poseIssueSurfacedAsModel = false;
   if (model && model.state !== "resolved" && !substituteModelId) {
     // Two different sentences, because the user's next move is different. An installable model has
     // a download button beside it; an unknown one has only the picker.
+    const modelMessage =
+      substituteModelIssue ||
+      poseReplayIssue ||
+      (model.state === "installable"
+        ? `${model.name ?? model.slug} is not downloaded here. Install it, or choose a model to use instead — nothing is substituted for you.`
+        : `This install has no model matching \`${model.slug}\`. Choose one to use instead — nothing is substituted for you, and the image will differ from the one you were sent.`);
     issues.push(
-      issue.error(
-        "model",
-        model.state === "installable"
-          ? `${model.name ?? model.slug} is not downloaded here. Install it, or choose a model to use instead — nothing is substituted for you.`
-          : `This install has no model matching \`${model.slug}\`. Choose one to use instead — nothing is substituted for you, and the image will differ from the one you were sent.`,
-      ),
+      issue.error("model", modelMessage),
     );
+    poseIssueSurfacedAsModel = Boolean(poseReplayIssue && modelMessage === poseReplayIssue);
+  }
+  if (poseReplayIssue && !poseIssueSurfacedAsModel) {
+    issues.push(issue.error("poses", poseReplayIssue));
   }
 
   // Every image the recipe needs, counted the way the report counts them. A picker with nothing in

--- a/apps/web/src/workflowReplayValidation.test.js
+++ b/apps/web/src/workflowReplayValidation.test.js
@@ -10,9 +10,11 @@ import { describe, expect, it } from "vitest";
 import { summarize } from "./validation/issues.js";
 import {
   keptSubstituteModelId,
+  modelSupportsWorkflowPoseReplay,
   pickedReferenceAssetIds,
   pickedSourceAssetId,
   workflowReplayValidation,
+  workflowSubstituteModels,
 } from "./workflowReplayValidation.js";
 
 function report(overrides = {}) {
@@ -204,6 +206,83 @@ describe("workflowReplayValidation", () => {
 });
 
 describe("carrying the user's own answers to the launch", () => {
+  it("filters pose-bearing substitutes to the visible pose lane for that workflow mode", () => {
+    const models = [
+      { id: "plain", capabilities: ["text_to_image"], ui: {} },
+      { id: "strict", capabilities: ["text_to_image"], ui: { controlModes: ["pose"] } },
+      { id: "edit_pose", capabilities: ["edit_image"], ui: { controlModes: ["pose"] } },
+      {
+        id: "character",
+        capabilities: ["character_image"],
+        ui: { poseLibrary: true },
+      },
+      { id: "library_only", capabilities: ["text_to_image"], ui: { poseLibrary: true } },
+    ];
+    const poses = [{ keypoints: [[0.2, 0.8]] }];
+
+    expect(
+      workflowSubstituteModels({ mode: "text_to_image", advanced: { poses } }, models).map(
+        (model) => model.id,
+      ),
+    ).toEqual(["strict"]);
+    expect(
+      workflowSubstituteModels({ mode: "character_image", advanced: { poses } }, models).map(
+        (model) => model.id,
+      ),
+    ).toEqual(["character"]);
+    expect(workflowSubstituteModels({ mode: "text_to_image", advanced: {} }, models)).toBe(models);
+  });
+
+  it("applies Image Studio's whole-model, reference, and pose-feature Mac gates", () => {
+    const macCapabilities = { macGatingActive: true };
+    const textPose = {
+      id: "text_pose",
+      capabilities: ["text_to_image"],
+      ui: { controlModes: ["pose"] },
+      macSupport: { supported: true, features: { pose: true } },
+    };
+    const characterPose = {
+      id: "character_pose",
+      capabilities: ["character_image"],
+      ui: { poseLibrary: true },
+      macSupport: { supported: true, features: { pose: true, reference: true } },
+    };
+
+    expect(modelSupportsWorkflowPoseReplay(textPose, "text_to_image", macCapabilities)).toBe(true);
+    expect(
+      modelSupportsWorkflowPoseReplay(
+        { ...textPose, macSupport: { supported: false, features: { pose: true } } },
+        "text_to_image",
+        macCapabilities,
+      ),
+    ).toBe(false);
+    expect(
+      modelSupportsWorkflowPoseReplay(
+        { ...textPose, macSupport: { supported: true, features: { pose: false } } },
+        "text_to_image",
+        macCapabilities,
+      ),
+    ).toBe(false);
+    expect(
+      modelSupportsWorkflowPoseReplay(
+        {
+          ...characterPose,
+          macSupport: { supported: true, features: { pose: true, reference: false } },
+        },
+        "character_image",
+        macCapabilities,
+      ),
+    ).toBe(false);
+    // The same declarations are inert when Mac gating is off.
+    expect(
+      modelSupportsWorkflowPoseReplay(
+        { ...textPose, macSupport: { supported: true, features: { pose: false } } },
+        "text_to_image",
+        { macGatingActive: false },
+      ),
+    ).toBe(true);
+  });
+
   it("drops a substitute model the catalog no longer offers", () => {
     // The panel can sit open across a catalog refetch: a model deleted (or a row that vanished)
     // must not stay selected, or the recipe seeds an id the studio's picker will drop on the next

--- a/apps/web/src/workflowShare.js
+++ b/apps/web/src/workflowShare.js
@@ -287,10 +287,7 @@ export const ADVANCED_PREFILL = {
   // reason reads like a bug.
   poses: {
     label: "Poses",
-    prefill: PREFILL_NONE,
-    detail:
-      "The coordinates travelled, but the pose-library ids that named them deliberately do not — " +
-      "so there is nothing for the pose picker to select. Tracked by sc-16132.",
+    prefill: PREFILL_CONTROL,
   },
   cnScale: {
     label: "Tile ControlNet",

--- a/apps/web/src/workflowShare.test.js
+++ b/apps/web/src/workflowShare.test.js
@@ -138,6 +138,23 @@ describe("recipeFromWorkflowShare", () => {
     expect(recipe.normalizedSettings.count).toBe(1);
   });
 
+  it("carries sanitized pose coordinates for replay and does not invent an omitted selection", () => {
+    const poses = [
+      { keypoints: [[0.1, 0.2]], hands: [[[0.3, 0.4]]], face: [[0.5, 0.6]] },
+      { keypoints: [[0.7, 0.8]] },
+    ];
+    const shared = share({ advanced: { poses, faceRestore: true } });
+    const recipe = recipeFromWorkflowShare(shared, report());
+    expect(recipe.rawAdapterSettings.poses).toEqual(poses);
+    expect(workflowSettingRows(shared, report()).find((row) => row.key === "poses")).toMatchObject({
+      restored: true,
+      value: "2 poses",
+    });
+
+    const omitted = recipeFromWorkflowShare(share({ advanced: { faceRestore: true } }), report());
+    expect(omitted.rawAdapterSettings).not.toHaveProperty("poses");
+  });
+
   it("does not prefill a model this install cannot resolve", () => {
     const missing = report({
       model: {
@@ -454,9 +471,9 @@ describe("ADVANCED_PREFILL is the source of truth for both the prefill and the p
       }
     }
     // …and the unrestored ones are exactly the lanes an envelope carries that THIS studio has no
-    // control for, plus the two the CONTRACT deliberately reduces past the point of replay:
-    // `poses`, whose library ids do not travel, and `structuredPrompt`, whose caption object does
-    // not (sc-15952 — the prompt is restored as prose instead, and the row says so).
+    // control for, plus `structuredPrompt`, whose caption object does not travel (sc-15952 — the
+    // prompt is restored as prose instead, and the row says so). Pose coordinates now hydrate
+    // session-only picker records through the ordinary pose-selection path (sc-16132).
     //
     // The eleven video keys (sc-15956) are here for the first reason, not the second: they travel
     // intact in a shared MP4 and replay in Video Studio, which is a different panel. A row that
@@ -475,7 +492,6 @@ describe("ADVANCED_PREFILL is the source of truth for both the prefill and the p
       "lightning",
       "ltxPipeline",
       "motion",
-      "poses",
       "structuredPrompt",
       "systemMessage",
       "textEncoderModel",
@@ -513,16 +529,13 @@ describe("ADVANCED_PREFILL is the source of truth for both the prefill and the p
 });
 
 describe("workflowNotRestored", () => {
-  it("names the knobs that travelled intact and still land nowhere", () => {
+  it("does not report replayable pose coordinates as unrestored", () => {
     const rows = workflowNotRestored(
       share({
         advanced: { steps: 28, cnScale: 0.4, poses: [{ keypoints: [] }, { keypoints: [] }] },
       }),
     );
-    expect(rows.map((row) => row.key)).toEqual(["cnScale", "poses"]);
-    // Successful transport must not be punished with silence: a 2-pose selection that arrived
-    // perfectly is now reported as loudly as one the writer dropped over its cap (`omitted`).
-    expect(rows.find((row) => row.key === "poses").title).toBe("Poses — 2 poses");
+    expect(rows.map((row) => row.key)).toEqual(["cnScale"]);
   });
 
   it("names a RESOLVED style preset, which is installed here and still not replayed", () => {


### PR DESCRIPTION
## Summary
- replay workflow-shared pose selections through the existing Image Studio picker and resolver
- preserve pose ordering, duplicates, keypoints, hands, face data, and face restoration settings for the current launch session
- keep missing or incompatible assets honest with visible placeholders and capability-aware model validation, including Mac/MLX gates
- retain oversized legacy selections without silently truncating them while allowing users to deselect items

## Review
- independent adversarial review: PASS / high confidence after five review cycles
- final review found no blocking issues

## Verification
- web tests: 234 files, 3437 tests passed
- focused platform and Mac capability tests: 67 passed
- Rust workflow-share tests: 84 passed
- lint passed
- production build passed
- git diff check passed
- all full gates rerun after rebasing onto current origin/main

Shortcut: sc-16132