### PR TITLE
Make a never-dumped engine backend fail loudly, and prove capabilities.mlx.json is a real dump (sc-17119)

### DIFF
--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -46,6 +46,11 @@ on:
       # manifest-only edit can turn this suite red — gate on it (matches the
       # windows-candle.yml / desktop-windows.yml filters). sc-8617.
       - "config/manifests/**"
+      # The stage-1 MLX facts dump this lane is the sole producer of (sc-17119). Without this entry
+      # the "real dump, not a restamp" step below is unreachable for the one edit it exists to
+      # catch: a restamp touches ONLY config/engine-capabilities/capabilities.mlx.json, matching no
+      # other path here, so the lane would not run at all on the PR that made the file wrong.
+      - "config/engine-capabilities/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".cargo/config.toml"
@@ -227,6 +232,50 @@ jobs:
       # SDPA guard, which is this lane's original reason to exist. sc-17026.
       - name: Workspace tests incl. the NAX 16-bit SDPA guard
         run: cargo test
+      # sc-17119. THE ONLY LANE THAT CAN PRODUCE capabilities.mlx.json, so it is the only place the
+      # checked-in file can be checked against a real registry rather than taken on trust.
+      #
+      # Every other guard reads that file as a source: `verifyEngineCapabilityFacts` compares its
+      # `inferenceRevision` string to the pin, and the vitest drift guard re-derives the catalog from
+      # its contents. Both are satisfied by editing one line. That is not hypothetical -- the file was
+      # RESTAMPED (revision line rewritten, 334 lines of content untouched) through two consecutive
+      # pin bumps, 35251a88 and 06e0c5e9, because no Mac was available to re-dump it and nothing
+      # could tell the difference. The restamps happened to be correct; nothing proved it until this
+      # step existed.
+      #
+      # Cheap: the build and test steps above already built the mlx-gen graph, so this is a link plus
+      # a weights-free registry walk. Dumps to a scratch dir, never over the checked-in file, so a
+      # red run leaves a readable diff instead of a mutated tree.
+      #
+      # LAST, deliberately -- the same rule the clippy steps above are ordered by, applied to a step
+      # that fires on a PREDICTABLE, routine event. A step failure aborts the job, and this one goes
+      # red on exactly the pin-bump PRs where nobody re-dumped on a Mac. Placed earlier it would
+      # cancel both clippy steps and `cargo test` -- and this lane is the ONLY place in CI that runs
+      # `nax_guard`, so a stale facts file would cost the repo its entire NAX kernel verdict for that
+      # commit, on precisely the PRs where descriptors just moved. A missing dump must not suppress
+      # unrelated coverage; it is the least urgent signal in this job, so it reports last.
+      #
+      # When this fails after a pin bump, the fix is to commit the dump it just produced and re-run
+      # `npm run gen:preview-support` from apps/web -- not to restamp the revision line.
+      #
+      # capabilities.candle.json still has this hole (it was restamped by the same commits). The
+      # mirror does NOT belong here: it needs the CUDA box, and windows-candle.yml runs every step
+      # under `shell: cmd`/`powershell` -- its own header records that `bash` there resolves to the
+      # box's WSL stub, and `cmd` has no `diff`. Tracked as sc-17592 rather than written blind.
+      - name: Verify capabilities.mlx.json is a real dump, not a restamp
+        run: |
+          set -euo pipefail
+          scratch="$(mktemp -d)"
+          trap 'rm -rf "$scratch"' EXIT
+          cargo run -p sceneworks-worker --bin dump-engine-capabilities -- "$scratch"
+          if ! diff -u config/engine-capabilities/capabilities.mlx.json \
+                     "$scratch/capabilities.mlx.json"; then
+            echo "::error::config/engine-capabilities/capabilities.mlx.json does not match a fresh"\
+                 "dump at this pin. Re-dump it on a Mac:"\
+                 "cargo run -p sceneworks-worker --bin dump-engine-capabilities,"\
+                 "then (cd apps/web && npm run gen:preview-support)."
+            exit 1
+          fi
       - name: Validate Qwen provisioning mode
         if: ${{ github.event_name == 'workflow_dispatch' }}
         env:

--- a/apps/web/scripts/generate-preview-support.mjs
+++ b/apps/web/scripts/generate-preview-support.mjs
@@ -30,14 +30,21 @@ import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import {
+  assertBackendCoverage,
   catalogToWebPreviewSupport,
   derivePreviewSupport,
   parseEngineModelTable,
+  parseSceneworksBackends,
 } from "../src/data/previewSupportDerivation.js";
 
 const factsDir = fileURLToPath(new URL("../../../config/engine-capabilities", import.meta.url));
 const enginesPath = fileURLToPath(
   new URL("../../../crates/sceneworks-worker/src/engines.rs", import.meta.url),
+);
+// The declared backend list (sc-17119). Read from the Rust const rather than the directory listing,
+// because the directory listing cannot see a file that was never written.
+const factsDeclarationPath = fileURLToPath(
+  new URL("../../../crates/sceneworks-worker/src/engine_capability_facts.rs", import.meta.url),
 );
 const manifestPath = fileURLToPath(
   new URL("../../../config/manifests/builtin.preview-support.jsonc", import.meta.url),
@@ -59,9 +66,19 @@ export function readFactsFiles(dir = factsDir) {
   return names.map((name) => JSON.parse(readFileSync(`${dir}/${name}`, "utf8")));
 }
 
+const factsFiles = readFactsFiles();
+// Refuse to write a catalog that is blind to a backend SceneWorks can run (sc-17119). Everything
+// else here is scoped to what is on disk, so without this the artifacts regenerate perfectly
+// happily with a whole engine's answers missing — reported downstream as "unknown", which renders
+// exactly as it did before the feature shipped.
+assertBackendCoverage(
+  parseSceneworksBackends(readFileSync(factsDeclarationPath, "utf8")),
+  factsFiles.map((facts) => facts.backend),
+);
+
 const catalog = derivePreviewSupport(
   parseEngineModelTable(readFileSync(enginesPath, "utf8")),
-  readFactsFiles(),
+  factsFiles,
 );
 
 writeFileSync(manifestPath, `${JSON.stringify(catalog, null, 2)}\n`, "utf8");

--- a/apps/web/src/data/previewSupportCatalog.test.js
+++ b/apps/web/src/data/previewSupportCatalog.test.js
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  assertBackendCoverage,
   catalogToWebPreviewSupport,
   derivePreviewSupport,
   parseEngineModelTable,
+  parseSceneworksBackends,
   PREVIEW_SUPPORT_GENERATOR,
 } from "./previewSupportDerivation.js";
 import previewSupport from "./previewSupport.json";
@@ -19,6 +21,10 @@ import previewSupportManifestRaw from "../../../../config/manifests/builtin.prev
 // `audit.inferenceRevision` to the live pin set AND runs in the parity lane); this is the same
 // assertion for the same class of artifact, on a guard that runs on every PR.
 import workerCargoToml from "../../../../crates/sceneworks-worker/Cargo.toml?raw";
+// The DECLARED backend set (sc-17119). Every other input below is discovered from the facts
+// directory, and a directory listing cannot see a file that was never written — which is why
+// `capabilities.mlx.json` was absent for four consecutive pins with the whole suite green.
+import factsDeclarationSource from "../../../../crates/sceneworks-worker/src/engine_capability_facts.rs?raw";
 import { fallbackModels } from "../constants.js";
 
 // DISCOVERED, never listed. The generator globs this directory so a newly dumped backend is picked
@@ -143,6 +149,120 @@ describe("preview-support catalog: the stage-1 facts files are non-vacuous", () 
 
   it("deriving with no facts files at all is refused", () => {
     expect(() => derivePreviewSupport(rows, [])).toThrow(/no stage-1 facts files/);
+  });
+});
+
+// sc-17119. The one assertion in this pipeline that can see a file which is NOT there.
+//
+// Everything above is scoped to what the facts directory contains — the generator globs it, this
+// guard globs it, and `verifyEngineCapabilityFacts` validates only the files that exist. So a
+// backend that was never dumped is not a failure anywhere: it is simply absent, and absence derives
+// as "unknown", which renders exactly as it did before the feature shipped. `capabilities.mlx.json`
+// was absent for four consecutive pins beginning with the one sc-16965 itself shipped on, with
+// every one of those guards green.
+//
+// The required set comes from the Rust const, parsed — not from a JS copy, whose stale-failure mode
+// is to stop requiring a backend, i.e. to silently re-open this hole.
+describe("preview-support catalog: every backend SceneWorks can run is dumped", () => {
+  const declared = parseSceneworksBackends(factsDeclarationSource);
+  const onDisk = factsEntries.map((entry) => entry.facts.backend).sort();
+
+  it("parses SCENEWORKS_BACKENDS out of engine_capability_facts.rs", () => {
+    expect(declared.length).toBeGreaterThan(0);
+    // Both shipped lanes, named: macOS links mlx, `--features backend-candle` links candle.
+    expect(declared).toEqual(expect.arrayContaining(["candle", "mlx"]));
+  });
+
+  it("every declared backend has a checked-in facts file", () => {
+    expect(() => assertBackendCoverage(declared, onDisk)).not.toThrow();
+    for (const backend of declared) {
+      expect(onDisk, `capabilities.${backend}.json was never dumped`).toContain(backend);
+    }
+  });
+
+  it("the served catalog advertises every declared backend, not just the dumped ones", () => {
+    // The `backends` array is what a consumer iterates. If it were ever a strict subset of the
+    // declared set, the UI would have no key at all for the missing engine's routes.
+    expect(JSON.parse(previewSupportManifestRaw).backends).toEqual(declared);
+    expect(previewSupport.backends).toEqual(declared);
+  });
+
+  // Mutation-shaped: this is what the guard is FOR, so assert it actually fires. Deleting
+  // capabilities.mlx.json reduces the on-disk set to ["candle"] and nothing else in this file
+  // notices — every other assertion iterates `factsEntries` and would simply do one less round.
+  it("a declared backend with no dump is a loud failure, naming it and how to dump it", () => {
+    expect(() => assertBackendCoverage(["candle", "mlx"], ["candle"])).toThrow(/mlx/);
+    expect(() => assertBackendCoverage(["candle", "mlx"], ["candle"])).toThrow(
+      /dump-engine-capabilities/,
+    );
+    // ...and the reverse, so the failure cannot be "fixed" by dumping the wrong lane twice.
+    expect(() => assertBackendCoverage(["candle", "mlx"], ["mlx"])).toThrow(/candle/);
+  });
+
+  it("a dump for a backend the Rust const does not declare is also a failure", () => {
+    // A stale const requires nothing for the new backend, so deleting its file again would pass.
+    expect(() => assertBackendCoverage(["candle"], ["candle", "mlx"])).toThrow(/mlx/);
+  });
+
+  it("refuses a renamed or restructured const rather than requiring nothing", () => {
+    const renamed = factsDeclarationSource.replace(
+      "const SCENEWORKS_BACKENDS: &[&str] = &[",
+      "const SCENEWORKS_ENGINE_BACKENDS: &[&str] = &[",
+    );
+    expect(renamed).not.toBe(factsDeclarationSource);
+    expect(() => parseSceneworksBackends(renamed)).toThrow(/SCENEWORKS_BACKENDS/);
+  });
+
+  it("refuses an entry it cannot read rather than dropping it", () => {
+    // Dropping an entry SHRINKS the required set — the one failure direction that is invisible,
+    // because a guard that asks for less always passes.
+    //
+    // Built synthetically rather than by `.replace()`-ing today's exact two-element literal: that
+    // fixture would silently become a no-op the moment a third backend is declared, which is the
+    // very change this list exists to accommodate.
+    expect(() =>
+      parseSceneworksBackends('pub const SCENEWORKS_BACKENDS: &[&str] = &["candle", "MLX2"];'),
+    ).toThrow(/only 1 parsed/);
+  });
+
+  it("does not anchor on the const's own doc comment", () => {
+    // The doc comment names both backends and `capabilities.mlx.json` in prose; a comment-blind
+    // parse could match there and read an empty or wrong list.
+    expect(parseSceneworksBackends(factsDeclarationSource)).toEqual(declared);
+    expect(() =>
+      parseSceneworksBackends("// const SCENEWORKS_BACKENDS: &[&str] = &[\"ghost\"];\n"),
+    ).toThrow(/SCENEWORKS_BACKENDS/);
+  });
+
+  it("refuses a duplicated entry", () => {
+    expect(() =>
+      parseSceneworksBackends('pub const SCENEWORKS_BACKENDS: &[&str] = &["mlx", "mlx"];'),
+    ).toThrow(/twice/);
+  });
+
+  it("refuses an empty list rather than requiring nothing", () => {
+    expect(() => parseSceneworksBackends("pub const SCENEWORKS_BACKENDS: &[&str] = &[];")).toThrow(
+      /empty/,
+    );
+  });
+
+  it("refuses an empty DECLARED set, not just an empty parse", () => {
+    // assertBackendCoverage is exported and called from three places, and not all of them get
+    // their list from parseSceneworksBackends. With an empty declared set every check below it is
+    // vacuously true — it would pass for any set of dumped files, including none at all.
+    expect(() => assertBackendCoverage([], ["candle", "mlx"])).toThrow(/empty/);
+    expect(() => assertBackendCoverage([], [])).toThrow(/empty/);
+  });
+
+  it("refuses a facts file with no readable backend rather than reporting a nameless one", () => {
+    // Without this, `undefined` flows through and the operator is told that backend(s) `[]` are
+    // undeclared — an empty bracket list that names neither the backend nor the file.
+    expect(() => assertBackendCoverage(["candle", "mlx"], ["candle", undefined])).toThrow(
+      /no readable `backend`/,
+    );
+    expect(() => assertBackendCoverage(["candle", "mlx"], ["candle", ""])).toThrow(
+      /no readable `backend`/,
+    );
   });
 });
 

--- a/apps/web/src/data/previewSupportDerivation.js
+++ b/apps/web/src/data/previewSupportDerivation.js
@@ -58,7 +58,7 @@ const MIN_EXPECTED_MODEL_ROWS = 50;
  * String literals are copied verbatim (escapes honoured) so a `//` inside a repo URL — every
  * `default_repo` is one — can never be mistaken for a comment.
  */
-function stripRustComments(source) {
+function stripRustComments(source, sourceLabel = "engines.rs") {
   let out = "";
   let index = 0;
   let blockDepth = 0; // Rust block comments nest.
@@ -108,7 +108,7 @@ function stripRustComments(source) {
     index += 1;
   }
   if (blockDepth > 0) {
-    throw new Error("parseEngineModelTable: engines.rs has an unterminated `/*` block comment");
+    throw new Error(`${sourceLabel} has an unterminated \`/*\` block comment`);
   }
   return out;
 }
@@ -175,7 +175,7 @@ export function parseEngineModelTable(rustSource) {
   }
   // Comments first, then locate the table: a `];` or a `ModelRow` mention inside a comment must not
   // be able to end the table or be counted as a row.
-  const body = sliceModelTableBody(stripRustComments(rustSource));
+  const body = sliceModelTableBody(stripRustComments(rustSource, "parseEngineModelTable: engines.rs"));
 
   // Rows carry only scalar/string fields today — no nested braces — so a brace-free match is exact.
   // The moment that stops being true this regex silently SKIPS the row, so the count below is what
@@ -225,6 +225,141 @@ export function parseEngineModelTable(rustSource) {
     seen.add(row.sceneworksId);
   }
   return rows;
+}
+
+// The `SCENEWORKS_BACKENDS` const in engine_capability_facts.rs. Anchored on the full declaration
+// so a rename or a type change is a loud parse failure rather than a silently empty required set.
+const SCENEWORKS_BACKENDS_OPEN = "const SCENEWORKS_BACKENDS: &[&str] = &[";
+
+/**
+ * Parse the declared backend list out of `crates/sceneworks-worker/src/engine_capability_facts.rs`.
+ *
+ * Parsed rather than mirrored, for the same reason `MODEL_TABLE` is: a JS-side copy of the list
+ * would have to be kept in step by hand, and the failure mode of a stale copy is that it stops
+ * requiring a backend — i.e. it re-opens the hole rather than closing it.
+ *
+ * Throws on anything it cannot read in full. A partial parse here is the DANGEROUS direction: a
+ * dropped entry shrinks the required set, so {@link assertBackendCoverage} stops asking for a
+ * backend and a never-dumped file passes again, silently.
+ */
+export function parseSceneworksBackends(rustSource) {
+  if (typeof rustSource !== "string" || rustSource.length === 0) {
+    throw new Error(
+      "parseSceneworksBackends: expected the engine_capability_facts.rs source text",
+    );
+  }
+  // Comments first: the doc comment above the const names the two backends in prose, and a
+  // `SCENEWORKS_BACKENDS` mention inside a comment must not be able to anchor the parse.
+  const source = stripRustComments(
+    rustSource,
+    "parseSceneworksBackends: engine_capability_facts.rs",
+  );
+  const open = source.indexOf(SCENEWORKS_BACKENDS_OPEN);
+  if (open === -1) {
+    throw new Error(
+      `parseSceneworksBackends: no ${JSON.stringify(SCENEWORKS_BACKENDS_OPEN)} in ` +
+        "engine_capability_facts.rs — the backend list was renamed or restructured; update this " +
+        "parser, or the stage-2 coverage guard silently stops requiring any backend at all",
+    );
+  }
+  const bodyStart = open + SCENEWORKS_BACKENDS_OPEN.length;
+  const bodyEnd = source.indexOf("]", bodyStart);
+  if (bodyEnd === -1) {
+    throw new Error("parseSceneworksBackends: SCENEWORKS_BACKENDS' opening `&[` is never closed");
+  }
+  const body = source.slice(bodyStart, bodyEnd);
+
+  const backends = [...body.matchAll(/"([a-z0-9_-]+)"/g)].map((match) => match[1]);
+  // Every string literal in the body must have been read. An entry the matcher cannot parse (an
+  // escape, an unexpected character class, a `concat!`) would otherwise be dropped — and dropping
+  // one WEAKENS the guard, which is invisible by construction.
+  const quotes = (body.match(/"/g) ?? []).length;
+  if (quotes !== backends.length * 2) {
+    throw new Error(
+      `parseSceneworksBackends: SCENEWORKS_BACKENDS holds ${quotes / 2} string literal(s) but only ` +
+        `${backends.length} parsed (${JSON.stringify(backends)}). A dropped entry would stop this ` +
+        "guard requiring that backend's dump. Teach this parser the new shape.",
+    );
+  }
+  if (backends.length === 0) {
+    throw new Error(
+      "parseSceneworksBackends: SCENEWORKS_BACKENDS is empty, which would make the coverage " +
+        "assertion vacuous — the exact class of hole it exists to close",
+    );
+  }
+  const seen = new Set();
+  for (const backend of backends) {
+    if (seen.has(backend)) {
+      throw new Error(`parseSceneworksBackends: SCENEWORKS_BACKENDS declares ${backend} twice`);
+    }
+    seen.add(backend);
+  }
+  return backends;
+}
+
+/**
+ * Assert the dumped facts files cover exactly the backends SceneWorks can run (sc-17119).
+ *
+ * Every other check in this pipeline is scoped to *what is on disk* — the generator globs the
+ * directory, the drift guard globs it, and `verifyEngineCapabilityFacts` validates only files that
+ * exist. So a backend that was NEVER dumped is not a failure anywhere; it is simply absent, and
+ * absence derives as "unknown", which renders exactly as it did before the feature shipped. This is
+ * the one assertion that can see a file that is not there.
+ *
+ * Both directions are errors:
+ * - **missing** — a declared backend has no dump; the catalog is silently blind to it.
+ * - **undeclared** — a dump exists for a backend the Rust list does not know about, so the list is
+ *   stale and cannot be trusted to require anything.
+ *
+ * @param {string[]} declaredBackends from {@link parseSceneworksBackends}
+ * @param {string[]} dumpedBackends the `backend` field of each checked-in facts file
+ */
+export function assertBackendCoverage(declaredBackends, dumpedBackends) {
+  // An empty declared set makes every check below vacuously true — the same hole
+  // `parseSceneworksBackends` refuses, refused again here because this function is exported and
+  // called from three places, not all of which get their list from that parser.
+  if (!Array.isArray(declaredBackends) || declaredBackends.length === 0) {
+    throw new Error(
+      "assertBackendCoverage: the declared backend set is empty, so this assertion would pass for " +
+        "ANY set of dumped files — including none. Read it from SCENEWORKS_BACKENDS in " +
+        "crates/sceneworks-worker/src/engine_capability_facts.rs.",
+    );
+  }
+  // A facts file with no readable `backend` would otherwise flow through as `undefined` and be
+  // reported as an unnamed entry — "facts exist for backend(s) []" — which tells the operator
+  // nothing about which file is wrong.
+  const nameless = dumpedBackends.filter(
+    (backend) => typeof backend !== "string" || backend.length === 0,
+  );
+  if (nameless.length > 0) {
+    throw new Error(
+      `assertBackendCoverage: ${nameless.length} facts file(s) carry no readable \`backend\` ` +
+        "field, so they cannot be matched against SCENEWORKS_BACKENDS. A facts file names the " +
+        "backend it belongs to; re-dump the offending file rather than hand-editing it.",
+    );
+  }
+  const dumped = new Set(dumpedBackends);
+  const missing = declaredBackends.filter((backend) => !dumped.has(backend));
+  if (missing.length > 0) {
+    throw new Error(
+      `engine-capability facts are missing for backend(s) [${missing.join(", ")}]. SceneWorks can ` +
+        "run them, so the served catalog reports \"unknown\" for every route they own — " +
+        "indistinguishable from \"not wired\". Dump each on the lane that owns it:\n" +
+        "  mlx    (macOS) : cargo run -p sceneworks-worker --bin dump-engine-capabilities\n" +
+        "  candle (off-Mac): cargo run -p sceneworks-worker --bin dump-engine-capabilities " +
+        "--no-default-features --features backend-candle\n" +
+        "then re-run `npm run gen:preview-support` from apps/web.",
+    );
+  }
+  const undeclared = [...dumped].filter((backend) => !declaredBackends.includes(backend));
+  if (undeclared.length > 0) {
+    throw new Error(
+      `engine-capability facts exist for backend(s) [${undeclared.join(", ")}] that ` +
+        `SCENEWORKS_BACKENDS (${JSON.stringify(declaredBackends)}) does not declare. Add them to ` +
+        "the const in crates/sceneworks-worker/src/engine_capability_facts.rs — until then nothing " +
+        "requires their dump, so deleting the file again would go unnoticed.",
+    );
+  }
 }
 
 /**

--- a/crates/sceneworks-worker/src/engine_capability_facts.rs
+++ b/crates/sceneworks-worker/src/engine_capability_facts.rs
@@ -58,6 +58,32 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+/// Every backend SceneWorks can link a **media** registry for, and therefore every backend stage 2
+/// requires a checked-in facts file for (sc-17119).
+///
+/// Scoped to [`crate::inference_runtime::media`] because that is the only registry this module
+/// dumps. [`crate::inference_runtime::audio`] is a separate registry whose descriptors are dumped
+/// **nowhere** — its `supports_preview` is unknown to the catalog on every platform. That gap is not
+/// closed here and is not visible to this list: audio is candle-native everywhere, so backend-level
+/// coverage is satisfied coincidentally rather than because anything checked. See sc-17593.
+///
+/// Without this list, "which backends are covered?" could only be answered by *the files on disk* —
+/// so a backend that was **never dumped** passed every guard forever, silently. That is not
+/// hypothetical: `capabilities.mlx.json` was absent for four consecutive pins beginning with the one
+/// sc-16965 itself shipped on (`d4802320`, `bf06bb56`, `5b6d6aa0`, `5f973a73`), and the vitest drift
+/// guard and the generator — which both glob this directory — were green throughout, as
+/// `verifyEngineCapabilityFacts` would have been had anything invoked it. Absence rendered as
+/// "unknown", which renders exactly as before — i.e. it looked fine.
+///
+/// This is the **union across both lanes**, so no single build can verify it whole: a macOS build
+/// links only `mlx`, a `backend-candle` build only `candle` (see [`crate::inference_runtime::media`],
+/// whose two cfg arms are the definition this list mirrors). What each lane *can* enforce is that
+/// the backend it actually links is declared here — see `the_linked_backend_is_declared`. Between
+/// the two lanes every entry is covered by a real registry.
+///
+/// Sorted and unique; stage 2 compares it against the sorted set of dumped files.
+pub const SCENEWORKS_BACKENDS: &[&str] = &["candle", "mlx"];
+
 /// One engine's weights-free preview facts, as written to a per-backend facts file.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -333,6 +359,52 @@ mod tests {
         )
         .expect_err("a duplicate engine id must be refused");
         assert!(error.contains("krea_2_turbo"), "got: {error}");
+    }
+
+    // Stage 2 compares SCENEWORKS_BACKENDS against the sorted list of dumped files, so an unsorted
+    // or duplicated entry would fail the coverage check for a reason that has nothing to do with a
+    // missing dump.
+    #[test]
+    fn sceneworks_backends_is_sorted_and_unique() {
+        let mut sorted = SCENEWORKS_BACKENDS.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted, SCENEWORKS_BACKENDS,
+            "SCENEWORKS_BACKENDS must be sorted and duplicate-free"
+        );
+        assert!(
+            !SCENEWORKS_BACKENDS.is_empty(),
+            "an empty backend list would make the stage-2 coverage assertion vacuous — the exact \
+             class of hole it exists to close"
+        );
+    }
+
+    // The half of SCENEWORKS_BACKENDS this lane can actually measure. The list is a union across
+    // two mutually exclusive lanes, so neither build sees it whole; what each build proves is that
+    // the backend IT links is declared. An undeclared backend would ship with no stage-2 coverage
+    // assertion at all — a third engine could be added, never dumped, and stay invisible exactly
+    // the way `mlx` did.
+    #[cfg(any(target_os = "macos", feature = "backend-candle"))]
+    #[test]
+    fn the_linked_backend_is_declared() {
+        let facts = collect_engine_capability_facts()
+            .expect("this lane links a media registry, so collecting facts must succeed");
+        assert!(
+            !facts.is_empty(),
+            "a lane that links a registry must produce at least one backend's facts"
+        );
+        for entry in &facts {
+            assert!(
+                SCENEWORKS_BACKENDS.contains(&entry.backend.as_str()),
+                "this build links backend {:?}, which SCENEWORKS_BACKENDS ({:?}) does not declare. \
+                 Stage 2 requires one dumped facts file per DECLARED backend, so an undeclared one \
+                 is covered by nothing. Add it to the list and dump {} on this lane.",
+                entry.backend,
+                SCENEWORKS_BACKENDS,
+                entry.file_name(),
+            );
+        }
     }
 
     #[test]

--- a/scripts/bump-inference.mjs
+++ b/scripts/bump-inference.mjs
@@ -25,6 +25,14 @@ import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+// The stage-2 derivation owns both halves of the facts-file contract, so the bump's fail-closed
+// check reuses them rather than re-implementing a second, drifting copy (the same cross-import
+// shape as scripts/check-scaffold.mjs).
+import {
+  assertBackendCoverage,
+  parseSceneworksBackends,
+} from "../apps/web/src/data/previewSupportDerivation.js";
+
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const MANIFEST = join(repoRoot, "crates/sceneworks-worker/Cargo.toml");
 const MEMORY_MANIFEST = join(repoRoot, "crates/sceneworks-memory-adapter/Cargo.toml");
@@ -283,6 +291,30 @@ function verifyEngineCapabilityFacts(sha) {
         "`npm run gen:preview-support` from apps/web.",
     );
   }
+  // Coverage BEFORE staleness (sc-17119). The loop below can only judge files that exist, so a
+  // backend that was never dumped is not "stale" — it is absent, and absence passed this check
+  // forever. `capabilities.mlx.json` was absent for four consecutive pins beginning with the one
+  // sc-16965 itself shipped on, and nothing in this function could have objected -- it validates
+  // only the files that are there.
+  const dumpedBackends = names.map((name) => {
+    const backend = JSON.parse(readFileSync(join(dir, name), "utf8"))?.backend;
+    if (typeof backend !== "string" || backend.length === 0) {
+      // Named here rather than left to `assertBackendCoverage`, which sees only the values: a
+      // nameless backend reads there as an unidentifiable entry, and the operator needs the file.
+      throw new Error(
+        `${name} carries no \`backend\` field, so it cannot be matched against SCENEWORKS_BACKENDS. ` +
+          "Re-dump it on the lane that owns it rather than hand-editing it.",
+      );
+    }
+    return backend;
+  });
+  assertBackendCoverage(
+    parseSceneworksBackends(
+      readFileSync(join(repoRoot, "crates/sceneworks-worker/src/engine_capability_facts.rs"), "utf8"),
+    ),
+    dumpedBackends,
+  );
+
   const stale = [];
   for (const name of names) {
     const facts = JSON.parse(readFileSync(join(dir, name), "utf8"));


### PR DESCRIPTION
Closes [sc-17119](https://app.shortcut.com/trefry/story/17119) (epic 16948).

## The headline ask, measured

Ran the real dumper on a Mac at the live pin:

```
cargo run -p sceneworks-worker --bin dump-engine-capabilities -- <scratch>
diff <scratch>/capabilities.mlx.json config/engine-capabilities/capabilities.mlx.json
```

**Byte-identical.** `npm run gen:preview-support` then regenerates both artifacts with zero drift, and the vitest drift guard passes against a real dump rather than the *simulated* one sc-16965 validated against.

So bullets 1–3 of the story produce **no artifact change**: the two restamps this story was filed over (`35251a88`, `06e0c5e9`) turn out to have been substantively correct. That was not knowable until measured — nothing had measured it. 65 engines / 38 `supportsPreview` on MLX; 51 / 29 on candle.

## The actual defect — bullet 4

Every guard here is scoped to the files that **exist**. The generator globs the facts directory, the drift guard globs it, and `verifyEngineCapabilityFacts` validates only what it finds. A never-dumped backend is not a failure anywhere — it is absent, and absence derives as *unknown*, which renders exactly as it did before the feature shipped.

`capabilities.mlx.json` was absent for **four consecutive pins** beginning with the one sc-16965 itself shipped on (`d4802320`, `bf06bb56`, `5b6d6aa0`, `5f973a73`), with every one of those guards green.

Closed by **declaring** the set instead of discovering it — `SCENEWORKS_BACKENDS` in `engine_capability_facts.rs`, *parsed* by stage 2 rather than mirrored (a JS copy's stale-failure mode is to stop requiring a backend, which re-opens the hole rather than closing it). Wired into the generator, the vitest guard and the bump script, so the "delete the dump, regenerate, everything is green again" path is refused at the generator.

The list is a union across two mutually exclusive lanes, so no build sees it whole. What each lane proves is that the backend **it** links is declared (`the_linked_backend_is_declared`).

## Also closed: the restamp hole

Every guard reads the facts file as a *source* — revision compared to the pin, contents re-derived — so **both are satisfied by editing one line**, which is literally what happened twice. `macos-mlx.yml` now re-dumps to a scratch dir and diffs against the checked-in file.

Two placement decisions that matter:
- **Runs last in the job.** It goes red on routine pin-bump PRs, a step failure aborts the job, and this lane is the only place in CI that runs `nax_guard`. A missing dump must not cost the repo its NAX verdict — the same "lint before test" rule the file already documents.
- **`config/engine-capabilities/**` added to `paths:`.** Without it the lane would not trigger on a restamp at all, since a restamp touches only that file.

## Mutation-proved (each reverted)

| Mutation | Result |
|---|---|
| delete `capabilities.mlx.json` | coverage test fails naming `[mlx]`; generator refuses |
| `SCENEWORKS_BACKENDS = &["candle"]` | Rust test fails naming the file to dump; 4 vitest failures |
| reverse the const | `sceneworks_backends_is_sorted_and_unique` fails |
| rewrite only the revision line | CI step exits 1 with a readable diff |

For contrast, the **pre-existing** suite went green again once the artifacts were regenerated without the mlx dump — its one red was an unrelated UI-seed assertion that happens to depend on which routes preview.

## Verification

`cargo fmt --all --check` · `cargo clippy --all-targets -- -D warnings` · `cargo test` **3329 passed / 0 failed** · web vitest **3518 passed / 236 files** · `npm run check` exit 0 · `eslint` exit 0 · `bump-inference --self-test` exit 0 · CI step run verbatim locally in both the pass and restamp-detected cases.

One `rust-api` dataset-catalog lease test is timing-flaky under concurrent load (passes 3/3 in isolation, untouched by this diff); the numbers above are from an unloaded run.

## Not done here — filed, not buried

- **[sc-17592](https://app.shortcut.com/trefry/story/17592)** — the candle twin of the restamp guard. `windows-candle.yml` runs every step under `cmd`/`powershell`, its own header records that `bash` there resolves to the box's WSL stub, and `cmd` has no `diff`. It needs the CUDA box; shipping unvalidated failing-capable CI onto a lane that gates main was the wrong trade.
- **[sc-17593](https://app.shortcut.com/trefry/story/17593)** — the audio registry's `supports_preview` is dumped nowhere. Backend-level coverage passes only *coincidentally* because audio is candle-native. Wording in this PR was narrowed to "media registry" rather than over-claiming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)