### PR TITLE
fix(runpod): make the entrypoint bash-3.2-clean, retire the LINUX_ONLY exemption

### DIFF
--- a/docker/runpod-entrypoint.sh
+++ b/docker/runpod-entrypoint.sh
@@ -69,7 +69,10 @@ ensure_writable_dir() {
 
 effective_api_host() {
   local host
-  if [[ -v SCENEWORKS_API_HOST ]]; then
+  # `${X+x}` rather than `[[ -v X ]]`: identical semantics for a scalar, but parses
+  # under bash 3.2, so scripts/check-runpod-supervisor.sh can exercise this
+  # entrypoint directly on a developer's Mac and not only inside the Linux image.
+  if [[ -n "${SCENEWORKS_API_HOST+x}" ]]; then
     host="$(trim_whitespace "${SCENEWORKS_API_HOST}")"
     # Match the API's env_string fallback for an explicitly blank value.
     [[ -n "${host}" ]] || host="127.0.0.1"

--- a/docs/rust-mlx-build.md
+++ b/docs/rust-mlx-build.md
@@ -94,11 +94,14 @@ in the pool can therefore hold different subsets. Keep track of which holds what
 | Box | Qwen tiers | Z-Image |
 | --- | --- | --- |
 | `nax-macos` | bf16, q4, q8 | q4 (plus the inference `real-weights` set) |
-| `nax-macos-2` | bf16 | q4 |
+| `nax-macos-2` | bf16, q4, q8 | q4 |
 
-A `qwen_tier: q4`/`q8` dispatch that lands on a box holding only `bf16` needs
-`provision_qwen_snapshot: true`, or pre-seed the missing tiers first (`q4` 26.4 GiB,
-`q8` 35.9 GiB).
+Both boxes currently hold every tier at revision `8080a417…` (Qwen) / `bb2bc989…`
+(Z-Image), so any `qwen_tier` dispatch resolves on either. That symmetry is a property of
+the current pool, not a guarantee — a box seeded with only the `bf16` default would fail a
+`q4`/`q8` dispatch at resolve unless it passed `provision_qwen_snapshot: true`. Sizes if
+you need to seed a new box: `bf16` 53.8 GiB, `q4` 26.4 GiB, `q8` 35.9 GiB, Z-Image `q4`
+5.5 GiB.
 
 This is why `release.yml` pins on `signing` rather than plain `nax`: it is tag-triggered
 with `cancel-in-progress: false`, so scheduling it onto an unsigned box means a broken

--- a/scripts/check-shell-scripts.mjs
+++ b/scripts/check-shell-scripts.mjs
@@ -17,13 +17,19 @@
 //  2. A scan for bash-4-only constructs. This is the part no `bash -n` can do in CI: on
 //     ubuntu a bash-4 idiom parses cleanly and then explodes on a Mac.
 //
-// SCRIPTS ARE CLASSIFIED BY WHERE THEY RUN, because a single rule cannot be right for
-// both. `docker/runpod-entrypoint.sh` legitimately uses `[[ -v VAR ]]` (bash 4.2): it only
-// ever executes inside a Linux container whose bash is 5.x. Holding it to 3.2 would be a
-// false positive, while holding scripts/*.sh to 5.x would miss the real thing. Worse, a
-// naive `bash -n` is PLATFORM-DEPENDENT — run on a Mac it rejects that container script,
-// run on CI's ubuntu it accepts a bash-4 idiom in a macOS-only script. Both directions are
-// wrong, so the classification below is what makes the gate mean the same thing anywhere.
+// SCRIPTS ARE CLASSIFIED BY WHERE THEY RUN, via LINUX_ONLY below, because a naive
+// `bash -n` is PLATFORM-DEPENDENT: run on a Mac it rejects a container-only script using
+// bash-4 syntax, run on CI's ubuntu it accepts a bash-4 idiom in a macOS-only script. Both
+// directions are wrong, so the classification is what makes the gate mean the same thing
+// anywhere. LINUX_ONLY is currently EMPTY — every tracked script is held to bash 3.2 — but
+// the mechanism stays for the next genuinely container-only script.
+//
+// `docker/runpod-entrypoint.sh` was the original exemption, on the stated grounds that it
+// only ever executes inside a Linux container whose bash is 5.x. That was not true: this
+// repo's own scripts/check-runpod-supervisor.sh executes it directly to assert its
+// fail-closed behavior, so on macOS its one `[[ -v ]]` was a syntax error and the supervisor
+// self-test reported a bogus assertion failure (`status was 2, expected 1`) on every Mac.
+// It is now 3.2-clean and scanned like everything else.
 //
 // DISCOVERY IS EXTENSION-BASED: `git ls-files '*.sh'`. A shell script without a `.sh`
 // extension (or an inline `run:` block in a workflow) is out of scope and unchecked. That
@@ -123,12 +129,15 @@ const BASH4_ONLY = [
 // Scripts that only ever run inside a Linux container (bash 5.x) and are therefore exempt
 // from the bash-3.2 portability scan. Everything else is treated as portable: the scripts/
 // directory is developer- and CI-facing on both macOS and Linux, and setup-nax-runner.sh is
-// macOS-only by definition. Keep this list minimal and justified — an entry here is an
-// assertion that no Mac ever sources the file.
-const LINUX_ONLY = new Set([
-  // Executed as the RunPod image entrypoint; never run on a developer's Mac.
-  "docker/runpod-entrypoint.sh",
-]);
+// macOS-only by definition.
+//
+// DELIBERATELY EMPTY. An entry here asserts that no Mac ever runs the file — and note that
+// "it ships in a Linux image" is not sufficient grounds, because a check in this repo may
+// execute it on a developer's machine to test it (see the runpod-entrypoint.sh history in the
+// header). Before adding one, grep for the script under scripts/ and .github/. Prefer making
+// a script 3.2-clean: the fix is usually `${X+x}` for `[[ -v X ]]`, and an exempt script is
+// one nobody can syntax-check locally.
+const LINUX_ONLY = new Set([]);
 
 function bashMajorOf(binary) {
   const result = spawnSync(binary, ["-c", "echo $BASH_VERSINFO"], { encoding: "utf8" });


### PR DESCRIPTION
Follow-up to #2087. Two small commits.

## 1. The RunPod entrypoint could not be syntax-checked on a Mac

`scripts/check-runpod-supervisor.sh` executes `docker/runpod-entrypoint.sh` directly on the host to assert its fail-closed behavior. That entrypoint used `[[ -v VAR ]]` (bash 4.2), and macOS ships bash 3.2.57 as `/bin/bash`, where that is a **syntax error** — so the entrypoint exited 2 where the assertion expected 1, and the harness reported a misleading failure:

```
runpod supervisor self-test failed: public-v4-missing status was 2, expected 1
```

Not a production bug — the entrypoint only ever runs in the RunPod Linux image, where bash is 5.x. It was a coverage gap: `npm run check:docker:runpod:supervisor` could never pass on half the team's machines, and failed inscrutably rather than saying it was unsupported.

Fixed by making the entrypoint 3.2-clean (`[[ -n "${X+x}" ]]`), which lets the exemption go away entirely rather than papering over it.

**Verified on macOS 26.6 / bash 3.2.57:**

```
SceneWorks RunPod supervisor lifecycle self-test passed.
```

### Why `LINUX_ONLY` is now empty rather than removed

#2087 added `docker/runpod-entrypoint.sh` to that exemption set on the stated grounds that "no Mac ever runs the file." That reasoning was wrong, and the failure above is why: a script can ship in a Linux image and still be *executed on a developer's machine by a check in this repo*. The set is retained but empty, with a comment recording that "it ships in a container" is insufficient grounds for an entry, and that making a script 3.2-clean is preferable — an exempt script is one nobody can syntax-check locally.

The gate now reports `4 scripts; 4 held to bash-3.2 portability, 0 container-only`.

## 2. Pool inventory correction

#2087 recorded `nax-macos-2` as holding Qwen `bf16` only. True when written, not now: `q4` and `q8` have since been seeded at the same revision and verified (no broken symlinks, no `.incomplete` files). Both boxes are now symmetric, so any `qwen_tier` dispatch resolves on either.

The `weights` label was applied to `nax-macos-2` only *after* all three tiers verified, since the label promises a snapshot host and a bf16-only box would accept a `q4`/`q8` dispatch and fail it at resolve.

## Type

Bug Fix + Docs

## Testing

- [x] `bash scripts/check-runpod-supervisor.sh` passes on macOS 26.6 (bash 3.2.57) — previously impossible
- [x] `check:shell` + self-test (8 positive, 16 negative, 1 mixed), with the legacy `/bin/bash` 3.2 parse pass active
- [x] `check-scaffold`, `check-source-control-bytes` (1380 files)
- [ ] Reviewer check: confirm the entrypoint's `${X+x}` rewrite is semantically identical to `[[ -v ]]` for the blank-vs-unset distinction the surrounding code relies on

## Note

Branched fresh off `main` rather than continuing the #2087 branch — that branch predates the squash merge, so a PR from it would have proposed reverting the newer work now on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)