### PR TITLE
fix(runpod): make the entrypoint bash-3.2-clean so the supervisor check works on macOS

### DIFF
--- a/docker/runpod-entrypoint.sh
+++ b/docker/runpod-entrypoint.sh
@@ -69,7 +69,10 @@ ensure_writable_dir() {
 
 effective_api_host() {
   local host
-  if [[ -v SCENEWORKS_API_HOST ]]; then
+  # `${X+x}` rather than `[[ -v X ]]`: identical semantics for a scalar, but parses
+  # under bash 3.2, so scripts/check-runpod-supervisor.sh can exercise this
+  # entrypoint directly on a developer's Mac and not only inside the Linux image.
+  if [[ -n "${SCENEWORKS_API_HOST+x}" ]]; then
     host="$(trim_whitespace "${SCENEWORKS_API_HOST}")"
     # Match the API's env_string fallback for an explicitly blank value.
     [[ -n "${host}" ]] || host="127.0.0.1"

--- a/scripts/check-shell-scripts.mjs
+++ b/scripts/check-shell-scripts.mjs
@@ -17,13 +17,19 @@
 //  2. A scan for bash-4-only constructs. This is the part no `bash -n` can do in CI: on
 //     ubuntu a bash-4 idiom parses cleanly and then explodes on a Mac.
 //
-// SCRIPTS ARE CLASSIFIED BY WHERE THEY RUN, because a single rule cannot be right for
-// both. `docker/runpod-entrypoint.sh` legitimately uses `[[ -v VAR ]]` (bash 4.2): it only
-// ever executes inside a Linux container whose bash is 5.x. Holding it to 3.2 would be a
-// false positive, while holding scripts/*.sh to 5.x would miss the real thing. Worse, a
-// naive `bash -n` is PLATFORM-DEPENDENT — run on a Mac it rejects that container script,
-// run on CI's ubuntu it accepts a bash-4 idiom in a macOS-only script. Both directions are
-// wrong, so the classification below is what makes the gate mean the same thing anywhere.
+// SCRIPTS ARE CLASSIFIED BY WHERE THEY RUN, via LINUX_ONLY below, because a naive
+// `bash -n` is PLATFORM-DEPENDENT: run on a Mac it rejects a container-only script using
+// bash-4 syntax, run on CI's ubuntu it accepts a bash-4 idiom in a macOS-only script. Both
+// directions are wrong, so the classification is what makes the gate mean the same thing
+// anywhere. LINUX_ONLY is currently EMPTY — every tracked script is held to bash 3.2 — but
+// the mechanism stays for the next genuinely container-only script.
+//
+// `docker/runpod-entrypoint.sh` was the original exemption, on the stated grounds that it
+// only ever executes inside a Linux container whose bash is 5.x. That was not true: this
+// repo's own scripts/check-runpod-supervisor.sh executes it directly to assert its
+// fail-closed behavior, so on macOS its one `[[ -v ]]` was a syntax error and the supervisor
+// self-test reported a bogus assertion failure (`status was 2, expected 1`) on every Mac.
+// It is now 3.2-clean and scanned like everything else.
 //
 // DISCOVERY IS EXTENSION-BASED: `git ls-files '*.sh'`. A shell script without a `.sh`
 // extension (or an inline `run:` block in a workflow) is out of scope and unchecked. That
@@ -123,12 +129,15 @@ const BASH4_ONLY = [
 // Scripts that only ever run inside a Linux container (bash 5.x) and are therefore exempt
 // from the bash-3.2 portability scan. Everything else is treated as portable: the scripts/
 // directory is developer- and CI-facing on both macOS and Linux, and setup-nax-runner.sh is
-// macOS-only by definition. Keep this list minimal and justified — an entry here is an
-// assertion that no Mac ever sources the file.
-const LINUX_ONLY = new Set([
-  // Executed as the RunPod image entrypoint; never run on a developer's Mac.
-  "docker/runpod-entrypoint.sh",
-]);
+// macOS-only by definition.
+//
+// DELIBERATELY EMPTY. An entry here asserts that no Mac ever runs the file — and note that
+// "it ships in a Linux image" is not sufficient grounds, because a check in this repo may
+// execute it on a developer's machine to test it (see the runpod-entrypoint.sh history in the
+// header). Before adding one, grep for the script under scripts/ and .github/. Prefer making
+// a script 3.2-clean: the fix is usually `${X+x}` for `[[ -v X ]]`, and an exempt script is
+// one nobody can syntax-check locally.
+const LINUX_ONLY = new Set([]);
 
 function bashMajorOf(binary) {
   const result = spawnSync(binary, ["-c", "echo $BASH_VERSINFO"], { encoding: "utf8" });


### PR DESCRIPTION
## What does this PR do?

`docker/runpod-entrypoint.sh` used `[[ -v SCENEWORKS_API_HOST ]]`, which is bash 4.2+. macOS ships bash 3.2.57 as `/bin/bash`, where `[[ -v ]]` is a **syntax error** rather than an unsupported test — so the script died at parse time with status 2.

`scripts/check-runpod-supervisor.sh` executes the entrypoint directly to assert its fail-closed auth/storage preflight. On any Mac that produced a misleading failure:

```
runpod supervisor self-test failed: public-v4-missing status was 2, expected 1
```

The harness reported a broken *security assertion* when the actual cause was the interpreter. Net effect: `npm run check:docker:runpod:supervisor` gave no local signal on every Apple-Silicon machine, and the failure it did give pointed at the wrong thing.

This is not a production bug. The entrypoint only ever runs inside the RunPod Linux image, where bash is 5.x. It is a coverage and developer-experience gap.

### Why the `LINUX_ONLY` exemption goes away too

`scripts/check-shell-scripts.mjs` (added in #2087) exempted this entrypoint from its bash-3.2 portability scan, on the stated grounds that it *"never runs on a developer's Mac."* That premise was not true — this repo's own supervisor check runs it there. Shipping only inside a Linux image is not sufficient grounds for the exemption; the **test** surface matters too.

So the two changes are one change: making the entrypoint 3.2-clean is what lets the exemption be retired, and retiring the exemption is what keeps it that way. They are deliberately in a single commit — split across two, the exemption removal would red-line CI until the entrypoint fix landed.

Worth knowing for reviewers: `main` today is the worst of both configurations. CI is **green** precisely *because* the exemption suppresses the entrypoint scan, while the supervisor check fails for every Mac developer. The passing checkmark conceals it. The gate's own `staleExemptions` guard does not catch this class either — it only fires when an exempt path matches no tracked file, so a no-longer-necessary exemption on a file that still exists sits silent.

## Changes Made

- **`docker/runpod-entrypoint.sh`** — `[[ -v X ]]` → `[[ -n "${X+x}" ]]`. Exactly equivalent for a scalar, and it preserves the unset/set-but-blank distinction `effective_api_host()` turns on: unset still means the Dockerfile's `0.0.0.0` production posture, explicitly blank still falls back to `127.0.0.1` to match the API's `env_string` behavior.
- **`scripts/check-shell-scripts.mjs`** — `LINUX_ONLY` is now empty; all 4 tracked `*.sh` are held to bash-3.2 portability (was 3 of 4).
- **`scripts/check-shell-scripts.mjs`** — rewrote the two comment blocks that justified the exemption, since both went stale. The new guidance records *why* the original premise was wrong, so the next person doesn't re-add an entry on the same reasoning. The mechanism is kept for a future genuinely container-only script.

No behavior change inside the container: bash 5.x evaluates both forms identically.

## Related

Follows up #2087, which introduced the shell gate and the exemption this removes. No Shortcut story — found while running the repo's checks on macOS.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

All on bash 3.2.57(1)-release (arm64-apple-darwin25) — the interpreter that exposed the bug.

- [x] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [ ] Not platform-specific (web UI, docs, shared crate)

| Check | Result |
| --- | --- |
| `npm run check:docker:runpod:supervisor` | **passes** (fails on `main` at the first assertion) |
| `npm run check:shell` | 4 scripts, **4/4** held to bash-3.2, 0 container-only |
| `npm run check:shell:self-test` | 8 positive, 16 negative, 1 mixed |
| `npm run check` | passes — 207 tests, 0 failures |

Behavior-preservation checks, done by hand because **the harness sets `SCENEWORKS_API_HOST` in every case** and so covers neither branch of the function I changed:

- unset `SCENEWORKS_API_HOST` → resolves `0.0.0.0` → refuses the bind without a token (production posture intact)
- `SCENEWORKS_API_HOST=` (explicitly blank) → resolves `127.0.0.1` → no refusal

Negative control, to confirm the gate now has teeth rather than just passing: restoring the old `[[ -v ]]` line with the exemption removed fails **three** independent ways — ambient `bash -n`, legacy `/bin/bash -n`, and the idiom scan.

**Not executed:** the RunPod container itself. The entrypoint's Linux path is unexercised here; the argument for it is that bash 5.x treats `[[ -v X ]]` and `[[ -n "${X+x}" ]]` identically for a scalar, not that I ran the image.

## Checklist

- [x] I ran `npm run check` (scaffold checks)
- [x] I updated documentation where relevant — the gate's own comments; no external docs describe this exemption
- [x] All my commits are signed off
- [x] My PR is focused on a single logical change
- [ ] ~~`npm run rust:check`~~ — no Rust touched
- [ ] ~~web app lint/test/build~~ — no web app changes
