### PR TITLE
chore(security): clear brace-expansion DoS alerts and add bounded Dependabot lanes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,13 @@
 # Keeps the SHA-pinned GitHub Actions in .github/workflows/ fresh (sc-8801).
 # Dependabot rewrites the pinned commit SHA and its trailing `# vX.Y.Z` comment
 # when upstream publishes a new release.
+#
+# The npm and cargo lanes below are VERSION updates only. Dependabot security
+# updates are a separate repo-level setting and already cover every ecosystem in
+# the dependency graph; these lanes exist so Cargo.lock and the two npm lockfiles
+# drift forward deliberately instead of only when unrelated work happens to touch
+# them. Each lane is grouped into a single PR and capped at 2 open PRs to keep the
+# review queue bounded, and restricted to minor/patch so major bumps stay manual.
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -11,3 +18,57 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/apps/web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      web-npm:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  - package-ecosystem: "npm"
+    directory: "/apps/desktop"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      desktop-npm:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
+  # Root workspace Cargo.toml / Cargo.lock covers apps/* and crates/*. Majors are
+  # ignored here because engine pins (mlx-rs, candle, tauri) need the full
+  # rust:check + :neither + :candle sweep, which a bot PR cannot self-serve.
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      cargo:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1349,9 +1349,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What does this PR do?

Clears the one actionable open Dependabot alert and closes the gap that let it sit unactioned.

**1. `brace-expansion` 1.1.15 → 1.1.18** (`apps/web/package-lock.json`)

Resolves alert [#5](https://github.com/SceneWorks/SceneWorks/security/dependabot/5) (`GHSA-3jxr-9vmj-r5cp`, exponential-time expansion DoS) and the auto-dismissed [#8](https://github.com/SceneWorks/SceneWorks/security/dependabot/8) (`GHSA-mh99-v99m-4gvg`, unbounded-expansion OOM).

Dev-only, reached solely via `eslint` / `@eslint/config-array` / `@eslint/eslintrc` / `eslint-plugin-react` → `minimatch@3.1.5` → `brace-expansion`. Never in the shipped bundle. 1.1.18 stays inside minimatch's `^1.1.7` range, so this is a lockfile-only change — `package.json` is untouched and exactly one package moves.

**2. Bounded npm + cargo Dependabot version-update lanes** (`.github/dependabot.yml`)

Dependabot *security* updates are already enabled repo-wide (`{"enabled":true,"paused":false}`), but the only *version*-update lane configured was `github-actions`. `Cargo.lock` and the two npm lockfiles therefore only moved forward when unrelated work happened to touch them.

Adds weekly lanes for `/apps/web`, `/apps/desktop`, and the root cargo workspace. Each is grouped into a single PR, capped at 2 open PRs, and restricted to minor/patch — majors stay manual because engine pins (mlx-rs, candle, tauri) need the full `rust:check` + `:neither` + `:candle` sweep a bot PR cannot self-serve.

### Reviewer note

`main` has no required status checks, so a grouped dependency PR can merge red. The grouping and PR cap bound the volume, but review discipline is what actually gates these. If that trade isn't worth it, the cargo lane is a contiguous block to delete.

### The other two alerts are not fixable and are not touched here

- **[#9](https://github.com/SceneWorks/SceneWorks/security/dependabot/9) `glib` 0.18.5** — patched version is 0.20, but `gtk 0.18.2` requires `glib ^0.18` and the gtk3 crate is EOL at 0.18.2. Pinned by `tauri 2.11.2`. Confirmed Linux-desktop-only: `cargo tree -i glib` resolves on `x86_64-unknown-linux-gnu` and finds nothing on `aarch64-apple-darwin`; `rust-api` and `rust-worker` never link it. Local NULL-deref crash in GTK paths, no CVE, CVSS 0.
- **[#11](https://github.com/SceneWorks/SceneWorks/security/dependabot/11) `thrift` 0.17.0** — every `parquet` release through 57.0.0 declares `thrift ^0.17` non-optionally (verified against the crates.io API); patched thrift 0.23/0.24 are semver-incompatible for a 0.x crate, so no `cargo update` reaches them. Reached via `parquet 53.4` in the worker's catalog scanner, parsing operator-selected local `.parquet` files. CVSS 5.3, availability only.

Both should be dismissed as `tolerable_risk` with the upstream reasoning, and revisited when Tauri moves to gtk4 / parquet drops `^0.17`.

## Related issue

No tracked issue — this originated from a review of the Dependabot alert queue.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [x] Refactor / chore (no user-facing behavior change)

## How was this tested?

- [ ] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (web UI, docs, shared crate)

Run on macOS (Apple Silicon):

- `npm --prefix apps/web ci` → installed `brace-expansion` confirmed at 1.1.18, `npm audit` reports **0 vulnerabilities** (was 1 high)
- `npm --prefix apps/web run lint` → exit 0
- `npm --prefix apps/web run test` → **236 files / 3502 tests passed**
- `npm --prefix apps/web run build` → built clean
- `npm run check` → exit 0, **207 tests passed** (includes `check-action-pins.mjs` and `check-scaffold.mjs`)
- `.github/dependabot.yml` parsed and the four lanes asserted

No Rust source changed, so `rust:check` is not applicable.

## Checklist

- [ ] I ran `npm run rust:check` (if I touched Rust) and it passed — n/a, no Rust source touched
- [x] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build` (if I touched the web app)
- [x] I ran `npm run check` (scaffold checks)
- [ ] I updated documentation where relevant — n/a
- [ ] All my commits are signed off (`git commit -s`) — **not signed off.** DCO is a provenance certification the author has to make; no CI gate enforces it and no commit on `main` carries one. Run `git rebase --signoff origin/main` before merge if you want them.
- [x] My PR is focused on a single logical change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
