### PR TITLE
The FLUX.2 audited window moved two closure paths, not three (sc-17524)

### DIFF
--- a/scripts/generate-memory-matrix.mjs
+++ b/scripts/generate-memory-matrix.mjs
@@ -66,7 +66,7 @@ export const FLUX2_COMPATIBILITY_AUDIT = Object.freeze({
   provider: "flux2_dev",
   capturedInferenceRevision: "5ffd7612e7de4e76b6db00a7148ed3d9c15b4c0d",
   compatibleInferenceRevision: "a4f409ae8ce73eda2ee8117b89b5f479666606b8",
-  // sc-17524: measured on the RTX PRO 6000 box (rustc 1.96.0, nvcc 12.9, `--features cuda`). Three
+  // sc-17524: measured on the RTX PRO 6000 box (rustc 1.96.0, nvcc 12.9, `--features cuda`). Two
   // closure paths moved across this window — `Cargo.lock` and `candle-gen` — and the
   // `candle-gen-flux2` lib test binary is byte-identical at both ends, so the compiled code the
   // measurements ran did not change. `adjudicates` is what that binary speaks for: the crate trees


### PR DESCRIPTION
One-word correction, follow-up to [#2117](https://github.com/SceneWorks/SceneWorks/pull/2117) ([sc-17524](https://app.shortcut.com/trefry/story/17524)).

The repin from `06e0c5e9` to `a4f409ae` was done with a `sed`, which rewrote each revision and left the measurement beside it. A review caught that and I swept the seven affected comments — but I grepped for the lowercase phrase, and in this one the count sits on the *previous* line and is capitalized. So it merged reading:

```
// ... `--features cuda`). Three
// closure paths moved across this window — `Cargo.lock` and `candle-gen` — and the
```

Three, above a list of two.

**Ground truth**, verified at both ends of the shipped window:

| path | `5ffd7612` | `a4f409ae` | |
|---|---|---|---|
| `Cargo.lock` | `8ab01e00` | `e5014b40` | moved |
| `crates/media/candle-gen/candle-gen` | `e8b8b3f0` | `b7e8ac11` | moved |
| `crates/contracts/gen-core` | `9a7e86f5` | `9a7e86f5` | **unchanged** |

gen-core moved at `06e0c5e9` and moved back by `a4f409ae`. The record has always said two (`changedClosurePaths: ["Cargo.lock", "crates/media/candle-gen/candle-gen"]`) — only the prose was wrong.

Worth its own PR rather than leaving: the comment sits directly above the frozen `artifactProof` it describes, which is where a reader looks to decide whether a re-audit is owed, and a wrong path count sends them hunting for a gen-core diff that does not exist.

Comment-only, so the cost-model source fingerprint treats it as inert (sc-16268) and no generated artifact moves. `npm run check` 290/290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)