### PR TITLE
fix(ci): audit checkpoint attribution model path

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1268,7 +1268,7 @@ fn imported_checkpoint_file_for_share(
     ) {
         return None;
     }
-    let raw_path = request
+    let Some(raw_path) = request
         .advanced
         .get("modelPath")
         .or_else(|| request.model_manifest_entry.get("modelPath"))
@@ -1278,7 +1278,10 @@ fn imported_checkpoint_file_for_share(
                 .get("paths")
                 .and_then(|paths| paths.get("model"))
         })
-        .and_then(Value::as_str)?;
+        .and_then(Value::as_str)
+    else {
+        return None;
+    };
     let path = crate::paths::normalize_app_managed_model_path(
         settings,
         raw_path,

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -565,6 +565,10 @@ def test_manifest_model_path_is_only_an_optional_override():
     is absent.
     """
     expected_readers = {
+        # sc-16426: gallery attribution reads the imported checkpoint only after the worker has
+        # selected an imported Krea/SDXL route, and declines attribution when every path source is
+        # absent. It does not affect generation's normal repo resolution.
+        "image_jobs.rs",
         "image_jobs/base.rs",
         "image_jobs/flux_ipadapter.rs",
         "image_jobs/instantid.rs",


### PR DESCRIPTION
## Summary
- express the checkpoint-attribution modelPath lookup as an explicit optional branch recognized by the manifest audit
- inventory image_jobs.rs as the worker-selected, attribution-only reader
- preserve lookup precedence and graceful no-attribution behavior exactly

## Validation
- python -m pytest -q tests/test_builtin_manifest_audit.py::test_manifest_model_path_is_only_an_optional_override
- cargo test -p sceneworks-worker --lib --no-fail-fast (665 passed, 4 ignored)
- cargo fmt --all -- --check
- git diff --check
- independent review: PASS, high confidence

Follow-up to #2028 / sc-16426: #2028 auto-merged before its parity job reported this audit failure.