### PR TITLE
Scan the recovery queue at an explicit instant (sc-17640)

### DIFF
--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -850,14 +850,34 @@ async fn process_pending_terminal_progress_side_effects(
         .map(Some)
 }
 
-/// Drain one bounded batch of durable terminal handoffs. Per-job failures are
-/// isolated and remain pending for the next cadence; a DB enumeration failure
-/// is returned so the lifecycle loop can report it without exiting.
+/// Drain the batch that is due *now* — the production entry point, called on
+/// startup and on the background cadence. Resolving the instant here rather
+/// than inside the scan is what lets the drain below be driven from a fixed
+/// instant; see it for the behavior and for why.
 pub(crate) async fn recover_pending_terminal_progress_side_effects_once(
     state: &AppState,
 ) -> Result<usize, ApiError> {
+    recover_pending_terminal_progress_side_effects_as_of(state, now_unix_seconds()).await
+}
+
+/// Drain one bounded batch of durable terminal handoffs, taking those due as of
+/// `as_of` (Unix seconds) rather than at the wall clock. Per-job failures are
+/// isolated and remain pending for the next cadence; a DB enumeration failure
+/// is returned so the lifecycle loop can report it without exiting.
+///
+/// Production passes `now` via the wrapper above; tests freeze the instant so an
+/// assertion about the durable backoff cannot be decided by how long the test
+/// took (sc-17640). Only this read side honors `as_of` — a failed attempt is
+/// still deferred against real time by the store.
+pub(crate) async fn recover_pending_terminal_progress_side_effects_as_of(
+    state: &AppState,
+    as_of: i64,
+) -> Result<usize, ApiError> {
     let ids = store_call(state.clone(), move |store, _timeout| {
-        store.pending_terminal_progress_side_effect_job_ids(PROGRESS_SIDE_EFFECT_RECOVERY_BATCH)
+        store.pending_terminal_progress_side_effect_job_ids_as_of(
+            as_of,
+            PROGRESS_SIDE_EFFECT_RECOVERY_BATCH,
+        )
     })
     .await?;
     let mut recovered = 0;

--- a/apps/rust-api/src/tests/training.rs
+++ b/apps/rust-api/src/tests/training.rs
@@ -2440,13 +2440,30 @@ async fn startup_drain_recovers_accepted_terminal_side_effect_failure_without_su
 }
 
 /// A fixed oldest-first batch must not let persistent failures monopolize the
-/// recovery queue. The first pass poisons a full production-sized batch; the
-/// durable retry schedule must rotate all of them out so the newer healthy row
-/// completes on the next pass, without retrying the poison rows every second.
+/// recovery queue. The fixture creates one more row than fits in a batch and
+/// poisons the full batch, leaving exactly one healthy row that the first pass
+/// never reaches. The durable retry schedule must rotate the poison rows out so
+/// that healthy row completes on the next pass, without retrying the poison
+/// rows every second — and must then bring them back once that backoff expires,
+/// rather than deferring them out of the queue for good.
+///
+/// (All 129 rows go terminal within the same second, and `updated_at` has
+/// second granularity, so the row left out is the largest-`id` one rather than
+/// the newest. Which row it is does not matter — only that it is healthy and
+/// that both enumerations agree on it, which the shared ordering guarantees.)
+///
+/// Every *scan* below is driven at an explicit instant rather than at the wall
+/// clock, so the schedule decides the outcome and machine speed cannot. The
+/// deferrals themselves still stamp real time; the assertions are written to
+/// hold for any instant those stamps can land on (sc-17640). The exact length
+/// of the backoff is pinned separately, next to the schedule that computes it,
+/// by `terminal_side_effect_retry_backoff_doubles_and_survives_restart` in
+/// `sceneworks-core`.
 #[tokio::test]
 async fn terminal_side_effect_recovery_backoff_prevents_poison_batch_starvation() {
     use sceneworks_core::contracts::{JobStatus, JobType, ProgressStage};
     use sceneworks_core::jobs_store::{CreateJob, ProgressUpdate, RegisterWorker};
+    use sceneworks_core::time::now_unix_seconds;
 
     const BATCH: usize = crate::jobs::PROGRESS_SIDE_EFFECT_RECOVERY_BATCH;
 
@@ -2520,8 +2537,18 @@ async fn terminal_side_effect_recovery_backoff_prevents_poison_batch_starvation(
         .lock()
         .extend(poison_ids.iter().cloned());
 
+    // Freeze the instant every scan below evaluates dueness against, captured
+    // BEFORE the first pass runs. Each poison row is deferred to
+    // `(its own deferral instant) + backoff`, and every deferral happens at or
+    // after `scan_at`, so relative to `scan_at` the whole batch is durably in
+    // the future no matter how slow this machine is. Scanning at the real wall
+    // clock instead made the final assertion a race against the 5-second
+    // first-failure backoff: a pass slow enough to outlast it (ordinary load, a
+    // busy CI runner) let correctly-deferred rows come back due, and the test
+    // reddened unrelated PRs through the shared `rust:test` gate (sc-17640).
+    let scan_at = now_unix_seconds();
     assert_eq!(
-        crate::jobs::recover_pending_terminal_progress_side_effects_once(&state)
+        crate::jobs::recover_pending_terminal_progress_side_effects_as_of(&state, scan_at)
             .await
             .expect("poison batch recovery returns"),
         0
@@ -2533,6 +2560,10 @@ async fn terminal_side_effect_recovery_backoff_prevents_poison_batch_starvation(
             .all(|job_id| first_attempts.get(job_id) == Some(&1)),
         "every poison row must be attempted exactly once in the first pass"
     );
+    // Every deferral above committed at or after `scan_at`, so no row's durable
+    // deadline can have landed on or before it — the assertions below are
+    // decided by the retry schedule, never by elapsed real time.
+    let deferred_by = now_unix_seconds();
 
     drop(state);
     let (_, restarted_state) =
@@ -2540,24 +2571,65 @@ async fn terminal_side_effect_recovery_backoff_prevents_poison_batch_starvation(
     restarted_state
         .progress_side_effects_fail_job_ids
         .lock()
-        .extend(poison_ids);
+        .extend(poison_ids.iter().cloned());
     assert_eq!(
-        crate::jobs::recover_pending_terminal_progress_side_effects_once(&restarted_state)
-            .await
-            .expect("healthy recovery returns"),
+        crate::jobs::recover_pending_terminal_progress_side_effects_as_of(
+            &restarted_state,
+            scan_at
+        )
+        .await
+        .expect("healthy recovery returns"),
         1,
         "durably deferred poison rows must not starve the newer healthy handoff after restart"
     );
     assert_eq!(
-        crate::jobs::recover_pending_terminal_progress_side_effects_once(&restarted_state)
-            .await
-            .expect("bounded retry scan returns"),
+        crate::jobs::recover_pending_terminal_progress_side_effects_as_of(
+            &restarted_state,
+            scan_at
+        )
+        .await
+        .expect("bounded retry scan returns"),
         0
     );
     assert_eq!(
         *restarted_state.progress_side_effects_attempts.lock(),
         std::collections::HashMap::new(),
         "poison rows must stay out of the due set across restart until durable backoff expires"
+    );
+
+    // ...and the deferral is a bounded backoff, not a silent drop. Without this
+    // the assertion above passes just as happily if a row is deferred forever,
+    // which would strand its side effects instead of retrying them.
+    //
+    // `deferred_by` was read after every deferral committed, so no deadline can
+    // exceed it by more than one delay, and one delay is capped at
+    // `PROGRESS_SIDE_EFFECT_RETRY_MAX_SECONDS` (5 minutes, in `sceneworks-core`).
+    // A day past `deferred_by` is therefore beyond every deadline the schedule
+    // can emit, by three orders of magnitude — so this scan too is decided by
+    // the schedule, not by the clock. Raising that cap past a day would fail
+    // this test loudly, on the `expired_attempts` assertion below.
+    //
+    // That assertion is the one with teeth: the `== 0` here is also what an
+    // empty batch returns, so the two must stay together.
+    assert_eq!(
+        crate::jobs::recover_pending_terminal_progress_side_effects_as_of(
+            &restarted_state,
+            deferred_by.saturating_add(24 * 60 * 60),
+        )
+        .await
+        .expect("expired backoff scan returns"),
+        0,
+        "the poison rows still fail, so none of them recovers"
+    );
+    let expired_attempts = restarted_state
+        .progress_side_effects_attempts
+        .lock()
+        .clone();
+    assert!(
+        poison_ids
+            .iter()
+            .all(|job_id| expired_attempts.get(job_id) == Some(&1)),
+        "once the durable backoff expires every poison row must be retried again"
     );
 }
 

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -2356,13 +2356,35 @@ impl JobsStore {
         }
     }
 
-    /// Return a bounded batch of terminal jobs whose API-owned side effects
-    /// still need recovery. The API drains this durable queue at startup and on
-    /// a background cadence, so recovery does not depend on a worker repeating
-    /// a terminal progress report after it already observed the committed
-    /// terminal state.
+    /// The batch that is due *now* — the shape production recovery wants.
+    /// Resolving the instant here, rather than inside the query, is what lets
+    /// [`Self::pending_terminal_progress_side_effect_job_ids_as_of`] be driven
+    /// from a fixed instant; see it for the behavior and for why.
     pub fn pending_terminal_progress_side_effect_job_ids(
         &self,
+        limit: usize,
+    ) -> JobsStoreResult<Vec<String>> {
+        self.pending_terminal_progress_side_effect_job_ids_as_of(now_unix_seconds(), limit)
+    }
+
+    /// Return a bounded batch of terminal jobs whose API-owned side effects
+    /// still need recovery, judging dueness as of `as_of` (Unix seconds)
+    /// instead of the wall clock. The API drains this durable queue at startup
+    /// and on a background cadence, so recovery does not depend on a worker
+    /// repeating a terminal progress report after it already observed the
+    /// committed terminal state. A row is due once its deadline has *arrived*,
+    /// so a row whose `progress_side_effects_retry_at` equals `as_of` is
+    /// included.
+    ///
+    /// Production always passes `now`. Tests pass a *frozen* instant so that an
+    /// assertion about which rows are due describes the durable retry schedule
+    /// rather than how long the test itself took to run: with the wall clock,
+    /// a slow pass could let the 5-second first-failure backoff expire between
+    /// deferring a row and scanning for it, and rows that were correctly
+    /// deferred would legitimately come back due (sc-17640).
+    pub fn pending_terminal_progress_side_effect_job_ids_as_of(
+        &self,
+        as_of: i64,
         limit: usize,
     ) -> JobsStoreResult<Vec<String>> {
         let connection = self.open_connection()?;
@@ -2377,7 +2399,7 @@ impl JobsStore {
         )?;
         let ids = statement
             .query_map(
-                params![now_unix_seconds(), i64::try_from(limit).unwrap_or(i64::MAX)],
+                params![as_of, i64::try_from(limit).unwrap_or(i64::MAX)],
                 |row| row.get(0),
             )?
             .collect::<Result<Vec<_>, _>>()?;

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -11,6 +11,7 @@ use sceneworks_core::jobs_store::{
     DuplicateJob, JobsStore, JobsStoreError, ProgressUpdate, RegisterWorker, RetryJob,
     WorkerHeartbeat, MAC_NOT_AVAILABLE_LABEL, MAX_JOB_ATTEMPTS,
 };
+use sceneworks_core::time::now_unix_seconds;
 use serde_json::{json, Map, Value};
 
 fn temp_db(name: &str) -> PathBuf {
@@ -7027,6 +7028,108 @@ fn terminal_side_effect_handoff_is_resumable_only_by_the_original_owner() {
         .expect("the owner may retry the same terminal state");
     assert!(!retry.applied);
     assert!(retry.side_effects_pending);
+}
+
+/// Pin the durable retry schedule that keeps a poison side-effect handoff from
+/// monopolizing the recovery batch: a fresh handoff is due immediately, each
+/// failure defers it by an exponentially growing delay, and the count backing
+/// that growth survives a process restart.
+///
+/// The rust-api fairness test
+/// (`terminal_side_effect_recovery_backoff_prevents_poison_batch_starvation`)
+/// covers the batch-rotation behavior, but is deliberately written to hold for
+/// *any* positive delay so it cannot race the wall clock. The delays themselves
+/// are therefore pinned here, next to the code that computes them (sc-17640).
+#[test]
+fn terminal_side_effect_retry_backoff_doubles_and_survives_restart() {
+    // Keep the path so the store can be reopened; `store()` wipes the file.
+    let path = temp_db("terminal-side-effect-backoff");
+    let store = JobsStore::new(path.clone());
+    store.initialize().expect("store initializes");
+    register_image_worker(&store);
+    let created = store
+        .create_job(image_job(Map::new()))
+        .expect("job creates");
+    store
+        .claim_next_job("worker-1")
+        .expect("claim succeeds")
+        .expect("job claimed");
+    store
+        .update_job_progress_with_outcome(
+            &created.id,
+            ProgressUpdate {
+                status: JobStatus::Completed,
+                stage: ProgressStage::Completed,
+                progress: 1.0,
+                message: "done".to_owned(),
+                error: None,
+                result: Some(object(json!({ "assetWrites": [] }))),
+                eta_seconds: None,
+                peak_gpu_memory_pct: None,
+                peak_gpu_load_pct: None,
+                backend: None,
+                worker_id: Some("worker-1".to_owned()),
+            },
+        )
+        .expect("terminal progress is accepted");
+
+    // An accepted handoff carries no backoff at all: its deadline is 0. That
+    // exactly-known deadline is what lets the scan's boundary be pinned to the
+    // second — a row is due once its deadline has ARRIVED (`<=`), not only
+    // strictly after it (`<`), so a one-second-late retry cannot creep in.
+    let due_as_of = |store: &JobsStore, as_of: i64| {
+        store
+            .pending_terminal_progress_side_effect_job_ids_as_of(as_of, 128)
+            .expect("recovery queue scans")
+    };
+    assert_eq!(
+        due_as_of(&store, 0),
+        vec![created.id.clone()],
+        "a row is due AT its deadline, not one second later"
+    );
+    assert!(
+        due_as_of(&store, -1).is_empty(),
+        "and is not due before its deadline"
+    );
+
+    // Each failed attempt brackets the row's new deadline. `defer` stamps
+    // `now + delay` at some instant in `before..=after`, so the deadline lands
+    // in `before + delay ..= after + delay`: it is never due at
+    // `before + delay - 1`, and always due at `after + delay`. Both bounds hold
+    // for any machine speed, so this cannot flake; together they pin `delay`
+    // whenever the two reads fall in the same second, which is the norm for a
+    // single sub-millisecond write.
+    let defer_and_bracket = |store: &JobsStore, delay: i64, what: &str| {
+        let before = now_unix_seconds();
+        assert!(
+            store
+                .defer_pending_terminal_progress_side_effects(&created.id)
+                .expect("a pending row defers"),
+            "{what}: the row is still pending, so it defers"
+        );
+        let after = now_unix_seconds();
+        assert!(
+            due_as_of(store, before + delay - 1).is_empty(),
+            "{what}: must not be due before {delay}s have passed"
+        );
+        assert_eq!(
+            due_as_of(store, after + delay),
+            vec![created.id.clone()],
+            "{what}: must be due once {delay}s have passed"
+        );
+    };
+
+    defer_and_bracket(&store, 5, "first failure");
+    defer_and_bracket(&store, 10, "second failure doubles the delay");
+
+    // Reopen the same database: the retry COUNT is durable, not process state,
+    // so the third failure continues the progression at 20s rather than
+    // restarting it at the 5s base. A worker that crash-loops the API cannot
+    // reset its own backoff.
+    drop(store);
+    let restarted = JobsStore::new(path);
+    restarted.initialize().expect("restarted store initializes");
+    defer_and_bracket(&restarted, 20, "third failure after restart");
 }
 
 #[test]


### PR DESCRIPTION
Fixes [sc-17640](https://app.shortcut.com/trefry/story/17640).

## The defect

`terminal_side_effect_recovery_backoff_prevents_poison_batch_starvation` asserted that poison rows stay out of the due set across a restart — but decided that against the **wall clock**. The first pass defers 128 poison rows one at a time, each to `now + 5s` (`PROGRESS_SIDE_EFFECT_RETRY_BASE_SECONDS`). If the pass plus the restart outlasted that 5-second window, the earliest-deferred rows *legitimately* became due again and the assertion's premise no longer held. It lives in the shared `rust:test` gate, so it could redden any unrelated PR.

**Reproduced deterministically:** injecting 4.2 s between the first pass and the restart produces the reported panic exactly, with every poison row attempted once. Under 40× load on a CUDA box the first pass alone takes ~2.2 s, so a busier machine crosses the threshold on its own.

## The fix

Split the due-set scan the same way [#2121](https://github.com/SceneWorks/SceneWorks/pull/2121) (sc-17597) split the retention cutoff — a caller-parameterized variant with a thin wrapper that supplies `now`:

- `JobsStore::pending_terminal_progress_side_effect_job_ids_as_of(as_of, limit)`
- `jobs::recover_pending_terminal_progress_side_effects_as_of(state, as_of)`

**Production behavior is unchanged** — it calls the wrapper, which passes `now`. The only observable shift is that `now` is resolved just before the blocking dispatch rather than inside `params!`, which makes the cutoff marginally *older*: strictly conservative (a row is skipped for one 1-second tick, never returned early).

The test now drives every scan at one instant captured **before** the first pass. Every deferral therefore commits at or after that instant, so each row's deadline is provably in its future no matter how slow the machine is.

## The seam closes two gaps the old test could not see

1. **Deferred forever passed just as happily as deferred 5 s** — a row dropped from the queue permanently would strand its side effects instead of retrying them. A final scan a day out now asserts the poison rows do come back.
2. **The retry schedule itself had no coverage anywhere.** Added `terminal_side_effect_retry_backoff_doubles_and_survives_restart` in `sceneworks-core`, pinning:
   - the `<=` due-set boundary **to the second** — a fresh handoff's deadline is exactly `0`, so `as_of(0)` vs `as_of(-1)` pins inclusivity without a clock race;
   - the 5 s base delay and the doubling on the second failure;
   - durability of the retry *count* across a store reopen (a crash-looping API cannot reset its own backoff).

## Verification

- `npm run rust:check` — green (**2648 passed, 0 failed**).
- The flaky test: **40/40** concurrent runs pass at ~7.8 s each, i.e. well past the 5 s backoff that used to break them.
- Survives a deliberately injected **12 s** stall (2.4× the backoff) between the first pass and the restart.
- **Mutation-checked** — each of these turns the suite red, so the tests still have teeth:
  | mutation | caught by |
  |---|---|
  | deferral removed (`retry_at` not advanced) | original starvation assertion |
  | deferral made permanent (`retry_at = i64::MAX`) | new expired-backoff scan *(passed before this PR)* |
  | base delay 5 s → 1 s | new core test |
  | doubling removed | new core test |
  | `<=` → `<` in the scan predicate | new core test |
  | retry count reset on restart | new core test |

Reviewed by an independent adversarial subagent; its substantive findings (untested retry schedule, doc comments left on the wrappers instead of the code that moved, `due_at` → `as_of` naming) are folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)