### PR TITLE
Bind the retention cutoff once instead of re-evaluating now (sc-17597)

### DIFF
--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -632,22 +632,39 @@ impl JobsStore {
 
     /// Remove terminal queue history older than `retention_days`.
     ///
-    /// Zero disables retention. Job-owned metrics are materialized into the
-    /// independent Generation Stats history and then deleted in the same
-    /// immediate transaction as their owning jobs. Legacy orphan metrics are
-    /// also removed.
+    /// Zero disables retention. The cutoff is resolved to a fixed timestamp
+    /// here, in Rust, rather than being left as a `datetime('now', ...)`
+    /// modifier for SQLite to evaluate: `now` is constant only within a single
+    /// `sqlite3_step`, so a modifier re-evaluated by each of the four statements
+    /// below would let the cutoff ADVANCE mid-transaction. A job whose
+    /// `completed_at` fell between two of those evaluations was then deleted
+    /// from `jobs` and `generation_metrics` without ever being materialized
+    /// into the history table — a silent, permanent loss of the run from
+    /// Generation Stats, re-rolled on every API start (sc-17597).
     pub fn purge_terminal_jobs_older_than(&self, retention_days: u32) -> JobsStoreResult<usize> {
         if retention_days == 0 {
             return Ok(0);
         }
+        let cutoff = format_unix_seconds(now_unix_seconds() - i64::from(retention_days) * 86_400);
+        self.purge_terminal_jobs_completed_before(&cutoff)
+    }
+
+    /// Remove terminal queue history completed strictly before `cutoff` (a
+    /// `YYYY-MM-DDTHH:MM:SSZ` UTC timestamp, the shape [`utc_now`] emits).
+    ///
+    /// Job-owned metrics are materialized into the independent Generation Stats
+    /// history and then deleted in the same immediate transaction as their
+    /// owning jobs. Legacy orphan metrics are also removed. Every statement
+    /// shares the one caller-supplied cutoff, so the window cannot move
+    /// underneath the sweep; a job completed exactly ON the cutoff is retained.
+    pub fn purge_terminal_jobs_completed_before(&self, cutoff: &str) -> JobsStoreResult<usize> {
         let mut guard = self.lock.lock();
         let connection = self.write_connection(&mut guard)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        let modifier = format!("-{retention_days} days");
         let terminal = terminal_statuses_sql();
         let predicate = format!(
             "status in ({terminal}) and completed_at is not null \
-             and datetime(completed_at) < datetime('now', ?1)"
+             and datetime(completed_at) < datetime(?1)"
         );
         transaction.execute(
             &format!(
@@ -656,14 +673,14 @@ impl JobsStore {
                    from generation_metrics m join jobs j on j.id = m.job_id
                   where j.{predicate}"
             ),
-            params![modifier],
+            params![cutoff],
         )?;
         transaction.execute(
             &format!(
                 "delete from generation_metrics where job_id in \
                  (select id from jobs where {predicate})"
             ),
-            params![modifier],
+            params![cutoff],
         )?;
         transaction.execute(
             "delete from generation_metrics
@@ -672,7 +689,7 @@ impl JobsStore {
         )?;
         let deleted = transaction.execute(
             &format!("delete from jobs where {predicate}"),
-            params![modifier],
+            params![cutoff],
         )?;
         transaction.commit()?;
         Ok(deleted)

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -87,31 +87,51 @@ fn startup_retention_purges_only_expired_terminal_jobs_and_owned_metrics() {
             )
             .expect("metrics seed");
     }
+    // Straddle the 90-day cutoff by half a day each way rather than sitting exactly on it: this
+    // test reads the wall clock twice (once to seed, once inside the purge), so a row seeded ON
+    // the cutoff lands on whichever side the clock reached by the time the sweep runs — it was
+    // asserting the elapsed time between two statements, not the retention window (sc-17597).
+    // Twelve hours of slack is ~40k× the observed jitter and still resolves a one-day error in
+    // either direction. The exact-tie semantics are pinned separately, and deterministically, by
+    // `retention_retains_a_job_completed_exactly_on_the_cutoff`. `strftime` rather than
+    // `datetime` so the fixtures carry the same `...THH:MM:SSZ` shape production writes.
+    for (id, days, hours) in [
+        ("boundary", "-89 days", "-12 hours"),
+        ("just-expired", "-90 days", "-12 hours"),
+    ] {
+        connection
+            .execute(
+                "insert into jobs (
+                   id,type,status,payload_json,result_json,requested_gpu,progress,stage,message,
+                   attempts,cancel_requested,created_at,updated_at,completed_at
+                 ) values (?1,'image_generate','completed','{}','{}','auto',1,'completed','',1,0,
+                           strftime('%Y-%m-%dT%H:%M:%SZ','now',?2,?3),
+                           strftime('%Y-%m-%dT%H:%M:%SZ','now',?2,?3),
+                           strftime('%Y-%m-%dT%H:%M:%SZ','now',?2,?3))",
+                params![id, days, hours],
+            )
+            .expect("cutoff-adjacent job seeds");
+        connection
+            .execute(
+                "insert into generation_metrics(job_id,updated_at)
+                 values (?1,strftime('%Y-%m-%dT%H:%M:%SZ','now',?2,?3))",
+                params![id, days, hours],
+            )
+            .expect("cutoff-adjacent metrics seed");
+    }
     connection
         .execute(
-            "insert into jobs (
-               id,type,status,payload_json,result_json,requested_gpu,progress,stage,message,
-               attempts,cancel_requested,created_at,updated_at,completed_at
-             ) values ('boundary','image_generate','completed','{}','{}','auto',1,'completed','',
-                       1,0,datetime('now','-90 days'),datetime('now','-90 days'),
-                       datetime('now','-90 days'))",
+            "insert into generation_metrics(job_id,updated_at) values ('orphan','2020-01-01T00:00:00Z')",
             [],
         )
-        .expect("boundary job seeds");
-    connection
-        .execute(
-            "insert into generation_metrics(job_id,updated_at) values
-             ('boundary',datetime('now','-90 days')),('orphan','2020-01-01T00:00:00Z')",
-            [],
-        )
-        .expect("boundary and orphan metrics seed");
+        .expect("orphan metrics seed");
     drop(connection);
 
     assert_eq!(
         store
             .purge_terminal_jobs_older_than(90)
             .expect("retention succeeds"),
-        4
+        5
     );
     let connection = Connection::open(&path).expect("db reopens");
     assert_eq!(
@@ -123,6 +143,48 @@ fn startup_retention_purges_only_expired_terminal_jobs_and_owned_metrics() {
             )
             .unwrap(),
         0
+    );
+    assert_eq!(
+        connection
+            .query_row(
+                "select count(*) from jobs where id='just-expired'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        0,
+        "a terminal job an hour past the cutoff is purged"
+    );
+    assert_eq!(
+        connection
+            .query_row(
+                "select count(*) from generation_metrics where job_id='just-expired'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        0,
+        "the purged job's owned metrics go with it"
+    );
+    assert_eq!(
+        connection
+            .query_row("select count(*) from jobs where id='boundary'", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap(),
+        1,
+        "a terminal job an hour inside the cutoff is retained"
+    );
+    assert_eq!(
+        connection
+            .query_row(
+                "select count(*) from generation_metrics where job_id='boundary'",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        1,
+        "the retained job keeps its owned metrics"
     );
     assert_eq!(
         connection
@@ -151,6 +213,17 @@ fn startup_retention_purges_only_expired_terminal_jobs_and_owned_metrics() {
         0,
         "legacy orphan metrics are job-owned garbage"
     );
+    assert_eq!(
+        connection
+            .query_row(
+                "select count(*) from generation_metrics_history",
+                [],
+                |row| row.get::<_, i64>(0)
+            )
+            .unwrap(),
+        5,
+        "only the purged jobs materialize — retained ones would double-count in the stats union"
+    );
     drop(connection);
     let historical = store
         .list_generation_metrics(None, None, None, 100)
@@ -165,7 +238,11 @@ fn startup_retention_purges_only_expired_terminal_jobs_and_owned_metrics() {
     );
     assert!(
         historical.iter().any(|row| row.job_id == "boundary"),
-        "the exact cutoff boundary is retained"
+        "the job inside the cutoff is still live in Generation Stats"
+    );
+    assert!(
+        historical.iter().any(|row| row.job_id == "just-expired"),
+        "a job purged from just past the cutoff is materialized into Generation Stats"
     );
     let connection = Connection::open(&path).expect("db reopens");
     assert!(connection
@@ -175,6 +252,66 @@ fn startup_retention_purges_only_expired_terminal_jobs_and_owned_metrics() {
             |_| Ok(())
         )
         .is_ok());
+}
+
+#[test]
+fn retention_retains_a_job_completed_exactly_on_the_cutoff() {
+    // "Older than 90 days" excludes a job that is exactly 90 days old, so the sweep compares with
+    // `<`, not `<=`. That tie is only observable if the caller owns the cutoff — while it was a
+    // `datetime('now','-90 days')` modifier that SQLite re-evaluated per statement, no test could
+    // seed a row onto it without racing the clock (sc-17597). Going through the cutoff-taking
+    // entry point pins the comparison exactly, with no wall-clock dependence at all.
+    let path = temp_db("retention-exact-tie");
+    let store = JobsStore::new(path.clone());
+    store.initialize().expect("store initializes");
+    let cutoff = "2026-05-07T00:00:00Z";
+    let connection = Connection::open(&path).expect("db opens");
+    for (id, completed_at) in [
+        ("one-second-before", "2026-05-06T23:59:59Z"),
+        ("exactly-on-cutoff", cutoff),
+        ("one-second-after", "2026-05-07T00:00:01Z"),
+    ] {
+        connection
+            .execute(
+                "insert into jobs (
+                   id,type,status,payload_json,result_json,requested_gpu,progress,stage,message,
+                   attempts,cancel_requested,created_at,updated_at,completed_at
+                 ) values (?1,'image_generate','completed','{}','{}','auto',1,'completed','',
+                           1,0,?2,?2,?2)",
+                params![id, completed_at],
+            )
+            .expect("tie job seeds");
+    }
+    drop(connection);
+
+    assert_eq!(
+        store
+            .purge_terminal_jobs_completed_before(cutoff)
+            .expect("retention succeeds"),
+        1,
+        "only the job completed strictly before the cutoff is purged"
+    );
+    let connection = Connection::open(&path).expect("db reopens");
+    let surviving = |id: &str| {
+        connection
+            .query_row(
+                "select count(*) from jobs where id=?1",
+                params![id],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap()
+    };
+    assert_eq!(surviving("one-second-before"), 0, "a second past is purged");
+    assert_eq!(
+        surviving("exactly-on-cutoff"),
+        1,
+        "a job exactly 90 days old is not OLDER than 90 days, so it is retained"
+    );
+    assert_eq!(
+        surviving("one-second-after"),
+        1,
+        "a second short is retained"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes [sc-17597](https://app.shortcut.com/trefry/story/17597).

The flaky test was the symptom. The cause was a silent data-loss window in the retention sweep itself.

## The reported flake

`startup_retention_purges_only_expired_terminal_jobs_and_owned_metrics` seeded a `boundary` job at exactly `datetime('now','-90 days')` and asserted it survived `purge_terminal_jobs_older_than(90)`. `datetime()` resolves to whole seconds, and the seed and the sweep each evaluated `now` independently — so whether the row survived depended on whether the second ticked in between. (The story said microseconds; it is really the second boundary.)

Reproduced deterministically by sleeping 1100 ms between the seed and the purge — the reported panic, every time:

```
assertion `left == right` failed
  left: 5
 right: 4
```

## The same defect, live in production

`purge_terminal_jobs_older_than` built one predicate containing `datetime('now', ?1)` and ran it in **four separate statements**. SQLite holds `now` constant only within a single `sqlite3_step`, so the cutoff could **advance mid-transaction**. A job whose `completed_at` fell between two evaluations was deleted from `jobs` and `generation_metrics` without ever being materialized into `generation_metrics_history`.

Forcing the tick between statements one and two, on the real code path:

```
deleted from jobs            : 1
generation_metrics for 'tie' : 0
history rows for 'tie'       : 0     <- the run is gone from Generation Stats entirely
```

That is silent, permanent loss of a completed run from Generation Stats, contradicting the function's own doc comment, and re-rolled on every API start (`apps/rust-api/src/lib.rs:1213`). Low probability per run — it needs a job completed in that exact second, 90 days ago — but unbounded over time and invisible when it happens.

## The fix

Resolve the cutoff **once**, in Rust, and bind that single literal to all four statements:

```rust
let cutoff = format_unix_seconds(now_unix_seconds() - i64::from(retention_days) * 86_400);
self.purge_terminal_jobs_completed_before(&cutoff)
```

`purge_terminal_jobs_older_than` keeps its signature and delegates to a new `purge_terminal_jobs_completed_before(cutoff)`. The window can no longer move underneath the sweep. Same forced-tick scenario after the fix: `deleted=0, jobs_rows=1` — retained, consistently.

## Why this also fixes the test properly

Seeding the fixtures at safe offsets alone would have de-flaked the test *and silently dropped coverage*: the old test caught a `<` → `<=` flip 100% of the time, and offset rows cannot see that tie at all. The adversarial review caught this in the first draft of the change.

Binding the cutoff is exactly the injection seam the story called for ("fine only if the test controls `now`"), so the tie is now pinned deterministically by a new `retention_retains_a_job_completed_exactly_on_the_cutoff` — three rows one second either side of a fixed cutoff, no wall-clock dependence at all.

The fixture rows also move to ±12 h around the cutoff (~40,000× the observed jitter, while still resolving a one-day error in either direction) and use `strftime('%Y-%m-%dT%H:%M:%SZ', …)` so they carry the same shape production writes rather than SQLite's space-separated form.

## Mutation results

Coverage was verified by mutating the production predicate and confirming the tests go red, not by inspection:

| Mutation | Old test | Offsets only | This PR |
|---|---|---|---|
| `<` → `<=` (exact-tie semantics) | caught | **survived** | **caught** |
| retention window widened by one day | **survived** | caught | caught |
| history insert unscoped (double-counts) | survived | survived | **caught** |
| drop orphan-metrics delete | caught | caught | caught |
| drop history materialization | caught | caught | caught |

## Verification

- `npm run rust:check` green end to end (9/9 steps, 0 failures) on the merge commit with `origin/main` merged in.
- The target test looped 200× with 0 failures; the whole `jobs_store` binary passes.
- Only production caller (`apps/rust-api/src/lib.rs:1213`) uses the unchanged public signature; `origin/main` did not touch `sceneworks-core`.

## Filed separately

Two unrelated pre-existing issues surfaced while running the gate; neither is touched here:

- [sc-17640](https://app.shortcut.com/trefry/story/17640) — `terminal_side_effect_recovery_backoff_prevents_poison_batch_starvation` is load-sensitive (failing run 9.93 s vs ~2 s passes). Same defect *class*, different crate and mechanism.
- [sc-17641](https://app.shortcut.com/trefry/story/17641) — `temp_db` leaks a database file per run (43,981 stale files in `%TEMP%`) and keys on PID alone, so a recycled PID can inherit a stale `-wal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
