### PR TITLE
Batch calibration rungs per model load (sc-16059)

### DIFF
--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -405,20 +405,31 @@ jobs:
           printf '.calibration/\n' >> .git/info/exclude
           cargo build --release --locked -p sceneworks-memory-adapter \
             --features mlx --bin memory-mlx-adapter
-          node scripts/memory-calibration-harness.mjs run \
+          node scripts/memory-calibration-harness.mjs assess-reuse \
             --config config/memory-calibration-plan.json \
             --backend mlx \
             --fixture fresh-five-rung-z-image-q4-768-seed16402-step2 \
             --provider-command '["target/release/memory-mlx-adapter"]' \
+            --output "$RUNNER_TEMP/sc-16059-mlx-reuse-assessment.json"
+          node -e 'const a=require(process.argv[1]); if(a.verdict!=="unable_to_amortize") throw new Error(`unexpected MLX reuse verdict: ${a.verdict}`)' \
+            "$RUNNER_TEMP/sc-16059-mlx-reuse-assessment.json"
+          node scripts/memory-calibration-harness.mjs run \
+            --config config/memory-calibration-plan.json \
+            --backend mlx \
+            --fixture fresh-five-rung-z-image-q4-768-seed16402-step2 \
+            --fresh-per-case \
+            --provider-command '["target/release/memory-mlx-adapter"]' \
             --sceneworks-repo "$GITHUB_WORKSPACE" \
             --inference-repo "$GITHUB_WORKSPACE/.calibration/inference" \
-            --output "$RUNNER_TEMP/sc-16402-mlx-fresh.json"
+            --output "$RUNNER_TEMP/sc-16059-mlx-fresh.json"
           node scripts/memory-calibration-harness.mjs check \
-            --input "$RUNNER_TEMP/sc-16402-mlx-fresh.json"
+            --input "$RUNNER_TEMP/sc-16059-mlx-fresh.json"
       - name: Upload raw schema-checked MLX five-rung reference
         if: ${{ success() && github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: sc-16402-mlx-fresh-${{ github.run_id }}
-          path: ${{ runner.temp }}/sc-16402-mlx-fresh.json
+          name: sc-16059-mlx-reuse-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/sc-16059-mlx-fresh.json
+            ${{ runner.temp }}/sc-16059-mlx-reuse-assessment.json
           if-no-files-found: error

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -180,14 +180,15 @@ jobs:
       # until someone ran Candle calibration on a CUDA host — which is exactly where this epic's
       # downstream Candle stories start (sc-15804 review: an exhaustive
       # `MemoryStrategyParameters` literal here went stale against the inference contract with
-      # nothing to catch it). `cargo check` is enough: this binary is only ever run by hand on a
-      # calibration host, so typechecking the CUDA build is the coverage that was missing.
-      - name: Check the candle memory adapter builds (memory-candle-adapter)
+      # nothing to catch it). Keep both the production typecheck and the binary's CUDA-only unit
+      # tests here: the batching contamination guard cannot be compiled or exercised on macOS.
+      - name: Check and test the candle memory adapter (memory-candle-adapter)
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
           set NVCC_CCBIN=%VCToolsInstallDir%bin\Hostx64\x64
           cargo check -p sceneworks-memory-adapter --features candle --bin memory-candle-adapter
+          cargo test -p sceneworks-memory-adapter --features candle --bin memory-candle-adapter
       - name: Validate five-rung reference inputs
         if: ${{ github.event_name == 'workflow_dispatch' }}
         shell: powershell
@@ -219,10 +220,17 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference }}
         with:
           node-version: 22
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - name: Validate runner Python for Krea provisioning
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && inputs.provision_krea_snapshot }}
-        with:
-          python-version: "3.12"
+        shell: powershell
+        run: |
+          $version = python --version
+          if ($LASTEXITCODE -ne 0 -or $version -notmatch '^Python 3\.(?<minor>\d+)\.') {
+            throw "the self-hosted CUDA runner requires Python 3.12 or newer, got: $version"
+          }
+          if ([int]$Matches.minor -lt 12) {
+            throw "the self-hosted CUDA runner requires Python 3.12 or newer, got: $version"
+          }
       - name: Provision exact public Krea reference snapshot
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && inputs.provision_krea_snapshot }}
         shell: powershell
@@ -276,7 +284,7 @@ jobs:
         with:
           repository: SceneWorks/inference
           ref: ${{ inputs.inference_revision }}
-          token: ${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}
+          token: ${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN || github.token }}
           path: .calibration/inference
           persist-credentials: false
       - name: Build and run the authoritative Candle five-rung reference
@@ -290,14 +298,21 @@ jobs:
           set NVCC_CCBIN=%VCToolsInstallDir%bin\Hostx64\x64
           echo .calibration/>>.git\info\exclude
           cargo build --release --locked -p sceneworks-memory-adapter --features candle --bin memory-candle-adapter
-          node scripts\memory-calibration-harness.mjs run --config config\memory-calibration-plan.json --backend candle --fixture fresh-five-rung-krea-q4-1024-seed16402-step2 --provider-command "[\"target/release/memory-candle-adapter.exe\"]" --sceneworks-repo "%GITHUB_WORKSPACE%" --inference-repo "%GITHUB_WORKSPACE%\.calibration\inference" --output "%RUNNER_TEMP%\sc-16402-candle-fresh.json"
-          node scripts\memory-calibration-harness.mjs check --input "%RUNNER_TEMP%\sc-16402-candle-fresh.json"
+          node scripts\memory-calibration-harness.mjs run --config config\memory-calibration-plan.json --backend candle --fixture fresh-five-rung-krea-q4-1024-seed16402-step2 --fresh-per-case --provider-command "[\"target/release/memory-candle-adapter.exe\"]" --sceneworks-repo "%GITHUB_WORKSPACE%" --inference-repo "%GITHUB_WORKSPACE%\.calibration\inference" --output "%RUNNER_TEMP%\sc-16059-candle-fresh.json"
+          node scripts\memory-calibration-harness.mjs run --config config\memory-calibration-plan.json --backend candle --fixture fresh-five-rung-krea-q4-1024-seed16402-step2 --batch-rungs --provider-command "[\"target/release/memory-candle-adapter.exe\"]" --sceneworks-repo "%GITHUB_WORKSPACE%" --inference-repo "%GITHUB_WORKSPACE%\.calibration\inference" --output "%RUNNER_TEMP%\sc-16059-candle-reused.json"
+          node scripts\memory-calibration-harness.mjs check --input "%RUNNER_TEMP%\sc-16059-candle-fresh.json"
+          node scripts\memory-calibration-harness.mjs check --input "%RUNNER_TEMP%\sc-16059-candle-reused.json"
+          node scripts\memory-calibration-harness.mjs compare-reuse --fresh "%RUNNER_TEMP%\sc-16059-candle-fresh.json" --reused "%RUNNER_TEMP%\sc-16059-candle-reused.json" --output "%RUNNER_TEMP%\sc-16059-candle-reuse-comparison.json"
+          node -e "const a=require(process.argv[1]); console.log(JSON.stringify(a,null,2)); if(!['amortizable','unable_to_amortize'].includes(a.verdict)) throw new Error('unexpected Candle reuse verdict: '+a.verdict)" "%RUNNER_TEMP%\sc-16059-candle-reuse-comparison.json"
       - name: Upload raw schema-checked Candle five-rung reference
         if: ${{ success() && github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: sc-16402-candle-fresh-${{ github.run_id }}
-          path: ${{ runner.temp }}/sc-16402-candle-fresh.json
+          name: sc-16059-candle-reuse-${{ github.run_id }}
+          path: |
+            ${{ runner.temp }}/sc-16059-candle-fresh.json
+            ${{ runner.temp }}/sc-16059-candle-reused.json
+            ${{ runner.temp }}/sc-16059-candle-reuse-comparison.json
           if-no-files-found: error
       - name: Clippy (candle worker)
         shell: cmd

--- a/crates/sceneworks-memory-adapter/src/bin/candle.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/candle.rs
@@ -570,8 +570,15 @@ fn measured_strategy(
     Ok(measured)
 }
 
-fn run_five_rung_reference(request: &Value) -> Result<Value, String> {
-    protocol::validate_plain_overlay_target(request, KREA_PLAIN_EXECUTION_PATH)?;
+fn load_five_rung_generator() -> Result<
+    (
+        String,
+        String,
+        Box<dyn runtime_cuda::gen_core::Generator>,
+        VramProbe,
+    ),
+    String,
+> {
     let repository = protocol::required_env("SCENEWORKS_KREA_REPOSITORY")?;
     let revision = protocol::required_env("SCENEWORKS_KREA_REVISION")?;
     protocol::validate_artifact_identity(&repository, &revision, protocol::KREA_REPOSITORY)?;
@@ -592,11 +599,27 @@ fn run_five_rung_reference(request: &Value) -> Result<Value, String> {
         .with_load_shape(LoadShape::DeferredMaterialization);
     let catalog =
         runtime_cuda::catalog().map_err(|error| format!("build CUDA catalog: {error}"))?;
-    let contract = catalog
+    let mut vram = VramProbe::start_rendered().assert_idle(1.0);
+    let load_sample = vram.phase();
+    let generator = catalog
         .media()
-        .memory_strategy_contract(KREA_ID, &spec)
-        .map_err(|error| format!("read {KREA_ID} memory-strategy contract: {error}"))?
-        .ok_or_else(|| format!("{KREA_ID} has no memory-strategy contract"))?;
+        .load(KREA_ID, &spec)
+        .map_err(|error| format!("load real {KREA_ID} q4 generator: {error}"))?;
+    vram.end_load(load_sample);
+    Ok((repository, revision, generator, vram))
+}
+
+fn run_five_rung_reference_loaded(
+    request: &Value,
+    generator: &dyn runtime_cuda::gen_core::Generator,
+    vram: &mut VramProbe,
+    repository: &str,
+    revision: &str,
+) -> Result<Value, String> {
+    protocol::validate_plain_overlay_target(request, KREA_PLAIN_EXECUTION_PATH)?;
+    let contract = generator
+        .memory_strategy_contract()
+        .ok_or_else(|| format!("loaded {KREA_ID} has no memory-strategy contract"))?;
     let selection = planned_selection(request)?;
     contract
         .validate_selection(&selection)
@@ -650,13 +673,6 @@ fn run_five_rung_reference(request: &Value) -> Result<Value, String> {
         cache_state: MemoryCacheState::Cold,
         evidence_revision: format!("sc-16402@{}", protocol::INFERENCE_PIN),
     };
-    let mut vram = VramProbe::start_rendered().assert_idle(1.0);
-    let load_sample = vram.phase();
-    let generator = catalog
-        .media()
-        .load(KREA_ID, &spec)
-        .map_err(|error| format!("load real {KREA_ID} q4 generator: {error}"))?;
-    vram.end_load(load_sample);
     let mut scope = generator
         .begin_memory_strategy_request(&context)
         .map_err(|error| format!("begin Krea fresh-reference scope: {error}"))?
@@ -748,7 +764,6 @@ fn run_five_rung_reference(request: &Value) -> Result<Value, String> {
         }
     }
     vram.end_gen(generation_sample);
-    let report = vram.report();
     if let Some(message) = phase_error {
         let _ = scope.finish(MemoryRunOutcome::Error {
             message: message.clone(),
@@ -789,9 +804,9 @@ fn run_five_rung_reference(request: &Value) -> Result<Value, String> {
     let decode_bytes = decimal_gb_to_bytes(
         decode_peak_gb.ok_or_else(|| "Krea fresh reference did not complete decode".to_owned())?,
     );
-    let overall_bytes = decimal_gb_to_bytes(report.peak_gb);
+    let overall_bytes = conditioning_bytes.max(denoise_bytes).max(decode_bytes);
     let blocker = concat!(
-        "fresh-process oracle capture measures exact per-rung memory and strategy identity for ",
+        "five-rung oracle capture measures exact per-rung memory and strategy identity for ",
         "sc-16059; it intentionally remains gated because this run does not repeat the full ",
         "promotion-quality, negative-mutation, and lifecycle scenario suite"
     );
@@ -799,14 +814,14 @@ fn run_five_rung_reference(request: &Value) -> Result<Value, String> {
         request,
         KREA_PLAIN_EXECUTION_PATH,
         protocol::PlainGatedFragment {
-            artifact: artifact(&repository, &revision),
+            artifact: artifact(repository, revision),
             sweep: protocol::reference_sweep(request, "passed")?,
             blocker,
             quality: json!({ "result": "not_run" }),
             negative_mutation: Value::Null,
             loadability: json!({
                 "result": "passed",
-                "resolvedPathFingerprint": loadability_fingerprint(&repository, &revision),
+                "resolvedPathFingerprint": loadability_fingerprint(repository, revision),
             }),
             diagnostics: protocol::diagnostics(
                 "memory-candle-adapter:krea-five-rung-reference",
@@ -829,6 +844,101 @@ fn run_five_rung_reference(request: &Value) -> Result<Value, String> {
         "overall": cuda_phase_metrics(overall_bytes),
     });
     Ok(fragment)
+}
+
+fn run_five_rung_reference(request: &Value) -> Result<Value, String> {
+    protocol::validate_plain_overlay_target(request, KREA_PLAIN_EXECUTION_PATH)?;
+    let (repository, revision, generator, mut vram) = load_five_rung_generator()?;
+    run_five_rung_reference_loaded(
+        request,
+        generator.as_ref(),
+        &mut vram,
+        &repository,
+        &revision,
+    )
+}
+
+fn update_warmed_retention_baseline(
+    settled_after_resident: &mut Option<u64>,
+    after: u64,
+) -> Result<(), String> {
+    if let Some(baseline) = *settled_after_resident {
+        if after > baseline.saturating_add(64 * MIB) {
+            return Err(format!(
+                "reused Krea rung retained {} bytes above the warmed resident baseline; refusing contaminated batching",
+                after - baseline
+            ));
+        }
+    } else {
+        *settled_after_resident = Some(after);
+    }
+    Ok(())
+}
+
+fn run_five_rung_batch(request: &Value) -> Result<Value, String> {
+    let planned = request
+        .get("planned")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "run_batch request.planned must be an array".to_owned())?;
+    let expected_rungs = [
+        "resident",
+        "staged_residency",
+        "bounded_decode",
+        "bounded_attention",
+        "bounded_transformer_residency",
+    ];
+    let actual_rungs = planned
+        .iter()
+        .map(|item| {
+            item.pointer("/strategy/rung")
+                .and_then(Value::as_str)
+                .ok_or_else(|| "batched planned strategy.rung must be a string".to_owned())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if actual_rungs != expected_rungs {
+        return Err(format!(
+            "run_batch requires one canonical five-rung target, got {actual_rungs:?}"
+        ));
+    }
+    let first_target = planned[0]
+        .get("target")
+        .ok_or_else(|| "batched planned target is missing".to_owned())?;
+    if planned
+        .iter()
+        .any(|item| item.get("target") != Some(first_target))
+    {
+        return Err("run_batch cannot mix calibration targets in one model load".to_owned());
+    }
+    for item in planned {
+        let mut per_rung_request = request.clone();
+        per_rung_request["action"] = json!("run");
+        per_rung_request["planned"] = item.clone();
+        protocol::validate_plain_overlay_target(&per_rung_request, KREA_PLAIN_EXECUTION_PATH)?;
+    }
+
+    let (repository, revision, generator, mut vram) = load_five_rung_generator()?;
+    let smi = NvidiaSmi::resolve()?;
+    // Krea uses DeferredMaterialization, so loading the generator does not establish its
+    // steady-state device residency. The canonical batch starts with `resident`; use the
+    // memory retained after that first rung as the contamination baseline, then require every
+    // later rung to release its transient allocations back to that warmed state.
+    let mut settled_after_resident = None;
+    let mut fragments = Vec::with_capacity(planned.len());
+    for item in planned {
+        let mut per_rung_request = request.clone();
+        per_rung_request["action"] = json!("run");
+        per_rung_request["planned"] = item.clone();
+        fragments.push(run_five_rung_reference_loaded(
+            &per_rung_request,
+            generator.as_ref(),
+            &mut vram,
+            &repository,
+            &revision,
+        )?);
+        let after = smi.used_bytes()?;
+        update_warmed_retention_baseline(&mut settled_after_resident, after)?;
+    }
+    Ok(json!({ "modelLoads": 1, "fragments": fragments }))
 }
 
 fn run(request: &Value) -> Result<Value, String> {
@@ -1304,8 +1414,30 @@ fn main() {
     let response = match protocol::action(&request).unwrap_or_else(|error| protocol::fail(error)) {
         "probe" => probe(),
         "run" => run(&request),
+        "run_batch" => run_five_rung_batch(&request),
         other => Err(format!("unsupported action {other:?}")),
     }
     .unwrap_or_else(|error| protocol::fail(error));
     protocol::write_response(&response).unwrap_or_else(|error| protocol::fail(error));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deferred_materialization_establishes_retention_baseline_after_resident_rung() {
+        let mut baseline = None;
+        update_warmed_retention_baseline(&mut baseline, 12 * GIB).unwrap();
+        assert_eq!(baseline, Some(12 * GIB));
+        update_warmed_retention_baseline(&mut baseline, 12 * GIB + 64 * MIB).unwrap();
+    }
+
+    #[test]
+    fn warmed_retention_baseline_rejects_later_growth() {
+        let mut baseline = Some(12 * GIB);
+        let error =
+            update_warmed_retention_baseline(&mut baseline, 12 * GIB + 64 * MIB + 1).unwrap_err();
+        assert!(error.contains("above the warmed resident baseline"));
+    }
 }

--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -663,9 +663,11 @@ fn attested_strategy(
     Ok(measured)
 }
 
-fn run_z_image_reference(request: &Value) -> Result<Value, String> {
+fn z_image_load_spec(
+    request: &Value,
+    load_shape: LoadShape,
+) -> Result<(String, String, LoadSpec), String> {
     protocol::validate_plain_overlay_target(request, Z_IMAGE_PLAIN_EXECUTION_PATH)?;
-    let (width, height) = protocol::target_geometry(request)?;
     let repository = protocol::required_env("SCENEWORKS_Z_IMAGE_REPOSITORY")?;
     let revision = protocol::required_env("SCENEWORKS_Z_IMAGE_REVISION")?;
     protocol::validate_artifact_identity(&repository, &revision, protocol::Z_IMAGE_REPOSITORY)?;
@@ -681,23 +683,40 @@ fn run_z_image_reference(request: &Value) -> Result<Value, String> {
         protocol::Z_IMAGE_REPOSITORY,
     )?;
 
-    let selection = planned_selection(request)?;
-    let load_shape = if selection.strategy == MemoryStrategy::BoundedTransformerResidency {
-        LoadShape::DeferredMaterialization
-    } else {
-        LoadShape::EagerMaterialization
-    };
     let spec = LoadSpec::new(WeightsSource::Dir(root))
         .with_quant(Quant::Q4)
         .with_offload_policy(OffloadPolicy::Resident)
         .with_load_shape(load_shape);
+    Ok((repository, revision, spec))
+}
+
+fn load_z_image_generator(
+    request: &Value,
+    load_shape: LoadShape,
+) -> Result<(String, String, Box<dyn Generator>), String> {
+    let (repository, revision, spec) = z_image_load_spec(request, load_shape)?;
     let catalog =
         runtime_macos::catalog().map_err(|error| format!("build MLX catalog: {error}"))?;
-    let contract = catalog
+    let generator = catalog
         .media()
-        .memory_strategy_contract(Z_IMAGE_PROVIDER, &spec)
-        .map_err(|error| format!("read {Z_IMAGE_PROVIDER} memory-strategy contract: {error}"))?
-        .ok_or_else(|| format!("{Z_IMAGE_PROVIDER} has no memory-strategy contract"))?;
+        .load(Z_IMAGE_PROVIDER, &spec)
+        .map_err(|error| format!("load real Z-Image Turbo q4 provider: {error}"))?;
+    Ok((repository, revision, generator))
+}
+
+fn run_z_image_reference_loaded(
+    request: &Value,
+    generator: &dyn Generator,
+    repository: &str,
+    revision: &str,
+    load_shape: LoadShape,
+) -> Result<Value, String> {
+    protocol::validate_plain_overlay_target(request, Z_IMAGE_PLAIN_EXECUTION_PATH)?;
+    let (width, height) = protocol::target_geometry(request)?;
+    let selection = planned_selection(request)?;
+    let contract = generator
+        .memory_strategy_contract()
+        .ok_or_else(|| format!("loaded {Z_IMAGE_PROVIDER} has no memory-strategy contract"))?;
     contract
         .validate_selection(&selection)
         .map_err(|error| format!("pinned Z-Image provider rejected planned selection: {error}"))?;
@@ -749,10 +768,6 @@ fn run_z_image_reference(request: &Value) -> Result<Value, String> {
         cache_state: MemoryCacheState::Cold,
         evidence_revision: format!("sc-16402@{}", protocol::INFERENCE_PIN),
     };
-    let generator = catalog
-        .media()
-        .load(Z_IMAGE_PROVIDER, &spec)
-        .map_err(|error| format!("load real Z-Image Turbo q4 provider: {error}"))?;
     let conditioning = Cell::new(PhaseMemory {
         active: 0,
         cache: 0,
@@ -763,8 +778,11 @@ fn run_z_image_reference(request: &Value) -> Result<Value, String> {
     });
     clear_cache();
     reset_peak_memory();
+    let pre_rung_active = get_active_memory() as u64;
+    let pre_rung_cache = get_cache_memory() as u64;
+    let peak_after_reset = get_peak_memory() as u64;
     one_image(scoped_generate(
-        generator.as_ref(),
+        generator,
         GenerationRequest {
             prompt: "a photorealistic red apple on a wooden table, studio lighting".to_owned(),
             width,
@@ -800,7 +818,7 @@ fn run_z_image_reference(request: &Value) -> Result<Value, String> {
     }
     let overall = PhaseMemory::overall(&[conditioning, denoise, decode]);
     let blocker = concat!(
-        "fresh-process oracle capture measures exact per-rung memory and strategy identity for ",
+        "five-rung oracle capture measures exact per-rung memory and strategy identity for ",
         "sc-16059; it intentionally remains gated because this run does not repeat the full ",
         "promotion-quality, negative-mutation, and lifecycle scenario suite"
     );
@@ -827,6 +845,9 @@ fn run_z_image_reference(request: &Value) -> Result<Value, String> {
                 "executed",
                 [blocker.to_owned()],
                 [
+                    ("preRungActiveAfterClear", "bytes", pre_rung_active),
+                    ("preRungCacheAfterClear", "bytes", pre_rung_cache),
+                    ("peakAfterReset", "bytes", peak_after_reset),
                     ("conditioningActivePeak", "bytes", conditioning.active),
                     ("denoiseActivePeak", "bytes", denoise.active),
                     ("decodeActivePeak", "bytes", decode.active),
@@ -846,7 +867,139 @@ fn run_z_image_reference(request: &Value) -> Result<Value, String> {
         "decode": decode.json(),
         "overall": overall.json(),
     });
+    fragment["diagnostics"]["measurements"]
+        .as_array_mut()
+        .ok_or_else(|| "Z-Image diagnostics.measurements must be an array".to_owned())?
+        .push(json!({
+            "name": "loadShapeDeferred",
+            "unit": "count",
+            "value": u64::from(load_shape == LoadShape::DeferredMaterialization),
+        }));
     Ok(fragment)
+}
+
+fn run_z_image_reference(request: &Value) -> Result<Value, String> {
+    let selection = planned_selection(request)?;
+    let load_shape = if selection.strategy == MemoryStrategy::BoundedTransformerResidency {
+        LoadShape::DeferredMaterialization
+    } else {
+        LoadShape::EagerMaterialization
+    };
+    let (repository, revision, generator) = load_z_image_generator(request, load_shape)?;
+    run_z_image_reference_loaded(
+        request,
+        generator.as_ref(),
+        &repository,
+        &revision,
+        load_shape,
+    )
+}
+
+fn validate_z_image_batch(request: &Value) -> Result<&[Value], String> {
+    let planned = request
+        .get("planned")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "assess_batch request.planned must be an array".to_owned())?;
+    let expected = [
+        "resident",
+        "staged_residency",
+        "bounded_decode",
+        "bounded_attention",
+        "bounded_transformer_residency",
+    ];
+    if planned.len() != expected.len() {
+        return Err(format!(
+            "Z-Image rung batch must contain exactly {} cases, got {}",
+            expected.len(),
+            planned.len()
+        ));
+    }
+    let target = planned[0]
+        .get("target")
+        .ok_or_else(|| "assess_batch planned target must be present".to_owned())?;
+    for (index, (item, expected_rung)) in planned.iter().zip(expected).enumerate() {
+        let rung = item
+            .pointer("/strategy/rung")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                format!("assess_batch planned[{index}].strategy.rung must be a string")
+            })?;
+        if rung != expected_rung {
+            return Err(format!(
+                "Z-Image rung batch must use canonical order; index {index} is {rung:?}, expected {expected_rung:?}"
+            ));
+        }
+        if item.get("target") != Some(target) {
+            return Err("Z-Image rung batch must keep one exact target tuple".to_owned());
+        }
+    }
+    Ok(planned)
+}
+
+fn assess_z_image_batch(request: &Value) -> Result<Value, String> {
+    let planned = validate_z_image_batch(request)?;
+    let mut representative = request.clone();
+    representative["action"] = json!("run");
+    representative["planned"] = planned[0].clone();
+    let catalog =
+        runtime_macos::catalog().map_err(|error| format!("build MLX catalog: {error}"))?;
+    let mut actual_fingerprints = Vec::new();
+    for load_shape in [
+        LoadShape::EagerMaterialization,
+        LoadShape::DeferredMaterialization,
+    ] {
+        let (_, _, spec) = z_image_load_spec(&representative, load_shape)?;
+        let contract = catalog
+            .media()
+            .memory_strategy_contract(Z_IMAGE_PROVIDER, &spec)
+            .map_err(|error| format!("read {Z_IMAGE_PROVIDER} memory-strategy contract: {error}"))?
+            .ok_or_else(|| format!("{Z_IMAGE_PROVIDER} has no memory-strategy contract"))?;
+        actual_fingerprints.push(
+            contract
+                .calibration
+                .as_ref()
+                .ok_or_else(|| "pinned Z-Image provider has no calibration identity".to_owned())?
+                .fingerprint
+                .clone(),
+        );
+    }
+    for item in planned {
+        let planned_fingerprint = item
+            .get("calibrationFingerprint")
+            .and_then(Value::as_str)
+            .ok_or_else(|| "batch calibrationFingerprint must be a string".to_owned())?;
+        let expected = if item.pointer("/strategy/rung").and_then(Value::as_str)
+            == Some("bounded_transformer_residency")
+        {
+            &actual_fingerprints[1]
+        } else {
+            &actual_fingerprints[0]
+        };
+        if planned_fingerprint != expected {
+            return Err(format!(
+                "plan/provider calibration mismatch in reuse assessment: plan={planned_fingerprint}, pinned provider={expected}"
+            ));
+        }
+    }
+    actual_fingerprints.sort_unstable();
+    actual_fingerprints.dedup();
+    if actual_fingerprints.len() > 1 {
+        return Ok(json!({
+            "verdict": "unable_to_amortize",
+            "reason": format!(
+                "one MLX model load cannot preserve the distinct calibrated load-shape identities required by the five rungs: {}",
+                actual_fingerprints.join(", ")
+            ),
+            "calibrationFingerprints": actual_fingerprints,
+            "evidence": "pinned provider contracts for eager and deferred load specs",
+        }));
+    }
+    Ok(json!({
+        "verdict": "eligible_for_measurement",
+        "reason": "all MLX rungs share one calibrated load-shape identity",
+        "calibrationFingerprints": actual_fingerprints,
+        "evidence": "pinned provider contracts for eager and deferred load specs",
+    }))
 }
 
 fn run_krea_control(request: &Value) -> Result<Value, String> {
@@ -1457,6 +1610,7 @@ fn main() {
     let response = match protocol::action(&request).unwrap_or_else(|error| protocol::fail(error)) {
         "probe" => probe(),
         "run" => run(&request),
+        "assess_batch" => assess_z_image_batch(&request),
         other => Err(format!("unsupported action {other:?}")),
     }
     .unwrap_or_else(|error| protocol::fail(error));

--- a/docs/generated/calibration-cost-model.json
+++ b/docs/generated/calibration-cost-model.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "generatedFrom": {
-    "sceneWorksRevision": "source-tree:f902a6b1f97f98b31e011741457c861eb56385d1921a8271931e4d9996385f66",
+    "sceneWorksRevision": "source-tree:4e7ab3b071a6c0c7a20e71628d2a6ade2ab6da11900f2918f0fc167f51b30ce3",
     "matrixRevision": "source-tree:9bd7b5e07e4e5226751ba693ba6a9fc7bc1a8afcb7531f5bf8f94053f7aef1d1",
     "inferenceRevision": "656a38bf25138c92a82e07ec0f8d0804d07b3dbb",
     "sources": {
@@ -15,7 +15,7 @@
       },
       "harness": {
         "path": "scripts/memory-calibration-harness.mjs",
-        "sha256": "a5a3a460e9bd28729e98c0a2966c34efb38e65f041a136b2ba86bc3ac2411411"
+        "sha256": "8f723f6b51b18099404b4c84872ebfdf8b05410838a3df838fa78bd9daef6a0a"
       },
       "matrixGenerator": {
         "path": "scripts/generate-memory-matrix.mjs",
@@ -43,11 +43,11 @@
       },
       "candleAdapter": {
         "path": "crates/sceneworks-memory-adapter/src/bin/candle.rs",
-        "sha256": "f8e474f6d266d9696074fbcfe773d7ee87bc35ad5c3b10a251906c45f77d2dc9"
+        "sha256": "248c89989e1b6b8a1f8ef4579da8b39d694febe1aec0668ff039ba8fd1d9ed68"
       },
       "mlxAdapter": {
         "path": "crates/sceneworks-memory-adapter/src/bin/mlx.rs",
-        "sha256": "a190ba5498e96dfbe413a269bad53180884159b52e9bfd4fa26b5d0043739973"
+        "sha256": "dc93243d87980b3ec11ed13f186adfe174b37ed9f51c74d6c4ef5613286cb67e"
       }
     }
   },
@@ -421,6 +421,10 @@
         "mlx": 924
       },
       "geometryExpanded": 8970,
+      "geometryExpandedByBackend": {
+        "mlx": 5616,
+        "candle": 3354
+      },
       "rungsPerSession": [
         5
       ]
@@ -431,7 +435,11 @@
         "candle": 192,
         "mlx": 324
       },
-      "tierSum": 1472
+      "tierSum": 1472,
+      "tierSumByBackend": {
+        "mlx": 924,
+        "candle": 548
+      }
     }
   },
   "overlayLoadContract": {
@@ -475,7 +483,7 @@
     "counterfactualPriceTagDisposition": "SC-16072 needs to know what the capability would be worth before deciding whether to build it. The counterfactual count is retained as structured metadata, but the unavailable overlay-amortised COLUMN is dropped from campaign and wall-clock tables. It is not pursued as an achievable campaign shape."
   },
   "collapsing": {
-    "runUnit": "One `action:\"run\"` provider invocation. `runProviderPlan` spawns the provider command once per planned case, so this is the unit that costs a model load.",
+    "runUnit": "One provider invocation. `runProviderPlan` uses `action:\"run\"` for a fresh case and `action:\"run_batch\"` for a compatible Candle five-rung group; either invocation attests one model load.",
     "runUnitCitation": "scripts/memory-calibration-harness.mjs#runProviderPlan",
     "requiredScenariosPerRecord": 8,
     "requiredScenarios": [
@@ -503,15 +511,15 @@
         "factor": "one record retires every passed sweep point",
         "rule": "One `complete` record carries a `sweep` whose passed cases each retire a distinct planned logical case, so a provider that sweeps its parameter domain internally needs one record for the whole domain rather than one per point.",
         "citation": "scripts/memory-calibration-harness.mjs#completedLogicalIds (maps every passed sweep case to its own logicalCaseId) and #validateComplete (every declared axis range must be derived from passed executed cases)",
-        "caveat": "Realised only ACROSS resumed invocations. `runProviderPlan` computes its skip set once from `--resume` and then spawns the provider command once per planned case, without feeding incoming records back into the skip set — so within a single invocation an N-point sweep still costs N process spawns."
+        "caveat": "`runProviderPlan` recomputes completed logical identities after every provider response. A complete record whose passed sweep covers other pending points retires those points before the runner chooses its next invocation, so the collapse is now realised both within one run and across `--resume` runs."
       },
       {
         "axis": "rung",
-        "verdict": "not collapsed by the harness; UNPROVEN in principle",
-        "factor": "5 (every session key spans exactly 5 rungs) — a CEILING, not a demonstrated saving",
-        "rule": "A record names ONE rung (`strategy.rung` is a single enum and is part of the record identity), and the matrix binds a record to exactly one cell on the (modelId, provider, backend, tier, mode, overlay, rung) key. So the schema forces one record per rung. Whether the PHYSICS also forces it is OPEN: nothing in this repository measures five rung peaks from one load, and the sources previously cited for it do not establish it. The 5x is therefore the size of a prize nobody has shown is collectable, not a saving being left on the table.",
-        "citation": "SCHEMA SIDE (established): scripts/memory-calibration-harness.mjs#recordId + #validateRecord (rung is in the identity); scripts/generate-memory-matrix.mjs (record->cell match includes `rung`). PHYSICS SIDE (does NOT establish the collapse): docs/memory-calibration-harness.md 'one loaded generator' covers four memory PHASES (conditioning, denoise, decode, overall) at ONE strategy — phases are not rungs; its warm-repeat A->B->A and crates/sceneworks-memory-adapter/src/bin/candle.rs#execute_parity_request compare PIXEL output across two strategies and sample no memory at all (the function returns an Image and never touches the VramProbe); and the Krea turboFit evidence records say only \"exclusive rendered-device phase peaks at 768x768 and 1024x1024\" in verification.method — 'exclusive' means exclusive HARDWARE, and no field in the record schema names a process, load or session, so one record cannot evidence one process. Those peaks also cover FOUR rungs, not five: packages/schemas/model-manifest.schema.json caps `observedPeaksGb` at threeStage/tiledVae/chunkedAttention/streamedBlocks with additionalProperties false, so the manifest cannot express a `resident` peak — the one rung that is the irreducible floor.",
-        "caveat": "The harness spawns a FRESH process per planned case, so today the model load is paid once per rung. Capturing this 5x needs either a warm provider daemon behind the argv command or a runner that batches a target's rungs into one invocation. Neither exists — AND neither is purely scheduling work, because reusing a process risks CONTAMINATING the measurement, asymmetrically across backends. CANDLE has partial protection: the adapter enforces a 64 MiB post-fault cleanup-growth tolerance and asserts `cudaCachingAllocatorPresent = 0`, so freed device bytes return to the device rather than into an allocator cache (though that constant is a hardcoded diagnostic, not a probe of live allocator state). MLX has NO equivalent structural guarantee: a buffer cache is present and is itself measured and published, and the adapter must call `clear_cache()` + `reset_peak_memory()` explicitly between measurements. That is not sufficient — `clear_cache()` reclaims only allocator-cache buffers and cannot release LIVE weight arrays, which is precisely the residue a multi-rung campaign accumulates, because rungs 1 and 4 change residency. SceneWorks' own MLX footprint harness (crates/sceneworks-worker/src/footprint_measure.rs) therefore mandates ONE TIER PER PROCESS and enforces it with a runtime assert, having found that process-global counters let a heavier earlier measurement leak into a lighter later one. A rung-batching runner must prove it beats that, on both backends. Tracked as SC-16059."
+        "verdict": "fresh per rung on both measured backends",
+        "factor": "0 records in 0 explicit group(s) save 0 loads; combined 7354 -> 7354 (1x)",
+        "rule": "A record names ONE rung (`strategy.rung` is a single enum and is part of the record identity), and the matrix binds a record to exactly one cell on the (modelId, provider, backend, tier, mode, overlay, rung) key, so records remain one-per-rung. The harness and Candle adapter can execute Krea's five-rung group as one `run_batch` provider invocation with `modelLoads: 1`, but the authoritative fresh/reused comparison exceeded the committed tolerance, so the shipped plan keeps Candle fresh-per-rung. MLX also stays fresh: its Z-Image ladder spans distinct eager and deferred calibration fingerprints, so one loaded generator cannot preserve every rung's calibrated identity. No target is priced as batched.",
+        "citation": "scripts/memory-calibration-harness.mjs#runProviderPlan (canonical `run_batch`, one-load attestation, and within-invocation sweep retirement); crates/sceneworks-memory-adapter/src/bin/candle.rs#run_five_rung_batch; crates/sceneworks-memory-adapter/src/bin/mlx.rs#assess_z_image_batch; .github/workflows/windows-candle.yml (fresh/reused evidence gate) and macos-mlx.yml (fresh capture plus provider-contract inability gate)",
+        "caveat": "The committed equivalence gate is the larger of 256 MiB absolute drift and 5% of the fresh metric, applied to every phase and allocator/device/wired/reclaimable metric. Candle's measured verdict and MLX's structural verdict are both `unable_to_amortize`. MLX's inability is structural, not an inferred timing result: the eager and deferred fingerprints differ before a reused process can truthfully execute all five identities, so the backend retains fresh-per-rung cost."
       },
       {
         "axis": "overlay",
@@ -537,7 +545,9 @@
         "rung": "resident",
         "evidenceScope": "authoritative",
         "plannedCases": 1,
-        "positiveCases": 1
+        "positiveCases": 1,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       },
       {
         "name": "mlx-z-image-q4-fresh-reference-staged",
@@ -545,7 +555,9 @@
         "rung": "staged_residency",
         "evidenceScope": "authoritative",
         "plannedCases": 1,
-        "positiveCases": 1
+        "positiveCases": 1,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       },
       {
         "name": "mlx-z-image-q4-fresh-reference-bounded-decode",
@@ -553,7 +565,9 @@
         "rung": "bounded_decode",
         "evidenceScope": "authoritative",
         "plannedCases": 1,
-        "positiveCases": 1
+        "positiveCases": 1,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       },
       {
         "name": "mlx-z-image-q4-fresh-reference-bounded-attention",
@@ -561,7 +575,9 @@
         "rung": "bounded_attention",
         "evidenceScope": "authoritative",
         "plannedCases": 1,
-        "positiveCases": 1
+        "positiveCases": 1,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       },
       {
         "name": "mlx-z-image-q4-fresh-reference-bounded-transformer",
@@ -569,7 +585,9 @@
         "rung": "bounded_transformer_residency",
         "evidenceScope": "authoritative",
         "plannedCases": 1,
-        "positiveCases": 1
+        "positiveCases": 1,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       },
       {
         "name": "candle-krea-q4-fresh-reference-resident",
@@ -577,7 +595,9 @@
         "rung": "resident",
         "evidenceScope": "authoritative",
         "plannedCases": 1,
-        "positiveCases": 1
+        "positiveCases": 1,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       },
       {
         "name": "candle-krea-q4-fresh-reference-staged",
@@ -585,7 +605,9 @@
         "rung": "staged_residency",
         "evidenceScope": "authoritative",
         "plannedCases": 1,
-        "positiveCases": 1
+        "positiveCases": 1,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       },
       {
         "name": "candle-krea-q4-fresh-reference-bounded-decode",
@@ -593,7 +615,9 @@
         "rung": "bounded_decode",
         "evidenceScope": "authoritative",
         "plannedCases": 1,
-        "positiveCases": 1
+        "positiveCases": 1,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       },
       {
         "name": "candle-krea-q4-fresh-reference-bounded-attention",
@@ -601,7 +625,9 @@
         "rung": "bounded_attention",
         "evidenceScope": "authoritative",
         "plannedCases": 1,
-        "positiveCases": 1
+        "positiveCases": 1,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       },
       {
         "name": "candle-krea-q4-fresh-reference-bounded-transformer",
@@ -609,7 +635,9 @@
         "rung": "bounded_transformer_residency",
         "evidenceScope": "authoritative",
         "plannedCases": 1,
-        "positiveCases": 1
+        "positiveCases": 1,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       },
       {
         "name": "mlx-qwen-vae-decode",
@@ -617,7 +645,9 @@
         "rung": "bounded_decode",
         "evidenceScope": "authoritative",
         "plannedCases": 8,
-        "positiveCases": 7
+        "positiveCases": 7,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       },
       {
         "name": "mlx-krea-pose-control-q4-768",
@@ -625,7 +655,9 @@
         "rung": "bounded_decode",
         "evidenceScope": "authoritative",
         "plannedCases": 1,
-        "positiveCases": 1
+        "positiveCases": 1,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       },
       {
         "name": "mlx-krea-pose-control-q4-896",
@@ -633,7 +665,9 @@
         "rung": "bounded_decode",
         "evidenceScope": "authoritative",
         "plannedCases": 1,
-        "positiveCases": 1
+        "positiveCases": 1,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       },
       {
         "name": "candle-krea-production-current-v1",
@@ -641,7 +675,9 @@
         "rung": "bounded_transformer_residency",
         "evidenceScope": "authoritative",
         "plannedCases": 1,
-        "positiveCases": 1
+        "positiveCases": 1,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       },
       {
         "name": "candle-krea-v2-candidates",
@@ -649,7 +685,9 @@
         "rung": "bounded_transformer_residency",
         "evidenceScope": "candidate",
         "plannedCases": 2,
-        "positiveCases": 2
+        "positiveCases": 2,
+        "modelLoadPolicy": "fresh_per_case",
+        "modelLoadGroup": null
       }
     ]
   },
@@ -675,6 +713,18 @@
       "mlx": 924,
       "candle": 548
     },
+    "shippedModelLoads": {
+      "mlx": 4620,
+      "candle": 2734,
+      "total": 7354
+    },
+    "shippedBatchCoverage": {
+      "sessionKeys": [],
+      "sessions": 0,
+      "records": 0,
+      "savedLoads": 0
+    },
+    "shippedLoadCollapseFactor": 1,
     "unavailableOverlayLoadPriceTag": {
       "availability": "unavailable",
       "disposition": "counterfactual metadata only; excluded from campaign and wall-clock columns",
@@ -706,6 +756,11 @@
           "mlx": 4620,
           "candle": 2734
         },
+        "shippedModelLoads": {
+          "mlx": 4620,
+          "candle": 2734,
+          "total": 7354
+        },
         "warmSessions": {
           "total": 1472,
           "mlx": 924,
@@ -729,6 +784,11 @@
           "total": 6621,
           "mlx": 4132,
           "candle": 2489
+        },
+        "shippedModelLoads": {
+          "mlx": 4132,
+          "candle": 2489,
+          "total": 6621
         },
         "warmSessions": {
           "total": 1472,
@@ -754,6 +814,11 @@
           "mlx": 3696,
           "candle": 2192
         },
+        "shippedModelLoads": {
+          "mlx": 3696,
+          "candle": 2192,
+          "total": 5888
+        },
         "warmSessions": {
           "total": 1472,
           "mlx": 924,
@@ -778,6 +843,11 @@
           "mlx": 3160,
           "candle": 1989
         },
+        "shippedModelLoads": {
+          "mlx": 3160,
+          "candle": 1989,
+          "total": 5149
+        },
         "warmSessions": {
           "total": 1472,
           "mlx": 924,
@@ -801,6 +871,11 @@
           "total": 1472,
           "mlx": 924,
           "candle": 548
+        },
+        "shippedModelLoads": {
+          "mlx": 924,
+          "candle": 548,
+          "total": 1472
         },
         "warmSessions": {
           "total": 1472,
@@ -850,6 +925,11 @@
           "mlx": 38.5,
           "candle": 22.8
         },
+        "shippedModelLoadHours": {
+          "total": 61.3,
+          "mlx": 38.5,
+          "candle": 22.8
+        },
         "warmSessionHours": {
           "total": 12.3,
           "mlx": 7.7,
@@ -859,6 +939,11 @@
       {
         "perRunSeconds": 60,
         "recordHours": {
+          "total": 122.6,
+          "mlx": 77,
+          "candle": 45.6
+        },
+        "shippedModelLoadHours": {
           "total": 122.6,
           "mlx": 77,
           "candle": 45.6
@@ -876,6 +961,11 @@
           "mlx": 154,
           "candle": 91.1
         },
+        "shippedModelLoadHours": {
+          "total": 245.1,
+          "mlx": 154,
+          "candle": 91.1
+        },
         "warmSessionHours": {
           "total": 49.1,
           "mlx": 30.8,
@@ -885,6 +975,11 @@
       {
         "perRunSeconds": 300,
         "recordHours": {
+          "total": 612.8,
+          "mlx": 385,
+          "candle": 227.8
+        },
+        "shippedModelLoadHours": {
           "total": 612.8,
           "mlx": 385,
           "candle": 227.8
@@ -902,6 +997,11 @@
           "mlx": 770,
           "candle": 455.7
         },
+        "shippedModelLoadHours": {
+          "total": 1225.7,
+          "mlx": 770,
+          "candle": 455.7
+        },
         "warmSessionHours": {
           "total": 245.3,
           "mlx": 154,
@@ -911,6 +1011,11 @@
       {
         "perRunSeconds": 1200,
         "recordHours": {
+          "total": 2451.3,
+          "mlx": 1540,
+          "candle": 911.3
+        },
+        "shippedModelLoadHours": {
           "total": 2451.3,
           "mlx": 1540,
           "candle": 911.3
@@ -1284,12 +1389,6 @@
       "story": 16072,
       "independentlyBlockingCells": 30,
       "cellsTouched": 4564
-    },
-    {
-      "input": "whether the harness can amortise a model load across a target's rungs",
-      "why": "A potential 5x on the whole campaign, currently NOT realised: the runner spawns a fresh process per planned case. Unlike the overlay load collapse this one is not ruled out by the load contract — but it is NOT established either. Nothing in the repository measures five rung peaks from one load, and the manifest cannot even express a `resident` peak alongside the other four. It is also not purely scheduling work: reusing a process risks contaminating the measurement, and the two backends have asymmetric protection (Candle asserts no caching allocator; MLX has a live buffer cache and its own footprint harness mandates one tier per process). See the `rung` axis for the full evidence review.",
-      "howToResolve": "Either batch a target's rungs into one provider invocation, or run the provider as a warm daemon behind the argv command — and in either case demonstrate that a rung measured in a reused process matches the fresh-process measurement within a stated tolerance, ON BOTH BACKENDS, before believing the 5x. Tracked as SC-16059.",
-      "story": 16059
     },
     {
       "input": "which geometry policy is true",

--- a/docs/generated/calibration-cost-model.md
+++ b/docs/generated/calibration-cost-model.md
@@ -97,13 +97,13 @@ The overlay axis is **4600** cells — 62.5% of the matrix — and it is not uni
 
 ## 2. The collapsing rule (derived)
 
-The run unit is one `action:"run"` provider invocation — scripts/memory-calibration-harness.mjs#runProviderPlan spawns the provider command once per planned case, so that is what costs a model load. A `complete` record must pass all 8 required scenarios plus quality and a measured negative mutation.
+One provider invocation. `runProviderPlan` uses `action:"run"` for a fresh case and `action:"run_batch"` for a compatible Candle five-rung group; either invocation attests one model load. A `complete` record must pass all 8 required scenarios plus quality and a measured negative mutation.
 
 | Axis | Verdict | Factor |
 | --- | --- | --- |
 | `geometry` | collapsed | already applied by the matrix generator |
 | `strategyParameters` | collapsed | one record retires every passed sweep point |
-| `rung` | not collapsed by the harness; UNPROVEN in principle | 5 (every session key spans exactly 5 rungs) — a CEILING, not a demonstrated saving |
+| `rung` | fresh per rung on both measured backends | 0 records in 0 explicit group(s) save 0 loads; combined 7354 -> 7354 (1x) |
 | `overlay` | NOT collapsed for records; NOT collapsible for model loads in the shipped contract | 1 today (the current 2.67x amortised load ratio prices a capability that does not exist) |
 | `cell` | NOT collapsed | 1 (cells map 1:1 to certifying records) |
 
@@ -117,13 +117,13 @@ The run unit is one `action:"run"` provider invocation — scripts/memory-calibr
 
 > Citation: scripts/memory-calibration-harness.mjs#completedLogicalIds (maps every passed sweep case to its own logicalCaseId) and #validateComplete (every declared axis range must be derived from passed executed cases)
 
-> Caveat: Realised only ACROSS resumed invocations. `runProviderPlan` computes its skip set once from `--resume` and then spawns the provider command once per planned case, without feeding incoming records back into the skip set — so within a single invocation an N-point sweep still costs N process spawns.
+> Caveat: `runProviderPlan` recomputes completed logical identities after every provider response. A complete record whose passed sweep covers other pending points retires those points before the runner chooses its next invocation, so the collapse is now realised both within one run and across `--resume` runs.
 
-**`rung` — not collapsed by the harness; UNPROVEN in principle.** A record names ONE rung (`strategy.rung` is a single enum and is part of the record identity), and the matrix binds a record to exactly one cell on the (modelId, provider, backend, tier, mode, overlay, rung) key. So the schema forces one record per rung. Whether the PHYSICS also forces it is OPEN: nothing in this repository measures five rung peaks from one load, and the sources previously cited for it do not establish it. The 5x is therefore the size of a prize nobody has shown is collectable, not a saving being left on the table.
+**`rung` — fresh per rung on both measured backends.** A record names ONE rung (`strategy.rung` is a single enum and is part of the record identity), and the matrix binds a record to exactly one cell on the (modelId, provider, backend, tier, mode, overlay, rung) key, so records remain one-per-rung. The harness and Candle adapter can execute Krea's five-rung group as one `run_batch` provider invocation with `modelLoads: 1`, but the authoritative fresh/reused comparison exceeded the committed tolerance, so the shipped plan keeps Candle fresh-per-rung. MLX also stays fresh: its Z-Image ladder spans distinct eager and deferred calibration fingerprints, so one loaded generator cannot preserve every rung's calibrated identity. No target is priced as batched.
 
-> Citation: SCHEMA SIDE (established): scripts/memory-calibration-harness.mjs#recordId + #validateRecord (rung is in the identity); scripts/generate-memory-matrix.mjs (record->cell match includes `rung`). PHYSICS SIDE (does NOT establish the collapse): docs/memory-calibration-harness.md 'one loaded generator' covers four memory PHASES (conditioning, denoise, decode, overall) at ONE strategy — phases are not rungs; its warm-repeat A->B->A and crates/sceneworks-memory-adapter/src/bin/candle.rs#execute_parity_request compare PIXEL output across two strategies and sample no memory at all (the function returns an Image and never touches the VramProbe); and the Krea turboFit evidence records say only "exclusive rendered-device phase peaks at 768x768 and 1024x1024" in verification.method — 'exclusive' means exclusive HARDWARE, and no field in the record schema names a process, load or session, so one record cannot evidence one process. Those peaks also cover FOUR rungs, not five: packages/schemas/model-manifest.schema.json caps `observedPeaksGb` at threeStage/tiledVae/chunkedAttention/streamedBlocks with additionalProperties false, so the manifest cannot express a `resident` peak — the one rung that is the irreducible floor.
+> Citation: scripts/memory-calibration-harness.mjs#runProviderPlan (canonical `run_batch`, one-load attestation, and within-invocation sweep retirement); crates/sceneworks-memory-adapter/src/bin/candle.rs#run_five_rung_batch; crates/sceneworks-memory-adapter/src/bin/mlx.rs#assess_z_image_batch; .github/workflows/windows-candle.yml (fresh/reused evidence gate) and macos-mlx.yml (fresh capture plus provider-contract inability gate)
 
-> Caveat: The harness spawns a FRESH process per planned case, so today the model load is paid once per rung. Capturing this 5x needs either a warm provider daemon behind the argv command or a runner that batches a target's rungs into one invocation. Neither exists — AND neither is purely scheduling work, because reusing a process risks CONTAMINATING the measurement, asymmetrically across backends. CANDLE has partial protection: the adapter enforces a 64 MiB post-fault cleanup-growth tolerance and asserts `cudaCachingAllocatorPresent = 0`, so freed device bytes return to the device rather than into an allocator cache (though that constant is a hardcoded diagnostic, not a probe of live allocator state). MLX has NO equivalent structural guarantee: a buffer cache is present and is itself measured and published, and the adapter must call `clear_cache()` + `reset_peak_memory()` explicitly between measurements. That is not sufficient — `clear_cache()` reclaims only allocator-cache buffers and cannot release LIVE weight arrays, which is precisely the residue a multi-rung campaign accumulates, because rungs 1 and 4 change residency. SceneWorks' own MLX footprint harness (crates/sceneworks-worker/src/footprint_measure.rs) therefore mandates ONE TIER PER PROCESS and enforces it with a runtime assert, having found that process-global counters let a heavier earlier measurement leak into a lighter later one. A rung-batching runner must prove it beats that, on both backends. Tracked as SC-16059.
+> Caveat: The committed equivalence gate is the larger of 256 MiB absolute drift and 5% of the fresh metric, applied to every phase and allocator/device/wired/reclaimable metric. Candle's measured verdict and MLX's structural verdict are both `unable_to_amortize`. MLX's inability is structural, not an inferred timing result: the eager and deferred fingerprints differ before a reused process can truthfully execute all five identities, so the backend retains fresh-per-rung cost.
 
 **`overlay` — NOT collapsed for records; NOT collapsible for model loads in the shipped contract.** 4600 of the 7360 cells carry a non-`none` overlay, so this axis is 62.5% of the matrix. It does NOT collapse on the record axis: `overlay` is part of the cell key and of `record.target`, and `validateComplete` requires the `overlay` scenario to actually pass (or carry a justified `not_applicable` reason) — a `none` record cannot certify a `lora` cell. Nor does it collapse on the model-load axis: adapters are resolved at LOAD time into `LoadSpec::adapters`, no API anywhere in `crates/` detaches or swaps an adapter on a loaded generator, and carrying adapters makes `vram_gate.rs` disable streamed blocks outright. Decisively, even a toggleable LoRA stays RESIDENT, so a `none` peak measured on an adapter-loaded generator is inflated by the adapter's own bytes — the collapse perturbs the very quantity being measured.
 
@@ -142,7 +142,8 @@ The run unit is one `action:"run"` provider invocation — scripts/memory-calibr
 | Unit | Total | MLX/Metal (this Mac) | Candle/CUDA (rented) |
 | --- | --- | --- | --- |
 | Certifying records (1 per cell) | 7354 | 4620 | 2734 |
-| Warm sessions (model loads, 5 rungs each) | 1472 | 924 | 548 |
+| Shipped model loads (explicit groups only) | 7354 | 4620 | 2734 |
+| All-backend warm-session floor (5 rungs each) | 1472 | 924 | 548 |
 
 **Does the overlay axis evaporate? No — on either axis.** On the record axis, each of the 4600 non-`none` cells needs its own record, because `overlay` is in the cell key and `validateComplete` requires the overlay scenario to actually pass.
 
@@ -163,7 +164,7 @@ On the model-load axis the answer is **unavailable in the shipped load contract*
 
 Excluded: 6 cells already classified `Structurally N/A`, which the epic exempts from measurement. Nothing else is excluded — `Missing` cells still need a run, they just need an implementation first.
 
-The warm-session row is **not currently achievable**. It is what the campaign would cost if one loaded generator covered a target's 5 rungs, at 4.996 records per load; the harness spawns a fresh process per planned case today, so every rung pays its own model load.
+The shipped campaign now costs **7354 model loads**. Exactly 0 records in 0 groups are configured for batching, saving 0 loads; every record remains fresh. That is a **1x** reduction from 7354 fresh-per-record loads. The 1472-load floor remains counterfactual because MLX is structurally unable and Candle failed the committed fresh/reused tolerance.
 
 ## 4. Structurally N/A sensitivity
 
@@ -171,19 +172,19 @@ SC-15969 (the per-family rung-4 applicability survey) has not run, so the final 
 
 Irreducible floor: the **1472** `resident` cells. Rung 0 is the unoptimised baseline every model has by definition, so it can never be Structurally N/A. No survey outcome can remove these cells from the campaign.
 
-| Scenario | Kind | Records | MLX | Candle | Warm sessions | Exempted MLX/Candle | ...if proportional |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `current` | fact | 7354 | 4620 | 2734 | 1472 | 0/0 | — |
-| `rung4-half` | projection | 6621 | 4132 | 2489 | 1472 | 488/245 | 462/271 ⚠ |
-| `rung4-all` | projection | 5888 | 3696 | 2192 | 1472 | 924/542 | 924/542 |
-| `rungs-2-3-4-half` | projection | 5149 | 3160 | 1989 | 1472 | 1460/745 | 1386/819 ⚠ |
-| `everything-but-baseline` | bound | 1472 | 924 | 548 | 1472 | 3696/2186 | 3696/2186 |
+| Scenario | Kind | Records | MLX | Candle | Shipped loads | Warm floor | Exempted MLX/Candle | ...if proportional |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `current` | fact | 7354 | 4620 | 2734 | 7354 | 1472 | 0/0 | — |
+| `rung4-half` | projection | 6621 | 4132 | 2489 | 6621 | 1472 | 488/245 | 462/271 ⚠ |
+| `rung4-all` | projection | 5888 | 3696 | 2192 | 5888 | 1472 | 924/542 | 924/542 |
+| `rungs-2-3-4-half` | projection | 5149 | 3160 | 1989 | 5149 | 1472 | 1460/745 | 1386/819 ⚠ |
+| `everything-but-baseline` | bound | 1472 | 924 | 548 | 1472 | 1472 | 3696/2186 | 3696/2186 |
 
 > **How cells are selected, and why the projection rows' backend columns are not findings.** Projected exemptions are applied to NAMED cells, not to a count, so the session arithmetic stays exact rather than becoming a division. Within each rung the exempted cells are the first N by ASCENDING CELL ID. That is deterministic but ARBITRARY: cell ids lead with the model id, so an alphabetical prefix does not split evenly across backends. Consequently the MLX/Candle columns of a PROJECTION row are partly an artifact of this rule. Only the `current` row's split is a fact. Each projection row therefore also reports what its split would be under proportional allocation, so the size of the artifact is visible instead of implied.
 
 Rows marked ⚠ have a per-backend split that differs from proportional allocation — that gap is the selection rule showing through, not a property of the projection. Only the `current` row's split is a fact.
 
-**The warm-session column does not move.** A session survives as long as any one of its rungs still needs measuring, and the resident baseline always does — so reclassifying rungs as `Structurally N/A` removes records but removes no model loads. If model load dominates the per-run cost, SC-15969's outcome changes the campaign's duration by far less than the record column suggests.
+**The all-backend warm floor does not move.** A session survives as long as any one rung still needs measuring, and the resident baseline always does. The shipped-load column can move because both backends still pay per surviving rung; only the counterfactual warm floor is one load per surviving session.
 
 ## 5. Wall clock (parameterised)
 
@@ -205,16 +206,16 @@ Per-run seconds is an **input**, defaulting to 300 s. ASSUMPTION — nothing in 
 
 ### Sweep
 
-| s/run | Record-hours (total) | MLX | Candle | Rungs amortised |
-| --- | --- | --- | --- | --- |
-| 30 | 61.3 | 38.5 | 22.8 | 12.3 |
-| 60 | 122.6 | 77 | 45.6 | 24.5 |
-| 120 | 245.1 | 154 | 91.1 | 49.1 |
-| 300 | 612.8 | 385 | 227.8 | 122.7 |
-| 600 | 1225.7 | 770 | 455.7 | 245.3 |
-| 1200 | 2451.3 | 1540 | 911.3 | 490.7 |
+| s/run | Record-hours (total) | MLX | Candle | Shipped load-hours | All-backend warm floor |
+| --- | --- | --- | --- | --- | --- |
+| 30 | 61.3 | 38.5 | 22.8 | 61.3 | 12.3 |
+| 60 | 122.6 | 77 | 45.6 | 122.6 | 24.5 |
+| 120 | 245.1 | 154 | 91.1 | 245.1 | 49.1 |
+| 300 | 612.8 | 385 | 227.8 | 612.8 | 122.7 |
+| 600 | 1225.7 | 770 | 455.7 | 1225.7 | 245.3 |
+| 1200 | 2451.3 | 1540 | 911.3 | 2451.3 | 490.7 |
 
-Only the first three columns are achievable with the harness as written; the final column prices the unimplemented rung collapse. The unavailable overlay-amortised column is deliberately absent. And per section 0, none of these hours can be spent today at all.
+The shipped load-hours column amortises only plan-declared, evidence-gated groups; all other records stay fresh. The final column is the unavailable all-backend warm floor. The unavailable overlay-amortised column is deliberately absent. And per section 0, none of these hours can be spent today at all.
 
 ## 6. Fit coefficients versus measure every cell
 
@@ -224,7 +225,7 @@ Worked precedent: **4** measurement records produced 36 curves (72 coefficients)
 
 > Tiers bf16, q8 carry ONE geometry point each, so their perMpxGb slopes cannot have been fitted. The zero-slope counts on the geometry-SENSITIVE phases (denoise, decode) show the consequence — bf16 (1 geometry point): 4/8 flat; q4 (2 geometry points): 1/8 flat; q8 (1 geometry point): 4/8 flat. A campaign budgeted from this precedent must budget two geometry points per tier, not the four records this evidence actually cost.
 
-| Strategy | Model loads | Provider invocations (harness as written) |
+| Strategy | Session points | Provider invocations (explicit batches only) |
 | --- | --- | --- |
 | `exhaustive-exact-geometry` | 8970 | 44850 |
 | `exhaustive-per-cell` | 1472 | 7354 |
@@ -305,13 +306,7 @@ DEMOTED, and this is the correction that matters most in this document. The firs
 
 > Resolve by: Still SC-16072, but sequenced AFTER catalog adapter coverage rather than ahead of it. Note that the load-side saving SC-16072 was expected to unlock is not available in the shipped load contract at all (see the `overlay` axis above), so this work should be scoped for RECORD correctness, not for a model-load reduction. Control coverage is now declared by CONTROL_LANE_MODELS and is not part of this remediation.
 
-### 5. whether the harness can amortise a model load across a target's rungs — not cell-gated
-
-A potential 5x on the whole campaign, currently NOT realised: the runner spawns a fresh process per planned case. Unlike the overlay load collapse this one is not ruled out by the load contract — but it is NOT established either. Nothing in the repository measures five rung peaks from one load, and the manifest cannot even express a `resident` peak alongside the other four. It is also not purely scheduling work: reusing a process risks contaminating the measurement, and the two backends have asymmetric protection (Candle asserts no caching allocator; MLX has a live buffer cache and its own footprint harness mandates one tier per process). See the `rung` axis for the full evidence review.
-
-> Resolve by: Either batch a target's rungs into one provider invocation, or run the provider as a warm daemon behind the argv command — and in either case demonstrate that a rung measured in a reused process matches the fresh-process measurement within a stated tolerance, ON BOTH BACKENDS, before believing the 5x. Tracked as SC-16059.
-
-### 6. which geometry policy is true — not cell-gated
+### 5. which geometry policy is true — not cell-gated
 
 The binding logic accepts any resolution inside the envelope; the manifest says exactly the opposite. The two policies differ by the geometry collapse factor across the whole campaign. Compounding it, the gate's own doc comment claims slopes 'fitted from real renders at multiple resolutions' while 2 of the 3 shipped tiers carry a single geometry point.
 

--- a/docs/memory-calibration-harness.md
+++ b/docs/memory-calibration-harness.md
@@ -49,6 +49,15 @@ stdin and expects one JSON response on stdout:
 
 1. `{ "action": "probe" }` → `{ "hardware": ... }`
 2. `{ "action": "run", "planned": ..., "repositories": ..., "hardware": ... }` → record fragment
+3. `{ "action": "run_batch", "planned": [...], ... }` → `{ "modelLoads": 1, "fragments": [...] }`
+4. `{ "action": "assess_batch", "planned": [...] }` → an explicit reuse-eligibility verdict
+
+`modelLoadPolicy: "batch_rungs"` plus a shared `modelLoadGroup` schedules pending cases for one
+target, backend, and fixture in canonical rung order. When multiple parameter points are pending for
+one rung, the runner selects one for the batch; a returned complete sweep can then retire the others.
+The adapter must attest exactly one model load, and every fragment preserves its existing logical and
+resolved identity. After every response the runner recomputes completed logical cases before choosing
+another provider invocation.
 
 The runner resolves both repositories using `git rev-parse HEAD` and `git status --porcelain`, reads
 the generated matrix source-tree identity, and probes them again after hardware probing and after
@@ -102,6 +111,25 @@ the adapter. `--provider <plan-provider-name>` optionally selects one named prov
 to run the current Krea v1 production point separately from non-promotable v2 candidates.
 `--fixture <fixture-name>` selects every provider block sharing that fixture, which is the intended
 way to execute a multi-rung reference ladder as one reproducible capture.
+`--fresh-per-case` overrides scheduling for an oracle capture; `--batch-rungs` forces one target's
+rungs into an experimental batch. Compare the two bundles with the committed larger-of tolerance
+(256 MiB absolute or 5% relative for every phase/metric):
+
+```text
+node scripts/memory-calibration-harness.mjs compare-reuse \
+  --fresh .tmp/fresh.json --reused .tmp/reused.json \
+  --output .tmp/reuse-comparison.json
+```
+
+When a backend cannot truthfully execute a batch, record that before measurement:
+
+```text
+node scripts/memory-calibration-harness.mjs assess-reuse \
+  --config config/memory-calibration-plan.json \
+  --backend mlx --fixture <five-rung-fixture> \
+  --provider-command '["/absolute/path/to/memory-provider-adapter"]' \
+  --output .tmp/reuse-assessment.json
+```
 
 Validate or merge captured output:
 

--- a/docs/memory-strategy-contract.md
+++ b/docs/memory-strategy-contract.md
@@ -409,10 +409,10 @@ rather than collapsing into the no-signal `Unknown` that took the zero-adaptatio
 prices every hosted Krea tier, including INT8-ConvRot, so this verdict is a fail-safe for malformed
 catalog entries and future tiers rather than a known shipping hole.
 
-## Fresh-process five-rung oracle (SC-16402)
+## Five-rung load reuse (SC-16059, oracle from SC-16402)
 
-`config/memory-calibration-plan.json` contains two same-target reference ladders used only as the
-fresh-process side of SC-16059's reused-vs-fresh comparison:
+`config/memory-calibration-plan.json` contains two same-target reference ladders used for the
+fresh/reused decision:
 
 - MLX/Metal: `z_image_turbo`, q4, 768×768 text-to-image, no overlay, seed 16402, two steps. Rungs 0–3
   use the eager provider fingerprint; rung 4 uses the provider-required deferred-materialization
@@ -423,7 +423,19 @@ fresh-process side of SC-16059's reused-vs-fresh comparison:
   through Krea's physical three-stage loader; the plain staged rung uses its one-boundary residency
   path.
 
-The harness starts one adapter process per planned case, so every row below is a fresh-process capture.
+The harness preserves a forced fresh-per-case oracle for both backends. Candle can execute its five
+cases as one diagnostic `run_batch` invocation; the adapter loads Krea once, returns five ordinary
+record fragments, and attests `modelLoads: 1`. A comparison passes only when every phase's active,
+allocator, device, wired, and reclaimable metric is within the larger of 256 MiB and 5% of its fresh
+value. The authoritative CUDA comparison returned `unable_to_amortize`, so the shipped plan keeps
+Candle fresh-per-case rather than changing the recorded peaks. MLX also remains fresh-per-case:
+rungs 0–3 require the eager calibration fingerprint while rung 4
+requires the deferred fingerprint, so one loaded Z-Image generator cannot preserve all five
+calibrated identities. `assess-reuse` reads both identities from the pinned provider contracts for
+the exact eager and deferred load specs and rejects any plan mismatch; it does not trust the plan's
+strings as capability evidence. The structured verdict records this backend as
+`unable_to_amortize`; it is not treated as a failed measurement or silently averaged.
+
 Two denoise steps are load-bearing for phase measurement: providers with an explicit loading boundary
 close conditioning there, while resident providers use the first Step callback as a conservative
 conditioning envelope and measure the second step as a denoise-only interval. Decoding always starts a
@@ -439,9 +451,15 @@ cargo build --release --locked -p sceneworks-memory-adapter --features mlx --bin
 node scripts/memory-calibration-harness.mjs run \
   --config config/memory-calibration-plan.json --backend mlx \
   --fixture fresh-five-rung-z-image-q4-768-seed16402-step2 \
+  --fresh-per-case \
   --provider-command '["target/release/memory-mlx-adapter"]' \
   --sceneworks-repo "$PWD" --inference-repo /absolute/path/to/inference-pin \
-  --output /tmp/sc-16402-mlx-fresh.json
+  --output /tmp/sc-16059-mlx-fresh.json
+node scripts/memory-calibration-harness.mjs assess-reuse \
+  --config config/memory-calibration-plan.json --backend mlx \
+  --fixture fresh-five-rung-z-image-q4-768-seed16402-step2 \
+  --provider-command '["target/release/memory-mlx-adapter"]' \
+  --output /tmp/sc-16059-mlx-reuse-assessment.json
 
 # Windows / NVIDIA CUDA (PowerShell; use target\release\memory-candle-adapter.exe)
 $env:SCENEWORKS_KREA_REPOSITORY='SceneWorks/krea-2-turbo-mlx'
@@ -450,14 +468,24 @@ $env:SCENEWORKS_KREA_ROOT='C:\absolute\path\to\models--SceneWorks--krea-2-turbo-
 cargo build --release --locked -p sceneworks-memory-adapter --features candle --bin memory-candle-adapter
 node scripts/memory-calibration-harness.mjs run --config config/memory-calibration-plan.json --backend candle `
   --fixture fresh-five-rung-krea-q4-1024-seed16402-step2 `
+  --fresh-per-case `
   --provider-command '["target/release/memory-candle-adapter.exe"]' `
   --sceneworks-repo $PWD --inference-repo C:\absolute\path\to\inference-pin `
-  --output $env:TEMP\sc-16402-candle-fresh.json
+  --output $env:TEMP\sc-16059-candle-fresh.json
+node scripts/memory-calibration-harness.mjs run --config config/memory-calibration-plan.json --backend candle `
+  --fixture fresh-five-rung-krea-q4-1024-seed16402-step2 --batch-rungs `
+  --provider-command '["target/release/memory-candle-adapter.exe"]' `
+  --sceneworks-repo $PWD --inference-repo C:\absolute\path\to\inference-pin `
+  --output $env:TEMP\sc-16059-candle-reused.json
+node scripts/memory-calibration-harness.mjs compare-reuse `
+  --fresh $env:TEMP\sc-16059-candle-fresh.json `
+  --reused $env:TEMP\sc-16059-candle-reused.json `
+  --output $env:TEMP\sc-16059-candle-reuse-comparison.json
 ```
 
 Validate either capture with `node scripts/memory-calibration-harness.mjs check --input <file>`.
 These authoritative records deliberately remain `gated`: they contain exact strategy identity and
-observed conditioning/denoise/decode/overall memory for SC-16059's oracle, but do not pretend that a
+observed conditioning/denoise/decode/overall memory for the reuse oracle, but do not pretend that a
 single reference render also completed the promotion-quality sweep, negative mutation, or lifecycle
 fault suite. They therefore cannot become current calibration evidence or update the cost model.
 

--- a/scripts/calibration-cost-model.mjs
+++ b/scripts/calibration-cost-model.mjs
@@ -180,6 +180,34 @@ function keyOf(cell, fields) {
   return fields.map((field) => cell[field]).join("\u0000");
 }
 
+export function batchedSessionKeysFromPlan(plan) {
+  const groups = new Map();
+  for (const provider of plan.providers.filter((item) => item.modelLoadPolicy === "batch_rungs")) {
+    if (!provider.modelLoadGroup) throw new Error("batch_rungs provider requires modelLoadGroup");
+    if (!groups.has(provider.modelLoadGroup)) groups.set(provider.modelLoadGroup, []);
+    groups.get(provider.modelLoadGroup).push(provider);
+  }
+  const keys = [];
+  for (const [group, providers] of groups) {
+    const rungs = providers.map((provider) => provider.rung).sort(
+      (left, right) => RUNG_ORDER.indexOf(left) - RUNG_ORDER.indexOf(right),
+    );
+    if (JSON.stringify(rungs) !== JSON.stringify(RUNG_ORDER)) {
+      throw new Error(`${group}: batched cost coverage requires one provider for every canonical rung`);
+    }
+    const sessions = new Set(providers.map((provider) => keyOf({
+      modelId: provider.target.modelId,
+      backend: provider.backend,
+      tier: provider.target.tier,
+      mode: provider.target.mode,
+      overlay: provider.target.overlay.replace(/^control:\d+$/, "control"),
+    }, SESSION_KEY_FIELDS)));
+    if (sessions.size !== 1) throw new Error(`${group}: batched providers must share one session key`);
+    keys.push(...sessions);
+  }
+  return [...new Set(keys)].sort();
+}
+
 function tally(values) {
   const counts = new Map();
   for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
@@ -293,61 +321,37 @@ export const COLLAPSING_AXES = [
       "to its own logicalCaseId) and #validateComplete (every declared axis range must be derived " +
       "from passed executed cases)",
     caveat:
-      "Realised only ACROSS resumed invocations. `runProviderPlan` computes its skip set once from " +
-      "`--resume` and then spawns the provider command once per planned case, without feeding " +
-      "incoming records back into the skip set — so within a single invocation an N-point sweep " +
-      "still costs N process spawns.",
+      "`runProviderPlan` recomputes completed logical identities after every provider response. A " +
+      "complete record whose passed sweep covers other pending points retires those points before " +
+      "the runner chooses its next invocation, so the collapse is now realised both within one run " +
+      "and across `--resume` runs.",
   },
   {
     axis: "rung",
-    verdict: "not collapsed by the harness; UNPROVEN in principle",
-    factor: "5 (every session key spans exactly 5 rungs) — a CEILING, not a demonstrated saving",
+    verdict: "fresh per rung on both measured backends",
+    factor: "1 record per model load; the 5-record warm floor remains counterfactual",
     rule:
       "A record names ONE rung (`strategy.rung` is a single enum and is part of the record " +
       "identity), and the matrix binds a record to exactly one cell on the " +
-      "(modelId, provider, backend, tier, mode, overlay, rung) key. So the schema forces one " +
-      "record per rung. Whether the PHYSICS also forces it is OPEN: nothing in this repository " +
-      "measures five rung peaks from one load, and the sources previously cited for it do not " +
-      "establish it. The 5x is therefore the size of a prize nobody has shown is collectable, not " +
-      "a saving being left on the table.",
-    // Downgraded to what each source actually proves. Every one of these was previously cited as
-    // establishing the five-rung collapse; none of them does.
+      "(modelId, provider, backend, tier, mode, overlay, rung) key, so records remain one-per-rung. " +
+      "The harness and Candle adapter can execute Krea's five-rung group as one `run_batch` provider " +
+      "invocation with `modelLoads: 1`, but the authoritative fresh/reused comparison exceeded the " +
+      "committed tolerance, so the shipped plan keeps Candle fresh-per-rung. MLX also stays fresh: its Z-Image " +
+      "ladder spans distinct eager and deferred calibration fingerprints, so one loaded generator " +
+      "cannot preserve every rung's calibrated identity. No target is priced as batched.",
     citation:
-      "SCHEMA SIDE (established): scripts/memory-calibration-harness.mjs#recordId + #validateRecord " +
-      "(rung is in the identity); scripts/generate-memory-matrix.mjs (record->cell match includes " +
-      "`rung`). " +
-      "PHYSICS SIDE (does NOT establish the collapse): " +
-      "docs/memory-calibration-harness.md 'one loaded generator' covers four memory PHASES " +
-      "(conditioning, denoise, decode, overall) at ONE strategy — phases are not rungs; " +
-      "its warm-repeat A->B->A and crates/sceneworks-memory-adapter/src/bin/candle.rs" +
-      "#execute_parity_request compare PIXEL output across two strategies and sample no memory at " +
-      "all (the function returns an Image and never touches the VramProbe); and the Krea " +
-      "turboFit evidence records say only " +
-      '"exclusive rendered-device phase peaks at 768x768 and 1024x1024" in verification.method — ' +
-      "'exclusive' means exclusive HARDWARE, and no field in the record schema names a process, " +
-      "load or session, so one record cannot evidence one process. Those peaks also cover FOUR " +
-      "rungs, not five: packages/schemas/model-manifest.schema.json caps `observedPeaksGb` at " +
-      "threeStage/tiledVae/chunkedAttention/streamedBlocks with additionalProperties false, so the " +
-      "manifest cannot express a `resident` peak — the one rung that is the irreducible floor.",
+      "scripts/memory-calibration-harness.mjs#runProviderPlan (canonical `run_batch`, one-load " +
+      "attestation, and within-invocation sweep retirement); " +
+      "crates/sceneworks-memory-adapter/src/bin/candle.rs#run_five_rung_batch; " +
+      "crates/sceneworks-memory-adapter/src/bin/mlx.rs#assess_z_image_batch; " +
+      ".github/workflows/windows-candle.yml (fresh/reused evidence gate) and macos-mlx.yml " +
+      "(fresh capture plus provider-contract inability gate)",
     caveat:
-      "The harness spawns a FRESH process per planned case, so today the model load is paid once " +
-      "per rung. Capturing this 5x needs either a warm provider daemon behind the argv command or " +
-      "a runner that batches a target's rungs into one invocation. Neither exists — AND neither is " +
-      "purely scheduling work, because reusing a process risks CONTAMINATING the measurement, " +
-      "asymmetrically across backends. " +
-      "CANDLE has partial protection: the adapter enforces a 64 MiB post-fault cleanup-growth " +
-      "tolerance and asserts `cudaCachingAllocatorPresent = 0`, so freed device bytes return to the " +
-      "device rather than into an allocator cache (though that constant is a hardcoded diagnostic, " +
-      "not a probe of live allocator state). " +
-      "MLX has NO equivalent structural guarantee: a buffer cache is present and is itself measured " +
-      "and published, and the adapter must call `clear_cache()` + `reset_peak_memory()` explicitly " +
-      "between measurements. That is not sufficient — `clear_cache()` reclaims only allocator-cache " +
-      "buffers and cannot release LIVE weight arrays, which is precisely the residue a multi-rung " +
-      "campaign accumulates, because rungs 1 and 4 change residency. SceneWorks' own MLX footprint " +
-      "harness (crates/sceneworks-worker/src/footprint_measure.rs) therefore mandates ONE TIER PER " +
-      "PROCESS and enforces it with a runtime assert, having found that process-global counters let " +
-      "a heavier earlier measurement leak into a lighter later one. A rung-batching runner must " +
-      "prove it beats that, on both backends. Tracked as SC-16059.",
+      "The committed equivalence gate is the larger of 256 MiB absolute drift and 5% of the fresh " +
+      "metric, applied to every phase and allocator/device/wired/reclaimable metric. Candle's measured " +
+      "verdict and MLX's structural verdict are both `unable_to_amortize`. MLX's inability is structural, not " +
+      "an inferred timing result: the eager and deferred fingerprints differ before a reused process " +
+      "can truthfully execute all five identities, so the backend retains fresh-per-rung cost.",
   },
   {
     axis: "overlay",
@@ -405,6 +409,16 @@ function collapsingAxesFor(census, runs) {
   const overlayCells = census.total - (census.byOverlay.none ?? 0);
   const overlayShare = round((overlayCells / census.total) * 100, 1);
   return COLLAPSING_AXES.map((axis) => {
+    if (axis.axis === "rung") {
+      return {
+        ...axis,
+        factor:
+          `${runs.shippedBatchCoverage.records} records in ${runs.shippedBatchCoverage.sessions} ` +
+          `explicit group(s) save ${runs.shippedBatchCoverage.savedLoads} loads; combined ` +
+          `${runs.certifyingRecords.total} -> ${runs.shippedModelLoads.total} ` +
+          `(${runs.shippedLoadCollapseFactor}x)`,
+      };
+    }
     if (axis.axis !== "overlay") return axis;
     return {
       ...axis,
@@ -701,6 +715,14 @@ export function cellCensus(cells) {
       total: sessions.size,
       byBackend: tally(sessionList.map((session) => session.backend)),
       geometryExpanded: sessionList.reduce((sum, session) => sum + session.geometryPoints, 0),
+      geometryExpandedByBackend: Object.fromEntries(
+        ["mlx", "candle"].map((backend) => [
+          backend,
+          sessionList
+            .filter((session) => session.backend === backend)
+            .reduce((sum, session) => sum + session.geometryPoints, 0),
+        ]),
+      ),
       // If this is not exactly [5] the rung collapse factor below is not a constant and the
       // model must not report one.
       rungsPerSession: [...rungSpans].sort((left, right) => left - right),
@@ -709,6 +731,14 @@ export function cellCensus(cells) {
       total: fitGroups.size,
       byBackend: tally([...fitGroups.values()].map((group) => group.backend)),
       tierSum: [...fitGroups.values()].reduce((sum, group) => sum + group.tiers.size, 0),
+      tierSumByBackend: Object.fromEntries(
+        ["mlx", "candle"].map((backend) => [
+          backend,
+          [...fitGroups.values()]
+            .filter((group) => group.backend === backend)
+            .reduce((sum, group) => sum + group.tiers.size, 0),
+        ]),
+      ),
     },
   };
 }
@@ -718,7 +748,7 @@ export function cellCensus(cells) {
  * each realisable strategy, split by hardware because MLX/Metal runs on a Mac and Candle/CUDA
  * needs rented CUDA — completely different cost structures.
  */
-export function collapseToRuns(cells, parameters = DEFAULT_PARAMETERS) {
+export function collapseToRuns(cells, parameters = DEFAULT_PARAMETERS, coverage = {}) {
   const naFractions = {
     ...DEFAULT_PARAMETERS.structurallyNotApplicableFractionByRung,
     ...(parameters.structurallyNotApplicableFractionByRung ?? {}),
@@ -780,6 +810,24 @@ export function collapseToRuns(cells, parameters = DEFAULT_PARAMETERS) {
   const census = cellCensus(cells);
   const rungCollapse =
     census.sessions.rungsPerSession.length === 1 ? census.sessions.rungsPerSession[0] : null;
+  const eligibleBatchKeys = new Set(coverage.batchedSessionKeys ?? []);
+  const batchCounts = new Map();
+  for (const cell of surviving) {
+    const key = keyOf(cell, SESSION_KEY_FIELDS);
+    if (!eligibleBatchKeys.has(key)) continue;
+    const current = batchCounts.get(key) ?? { backend: cell.backend, records: 0 };
+    current.records += 1;
+    batchCounts.set(key, current);
+  }
+  const savedLoads = { mlx: 0, candle: 0 };
+  for (const session of batchCounts.values()) {
+    savedLoads[session.backend] += Math.max(0, session.records - 1);
+  }
+  const shippedModelLoads = {
+    mlx: certifyingRecords.mlx - savedLoads.mlx,
+    candle: certifyingRecords.candle - savedLoads.candle,
+    total: certifyingRecords.total - savedLoads.mlx - savedLoads.candle,
+  };
 
   return {
     exemptions: {
@@ -791,6 +839,17 @@ export function collapseToRuns(cells, parameters = DEFAULT_PARAMETERS) {
     certifyingRecords,
     // The unit that costs a model load, IF a provider amortises one across a target's rungs.
     warmSessions,
+    shippedModelLoads,
+    shippedBatchCoverage: {
+      sessionKeys: [...batchCounts.keys()].sort(),
+      sessions: batchCounts.size,
+      records: [...batchCounts.values()].reduce((sum, session) => sum + session.records, 0),
+      savedLoads: savedLoads.mlx + savedLoads.candle,
+    },
+    shippedLoadCollapseFactor:
+      shippedModelLoads.total === 0
+        ? null
+        : round(certifyingRecords.total / shippedModelLoads.total, 3),
     unavailableOverlayLoadPriceTag: {
       availability: "unavailable",
       disposition: "counterfactual metadata only; excluded from campaign and wall-clock columns",
@@ -845,7 +904,7 @@ function proportionalExemptions(cells, fractions) {
  * N/A sensitivity. SC-15969 has not run, so the honest output is a curve, not a number.
  * The scenarios below are labelled projections; only `current` is a fact.
  */
-export function naSensitivity(cells) {
+export function naSensitivity(cells, coverage = {}) {
   const scenarios = [
     {
       name: "current",
@@ -896,7 +955,7 @@ export function naSensitivity(cells) {
     },
   ];
 
-  const baseline = collapseToRuns(cells, DEFAULT_PARAMETERS).certifyingRecords;
+  const baseline = collapseToRuns(cells, DEFAULT_PARAMETERS, coverage).certifyingRecords;
 
   return scenarios.map((scenario) => {
     const runs = collapseToRuns(cells, {
@@ -905,7 +964,7 @@ export function naSensitivity(cells) {
         ...DEFAULT_PARAMETERS.structurallyNotApplicableFractionByRung,
         ...scenario.fractions,
       },
-    });
+    }, coverage);
     const exemptedByBackend = {
       mlx: baseline.mlx - runs.certifyingRecords.mlx,
       candle: baseline.candle - runs.certifyingRecords.candle,
@@ -916,6 +975,7 @@ export function naSensitivity(cells) {
       kind: scenario.kind,
       note: scenario.note,
       certifyingRecords: runs.certifyingRecords,
+      shippedModelLoads: runs.shippedModelLoads,
       warmSessions: runs.warmSessions,
       // Emitted so a projection's per-backend column is never mistaken for a finding. See
       // NA_SELECTION_RULE.
@@ -990,6 +1050,11 @@ export function wallClock(runs, parameters = DEFAULT_PARAMETERS) {
         mlx: hours(runs.certifyingRecords.mlx, seconds),
         candle: hours(runs.certifyingRecords.candle, seconds),
       },
+      shippedModelLoadHours: {
+        total: hours(runs.shippedModelLoads.total, seconds),
+        mlx: hours(runs.shippedModelLoads.mlx, seconds),
+        candle: hours(runs.shippedModelLoads.candle, seconds),
+      },
       warmSessionHours: {
         total: hours(runs.warmSessions.total, seconds),
         mlx: hours(runs.warmSessions.mlx, seconds),
@@ -1016,7 +1081,7 @@ export function wallClock(runs, parameters = DEFAULT_PARAMETERS) {
  * The INVERSION IS ROBUST: fit/per-cell stays above 1 at every grid point, so "fitting costs more
  * than the per-cell campaign" does not depend on the defaults. Only the magnitude moves.
  */
-export function fitSensitivity(cells, grid = FIT_SENSITIVITY_GRID) {
+export function fitSensitivity(cells, grid = FIT_SENSITIVITY_GRID, coverage = {}) {
   const precedentStub = { measurementRecords: 0, tiers: [], curves: 0, coefficients: 0 };
   const rows = [];
   for (const points of grid.geometryPointsPerFit) {
@@ -1027,7 +1092,7 @@ export function fitSensitivity(cells, grid = FIT_SENSITIVITY_GRID) {
           geometryPointsPerFit: points,
           slopeSharedAcrossTiers: shared,
           validationSampleFraction: fraction,
-        });
+        }, coverage);
         const fit = result.strategies.find((strategy) => strategy.name === "fit-then-validate");
         rows.push({
           geometryPointsPerFit: points,
@@ -1067,12 +1132,12 @@ export function fitSensitivity(cells, grid = FIT_SENSITIVITY_GRID) {
   };
 }
 
-export function fitVersusExhaustive(cells, kreaPrecedent, parameters = DEFAULT_PARAMETERS) {
+export function fitVersusExhaustive(cells, kreaPrecedent, parameters = DEFAULT_PARAMETERS, coverage = {}) {
   const census = cellCensus(cells);
-  const runs = collapseToRuns(cells, parameters);
+  const runs = collapseToRuns(cells, parameters, coverage);
   const points = Math.max(1, Math.trunc(parameters.geometryPointsPerFit ?? 2));
-  // Under the harness as written every rung costs its own provider invocation, so a session-level
-  // count must be restated in invocations before it can be compared to a wall-clock budget.
+  // Only explicitly planned batch groups reduce provider invocations. The exact-geometry and fit
+  // campaigns include unplanned geometry points, so they retain the conservative fresh-rung count.
   const rungSpan = runs.rungCollapseFactor ?? 1;
 
   // Exhaustive at the exact geometry the manifest's own policy demands ("not permission to
@@ -1087,9 +1152,8 @@ export function fitVersusExhaustive(cells, kreaPrecedent, parameters = DEFAULT_P
   const fitSessions = parameters.slopeSharedAcrossTiers
     ? census.fitGroups.tierSum + census.fitGroups.total * (points - 1)
     : census.fitGroups.tierSum * points;
-  const validationSessions = Math.ceil(
-    census.sessions.total * Math.min(Math.max(parameters.validationSampleFraction ?? 0, 0), 1),
-  );
+  const validationFraction = Math.min(Math.max(parameters.validationSampleFraction ?? 0, 0), 1);
+  const validationSessions = Math.ceil(census.sessions.total * validationFraction);
 
   return {
     formula: {
@@ -1112,7 +1176,7 @@ export function fitVersusExhaustive(cells, kreaPrecedent, parameters = DEFAULT_P
       {
         name: "exhaustive-per-cell",
         sessions: exhaustivePerCell,
-        providerInvocations: runs.certifyingRecords.total,
+        providerInvocations: runs.shippedModelLoads.total,
         policy:
           "One measurement per cell at one geometry, relying on the binding logic accepting any " +
           "resolution inside the envelope. Cheaper, but it certifies an envelope from a point.",
@@ -1369,24 +1433,6 @@ export function rankUncertainties(
     perRunSeconds,
     ...codeGated.slice(1),
     {
-      input: "whether the harness can amortise a model load across a target's rungs",
-      why:
-        "A potential 5x on the whole campaign, currently NOT realised: the runner spawns a fresh " +
-        "process per planned case. Unlike the overlay load collapse this one is not ruled out by the " +
-        "load contract — but it is NOT established either. Nothing in the repository measures five " +
-        "rung peaks from one load, and the manifest cannot even express a `resident` peak alongside " +
-        "the other four. It is also not purely scheduling work: reusing a process risks contaminating " +
-        "the measurement, and the two backends have asymmetric protection (Candle asserts no caching " +
-        "allocator; MLX has a live buffer cache and its own footprint harness mandates one tier per " +
-        "process). See the `rung` axis for the full evidence review.",
-      howToResolve:
-        "Either batch a target's rungs into one provider invocation, or run the provider as a warm " +
-        "daemon behind the argv command — and in either case demonstrate that a rung measured in a " +
-        "reused process matches the fresh-process measurement within a stated tolerance, ON BOTH " +
-        "BACKENDS, before believing the 5x. Tracked as SC-16059.",
-      story: 16059,
-    },
-    {
       input: "which geometry policy is true",
       why:
         "The binding logic accepts any resolution inside the envelope; the manifest says exactly the " +
@@ -1451,7 +1497,8 @@ export async function buildCostModel({ sourceOverrides = {} } = {}) {
 
   const cells = matrix.cells;
   const census = cellCensus(cells);
-  const runs = collapseToRuns(cells, DEFAULT_PARAMETERS);
+  const batchCoverage = { batchedSessionKeys: batchedSessionKeysFromPlan(plan) };
+  const runs = collapseToRuns(cells, DEFAULT_PARAMETERS, batchCoverage);
   const precedent = kreaFitPrecedent(manifest);
 
   // Completed work is derived rather than assumed, from two independent places that must agree:
@@ -1543,6 +1590,8 @@ export async function buildCostModel({ sourceOverrides = {} } = {}) {
     evidenceScope: provider.evidenceScope,
     plannedCases: provider.cases.length,
     positiveCases: provider.cases.filter((item) => item.expectedResult === "passed").length,
+    modelLoadPolicy: provider.modelLoadPolicy ?? "fresh_per_case",
+    modelLoadGroup: provider.modelLoadGroup ?? null,
   }));
 
   const model = {
@@ -1577,8 +1626,9 @@ export async function buildCostModel({ sourceOverrides = {} } = {}) {
     overlayLoadContract: OVERLAY_LOAD_CONTRACT,
     collapsing: {
       runUnit:
-        "One `action:\"run\"` provider invocation. `runProviderPlan` spawns the provider command " +
-        "once per planned case, so this is the unit that costs a model load.",
+        "One provider invocation. `runProviderPlan` uses `action:\"run\"` for a fresh case and " +
+        "`action:\"run_batch\"` for a compatible Candle five-rung group; either invocation attests " +
+        "one model load.",
       runUnitCitation: "scripts/memory-calibration-harness.mjs#runProviderPlan",
       requiredScenariosPerRecord: REQUIRED_SCENARIOS.length,
       requiredScenarios: [...REQUIRED_SCENARIOS].sort(),
@@ -1598,14 +1648,14 @@ export async function buildCostModel({ sourceOverrides = {} } = {}) {
           "Rung 0 is the unoptimised baseline every model has by definition, so it can never be " +
           "Structurally N/A. No survey outcome can remove these cells from the campaign.",
       },
-      scenarios: naSensitivity(cells),
+      scenarios: naSensitivity(cells, batchCoverage),
     },
     wallClock: wallClock(runs, DEFAULT_PARAMETERS),
     fitVersusExhaustive: {
-      ...fitVersusExhaustive(cells, precedent, DEFAULT_PARAMETERS),
+      ...fitVersusExhaustive(cells, precedent, DEFAULT_PARAMETERS, batchCoverage),
       // Attached here rather than inside `fitVersusExhaustive` because the sweep calls that function
       // once per grid point and nesting it would recurse.
-      sensitivity: fitSensitivity(cells),
+      sensitivity: fitSensitivity(cells, FIT_SENSITIVITY_GRID, batchCoverage),
     },
     parameters: DEFAULT_PARAMETERS,
     biggestUncertainties: rankUncertainties(producible, {
@@ -1744,7 +1794,7 @@ function renderMarkdown(model) {
     "",
     "## 2. The collapsing rule (derived)",
     "",
-    `The run unit is one \`action:"run"\` provider invocation — ${model.collapsing.runUnitCitation} spawns the provider command once per planned case, so that is what costs a model load. A \`complete\` record must pass all ${model.collapsing.requiredScenariosPerRecord} required scenarios plus quality and a measured negative mutation.`,
+    `${model.collapsing.runUnit} A \`complete\` record must pass all ${model.collapsing.requiredScenariosPerRecord} required scenarios plus quality and a measured negative mutation.`,
     "",
     ...markdownTable(
       ["Axis", "Verdict", "Factor"],
@@ -1771,7 +1821,13 @@ function renderMarkdown(model) {
           String(runs.certifyingRecords.candle),
         ],
         [
-          `Warm sessions (model loads, ${runs.rungCollapseFactor} rungs each)`,
+          "Shipped model loads (explicit groups only)",
+          String(runs.shippedModelLoads.total),
+          String(runs.shippedModelLoads.mlx),
+          String(runs.shippedModelLoads.candle),
+        ],
+        [
+          `All-backend warm-session floor (${runs.rungCollapseFactor} rungs each)`,
           String(runs.warmSessions.total),
           String(runs.warmSessions.mlx),
           String(runs.warmSessions.candle),
@@ -1803,7 +1859,7 @@ function renderMarkdown(model) {
     "",
     `Excluded: ${runs.exemptions.alreadyStructurallyNotApplicable} cells already classified \`Structurally N/A\`, which the epic exempts from measurement. Nothing else is excluded — \`Missing\` cells still need a run, they just need an implementation first.`,
     "",
-    `The warm-session row is **not currently achievable**. It is what the campaign would cost if one loaded generator covered a target's ${runs.rungCollapseFactor} rungs, at ${runs.recordsPerWarmSession} records per load; the harness spawns a fresh process per planned case today, so every rung pays its own model load.`,
+    `The shipped campaign now costs **${runs.shippedModelLoads.total} model loads**. Exactly ${runs.shippedBatchCoverage.records} records in ${runs.shippedBatchCoverage.sessions} groups are configured for batching, saving ${runs.shippedBatchCoverage.savedLoads} loads; every record remains fresh. That is a **${runs.shippedLoadCollapseFactor}x** reduction from ${runs.certifyingRecords.total} fresh-per-record loads. The ${runs.warmSessions.total}-load floor remains counterfactual because MLX is structurally unable and Candle failed the committed fresh/reused tolerance.`,
     "",
     "## 4. Structurally N/A sensitivity",
     "",
@@ -1812,13 +1868,14 @@ function renderMarkdown(model) {
     `Irreducible floor: the **${model.naSensitivity.irreducibleFloor.cells}** \`${model.naSensitivity.irreducibleFloor.rung}\` cells. ${model.naSensitivity.irreducibleFloor.reason}`,
     "",
     ...markdownTable(
-      ["Scenario", "Kind", "Records", "MLX", "Candle", "Warm sessions", "Exempted MLX/Candle", "...if proportional"],
+      ["Scenario", "Kind", "Records", "MLX", "Candle", "Shipped loads", "Warm floor", "Exempted MLX/Candle", "...if proportional"],
       model.naSensitivity.scenarios.map((scenario) => [
         `\`${scenario.name}\``,
         scenario.kind,
         String(scenario.certifyingRecords.total),
         String(scenario.certifyingRecords.mlx),
         String(scenario.certifyingRecords.candle),
+        String(scenario.shippedModelLoads.total),
         String(scenario.warmSessions.total),
         `${scenario.exemptedByBackend.mlx}/${scenario.exemptedByBackend.candle}`,
         scenario.kind === "fact"
@@ -1831,7 +1888,7 @@ function renderMarkdown(model) {
     "",
     `Rows marked ⚠ have a per-backend split that differs from proportional allocation — that gap is the selection rule showing through, not a property of the projection. Only the \`current\` row's split is a fact.`,
     "",
-    `**The warm-session column does not move.** A session survives as long as any one of its rungs still needs measuring, and the resident baseline always does — so reclassifying rungs as \`Structurally N/A\` removes records but removes no model loads. If model load dominates the per-run cost, SC-15969's outcome changes the campaign's duration by far less than the record column suggests.`,
+    `**The all-backend warm floor does not move.** A session survives as long as any one rung still needs measuring, and the resident baseline always does. The shipped-load column can move because both backends still pay per surviving rung; only the counterfactual warm floor is one load per surviving session.`,
     "",
     "## 5. Wall clock (parameterised)",
     "",
@@ -1855,18 +1912,20 @@ function renderMarkdown(model) {
         "Record-hours (total)",
         "MLX",
         "Candle",
-        "Rungs amortised",
+        "Shipped load-hours",
+        "All-backend warm floor",
       ],
       model.wallClock.sweep.map((row) => [
         String(row.perRunSeconds),
         String(row.recordHours.total),
         String(row.recordHours.mlx),
         String(row.recordHours.candle),
+        String(row.shippedModelLoadHours.total),
         String(row.warmSessionHours.total),
       ]),
     ),
     "",
-    "Only the first three columns are achievable with the harness as written; the final column prices the unimplemented rung collapse. The unavailable overlay-amortised column is deliberately absent. And per section 0, none of these hours can be spent today at all.",
+    "The shipped load-hours column amortises only plan-declared, evidence-gated groups; all other records stay fresh. The final column is the unavailable all-backend warm floor. The unavailable overlay-amortised column is deliberately absent. And per section 0, none of these hours can be spent today at all.",
     "",
     "## 6. Fit coefficients versus measure every cell",
     "",
@@ -1877,7 +1936,7 @@ function renderMarkdown(model) {
     `> ${fit.kreaPrecedent.honestyNote}`,
     "",
     ...markdownTable(
-      ["Strategy", "Model loads", "Provider invocations (harness as written)"],
+      ["Strategy", "Session points", "Provider invocations (explicit batches only)"],
       fit.strategies.map((strategy) => [
         `\`${strategy.name}\``,
         String(strategy.sessions),

--- a/scripts/calibration-cost-model.test.mjs
+++ b/scripts/calibration-cost-model.test.mjs
@@ -9,6 +9,7 @@ import {
   OVERLAY_LOAD_CONTRACT,
   PRODUCIBILITY_GATES,
   SOURCE_PATHS,
+  batchedSessionKeysFromPlan,
   buildCostModel,
   cellCensus,
   collapseToRuns,
@@ -130,6 +131,31 @@ test("control coverage follows CONTROL_LANE_MODELS, not backend measurement bloc
   );
 });
 
+test("shipped batch coverage is empty while complete opted-in groups remain derivable", () => {
+  const plan = JSON.parse(readFileSync(
+    new URL("../config/memory-calibration-plan.json", import.meta.url),
+    "utf8",
+  ));
+  assert.deepEqual(batchedSessionKeysFromPlan(plan), []);
+
+  const optedIn = structuredClone(plan);
+  for (const provider of optedIn.providers.filter(
+    (item) => item.fixture === "fresh-five-rung-krea-q4-1024-seed16402-step2",
+  )) {
+    provider.modelLoadPolicy = "batch_rungs";
+    provider.modelLoadGroup = "synthetic-complete-krea-group";
+  }
+  assert.deepEqual(batchedSessionKeysFromPlan(optedIn), [[
+    "krea_2_turbo", "candle", "q4", "text_to_image", "none",
+  ].join("\0")]);
+
+  const incomplete = structuredClone(optedIn);
+  incomplete.providers = incomplete.providers.filter(
+    (provider) => provider.name !== "candle-krea-q4-fresh-reference-resident",
+  );
+  assert.throws(() => batchedSessionKeysFromPlan(incomplete), /every canonical rung/);
+});
+
 test("published overlay prose derives its census and load ratio from the current matrix", async () => {
   const model = await buildCostModel();
   const overlayCells = model.cells.total - model.cells.byOverlay.none;
@@ -230,6 +256,8 @@ test("the collapsing rule maps cells 1:1 to records and counts sessions rather t
 
   // Model loads: all three session keys still have work, including beta's (4 of 5 rungs survive).
   assert.deepEqual(runs.warmSessions, { total: 3, mlx: 2, candle: 1 });
+  assert.deepEqual(runs.shippedModelLoads, { total: 14, mlx: 10, candle: 4 });
+  assert.equal(runs.shippedLoadCollapseFactor, 1);
   assert.equal(runs.rungCollapseFactor, 5);
   // 14 records over 3 loads — NOT the rung span, because one cell is already exempt. Reported to
   // three places precisely so an exempt cell cannot round away into a clean "5".
@@ -264,6 +292,20 @@ test("mutation: a tier-collapsing rule disagrees with the shipped rule", () => {
     tierCollapsed.size,
     "tier must not collapse — a q4 record cannot certify a q8 cell",
   );
+});
+
+test("only an explicitly covered complete rung group reduces shipped model loads", () => {
+  const betaKey = ["beta", "candle", "q4", "text_to_image", "none"].join("\0");
+  const runs = collapseToRuns(syntheticCells(), DEFAULT_PARAMETERS, {
+    batchedSessionKeys: [betaKey],
+  });
+  assert.deepEqual(runs.shippedModelLoads, { total: 11, mlx: 10, candle: 1 });
+  assert.deepEqual(runs.shippedBatchCoverage, {
+    sessionKeys: [betaKey],
+    sessions: 1,
+    records: 4,
+    savedLoads: 3,
+  });
 });
 
 /**
@@ -596,40 +638,23 @@ test("the overlay load-axis collapse is recorded as unavailable in the shipped l
 });
 
 /**
- * MAJOR 4, pinned. The rung collapse was cited to four sources, none of which establishes that one
- * load can measure five rung peaks: two docs lines describe PHASES at one strategy and pixel parity
- * across two strategies, `execute_parity_request` samples no memory at all, and one manifest record
- * is not evidence of one process. The verdict must be UNPROVEN, and the backend asymmetry in
- * measurement contamination must be recorded because it is what makes SC-16059 more than scheduling.
+ * SC-16059 resolves the rung uncertainty per backend. Candle proves a one-load batch can execute but
+ * fails the fresh/reused tolerance gate. MLX remains fresh because its eager and deferred rungs carry
+ * distinct calibration identities.
  */
-test("the rung axis is UNPROVEN, with its citations downgraded and the MLX/Candle asymmetry recorded", () => {
+test("the rung axis records both backends' explicit inability to amortize", () => {
   const rung = COLLAPSING_AXES.find((axis) => axis.axis === "rung");
 
-  assert.equal(rung.verdict, "not collapsed by the harness; UNPROVEN in principle");
-  assert.match(rung.factor, /CEILING/);
-
-  // The claim itself must be stated as open rather than as physics.
-  assert.match(rung.rule, /OPEN/);
-  assert.doesNotMatch(rung.rule, /The PHYSICS does not/);
-
-  // Citations split into what IS established (schema) and what is NOT (physics).
-  assert.match(rung.citation, /SCHEMA SIDE \(established\)/);
-  assert.match(rung.citation, /PHYSICS SIDE \(does NOT establish the collapse\)/);
-  // Phases are not rungs.
-  assert.match(rung.citation, /phases are not rungs/);
-  // The parity path measures pixels, not memory.
-  assert.match(rung.citation, /returns an Image and never touches the VramProbe/);
-  // "exclusive" means exclusive hardware, not one process.
-  assert.match(rung.citation, /exclusive HARDWARE/);
-  // The manifest cannot even express the fifth rung's peak.
-  assert.match(rung.citation, /cannot express a `resident` peak/);
-
-  // The asymmetry: Candle asserts no caching allocator; MLX has a live cache and its own footprint
-  // harness mandates one tier per process because clear_cache() cannot free live weights.
-  assert.match(rung.caveat, /cudaCachingAllocatorPresent = 0/);
-  assert.match(rung.caveat, /MLX has NO equivalent structural guarantee/);
-  assert.match(rung.caveat, /ONE TIER PER\s+PROCESS/);
-  assert.match(rung.caveat, /cannot release LIVE weight arrays/);
+  assert.equal(rung.verdict, "fresh per rung on both measured backends");
+  assert.match(rung.factor, /warm floor remains counterfactual/);
+  assert.match(rung.rule, /run_batch/);
+  assert.match(rung.rule, /exceeded the/);
+  assert.match(rung.rule, /eager and deferred calibration fingerprints/);
+  assert.match(rung.rule, /No target is priced as batched/);
+  assert.match(rung.citation, /run_five_rung_batch/);
+  assert.match(rung.citation, /assess_z_image_batch/);
+  assert.match(rung.caveat, /256 MiB/);
+  assert.match(rung.caveat, /5%/);
 });
 
 test("the perRunSeconds remediation derives current completion counts and asks for timing", () => {
@@ -1029,8 +1054,7 @@ test("fit-versus-exhaustive is sensitive to the geometry points parameter, not h
 
   // Exhaustive strategies are geometry-policy facts and must not move with a fit parameter.
   // Session-level, not cell-level: alpha's two session keys advertise 2 resolutions each and
-  // beta's advertises 1, so measuring every advertised resolution is 5 model loads (25 provider
-  // invocations once each load's five rungs are counted).
+  // beta's advertises 1. Both backends pay five fresh invocations per session point.
   assert.equal(twoPoints["exhaustive-exact-geometry"], 5);
   assert.equal(threePoints["exhaustive-exact-geometry"], 5);
   assert.equal(twoPoints["exhaustive-per-cell"], 3);

--- a/scripts/fixtures/memory-provider-fixture.mjs
+++ b/scripts/fixtures/memory-provider-fixture.mjs
@@ -3,6 +3,13 @@ import process from "node:process";
 let body = "";
 for await (const chunk of process.stdin) body += chunk;
 const request = JSON.parse(body);
+if (request.action === "assess_batch") {
+  process.stdout.write(JSON.stringify({
+    verdict: "eligible_for_measurement",
+    reason: "fixture provider exposes one compatible load shape",
+  }));
+  process.exit(0);
+}
 if (request.action === "probe") {
   process.stdout.write(JSON.stringify({
     hardware: {
@@ -17,44 +24,54 @@ if (request.action === "probe") {
   }));
   process.exit(0);
 }
-const p = request.planned.strategy.parameters;
 const phase = (value) => ({
   activeBytes: value, allocatorBytes: value + 10, deviceBytes: value + 20,
   wiredBytes: value + 30, reclaimableBytes: 0
 });
-process.stdout.write(JSON.stringify({
-  status: request.repositories.sceneWorks.dirty || request.repositories.inference.dirty ? "gated" : "complete",
-  strategy: request.planned.strategy,
-  artifact: { repository: "SceneWorks/fixture", resolvedRevision: "cccccccccccccccccccccccccccccccccccccccc", variant: "q4" },
-  sweep: {
-    axes: [{ parameter: "decodeTileEdge", testedValues: [384, 512] }],
-    cases: [
-      { parameters: { ...p, decodeTileEdge: 384 }, result: "passed" },
-      { parameters: { ...p, decodeTileEdge: 512 }, result: "passed" }
+const fragment = (planned) => {
+  const p = planned.strategy.parameters;
+  return {
+    status: request.repositories.sceneWorks.dirty || request.repositories.inference.dirty ? "gated" : "complete",
+    strategy: planned.strategy,
+    artifact: { repository: "SceneWorks/fixture", resolvedRevision: "cccccccccccccccccccccccccccccccccccccccc", variant: "q4" },
+    sweep: {
+      axes: [{ parameter: "decodeTileEdge", testedValues: [384, 512] }],
+      cases: [
+        { parameters: { ...p, decodeTileEdge: 384 }, result: "passed" },
+        { parameters: { ...p, decodeTileEdge: 512 }, result: "passed" }
+      ],
+      rangeVerified: true
+    },
+    scenarios: [
+      { name: "exact_fit", result: "passed", predictedBytes: 200, effectiveBudgetBytes: 200 },
+      { name: "unknown_budget", result: "passed" },
+      { name: "stale_evidence", result: "passed" },
+      { name: "warm_repeat", result: "passed" },
+      { name: "cancel", result: "passed", cleanupVerified: true, warmFollowUpPassed: true },
+      { name: "error", result: "passed", cleanupVerified: true, warmFollowUpPassed: true },
+      { name: "loadability", result: "passed" },
+      { name: "overlay", result: "not_applicable", reason: "fixture has no overlay" }
     ],
-    rangeVerified: true
-  },
-  scenarios: [
-    { name: "exact_fit", result: "passed", predictedBytes: 200, effectiveBudgetBytes: 200 },
-    { name: "unknown_budget", result: "passed" },
-    { name: "stale_evidence", result: "passed" },
-    { name: "warm_repeat", result: "passed" },
-    { name: "cancel", result: "passed", cleanupVerified: true, warmFollowUpPassed: true },
-    { name: "error", result: "passed", cleanupVerified: true, warmFollowUpPassed: true },
-    { name: "loadability", result: "passed" },
-    { name: "overlay", result: "not_applicable", reason: "fixture has no overlay" }
-  ],
-  predictedPeakBytes: { conditioning: 100, denoise: 200, decode: 150, overall: 200 },
-  observedMemory: { conditioning: phase(100), denoise: phase(200), decode: phase(150), overall: phase(200) },
-  quality: {
-    contract: "tolerance", identicalLatents: true, result: "passed",
-    maximumError: 0.01, meanError: 0.001,
-    maximumErrorThreshold: 0.08, meanErrorThreshold: 0.01
-  },
-  negativeMutation: {
-    parameters: { decodeTileEdge: 256, decodeOverlap: 32 }, measured: true,
-    result: "failed_as_expected", maximumError: 0.09, meanError: 0.02
-  },
-  loadability: { result: "passed", resolvedPathFingerprint: "fixture@resolved:q4" },
-  capturedAt: "2026-07-28T12:00:00Z"
-}));
+    predictedPeakBytes: { conditioning: 100, denoise: 200, decode: 150, overall: 200 },
+    observedMemory: { conditioning: phase(100), denoise: phase(200), decode: phase(150), overall: phase(200) },
+    quality: {
+      contract: "tolerance", identicalLatents: true, result: "passed",
+      maximumError: 0.01, meanError: 0.001,
+      maximumErrorThreshold: 0.08, meanErrorThreshold: 0.01
+    },
+    negativeMutation: {
+      parameters: { decodeTileEdge: 256, decodeOverlap: 32 }, measured: true,
+      result: "failed_as_expected", maximumError: 0.09, meanError: 0.02
+    },
+    loadability: { result: "passed", resolvedPathFingerprint: "fixture@resolved:q4" },
+    capturedAt: "2026-07-28T12:00:00Z"
+  };
+};
+if (request.action === "run_batch") {
+  process.stdout.write(JSON.stringify({
+    modelLoads: 1,
+    fragments: request.planned.map(fragment),
+  }));
+} else {
+  process.stdout.write(JSON.stringify(fragment(request.planned)));
+}

--- a/scripts/memory-calibration-harness.mjs
+++ b/scripts/memory-calibration-harness.mjs
@@ -22,6 +22,10 @@ const RUNGS = [
   "bounded_attention", "bounded_transformer_residency",
 ];
 const RUNG_SET = new Set(RUNGS);
+export const RUNG_REUSE_TOLERANCE = Object.freeze({
+  absoluteBytes: 256 * 1024 * 1024,
+  relative: 0.05,
+});
 
 function stable(value) {
   if (Array.isArray(value)) return value.map(stable);
@@ -423,6 +427,64 @@ export function mergeBundles(left, right) {
   return { schemaVersion: 3, harnessVersion: HARNESS_VERSION, records: [...records.values()].sort((a, b) => a.id.localeCompare(b.id)) };
 }
 
+export function compareRungReuse(fresh, reused, tolerance = RUNG_REUSE_TOLERANCE) {
+  validateBundle(fresh);
+  validateBundle(reused);
+  const freshByLogicalId = new Map(fresh.records.map((record) => [record.logicalCaseId, record]));
+  const reusedByLogicalId = new Map(reused.records.map((record) => [record.logicalCaseId, record]));
+  if (freshByLogicalId.size !== fresh.records.length || reusedByLogicalId.size !== reused.records.length) {
+    fail("fresh/reused comparison cannot contain duplicate logical cases");
+  }
+  if (freshByLogicalId.size !== reusedByLogicalId.size) {
+    fail(`fresh/reused comparison cardinality differs: ${freshByLogicalId.size} != ${reusedByLogicalId.size}`);
+  }
+  const comparisons = [];
+  for (const [logicalCaseId, freshRecord] of freshByLogicalId) {
+    const reusedRecord = reusedByLogicalId.get(logicalCaseId);
+    if (!reusedRecord) fail(`reused capture is missing ${logicalCaseId}`);
+    if (freshRecord.id !== reusedRecord.id) {
+      fail(`${logicalCaseId}: fresh/reused comparison domain differs in repository, hardware, or artifact provenance`);
+    }
+    if (!freshRecord.observedMemory || !reusedRecord.observedMemory) {
+      fail(`${logicalCaseId}: fresh/reused comparison requires observedMemory on both records`);
+    }
+    const metrics = [];
+    for (const phase of ["conditioning", "denoise", "decode", "overall"]) {
+      for (const metric of ["activeBytes", "allocatorBytes", "deviceBytes", "wiredBytes", "reclaimableBytes"]) {
+        const freshBytes = freshRecord.observedMemory[phase][metric];
+        const reusedBytes = reusedRecord.observedMemory[phase][metric];
+        const differenceBytes = Math.abs(reusedBytes - freshBytes);
+        const allowedBytes = Math.max(tolerance.absoluteBytes, Math.ceil(freshBytes * tolerance.relative));
+        metrics.push({ phase, metric, freshBytes, reusedBytes, differenceBytes, allowedBytes,
+          passed: differenceBytes <= allowedBytes });
+      }
+    }
+    comparisons.push({
+      logicalCaseId,
+      rung: freshRecord.strategy.rung,
+      passed: metrics.every((metric) => metric.passed),
+      metrics,
+    });
+  }
+  const backend = fresh.records[0]?.backend;
+  if (
+    !backend ||
+    fresh.records.some((record) => record.backend !== backend) ||
+    reused.records.some((record) => record.backend !== backend)
+  ) {
+    fail("fresh/reused comparison must contain exactly one backend");
+  }
+  return {
+    schemaVersion: 1,
+    backend,
+    tolerance,
+    verdict: comparisons.every((comparison) => comparison.passed)
+      ? "amortizable"
+      : "unable_to_amortize",
+    comparisons,
+  };
+}
+
 function completedLogicalIds(record) {
   if (record.status === "negative_complete") return [record.logicalCaseId];
   if (record.status !== "complete") return [];
@@ -471,10 +533,40 @@ export function expandPlan(config, completed = []) {
         negative: candidate.negative === true,
       };
       const id = logicalCaseId(spec);
-      if (!completedLogical.has(id)) cases.push({ logicalCaseId: id, ...spec, expectedResult: candidate.expectedResult });
+      if (!completedLogical.has(id)) cases.push({
+        logicalCaseId: id,
+        ...spec,
+        expectedResult: candidate.expectedResult,
+        modelLoadPolicy: provider.modelLoadPolicy ?? "fresh_per_case",
+        modelLoadGroup: provider.modelLoadGroup ?? null,
+      });
     }
   }
   return cases.sort((a, b) => a.logicalCaseId.localeCompare(b.logicalCaseId));
+}
+
+export async function assessProviderReuse({ config, providerCommand, backend, fixture }) {
+  if (!Array.isArray(providerCommand) || !providerCommand.length) fail("provider command must be a JSON argv array");
+  const planned = expandPlan(config).filter(
+    (candidate) => candidate.backend === backend && (!fixture || candidate.fixture === fixture),
+  ).sort((left, right) => RUNGS.indexOf(left.strategy.rung) - RUNGS.indexOf(right.strategy.rung));
+  if (planned.length === 0) fail(`reuse assessment selected no ${backend} cases`);
+  const response = JSON.parse(await execute(
+    providerCommand[0],
+    providerCommand.slice(1),
+    canonicalJson({ action: "assess_batch", planned }),
+  ));
+  if (!["eligible_for_measurement", "unable_to_amortize"].includes(response.verdict)) {
+    fail(`provider returned invalid reuse-assessment verdict ${JSON.stringify(response.verdict)}`);
+  }
+  text(response.reason, "reuse assessment reason");
+  return {
+    schemaVersion: 1,
+    backend,
+    fixture: fixture ?? null,
+    tolerance: RUNG_REUSE_TOLERANCE,
+    ...response,
+  };
 }
 
 function execute(command, args, input) {
@@ -511,6 +603,7 @@ function execute(command, args, input) {
 
 export async function runProviderPlan({
   config, providerCommand, sceneWorksRepo, inferenceRepo, resume, backend, providerName, fixture,
+  onProviderInvocation, forceFreshPerCase = false, forceBatchRungs = false,
 }) {
   if (!Array.isArray(providerCommand) || !providerCommand.length) fail("provider command must be a JSON argv array");
   const gitState = async (repo, sceneWorks = false) => ({
@@ -546,7 +639,18 @@ export async function runProviderPlan({
   if (fixture && selectedConfig.providers.length === 0) {
     fail(`provider run selected no plan provider with fixture ${fixture}`);
   }
-  const expanded = expandPlan(selectedConfig, existing.records);
+  let expanded = expandPlan(selectedConfig, existing.records);
+  if (forceFreshPerCase && forceBatchRungs) fail("cannot force both fresh and batched provider execution");
+  if (forceFreshPerCase) {
+    expanded = expanded.map((planned) => ({ ...planned, modelLoadPolicy: "fresh_per_case", modelLoadGroup: null }));
+  }
+  if (forceBatchRungs) {
+    expanded = expanded.map((planned) => ({
+      ...planned,
+      modelLoadPolicy: "batch_rungs",
+      modelLoadGroup: `forced-${digest({ backend: planned.backend, target: planned.target, fixture: planned.fixture })}`,
+    }));
+  }
   const cases = backend ? expanded.filter((planned) => planned.backend === backend) : expanded;
   if (cases.length === 0) fail(`provider run selected no ${backend ?? "remaining"} cases`);
   const backends = new Set(cases.map((planned) => planned.backend));
@@ -560,49 +664,93 @@ export async function runProviderPlan({
   ));
   await assertRepositoriesStable();
   const incoming = [];
-  for (const planned of cases) {
+  let remaining = cases;
+  const sameBatch = (left, right) =>
+    left.modelLoadPolicy === "batch_rungs" &&
+    right.modelLoadPolicy === "batch_rungs" &&
+    left.modelLoadGroup &&
+    left.modelLoadGroup === right.modelLoadGroup &&
+    left.backend === right.backend &&
+    equal(left.target, right.target) &&
+    left.fixture === right.fixture;
+  while (remaining.length > 0) {
+    const first = remaining[0];
+    const batchRungs = new Set();
+    const invocation = first.modelLoadPolicy === "batch_rungs"
+      ? remaining
+          .filter((planned) => sameBatch(first, planned))
+          .sort((left, right) => RUNGS.indexOf(left.strategy.rung) - RUNGS.indexOf(right.strategy.rung))
+          .filter((planned) => {
+            if (batchRungs.has(planned.strategy.rung)) return false;
+            batchRungs.add(planned.strategy.rung);
+            return true;
+          })
+      : [first];
+    const uniqueRungs = new Set(invocation.map((planned) => planned.strategy.rung));
+    if (first.modelLoadPolicy === "batch_rungs" && uniqueRungs.size !== invocation.length) {
+      fail(`${first.modelLoadGroup}: a rung batch may contain only one pending case per rung`);
+    }
+    const action = invocation.length > 1 ? "run_batch" : "run";
+    onProviderInvocation?.({ action, cases: invocation });
     const providerOutput = await execute(
       providerCommand[0],
       providerCommand.slice(1),
       canonicalJson({
-        action: "run",
-        planned,
+        action,
+        ...(action === "run" ? { planned: first } : { planned: invocation }),
         repositories,
         repositoryPaths: { sceneWorks: sceneWorksRepo, inference: inferenceRepo },
         hardware: probe.hardware,
       }),
     );
     await assertRepositoriesStable();
-    const fragment = JSON.parse(providerOutput);
-    if (!fragment.strategy || typeof fragment.strategy !== "object" || Array.isArray(fragment.strategy)) {
-      fail(`${planned.logicalCaseId}: provider fragment.strategy must attest the executed strategy`);
+    const response = JSON.parse(providerOutput);
+    const fragments = action === "run_batch" ? response.fragments : [response];
+    if (!Array.isArray(fragments) || fragments.length !== invocation.length) {
+      fail(`${first.modelLoadGroup ?? first.logicalCaseId}: provider returned ${
+        Array.isArray(fragments) ? fragments.length : "a non-array"
+      } fragments for ${invocation.length} planned cases`);
     }
-    validateEngagedRungs(fragment.strategy, `${planned.logicalCaseId}.provider strategy`);
-    if (!equal(fragment.strategy, planned.strategy)) {
-      fail(`${planned.logicalCaseId}: adapter measured strategy does not match planned strategy`);
+    if (action === "run_batch" && response.modelLoads !== 1) {
+      fail(`${first.modelLoadGroup}: batched provider must attest exactly one model load`);
     }
-    const record = {
-      ...fragment,
-      logicalCaseId: planned.logicalCaseId,
-      evidenceScope: planned.evidenceScope,
-      backend: planned.backend,
-      repositories,
-      hardware: probe.hardware,
-      target: planned.target,
-      strategy: fragment.strategy,
-      calibrationFingerprint: planned.calibrationFingerprint,
-      fixture: planned.fixture,
-      harnessVersion: HARNESS_VERSION,
-    };
-    if (planned.expectedResult === "failed" && record.status !== "negative_complete") {
-      fail(`${planned.logicalCaseId}: negative plan case must return status=negative_complete`);
+    for (const [index, fragment] of fragments.entries()) {
+      const planned = invocation[index];
+      if (!fragment.strategy || typeof fragment.strategy !== "object" || Array.isArray(fragment.strategy)) {
+        fail(`${planned.logicalCaseId}: provider fragment.strategy must attest the executed strategy`);
+      }
+      validateEngagedRungs(fragment.strategy, `${planned.logicalCaseId}.provider strategy`);
+      if (!equal(fragment.strategy, planned.strategy)) {
+        fail(`${planned.logicalCaseId}: adapter measured strategy does not match planned strategy`);
+      }
+      const record = {
+        ...fragment,
+        logicalCaseId: planned.logicalCaseId,
+        evidenceScope: planned.evidenceScope,
+        backend: planned.backend,
+        repositories,
+        hardware: probe.hardware,
+        target: planned.target,
+        strategy: fragment.strategy,
+        calibrationFingerprint: planned.calibrationFingerprint,
+        fixture: planned.fixture,
+        harnessVersion: HARNESS_VERSION,
+      };
+      if (planned.expectedResult === "failed" && record.status !== "negative_complete") {
+        fail(`${planned.logicalCaseId}: negative plan case must return status=negative_complete`);
+      }
+      if (planned.expectedResult === "passed" && record.status === "negative_complete") {
+        fail(`${planned.logicalCaseId}: passing plan case returned a negative result`);
+      }
+      record.id = recordId(record);
+      validateRecord(record);
+      incoming.push(record);
     }
-    if (planned.expectedResult === "passed" && record.status === "negative_complete") {
-      fail(`${planned.logicalCaseId}: passing plan case returned a negative result`);
-    }
-    record.id = recordId(record);
-    validateRecord(record);
-    incoming.push(record);
+    const completed = new Set([...existing.records, ...incoming].flatMap(completedLogicalIds));
+    const invoked = new Set(invocation.map((planned) => planned.logicalCaseId));
+    remaining = remaining.filter(
+      (planned) => !invoked.has(planned.logicalCaseId) && !completed.has(planned.logicalCaseId),
+    );
   }
   return mergeBundles(existing, { schemaVersion: 3, harnessVersion: HARNESS_VERSION, records: incoming });
 }
@@ -633,6 +781,20 @@ async function main() {
     const output = value("--resume") ? mergeBundles(validateBundle(await readJson(value("--resume"))), incoming) : incoming;
     return void await atomicWrite(value("--output"), output);
   }
+  if (command === "compare-reuse") {
+    return void await atomicWrite(
+      value("--output"),
+      compareRungReuse(await readJson(value("--fresh")), await readJson(value("--reused"))),
+    );
+  }
+  if (command === "assess-reuse") {
+    return void await atomicWrite(value("--output"), await assessProviderReuse({
+      config: await readJson(value("--config")),
+      providerCommand: JSON.parse(value("--provider-command")),
+      backend: value("--backend"),
+      fixture: value("--fixture"),
+    }));
+  }
   if (command === "run") {
     const output = await runProviderPlan({
       config: await readJson(value("--config")),
@@ -643,10 +805,12 @@ async function main() {
       backend: value("--backend"),
       providerName: value("--provider"),
       fixture: value("--fixture"),
+      forceFreshPerCase: args.includes("--fresh-per-case"),
+      forceBatchRungs: args.includes("--batch-rungs"),
     });
     return void await atomicWrite(value("--output"), output);
   }
-  fail("usage: check|plan|ingest|run (see docs/memory-calibration-harness.md)");
+  fail("usage: check|plan|ingest|assess-reuse|compare-reuse|run (see docs/memory-calibration-harness.md)");
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) await main();

--- a/scripts/memory-calibration-harness.test.mjs
+++ b/scripts/memory-calibration-harness.test.mjs
@@ -1,13 +1,35 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 
 import {
-  HARNESS_VERSION, canonicalJson, evidenceSemantics, expandPlan, logicalCaseId,
-  mergeBundles, recordId, runProviderPlan, validateBundle, validateRecord,
+  HARNESS_VERSION, RUNG_REUSE_TOLERANCE, assessProviderReuse, canonicalJson,
+  compareRungReuse, evidenceSemantics, expandPlan, logicalCaseId, mergeBundles, recordId,
+  runProviderPlan, validateBundle, validateRecord,
 } from "./memory-calibration-harness.mjs";
 import { calibrationBinding } from "./generate-memory-matrix.mjs";
+
+const execFileAsync = promisify(execFile);
+
+async function cleanFixtureRepo() {
+  const root = await mkdtemp(path.join(tmpdir(), "memory-harness-repo-"));
+  await mkdir(path.join(root, "docs/generated"), { recursive: true });
+  await writeFile(
+    path.join(root, "docs/generated/memory-matrix.json"),
+    JSON.stringify({ generatedFrom: { sceneWorksRevision: `source-tree:${"1".repeat(64)}` } }),
+  );
+  await execFileAsync("git", ["init", root]);
+  await execFileAsync("git", ["-C", root, "config", "user.email", "fixture@example.invalid"]);
+  await execFileAsync("git", ["-C", root, "config", "user.name", "Fixture"]);
+  await execFileAsync("git", ["-C", root, "add", "docs/generated/memory-matrix.json"]);
+  await execFileAsync("git", ["-C", root, "commit", "-m", "fixture"]);
+  return root;
+}
 
 const phase = (value) => ({
   activeBytes: value,
@@ -244,6 +266,34 @@ test("merge is commutative and rejects conflicting exact-identity captures", () 
   );
 });
 
+test("fresh and reused rung captures use a committed absolute-or-relative tolerance", () => {
+  const freshRecord = complete();
+  const reusedRecord = structuredClone(freshRecord);
+  const withinTolerance = RUNG_REUSE_TOLERANCE.absoluteBytes;
+  for (const phaseName of ["conditioning", "denoise", "decode", "overall"]) {
+    for (const metric of ["activeBytes", "allocatorBytes", "deviceBytes", "wiredBytes"]) {
+      reusedRecord.observedMemory[phaseName][metric] += withinTolerance;
+    }
+  }
+  const fresh = { schemaVersion: 3, harnessVersion: HARNESS_VERSION, records: [freshRecord] };
+  const reused = { schemaVersion: 3, harnessVersion: HARNESS_VERSION, records: [reusedRecord] };
+  assert.equal(compareRungReuse(fresh, reused).verdict, "amortizable");
+
+  reusedRecord.observedMemory.conditioning.activeBytes += 1;
+  reusedRecord.observedMemory.conditioning.allocatorBytes += 1;
+  reusedRecord.observedMemory.conditioning.deviceBytes += 1;
+  reusedRecord.observedMemory.conditioning.wiredBytes += 1;
+  assert.equal(compareRungReuse(fresh, reused).verdict, "unable_to_amortize");
+
+  const differentHardware = structuredClone(reusedRecord);
+  differentHardware.hardware.driverVersion = "different";
+  differentHardware.id = recordId(differentHardware);
+  assert.throws(
+    () => compareRungReuse(fresh, { ...reused, records: [differentHardware] }),
+    /comparison domain differs/,
+  );
+});
+
 test("gated and fixture semantics can never become current", () => {
   const fixture = complete();
   assert.equal(evidenceSemantics(fixture, {
@@ -330,7 +380,7 @@ test("plan separates seven identical-latent positives from a deterministic outpu
   });
 });
 
-test("shipped fresh-process oracle declares exact five-rung ladders for MLX and Candle", async () => {
+test("shipped five-rung oracles stay fresh after backend reuse verdicts", async () => {
   const config = JSON.parse(await readFile(new URL("../config/memory-calibration-plan.json", import.meta.url)));
   const expectedRungs = [
     "resident",
@@ -380,8 +430,15 @@ test("shipped fresh-process oracle declares exact five-rung ladders for MLX and 
         ],
       },
     );
+    const mlx = cases.filter(
+      (item) => item.fixture === "fresh-five-rung-z-image-q4-768-seed16402-step2",
+    );
+    assert.ok(mlx.every((item) => item.modelLoadPolicy === "fresh_per_case"));
+    const candle = cases.filter(
+      (item) => item.fixture === "fresh-five-rung-krea-q4-1024-seed16402-step2",
+    );
     assertLadder(
-      cases.filter((item) => item.fixture === "fresh-five-rung-krea-q4-1024-seed16402-step2"),
+      candle,
       "candle",
       {
         provider: "krea_2_turbo", modelId: "krea_2_turbo", tier: "q4",
@@ -399,6 +456,8 @@ test("shipped fresh-process oracle declares exact five-rung ladders for MLX and 
         ],
       },
     );
+    assert.ok(candle.every((item) => item.modelLoadPolicy === "fresh_per_case"));
+    assert.ok(candle.every((item) => item.modelLoadGroup === null));
   };
   assertPlan(config);
 
@@ -538,7 +597,7 @@ test("gated no-parameter references use an empty sweep instead of a fabricated f
   );
 });
 
-test("executable runner handles fragmented responses across probe and multiple case processes", async () => {
+test("executable runner handles fragmented responses across provider processes", async () => {
   const config = {
     providers: [{
       evidenceScope: "fixture",
@@ -563,9 +622,157 @@ test("executable runner handles fragmented responses across probe and multiple c
     sceneWorksRepo: fileURLToPath(new URL("..", import.meta.url)),
     inferenceRepo: fileURLToPath(new URL("..", import.meta.url)),
   });
-  assert.equal(result.records.length, 2);
+  const clean = result.records.every((record) =>
+    !record.repositories.sceneWorks.dirty && !record.repositories.inference.dirty
+  );
+  assert.equal(result.records.length, clean ? 1 : 2);
+  assert.equal(expandPlan(config, result.records).length, clean ? 0 : 2);
   assert.equal(result.records[0].hardware.deviceId, "fixture:0");
   assert.match(result.records[0].repositories.sceneWorks.revision, /^[0-9a-f]{40}$/);
+});
+
+test("runner batches one target's five rungs into one attested model load", async () => {
+  const rungs = [
+    ["resident", ["resident"]],
+    ["staged_residency", ["resident", "staged_residency"]],
+    ["bounded_decode", ["resident", "bounded_decode"]],
+    ["bounded_attention", ["resident", "bounded_decode", "bounded_attention"]],
+    [
+      "bounded_transformer_residency",
+      ["resident", "bounded_decode", "bounded_attention", "bounded_transformer_residency"],
+    ],
+  ];
+  const config = {
+    providers: rungs.map(([rung, engagedRungs]) => ({
+      evidenceScope: "fixture",
+      backend: "candle",
+      target: complete().target,
+      rung,
+      engagedRungs,
+      calibrationFingerprint: "fixture-formula-v2",
+      fixture: "fixture-five-rungs",
+      modelLoadPolicy: "batch_rungs",
+      modelLoadGroup: "fixture-target",
+      cases: [
+        { parameters: { decodeTileEdge: 384, decodeOverlap: 128 }, expectedResult: "passed" },
+        { parameters: { decodeTileEdge: 512, decodeOverlap: 128 }, expectedResult: "passed" },
+      ],
+    })),
+  };
+  const invocations = [];
+  const cleanRepo = await cleanFixtureRepo();
+  const result = await runProviderPlan({
+    config,
+    providerCommand: [
+      process.execPath,
+      fileURLToPath(new URL("./fixtures/memory-provider-fixture.mjs", import.meta.url)),
+    ],
+    sceneWorksRepo: cleanRepo,
+    inferenceRepo: cleanRepo,
+    onProviderInvocation: (invocation) => invocations.push(invocation),
+  });
+  assert.equal(result.records.length, 5);
+  assert.deepEqual(invocations.map(({ action, cases }) => [action, cases.length]), [["run_batch", 5]]);
+  assert.equal(expandPlan(config, result.records).length, 0);
+});
+
+test("runner flags provide explicit fresh and experimental batch controls", async () => {
+  const config = {
+    providers: ["resident", "bounded_decode"].map((rung) => ({
+      evidenceScope: "fixture",
+      backend: "candle",
+      target: complete().target,
+      rung,
+      engagedRungs: rung === "resident" ? ["resident"] : ["resident", "bounded_decode"],
+      calibrationFingerprint: "fixture-formula-v2",
+      fixture: "fixture-forced-rungs",
+      cases: [{ parameters: { decodeTileEdge: 512, decodeOverlap: 128 }, expectedResult: "passed" }],
+    })),
+  };
+  const fixtureCommand = [
+    process.execPath,
+    fileURLToPath(new URL("./fixtures/memory-provider-fixture.mjs", import.meta.url)),
+  ];
+  const freshInvocations = [];
+  await runProviderPlan({
+    config,
+    providerCommand: fixtureCommand,
+    sceneWorksRepo: fileURLToPath(new URL("..", import.meta.url)),
+    inferenceRepo: fileURLToPath(new URL("..", import.meta.url)),
+    forceFreshPerCase: true,
+    onProviderInvocation: (invocation) => freshInvocations.push(invocation),
+  });
+  assert.deepEqual(freshInvocations.map(({ action }) => action), ["run", "run"]);
+
+  const batchInvocations = [];
+  await runProviderPlan({
+    config,
+    providerCommand: fixtureCommand,
+    sceneWorksRepo: fileURLToPath(new URL("..", import.meta.url)),
+    inferenceRepo: fileURLToPath(new URL("..", import.meta.url)),
+    forceBatchRungs: true,
+    onProviderInvocation: (invocation) => batchInvocations.push(invocation),
+  });
+  assert.deepEqual(batchInvocations.map(({ action, cases }) => [action, cases.length]), [["run_batch", 2]]);
+});
+
+test("provider reuse assessment records whether a batch can be measured", async () => {
+  const config = {
+    providers: [{
+      evidenceScope: "fixture",
+      backend: "candle",
+      target: complete().target,
+      rung: "resident",
+      engagedRungs: ["resident"],
+      calibrationFingerprint: "fixture-formula-v2",
+      fixture: "fixture-assessment",
+      cases: [{ parameters: {}, expectedResult: "passed" }],
+    }],
+  };
+  const assessment = await assessProviderReuse({
+    config,
+    backend: "candle",
+    fixture: "fixture-assessment",
+    providerCommand: [
+      process.execPath,
+      fileURLToPath(new URL("./fixtures/memory-provider-fixture.mjs", import.meta.url)),
+    ],
+  });
+  assert.equal(assessment.verdict, "eligible_for_measurement");
+  assert.deepEqual(assessment.tolerance, RUNG_REUSE_TOLERANCE);
+});
+
+test("a completed sweep retires its other parameter points before another spawn", async () => {
+  const config = {
+    providers: [{
+      evidenceScope: "fixture",
+      backend: "candle",
+      target: complete().target,
+      rung: "bounded_decode",
+      engagedRungs: ["resident", "bounded_decode"],
+      calibrationFingerprint: "fixture-formula-v2",
+      fixture: "fixture-seed42",
+      cases: [
+        { parameters: { decodeTileEdge: 384, decodeOverlap: 128 }, expectedResult: "passed" },
+        { parameters: { decodeTileEdge: 512, decodeOverlap: 128 }, expectedResult: "passed" },
+      ],
+    }],
+  };
+  const invocations = [];
+  const cleanRepo = await cleanFixtureRepo();
+  const result = await runProviderPlan({
+    config,
+    providerCommand: [
+      process.execPath,
+      fileURLToPath(new URL("./fixtures/memory-provider-fixture.mjs", import.meta.url)),
+    ],
+    sceneWorksRepo: cleanRepo,
+    inferenceRepo: cleanRepo,
+    onProviderInvocation: (invocation) => invocations.push(invocation),
+  });
+  assert.equal(result.records.length, 1);
+  assert.deepEqual(invocations.map(({ action, cases }) => [action, cases.length]), [["run", 1]]);
+  assert.equal(expandPlan(config, result.records).length, 0);
 });
 
 test("provider execution can select every rung sharing one reproducible fixture", async () => {

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -30,6 +30,27 @@ test("Windows runner prep falls back when its optional rustc wrapper is missing"
   );
 });
 
+test("Windows Krea provisioning accepts supported newer Python 3 runtimes", async () => {
+  const workflow = await source(".github/workflows/windows-candle.yml");
+  assert.match(workflow, /Python 3\.12 or newer/);
+  assert.match(workflow, /\[int\]\$Matches\.minor -lt 12/);
+  assert.doesNotMatch(workflow, /\^Python 3\\\.12\\\./);
+  assert.match(
+    workflow,
+    /token: \$\{\{ secrets\.SCENEWORKS_INFERENCE_READ_TOKEN \|\| github\.token \}\}/,
+  );
+});
+
+test("Windows CUDA runs the Candle adapter's platform-only unit tests", async () => {
+  const workflow = await source(".github/workflows/windows-candle.yml");
+  assert.match(
+    workflow,
+    /cargo test -p sceneworks-memory-adapter --features candle --bin memory-candle-adapter/,
+  );
+  assert.match(workflow, /console\.log\(JSON\.stringify\(a,null,2\)\)/);
+  assert.match(workflow, /'amortizable','unable_to_amortize'/);
+});
+
 test("Docker relevance gate paginates and checks for truncated file lists", async () => {
   const workflow = await source(".github/workflows/check.yml");
   assert.match(workflow, /gh api --paginate/);
@@ -288,8 +309,13 @@ test("memory adapters bind every emitted overlay verdict to the requested target
     /validate_plain_overlay_target\(request, KREA_PLAIN_EXECUTION_PATH\)\?/,
   );
   assert.ok(
-    candleReference.indexOf("validate_plain_overlay_target") < candleReference.indexOf("required_env"),
+    candleReference.indexOf("validate_plain_overlay_target") < candleReference.indexOf("load_five_rung_generator"),
     "the Candle five-rung reference must reject a mismatched overlay before provider work",
+  );
+  assert.ok(
+    candleReference.indexOf("for item in planned") <
+      candleReference.lastIndexOf("let (repository, revision, generator, mut vram)"),
+    "the Candle batch must validate every target before its one model load",
   );
   assert.equal(candle.match(/protocol::plain_gated_fragment\(/g)?.length, 3);
   assert.doesNotMatch(candle, /protocol::gated_fragment\(/);


### PR DESCRIPTION
## Summary

- batch one target's five calibration rungs into a single provider invocation when the backend proves shared residency is valid
- add Candle Krea fresh-versus-reused capture and comparison, plus a provider-contract assessment that formally records why MLX Z-Image cannot reuse this load today
- derive the shipped load-cost reduction only from complete, explicitly declared batch groups and update the generated evidence, protocol, workflows, and tests

## Validation

- `npm run check` (178/178)
- `npm run rust:check:candle`
- `cargo check --manifest-path src-tauri/Cargo.toml --no-default-features --features backend-mlx --bin memory_strategy_mlx_z_image_adapter`
- local real-weight MLX five-rung fresh capture; all five records validated and each pre-rung cache cleared to zero
- independent adversarial review: approved with no actionable findings

Hosted macOS MLX and Windows CUDA fresh/reused acceptance runs are required before merge and will be linked here when complete.

Shortcut: [sc-16059](https://app.shortcut.com/trefry/story/16059/calibration-harness-pays-a-model-load-per-rung-batch-a-target-s-rungs-into-one-provider-invocation)
