### PR TITLE
Stop test temp databases and snapshots leaking into %TEMP% (sc-17641)

### DIFF
--- a/crates/sceneworks-core/src/base_weights.rs
+++ b/crates/sceneworks-core/src/base_weights.rs
@@ -1571,13 +1571,11 @@ mod tests {
     /// is refused — a torn artifact must not register as a model that then fails at load.
     #[test]
     fn is_mage_flow_transformer_dir_requires_both_the_config_and_the_weights() {
-        let root = std::env::temp_dir().join(format!(
-            "mage-dir-probe-{}-{:?}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-        ));
+        // Guarded rather than hand-cleaned: the trailing `remove_dir_all` this replaces was
+        // skipped whenever an assertion below panicked, which is exactly when the leftovers
+        // pile up (sc-17641).
+        let root_guard = tempfile::tempdir().expect("temp dir for the probe fixtures");
+        let root = root_guard.path();
         let case = |name: &str, files: &[&str]| {
             let dir = root.join(name);
             fs::create_dir_all(&dir).unwrap();
@@ -1610,8 +1608,6 @@ mod tests {
         );
         assert!(!is_mage_flow_transformer_dir(&case("empty", &[])));
         assert!(!is_mage_flow_transformer_dir(&root.join("absent")));
-
-        fs::remove_dir_all(root).ok();
     }
 
     #[test]

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1,5 +1,5 @@
 use std::ops::Deref;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use rusqlite::{params, Connection};
 use sceneworks_core::contracts::{
@@ -72,6 +72,14 @@ impl Deref for TestStore {
     }
 }
 
+/// Empty, but load-bearing: a `Drop` impl makes `TestStore` non-destructurable, so no
+/// caller can write `store("name").store` and move the `JobsStore` out on its own. That
+/// would drop the directory guard at the end of the statement and delete the database
+/// out from under a still-live connection.
+impl Drop for TestStore {
+    fn drop(&mut self) {}
+}
+
 fn store(name: &str) -> TestStore {
     let db = temp_db(name);
     let store = JobsStore::new(db.path());
@@ -106,30 +114,69 @@ fn register_image_worker(store: &JobsStore) {
         .expect("worker registers");
 }
 
+/// Assert a guarded directory is gone once its guard has dropped.
+///
+/// `TempDir::drop` removes the directory and SWALLOWS any failure, so a one-shot
+/// `exists()` here would itself be a flake — in the very suite this story de-flaked.
+/// A bounded wait costs nothing when cleanup worked (the first look succeeds) and
+/// still fails loudly when it did not: a genuinely leaked directory stays forever,
+/// not for a second.
+fn assert_removed(directory: &Path) {
+    for _ in 0..40 {
+        if !directory.exists() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+    panic!(
+        "temp database directory outlived its guard: {}",
+        directory.display()
+    );
+}
+
+/// Rows currently in a store's `jobs` table, read through a fresh connection.
+fn job_count(store: &JobsStore) -> i64 {
+    let connection = Connection::open(store.db_path()).expect("db opens");
+    connection
+        .query_row("select count(*) from jobs", [], |row| row.get(0))
+        .expect("job count reads")
+}
+
 #[test]
-fn temp_db_paths_are_unique_per_call_not_per_process() {
-    // The old scheme keyed uniqueness on `std::process::id()`, so a run that landed
-    // on a recycled PID reopened an earlier run's path — inheriting whatever `-wal`
-    // that run had stranded there. Uniqueness has to come from the call site.
-    let first = temp_db("uniqueness");
-    let second = temp_db("uniqueness");
+fn same_named_stores_are_independent_databases() {
+    // The old scheme keyed uniqueness on `std::process::id()`, so two same-named
+    // databases in one process WERE one file, and a run landing on a recycled PID
+    // reopened an earlier run's path — inheriting whatever `-wal` it had stranded
+    // there. Assert the behaviour rather than just the names: separate paths are only
+    // interesting because the stores cannot see each other's rows.
+    let first = store("uniqueness");
+    let second = store("uniqueness");
     assert_ne!(
-        first.path(),
-        second.path(),
-        "two temp_db calls with the same name must not share a path"
+        first.db_path(),
+        second.db_path(),
+        "two stores with the same name must not share a path"
+    );
+
+    register_image_worker(&first);
+    first
+        .create_job(image_job(object(
+            json!({ "prompt": "only in the first store" }),
+        )))
+        .expect("job creates");
+
+    assert_eq!(job_count(&first), 1, "the first store holds its own job");
+    assert_eq!(
+        job_count(&second),
+        0,
+        "a same-named store must be a separate database, not the same file reopened"
     );
 }
 
 #[test]
 fn temp_db_guard_removes_the_database_and_its_wal_siblings() {
-    let directory;
-    {
+    let directory = {
         let db = temp_db("guard-cleanup");
         let path = db.path();
-        directory = path
-            .parent()
-            .expect("database sits in its own directory")
-            .to_path_buf();
 
         let store = JobsStore::new(path.clone());
         store.initialize().expect("store initializes");
@@ -140,19 +187,32 @@ fn temp_db_guard_removes_the_database_and_its_wal_siblings() {
             )))
             .expect("job creates");
 
-        // WAL mode parks `-wal`/`-shm` next to the database while a connection is
-        // open. The old cleanup unlinked only the `.db`, stranding exactly these.
-        assert!(
-            path.with_extension("db-wal").exists(),
-            "expected a -wal sibling while the write connection is open"
-        );
-    }
+        // WAL mode parks `-wal`/`-shm` next to the database while a connection is open,
+        // and the old cleanup unlinked only the `.db`, stranding exactly those. Enabling
+        // WAL is explicitly allowed to fail (sc-4275 / F-CORE-16), in which case there is
+        // no sidecar to strand — so only demand the siblings when WAL actually took.
+        let connection = Connection::open(&path).expect("db opens");
+        let journal_mode: String = connection
+            .query_row("pragma journal_mode", [], |row| row.get(0))
+            .expect("journal mode reads");
+        drop(connection);
+        if journal_mode.eq_ignore_ascii_case("wal") {
+            assert!(
+                path.with_extension("db-wal").exists(),
+                "expected a -wal sibling while the write connection is open"
+            );
+            assert!(
+                path.with_extension("db-shm").exists(),
+                "expected a -shm sibling while the write connection is open"
+            );
+        }
 
-    assert!(
-        !directory.exists(),
-        "temp database directory outlived its guard: {}",
-        directory.display()
-    );
+        path.parent()
+            .expect("database sits in its own directory")
+            .to_path_buf()
+    };
+
+    assert_removed(&directory);
 }
 
 #[test]
@@ -172,14 +232,12 @@ fn store_helper_removes_its_directory_after_closing_the_connection() {
             .to_path_buf()
     };
 
-    // Windows refuses to unlink a file that still has an open handle, so a
-    // directory that is gone here also proves the store's long-lived write
-    // connection was closed before the guard removed it.
-    assert!(
-        !directory.exists(),
-        "store() directory outlived its guard: {}",
-        directory.display()
-    );
+    // On WINDOWS this also pins the drop ORDER of `TestStore`'s fields: the OS refuses to
+    // unlink a file that still has an open handle, so a directory that is gone here proves
+    // the store's long-lived write connection closed before the guard removed it. On Unix
+    // `remove_dir_all` succeeds against an open descriptor, so there this checks only that
+    // cleanup happened at all — the ordering guarantee is Windows-verified.
+    assert_removed(&directory);
 }
 
 #[test]

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::ops::Deref;
 use std::path::PathBuf;
 
 use rusqlite::{params, Connection};
@@ -13,21 +13,70 @@ use sceneworks_core::jobs_store::{
 };
 use serde_json::{json, Map, Value};
 
-fn temp_db(name: &str) -> PathBuf {
-    let mut path = std::env::temp_dir();
-    path.push(format!("sceneworks-core-{name}-{}.db", std::process::id()));
-    let _ = fs::remove_file(&path);
-    path
+/// A test database that owns the directory it lives in and takes the whole
+/// directory with it when it drops.
+///
+/// The shape this replaces — `temp_dir()/sceneworks-core-{name}-{pid}.db`,
+/// unlinked at the *start* of a run — was wrong twice over (sc-17641). Nothing
+/// ever removed the file, so every test in every run left its database behind:
+/// 46,773 of them had piled up in this box's `%TEMP%`, roughly a third of
+/// everything in it. And because the uniqueness key was the PID while only the
+/// `.db` was unlinked, a run that landed on a recycled PID opened a fresh, empty
+/// database next to a stale `-wal` left by an unrelated earlier run — a silent
+/// and very hard to trace flake source.
+///
+/// Owning a directory fixes both halves: `tempfile` names it uniquely per *call*
+/// rather than per process, and the `-wal`/`-shm` siblings leave with their
+/// parent. Cleanup rides on `Drop` rather than a line at the end of each test,
+/// because a test that panics is exactly the one whose leftovers matter.
+struct TempDb {
+    dir: tempfile::TempDir,
+}
+
+impl TempDb {
+    /// Path to the database file inside the guarded directory.
+    fn path(&self) -> PathBuf {
+        self.dir.path().join("jobs.db")
+    }
+}
+
+fn temp_db(name: &str) -> TempDb {
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("sceneworks-core-{name}-"))
+        .tempdir()
+        .expect("temp dir for the test database");
+    TempDb { dir }
 }
 
 fn object(value: Value) -> Map<String, Value> {
     value.as_object().expect("test value is an object").clone()
 }
 
-fn store(name: &str) -> JobsStore {
-    let store = JobsStore::new(temp_db(name));
+/// A [`JobsStore`] bundled with the temp directory it lives in, so callers keep
+/// writing `let store = store("name");` and still get cleanup for free.
+///
+/// Field order is load-bearing: `store` drops first, closing the long-lived write
+/// connection, and only then does `_db` remove the directory. Windows refuses to
+/// delete a file that still has an open handle, so the reverse order would leave
+/// the database behind — the very leak this replaces.
+struct TestStore {
+    store: JobsStore,
+    _db: TempDb,
+}
+
+impl Deref for TestStore {
+    type Target = JobsStore;
+
+    fn deref(&self) -> &JobsStore {
+        &self.store
+    }
+}
+
+fn store(name: &str) -> TestStore {
+    let db = temp_db(name);
+    let store = JobsStore::new(db.path());
     store.initialize().expect("store initializes");
-    store
+    TestStore { store, _db: db }
 }
 
 fn image_job(payload: Map<String, Value>) -> CreateJob {
@@ -58,8 +107,85 @@ fn register_image_worker(store: &JobsStore) {
 }
 
 #[test]
+fn temp_db_paths_are_unique_per_call_not_per_process() {
+    // The old scheme keyed uniqueness on `std::process::id()`, so a run that landed
+    // on a recycled PID reopened an earlier run's path — inheriting whatever `-wal`
+    // that run had stranded there. Uniqueness has to come from the call site.
+    let first = temp_db("uniqueness");
+    let second = temp_db("uniqueness");
+    assert_ne!(
+        first.path(),
+        second.path(),
+        "two temp_db calls with the same name must not share a path"
+    );
+}
+
+#[test]
+fn temp_db_guard_removes_the_database_and_its_wal_siblings() {
+    let directory;
+    {
+        let db = temp_db("guard-cleanup");
+        let path = db.path();
+        directory = path
+            .parent()
+            .expect("database sits in its own directory")
+            .to_path_buf();
+
+        let store = JobsStore::new(path.clone());
+        store.initialize().expect("store initializes");
+        register_image_worker(&store);
+        store
+            .create_job(image_job(object(
+                json!({ "prompt": "leaves a wal behind" }),
+            )))
+            .expect("job creates");
+
+        // WAL mode parks `-wal`/`-shm` next to the database while a connection is
+        // open. The old cleanup unlinked only the `.db`, stranding exactly these.
+        assert!(
+            path.with_extension("db-wal").exists(),
+            "expected a -wal sibling while the write connection is open"
+        );
+    }
+
+    assert!(
+        !directory.exists(),
+        "temp database directory outlived its guard: {}",
+        directory.display()
+    );
+}
+
+#[test]
+fn store_helper_removes_its_directory_after_closing_the_connection() {
+    let directory = {
+        let store = store("guard-store-cleanup");
+        register_image_worker(&store);
+        store
+            .create_job(image_job(object(
+                json!({ "prompt": "opens the long-lived write connection" }),
+            )))
+            .expect("job creates");
+        store
+            .db_path()
+            .parent()
+            .expect("database sits in its own directory")
+            .to_path_buf()
+    };
+
+    // Windows refuses to unlink a file that still has an open handle, so a
+    // directory that is gone here also proves the store's long-lived write
+    // connection was closed before the guard removed it.
+    assert!(
+        !directory.exists(),
+        "store() directory outlived its guard: {}",
+        directory.display()
+    );
+}
+
+#[test]
 fn startup_retention_purges_only_expired_terminal_jobs_and_owned_metrics() {
-    let path = temp_db("retention");
+    let db = temp_db("retention");
+    let path = db.path();
     let store = JobsStore::new(path.clone());
     store.initialize().expect("store initializes");
     let connection = Connection::open(&path).expect("db opens");
@@ -261,7 +387,8 @@ fn retention_retains_a_job_completed_exactly_on_the_cutoff() {
     // `datetime('now','-90 days')` modifier that SQLite re-evaluated per statement, no test could
     // seed a row onto it without racing the clock (sc-17597). Going through the cutoff-taking
     // entry point pins the comparison exactly, with no wall-clock dependence at all.
-    let path = temp_db("retention-exact-tie");
+    let db = temp_db("retention-exact-tie");
+    let path = db.path();
     let store = JobsStore::new(path.clone());
     store.initialize().expect("store initializes");
     let cutoff = "2026-05-07T00:00:00Z";
@@ -316,7 +443,8 @@ fn retention_retains_a_job_completed_exactly_on_the_cutoff() {
 
 #[test]
 fn retention_is_atomic_when_job_deletion_fails() {
-    let path = temp_db("retention-rollback");
+    let db = temp_db("retention-rollback");
+    let path = db.path();
     let store = JobsStore::new(path.clone());
     store.initialize().expect("store initializes");
     let connection = Connection::open(&path).expect("db opens");
@@ -362,7 +490,8 @@ fn retention_is_atomic_when_job_deletion_fails() {
 
 #[test]
 fn zero_retention_preserves_terminal_history() {
-    let path = temp_db("retention-disabled");
+    let db = temp_db("retention-disabled");
+    let path = db.path();
     let store = JobsStore::new(path.clone());
     store.initialize().expect("store initializes");
     let connection = Connection::open(&path).expect("db opens");
@@ -6621,7 +6750,8 @@ fn concurrent_claims_never_lock_and_stay_exactly_once() {
     const WORKERS: usize = 4;
     const JOBS: usize = 60;
 
-    let path = temp_db("concurrent-claim");
+    let db = temp_db("concurrent-claim");
+    let path = db.path();
     let primary = JobsStore::new(path.clone());
     primary.initialize().expect("store initializes");
 
@@ -6714,7 +6844,8 @@ fn reads_proceed_while_a_writer_holds_the_write_lock() {
     use std::thread;
     use std::time::{Duration, Instant};
 
-    let path = temp_db("read-during-write");
+    let db = temp_db("read-during-write");
+    let path = db.path();
     let store = JobsStore::new(path.clone());
     store.initialize().expect("store initializes");
     register_image_worker(&store);
@@ -7226,7 +7357,8 @@ fn mlx_worker_refuses_anima_edit_image_jobs() {
 /// connection preserves the concurrency contract the per-op opener guaranteed.
 #[test]
 fn long_lived_connection_survives_many_sequential_ops() {
-    let path = temp_db("long-lived-sequential");
+    let db = temp_db("long-lived-sequential");
+    let path = db.path();
     let store = JobsStore::new(path.clone());
     store.initialize().expect("store initializes");
     register_image_worker(&store);

--- a/crates/sceneworks-worker/src/krea_control_fit.rs
+++ b/crates/sceneworks-worker/src/krea_control_fit.rs
@@ -598,13 +598,14 @@ fn fit_ladder_for_tier(
 fn registered_contract_for_tier(tier_key: &str) -> Option<MemoryProviderContract> {
     // One directory per CALL: parallel tests sharing a per-process path race between this
     // writer and the provider's reader, which surfaces as a spurious `Unknown` ladder verdict.
-    static SNAPSHOT_SERIAL: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-    let serial = SNAPSHOT_SERIAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let root = std::env::temp_dir().join(format!(
-        "sw-krea-control-fit-{}-{serial}-{tier_key}",
-        std::process::id()
-    ));
-    let transformer = root.join("transformer");
+    // The guard also takes the snapshot with it when the call returns — the previous
+    // per-process path was never removed and had piled up 31,264 directories under `%TEMP%`
+    // on one box, the single largest leaker there (sc-17641).
+    let root = tempfile::Builder::new()
+        .prefix(&format!("sw-krea-control-fit-{tier_key}-"))
+        .tempdir()
+        .ok()?;
+    let transformer = root.path().join("transformer");
     std::fs::create_dir_all(&transformer).ok()?;
     let config = match tier_key {
         "q4" => Some(r#"{"quantization":{"bits":4,"group_size":64}}"#),
@@ -614,7 +615,7 @@ fn registered_contract_for_tier(tier_key: &str) -> Option<MemoryProviderContract
     if let Some(text) = config {
         std::fs::write(transformer.join("config.json"), text).ok()?;
     }
-    let mut spec = gen_core::LoadSpec::new(gen_core::WeightsSource::Dir(root));
+    let mut spec = gen_core::LoadSpec::new(gen_core::WeightsSource::Dir(root.path().to_path_buf()));
     if let Some(quant) = quant_for_tier_key(tier_key) {
         spec = spec.with_quant(quant);
     }

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -5006,9 +5006,8 @@ fn wav_header_is_canonical_and_preserves_in_range_amplitude() {
         sample_rate: 48_000,
         channels: 1,
     };
-    let dir = std::env::temp_dir().join(format!("sw_wav_{}", Uuid::new_v4().simple()));
-    std::fs::create_dir_all(&dir).unwrap();
-    let path = dir.join("a.wav");
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("a.wav");
     write_wav_pcm16(&audio, &path).unwrap();
     let bytes = std::fs::read(&path).unwrap();
     assert_eq!(&bytes[0..4], b"RIFF");
@@ -5032,9 +5031,8 @@ fn wav_normalizes_only_over_range_audio() {
         sample_rate: 48_000,
         channels: 1,
     };
-    let dir = std::env::temp_dir().join(format!("sw_wav_{}", Uuid::new_v4().simple()));
-    std::fs::create_dir_all(&dir).unwrap();
-    let path = dir.join("over-range.wav");
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("over-range.wav");
     write_wav_pcm16(&audio, &path).unwrap();
     let bytes = std::fs::read(path).unwrap();
     assert_eq!(i16::from_le_bytes([bytes[44], bytes[45]]), i16::MAX);
@@ -5130,9 +5128,8 @@ fn silent_audio_does_not_divide_by_zero() {
         sample_rate: 48_000,
         channels: 1,
     };
-    let dir = std::env::temp_dir().join(format!("sw_wav_{}", Uuid::new_v4().simple()));
-    std::fs::create_dir_all(&dir).unwrap();
-    let path = dir.join("silent.wav");
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("silent.wav");
     write_wav_pcm16(&audio, &path).unwrap();
     let bytes = std::fs::read(&path).unwrap();
     assert!(bytes[44..].iter().all(|&b| b == 0));

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -5041,8 +5041,8 @@ fn wav_normalizes_only_over_range_audio() {
 
 #[tokio::test]
 async fn seedvr2_failed_mux_cleanup_removes_silent_and_partial_outputs() {
-    let dir = std::env::temp_dir().join(format!("sw_seedvr2_mux_{}", Uuid::new_v4().simple()));
-    std::fs::create_dir_all(&dir).unwrap();
+    let dir_guard = tempfile::tempdir().expect("temp dir");
+    let dir = dir_guard.path();
     let media_path = dir.join("upscaled.mp4");
     let mux_tmp = dir.join("upscaled.audiomux.mp4");
     let poster_path = media_path.with_extension("poster.jpg");
@@ -5055,13 +5055,12 @@ async fn seedvr2_failed_mux_cleanup_removes_silent_and_partial_outputs() {
     assert!(!media_path.exists());
     assert!(!mux_tmp.exists());
     assert!(!poster_path.exists());
-    let _ = std::fs::remove_dir_all(dir);
 }
 
 #[test]
 fn seedvr2_output_guard_covers_the_full_post_encode_interval() {
-    let dir = std::env::temp_dir().join(format!("sw_seedvr2_guard_{}", Uuid::new_v4().simple()));
-    std::fs::create_dir_all(&dir).unwrap();
+    let dir_guard = tempfile::tempdir().expect("temp dir");
+    let dir = dir_guard.path();
     let media_path = dir.join("upscaled.mp4");
     let mux_tmp = dir.join("upscaled.audiomux.mp4");
     let poster_path = media_path.with_extension("poster.jpg");
@@ -5077,13 +5076,12 @@ fn seedvr2_output_guard_covers_the_full_post_encode_interval() {
     assert!(!media_path.exists());
     assert!(!mux_tmp.exists());
     assert!(!poster_path.exists());
-    let _ = std::fs::remove_dir_all(dir);
 }
 
 #[test]
 fn seedvr2_output_guard_preserves_published_outputs_after_disarm() {
-    let dir = std::env::temp_dir().join(format!("sw_seedvr2_guard_{}", Uuid::new_v4().simple()));
-    std::fs::create_dir_all(&dir).unwrap();
+    let dir_guard = tempfile::tempdir().expect("temp dir");
+    let dir = dir_guard.path();
     let media_path = dir.join("upscaled.mp4");
     let mux_tmp = dir.join("upscaled.audiomux.mp4");
     let poster_path = media_path.with_extension("poster.jpg");
@@ -5099,7 +5097,6 @@ fn seedvr2_output_guard_preserves_published_outputs_after_disarm() {
     assert!(media_path.exists());
     assert!(mux_tmp.exists());
     assert!(poster_path.exists());
-    let _ = std::fs::remove_dir_all(dir);
 }
 
 #[test]


### PR DESCRIPTION
Closes [sc-17641](https://app.shortcut.com/trefry/story/17641).

`sceneworks-core`'s `temp_db` built every test database as `temp_dir()/sceneworks-core-{name}-{pid}.db` and unlinked it at the **start** of a run. That was wrong twice over.

Nothing ever removed the file, so every test in every run left its database behind — **46,773** had piled up in this box's `%TEMP%`, about a third of all 147,249 entries in it. And because the uniqueness key was the PID while only the `.db` was unlinked, a run landing on a recycled PID opened a fresh, empty database next to a stale `-wal` from an unrelated earlier run: a silent, very hard to trace flake source in the same suite [sc-17597](https://app.shortcut.com/trefry/story/17597) was filed against.

## The fix

`temp_db` returns a `TempDb` guard owning a `tempfile::TempDir`, so uniqueness comes from the **call** rather than the process, and the `-wal`/`-shm` siblings leave with their parent. A second guard, `TestStore`, pairs the store with its directory and derefs to `JobsStore`, so all ~130 `store("name")` call sites are untouched.

Its field order is load-bearing and commented as such: the store drops first, closing the long-lived write connection, before the directory is removed — Windows will not unlink a file that still has an open handle. `TestStore` also carries an empty `Drop` impl, which makes it non-destructurable so nobody can move the `JobsStore` out on its own and drop the guard early. Cleanup rides on `Drop` rather than a line per test, because a panicking test is exactly the one whose leftovers matter.

## The sweep found the real monster elsewhere

The story asked for a sweep of the same pattern. Measuring rather than grepping: **85,189** SceneWorks-attributable `%TEMP%` entries, of which **85,122 (99.92%)** came from four families.

| family | entries | disposition |
| --- | --- | --- |
| `sw-krea-control-fit-*` | 31,264 | fixed — `krea_control_fit.rs`, same pattern, the single largest leaker anywhere in `%TEMP%` |
| `sceneworks-core-*.db` | 46,773 | fixed — the story's own target |
| `sw_wav_*` | 6,185 | fixed — 3 sites in `video_jobs/tests.rs` |
| `wan-text-encode-test-*`, `candle_flow_match_driver_*` | 1,418 | **inference repo** → [sc-17704](https://app.shortcut.com/trefry/story/17704) |

Also converted `base_weights.rs` (the last such site in `sceneworks-core` itself) and the three `sw_seedvr2_*` tests twenty lines from the `sw_wav_` ones — both used the trailing cleanup line the story explicitly names as wrong, since a panicking test skips it. The remaining repo-wide tail (67 entries, plus one macOS-gated fixture that cannot be compiled from this box) is inventoried per-site in [sc-17707](https://app.shortcut.com/trefry/story/17707).

## Tests

Three new tests, each **mutation-checked** to confirm it goes RED when its specific guarantee is broken — a cleanup test that cannot fail is worthless:

| mutation | test that fails |
| --- | --- |
| swap the two `TestStore` fields (wrong drop order) | `store_helper_removes_its_directory_after_closing_the_connection` — the open handle blocks removal on Windows |
| `ManuallyDrop` the `TempDir` (defeat cleanup) | `temp_db_guard_removes_the_database_and_its_wal_siblings` |
| point `TempDb::path` back at a shared per-process path | `same_named_stores_are_independent_databases` |

`assert_removed` uses a bounded wait rather than a one-shot `exists()`: `TempDir::drop` swallows removal failures, so a single check would itself be a flake in the suite this story de-flaked. The mutations were re-run afterwards to confirm the tolerance does not mask the defects. The `-wal` assertion is gated on `pragma journal_mode` actually being `wal`, because enabling WAL is explicitly allowed to fail (sc-4275 / F-CORE-16) and then leaves no sidecar at all.

## Verification

- `npm run rust:check` green on the merge commit with `main` (derived-docs + fmt + `clippy -D warnings` + test + build).
- `clippy -p sceneworks-worker --all-targets --features backend-candle -- -D warnings` exit 0, and the **30 candle-gated `krea_control_fit` tests pass** — that lane is the only compiler for that file, so a default build would not have caught a break there. Those tests also settle the lifetime question: several are q4-specific and would have mis-shaped to "dense" had the provider read the snapshot after the guard dropped.
- Leak deltas measured before/after real runs: `sceneworks-core` **0** across 5 full suite runs (was ~140/run), `sw-krea-control-fit` **0** across 30 calls, `sw_wav_` **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
