### PR TITLE
fix(sc-15957): export resolved Krea sampler

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1528,6 +1528,23 @@ fn resolved_steps_for_share(
         .and_then(|steps| u32::try_from(steps).ok())
 }
 
+/// Return a sampler name that the worker recorded after resolving the actual execution path.
+///
+/// `resolvedSampler` is deliberately separate from the request's `advanced.sampler`: some lanes
+/// ignore that request setting and choose their sampler inside the runtime. Promotion is bound to
+/// the worker-selected imported-Krea adapter, not to any field in the client payload; the Krea
+/// execution seam overwrites this raw fact before writing the asset. Keep both the route and value
+/// vocabularies narrow until another execution lane records a proven value of its own.
+fn resolved_sampler_for_share<'a>(adapter: &str, raw_settings: &'a JsonObject) -> Option<&'a str> {
+    if !matches!(adapter, "mlx_krea_imported" | "candle_krea_imported") {
+        return None;
+    }
+    raw_settings
+        .get("resolvedSampler")
+        .and_then(Value::as_str)
+        .filter(|sampler| matches!(*sampler, "euler"))
+}
+
 /// Save image `index` (its RGB8 `pixels`) under `assets/images/` and return the flat
 /// fact the API turns into an indexed asset (every key here is consumed by
 /// `build_image_sidecar_parts`). Shared by the stub and real paths.
@@ -1587,6 +1604,9 @@ pub(crate) fn write_image_asset(
             || share.omitted.iter().any(|field| field == OMITTED_PHASES);
         if let Some(steps) = resolved_steps_for_share(payload, &raw_settings, has_multi_phase) {
             share.advanced.insert("steps".to_owned(), json!(steps));
+        }
+        if let Some(sampler) = resolved_sampler_for_share(adapter, &raw_settings) {
+            share.advanced.insert("sampler".to_owned(), json!(sampler));
         }
         // This function only ever writes a BASE render. The inline-upscale post-pass writes its
         // output through `write_upscaled_asset` and keeps the base as its own retained asset, so a

--- a/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
@@ -63,6 +63,10 @@ const KREA_IMPORTED_BASE_TIER: &str = "bf16";
 /// distilled-Turbo dense merges, like variant5). The UI normally supplies `advanced.steps`; this only
 /// applies when it does not.
 const KREA_IMPORTED_DEFAULT_STEPS: u32 = 8;
+// The pinned Krea runtime's curated sampler falls back to Euler when `GenerationRequest.sampler` is
+// absent. Name it explicitly in both the request and telemetry so execution and exported metadata
+// cannot drift if that library default changes.
+const KREA_IMPORTED_SAMPLER: &str = "euler";
 
 /// A single-file checkpoint is one on-disk `.safetensors` FILE (the imported transformer), as opposed to
 /// a diffusers snapshot DIRECTORY (a builtin turnkey tier). This is the single-file-vs-snapshot-dir
@@ -319,6 +323,10 @@ fn krea_imported_raw_settings(
     raw.insert("realModelInference".to_owned(), Value::Bool(true));
     raw.insert("numInferenceSteps".to_owned(), json!(steps));
     raw.insert(
+        "resolvedSampler".to_owned(),
+        Value::String(KREA_IMPORTED_SAMPLER.to_owned()),
+    );
+    raw.insert(
         "mode".to_owned(),
         Value::String(
             if is_edit {
@@ -537,7 +545,7 @@ async fn generate_krea_imported_stream(
                         &[],
                         None,
                         None,
-                        None,
+                        Some(KREA_IMPORTED_SAMPLER),
                         None,
                         None,
                         None,
@@ -559,6 +567,7 @@ async fn generate_krea_imported_stream(
                     count: 1,
                     seed: Some(seed as u64),
                     steps: Some(steps),
+                    sampler: Some(KREA_IMPORTED_SAMPLER.to_owned()),
                     conditioning: conditioning.clone(),
                     cancel: cancel.clone(),
                     ..Default::default()

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -587,11 +587,12 @@ fn a_generated_png_carries_the_sanitized_workflow_of_its_own_render() {
 }
 
 #[test]
-fn a_kreamania_generation_records_the_worker_resolved_steps_civitai_requires() {
+fn a_kreamania_generation_records_the_worker_resolved_settings_civitai_requires() {
     // Regression for Civitai post 30111231. The uploaded PNG's request envelope carried only
     // `advanced.resolution`, while the imported-Krea worker actually ran its resolved 8-step default
-    // and recorded that fact in `raw_settings.numInferenceSteps`. Civitai requires a numeric `Steps:`
-    // value; a non-numeric placeholder passes its first gate but fails its schema and drops everything.
+    // and recorded that fact in `raw_settings.numInferenceSteps`. Its runtime also resolved Euler,
+    // but neither fact existed in the request. Civitai requires a numeric `Steps:` value; a
+    // non-numeric placeholder passes its first gate but fails its schema and drops everything.
     let dir = tempfile::tempdir().unwrap();
     let project_path = dir.path().join("project");
     std::fs::create_dir_all(project_path.join("assets").join("images")).unwrap();
@@ -619,6 +620,7 @@ fn a_kreamania_generation_records_the_worker_resolved_steps_civitai_requires() {
     let raw_settings = json!({
         "realModelInference": true,
         "numInferenceSteps": 8,
+        "resolvedSampler": "euler",
         "engine": "candle_krea_imported"
     })
     .as_object()
@@ -642,9 +644,11 @@ fn a_kreamania_generation_records_the_worker_resolved_steps_civitai_requires() {
         .unwrap()
         .expect("the generated PNG carries its workflow");
     assert_eq!(share.advanced.get("steps"), Some(&json!(8)));
+    assert_eq!(share.advanced.get("sampler"), Some(&json!("euler")));
 
     let parameters = sceneworks_core::workflow_parameters::parameters_text(&share, (1024, 1024));
     assert!(parameters.contains("Steps: 8"), "{parameters:?}");
+    assert!(parameters.contains("Sampler: euler"), "{parameters:?}");
     assert!(!parameters.contains("Steps: Unknown"), "{parameters:?}");
     assert_eq!(
         parameters
@@ -663,10 +667,16 @@ fn a_kreamania_generation_records_the_worker_resolved_steps_civitai_requires() {
             .any(|window| window == b"Steps: 8"),
         "the numeric value must reach the actual PNG parameters chunk"
     );
+    assert!(
+        bytes
+            .windows(b"Sampler: euler".len())
+            .any(|window| window == b"Sampler: euler"),
+        "the actual sampler must reach the physical PNG parameters chunk"
+    );
 }
 
 #[test]
-fn only_worker_resolved_steps_can_enrich_the_share_envelope() {
+fn only_worker_resolved_settings_can_enrich_the_share_envelope() {
     let forged = json!({
         "projectId": "p",
         "advanced": { "numInferenceSteps": 999 }
@@ -696,6 +706,89 @@ fn only_worker_resolved_steps_can_enrich_the_share_envelope() {
         None,
         "a multi-phase schedule must not be collapsed into one top-level step count"
     );
+
+    let resolved_sampler = json!({ "resolvedSampler": "euler" })
+        .as_object()
+        .cloned()
+        .unwrap();
+    assert_eq!(
+        resolved_sampler_for_share("stub", &resolved_sampler),
+        None,
+        "an internal-looking field cannot promote a sampler outside the trusted execution route"
+    );
+    assert_eq!(
+        resolved_sampler_for_share("candle_krea_imported", &resolved_sampler),
+        Some("euler"),
+        "the worker-resolved sampler should enrich the imported-Krea route"
+    );
+}
+
+#[test]
+fn client_sampler_fields_cannot_suppress_the_imported_krea_execution_fact() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_path = dir.path().join("project");
+    std::fs::create_dir_all(project_path.join("assets").join("images")).unwrap();
+    let settings = settings_with_config_dir(&dir.path().join("config"));
+    let payload = json!({
+        "projectId": "p",
+        "mode": "text_to_image",
+        "model": "kreamania_v4_int8",
+        "prompt": "conflicting sampler regression",
+        "width": 64,
+        "height": 64,
+        "advanced": {
+            "sampler": "dpmpp_2m",
+            "resolvedSampler": "client-supplied"
+        }
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+    let req = ImageRequest::from_payload(&payload);
+    let plan = ImagePlan::with_count(&req, 1, workflow_source(&settings, &payload));
+    let raw_settings = json!({
+        "resolvedSampler": "euler",
+        "engine": "candle_krea_imported"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+    let fact = write_image_asset(
+        &plan,
+        0,
+        7,
+        64,
+        64,
+        stub_rgb8(64, 64, 7),
+        "candle_krea_imported",
+        raw_settings,
+        &project_path,
+    )
+    .unwrap();
+
+    let media = project_path.join(fact["mediaPath"].as_str().unwrap());
+    let share = sceneworks_core::workflow_png::read_workflow_chunk_file(&media)
+        .unwrap()
+        .expect("the generated PNG carries its workflow");
+    assert_eq!(share.advanced.get("sampler"), Some(&json!("euler")));
+    let parameters = sceneworks_core::workflow_parameters::parameters_text(&share, (64, 64));
+    assert!(parameters.contains("Sampler: euler"), "{parameters:?}");
+    assert!(!parameters.contains("dpmpp_2m"), "{parameters:?}");
+}
+
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn imported_krea_records_the_sampler_it_explicitly_executes() {
+    let req = request(json!({
+        "projectId": "p",
+        "model": "kreamania_v4_int8",
+        "advanced": { "sampler": "not-the-runtime-sampler" }
+    }));
+    let raw = krea_imported_raw_settings(&req, 8, false, 0);
+    assert_eq!(raw.get("resolvedSampler"), Some(&json!("euler")));
 }
 
 /// Turning the setting off writes the file SceneWorks writes today, to the byte.

--- a/docs/workflow-share-envelope.md
+++ b/docs/workflow-share-envelope.md
@@ -168,11 +168,12 @@ appear in it, because the renderer never sees one. `Version:` is fed from `produ
 same envelope, so the two blocks in one file cannot disagree about which build wrote it, and
 [the setting](#the-setting) governs both together — off means neither is written.
 
-For generated base images, the worker adds one post-resolution fact before the two blocks are
-written: when a generation lane chose the actual denoise count after request parsing, its trusted
-`numInferenceSteps` result becomes `advanced.steps`. This is the count that really ran, not a model
-default guessed later. A client-supplied `numInferenceSteps` is never promoted, and multi-phase
-schedules remain uncollapsed.
+For generated base images, the worker adds trusted post-resolution facts before the two blocks are
+written. When a generation lane chose the actual denoise count after request parsing, its trusted
+`numInferenceSteps` result becomes `advanced.steps`. The imported-Krea lane also records and exports
+the actual `euler` sampler it passes to the runtime. These are execution facts, not model defaults
+guessed later. Client-supplied internal telemetry is never promoted, and multi-phase schedules
+remain uncollapsed.
 
 ### Omit rather than approximate
 
@@ -185,7 +186,7 @@ anything without a clean equivalent is **left out rather than approximated**.
 | Field | What it is |
 | --- | --- |
 | `Steps` | `advanced.steps`, when it is a whole number of at least one and no multi-phase schedule overrides it. This includes the worker-resolved count above when the request omitted its own value. |
-| `Sampler` | `advanced.sampler`, verbatim — except the literal `default`, which names no sampler and is omitted. |
+| `Sampler` | `advanced.sampler`, verbatim — except the literal `default`, which names no sampler and is omitted. For imported Krea, the worker overwrites this with the actual `euler` sampler it executes. |
 | `CFG scale` | `advanced.guidanceScale`, only when `advanced.guidanceMethod` is absent. The studio emits that key only for a method that is not plain CFG, so its presence means the number is not a CFG scale. |
 | `Seed` | `seed`, verbatim — the seed of this image, which is the only one the envelope carries. |
 | `Size` | `width` x `height`, only when they are the dimensions of the file being written. |


### PR DESCRIPTION
## Summary
- make imported Krea execute its resolved Euler sampler explicitly
- export the trusted sampler into the sanitized workflow and physical A1111 parameters chunk
- prevent conflicting client sampler metadata from suppressing or forging the execution fact

## Validation
- cargo test -p sceneworks-worker --lib (661 passed, 4 ignored)
- cargo test -p sceneworks-core --test workflow_parameters
- cargo test -p sceneworks-core --test workflow_share_doc
- cargo clippy -p sceneworks-worker --lib -- -D warnings
- cargo clippy -p sceneworks-core --tests -- -D warnings
- independent adversarial review: PASS/high after one major trust-boundary fix

The local backend-candle compile is blocked by the host's CUDA 12.9 / Visual Studio 18 incompatibility; GitHub CI is the platform gate.

Shortcut: https://app.shortcut.com/trefry/story/15957