### PR TITLE
fix(sc-16426): attribute imported checkpoints

### DIFF
--- a/apps/web/src/workflowEmbed.js
+++ b/apps/web/src/workflowEmbed.js
@@ -95,6 +95,8 @@ const L_MARKER = "a marker saying this is a SceneWorks recipe, and which version
 const L_PRODUCER = "the SceneWorks name, project URL and released version of the build that wrote the file";
 const L_MODE = "the generation mode";
 const L_NAMES = "the model and style names";
+const L_RESOURCE_HASHES =
+  "the exact checkpoint content hash, when available, so galleries can attribute the model version";
 const L_PROSE = "the prompt fields named above, verbatim";
 const L_SEED = "the seed for this image";
 const L_SIZE = "the image size the run asked for";
@@ -130,6 +132,7 @@ export const WORKFLOW_FIELDS_IN_FILE = Object.freeze([
   ["producer.version", L_PRODUCER],
   ["mode", L_MODE],
   ["model", L_NAMES],
+  ["modelHash", L_RESOURCE_HASHES],
   ["stylePreset", L_NAMES],
   ["styleId", L_NAMES],
   ["advanced.styleId", L_NAMES],

--- a/crates/sceneworks-core/src/workflow_parameters.rs
+++ b/crates/sceneworks-core/src/workflow_parameters.rs
@@ -127,8 +127,12 @@ pub const SETTINGS_FIELDS: &[(&str, &str)] = &[
     ),
     (
         "Model",
-        "`model`, the catalog slug, verbatim. A1111's companion `Model hash` is omitted: we have no \
-         checkpoint hash to give and inventing one would be a claim about bytes we never read.",
+        "`model`, the safe readable catalog slug, verbatim.",
+    ),
+    (
+        "Model hash",
+        "`modelHash`, only when it is the exact SHA-256 of the executed checkpoint and `Model` is \
+         also present. Civitai uses the pair to resolve its linked model-version resource.",
     ),
     (
         "Version",
@@ -250,6 +254,9 @@ fn settings_line(share: &WorkflowShare, encoded: (u32, u32)) -> String {
     }
     if !share.model.is_empty() {
         push("Model", share.model.clone());
+        if let Some(model_hash) = &share.model_hash {
+            push("Model hash", model_hash.clone());
+        }
     }
     // Fed from the envelope's own producer block rather than from `PRODUCER_VERSION` directly, so
     // the two chunks in one file cannot disagree about which build wrote it. An envelope whose

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -61,7 +61,7 @@
 
 use std::fmt;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
 
 use crate::contracts::{Asset, JsonObject};
@@ -90,6 +90,24 @@ pub const WORKFLOW_KIND_IMAGE: &str = "image";
 /// the surrounding rule this follows: an older reader that would present a recipe it does not
 /// really understand is worse than one that refuses, so the refusal is arranged to happen.
 pub const WORKFLOW_KIND_VIDEO: &str = "video";
+
+/// Normalize a full SHA-256 digest without accepting filenames, short hashes, or prefixed values.
+/// Lowercase is canonical so byte-identical files serialize identically across producers.
+fn normalize_sha256(value: &str) -> Option<String> {
+    let value = value.trim();
+    (value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .then(|| value.to_ascii_lowercase())
+}
+
+/// A malformed foreign attribution field must not make the rest of an otherwise useful recipe
+/// unreadable. Deserialize through `Value` so wrong JSON types degrade to `None` as well.
+fn deserialize_optional_sha256<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    Ok(value.as_str().and_then(normalize_sha256))
+}
 
 /// The workflow kinds this build understands, in the order a reader should think about them.
 ///
@@ -223,6 +241,14 @@ pub struct WorkflowShare {
     pub mode: String,
     /// The model catalog slug (`z_image_turbo`), never a resolved weights location.
     pub model: String,
+    /// SHA-256 of the exact checkpoint bytes used for this image, when the worker can prove it.
+    /// This is content identity for gallery attribution, never a local path or user-entered id.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_sha256"
+    )]
+    pub model_hash: Option<String>,
     pub prompt: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub negative_prompt: String,
@@ -2126,6 +2152,9 @@ fn build_share_of_kind(
         producer: WorkflowProducer::default(),
         mode,
         model,
+        // Only the worker write seam may add a trusted checkpoint digest. A client payload cannot
+        // claim one merely by spelling an internal-looking field.
+        model_hash: None,
         prompt,
         negative_prompt,
         seed,
@@ -2534,6 +2563,7 @@ fn reduce_workflow_share(share: WorkflowShare) -> WorkflowShare {
         producer,
         mode,
         model,
+        model_hash,
         prompt,
         negative_prompt,
         seed,
@@ -2589,6 +2619,7 @@ fn reduce_workflow_share(share: WorkflowShare) -> WorkflowShare {
         producer: reduce_producer(producer),
         mode: shareable_label(&mode).unwrap_or_default(),
         model: shareable_label(&model).unwrap_or_default(),
+        model_hash: model_hash.as_deref().and_then(normalize_sha256),
         // Authored prose: exempt from the PATH check on purpose (see `is_path_shaped`), but not
         // from the other two bounds — on the way IN this is a stranger's text, and sc-15952
         // renders it.

--- a/crates/sceneworks-core/tests/workflow_parameters.rs
+++ b/crates/sceneworks-core/tests/workflow_parameters.rs
@@ -427,6 +427,29 @@ fn a_generated_png_round_trips_through_a_gallery_parser() {
 }
 
 #[test]
+fn an_exact_checkpoint_hash_becomes_a_civitai_model_resource_key() {
+    let mut share = built("a lighthouse in heavy fog", "", json!({}));
+    share.model_hash =
+        Some("312f5ab87eaa1d8109177655d3bb48b711677fbd1b8f1b92129f282cb6011b07".to_owned());
+
+    let (_path, bytes, _dir) = embedded_png(&share, (64, 48));
+    let parsed = parse_a1111(&parameters_chunk_of(&bytes).text);
+
+    assert_eq!(parsed.params["Model"], "z_image_turbo");
+    assert_eq!(
+        parsed.params["Model hash"],
+        "312f5ab87eaa1d8109177655d3bb48b711677fbd1b8f1b92129f282cb6011b07"
+    );
+    assert!(
+        contains(
+            &bytes,
+            b"Model hash: 312f5ab87eaa1d8109177655d3bb48b711677fbd1b8f1b92129f282cb6011b07"
+        ),
+        "the exact digest must reach the physical PNG parameters chunk"
+    );
+}
+
+#[test]
 fn a_generated_kreamania_png_with_resolved_steps_is_recognized_by_civitai() {
     // The worker regression covers the original missing-input field and copies the actually executed
     // count into the sanitized envelope. This is the downstream PNG/parser half: the numeric count
@@ -1059,7 +1082,7 @@ fn the_settings_line_emits_exactly_the_declared_keys() {
     // `SETTINGS_FIELDS` is the decision record for "omit rather than approximate", and it is only
     // worth anything if it is the truth. Pinned in BOTH directions: an envelope carrying everything
     // must emit every declared key, and it must emit nothing else.
-    let share = built(
+    let mut share = built(
         "a lighthouse",
         "text",
         json!({
@@ -1086,6 +1109,8 @@ fn the_settings_line_emits_exactly_the_declared_keys() {
             "loras": [{ "name": "Mira", "weight": 0.8, "repo": "acme/mira" }]
         }),
     );
+    share.model_hash =
+        Some("312f5ab87eaa1d8109177655d3bb48b711677fbd1b8f1b92129f282cb6011b07".to_owned());
     let text = parameters_text(&share, (64, 48));
     let emitted: BTreeSet<String> = parse_params(text.lines().last().expect("a settings line"))
         .into_keys()

--- a/crates/sceneworks-core/tests/workflow_share.rs
+++ b/crates/sceneworks-core/tests/workflow_share.rs
@@ -36,6 +36,22 @@ fn read_repo_file(relative_path: &str) -> String {
         .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
 }
 
+#[test]
+fn malformed_foreign_model_hash_is_ignored_without_losing_the_recipe() {
+    let mut value = serde_json::to_value(build_workflow_share(
+        &golden_asset(),
+        json!({ "projectId": "project_7a10", "prompt": "still import me" })
+            .as_object()
+            .expect("payload object"),
+    ))
+    .expect("serializes");
+    value["modelHash"] = json!("not a sha-256");
+
+    let parsed = parse_workflow_share(&value).expect("the rest of the recipe remains usable");
+    assert_eq!(parsed.prompt, "still import me");
+    assert_eq!(parsed.model_hash, None);
+}
+
 // ---------------------------------------------------------------------------
 // Golden input
 // ---------------------------------------------------------------------------

--- a/crates/sceneworks-core/tests/workflow_share_doc.rs
+++ b/crates/sceneworks-core/tests/workflow_share_doc.rs
@@ -327,6 +327,9 @@ fn fully_populated_envelope() -> WorkflowShare {
         producer: WorkflowProducer::default(),
         mode: "text_to_image".to_owned(),
         model: "z_image_turbo".to_owned(),
+        model_hash: Some(
+            "312f5ab87eaa1d8109177655d3bb48b711677fbd1b8f1b92129f282cb6011b07".to_owned(),
+        ),
         prompt: "a lighthouse".to_owned(),
         negative_prompt: "blurry".to_owned(),
         seed: Some(7),

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -658,9 +658,9 @@ pub(crate) async fn verify_file_sha256(
     path: &Path,
     expected: &str,
     label: &str,
-) -> WorkerResult<()> {
+) -> WorkerResult<Option<String>> {
     let Some(expected) = normalize_sha256(expected) else {
-        return Ok(());
+        return Ok(None);
     };
     let actual = sha256_file(api, settings, job_id, path).await?;
     if actual != expected {
@@ -670,7 +670,7 @@ pub(crate) async fn verify_file_sha256(
              the download was corrupted. Re-download the file."
         )));
     }
-    Ok(())
+    Ok(Some(actual))
 }
 
 /// Stream `path` through SHA-256 on the blocking pool (weights are multi-GB; hashing on the async
@@ -680,7 +680,7 @@ pub(crate) async fn verify_file_sha256(
 /// `interrupted` the moment the byte-streaming loop's own heartbeats stop — the exact "No heartbeat
 /// from the worker for 90s" freeze the transfer-only sc-11939 watchdog left uncovered (sc-13856 /
 /// GitHub #1690).
-async fn sha256_file(
+pub(crate) async fn sha256_file(
     api: &ApiClient,
     settings: &Settings,
     job_id: &str,

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -284,6 +284,12 @@ pub(crate) async fn run_image_generate_job(
     ))]
     let plan = ImagePlan::with_count(&request, request.count * upscale_mult, workflow_source);
 
+    let mut plan = plan;
+    if plan.workflow_source.is_some() {
+        plan.model_hash =
+            trusted_imported_model_hash(api, settings, job, plan.adapter, &request).await;
+    }
+
     // Pre-flight LoRA family-compat guardrail (sc-3027): reject an incompatible LoRA
     // (e.g. a Flux LoRA on an SDXL model, or a Wan 5B LoRA on the 14B base) before any
     // heavy load, with the same message the Python worker raised — instead of failing
@@ -1244,6 +1250,136 @@ pub(crate) struct ImagePlan {
     /// `Arc` because every per-image asset writer clones the plan into a `spawn_blocking` encode
     /// task and a payload carries the resolved model manifest.
     pub(crate) workflow_source: Option<Arc<JsonObject>>,
+    /// Worker-proven SHA-256 of the exact imported checkpoint selected by the resolved route.
+    /// Never populated from the request payload.
+    pub(crate) model_hash: Option<String>,
+}
+
+/// Resolve the exact single-file checkpoint for an imported Krea/SDXL route. The adapter label is
+/// the worker's route decision, so a client cannot opt an arbitrary manifest path into attribution.
+fn imported_checkpoint_file_for_share(
+    adapter: &str,
+    request: &ImageRequest,
+    settings: &Settings,
+) -> Option<PathBuf> {
+    if !matches!(
+        adapter,
+        "mlx_krea_imported" | "candle_krea_imported" | "mlx_sdxl_imported" | "candle_sdxl_imported"
+    ) {
+        return None;
+    }
+    let raw_path = request
+        .advanced
+        .get("modelPath")
+        .or_else(|| request.model_manifest_entry.get("modelPath"))
+        .or_else(|| {
+            request
+                .model_manifest_entry
+                .get("paths")
+                .and_then(|paths| paths.get("model"))
+        })
+        .and_then(Value::as_str)?;
+    let path = crate::paths::normalize_app_managed_model_path(
+        settings,
+        raw_path,
+        "Imported checkpoint attribution",
+    )
+    .ok()?;
+    if path.is_file() {
+        return path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("safetensors"))
+            .then_some(path);
+    }
+    let mut found = None;
+    for entry in std::fs::read_dir(path).ok()?.filter_map(Result::ok) {
+        let candidate = entry.path();
+        if candidate.is_file()
+            && candidate
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("safetensors"))
+        {
+            if found.is_some() {
+                return None;
+            }
+            found = Some(candidate);
+        }
+    }
+    found
+}
+
+fn cached_model_hash_for_file(file: &Path, marker: &JsonObject) -> Option<String> {
+    let identity = model_file_identity(file)?;
+    (marker.get("modelFileName").and_then(Value::as_str) == Some(identity.name.as_str())
+        && marker.get("modelFileBytes").and_then(Value::as_u64) == Some(identity.bytes)
+        && marker.get("modelFileModifiedNanos").and_then(Value::as_str)
+            == Some(identity.modified_nanos.as_str()))
+    .then(|| {
+        marker
+            .get("modelFileSha256")
+            .and_then(Value::as_str)
+            .and_then(normalize_sha256)
+    })
+    .flatten()
+}
+
+/// Read the digest retained by model import, or backfill one legacy marker once. Hashing failure is
+/// attribution failure, not generation failure: the image remains usable and merely lacks a card.
+async fn trusted_imported_model_hash(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+    adapter: &str,
+    request: &ImageRequest,
+) -> Option<String> {
+    let file = imported_checkpoint_file_for_share(adapter, request, settings)?;
+    let marker_path = file.parent()?.join(INSTALL_MARKER);
+    let bytes = tokio::fs::read(&marker_path).await.ok()?;
+    let mut marker = serde_json::from_slice::<Value>(&bytes).ok()?;
+    let object = marker.as_object_mut()?;
+    if let Some(hash) = cached_model_hash_for_file(&file, object) {
+        return Some(hash);
+    }
+
+    let identity_before = model_file_identity(&file)?;
+    let hash = match sha256_file(api, settings, &job.id, &file).await {
+        Ok(hash) => hash,
+        Err(error) => {
+            tracing::warn!(path = %file.display(), %error, "checkpoint attribution hash failed");
+            return None;
+        }
+    };
+    let identity_after = model_file_identity(&file)?;
+    if identity_after != identity_before {
+        tracing::warn!(path = %file.display(), "checkpoint changed while attribution hash was being computed");
+        return None;
+    }
+    object.insert(
+        "modelFileName".to_owned(),
+        Value::String(identity_after.name),
+    );
+    object.insert(
+        "modelFileBytes".to_owned(),
+        Value::Number(identity_after.bytes.into()),
+    );
+    object.insert(
+        "modelFileModifiedNanos".to_owned(),
+        Value::String(identity_after.modified_nanos),
+    );
+    object.insert("modelFileSha256".to_owned(), Value::String(hash.clone()));
+    match serde_json::to_vec_pretty(&marker) {
+        Ok(bytes) => {
+            if let Err(error) = tokio::fs::write(&marker_path, bytes).await {
+                tracing::warn!(path = %marker_path.display(), %error, "could not cache checkpoint attribution hash");
+            }
+        }
+        Err(error) => {
+            tracing::warn!(path = %marker_path.display(), %error, "could not serialize checkpoint attribution marker");
+        }
+    }
+    Some(hash)
 }
 
 /// The workflow-envelope source for one job, or `None` for "write the file exactly as today"
@@ -1494,6 +1630,7 @@ impl ImagePlan {
             adapter,
             image_count,
             workflow_source,
+            model_hash: None,
         }
     }
 }
@@ -1608,6 +1745,7 @@ pub(crate) fn write_image_asset(
         if let Some(sampler) = resolved_sampler_for_share(adapter, &raw_settings) {
             share.advanced.insert("sampler".to_owned(), json!(sampler));
         }
+        share.model_hash = plan.model_hash.clone();
         // This function only ever writes a BASE render. The inline-upscale post-pass writes its
         // output through `write_upscaled_asset` and keeps the base as its own retained asset, so a
         // `upscale.enabled: true` from the request would describe, on this file, a pass this file
@@ -1861,10 +1999,13 @@ fn write_upscaled_asset(
     let temp_path = media_path.with_extension("tmp.png");
     // The upscaled variant is the asset users share most, so it carries the workflow that produced
     // IT rather than a stale base-generation envelope (sc-15948) — see `upscaled_workflow_share`.
-    let share = plan
+    let mut share = plan
         .workflow_source
         .as_deref()
         .and_then(|payload| upscaled_workflow_share(request, base_fact, payload, &upscale_record));
+    if let Some(share) = share.as_mut() {
+        share.model_hash = plan.model_hash.clone();
+    }
     write_workflow_chunk(upscaled, &temp_path, share.as_ref())
         .map_err(|error| WorkerError::Io(std::io::Error::other(error)))?;
     std::fs::rename(&temp_path, &media_path).inspect_err(|_| {

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -448,6 +448,141 @@ fn write_embed_preference(config_dir: &Path, enabled: bool) {
     .unwrap();
 }
 
+#[test]
+fn imported_checkpoint_attribution_requires_the_worker_route_and_one_exact_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut settings = settings_with_config_dir(&dir.path().join("config"));
+    settings.data_dir = dir.path().join("data");
+    let install = settings.data_dir.join("models").join("kreamania-v4");
+    std::fs::create_dir_all(&install).unwrap();
+    let checkpoint = install.join("renamed.safetensors");
+    std::fs::write(&checkpoint, b"exact checkpoint bytes").unwrap();
+    let req = request(json!({
+        "projectId": "p",
+        "model": "kreamania-v4",
+        "modelManifestEntry": {
+            "family": "krea_2",
+            "paths": { "model": install }
+        }
+    }));
+
+    assert_eq!(
+        imported_checkpoint_file_for_share("stub", &req, &settings),
+        None,
+        "a client manifest path is not trusted without the worker's imported-model route"
+    );
+    assert_eq!(
+        imported_checkpoint_file_for_share("candle_krea_imported", &req, &settings),
+        Some(std::fs::canonicalize(&checkpoint).unwrap()),
+        "the worker-selected imported route identifies the exact lone checkpoint"
+    );
+
+    std::fs::write(install.join("another.safetensors"), b"different model").unwrap();
+    assert_eq!(
+        imported_checkpoint_file_for_share("candle_krea_imported", &req, &settings),
+        None,
+        "an ambiguous directory must not attribute an arbitrary checkpoint"
+    );
+}
+
+#[test]
+fn cached_checkpoint_hash_is_bound_to_the_file_that_will_execute() {
+    let dir = tempfile::tempdir().unwrap();
+    let checkpoint = dir.path().join("selected.safetensors");
+    std::fs::write(&checkpoint, b"checkpoint A").unwrap();
+    let identity = model_file_identity(&checkpoint).unwrap();
+    let hash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let marker = json!({
+        "modelFileName": identity.name,
+        "modelFileBytes": identity.bytes,
+        "modelFileModifiedNanos": identity.modified_nanos,
+        "modelFileSha256": hash
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+    assert_eq!(
+        cached_model_hash_for_file(&checkpoint, &marker).as_deref(),
+        Some(hash)
+    );
+
+    let mut sibling_marker = marker.clone();
+    sibling_marker.insert(
+        "modelFileName".to_owned(),
+        Value::String("different.safetensors".to_owned()),
+    );
+    assert_eq!(
+        cached_model_hash_for_file(&checkpoint, &sibling_marker),
+        None,
+        "a sibling checkpoint must never inherit the marker's cached digest"
+    );
+
+    std::fs::write(
+        &checkpoint,
+        b"replacement checkpoint B with different bytes",
+    )
+    .unwrap();
+    assert_eq!(
+        cached_model_hash_for_file(&checkpoint, &marker),
+        None,
+        "replacing the selected file must invalidate its old attribution digest"
+    );
+}
+
+#[test]
+fn worker_proven_model_hash_reaches_the_physical_png_but_client_input_does_not() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_path = dir.path().join("project");
+    std::fs::create_dir_all(project_path.join("assets").join("images")).unwrap();
+    let settings = settings_with_config_dir(&dir.path().join("config"));
+    let payload = json!({
+        "projectId": "p",
+        "model": "kreamania-v4",
+        "modelHash": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "prompt": "resource attribution regression",
+        "width": 64,
+        "height": 64
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+    let req = ImageRequest::from_payload(&payload);
+    let mut plan = ImagePlan::with_count(&req, 1, workflow_source(&settings, &payload));
+    assert_eq!(
+        plan.model_hash, None,
+        "the payload cannot populate trusted identity"
+    );
+    plan.model_hash =
+        Some("312f5ab87eaa1d8109177655d3bb48b711677fbd1b8f1b92129f282cb6011b07".to_owned());
+
+    let fact = write_image_asset(
+        &plan,
+        0,
+        7,
+        64,
+        64,
+        stub_rgb8(64, 64, 7),
+        "candle_krea_imported",
+        JsonObject::new(),
+        &project_path,
+    )
+    .unwrap();
+    let media = project_path.join(fact["mediaPath"].as_str().unwrap());
+    let share = sceneworks_core::workflow_png::read_workflow_chunk_file(&media)
+        .unwrap()
+        .expect("generated PNG carries the workflow");
+    assert_eq!(share.model_hash, plan.model_hash);
+    let parameters = sceneworks_core::workflow_parameters::parameters_text(&share, (64, 64));
+    assert!(parameters
+        .contains("Model hash: 312f5ab87eaa1d8109177655d3bb48b711677fbd1b8f1b92129f282cb6011b07"));
+    assert!(!parameters.contains("ffffffffffffffff"));
+    assert!(!parameters.contains(project_path.to_string_lossy().as_ref()));
+    let bytes = std::fs::read(media).unwrap();
+    assert!(bytes
+        .windows(b"Model hash: 312f5ab8".len())
+        .any(|window| { window == b"Model hash: 312f5ab8" }));
+}
+
 /// A representative Image Studio payload: an edit with a reference and a mask, LoRAs, a style, an
 /// upscale pass, and `advanced` carrying both allow-listed knobs and denied ones.
 fn embed_payload() -> JsonObject {

--- a/crates/sceneworks-worker/src/imports.rs
+++ b/crates/sceneworks-worker/src/imports.rs
@@ -101,17 +101,48 @@ pub(crate) async fn copy_dir_recursive(source: &Path, target: &Path) -> WorkerRe
     Ok(())
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ModelFileIdentity {
+    pub(crate) name: String,
+    pub(crate) bytes: u64,
+    pub(crate) modified_nanos: String,
+}
+
+/// Cheap cache identity for a checkpoint digest. Renames and replacements deliberately miss this
+/// cache and trigger one fresh content hash; byte-identical renames still resolve after that hash.
+pub(crate) fn model_file_identity(path: &Path) -> Option<ModelFileIdentity> {
+    let metadata = std::fs::metadata(path).ok()?;
+    let modified_nanos = metadata
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_nanos()
+        .to_string();
+    Some(ModelFileIdentity {
+        name: path.file_name()?.to_string_lossy().into_owned(),
+        bytes: metadata.len(),
+        modified_nanos,
+    })
+}
+
 pub(crate) async fn write_model_install_marker(
     target_dir: &Path,
     payload: &JsonObject,
     repo: &str,
     job_id: &str,
+    model_file_identity: Option<&ModelFileIdentity>,
+    model_file_sha256: Option<&str>,
 ) -> WorkerResult<()> {
     tokio::fs::create_dir_all(target_dir).await?;
     let marker = json!({
         "repo": repo,
         "modelId": payload.get("modelId").cloned().unwrap_or(Value::Null),
         "modelName": payload.get("modelName").cloned().unwrap_or(Value::Null),
+        "modelFileName": model_file_identity.map(|identity| identity.name.as_str()),
+        "modelFileBytes": model_file_identity.map(|identity| identity.bytes),
+        "modelFileModifiedNanos": model_file_identity.map(|identity| identity.modified_nanos.as_str()),
+        "modelFileSha256": model_file_sha256,
         "jobId": job_id,
         "completedAt": now_rfc3339(),
     });

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -4102,6 +4102,34 @@ pub(crate) async fn reconcile_downloaded_model_family(
     }
 }
 
+async fn stable_model_file_sha256(
+    api: &ApiClient,
+    settings: &Settings,
+    job_id: &str,
+    file: &Path,
+) -> WorkerResult<(String, ModelFileIdentity)> {
+    let before = model_file_identity(file).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "Imported checkpoint identity could not be read: {}",
+            file.display()
+        ))
+    })?;
+    let hash = sha256_file(api, settings, job_id, file).await?;
+    let after = model_file_identity(file).ok_or_else(|| {
+        WorkerError::InvalidPayload(format!(
+            "Imported checkpoint identity could not be re-read: {}",
+            file.display()
+        ))
+    })?;
+    if before != after {
+        return Err(WorkerError::InvalidPayload(
+            "The imported checkpoint changed while SceneWorks was hashing it; retry the import after the file is stable."
+                .to_owned(),
+        ));
+    }
+    Ok((hash, after))
+}
+
 pub(crate) async fn run_model_import_job(
     api: &ApiClient,
     settings: &Settings,
@@ -4216,28 +4244,43 @@ pub(crate) async fn run_model_import_job(
         .await;
     }
 
+    let imported_model_file = first_safetensors_path(&target_dir);
+    let mut model_file_sha256 = None;
+    let mut verified_model_file_identity = None;
+
     // sc-6137: verify a caller-supplied content digest for source-URL/uploaded model
     // imports (HF repo files are per-file verified during download). On mismatch the
     // file is removed and the job fails with an actionable message.
-    if let Some(expected_sha256) = optional_payload_string(&job.payload, "expectedSha256") {
-        if let Some(file) = first_safetensors_path(&target_dir) {
-            if let Err(error) = verify_file_sha256(
-                api,
-                settings,
-                &job.id,
-                &file,
-                expected_sha256,
-                "Imported model",
-            )
-            .await
-            {
-                return fail_job(
-                    api,
-                    &job.id,
-                    "Model import failed.",
-                    Some(error.to_string()),
-                )
-                .await;
+    if let Some(expected_sha256) =
+        optional_payload_string(&job.payload, "expectedSha256").and_then(normalize_sha256)
+    {
+        if let Some(file) = imported_model_file.as_ref() {
+            match stable_model_file_sha256(api, settings, &job.id, file).await {
+                Ok((hash, identity)) if hash == expected_sha256 => {
+                    model_file_sha256 = Some(hash);
+                    verified_model_file_identity = Some(identity);
+                }
+                Ok((hash, _)) => {
+                    let _ = tokio::fs::remove_file(file).await;
+                    return fail_job(
+                        api,
+                        &job.id,
+                        "Model import failed.",
+                        Some(format!(
+                            "Imported model failed its integrity check (sha256 {hash}, but the source declares {expected_sha256}); the download was corrupted. Re-download the file."
+                        )),
+                    )
+                    .await;
+                }
+                Err(error) => {
+                    return fail_job(
+                        api,
+                        &job.id,
+                        "Model import failed.",
+                        Some(error.to_string()),
+                    )
+                    .await;
+                }
             }
         }
     }
@@ -4249,8 +4292,8 @@ pub(crate) async fn run_model_import_job(
     // source-URL, and uploaded imports uniformly (the API's synchronous `import_source_supported`
     // only sees on-disk uploads at queue time). NEVER a silent fallback. `target_dir` is
     // app-managed (`resolve_model_import_target`) — this gate is purely additive to confinement.
-    let base_weight_family = match first_safetensors_path(&target_dir) {
-        Some(weight_file) => match detect_base_weight_file(&weight_file) {
+    let base_weight_family = match imported_model_file.as_ref() {
+        Some(weight_file) => match detect_base_weight_file(weight_file) {
             Ok(detection) => {
                 if let Err(reason) = import_detection_supported(&detection) {
                     return fail_job(
@@ -4329,7 +4372,25 @@ pub(crate) async fn run_model_import_job(
         }
     };
 
-    write_model_install_marker(&target_dir, &job.payload, repo.unwrap_or(""), &job.id).await?;
+    // Attribution is content-derived and retained with the import so generation does not reread a
+    // multi-gigabyte checkpoint on every image job. When integrity verification already streamed
+    // the file, reuse that exact digest; otherwise hash it once now.
+    if model_file_sha256.is_none() {
+        if let Some(file) = imported_model_file.as_ref() {
+            let (hash, identity) = stable_model_file_sha256(api, settings, &job.id, file).await?;
+            model_file_sha256 = Some(hash);
+            verified_model_file_identity = Some(identity);
+        }
+    }
+    write_model_install_marker(
+        &target_dir,
+        &job.payload,
+        repo.unwrap_or(""),
+        &job.id,
+        verified_model_file_identity.as_ref(),
+        model_file_sha256.as_deref(),
+    )
+    .await?;
     if let Some(manifest_entry) = job
         .payload
         .get("manifestEntry")

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -78,13 +78,14 @@ use super::supervisor::{
 use super::{
     allow_pattern_matches, bounded_tail, cancel_requested_peek, cleanup_uploaded_import_source,
     copy_lora_source, fresh_asset_id, heartbeat_while_blocking, import_lora_source_file_as,
-    import_lora_source_path, is_database_locked, normalize_app_managed_cache_path, now_rfc3339,
-    parse_credentials_env, resolve_model_convert_output, resolve_model_import_target,
-    safe_download_dir, safe_project_path, value_f64, wait_for_shutdown_latch,
-    wan_moe_pair_filenames, write_model_download_receipt, write_model_install_marker,
-    CredentialScheme, IdleHeartbeat, JsonObject, SafetensorsHeaderError, Settings,
-    WorkerCredential, WorkerError, DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES,
-    DEFAULT_TRANSITION_DURATION_SECONDS, INSTALL_MARKER, MODEL_CONVERSION_BACKUPS_DIR_NAME,
+    import_lora_source_path, is_database_locked, model_file_identity,
+    normalize_app_managed_cache_path, now_rfc3339, parse_credentials_env,
+    resolve_model_convert_output, resolve_model_import_target, safe_download_dir,
+    safe_project_path, value_f64, wait_for_shutdown_latch, wan_moe_pair_filenames,
+    write_model_download_receipt, write_model_install_marker, CredentialScheme, IdleHeartbeat,
+    JsonObject, SafetensorsHeaderError, Settings, WorkerCredential, WorkerError,
+    DEFAULT_MAX_LORA_URL_BYTES, DEFAULT_MAX_MODEL_URL_BYTES, DEFAULT_TRANSITION_DURATION_SECONDS,
+    INSTALL_MARKER, MODEL_CONVERSION_BACKUPS_DIR_NAME,
 };
 
 // HF-CLI input validation, downloaded-model family detection, atomic converted-dir finalize, and the

--- a/crates/sceneworks-worker/src/tests/supervisor_lifecycle.rs
+++ b/crates/sceneworks-worker/src/tests/supervisor_lifecycle.rs
@@ -674,13 +674,25 @@ fn child_died_abnormally_reports_signals_and_non_zero_exits_not_clean_exits() {
 #[tokio::test]
 async fn writes_model_install_marker_with_expected_keys() {
     let temp = tempdir().expect("tempdir creates");
+    let model_file = temp.path().join("renamed.safetensors");
+    tokio::fs::write(&model_file, b"checkpoint bytes")
+        .await
+        .unwrap();
+    let model_identity = model_file_identity(&model_file).unwrap();
     let mut payload = serde_json::Map::new();
     payload.insert("modelId".to_owned(), json!("base-model"));
     payload.insert("modelName".to_owned(), json!("Base Model"));
 
-    write_model_install_marker(temp.path(), &payload, "owner/model", "job-1")
-        .await
-        .expect("marker writes");
+    write_model_install_marker(
+        temp.path(),
+        &payload,
+        "owner/model",
+        "job-1",
+        Some(&model_identity),
+        Some("312f5ab87eaa1d8109177655d3bb48b711677fbd1b8f1b92129f282cb6011b07"),
+    )
+    .await
+    .expect("marker writes");
 
     let marker_path = temp.path().join(INSTALL_MARKER);
     let marker: serde_json::Value =
@@ -688,8 +700,54 @@ async fn writes_model_install_marker_with_expected_keys() {
     assert_eq!(marker["repo"], "owner/model");
     assert_eq!(marker["modelId"], "base-model");
     assert_eq!(marker["modelName"], "Base Model");
+    assert_eq!(marker["modelFileName"], "renamed.safetensors");
+    assert_eq!(marker["modelFileBytes"], 16);
+    assert!(marker["modelFileModifiedNanos"].as_str().is_some());
+    assert_eq!(
+        marker["modelFileSha256"],
+        "312f5ab87eaa1d8109177655d3bb48b711677fbd1b8f1b92129f282cb6011b07"
+    );
     assert_eq!(marker["jobId"], "job-1");
     assert!(marker["completedAt"].as_str().is_some());
+}
+
+#[tokio::test]
+async fn model_marker_uses_the_identity_verified_with_its_hash_not_later_file_state() {
+    let temp = tempdir().expect("tempdir creates");
+    let model_file = temp.path().join("checkpoint.safetensors");
+    tokio::fs::write(&model_file, b"checkpoint A")
+        .await
+        .unwrap();
+    let verified_identity = model_file_identity(&model_file).unwrap();
+    tokio::fs::write(&model_file, b"replacement checkpoint B")
+        .await
+        .unwrap();
+    let later_identity = model_file_identity(&model_file).unwrap();
+    assert_ne!(verified_identity, later_identity);
+
+    write_model_install_marker(
+        temp.path(),
+        &serde_json::Map::new(),
+        "",
+        "job-expected-sha",
+        Some(&verified_identity),
+        Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+    )
+    .await
+    .expect("marker writes");
+
+    let marker: Value = serde_json::from_slice(
+        &tokio::fs::read(temp.path().join(INSTALL_MARKER))
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(marker["modelFileBytes"], verified_identity.bytes);
+    assert_eq!(
+        marker["modelFileModifiedNanos"],
+        verified_identity.modified_nanos
+    );
+    assert_ne!(marker["modelFileBytes"], later_identity.bytes);
 }
 
 #[tokio::test]

--- a/docs/workflow-share-envelope.md
+++ b/docs/workflow-share-envelope.md
@@ -190,7 +190,8 @@ anything without a clean equivalent is **left out rather than approximated**.
 | `CFG scale` | `advanced.guidanceScale`, only when `advanced.guidanceMethod` is absent. The studio emits that key only for a method that is not plain CFG, so its presence means the number is not a CFG scale. |
 | `Seed` | `seed`, verbatim — the seed of this image, which is the only one the envelope carries. |
 | `Size` | `width` x `height`, only when they are the dimensions of the file being written. |
-| `Model` | `model`, the catalog slug, verbatim. A1111's companion `Model hash` is omitted: we have no checkpoint hash to give. |
+| `Model` | `model`, the safe readable catalog slug, verbatim. |
+| `Model hash` | `modelHash`, only when the worker retained the exact SHA-256 of the imported checkpoint that the resolved route executed. Civitai uses it with `Model` to link the precise model version and author. |
 | `Version` | `producer.version` off the envelope's own producer block. |
 
 <!-- END PINNED: a1111-fields -->
@@ -273,6 +274,7 @@ keys in either direction: a key this table does not name is dropped on write **a
 | `producer.version` | The released version of the build that wrote the file. |
 | `mode` | The generation mode (`text_to_image`, `edit_image`, `character_image`, …). |
 | `model` | The model catalog **slug** (`z_image_turbo`), never a weights location. |
+| `modelHash` | SHA-256 of the exact imported checkpoint bytes, when worker-proven. It is content identity for gallery attribution, never a local path or user-entered Civitai id. |
 | `prompt` | The prompt, verbatim. See the callout above. |
 | `negativePrompt` | The negative prompt, verbatim. |
 | `seed` | The seed of **this** image. The rest of the batch's seeds do not travel. |


### PR DESCRIPTION
## Summary

- compute and retain SHA-256 for the exact imported checkpoint bytes
- bind cached digests to the worker-selected file identity and rehash legacy or changed imports
- emit Civitai/A1111-compatible `Model` + `Model hash` metadata without exposing local paths
- ignore malformed foreign model hashes without breaking recipe import

## Validation

- `cargo test -p sceneworks-core --test workflow_parameters --test workflow_share --test workflow_share_doc`
- `cargo test -p sceneworks-worker` (665 passed, 4 ignored)
- `cargo clippy -p sceneworks-core -p sceneworks-worker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- independent adversarial review: PASS (high confidence)

Shortcut: [sc-16426](https://app.shortcut.com/trefry/story/16426)
