### PR TITLE
docs(calibration): name the third invalidation mechanism in what sc-17776 does not cover

### DIFF
--- a/docs/calibration-invalidation-unit-sc-17776.md
+++ b/docs/calibration-invalidation-unit-sc-17776.md
@@ -645,7 +645,14 @@ false-green questions, and an `adjudicates` re-derivation. The non-test target c
 | A change confined to unwind/EH data | irrelevant to items 1–4 (they hash whole images), but an open false-green question for candidate 1 if it is ever revisited |
 | SceneWorks' own feature unification widening FLUX.2's linked packages | sc-17639, unchanged |
 | A ladder registered upstream but never admitted by the worker selector — sc-17775 §9's exposure 3 | **Nothing here, and nothing here should.** That is an admission bug, not an invalidation one: the calibration is valid and simply never consulted. A reader who takes this recommendation as covering it will be wrong in the expensive direction. |
+| The candle control lane's **third** invalidation mechanism — `krea_control_fit.rs` (sc-17775 §9.4) | **Nothing, and this one *is* an invalidation mechanism**, so the omission matters more than the row above. It carries its own hardcoded `KREA_CONTROL_INFERENCE_REVISION` / `KREA_CONTROL_CALIBRATION` and gates currency on two hand-maintained manifest booleans (`measured`, `supersededBy`) rather than on anything derived from the code. Every item in this recommendation assumes the two gates sc-17775 §2 describes; none of them reaches this path. Item (4) does not either: `krea_2_turbo_control`'s *bound* calibration is the **mlx** one, so asserting bound fingerprints against inference source leaves the candle constants above untouched. Characterising it is its own work — sc-17775 recorded it deliberately unassessed and filed no story for it. |
 | The five providers with no artifact layer at all — 26 of 31 bound calibrations | **Item (4) only**, as a declared-vs-source check. Items (1)–(3) are `flux2_dev`-shaped because the audit record is. Item (2) is the one that *would* generalise — it needs no measurement binary — and that is the strongest argument for building it. |
+
+**Two mechanisms, not one, are outside everything above.** The row immediately above is an
+*admission* gap and correctly out of scope; the one before it is an *invalidation* mechanism and is
+not. This document's whole frame — two gates, one artifact audit bolted to `flux2_dev` — is the frame
+sc-17775 §2 established, and `krea_control_fit.rs` sits outside it. Anyone implementing the
+recommendation should read that section before assuming "calibration invalidation" is one system.
 
 That last row is the one to weigh against the rest. sc-17775 measured the larger exposure as the five
 families that have no relief mechanism at all; items 1–3 improve the one provider that already has


### PR DESCRIPTION
Follow-up to #2159 ([sc-17776](https://app.shortcut.com/trefry/story/17776)). Docs-only, one file.

`docs/calibration-invalidation-survey-sc-17775.md` §9.4 merged into `main` while #2159 was in review, and it documents a **third** invalidation mechanism: `crates/sceneworks-worker/src/krea_control_fit.rs`, reached from `image_jobs/krea_control_candle.rs:785`, carrying its own hardcoded `KREA_CONTROL_INFERENCE_REVISION` / `KREA_CONTROL_CALIBRATION` and gating currency on two hand-maintained manifest booleans (`measured`, `supersededBy`).

sc-17776's recommendation assumes throughout that calibration invalidation is the two-gate model sc-17775 §2 describes. Its "what the recommendation does NOT cover" table listed nine gaps and omitted the one mechanism genuinely outside every item in it — including item (4), because `krea_2_turbo_control`'s *bound* calibration is the mlx one, so asserting bound fingerprints against inference source never reaches those candle constants.

That explicit statement is one of the story's acceptance criteria, so this is a correction to the deliverable rather than an addition to it. Two changes: a row in the does-not-cover table, and a short note distinguishing it from the exposure-3 row above it — that one is an *admission* gap and correctly out of scope; this one is an *invalidation* mechanism and is not.

`npm run check` green (323 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)