### PR TITLE
chore(credentials): move the download-credential store out of the config dir (sc-16540)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,27 @@ SCENEWORKS_CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
 SCENEWORKS_DATA_DIR=data
 SCENEWORKS_CONFIG_DIR=config
 
+# Download-credential store (`credentials.json`) — sc-16540. LEFT UNSET ON PURPOSE.
+#
+# Note that SCENEWORKS_CONFIG_DIR above is `config`, i.e. the repo checkout: that is
+# deliberate, so a developer editing config/manifests/builtin.models.jsonc sees the
+# change live. It is also exactly why the credential store does not live there — the
+# file holds plaintext API tokens, and a directory built for hand-editing and copying
+# between machines is the wrong place for one.
+#
+# Unset, the store resolves to the OS app-config dir (never a checkout):
+#   macOS    ~/Library/Application Support/SceneWorks/config
+#   Windows  %APPDATA%\SceneWorks\config
+#   Linux    $XDG_CONFIG_HOME/sceneworks
+# Set it only to pin the store somewhere specific — a mounted volume, a shared
+# operator path. Docker sets it (to /sceneworks/credentials) because a container's OS
+# default is not a mounted path and the tokens would not survive a restart.
+# SCENEWORKS_CREDENTIALS_DIR=
+
+# Host path backing the compose credentials mount. Defaults OUTSIDE the repo so a
+# plaintext token never lands in the working tree; override to relocate it.
+# SCENEWORKS_CREDENTIALS_BIND=~/.sceneworks/credentials
+
 # Reuse model weights you already have — point this at an existing ComfyUI
 # `models/` directory and its `loras/` subtree is scanned (recursively) and listed
 # alongside the built-in catalog. Files are read IN PLACE: nothing is copied,

--- a/.gitignore
+++ b/.gitignore
@@ -241,7 +241,10 @@ apps/desktop/cuda/
 #
 # Written to the config-dir ROOT (all named in crates/sceneworks-core/src/app_paths.rs, except
 # credentials.json which is crates/sceneworks-core/src/credentials.rs):
-#   credentials.json   download tokens — a SECRET; the store is created 0600 and must never be committed
+#   credentials.json   download tokens — a SECRET. Since sc-16540 the store lives OUTSIDE the
+#                      config dir (see sceneworks_core::credentials::resolve_credentials_dir);
+#                      this entry still covers the pre-migration file, which the rust-api moves
+#                      on first start but which exists until then.
 #   gpu_memory_limit   live desktop -> worker memory-cap handoff, a bare decimal byte count (sc-7824)
 #   gpu_telemetry.json MLX worker memory telemetry for the Settings readout (sc-7825)
 #   ui-preferences.json durable UI preference store written by PUT /api/v1/ui-preferences

--- a/README.md
+++ b/README.md
@@ -383,9 +383,12 @@ single `SCENEWORKS_VOLUME` base defaults there and gives the following layout:
 
 Set `SCENEWORKS_VOLUME=/runpod-volume` for a serverless network-volume mount, or
 another absolute container path for a custom mount. Explicit
-`SCENEWORKS_DATA_DIR`, `SCENEWORKS_CONFIG_DIR`, `SCENEWORKS_JOBS_DB_PATH`,
-`HF_HOME`, `HF_HUB_CACHE`, and `HUGGINGFACE_HUB_CACHE` values take precedence
-over derived defaults.
+`SCENEWORKS_DATA_DIR`, `SCENEWORKS_CONFIG_DIR`, `SCENEWORKS_CREDENTIALS_DIR`,
+`SCENEWORKS_JOBS_DB_PATH`, `HF_HOME`, `HF_HUB_CACHE`, and
+`HUGGINGFACE_HUB_CACHE` values take precedence over derived defaults.
+`SCENEWORKS_CREDENTIALS_DIR` defaults to `${SCENEWORKS_VOLUME}/credentials` — the
+download-credential store is kept out of the config dir (sc-16540) because that
+directory is a repo checkout in development and the store is plaintext tokens.
 
 The image intentionally runs as root, matching RunPod's default volume owner.
 At startup it creates and write-probes only the exact managed directories; it

--- a/apps/rust-api/README.md
+++ b/apps/rust-api/README.md
@@ -13,6 +13,13 @@ The API uses these compose contracts:
   unauthenticated and logs a startup warning.
 - `SCENEWORKS_DATA_DIR=/sceneworks/data` maps to `${SCENEWORKS_DATA_BIND:-./data}`.
 - `SCENEWORKS_CONFIG_DIR=/sceneworks/config` maps writable to `${SCENEWORKS_CONFIG_BIND:-./config}` for user manifests.
+- `SCENEWORKS_CREDENTIALS_DIR=/sceneworks/credentials` maps writable to
+  `${SCENEWORKS_CREDENTIALS_BIND:-~/.sceneworks/credentials}` and holds the `0600`
+  `credentials.json` written by Settings → Service credentials. Kept off the config
+  bind on purpose (sc-16540): that one defaults to the repo checkout, and the store is
+  plaintext tokens. Outside Docker the variable is normally unset and the store
+  resolves to the OS app-config dir; set it only to pin the store to a specific volume.
+  An existing `<config>/credentials.json` is migrated here automatically on first start.
 - `SCENEWORKS_JOBS_DB_PATH=/sceneworks/data/cache/jobs.db` stores queue state on the existing data bind mount.
 - `SCENEWORKS_ACCESS_TOKEN`, `SCENEWORKS_CORS_ORIGINS`, and `SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE` are honored by the Rust API.
 

--- a/apps/rust-api/src/credentials.rs
+++ b/apps/rust-api/src/credentials.rs
@@ -1,6 +1,8 @@
 //! Server/Docker credential management (sc-1893). Backs the same Settings
 //! "Service credentials" screen used on desktop, but over HTTP against a `0600`
-//! file in the config dir instead of the OS keychain. The token is write-only —
+//! file (in `Settings::credentials_dir`, sc-16540) instead of the OS keychain. The
+//! store deliberately does NOT live in the config dir — see
+//! [`sceneworks_core::credentials::resolve_credentials_dir`]. The token is write-only —
 //! `GET` never returns it, only host/label/scheme/present. Routes sit behind the
 //! standard access-token middleware like the rest of `/api/*`.
 
@@ -9,7 +11,7 @@ use super::*;
 use sceneworks_core::credentials::{normalize_host, CredentialFileStore, CredentialStatus};
 
 fn credential_store(state: &AppState) -> CredentialFileStore {
-    CredentialFileStore::new(&state.settings.config_dir)
+    CredentialFileStore::new(&state.settings.credentials_dir)
 }
 
 /// Redacted listing of stored credentials — never includes tokens.

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -61,6 +61,11 @@ pub struct Settings {
     pub port: u16,
     pub data_dir: PathBuf,
     pub config_dir: PathBuf,
+    /// Directory holding the `credentials.json` store (sc-16540). Resolved by
+    /// [`sceneworks_core::credentials::credentials_dir`] and deliberately independent
+    /// of `config_dir`, which is pointed at the repo checkout in dev — see that
+    /// function for the precedence and why a plaintext token must not live there.
+    pub credentials_dir: PathBuf,
     pub access_token: String,
     pub cors_origins: Vec<String>,
     pub worker_timeout_seconds: u64,
@@ -161,12 +166,15 @@ impl Settings {
             .and_then(|value| value.parse().ok())
             .unwrap_or(8000);
         let host = env_string("SCENEWORKS_API_HOST", DEFAULT_API_HOST);
+        let config_dir = env_path_or("SCENEWORKS_CONFIG_DIR", &defaults.config_dir);
+        let credentials_dir = sceneworks_core::credentials::credentials_dir(&config_dir);
         Self {
             app_version: env_string("SCENEWORKS_APP_VERSION", "0.2.0"),
             host: host.clone(),
             port,
             data_dir,
-            config_dir: env_path_or("SCENEWORKS_CONFIG_DIR", &defaults.config_dir),
+            config_dir,
+            credentials_dir,
             access_token: std::env::var("SCENEWORKS_ACCESS_TOKEN")
                 .unwrap_or_default()
                 .trim()
@@ -627,10 +635,45 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // HTTP, but a sysadmin or restore could leave the on-disk file group/world
     // readable. Warn (don't fail) at startup so the secret's only at-rest
     // protection — its file mode — is visibly broken instead of silently so.
+    // Move a pre-sc-16540 store out of the config dir before anything reads it. The
+    // API is the file's sole writer, so this is the one place it can happen without a
+    // race. A failure here is logged, not fatal: the worker still falls back to the
+    // legacy path, so an un-migrated install keeps working.
+    match sceneworks_core::credentials::migrate_legacy_store(
+        &settings.config_dir,
+        &settings.credentials_dir,
+    ) {
+        Ok(sceneworks_core::credentials::LegacyMigration::Migrated(from)) => {
+            tracing::info!(
+                event = "credentials_store_migrated",
+                from = %from.display(),
+                to = %settings.credentials_dir.display(),
+                "moved the credential store out of the config dir (sc-16540)",
+            );
+        }
+        Ok(sceneworks_core::credentials::LegacyMigration::BothPresent(legacy)) => {
+            tracing::warn!(
+                event = "credentials_store_duplicate",
+                legacy = %legacy.display(),
+                active = %settings.credentials_dir.display(),
+                "a credential store exists at BOTH the old and new locations; the new one is \
+                 authoritative. Delete the old file — it still holds tokens in plaintext.",
+            );
+        }
+        Ok(sceneworks_core::credentials::LegacyMigration::NotNeeded) => {}
+        Err(error) => {
+            tracing::warn!(
+                event = "credentials_store_migration_failed",
+                error = %error,
+                "could not migrate the credential store out of the config dir; leaving it in \
+                 place (readers fall back to the old path)",
+            );
+        }
+    }
     #[cfg(unix)]
     {
         let creds_path = settings
-            .config_dir
+            .credentials_dir
             .join(sceneworks_core::credentials::CREDENTIALS_FILENAME);
         if let Some(mode) = sceneworks_core::credentials::loose_credentials_mode(&creds_path) {
             tracing::warn!(

--- a/apps/rust-api/src/tests/auth.rs
+++ b/apps/rust-api/src/tests/auth.rs
@@ -1166,6 +1166,18 @@ async fn credentials_routes_store_redact_and_delete() {
         !body.to_string().contains("secret-key"),
         "token leaked in the response"
     );
+    // sc-16540: the token lands in the credentials dir, NOT the config dir. The config
+    // dir is the repo checkout in dev, so a store written there puts a plaintext token
+    // in a git working tree — the regression this asserts against.
+    let filename = sceneworks_core::credentials::CREDENTIALS_FILENAME;
+    assert!(
+        settings.credentials_dir.join(filename).is_file(),
+        "credential store must be written to the credentials dir",
+    );
+    assert!(
+        !settings.config_dir.join(filename).exists(),
+        "no credential store may be created in the config dir",
+    );
 
     // A separate GET is likewise redacted.
     let (status, body) = request(

--- a/apps/rust-api/src/tests/support.rs
+++ b/apps/rust-api/src/tests/support.rs
@@ -151,6 +151,11 @@ pub(crate) fn test_settings(temp_dir: &tempfile::TempDir) -> Settings {
         port: 0,
         data_dir: temp_dir.path().join("data"),
         config_dir: temp_dir.path().join("config"),
+        // Pinned to the tempdir on purpose. Resolving this the way production does
+        // (`credentials::credentials_dir`) would hand tests the developer's REAL OS
+        // app-config dir, so a credential test would read — and `set`/`delete` would
+        // overwrite — their actual tokens (sc-16540).
+        credentials_dir: temp_dir.path().join("credentials"),
         access_token: String::new(),
         cors_origins: vec![
             "http://localhost:5173".to_owned(),

--- a/crates/sceneworks-core/src/app_paths.rs
+++ b/crates/sceneworks-core/src/app_paths.rs
@@ -31,6 +31,19 @@ impl AppPaths {
         platform_default_paths().unwrap_or_else(repo_relative_paths)
     }
 
+    /// Platform defaults **only** when the OS actually gave us a home directory —
+    /// i.e. without the repo-relative fallback [`AppPaths::platform_default`] applies.
+    ///
+    /// That fallback is right for the data/config roots (it reproduces the historical
+    /// default rather than panicking), but it resolves to a *relative* `config`, which
+    /// means "whatever directory this process was started in". For anything that must
+    /// never land in the current working directory — the credential store, which would
+    /// otherwise put a plaintext token inside a git checkout — a relative answer is
+    /// worse than no answer. Callers that care take the `None` and decide themselves.
+    pub fn platform_default_checked() -> Option<Self> {
+        platform_default_paths()
+    }
+
     /// Create the data, config, and cache directories if they do not yet exist.
     pub fn ensure_exists(&self) -> std::io::Result<()> {
         std::fs::create_dir_all(&self.data_dir)?;

--- a/crates/sceneworks-core/src/credentials.rs
+++ b/crates/sceneworks-core/src/credentials.rs
@@ -1,9 +1,14 @@
-//! Host-keyed download credential store backed by a `0600` JSON file in the config
-//! dir (sc-1893). Used by the server/Docker deployment, where there is no per-user
-//! OS keychain: the rust-api manages the file via `/api/v1/credentials` and the
-//! worker reads it. The on-disk shape mirrors the worker's `SCENEWORKS_CREDENTIALS`
-//! env map (`{ host: { token, scheme } }`) with an extra `label`, so the worker can
-//! parse either source the same way.
+//! Host-keyed download credential store backed by a `0600` JSON file (sc-1893). Used
+//! by the server/Docker deployment, where there is no per-user OS keychain: the
+//! rust-api manages the file via `/api/v1/credentials` and the worker reads it. The
+//! on-disk shape mirrors the worker's `SCENEWORKS_CREDENTIALS` env map
+//! (`{ host: { token, scheme } }`) with an extra `label`, so the worker can parse
+//! either source the same way.
+//!
+//! The file lived in the config dir until sc-16540, which is a directory pointed at
+//! the repo checkout on purpose (see [`resolve_credentials_dir`]). It now resolves
+//! independently, with [`migrate_legacy_store`] moving an existing install's tokens
+//! across on first start.
 //!
 //! There is no application-level encryption: a headless container has no per-user
 //! vault and any key would have to live beside the data, so the realistic
@@ -17,9 +22,125 @@ use serde::{Deserialize, Serialize};
 
 use crate::store_util::{lock_store_path, random_hex};
 
-/// Filename of the credential store within the config dir. Shared so the rust-api
-/// (writer) and the worker (reader) never drift.
+/// Filename of the credential store. Shared so the rust-api (writer) and the worker
+/// (reader) never drift.
 pub const CREDENTIALS_FILENAME: &str = "credentials.json";
+
+/// Env var naming the directory that holds [`CREDENTIALS_FILENAME`] (sc-16540).
+///
+/// Needed because the *default* deliberately ignores `SCENEWORKS_CONFIG_DIR`, and a
+/// container's OS-default config dir is not on a mounted volume — so Docker/RunPod
+/// must say where the store lives or it would not survive a restart.
+pub const CREDENTIALS_DIR_ENV: &str = "SCENEWORKS_CREDENTIALS_DIR";
+
+/// Where the credential store lives, given the config dir (sc-16540).
+///
+/// **Deliberately not `config_dir`.** `SCENEWORKS_CONFIG_DIR` is pointed at the repo
+/// checkout on purpose — `.env.example` sets `SCENEWORKS_CONFIG_DIR=config` and
+/// docker-compose bind-mounts `./config` — because that is how a developer editing
+/// `builtin.models.jsonc` sees the change live. That makes it exactly the wrong home
+/// for a plaintext token: a directory whose whole job is being edited, copied between
+/// machines and scanned by tooling. Secrets and hand-edited source want opposite
+/// handling, so the store gets its own resolution.
+///
+/// Precedence:
+/// 1. [`CREDENTIALS_DIR_ENV`], when set and non-blank — the operator/orchestrator has
+///    said where a persistent volume is, and that answer beats any guess.
+/// 2. The OS app-config dir ([`crate::app_paths::AppPaths::platform_default_checked`]),
+///    which is never a checkout.
+/// 3. `config_dir` — the pre-sc-16540 location. Only reachable when the OS gave us no
+///    home directory at all (a minimal container with no `HOME`). Keeping the old
+///    behavior there is not a regression, and the alternative — a *relative* `config`
+///    from the repo-relative fallback — is the very bug being fixed.
+///
+/// Pure so the precedence is unit-testable without mutating process env; see
+/// [`credentials_dir`] for the env-reading wrapper.
+pub fn resolve_credentials_dir(
+    env_override: Option<&str>,
+    platform_config_dir: Option<&Path>,
+    config_dir: &Path,
+) -> PathBuf {
+    if let Some(explicit) = env_override
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return PathBuf::from(explicit);
+    }
+    platform_config_dir.map_or_else(|| config_dir.to_path_buf(), Path::to_path_buf)
+}
+
+/// [`resolve_credentials_dir`] against the live process environment.
+pub fn credentials_dir(config_dir: &Path) -> PathBuf {
+    let env_override = std::env::var(CREDENTIALS_DIR_ENV).ok();
+    let platform = crate::app_paths::AppPaths::platform_default_checked();
+    resolve_credentials_dir(
+        env_override.as_deref(),
+        platform.as_ref().map(|paths| paths.config_dir.as_path()),
+        config_dir,
+    )
+}
+
+/// The pre-sc-16540 store location: `<config_dir>/credentials.json`. Retained so an
+/// existing install's tokens are found and migrated rather than silently lost.
+pub fn legacy_credentials_file(config_dir: &Path) -> PathBuf {
+    config_dir.join(CREDENTIALS_FILENAME)
+}
+
+/// Outcome of [`migrate_legacy_store`], so the caller can log precisely what happened
+/// instead of inferring it from a bare `bool`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LegacyMigration {
+    /// Nothing to do: no legacy file, or the two paths are the same directory.
+    NotNeeded,
+    /// Legacy store moved to the new location. Carries the path that was removed.
+    Migrated(PathBuf),
+    /// Both stores exist. The new one is authoritative and the legacy file was left
+    /// alone — it may hold credentials the new one does not, and deleting a secret
+    /// we did not write is not ours to do. The operator is told to remove it.
+    BothPresent(PathBuf),
+}
+
+/// Move a pre-sc-16540 `<config_dir>/credentials.json` to the resolved credentials dir.
+///
+/// Called by the rust-api at startup because the API is the store's sole writer. The
+/// migration goes through [`CredentialFileStore::load`]/[`CredentialFileStore::save`]
+/// rather than copying bytes, so a corrupt legacy file surfaces as an error (and is
+/// left in place) instead of being faithfully reproduced at the new path, and so the
+/// new file is created `0600` with the same atomic-rename + fsync guarantees as any
+/// other write.
+///
+/// Removing the legacy file is the point of the exercise — leaving it would keep the
+/// plaintext token in the checkout — but it happens only after the new store is
+/// durably written, and a failure to unlink is a warning, not an error: the new file
+/// is already authoritative by then.
+pub fn migrate_legacy_store(
+    config_dir: &Path,
+    credentials_dir: &Path,
+) -> io::Result<LegacyMigration> {
+    let legacy_path = legacy_credentials_file(config_dir);
+    let current = CredentialFileStore::new(credentials_dir);
+    if current.path() == legacy_path {
+        return Ok(LegacyMigration::NotNeeded);
+    }
+    if !legacy_path.is_file() {
+        return Ok(LegacyMigration::NotNeeded);
+    }
+    if current.path().is_file() {
+        return Ok(LegacyMigration::BothPresent(legacy_path));
+    }
+    let legacy = CredentialFileStore::new(config_dir);
+    let map = legacy.load()?;
+    current.save(&map)?;
+    if let Err(error) = std::fs::remove_file(&legacy_path) {
+        tracing::warn!(
+            path = %legacy_path.display(),
+            error = %error,
+            "migrated the credential store but could not remove the old file; delete it by hand \
+             — it still holds your tokens in plaintext",
+        );
+    }
+    Ok(LegacyMigration::Migrated(legacy_path))
+}
 
 /// A stored credential's persisted fields. The token is the only secret.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -48,9 +169,11 @@ pub struct CredentialFileStore {
 }
 
 impl CredentialFileStore {
-    pub fn new(config_dir: &Path) -> Self {
+    /// `dir` is the directory holding [`CREDENTIALS_FILENAME`] — resolve it with
+    /// [`credentials_dir`] rather than passing `config_dir` directly (sc-16540).
+    pub fn new(dir: &Path) -> Self {
         Self {
-            path: config_dir.join(CREDENTIALS_FILENAME),
+            path: dir.join(CREDENTIALS_FILENAME),
         }
     }
 
@@ -291,6 +414,166 @@ pub fn loose_credentials_mode(path: &Path) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The credential store must NEVER default into the config dir, because that dir is
+    /// deliberately pointed at the repo checkout (`.env.example` sets
+    /// `SCENEWORKS_CONFIG_DIR=config`; compose bind-mounts `./config`). sc-16540.
+    #[test]
+    fn credentials_dir_prefers_env_then_platform_and_never_config_by_default() {
+        let config = Path::new("/repo/config");
+        let platform = Path::new("/home/u/.config/sceneworks");
+
+        // 1. An explicit env override wins over everything — the operator knows where
+        //    their persistent volume is.
+        assert_eq!(
+            resolve_credentials_dir(Some("/mnt/secrets"), Some(platform), config),
+            PathBuf::from("/mnt/secrets"),
+        );
+        // A blank/whitespace env var is "unset", not "use the empty path".
+        for blank in ["", "   "] {
+            assert_eq!(
+                resolve_credentials_dir(Some(blank), Some(platform), config),
+                platform.to_path_buf(),
+                "a blank {blank:?} override must fall through, not resolve to an empty path",
+            );
+        }
+        // 2. Otherwise the OS app-config dir — NOT the config dir.
+        assert_eq!(
+            resolve_credentials_dir(None, Some(platform), config),
+            platform.to_path_buf(),
+        );
+        // 3. Only with no home directory at all does it fall back to the config dir.
+        //    That is the pre-sc-16540 behavior, so it is not a regression — and it beats
+        //    the alternative, `AppPaths::platform_default`'s RELATIVE `config`, which
+        //    would mean "wherever this process happened to start".
+        assert_eq!(
+            resolve_credentials_dir(None, None, config),
+            config.to_path_buf(),
+        );
+    }
+
+    #[test]
+    fn migrate_moves_the_legacy_store_and_removes_the_plaintext_original() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config = temp.path().join("config");
+        let creds = temp.path().join("credentials");
+        std::fs::create_dir_all(&config).expect("config dir");
+
+        CredentialFileStore::new(&config)
+            .set("huggingface.co", "HF", "bearer", "secret-token")
+            .expect("seed legacy store");
+        let legacy_path = legacy_credentials_file(&config);
+        assert!(legacy_path.is_file(), "legacy store seeded");
+
+        assert_eq!(
+            migrate_legacy_store(&config, &creds).expect("migrate"),
+            LegacyMigration::Migrated(legacy_path.clone()),
+        );
+
+        // The token survived...
+        let moved = CredentialFileStore::new(&creds).load().expect("load moved");
+        assert_eq!(
+            moved
+                .get("huggingface.co")
+                .map(|entry| entry.token.as_str()),
+            Some("secret-token"),
+        );
+        // ...and the plaintext copy is GONE from the config dir. Leaving it behind
+        // would defeat the entire point of the move.
+        assert!(
+            !legacy_path.exists(),
+            "the legacy plaintext store must not survive the migration",
+        );
+
+        // Re-running is a no-op rather than an error or a resurrection.
+        assert_eq!(
+            migrate_legacy_store(&config, &creds).expect("second migrate"),
+            LegacyMigration::NotNeeded,
+        );
+    }
+
+    #[test]
+    fn migrate_is_a_noop_without_a_legacy_store_or_when_the_dirs_match() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config = temp.path().join("config");
+        std::fs::create_dir_all(&config).expect("config dir");
+
+        assert_eq!(
+            migrate_legacy_store(&config, &temp.path().join("credentials")).expect("migrate"),
+            LegacyMigration::NotNeeded,
+            "no legacy file means nothing to do",
+        );
+
+        // Same directory (the no-home fallback in `resolve_credentials_dir`): the file is
+        // already where it belongs, and a naive implementation would delete it.
+        CredentialFileStore::new(&config)
+            .set("civitai.com", "Civit", "query", "k")
+            .expect("seed");
+        assert_eq!(
+            migrate_legacy_store(&config, &config).expect("migrate"),
+            LegacyMigration::NotNeeded,
+        );
+        assert!(
+            legacy_credentials_file(&config).is_file(),
+            "migrating a directory onto itself must not delete the store",
+        );
+    }
+
+    /// Both present: the new store wins and the old file is LEFT ALONE. It may hold
+    /// hosts the new one does not, and silently deleting a secret we did not write is
+    /// not ours to do — the API warns the operator instead.
+    #[test]
+    fn migrate_reports_both_present_without_touching_either_store() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config = temp.path().join("config");
+        let creds = temp.path().join("credentials");
+        std::fs::create_dir_all(&config).expect("config dir");
+
+        CredentialFileStore::new(&config)
+            .set("huggingface.co", "old", "bearer", "old-token")
+            .expect("seed legacy");
+        CredentialFileStore::new(&creds)
+            .set("huggingface.co", "new", "bearer", "new-token")
+            .expect("seed current");
+
+        assert_eq!(
+            migrate_legacy_store(&config, &creds).expect("migrate"),
+            LegacyMigration::BothPresent(legacy_credentials_file(&config)),
+        );
+        assert!(legacy_credentials_file(&config).is_file(), "legacy kept");
+        assert_eq!(
+            CredentialFileStore::new(&creds)
+                .load()
+                .expect("load")
+                .get("huggingface.co")
+                .map(|entry| entry.token.as_str()),
+            Some("new-token"),
+            "the existing store must not be overwritten by the legacy one",
+        );
+    }
+
+    /// A corrupt legacy store must ERROR rather than migrate an empty map — that would
+    /// turn "unreadable" into "you have no credentials" permanently, by deleting the
+    /// only copy. Same reasoning as `load`'s refusal to treat corruption as empty.
+    #[test]
+    fn migrate_refuses_a_corrupt_legacy_store_and_leaves_it_in_place() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config = temp.path().join("config");
+        let creds = temp.path().join("credentials");
+        std::fs::create_dir_all(&config).expect("config dir");
+        std::fs::write(legacy_credentials_file(&config), "{ not json").expect("write corrupt");
+
+        let error = migrate_legacy_store(&config, &creds).expect_err("corrupt store must error");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(
+            legacy_credentials_file(&config).is_file(),
+            "a corrupt store must be left for the operator to fix, not deleted",
+        );
+        assert!(
+            !CredentialFileStore::new(&creds).path().exists(),
+            "nothing must be written to the new location from a corrupt source",
+        );
+    }
 
     #[test]
     fn set_list_delete_round_trip_redacts_token() {

--- a/crates/sceneworks-worker/src/credentials.rs
+++ b/crates/sceneworks-worker/src/credentials.rs
@@ -81,14 +81,25 @@ pub(crate) fn merge_credentials(
     by_host.into_values().collect()
 }
 
-/// Worker credentials from the server/Docker file store (`<config>/credentials.json`)
-/// overlaid with the `SCENEWORKS_CREDENTIALS` env (desktop injection / operator
-/// override). Same parser for both (the file carries an extra `label` the worker
-/// ignores). Picked up at startup, so changing credentials needs a worker restart —
-/// consistent with the desktop, which already re-injects on restart.
-pub(crate) fn load_worker_credentials(config_dir: &Path) -> Vec<WorkerCredential> {
-    let file = config_dir.join(sceneworks_core::credentials::CREDENTIALS_FILENAME);
+/// Worker credentials from the server/Docker file store overlaid with the
+/// `SCENEWORKS_CREDENTIALS` env (desktop injection / operator override). Same parser
+/// for both (the file carries an extra `label` the worker ignores). Picked up at
+/// startup, so changing credentials needs a worker restart — consistent with the
+/// desktop, which already re-injects on restart.
+///
+/// Reads `credentials_dir` first and falls back to the pre-sc-16540
+/// `<config>/credentials.json`. The fallback is not just for un-upgraded installs: the
+/// rust-api owns the migration and a worker can start before it has run (compose
+/// gates on the API's health check, but a worker-only deployment does not), so without
+/// it a worker could come up credential-less for one restart cycle.
+pub(crate) fn load_worker_credentials(
+    credentials_dir: &Path,
+    config_dir: &Path,
+) -> Vec<WorkerCredential> {
+    let file = credentials_dir.join(sceneworks_core::credentials::CREDENTIALS_FILENAME);
+    let legacy = sceneworks_core::credentials::legacy_credentials_file(config_dir);
     let file_credentials = std::fs::read_to_string(&file)
+        .or_else(|_| std::fs::read_to_string(&legacy))
         .ok()
         .map(|body| parse_credentials_env(&body))
         .unwrap_or_default();

--- a/crates/sceneworks-worker/src/settings.rs
+++ b/crates/sceneworks-worker/src/settings.rs
@@ -92,6 +92,7 @@ impl Settings {
     pub fn from_env() -> Self {
         let defaults = sceneworks_core::app_paths::AppPaths::platform_default();
         let config_dir = env_path_or("SCENEWORKS_CONFIG_DIR", &defaults.config_dir);
+        let credentials_dir = sceneworks_core::credentials::credentials_dir(&config_dir);
         Self {
             api_url: env_string("SCENEWORKS_API_URL", DEFAULT_API_URL),
             access_token: std::env::var("SCENEWORKS_ACCESS_TOKEN")
@@ -127,7 +128,7 @@ impl Settings {
                 .ok()
                 .map(|value| value.trim().to_owned())
                 .filter(|value| !value.is_empty()),
-            credentials: load_worker_credentials(&config_dir),
+            credentials: load_worker_credentials(&credentials_dir, &config_dir),
             max_lora_url_bytes: env_u64_any(
                 &["SCENEWORKS_MAX_LORA_URL_BYTES"],
                 DEFAULT_MAX_LORA_URL_BYTES,

--- a/crates/sceneworks-worker/src/tests/credentials_and_source_url.rs
+++ b/crates/sceneworks-worker/src/tests/credentials_and_source_url.rs
@@ -58,6 +58,46 @@ fn credential_for_host_matches_case_insensitively() {
     assert!(credential_for_host(&settings, "").is_none());
 }
 
+/// sc-16540 moved the store out of the config dir. The worker reads the new location
+/// but must still find a pre-migration file, because the rust-api owns the migration
+/// and a worker can start before it has run — without the fallback such a worker comes
+/// up credential-less until the next restart, and every gated download fails.
+#[test]
+fn worker_reads_the_new_store_and_falls_back_to_the_pre_migration_path() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let config = temp.path().join("config");
+    let creds = temp.path().join("credentials");
+    std::fs::create_dir_all(&config).expect("config dir");
+    std::fs::create_dir_all(&creds).expect("credentials dir");
+    let filename = sceneworks_core::credentials::CREDENTIALS_FILENAME;
+
+    // Neither present: no credentials, no panic.
+    assert!(super::load_worker_credentials(&creds, &config).is_empty());
+
+    // Legacy only (an install the API has not migrated yet) — must still be found.
+    std::fs::write(
+        config.join(filename),
+        r#"{ "huggingface.co": { "token": "legacy-hf", "scheme": "bearer" } }"#,
+    )
+    .expect("write legacy");
+    let legacy_only = super::load_worker_credentials(&creds, &config);
+    assert_eq!(legacy_only.len(), 1);
+    assert_eq!(legacy_only[0].token, "legacy-hf");
+
+    // Once migrated, the new location wins even while a stale legacy file lingers.
+    std::fs::write(
+        creds.join(filename),
+        r#"{ "huggingface.co": { "token": "migrated-hf", "scheme": "bearer" } }"#,
+    )
+    .expect("write current");
+    let migrated = super::load_worker_credentials(&creds, &config);
+    assert_eq!(migrated.len(), 1);
+    assert_eq!(
+        migrated[0].token, "migrated-hf",
+        "the resolved store must win over a leftover legacy file",
+    );
+}
+
 #[test]
 fn worker_credentials_env_overrides_file_per_host() {
     // Server reads the config-dir file store; an operator's SCENEWORKS_CREDENTIALS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,12 @@ services:
       SCENEWORKS_API_PORT: ${SCENEWORKS_API_PORT:-8010}
       SCENEWORKS_DATA_DIR: /sceneworks/data
       SCENEWORKS_CONFIG_DIR: /sceneworks/config
+      # Download-credential store (sc-16540). Deliberately NOT under /sceneworks/config:
+      # that path is bind-mounted from the repo checkout by default, and a plaintext
+      # token must not live in a git working tree. Its own mount below defaults OUTSIDE
+      # the repo. Must be set explicitly here — the app's OS-default config dir is not a
+      # mounted path, so the store would not survive a container restart.
+      SCENEWORKS_CREDENTIALS_DIR: /sceneworks/credentials
       SCENEWORKS_JOBS_DB_PATH: /sceneworks/data/cache/jobs.db
       SCENEWORKS_ACCESS_TOKEN: ${SCENEWORKS_ACCESS_TOKEN:-}
       SCENEWORKS_ALLOW_OPEN_BIND: ${SCENEWORKS_ALLOW_OPEN_BIND:-}
@@ -39,6 +45,7 @@ services:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data
       - ${SCENEWORKS_HF_CACHE_BIND:-${HF_HOME:-${USERPROFILE:-$HOME}/.cache/huggingface}}:/sceneworks/data/cache/huggingface
       - ${SCENEWORKS_CONFIG_BIND:-./config}:/sceneworks/config
+      - ${SCENEWORKS_CREDENTIALS_BIND:-${USERPROFILE:-$HOME}/.sceneworks/credentials}:/sceneworks/credentials
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS \"http://127.0.0.1:$${SCENEWORKS_API_PORT:-8010}/api/v1/health\" >/dev/null"]
       interval: 20s
@@ -67,13 +74,16 @@ services:
       SCENEWORKS_API_URL: http://api:${SCENEWORKS_API_PORT:-8010}
       SCENEWORKS_DATA_DIR: /sceneworks/data
       SCENEWORKS_CONFIG_DIR: /sceneworks/config
+      # Download-credential store — see the api service for why it is not under
+      # /sceneworks/config (sc-16540).
+      SCENEWORKS_CREDENTIALS_DIR: /sceneworks/credentials
       SCENEWORKS_WORKER_ID: candle-inference-worker-0
       # Real CUDA device index (not the macOS `mlx` sentinel). `auto` picks the first
       # visible GPU; override to pin a device (e.g. on a multi-GPU host).
       SCENEWORKS_GPU_ID: ${SCENEWORKS_CANDLE_GPU_ID:-auto}
       SCENEWORKS_ACCESS_TOKEN: ${SCENEWORKS_ACCESS_TOKEN:-}
       # Download credentials (same contract as rust-worker): `credentials.json` from the
-      # mounted config volume, with HF_TOKEN / SCENEWORKS_CREDENTIALS as host overrides.
+      # mounted credentials volume, with HF_TOKEN / SCENEWORKS_CREDENTIALS as host overrides.
       HF_TOKEN: ${HF_TOKEN:-}
       SCENEWORKS_CREDENTIALS: ${SCENEWORKS_CREDENTIALS:-}
       HF_HOME: ${SCENEWORKS_HF_HOME:-/sceneworks/data/cache/huggingface}
@@ -88,6 +98,7 @@ services:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data
       - ${SCENEWORKS_HF_CACHE_BIND:-${HF_HOME:-${USERPROFILE:-$HOME}/.cache/huggingface}}:/sceneworks/data/cache/huggingface
       - ${SCENEWORKS_CONFIG_BIND:-./config}:/sceneworks/config
+      - ${SCENEWORKS_CREDENTIALS_BIND:-${USERPROFILE:-$HOME}/.sceneworks/credentials}:/sceneworks/credentials
     depends_on:
       api:
         condition: service_healthy
@@ -115,6 +126,9 @@ services:
       SCENEWORKS_API_URL: http://api:${SCENEWORKS_API_PORT:-8010}
       SCENEWORKS_DATA_DIR: /sceneworks/data
       SCENEWORKS_CONFIG_DIR: /sceneworks/config
+      # Download-credential store — see the api service for why it is not under
+      # /sceneworks/config (sc-16540).
+      SCENEWORKS_CREDENTIALS_DIR: /sceneworks/credentials
       SCENEWORKS_WORKER_ID: rust-utility-worker-0
       SCENEWORKS_GPU_ID: ${SCENEWORKS_RUST_WORKER_GPU_ID:-cpu}
       # Utility jobs (downloads, imports, frame extract, exports) are I/O-bound and
@@ -123,9 +137,9 @@ services:
       SCENEWORKS_UTILITY_WORKERS: ${SCENEWORKS_UTILITY_WORKERS:-4}
       SCENEWORKS_ACCESS_TOKEN: ${SCENEWORKS_ACCESS_TOKEN:-}
       # Download credentials. The rust-worker reads `credentials.json` (written by
-      # the API's Settings -> Service credentials screen) from the mounted config
-      # volume below. HF_TOKEN and SCENEWORKS_CREDENTIALS are optional overrides
-      # for headless deployments and win per host over that file.
+      # the API's Settings -> Service credentials screen) from the mounted
+      # credentials volume below. HF_TOKEN and SCENEWORKS_CREDENTIALS are optional
+      # overrides for headless deployments and win per host over that file.
       HF_TOKEN: ${HF_TOKEN:-}
       SCENEWORKS_CREDENTIALS: ${SCENEWORKS_CREDENTIALS:-}
       HF_HOME: ${SCENEWORKS_HF_HOME:-/sceneworks/data/cache/huggingface}
@@ -135,6 +149,7 @@ services:
       - ${SCENEWORKS_DATA_BIND:-./data}:/sceneworks/data
       - ${SCENEWORKS_HF_CACHE_BIND:-${HF_HOME:-${USERPROFILE:-$HOME}/.cache/huggingface}}:/sceneworks/data/cache/huggingface
       - ${SCENEWORKS_CONFIG_BIND:-./config}:/sceneworks/config
+      - ${SCENEWORKS_CREDENTIALS_BIND:-${USERPROFILE:-$HOME}/.sceneworks/credentials}:/sceneworks/credentials
     depends_on:
       api:
         condition: service_healthy

--- a/docker/runpod-entrypoint.sh
+++ b/docker/runpod-entrypoint.sh
@@ -184,6 +184,10 @@ unset access_token_trimmed
 SCENEWORKS_VOLUME="${SCENEWORKS_VOLUME:-/workspace}"
 SCENEWORKS_DATA_DIR="${SCENEWORKS_DATA_DIR:-${SCENEWORKS_VOLUME}/data}"
 SCENEWORKS_CONFIG_DIR="${SCENEWORKS_CONFIG_DIR:-${SCENEWORKS_VOLUME}/config}"
+# Download-credential store (sc-16540). Its own directory rather than the config
+# dir: the store holds plaintext tokens and the config dir is a checkout in dev.
+# Must be on the durable volume or tokens vanish when the pod restarts.
+SCENEWORKS_CREDENTIALS_DIR="${SCENEWORKS_CREDENTIALS_DIR:-${SCENEWORKS_VOLUME}/credentials}"
 SCENEWORKS_JOBS_DB_PATH="${SCENEWORKS_JOBS_DB_PATH:-/tmp/sceneworks/cache/jobs.db}"
 HF_HOME="${HF_HOME:-${SCENEWORKS_VOLUME}/cache/huggingface}"
 
@@ -200,7 +204,7 @@ else
   effective_hf_hub_cache="${HF_HUB_CACHE}"
 fi
 
-export SCENEWORKS_VOLUME SCENEWORKS_DATA_DIR SCENEWORKS_CONFIG_DIR
+export SCENEWORKS_VOLUME SCENEWORKS_DATA_DIR SCENEWORKS_CONFIG_DIR SCENEWORKS_CREDENTIALS_DIR
 export SCENEWORKS_JOBS_DB_PATH HF_HOME HF_HUB_CACHE HUGGINGFACE_HUB_CACHE
 
 jobs_db_parent="${SCENEWORKS_JOBS_DB_PATH%/*}"
@@ -216,11 +220,13 @@ fi
 require_absolute_path "SCENEWORKS_VOLUME" "${SCENEWORKS_VOLUME}" || exit 1
 require_absolute_path "SceneWorks data directory" "${SCENEWORKS_DATA_DIR}" || exit 1
 require_absolute_path "SceneWorks config directory" "${SCENEWORKS_CONFIG_DIR}" || exit 1
+require_absolute_path "SceneWorks credentials directory" "${SCENEWORKS_CREDENTIALS_DIR}" || exit 1
 require_absolute_path "Hugging Face home" "${HF_HOME}" || exit 1
 require_absolute_path "Hugging Face hub cache" "${effective_hf_hub_cache}" || exit 1
 require_absolute_path "jobs.db parent directory" "${jobs_db_parent}" || exit 1
 ensure_writable_dir "SceneWorks data directory" "${SCENEWORKS_DATA_DIR}" || exit 1
 ensure_writable_dir "SceneWorks config directory" "${SCENEWORKS_CONFIG_DIR}" || exit 1
+ensure_writable_dir "SceneWorks credentials directory" "${SCENEWORKS_CREDENTIALS_DIR}" || exit 1
 ensure_writable_dir "Hugging Face home" "${HF_HOME}" || exit 1
 ensure_writable_dir "Hugging Face hub cache" "${effective_hf_hub_cache}" || exit 1
 ensure_writable_dir "jobs.db parent directory" "${jobs_db_parent}" || exit 1

--- a/scripts/check-compose-config.mjs
+++ b/scripts/check-compose-config.mjs
@@ -89,6 +89,39 @@ function assertRuntimeDefaults(config, label, options = {}) {
   assertEqual(rustWorker?.environment?.SCENEWORKS_GPU_ID, "cpu", `${label} rust worker gpu mode`);
   assertEqual(rustWorker?.environment?.SCENEWORKS_CONFIG_DIR, "/sceneworks/config", `${label} rust worker config dir`);
   assertServiceMountsTarget(rustWorker, "/sceneworks/config", `${label} rust worker config mount`);
+  // sc-16540: the credential store must be its own writable mount on every service
+  // that touches it, and must NOT resolve under /sceneworks/config — that path is
+  // bind-mounted from the repo checkout by default, and the store is plaintext tokens.
+  for (const [service, serviceLabel] of [
+    [api, "api"],
+    [worker, "candle worker"],
+    [rustWorker, "rust worker"],
+  ]) {
+    assertEqual(
+      service?.environment?.SCENEWORKS_CREDENTIALS_DIR,
+      "/sceneworks/credentials",
+      `${label} ${serviceLabel} credentials dir`,
+    );
+    assertWritableMount(service, "/sceneworks/credentials", `${label} ${serviceLabel} credentials mount`);
+  }
+  assertCredentialsBindOutsideRepo(config, label);
+}
+
+// The credentials bind must default outside the repo working tree — putting it back
+// under ./config or ./data would reinstate exactly the problem sc-16540 fixed.
+function assertCredentialsBindOutsideRepo(config, label) {
+  for (const name of ["api", "worker", "rust-worker"]) {
+    const service = config.services?.[name];
+    const volume = (service?.volumes ?? []).find(
+      (item) => item?.target === "/sceneworks/credentials",
+    );
+    const source = volume?.source ?? "";
+    if (source.startsWith("./") || source === "." || source.startsWith("../")) {
+      throw new Error(
+        `${label} ${name} credentials bind: expected a source outside the repo, got ${source}`,
+      );
+    }
+  }
 }
 
 const tempRoot = await mkdtemp(path.join(os.tmpdir(), "sceneworks-compose-config-"));

--- a/scripts/check-runpod-supervisor.sh
+++ b/scripts/check-runpod-supervisor.sh
@@ -44,10 +44,11 @@ else
   printf 'api:token:absent\n' >>"${SCENEWORKS_TEST_EVENTS}"
 fi
 if [[ "${SCENEWORKS_TEST_RECORD_PATHS:-0}" == "1" ]]; then
-  printf 'api:paths:%s|%s|%s|%s|%s|%s\n' \
+  printf 'api:paths:%s|%s|%s|%s|%s|%s|%s\n' \
     "${SCENEWORKS_VOLUME}" \
     "${SCENEWORKS_DATA_DIR}" \
     "${SCENEWORKS_CONFIG_DIR}" \
+    "${SCENEWORKS_CREDENTIALS_DIR}" \
     "${SCENEWORKS_JOBS_DB_PATH}" \
     "${HF_HOME}" \
     "${HF_HUB_CACHE:-${HUGGINGFACE_HUB_CACHE:-}}" \
@@ -123,6 +124,7 @@ assert_public_bind_rejected() {
       SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
       SCENEWORKS_DATA_DIR="${run_dir}/data" \
       SCENEWORKS_CONFIG_DIR="${run_dir}/config" \
+      SCENEWORKS_CREDENTIALS_DIR="${run_dir}/credentials" \
       HF_HOME="${run_dir}/hf" \
       bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr"
   else
@@ -134,6 +136,7 @@ assert_public_bind_rejected() {
     SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
     SCENEWORKS_DATA_DIR="${run_dir}/data" \
     SCENEWORKS_CONFIG_DIR="${run_dir}/config" \
+    SCENEWORKS_CREDENTIALS_DIR="${run_dir}/credentials" \
     HF_HOME="${run_dir}/hf" \
     bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr"
   fi
@@ -266,7 +269,7 @@ env -u SCENEWORKS_DATA_DIR \
   bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr" &
 supervisor_pid=$!
 wait_for_event \
-  "api:paths:${run_dir}/volume|${run_dir}/volume/data|${run_dir}/volume/config|${run_dir}/ephemeral/jobs.db|${run_dir}/volume/cache/huggingface|${run_dir}/volume/cache/huggingface/hub" \
+  "api:paths:${run_dir}/volume|${run_dir}/volume/data|${run_dir}/volume/config|${run_dir}/volume/credentials|${run_dir}/ephemeral/jobs.db|${run_dir}/volume/cache/huggingface|${run_dir}/volume/cache/huggingface/hub" \
   "${events}"
 wait_for_event \
   "api:hf-env:${run_dir}/volume/cache/huggingface/hub|${run_dir}/volume/cache/huggingface/hub" \
@@ -299,6 +302,7 @@ env -u HF_HUB_CACHE \
   SCENEWORKS_VOLUME= \
   SCENEWORKS_DATA_DIR="${run_dir}/custom-data" \
   SCENEWORKS_CONFIG_DIR="${run_dir}/custom-config" \
+  SCENEWORKS_CREDENTIALS_DIR="${run_dir}/custom-credentials" \
   SCENEWORKS_JOBS_DB_PATH="${run_dir}/custom-runtime/jobs.db" \
   HF_HOME="${run_dir}/custom-hf-home" \
   HUGGINGFACE_HUB_CACHE="${run_dir}/legacy-hub-cache" \
@@ -312,7 +316,7 @@ env -u HF_HUB_CACHE \
   bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr" &
 supervisor_pid=$!
 wait_for_event \
-  "api:paths:/workspace|${run_dir}/custom-data|${run_dir}/custom-config|${run_dir}/custom-runtime/jobs.db|${run_dir}/custom-hf-home|${run_dir}/legacy-hub-cache" \
+  "api:paths:/workspace|${run_dir}/custom-data|${run_dir}/custom-config|${run_dir}/custom-credentials|${run_dir}/custom-runtime/jobs.db|${run_dir}/custom-hf-home|${run_dir}/legacy-hub-cache" \
   "${events}"
 wait_for_event "api:hf-env:<unset>|${run_dir}/legacy-hub-cache" "${events}"
 wait_for_event "worker:start:http://127.0.0.1:8010:auto" "${events}"
@@ -346,7 +350,7 @@ SCENEWORKS_SHUTDOWN_GRACE_INTERVAL_SECONDS=0.05 \
 bash "${entrypoint}" >"${run_dir}/stdout" 2>"${run_dir}/stderr" &
 supervisor_pid=$!
 wait_for_event \
-  "api:paths:${run_dir}/volume|${run_dir}/data|${run_dir}/config|${run_dir}/runtime/jobs.db|${run_dir}/hf-home|${run_dir}/priority-hub-cache" \
+  "api:paths:${run_dir}/volume|${run_dir}/data|${run_dir}/config|${run_dir}/volume/credentials|${run_dir}/runtime/jobs.db|${run_dir}/hf-home|${run_dir}/priority-hub-cache" \
   "${events}"
 wait_for_event \
   "api:hf-env:${run_dir}/priority-hub-cache|${run_dir}/legacy-hub-cache" \
@@ -371,6 +375,7 @@ SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
 SCENEWORKS_CURL_BIN="${temp_root}/fake-curl" \
 SCENEWORKS_DATA_DIR="${run_dir}/data" \
 SCENEWORKS_CONFIG_DIR="${run_dir}/config" \
+SCENEWORKS_CREDENTIALS_DIR="${run_dir}/credentials" \
 HF_HOME="${run_dir}/hf" \
 SCENEWORKS_READINESS_MAX_ATTEMPTS=5 \
 SCENEWORKS_READINESS_INTERVAL_SECONDS=0.05 \
@@ -406,6 +411,7 @@ SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
 SCENEWORKS_CURL_BIN="${temp_root}/fake-curl" \
 SCENEWORKS_DATA_DIR="${run_dir}/data" \
 SCENEWORKS_CONFIG_DIR="${run_dir}/config" \
+SCENEWORKS_CREDENTIALS_DIR="${run_dir}/credentials" \
 HF_HOME="${run_dir}/hf" \
 SCENEWORKS_READINESS_MAX_ATTEMPTS=5 \
 SCENEWORKS_READINESS_INTERVAL_SECONDS=0.05 \
@@ -433,6 +439,7 @@ SCENEWORKS_WORKER_BIN="${temp_root}/fake-worker" \
 SCENEWORKS_CURL_BIN="${temp_root}/fake-curl" \
 SCENEWORKS_DATA_DIR="${run_dir}/data" \
 SCENEWORKS_CONFIG_DIR="${run_dir}/config" \
+SCENEWORKS_CREDENTIALS_DIR="${run_dir}/credentials" \
 HF_HOME="${run_dir}/hf" \
 SCENEWORKS_READINESS_MAX_ATTEMPTS=3 \
 SCENEWORKS_READINESS_INTERVAL_SECONDS=0.05 \


### PR DESCRIPTION
Closes [sc-16540](https://app.shortcut.com/trefry/story/16540). Follow-up to #2054, which gitignored the store; this moves it.

## Problem

`credentials.json` holds plaintext download tokens (HuggingFace and any host the user registers) and lived in the config dir. That dir points at the repo checkout **on purpose** — `.env.example` sets `SCENEWORKS_CONFIG_DIR=config`, `docker-compose.yml` bind-mounts `./config` — because it's how a developer editing `builtin.models.jsonc` sees the change live.

That's a good reason, and it's exactly why a secret shouldn't share the directory: `config/` is built for hand-editing, copying between machines, and being scanned by tooling. #2054 stopped the file being committed; it didn't get it out of the working tree.

## Resolution

`resolve_credentials_dir` is pure and unit-tested, so the precedence is asserted rather than described:

1. `SCENEWORKS_CREDENTIALS_DIR`, when set and non-blank
2. the OS app-config dir — never a checkout
3. `config_dir`, the old location

Step 3 is only reachable when the OS gave us no home directory at all (a minimal container with no `HOME`). It deliberately does **not** go through `AppPaths::platform_default`, whose repo-relative fallback returns a *relative* `config` — "wherever this process happened to start", which is the bug being fixed. `platform_default_checked` exposes the un-fallen-back answer so callers that can't tolerate a relative path get `None` and decide for themselves.

Docker and RunPod set the variable explicitly, because a container's OS-default config dir isn't a mounted path and the tokens wouldn't survive a restart:

- compose gets its own `/sceneworks/credentials` mount, defaulting to `${USERPROFILE:-$HOME}/.sceneworks/credentials` — **outside** the repo (same `USERPROFILE`/`HOME` pattern the HF-cache mount already uses)
- the RunPod entrypoint derives `${SCENEWORKS_VOLUME}/credentials` and write-probes it alongside every other durable path

## Migration

The rust-api migrates `<config>/credentials.json` at startup — it's the store's sole writer, so that's the one race-free place. Deliberate choices:

- **Goes through `load`/`save`, not a byte copy.** A corrupt legacy file therefore errors and is left in place rather than faithfully reproduced, and the new file gets the same `0600` + atomic-rename + fsync guarantees as any other write.
- **Removes the old file on success.** Leaving it would defeat the point — but only after the new store is durably written, and a failed unlink is a warning, not an error.
- **Both present → new wins, old untouched, operator warned.** The legacy file may hold hosts the new one doesn't, and deleting a secret we didn't write isn't ours to do.
- **The worker reads the new path and falls back to the old one.** Not just for un-upgraded installs: a worker can start before the API has migrated (compose gates on the API health check, a worker-only deployment doesn't), and without the fallback it would come up credential-less for a restart cycle.

## Not in scope

Desktop is unaffected — it uses the OS keychain (`keyring::Entry`, `KEYRING_SERVICE="SceneWorks"`), and on macOS the worker pulls lazily over a `0600` Unix socket (`credentials_ipc.rs`, sc-5891) to avoid a keychain prompt at every launch. The file store remains the headless/Docker substitute for a keychain.

## Testing

`npm run rust:check` green on this base — **3290 passed, 0 failed** — plus `check-compose-config.mjs`, `check-runpod-supervisor.sh`, and the new sc-16078 control-byte gate.

New coverage:
- precedence incl. blank-env fall-through and the no-home fallback
- migration moves the store **and removes the plaintext original**; re-running is a no-op
- migrating a directory onto itself does not delete the store
- both-present leaves each store untouched
- a corrupt legacy store errors, is left in place, and writes nothing to the new path
- worker finds the pre-migration file, and prefers the new one when both exist
- the API route writes to the credentials dir and creates nothing in the config dir

Two test-harness notes: `check-runpod-supervisor.sh` now records the credentials dir in its `api:paths:` event so resolution is asserted, and the cases that isolate to temp dirs override the new path exactly as they already override `DATA`/`CONFIG` (the default derives from `SCENEWORKS_VOLUME`, same as `SCENEWORKS_DATA_DIR`). `check-compose-config.mjs` now asserts the mount exists, is writable, and has a source outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)