### PR TITLE
fix(ci): resolve rustup outside the job CARGO_HOME on the self-hosted runner (sc-17614)

### DIFF
--- a/.github/actions/prepare-rust-runner/action.yml
+++ b/.github/actions/prepare-rust-runner/action.yml
@@ -51,6 +51,14 @@ description: >
 # clippy-driver.exe/rustdoc.exe are thin launchers that load rustc_driver-*.dll /
 # std-*.dll from their OWN directory, so a copy without those DLLs would break — and
 # re-symlinking is the very thing that fails in the service context.)
+#
+# CARGO_HOME IS NOT RUSTUP'S HOME HERE. Every path this action needs from rustup —
+# rustup.exe itself, and the .cargo\bin an interactive shell resolves — hangs off the
+# profile that installed rustup, NOT off $env:CARGO_HOME. The runner services pin
+# CARGO_HOME to a per-runner dependency cache (D:\cargo-home-N) and windows-candle.yml
+# repoints it again at $RUNNER_TEMP\cargo-home; neither has a bin\. Deriving rustup
+# from CARGO_HOME silently skipped the authoritative resolution and emitted a
+# permanent bogus "rustup was deleted" warning. Keep the two notions separate.
 runs:
   using: composite
   steps:
@@ -61,8 +69,36 @@ runs:
 
         # rustup's homes are overridable by env; honor them, else the rustup defaults.
         $rustupHome = if ($env:RUSTUP_HOME) { $env:RUSTUP_HOME } else { Join-Path $env:USERPROFILE '.rustup' }
-        $cargoHome  = if ($env:CARGO_HOME)  { $env:CARGO_HOME }  else { Join-Path $env:USERPROFILE '.cargo' }
         $toolchainsDir = Join-Path $rustupHome 'toolchains'
+
+        # WHERE rustup.exe ACTUALLY LIVES — do NOT derive it from $env:CARGO_HOME.
+        # rustup drops itself and its 13 proxies into whatever CARGO_HOME was in effect
+        # AT INSTALL TIME, i.e. the developer profile. The JOB's CARGO_HOME is a wholly
+        # different thing on these runners: each runner service pins it to a per-runner
+        # dependency cache (D:\cargo-home-N — registry\, git\, config.toml, and no bin\
+        # at all) so four concurrent jobs stop racing one shared checkout (os error 267),
+        # and windows-candle.yml repoints it again at $RUNNER_TEMP\cargo-home a few steps
+        # later. Resolving rustup under CARGO_HOME therefore probed a directory that has
+        # never existed on this box: it silently disabled the authoritative resolution in
+        # (1) below — every job has been falling through to the directory scan in (2) —
+        # and made the closing .cargo\bin check report "rustup was deleted" on every
+        # single run of a box whose rustup is present and healthy.
+        $userCargoBin = Join-Path (Join-Path $env:USERPROFILE '.cargo') 'bin'
+        $rustupProbe = New-Object System.Collections.Generic.List[string]
+        if ($env:CARGO_HOME) { $rustupProbe.Add((Join-Path $env:CARGO_HOME 'bin\rustup.exe')) }
+        $rustupProbe.Add((Join-Path $userCargoBin 'rustup.exe'))
+        $onPath = Get-Command rustup.exe -CommandType Application -ErrorAction SilentlyContinue
+        if ($onPath) { $rustupProbe.Add($onPath.Source) }
+        # rustup.exe is a real ~12.8 MB binary. A reparse point or 0-byte file under that
+        # name would be a proxy dispatching to nothing, not a usable rustup.
+        $rustupExe = $rustupProbe |
+          Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } |
+          Where-Object {
+            $ri = Get-Item -LiteralPath $_ -Force
+            -not ($ri.Attributes -band [IO.FileAttributes]::ReparsePoint) -and $ri.Length -gt 0
+          } |
+          Select-Object -First 1
+        Write-Host "rustup.exe: $(if ($rustupExe) { $rustupExe } else { '<none found>' })"
 
         # The channel this repo PINS (rust-toolchain.toml at the workspace root). CI must
         # build exactly this toolchain, not whatever the box default happens to be: this box
@@ -80,20 +116,19 @@ runs:
 
         $binDir = $null
 
-        # 1) Authoritative: ask the real rustup.exe. It is a real ~12.8 MB binary (NOT one of
-        #    the fragile proxy symlinks), so it launches under the runner service token and
-        #    resolves this repo's rust-toolchain.toml exactly the way an in-repo cargo would.
-        $rustupExe = Join-Path $cargoHome 'bin\rustup.exe'
-        if (Test-Path $rustupExe) {
-          $ri = Get-Item $rustupExe -Force
-          if (-not ($ri.Attributes -band [IO.FileAttributes]::ReparsePoint) -and $ri.Length -gt 0) {
-            try {
-              $cargoPath = (& $rustupExe which cargo | Out-String).Trim()
-              if ($LASTEXITCODE -eq 0 -and $cargoPath -and (Test-Path $cargoPath)) {
-                $binDir = Split-Path -Parent $cargoPath
-              }
-            } catch { }
-          }
+        # 1) Authoritative: ask the real rustup.exe (resolved above). It is a real binary
+        #    (NOT one of the fragile proxy symlinks), so it launches under the runner
+        #    service token and resolves this repo's rust-toolchain.toml exactly the way an
+        #    in-repo cargo would — including a pinned channel the scan in (2) cannot see,
+        #    because rustup installs a toolchain-file channel on demand where the scan can
+        #    only pick from what is already on disk.
+        if ($rustupExe) {
+          try {
+            $cargoPath = (& $rustupExe which cargo | Out-String).Trim()
+            if ($LASTEXITCODE -eq 0 -and $cargoPath -and (Test-Path $cargoPath)) {
+              $binDir = Split-Path -Parent $cargoPath
+            }
+          } catch { }
         }
 
         # 2) Fallback for the dangling-shim state (rustup.exe itself deleted): resolve by
@@ -174,17 +209,35 @@ runs:
         # the entry survives the `call vcvars64.bat` cmd steps (vcvars only appends).
         Add-Content -Path $env:GITHUB_PATH -Value $binDir
 
-        # Informational only (never fatal): surface a broken .cargo\bin so the box's
-        # INTERACTIVE cargo (used by dev + sibling sessions) gets repaired too. CI itself
-        # is already immune via the PATH prepend above.
+        # Informational only (never fatal): surface a GENUINELY broken .cargo\bin so the
+        # box's INTERACTIVE cargo (used by dev + sibling sessions) gets repaired too. CI
+        # itself is already immune via the PATH prepend above.
+        #
+        # "Is a 0-byte reparse point" is NOT evidence of breakage: that is rustup's NORMAL
+        # Windows proxy layout wherever symlinks are available, and those proxies dispatch
+        # fine interactively (`.cargo\bin\cargo.exe --version` prints cargo 1.97.1 on this
+        # box, while the old check was calling it broken). Flagging that healthy shape —
+        # and flagging a bin-less job CARGO_HOME as "rustup was deleted" — fired this
+        # warning on 100% of runs and trained everyone to scroll past it. The one state
+        # worth reporting is failure mode 1 from the header: the DANGLING shim, where the
+        # rustup.exe all 13 proxies reach by argv[0] is gone and every one of them dies
+        # with ERROR_NO_ASSOCIATION. Keyed off the profile .cargo\bin, which is what an
+        # interactive shell resolves — never off the job's CARGO_HOME.
         $ErrorActionPreference = 'Continue'
-        $proxyCargo = Join-Path $cargoHome 'bin\cargo.exe'
-        if (Test-Path $proxyCargo) {
-          $i = Get-Item $proxyCargo -Force
-          if (($i.Attributes -band [IO.FileAttributes]::ReparsePoint) -or $i.Length -eq 0) {
-            Write-Host "::warning title=Fragile .cargo\bin on candle runner::'$proxyCargo' is a $([int]$i.Length)-byte reparse point (rustup proxy). This CI lane is unaffected (it uses '$binDir'), but interactive 'cargo' on the box is broken until rustup is reinstalled + Defender excludes .cargo/.rustup (sc-13166)."
+        if (Test-Path -LiteralPath $userCargoBin -PathType Container) {
+          $profileRustup = Join-Path $userCargoBin 'rustup.exe'
+          $rustupIntact = $false
+          if (Test-Path -LiteralPath $profileRustup -PathType Leaf) {
+            $ru = Get-Item -LiteralPath $profileRustup -Force
+            $rustupIntact = -not ($ru.Attributes -band [IO.FileAttributes]::ReparsePoint) -and $ru.Length -gt 0
           }
-        } else {
-          Write-Host "::warning title=Fragile .cargo\bin on candle runner::'$proxyCargo' is missing (rustup was deleted). This CI lane is unaffected (it uses '$binDir'), but interactive 'cargo' on the box is broken until rustup is reinstalled (sc-13166)."
+          if (-not $rustupIntact) {
+            # ASCII ONLY in this string, as in every other message this action emits.
+            # An em dash is UTF-8 E2 80 94; if the script is ever decoded as CP1252 the
+            # trailing 0x94 becomes U+201D, which PowerShell accepts as a STRING
+            # DELIMITER and the whole step dies on a parse error. Comments survive that
+            # mangling (rest of line ignored); quoted message strings do not.
+            Write-Host "::warning title=Dangling .cargo\bin proxies on candle runner::'$profileRustup' is missing or empty, so every rustup proxy in '$userCargoBin' dispatches to nothing and dies with ERROR_NO_ASSOCIATION. This CI lane is unaffected (it uses '$binDir'), but interactive 'cargo' on the box is broken until rustup is reinstalled (https://win.rustup.rs). First confirm no workflow runs Swatinem/rust-cache with cache-bin enabled: its post step is what deletes rustup here (scripts/lib/rust-cache-bin.mjs, sc-13166)."
+          }
         }
         exit 0

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -30,6 +30,50 @@ test("Windows runner prep falls back when its optional rustc wrapper is missing"
   );
 });
 
+test("Windows runner prep resolves rustup outside the job's CARGO_HOME", async () => {
+  const action = await source(".github/actions/prepare-rust-runner/action.yml");
+  // rustup lives in the profile that installed it. The runner services pin CARGO_HOME
+  // to a per-runner dependency cache (D:\cargo-home-N) that has no bin\ at all, and
+  // windows-candle.yml repoints it again at $RUNNER_TEMP\cargo-home — so deriving
+  // rustup.exe from CARGO_HOME alone finds nothing and skips the authoritative
+  // `rustup which cargo` resolution on every run (sc-13166).
+  assert.match(action, /\$userCargoBin = Join-Path \(Join-Path \$env:USERPROFILE '\.cargo'\) 'bin'/);
+  assert.match(action, /Get-Command rustup\.exe -CommandType Application/);
+  assert.match(action, /\$cargoPath = \(& \$rustupExe which cargo \| Out-String\)\.Trim\(\)/);
+  assert.doesNotMatch(action, /\$rustupExe = Join-Path \$cargoHome/);
+});
+
+test("Windows runner prep only warns about a genuinely dangling .cargo\\bin", async () => {
+  const action = await source(".github/actions/prepare-rust-runner/action.yml");
+  // A 0-byte reparse point is rustup's NORMAL Windows proxy shape and dispatches fine;
+  // the only state worth reporting is rustup.exe itself being gone. The old check
+  // warned on both the healthy shape and on a bin-less CARGO_HOME ("rustup was
+  // deleted"), so it fired on 100% of runs and became invisible (sc-13166).
+  // Scoped to the emitted ::warning lines — the header comment still narrates the old
+  // wording as history, and that prose must not trip this guard.
+  assert.doesNotMatch(action, /::warning[^\n]*rustup was deleted/);
+  assert.doesNotMatch(action, /::warning[^\n]*byte reparse point/);
+  assert.match(action, /\$profileRustup = Join-Path \$userCargoBin 'rustup\.exe'/);
+  assert.match(action, /if \(-not \$rustupIntact\)/);
+  // Still non-fatal: the lane is immune via the PATH prepend.
+  assert.match(action, /::warning title=Dangling \.cargo\\bin proxies on candle runner::/);
+});
+
+test("Windows runner prep emits only ASCII inside its PowerShell strings", async () => {
+  const action = await source(".github/actions/prepare-rust-runner/action.yml");
+  // The step body is handed to powershell.exe as a file. If it is ever decoded as
+  // CP1252 rather than UTF-8, an em dash (E2 80 94) becomes "â€" + U+201D, and
+  // PowerShell honors U+201D as a STRING DELIMITER — the whole step dies on a parse
+  // error before it can resolve a toolchain. Comments tolerate the mangling (the rest
+  // of the line is ignored); quoted strings do not. So: non-ASCII stays in comments.
+  const offenders = [];
+  for (const [i, line] of action.split("\n").entries()) {
+    if (/^\s*#/.test(line)) continue; // YAML/PowerShell comment lines are safe
+    if (!/^[\x09\x20-\x7e]*$/.test(line)) offenders.push(`${i + 1}: ${line.trim()}`);
+  }
+  assert.deepEqual(offenders, []);
+});
+
 test("Windows CUDA isolates Cargo dependency checkouts after toolchain discovery", async () => {
   const workflow = await source(".github/workflows/windows-candle.yml");
   const prepare = workflow.indexOf("uses: ./.github/actions/prepare-rust-runner");


### PR DESCRIPTION
Fixes the `rustup was deleted` warning the self-hosted CUDA runners emit on every job — and the silent defect hiding behind it. Follow-up to the (Done) sc-13166.

## The false premise

`prepare-rust-runner` derived rustup's location from the job's `CARGO_HOME`:

```powershell
$cargoHome  = if ($env:CARGO_HOME) { $env:CARGO_HOME } else { Join-Path $env:USERPROFILE '.cargo' }
$rustupExe  = Join-Path $cargoHome 'bin\rustup.exe'
```

rustup installs itself and its 13 proxies into the `CARGO_HOME` in effect **at install time** — the user profile, `C:\Users\Michael\.cargo\bin`. The **job's** `CARGO_HOME` is something else entirely on this box: each of the four runner services pins it to a per-runner dependency cache in its `.env` (`CARGO_HOME=D:\cargo-home-N`), holding only `registry\`, `git\`, `config.toml` and **no `bin\` at all**; `windows-candle.yml` then repoints it again at `$RUNNER_TEMP\cargo-home` a few steps later.

## What that broke

**1. The visible symptom.** The closing informational check probed `$cargoHome\bin\cargo.exe`, found nothing, and took the else-branch:

> `::warning ... 'D:\cargo-home-1\bin\cargo.exe' is missing (rustup was deleted). ... interactive 'cargo' on the box is broken until rustup is reinstalled (sc-13166).`

Both halves are false. On the box right now:

```
C:\Users\Michael\.cargo\bin\rustup.exe   12,814,336 bytes   rustup 1.29.0
C:\Users\Michael\.cargo\bin\cargo.exe --version  ->  cargo 1.97.1  (exit 0)
```

The *other* branch was wrong too: it treated "is a 0-byte reparse point" as breakage, but that is rustup's **normal** Windows proxy layout wherever symlinks are available. (sc-13166 replaced the proxies with real copies in July; rustup has since been reinstalled and recreated them as symlinks — the healthy steady state.) Whichever branch was taken, the warning was noise, which is how it earned being scrolled past.

**2. The silent half, and the more serious one.** Step (1) of the action — the **authoritative** `& $rustupExe which cargo`, which resolves `rust-toolchain.toml` the way an in-repo cargo would — was guarded on that same wrong path, so it has **never executed on these runners**. Every job silently fell through to the step (2) directory scan of `.rustup\toolchains`.

That lands correctly today *only* because the repo pins `channel = "stable"` and a `stable-*` toolchain is installed. The scan can only choose among toolchains already on disk, where rustup would install a pinned-but-absent channel on demand. The day the pin moves to a channel that is not installed, the scan falls through to the recorded `default_toolchain` — this box carries a `1.96.0` default alongside `stable` — and silently builds a different rustc/clippy than every other lane. That is precisely the failure the action's own header says it exists to prevent.

## The fix

- Resolve `rustup.exe` independently of the job's `CARGO_HOME`: probe `$env:CARGO_HOME\bin`, then `%USERPROFILE%\.cargo\bin`, then `Get-Command rustup.exe` on PATH, requiring a real non-reparse, non-empty binary. This restores step (1).
- Key the interactive-health warning off the profile `.cargo\bin` (what an interactive shell actually resolves) and fire it only on the genuinely broken state — failure mode 1 from the header, where `rustup.exe` itself is missing/empty so all 13 proxies dangle with `ERROR_NO_ASSOCIATION`. Silent on the healthy symlink layout.
- Still non-fatal; the lane remains immune via the PATH prepend.

## Also found while fixing

Every message this action emits is ASCII, and it must stay that way. An em dash inside a `Write-Host` string is UTF-8 `E2 80 94`; decoded as CP1252 the trailing `0x94` becomes `U+201D`, which PowerShell honors as a **string delimiter** — the step then dies on a parse error before it can resolve any toolchain:

```
Missing argument in parameter list.
The string is missing the terminator: ".
```

Comments tolerate the mangling (rest of line ignored); quoted strings do not. This was caught by *executing* the extracted step body, not by reading it, and is now enforced by test.

## Verification

Executed the real step body against the real box with `CARGO_HOME=D:\cargo-home-1` (the exact path from the reported warning):

**Healthy box —**
```
rustup.exe: C:\Users\Michael\.cargo\bin\rustup.exe
Repo-pinned toolchain channel: stable
Real toolchain cargo: C:\Users\Michael\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\cargo.exe
OK: cargo 1.97.1 (c980f4866 2026-06-30)
ACTION EXIT CODE: 0
```
Authoritative path used (previously never reached), **no warning**, correct PATH prepend.

**Simulated dangling shim** (proxies present, `rustup.exe` removed) — warning fires with the accurate message, still `exit 0`, lane still resolves the real toolchain. Confirms the check isn't now dead code.

`js-yaml` parses the action (1 step, 177 run-lines, 0 non-ASCII in non-comment lines).

## Guards added

In `scripts/platform-review-contracts.test.mjs` (already wired into `npm run check`) — 25/25 pass:

- rustup is not resolved from `CARGO_HOME` alone; `%USERPROFILE%\.cargo\bin` and the PATH probe are present; the authoritative `rustup which cargo` call is present.
- Neither bogus warning text can return (scoped to emitted `::warning` lines, so the header comment may still narrate the old wording as history).
- No non-comment line in the action may contain a non-ASCII character.

Also re-ran `check-rust-cache-bin.mjs` (10 workflows pass) and `scripts/lib/rust-cache-bin.test.mjs` (11 pass), since the new warning points at that invariant as the first thing to check.

## Scope note

`desktop-windows.yml` uses the same composite action, so it gets the identical fix. No runner-side or on-box changes are needed — the box is healthy; only the action's beliefs about it were wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
