### PR TITLE
fix: identify SceneWorks in gallery metadata

### DIFF
--- a/crates/sceneworks-core/src/workflow_parameters.rs
+++ b/crates/sceneworks-core/src/workflow_parameters.rs
@@ -139,6 +139,11 @@ pub const SETTINGS_FIELDS: &[(&str, &str)] = &[
         "`producer.version` off the envelope's own producer block, so the two chunks in one file \
          cannot disagree about which build wrote it.",
     ),
+    (
+        "software",
+        "`producer.name` from the trusted envelope producer block. Civitai displays this canonical \
+         lowercase field as the generating-software badge.",
+    ),
 ];
 
 /// Render `share` as the A1111 `parameters` text for an image encoded at `encoded` pixels.
@@ -146,7 +151,7 @@ pub const SETTINGS_FIELDS: &[(&str, &str)] = &[
 /// ```text
 /// <prompt>
 /// Negative prompt: <negative>
-/// Steps: N, Sampler: X, CFG scale: N, Seed: N, Size: WxH, Model: <slug>, Version: <version>
+/// Steps: N, Sampler: X, CFG scale: N, Seed: N, Size: WxH, Model: <slug>, Version: <version>, software: SceneWorks
 /// ```
 ///
 /// The prompt is always the first line, even when it is empty, because the layout is positional:
@@ -181,8 +186,8 @@ pub const SETTINGS_FIELDS: &[(&str, &str)] = &[
 /// * **A settings line of fewer than three pairs is prompt text to A1111's parser.** Inherited, but
 ///   not left to chance: [`SETTINGS_PAIR_FLOOR`] omits the line entirely rather than emitting one a
 ///   gallery would append to the prompt. Every shipping lane clears the floor on its own — the
-///   thinnest, a standalone upscale, emits exactly `Seed` + `Model` + `Version` with no margin —
-///   and `the_settings_line_clears_the_pair_floor_a_gallery_parses_with` in
+///   thinnest, a standalone upscale, emits `Seed` + `Model` + `Version` + `software`, one field
+///   above the floor — and `the_settings_line_clears_the_pair_floor_a_gallery_parses_with` in
 ///   `crates/sceneworks-core/tests/workflow_parameters.rs` pins the lane SHAPES rather than assuming
 ///   a well-populated one.
 ///
@@ -264,6 +269,9 @@ fn settings_line(share: &WorkflowShare, encoded: (u32, u32)) -> String {
     // therefore omits the field rather than substituting this build's.
     if !share.producer.version.is_empty() {
         push("Version", share.producer.version.clone());
+    }
+    if !share.producer.name.is_empty() {
+        push("software", share.producer.name.clone());
     }
 
     // Below the floor the line is not a settings line to anything that reads this chunk — it is a
@@ -377,7 +385,7 @@ mod tests {
             "a lighthouse in heavy fog\n\
              Negative prompt: text, watermark\n\
              Steps: 28, Sampler: euler, CFG scale: 3.5, Seed: 880412, Size: 1024x768, \
-             Model: z_image_turbo, Version: 0.8.1"
+             Model: z_image_turbo, Version: 0.8.1, software: SceneWorks"
         );
     }
 
@@ -389,7 +397,7 @@ mod tests {
         assert!(!text.contains(NEGATIVE_PROMPT_LABEL), "{text:?}");
         assert_eq!(
             text,
-            "a lighthouse in heavy fog\nSeed: 7, Model: z_image_turbo, Version: 0.8.1"
+            "a lighthouse in heavy fog\nSeed: 7, Model: z_image_turbo, Version: 0.8.1, software: SceneWorks"
         );
     }
 
@@ -509,32 +517,28 @@ mod tests {
     fn the_version_is_the_envelopes_own_producer_version() {
         // The AC: the two chunks cannot disagree about which build wrote the file.
         //
-        // Carries a seed so the line clears `SETTINGS_PAIR_FLOOR` — without one this envelope emits
-        // Model + Version and the floor guard withholds the whole line, which is the right answer
-        // and the wrong fixture for this question.
+        // Carries a seed so this also proves the version remains the envelope's value when ordinary
+        // numeric settings share the same gallery-readable line.
         let share = envelope(serde_json::json!({ "seed": 7 }));
         assert_eq!(share.producer.version, "0.8.1");
-        assert!(parameters_text(&share, (1, 1)).ends_with("Version: 0.8.1"));
+        assert!(parameters_text(&share, (1, 1)).contains("Version: 0.8.1, software: SceneWorks"));
     }
 
     #[test]
-    fn a_line_under_the_pair_floor_is_withheld_rather_than_emitted() {
-        // The cliff, and which way it falls. This envelope maps two fields exactly — Model and
-        // Version — and two pairs is PROMPT to every parser this chunk is written for. Emitting them
-        // would not give a reader a thin settings block, it would give them a wrong prompt.
-        let two = envelope(serde_json::json!({}));
+    fn the_resource_line_meets_the_pair_floor_without_numeric_settings() {
+        // Model + Version + software is exactly A1111's three-pair recognition floor. A sparse
+        // recipe can therefore identify its model and generator without becoming prompt text.
+        let resources = envelope(serde_json::json!({}));
         assert_eq!(
-            parameters_text(&two, (1, 1)),
-            "a lighthouse in heavy fog",
-            "a sub-floor line must be withheld whole, leaving the prompt correct"
+            parameters_text(&resources, (1, 1)),
+            "a lighthouse in heavy fog\nModel: z_image_turbo, Version: 0.8.1, software: SceneWorks"
         );
 
-        // One more mapped field and the line is legible, so it travels. The guard is a floor, not a
-        // preference for silence.
-        let three = envelope(serde_json::json!({ "seed": 7 }));
+        // Additional exact fields join the same line; the guard remains a floor, not a ceiling.
+        let with_seed = envelope(serde_json::json!({ "seed": 7 }));
         assert_eq!(
-            parameters_text(&three, (1, 1)),
-            "a lighthouse in heavy fog\nSeed: 7, Model: z_image_turbo, Version: 0.8.1"
+            parameters_text(&with_seed, (1, 1)),
+            "a lighthouse in heavy fog\nSeed: 7, Model: z_image_turbo, Version: 0.8.1, software: SceneWorks"
         );
         assert_eq!(SETTINGS_PAIR_FLOOR, 3, "A1111's threshold, not ours");
     }

--- a/crates/sceneworks-core/tests/workflow_parameters.rs
+++ b/crates/sceneworks-core/tests/workflow_parameters.rs
@@ -417,6 +417,7 @@ fn a_generated_png_round_trips_through_a_gallery_parser() {
     assert_eq!(parsed.params["Size"], "64x48");
     assert_eq!(parsed.params["Model"], "z_image_turbo");
     assert_eq!(parsed.params["Version"], PRODUCER_VERSION);
+    assert_eq!(parsed.params["software"], "SceneWorks");
 
     // The recipe chunk is still there and still the authoritative one — the second chunk is a
     // display convenience and does not replace the thing a SceneWorks install reads back.
@@ -447,6 +448,18 @@ fn an_exact_checkpoint_hash_becomes_a_civitai_model_resource_key() {
         ),
         "the exact digest must reach the physical PNG parameters chunk"
     );
+}
+
+#[test]
+fn client_software_input_cannot_replace_the_trusted_sceneworks_badge() {
+    let share = built(
+        "a lighthouse",
+        "",
+        json!({ "software": "Forged Generator", "producer": { "name": "Forged Producer" } }),
+    );
+    let parsed = parse_a1111(&parameters_text(&share, (64, 48)));
+    assert_eq!(parsed.params["software"], "SceneWorks");
+    assert!(!parsed.params.values().any(|value| value.contains("Forged")));
 }
 
 #[test]
@@ -542,7 +555,7 @@ fn the_settings_line_clears_the_pair_floor_a_gallery_parses_with() {
         (
             // `standalone_upscale_workflow_share` in the worker: mode `image_upscale`, the engine
             // as the model, no prompt at all, and the SOURCE geometry — so `Size` is correctly
-            // withheld from a file twice that size. Seed + Model + Version and nothing else.
+            // withheld from a file twice that size. Seed + Model + Version + software and nothing else.
             "the standalone upscale lane",
             lane_share(
                 WorkflowAssetFacts {
@@ -598,16 +611,14 @@ fn the_settings_line_clears_the_pair_floor_a_gallery_parses_with() {
         "the detail fixture must carry both allow-listed knobs and nothing that maps: {:?}",
         lanes[3].1.advanced
     );
-    // And the sharpest statement of where the cliff is: the upscale lane clears the floor by
-    // NOTHING. Stated as an equality so a change that removes a mapped field fails here rather than
-    // silently reducing the margin from zero to negative.
+    // The thinnest shipping lane now has one field of margin: Civitai's software badge joins the
+    // original Seed + Model + Version trio.
     assert_eq!(
         parse_a1111(&parameters_text(&lanes[2].1, lanes[2].2))
             .params
             .len(),
-        SETTINGS_PAIR_FLOOR,
-        "the standalone upscale lane is the one that sits ON the floor; if it no longer does, the \
-         lane that does is the one this test should be pinning"
+        SETTINGS_PAIR_FLOOR + 1,
+        "the standalone upscale lane should retain exactly one field of parser margin"
     );
 
     for (label, share, encoded, prompt) in lanes {
@@ -629,15 +640,14 @@ fn the_settings_line_clears_the_pair_floor_a_gallery_parses_with() {
 #[test]
 fn a_lane_that_cannot_reach_the_floor_withholds_the_line_instead_of_leaking_it_into_the_prompt() {
     // The other half, and the reason the pin above is worth extending rather than just widening.
-    // The upscale lane clears the floor by ZERO margin, so any envelope that loses one of its three
-    // fields falls off the cliff — and the renderer used to emit the two-pair remainder, which every
-    // gallery displays as prompt text.
+    // A malformed foreign producer plus a withheld model can still leave only two mapped fields,
+    // and every gallery displays those two as prompt text, so the renderer withholds them whole.
     //
     // Reachable? Not through today's catalog: `model` here is an upscaler engine id, and no id in it
     // is empty, over 200 characters or path-shaped, which are the three ways the sanitizer drops a
     // label. So this is latent rather than live — which is exactly the kind of thing that becomes
     // live when someone adds an engine whose id happens to look like a path.
-    let stripped = lane_share(
+    let mut stripped = lane_share(
         WorkflowAssetFacts {
             mode: "image_upscale".to_owned(),
             // Three segments, so `is_path_shaped` catches it and `shareable_label` withholds it —
@@ -656,6 +666,7 @@ fn a_lane_that_cannot_reach_the_floor_withholds_the_line_instead_of_leaking_it_i
         "the fixture must actually lose its model or it proves nothing: {:?}",
         stripped.model
     );
+    stripped.producer.name.clear();
 
     let text = parameters_text(&stripped, (2048, 2048));
     assert_eq!(

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -737,6 +737,8 @@ fn a_kreamania_generation_records_the_worker_resolved_settings_civitai_requires(
         "mode": "text_to_image",
         "model": "kreamania_v5",
         "prompt": "An expressive impasto oil painting of deep crimson roses",
+        "software": "Forged Generator",
+        "producer": { "name": "Forged Producer" },
         "count": 2,
         "width": 1024,
         "height": 1024,
@@ -784,6 +786,11 @@ fn a_kreamania_generation_records_the_worker_resolved_settings_civitai_requires(
     let parameters = sceneworks_core::workflow_parameters::parameters_text(&share, (1024, 1024));
     assert!(parameters.contains("Steps: 8"), "{parameters:?}");
     assert!(parameters.contains("Sampler: euler"), "{parameters:?}");
+    assert!(
+        parameters.contains("software: SceneWorks"),
+        "{parameters:?}"
+    );
+    assert!(!parameters.contains("Forged"), "{parameters:?}");
     assert!(!parameters.contains("Steps: Unknown"), "{parameters:?}");
     assert_eq!(
         parameters
@@ -807,6 +814,12 @@ fn a_kreamania_generation_records_the_worker_resolved_settings_civitai_requires(
             .windows(b"Sampler: euler".len())
             .any(|window| window == b"Sampler: euler"),
         "the actual sampler must reach the physical PNG parameters chunk"
+    );
+    assert!(
+        bytes
+            .windows(b"software: SceneWorks".len())
+            .any(|window| window == b"software: SceneWorks"),
+        "the trusted producer name must reach the physical PNG parameters chunk"
     );
 }
 

--- a/docs/workflow-share-envelope.md
+++ b/docs/workflow-share-envelope.md
@@ -148,7 +148,7 @@ the layout AUTOMATIC1111's WebUI popularised (sc-15957):
 ```
 <prompt>
 Negative prompt: <negative>
-Steps: N, Sampler: X, CFG scale: N, Seed: N, Size: WxH, Model: <slug>, Version: <producer.version>
+Steps: N, Sampler: X, CFG scale: N, Seed: N, Size: WxH, Model: <slug>, Version: <producer.version>, software: SceneWorks
 ```
 
 Civitai and most galleries and viewers parse that block. They **display** generation settings; they
@@ -193,6 +193,7 @@ anything without a clean equivalent is **left out rather than approximated**.
 | `Model` | `model`, the safe readable catalog slug, verbatim. |
 | `Model hash` | `modelHash`, only when the worker retained the exact SHA-256 of the imported checkpoint that the resolved route executed. Civitai uses it with `Model` to link the precise model version and author. |
 | `Version` | `producer.version` off the envelope's own producer block. |
+| `software` | `producer.name` from the trusted producer block. Civitai displays this canonical lowercase field as the generating-software badge. |
 
 <!-- END PINNED: a1111-fields -->
 
@@ -206,9 +207,9 @@ reader in the wild.
 fewer than three `Key: value` pairs back into the *prompt*, and every gallery modelled on it does the
 same — so a two-pair line is not a thin settings block, it is a wrong prompt. `SETTINGS_PAIR_FLOOR`
 in `workflow_parameters.rs` drops the line rather than emitting one below the threshold. Every
-shipping lane clears it unaided; the thinnest, a standalone upscale, emits exactly
-`Seed` + `Model` + `Version` and clears it by nothing at all, which is why the floor is a guard
-rather than an observation.
+shipping lane clears it unaided; the thinnest, a standalone upscale, emits
+`Seed` + `Model` + `Version` + `software`, one field above the floor. The floor remains a guard
+rather than an observation because malformed foreign producer/model labels can still be reduced.
 
 What is deliberately **not** in the trailer, and why: the multi-phase Krea schedule (a list of
 `(steps, guidance)` pairs has no single-number form — and its presence suppresses `Steps` and `CFG


### PR DESCRIPTION
## Summary
- emit Civitai's canonical lowercase software field from the trusted SceneWorks producer block
- prevent client payload fields from forging the generator identity
- cover gallery parsing and the physical Kreamania PNG bytes
- update the workflow metadata contract

## Validation
- cargo test -p sceneworks-core workflow_parameters --no-fail-fast
- full sceneworks-worker library suite: 665 passed, 4 ignored
- cargo fmt --all -- --check
- git diff --check
- independent adversarial review: PASS

Shortcut: sc-16430