### PR TITLE
sc-17763: de-flake the proxy validator's SSE observation test

### DIFF
--- a/scripts/validate-runpod-proxy.mjs
+++ b/scripts/validate-runpod-proxy.mjs
@@ -257,6 +257,7 @@ export async function validateProxy({
   minimumHeartbeats = 5,
   maximumEventLatencyMs = 10_000,
   allowNonRunpod = false,
+  stopWhenSatisfied = false,
 }) {
   if (!token) {
     fail("SCENEWORKS_ACCESS_TOKEN is required");
@@ -324,10 +325,22 @@ export async function validateProxy({
       fail("placeholder job response did not include an id");
     }
 
-    const observationDeadline = performance.now() + observationSeconds * 1000;
+    // `observationSeconds` is a *ceiling*, not a fixed dwell. A real proxy run
+    // keeps `stopWhenSatisfied` false so the full window elapses -- that is what
+    // proves RunPod's proxy does not sever an idle SSE stream. Callers that only
+    // need to prove events flow (the tests) set it true, which turns the window
+    // into "wait up to this long for the contract to be met" instead of a
+    // wall-clock race that a scheduling stall can lose.
+    const observationStartedAt = performance.now();
+    const observationDeadline = observationStartedAt + observationSeconds * 1000;
     const heartbeatTimes = [];
     let jobEventLatencyMs = null;
+    const observationSatisfied = () =>
+      jobEventLatencyMs !== null && heartbeatTimes.length >= minimumHeartbeats;
     while (performance.now() < observationDeadline) {
+      if (stopWhenSatisfied && observationSatisfied()) {
+        break;
+      }
       const remaining = observationDeadline - performance.now();
       const waitMs = Math.min(25_000, Math.max(1, remaining));
       const next = await nextEvent(events, waitMs);
@@ -361,6 +374,8 @@ export async function validateProxy({
         `only ${heartbeatTimes.length} heartbeat events arrived; expected ${minimumHeartbeats}`,
       );
     }
+    const observedSeconds =
+      Math.round(performance.now() - observationStartedAt) / 1000;
 
     const upload = multipartUpload(uploadFile);
     const uploadStartedAt = performance.now();
@@ -415,7 +430,12 @@ export async function validateProxy({
       sse: {
         readyLatencyMs,
         jobEventLatencyMs,
+        // `observationSeconds` is the configured ceiling; `observedSeconds` is
+        // what the window actually spent. They are equal on a real proxy run
+        // (`stopWhenSatisfied` false) and diverge when a caller opts into the
+        // early break, so the logged record never overstates the observation.
         observationSeconds,
+        observedSeconds,
         heartbeatCount: heartbeatTimes.length,
         remainedConnected: true,
       },

--- a/scripts/validate-runpod-proxy.test.mjs
+++ b/scripts/validate-runpod-proxy.test.mjs
@@ -38,6 +38,114 @@ test("SSE parser preserves CRLF framing when the pair is split across chunks", a
   ]);
 });
 
+/**
+ * Minimal SSE-only fake proxy: enough surface for `validateProxy` to reach the
+ * observation-window assertions and then run its cleanup `finally`. Pass
+ * `heartbeatIntervalMs: null` to serve a stream that never heartbeats.
+ *
+ * Deliberately *not* shared with the happy-path test below, which keeps its own
+ * inline server: that one is the full-surface fixture (assets upload, delete,
+ * purge, and the `canceledJob`/`clearedJob` witnesses) and asserting on those
+ * witnesses is most of its point. This helper stops at the event stream because
+ * the negative cases below never reach the upload. If a third caller ever wants
+ * the full surface, merge the two rather than adding a third copy.
+ *
+ * Note both fakes answer `/cancel` with `status: "canceled"`, which is in
+ * `TERMINAL_JOB_STATUSES`, so `cleanupProbeJob`'s 250 ms poll loop never runs a
+ * single iteration. sc-17763 listed that poll as a flake candidate; it has no
+ * flake surface here, and this comment is the record of that being checked.
+ */
+function startEventOnlyProxy({ heartbeatIntervalMs = 20 } = {}) {
+  const clients = new Set();
+  const intervals = new Set();
+  const server = createServer(async (request, response) => {
+    const url = new URL(request.url, "http://localhost");
+    const isTicketedSse =
+      request.method === "GET" &&
+      url.pathname === "/api/v1/jobs/events" &&
+      url.searchParams.get("ticket") === "single-use-ticket";
+    if (!isTicketedSse && request.headers["x-sceneworks-token"] !== "test-token") {
+      response.writeHead(401).end();
+      return;
+    }
+    if (request.method === "GET" && url.pathname === "/api/v1/projects") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify([{ id: "project-1", name: "Proxy Test" }]));
+      return;
+    }
+    if (request.method === "POST" && url.pathname === "/api/v1/jobs/events/ticket") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ ticket: "single-use-ticket" }));
+      return;
+    }
+    if (isTicketedSse) {
+      response.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+      });
+      response.write('event: ready\ndata: {"status":"connected"}\n\n');
+      clients.add(response);
+      let interval;
+      if (heartbeatIntervalMs !== null) {
+        interval = setInterval(
+          () => response.write('event: heartbeat\ndata: {"status":"ok"}\n\n'),
+          heartbeatIntervalMs,
+        );
+        intervals.add(interval);
+      }
+      request.on("close", () => {
+        if (interval) {
+          clearInterval(interval);
+          intervals.delete(interval);
+        }
+        clients.delete(response);
+      });
+      return;
+    }
+    if (request.method === "POST" && url.pathname === "/api/v1/jobs") {
+      for await (const _chunk of request) {
+        // Drain the JSON request.
+      }
+      const job = { id: "job-1", status: "queued" };
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify(job));
+      for (const client of clients) {
+        client.write(`event: job.updated\ndata: ${JSON.stringify(job)}\n\n`);
+      }
+      return;
+    }
+    if (
+      request.method === "POST" &&
+      (url.pathname === "/api/v1/jobs/job-1/cancel" ||
+        url.pathname === "/api/v1/jobs/job-1/clear")
+    ) {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ id: "job-1", status: "canceled" }));
+      return;
+    }
+    response.writeHead(404).end();
+  });
+
+  return {
+    server,
+    async listen() {
+      await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+      return `http://127.0.0.1:${server.address().port}`;
+    },
+    async close() {
+      for (const interval of intervals) {
+        clearInterval(interval);
+      }
+      intervals.clear();
+      for (const client of clients) {
+        client.end();
+      }
+      server.closeAllConnections();
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
 test("proxy validator observes live SSE, streams multipart, and cleans up", async () => {
   const tempDir = await mkdtemp(join(tmpdir(), "sceneworks-proxy-test-"));
   const fixture = join(tempDir, "representative.mp4");
@@ -162,12 +270,32 @@ test("proxy validator observes live SSE, streams multipart, and cleans up", asyn
       token: "test-token",
       uploadFile: fixture,
       minimumUploadBytes: 4096,
-      observationSeconds: 0.12,
+      // `stopWhenSatisfied` ends the window the moment the contract is met
+      // (~40 ms with a 20 ms heartbeat interval), so this 10 s is a ceiling the
+      // test never spends, not a dwell. sc-17763 flaked because the old 120 ms
+      // wall-clock window had to survive 17 sibling test files competing for the
+      // CPU, and an ~80 ms scheduling stall lost the second heartbeat.
+      observationSeconds: 10,
       minimumHeartbeats: 2,
-      maximumEventLatencyMs: 1_000,
+      // Slack, not a budget: the loop is already bounded by the 10 s ceiling
+      // above, so this can never fire here. The latency branch is pinned
+      // deterministically by its own test below instead of by a wall-clock
+      // margin that a loaded box can blow through.
+      maximumEventLatencyMs: 10_000,
       allowNonRunpod: true,
+      stopWhenSatisfied: true,
     });
-
+    // Pins the claim the comment above makes: deleting `stopWhenSatisfied` from
+    // the validator turns this red instead of merely making CI mysteriously
+    // slower. Deliberately expressed as a fraction of the ceiling rather than a
+    // fixed millisecond bound -- a bare wall-clock threshold here would be the
+    // exact defect sc-17763 is about. The only way to lose this is a multi-second
+    // stall, which every other budget in the file would lose first.
+    assert.ok(
+      result.sse.observedSeconds < result.sse.observationSeconds / 2,
+      `expected the satisfied contract to end the window early, observed ` +
+        `${result.sse.observedSeconds}s of a ${result.sse.observationSeconds}s ceiling`,
+    );
     assert.equal(result.sse.remainedConnected, true);
     assert.equal(result.upload.fileBytes, 4096);
     assert.ok(uploadedBodyBytes > 4096, "multipart framing is sent with the file");
@@ -183,6 +311,78 @@ test("proxy validator observes live SSE, streams multipart, and cleans up", asyn
     }
     server.closeAllConnections();
     await new Promise((resolve) => server.close(resolve));
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+// The main test above waits for heartbeats rather than racing a 120 ms clock,
+// so on its own it would still pass if the heartbeat path were deleted -- it
+// would simply run to its 10 s ceiling and then fail, which no green run
+// proves. These two negative tests pin the failure side directly: each drives
+// a server that violates one contract and asserts the specific `fail()` fires.
+
+test("proxy validator fails when the stream never heartbeats", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "sceneworks-proxy-test-"));
+  const fixture = join(tempDir, "representative.mp4");
+  await writeFile(fixture, Buffer.alloc(4096, 0x5a));
+  const proxy = startEventOnlyProxy({ heartbeatIntervalMs: null });
+
+  try {
+    const rawBaseUrl = await proxy.listen();
+    await assert.rejects(
+      validateProxy({
+        rawBaseUrl,
+        token: "test-token",
+        uploadFile: fixture,
+        minimumUploadBytes: 4096,
+        // This one genuinely dwells: heartbeats never arrive, so
+        // `stopWhenSatisfied` can never fire and the window always runs to the
+        // ceiling. That makes the ceiling a real budget for the *other*
+        // requirement -- `job.updated` must land inside it, or validateProxy
+        // throws "matching job.updated event was not observed" and the regex
+        // below fails on the wrong message. At 250 ms that was sc-17763's own
+        // flake class at 2x the budget (a ~300 ms stall flips the message);
+        // 3 s buys ~12x margin for the cost of a 3 s dwell.
+        observationSeconds: 3,
+        minimumHeartbeats: 2,
+        maximumEventLatencyMs: 10_000,
+        allowNonRunpod: true,
+        stopWhenSatisfied: true,
+      }),
+      /only 0 heartbeat events arrived; expected 2/,
+    );
+  } finally {
+    await proxy.close();
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("proxy validator fails when the job event exceeds the latency ceiling", async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), "sceneworks-proxy-test-"));
+  const fixture = join(tempDir, "representative.mp4");
+  await writeFile(fixture, Buffer.alloc(4096, 0x5a));
+  const proxy = startEventOnlyProxy();
+
+  try {
+    const rawBaseUrl = await proxy.listen();
+    await assert.rejects(
+      validateProxy({
+        rawBaseUrl,
+        token: "test-token",
+        uploadFile: fixture,
+        minimumUploadBytes: 4096,
+        observationSeconds: 10,
+        minimumHeartbeats: 2,
+        // Any real delivery exceeds a 0 ms ceiling, so this branch fires
+        // deterministically instead of relying on a loaded box to be slow.
+        maximumEventLatencyMs: 0,
+        allowNonRunpod: true,
+        stopWhenSatisfied: true,
+      }),
+      /matching job\.updated event took \d+ ms \(limit 0 ms\)/,
+    );
+  } finally {
+    await proxy.close();
     await rm(tempDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Fixes [sc-17763](https://app.shortcut.com/trefry/story/17763).

## The flake

`proxy validator observes live SSE, streams multipart, and cleans up` drove `validateProxy` with a **120 ms** observation window requiring **2 heartbeats**, against a fake server ticking every 20 ms — while the other 17 test files in `npm run check`'s `node --test` batch competed for the CPU. An ~80 ms scheduling stall lost the second heartbeat.

**Reproduced on unmodified code** under CPU oversubscription: **8/25** and **6/15** failures, message `only 1 heartbeat events arrived; expected 2`. That confirms the heartbeat budget is the firing assertion and rules out the two other candidates the story flagged (`maximumEventLatencyMs`, and the 250 ms cancel poll — the latter has no flake surface at all, since every fake returns a terminal `canceled` from `/cancel`, so the poll loop never iterates).

The margin was also thinner than the story's arithmetic implied: an instrumented harness measured **3–4 heartbeats on an idle box, not 5–6**, because the window loses time to the ready handshake and the job POST round trip. Real headroom above the required 2 was 1–2 events, not 3×.

Stall injection against the pristine validator, for calibration:

| injected client stall | outcome over 40 runs |
| --- | --- |
| 40 ms | all pass, but 7/40 land on exactly 2 heartbeats |
| 80 ms | **11/40 FAIL** `only 1 heartbeat` |
| 120 ms | **15/40 FAIL** (12× "only 1", 3× "only 0") |

A *server*-side stall does not reproduce it — heartbeats buffer in the socket and all arrive — which is why this only surfaces as client-side contention from sibling test files.

## The fix

`stopWhenSatisfied` (**default `false`**) ends the observation window once *both* a matching `job.updated` event and `minimumHeartbeats` heartbeats have been seen.

A real RunPod run leaves it false, so the full 110 s still elapses — that dwell is the whole point there, since it proves the proxy does not sever an idle SSE stream. The CLI cannot set the flag (`parseCli` exposes no option for it), so production behavior is byte-for-byte unchanged. The test opts in and treats `observationSeconds` as a *ceiling* rather than a race, exiting in ~40 ms.

`observedSeconds` is now reported next to the configured `observationSeconds`, so the JSON record never overstates the window when the early break fires. The two are equal on every real run.

## Keeping it able to fail

A test that merely waits for heartbeats still passes with the heartbeat path deleted — it just runs to its ceiling. Two negative tests pin the failure side directly: a stream that never heartbeats, and a job event against a 0 ms latency ceiling.

Verified by mutation — each turns **exactly one** expected test red:

| mutation | red test |
| --- | --- |
| disable the heartbeat `fail()` | `never heartbeats` |
| remove `heartbeatTimes.push(...)` | main test |
| disable the latency `fail()` | `exceeds the latency ceiling` |
| delete the `stopWhenSatisfied` early break | main test |

That last row is new: without an assertion on `observedSeconds`, deleting the early break was invisible — every test still passed and the only signal was CI wall time.

The early-exit assertion is expressed as `observedSeconds < observationSeconds / 2` rather than a fixed millisecond bound, deliberately: a bare wall-clock threshold would re-introduce the exact defect this story removes.

## Verification

- Target file 5/5; full 18-file concurrent batch **8/8 clean** (plus 10/10 before the review fixes).
- Stall stress against the fixed budget: **160/160 pass** at 80/120/400/1500 ms stalls, where the old code failed ~30% at 80–120 ms.
- Gates: `check-source-control-bytes.mjs`, `check-runpod-template.mjs`, `check:runpod:proxy:self-test` all PASS. Both files are ASCII-clean.
- Adversarial review returned SHIP WITH FIXES; all eight findings addressed, including a residual 250 ms race in one of the new negative tests (same flake class at 2× the budget) now widened to 3 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
