### PR TITLE
Stop waking a self-hosted lane for the other backend's capability dump (sc-17665)

### DIFF
--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -50,7 +50,22 @@ on:
       # the "real dump, not a restamp" step below is unreachable for the one edit it exists to
       # catch: a restamp touches ONLY config/engine-capabilities/capabilities.mlx.json, matching no
       # other path here, so the lane would not run at all on the PR that made the file wrong.
-      - "config/engine-capabilities/**"
+      #
+      # THIS FILE, not `config/engine-capabilities/**` (sc-17665). The directory glob also matched
+      # capabilities.candle.json, so a candle-only restamp woke this whole macOS job -- including the
+      # bare `cargo test` over every default member -- for a file its verify step never opens.
+      # Self-hosted runners are the fleet's most constrained resource. Nothing here reads the sibling
+      # file: no Rust reads the facts directory at all (`default_facts_dir()` only builds the dumper
+      # bin's default OUTPUT path), and the three consumers that DO glob it sit outside this job --
+      # previewSupportCatalog.test.js runs in check.yml's hosted Linux `web` job, and
+      # generate-preview-support.mjs / bump-inference.mjs are manual scripts no workflow invokes.
+      #
+      # No coverage is lost. A restamp is the only edit this drops, and it is exactly the edit this
+      # lane cannot check; a *material* sibling change also regenerates
+      # config/manifests/builtin.preview-support.jsonc, and `config/manifests/**` above still wakes
+      # both lanes. Path filters match DELETES and ADDS too, so a restamp, delete or re-add of this
+      # file still triggers the lane.
+      - "config/engine-capabilities/capabilities.mlx.json"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".cargo/config.toml"

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -63,7 +63,24 @@ on:
       # config/engine-capabilities/capabilities.candle.json, which matches no other path
       # here, so the lane would not run at all on the PR that made the file wrong. Same
       # gap sc-17119 closed on the macOS side.
-      - "config/engine-capabilities/**"
+      #
+      # THIS FILE, not `config/engine-capabilities/**` (sc-17665). The directory glob also
+      # matched capabilities.mlx.json, so an mlx-only restamp woke this ENTIRE job — every
+      # step below, on the fleet's single `cuda` box — for a file the verify step never
+      # opens. Nothing in this lane reads it: no Rust reads the facts directory at all
+      # (`default_facts_dir()` only builds the dumper bin's default OUTPUT path; a repo-wide
+      # grep finds no reader), and the three consumers that DO glob the whole directory are
+      # all outside this job — `previewSupportCatalog.test.js` runs in check.yml's hosted
+      # Linux `web` job, while `generate-preview-support.mjs` and `bump-inference.mjs` are
+      # manual developer scripts that no workflow invokes at all.
+      #
+      # Narrowing costs no coverage. A restamp is the ONLY edit this drops, and it is
+      # precisely the edit this lane cannot check; any *material* change to the sibling dump
+      # also regenerates config/manifests/builtin.preview-support.jsonc, and
+      # `config/manifests/**` above still wakes both lanes. Path filters match DELETES and
+      # ADDS as well as modifications, so a restamp, a delete or a re-add of this file still
+      # triggers the lane, and a rename is a delete+add that still matches.
+      - "config/engine-capabilities/capabilities.candle.json"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/actions/prepare-rust-runner/**"

--- a/apps/web/scripts/generate-preview-support.mjs
+++ b/apps/web/scripts/generate-preview-support.mjs
@@ -26,8 +26,10 @@
 //
 // Those two lanes DO verify their own dump on every PR that can invalidate it: `macos-mlx.yml`
 // re-dumps and diffs `capabilities.mlx.json` (sc-17119), and `windows-candle.yml` does the same for
-// `capabilities.candle.json` (sc-17592); both watch `config/engine-capabilities/**`. So a restamp —
-// the `inferenceRevision` line rewritten over a stale engine list — cannot reach main unnoticed.
+// `capabilities.candle.json` (sc-17592); each watches its OWN dump by exact path, not the whole
+// directory, so neither self-hosted box is woken for the other backend's file (sc-17665). So a
+// restamp — the `inferenceRevision` line rewritten over a stale engine list — cannot reach main
+// unnoticed.
 // (The remaining candle lanes verify nothing: `desktop-windows.yml` does its candle work in the
 // `package-windows` job, which is skipped on pull_request, and `server-candle-linux.yml` is
 // `workflow_dispatch`-only.) Descriptor-level truth is additionally guarded upstream and

--- a/crates/sceneworks-worker/src/engine_capability_facts.rs
+++ b/crates/sceneworks-worker/src/engine_capability_facts.rs
@@ -35,9 +35,10 @@
 //! **Both files are nevertheless VERIFIED on every PR** that can invalidate them. `macos-mlx.yml`
 //! re-dumps to a scratch dir and diffs `capabilities.mlx.json` against it (sc-17119); the
 //! self-hosted CUDA lane `windows-candle.yml` does the same for `capabilities.candle.json` under
-//! `shell: cmd` (sc-17592). Both lanes watch `config/engine-capabilities/**`, so the one edit these
-//! guards exist to catch — a **restamp**, where the `inferenceRevision` line is rewritten and the
-//! engine list is left stale — cannot slip through by touching that file alone. Without those steps
+//! `shell: cmd` (sc-17592). Each lane watches its OWN dump by exact path — not the directory
+//! (sc-17665), which would wake each self-hosted box for the other backend's file — so the one edit
+//! these guards exist to catch — a **restamp**, where the `inferenceRevision` line is rewritten and
+//! the engine list is left stale — cannot slip through by touching that file alone. Without those steps
 //! every remaining guard reads this file as a *source* and is satisfied by editing one line. (The
 //! other candle lanes still verify nothing: `desktop-windows.yml` builds the sidecar on main/release
 //! only, and `server-candle-linux.yml` is `workflow_dispatch`-only.)

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -642,6 +642,68 @@ test("both stage-1 lanes verify their own capability dump, LAST and reachably", 
     // Reachability. A restamp touches ONLY the facts file, so without this path entry the lane does
     // not run at all on the one PR the step exists to catch — declared but unreachable, the same
     // trap sc-17026 was about.
-    assert.match(lane, /^ {6}- "config\/engine-capabilities\/\*\*"$/m, path);
+    //
+    // Pinned to THIS lane's own file, not `config/engine-capabilities/**` (sc-17665). The directory
+    // glob satisfied reachability too, but it also woke each lane for the OTHER backend's dump — a
+    // whole self-hosted job, on the fleet's most constrained resource, for a file the woken lane
+    // never opens.
+    //
+    // Asserted by MATCHING the declared globs against both filenames, not by forbidding particular
+    // spellings. A spelling blocklist only catches a straight revert: keeping the narrow entry and
+    // *adding* `config/engine-capabilities/*.json`, `config/engine-capabilities/**/*` or `config/**`
+    // restores the cross-wake in full, and every one of those passes a `**`/`*` blocklist. Matching
+    // is spelling-independent and closes all of them at once.
+    const anchorAt = lane.indexOf("paths: &");
+    assert.ok(anchorAt > 0, `${path} must declare a paths anchor`);
+    const declared = [
+      ...lane
+        .slice(anchorAt, lane.indexOf("pull_request:"))
+        .matchAll(/^ {6}- "([^"]+)"$/gm),
+    ].map((match) => match[1]);
+    // GitHub filter-pattern syntax: `*` matches any run of characters except `/`, `**` matches any
+    // run including `/`. `**/` is treated as "zero or more directories", matching the convention
+    // GitHub's own `**/README.md` example implies. That reading is also the SAFE one here: it makes
+    // `config/engine-capabilities/**/*` count as matching a file directly in that directory, so an
+    // ambiguous pattern is rejected rather than quietly permitted. Nobody needs to spell it that way.
+    const matches = (glob, target) => {
+      let source = "";
+      for (let i = 0; i < glob.length; i += 1) {
+        const char = glob[i];
+        if (char === "*") {
+          if (glob[i + 1] === "*") {
+            if (glob[i + 2] === "/") {
+              source += "(?:.*/)?";
+              i += 2;
+            } else {
+              source += ".*";
+              i += 1;
+            }
+          } else {
+            source += "[^/]*";
+          }
+        } else {
+          source += "\\^$+?.()|[]{}".includes(char) ? `\\${char}` : char;
+        }
+      }
+      return new RegExp(`^${source}$`).test(target);
+    };
+    const own = `config/engine-capabilities/${file}`;
+    assert.ok(
+      declared.some((glob) => matches(glob, own)),
+      `${path} must watch ${own}, or a restamp of it — which touches nothing else — never ` +
+        "triggers the lane and the verification step is declared but unreachable.",
+    );
+    for (const [, otherFile] of lanes) {
+      if (otherFile === file) continue;
+      const foreign = `config/engine-capabilities/${otherFile}`;
+      const culprits = declared.filter((glob) => matches(glob, foreign));
+      assert.deepEqual(
+        culprits,
+        [],
+        `${path} triggers on ${foreign} via ${JSON.stringify(culprits)}, but has no step that ` +
+          "reads it. That wakes an entire self-hosted job — the fleet's most constrained " +
+          "resource — for a file this lane cannot check. Narrow the pattern to this lane's own dump.",
+      );
+    }
   }
 });


### PR DESCRIPTION
Closes [sc-17665](https://app.shortcut.com/trefry/story/17665). Follow-up to [#2124](https://github.com/SceneWorks/SceneWorks/pull/2124) (sc-17592), correcting a choice made there and inherited from sc-17119.

## The problem

Both stage-1 lanes watched the whole **directory**:

```yaml
- "config/engine-capabilities/**"
```

That matches **both** backends' dumps. So an mlx-only restamp woke the entire `candle-worker` job on the fleet's single `cuda` box, and a candle-only restamp woke `nax-worker` on the macOS box — in each case for a file the woken lane never opens. sc-17119 introduced the shape; sc-17592 copied it for symmetry and defended it as deliberate parity. Symmetry was the wrong reason. The self-hosted runners are the most constrained resource in the fleet, and the wildcard buys nothing.

## Verified, not assumed

- **No Rust reads the checked-in facts directory.** `default_facts_dir()` only builds the dumper binary's default *output* path; a repo-wide grep finds no reader. Checked every default member, not just the worker — `macos-mlx.yml` runs a bare `cargo test` over all six.
- **Each lane's verify step names exactly one file.**
- **The three consumers that glob the whole directory all sit outside these jobs.** `previewSupportCatalog.test.js` runs in `check.yml`'s hosted Linux `web` job; `generate-preview-support.mjs` and `bump-inference.mjs` are manual scripts that **no workflow invokes at all**.

## The actual cost

From #2124's real `candle-worker` run (job 92172542886):

| Step | Time |
| --- | --- |
| Check and test the candle memory adapter | 476s |
| Test the candle GPU worker (backend-candle) | 371s |
| Fetch the private inference release | 299s |
| Check the candle sidecar builds | 234s |
| Verify capabilities.candle.json | 68s |
| Clippy (candle worker) | 41s |

The wildcard never cost the verify step's 68s — it cost a **whole job**: ~4.2 min median per the lane's own header, and 25m19s on that run once upstream changes forced rebuilds.

## No coverage lost

A restamp is the only edit dropped, and it is precisely the edit the woken lane cannot check. Any *material* change to the sibling dump also regenerates `config/manifests/builtin.preview-support.jsonc`, and `config/manifests/**` still wakes both lanes. GitHub path filters match deletes and adds as well as modifications, so a restamp, delete, or re-add of a lane's own file still triggers it; a rename is delete+add and still matches. A future third backend file wakes neither lane — correct, since neither verifies it, and adding a backend means editing `SCENEWORKS_BACKENDS` under `crates/**` (watched by both) with `assertBackendCoverage` failing closed in the unfiltered vitest job.

## The test asserts the property, not a spelling

The contract test now **matches the declared globs against both filenames** instead of forbidding particular spellings. That distinction is load-bearing: a spelling blocklist only catches a straight revert. Keeping the narrow entry and *additively* declaring `config/engine-capabilities/*.json`, `**/*`, or `config/**` restores the cross-wake in full and passes a blocklist clean.

Mutation matrix — every row turns the suite **red**:

| Mutation | Result |
| --- | --- |
| additive `config/engine-capabilities/**` | RED |
| additive `config/engine-capabilities/*.json` | RED |
| additive `config/engine-capabilities/**/*` | RED |
| additive `config/**` | RED |
| additive `**/*.json` | RED |
| additive sibling `capabilities.mlx.json` | RED |
| straight revert to the directory glob | RED |
| drop the entry entirely (guard unreachable) | RED |

`**/` is treated as *zero or more* directories — the convention GitHub's own `**/README.md` example implies, and the safe reading here, since it rejects an ambiguous pattern rather than quietly permitting it.

## Three false claims from #2124, corrected

Caught in adversarial review of this change:

1. **The sc-12399 citation was backwards.** I described `github.sha` concurrency keying as a design that conserves the CUDA box. It does the opposite — it *spends* box time (~34m per ~37h, per the measurement in that same file) to stop main-push runs being evicted and losing their candle verdict.
2. **"The Node consumers run in the hosted parity/web jobs under their own filters"** was wrong twice: two of the three run in no workflow, and the one that does runs under **no path filter at all**. That is a *stronger* argument for this narrowing than the one I originally wrote.
3. **Two module docs still asserted the `**` spelling** — `engine_capability_facts.rs` and `generate-preview-support.mjs`. Nothing tests those strings, so they would have rotted silently.

## Validation

- `node --test scripts/platform-review-contracts.test.mjs` — 26/26
- `npm run check` — exit 0
- `rustfmt --check` on the touched file — clean
- `npm run gen:preview-support` — no drift
- YAML parsed: both `&mlx_paths` / `&candle_paths` anchors still propagate the new entry to **both** the `push` and `pull_request` triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
