### PR TITLE
test(memory): include Lens in rung-4 peak contract (SC-15800)

### DIFF
--- a/tests/test_memory_matrix.py
+++ b/tests/test_memory_matrix.py
@@ -366,7 +366,7 @@ def test_rung4_survey_covers_every_family_and_rides_only_its_own_cells():
         (row["familyStory"], row["backend"])
         for row in rows
         if row["requestPeak"] == "moves"
-    ] == [(15510, "mlx"), (15517, "candle")]
+    ] == [(15510, "mlx"), (15512, "mlx"), (15517, "candle")]
     assert all(
         row["implementation"] != "none"
         for row in rows


### PR DESCRIPTION
## Summary

- update the Python memory-matrix contract to include Lens MLX among families whose measured rung 4 moves the request peak
- fixes the parity failure exposed after #2032 merged

## Validation

- exact hosted worker-test command: 85 passed, 19 deselected
- focused memory-matrix module: 9 passed

Shortcut: [SC-15800](https://app.shortcut.com/trefry/story/15800/measure-rung-4-encoder-streaming-on-a-te-dominant-family-lens-or-mage-flow)
