### PR TITLE
Fix the two pre-existing npm run check failures (sc-17802, sc-17803)

### DIFF
--- a/scripts/inference-artifact-audit.test.mjs
+++ b/scripts/inference-artifact-audit.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -89,6 +89,27 @@ function closureRepo() {
   git("add", "-A");
   git("commit", "-qm", "doc comment only");
   return { repo, git, captured, compatible: git("rev-parse", "HEAD"), moved };
+}
+
+/**
+ * A temp build directory whose path is CANONICAL, for fixtures that also synthesize cargo
+ * `manifest_path` values underneath it.
+ *
+ * `coveredClosurePaths` resolves the workdir with `realpathSync` — deliberately, because real cargo
+ * reports canonical manifest paths. A fixture manifest does NOT exist on disk, so the same helper
+ * falls back to `path.resolve` and keeps whatever spelling the fixture used. On macOS `os.tmpdir()`
+ * is `/var/folders/…`, a symlink to `/private/var/folders/…`, so a raw `mkdtempSync` result and its
+ * realpath disagree: every closure path then resolves to "outside the worktree", the covered set
+ * comes back EMPTY, and `auditRecord` refuses the record with "the audited artifact does not
+ * link …".
+ *
+ * Canonicalizing here makes the fake cargo output match what real cargo emits, instead of
+ * describing a machine cargo could never produce. A no-op on Linux, where `/tmp` is its own
+ * realpath — which is why CI never caught this: `npm run check` runs only in the ubuntu-latest
+ * `parity` job, so nothing in `scripts/*.test.mjs` is exercised on macOS at all.
+ */
+function canonicalTempDir(prefix) {
+  return realpathSync(mkdtempSync(path.join(os.tmpdir(), prefix)));
 }
 
 test("closure object pairs cover the declared closure and isolate the one path that moved", () => {
@@ -824,7 +845,7 @@ test("main resolves one witness per revision and puts each digest on its own sid
   // `capturedWitness.digest` makes the layer permanently green and leaves them all passing. This is
   // the same argument that pulled `assertComparableToolchains` out of `main` in sc-17497.
   const out = path.join(mkdtempSync(path.join(os.tmpdir(), "sceneworks-audit-main-")), "record.json");
-  const workdir = mkdtempSync(path.join(os.tmpdir(), "sceneworks-audit-main-wd-"));
+  const workdir = canonicalTempDir("sceneworks-audit-main-wd-");
   const members = ["candle-gen-flux2 v0.0.0|cuda"];
   const fake = fakeAudit({
     trees: {
@@ -876,7 +897,7 @@ test("main resolves one witness per revision and puts each digest on its own sid
 
 test("main exits 0 and records a witness when the shipped resolution is unchanged", async () => {
   const out = path.join(mkdtempSync(path.join(os.tmpdir(), "sceneworks-audit-main-")), "record.json");
-  const workdir = mkdtempSync(path.join(os.tmpdir(), "sceneworks-audit-main-wd-"));
+  const workdir = canonicalTempDir("sceneworks-audit-main-wd-");
   const tree = {
     "runtime-cuda": ["candle-gen-flux2 v0.0.0|cuda", "serde_json v1.0.150|default,std"],
     "candle-gen-flux2": ["candle-gen-flux2 v0.0.0|cuda", "serde_json v1.0.150|default,std"],
@@ -903,7 +924,7 @@ test("main puts each BUILD's digest on its own side, and reports both layers ind
   // The artifact layer's wiring has the same untestable-from-below shape as the witness layer's.
   // Driven on `--lane metal` so the nvcc probe is not reached; the record is inert by construction.
   const out = path.join(mkdtempSync(path.join(os.tmpdir(), "sceneworks-audit-main-")), "record.json");
-  const workdir = mkdtempSync(path.join(os.tmpdir(), "sceneworks-audit-main-wd-"));
+  const workdir = canonicalTempDir("sceneworks-audit-main-wd-");
   const moved = "crates/media/candle-gen/candle-gen";
   const tree = {
     "runtime-cuda": ["candle-gen-flux2 v0.0.0|metal"],

--- a/scripts/validate-runpod-proxy.test.mjs
+++ b/scripts/validate-runpod-proxy.test.mjs
@@ -55,9 +55,14 @@ test("SSE parser preserves CRLF framing when the pair is split across chunks", a
  * single iteration. sc-17763 listed that poll as a flake candidate; it has no
  * flake surface here, and this comment is the record of that being checked.
  */
-function startEventOnlyProxy({ heartbeatIntervalMs = 20 } = {}) {
+function startEventOnlyProxy({ heartbeatIntervalMs = 20, jobEventDelayMs = 0 } = {}) {
   const clients = new Set();
   const intervals = new Set();
+  const timers = new Set();
+  // Set when the validator reaches the multipart upload, which this stub deliberately does not
+  // serve. Without it a validator that runs FURTHER than the test expects fails against a bare
+  // `HTTP 404 Not Found` from the catch-all, which says nothing about what actually went wrong.
+  const reached = { upload: false };
   const server = createServer(async (request, response) => {
     const url = new URL(request.url, "http://localhost");
     const isTicketedSse =
@@ -109,8 +114,24 @@ function startEventOnlyProxy({ heartbeatIntervalMs = 20 } = {}) {
       const job = { id: "job-1", status: "queued" };
       response.setHeader("content-type", "application/json");
       response.end(JSON.stringify(job));
-      for (const client of clients) {
-        client.write(`event: job.updated\ndata: ${JSON.stringify(job)}\n\n`);
+      // `jobEventDelayMs` makes the OBSERVED latency exceed a ceiling by construction rather than
+      // by hoping the machine is slow. `validateProxy` computes the latency as
+      // `Math.round(now - jobStartedAt)`, so a loopback delivery under 0.5 ms rounds to exactly 0 —
+      // and `0 > 0` is false, so a 0 ms ceiling never fires (sc-17803). A fixed server-side delay
+      // is deterministic in the safe direction: load can only make it larger.
+      const emit = () => {
+        for (const client of clients) {
+          client.write(`event: job.updated\ndata: ${JSON.stringify(job)}\n\n`);
+        }
+      };
+      if (jobEventDelayMs > 0) {
+        const timer = setTimeout(() => {
+          timers.delete(timer);
+          emit();
+        }, jobEventDelayMs);
+        timers.add(timer);
+      } else {
+        emit();
       }
       return;
     }
@@ -123,11 +144,15 @@ function startEventOnlyProxy({ heartbeatIntervalMs = 20 } = {}) {
       response.end(JSON.stringify({ id: "job-1", status: "canceled" }));
       return;
     }
+    if (request.method === "POST" && /^\/api\/v1\/projects\/[^/]+\/assets$/.test(url.pathname)) {
+      reached.upload = true;
+    }
     response.writeHead(404).end();
   });
 
   return {
     server,
+    reached,
     async listen() {
       await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
       return `http://127.0.0.1:${server.address().port}`;
@@ -137,6 +162,10 @@ function startEventOnlyProxy({ heartbeatIntervalMs = 20 } = {}) {
         clearInterval(interval);
       }
       intervals.clear();
+      for (const timer of timers) {
+        clearTimeout(timer);
+      }
+      timers.clear();
       for (const client of clients) {
         client.end();
       }
@@ -361,7 +390,14 @@ test("proxy validator fails when the job event exceeds the latency ceiling", asy
   const tempDir = await mkdtemp(join(tmpdir(), "sceneworks-proxy-test-"));
   const fixture = join(tempDir, "representative.mp4");
   await writeFile(fixture, Buffer.alloc(4096, 0x5a));
-  const proxy = startEventOnlyProxy();
+  // The event is held back a fixed 25 ms so the observed latency clears the ceiling BY
+  // CONSTRUCTION. The previous fixture emitted immediately and relied on "any real delivery
+  // exceeds a 0 ms ceiling" -- which is false: `validateProxy` rounds the latency to whole
+  // milliseconds, a loopback delivery lands under 0.5 ms, and `0 > 0` does not fire. The run then
+  // sailed past the ceiling check into the upload this stub does not serve and failed on the
+  // catch-all 404. Measured 12/12 sub-millisecond in isolation, ~1-in-3 inside the suite, where
+  // concurrent tests add just enough load to sometimes push it over (sc-17803).
+  const proxy = startEventOnlyProxy({ jobEventDelayMs: 25 });
 
   try {
     const rawBaseUrl = await proxy.listen();
@@ -373,13 +409,18 @@ test("proxy validator fails when the job event exceeds the latency ceiling", asy
         minimumUploadBytes: 4096,
         observationSeconds: 10,
         minimumHeartbeats: 2,
-        // Any real delivery exceeds a 0 ms ceiling, so this branch fires
-        // deterministically instead of relying on a loaded box to be slow.
         maximumEventLatencyMs: 0,
         allowNonRunpod: true,
         stopWhenSatisfied: true,
       }),
       /matching job\.updated event took \d+ ms \(limit 0 ms\)/,
+    );
+    // The ceiling must stop the run BEFORE the upload. Asserting this keeps a future regression
+    // legible: without it, falling through surfaces as a bare `HTTP 404 Not Found`.
+    assert.equal(
+      proxy.reached.upload,
+      false,
+      "the latency ceiling must abort the run before the multipart upload is attempted",
     );
   } finally {
     await proxy.close();


### PR DESCRIPTION
Fixes the two `npm run check` failures that were sitting on `main`. Neither came from PR #2150 — I verified both against a clean `origin/main` worktree before touching anything.

`npm run check` now exits **0** (320 assertions, 0 failures).

## sc-17802 — artifact-audit fixture reports a path cargo never emits

`node --test scripts/inference-artifact-audit.test.mjs` failed on **every developer Mac**, and had done for a while:

```
✖ main puts each BUILD's digest on its own side, and reports both layers independently
  Error: the audited artifact does not link crates/media/candle-gen/candle-gen
```

**A fixture bug, not a production bug.** `coveredClosurePaths` resolves the workdir through `realpathSync` — deliberately, because real cargo reports *canonical* manifest paths. The fixtures built their fake cargo output from the raw `mkdtempSync` result, and since a fixture manifest doesn't exist on disk it took the `path.resolve` fallback and kept the uncanonical spelling. On macOS those differ:

```
realpath workdir : /private/var/folders/…/probe-faCofZ
resolved manifest: /var/folders/…/probe-faCofZ/crates/…/Cargo.toml
path.relative    : ../../../../../../../var/folders/…
```

Every closure path resolved to "outside the worktree", the covered set came back **empty**, and `auditRecord` correctly refused. Production is unaffected — in a real run the manifest exists, so both sides realpath consistently.

Fixed with a shared `canonicalTempDir` helper applied to **all three** fixtures that synthesize manifest paths under a real temp dir, not just the one that happened to fail. (The other fixtures use synthetic `/w/…` roots that exist on neither side, so they were already self-consistent.)

**Verified not vacuous:** dropping `candle-gen` from `AUDIT_CLOSURE_CRATES` — a genuine coverage gap — still turns the suite red (6 failures).

## sc-17803 — latency-ceiling test flake

2/4 runs failed on `main`, with a misleading `HTTP 404 Not Found` rather than the assertion the test is about. It survived sc-17763, which de-flaked the *sibling* SSE test.

The fixture's stated premise was false. Its comment claimed:

> Any real delivery exceeds a 0 ms ceiling, so this branch fires deterministically instead of relying on a loaded box to be slow.

`validateProxy` computes `Math.round(now - jobStartedAt)` and compares with `>`. On loopback the event lands in **under 0.5 ms**, so the latency rounds to exactly `0` — and `0 > 0` is false. The ceiling never fired, the run continued into a multipart upload the stub doesn't serve, and the catch-all 404 is what the assertion saw.

Measured with a standalone harness on the same stub and options: **12/12 runs rounded to zero**. Inside the suite it's ~1-in-3, because concurrent tests add just enough load to sometimes clear 0.5 ms — precisely the machine-speed dependence the comment claimed to have removed.

The stub now holds the event back a fixed 25 ms, so the latency clears the ceiling **by construction**. Deterministic in the safe direction: load can only make the delay larger. It also models what the ceiling actually exists to catch — a proxy delivering events late.

Production is untouched: `maximumEventLatencyMs` defaults to `10_000`, and the rounding only matters at a 0 ms ceiling that no real caller uses.

Also added: the stub records whether the upload route was reached and the test asserts it wasn't, so a future fall-through fails with that sentence instead of a bare `HTTP 404`.

**Verified:** 8/8 green (was 2/4 failing). Mutation-checked both directions — restoring the 0 ms delay reproduces the flake, and deleting the production ceiling check turns this test red, so it still guards the behaviour rather than merely passing.

## The structural finding — filed, not fixed here

`npm run check` runs in **exactly one** CI job: `parity`, on `ubuntu-latest`. `check-macos` sounds like its counterpart but is a Tauri desktop build in a different workflow. **Nothing runs `scripts/*.test.mjs` on macOS, ever.**

That is why sc-17802 could sit on `main` indefinitely while being red on every Mac. And it is a category, not a one-off: `os.tmpdir()` is a symlink on macOS and its own realpath on Linux, so any test comparing a resolved path against a constructed one is Linux-green and macOS-red by construction. The suite uses `mkdtempSync` heavily.

Filed as **sc-17804** rather than fixed here — it is a CI cost decision landing right after the OOM-driven CI work, so it should be a deliberate choice, not a side effect of a bug fix. The story lays out four options, including a zero-CI-spend one.

Closes sc-17802, sc-17803.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
