### PR TITLE
ci: correct the candle lane cost model and the "single cuda box" claim

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -195,8 +195,10 @@ jobs:
   # `all(not(target_os = "macos"), feature = "backend-candle")` — `vram_gate`, `krea_control_fit`,
   # the candle-control image modules, `generate_candle_video` and its Mochi fit gates. Until this job
   # existed the ONLY compiler of that cfg anywhere in CI was windows-candle.yml, which runs on the
-  # fleet's single `cuda` box, takes ~28 min, and has no `merge_group:` trigger — so a candle-side
-  # semantic conflict merged green and broke `main` for everyone behind it.
+  # self-hosted `cuda` pool at a ~24m median (p90 32m, measured 2026-08-05 over 85 runs) and has no
+  # `merge_group:` trigger — so a candle-side semantic conflict merged green and broke `main` for
+  # everyone behind it. This job is ~4m and hosted, which is what makes it affordable per merge
+  # group where that lane is not.
   #
   # It does not need a GPU. `scripts/check-candle-build.mjs` (sc-12356) writes a stub `nvcc` that
   # satisfies the three build scripts that shell out to the CUDA toolkit, and `cargo clippy`/`check`

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -11,7 +11,7 @@ name: Desktop (Windows)
 #     the desktop crate, so this is the only lane that exercises it
 #     (epic 1330 Phase 3 / sc-1356).
 #
-#   package-windows  (push:main + workflow_dispatch, SELF-HOSTED cuda box) — the full
+#   package-windows  (push:main + workflow_dispatch, SELF-HOSTED `cuda` pool) — the full
 #     candle/CUDA sidecar build + NSIS/MSI packaging, as an UNSIGNED smoke so a
 #     packaging break (NSIS's ~2 GB datablock limit, Tauri bundling) surfaces the
 #     moment it lands on main — before a release tag, not during one. Runs on the same
@@ -64,8 +64,8 @@ on:
 # Cancel superseded PR runs, but never cancel a main-push run — same reasoning as
 # windows-candle.yml (sc-12399). `package-windows` below is non-PR-only, so main is
 # the ONLY place the full candle/CUDA desktop package is built before a release tag;
-# cancelling it pushes packaging breaks to release time. It also shares the one
-# `cuda` box with windows-candle.yml, so it is part of the same queue.
+# cancelling it pushes packaging breaks to release time. It also shares the `cuda`
+# runner pool with windows-candle.yml, so it is part of the same queue.
 #
 # Main must key on `github.sha`, not `github.ref`: GitHub keeps at most ONE pending
 # run per group and evicts it when a newer run queues, so a shared main group still
@@ -154,14 +154,14 @@ jobs:
       CARGO_NET_OFFLINE: "true"
     # Guardrail so a wedged step fails fast instead of riding GitHub's 6-hour
     # default (sc-10420). This is the full candle/CUDA sidecar build + NSIS/MSI
-    # packaging on the SOLE self-hosted cuda box (shared with windows-candle.yml),
-    # so a wedge here holds that box and starves every queued PR/main run on it
+    # packaging on the self-hosted `cuda` pool (shared with windows-candle.yml), so a
+    # wedge here holds a box and starves queued PR/main runs behind it
     # (sc-13603). Well above the healthy ~13-17 min warm package — a cold candle
     # rebuild fits.
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # sc-13166: same self-hosted cuda box as windows-candle.yml — point this lane at
+      # sc-13166: same self-hosted `cuda` pool as windows-candle.yml — point this lane at
       # the real rustup toolchain bin (prepended to PATH) so it never dispatches through
       # the fragile %USERPROFILE%\.cargo\bin proxies that go dangling on rustup
       # self-update/deletion and fail with ERROR_NO_ASSOCIATION. package-windows is

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -57,8 +57,8 @@ on:
       # and no candle-gated code, nothing in the workspace depends on it, and
       # nothing this job runs builds it: every cargo invocation below is
       # -p sceneworks-worker, -p sceneworks-rust-api or
-      # -p sceneworks-memory-adapter. Watching it woke this whole job — the
-      # fleet's single cuda box — for zero coverage. The two lanes legitimately
+      # -p sceneworks-memory-adapter. Watching it woke this whole job — a ~24m
+      # median run on the `cuda` pool — for zero coverage. The two lanes legitimately
       # differ: macos-mlx.yml's HOSTED macos-checks job runs the bare
       # workspace-wide `cargo test` / `cargo clippy --all-targets` over every
       # default member, which DOES compile the wrapper, so the entry earns its
@@ -81,7 +81,7 @@ on:
       #
       # THIS FILE, not `config/engine-capabilities/**` (sc-17665). The directory glob also
       # matched capabilities.mlx.json, so an mlx-only restamp woke this ENTIRE job — every
-      # step below, on the fleet's single `cuda` box — for a file the verify step never
+      # step below, ~24m median on the `cuda` pool — for a file the verify step never
       # opens. Nothing in this lane reads it: no Rust reads the facts directory at all
       # (`default_facts_dir()` only builds the dumper bin's default OUTPUT path; a repo-wide
       # grep finds no reader), and the three consumers that DO glob the whole directory are
@@ -169,11 +169,36 @@ on:
 # own group, where nothing can evict it; runs then serialize on the single
 # self-hosted box instead. Do NOT collapse this back to `group: ...${{ github.ref }}`.
 #
-# Cost is bounded and was measured before landing: the lane is ~4.2m median (p90
-# 4.5m) and the box sits ~12% utilized, so restoring the cancelled main runs adds
-# ~34m of box time per ~37h (≈12% -> ≈13% utilization). `queue: max` would be the
-# other way to do this, but it cannot combine with `cancel-in-progress: true`,
-# which the PR side still wants.
+# COST, re-measured 2026-08-05 over 85 completed `candle-worker` jobs in a 29.5h
+# window. This block previously claimed "~4.2m median (p90 4.5m)" and "the box sits
+# ~12% utilized". Both were wrong by the time anyone read them: duration was ~6x low,
+# and "the box" described a single machine that does not exist.
+#
+#   job duration   median 24.1m   p90 31.9m   max 44.0m   min 8.2m
+#   queue wait     median  0.1m   p90 18.0m   max 55.5m
+#   pool           FOUR runners carried the `cuda` label over that window
+#                  (cuda-windows, -2, -3, -4), load spread evenly across them:
+#                  23/18/22/22 jobs, 516/424/591/537 busy minutes
+#   utilization    ~29% per box
+#
+# THE CONCLUSION IS UNCHANGED — keeping main-push runs uncancelled is affordable, and
+# with more headroom than the old numbers implied. Only the magnitudes were wrong, and
+# they were wrong in both directions at once (each run costs ~6x more than stated; there
+# are ~4x more boxes to absorb it). Do not read the correction as "this lane got cheap".
+#
+# `queue: max` would be the other way to do this, but it cannot combine with
+# `cancel-in-progress: true`, which the PR side still wants.
+#
+# RE-MEASURE; DO NOT TRUST THESE NUMBERS ON SIGHT. They went ~6x stale without anyone
+# noticing, because nothing recomputes them and no test can — they describe fleet state,
+# not repo content. Method, so the next re-measure is comparable:
+#   * duration = repo-scoped jobs API `started_at` -> `completed_at`. Do NOT use
+#     `gh run list`'s createdAt -> updatedAt: that folds queue wait into run time and
+#     reports ~50m for a 24m job, which is how a wrong number gets quoted confidently.
+#   * exclude `cancelled` runs — they truncate low and drag the median down.
+#   * pool size = `gh api repos/{owner}/{repo}/actions/runners`. It is NOT fixed: two of
+#     the four boxes above were no longer online hours after this measurement, so quote
+#     the pool size and date together or the utilization figure means nothing.
 concurrency:
   group: windows-candle-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/scripts/merge-group-relevance.mjs
+++ b/scripts/merge-group-relevance.mjs
@@ -6,8 +6,8 @@
 // GitHub's `merge_group` event supports NO `paths:` / `paths-ignore:` filter — only `branches:`
 // (community discussion 45899; still open). Every other trigger on the backend lanes is path-gated,
 // and those filters are not decoration: `macos-mlx.yml` runs on a hand-registered pool of two Macs,
-// one of them a developer's daily driver, and `windows-candle.yml` runs on the fleet's single `cuda`
-// box. A bare `merge_group:` would wake them for a README-only queue entry.
+// one of them a developer's daily driver, and `windows-candle.yml` runs on the self-hosted `cuda`
+// pool at a ~24m median per job. A bare `merge_group:` would wake them for a README-only queue entry.
 //
 // So the filter moves from the trigger into a hosted gate job, and this script is that gate.
 //

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -760,7 +760,7 @@ test("every workspace path a self-hosted lane watches maps to a package that lan
   // sc-17703, generalising sc-17665's lesson to the whole trigger surface. `apps/rust-worker/**`
   // sat in windows-candle.yml's paths while no cargo invocation in that job built the package
   // living there (`sceneworks-rust-worker` — a 4-line binary wrapper nothing depends on), so a
-  // wrapper edit woke the fleet's single cuda box for zero coverage. Pin the PROPERTY, not the
+  // wrapper edit woke a ~24m run on the `cuda` pool for zero coverage. Pin the PROPERTY, not the
   // spelling (epic 17702 rule 6): every `crates/`- or `apps/`-shaped `paths:` entry on a
   // self-hosted lane may only wake the lane for workspace members that lane's own cargo
   // invocations build, directly or through the local dependency graph; every other entry must be
@@ -1066,16 +1066,20 @@ test("every backend cfg the queue can break is compiled by a merge-group-trigger
 });
 
 test("merge groups never reach the scarce self-hosted boxes", async () => {
-  // windows-candle.yml is the fleet's single `cuda` box at ~28 min a run, and nax-worker is a
-  // two-Mac pool including a developer's daily driver. The queue can build several speculative
-  // groups at once, so a `merge_group:` trigger here multiplies the scarcest hardware in the fleet.
+  // windows-candle.yml runs on the self-hosted `cuda` pool at a ~24m median (p90 32m, max 44m;
+  // measured 2026-08-05 over 85 runs), and nax-worker is a two-Mac pool including a developer's
+  // daily driver. The queue can build several speculative groups at once, so a `merge_group:`
+  // trigger here multiplies self-hosted load — and with `check_response_timeout_minutes: 60`, a
+  // p90 queue wait (18m) plus a p90 run (32m) already reaches ~50m, so a required check on this
+  // lane would sit close to the eviction threshold on an ordinary day.
   // Their merge-time coverage is check.yml's `candle` job and macos-mlx.yml's hosted `macos-checks`
   // respectively — both on elastic runners.
   assert.doesNotMatch(
     await source(".github/workflows/windows-candle.yml"),
     /^ {2}merge_group:$/m,
     "windows-candle.yml must stay out of the merge queue; check.yml's `candle` job is its " +
-      "merge-time stand-in. Putting the single cuda box in the queue would wedge it.",
+      "merge-time stand-in. A ~24m median run (p90 32m) against a 60m check-response timeout " +
+      "leaves too little margin to gate the queue on this lane.",
   );
   assert.match(
     await source(".github/workflows/macos-mlx.yml"),


### PR DESCRIPTION
## What does this PR do?

Corrects two wrong load-bearing claims in CI prose. **One of them I introduced in #2145**, so this corrects the record, not just the text.

### 1. Duration was ~6× low

`windows-candle.yml`'s concurrency block claimed *"~4.2m median (p90 4.5m)"* and *"the box sits ~12% utilized"*. Measured over **85 completed `candle-worker` jobs in a 29.5h window**:

| | median | p90 | max | min |
|---|---|---|---|---|
| job duration | **24.1m** | **31.9m** | 44.0m | 8.2m |
| queue wait | 0.1m | 18.0m | 55.5m | — |

### 2. There is no "single cuda box"

`windows-candle.yml`, `desktop-windows.yml`, `check.yml` and `platform-review-contracts.test.mjs` all described *"the fleet's single"* / *"the SOLE"* cuda box. **Four** runners carried the `cuda` label over that window — `cuda-windows`, `-2`, `-3`, `-4` — evenly loaded:

| runner | jobs | busy |
|---|---|---|
| cuda-windows | 23 | 516m |
| cuda-windows-2 | 18 | 424m |
| cuda-windows-3 | 22 | 591m |
| cuda-windows-4 | 22 | 537m |

That's **~29% per box**, not one saturated machine.

**The two errors point opposite ways** — each run costs ~6× more than stated, *and* there are ~4× more boxes to absorb it. Neither "the lane got cheap" nor "the pool is saturated" is true, which is why the numbers are now stated together with date, sample size, and pool size.

## How I got this wrong in #2145

Worth recording, because the failure mode is reusable. I derived duration from `gh run list`'s `createdAt → updatedAt`, which **folds queue wait into run time** and reports ~50m for a 24m job. A ~50m job against ~30 merges/day reads as a saturated single box — and I asserted that in a merged PR body and commit message **without ever checking `runner_name` on the jobs API**, which had the answer the whole time.

The replacement comments now record the *method*, not just the result: use the repo-scoped jobs API `started_at → completed_at`, exclude `cancelled` runs (they truncate low), and read pool size from the runners API — which is **not fixed**, as two of those four boxes were offline hours after the measurement.

## Does the #2145 design still stand?

**Yes, but on a different reason, which is stated plainly rather than quietly swapped.** `windows-candle.yml` stays out of the merge queue not because one box is saturated, but because a p90 queue wait (18m) plus a p90 run (32m) already reaches ~50m against `check_response_timeout_minutes: 60` — too little margin to gate on. `check.yml`'s hosted `candle` job (~4m) remains its merge-time stand-in.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Documentation only (CI comments + one assertion message)
- [x] Refactor / chore (no user-facing behavior change)

## How was this tested?

**No behavior changes** — comments, one contract-test assertion message, one contract-test rationale block. All three workflows re-parsed as valid YAML with triggers and jobs unchanged.

- `platform-review-contracts.test.mjs` 31/31
- `merge-group-relevance.test.mjs` 7/7
- `npm run check` **318/320**

- [x] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (CI comments)

## Checklist

- [x] I ran `npm run rust:check` — n/a, no Rust changed
- [ ] Web checks — n/a, web untouched
- [x] I ran `npm run check` — 318/320, see below
- [x] I updated documentation where relevant — this PR *is* the documentation fix
- [x] All my commits are signed off
- [x] My PR is focused on a single logical change

### Two failures, neither introduced here

1. **`inference-artifact-audit`** — pre-existing, reproduces on clean `HEAD` (verified during #2145).
2. **`validate-runpod-proxy`'s latency-ceiling test — still flaky after sc-17763's de-flake.** 2 of 5 consecutive local runs fail. My diff does not touch that file. Flagging rather than fixing, since it's someone else's in-flight work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)