### PR TITLE
ci: pin the Rust toolchain to 1.97.1 everywhere, never floating stable (sc-17717)

### DIFF
--- a/.github/actions/prepare-rust-runner/action.yml
+++ b/.github/actions/prepare-rust-runner/action.yml
@@ -102,10 +102,12 @@ runs:
 
         # The channel this repo PINS (rust-toolchain.toml at the workspace root). CI must
         # build exactly this toolchain, not whatever the box default happens to be: this box
-        # carries both a version-pinned '1.96.0' default AND a 'stable' toolchain, and the
-        # repo pins channel="stable", so resolving the box default would silently build a
-        # different rustc/clippy than every other lane and could redden clippy on a lint
-        # delta that has nothing to do with the PR.
+        # carries several toolchains (a version-pinned default, 'stable', and the repo's
+        # pinned version), so resolving the box default would silently build a different
+        # rustc/clippy than every other lane and could redden clippy on a lint delta that
+        # has nothing to do with the PR. Since sc-17717 the channel is a concrete x.y.z,
+        # which names its OWN rustup toolchain dir — a bump must pre-install it on this box
+        # (see the bump recipe in rust-toolchain.toml) or the resolution below fails loudly.
         $repoChannel = $null
         if (Test-Path 'rust-toolchain.toml') {
           $cm = Select-String -Path 'rust-toolchain.toml' -Pattern '^\s*channel\s*=\s*"(.+?)"' -ErrorAction SilentlyContinue |
@@ -173,12 +175,21 @@ runs:
           $out = (& $cargo --version | Out-String).Trim()
         } catch {
           $why = ($_.Exception.Message -replace '\s+', ' ').Trim()
-          Write-Host "::error title=Rust toolchain broken on candle runner::Could not execute '$cargo' ($why). Reinstall the toolchain on the box: 'rustup toolchain install stable --force' (sc-13166)."
+          Write-Host "::error title=Rust toolchain broken on candle runner::Could not execute '$cargo' ($why). Reinstall the pinned toolchain on the box: 'rustup toolchain install $repoChannel --no-self-update -c rustfmt -c clippy' (sc-13166 / rust-toolchain.toml)."
           exit 1
         }
         if ($LASTEXITCODE -ne 0 -or $out -notmatch '^cargo\s') {
           $outLine = ($out -replace '\s+', ' ').Trim()
           Write-Host "::error title=Rust toolchain broken on candle runner::'$cargo --version' failed (exit=$LASTEXITCODE) output='$outLine'. See sc-13166: reinstall the pinned toolchain."
+          exit 1
+        }
+        # The pin must actually BE what got resolved (sc-17717). Fallback (2) above can
+        # select the recorded default or the newest install whenever (1) returns nothing
+        # (rustup missing, or a pinned version that is not installed and could not be
+        # fetched) - without this check that silently builds a DIFFERENT rustc/clippy
+        # than every other lane, the exact drift class the version pin exists to kill.
+        if ($repoChannel -match '^\d+\.\d+\.\d+$' -and $out -notmatch [regex]::Escape($repoChannel)) {
+          Write-Host "::error title=Wrong Rust toolchain on candle runner::Resolved '$cargo' reports '$out', not the pinned $repoChannel from rust-toolchain.toml. The pinned toolchain is missing on this box or resolution fell back to another install. Fix: 'rustup toolchain install $repoChannel --no-self-update -c rustfmt -c clippy' (see the bump recipe in rust-toolchain.toml)."
           exit 1
         }
         Write-Host "OK: $out"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,7 +54,7 @@ jobs:
           node-version: "20"
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
-          toolchain: stable
+          toolchain: "1.97.1"
           components: clippy,rustfmt
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
       - name: Fetch the private inference release

--- a/.github/workflows/desktop-linux-check.yml
+++ b/.github/workflows/desktop-linux-check.yml
@@ -63,7 +63,7 @@ jobs:
           node-version: "20"
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
-          toolchain: stable
+          toolchain: "1.97.1"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
 
       # The Tauri/WebKitGTK prerequisites desktop-linux.yml installs, minus the

--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -33,7 +33,7 @@ jobs:
             apps/desktop/package-lock.json
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
-          toolchain: stable
+          toolchain: "1.97.1"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
 
       # Tauri v2's Ubuntu/WebKitGTK build prerequisites. gstreamer1.0-libav

--- a/.github/workflows/desktop-macos-check.yml
+++ b/.github/workflows/desktop-macos-check.yml
@@ -90,7 +90,7 @@ jobs:
           node-version: "20"
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
-          toolchain: stable
+          toolchain: "1.97.1"
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
 

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -102,7 +102,7 @@ jobs:
         run: npm --prefix apps/desktop test
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
-          toolchain: stable
+          toolchain: "1.97.1"
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
       - name: Fetch the private inference release

--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -69,11 +69,11 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       # sc-17703 (Michael's call — a deliberate under-trigger fix): rust-toolchain.toml
-      # governs which toolchain cargo resolves even under the dtolnay stable install
-      # both jobs run, so a bump changes what this lane compiles with — and nothing
-      # else here would trigger on it. Floating-channel drift (the pinned `stable`
-      # moving with no file change) remains uncatchable by any paths: entry; that
-      # residual gap is tracked as its own story.
+      # governs which toolchain cargo resolves, so a bump changes what this lane
+      # compiles with — and nothing else here would trigger on it. The channel is a
+      # concrete version, never floating `stable` (sc-17717), and both jobs' dtolnay
+      # `toolchain:` inputs carry the same version (contract-test enforced), so a
+      # toolchain change is always an edit that wakes this lane.
       - "rust-toolchain.toml"
       - ".cargo/config.toml"
       - ".github/workflows/macos-mlx.yml"
@@ -260,7 +260,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
-          toolchain: stable
+          toolchain: "1.97.1"
           components: clippy
       # Keyed by job + rustc version + lockfile by default, which is what we want: the MLX pin
       # moves with `Cargo.lock`, so a pin bump invalidates the native build rather than
@@ -354,7 +354,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
-          toolchain: stable
+          toolchain: "1.97.1"
           components: clippy
       - name: Fetch the pinned inference release
         env:

--- a/.github/workflows/publish-runpod.yml
+++ b/.github/workflows/publish-runpod.yml
@@ -73,7 +73,7 @@ jobs:
           node-version: "20"
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
-          toolchain: stable
+          toolchain: "1.97.1"
 
       # Do the cheap repository invariants before spending runner time on nvcc.
       # The Dockerfile itself performs the web + embed-web/backend-candle release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
-          toolchain: stable
+          toolchain: "1.97.1"
       - name: Fetch the private inference release
         env:
           CARGO_NET_OFFLINE: "false"
@@ -259,7 +259,7 @@ jobs:
           node-version: "20"
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
-          toolchain: stable
+          toolchain: "1.97.1"
       - name: Fetch the private inference release
         env:
           CARGO_NET_OFFLINE: "false"
@@ -405,7 +405,7 @@ jobs:
             apps/desktop/package-lock.json
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
-          toolchain: stable
+          toolchain: "1.97.1"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
 
       # Match the manual Linux packaging lane. gstreamer1.0-libav supplies H.264

--- a/.github/workflows/server-candle-linux.yml
+++ b/.github/workflows/server-candle-linux.yml
@@ -47,7 +47,7 @@ jobs:
           node-version: "20"
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
-          toolchain: stable
+          toolchain: "1.97.1"
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
       - name: Fetch the private inference release

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -106,10 +106,13 @@ on:
       # below), so a bump changes what this entire job compiles with. And
       # .cargo/config.toml carries `git-fetch-with-cli = true`, without which
       # cargo's built-in fetch ignores the GIT_CONFIG_* token injection in "Fetch
-      # the private inference release" and the lane cannot fetch at all. NB
-      # `channel = "stable"` is a floating channel — the effective toolchain can
-      # move with NO file changing, which no paths: entry can catch; that residual
-      # gap is tracked as its own story.
+      # the private inference release" and the lane cannot fetch at all. The
+      # channel is a concrete version, never floating `stable` (sc-17717): a
+      # toolchain change is therefore always an edit to that file, which this
+      # entry turns into a run of this lane — and the contract test keeps every
+      # workflow's dtolnay `toolchain:` input in lockstep with the pin. When
+      # bumping, pre-install the new version on this box first; see the bump
+      # recipe in rust-toolchain.toml.
       - "rust-toolchain.toml"
       - ".cargo/config.toml"
       - ".github/actions/prepare-rust-runner/**"

--- a/docker/rust.Dockerfile
+++ b/docker/rust.Dockerfile
@@ -168,8 +168,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates curl git build-essential pkg-config libssl-dev \
     && rm -rf /var/lib/apt/lists/*
-# Rust toolchain. The default rustup profile ships rustfmt+clippy, satisfying
-# rust-toolchain.toml (stable + those components).
+# Rust toolchain. The default rustup profile ships rustfmt+clippy; the COPY'd
+# rust-toolchain.toml (a pinned concrete version + those components) is what any
+# in-repo cargo actually resolves, auto-installed by rustup on first use.
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:/usr/local/cuda/bin:${PATH}"
 ENV CUDA_PATH=/usr/local/cuda

--- a/docs/rust-mlx-build.md
+++ b/docs/rust-mlx-build.md
@@ -15,7 +15,8 @@ them). Only macOS compiles MLX from source.
   kernels). The app's runtime floor is pinned at cutover (sc-3032).
 - **Full Xcode + the Metal Toolchain** (`xcode-select -p` must point at Xcode, not
   the Command Line Tools; `xcrun --find metal` must resolve).
-- A recent stable Rust toolchain (`rust-toolchain.toml` pins `stable`).
+- A Rust toolchain via rustup (`rust-toolchain.toml` pins a concrete version, sc-17717;
+  rustup auto-installs it on the first in-repo cargo run).
 - **CMake** (`brew install cmake`). MLX is a CMake project and `pmetal-mlx-sys`'s
   build.rs invokes `cmake` by name, so without it the build dies at "failed to run
   custom build command for `pmetal-mlx-sys`" — a message that points at the dependency,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,25 @@
+# PINNED to a concrete version, deliberately — never a floating channel (sc-17717).
+#
+# `channel = "stable"` let the effective toolchain move with NO file changing: the
+# hosted lanes' dtolnay step installs whatever stable is current at run time, while the
+# self-hosted boxes use whatever is on disk — so lanes could compile with DIFFERENT
+# rustcs on the same commit, and a new stable's clippy lints could red `-D warnings`
+# lanes on PRs that touched nothing related. A concrete version makes every toolchain
+# change a reviewed PR that (since sc-17703) triggers both self-hosted lanes.
+#
+# The workflows' `dtolnay/rust-toolchain` steps carry this same version in their
+# `toolchain:` inputs — kept in lockstep by a contract test in
+# scripts/platform-review-contracts.test.mjs (leaving them at `stable` would
+# double-install on every hosted job and re-float the persistent Macs).
+#
+# TO BUMP: (1) edit `channel` here; (2) update every workflow `toolchain:` input to
+# match (the contract test reds any straggler); (3) pre-install on the self-hosted
+# cuda box BEFORE merging:
+#     rustup toolchain install <version> --no-self-update -c rustfmt -c clippy
+# (the box resolves this file via `rustup which cargo` in prepare-rust-runner, and a
+# version pin names its own toolchain dir — `stable` being current does not cover it).
+# The self-hosted Macs auto-install the pin via rustup on their first run after the
+# bump. The bump PR itself triggers both self-hosted lanes, which is the verdict.
 [toolchain]
-channel = "stable"
+channel = "1.97.1"
 components = ["rustfmt", "clippy"]

--- a/scripts/check-neither-build.mjs
+++ b/scripts/check-neither-build.mjs
@@ -101,7 +101,7 @@ function runDocker() {
     RUST_IMAGE,
     "bash",
     "-euc",
-    // rust-toolchain.toml pins `stable`; add clippy to it (no-op if already present) then lint.
+    // rust-toolchain.toml pins a concrete version; add clippy to it (no-op if already present) then lint.
     `rustup component add clippy && exec cargo ${CLIPPY_ARGS.join(" ")}`,
   ];
   console.log(

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import test from "node:test";
 
 async function source(path) {
@@ -916,4 +916,66 @@ test("every workspace path a self-hosted lane watches maps to a package that lan
       }
     }
   }
+});
+
+test("the Rust toolchain is pinned to one concrete version, everywhere", async () => {
+  // sc-17717. `channel = "stable"` let the effective toolchain move with NO file changing:
+  // hosted lanes' dtolnay steps installed whatever stable was current at run time while the
+  // self-hosted boxes used whatever was on disk — so lanes could compile the same commit
+  // with DIFFERENT rustcs, and a new stable's clippy lints could red `-D warnings` lanes on
+  // unrelated PRs. Three properties pinned here:
+  //
+  //   1. rust-toolchain.toml's channel is a concrete x.y.z, never a floating channel.
+  //   2. Every workflow's dtolnay `toolchain:` input equals that exact version — a
+  //      straggler left at `stable` double-installs on every hosted job and re-floats the
+  //      persistent Macs. Deriving the expectation from rust-toolchain.toml means a bump
+  //      only has to edit files, never this test.
+  //   3. Every dtolnay step HAS a `toolchain:` input. Omitting it makes the action fall
+  //      back to its tag (the pinned SHA tracks dtolnay's `stable` branch), which
+  //      reintroduces the float without the word "stable" appearing anywhere.
+  //
+  // The rustfmt/clippy components ride along: the self-hosted boxes pre-install the pin
+  // with both (see the bump recipe in rust-toolchain.toml), and clippy lanes assume them.
+  const toolchainFile = await source("rust-toolchain.toml");
+  const channelMatch = toolchainFile.match(/^channel = "([^"]+)"$/m);
+  assert.ok(channelMatch, "rust-toolchain.toml must declare a channel");
+  const pin = channelMatch[1];
+  assert.match(
+    pin,
+    /^\d+\.\d+\.\d+$/,
+    "rust-toolchain.toml must pin a concrete x.y.z version. 'stable' floats: the effective " +
+      "toolchain then changes with no file changing, which no CI trigger can catch (sc-17717).",
+  );
+  assert.match(
+    toolchainFile,
+    /^components = \["rustfmt", "clippy"\]$/m,
+    "the pin must carry rustfmt and clippy — the fmt gate and every -D warnings lane assume them",
+  );
+
+  const workflowFiles = (await readdir(new URL("../.github/workflows/", import.meta.url)))
+    .filter((file) => file.endsWith(".yml") || file.endsWith(".yaml"))
+    .sort();
+  assert.ok(workflowFiles.length > 0, "no workflows found — the audit would be vacuous");
+  let inputsSeen = 0;
+  for (const file of workflowFiles) {
+    const workflow = await source(`.github/workflows/${file}`);
+    const dtolnaySteps = [...workflow.matchAll(/uses: dtolnay\/rust-toolchain@/g)].length;
+    const inputs = [...workflow.matchAll(/^\s+toolchain: (.+)$/gm)].map((entry) => entry[1]);
+    assert.equal(
+      inputs.length,
+      dtolnaySteps,
+      `${file}: every dtolnay/rust-toolchain step needs an explicit toolchain: input — ` +
+        "omitting it falls back to the action tag's floating stable.",
+    );
+    for (const value of inputs) {
+      inputsSeen += 1;
+      assert.equal(
+        value,
+        `"${pin}"`,
+        `${file}: toolchain input ${value} must be "${pin}" (quoted), the version ` +
+          "rust-toolchain.toml pins — one version everywhere, bumped together.",
+      );
+    }
+  }
+  assert.ok(inputsSeen > 0, "no toolchain inputs found anywhere — the lockstep audit is vacuous");
 });

--- a/scripts/setup-nax-runner.sh
+++ b/scripts/setup-nax-runner.sh
@@ -252,7 +252,7 @@ preflight() {
       note "(not on this shell's PATH; it is written into the runner's .path so the service still finds it)"
     fi
   else
-    bad "no cargo/rustc found on PATH or in ~/.cargo/bin. Install rustup (https://rustup.rs); rust-toolchain.toml pins stable."
+    bad "no cargo/rustc found on PATH or in ~/.cargo/bin. Install rustup (https://rustup.rs); rust-toolchain.toml pins a concrete version that rustup auto-installs on the first in-repo cargo run."
   fi
 
   # MLX is a CMake project, and `pmetal-mlx-sys`'s build.rs shells out to `cmake` by name.


### PR DESCRIPTION
Implements [sc-17717](https://app.shortcut.com/trefry/story/17717) — the residual half of sc-17703's toolchain gap that no `paths:` filter could close.

## The problem

`channel = "stable"` floats: hosted dtolnay steps installed whatever stable was current at run time, the self-hosted boxes used whatever was on disk — so lanes could compile the same commit with **different rustcs**, and a new stable's clippy lints could red `-D warnings` lanes on PRs that touched nothing related. The effective toolchain could change with no file changing.

## The change

- **`rust-toolchain.toml` pins `1.97.1`** — what `stable` resolves to today on every lane, so day-one behavior is identical; this freezes the status quo. The bump recipe is documented in the file (edit channel + all workflow inputs, pre-install on the cuda box). Since sc-17703, a bump PR triggers both self-hosted lanes — toolchain changes become reviewed, gated events.
- **All 12 dtolnay `toolchain:` inputs across 9 workflows** carry the same version (leaving them at `stable` would double-install on every ephemeral runner and keep the persistent Macs tracking new stables).
- **Contract test** enforces the lockstep three ways: concrete `x.y.z` channel; every dtolnay step has an explicit `toolchain:` input (omitting one silently falls back to the action tag's floating stable); every input equals the pin. Expectation derived from `rust-toolchain.toml`, so bumps never edit the test. Mutation-checked red: channel→stable, one input→stable, one input deleted.
- **`prepare-rust-runner` asserts the resolved cargo IS the pinned version** (adversarial-review finding: its directory-scan fallback could silently select the box default when the pin is missing — the exact drift class this PR kills). Repair messages now name the pinned version.
- Stale "pins stable" wording fixed in `docs/rust-mlx-build.md`, `scripts/setup-nax-runner.sh`, `scripts/check-neither-build.mjs`, `docker/rust.Dockerfile` (the Docker/runpod paths COPY the toml before any cargo, so they follow the pin automatically).

## Box-side prerequisite: DONE

`1.97.1` is pre-installed on the self-hosted cuda box with rustfmt+clippy, and `rustup which cargo` from this worktree resolves the `1.97.1` toolchain dir — the exact mechanism the prep action uses. The nax Macs auto-install the pin via rustup on their first run (dtolnay at the pinned SHA passes a three-part version through literally, `--no-self-update`).

`npm run check`: 296/296 green.

Note: this PR edits both self-hosted lane workflow files, so both lanes run on it — which doubles as the end-to-end proof that the pinned toolchain builds green on the real boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)