### PR TITLE
chore(config): gitignore runtime artifacts written into config/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -231,8 +231,30 @@ apps/desktop/mlx/
 apps/desktop/cuda/
 
 # SceneWorks local runtime data
+#
+# config/ holds tracked source (builtin.*.jsonc, tier-integrity.jsonc, the calibration and
+# rung-4 plans), but it is ALSO a live runtime directory: docker-compose bind-mounts ./config
+# as /sceneworks/config and sets SCENEWORKS_CONFIG_DIR to it, so `npm run dev` — and any native
+# run with SCENEWORKS_CONFIG_DIR=<repo>/config — drops the app's own state into the working tree.
+# Ignore each runtime file by name rather than a config/* wildcard, so a genuinely new source
+# file still shows up in `git status` instead of being silently swallowed.
+#
+# Written to the config-dir ROOT (all named in crates/sceneworks-core/src/app_paths.rs, except
+# credentials.json which is crates/sceneworks-core/src/credentials.rs):
+#   credentials.json   download tokens — a SECRET; the store is created 0600 and must never be committed
+#   gpu_memory_limit   live desktop -> worker memory-cap handoff, a bare decimal byte count (sc-7824)
+#   gpu_telemetry.json MLX worker memory telemetry for the Settings readout (sc-7825)
+#   ui-preferences.json durable UI preference store written by PUT /api/v1/ui-preferences
+config/credentials.json
+config/gpu_memory_limit
+config/gpu_telemetry.json
+config/ui-preferences.json
 # user.*.jsonc manifests are rewritten by the SceneWorks API at runtime (local state, not source).
 config/manifests/user.*.jsonc
+# Preset lastUsedAt side store, written on the generate hot path (sc-10520,
+# apps/rust-api/src/recipe_presets.rs). Lives under manifests/ but is state, not a manifest, so
+# the user.*.jsonc pattern above does not cover it.
+config/manifests/recipe-preset-usage.json
 data/projects/*
 !data/projects/.gitkeep
 data/recent-projects.json


### PR DESCRIPTION
## Problem

`config/` is tracked source, but it is **also** a live runtime directory. `docker-compose.yml` bind-mounts `./config` as `/sceneworks/config` and sets `SCENEWORKS_CONFIG_DIR` to it (lines ~21/69/117), and `.env.example:34` sets `SCENEWORKS_CONFIG_DIR=config` for native runs. So any developer running `npm run dev` gets the app's own runtime state written into their working tree.

None of it was gitignored, so it showed as `??` in `git status` and a `git add -A` would have committed it.

## What's ignored

Five runtime artifacts, named individually rather than via a `config/*` wildcard — a wildcard would silently swallow genuinely new source files, which is a worse failure mode than the one being fixed:

| File | Writer |
|---|---|
| `config/credentials.json` | `crates/sceneworks-core/src/credentials.rs:53` |
| `config/gpu_memory_limit` | `crates/sceneworks-core/src/app_paths.rs:50` |
| `config/gpu_telemetry.json` | `crates/sceneworks-core/src/app_paths.rs:58` |
| `config/ui-preferences.json` | `crates/sceneworks-core/src/app_paths.rs:69` |
| `config/manifests/recipe-preset-usage.json` | `apps/rust-api/src/recipe_presets.rs:1108` |

Two of these are easy to miss:

- **`credentials.json` holds download tokens.** The store is created `0600` and the API never returns tokens over HTTP, but nothing stopped `git add -A` from committing it. Anyone who had configured a gated-repo token had a live secret one command away from the tree.
- **`recipe-preset-usage.json` is not in the config root** — it goes to `config_dir/manifests/`, so the existing `config/manifests/user.*.jsonc` pattern did not match it. It's written on the generate hot path, so any dev who runs a job produces it.

## Verification

- `git log --all` is **empty** for all five paths — none has ever been committed.
- With all five present on disk with realistic contents, `git status --porcelain` and `git add -A --dry-run` reported only the `.gitignore` edit itself. Files were then removed.
- Every path in `git ls-files config/` was checked against `git check-ignore` and is still **unignored** — `builtin.*.jsonc`, `tier-integrity.jsonc`, `memory-calibration-plan.json`, `rung4-applicability-survey.json`, `runpod-template.json` and the inference provenance files remain tracked source.

## Deliberately not covered

- **`config/settings.json`** — `apps/desktop/src/setup.rs:359` writes it, but into the desktop's own platform dir. `config_dir()` (`setup.rs:461`) resolves platform paths and never *reads* `SCENEWORKS_CONFIG_DIR`; it exports it to child processes. It cannot reach the checkout.
- **`builtin.*.jsonc` seeding** — `BUILTIN_MANIFESTS` uses `include_str!` on the tracked files themselves, so `seed_builtin_manifests` can only rewrite existing tracked source. It cannot produce an untracked file.

## Follow-up

This closes the commit risk but does not move the secret out of the working tree. Relocating the credential store out of the config dir — keeping `config/` as the live manifest-editing surface, which is why it points at the checkout in the first place — is filed as [sc-16540](https://app.shortcut.com/trefry/story/16540).

## Testing

No code changed — `.gitignore` only, which cannot affect compilation. Verification was the git-behavior checks above rather than a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)