### PR TITLE
ci: stop fork PRs skipping the required macOS check into a vacuous green

### DIFF
--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -288,12 +288,24 @@ jobs:
   # on a persistent box — harmless on an ephemeral hosted runner, which is what this is.
   macos-checks:
     name: macOS build, lint and workspace tests (hosted)
-    # Same-repo only, but for a DIFFERENT reason than `nax-worker` below. Nothing here
-    # touches a self-hosted box, so untrusted code is not the concern; the "Fetch the
-    # pinned inference release" step reads the private SceneWorks/inference repo, and a
-    # fork PR has neither the secret nor a `github.token` that can see it. Without this
-    # guard such a PR would fail at `cargo fetch` with an authentication error that looks
-    # nothing like its actual cause.
+    # NO same-repo guard, deliberately — it was removed once its premise proved false. It read:
+    # "the 'Fetch the pinned inference release' step reads the PRIVATE SceneWorks/inference repo,
+    # and a fork PR has neither the secret nor a `github.token` that can see it."
+    #
+    # SceneWorks/inference is PUBLIC and was never intended to be private. Verified two ways:
+    # the pinned rev fetches with no token, no credential helper and no HOME; and the same fetch
+    # succeeds with the EMPTY token a fork PR would supply. So the guard protected nothing.
+    #
+    # It also became actively harmful when `macos-checks` was made a required status check
+    # (sc-17014): a fork PR matched the guard, this job was SKIPPED, and a skipped job reports
+    # Success — so the required macOS check went green having validated nothing. That is the same
+    # false-green class the fail-open work removed one level down, and it was reachable, not
+    # theoretical.
+    #
+    # This job is HOSTED and ephemeral, so running fork code here is ordinary CI. The two
+    # SELF-HOSTED jobs — `nax-worker` below and windows-candle.yml's `candle-worker` — KEEP their
+    # guards: there the concern is untrusted code on a persistent box, which repo visibility has
+    # nothing to do with. Do not "restore symmetry" by adding one back here.
     #
     # THE MERGE-QUEUE GATE runs through here: `changes` supplies the path filter the `merge_group`
     # trigger cannot carry. On push / pull_request it always answers `true` (those triggers are
@@ -309,7 +321,7 @@ jobs:
     # level up. A gate that did not succeed must therefore RUN the lane, matching
     # merge-group-relevance.mjs's own internal fallback. Do not "simplify" this back to a bare
     # `needs.changes.outputs.relevant == 'true'`.
-    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.relevant == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.relevant == 'true') }}
     runs-on: macos-26
     env:
       # See the WHY 15.0 block above. Provisional, pending the `is_nax_available()` trial.

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1197,3 +1197,35 @@ test("a broken relevance gate runs the lane instead of silently passing its requ
     }
   }
 });
+
+test("hosted required checks do not skip fork PRs into a vacuous green", async () => {
+  // A same-repo guard on a REQUIRED check is a false green: the fork PR matches it, the job is
+  // SKIPPED, and a skipped job reports Success. `macos-checks` carried one justified by
+  // "SceneWorks/inference is private, a fork cannot read it" — which is not true. The repo is
+  // public and was never intended to be private; the pinned rev fetches with no token at all, and
+  // also with the EMPTY token a fork PR supplies.
+  //
+  // Self-hosted jobs are the exception and MUST keep their guards: untrusted code on a persistent
+  // box is a real concern that has nothing to do with repo visibility.
+  const mlx = await source(".github/workflows/macos-mlx.yml");
+  const macosChecks = mlx.slice(mlx.indexOf("  macos-checks:"), mlx.indexOf("  nax-worker:"));
+  assert.ok(macosChecks.length > 0, "macos-checks job not found");
+  assert.doesNotMatch(
+    macosChecks,
+    /head\.repo\.full_name/,
+    "macos-checks is a HOSTED required check — a same-repo guard makes a fork PR skip it, and a " +
+      "skipped job satisfies the required check, so the macOS verdict goes green having run nothing.",
+  );
+  // Positive half, so this never reads as "guards are bad".
+  const nax = mlx.slice(mlx.indexOf("  nax-worker:"));
+  assert.match(
+    nax,
+    /head\.repo\.full_name/,
+    "nax-worker MUST keep its same-repo guard — fork code must not execute on the nax pool.",
+  );
+  assert.match(
+    await source(".github/workflows/windows-candle.yml"),
+    /head\.repo\.full_name/,
+    "candle-worker MUST keep its same-repo guard — fork code must not execute on the cuda pool.",
+  );
+});


### PR DESCRIPTION
## The bug

`macos-checks` carried a same-repo guard justified in-file by:

> the "Fetch the pinned inference release" step reads the **private** SceneWorks/inference repo, and a fork PR has neither the secret nor a `github.token` that can see it.

**That premise is false.** `SceneWorks/inference` is public and was never intended to be private. Verified two ways rather than taken on trust:

- the pinned rev `fbb00d6b` fetches with **no token, no credential helper, `HOME=/nonexistent`** — exit 0, object present;
- the same fetch succeeds under the **exact `GIT_CONFIG` rewrite a fork PR produces**, where `secrets.*` expands to empty (`https://x-access-token:@github.com/...`).

## Why it matters as of today

sc-17014 made `macos-checks` a **required status check** a few hours ago. A job skipped by `if:` reports **Success** and satisfies a required check — so from that moment:

> a fork PR matched the guard → the job was **skipped** → the required macOS verdict went **green having compiled nothing**.

Same false-green class #2160 removed one level down, reintroduced here by a stale *comment* rather than by a code change.

**Reachable, not theoretical.** The repo is public and AGPL-3.0, and I measured that a fork's `cargo fetch` succeeds — so such a PR reaches a fully green board. It still needs maintainer approval to run workflows and a maintainer to press merge, but a green board is exactly what that decision is made on.

## The self-hosted guards stay

The contract test asserts this **positively**, so it never reads as "guards are bad":

| job | guard | why |
|---|---|---|
| `macos-checks` | **removed** | hosted + ephemeral; running fork code is ordinary CI |
| `nax-worker` | **kept** | two-Mac pool, one a developer's daily driver |
| `candle-worker` | **kept** | the `cuda` pool |

For the self-hosted pair the concern is untrusted code on a *persistent box* — which has nothing to do with repo visibility, and is unaffected by this change.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only
- [x] Refactor / chore

## How was this tested?

- `npm run check` — **324/324**, exit 0
- Both mutations caught: restoring the guard on `macos-checks`, and removing it from `candle-worker`

One process note worth recording: my first mutation run reported a false **NO TEETH** because unescaped parens in a `perl` regex meant the mutation never applied. Re-run with an exact-string edit guarded by a count assertion, it's caught. A mutation test that silently fails to mutate looks identical to a weak assertion.

- [x] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server
- [x] Not platform-specific (CI configuration)

## Checklist

- [x] `npm run rust:check` — n/a, no Rust changed
- [ ] Web checks — n/a
- [x] `npm run check` — 324/324
- [x] Documentation updated — the corrected rationale is inline, replacing the false one
- [x] Commits signed off
- [x] Single logical change

### Deliberately NOT in this PR

The same false premise motivates a `GIT_CONFIG_*` credential injection for the inference fetch across ~10 workflows, which is equally unnecessary. I started that sweep and **backed it out**: it touches `release.yml` and `publish-runpod.yml` (neither exercised by PR CI) and collides with an existing calibration contract test that asserts the injected URL literally. Half-landing it behind a security fix would have been worse than doing it properly. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)