### PR TITLE
sc-16390: replace workflow disclosure banner with choice modal

### DIFF
--- a/apps/web/src/App.imageStudio.test.jsx
+++ b/apps/web/src/App.imageStudio.test.jsx
@@ -5,6 +5,7 @@ import { App } from "./main.jsx";
 import { withImageStudioContext, FakeEventSource, response, settle } from "./main.testSupport.jsx";
 import { styleTextForId } from "./data/styleCatalog.js";
 import { composeStyledPrompt } from "./styleComposer.js";
+import { writeWorkflowEmbedNoticeSeen } from "./workflowEmbed.js";
 
 describe("SceneWorks app shell", () => {
   let container;
@@ -17,6 +18,9 @@ describe("SceneWorks app shell", () => {
     FakeEventSource.instances = [];
     window.EventSource = FakeEventSource;
     window.localStorage.clear();
+    // These are image-studio behavior tests, not first-run decision tests. Treat the fixture as an
+    // established install so generation reaches the job/event assertions below.
+    writeWorkflowEmbedNoticeSeen(true);
     global.fetch = vi.fn((url) => {
       const path = new URL(url).pathname;
       if (path.endsWith("/health")) {

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -31,7 +31,7 @@ import { useAccessGate } from "./hooks/useAccessGate.js";
 import { useDropNavigationGuard } from "./hooks/useDropNavigationGuard.js";
 import { useWorkflowDrop } from "./hooks/useWorkflowDrop.js";
 import { WorkflowDropPanel } from "./components/WorkflowDropPanel.jsx";
-import { WorkflowEmbedNotice } from "./components/WorkflowEmbedNotice.jsx";
+import { WorkflowEmbedDecisionModal } from "./components/WorkflowEmbedNotice.jsx";
 import {
   persistWorkflowEmbedPreference,
   readEmbedWorkflowInImages,
@@ -748,15 +748,20 @@ export function App() {
   // origin wipes localStorage, so a preference stored only there would silently revert to the ON
   // default on the next launch — turning a deliberate privacy opt-out back on.
   const [embedWorkflow, setEmbedWorkflow] = useState(readEmbedWorkflowInImages);
-  // Whether the one-time disclosure has been shown and dismissed, and whether it is on screen now.
-  // `seen` is durable for the same reason; `open` is this session's.
+  // `workflowEmbedNoticeSeen` is the legacy persisted key, now used as the durable "choice made"
+  // marker. Keeping the key preserves every prior decision across upgrades.
   const [workflowEmbedNoticeSeen, setWorkflowEmbedNoticeSeen] = useState(
     readWorkflowEmbedNoticeSeen,
   );
   const [workflowEmbedNoticeOpen, setWorkflowEmbedNoticeOpen] = useState(false);
-  // Read by the generation trigger below, which is memoized and would otherwise close over stale
-  // values — and gated on the durable GET having landed, so a generation submitted in the first
-  // few hundred milliseconds after a desktop relaunch cannot re-show a notice already dismissed.
+  const [workflowEmbedDecisionSaving, setWorkflowEmbedDecisionSaving] = useState(false);
+  const [workflowEmbedDecisionError, setWorkflowEmbedDecisionError] = useState("");
+  const [settingsSharingFocusRequest, setSettingsSharingFocusRequest] = useState(0);
+  const pendingWorkflowGenerationRef = useRef(null);
+  const workflowEmbedHydrationWaitersRef = useRef([]);
+  const workflowEmbedDecisionSavingRef = useRef(false);
+  // Read by the generation gate below, which is memoized and would otherwise close over stale
+  // values. The gate waits for durable hydration before it decides whether the modal is needed.
   const workflowEmbedRef = useRef({ hydrated: false, embed: true, seen: false });
   workflowEmbedRef.current.embed = embedWorkflow;
   workflowEmbedRef.current.seen = workflowEmbedNoticeSeen;
@@ -779,20 +784,53 @@ export function App() {
     },
     [pushNotice],
   );
-  const dismissWorkflowEmbedNotice = useCallback(() => {
+  const settlePendingWorkflowGeneration = useCallback((allow) => {
+    const pending = pendingWorkflowGenerationRef.current;
+    if (!pending) return;
+    pendingWorkflowGenerationRef.current = null;
+    pending(Boolean(allow));
+  }, []);
+
+  const chooseWorkflowEmbedding = useCallback(
+    async (next) => {
+      if (workflowEmbedDecisionSavingRef.current) return;
+      workflowEmbedDecisionSavingRef.current = true;
+      setWorkflowEmbedDecisionSaving(true);
+      setWorkflowEmbedDecisionError("");
+      try {
+        await persistWorkflowEmbedPreference({
+          embedWorkflowInImages: Boolean(next),
+          workflowEmbedNoticeSeen: true,
+        });
+        workflowEmbedRef.current.embed = Boolean(next);
+        workflowEmbedRef.current.seen = true;
+        setEmbedWorkflow(Boolean(next));
+        setWorkflowEmbedNoticeSeen(true);
+        writeEmbedWorkflowInImages(Boolean(next));
+        writeWorkflowEmbedNoticeSeen(true);
+        setWorkflowEmbedNoticeOpen(false);
+        settlePendingWorkflowGeneration(true);
+      } catch {
+        setWorkflowEmbedDecisionError(
+          "SceneWorks could not save your choice. Check the connection and try again.",
+        );
+      } finally {
+        workflowEmbedDecisionSavingRef.current = false;
+        setWorkflowEmbedDecisionSaving(false);
+      }
+    },
+    [settlePendingWorkflowGeneration],
+  );
+
+  const openWorkflowSharingSettings = useCallback(() => {
     setWorkflowEmbedNoticeOpen(false);
-    setWorkflowEmbedNoticeSeen(true);
-    writeWorkflowEmbedNoticeSeen(true);
-    persistWorkflowEmbedPreference({ workflowEmbedNoticeSeen: true }).catch(() => {
-      pushNotice(
-        "workflow-embed",
-        "Could not record that this notice was dismissed, so it may appear again.",
-      );
-    });
-  }, [pushNotice]);
-  // A second tab that was already mounted when the notice was dismissed holds `seen: false` and
-  // would show the disclosure again on its own next generation — "once" being per tab rather than
-  // per user. The mirror write raises a `storage` event in every other tab, so they follow.
+    setWorkflowEmbedDecisionError("");
+    settlePendingWorkflowGeneration(false);
+    setSettingsSharingFocusRequest((request) => request + 1);
+    setSimpleActiveScreen("settings");
+    setActiveView("Settings");
+  }, [settlePendingWorkflowGeneration]);
+  // A completed choice is mirrored to other mounted tabs so they cannot ask independently.
   useEffect(
     () =>
       subscribeWorkflowEmbedFlags(({ embed, seen }) => {
@@ -800,21 +838,34 @@ export function App() {
         // One-way: see `subscribeWorkflowEmbedFlags`. `seen` is a record that something was said,
         // and another tab clearing its storage is not evidence it never was.
         if (seen) {
+          workflowEmbedRef.current.seen = true;
           setWorkflowEmbedNoticeSeen(true);
           setWorkflowEmbedNoticeOpen(false);
+          settlePendingWorkflowGeneration(true);
         }
       }),
-    [],
+    [settlePendingWorkflowGeneration],
   );
-  // The observable event the disclosure hangs off: a generation was accepted while embedding is
-  // on. Submission rather than completion, so the user is told BEFORE the files with their prompt
-  // in them exist — and only on a job the API actually took, so a failed POST does not burn it.
-  const noteGenerationForWorkflowEmbed = useCallback((job) => {
-    const state = workflowEmbedRef.current;
-    if (!job || !state.hydrated || !state.embed || state.seen) {
-      return;
+  // The first undecided generation is held before its POST. A choice resumes that one request;
+  // Settings cancels it so no image can be written with an unresolved preference.
+  const confirmWorkflowEmbeddingBeforeGeneration = useCallback(async () => {
+    if (!workflowEmbedRef.current.hydrated) {
+      await new Promise((resolve) => {
+        workflowEmbedHydrationWaitersRef.current.push(resolve);
+      });
     }
+    const state = workflowEmbedRef.current;
+    if (state.seen) {
+      return true;
+    }
+    if (pendingWorkflowGenerationRef.current) {
+      return false;
+    }
+    setWorkflowEmbedDecisionError("");
     setWorkflowEmbedNoticeOpen(true);
+    return new Promise((resolve) => {
+      pendingWorkflowGenerationRef.current = resolve;
+    });
   }, []);
   const activeProjectRef = useRef(null);
   const activeViewRef = useRef(activeView);
@@ -1475,13 +1526,26 @@ export function App() {
         // worker's own reader agrees), and an absent notice flag means the user has never been
         // told — which is exactly the state an install upgrading into this build is in, so the
         // disclosure fires once for them rather than only for fresh installs.
-        if (typeof prefs?.embedWorkflowInImages === "boolean") {
+        // A choice may finish while this launch GET is still in flight. Once `seen` has moved
+        // true locally, an older response must not roll either half of that atomic choice back.
+        if (
+          !workflowEmbedRef.current.seen &&
+          typeof prefs?.embedWorkflowInImages === "boolean"
+        ) {
           setEmbedWorkflow(prefs.embedWorkflowInImages);
           writeEmbedWorkflowInImages(prefs.embedWorkflowInImages);
         }
-        if (typeof prefs?.workflowEmbedNoticeSeen === "boolean") {
+        if (
+          !workflowEmbedRef.current.seen &&
+          typeof prefs?.workflowEmbedNoticeSeen === "boolean"
+        ) {
           setWorkflowEmbedNoticeSeen(prefs.workflowEmbedNoticeSeen);
           writeWorkflowEmbedNoticeSeen(prefs.workflowEmbedNoticeSeen);
+          if (prefs.workflowEmbedNoticeSeen) {
+            workflowEmbedRef.current.seen = true;
+            setWorkflowEmbedNoticeOpen(false);
+            settlePendingWorkflowGeneration(true);
+          }
         }
         const persistedView = prefs?.activeView;
         if (navSections.some((section) => section.items.some((item) => item.id === persistedView))) {
@@ -1494,13 +1558,16 @@ export function App() {
           // Only now may the disclosure fire: before this, `seen` is whatever localStorage said,
           // which on the desktop shell is a fresh empty store every launch.
           workflowEmbedRef.current.hydrated = true;
+          for (const resolve of workflowEmbedHydrationWaitersRef.current.splice(0)) {
+            resolve();
+          }
           setNavigationHydrated(true);
         }
       });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [settlePendingWorkflowGeneration]);
 
   const refreshHealth = useCallback(() => {
     healthRequestRef.current?.abort();
@@ -2250,12 +2317,11 @@ export function App() {
         requestedGpu,
         setJobs,
         setError,
-        // sc-15953: the one image-generation choke point every studio goes through (Image Studio,
-        // Simple, and the Character studio's angle/pose forms all call this), so the first-run
-        // disclosure hangs off it rather than off each lane's submit button.
-        afterCreate: noteGenerationForWorkflowEmbed,
+        // Every image-producing studio shares this preflight. The first undecided request waits
+        // here, before the POST, until the recipe-sharing choice is durably saved.
+        beforeCreate: confirmWorkflowEmbeddingBeforeGeneration,
       }),
-    [token, activeProject, requestedGpu, setError, noteGenerationForWorkflowEmbed],
+    [token, activeProject, requestedGpu, setError, confirmWorkflowEmbeddingBeforeGeneration],
   );
 
   // Standalone video upscale (epic 4811 / sc-4816): the net-new `video_upscale` job runs
@@ -3438,12 +3504,22 @@ export function App() {
             onModeChange={setUiModeOverride}
             onScreenChange={setSimpleActiveScreen}
             onSimpleDefaultChange={changeSimpleUiDefault}
+            requestedScreen={simpleActiveScreen}
+            settingsSharingFocusRequest={settingsSharingFocusRequest}
             /* The same flag that gates the durable `activeView` write: until the
                ui-preferences GET has landed, the Simple studios must neither restore from
                a possibly-empty cache nor write their catalog defaults over the stored copy. */
             preferencesHydrated={navigationHydrated}
             simpleDefault={simpleUiDefault}
           />
+          {workflowEmbedNoticeOpen ? (
+            <WorkflowEmbedDecisionModal
+              error={workflowEmbedDecisionError}
+              onChoose={chooseWorkflowEmbedding}
+              onOpenSettings={openWorkflowSharingSettings}
+              saving={workflowEmbedDecisionSaving}
+            />
+          ) : null}
           {/* The dropped-workflow offer (sc-15951). The drop guard is installed at App level
               and therefore runs in BOTH shells, so the panel it opens has to render in both
               too — otherwise a Simple-UI user's drop would be inspected and then answered by
@@ -3577,12 +3653,11 @@ export function App() {
         ))}
 
         {workflowEmbedNoticeOpen ? (
-          <WorkflowEmbedNotice
-            onDismiss={dismissWorkflowEmbedNotice}
-            onOpenSettings={() => {
-              dismissWorkflowEmbedNotice();
-              setActiveView("Settings");
-            }}
+          <WorkflowEmbedDecisionModal
+            error={workflowEmbedDecisionError}
+            onChoose={chooseWorkflowEmbedding}
+            onOpenSettings={openWorkflowSharingSettings}
+            saving={workflowEmbedDecisionSaving}
           />
         ) : null}
 
@@ -3618,6 +3693,7 @@ export function App() {
             onAccentChange={changeAccent}
             onEmbedWorkflowChange={changeEmbedWorkflow}
             onSimpleDefaultChange={changeSimpleUiDefault}
+            sharingFocusRequest={settingsSharingFocusRequest}
             simpleDefault={simpleUiDefault}
           />
         ) : null}

--- a/apps/web/src/App.workflowEmbed.test.jsx
+++ b/apps/web/src/App.workflowEmbed.test.jsx
@@ -6,14 +6,9 @@ import { click } from "./testUtils/dom.js";
 import { resetStartupTimingForTests } from "./startupTiming.js";
 import { resetAccessTokenForTests } from "./accessToken.js";
 
-// The first-run embedded-workflow disclosure (sc-15953), asserted through the REAL App shell.
-//
-// The observable event is "a generation was accepted while embedding is on", which App hangs off
-// the `afterCreate` hook of the ONE image-job creator every studio goes through. Rather than
-// driving a whole studio form to reach it, this captures the hook App actually hands that creator
-// and calls it — so what is under test is App's wiring, its once-only rule and its persistence,
-// without a test that would break the next time a studio's submit button moved.
-const hoisted = vi.hoisted(() => ({ afterCreate: null }));
+// Capture the pre-submit hook from the one image-job creator shared by every image studio. That
+// proves the request is held before its POST without coupling this suite to a particular form.
+const hoisted = vi.hoisted(() => ({ beforeCreate: null }));
 
 vi.mock("./createJob.js", async (importOriginal) => {
   const actual = await importOriginal();
@@ -21,7 +16,7 @@ vi.mock("./createJob.js", async (importOriginal) => {
     ...actual,
     makeCreateJob(options) {
       if (options.definition === actual.CREATE_JOB_DEFINITIONS.image) {
-        hoisted.afterCreate = options.afterCreate;
+        hoisted.beforeCreate = options.beforeCreate;
       }
       return actual.makeCreateJob(options);
     },
@@ -30,9 +25,9 @@ vi.mock("./createJob.js", async (importOriginal) => {
 
 const { App } = await import("./main.jsx");
 
-const NOTICE_TITLE = "Your generated images carry their recipe";
+const MODAL_TITLE = "Include the recipe in generated images?";
 
-function fakeApi(storedPreferences) {
+function fakeApi(storedPreferences, failurePlan = { workflowPuts: 0 }) {
   return vi.fn((url, init) => {
     const path = new URL(url).pathname;
     if (path.endsWith("/health")) {
@@ -49,7 +44,18 @@ function fakeApi(storedPreferences) {
     }
     if (path.endsWith("/ui-preferences")) {
       if (init?.method === "PUT") {
-        return Promise.resolve(response({ ...storedPreferences, ...JSON.parse(init.body) }));
+        const patch = JSON.parse(init.body);
+        if (
+          Object.hasOwn(patch, "workflowEmbedNoticeSeen") &&
+          failurePlan.workflowPuts > 0
+        ) {
+          failurePlan.workflowPuts -= 1;
+          return Promise.reject(new Error("offline"));
+        }
+        return Promise.resolve(response({ ...storedPreferences, ...patch }));
+      }
+      if (failurePlan.preferencesGet) {
+        return failurePlan.preferencesGet.then((preferences) => response(preferences));
       }
       return Promise.resolve(response(storedPreferences));
     }
@@ -66,9 +72,20 @@ function preferenceWrites() {
     .map(([, init]) => JSON.parse(init.body));
 }
 
-const noticeIsShowing = () => document.body.textContent.includes(NOTICE_TITLE);
+const workflowDecisionWrites = () =>
+  preferenceWrites().filter(
+    (patch) =>
+      Object.hasOwn(patch, "embedWorkflowInImages") ||
+      Object.hasOwn(patch, "workflowEmbedNoticeSeen"),
+  );
 
-describe("App — the one-time embedded-workflow disclosure (sc-15953)", () => {
+const modalIsShowing = () => document.body.textContent.includes(MODAL_TITLE);
+const buttonNamed = (name) =>
+  [...document.body.querySelectorAll("button")].find(
+    (button) => button.textContent.trim() === name,
+  );
+
+describe("App - the one-time embedded-workflow choice (sc-16390)", () => {
   let container;
   let root;
 
@@ -81,7 +98,7 @@ describe("App — the one-time embedded-workflow disclosure (sc-15953)", () => {
     window.localStorage.clear();
     resetAccessTokenForTests();
     window.innerWidth = 1440;
-    hoisted.afterCreate = null;
+    hoisted.beforeCreate = null;
   });
 
   afterEach(async () => {
@@ -93,8 +110,8 @@ describe("App — the one-time embedded-workflow disclosure (sc-15953)", () => {
     vi.restoreAllMocks();
   });
 
-  async function renderApp(storedPreferences = {}) {
-    global.fetch = fakeApi(storedPreferences);
+  async function renderApp(storedPreferences = {}, failurePlan) {
+    global.fetch = fakeApi(storedPreferences, failurePlan);
     root = createRoot(container);
     await act(async () => {
       root.render(<App />);
@@ -102,78 +119,155 @@ describe("App — the one-time embedded-workflow disclosure (sc-15953)", () => {
     await settle();
   }
 
-  async function generate() {
-    expect(hoisted.afterCreate, "App must hand the image-job creator an afterCreate hook").toBeTypeOf(
+  async function startGeneration() {
+    expect(hoisted.beforeCreate, "App must provide the image pre-submit hook").toBeTypeOf(
       "function",
     );
+    let gate;
     await act(async () => {
-      hoisted.afterCreate({ id: "job-1" });
+      gate = hoisted.beforeCreate({ prompt: "roses" });
     });
     await settle();
+    return { gate };
   }
 
-  it("is not on screen until a generation is submitted", async () => {
-    // It is a disclosure about what a generated file will carry, so it has nothing to say to
-    // someone who has not generated anything.
+  it("does not interrupt the app before a generation is attempted", async () => {
     await renderApp();
-    expect(noticeIsShowing()).toBe(false);
+    expect(modalIsShowing()).toBe(false);
   });
 
-  it("appears on the first generation, is dismissible, and never comes back", async () => {
+  it("holds the first generation until Ok atomically enables embedding and records the choice", async () => {
     await renderApp();
-    await generate();
-    expect(noticeIsShowing()).toBe(true);
+    const { gate } = await startGeneration();
+    expect(modalIsShowing()).toBe(true);
+    expect(workflowDecisionWrites()).toEqual([]);
+    expect(
+      [...document.body.querySelector("[role=dialog]").querySelectorAll("button")].map(
+        (button) => button.textContent.trim(),
+      ),
+    ).toEqual(["Go to settings", "No thanks!", "Ok, got it"]);
+    const dialog = document.body.querySelector("[role=dialog]");
+    const description = document.getElementById(dialog.getAttribute("aria-describedby"));
+    expect(description?.textContent).toContain("model, and LoRA details");
 
-    const dismiss = [...document.body.querySelectorAll("button")].find(
-      (button) => button.textContent.trim() === "Got it",
-    );
-    expect(dismiss, "a dismiss button").toBeTruthy();
-    await click(dismiss);
+    await click(buttonNamed("Ok, got it"));
     await settle();
 
-    expect(noticeIsShowing()).toBe(false);
-    // Durable, not a browser flag: the desktop shell's origin changes each launch and would take
-    // localStorage with it, re-showing the notice forever.
-    expect(preferenceWrites()).toContainEqual({ workflowEmbedNoticeSeen: true });
-
-    // A second, third and fourth generation in the same session must not bring it back.
-    await generate();
-    await generate();
-    expect(noticeIsShowing()).toBe(false);
+    await expect(gate).resolves.toBe(true);
+    expect(modalIsShowing()).toBe(false);
+    expect(preferenceWrites()).toContainEqual({
+      embedWorkflowInImages: true,
+      workflowEmbedNoticeSeen: true,
+    });
+    const second = await startGeneration();
+    await expect(second.gate).resolves.toBe(true);
+    expect(modalIsShowing()).toBe(false);
   });
 
-  it("never appears for a user who has already been told, across a relaunch", async () => {
-    // The stored flag is what a restart restores. This is the case that would regress into
-    // "fires on every launch" if the flag lived only in localStorage.
-    await renderApp({ workflowEmbedNoticeSeen: true });
-    await generate();
-    expect(noticeIsShowing()).toBe(false);
-  });
-
-  it("fires once for an install that was already generating before the feature shipped", async () => {
-    // The upgrade case. An existing install has no stored flag — which reads as "never told" —
-    // and embedding defaults ON, so this is exactly the user the disclosure exists for. A
-    // mechanism keyed on "this is a fresh install" would stay silent here.
-    await renderApp({ theme: "dark", accent: "coral", defaultGenerationQuality: "q8" });
-    await generate();
-    expect(noticeIsShowing()).toBe(true);
-  });
-
-  it("stays silent when the user has turned embedding off", async () => {
-    // Nothing is being disclosed, because nothing is being embedded.
-    await renderApp({ embedWorkflowInImages: false });
-    await generate();
-    expect(noticeIsShowing()).toBe(false);
-  });
-
-  it("does not fire for a POST the API refused", async () => {
-    // `afterCreate` only runs on a job the server accepted; a failed submit writes no file and
-    // must not burn the one disclosure the user gets.
+  it("persists No thanks atomically and resumes the held generation with embedding off", async () => {
     await renderApp();
+    const { gate } = await startGeneration();
+
+    await click(buttonNamed("No thanks!"));
+    await settle();
+
+    await expect(gate).resolves.toBe(true);
+    expect(preferenceWrites()).toContainEqual({
+      embedWorkflowInImages: false,
+      workflowEmbedNoticeSeen: true,
+    });
+  });
+
+  it("opens Sharing and cancels the held request without recording a decision", async () => {
+    await renderApp();
+    const { gate } = await startGeneration();
+
+    await click(buttonNamed("Go to settings"));
+    await settle();
+
+    await expect(gate).resolves.toBe(false);
+    expect(workflowDecisionWrites()).toEqual([]);
+    expect(document.body.textContent).toContain("Include the recipe in generated images");
+    expect(document.activeElement?.textContent).toBe("Sharing");
+
+    const { gate: nextGate } = await startGeneration();
+    expect(modalIsShowing()).toBe(true);
+    await click(buttonNamed("No thanks!"));
+    await expect(nextGate).resolves.toBe(true);
+  });
+
+  it("never asks again when the durable decision marker is already present", async () => {
+    await renderApp({ workflowEmbedNoticeSeen: true });
+    const { gate } = await startGeneration();
+    await expect(gate).resolves.toBe(true);
+    expect(modalIsShowing()).toBe(false);
+  });
+
+  it("waits for the durable preference GET before deciding whether to show the modal", async () => {
+    let releasePreferences;
+    const preferencesGet = new Promise((resolve) => {
+      releasePreferences = resolve;
+    });
+    await renderApp({}, { preferencesGet, workflowPuts: 0 });
+
+    const { gate } = await startGeneration();
+    expect(modalIsShowing()).toBe(false);
+
     await act(async () => {
-      hoisted.afterCreate(null);
+      releasePreferences({ embedWorkflowInImages: false, workflowEmbedNoticeSeen: true });
     });
     await settle();
-    expect(noticeIsShowing()).toBe(false);
+
+    await expect(gate).resolves.toBe(true);
+    expect(modalIsShowing()).toBe(false);
+    expect(workflowDecisionWrites()).toEqual([]);
+  });
+
+  it("asks an upgraded install that has no decision marker", async () => {
+    await renderApp({ theme: "dark", accent: "coral", defaultGenerationQuality: "q8" });
+    await startGeneration();
+    expect(modalIsShowing()).toBe(true);
+  });
+
+  it("asks for an explicit decision even when the current setting is off", async () => {
+    await renderApp({ embedWorkflowInImages: false });
+    await startGeneration();
+    expect(modalIsShowing()).toBe(true);
+  });
+
+  it("keeps the choice open after a persistence failure and retries the same action", async () => {
+    const failurePlan = { workflowPuts: 3 };
+    await renderApp({}, failurePlan);
+    const { gate } = await startGeneration();
+
+    await click(buttonNamed("No thanks!"));
+    await new Promise((resolve) => setTimeout(resolve, 1300));
+    await settle();
+
+    expect(modalIsShowing()).toBe(true);
+    expect(document.body.textContent).toContain("could not save your choice");
+    let resolved = false;
+    gate.then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    await click(buttonNamed("No thanks!"));
+    await settle();
+    await expect(gate).resolves.toBe(true);
+  });
+
+  it("opens and focuses Sharing inside the Simple shell too", async () => {
+    window.innerWidth = 390;
+    await renderApp();
+    const { gate } = await startGeneration();
+
+    await click(buttonNamed("Go to settings"));
+    await settle();
+
+    await expect(gate).resolves.toBe(false);
+    expect(document.body.querySelector(".su-group-title")?.textContent).toBe("Appearance");
+    expect(document.activeElement?.textContent).toBe("Sharing");
   });
 });

--- a/apps/web/src/components/Modal.jsx
+++ b/apps/web/src/components/Modal.jsx
@@ -31,7 +31,7 @@ function focusableChildren(dialog) {
 // a direct child of `body`, immune to any such ancestor. React portals preserve
 // synthetic event bubbling, so the Escape / backdrop-click / focus handlers
 // below keep working exactly as before.
-export function Modal({ children, onClose, className, labelledBy, label }) {
+export function Modal({ children, onClose, className, describedBy, labelledBy, label }) {
   const dialogRef = useRef(null);
 
   useEffect(() => {
@@ -51,6 +51,7 @@ export function Modal({ children, onClose, className, labelledBy, label }) {
     >
       <div
         aria-label={label}
+        aria-describedby={describedBy}
         aria-labelledby={labelledBy}
         aria-modal="true"
         className={className}

--- a/apps/web/src/components/WorkflowEmbedNotice.jsx
+++ b/apps/web/src/components/WorkflowEmbedNotice.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Icon } from "./Icons.jsx";
+import { Modal } from "./Modal.jsx";
 import {
   GALLERY_READABLE_COPY,
   SAVE_WITHOUT_WORKFLOW_LABEL,
@@ -29,8 +29,8 @@ import {
 // path is caught, and it says the switch applies to the NEXT generation rather than implying
 // anything about images already on disk.
 
-// The paragraphs under the Settings toggle. Also rendered inside the first-run notice, so the two
-// surfaces cannot drift.
+// The detailed paragraphs under the Settings toggle. The first-run modal deliberately uses a
+// concise summary so the decision is readable on phones.
 export function WorkflowEmbedDetails() {
   return (
     <>
@@ -74,38 +74,51 @@ export function WorkflowEmbedDetails() {
   );
 }
 
-// The one-time disclosure. Rendered the first time a generation is submitted while embedding is on
-// and the user has never been told; dismissing it records a durable server-side flag, so it does
-// not come back on the next launch (the desktop shell's per-launch origin makes a localStorage-only
-// flag useless for this).
-//
-// Deliberately NOT a modal. It is a disclosure, not a decision — blocking a generation the user
-// already asked for to make them read a paragraph would train them to dismiss it unread, which is
-// the opposite of the point.
-export function WorkflowEmbedNotice({ onDismiss, onOpenSettings }) {
+// The one-time decision surface. The first undecided generation waits behind it, and only an
+// explicit yes/no choice records the durable decision. The detailed sharing envelope remains in
+// Settings; this modal intentionally keeps only the context needed to choose.
+export function WorkflowEmbedDecisionModal({ error, onChoose, onOpenSettings, saving }) {
   return (
-    <section
-      aria-labelledby="workflow-embed-notice-title"
-      className="settings-notice workflow-embed-notice"
-      role="region"
+    <Modal
+      className="workflow-embed-decision-modal"
+      describedBy="workflow-embed-decision-description"
+      labelledBy="workflow-embed-decision-title"
+      onClose={() => {}}
     >
-      <Icon.Warning size={16} />
-      <div>
-        <div className="workflow-embed-notice-title" id="workflow-embed-notice-title">
-          Your generated images carry their recipe
-        </div>
-        <WorkflowEmbedDetails />
-        <div className="settings-button-row">
-          {onOpenSettings ? (
-            <button className="settings-btn" onClick={onOpenSettings} type="button">
-              Open settings
-            </button>
-          ) : null}
-          <button className="settings-btn" onClick={onDismiss} type="button">
-            Got it
-          </button>
-        </div>
+      <div className="workflow-embed-decision-copy">
+        <h2 id="workflow-embed-decision-title">Include the recipe in generated images?</h2>
+        <p id="workflow-embed-decision-description">
+          SceneWorks can embed the prompt, settings, model, and LoRA details used to make an image.
+          That makes recipes reusable and helps galleries such as Civitai identify the resources.
+        </p>
+        <p>You can change this later from Settings.</p>
       </div>
-    </section>
+      {error ? (
+        <p className="workflow-embed-decision-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <div className="workflow-embed-decision-actions">
+        <button className="settings-btn" disabled={saving} onClick={onOpenSettings} type="button">
+          Go to settings
+        </button>
+        <button
+          className="settings-btn"
+          disabled={saving}
+          onClick={() => onChoose(false)}
+          type="button"
+        >
+          No thanks!
+        </button>
+        <button
+          className="settings-btn settings-btn--primary"
+          disabled={saving}
+          onClick={() => onChoose(true)}
+          type="button"
+        >
+          {saving ? "Saving..." : "Ok, got it"}
+        </button>
+      </div>
+    </Modal>
   );
 }

--- a/apps/web/src/createJob.js
+++ b/apps/web/src/createJob.js
@@ -60,6 +60,7 @@ export function makeCreateJob({
   requestedGpu,
   setJobs,
   setError,
+  beforeCreate,
   afterCreate,
 }) {
   return async (...args) => {
@@ -68,6 +69,9 @@ export function makeCreateJob({
       return null;
     }
     try {
+      if (beforeCreate && (await beforeCreate(...args)) === false) {
+        return null;
+      }
       const job = await apiFetch(definition.path, token, {
         method: "POST",
         body: JSON.stringify(definition.buildBody(args, project, requestedGpu)),

--- a/apps/web/src/createJob.test.js
+++ b/apps/web/src/createJob.test.js
@@ -139,6 +139,25 @@ describe("makeCreateJob", () => {
     );
   });
 
+  it("can hold or cancel a request before the POST", async () => {
+    const beforeCreate = vi.fn(async () => false);
+    const creator = makeCreateJob({
+      definition: CREATE_JOB_DEFINITIONS.image,
+      token: "",
+      project,
+      requestedGpu: "auto",
+      setJobs: vi.fn(),
+      setError: vi.fn(),
+      beforeCreate,
+    });
+    const payload = { prompt: "wait for the decision" };
+
+    await expect(creator(payload)).resolves.toBeNull();
+
+    expect(beforeCreate).toHaveBeenCalledWith(payload);
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
   it("retains the missing-project and request-error contracts", async () => {
     const setError = vi.fn();
     const missingProjectCreator = makeCreateJob({

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -68,6 +68,7 @@ export function SettingsScreen({
   lockedToSimple = false,
   embedWorkflow = true,
   onEmbedWorkflowChange,
+  sharingFocusRequest = 0,
 }) {
   // theme/changeTheme and the worker registry come from the app context (the same values the
   // topbar toggle and Simple Settings read); accent + the Simple-mode default are drilled from
@@ -83,6 +84,16 @@ export function SettingsScreen({
   const [status, setStatus] = useState("");
   // Which tab is showing. Not persisted — the screen is short-lived.
   const [tab, setTab] = useState("appearance");
+  const sharingHeadingRef = useRef(null);
+  useEffect(() => {
+    if (!sharingFocusRequest) return undefined;
+    setTab("settings");
+    const timer = setTimeout(() => {
+      sharingHeadingRef.current?.scrollIntoView?.({ block: "start" });
+      sharingHeadingRef.current?.focus();
+    }, 0);
+    return () => clearTimeout(timer);
+  }, [sharingFocusRequest]);
   // LAN remote access (epic 4484 stories 4/11). `remote` is the RemoteAccessStatus
   // snapshot from the shell; only fetched/rendered on desktop.
   const [remote, setRemote] = useState(null);
@@ -496,7 +507,7 @@ export function SettingsScreen({
                 so the change lands on the next generation with no restart. The copy under it is
                 the same block the first-run disclosure shows; see WorkflowEmbedNotice.jsx for why
                 its claims are shaped the way they are. */}
-            <div className="settings-group-title">Sharing</div>
+            <div className="settings-group-title" ref={sharingHeadingRef} tabIndex={-1}>Sharing</div>
             <div className="settings-row">
               <div>
                 <div className="settings-row-title">Include the recipe in generated images</div>

--- a/apps/web/src/simple/SimpleSettings.jsx
+++ b/apps/web/src/simple/SimpleSettings.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "../components/Icons.jsx";
 import { putUiPreferences } from "../uiPreferences.js";
 import { useAppContext } from "../context/AppContext.js";
@@ -32,6 +32,7 @@ export function SimpleSettings({
   lockedToSimple,
   embedWorkflow = true,
   onEmbedWorkflowChange,
+  sharingFocusRequest = 0,
 }) {
   const { theme, changeTheme, visibleWorkers = [], macCapabilities } = useAppContext();
   const { toast } = useSimpleUi();
@@ -40,6 +41,16 @@ export function SimpleSettings({
   const [host, setHost] = useState("");
   const [token, setToken] = useState("");
   const [saving, setSaving] = useState(false);
+  const sharingHeadingRef = useRef(null);
+
+  useEffect(() => {
+    if (!sharingFocusRequest) return undefined;
+    const timer = setTimeout(() => {
+      sharingHeadingRef.current?.scrollIntoView?.({ block: "start" });
+      sharingHeadingRef.current?.focus();
+    }, 0);
+    return () => clearTimeout(timer);
+  }, [sharingFocusRequest]);
 
   useEffect(() => {
     let cancelled = false;
@@ -190,7 +201,7 @@ export function SimpleSettings({
           leaving the switch out of it would make "discoverable" untrue for most of the people
           the disclosure is aimed at. */}
       <div className="su-group">
-        <div className="su-group-title">Sharing</div>
+        <div className="su-group-title" ref={sharingHeadingRef} tabIndex={-1}>Sharing</div>
         <div className="su-card su-card--split">
           <div>
             <div className="su-card-title">Include the recipe in generated images</div>

--- a/apps/web/src/simple/SimpleShell.jsx
+++ b/apps/web/src/simple/SimpleShell.jsx
@@ -81,6 +81,8 @@ export function SimpleShell({
   onSimpleDefaultChange,
   onModeChange,
   onScreenChange,
+  requestedScreen,
+  settingsSharingFocusRequest,
   lockedToSimple,
   preferencesHydrated = true,
 }) {
@@ -183,6 +185,16 @@ export function SimpleShell({
   useEffect(() => {
     onScreenChange?.(screen);
   }, [onScreenChange, screen]);
+
+  useEffect(() => {
+    if (requestedScreen && SCREEN_BY_ID.has(requestedScreen)) {
+      setScreen(requestedScreen);
+      setDrawer(false);
+      setSheet(null);
+      setPreview(null);
+      setGuideOpen(false);
+    }
+  }, [requestedScreen]);
 
   // Opening an asset. An audio asset also becomes the loaded take, so the grid rings it and
   // the viewer opens on its deck; `play` (the tile's play button) starts it immediately.
@@ -370,6 +382,7 @@ export function SimpleShell({
                   onAccentChange={onAccentChange}
                   onEmbedWorkflowChange={onEmbedWorkflowChange}
                   onSimpleDefaultChange={onSimpleDefaultChange}
+                  sharingFocusRequest={settingsSharingFocusRequest}
                   simpleDefault={simpleDefault}
                 />
               ) : null}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -14627,27 +14627,62 @@ details[open] > summary.lora-scope-group-heading::before,
   color: var(--text-muted);
 }
 
-/* The one-time embedded-workflow disclosure (sc-15953). Reuses the warn-bordered band, but
-   carries a title, several paragraphs and its own buttons rather than one line of text. */
-.workflow-embed-notice {
-  margin-bottom: var(--gap-3);
+/* The first-generation recipe choice (sc-16390). The exhaustive sharing envelope stays in
+   Settings; this modal is intentionally compact and only explains the immediate decision. */
+.workflow-embed-decision-modal {
+  display: grid;
+  gap: 18px;
+  width: min(520px, calc(100vw - 32px));
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: var(--surface);
+  box-shadow: var(--shadow-lg);
 }
 
-.workflow-embed-notice > div {
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-  min-width: 0;
+.workflow-embed-decision-copy {
+  display: grid;
+  gap: 10px;
 }
 
-.workflow-embed-notice-title {
+.workflow-embed-decision-copy h2,
+.workflow-embed-decision-copy p,
+.workflow-embed-decision-error {
+  margin: 0;
+}
+
+.workflow-embed-decision-copy h2 {
+  font-size: 20px;
+  line-height: 1.25;
+}
+
+.workflow-embed-decision-copy p {
+  color: var(--text-muted);
+  line-height: 1.55;
+}
+
+.workflow-embed-decision-error {
+  color: var(--danger);
   font-size: 12.5px;
-  font-weight: 600;
-  color: var(--text);
 }
 
-.workflow-embed-notice .settings-button-row {
-  margin-top: 3px;
+.workflow-embed-decision-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+@media (max-width: 520px) {
+  .workflow-embed-decision-modal {
+    padding: 20px;
+  }
+
+  .workflow-embed-decision-actions {
+    display: grid;
+  }
 }
 
 /* The "also in the file" / "not in the file" bullets (sc-15953). A LIST rather than one long

--- a/apps/web/src/workflowEmbed.js
+++ b/apps/web/src/workflowEmbed.js
@@ -352,9 +352,8 @@ export function writeEmbedWorkflowInImages(value) {
   return writeFlag(EMBED_STORAGE_KEY, value);
 }
 
-// Whether the first-run disclosure has already been shown and dismissed. Absent means NOT seen,
-// which is what makes an existing install upgrading into this build get the notice once: the
-// default is silently ON, and someone who has been generating for months has never been told.
+// Durable one-time decision marker. The old `notice seen` storage/API name is retained so existing
+// installs do not lose their completed decision during the modal redesign.
 export function readWorkflowEmbedNoticeSeen() {
   return readFlag(NOTICE_STORAGE_KEY, false);
 }


### PR DESCRIPTION
## Summary
- replace the error-like inline recipe banner with a concise, centered one-time modal
- hold the first undecided image submission before its POST; atomically persist yes/no before resuming exactly once
- cancel the held request when opening Settings and focus the Sharing control in both Advanced and Simple shells
- preserve completed choices across relaunches/tabs, surface persistence failures with retry, and keep actions reachable on small-height viewports

## Validation
- 
pm.cmd test (234 files, 3,434 tests)
- 
pm.cmd run lint
- 
pm.cmd run build
- independent adversarial review: PASS (high confidence)

Shortcut: https://app.shortcut.com/trefry/story/16390