### PR TITLE
fix(ci): accept audited optional model path

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1268,7 +1268,7 @@ fn imported_checkpoint_file_for_share(
     ) {
         return None;
     }
-    let Some(raw_path) = request
+    let raw_path = request
         .advanced
         .get("modelPath")
         .or_else(|| request.model_manifest_entry.get("modelPath"))
@@ -1278,10 +1278,7 @@ fn imported_checkpoint_file_for_share(
                 .get("paths")
                 .and_then(|paths| paths.get("model"))
         })
-        .and_then(Value::as_str)
-    else {
-        return None;
-    };
+        .and_then(Value::as_str)?;
     let path = crate::paths::normalize_app_managed_model_path(
         settings,
         raw_path,

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -597,7 +597,31 @@ def test_manifest_model_path_is_only_an_optional_override():
             relative_path = path.relative_to(WORKER_SOURCE_PATH).as_posix()
             actual_readers.append(relative_path)
             prefix = source[max(0, match.start() - 500) : match.start()]
-            assert "if let Some(path) = request" in prefix or "let Some(raw_path) = request" in prefix, (
+            statement_start = source.rfind(
+                "let raw_path = request", max(0, match.start() - 500), match.start()
+            )
+            statement_end = source.find(";", match.end())
+            statement = (
+                source[statement_start : statement_end + 1]
+                if statement_start >= 0 and statement_end >= 0
+                else ""
+            )
+            compact_statement = re.sub(r"\s+", "", statement)
+            # sc-16426's attribution-only reader uses idiomatic `?`, which Clippy requires. Keep
+            # that exception exact: any new source, precedence change, panic/error conversion, or
+            # fallback change must fail this inventory audit and be reviewed explicitly.
+            question_mark_optional = relative_path == "image_jobs.rs" and compact_statement == (
+                'letraw_path=request.advanced.get("modelPath")'
+                '.or_else(||request.model_manifest_entry.get("modelPath"))'
+                '.or_else(||{request.model_manifest_entry.get("paths")'
+                '.and_then(|paths|paths.get("model"))})'
+                ".and_then(Value::as_str)?;"
+            )
+            assert (
+                "if let Some(path) = request" in prefix
+                or "let Some(raw_path) = request" in prefix
+                or question_mark_optional
+            ), (
                 f"{relative_path}: modelPath is no longer read through an "
                 "optional branch"
             )


### PR DESCRIPTION
## Summary
- restore the idiomatic Option question-mark exit required by Clippy
- keep image_jobs.rs in the exact production modelPath-reader inventory
- teach the audit to accept only the complete, whitespace-normalized sc-16426 fallback chain
- force any precedence, fallback, panic, or error-conversion change back through explicit audit review

## Validation
- focused manifest audit: passed
- cargo clippy --all-targets -- -D warnings: passed
- sceneworks-worker lib: 665 passed, 4 ignored
- cargo fmt --all -- --check
- git diff --check
- fresh adversarial re-review: PASS, high confidence

Follow-up to #2031 / #2028 / sc-16426. #2031 merged before its Clippy job reported the syntax conflict.