### PR TITLE
test(rust-api): de-flake the two catalog tests redding the hosted macOS lane (sc-17723)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -4116,7 +4116,26 @@ static TEST_CATALOG_PROBES_PEAK: std::sync::atomic::AtomicUsize =
 #[cfg(test)]
 pub(crate) fn test_reset_catalog_probe_concurrency() {
     use std::sync::atomic::Ordering;
-    TEST_CATALOG_PROBES_ACTIVE.store(0, Ordering::SeqCst);
+    // DRAIN, do not clobber. Delayed probes run via spawn_blocking on pool OS threads
+    // that cannot be cancelled mid-sleep, and the probe tests run concurrently in one
+    // binary against these process-global atomics (their sleeps are bounded: <=250ms).
+    // Storing 0 into ACTIVE while a concurrent test's probe was mid-sleep made that
+    // probe's later decrement wrap to usize::MAX, and the next probe's `+ 1` panicked
+    // with "attempt to add with overflow" — a cross-test 500 that only surfaced on the
+    // slower hosted macos-26 runners once the workspace suite moved there (sc-17723).
+    // Waiting live probes out keeps ACTIVE's +1/-1 pairing intact, so it can never go
+    // below zero; only PEAK is forced. The probe tests additionally serialize behind
+    // catalog_probe_test_lock() in tests/catalog.rs, which also keeps a neighbor's
+    // probes from clobbering a PEAK measurement — this drain is the belt-and-braces
+    // for any future probe user outside that lock.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while TEST_CATALOG_PROBES_ACTIVE.load(Ordering::SeqCst) != 0 {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "catalog probe stragglers did not drain within 10s — a probe thread is leaking"
+        );
+        std::thread::sleep(Duration::from_millis(2));
+    }
     TEST_CATALOG_PROBES_PEAK.store(0, Ordering::SeqCst);
 }
 
@@ -4140,10 +4159,18 @@ fn test_delay_catalog_probe(model: &Value) {
     else {
         return;
     };
-    let active = TEST_CATALOG_PROBES_ACTIVE.fetch_add(1, Ordering::SeqCst) + 1;
+    // saturating_add / checked_sub: with the draining reset above, ACTIVE can no longer
+    // underflow — but these keep any future reset-style edit from reintroducing the
+    // wrap-then-panic class (a straggler now parks at 0 instead of poisoning every later
+    // sample with usize::MAX).
+    let active = TEST_CATALOG_PROBES_ACTIVE
+        .fetch_add(1, Ordering::SeqCst)
+        .saturating_add(1);
     TEST_CATALOG_PROBES_PEAK.fetch_max(active, Ordering::SeqCst);
     std::thread::sleep(Duration::from_millis(delay_ms));
-    TEST_CATALOG_PROBES_ACTIVE.fetch_sub(1, Ordering::SeqCst);
+    let _ = TEST_CATALOG_PROBES_ACTIVE.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |count| {
+        count.checked_sub(1)
+    });
 }
 
 fn apply_model_catalog_size_fields(

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -394,8 +394,20 @@ async fn real_builtin_catalog_serves_engine_keyed_live_preview_support() {
     }
 }
 
+// The three probe-delay tests (this one and the two 250ms ones below) share the
+// process-global TEST_CATALOG_PROBES_* atomics and the probe-concurrency semaphore, and
+// cargo's default harness runs them concurrently. Serialize them: an unserialized
+// neighbor's live probes can zero PEAK mid-measurement (via the draining reset) or
+// spuriously satisfy `peak > 1` — flakes that only surface on the slow hosted macos-26
+// runners (sc-17723). Same pattern as dataset_catalogs.rs's catalog_scan_hook_test_lock.
+fn catalog_probe_test_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
 #[tokio::test]
 async fn models_route_overlaps_slow_probes_with_bounded_fanout() {
+    let _probe_guard = catalog_probe_test_lock().lock().await;
     let _env = isolate_hf_cache();
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
@@ -733,6 +745,7 @@ async fn concurrent_failed_estimate_is_shared_and_retries_after_negative_ttl_exp
 
 #[tokio::test]
 async fn models_catalog_starts_install_sweep_before_size_estimation_completes() {
+    let _probe_guard = catalog_probe_test_lock().lock().await;
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
     std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
@@ -794,6 +807,7 @@ async fn models_catalog_starts_install_sweep_before_size_estimation_completes() 
 
 #[tokio::test]
 async fn concurrent_models_and_preset_routes_share_one_install_state_sweep() {
+    let _probe_guard = catalog_probe_test_lock().lock().await;
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let config_dir = temp_dir.path().join("config/manifests");
     std::fs::create_dir_all(&config_dir).expect("manifest dir creates");

--- a/apps/rust-api/src/tests/dataset_catalogs.rs
+++ b/apps/rust-api/src/tests/dataset_catalogs.rs
@@ -1580,7 +1580,12 @@ async fn parquet_create_pause_resume_and_completion_run_through_public_api_sched
     let id = created["id"].as_str().unwrap();
 
     let mut paused_response = None;
-    for _ in 0..500 {
+    // Deadline-based waits throughout this test, not fixed iteration counts: the old
+    // budgets were calibrated on the fast self-hosted M5 and flaked once the suite moved
+    // to the slower hosted macos-26 runners (sc-17723). These are completion waits, not
+    // boundary assertions, so generous ceilings delete no coverage.
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    while std::time::Instant::now() < deadline && paused_response.is_none() {
         let (_, status_body) = request(
             app.clone(),
             "GET",
@@ -1613,7 +1618,8 @@ async fn parquet_create_pause_resume_and_completion_run_through_public_api_sched
     );
 
     let mut paused = None;
-    for _ in 0..500 {
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    while std::time::Instant::now() < deadline {
         let (_, status_body) = request(
             app.clone(),
             "GET",
@@ -1649,7 +1655,10 @@ async fn parquet_create_pause_resume_and_completion_run_through_public_api_sched
     assert_eq!(resumed["processingControl"]["desiredState"], "running");
 
     let mut completed = None;
-    for _ in 0..2_000 {
+    // 120s: resuming the 50k-record scan is the long pole of this test on a loaded
+    // hosted runner (the old 2000 x 5ms budget was the M5-calibrated one).
+    let deadline = std::time::Instant::now() + Duration::from_secs(120);
+    while std::time::Instant::now() < deadline {
         let (_, status_body) = request(
             app.clone(),
             "GET",
@@ -2660,7 +2669,10 @@ async fn graceful_catalog_shutdown_drains_and_public_restart_resumes_checkpoint(
     let id = created["id"].as_str().expect("catalog id").to_owned();
 
     let mut running = None;
-    for _ in 0..500 {
+    // Deadline-based, not a fixed iteration count — M5-calibrated budgets flake on the
+    // slower hosted macos-26 runners (sc-17723).
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    while std::time::Instant::now() < deadline {
         let (_, status_body) = request(
             app.clone(),
             "GET",
@@ -2728,7 +2740,14 @@ async fn graceful_catalog_shutdown_drains_and_public_restart_resumes_checkpoint(
     .await;
     assert_eq!(status, StatusCode::OK, "{resumed}");
     let mut completed = None;
-    for _ in 0..2_000 {
+    // Deadline-based, not a fixed iteration count: 2000 x 3ms (~6s) was calibrated on
+    // the fast self-hosted M5 and flaked once the suite moved to the slower hosted
+    // macos-26 runners, where resuming a 50k-record scan can outlast that budget under
+    // load (sc-17723). This is a completion wait, not a boundary assertion, so a
+    // generous ceiling deletes no coverage — the assert below still demands the full
+    // record count.
+    let resume_deadline = std::time::Instant::now() + Duration::from_secs(120);
+    while std::time::Instant::now() < resume_deadline {
         let (_, status_body) = request(
             restarted_app.clone(),
             "GET",


### PR DESCRIPTION
Implements [sc-17723](https://app.shortcut.com/trefry/story/17723). The sc-14708 split moved the workspace suite from the fast self-hosted M5 to slower hosted `macos-26` runners, surfacing two latent timing flakes that have redded the lane on **main itself** (run 31019776746), PR #2137, and an unrelated PR branch — three different reds in one afternoon.

## Failure 1: `attempt to add with overflow` at the catalog probe counter (main + anima PR)

`test_reset_catalog_probe_concurrency()` stored 0 into `TEST_CATALOG_PROBES_ACTIVE` while a concurrent probe test's `spawn_blocking` probe was mid-sleep; that probe's later `fetch_sub(1)` wrapped to `usize::MAX` and the next probe's `+ 1` panicked in debug, 500ing the route under test. Fix, three layers:

- the reset now **drains** (bounded wait for ACTIVE to reach 0, 10s panic backstop) and forces only PEAK — ACTIVE's +1/-1 pairing is never broken, so underflow is impossible by construction;
- `saturating_add`/`checked_sub` on the samples, so no future reset-style edit can reintroduce the wrap-then-panic class;
- the three probe-delay tests serialize behind a shared `catalog_probe_test_lock()` (same pattern as `catalog_scan_hook_test_lock`), closing the residual PEAK-clobber races a drain alone cannot: a neighbor zeroing PEAK mid-measurement, or a neighbor's probe spuriously satisfying `peak > 1`.

## Failure 2: M5-calibrated fixed-iteration polls (PR #2137's red)

The checkpoint-restart test gave a 50k-record resume ~6s (2000×3ms); adversarial review found the **same pattern with the same 50k resume** in the public-API scheduler test (~10s) — the lane's next flake-in-waiting — plus three sibling `0..500` state waits. All six are now deadline-based (60s transitions / 120s completions). These are completion waits, not boundary assertions; the asserts still demand full record counts, so no coverage is deleted.

## Validation (Windows, this box)

- Five affected tests pass; **15 consecutive stress rounds** of the three probe tests running concurrently, all green.
- Full `sceneworks-rust-api` lib suite: 533 passed / 0 failed.
- `cargo fmt --all --check` and `cargo clippy -p sceneworks-rust-api --all-targets -- -D warnings` clean.
- Adversarial review verdict applied in full (fmt reflow, the second 50k poll, the probe-test lock, corrected drain comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)