### PR TITLE
ci: make the relevance gates fail OPEN before they become required (sc-17014)

### DIFF
--- a/.github/workflows/desktop-linux-check.yml
+++ b/.github/workflows/desktop-linux-check.yml
@@ -71,7 +71,16 @@ jobs:
 
   check-linux:
     needs: changes
-    if: ${{ needs.changes.outputs.relevant == 'true' }}
+    # FAIL OPEN. `!cancelled()` and the `result != 'success'` clause are BOTH load-bearing, and
+    # neither is decoration: in GitHub Actions a job whose `needs:` FAILED is skipped, and a
+    # skipped job reports **Success**, which satisfies a required status check. So without this,
+    # a broken gate — a checkout failure, a dead runner, a syntax error in the reusable workflow —
+    # would silently skip this lane and turn its required check green without running a thing.
+    # That is the exact false-green shape this whole story exists to remove, reintroduced one
+    # level up. A gate that did not succeed must therefore RUN the lane, matching
+    # merge-group-relevance.mjs's own internal fallback. Do not "simplify" this back to a bare
+    # `needs.changes.outputs.relevant == 'true'`.
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.relevant == 'true') }}
     runs-on: ubuntu-22.04
     env:
       CARGO_NET_OFFLINE: "true"

--- a/.github/workflows/desktop-macos-check.yml
+++ b/.github/workflows/desktop-macos-check.yml
@@ -95,7 +95,16 @@ jobs:
 
   check-macos:
     needs: changes
-    if: ${{ needs.changes.outputs.relevant == 'true' }}
+    # FAIL OPEN. `!cancelled()` and the `result != 'success'` clause are BOTH load-bearing, and
+    # neither is decoration: in GitHub Actions a job whose `needs:` FAILED is skipped, and a
+    # skipped job reports **Success**, which satisfies a required status check. So without this,
+    # a broken gate — a checkout failure, a dead runner, a syntax error in the reusable workflow —
+    # would silently skip this lane and turn its required check green without running a thing.
+    # That is the exact false-green shape this whole story exists to remove, reintroduced one
+    # level up. A gate that did not succeed must therefore RUN the lane, matching
+    # merge-group-relevance.mjs's own internal fallback. Do not "simplify" this back to a bare
+    # `needs.changes.outputs.relevant == 'true'`.
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.relevant == 'true') }}
     runs-on: macos-15
     env:
       CARGO_NET_OFFLINE: "true"

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -101,7 +101,16 @@ jobs:
     # Both events, not just pull_request: this is the required check, so it has to actually run
     # against the speculative merge rather than skip into a free Success.
     needs: changes
-    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.changes.outputs.relevant == 'true' }}
+    # FAIL OPEN. `!cancelled()` and the `result != 'success'` clause are BOTH load-bearing, and
+    # neither is decoration: in GitHub Actions a job whose `needs:` FAILED is skipped, and a
+    # skipped job reports **Success**, which satisfies a required status check. So without this,
+    # a broken gate — a checkout failure, a dead runner, a syntax error in the reusable workflow —
+    # would silently skip this lane and turn its required check green without running a thing.
+    # That is the exact false-green shape this whole story exists to remove, reintroduced one
+    # level up. A gate that did not succeed must therefore RUN the lane, matching
+    # merge-group-relevance.mjs's own internal fallback. Do not "simplify" this back to a bare
+    # `needs.changes.outputs.relevant == 'true'`.
+    if: ${{ !cancelled() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.changes.result != 'success' || needs.changes.outputs.relevant == 'true') }}
     # windows-2022 ships VS2022 with an MSVC 14.4x toolset (matches the desktop
     # crate's expectations); pinned rather than windows-latest per sc-3676.
     runs-on: windows-2022

--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -300,7 +300,16 @@ jobs:
     # already filtered), so this only ever subtracts merge-group runs for diffs this lane cannot
     # be affected by.
     needs: changes
-    if: ${{ needs.changes.outputs.relevant == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # FAIL OPEN. `!cancelled()` and the `result != 'success'` clause are BOTH load-bearing, and
+    # neither is decoration: in GitHub Actions a job whose `needs:` FAILED is skipped, and a
+    # skipped job reports **Success**, which satisfies a required status check. So without this,
+    # a broken gate — a checkout failure, a dead runner, a syntax error in the reusable workflow —
+    # would silently skip this lane and turn its required check green without running a thing.
+    # That is the exact false-green shape this whole story exists to remove, reintroduced one
+    # level up. A gate that did not succeed must therefore RUN the lane, matching
+    # merge-group-relevance.mjs's own internal fallback. Do not "simplify" this back to a bare
+    # `needs.changes.outputs.relevant == 'true'`.
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.relevant == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     runs-on: macos-26
     env:
       # See the WHY 15.0 block above. Provisional, pending the `is_nax_available()` trial.
@@ -380,7 +389,16 @@ jobs:
     # wake this job on the two-Mac `nax` pool, including docs-only ones. The trigger filter used to
     # be what protected that pool; this is now.
     needs: changes
-    if: ${{ github.event_name != 'merge_group' && needs.changes.outputs.relevant == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # FAIL OPEN. `!cancelled()` and the `result != 'success'` clause are BOTH load-bearing, and
+    # neither is decoration: in GitHub Actions a job whose `needs:` FAILED is skipped, and a
+    # skipped job reports **Success**, which satisfies a required status check. So without this,
+    # a broken gate — a checkout failure, a dead runner, a syntax error in the reusable workflow —
+    # would silently skip this lane and turn its required check green without running a thing.
+    # That is the exact false-green shape this whole story exists to remove, reintroduced one
+    # level up. A gate that did not succeed must therefore RUN the lane, matching
+    # merge-group-relevance.mjs's own internal fallback. Do not "simplify" this back to a bare
+    # `needs.changes.outputs.relevant == 'true'`.
+    if: ${{ !cancelled() && github.event_name != 'merge_group' && (needs.changes.result != 'success' || needs.changes.outputs.relevant == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     # The PR/main path needs only `nax`. The workflow_dispatch calibration paths
     # additionally need the HF snapshots, and those are HOST STATE that does not travel
     # with a label — the same defect class this repo just fixed for release.yml's signing

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1101,11 +1101,21 @@ test("dropping the PR path filter did not expose the self-hosted pools", async (
   // kept docs-only PRs off the two-Mac `nax` pool and the `cuda` pool; with it gone, ONLY the
   // `changes` gate does. A self-hosted job that forgot `needs: changes` would run on every PR.
   const mlx = await source(".github/workflows/macos-mlx.yml");
+  // Pin the two PROPERTIES, not the spelling: nax-worker must be excluded from merge groups AND
+  // consult the gate. A spelling-exact assertion broke the moment the fail-open clause was added,
+  // which is the wrong kind of brittleness for a guard protecting a developer's daily driver.
+  const naxCondition = [...mlx.matchAll(/^ {4}if: (\$\{\{[^\n]*\}\})$/gm)]
+    .map((match) => match[1])
+    .find((condition) => condition.includes("github.event_name != 'merge_group'"));
+  assert.ok(
+    naxCondition,
+    "nax-worker must stay excluded from merge groups — the two-Mac nax pool is not queue capacity.",
+  );
   assert.match(
-    mlx,
-    /if: \$\{\{ github\.event_name != 'merge_group' && needs\.changes\.outputs\.relevant == 'true'/,
-    "nax-worker must be gated on `changes` AND excluded from merge groups — without the gate, " +
-      "every docs-only PR now wakes the two-Mac nax pool.",
+    naxCondition,
+    /needs\.changes/,
+    "nax-worker must consult the `changes` gate — without it, every docs-only PR now wakes the " +
+      "two-Mac nax pool, because the pull_request path filter that used to do this is gone.",
   );
 
   const desktop = await source(".github/workflows/desktop-windows.yml");
@@ -1150,4 +1160,40 @@ test("the always-on lanes stay unfiltered so they can be required", async () => 
     /paths:/,
     "check.yml must stay unfiltered — web, parity and candle are all required checks",
   );
+});
+
+test("a broken relevance gate runs the lane instead of silently passing its required check", async () => {
+  // The false-green one level up. In GitHub Actions a job whose `needs:` FAILED is skipped, and a
+  // skipped job reports Success — which SATISFIES a required status check. So a gate that dies
+  // (checkout failure, dead runner, a syntax error in the reusable workflow) would skip the lane
+  // and turn its required check green without running anything.
+  //
+  // Every gated job must therefore fail OPEN: `!cancelled()` to survive a failed dependency at all,
+  // plus a `result != 'success'` clause so a non-green gate means RUN rather than skip. This
+  // mirrors merge-group-relevance.mjs's own internal fallback, where an unparseable anchor or a
+  // failed diff also runs the lane.
+  for (const { path } of REQUIRED_LANES) {
+    const lane = await source(path);
+    const conditions = [...lane.matchAll(/^ {4}if: (\$\{\{ [^\n]*needs\.changes[^\n]*\}\})$/gm)].map(
+      (match) => match[1],
+    );
+    assert.ok(
+      conditions.length > 0,
+      `${path}: expected at least one job conditioned on the changes gate`,
+    );
+    for (const condition of conditions) {
+      assert.match(
+        condition,
+        /!cancelled\(\)/,
+        `${path}: gated job must use !cancelled(), or a FAILED gate skips it — and a skipped job ` +
+          "satisfies a required check, so the lane silently never runs.",
+      );
+      assert.match(
+        condition,
+        /needs\.changes\.result != 'success'/,
+        `${path}: gated job must run when the gate did not succeed. A bare ` +
+          "`relevant == 'true'` treats a broken gate as 'not relevant' — a false green.",
+      );
+    }
+  }
 });


### PR DESCRIPTION
## ⚠️ Land this before adding the four contexts to the ruleset

#2157 moved each path-filtered lane's filter into a `changes` gate job so its check could be required. That introduced **a false green one level up**, and the window between merging #2157 and adding the contexts is exactly when it matters: a merge gate that can silently pass without running anything.

## The hole

In GitHub Actions, a job whose `needs:` **failed** is *skipped* — and a **skipped job reports Success**, which **satisfies a required status check**. So:

```yaml
needs: changes
if: ${{ needs.changes.outputs.relevant == 'true' }}
```

means a gate that *dies* — checkout failure, dead runner, a syntax error in the reusable workflow — skips the lane and turns its required check **green without compiling a line**. That's the exact shape sc-17014 exists to remove, reproduced at the gate instead of at the lane.

`merge-group-relevance.mjs` already fails open *internally* (unparseable anchor, failed diff, empty file list ⇒ run the lane). Nothing covered the job around it.

## The fix

```yaml
if: ${{ !cancelled() && (needs.changes.result != 'success'
        || needs.changes.outputs.relevant == 'true') && ... }}
```

**Both clauses are load-bearing:**

- `!cancelled()` is what lets the job be considered at all after a failed dependency. Without it the `if:` is never evaluated and the job is skipped regardless of what it says.
- `result != 'success'` is what turns "gate broke" into **run the lane** rather than "not relevant".

Applied to all five gated jobs: `macos-checks`, `nax-worker`, `build-windows`, `check-linux`, `check-macos`.

## Guard

A new contract test asserts **both** clauses on every `if:` mentioning `needs.changes`, across every required lane. All 4 mutations caught: reverting to the bare gate, dropping `!cancelled()`, dropping the fail-open clause, and exposing `nax-worker` to merge groups.

I also re-pinned the `nax-worker` guard on its **properties** rather than an exact string — the previous assertion matched literal `if:` text and broke the moment this fix touched it. That's the wrong brittleness for a guard whose job is keeping docs-only PRs off a developer's daily driver.

`npm run check` **323/323**.

## #2157's behaviour on main is confirmed correct

Found this while verifying that, not instead of it. Real merge groups since the merge:

| merge group | irrelevant diff | relevant diff |
|---|---|---|
| `805278def53c` | `check-linux`, `check-macos`, `macos-checks`, `nax-worker`, `build-windows`, `package-windows` **all skipped** | — |
| `27451b7ab86d` | — | `build-windows`, `check-macos`, `check-linux` **ran** |

`nax-worker` and `package-windows` skipped in **both**, as designed — no merge group touches the two-Mac `nax` pool or the `cuda` pool. All five workflows now produce merge-group runs (previously only two did).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only
- [x] Refactor / chore (no user-facing behavior change)

## How was this tested?

- `npm run check` — **323/323**, exit 0
- 4 mutations, all caught
- All four workflows re-parsed as valid YAML with jobs and triggers unchanged

- [x] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (CI configuration)

## Checklist

- [x] `npm run rust:check` — n/a, no Rust changed
- [ ] Web checks — n/a, web untouched
- [x] `npm run check` — 323/323
- [x] Documentation updated where relevant — rationale is inline at each `if:`
- [x] All commits signed off
- [x] Focused on a single logical change

### After this merges

Ruleset `17708030` can take the four contexts, all now registered on `main`: `macOS build, lint and workspace tests (hosted)`, `build-windows`, `check-linux`, `check-macos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)