### PR TITLE
fix(workflow): record resolved steps for Civitai (sc-15957)

### DIFF
--- a/crates/sceneworks-core/tests/workflow_parameters.rs
+++ b/crates/sceneworks-core/tests/workflow_parameters.rs
@@ -107,6 +107,21 @@ fn parse_a1111(text: &str) -> Parsed {
     }
 }
 
+/// Civitai first requires a `Steps: ` marker, then validates the mapped `steps` field as a number.
+/// Both boundaries matter: a non-numeric placeholder passes format selection but makes Civitai's
+/// `imageMetaSchema.safeParse` discard the entire metadata object.
+///
+/// Source inspected 2026-07-31:
+/// https://github.com/civitai/civitai/blob/main/src/utils/metadata/automatic.metadata.ts
+fn civitai_accepts_automatic_metadata(text: &str) -> bool {
+    text.contains("Steps: ")
+        && parse_a1111(text)
+            .params
+            .get("Steps")
+            .and_then(|value| value.parse::<f64>().ok())
+            .is_some_and(f64::is_finite)
+}
+
 fn push_line(buffer: &mut String, line: &str) {
     if !buffer.is_empty() {
         buffer.push('\n');
@@ -409,6 +424,37 @@ fn a_generated_png_round_trips_through_a_gallery_parser() {
         contains(&bytes, WORKFLOW_CHUNK_KEYWORD.as_bytes()),
         "the envelope chunk must ride alongside"
     );
+}
+
+#[test]
+fn a_generated_kreamania_png_with_resolved_steps_is_recognized_by_civitai() {
+    // The worker regression covers the original missing-input field and copies the actually executed
+    // count into the sanitized envelope. This is the downstream PNG/parser half: the numeric count
+    // must survive both Civitai's format-selection marker and numeric schema validation.
+    let mut share = built(
+        "an expressive impasto oil painting of deep space",
+        "",
+        json!({
+            "model": "kreamania_v5",
+            "width": 1024,
+            "height": 1024,
+            "advanced": { "resolution": "1k", "steps": 8 }
+        }),
+    );
+    share.seed = Some(3_502_903_515);
+    let (_path, bytes, _dir) = embedded_png(&share, (1024, 1024));
+    let chunk = parameters_chunk_of(&bytes);
+
+    assert!(
+        civitai_accepts_automatic_metadata(&chunk.text),
+        "Civitai must accept the marker and the numeric schema value: {:?}",
+        chunk.text
+    );
+    let parsed = parse_a1111(&chunk.text);
+    assert_eq!(parsed.params["Steps"], "8");
+    assert_eq!(parsed.params["Seed"], "3502903515");
+    assert_eq!(parsed.params["Size"], "1024x1024");
+    assert_eq!(parsed.params["Model"], "kreamania_v5");
 }
 
 #[test]

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -25,7 +25,9 @@ use super::*;
 use sceneworks_core::contracts::GenerationMetrics;
 use sceneworks_core::image_request::ImageRequest;
 use sceneworks_core::workflow_png::write_workflow_chunk;
-use sceneworks_core::workflow_share::{embeddable_workflow_share, WorkflowAssetFacts};
+use sceneworks_core::workflow_share::{
+    embeddable_workflow_share, WorkflowAssetFacts, OMITTED_PHASES,
+};
 use std::sync::Arc;
 
 // Backend-neutral contract types come from the canonical inference release. The selected runtime
@@ -1496,6 +1498,36 @@ impl ImagePlan {
     }
 }
 
+/// Add the worker-resolved denoise count to the sanitized share envelope when the request did not
+/// already carry one.
+///
+/// Several generation lanes choose a real default after request parsing and record it as
+/// `raw_settings.numInferenceSteps`. The original workflow source is the user request, so without
+/// this narrow overlay a generated PNG can omit the step count even though the worker knows exactly
+/// what ran. Civitai then rejects the entire A1111 `parameters` block.
+///
+/// Only the single trusted field is copied, and only when `numInferenceSteps` was absent from the raw
+/// request. That provenance check prevents an API caller from forging an internal telemetry value.
+/// Multi-phase schedules remain untouched: one numeric A1111 `Steps` value cannot represent them.
+fn resolved_steps_for_share(
+    workflow_source: &JsonObject,
+    raw_settings: &JsonObject,
+    has_multi_phase: bool,
+) -> Option<u32> {
+    let source_supplied_runtime_steps = workflow_source
+        .get("advanced")
+        .and_then(Value::as_object)
+        .is_some_and(|advanced| advanced.contains_key("numInferenceSteps"));
+    if has_multi_phase || source_supplied_runtime_steps {
+        return None;
+    }
+    raw_settings
+        .get("numInferenceSteps")
+        .and_then(Value::as_u64)
+        .filter(|steps| *steps >= 1)
+        .and_then(|steps| u32::try_from(steps).ok())
+}
+
 /// Save image `index` (its RGB8 `pixels`) under `assets/images/` and return the flat
 /// fact the API turns into an indexed asset (every key here is consumed by
 /// `build_image_sidecar_parts`). Shared by the stub and real paths.
@@ -1551,6 +1583,11 @@ pub(crate) fn write_image_asset(
             },
             payload,
         )?;
+        let has_multi_phase = share.advanced.contains_key("phases")
+            || share.omitted.iter().any(|field| field == OMITTED_PHASES);
+        if let Some(steps) = resolved_steps_for_share(payload, &raw_settings, has_multi_phase) {
+            share.advanced.insert("steps".to_owned(), json!(steps));
+        }
         // This function only ever writes a BASE render. The inline-upscale post-pass writes its
         // output through `write_upscaled_asset` and keeps the base as its own retained asset, so a
         // `upscale.enabled: true` from the request would describe, on this file, a pass this file

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -586,6 +586,118 @@ fn a_generated_png_carries_the_sanitized_workflow_of_its_own_render() {
     assert_eq!((decoded.width(), decoded.height()), (320, 256));
 }
 
+#[test]
+fn a_kreamania_generation_records_the_worker_resolved_steps_civitai_requires() {
+    // Regression for Civitai post 30111231. The uploaded PNG's request envelope carried only
+    // `advanced.resolution`, while the imported-Krea worker actually ran its resolved 8-step default
+    // and recorded that fact in `raw_settings.numInferenceSteps`. Civitai requires a numeric `Steps:`
+    // value; a non-numeric placeholder passes its first gate but fails its schema and drops everything.
+    let dir = tempfile::tempdir().unwrap();
+    let project_path = dir.path().join("project");
+    std::fs::create_dir_all(project_path.join("assets").join("images")).unwrap();
+    let settings = settings_with_config_dir(&dir.path().join("config"));
+    let payload = json!({
+        "projectId": "p",
+        "mode": "text_to_image",
+        "model": "kreamania_v5",
+        "prompt": "An expressive impasto oil painting of deep crimson roses",
+        "count": 2,
+        "width": 1024,
+        "height": 1024,
+        "seed": 3_502_903_515_i64,
+        "advanced": { "resolution": "1024x1024" }
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+    assert!(
+        payload["advanced"].get("steps").is_none(),
+        "the regression must begin with the same missing request field as the uploaded image"
+    );
+    let req = ImageRequest::from_payload(&payload);
+    let plan = ImagePlan::with_count(&req, req.count, workflow_source(&settings, &payload));
+    let raw_settings = json!({
+        "realModelInference": true,
+        "numInferenceSteps": 8,
+        "engine": "candle_krea_imported"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+    let fact = write_image_asset(
+        &plan,
+        0,
+        3_502_903_515,
+        1024,
+        1024,
+        stub_rgb8(1024, 1024, 3_502_903_515),
+        "candle_krea_imported",
+        raw_settings,
+        &project_path,
+    )
+    .unwrap();
+
+    let media = project_path.join(fact["mediaPath"].as_str().unwrap());
+    let share = sceneworks_core::workflow_png::read_workflow_chunk_file(&media)
+        .unwrap()
+        .expect("the generated PNG carries its workflow");
+    assert_eq!(share.advanced.get("steps"), Some(&json!(8)));
+
+    let parameters = sceneworks_core::workflow_parameters::parameters_text(&share, (1024, 1024));
+    assert!(parameters.contains("Steps: 8"), "{parameters:?}");
+    assert!(!parameters.contains("Steps: Unknown"), "{parameters:?}");
+    assert_eq!(
+        parameters
+            .lines()
+            .last()
+            .and_then(|line| line.strip_prefix("Steps: "))
+            .and_then(|rest| rest.split(',').next())
+            .and_then(|steps| steps.parse::<u32>().ok()),
+        Some(8),
+        "Civitai validates the mapped steps value as a number"
+    );
+    let bytes = std::fs::read(media).unwrap();
+    assert!(
+        bytes
+            .windows(b"Steps: 8".len())
+            .any(|window| window == b"Steps: 8"),
+        "the numeric value must reach the actual PNG parameters chunk"
+    );
+}
+
+#[test]
+fn only_worker_resolved_steps_can_enrich_the_share_envelope() {
+    let forged = json!({
+        "projectId": "p",
+        "advanced": { "numInferenceSteps": 999 }
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+    let resolved = json!({ "numInferenceSteps": 8 })
+        .as_object()
+        .cloned()
+        .unwrap();
+    assert_eq!(
+        resolved_steps_for_share(&forged, &resolved, false),
+        None,
+        "a client-supplied telemetry key must never be promoted into the trusted envelope"
+    );
+
+    let phased = json!({
+        "projectId": "p",
+        "advanced": { "phases": [{ "steps": 4 }, { "steps": 4 }] }
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+    assert_eq!(
+        resolved_steps_for_share(&phased, &resolved, true),
+        None,
+        "a multi-phase schedule must not be collapsed into one top-level step count"
+    );
+}
+
 /// Turning the setting off writes the file SceneWorks writes today, to the byte.
 ///
 /// Proven by comparison against a real `save_with_format` write of the same pixel buffer rather

--- a/docs/workflow-share-envelope.md
+++ b/docs/workflow-share-envelope.md
@@ -168,6 +168,12 @@ appear in it, because the renderer never sees one. `Version:` is fed from `produ
 same envelope, so the two blocks in one file cannot disagree about which build wrote it, and
 [the setting](#the-setting) governs both together — off means neither is written.
 
+For generated base images, the worker adds one post-resolution fact before the two blocks are
+written: when a generation lane chose the actual denoise count after request parsing, its trusted
+`numInferenceSteps` result becomes `advanced.steps`. This is the count that really ran, not a model
+default guessed later. A client-supplied `numInferenceSteps` is never promoted, and multi-phase
+schedules remain uncollapsed.
+
 ### Omit rather than approximate
 
 A guessed mapping ships misleading data to a public gallery, and nobody downstream can tell a guess
@@ -178,7 +184,7 @@ anything without a clean equivalent is **left out rather than approximated**.
 
 | Field | What it is |
 | --- | --- |
-| `Steps` | `advanced.steps`, when it is a whole number of at least one and no multi-phase schedule overrides it. |
+| `Steps` | `advanced.steps`, when it is a whole number of at least one and no multi-phase schedule overrides it. This includes the worker-resolved count above when the request omitted its own value. |
 | `Sampler` | `advanced.sampler`, verbatim — except the literal `default`, which names no sampler and is omitted. |
 | `CFG scale` | `advanced.guidanceScale`, only when `advanced.guidanceMethod` is absent. The studio emits that key only for a method that is not plain CFG, so its presence means the number is not a CFG scale. |
 | `Seed` | `seed`, verbatim — the seed of this image, which is the only one the envelope carries. |


### PR DESCRIPTION
## Summary
- record the worker's exact resolved denoise count in the sanitized workflow envelope when the request omitted `advanced.steps`
- keep client-supplied `numInferenceSteps` untrusted and leave multi-phase schedules uncollapsed
- cover Civitai's `Steps: ` selection gate and its numeric metadata schema with the exact Kreamania failure shape

## Why
The image uploaded to https://civitai.com/posts/30111231 contained a valid `parameters` chunk but no `Steps:` field, so Civitai rejected the entire block. The Kreamania worker had actually resolved and run 8 steps; embedding used only the original request and dropped that execution fact.

A non-numeric placeholder is not sufficient: Civitai would pass format selection and then discard the metadata at `imageMetaSchema.safeParse`. This change carries the truthful executed value instead.

## Acceptance criteria
- [x] Existing `parameters`/SceneWorks chunk pairing, setting gate, encoding, sanitization, and version behavior preserved
- [x] Numeric steps preserved when supplied
- [x] Worker-resolved numeric steps recorded when the request omitted them
- [x] Client-supplied runtime telemetry cannot forge `Steps`
- [x] Multi-phase Krea remains omitted rather than approximated
- [x] Exact Kreamania PNG shape passes both modeled Civitai boundaries
- [ ] Repeat a live Civitai upload after merge and record the displayed result on sc-15957

## Validation
- `cargo fmt --all -- --check`
- `npm.cmd run rust:lint`
- `cargo test -p sceneworks-core` (green: 834 core tests plus integrations/docs)
- `cargo test -p sceneworks-worker --lib` (green: 660 passed, 4 ignored)
- `cargo test -p sceneworks-core --test workflow_parameters` (16 passed, including Pillow)
- workflow seam registry guard (green)
- mutation check: removing the resolved-step overlay makes the Kreamania regression fail
- independent adversarial review: PASS after catching and removing the rejected `Steps: Unknown` approach
- `npm.cmd run rust:build`

`npm.cmd run rust:check` reaches derived-doc checks, fmt, Clippy, and tests, but the local Windows host has an unrelated baseline failure in `tests::server::parent_death_resolves_when_watched_parent_exits_windows` (`freshly spawned parent reads as dead`), reproducible in isolation; no rust-api files are changed here.

Shortcut: https://app.shortcut.com/trefry/story/15957