### PR TITLE
fix(worker): gate bespoke Candle image loads

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -2886,6 +2886,15 @@ use flux_ipadapter::{flux_ipadapter_available, generate_candle_flux_ipadapter_st
 mod conditioning_gate;
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 use conditioning_gate::{admit_conditioning_overlay, admit_conditioning_paths};
+// Shared admission seam for bespoke single-base Candle routes (sc-16093). Built-in tiers use catalog
+// catalog peaks; imported/ComfyUI checkpoints use an explicitly weaker on-disk weights floor.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+mod base_admission;
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+use base_admission::{
+    admit_candle_base, admit_candle_base_floor, admit_candle_load_spec_floor,
+    safetensors_tensor_bytes_with_prefixes, CandleBaseEvidence,
+};
 // Shared candle strict-control driver (sc-8304, epic 8236): the `CandleStrictControl` trait + the one
 // `run_candle_strict_control` driver the candle trio (qwen/zimage/flux2 control below) route through —
 // reusing the SAME `STRICT_CONTROL_ENGINES` table + `preprocess_control_entry` (pose/canny/depth) as the

--- a/crates/sceneworks-worker/src/image_jobs/base_admission.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base_admission.rs
@@ -360,16 +360,17 @@ pub(super) async fn admit_candle_load_spec_floor(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn catalog_evidence_requires_a_per_tier_row_not_the_static_minimum() {
-        let static_only = serde_json::json!({ "candle": { "minMemoryGb": 24 } })
+        let static_only = json!({ "candle": { "minMemoryGb": 24 } })
             .as_object()
             .unwrap()
             .clone();
         assert!(!has_tier_peak_row(&static_only, "q4"));
 
-        let evidenced = serde_json::json!({
+        let evidenced = json!({
             "candle": { "vramGbByTier": { "q4": 18.0, "q8": 24.0 } }
         })
         .as_object()
@@ -403,7 +404,7 @@ mod tests {
     fn tensor_prefix_accounting_counts_only_selected_subtrees() {
         let root = tempfile::tempdir().unwrap();
         let file = root.path().join("model.safetensors");
-        let header = serde_json::json!({
+        let header = json!({
             "visual.block.weight": { "dtype": "F32", "shape": [2], "data_offsets": [0, 8] },
             "language_model.weight": { "dtype": "F32", "shape": [4], "data_offsets": [8, 24] },
             "encoder.conv.weight": { "dtype": "F32", "shape": [3], "data_offsets": [24, 36] },

--- a/crates/sceneworks-worker/src/image_jobs/base_admission.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base_admission.rs
@@ -1,0 +1,424 @@
+//! Admission for bespoke Candle image routes that load one base model outside
+//! `generate_candle_stream` (sc-16093).
+//!
+//! Built-in tiered models use the catalog's per-tier `candle.vramGbByTier` and
+//! `candle.sequentialPeakGb` rows. Imported and ComfyUI checkpoints have no stable
+//! catalog tier, so they use an explicitly weaker on-disk weights floor. Both checks
+//! run before the handler hands control to `start_*_gen_stream`.
+
+use super::*;
+
+use crate::fit_gate::BYTES_PER_GIB;
+use crate::vram_gate::LoadPlan;
+
+fn source_path(source: &WeightsSource) -> &Path {
+    match source {
+        WeightsSource::Dir(path) | WeightsSource::File(path) => path,
+    }
+}
+
+fn path_weight_bytes(path: &Path) -> u64 {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() => metadata.len(),
+        Ok(metadata) if metadata.is_dir() => crate::mlx_fit_gate::sum_safetensors_bytes(path),
+        _ => 0,
+    }
+}
+
+/// Sum the exact files/directories a bespoke load consumes without double-counting a
+/// file already covered by a recursively scanned directory.
+fn distinct_weight_bytes(paths: &[&Path]) -> u64 {
+    let mut ordered = paths.to_vec();
+    ordered.sort_by_key(|path| path.as_os_str().len());
+    let mut kept: Vec<&Path> = Vec::with_capacity(ordered.len());
+    for path in ordered {
+        if kept.iter().any(|parent| path.starts_with(parent)) {
+            continue;
+        }
+        kept.push(path);
+    }
+    kept.into_iter().fold(0_u64, |total, path| {
+        total.saturating_add(path_weight_bytes(path))
+    })
+}
+
+/// Count only selected tensor subtrees from every safetensors file below `dir`.
+/// Header failures fall back to the whole file so admission never underprices a
+/// checkpoint merely because its metadata cannot be inspected.
+pub(super) fn safetensors_tensor_bytes_with_prefixes(dir: &Path, prefixes: &[&str]) -> u64 {
+    fn tensor_bytes(path: &Path, metadata: &std::fs::Metadata, prefixes: &[&str]) -> u64 {
+        let Ok(header) = sceneworks_core::lora_family::read_safetensors_header(path) else {
+            return metadata.len();
+        };
+        header.as_object().map_or(0, |entries| {
+            entries.iter().fold(0_u64, |total, (name, tensor)| {
+                if !prefixes.iter().any(|prefix| name.starts_with(prefix)) {
+                    return total;
+                }
+                let Some(offsets) = tensor.get("data_offsets").and_then(Value::as_array) else {
+                    return total;
+                };
+                let Some(start) = offsets.first().and_then(Value::as_u64) else {
+                    return total;
+                };
+                let Some(end) = offsets.get(1).and_then(Value::as_u64) else {
+                    return total;
+                };
+                total.saturating_add(end.saturating_sub(start))
+            })
+        })
+    }
+
+    fn visit(
+        dir: &Path,
+        prefixes: &[&str],
+        visited_dirs: &mut std::collections::HashSet<PathBuf>,
+    ) -> u64 {
+        // Follow HF shard symlinks, but canonicalize directory identities so an
+        // operator-provided junction/symlink cycle cannot recurse forever.
+        let Ok(canonical_dir) = std::fs::canonicalize(dir) else {
+            return 0;
+        };
+        if !visited_dirs.insert(canonical_dir.clone()) {
+            return 0;
+        }
+        let Ok(entries) = std::fs::read_dir(canonical_dir) else {
+            return 0;
+        };
+        entries.flatten().fold(0_u64, |total, entry| {
+            let path = entry.path();
+            let Ok(metadata) = std::fs::metadata(&path) else {
+                return total;
+            };
+            if metadata.is_dir() {
+                return total.saturating_add(visit(&path, prefixes, visited_dirs));
+            }
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if !name.ends_with(".safetensors") || name.starts_with("._") {
+                return total;
+            }
+            total.saturating_add(tensor_bytes(&path, &metadata, prefixes))
+        })
+    }
+
+    visit(dir, prefixes, &mut std::collections::HashSet::new())
+}
+
+fn reject_message(
+    model: &str,
+    lane: &str,
+    tier: Option<&str>,
+    needed_gb: f64,
+    available_gb: f64,
+    gpu_id: &str,
+    catalog_evidence: bool,
+) -> WorkerError {
+    let tier = tier.map_or_else(String::new, |tier| format!(" at the {tier} tier"));
+    let evidence = if catalog_evidence {
+        "the per-tier catalog peak (including headroom)"
+    } else {
+        "at least the on-disk weights plus headroom; activations are not measured for this external checkpoint"
+    };
+    WorkerError::InvalidPayload(format!(
+        "{model}{tier} cannot run through the {lane} lane: {evidence} needs ~{} GB of VRAM, but GPU \
+         {gpu_id} has ~{} GB available. Select a smaller checkpoint/tier or use a GPU with more VRAM.",
+        needed_gb.round() as i64,
+        available_gb.round() as i64,
+    ))
+}
+
+fn has_tier_peak_row(entry: &JsonObject, tier: &str) -> bool {
+    let rows = entry
+        .get("candle")
+        .and_then(|candle| candle.get("vramGbByTier"))
+        .and_then(Value::as_object);
+    let numeric = |key: &str| rows.and_then(|rows| rows.get(key)).and_then(Value::as_f64);
+    numeric(tier).is_some() || (tier == NVFP4_TIER && numeric("q8").is_some())
+}
+
+fn builtin_model_entry(id: &str) -> Option<&'static JsonObject> {
+    static MANIFEST: std::sync::OnceLock<Value> = std::sync::OnceLock::new();
+    let manifest = MANIFEST.get_or_init(|| {
+        let raw = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
+            .iter()
+            .find(|(name, _)| *name == "builtin.models.jsonc")
+            .map(|(_, contents)| *contents)
+            .expect("builtin.models.jsonc is embedded");
+        serde_json::from_str(&sceneworks_core::jsonc::strip_jsonc_comments(raw))
+            .expect("embedded builtin.models.jsonc parses")
+    });
+    manifest
+        .get("models")?
+        .as_array()?
+        .iter()
+        .find(|model| model.get("id").and_then(Value::as_str) == Some(id))?
+        .as_object()
+}
+
+/// Gate one built-in bespoke route on the catalog peak for the tier that its resolved
+/// directory actually names. Returns the residency policy the caller must carry into
+/// its `LoadSpec`; direct resident-only providers pass `sequential_capable = false` and
+/// ignore the returned (necessarily resident) value. An `Alias` records the canonical
+/// builtin whose identical base weights supply an alias route's evidence.
+pub(super) enum CandleBaseEvidence {
+    Catalog,
+    Alias(&'static str),
+    Ungateable(&'static str),
+}
+
+pub(super) async fn admit_candle_base(
+    request: &ImageRequest,
+    settings: &Settings,
+    resolved_dir: &Path,
+    lane: &'static str,
+    evidence: CandleBaseEvidence,
+    adapter_resident_bytes: u64,
+    sequential_capable: bool,
+) -> WorkerResult<gen_core::OffloadPolicy> {
+    let (evidence_entry, unmeasured_reason) = match evidence {
+        CandleBaseEvidence::Alias(id) => (builtin_model_entry(id).ok_or_else(|| {
+            WorkerError::InvalidPayload(format!(
+                "{model} cannot run through the {lane} lane because its catalog evidence alias {id} is missing",
+                model = request.model,
+            ))
+        })?, None),
+        CandleBaseEvidence::Catalog => (&request.model_manifest_entry, None),
+        CandleBaseEvidence::Ungateable(reason) => (&request.model_manifest_entry, Some(reason)),
+    };
+    let tier = gate_tier_key(
+        false,
+        resolved_dir,
+        &request.advanced,
+        &request.model_manifest_entry,
+        nvfp4_selected(request, nvfp4_host_eligible(), Some(resolved_dir)),
+    );
+    if !has_tier_peak_row(evidence_entry, tier) {
+        if let Some(reason) = unmeasured_reason {
+            tracing::warn!(
+                model = %request.model,
+                lane,
+                tier,
+                reason,
+                "candle base admission: explicitly un-gateable for this request; admitting without a \
+                 per-tier catalog peak (sc-16093)"
+            );
+            return Ok(gen_core::OffloadPolicy::Resident);
+        }
+        return Err(WorkerError::InvalidPayload(format!(
+            "{model} cannot run through the {lane} lane because its resolved {tier} tier has no \
+             candle.vramGbByTier catalog peak. This is a model-catalog error; reinstall or update \
+             SceneWorks before retrying.",
+            model = request.model,
+        )));
+    }
+    let needed = crate::vram_gate::predicted_peak_gb_with_adapter_bytes(
+        evidence_entry,
+        tier,
+        adapter_resident_bytes,
+    );
+    let resident_peak_gb = needed.expect("a resident tier catalog row predicts a peak");
+    let sequential_needed = sequential_capable
+        .then(|| {
+            crate::vram_gate::predicted_sequential_peak_gb_with_adapter_bytes(
+                evidence_entry,
+                tier,
+                adapter_resident_bytes,
+            )
+        })
+        .flatten();
+    if sequential_capable && sequential_needed.is_none() {
+        tracing::warn!(
+            model = %request.model,
+            lane,
+            tier,
+            "candle base admission: resident peak is cataloged but this sequential-capable tier has no \
+             candle.sequentialPeakGb row; resident overflow will stage best-effort (sc-16093)"
+        );
+    }
+
+    let raw_budget = crate::vram_gate::apply_vram_cap(
+        crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
+        crate::vram_gate::cuda_vram_cap_gb(),
+    );
+    let (plan, budget) = gate_with_evict_reclaim(
+        &settings.gpu_id,
+        raw_budget,
+        |budget| crate::vram_gate::load_plan(needed, sequential_needed, budget, sequential_capable),
+        |raw, reclaimed| raw != reclaimed,
+    )
+    .await?;
+    let available_gb = budget.map_or(0.0, |budget| budget.free_gb);
+
+    match plan {
+        LoadPlan::Resident => {
+            crate::vram_gate::note_loaded_peak(&settings.gpu_id, resident_peak_gb);
+            Ok(gen_core::OffloadPolicy::Resident)
+        }
+        LoadPlan::Sequential => {
+            if let Some(peak_gb) = sequential_needed {
+                crate::vram_gate::note_loaded_peak(&settings.gpu_id, peak_gb);
+            }
+            tracing::info!(
+                model = %request.model,
+                lane,
+                tier,
+                available_gb,
+                "candle base admission: selected sequential component residency (sc-16093)"
+            );
+            Ok(gen_core::OffloadPolicy::Sequential)
+        }
+        LoadPlan::Reject => {
+            let rejected_peak = crate::vram_gate::sequential_overflow_gb(sequential_needed, budget)
+                .unwrap_or(resident_peak_gb);
+            Err(reject_message(
+                &request.model,
+                lane,
+                Some(tier),
+                rejected_peak,
+                available_gb,
+                &settings.gpu_id,
+                true,
+            ))
+        }
+    }
+}
+
+/// Gate an imported/ComfyUI base whose user-owned paths have no stable catalog row.
+/// This is intentionally a floor: it can reject only when the weights alone cannot fit.
+pub(super) async fn admit_candle_base_floor(
+    model: &str,
+    lane: &'static str,
+    settings: &Settings,
+    paths: &[&Path],
+) -> WorkerResult<()> {
+    let bytes = distinct_weight_bytes(paths);
+    let needed = (bytes > 0).then(|| bytes as f64 / BYTES_PER_GIB + crate::vram_gate::HEADROOM_GB);
+    let Some(floor_gb) = needed else {
+        tracing::warn!(
+            model,
+            lane,
+            "candle base admission: explicitly un-gateable because the external checkpoint paths contain \
+             no countable weights; admitting without a floor (sc-16093)"
+        );
+        return Ok(());
+    };
+    let raw_budget = crate::vram_gate::apply_vram_cap(
+        crate::gpu::nvidia_vram_budget_gb(&settings.gpu_id).await,
+        crate::vram_gate::cuda_vram_cap_gb(),
+    );
+    let (plan, budget) = gate_with_evict_reclaim(
+        &settings.gpu_id,
+        raw_budget,
+        |budget| crate::vram_gate::load_plan(needed, None, budget, false),
+        |raw, reclaimed| raw != reclaimed,
+    )
+    .await?;
+    match plan {
+        LoadPlan::Resident => {
+            crate::vram_gate::note_loaded_peak(&settings.gpu_id, floor_gb);
+            tracing::info!(
+                model,
+                lane,
+                floor_gb,
+                "candle base admission: external checkpoint admitted on its on-disk weights floor; \
+                 activation peaks remain unmeasured (sc-16093)"
+            );
+            Ok(())
+        }
+        LoadPlan::Sequential => unreachable!("a floor-only route is never sequential-capable"),
+        LoadPlan::Reject => Err(reject_message(
+            model,
+            lane,
+            None,
+            floor_gb,
+            budget.map_or(0.0, |budget| budget.free_gb),
+            &settings.gpu_id,
+            false,
+        )),
+    }
+}
+
+/// Imported SDXL already materializes a `LoadSpec` containing its external checkpoint,
+/// adapters, PiD weights, and caller-staged components. Price exactly those sources.
+pub(super) async fn admit_candle_load_spec_floor(
+    model: &str,
+    lane: &'static str,
+    settings: &Settings,
+    spec: &LoadSpec,
+) -> WorkerResult<()> {
+    let mut paths = vec![source_path(&spec.weights)];
+    paths.extend(spec.adapters.iter().map(|adapter| adapter.path.as_path()));
+    paths.extend(spec.components.values().map(source_path));
+    if let Some(pid) = &spec.pid {
+        paths.push(source_path(&pid.checkpoint));
+        paths.push(source_path(&pid.gemma));
+    }
+    admit_candle_base_floor(model, lane, settings, &paths).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_evidence_requires_a_per_tier_row_not_the_static_minimum() {
+        let static_only = serde_json::json!({ "candle": { "minMemoryGb": 24 } })
+            .as_object()
+            .unwrap()
+            .clone();
+        assert!(!has_tier_peak_row(&static_only, "q4"));
+
+        let evidenced = serde_json::json!({
+            "candle": { "vramGbByTier": { "q4": 18.0, "q8": 24.0 } }
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        assert!(has_tier_peak_row(&evidenced, "q4"));
+        assert!(
+            has_tier_peak_row(&evidenced, NVFP4_TIER),
+            "NVFP4 conservatively reuses the catalog q8 row, matching predicted_peak_gb"
+        );
+        assert!(!has_tier_peak_row(&evidenced, "bf16"));
+    }
+
+    #[test]
+    fn floor_deduplicates_nested_paths_and_counts_files() {
+        let root = tempfile::tempdir().unwrap();
+        let model = root.path().join("model");
+        std::fs::create_dir_all(&model).unwrap();
+        let shard = model.join("model.safetensors");
+        std::fs::write(&shard, vec![0_u8; 17]).unwrap();
+        let external = root.path().join("external.safetensors");
+        std::fs::write(&external, vec![0_u8; 23]).unwrap();
+        assert_eq!(
+            distinct_weight_bytes(&[&model, &shard, &external]),
+            40,
+            "the shard inside model/ is counted once; the external file is additive"
+        );
+    }
+
+    #[test]
+    fn tensor_prefix_accounting_counts_only_selected_subtrees() {
+        let root = tempfile::tempdir().unwrap();
+        let file = root.path().join("model.safetensors");
+        let header = serde_json::json!({
+            "visual.block.weight": { "dtype": "F32", "shape": [2], "data_offsets": [0, 8] },
+            "language_model.weight": { "dtype": "F32", "shape": [4], "data_offsets": [8, 24] },
+            "encoder.conv.weight": { "dtype": "F32", "shape": [3], "data_offsets": [24, 36] },
+            "decoder.conv.weight": { "dtype": "F32", "shape": [5], "data_offsets": [36, 56] }
+        });
+        let encoded = serde_json::to_vec(&header).unwrap();
+        let mut bytes = (encoded.len() as u64).to_le_bytes().to_vec();
+        bytes.extend_from_slice(&encoded);
+        bytes.extend_from_slice(&[0_u8; 56]);
+        std::fs::write(file, bytes).unwrap();
+
+        assert_eq!(
+            safetensors_tensor_bytes_with_prefixes(root.path(), &["visual.", "encoder."]),
+            20,
+            "language-model and decoder tensors are not charged to edit-only residency"
+        );
+    }
+}

--- a/crates/sceneworks-worker/src/image_jobs/bernini.rs
+++ b/crates/sceneworks-worker/src/image_jobs/bernini.rs
@@ -507,6 +507,16 @@ async fn generate_candle_bernini_image_stream(
         .get("mlxQuantize")
         .and_then(|v| v.as_i64().or_else(|| v.as_str()?.trim().parse().ok()));
     let (weights_dir, quant) = resolve_candle_bernini_tier_dir_and_quant(settings, tier_bits)?;
+    let offload_policy = admit_candle_base(
+        request,
+        settings,
+        &weights_dir,
+        "Bernini still image",
+        CandleBaseEvidence::Ungateable("Bernini still-image tiers have not been CUDA-calibrated"),
+        0,
+        crate::mlx_fit_gate::engine_supports_sequential(engine_id),
+    )
+    .await?;
 
     // i2i (`edit_image`): resolve the source image into the engine's `Conditioning::Reference` (the
     // engine ViT/VAE-encodes it at native resolution, no worker-side fit, and ignores the reference
@@ -547,7 +557,8 @@ async fn generate_candle_bernini_image_stream(
 
     // Load the resolved tier subfolder at its matching quant: `bf16/` dense (quant `None`), or the
     // packed `q4/`|`q8/` tree with `Quant::Q4`|`Quant::Q8` (sc-11003).
-    let spec = load_spec(weights_dir, quant, Vec::new(), None);
+    let spec = load_spec(weights_dir, quant, Vec::new(), None)
+        .with_offload_policy(offload_policy);
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),
         engine_id,

--- a/crates/sceneworks-worker/src/image_jobs/flux2_comfyui_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_comfyui_candle.rs
@@ -1,9 +1,9 @@
 use super::huggingface_snapshot_dir;
 use super::{
-    consume_gen_events, drive_gen_items, pose_entries, resolve_advanced_or_manifest_u32,
-    resolve_seed, start_gen_stream, ApiClient, GenerationOutput, GenerationRequest, ImagePlan,
-    ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, Quant, Settings, Value, WorkerError,
-    WorkerResult,
+    admit_candle_base_floor, consume_gen_events, drive_gen_items, pose_entries,
+    resolve_advanced_or_manifest_u32, resolve_seed, start_gen_stream, ApiClient, GenerationOutput,
+    GenerationRequest, ImagePlan, ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, Quant,
+    Settings, Value, WorkerError, WorkerResult,
 };
 use serde_json::json;
 
@@ -282,6 +282,19 @@ pub(super) async fn generate_candle_flux2_comfyui_stream(
                 .to_owned(),
         )
     })?;
+    let snapshot_text_encoder = paths.snapshot_dir.join("text_encoder");
+    let snapshot_vae = paths.snapshot_dir.join("vae");
+    admit_candle_base_floor(
+        &request.model,
+        "ComfyUI FLUX.2",
+        settings,
+        &[
+            paths.transformer.as_path(),
+            snapshot_text_encoder.as_path(),
+            snapshot_vae.as_path(),
+        ],
+    )
+    .await?;
 
     let (width, height) = (request.width, request.height);
     let steps =

--- a/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/flux2_edit_candle.rs
@@ -1,10 +1,11 @@
 use super::{
-    consume_gen_events, drive_gen_items, fit_engine_image, load_reference_image, mlx_model,
-    model_repo, non_empty, pid_effective_dims, pid_output_tier, resolve_advanced_or_manifest_f32,
-    resolve_advanced_or_manifest_u32, resolve_pid_weights, resolve_quant, resolve_seed,
-    resolve_weights_dir, start_gen_stream, ApiClient, Flux2Edit, Flux2EditPaths, Flux2EditRequest,
-    Image, ImagePlan, ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, Settings, Value,
-    WorkerError, WorkerResult,
+    admit_candle_base, consume_gen_events, drive_gen_items, fit_engine_image, load_reference_image,
+    mlx_model, model_repo, non_empty, pid_effective_dims, pid_output_tier,
+    resolve_advanced_or_manifest_f32, resolve_advanced_or_manifest_u32, resolve_pid_weights,
+    resolve_quant, resolve_seed, resolve_weights_dir, start_gen_stream, ApiClient,
+    CandleBaseEvidence, Flux2Edit, Flux2EditPaths, Flux2EditRequest, Image, ImagePlan,
+    ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, Settings, Value, WorkerError,
+    WorkerResult,
 };
 use serde_json::json;
 
@@ -244,6 +245,22 @@ pub(super) async fn generate_candle_flux2_edit_stream(
             "FLUX.2 edit requires edit_image mode + a source image".to_owned(),
         ));
     }
+    admit_candle_base(
+        request,
+        settings,
+        &flux2_base,
+        "FLUX.2 edit",
+        if request.model == "flux2_klein_9b_true_v2" {
+            CandleBaseEvidence::Ungateable(
+                "the local True V2 converted fine-tune has no CUDA calibration row",
+            )
+        } else {
+            CandleBaseEvidence::Catalog
+        },
+        0,
+        false,
+    )
+    .await?;
     let is_dev = is_flux2_edit_candle_dev(&request.model);
     // Per-generation PiD decode (epic 7840, sc-8044) + output tier (sc-10054), resolved BEFORE the
     // references are loaded/fit so a 2K tier sizes the effective base and the edit references land at THAT

--- a/crates/sceneworks-worker/src/image_jobs/krea_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_edit_candle.rs
@@ -1,8 +1,9 @@
 use super::resolve_seed;
 use super::{
-    consume_gen_events, drive_gen_items, fit_engine_image, load_reference_image, resolve_adapters,
-    resolve_advanced_or_manifest_f32, resolve_advanced_or_manifest_u32, resolve_text_style_gain,
-    resolve_weights_dir, start_gen_stream, ApiClient, Image, ImagePlan, ImageRequest, JobSnapshot,
+    admit_candle_base, consume_gen_events, drive_gen_items, fit_engine_image, load_reference_image,
+    resolve_adapters, resolve_advanced_or_manifest_f32, resolve_advanced_or_manifest_u32,
+    resolve_text_style_gain, resolve_weights_dir, safetensors_tensor_bytes_with_prefixes,
+    start_gen_stream, ApiClient, CandleBaseEvidence, Image, ImagePlan, ImageRequest, JobSnapshot,
     JsonObject, Path, Settings, Value, WorkerError, WorkerResult,
 };
 use serde_json::json;
@@ -237,6 +238,34 @@ pub(super) async fn generate_candle_krea_edit_stream(
     // The selected LoRAs → adapter specs (the edit LoRA + any user LoRAs), folded into the DiT at load.
     let adapters = resolve_adapters(request, settings)?;
     let adapter_count = adapters.len();
+    let adapter_resident_bytes = adapters
+        .iter()
+        .fold(0_u64, |total, adapter| {
+            total.saturating_add(gen_core::safetensors_path_bytes(&adapter.path))
+        })
+        // Edit additionally materializes the Qwen3-VL `visual.*` tower at f32 from dense bf16
+        // source tensors, so charge twice their on-disk bytes. The base catalog peak already prices
+        // the language model; prefix accounting avoids charging that large subtree again.
+        .saturating_add(
+            safetensors_tensor_bytes_with_prefixes(&weights_dir.join("text_encoder"), &["visual."])
+                .saturating_mul(2),
+        )
+        // The edit-only Qwen VAE encoder stays f32 like its source. The base peak already includes
+        // the decoder, so count only the encoder and its input quantization convolution.
+        .saturating_add(safetensors_tensor_bytes_with_prefixes(
+            &weights_dir.join("vae"),
+            &["encoder.", "quant_conv."],
+        ));
+    admit_candle_base(
+        request,
+        settings,
+        &weights_dir,
+        "Krea edit",
+        CandleBaseEvidence::Catalog,
+        adapter_resident_bytes,
+        false,
+    )
+    .await?;
     // Telemetry `repo` — the manifest `repo` else the Krea 2 Raw default.
     let repo = request
         .model_manifest_entry

--- a/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_imported.rs
@@ -446,6 +446,18 @@ async fn generate_krea_imported_stream(
     })?;
     // Require the resident base tier before any compute — a clear "install the Krea 2 base first" error.
     let base_dir = resolve_krea_imported_base_tier(settings)?;
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    {
+        let text_encoder = base_dir.join("text_encoder");
+        let vae = base_dir.join("vae");
+        admit_candle_base_floor(
+            &request.model,
+            "Krea imported",
+            settings,
+            &[dit.as_path(), text_encoder.as_path(), vae.as_path()],
+        )
+        .await?;
+    }
 
     let is_edit = request.mode == "edit_image";
 

--- a/crates/sceneworks-worker/src/image_jobs/krea_multiphase.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_multiphase.rs
@@ -465,6 +465,19 @@ async fn generate_krea_multiphase_stream(
     // per `request.loras` entry, in order, so `LoadSpec::adapters[i]` is `request.loras[i]` and a
     // phase's lora `index` selects it directly.
     let adapters = resolve_adapters(request, settings)?;
+    let adapter_resident_bytes = adapters.iter().fold(0_u64, |total, adapter| {
+        total.saturating_add(gen_core::safetensors_path_bytes(&adapter.path))
+    });
+    let offload_policy = admit_candle_base(
+        request,
+        settings,
+        &weights_dir,
+        "Krea multi-phase",
+        CandleBaseEvidence::Catalog,
+        adapter_resident_bytes,
+        crate::mlx_fit_gate::engine_supports_sequential(engine_id),
+    )
+    .await?;
     let repo = model_repo(request, &raw_model);
     let adapter_label = raw_model.adapter_label();
     let text_style_gain = resolve_text_style_gain(request);
@@ -486,7 +499,7 @@ async fn generate_krea_multiphase_stream(
 
     let (width, height) = (request.width, request.height);
     let adapter_count = adapters.len();
-    let spec = load_spec(weights_dir, quant, adapters, None);
+    let spec = load_spec(weights_dir, quant, adapters, None).with_offload_policy(offload_policy);
 
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/krea_multiphase.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_multiphase.rs
@@ -465,9 +465,11 @@ async fn generate_krea_multiphase_stream(
     // per `request.loras` entry, in order, so `LoadSpec::adapters[i]` is `request.loras[i]` and a
     // phase's lora `index` selects it directly.
     let adapters = resolve_adapters(request, settings)?;
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     let adapter_resident_bytes = adapters.iter().fold(0_u64, |total, adapter| {
         total.saturating_add(gen_core::safetensors_path_bytes(&adapter.path))
     });
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     let offload_policy = admit_candle_base(
         request,
         settings,
@@ -499,7 +501,9 @@ async fn generate_krea_multiphase_stream(
 
     let (width, height) = (request.width, request.height);
     let adapter_count = adapters.len();
-    let spec = load_spec(weights_dir, quant, adapters, None).with_offload_policy(offload_policy);
+    let spec = load_spec(weights_dir, quant, adapters, None);
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    let spec = spec.with_offload_policy(offload_policy);
 
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/krea_turbo_raw.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_turbo_raw.rs
@@ -208,9 +208,11 @@ async fn generate_krea_turbo_on_raw_stream(
     let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
     let steps = resolve_steps(request, &turbo);
     let adapters = resolve_adapters(request, settings)?;
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     let adapter_resident_bytes = adapters.iter().fold(0_u64, |total, adapter| {
         total.saturating_add(gen_core::safetensors_path_bytes(&adapter.path))
     });
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     let offload_policy = admit_candle_base(
         request,
         settings,
@@ -237,7 +239,9 @@ async fn generate_krea_turbo_on_raw_stream(
 
     let (width, height) = (request.width, request.height);
     let adapter_count = adapters.len();
-    let spec = load_spec(weights_dir, quant, adapters, None).with_offload_policy(offload_policy);
+    let spec = load_spec(weights_dir, quant, adapters, None);
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    let spec = spec.with_offload_policy(offload_policy);
 
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/krea_turbo_raw.rs
+++ b/crates/sceneworks-worker/src/image_jobs/krea_turbo_raw.rs
@@ -208,6 +208,19 @@ async fn generate_krea_turbo_on_raw_stream(
     let (quant, quant_bits) = resolve_quant(request, Some(&weights_dir));
     let steps = resolve_steps(request, &turbo);
     let adapters = resolve_adapters(request, settings)?;
+    let adapter_resident_bytes = adapters.iter().fold(0_u64, |total, adapter| {
+        total.saturating_add(gen_core::safetensors_path_bytes(&adapter.path))
+    });
+    let offload_policy = admit_candle_base(
+        request,
+        settings,
+        &weights_dir,
+        "Krea turbo-on-Raw",
+        CandleBaseEvidence::Catalog,
+        adapter_resident_bytes,
+        crate::mlx_fit_gate::engine_supports_sequential(engine_id),
+    )
+    .await?;
     let repo = model_repo(request, &raw_model);
     // Raw and Turbo share the `mlx_krea` adapter label, so telemetry names the family either way.
     let adapter_label = raw_model.adapter_label();
@@ -224,7 +237,7 @@ async fn generate_krea_turbo_on_raw_stream(
 
     let (width, height) = (request.width, request.height);
     let adapter_count = adapters.len();
-    let spec = load_spec(weights_dir, quant, adapters, None);
+    let spec = load_spec(weights_dir, quant, adapters, None).with_offload_policy(offload_policy);
 
     let (cancel, rx, blocking) = start_cached_gen_stream(
         job.id.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/qwen_comfyui_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_comfyui_candle.rs
@@ -1,9 +1,9 @@
 use super::huggingface_snapshot_dir;
 use super::{
-    consume_gen_events, drive_gen_items, pose_entries, resolve_advanced_or_manifest_u32,
-    resolve_seed, start_gen_stream, ApiClient, GenerationOutput, GenerationRequest, ImagePlan,
-    ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, Settings, Value, WorkerError,
-    WorkerResult,
+    admit_candle_base_floor, consume_gen_events, drive_gen_items, pose_entries,
+    resolve_advanced_or_manifest_u32, resolve_seed, start_gen_stream, ApiClient, GenerationOutput,
+    GenerationRequest, ImagePlan, ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, Settings,
+    Value, WorkerError, WorkerResult,
 };
 use serde_json::json;
 
@@ -211,6 +211,21 @@ pub(super) async fn generate_candle_qwen_comfyui_stream(
                 .to_owned(),
         )
     })?;
+    let snapshot_text_encoder = paths.snapshot_dir.join("text_encoder");
+    let snapshot_vae = paths.snapshot_dir.join("vae");
+    let admission_vae = paths.vae.as_deref().unwrap_or(snapshot_vae.as_path());
+    let admission_paths = [
+        paths.transformer.as_path(),
+        snapshot_text_encoder.as_path(),
+        admission_vae,
+    ];
+    admit_candle_base_floor(
+        &request.model,
+        "ComfyUI Qwen-Image",
+        settings,
+        &admission_paths,
+    )
+    .await?;
 
     let (width, height) = (request.width, request.height);
     let steps =

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_edit_candle.rs
@@ -1,12 +1,13 @@
-use super::{advanced, huggingface_snapshot_dir, resolve_app_managed_model_dir};
 use super::{
-    consume_gen_events, dense_tier_subdir, drive_gen_items, fit_engine_image, load_reference_image,
-    non_empty, pid_effective_dims, pid_output_tier, resolve_advanced_or_manifest_f32,
-    resolve_advanced_or_manifest_u32, resolve_pid_weights, resolve_sdxl_components, resolve_seed,
-    standard_tier_subdir, start_gen_stream, uses_standard_tier_layout, ApiClient, Image, ImagePlan,
-    ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, SdxlEdit, SdxlEditPaths, SdxlEditRequest,
-    Settings, Value, WorkerError, WorkerResult,
+    admit_candle_base, consume_gen_events, dense_tier_subdir, drive_gen_items, fit_engine_image,
+    load_reference_image, non_empty, pid_effective_dims, pid_output_tier,
+    resolve_advanced_or_manifest_f32, resolve_advanced_or_manifest_u32, resolve_pid_weights,
+    resolve_sdxl_components, resolve_seed, standard_tier_subdir, start_gen_stream,
+    uses_standard_tier_layout, ApiClient, CandleBaseEvidence, Image, ImagePlan, ImageRequest,
+    JobSnapshot, JsonObject, Path, PathBuf, SdxlEdit, SdxlEditPaths, SdxlEditRequest, Settings,
+    Value, WorkerError, WorkerResult,
 };
+use super::{advanced, huggingface_snapshot_dir, resolve_app_managed_model_dir};
 use serde_json::json;
 
 // Candle (Windows/CUDA) SDXL img2img / inpaint / outpaint edit route (sc-5487, epic 5480) — pixel-
@@ -226,6 +227,18 @@ pub(super) async fn generate_candle_sdxl_edit_stream(
             "SDXL edit requires edit_image mode + a source image".to_owned(),
         )
     })?;
+    admit_candle_base(
+        request,
+        settings,
+        &sdxl_base,
+        "SDXL edit",
+        CandleBaseEvidence::Ungateable(
+            "SDXL-family Candle edit has not been CUDA-calibrated per tier",
+        ),
+        0,
+        false,
+    )
+    .await?;
     // Per-generation PiD decode (epic 7840, sc-8044) + output tier (sc-10054), resolved BEFORE the
     // source/mask fit so a 2K tier sizes the effective base and the edit source + mask are fit to THAT
     // base (source, mask, and latent stay aligned). `use_pid`/`with_pid` stay paired at the load below.

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_imported.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_imported.rs
@@ -284,6 +284,8 @@ async fn generate_sdxl_imported_stream(
     let tokenizer_root = stage_sdxl_tokenizer(api, settings, job).await?;
     #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
     let spec = attach_imported_sdxl_components(spec, api, settings, job).await?;
+    #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+    admit_candle_load_spec_floor(&request.model, "SDXL imported", settings, &spec).await?;
 
     let (cancel, rx, blocking) = start_gen_stream(
         job.id.clone(),

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -14682,13 +14682,12 @@ fn every_candle_conditioning_route_is_admitted_through_a_gate() {
     // Routes that overlay NO second network, so the conditioning gate does not apply to them. Each is
     // listed to make the classification explicit rather than implied by absence.
     //
-    // **This list asserts only that a route is not a CONDITIONING route — never that it is gated.** The
-    // edit / imported / ComfyUI lanes load a single base model, so the right admission check for them is
-    // the measured per-tier `vram_gate::predicted_peak_gb` + `load_plan` path that `qwen_edit_candle`
-    // runs — and most of them do not run it yet. That is a real but SEPARATE defect (a base-model peak
-    // gate needs per-lane sequential-capability and per-tier measured rows, not this overlay floor); it
-    // is tracked on its own story and is deliberately outside sc-16069, whose scope is the conditioning
-    // table. Do not read a row here as "admitted".
+    // This list remains only the overlay classification. The edit / imported / ComfyUI / Bernini routes
+    // that load a single base are ALSO enumerated in BASE_ADMITTED below: built-in tiered models use the
+    // catalog per-tier gate when evidenced (or a pinned, reasoned exception), while user-owned
+    // checkpoints use the explicitly weaker weights floor.
+    // Keeping the classifications separate prevents an overlay floor from being substituted for catalog
+    // base evidence while ensuring "not conditioning" can no longer disguise an ungated base lane.
     const NOT_CONDITIONING: &[&str] = &[
         // Edit lanes: one base model, reference/source conditioning, no second network.
         "SdxlEdit",
@@ -14714,6 +14713,116 @@ fn every_candle_conditioning_route_is_admitted_through_a_gate() {
         // The generic arm — the one route that DOES reach the shared `generate_candle_stream` gate.
         "CandleTxt2Img",
     ];
+
+    // Every bespoke single-base route named by sc-16093, plus the already-correct Qwen Edit reference.
+    // The marker is route-local live code: deleting/commenting any call turns this guard red. External
+    // checkpoints deliberately use the floor marker because no stable manifest tier exists for them.
+    const BASE_ADMITTED: &[(&str, &str, &str, &str)] = &[
+        (
+            "SdxlEdit",
+            "sdxl_edit_candle.rs",
+            include_str!("sdxl_edit_candle.rs"),
+            "admit_candle_base(",
+        ),
+        (
+            "Flux2Edit",
+            "flux2_edit_candle.rs",
+            include_str!("flux2_edit_candle.rs"),
+            "admit_candle_base(",
+        ),
+        (
+            "QwenEdit",
+            "qwen_edit_candle.rs",
+            include_str!("qwen_edit_candle.rs"),
+            "crate::vram_gate::load_plan(",
+        ),
+        (
+            "ZimageEdit",
+            "zimage_edit_candle.rs",
+            include_str!("zimage_edit_candle.rs"),
+            "admit_candle_base(",
+        ),
+        (
+            "KreaEdit",
+            "krea_edit_candle.rs",
+            include_str!("krea_edit_candle.rs"),
+            "admit_candle_base(",
+        ),
+        (
+            "KreaTurboOnRaw",
+            "krea_turbo_raw.rs",
+            include_str!("krea_turbo_raw.rs"),
+            "admit_candle_base(",
+        ),
+        (
+            "KreaMultiPhase",
+            "krea_multiphase.rs",
+            include_str!("krea_multiphase.rs"),
+            "admit_candle_base(",
+        ),
+        (
+            "KreaImported",
+            "krea_imported.rs",
+            include_str!("krea_imported.rs"),
+            "admit_candle_base_floor(",
+        ),
+        (
+            "SdxlImported",
+            "sdxl_imported.rs",
+            include_str!("sdxl_imported.rs"),
+            "admit_candle_load_spec_floor(",
+        ),
+        (
+            "ZimageComfyui",
+            "zimage_comfyui_candle.rs",
+            include_str!("zimage_comfyui_candle.rs"),
+            "admit_candle_base_floor(",
+        ),
+        (
+            "QwenImageComfyui",
+            "qwen_comfyui_candle.rs",
+            include_str!("qwen_comfyui_candle.rs"),
+            "admit_candle_base_floor(",
+        ),
+        (
+            "Flux2Comfyui",
+            "flux2_comfyui_candle.rs",
+            include_str!("flux2_comfyui_candle.rs"),
+            "admit_candle_base_floor(",
+        ),
+        (
+            "Bernini",
+            "bernini.rs",
+            include_str!("bernini.rs"),
+            "admit_candle_base(",
+        ),
+    ];
+    for (route, file, source, marker) in BASE_ADMITTED {
+        let gate = source
+            .lines()
+            .position(|line| line.contains(marker) && !line.trim_start().starts_with("//"))
+            .unwrap_or_else(|| {
+                panic!("{route} ({file}) has no live base-admission call `{marker}`")
+            });
+        let handoff = ["start_gen_stream(", "start_cached_gen_stream("]
+            .iter()
+            .filter_map(|needle| {
+                source
+                    .lines()
+                    .enumerate()
+                    .skip(gate + 1)
+                    .find(|(_, line)| line.contains(needle) && !line.trim_start().starts_with("//"))
+                    .map(|(line, _)| line)
+            })
+            .min()
+            .unwrap_or_else(|| {
+                panic!("{route} ({file}) has no generation-stream handoff after its gate")
+            });
+        assert!(
+            gate < handoff,
+            "{route} ({file}) gates after allocation begins; base admission must be pre-load (sc-16093)"
+        );
+    }
 
     // Every route the resolver can actually produce, read out of its source. `Some(CandleImageRoute::`
     // is the production form, so prose mentioning a variant cannot inflate this set.

--- a/crates/sceneworks-worker/src/image_jobs/zimage_comfyui_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_comfyui_candle.rs
@@ -1,9 +1,9 @@
 use super::huggingface_snapshot_dir;
 use super::{
-    consume_gen_events, drive_gen_items, pose_entries, resolve_advanced_or_manifest_u32,
-    resolve_seed, start_gen_stream, ApiClient, GenerationOutput, GenerationRequest, ImagePlan,
-    ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, Settings, Value, WorkerError,
-    WorkerResult,
+    admit_candle_base_floor, consume_gen_events, drive_gen_items, pose_entries,
+    resolve_advanced_or_manifest_u32, resolve_seed, start_gen_stream, ApiClient, GenerationOutput,
+    GenerationRequest, ImagePlan, ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, Settings,
+    Value, WorkerError, WorkerResult,
 };
 use serde_json::json;
 
@@ -147,6 +147,17 @@ pub(super) async fn generate_candle_zimage_comfyui_stream(
                 .to_owned(),
         )
     })?;
+    admit_candle_base_floor(
+        &request.model,
+        "ComfyUI Z-Image",
+        settings,
+        &[
+            paths.transformer.as_path(),
+            paths.text_encoder.as_path(),
+            paths.vae.as_path(),
+        ],
+    )
+    .await?;
 
     let (width, height) = (request.width, request.height);
     let steps =

--- a/crates/sceneworks-worker/src/image_jobs/zimage_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/zimage_edit_candle.rs
@@ -1,11 +1,11 @@
 use super::{
-    advanced, huggingface_snapshot_dir, resolve_app_managed_model_dir, standard_tier_subdir,
+    admit_candle_base, consume_gen_events, drive_gen_items, fit_engine_image, load_reference_image,
+    non_empty, resolve_advanced_or_manifest_u32, resolve_seed, start_gen_stream, ApiClient,
+    CandleBaseEvidence, Image, ImagePlan, ImageRequest, JobSnapshot, JsonObject, Path, PathBuf,
+    Settings, Value, WorkerError, WorkerResult, ZImageEdit, ZImageEditPaths, ZImageEditRequest,
 };
 use super::{
-    consume_gen_events, drive_gen_items, fit_engine_image, load_reference_image, non_empty,
-    resolve_advanced_or_manifest_u32, resolve_seed, start_gen_stream, ApiClient, Image, ImagePlan,
-    ImageRequest, JobSnapshot, JsonObject, Path, PathBuf, Settings, Value, WorkerError,
-    WorkerResult, ZImageEdit, ZImageEditPaths, ZImageEditRequest,
+    advanced, huggingface_snapshot_dir, resolve_app_managed_model_dir, standard_tier_subdir,
 };
 use serde_json::json;
 
@@ -153,6 +153,20 @@ pub(super) async fn generate_candle_zimage_edit_stream(
     let base = resolve_zimage_edit_candle_base(request, settings)?.ok_or_else(|| {
         WorkerError::InvalidPayload("Z-Image base (Z-Image-Turbo) weights not found".to_owned())
     })?;
+    admit_candle_base(
+        request,
+        settings,
+        &base,
+        "Z-Image edit",
+        if request.model == "z_image_edit" {
+            CandleBaseEvidence::Alias("z_image_turbo")
+        } else {
+            CandleBaseEvidence::Catalog
+        },
+        0,
+        false,
+    )
+    .await?;
 
     let (width, height) = (request.width, request.height);
     // Load + fit the source to the render geometry honoring `fit_mode` (crop/pad/stretch — the provider

--- a/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
+++ b/crates/sceneworks-worker/src/tests/gpu_and_manifest.rs
@@ -1708,6 +1708,96 @@ fn qwen_edit_candle_blocks_drive_the_fit_gate_and_reject() {
     );
 }
 
+/// sc-16093: every built-in model that a bespoke single-base Candle route can load either carries a
+/// live per-tier peak row or is pinned here as an explicit unmeasured exception. This is the data half
+/// of the source guard in `image_jobs/tests.rs`: deleting a handler call fails there; deleting a row
+/// that makes an evidenced call effective fails here. Adding evidence to an exception also fails so
+/// its call site cannot quietly keep bypassing newly available evidence.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
+#[test]
+fn bespoke_candle_base_evidence_is_live_or_explicitly_unmeasured() {
+    const EVIDENCED: &[&str] = &[
+        "flux2_klein_9b",
+        "flux2_dev",
+        "z_image_turbo",
+        "krea_2_raw",
+        "krea_2_turbo",
+    ];
+    const EXPLICITLY_UNMEASURED: &[(&str, &str, &str)] = &[
+        (
+            "sdxl",
+            "SDXL-family Candle edit has not been CUDA-calibrated per tier",
+            include_str!("../image_jobs/sdxl_edit_candle.rs"),
+        ),
+        (
+            "realvisxl",
+            "SDXL-family Candle edit has not been CUDA-calibrated per tier",
+            include_str!("../image_jobs/sdxl_edit_candle.rs"),
+        ),
+        (
+            "illustrious_xl_v1",
+            "SDXL-family Candle edit has not been CUDA-calibrated per tier",
+            include_str!("../image_jobs/sdxl_edit_candle.rs"),
+        ),
+        (
+            "illustrious_xl_v2",
+            "SDXL-family Candle edit has not been CUDA-calibrated per tier",
+            include_str!("../image_jobs/sdxl_edit_candle.rs"),
+        ),
+        (
+            "flux2_klein_9b_true_v2",
+            "the local True V2 converted fine-tune has no CUDA calibration row",
+            include_str!("../image_jobs/flux2_edit_candle.rs"),
+        ),
+        (
+            "bernini_image",
+            "Bernini still-image tiers have not been CUDA-calibrated",
+            include_str!("../image_jobs/bernini.rs"),
+        ),
+    ];
+
+    let assert_resident_rows = |id: &str| {
+        let model = builtin_model_entry(id);
+        let tiers = model
+            .get("candle")
+            .and_then(|candle| candle.get("vramGbByTier"))
+            .and_then(Value::as_object)
+            .unwrap_or_else(|| panic!("{id}: bespoke Candle base route requires vramGbByTier"));
+        assert!(!tiers.is_empty(), "{id}: vramGbByTier must not be empty");
+        let default = default_tier_key(&model);
+        assert!(
+            tiers.get(default).and_then(Value::as_f64).is_some(),
+            "{id}: resolved/default tier {default} has no numeric resident peak"
+        );
+        tiers.clone()
+    };
+
+    for id in EVIDENCED {
+        assert_resident_rows(id);
+    }
+    assert!(
+        include_str!("../image_jobs/zimage_edit_candle.rs")
+            .contains("CandleBaseEvidence::Alias(\"z_image_turbo\")"),
+        "z_image_edit loads the identical Turbo base and must name z_image_turbo as its evidence alias"
+    );
+    for (id, reason, source) in EXPLICITLY_UNMEASURED {
+        let model = builtin_model_entry(id);
+        let resident = model
+            .get("candle")
+            .and_then(|candle| candle.get("vramGbByTier"))
+            .and_then(Value::as_object);
+        assert!(
+            resident.is_none_or(serde_json::Map::is_empty),
+            "{id}: now has catalog rows; remove its explicit unmeasured reason from the route and this guard"
+        );
+        assert!(!reason.trim().is_empty(), "{id}: unmeasured exception needs a recorded reason");
+        assert!(
+            source.contains(reason),
+            "{id}: its unmeasured reason must remain recorded at the live route call site"
+        );
+    }
+}
+
 /// sc-7875 (SD3.5 S6, MLX-path validation boundary): the three SD3.5 builtin-manifest entries gate
 /// correctly at the catalog layer — `macOnly: false` (cross-platform now that the candle off-Mac lane
 /// is wired, sc-7880/epic 7982; availability is driven by the routing tables, not this flag),


### PR DESCRIPTION
## Summary
- add a shared admission seam for bespoke single-base Candle edit, imported, ComfyUI, and Bernini lanes
- use resolved-tier catalog peaks and load-plan/offload selection for evidenced builtins, with explicit recorded exceptions when no catalog evidence exists
- gate external checkpoints on the exact consumed weight floor and account for Krea edit-only tensor subtrees
- add source-level mutation guards and builtin-manifest evidence coverage

## Validation
- `npm.cmd run rust:check:neither`
- `npm.cmd run rust:check:candle`
- `cargo test -p sceneworks-worker --features backend-candle image_jobs::base_admission::tests:: -- --nocapture`
- `cargo test -p sceneworks-worker --features backend-candle every_candle_conditioning_route_is_admitted_through_a_gate -- --nocapture`
- `cargo test -p sceneworks-worker --features backend-candle bespoke_candle_base_evidence_is_live_or_explicitly_unmeasured -- --nocapture`

Shortcut: [sc-16093](https://app.shortcut.com/trefry/story/16093)