### PR TITLE
fix(runners): fail closed on a missing cmake, not just cargo and node

### DIFF
--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -14,7 +14,9 @@ name: macOS MLX worker
 # (the runner reuses its target dir), so MLX compiles once, not every run.
 #
 # Runner prerequisites: macOS >= 26.2, full Xcode + the Metal Toolchain, a Rust
-# toolchain, registered with the `nax` label. See docs/rust-mlx-build.md.
+# toolchain, cmake (MLX builds through CMake — a box without it fails in
+# pmetal-mlx-sys's build script), registered with the `nax` label. See
+# docs/rust-mlx-build.md.
 #
 # SECURITY: this repo is PUBLIC, and GitHub warns against running self-hosted runners
 # for public repos because a fork PR could execute arbitrary code on the runner. The

--- a/docs/rust-mlx-build.md
+++ b/docs/rust-mlx-build.md
@@ -16,6 +16,10 @@ them). Only macOS compiles MLX from source.
 - **Full Xcode + the Metal Toolchain** (`xcode-select -p` must point at Xcode, not
   the Command Line Tools; `xcrun --find metal` must resolve).
 - A recent stable Rust toolchain (`rust-toolchain.toml` pins `stable`).
+- **CMake** (`brew install cmake`). MLX is a CMake project and `pmetal-mlx-sys`'s
+  build.rs invokes `cmake` by name, so without it the build dies at "failed to run
+  custom build command for `pmetal-mlx-sys`" — a message that points at the dependency,
+  not at the missing host tool. No version floor: cmake 4.x builds MLX fine.
 
 ## The deployment-target build seam
 
@@ -63,7 +67,7 @@ schedule onto them by label:
 
 | Label | Consumed by | Requires on the host |
 | --- | --- | --- |
-| `nax` | `macos-mlx.yml` (this repo), `SceneWorks/inference` `ci.yml` | macOS >= 26.2, **Apple M5 or newer**, full Xcode + Metal, Rust |
+| `nax` | `macos-mlx.yml` (this repo), `SceneWorks/inference` `ci.yml` | macOS >= 26.2, **Apple M5 or newer**, full Xcode + Metal, Rust, CMake |
 | `signing` | `release.yml` (this repo) | Developer ID cert in the **login keychain** + notary `.p8` on disk |
 | `weights` | `macos-mlx.yml` `workflow_dispatch` calibration paths | the Qwen / Z-Image calibration snapshots in the local HF cache |
 | `real-weights` | `SceneWorks/inference` `real-weights.yml` (22 jobs, weekly) | the full real-weight snapshot set + runner-local HF auth |
@@ -158,8 +162,8 @@ scripts/setup-nax-runner.sh --check
 ```
 
 That preflights every prerequisite the lane assumes but never verifies (the 26.2 floor,
-Apple silicon, full Xcode + Metal, a Rust toolchain, node >= 20, disk headroom, sleep
-settings, `gh` auth and admin) and changes nothing. Drop `--check` to install:
+Apple silicon, full Xcode + Metal, a Rust toolchain, CMake, node >= 20, disk headroom,
+sleep settings, `gh` auth and admin) and changes nothing. Drop `--check` to install:
 
 ```sh
 scripts/setup-nax-runner.sh
@@ -195,8 +199,15 @@ recovers `PATH` solely by sourcing a `.path` file that `config.sh` wrote from wh
 `PATH` the configuring shell happened to have. Configure from a shell without
 `~/.cargo/bin` and every job dies at `cargo build` with "command not found" — while the
 runner still reports healthy and idle in the Actions UI. `setup-nax-runner.sh` writes
-`.path` explicitly and asserts that `cargo` and `node` resolve through it; if you
-register by hand, check `cat ~/actions-runner-nax/.path`.
+`.path` explicitly and asserts that `cargo`, `node`, and `cmake` resolve through it; if
+you register by hand, check `cat ~/actions-runner-nax/.path`.
+
+That assertion has to cover the tools the *build* shells out to, not just the ones a
+`run:` step names. `cmake` was missing from it until 2026-08-03, when nax-macos-2 passed
+provisioning and then failed three `nax-worker` runs inside `pmetal-mlx-sys`'s build
+script — healthy in the UI, red on every job, which is exactly the trap above one
+indirection down. `brew install cmake` fixed it (Homebrew's `/opt/homebrew/bin` was
+already on `.path`) and the next run went green in 7m08s.
 
 A LaunchAgent (user session) rather than a LaunchDaemon is correct here: Metal needs a
 real logged-in GUI session. So the box must **stay logged in and never sleep**

--- a/scripts/setup-nax-runner.sh
+++ b/scripts/setup-nax-runner.sh
@@ -20,7 +20,8 @@
 # PATH the configuring shell happened to have. Configure from a shell without
 # ~/.cargo/bin and every job dies at `cargo build` with "command not found" — while the
 # runner still shows healthy/idle in the Actions UI. This script writes `.path`
-# explicitly and verifies cargo/node resolve through it.
+# explicitly and verifies that every tool the build shells out to — cargo, node, and
+# cmake — resolves through it.
 #
 # A LaunchAgent (user session) is also correct rather than a LaunchDaemon: Metal work
 # needs a real logged-in GUI session, so the box must be logged in and not asleep.
@@ -254,6 +255,18 @@ preflight() {
     bad "no cargo/rustc found on PATH or in ~/.cargo/bin. Install rustup (https://rustup.rs); rust-toolchain.toml pins stable."
   fi
 
+  # MLX is a CMake project, and `pmetal-mlx-sys`'s build.rs shells out to `cmake` by name.
+  # Missing, the lane fails at "failed to run custom build command for pmetal-mlx-sys ...
+  # failed to execute command: No such file or directory (os error 2)" — which reads as a
+  # broken dependency rather than an unprovisioned host. nax-macos-2 lost three runs to
+  # exactly that on 2026-08-03. No version floor: cmake 4.x builds MLX without hitting a
+  # `cmake_minimum_required` compatibility wall, so any Homebrew cmake is fine.
+  if command -v cmake >/dev/null 2>&1; then
+    ok "cmake $(cmake --version 2>/dev/null | head -1 | awk '{print $3}') at $(command -v cmake)"
+  else
+    bad "no cmake on PATH; MLX builds through CMake and pmetal-mlx-sys's build.rs invokes it directly, so every job would die in that dependency's build script. Install it: brew install cmake"
+  fi
+
   if command -v node >/dev/null 2>&1; then
     local node_major
     node_major="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
@@ -404,7 +417,7 @@ Refusing to unpack. If you intentionally bumped RUNNER_VERSION, update RUNNER_SH
 
 # `config.sh` snapshots the configuring shell's PATH into `.path`, and bin/runsvc.sh
 # makes that file the ONLY PATH the launchd service ever sees. Ensure the directories the
-# lane actually needs are in it, and prove cargo/node resolve through it.
+# lane actually needs are in it, and prove the build's tools resolve through it.
 repair_runner_path() {
   local path_file="${RUNNER_DIR}/.path"
   # Derive the directories from where the tools ACTUALLY are rather than assuming
@@ -413,7 +426,7 @@ repair_runner_path() {
   # version-pinned, so it would break on the next node upgrade even if hardcoded once.
   local wanted="${HOME}/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
   local tool tool_path
-  for tool in cargo node npm rustc; do
+  for tool in cargo node npm rustc cmake; do
     tool_path="$(command -v "$tool" 2>/dev/null || true)"
     [[ -n "$tool_path" ]] && wanted="$(dirname "$tool_path"):${wanted}"
   done
@@ -441,8 +454,14 @@ repair_runner_path() {
   # healthy and idle in the Actions UI while failing every job at `cargo build`. A box
   # that cannot build is worse than no box, because its failures look like code
   # regressions and it consumes the scheduling slot either way.
+  #
+  # The list must cover every tool the BUILD shells out to, not just the ones the workflow
+  # names in a `run:` step. Checking cargo and node alone is how nax-macos-2 shipped
+  # provisioned-and-green on 2026-08-03 and then failed three `nax-worker` runs inside
+  # `pmetal-mlx-sys`'s build script, which invokes `cmake` — the exact failure this guard
+  # exists to prevent, one indirection down.
   local missing=""
-  for tool in cargo node; do
+  for tool in cargo node cmake; do
     if ! PATH="$merged" command -v "$tool" >/dev/null 2>&1; then
       missing="${missing:+${missing}, }${tool}"
     fi
@@ -451,9 +470,10 @@ repair_runner_path() {
     die "'${missing}' does not resolve through ${path_file}.
 bin/runsvc.sh gives the launchd service no PATH except this file, so the runner would come
 up healthy and fail every job at the build step. Not starting the service. Install the
-missing tool, or pass its directory on PATH when re-running this script."
+missing tool (cmake: brew install cmake), or pass its directory on PATH when re-running
+this script."
   fi
-  ok "cargo and node both resolve through .path"
+  ok "cargo, node, and cmake all resolve through .path"
 }
 
 install_runner() {


### PR DESCRIPTION
## What does this PR do?

`repair_runner_path()` in `scripts/setup-nax-runner.sh` has a fail-closed dependency
check whose stated purpose is to prevent "a runner that reports healthy and idle in the
Actions UI while failing every job at `cargo build`". It only ever looked for `cargo` and
`node` — so it missed the tool that actually produced that outcome.

On 2026-08-03 `nax-macos-2` passed provisioning, came up healthy, and then failed the
`nax-worker` job three times at "Build the MLX GPU worker (mlx-gen linked, NAX at 26.2)":

```
error: failed to run custom build command for `pmetal-mlx-sys v0.2.4`
  running: cd ".../out/build" && ... "cmake" "-Wdev" ...
  failed to execute command: No such file or directory (os error 2)
```

MLX is a CMake project and `pmetal-mlx-sys`'s build.rs shells out to `cmake` by name.
That is the guard's exact failure mode, one indirection down: the check tracked the tools
the workflow names in a `run:` step rather than the tools the *build* invokes.

Changes:

- **`cmake` added to the fail-closed loop** so provisioning refuses to install/start the
  launchd service on a box that cannot build MLX. Die message now names the fix
  (`cmake: brew install cmake`) instead of a generic "install the missing tool", and the
  success line reads `cargo, node, and cmake all resolve through .path`.
- **`cmake` added to the PATH-derivation loop** that feeds `.path`, so a non-Homebrew
  install (a CMake.app bundle, `/usr/local`) also gets its directory written in.
  Homebrew's `/opt/homebrew/bin` was already in the static list, which is why
  `brew install cmake` alone fixed the box.
- **New preflight check** next to the Rust/node checks, so `--check` reports a missing
  host tool up front rather than leaving it to surface later as an opaque
  `pmetal-mlx-sys` build-script failure.
- **No version pin.** cmake 4.4.2 built MLX without hitting a `cmake_minimum_required`
  compatibility wall — the run immediately after `brew install cmake` went green in
  7m08s — so gating on a maximum version would reject a working toolchain.
- **Docs.** `docs/rust-mlx-build.md` gains CMake in the Requirements list, in the `nax`
  label's host requirements table, and in the `--check` preflight summary; the launchd
  PATH-trap section now states the assertion covers `cmake` and records the incident as
  the reason the assertion has to follow the build's tools. `macos-mlx.yml`'s header
  prerequisites listed "macOS >= 26.2, full Xcode + the Metal Toolchain, a Rust
  toolchain" and omitted cmake; fixed.

## Related issue

No issue — the fix follows directly from the `nax-macos-2` failures on 2026-08-03.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

- `npm run check` passes end to end (207/207 tests). This is the gate that matters here:
  it runs `node scripts/check-shell-scripts.mjs`, which holds this script to bash-3.2
  portability, and it runs mid-`&&`-chain so a failure would have short-circuited.
- `/bin/bash -n scripts/setup-nax-runner.sh` under the real macOS bash (3.2.57) parses
  clean — the new code uses no bash-4 constructs.
- Both new snippets exercised in a live bash 3.2 subshell: the version parse yields
  `ok    cmake 4.4.2 at /opt/homebrew/bin/cmake`, and under a stripped
  `PATH=/usr/bin:/bin` the fail-closed loop correctly accumulates `cargo, node, cmake`
  into `missing`.
- The underlying fix is already field-verified on `nax-macos-2`: `brew install cmake`
  (4.4.2 at `/opt/homebrew/bin/cmake`, already on the runner's `.path`) turned three
  consecutive red `nax-worker` runs into a green 7m08s run.

Not run: the full provisioning path against a live runner registration. No Rust or web
code was touched, so `rust:check` and the web lane are not implicated.

- [x] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [ ] Not platform-specific (web UI, docs, shared crate)

## Checklist

- [ ] I ran `npm run rust:check` (if I touched Rust) and it passed — n/a, no Rust changes
- [ ] I ran the web app lint/test/build — n/a, no web changes
- [x] I ran `npm run check` (scaffold checks)
- [x] I updated documentation where relevant
- [x] All my commits are signed off (`git commit -s`)
- [x] My PR is focused on a single logical change

## Reviewer notes

The judgement call worth a look: the preflight uses `bad` (a blocking failure) for a
missing cmake rather than `warn`. That matches the fail-closed loop it feeds and the
existing treatment of cargo/node — a box without cmake takes jobs and fails all of them,
and those failures read as code regressions. Unlike the Rust check, there is no
off-PATH fallback location to probe (the cargo check accepts `~/.cargo/bin` because
rustup only edits interactive profiles); cmake has no equivalent canonical home, so a
plain `command -v` is the whole check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
