### PR TITLE
fix(api): refuse a model convert whose source weights are still downloading

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -983,6 +983,56 @@ pub(crate) async fn create_model_convert_job(
             "Model does not require MLX conversion",
         ));
     };
+    // Pre-flight the source weights (sc-14708 follow-up). The worker resolves the same HF snapshot and
+    // fails the job when the checkpoint is absent, which reads as a defect to the user: the three Anima
+    // variants share `circlestone-labs/Anima`, their per-variant downloads are serialized, and the
+    // sibling cards flip to *downloaded* the moment THEIR files land — so converting the variant whose
+    // 4 GB DiT is still streaming produced a bare "Anima source DiT is missing." Refuse it here, while
+    // the request can still carry an explanation. Only `requiresConversion` reads a native checkpoint;
+    // the legacy quantize-only path has its own worker-side rejection.
+    if requires_conversion {
+        if let Some(download) = store_call(state.clone(), {
+            let model_id = model_id.clone();
+            move |store, _timeout| store.find_active_model_download_job(&model_id)
+        })
+        .await?
+        {
+            let model_name = model
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or(model_id.as_str());
+            return Err(ApiError::conflict(format!(
+                "{model_name} is still downloading ({percent}%). Wait for the download to finish \
+                 before converting it.",
+                percent = (download.progress.as_f64().unwrap_or(0.0) * 100.0).round() as i64,
+            )));
+        }
+        if let Some(source_file) = mlx
+            .get("convertSourceFile")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+        {
+            match sceneworks_worker::convert_source_state(
+                &state.settings.data_dir,
+                &source_repo,
+                source_file,
+            ) {
+                sceneworks_worker::ConvertSourceState::Ready => {}
+                sceneworks_worker::ConvertSourceState::RepoNotCached => {
+                    return Err(ApiError::conflict(format!(
+                        "{source_repo} is not downloaded yet. Download it before converting."
+                    )));
+                }
+                sceneworks_worker::ConvertSourceState::FileMissing => {
+                    return Err(ApiError::conflict(format!(
+                        "{source_file} has not finished downloading from {source_repo}. Wait for \
+                         the download to complete, then convert."
+                    )));
+                }
+            }
+        }
+    }
+
     let job_payload = build_model_convert_job_payload(ModelConvertJobPayload {
         model: &model,
         model_id: &model_id,

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -427,6 +427,147 @@ async fn raw_model_convert_rejects_unrecoverable_output_before_enqueue() {
     );
 }
 
+/// Write a two-variant convert-at-install family that SHARES one source repo — the Anima shape: each
+/// card names its own `mlx.convertSourceFile` inside `owner/shared`, and the per-variant downloads are
+/// serialized, so one variant's weights land while the other's are still streaming.
+fn shared_repo_convert_manifest(config_dir: &std::path::Path) {
+    std::fs::create_dir_all(config_dir).expect("manifest dir creates");
+    let models = ["alpha", "beta"]
+        .into_iter()
+        .map(|variant| {
+            json!({
+                "id": format!("fixture_{variant}"),
+                "name": format!("Fixture {variant}"),
+                "type": "image",
+                "family": "fixture",
+                "downloads": [{
+                    "provider": "huggingface",
+                    "repo": "owner/shared",
+                    "files": [format!("split_files/diffusion_models/{variant}.safetensors")]
+                }],
+                "mlx": {
+                    "requiresConversion": true,
+                    "converter": "fixture_quant",
+                    "convertSourceRepo": "owner/shared",
+                    "convertSourceFile": format!("split_files/diffusion_models/{variant}.safetensors")
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        serde_json::to_vec(&json!({ "schemaVersion": 1, "models": models }))
+            .expect("manifest serializes"),
+    )
+    .expect("builtin models writes");
+    write_empty_sibling_manifests(config_dir);
+}
+
+/// Seed `file` into the HF cache snapshot for `repo` under `data_dir`, the way a completed download
+/// leaves it (`refs/main` → `snapshots/<rev>/<file>`).
+fn seed_snapshot_file(data_dir: &std::path::Path, repo: &str, file: &str) {
+    let revision = "a".repeat(40);
+    let repo_dir = huggingface_repo_cache_path(data_dir, repo).expect("repo cache path");
+    let snapshot = repo_dir.join("snapshots").join(&revision);
+    let path = snapshot.join(file);
+    std::fs::create_dir_all(path.parent().expect("snapshot parent")).expect("snapshot dir creates");
+    std::fs::write(&path, b"weights").expect("source file writes");
+    std::fs::create_dir_all(repo_dir.join("refs")).expect("refs dir creates");
+    std::fs::write(repo_dir.join("refs").join("main"), &revision).expect("refs/main writes");
+}
+
+/// Michael, on-device (Anima 2B Turbo): the three Anima variants share `circlestone-labs/Anima` and
+/// download one at a time, so the sibling cards flipped to *downloaded* the moment THEIR files landed.
+/// Converting the variant whose 4 GB DiT was still streaming enqueued a job that the worker failed
+/// instantly with a bare "Anima source DiT is missing." — indistinguishable from a real defect. The
+/// convert request boundary must refuse it while it can still explain why, and must NOT block the
+/// sibling whose weights ARE on disk.
+#[tokio::test]
+async fn model_convert_is_refused_while_its_source_weights_are_still_downloading() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let _env = isolate_hf_cache();
+    shared_repo_convert_manifest(&temp_dir.path().join("config/manifests"));
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    let app = create_app(settings).expect("app creates");
+
+    // Nothing cached at all: the source repo, not just one variant's file, is missing.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/models/fixture_alpha/convert",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert!(
+        body["detail"].as_str().is_some_and(
+            |detail| detail.contains("owner/shared") && detail.contains("not downloaded")
+        ),
+        "an uncached source repo must say so: {body}"
+    );
+
+    // Alpha's weights land; beta's are still streaming (the Anima situation).
+    seed_snapshot_file(
+        &data_dir,
+        "owner/shared",
+        "split_files/diffusion_models/alpha.safetensors",
+    );
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/models/fixture_beta/convert",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert!(
+        body["detail"].as_str().is_some_and(|detail| detail
+            .contains("split_files/diffusion_models/beta.safetensors")
+            && detail.contains("has not finished downloading")),
+        "a shared-repo sibling's missing file must name the file, not the repo: {body}"
+    );
+
+    // The variant whose weights ARE cached converts — the gate refuses the unready one only.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/models/fixture_alpha/convert",
+        json!({}),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "a cached source must still convert: {body}"
+    );
+
+    // An in-flight download for the model itself is reported as such, with its progress, even once
+    // the file exists (a re-download of the same variant).
+    let (status, download) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/models/fixture_alpha/download",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{download}");
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/models/fixture_alpha/convert",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert!(
+        body["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("still downloading")),
+        "an in-flight download for this model must be named as the reason: {body}"
+    );
+}
+
 /// The route-derived output path is a trust-boundary input too. Confinement must run before
 /// `model_catalog` performs its filesystem/cache sweep, so an invalid path-shaped ID wins over the
 /// catalog's otherwise-observable "Model not found" response.

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -883,6 +883,37 @@ impl JobsStore {
         }))
     }
 
+    /// Find an in-flight (non-terminal) `model_download` job for `model_id`, so the convert request
+    /// boundary can refuse a convert whose source weights are still streaming instead of queueing a
+    /// job that fails the moment a worker claims it. Returns the newest such job, or `None`.
+    ///
+    /// Keyed on the payload `modelId`, not the repo: a shared source repo backs several catalog cards
+    /// (the three Anima variants live in `circlestone-labs/Anima`), and converting variant A while
+    /// variant B downloads is legitimate — A's own weights are already on disk. The file-presence
+    /// half of the gate (`convert_source_state`) covers the rest.
+    ///
+    /// Read-only single-SELECT: no write mutex, relies on WAL reader isolation like `list_jobs`
+    /// (sc-8950 / F-148).
+    pub fn find_active_model_download_job(
+        &self,
+        model_id: &str,
+    ) -> JobsStoreResult<Option<JobSnapshot>> {
+        let connection = self.open_connection()?;
+        let mut statement = connection.prepare(&format!(
+            "
+            select * from jobs
+             where type = 'model_download'
+               and status not in ({terminal})
+             order by created_at desc
+            ",
+            terminal = terminal_statuses_sql()
+        ))?;
+        let candidates = collect_jobs(statement.query_map([], row_to_job)?)?;
+        Ok(candidates
+            .into_iter()
+            .find(|job| job.payload.get("modelId").and_then(Value::as_str) == Some(model_id)))
+    }
+
     pub fn list_jobs(
         &self,
         project_id: Option<&str>,

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -179,7 +179,11 @@ mod conditioning_fit;
 use supervisor::*;
 mod model_jobs;
 pub use model_jobs::recover_stranded_model_conversions;
+// The convert pre-flight the rust-api calls before queueing a `model_convert` job, so a convert
+// requested against a still-downloading source is refused at the request boundary instead of failing
+// in the worker (see `convert_source_state`).
 use model_jobs::*;
+pub use model_jobs::{convert_source_state, ConvertSourceState};
 mod media_jobs;
 use media_jobs::*;
 // Image-decode backstop (sc-6143): transcodes a valid-but-unsupported image (AVIF/HEIC/HEIF/TIFF/

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -1775,6 +1775,42 @@ pub(crate) fn huggingface_snapshot_dir(data_dir: &Path, repo: &str) -> Option<Pa
     Some(dir)
 }
 
+/// Whether a convert job's declared source file is already materialized in the HF cache — the
+/// API-side pre-flight for `POST /models/:id/convert` (see `create_model_convert_job`).
+///
+/// The worker resolves `checkpoint_dir` the same way ([`huggingface_snapshot_dir`]) and fails the job
+/// when the source weights are absent; without this the API happily queued a convert against a
+/// half-downloaded snapshot, so a shared-repo family whose sibling cards had already flipped to
+/// *downloaded* (the three Anima variants share `circlestone-labs/Anima`, and the per-variant
+/// downloads are serialized) surfaced a bare "source DiT is missing" failure while the variant's own
+/// 4 GB DiT was still streaming. HF only links `snapshots/<rev>/…` into `blobs/` once a blob
+/// completes, so file presence is the authoritative "ready to convert" signal.
+///
+/// `source_file` is the catalog-declared `mlx.convertSourceFile` (repo-relative); an unsafe path is
+/// reported [`ConvertSourceState::FileMissing`] rather than joined.
+pub fn convert_source_state(data_dir: &Path, repo: &str, source_file: &str) -> ConvertSourceState {
+    let Some(snapshot) = huggingface_snapshot_dir(data_dir, repo) else {
+        return ConvertSourceState::RepoNotCached;
+    };
+    match safe_join(&snapshot, source_file) {
+        Ok(path) if path.is_file() => ConvertSourceState::Ready,
+        _ => ConvertSourceState::FileMissing,
+    }
+}
+
+/// The outcome of [`convert_source_state`]. `RepoNotCached` and `FileMissing` are distinguished so
+/// the API can say "download it first" vs "this variant's weights have not landed yet" — on a shared
+/// repo the second is the common case and the first would be misleading.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConvertSourceState {
+    /// The declared source file is on disk; the worker will find it.
+    Ready,
+    /// The repo has no materialized snapshot in the HF cache at all.
+    RepoNotCached,
+    /// The snapshot exists but this variant's source file has not landed yet.
+    FileMissing,
+}
+
 /// Resolve the local HF snapshot dir for a repo PINNED to an exact commit (`snapshots/<revision>/`) —
 /// the cache-only twin of [`huggingface_snapshot_dir`] for a download that carries an immutable
 /// `revision` (F-029). Unlike [`huggingface_snapshot_dir`] (which prefers `refs/main`), this reads the
@@ -2648,6 +2684,51 @@ mod artifact_provenance_tests {
             .expect("receipt json"),
         )
         .expect("receipt");
+    }
+
+    /// The API convert pre-flight must agree with what `resolve_convert_plan` will find: a missing
+    /// snapshot, a snapshot missing THIS variant's file (the shared-repo case — the three Anima
+    /// variants live in one repo and download one at a time), and the ready case are distinguished so
+    /// the request boundary can explain itself instead of leaving the worker to fail the job.
+    #[test]
+    fn convert_source_state_separates_uncached_repo_from_a_variant_still_downloading() {
+        let data = tempfile::tempdir().expect("data dir");
+        let hub = data.path().join("hub");
+        let _env =
+            crate::test_env::EnvVars::set(&[("HF_HUB_CACHE", hub.to_str().expect("hub path"))]);
+
+        let repo = "owner/shared";
+        let alpha = "split_files/diffusion_models/alpha.safetensors";
+        let beta = "split_files/diffusion_models/beta.safetensors";
+        assert_eq!(
+            convert_source_state(data.path(), repo, alpha),
+            ConvertSourceState::RepoNotCached
+        );
+
+        let snapshot = huggingface_repo_cache_path(data.path(), repo)
+            .expect("cache")
+            .join("snapshots/rev-shared");
+        std::fs::create_dir_all(snapshot.join("split_files/diffusion_models")).expect("dit dir");
+        std::fs::write(snapshot.join(alpha), b"weights").expect("alpha weights");
+        assert_eq!(
+            convert_source_state(data.path(), repo, alpha),
+            ConvertSourceState::Ready
+        );
+        assert_eq!(
+            convert_source_state(data.path(), repo, beta),
+            ConvertSourceState::FileMissing,
+            "a sibling variant sharing the repo is NOT ready just because the snapshot exists"
+        );
+        // A directory is not a convertible source file, and a traversal-shaped path is refused rather
+        // than probed outside the snapshot.
+        assert_eq!(
+            convert_source_state(data.path(), repo, "split_files/diffusion_models"),
+            ConvertSourceState::FileMissing
+        );
+        assert_eq!(
+            convert_source_state(data.path(), repo, "../../../etc/passwd"),
+            ConvertSourceState::FileMissing
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What does this PR do?

Refuses a `model_convert` request at the API boundary when the model's source weights are not on disk yet, instead of queueing a job that fails the instant a worker claims it.

Observed on-device with Anima 2B Turbo. The three Anima variants share `circlestone-labs/Anima` and their per-variant downloads are serialized, so the sibling cards flip to *downloaded* the moment THEIR files land. Turbo's download job only started at the tick base/aesthetic finished and ran for another three minutes; the two convert attempts inside that window each failed with a bare:

```
Anima source DiT is missing.
Expected split_files/diffusion_models/anima-turbo-v1.0.safetensors in circlestone-labs/Anima.
```

HF only links `snapshots/<rev>/…` into `blobs/` once a blob completes, so the worker's check was correct — the file genuinely was not there. But `create_model_convert_job` validated the output path, the catalog entry and the MLX config and never the source weights, so the only signal the user got was a failed job that reads exactly like a defect.

Two halves of the gate, both returning **409**:

- **`JobsStore::find_active_model_download_job`** — newest non-terminal `model_download` for this `modelId`. Keyed on the model, not the repo: a shared source repo backs several cards, and converting variant A while variant B downloads is legitimate because A's weights are already on disk.
- **`sceneworks_worker::convert_source_state`** — resolves the HF snapshot through the same `huggingface_snapshot_dir` the worker uses, and separates `RepoNotCached` from `FileMissing` so the message names the right thing (on a shared repo the second is the common case and the first would mislead).

Messages the user now sees instead of a failed job:

- `Anima 2B Turbo is still downloading (37%). Wait for the download to finish before converting it.`
- `split_files/diffusion_models/anima-turbo-v1.0.safetensors has not finished downloading from circlestone-labs/Anima. Wait for the download to complete, then convert.`
- `circlestone-labs/Anima is not downloaded yet. Download it before converting.`

## Related issue

None — reported on-device, no tracker item filed.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## Notes for the reviewer

- **No frontend change needed.** `createModelConvertJob` (`apps/web/src/hooks/useModelsAndLoras.js`) already routes the failure into `setError(err.message)`, and `apps/web/src/api.js` lifts the response `detail` into that message, so the 409 lands in the error banner.
- **The gate only covers `requiresConversion` models.** The legacy `quantizeOnly` path reads no native checkpoint and keeps its existing worker-side rejection.
- **The catalog's `conversion_state` is untouched.** It already reported `needs_source` correctly; the card state was never the wrong thing here, only the unguarded POST.
- **`convert_source_state` joins through `safe_join`.** `convertSourceFile` is catalog-declared rather than client-supplied, but a traversal-shaped path reports `FileMissing` rather than probing outside the snapshot.
- The one new public seam on `sceneworks-worker` (`convert_source_state` / `ConvertSourceState`) exists so the API resolves the snapshot with the worker's own logic instead of a second copy that could drift from `resolve_convert_plan`.

## On the first CI failure

The first run failed `tests::catalog::models_route_overlaps_slow_probes_with_bounded_fanout` on the hosted macOS runner (`left: 500, right: 200`, behind an `attempt to add with overflow` panic in the catalog-probe test instrumentation). That is a pre-existing race in process-global test counters, unrelated to this change — the new test touches neither `__testCatalogProbeDelayMs` nor those counters; it just shifted thread scheduling into an existing window.

It has since been fixed on main by sc-17723 (#2139), which diagnoses the same root cause and also deflakes six M5-calibrated polls in `dataset_catalogs`. This branch is rebased onto that, so it carries only the convert gate.

## How was this tested?

`npm run rust:check` and `npm run check` both pass on macOS (Apple Silicon), re-run after the rebase onto sc-17723.

New coverage:

- `sceneworks-worker` unit test pinning all three states — uncached repo, ready, and a sibling variant sharing the snapshot whose file has not landed — plus a directory and a traversal-shaped path.
- `sceneworks-rust-api` end-to-end test on a two-variant fixture family sharing one source repo (the Anima shape): uncached repo → 409; sibling still streaming → 409 naming the file; **the cached variant → 201**, so the gate cannot over-block; in-flight download for the model itself → 409 carrying its progress.

- [x] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [ ] Not platform-specific (web UI, docs, shared crate)

The change itself is platform-neutral (rust-api + shared crates, no MLX/candle code paths); only the verification run was macOS.

## Checklist

- [x] I ran `npm run rust:check` (if I touched Rust) and it passed
- [ ] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build` (if I touched the web app) — no web changes
- [x] I ran `npm run check` (scaffold checks)
- [ ] I updated documentation where relevant — no doc surface for this; rationale is in the code comments
- [x] All my commits are signed off (`git commit -s`)
- [x] My PR is focused on a single logical change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
