### PR TITLE
ci: let the path-filtered lanes become required checks (sc-17014)

### DIFF
--- a/.github/workflows/changed-paths.yml
+++ b/.github/workflows/changed-paths.yml
@@ -1,0 +1,108 @@
+name: Changed paths
+
+# THE PATH FILTER A REQUIRED CHECK IS ALLOWED TO HAVE.
+#
+# Background, because the constraint is not obvious and the naive fix is a trap:
+#
+# GitHub treats the two ways a check can fail to appear COMPLETELY differently
+# (docs: "Troubleshooting required status checks"):
+#
+#   * a JOB skipped by an `if:` condition reports **Success** and satisfies a required check;
+#   * a WORKFLOW skipped by a `paths:` filter reports nothing and stays **Pending** forever.
+#
+# So a `paths:`-filtered lane can never simply be added to the required set — a PR that does not
+# touch its paths would be blocked permanently. And the merge queue makes it worse rather than
+# better: it evaluates the SAME required set against its speculative `gh-readonly-queue/main/**`
+# ref, so a lane with no `merge_group:` trigger leaves its check pending until
+# `check_response_timeout_minutes` expires and the queued entries are EVICTED — which silently
+# re-orders the queue instead of failing loudly.
+#
+# The fix is to stop filtering at the trigger and start filtering at the job: every candidate lane
+# triggers unconditionally, calls this workflow, and gates its real jobs on the answer. Skipped
+# jobs then satisfy the required check, and no expensive box is woken for an irrelevant diff.
+#
+# `merge_group` additionally supports NO `paths:` / `paths-ignore:` filter at all (community
+# discussion 45899, still open), so for that event this is the only filtering mechanism available.
+#
+# WHY THIS READS THE LANE'S OWN ANCHOR instead of taking a path list as an input: the anchor is
+# already the single source of truth for the `push:` trigger, and
+# scripts/platform-review-contracts.test.mjs already forces newly-watched paths into it. Passing a
+# duplicate list here would rot in the SILENT direction — a path this workflow did not know about
+# reads as "not relevant", skips the lane, and shows up as a green required check rather than as a
+# hole.
+
+on:
+  workflow_call:
+    inputs:
+      lane:
+        description: "Path to the workflow file whose `paths:` anchor defines relevance."
+        required: true
+        type: string
+      anchor:
+        description: "Name of the YAML anchor inside that file (e.g. mlx_paths)."
+        required: true
+        type: string
+    outputs:
+      relevant:
+        description: "'true' when the change can affect this lane; 'false' when it provably cannot."
+        value: ${{ jobs.decide.outputs.relevant }}
+
+jobs:
+  decide:
+    runs-on: ubuntu-latest
+    # Hosted, and ~20s in practice — this must stay far cheaper than the lane it gates or it defeats
+    # its own purpose. The cap is a guardrail against a wedged checkout, not a target.
+    timeout-minutes: 10
+    outputs:
+      relevant: ${{ steps.gate.outputs.run }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The diff spans a whole merge group or a whole PR, either of which can reach further back
+          # than a shallow clone contains. The pack is ~130 MB, which costs a few seconds here and
+          # saves a ~24m self-hosted run when the answer is "not relevant".
+          fetch-depth: 0
+      - name: Decide whether this change can affect ${{ inputs.lane }}
+        id: gate
+        env:
+          LANE: ${{ inputs.lane }}
+          ANCHOR: ${{ inputs.anchor }}
+          MERGE_GROUP_BASE: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_HEAD: ${{ github.event.merge_group.head_sha }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+          case "${GITHUB_EVENT_NAME}" in
+            merge_group)
+              # Two-dot: the merge group ref is built directly on base_sha, so this is exactly the
+              # set of changes the queue is about to land.
+              range=("${MERGE_GROUP_BASE}" "${MERGE_GROUP_HEAD}")
+              ;;
+            pull_request|pull_request_target)
+              # Three-dot: diff against the MERGE BASE, not the base branch tip, so commits that
+              # landed on main since the PR opened are not counted as this PR's changes. This is
+              # what GitHub's own `paths:` filter does for a pull request.
+              range=("${PR_BASE}...${PR_HEAD}")
+              ;;
+            *)
+              # push / workflow_dispatch / anything else: not a gated event. Those triggers keep
+              # their own `paths:` filters, and a dispatch is a deliberate human request.
+              echo "${GITHUB_EVENT_NAME} is not a gated event; running the lane."
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          # A failure here must not silently skip a lane, so the diff is captured and its exit
+          # status checked explicitly rather than piped straight into the decider (a pipeline would
+          # report only the LAST command's status). An empty or failed diff falls through to the
+          # script, which runs the lane conservatively.
+          if ! changed=$(git diff --name-only "${range[@]}" 2>&1); then
+            echo "::warning title=Path gate fell back to running the lane::git diff failed: ${changed}"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          printf '%s\n' "${changed}" |
+            node scripts/merge-group-relevance.mjs --workflow "${LANE}" --anchor "${ANCHOR}"

--- a/.github/workflows/desktop-linux-check.yml
+++ b/.github/workflows/desktop-linux-check.yml
@@ -33,7 +33,20 @@ name: Desktop (Linux typecheck)
 # 0-byte file still leaves `cargo check -p sceneworks-desktop` at exit 0.
 
 on:
+  # THE MERGE QUEUE'S SPECULATIVE MERGE (sc-17014). A required check MUST report here too: the queue
+  # evaluates the same required set against `gh-readonly-queue/main/**`, and a workflow with no
+  # `merge_group:` trigger never produces a run for that ref, so the check stays pending until the
+  # group times out and its entries are EVICTED. `merge_group` supports no `paths:` filter at all
+  # (community discussion 45899), which is the other reason the filtering moved into `changes`.
+  merge_group:
+  # NO `paths:` FILTER, deliberately (sc-17014). `check-linux` is a REQUIRED status check, and GitHub
+  # leaves a path-filtered workflow's check **Pending** forever rather than passing it — so a filter
+  # here would block every PR that does not touch these paths, and would strand every merge-queue
+  # entry until `check_response_timeout_minutes` evicted it. The `changes` gate job replaces the
+  # filter: a job skipped by `if:` reports Success, which a required check accepts.
   pull_request:
+  push:
+    branches: [main]
     paths: &desktop_linux_check_paths
       - "apps/desktop/**"
       # The only workspace crate apps/desktop depends on.
@@ -41,9 +54,6 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/desktop-linux-check.yml"
-  push:
-    branches: [main]
-    paths: *desktop_linux_check_paths
   workflow_dispatch:
 
 concurrency:
@@ -51,7 +61,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Supplies the path filter the triggers above gave up so `check-linux` could become a required check.
+  # See .github/workflows/changed-paths.yml for why a required check cannot carry a `paths:` filter.
+  changes:
+    uses: ./.github/workflows/changed-paths.yml
+    with:
+      lane: .github/workflows/desktop-linux-check.yml
+      anchor: desktop_linux_check_paths
+
   check-linux:
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-22.04
     env:
       CARGO_NET_OFFLINE: "true"

--- a/.github/workflows/desktop-macos-check.yml
+++ b/.github/workflows/desktop-macos-check.yml
@@ -45,7 +45,20 @@ name: Desktop (macOS typecheck)
 # nothing here bundles them.
 
 on:
+  # THE MERGE QUEUE'S SPECULATIVE MERGE (sc-17014). A required check MUST report here too: the queue
+  # evaluates the same required set against `gh-readonly-queue/main/**`, and a workflow with no
+  # `merge_group:` trigger never produces a run for that ref, so the check stays pending until the
+  # group times out and its entries are EVICTED. `merge_group` supports no `paths:` filter at all
+  # (community discussion 45899), which is the other reason the filtering moved into `changes`.
+  merge_group:
+  # NO `paths:` FILTER, deliberately (sc-17014). `check-macos` is a REQUIRED status check, and GitHub
+  # leaves a path-filtered workflow's check **Pending** forever rather than passing it — so a filter
+  # here would block every PR that does not touch these paths, and would strand every merge-queue
+  # entry until `check_response_timeout_minutes` evicted it. The `changes` gate job replaces the
+  # filter: a job skipped by `if:` reports Success, which a required check accepts.
   pull_request:
+  push:
+    branches: [main]
     paths: &desktop_macos_check_paths
       - "apps/desktop/**"
       # The only workspace crate apps/desktop depends on.
@@ -59,9 +72,6 @@ on:
       # In-repo cargo auto-selects the pinned toolchain from this file.
       - "rust-toolchain.toml"
       - ".github/workflows/desktop-macos-check.yml"
-  push:
-    branches: [main]
-    paths: *desktop_macos_check_paths
   workflow_dispatch:
 
 # Cancel superseded PR runs, but never cancel a main-push run — the reasoning
@@ -75,7 +85,17 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Supplies the path filter the triggers above gave up so `check-macos` could become a required check.
+  # See .github/workflows/changed-paths.yml for why a required check cannot carry a `paths:` filter.
+  changes:
+    uses: ./.github/workflows/changed-paths.yml
+    with:
+      lane: .github/workflows/desktop-macos-check.yml
+      anchor: desktop_macos_check_paths
+
   check-macos:
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: macos-15
     env:
       CARGO_NET_OFFLINE: "true"

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -36,7 +36,23 @@ name: Desktop (Windows)
 # desktop-candle-windows.yml lane.)
 
 on:
+  # THE MERGE QUEUE'S SPECULATIVE MERGE (sc-17014). `build-windows` is a REQUIRED status check, and
+  # the queue evaluates the same required set against `gh-readonly-queue/main/**` — without a run
+  # for that ref the check stays pending until the group times out and its entries are EVICTED.
+  #
+  # READ THE TWO JOB-LEVEL `if:`s BELOW BEFORE TOUCHING THIS. They split on `pull_request`, so a
+  # bare `merge_group:` would have done exactly the wrong thing on both sides: skipped the cheap
+  # hosted `build-windows` (reporting Success with no coverage — a required check that validates
+  # nothing) while waking `package-windows`, the ~13-17m candle/CUDA packaging job, on the
+  # self-hosted `cuda` pool for every queued entry. Both conditions are now explicit about
+  # merge_group rather than inferring it from "not a pull request".
+  merge_group:
+  # NO `paths:` FILTER, deliberately (sc-17014) — see the `changes` gate job. A path-filtered
+  # workflow's required check stays Pending forever instead of passing.
   pull_request:
+  push:
+    branches:
+      - main
     paths: &desktop_paths
       - "apps/desktop/**"
       - "apps/web/**"
@@ -55,10 +71,6 @@ on:
       - "package.json"
       - ".github/actions/prepare-rust-runner/**"
       - ".github/workflows/desktop-windows.yml"
-  push:
-    branches:
-      - main
-    paths: *desktop_paths
   workflow_dispatch:
 
 # Cancel superseded PR runs, but never cancel a main-push run — same reasoning as
@@ -76,9 +88,20 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # PR gate — cheap desktop-crate checks on a hosted runner. No candle/CUDA/packaging.
+  # Supplies the path filter the triggers above gave up so `build-windows` could become a required
+  # check. See .github/workflows/changed-paths.yml for why a required check cannot carry one.
+  changes:
+    uses: ./.github/workflows/changed-paths.yml
+    with:
+      lane: .github/workflows/desktop-windows.yml
+      anchor: desktop_paths
+
+  # PR + MERGE-QUEUE gate — cheap desktop-crate checks on a hosted runner. No candle/CUDA/packaging.
   build-windows:
-    if: ${{ github.event_name == 'pull_request' }}
+    # Both events, not just pull_request: this is the required check, so it has to actually run
+    # against the speculative merge rather than skip into a free Success.
+    needs: changes
+    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.relevant == 'true' }}
     # windows-2022 ships VS2022 with an MSVC 14.4x toolset (matches the desktop
     # crate's expectations); pinned rather than windows-latest per sc-3676.
     runs-on: windows-2022
@@ -142,7 +165,11 @@ jobs:
   # only (never PRs). Same box as windows-candle.yml; see the header for why it lives
   # here (off the 10 GB Actions cache).
   package-windows:
-    if: ${{ github.event_name != 'pull_request' }}
+    # main + workflow_dispatch ONLY. `!= 'pull_request'` used to mean exactly that; with a
+    # merge_group trigger it no longer does, and this is the heavy candle/CUDA package on the
+    # self-hosted `cuda` pool. Deliberately NOT a required check either: it never runs on a PR, so
+    # requiring it would strand every PR on a check that cannot report.
+    if: ${{ github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
     runs-on: [self-hosted, Windows, X64, cuda]
     env:
       # compute_80 PTX the driver JITs forward to sm_120 — one binary covers

--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -101,9 +101,13 @@ on:
       - "rust-toolchain.toml"
       - ".cargo/config.toml"
       - ".github/workflows/macos-mlx.yml"
+  # NO `paths:` FILTER, deliberately (sc-17014). `macos-checks` below is a REQUIRED status check,
+  # and GitHub leaves a path-filtered workflow's check **Pending** forever rather than passing it —
+  # so a filter here would block every PR that does not touch these paths. The `changes` gate job
+  # replaces it: a job skipped by `if:` reports Success, which a required check accepts. The `push:`
+  # trigger above keeps its filter, since nothing gates on main pushes.
   pull_request:
     branches: [main]
-    paths: *mlx_paths
   workflow_dispatch:
     inputs:
       run_memory_calibration:
@@ -221,33 +225,10 @@ jobs:
   # push / pull_request runs reach this job already path-filtered by the triggers, so it re-answers
   # `true` for them; that is a couple of cheap seconds to keep one code path rather than two.
   changes:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      relevant: ${{ steps.gate.outputs.run }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # The diff below spans the whole merge group, which can be several commits behind the
-          # checked-out head; a shallow clone would not contain its base. The pack is ~130 MB.
-          fetch-depth: 0
-      - name: Decide whether this change can affect the macOS/MLX build
-        id: gate
-        run: |
-          set -euo pipefail
-          if [ "${{ github.event_name }}" = "merge_group" ]; then
-            base="${{ github.event.merge_group.base_sha }}"
-            head="${{ github.event.merge_group.head_sha }}"
-          else
-            # Non-merge-group events already passed the trigger's own path filter.
-            echo "${{ github.event_name }} is path-filtered by its trigger; running the lane."
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # An empty diff falls through to the script, which runs the lane conservatively.
-          git diff --name-only "$base" "$head" |
-            node scripts/merge-group-relevance.mjs \
-              --workflow .github/workflows/macos-mlx.yml --anchor mlx_paths
+    uses: ./.github/workflows/changed-paths.yml
+    with:
+      lane: .github/workflows/macos-mlx.yml
+      anchor: mlx_paths
 
   # THE HOSTED HALF. Everything on this lane that does not need Apple matrix-unit silicon.
   #
@@ -392,7 +373,14 @@ jobs:
     # asserts a property of the M5 matrix-unit kernels, not of how two PRs compose, so it is a poor
     # fit for the class the merge queue exists to catch. It still runs on every PR and on the
     # post-merge main push, which is where a NAX regression would surface anyway.
-    if: ${{ github.event_name != 'merge_group' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    #
+    # `needs: changes` IS LOAD-BEARING HERE, not just an optimisation. sc-17014 dropped the
+    # `paths:` filter from this workflow's pull_request trigger so `macos-checks` could become a
+    # required check — which means that without this gate, EVERY pull request in the repo would
+    # wake this job on the two-Mac `nax` pool, including docs-only ones. The trigger filter used to
+    # be what protected that pool; this is now.
+    needs: changes
+    if: ${{ github.event_name != 'merge_group' && needs.changes.outputs.relevant == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     # The PR/main path needs only `nax`. The workflow_dispatch calibration paths
     # additionally need the HF snapshots, and those are HOST STATE that does not travel
     # with a label — the same defect class this repo just fixed for release.yml's signing

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1022,88 +1022,132 @@ test("the Rust toolchain is pinned to one concrete version, everywhere", async (
 });
 
 // ---------------------------------------------------------------------------------------------
-// MERGE-QUEUE COVERAGE
+// REQUIRED CHECKS AND THE MERGE QUEUE (sc-17014)
 //
-// The queue merges a SPECULATIVE ref (`gh-readonly-queue/main/**`) that no PR ever built. A lane
-// with no `merge_group:` trigger is blind to it, so two individually-green PRs whose merge does not
-// compile land anyway — the shape that broke `main` in e71b932f. These guards pin which lanes see
-// that ref, and — just as important — which deliberately do not, because the scarce self-hosted
-// boxes cannot absorb it.
+// A check can only be REQUIRED if it reports on every gated event. GitHub distinguishes the two
+// ways a check can go missing, and only one of them is safe:
+//   * job skipped by `if:`            -> Success, satisfies a required check;
+//   * workflow skipped by `paths:`    -> Pending forever, blocks the PR.
+// The merge queue adds a second, louder failure mode: it evaluates the same required set against
+// `gh-readonly-queue/main/**`, so a lane with no `merge_group:` trigger strands the group until
+// `check_response_timeout_minutes` evicts its entries — silently re-ordering the queue.
+//
+// So every required lane must (a) trigger on merge_group, (b) NOT path-filter its pull_request
+// trigger, and (c) gate its expensive jobs on the shared `changes` relevance job instead.
 // ---------------------------------------------------------------------------------------------
 
-test("every backend cfg the queue can break is compiled by a merge-group-triggered lane", async () => {
-  // Three configurations exist, and each has exactly one compiler in CI:
-  //   macOS / mlx        -> macos-mlx.yml `macos-checks`
-  //   Linux, candle OFF  -> check.yml `parity` (native on ubuntu: not(macos) + candle off)
-  //   Linux, candle ON   -> check.yml `candle`
-  // All three must therefore carry `merge_group:`, or that configuration is unvalidated at merge.
-  for (const file of [".github/workflows/check.yml", ".github/workflows/macos-mlx.yml"]) {
+/** Lanes whose jobs are (or are intended to be) required status checks. */
+const REQUIRED_LANES = [
+  { path: ".github/workflows/macos-mlx.yml", anchor: "mlx_paths" },
+  { path: ".github/workflows/desktop-windows.yml", anchor: "desktop_paths" },
+  { path: ".github/workflows/desktop-linux-check.yml", anchor: "desktop_linux_check_paths" },
+  { path: ".github/workflows/desktop-macos-check.yml", anchor: "desktop_macos_check_paths" },
+];
+
+test("every required lane reports on the merge queue and drops its PR path filter", async () => {
+  for (const { path } of REQUIRED_LANES) {
+    const lane = await source(path);
     assert.match(
-      await source(file),
+      lane,
       /^ {2}merge_group:$/m,
-      `${file}: the queue's speculative merge is unvalidated by this lane without a ` +
-        "`merge_group:` trigger — the required checks would gate on a ref this lane never built.",
+      `${path}: a required check with no merge_group: trigger strands every queued entry until ` +
+        "check_response_timeout_minutes evicts it.",
+    );
+    // The pull_request trigger must carry no `paths:` — anchor definition or alias. A filtered
+    // workflow's check sits Pending forever, which is the deadlock this whole restructure exists
+    // to avoid. Scoped to the pull_request block so `push:` keeping its filter stays legal.
+    const prAt = lane.indexOf("\n  pull_request:");
+    assert.ok(prAt > 0, `${path} must declare a pull_request trigger`);
+    const prBlock = lane.slice(prAt + 1).split(/\n {2}(?=[a-z_]+:)/)[0];
+    assert.doesNotMatch(
+      prBlock,
+      /^\s+paths:/m,
+      `${path}: the pull_request trigger must NOT be path-filtered — its check would stay ` +
+        "Pending instead of passing. Filter in the `changes` job instead.",
     );
   }
+});
 
-  const check = await source(".github/workflows/check.yml");
-  // The candle typecheck is the whole reason the `cuda` box can stay out of the queue. If this job
-  // or its command is dropped, `all(not(target_os = "macos"), feature = "backend-candle")` goes back
-  // to having no merge-time compiler at all.
-  assert.match(check, /^ {2}candle:$/m, "check.yml must carry the hosted candle typecheck job");
+test("every required lane delegates its path filter to the shared gate, with a real anchor", async () => {
+  const { parseWorkflowPaths } = await import("./merge-group-relevance.mjs");
+  for (const { path, anchor } of REQUIRED_LANES) {
+    const lane = await source(path);
+    assert.match(
+      lane,
+      /uses: \.\/\.github\/workflows\/changed-paths\.yml/,
+      `${path} must call the shared changed-paths gate rather than re-implementing it`,
+    );
+    // The gate reads the lane's own anchor at runtime, so a typo in either input silently turns
+    // the filter into a permanent "run everything" — safe, but dead. Pin both against the file.
+    const declared = /lane: (\S+)\s+anchor: (\S+)/.exec(lane);
+    assert.ok(declared, `${path} must pass both lane: and anchor: to the gate`);
+    assert.equal(declared[1], path, `${path}: the gate must be pointed at its own lane file`);
+    assert.equal(declared[2], anchor, `${path}: gate anchor input must be ${anchor}`);
+    assert.ok(
+      parseWorkflowPaths(lane, declared[2]).length > 0,
+      `${path} has no \`paths: &${declared[2]}\` anchor for the gate to read`,
+    );
+    // A gate nothing consumes is decoration.
+    assert.match(
+      lane,
+      /needs\.changes\.outputs\.relevant == 'true'/,
+      `${path}: at least one job must be conditioned on the gate's verdict`,
+    );
+  }
+});
+
+test("dropping the PR path filter did not expose the self-hosted pools", async () => {
+  // This is the hazard the restructure creates. The pull_request `paths:` filter used to be what
+  // kept docs-only PRs off the two-Mac `nax` pool and the `cuda` pool; with it gone, ONLY the
+  // `changes` gate does. A self-hosted job that forgot `needs: changes` would run on every PR.
+  const mlx = await source(".github/workflows/macos-mlx.yml");
   assert.match(
-    check,
-    /run: npm run rust:check:candle$/m,
-    "the candle job must invoke rust:check:candle — the stub-nvcc typecheck of the candle cfg",
+    mlx,
+    /if: \$\{\{ github\.event_name != 'merge_group' && needs\.changes\.outputs\.relevant == 'true'/,
+    "nax-worker must be gated on `changes` AND excluded from merge groups — without the gate, " +
+      "every docs-only PR now wakes the two-Mac nax pool.",
   );
-  // No `--allow-skip` here: on a Linux runner a "cannot run" is a real failure, not an un-opted-in
-  // dev. The pre-push hook passes it; CI must not.
-  assert.doesNotMatch(
-    check,
-    /rust:check:candle -- --allow-skip/,
-    "CI must not let the candle typecheck skip itself into a green",
+
+  const desktop = await source(".github/workflows/desktop-windows.yml");
+  // package-windows is main + dispatch only. Before merge_group existed, `!= 'pull_request'`
+  // expressed that; it no longer does, and this job is the heavy candle/CUDA package on the
+  // `cuda` pool. It must exclude merge_group explicitly.
+  assert.match(
+    desktop,
+    /if: \$\{\{ github\.event_name != 'pull_request' && github\.event_name != 'merge_group' \}\}/,
+    "package-windows must exclude merge_group explicitly, or every queued entry wakes the " +
+      "candle/CUDA packaging job on the self-hosted cuda pool.",
+  );
+  // …and its cheap sibling must NOT skip on merge groups, or the required check passes vacuously.
+  assert.match(
+    desktop,
+    /github\.event_name == 'pull_request' \|\| github\.event_name == 'merge_group'/,
+    "build-windows is the required check; it must actually run on the speculative merge rather " +
+      "than skip into a free Success.",
   );
 });
 
-test("merge groups never reach the scarce self-hosted boxes", async () => {
-  // windows-candle.yml runs on the self-hosted `cuda` pool at a ~24m median (p90 32m, max 44m;
-  // measured 2026-08-05 over 85 runs), and nax-worker is a two-Mac pool including a developer's
-  // daily driver. The queue can build several speculative groups at once, so a `merge_group:`
-  // trigger here multiplies self-hosted load — and with `check_response_timeout_minutes: 60`, a
-  // p90 queue wait (18m) plus a p90 run (32m) already reaches ~50m, so a required check on this
-  // lane would sit close to the eviction threshold on an ordinary day.
-  // Their merge-time coverage is check.yml's `candle` job and macos-mlx.yml's hosted `macos-checks`
-  // respectively — both on elastic runners.
+test("windows-candle stays out of the queue and out of the required set", async () => {
+  // ~24m median, p90 32m (measured 2026-08-05 over 85 runs) against a 60m check-response timeout,
+  // on the self-hosted `cuda` pool. Its merge-time stand-in is check.yml's hosted `candle`
+  // typecheck. Making candle-worker required would force a merge_group: trigger here, and p90
+  // queue wait (18m) + p90 run already reaches ~50m of the 60m budget.
   assert.doesNotMatch(
     await source(".github/workflows/windows-candle.yml"),
     /^ {2}merge_group:$/m,
     "windows-candle.yml must stay out of the merge queue; check.yml's `candle` job is its " +
-      "merge-time stand-in. A ~24m median run (p90 32m) against a 60m check-response timeout " +
-      "leaves too little margin to gate the queue on this lane.",
-  );
-  assert.match(
-    await source(".github/workflows/macos-mlx.yml"),
-    /if: \$\{\{ github\.event_name != 'merge_group' &&/,
-    "nax-worker must exclude merge_group — the hosted macos-checks job carries the queue verdict",
+      "merge-time stand-in. See sc-17014 for the (A)/(B)/(C) decision if this changes.",
   );
 });
 
-test("the merge-group path gate reads an anchor that actually exists", async () => {
-  // `merge_group` supports no `paths:` filter, so the gate job re-derives one by parsing the lane's
-  // own anchor. A typo in either argument would make the script fall back to "run the lane"
-  // (conservative, but permanently — the filter would be silently dead). Pin both against the file.
-  const { parseWorkflowPaths } = await import("./merge-group-relevance.mjs");
-  const lane = await source(".github/workflows/macos-mlx.yml");
-  const invocation =
-    /--workflow (\S+) \\?\s*--anchor (\S+)/.exec(lane) ??
-    assert.fail("macos-mlx.yml must invoke scripts/merge-group-relevance.mjs with both arguments");
-  const [, workflowArg, anchorArg] = invocation;
-  assert.equal(workflowArg, ".github/workflows/macos-mlx.yml", "the gate must read its own lane");
-  assert.ok(
-    parseWorkflowPaths(lane, anchorArg).length > 0,
-    `macos-mlx.yml has no \`paths: &${anchorArg}\` anchor for the gate to read`,
+test("the always-on lanes stay unfiltered so they can be required", async () => {
+  const check = await source(".github/workflows/check.yml");
+  assert.match(check, /^ {2}merge_group:$/m, "check.yml carries web + parity + candle");
+  // check.yml has never had path filters, and must not grow one: all three of its jobs are
+  // required, and a filter would strand them Pending.
+  assert.doesNotMatch(
+    check.slice(check.indexOf("on:"), check.indexOf("jobs:")),
+    /paths:/,
+    "check.yml must stay unfiltered — web, parity and candle are all required checks",
   );
-  // The gate only makes sense if the job it feeds is actually conditioned on it.
-  assert.match(lane, /needs: changes/, "macos-checks must depend on the gate job");
-  assert.match(lane, /needs\.changes\.outputs\.relevant == 'true'/, "…and be conditioned on it");
 });


### PR DESCRIPTION
## What does this PR do?

`main` accepted merges from red PRs because it had no required status checks. **sc-17014** diagnosed that on 2026-08-02 and named the reason it stayed unfixed: the lanes worth requiring are all `paths:`-filtered, and GitHub leaves a path-filtered workflow's check **Pending** forever rather than passing it — so naively requiring one wedges every PR that doesn't touch its paths.

`web`, `parity` and `candle` are already required (they live in `check.yml`, which has never had a path filter). This makes the remaining candidates *requirable*.

### The merge queue adds a constraint sc-17014 predates

The queue evaluates the **same** required set against its speculative `gh-readonly-queue/main/**` ref. A lane with no `merge_group:` trigger leaves its check pending until `check_response_timeout_minutes` (60m) expires and the queued entries are **evicted** — which fails worse than a blocked PR, because it silently re-orders the queue. Verified only two workflows produced merge-group runs at all:

```
gh run list --limit 60 --json event,workflowName --jq '.[]|select(.event=="merge_group")|.workflowName' | sort -u
Check
macOS MLX worker
```

So each lane needs **both** a `merge_group:` trigger and a filter that lives somewhere a skipped job still reports Success. GitHub's own asymmetry is what makes this work — a job skipped by `if:` reports **Success**; a workflow skipped by `paths:` does not.

### The change

**`.github/workflows/changed-paths.yml`** (new, reusable) — diffs the merge group or PR and answers "can this change affect the lane?" by **parsing the lane's own `paths: &anchor` block**. Reading the anchor rather than duplicating the list is the point: a copy rots in the *silent* direction — a path it doesn't know about reads as "not relevant", skips the lane, and surfaces as a **green required check rather than a hole**. Conservative everywhere else (unparseable anchor, failed diff, or empty file list ⇒ run the lane).

**Four lanes converted** — `macos-mlx.yml`, `desktop-windows.yml`, `desktop-linux-check.yml`, `desktop-macos-check.yml`: `merge_group:` added, `paths:` dropped from `pull_request` (`push` keeps its filter — nothing gates on main pushes), jobs gated on the shared verdict.

### ⚠️ Two places where dropping the trigger filter was a trap

Both are contract-tested, because both silently spend scarce hardware:

1. **`nax-worker`** — the PR path filter was what kept docs-only PRs off the two-Mac `nax` pool (one of them a developer's daily driver, which already produced six jetsam kills on 2026-08-04). Without `needs: changes` it would now run on **every** PR. Gated, and still excluded from merge groups.

2. **`desktop-windows.yml`'s two jobs split on `github.event_name == 'pull_request'`**, so a bare `merge_group:` trigger would have been wrong on *both sides at once*: `build-windows` (the required check) would **skip into a free Success while validating nothing**, and `package-windows` — the ~13–17m candle/CUDA package on the self-hosted `cuda` pool — would **wake for every queued entry**. Both conditions are now explicit about `merge_group` instead of inferring it from "not a pull request".

### What is deliberately not done

`windows-candle.yml` is untouched. Requiring `candle-worker` would force a `merge_group:` trigger there, and at **24.1m median / 31.9m p90** with an **18m p90 queue wait** it already consumes ~50m of the 60m timeout budget — adding merge-group load widens the wait. Its merge-time stand-in stays `check.yml`'s hosted `candle` typecheck. sc-17014 records options (A)/(B)/(C); this implements **(A)**, which is no change.

`package-windows` is also not a candidate: it never runs on a PR, so requiring it would strand every PR on a check that cannot report.

## Related issue

sc-17014. (sc-17773 was closed as superseded — it duplicated this.)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only
- [x] Refactor / chore (no user-facing behavior change)

## How was this tested?

**Gate verdicts verified by hand across all four lanes:**

| diff | macos-mlx | desktop-windows | desktop-linux | desktop-macos |
|---|---|---|---|---|
| docs-only | skip | skip | skip | skip |
| `apps/desktop/**` | skip | run | run | run |
| `crates/sceneworks-core/**` | run | run | run | run |

**5 new contract tests**, written generically over every required lane: has `merge_group`, has no PR path filter, delegates to the shared gate with a `lane`/`anchor` that resolve against the real file, and something actually consumes the verdict.

**All 7 mutations caught** — dropping a `merge_group` trigger, restoring a PR path filter, un-gating `nax-worker`, exposing `package-windows` to merge groups, making `build-windows` skip merge groups into a vacuous pass, an anchor typo, and pulling the `cuda` pool into the queue.

`npm run check` **322/322**, exit 0.

- [x] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (CI configuration)

## Checklist

- [x] `npm run rust:check` — n/a, no Rust changed
- [ ] Web checks — n/a, web untouched
- [x] `npm run check` — 322/322
- [x] Documentation updated where relevant — the reasoning lives in `changed-paths.yml`'s header
- [x] All commits signed off
- [x] Focused on a single logical change

### Reviewer note: this PR is its own first test

Because these lanes now trigger unconditionally, **this PR's own checks exercise the new gate**. `changes` should pass in ~20s on each converted lane; `check-linux` / `check-macos` should **skip** (this PR touches no `apps/desktop/**` or `crates/**`), while `macos-mlx`'s and `desktop-windows`'s gates should say run=true because the diff touches their own workflow files. Worth eyeballing against that expectation before merging.

### Follow-up that is NOT in this PR

Adding the contexts to ruleset `17708030` is a repo-settings change and is Michael's to make — and only *after* these lanes report green on `main`, so the context names are registered. Candidate additions: `macOS build, lint and workspace tests (hosted)`, `build-windows`, `check-linux`, `check-macos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)