### PR TITLE
docs(runners): nax-macos-2 now holds every Qwen tier, not just the bf16 default

### DIFF
--- a/docs/rust-mlx-build.md
+++ b/docs/rust-mlx-build.md
@@ -94,11 +94,14 @@ in the pool can therefore hold different subsets. Keep track of which holds what
 | Box | Qwen tiers | Z-Image |
 | --- | --- | --- |
 | `nax-macos` | bf16, q4, q8 | q4 (plus the inference `real-weights` set) |
-| `nax-macos-2` | bf16 | q4 |
+| `nax-macos-2` | bf16, q4, q8 | q4 |
 
-A `qwen_tier: q4`/`q8` dispatch that lands on a box holding only `bf16` needs
-`provision_qwen_snapshot: true`, or pre-seed the missing tiers first (`q4` 26.4 GiB,
-`q8` 35.9 GiB).
+Both boxes currently hold every tier at revision `8080a417…` (Qwen) / `bb2bc989…`
+(Z-Image), so any `qwen_tier` dispatch resolves on either. That symmetry is a property of
+the current pool, not a guarantee — a box seeded with only the `bf16` default would fail a
+`q4`/`q8` dispatch at resolve unless it passed `provision_qwen_snapshot: true`. Sizes if
+you need to seed a new box: `bf16` 53.8 GiB, `q4` 26.4 GiB, `q8` 35.9 GiB, Z-Image `q4`
+5.5 GiB.
 
 This is why `release.yml` pins on `signing` rather than plain `nax`: it is tag-triggered
 with `cancel-in-progress: false`, so scheduling it onto an unsigned box means a broken


### PR DESCRIPTION
## Summary

Docs-only. The nax pool's snapshot inventory in `docs/rust-mlx-build.md` (added in #2087) records `nax-macos-2` as holding Qwen `bf16` only. That was accurate when written and is not now — `q4` and `q8` have since been seeded at the same revision.

## Why it matters beyond bookkeeping

The `weights` label promises a *snapshot host*, and the resolve step matches an exact `/snapshots/<40-hex>/<tier>` path. A box holding only `bf16` will accept a `qwen_tier: q4`/`q8` dispatch and then fail it at resolve — after paying the full build. So the inventory is what tells an operator whether a dispatch will land somewhere that can serve it.

`weights` was applied to `nax-macos-2` only once all three tiers verified, for exactly that reason.

## Verified on the box

```
bf16:  54G  broken=0
q4:    26G  broken=0
q8:    36G  broken=0
incomplete files: 0
```

Both boxes are now symmetric, so any `qwen_tier` dispatch resolves on either. Reworded so that reads as a property of the current pool rather than a guarantee, and added per-tier sizes (`bf16` 53.8, `q4` 26.4, `q8` 35.9, Z-Image `q4` 5.5 GiB) so seeding a third box doesn't need a trip to the Hub API.

## Type

Docs

## Testing

- [x] `check-scaffold`, `check-source-control-bytes`

## Note

Split out of a now-closed #2094, which duplicated #2093's fix. This docs change was the only part of it not already covered there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)