### PR TITLE
Re-dump the audio facts at the pin main now carries (sc-17593)

### DIFF
--- a/config/engine-capabilities/audio/capabilities.candle.json
+++ b/config/engine-capabilities/audio/capabilities.candle.json
@@ -2,7 +2,7 @@
   "registry": "audio",
   "backend": "candle",
   "generatedFrom": {
-    "inferenceRevision": "a4f409ae8ce73eda2ee8117b89b5f479666606b8",
+    "inferenceRevision": "fbb00d6b4147bd220fe324050534708c12fb022d",
     "dumper": "cargo run -p sceneworks-worker --bin dump-engine-capabilities [--no-default-features --features backend-candle]"
   },
   "engines": [


### PR DESCRIPTION
## What does this PR do?

Unbreaks `main`. One line: re-dumps `config/engine-capabilities/audio/capabilities.candle.json` at `fbb00d6b`, the pin main now carries.

## What happened

`main` is red on two lanes:

- **macOS MLX worker** — `Verify capabilities.mlx.json is a real dump, not a restamp`. The mlx half passed; the audio half failed, printing the exact one-line diff.
- **Check → web** — the stage-2 drift guard refused to derive at all: `derivePreviewSupport: backend candle was dumped at two different inference revisions (fbb00d6b… and a4f409ae…)`.

Both are correct. `main` carries pin `fbb00d6b` with `capabilities.candle.json` and `capabilities.mlx.json` at that revision, and `audio/capabilities.candle.json` still at `a4f409ae`.

### Neither contributing PR was wrong, and neither could have seen it

| | pin in its tree | media facts | audio facts |
|---|---|---|---|
| [#2120](https://github.com/SceneWorks/SceneWorks/pull/2120) (repin FLUX.2 Klein parity) | `fbb00d6b` | restamped to `fbb00d6b` | *file does not exist in this tree* |
| [#2125](https://github.com/SceneWorks/SceneWorks/pull/2125) (sc-17593 audio dump) | `a4f409ae` | `a4f409ae` | added at `a4f409ae` |
| **merged** | `fbb00d6b` | `fbb00d6b` | **`a4f409ae`** ← stale |

Each branch was internally consistent and green. They touch **different files**, so git merged them with no textual conflict and produced a tree neither branch ever built. `22b0c6fb0` (the pin bump) is not an ancestor of any commit on the sc-17593 branch — including `9063de0d5`, where I *did* merge `origin/main` in before verifying. It landed on main afterwards, via #2120.

## The fix

Re-dumped for real on the CUDA box at `fbb00d6b` — not restamped. All 14 audio generators and their `supportsPreview` values are identical between the two revisions, so only the provenance line moves.

Two things the same dump run establishes for free:

- **`capabilities.candle.json` came back byte-identical** to what main carries, so #2120's restamp of it was correct. The macOS lane had already proven the same for `capabilities.mlx.json`.
- **The derived artifacts needed no regeneration.** `builtin.preview-support.jsonc` already stamps `fbb00d6b` for both backends and the `models` block does not change, so `npm run gen:preview-support` produces no diff. Verified rather than assumed.

## Related issue

Story: [sc-17593](https://app.shortcut.com/trefry/story/17593). Fallout from #2125 × #2120 landing in that order.

No GitHub issue — tracked in Shortcut.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

Data-only. No Rust or JS source changes; the changed file is a stage-1 facts file that no Rust code reads (Rust reads the derived `builtin.preview-support.jsonc`, which is unchanged).

## How was this tested?

- [ ] macOS (Apple Silicon / MLX)
- [x] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [ ] Not platform-specific (web UI, docs, shared crate)

Reproduced main's failure locally first — the drift guard threw the same two-revisions error before the fix, and passes 51/51 after. Then `npm run check` (exit 0, including `bump-inference.mjs --self-test`) and the full web suite, **3530 passed / 236 files**.

Both CI lanes that are red on main will re-run this diff: the macOS restamp lane and `Check → web`.

## Checklist

- [x] I ran `npm run rust:check` (if I touched Rust) — n/a, no Rust changed
- [x] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build` (if I touched the web app) — n/a for source; the web suite was run in full regardless
- [x] I ran `npm run check` (scaffold checks)
- [x] I updated documentation where relevant — n/a
- [ ] All my commits are signed off (`git commit -s` — see the DCO section in CONTRIBUTING.md)
- [x] My PR is focused on a single logical change

## Reviewer note — no guard is missing

Both guards fired, in the right order and with the right message: the cheap every-PR one refused to derive rather than emitting a mixed-revision artifact, and the expensive lane one named the file and the command to fix it. What neither can do is run against a tree that did not exist until the merge button was pressed.

That class of failure — two green PRs that are incompatible only when combined — is not addressable in code from either side. The repo-level lever is branch protection's **"Require branches to be up to date before merging"** (or a merge queue) on `main`, which would have forced #2125 to re-run against #2120's pin and gone red before merge. That is a settings change and a real cost in CI time on the self-hosted lanes, so I have not touched it — flagging it as your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
