### PR TITLE
ci(windows-candle): drop apps/rust-worker/** and pin lane paths to what each job builds (sc-17703)

### DIFF
--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -68,6 +68,13 @@ on:
       - "config/engine-capabilities/capabilities.mlx.json"
       - "Cargo.toml"
       - "Cargo.lock"
+      # sc-17703 (Michael's call — a deliberate under-trigger fix): rust-toolchain.toml
+      # governs which toolchain cargo resolves even under the dtolnay stable install
+      # both jobs run, so a bump changes what this lane compiles with — and nothing
+      # else here would trigger on it. Floating-channel drift (the pinned `stable`
+      # moving with no file change) remains uncatchable by any paths: entry; that
+      # residual gap is tracked as its own story.
+      - "rust-toolchain.toml"
       - ".cargo/config.toml"
       - ".github/workflows/macos-mlx.yml"
   pull_request:

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -51,7 +51,22 @@ on:
     branches: [main]
     paths: &candle_paths
       - "crates/**"
-      - "apps/rust-worker/**"
+      # NO apps/rust-worker/** here, deliberately — do not re-symmetrise with
+      # macos-mlx.yml's anchor (sc-17703). That package (`sceneworks-rust-worker`)
+      # is a 4-line binary wrapper over sceneworks-worker with no [features] block
+      # and no candle-gated code, nothing in the workspace depends on it, and
+      # nothing this job runs builds it: every cargo invocation below is
+      # -p sceneworks-worker, -p sceneworks-rust-api or
+      # -p sceneworks-memory-adapter. Watching it woke this whole job — the
+      # fleet's single cuda box — for zero coverage. The two lanes legitimately
+      # differ: macos-mlx.yml's HOSTED macos-checks job runs the bare
+      # workspace-wide `cargo test` / `cargo clippy --all-targets` over every
+      # default member, which DOES compile the wrapper, so the entry earns its
+      # keep there. The contract test in scripts/platform-review-contracts.test.mjs
+      # derives all of this from each workflow's own cargo invocations and the
+      # Cargo.toml dependency graph, so re-adding the entry here (or narrowing
+      # what a lane builds out from under one of its path entries) goes red
+      # instead of quietly rotting.
       - "apps/rust-api/**"
       # The builtin model catalog is include_str!'d into the worker and read by the
       # `manifest_menu_is_subset_of_descriptor` drift guard, so a manifest edit can

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -98,6 +98,20 @@ on:
       - "config/engine-capabilities/capabilities.candle.json"
       - "Cargo.toml"
       - "Cargo.lock"
+      # The toolchain and cargo-config seams (sc-17703, Michael's call — these are
+      # UNDER-trigger fixes that deliberately spend box time on two rare-edit,
+      # high-blast-radius files whose breakage would otherwise merge green and red
+      # main misattributed). This lane runs no rust-toolchain action: cargo in-repo
+      # auto-selects the toolchain rust-toolchain.toml pins (see the step comment
+      # below), so a bump changes what this entire job compiles with. And
+      # .cargo/config.toml carries `git-fetch-with-cli = true`, without which
+      # cargo's built-in fetch ignores the GIT_CONFIG_* token injection in "Fetch
+      # the private inference release" and the lane cannot fetch at all. NB
+      # `channel = "stable"` is a floating channel — the effective toolchain can
+      # move with NO file changing, which no paths: entry can catch; that residual
+      # gap is tracked as its own story.
+      - "rust-toolchain.toml"
+      - ".cargo/config.toml"
       - ".github/actions/prepare-rust-runner/**"
       - ".github/workflows/windows-candle.yml"
   pull_request:

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -804,6 +804,8 @@ test("every workspace path a self-hosted lane watches maps to a package that lan
         "config/engine-capabilities/capabilities.candle.json", // the restamp-verify step diffs it
         "Cargo.toml", // workspace graph + lints: changes what every invocation here resolves
         "Cargo.lock", // dependency pins, incl. the inference revision the whole lane compiles
+        "rust-toolchain.toml", // no toolchain action on this lane; cargo auto-selects this pin
+        ".cargo/config.toml", // git-fetch-with-cli, without which the token-injected inference fetch breaks
         ".github/actions/prepare-rust-runner/**", // the job's own first step
         ".github/workflows/windows-candle.yml", // the lane itself
       ],
@@ -815,6 +817,7 @@ test("every workspace path a self-hosted lane watches maps to a package that lan
         "config/engine-capabilities/capabilities.mlx.json", // the restamp-verify step diffs it
         "Cargo.toml", // workspace graph + lints: changes what every invocation here resolves
         "Cargo.lock", // dependency pins, incl. the MLX revision the whole lane compiles
+        "rust-toolchain.toml", // governs the toolchain cargo resolves under the dtolnay install
         ".cargo/config.toml", // the MACOSX_DEPLOYMENT_TARGET=26.2 pin every build here compiles under
         ".github/workflows/macos-mlx.yml", // the lane itself
       ],

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -6,6 +6,35 @@ async function source(path) {
   return readFile(new URL(`../${path}`, import.meta.url), "utf8");
 }
 
+// GitHub filter-pattern syntax: `*` matches any run of characters except `/`, `**` matches any
+// run including `/`. `**/` is treated as "zero or more directories", matching the convention
+// GitHub's own `**/README.md` example implies. That reading is also the SAFE one for every guard
+// below: it makes `config/engine-capabilities/**/*` count as matching a file directly in that
+// directory, so an ambiguous pattern is rejected rather than quietly permitted. Nobody needs to
+// spell it that way.
+function matches(glob, target) {
+  let pattern = "";
+  for (let i = 0; i < glob.length; i += 1) {
+    const char = glob[i];
+    if (char === "*") {
+      if (glob[i + 1] === "*") {
+        if (glob[i + 2] === "/") {
+          pattern += "(?:.*/)?";
+          i += 2;
+        } else {
+          pattern += ".*";
+          i += 1;
+        }
+      } else {
+        pattern += "[^/]*";
+      }
+    } else {
+      pattern += "\\^$+?.()|[]{}".includes(char) ? `\\${char}` : char;
+    }
+  }
+  return new RegExp(`^${pattern}$`).test(target);
+}
+
 test("Windows workflows watch the local Rust runner action", async () => {
   for (const workflow of [
     ".github/workflows/windows-candle.yml",
@@ -675,33 +704,6 @@ test("both stage-1 lanes verify their own capability dump, LAST and reachably", 
         .slice(anchorAt, lane.indexOf("pull_request:"))
         .matchAll(/^ {6}- "([^"]+)"$/gm),
     ].map((match) => match[1]);
-    // GitHub filter-pattern syntax: `*` matches any run of characters except `/`, `**` matches any
-    // run including `/`. `**/` is treated as "zero or more directories", matching the convention
-    // GitHub's own `**/README.md` example implies. That reading is also the SAFE one here: it makes
-    // `config/engine-capabilities/**/*` count as matching a file directly in that directory, so an
-    // ambiguous pattern is rejected rather than quietly permitted. Nobody needs to spell it that way.
-    const matches = (glob, target) => {
-      let source = "";
-      for (let i = 0; i < glob.length; i += 1) {
-        const char = glob[i];
-        if (char === "*") {
-          if (glob[i + 1] === "*") {
-            if (glob[i + 2] === "/") {
-              source += "(?:.*/)?";
-              i += 2;
-            } else {
-              source += ".*";
-              i += 1;
-            }
-          } else {
-            source += "[^/]*";
-          }
-        } else {
-          source += "\\^$+?.()|[]{}".includes(char) ? `\\${char}` : char;
-        }
-      }
-      return new RegExp(`^${source}$`).test(target);
-    };
     const own = `config/engine-capabilities/${file}`;
     assert.ok(
       declared.some((glob) => matches(glob, own)),
@@ -719,6 +721,196 @@ test("both stage-1 lanes verify their own capability dump, LAST and reachably", 
           "reads it. That wakes an entire self-hosted job — the fleet's most constrained " +
           "resource — for a file this lane cannot check. Narrow the pattern to this lane's own dump.",
       );
+    }
+  }
+});
+
+test("every workspace path a self-hosted lane watches maps to a package that lane builds", async () => {
+  // sc-17703, generalising sc-17665's lesson to the whole trigger surface. `apps/rust-worker/**`
+  // sat in windows-candle.yml's paths while no cargo invocation in that job built the package
+  // living there (`sceneworks-rust-worker` — a 4-line binary wrapper nothing depends on), so a
+  // wrapper edit woke the fleet's single cuda box for zero coverage. Pin the PROPERTY, not the
+  // spelling (epic 17702 rule 6): every `crates/`- or `apps/`-shaped `paths:` entry on a
+  // self-hosted lane may only wake the lane for workspace members that lane's own cargo
+  // invocations build, directly or through the local dependency graph; every other entry must be
+  // declared in the reasons-required allow-list below.
+  //
+  // Derived from the artifacts, not restated: the built set is parsed from each workflow's
+  // `cargo ... -p <pkg>` lines (a package-less `cargo test`/`clippy`/`check`/`build` acts on the
+  // whole default-member set, which is what macos-mlx.yml's hosted macos-checks job runs), and
+  // the closure comes from the `path = "..."` edges in the members' Cargo.toml files. So
+  // re-adding the rust-worker entry to the candle lane, watching a member no invocation reaches,
+  // or narrowing a lane's build out from under an entry it still watches all go red with no test
+  // edit.
+  const rootManifest = await source("Cargo.toml");
+  const listOf = (key) => {
+    // Anchored to line start: a bare indexOf("members = [") would land inside
+    // "default-members = [" if the root manifest's blocks were ever reordered.
+    const start = rootManifest.search(new RegExp(`^${key} = \\[`, "m"));
+    assert.ok(start >= 0, `root Cargo.toml must declare ${key}`);
+    const block = rootManifest.slice(start, rootManifest.indexOf("]", start));
+    return [...block.matchAll(/"([^"]+)"/g)].map((entry) => entry[1]);
+  };
+  const memberDirs = listOf("members");
+  const defaultMemberDirs = listOf("default-members");
+
+  const normalize = (base, rel) => {
+    const parts = base.split("/");
+    for (const seg of rel.split("/")) {
+      if (seg === "..") parts.pop();
+      else if (seg !== "." && seg !== "") parts.push(seg);
+    }
+    return parts.join("/");
+  };
+  const dirOf = new Map();
+  const manifests = new Map();
+  for (const dir of memberDirs) {
+    const manifest = await source(`${dir}/Cargo.toml`);
+    const name = manifest.match(/^name = "([^"]+)"$/m);
+    assert.ok(name, `${dir}/Cargo.toml must name its package`);
+    dirOf.set(name[1], dir);
+    manifests.set(dir, manifest);
+  }
+  const dependsOn = new Map();
+  for (const [dir, manifest] of manifests) {
+    // `path = "..."` also appears under [[bin]] targets (e.g. sceneworks-memory-adapter's
+    // src/bin/mlx.rs); resolving against the member set filters those out — only an edge that
+    // lands on another workspace member is a dependency.
+    const edges = [...manifest.matchAll(/path\s*=\s*"([^"]+)"/g)]
+      .map((edge) => normalize(dir, edge[1]))
+      .filter((target) => manifests.has(target));
+    dependsOn.set(dir, edges);
+  }
+  const closure = (seedDirs) => {
+    const reached = new Set();
+    const queue = [...seedDirs];
+    while (queue.length > 0) {
+      const dir = queue.pop();
+      if (reached.has(dir)) continue;
+      reached.add(dir);
+      queue.push(...dependsOn.get(dir));
+    }
+    return reached;
+  };
+
+  const lanes = [
+    {
+      path: ".github/workflows/windows-candle.yml",
+      // Every non-cargo entry needs its reason recorded HERE, or the test fails. Watching a path
+      // no step reads costs a whole self-hosted job (epic 17702 rule 1), and "symmetry with the
+      // sibling lane" is never the reason (rule 2; sc-17592 is the scar).
+      allowed: [
+        "config/manifests/**", // include_str!'d into the worker; the manifest drift guard reads it
+        "config/engine-capabilities/capabilities.candle.json", // the restamp-verify step diffs it
+        "Cargo.toml", // workspace graph + lints: changes what every invocation here resolves
+        "Cargo.lock", // dependency pins, incl. the inference revision the whole lane compiles
+        ".github/actions/prepare-rust-runner/**", // the job's own first step
+        ".github/workflows/windows-candle.yml", // the lane itself
+      ],
+    },
+    {
+      path: ".github/workflows/macos-mlx.yml",
+      allowed: [
+        "config/manifests/**", // include_str!'d into the worker; the manifest drift guard reads it
+        "config/engine-capabilities/capabilities.mlx.json", // the restamp-verify step diffs it
+        "Cargo.toml", // workspace graph + lints: changes what every invocation here resolves
+        "Cargo.lock", // dependency pins, incl. the MLX revision the whole lane compiles
+        ".cargo/config.toml", // the MACOSX_DEPLOYMENT_TARGET=26.2 pin every build here compiles under
+        ".github/workflows/macos-mlx.yml", // the lane itself
+      ],
+    },
+  ];
+  for (const { path, allowed } of lanes) {
+    const lane = await source(path);
+    // Only steps a pull_request actually executes may justify a PR path entry. A
+    // dispatch-only calibration build that reaches a member is not PR coverage of it, so
+    // drop every step block gated on workflow_dispatch before scanning (same step-splitting
+    // idiom as the capability-dump ordering check above).
+    const prSteps = lane
+      .split(/\n {6}- (?=name: |uses: )/)
+      .filter(
+        (block) => !/if: \$\{\{[^\n]*github\.event_name == 'workflow_dispatch'/.test(block),
+      )
+      .join("\n");
+    // Strip comment lines, then re-join backslash line continuations so a `-p <pkg>` split
+    // across lines cannot degrade into a "package-less" invocation (which the rule below
+    // would over-widen into the whole default-member set).
+    const executable = prSteps
+      .split("\n")
+      .filter((line) => !/^\s*#/.test(line))
+      .join("\n")
+      .replace(/\\\n\s*/g, " ");
+    // LINE-INITIAL commands only. An `echo`ed fix-it message that merely QUOTES a
+    // package-less `cargo test` must not count as a workspace-wide build — counting it
+    // would quietly widen `covered` to every default member and defuse this whole guard.
+    const invocations = [
+      ...executable.matchAll(/^\s*(?:run: )?cargo +(?:test|check|clippy|build|run)\b[^\n]*/gm),
+    ];
+    assert.ok(invocations.length > 0, `${path} must contain cargo invocations to audit against`);
+    const built = new Set();
+    for (const [invocation] of invocations) {
+      const packages = [...invocation.matchAll(/(?:-p|--package)[ =]([A-Za-z0-9_-]+)/g)];
+      if (packages.length === 0) {
+        // A package-less build/test/lint acts on the whole default-member set — that is
+        // exactly macos-mlx.yml's hosted workspace-wide `cargo test` / `cargo clippy`.
+        for (const dir of defaultMemberDirs) built.add(dir);
+      } else {
+        for (const [, pkg] of packages) {
+          const dir = dirOf.get(pkg);
+          assert.ok(dir, `${path} invokes cargo on ${pkg}, which is not a workspace member`);
+          built.add(dir);
+        }
+      }
+    }
+    const covered = closure(built);
+
+    const anchorAt = lane.indexOf("paths: &");
+    assert.ok(anchorAt > 0, `${path} must declare a paths anchor`);
+    const anchorBlock = lane.slice(anchorAt, lane.indexOf("pull_request:"));
+    const declared = [...anchorBlock.matchAll(/^ {6}- "([^"]+)"$/gm)].map((entry) => entry[1]);
+    assert.ok(declared.length > 0, `${path} must declare path filters`);
+    // Completeness: an unquoted entry (`- apps/x/**`) or a trailing inline comment would
+    // fail the parse above and slip past this audit entirely. Every list item must be a
+    // bare quoted string, or the "EVERY paths entry" contract is fiction.
+    const entryLines = anchorBlock.split("\n").filter((line) => /^ {6}- /.test(line));
+    assert.equal(
+      declared.length,
+      entryLines.length,
+      `${path}: every paths entry must be a bare double-quoted string so this audit can ` +
+        "parse it; rewrite the unmatched entries.",
+    );
+
+    for (const glob of declared) {
+      if (!/^(?:crates|apps)\//.test(glob)) {
+        assert.ok(
+          allowed.includes(glob),
+          `${path} watches ${JSON.stringify(glob)}, which is neither a workspace path this job ` +
+            "builds nor a declared non-cargo entry. If a step really reads it, add it to this " +
+            "test's allow-list WITH the reason; symmetry with the sibling lane is not one (sc-17592).",
+        );
+        continue;
+      }
+      // Judge the entry by every member it can wake the lane for: a glob wakes a member if
+      // it can match the member's own manifest (`<dir>/Cargo.toml` — every member has one)
+      // or if it names a path INSIDE the member (a legitimate narrowing like
+      // "crates/x/tests/**", which cannot match the manifest but still wakes only that member).
+      const woken = memberDirs.filter(
+        (dir) => matches(glob, `${dir}/Cargo.toml`) || glob.startsWith(`${dir}/`),
+      );
+      assert.ok(
+        woken.length > 0,
+        `${path} watches ${JSON.stringify(glob)}, which matches no workspace member — dead ` +
+          "weight or a typo.",
+      );
+      for (const dir of woken) {
+        assert.ok(
+          covered.has(dir),
+          `${path} triggers on ${dir} via ${JSON.stringify(glob)}, but no cargo invocation in ` +
+            "that workflow builds it, directly or through a path dependency. That wakes a whole " +
+            "self-hosted job for an edit it cannot cover — exactly how apps/rust-worker/** sat " +
+            "on the candle lane (sc-17703). Narrow the entry, or make the job build the member.",
+        );
+      }
     }
   }
 });


### PR DESCRIPTION
Implements [sc-17703](https://app.shortcut.com/trefry/story/17703) (epic 17702, self-hosted trigger-surface cost) — all three scope items.

## What

1. **Remove `apps/rust-worker/**` from `&candle_paths`** in windows-candle.yml. The lane builds only `sceneworks-worker`, `sceneworks-rust-api` and `sceneworks-memory-adapter`; the package in `apps/rust-worker` (`sceneworks-rust-worker`) is a 4-line leaf binary wrapper nothing depends on, so an edit there woke the single `cuda` box for zero coverage. A comment at the anchor explains why the mlx anchor legitimately differs **post-split**: macos-mlx.yml's hosted `macos-checks` job runs the bare workspace-wide `cargo test`/`clippy`, which does compile the wrapper.
2. **New contract test** in `scripts/platform-review-contracts.test.mjs`: every `crates/**`- or `apps/**`-shaped `paths:` entry on a self-hosted lane must map to a workspace member that lane's PR-path cargo invocations build (directly or via the Cargo.toml `path` dependency closure); all other entries must be in a per-lane, reasons-required allow-list. Derived from the workflow text and manifests, not restated — so the guard tracks future edits without test changes. The sc-17665 glob matcher is hoisted to module scope and shared.
3. **Close the two under-triggers** (Michael's call, a deliberate spend): both lanes now watch `rust-toolchain.toml` (the candle lane has no toolchain action — cargo auto-selects this pin) and `.cargo/config.toml` (its `git-fetch-with-cli = true` is what makes the candle lane's token-injected inference fetch work). Today an edit to either merged green and redded main misattributed. The residual — the floating `stable` channel moving the effective toolchain with **no** file change, uncatchable by any `paths:` entry — is filed as [sc-17717](https://app.shortcut.com/trefry/story/17717).

## Hardening (from adversarial review)

- Only **line-initial** cargo commands count — an `echo`ed fix-it message quoting a bare `cargo test` cannot widen coverage to the default-member set (this attack was demonstrated against the first draft and now goes red).
- `workflow_dispatch`-only steps are excluded — a calibration build cannot stand in for PR coverage.
- Backslash continuations are rejoined so a split `-p <pkg>` cannot degrade to "package-less".
- The paths parse asserts completeness — an unquoted entry can't dodge the audit.
- `listOf` anchors to line start so `members` can't land inside `default-members`.

## Mutation checks (all verified red, then reverted)

| Mutation | Result |
|---|---|
| Re-add `apps/rust-worker/**` to candle lane | RED (story AC) |
| Bare quoted `cargo test` inside an echo + re-added entry | RED |
| Unquoted paths entry | RED (completeness assert) |
| Dead-weight glob matching no member | RED |
| Strip unconditional memory-adapter step, keep dispatch-only build | RED |

`npm run check`: 295/295 green at each commit (branch fast-forwarded onto 3315eb01b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)