### PR TITLE
fix(api): let SCAIL-2 animate_character reach the queue (sc-17009)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -4118,6 +4118,13 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
         // and ads2v (source video + reference video + reference images).
         "multi_video_to_video",
         "ads2v",
+        // SCAIL-2 standalone character animation (sc-5448 / sc-5449, epic 5439): reference
+        // character image + driving video → animated clip. It was wired end-to-end — catalog
+        // `capabilities`, `VIDEO_UI_MODES`, `video_mode_is_mlx_eligible`, the candle claim gate,
+        // the worker's `generate_scail2` — and offered in the Video Studio, but never added
+        // HERE, so every submission 400'd on "Unsupported video mode" and the mode was
+        // unreachable from the moment it shipped (GH #2074).
+        "animate_character",
     ]
     .contains(&payload.mode.as_str())
     {
@@ -4241,6 +4248,21 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
         "ads2v" if payload.reference_asset_ids.is_empty() => Err(ApiError::bad_request(
             "Source + Reference Video requires at least one reference image.",
         )),
+        // SCAIL-2 standalone character animation (sc-5449): the same required-media contract the
+        // worker's `resolve_scail2_conditioning` enforces — the character is `referenceAssetIds[0]`
+        // (preferred) or the i2v `sourceAssetId`, and the motion comes from `sourceClipAssetId`.
+        // Both are hard engine inputs (`Reference` + `ControlClip`), so a missing one is a rejected
+        // enqueue rather than a job that fails minutes later inside the worker.
+        "animate_character" if payload.source_clip_asset_id.is_none() => Err(
+            ApiError::bad_request("Animate Character requires a driving video."),
+        ),
+        "animate_character"
+            if payload.reference_asset_ids.is_empty() && payload.source_asset_id.is_none() =>
+        {
+            Err(ApiError::bad_request(
+                "Animate Character requires a reference character image.",
+            ))
+        }
         _ => Ok(()),
     }
 }

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -3745,6 +3745,113 @@ async fn bernini_video_modes_validate_required_media() {
     assert_eq!(ads2v_job["payload"]["referenceAssetIds"][0], "ref-1");
 }
 
+/// SCAIL-2 standalone character animation reaches the queue (GH #2074). `animate_character` was
+/// wired everywhere BUT this route's mode allow-list — catalog `capabilities`, `VIDEO_UI_MODES`,
+/// `video_mode_is_mlx_eligible`, the candle claim gate, the worker's `generate_scail2`, and the
+/// Video Studio mode picker all shipped it (sc-5448 / sc-5449), so the studio offered a mode the
+/// API answered with 400 "Unsupported video mode". The declaration being correct in every OTHER
+/// layer is exactly why nothing caught it; this test pins REACHABILITY, not declaration.
+///
+/// It also pins the required-media contract, which mirrors the worker's
+/// `resolve_scail2_conditioning`: a driving clip plus a character image (`referenceAssetIds[0]`
+/// preferred, `sourceAssetId` accepted) — both hard engine inputs, so an incomplete request is
+/// refused at enqueue instead of failing minutes into the render.
+#[tokio::test]
+async fn scail2_animate_character_reaches_the_queue_and_validates_media() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "SCAIL-2" }),
+    )
+    .await;
+
+    // The regression itself: a complete request is ACCEPTED, not "Unsupported video mode".
+    let (status, animate_job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "scail2_14b",
+            "mode": "animate_character",
+            "prompt": "the character dances",
+            "sourceClipAssetId": "clip-driving",
+            "referenceAssetIds": ["ref-character"]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    // The base video type, which is what `video_job_is_mlx_eligible` gates on for this mode.
+    assert_eq!(animate_job["type"], "video_generate");
+    assert_eq!(animate_job["payload"]["mode"], "animate_character");
+    assert_eq!(animate_job["payload"]["sourceClipAssetId"], "clip-driving");
+    assert_eq!(
+        animate_job["payload"]["referenceAssetIds"][0],
+        "ref-character"
+    );
+
+    // The worker also accepts the i2v `sourceAssetId` as the character.
+    let (status, source_asset_job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "scail2_14b",
+            "mode": "animate_character",
+            "prompt": "the character dances",
+            "sourceClipAssetId": "clip-driving",
+            "sourceAssetId": "ref-character"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(
+        source_asset_job["payload"]["sourceAssetId"],
+        "ref-character"
+    );
+
+    // No driving video, and no character image: each is refused on its own.
+    let incomplete = [
+        json!({ "referenceAssetIds": ["ref-character"] }),
+        json!({ "sourceClipAssetId": "clip-driving" }),
+    ];
+    for extra in incomplete {
+        let mut body = json!({
+            "projectId": "project-1",
+            "model": "scail2_14b",
+            "mode": "animate_character",
+            "prompt": "the character dances"
+        });
+        let object = body.as_object_mut().unwrap();
+        for (key, value) in extra.as_object().unwrap() {
+            object.insert(key.clone(), value.clone());
+        }
+        let (status, _) = request(app.clone(), "POST", "/api/v1/video/jobs", body).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    // An unknown mode still 400s — the allow-list widened by exactly one entry.
+    let (status, _) = request(
+        app,
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "scail2_14b",
+            "mode": "animate_creature",
+            "prompt": "the character dances",
+            "sourceClipAssetId": "clip-driving",
+            "referenceAssetIds": ["ref-character"]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
 #[tokio::test]
 async fn person_tracking_routes_match_contracts() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");


### PR DESCRIPTION
Fixes https://github.com/SceneWorks/SceneWorks/issues/2074 · [sc-17009](https://app.shortcut.com/trefry/story/17009)

## The bug

`validate_video_job` opens with a hard-coded array of video modes and 400s anything not in it. `animate_character` was never added, so every SCAIL-2 **Animate character** submission was answered with `Unsupported video mode` before preset expansion, before the manifest entry resolved, before the job was stored.

The mode was wired correctly in every other layer when it shipped on 2026-06-14:

| Layer | Status |
| --- | --- |
| `builtin.models.jsonc` → `scail2_14b.capabilities` | ✅ sc-5447 |
| `VIDEO_UI_MODES` (`routing/catalog.rs`) | ✅ sc-5448 |
| `video_mode_is_mlx_eligible` (`routing/mlx.rs`) | ✅ sc-5448 |
| candle claim gate (`routing/candle.rs`) | ✅ sc-6837 |
| worker dispatch → `generate_scail2` | ✅ sc-5448 |
| Video Studio mode / slots / payload | ✅ sc-5449 |
| **this route's allow-list** | ❌ **never added** |

`git log -L` on the list confirms it changed exactly twice since the original port — sc-4703 (Bernini editing modes) and sc-5425 (mv2v/ads2v) — and neither touched SCAIL-2. So the studio has been offering a mode the API refuses, and the standalone animate flow has been unreachable since the day it shipped. Cross-identity `replace_person` on SCAIL-2 was unaffected because that mode predates the list.

## The change

1. `animate_character` added to the allow-list.
2. Per-mode required-media guards mirroring the worker's `resolve_scail2_conditioning` — a driving clip (`sourceClipAssetId`) plus a character image (`referenceAssetIds[0]` preferred, `sourceAssetId` accepted). Both are hard engine inputs (`Reference` + `ControlClip`), so an incomplete request is refused at enqueue instead of failing minutes into a render. Same shape every other conditioned video mode already has.
3. `scail2_animate_character_reaches_the_queue_and_validates_media` — POSTs to `/api/v1/video/jobs` and asserts 201 plus a `video_generate` job (the type `video_job_is_mlx_eligible` gates on for this mode), each incomplete variant 400s, and an unknown mode still 400s.

No worker, routing, manifest, or web change — the rest of the path was already correct.

## Why the test is shaped this way

It pins **reachability**, not declaration. A test asserting `animate_character ∈ VIDEO_UI_MODES`, or that the manifest declares the capability, would have passed throughout the entire outage — that is precisely why six correct layers didn't catch one missing one. sc-5450 ("MLX-only validation — routing/manifest/contract tests") validated routing and manifest, not the route.

Mutation-checked: with the allow-list entry reverted the test fails `left: 400, right: 201` — the exact symptom in the issue.

## Verification

- `cargo test` (workspace): **3298 passed, 0 failed**
- `cargo fmt --all -- --check`: clean
- `npm run check:rust-derived-docs`: clean

⚠️ `cargo clippy --all-targets -- -D warnings` fails on `apply_candle_qwen_load_shape is never used` (`crates/sceneworks-worker/src/image_jobs/base.rs:3046`). **Pre-existing and unrelated** — every caller is behind `backend-candle`, so the fn is dead on a plain macOS build. Verified by running the same command against a clean tree with zero changes: identical failure, exit 101. Arrived with `d26d818b feat(memory): integrate Qwen CUDA ladder`. Deliberately not fixed here to keep this PR scoped; flagged for a separate story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)