### PR TITLE
feat(web): show the live denoise preview in WorkerProgressCard (sc-16905)

### DIFF
--- a/apps/web/src/components/WorkerProgressCard.jsx
+++ b/apps/web/src/components/WorkerProgressCard.jsx
@@ -240,6 +240,30 @@ function ProgressBar({ status, progress }) {
 // ships interimAssets is just empty.
 const THUMBNAIL_VARIANTS = new Set(["image-grid", "video-player", "audio-player", "small-row", "hidden"]);
 
+// Live denoise preview (epic 16624, sc-16905). Image workers stream a single latent-resolution
+// frame of the developing render as `result.previewFrame` (sc-16904: `{imageIndex, current,
+// total, dataUrl}`, single slot, replaced per progress POST and dropped when the image's final
+// asset lands). Shim it into the sc-2085 interim-thumbnail seam so every screen that renders this
+// card gets the live preview without threading a prop. The stable id keeps the grid cell in place
+// across frames (the <img> src just updates), and can never collide with a real asset id, so the
+// finals-supersede-interims dedupe in mergeThumbnails is untouched. Terminal jobs never show a
+// frame even if a stale one survived in the record (e.g. a failure between POSTs). Engines that
+// don't emit previews simply never produce the field — the card looks exactly as before.
+export function livePreviewInterimAssets(job) {
+  const frame = job?.result?.previewFrame;
+  if (!frame?.dataUrl || terminalStatuses.has(job.status)) {
+    return [];
+  }
+  return [
+    {
+      id: "live-denoise-preview",
+      type: "image",
+      url: frame.dataUrl,
+      __interim: true,
+    },
+  ];
+}
+
 function mergeThumbnails(finalAssets, interimAssets) {
   const finalArray = Array.isArray(finalAssets) ? finalAssets : [];
   const interimArray = Array.isArray(interimAssets) ? interimAssets : [];
@@ -737,7 +761,7 @@ export function WorkerProgressCard({
         variant={thumbnailsVariant}
         finalAssets={thumbnailAssets}
         thumbnailGroups={thumbnailGroups}
-        interimAssets={interimThumbnailAssets}
+        interimAssets={interimThumbnailAssets ?? livePreviewInterimAssets(job)}
         onThumbnailClick={onThumbnailClick}
         isRunning={!isTerminal}
         expectedCount={expectedThumbnailCount}

--- a/apps/web/src/components/WorkerProgressCard.test.jsx
+++ b/apps/web/src/components/WorkerProgressCard.test.jsx
@@ -927,3 +927,87 @@ describe("useLiveJobElapsedSeconds keep-alive gating (sc-11961)", () => {
     expect(Number(container.querySelector("[data-testid='elapsed']").textContent)).toBe(8);
   });
 });
+
+// Live denoise preview (epic 16624, sc-16905): the card derives an interim thumbnail from the
+// worker-streamed result.previewFrame slot — no screen threads a prop for it.
+describe("live denoise preview", () => {
+  let api;
+
+  afterEach(() => {
+    api?.cleanup();
+    api = undefined;
+  });
+
+  const DATA_URL = "data:image/jpeg;base64,QUJD";
+  const previewJob = (status) => ({
+    id: "job-preview",
+    type: "image_generate",
+    status,
+    progress: 0.4,
+    attempts: 1,
+    startedAt: "2026-05-28T12:00:00Z",
+    payload: {},
+    result: { previewFrame: { imageIndex: 0, current: 8, total: 20, dataUrl: DATA_URL } },
+  });
+
+  it("shows the streamed frame as an interim cell while the job runs", () => {
+    api = render(
+      <WorkerProgressCard job={previewJob("running")} thumbnailsVariant="image-grid" />,
+      makeContext([]),
+    );
+    const cell = api.container.querySelector(".worker-progress-card__thumb-cell.interim");
+    expect(cell).not.toBeNull();
+    const img = cell.querySelector("img");
+    expect(img).not.toBeNull();
+    // The data URL must reach the <img> byte-identical: no API prefix, no media
+    // ticket, no thumbnail param (any of those would corrupt the base64 body).
+    expect(img.getAttribute("src")).toBe(DATA_URL);
+  });
+
+  it("never shows a frame on a terminal job, even when one survived in the record", () => {
+    api = render(
+      <WorkerProgressCard job={previewJob("canceled")} thumbnailsVariant="image-grid" />,
+      makeContext([]),
+    );
+    expect(api.container.querySelector(".worker-progress-card__thumb-cell.interim")).toBeNull();
+  });
+
+  it("an explicit interimThumbnailAssets prop keeps precedence over the derived frame", () => {
+    const explicit = [{ id: "explicit-1", type: "image", url: "/api/v1/files/e-1.png", __interim: true }];
+    api = render(
+      <WorkerProgressCard
+        job={previewJob("running")}
+        thumbnailsVariant="image-grid"
+        interimThumbnailAssets={explicit}
+      />,
+      makeContext([]),
+    );
+    const cells = api.container.querySelectorAll(".worker-progress-card__thumb-cell.interim");
+    expect(cells).toHaveLength(1);
+    expect(cells[0].querySelector("img")?.getAttribute("src") ?? "").not.toBe(DATA_URL);
+  });
+
+  it("final assets render alongside the live frame without colliding", () => {
+    const job = previewJob("running");
+    api = render(
+      <WorkerProgressCard
+        job={job}
+        thumbnailsVariant="image-grid"
+        thumbnailAssets={[{ id: "a-1", type: "image", url: "/api/v1/files/a-1.png" }]}
+      />,
+      makeContext([]),
+    );
+    const cells = api.container.querySelectorAll(".worker-progress-card__thumb-cell:not(.skeleton)");
+    expect(cells).toHaveLength(2);
+    expect(api.container.querySelectorAll(".worker-progress-card__thumb-cell.interim")).toHaveLength(1);
+  });
+
+  it("renders nothing extra for jobs without a streamed frame", () => {
+    const job = { ...previewJob("running"), result: {} };
+    api = render(
+      <WorkerProgressCard job={job} thumbnailsVariant="image-grid" />,
+      makeContext([]),
+    );
+    expect(api.container.querySelector(".worker-progress-card__thumb-cell.interim")).toBeNull();
+  });
+});

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -5,6 +5,12 @@ import { API_BASE_URL, withMediaTicket } from "../api.js";
 // ticket (sc-8810) exactly once, and posterUrl can swap the file extension before
 // the query string exists.
 function bareAssetUrl(asset) {
+  // Inline payloads (the live denoise preview frame, sc-16905) are complete URLs already:
+  // no API prefix, and downstream no ticket or thumbnail params — appending either would
+  // corrupt the base64 body.
+  if (asset?.url?.startsWith("data:")) {
+    return asset.url;
+  }
   if (asset?.url) {
     return API_BASE_URL + asset.url;
   }
@@ -24,7 +30,8 @@ function bareAssetUrl(asset) {
 // media ticket so element-driven requests (<img>/<video>/<a download>) — which
 // cannot send the token header — still authenticate (sc-8810).
 export function assetUrl(asset) {
-  return withMediaTicket(bareAssetUrl(asset));
+  const bare = bareAssetUrl(asset);
+  return bare.startsWith("data:") ? bare : withMediaTicket(bare);
 }
 
 // Grid thumbnails use one bounded, server-cached representation. The API
@@ -37,6 +44,9 @@ export const ASSET_THUMBNAIL_SIZE = 384;
 function withThumbnailRequest(url) {
   if (!url) {
     return "";
+  }
+  if (url.startsWith("data:")) {
+    return url;
   }
   const thumbnail = new URL(url);
   thumbnail.searchParams.set("thumbnail", String(ASSET_THUMBNAIL_SIZE));

--- a/apps/web/src/components/assetMedia.test.jsx
+++ b/apps/web/src/components/assetMedia.test.jsx
@@ -1,7 +1,7 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { AssetMedia, AssetThumbnail, MissingMedia, posterUrl, thumbnailUrl } from "./assetMedia.jsx";
+import { AssetMedia, AssetThumbnail, MissingMedia, assetUrl, posterUrl, thumbnailUrl } from "./assetMedia.jsx";
 
 const imageAsset = {
   id: "img",
@@ -192,5 +192,20 @@ describe("posterUrl poster-existence gating (sc-10468)", () => {
       projectId: "p1",
     };
     expect(posterUrl(asset)).toContain(".poster.jpg");
+  });
+});
+
+// Live denoise preview frames (sc-16905) arrive as complete data: URLs. Every URL producer must
+// pass them through byte-identical — an API prefix, media ticket, or thumbnail param anywhere in
+// the chain corrupts the base64 body.
+describe("data URL passthrough", () => {
+  const asset = { id: "live-denoise-preview", type: "image", url: "data:image/jpeg;base64,QUJD", __interim: true };
+
+  it("assetUrl returns the data URL unchanged", () => {
+    expect(assetUrl(asset)).toBe(asset.url);
+  });
+
+  it("thumbnailUrl returns the data URL unchanged (no thumbnail param, no ticket)", () => {
+    expect(thumbnailUrl(asset)).toBe(asset.url);
   });
 });

--- a/docs/design/worker-progress-card.md
+++ b/docs/design/worker-progress-card.md
@@ -151,7 +151,7 @@ Existing test coverage:
 - `apps/web/src/main.test.jsx::reconstructs running image batch slots from partial asset records`
 - `apps/web/src/main.test.jsx::shows active training progress with live sample previews`
 
-A separate "per-denoising-step preview of a single image" (showing the partial latent at step N before the full image is saved) is **not** in scope. If we want that later it needs a decode-latent-to-jpeg call inside the diffusion loop and a transient storage slot — that's a polish slice for a future story, not part of sc-2085.
+**Per-denoising-step preview** (epic 16624, sc-16904/sc-16905 — the "later" this section used to defer): the engine projects the developing latent to a small RGB frame each step (gen-core `PreviewSink`, a cheap linear latent→RGB approximation, not a VAE decode), and the worker rides the latest frame on the existing per-step progress POST as `result.previewFrame` `{imageIndex, current, total, dataUrl}` — a single ~10 KB `data:image/jpeg` slot, replaced each tick and dropped when the image's final asset lands, so there is no file lifecycle. The card shims it into the sc-2085 interim seam itself (`livePreviewInterimAssets`), so every render site shows the live preview with no per-screen wiring; the interim cell's `dataUrl` updates in place under a stable key. Engines that don't emit (the candle lane today) never produce the field and the card is unchanged. Terminal jobs never show a frame even if a stale one survived in the snapshot.
 
 ## Job Title rules
 


### PR DESCRIPTION
Shortcut: [sc-16905](https://app.shortcut.com/trefry/story/16905) (epic 16624). **Stacked on the sc-16904 worker PR** — retarget as the stack merges.

## What

Feeds the sc-2085 interim-thumbnail seam — wired since that story but never fed by any producer — from the worker's streamed `result.previewFrame` slot. The card derives the interim asset itself from the `job` prop (`livePreviewInterimAssets`), so **every screen that renders the card gets the live preview with zero per-screen wiring**; an explicitly passed `interimThumbnailAssets` prop keeps precedence. Stable cell id ⇒ the `<img>` updates in place each frame; the finals-supersede-interims merge is untouched; terminal jobs never show a frame even when a stale one survived the snapshot.

`assetMedia` passes `data:` URLs through byte-identical — the API prefix, media ticket, and thumbnail derivative param would each corrupt the base64 body.

The design doc's "per-step preview not in scope" section is rewritten to document the shipped mechanism.

## Verified

- Live in the browser against a real MLX Krea render: the Queue card showed the developing frame (noise → warm tones as steps advanced) and the final asset replaced it at completion.
- 7 new vitest cases (derivation, terminal suppression, prop precedence, final coexistence, data-URL passthrough); full web suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)