### PR TITLE
chore(ci): drop the vestigial inference credential injection from ~10 workflows (sc-17879)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -44,6 +44,8 @@ MACOSX_DEPLOYMENT_TARGET = "26.2"
 # See docs/rust-mlx-build.md.
 
 [net]
-# The canonical inference workspace is a private SceneWorks repository. Use the system Git client so
-# Cargo honors the same credential helper as `git clone` and `gh auth setup-git`.
+# Route git dependencies (the canonical `SceneWorks/inference` workspace among them) through the
+# system Git client rather than Cargo's built-in transport, so they resolve exactly the way
+# `git clone` does. The inference repo is PUBLIC, so no credential is involved: the pinned revision
+# fetches with no token, no credential helper, GIT_CONFIG_NOSYSTEM=1 and an empty HOME (sc-17879).
 git-fetch-with-cli = true

--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,6 @@ SCENEWORKS_API_PORT=8010
 
 # Docker API image. The Rust API is the only supported backend runtime.
 
-# Read-only GitHub token used only as a BuildKit secret while Cargo fetches the private canonical
-# SceneWorks/inference runtime. Required for local container builds; never bake it into an image.
-SCENEWORKS_INFERENCE_READ_TOKEN=
-
 # Vite dev server port exposed by docker-compose.
 SCENEWORKS_WEB_PORT=5173
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,8 +37,8 @@ jobs:
   parity:
     runs-on: ubuntu-latest
     env:
-      # Fetch the private inference source once with a scoped credential, then force every build
-      # and build.rs process offline so the token is absent from their environment.
+      # Fetch the pinned inference source once, then force every build and build.rs process
+      # offline so nothing else can reach the network mid-build.
       CARGO_NET_OFFLINE: "true"
     # A stalled step (e.g. a transient `docker compose up --build` layer/registry
     # hang in the Docker smoke) otherwise rides GitHub's 6-hour default timeout,
@@ -62,12 +62,9 @@ jobs:
           toolchain: "1.97.1"
           components: clippy,rustfmt
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
-      - name: Fetch the private inference release
+      - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
       - name: Install contract test dependencies
         # pillow / numpy / opencv were only needed by the retired Python worker's
@@ -181,8 +178,6 @@ jobs:
             node scripts/docker-smoke-relevance.mjs --expected-count "$changed_file_count"
       - name: Smoke default Rust API Docker runtime
         if: steps.docker_smoke_gate.outputs.run == 'true'
-        env:
-          SCENEWORKS_INFERENCE_READ_TOKEN: ${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}
         run: npm run check:docker:rust-api
 
   # THE CANDLE TYPECHECK, ON A HOSTED BOX. The merge queue's whole job is catching semantic
@@ -214,8 +209,8 @@ jobs:
   candle:
     runs-on: ubuntu-latest
     env:
-      # Same posture as `parity`: fetch the private inference source once with a scoped credential,
-      # then force every build and build.rs process offline so the token is absent from them.
+      # Same posture as `parity`: fetch the pinned inference source once, then force every build
+      # and build.rs process offline so nothing else can reach the network mid-build.
       CARGO_NET_OFFLINE: "true"
     # The three cargo invocations are two `check`s and one `clippy`, all warm-cached after the first
     # run. Sized like `parity` so a wedge fails in minutes rather than riding the 6-hour default
@@ -234,12 +229,9 @@ jobs:
           # A distinct key from `parity`'s: this job compiles the same crates under a different
           # feature set, so sharing one cache would thrash both.
           key: candle
-      - name: Fetch the private inference release
+      - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
       - name: Typecheck the candle backend configuration
         # No `--allow-skip`: this host is Linux, so `not(target_os = "macos")` holds natively and

--- a/.github/workflows/desktop-linux-check.yml
+++ b/.github/workflows/desktop-linux-check.yml
@@ -112,12 +112,9 @@ jobs:
             libwebkit2gtk-4.1-dev \
             libxdo-dev
 
-      - name: Fetch the private inference release
+      - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
 
       - name: Stage desktop test sidecar placeholders

--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -59,12 +59,9 @@ jobs:
             patchelf \
             wget
 
-      - name: Fetch the private inference release
+      - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
 
       # Pin exactly matches server-candle-linux.yml / release.yml. The Windows

--- a/.github/workflows/desktop-macos-check.yml
+++ b/.github/workflows/desktop-macos-check.yml
@@ -123,12 +123,9 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
 
-      - name: Fetch the private inference release
+      - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
 
       - name: Stage desktop test sidecar placeholders

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -137,12 +137,9 @@ jobs:
           toolchain: "1.97.1"
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
-      - name: Fetch the private inference release
+      - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
       # MSVC (cl.exe) on PATH so the desktop crate's cargo test/clippy link cleanly.
       # Cheap (~9s).
@@ -204,12 +201,9 @@ jobs:
       # main + dispatch only, so this failure reddens `main` rather than PRs, but the
       # remedy is identical. See .github/actions/prepare-rust-runner.
       - uses: ./.github/actions/prepare-rust-runner
-      - name: Fetch the private inference release
+      - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
       # No setup-node / rust-toolchain / CUDA-toolkit / rust-cache actions: this box
       # has Node, rustup + the repo's pinned toolchain, the CUDA 12.9 Toolkit, and the

--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -356,9 +356,6 @@ jobs:
       - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN || github.token }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
       - name: Build the MLX GPU worker (mlx-gen linked)
         run: cargo build -p sceneworks-worker
@@ -462,9 +459,6 @@ jobs:
       - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN || github.token }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
       # No MACOSX_DEPLOYMENT_TARGET override: the workspace /.cargo/config.toml pins
       # 26.2, so the NAX kernels compile in and the fast path is actually built.

--- a/.github/workflows/publish-runpod.yml
+++ b/.github/workflows/publish-runpod.yml
@@ -82,15 +82,9 @@ jobs:
         run: |
           npm run check
           npm run check:runpod:image-contract
-      - name: Fetch the private inference release
+      - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          # The dedicated read token takes precedence if inference becomes
-          # private again. It is currently public, so GITHUB_TOKEN is a secure,
-          # always-nonempty fallback rather than an empty BuildKit secret.
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN || github.token }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
       - name: Guard against gen-core version skew (candle)
         run: |
@@ -125,8 +119,6 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-          secrets: |
-            inference_token=${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN || github.token }}
           cache-from: type=gha,scope=runpod-amd64
           cache-to: type=gha,mode=max,scope=runpod-amd64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,12 +88,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
           toolchain: "1.97.1"
-      - name: Fetch the private inference release
+      - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -260,12 +257,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
           toolchain: "1.97.1"
-      - name: Fetch the private inference release
+      - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
       # Put the VS2022 MSVC toolchain (cl.exe) on PATH so nvcc finds the host
       # compiler when candle-kernels' build script compiles the CUDA kernels.
@@ -428,12 +422,9 @@ jobs:
             patchelf \
             wget
 
-      - name: Fetch the private inference release
+      - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
 
       - name: Install CUDA Toolkit 12.9

--- a/.github/workflows/server-candle-linux.yml
+++ b/.github/workflows/server-candle-linux.yml
@@ -50,12 +50,9 @@ jobs:
           toolchain: "1.97.1"
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
-      - name: Fetch the private inference release
+      - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
       # Install the CUDA 12.9 Toolkit (nvcc + cudart/cublas/curand/nvrtc dev libs)
       # the candle `cuda` feature links against. Sets CUDA_PATH for the build.

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -114,9 +114,10 @@ on:
       # main misattributed). This lane runs no rust-toolchain action: cargo in-repo
       # auto-selects the toolchain rust-toolchain.toml pins (see the step comment
       # below), so a bump changes what this entire job compiles with. And
-      # .cargo/config.toml carries `git-fetch-with-cli = true`, without which
-      # cargo's built-in fetch ignores the GIT_CONFIG_* token injection in "Fetch
-      # the private inference release" and the lane cannot fetch at all. The
+      # .cargo/config.toml carries `git-fetch-with-cli = true`, which routes every
+      # git dependency fetch (including the pinned inference release) through the
+      # system git rather than cargo's built-in transport — so an edit there
+      # changes how this lane resolves its dependencies. The
       # channel is a concrete version, never floating `stable` (sc-17717): a
       # toolchain change is therefore always an edit to that file, which this
       # entry turns into a run of this lane — and the contract test keeps every
@@ -206,7 +207,7 @@ on:
 # 18.0 - 25.8m end to end; the 24.1m median above is over 85 runs, so do not expect this
 # table to sum to it. Ranges are truncated to 0.1m, which always understates a max.
 #
-#   Fetch the private inference release          3.5 - 8.8m
+#   Fetch the pinned inference release           3.5 - 8.8m
 #   Test the candle GPU worker (backend-candle)  3.6 - 5.6m
 #   Check the candle sidecar builds (rust-api)   2.5 - 4.0m
 #   Check and test the candle memory adapter     4.5 - 6.7m
@@ -307,12 +308,9 @@ jobs:
           $jobCargoHome = Join-Path $env:RUNNER_TEMP 'cargo-home'
           New-Item -ItemType Directory -Force -Path $jobCargoHome | Out-Null
           Add-Content -Path $env:GITHUB_ENV -Value "CARGO_HOME=$jobCargoHome"
-      - name: Fetch the private inference release
+      - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: "url.https://x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN }}@github.com/SceneWorks/inference.insteadOf"
-          GIT_CONFIG_VALUE_0: "https://github.com/SceneWorks/inference"
         run: cargo fetch --locked
       # No rust-toolchain action: the self-hosted box has rustup + the repo's
       # `rust-toolchain.toml`-pinned toolchain (incl. clippy) pre-installed, and the

--- a/README.md
+++ b/README.md
@@ -173,15 +173,13 @@ For the full per-job-kind breakdown of which capability each build advertises an
 the routing rules that decide, see the
 [Worker Capability Matrix](crates/sceneworks-worker/ARCHITECTURE.md).
 
-Developer builds require read access to the private
-[`SceneWorks/inference`](https://github.com/SceneWorks/inference) repository. Authenticate the
-system Git client (for example with `gh auth login` followed by `gh auth setup-git`) before running
-Cargo. GitHub Actions Rust/package jobs use the repository secret
-`SCENEWORKS_INFERENCE_READ_TOKEN`, scoped to read that repository. The product repository remains
-public and the inference repository remains private; unauthenticated source builds therefore cannot
-fetch the runtime at this cutover boundary. Container builds additionally read that same environment
-variable through a BuildKit secret mount during `cargo fetch`; the value is not persisted in an
-image layer or exposed to Rust build scripts.
+Developer builds fetch the canonical runtime from
+[`SceneWorks/inference`](https://github.com/SceneWorks/inference). Both repositories are public, so
+Cargo resolves the pinned revision anonymously — no GitHub identity, credential helper, or CI secret
+is involved in any build lane, on the host or inside a container build. Fork pull requests therefore
+build the Rust lanes with nothing configured. (Two workflows still name a
+`SCENEWORKS_INFERENCE_READ_TOKEN` secret, but only on the dispatch-only memory-calibration
+`actions/checkout`, and it falls back to `github.token`.)
 
 ## LoRA training
 
@@ -318,13 +316,10 @@ error instead of waiting forever.
 To build a production API image that serves the React SPA, static assets, and
 `/api/v1/*` from the same process and origin, use the opt-in `rust-api-embed`
 target. The plain `rust-api` target remains the non-embedded image used by
-Compose. The build needs a read token for the private inference dependency; this
-PowerShell example reuses the authenticated GitHub CLI token without writing it
-to disk:
+Compose:
 
 ```powershell
-$env:SCENEWORKS_INFERENCE_READ_TOKEN = gh auth token
-docker build --secret id=inference_token,env=SCENEWORKS_INFERENCE_READ_TOKEN `
+docker build `
   --file docker/rust.Dockerfile `
   --target rust-api-embed `
   --build-arg BIN=sceneworks-rust-api `
@@ -349,7 +344,7 @@ exclusions, and measured large-response CPU tradeoff are documented in
 [API response compression](docs/api-response-compression.md).
 
 ```powershell
-docker build --secret id=inference_token,env=SCENEWORKS_INFERENCE_READ_TOKEN `
+docker build `
   --file docker/rust.Dockerfile `
   --target runpod `
   --tag sceneworks-runpod:local .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
       context: .
       dockerfile: docker/rust.Dockerfile
       target: rust-api
-      secrets:
-        - inference_token
       args:
         BIN: sceneworks-rust-api
     environment:
@@ -67,8 +65,6 @@ services:
       context: .
       dockerfile: docker/rust.Dockerfile
       target: rust-worker-candle
-      secrets:
-        - inference_token
     restart: unless-stopped
     environment:
       SCENEWORKS_API_URL: http://api:${SCENEWORKS_API_PORT:-8010}
@@ -117,8 +113,6 @@ services:
       context: .
       dockerfile: docker/rust.Dockerfile
       target: rust-worker
-      secrets:
-        - inference_token
       args:
         BIN: sceneworks-rust-worker
     restart: unless-stopped
@@ -177,9 +171,3 @@ services:
       timeout: 5s
       retries: 3
       start_period: 20s
-
-secrets:
-  # Build-only credential for Cargo's private canonical runtime dependency. BuildKit mounts it for
-  # `cargo fetch` and does not persist it in an image layer or expose it to build scripts.
-  inference_token:
-    environment: SCENEWORKS_INFERENCE_READ_TOKEN

--- a/docker/rust.Dockerfile
+++ b/docker/rust.Dockerfile
@@ -61,12 +61,7 @@ RUN mkdir -p \
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=secret,id=inference_token,required=true \
-    token="$(cat /run/secrets/inference_token)" \
-    && GIT_CONFIG_COUNT=1 \
-       GIT_CONFIG_KEY_0="url.https://x-access-token:${token}@github.com/SceneWorks/inference.insteadOf" \
-       GIT_CONFIG_VALUE_0="https://github.com/SceneWorks/inference" \
-       cargo fetch --locked
+    cargo fetch --locked
 
 COPY crates ./crates
 COPY apps/rust-api ./apps/rust-api
@@ -204,12 +199,7 @@ RUN mkdir -p \
       crates/sceneworks-memory-adapter/src/bin/mlx.rs
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    --mount=type=secret,id=inference_token,required=true \
-    token="$(cat /run/secrets/inference_token)" \
-    && GIT_CONFIG_COUNT=1 \
-       GIT_CONFIG_KEY_0="url.https://x-access-token:${token}@github.com/SceneWorks/inference.insteadOf" \
-       GIT_CONFIG_VALUE_0="https://github.com/SceneWorks/inference" \
-       cargo fetch --locked
+    cargo fetch --locked
 
 COPY crates ./crates
 COPY apps/rust-api ./apps/rust-api

--- a/documents/rearchitecture/PHASE_5_CUTOVER.md
+++ b/documents/rearchitecture/PHASE_5_CUTOVER.md
@@ -104,6 +104,15 @@ inference package.
 
 ## Private repository access
 
+> **Superseded, 2026-08-07 (sc-17879).** This section and the credential paragraphs of
+> "Administrative release configuration" below are a record of the cutover, not current
+> guidance. `SceneWorks/inference` is public; a pinned revision fetches anonymously with no
+> credential helper, `GIT_CONFIG_NOSYSTEM=1` and `HOME=/nonexistent`. The
+> `SCENEWORKS_INFERENCE_READ_TOKEN` rewrite described below has been removed from every workflow
+> and from the container build, so fork pull requests now build the Rust lanes with nothing
+> configured. Only the dispatch-only calibration `actions/checkout` still names the secret, and it
+> falls back to `github.token`. See the README for the current posture.
+
 SceneWorks and ChatWorks remain public while the canonical inference repository remains private.
 That accepted visibility boundary has two operational consequences:
 

--- a/scripts/check-runpod-publish-workflow.mjs
+++ b/scripts/check-runpod-publish-workflow.mjs
@@ -54,8 +54,6 @@ for (const contract of [
   "target: runpod",
   "platforms: linux/amd64",
   "push: true",
-  "inference_token=${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN || github.token }}",
-  "x-access-token:${{ secrets.SCENEWORKS_INFERENCE_READ_TOKEN || github.token }}@github.com",
   "npm run check",
   "npm run check:runpod:image-contract",
   "scripts/check-gen-core-skew.sh --self-test",
@@ -84,14 +82,21 @@ assert.equal(
   1,
   "latest must have exactly one guarded metadata rule",
 );
+// sc-17879: this lane used to inject an inference read token twice -- once as a `url.…insteadOf`
+// rewrite for the host `cargo fetch`, once as a BuildKit secret the Dockerfile turned into the same
+// rewrite. `SceneWorks/inference` is public and always was, so both bought nothing; the guard is now
+// that NEITHER exists, in either place. Both fetches resolve the pinned revision anonymously.
 assert.ok(
-  !/build-args:[\s\S]*SCENEWORKS_INFERENCE_READ_TOKEN/.test(workflow),
-  "private inference token must be a BuildKit secret, never a build arg",
+  !/SCENEWORKS_INFERENCE_READ_TOKEN/.test(workflow),
+  "the inference repo is public; this workflow must carry no inference credential (sc-17879)",
 );
-assert.equal(
-  workflow.match(/secrets\.SCENEWORKS_INFERENCE_READ_TOKEN \|\| github\.token/g)?.length,
-  2,
-  "host fetch and BuildKit must both use the dedicated-token/GITHUB_TOKEN fallback",
+assert.ok(
+  !/inference_token/.test(workflow) && !/inference_token/.test(dockerfile),
+  "the vestigial inference BuildKit secret must not come back (sc-17879)",
+);
+assert.ok(
+  !/x-access-token:/.test(workflow) && !/x-access-token:/.test(dockerfile),
+  "no credential rewrite for the public inference repo, in the workflow or the Dockerfile (sc-17879)",
 );
 assert.ok(
   !/(?:echo|printf)[^\n]*\$\{\{\s*(?:secrets\.|github\.token)/.test(workflow),

--- a/scripts/check-scaffold.mjs
+++ b/scripts/check-scaffold.mjs
@@ -1,4 +1,4 @@
-import { access, constants, readFile } from "node:fs/promises";
+import { access, constants, readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { promptGuideRequiredForModel } from "../apps/web/src/promptGuideContract.js";
@@ -222,6 +222,39 @@ async function assertContains(relativePath, expected) {
   const body = await readFile(path.join(root, relativePath), "utf8");
   if (!body.includes(expected)) {
     throw new Error(`${relativePath} does not contain ${expected}`);
+  }
+}
+
+// Every CI definition on disk: workflows plus composite actions. Used for the NEGATIVE assertions,
+// which must cover lanes nobody remembered to add to a list (sc-17879).
+async function discoverCiDefinitions() {
+  const found = [];
+  for (const entry of await readdir(path.join(root, ".github/workflows"), {
+    withFileTypes: true,
+  })) {
+    if (entry.isFile() && /\.ya?ml$/.test(entry.name)) {
+      found.push(`.github/workflows/${entry.name}`);
+    }
+  }
+  for (const entry of await readdir(path.join(root, ".github/actions"), {
+    withFileTypes: true,
+    recursive: true,
+  })) {
+    if (entry.isFile() && /^action\.ya?ml$/.test(entry.name)) {
+      const dir = path.relative(root, entry.parentPath ?? entry.path).replaceAll("\\", "/");
+      found.push(`${dir}/${entry.name}`);
+    }
+  }
+  if (found.length < 10) {
+    throw new Error(`CI definition scan found only ${found.length} files; the walk is broken`);
+  }
+  return found;
+}
+
+async function assertLacks(relativePath, forbidden, why) {
+  const body = await readFile(path.join(root, relativePath), "utf8");
+  if (body.includes(forbidden)) {
+    throw new Error(`${relativePath} must not contain ${forbidden} -- ${why}`);
   }
 }
 
@@ -549,19 +582,65 @@ await assertContains("docker-compose.yml", "dockerfile: docker/rust.Dockerfile")
 await assertContains("docker-compose.yml", "SCENEWORKS_RUST_WORKER_GPU_ID:-cpu");
 await assertContains("docker-compose.yml", "/sceneworks/data/cache/jobs.db");
 await assertContains("docker-compose.yml", "SCENEWORKS_ALLOW_OPEN_BIND");
-await assertContains("docker-compose.yml", "environment: SCENEWORKS_INFERENCE_READ_TOKEN");
 await assertContains(".env.example", "SCENEWORKS_RUST_WORKER_GPU_ID=cpu");
-await assertContains(".env.example", "SCENEWORKS_INFERENCE_READ_TOKEN=");
 await assertContains("docker/rust.Dockerfile", "sceneworks-rust-api");
-await assertContains("docker/rust.Dockerfile", "type=secret,id=inference_token,required=true");
 await assertContains("docker/rust.Dockerfile", "cargo build --offline");
 await assertEmbeddedApiDockerTarget();
 await assertContains(".cargo/config.toml", "git-fetch-with-cli = true");
-for (const workflowPath of inferenceCargoWorkflows) {
-  await assertContains(workflowPath, "SCENEWORKS_INFERENCE_READ_TOKEN");
-  await assertContains(workflowPath, 'CARGO_NET_OFFLINE: "true"');
-  await assertContains(workflowPath, "cargo fetch --locked");
+// sc-17879: `SceneWorks/inference` is public and always was, so nothing needs a credential to
+// fetch the pinned revision -- verified anonymously with no credential helper, GIT_CONFIG_NOSYSTEM=1
+// and HOME=/nonexistent. The `url.…insteadOf` rewrite these lanes carried bought nothing and
+// actively BROKE fork pull requests, where `secrets.*` expands to empty and the rewrite emits
+// `https://x-access-token:@github.com/...`. Guard both halves of that rewrite -- the injection
+// mechanism AND the rewritten URL -- because a copy-paste that swapped `x-access-token` for
+// `oauth2` would otherwise reintroduce it on a green build. Scanned over EVERY workflow and
+// composite action on disk, not a hand-maintained list, so a lane added later cannot regrow it.
+for (const ciPath of await discoverCiDefinitions()) {
+  await assertLacks(
+    ciPath,
+    "GIT_CONFIG_KEY_0",
+    "SceneWorks/inference is public; the credential rewrite is vestigial and breaks fork PRs (sc-17879)",
+  );
+  await assertLacks(
+    ciPath,
+    "x-access-token:",
+    "SceneWorks/inference is public; no credential belongs in a dependency URL (sc-17879)",
+  );
 }
+// The fetch step is the ONE place allowed online; every build and build.rs after it runs under the
+// job-level `CARGO_NET_OFFLINE: "true"`. Count rather than substring-match: release.yml has three
+// fetch steps, and a file-level `includes` would stay green with two of the three left offline --
+// which fails only at tag time, where nobody is watching (sc-17879).
+for (const workflowPath of [...inferenceCargoWorkflows, ".github/workflows/publish-runpod.yml"]) {
+  const body = await readFile(path.join(root, workflowPath), "utf8");
+  const fetches = body.match(/cargo fetch --locked/g)?.length ?? 0;
+  const online = body.match(/CARGO_NET_OFFLINE: "false"/g)?.length ?? 0;
+  if (fetches < 1) throw new Error(`${workflowPath} no longer fetches the pinned inference release`);
+  if (online !== fetches) {
+    throw new Error(
+      `${workflowPath} has ${fetches} \`cargo fetch --locked\` steps but ${online} carry ` +
+        `CARGO_NET_OFFLINE: "false" -- an unmarked fetch runs offline and fails (sc-17879)`,
+    );
+  }
+}
+for (const workflowPath of inferenceCargoWorkflows) {
+  await assertContains(workflowPath, 'CARGO_NET_OFFLINE: "true"');
+}
+await assertLacks(
+  "docker/rust.Dockerfile",
+  "x-access-token:",
+  "the container build fetches the public inference repo anonymously (sc-17879)",
+);
+await assertLacks(
+  "docker/rust.Dockerfile",
+  "GIT_CONFIG_KEY_0",
+  "the container build needs no credential rewrite for a public repo (sc-17879)",
+);
+await assertLacks(
+  "docker/rust.Dockerfile",
+  "id=inference_token",
+  "the BuildKit credential mount is vestigial; a required=true secret makes fork builds fail (sc-17879)",
+);
 await assertContains("README.md", "SCENEWORKS_ACCESS_TOKEN");
 await assertManifestSchemasParse();
 await assertManifestSchemaReferences();

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -110,7 +110,7 @@ test("Windows CUDA isolates Cargo dependency checkouts after toolchain discovery
     "name: Disable unstable sccache wrapper for the heavy Candle lane",
   );
   const isolate = workflow.indexOf("name: Isolate Cargo dependency checkout");
-  const fetch = workflow.indexOf("name: Fetch the private inference release");
+  const fetch = workflow.indexOf("name: Fetch the pinned inference release");
   assert.ok(
     prepare >= 0 && prepare < disableWrapper && disableWrapper < isolate && isolate < fetch,
   );
@@ -339,10 +339,13 @@ test("macOS memory-strategy calibration dispatch is opt-in and secret-scoped", a
     inferenceCheckout,
     /token: \$\{\{ secrets\.SCENEWORKS_INFERENCE_READ_TOKEN \|\| github\.token \}\}/,
   );
-  assert.match(
-    workflow,
-    /x-access-token:\$\{\{ secrets\.SCENEWORKS_INFERENCE_READ_TOKEN \|\| github\.token \}\}@github\.com\/SceneWorks\/inference\.insteadOf/,
-  );
+  // The Cargo fetch itself carries NO credential (sc-17879). `SceneWorks/inference` is public, so
+  // the `url.…insteadOf` rewrite this lane used to inject bought nothing, and on a fork -- where
+  // `secrets.*` expands to empty -- it emitted `https://x-access-token:@github.com/...` and broke
+  // the fetch outright. The dispatch-only calibration checkout above is a separate mechanism and
+  // keeps its `|| github.token` fallback.
+  assert.doesNotMatch(workflow, /x-access-token:/);
+  assert.doesNotMatch(workflow, /GIT_CONFIG_(?:COUNT|KEY_0|VALUE_0)/);
   assert.match(workflow, /--backend mlx/);
   assert.match(workflow, /QWEN_SEED=15511/);
   assert.match(workflow, /QWEN_SEED=16353/);


### PR DESCRIPTION
Closes [sc-17879](https://app.shortcut.com/trefry/story/17879).

`SceneWorks/inference` is public and always was, so the `url.…insteadOf` credential rewrite every Rust lane injected bought nothing. Worse, on a **fork** pull request `secrets.*` expands to empty, so the rewrite emitted `https://x-access-token:@github.com/...` on exactly the runs least equipped to debug it. Removing it is what makes fork PRs build the Rust lanes — the repo is public and AGPL-3.0, so outside contributors should be able to run CI.

It was also a live dependency on a secret nothing needs — the shape that breaks silently when an account goes away, which is how it surfaced.

## Verified, not assumed

- The exact pinned rev `fbb00d6b4147bd220fe324050534708c12fb022d` fetches with no token, no credential helper, `GIT_CONFIG_NOSYSTEM=1` and an empty `HOME` → exit 0, `git cat-file -t` returns `commit`.
- A full `cargo fetch --locked` over a **fresh `CARGO_HOME`**, with no global/system git config, no credential helper and no `GH_TOKEN`/`GITHUB_TOKEN`, resolves the whole graph including the inference git dependency (`$CARGO_HOME/git/checkouts/inference-49f35a375a576bbb` present).

That second one is the same command `release.yml`, `publish-runpod.yml` and the container build run — which is how the two **tag-triggered lanes PR CI never exercises** got real verification rather than a regex sweep.

## What changed

All 16 `GIT_CONFIG_*` blocks across 10 workflows go. `CARGO_NET_OFFLINE: "false"` stays on every fetch step — a separate, still-correct mechanism.

The story flagged three distinct token usages and asked that they not be swept together:

| usage | disposition |
|---|---|
| the `GIT_CONFIG_*` rewrite | **removed** — this story |
| `token:` on the dispatch-only calibration `actions/checkout` | **untouched** — separate decision, already has `\|\| github.token` |
| `SCENEWORKS_INFERENCE_READ_TOKEN` → `npm run check:docker:rust-api` | **traced, then removed** — see below |

Tracing the third: `docker/rust.Dockerfile` turned the `inference_token` BuildKit secret into *identical* `GIT_CONFIG_*` lines, and its `required=true` mount made a fork's Docker smoke fail outright. It is the same mechanism, so it is removed end to end — Dockerfile (×2), `docker-compose.yml` build secrets + top-level block, `.env.example`, both README build examples, `publish-runpod.yml` `secrets:`, and the `check.yml` step env.

## Guards — each mutation-checked RED before landing

- `check-scaffold.mjs` scans **every workflow and composite action on disk**, not a hand-maintained list, and forbids both `GIT_CONFIG_KEY_0` and `x-access-token:`. An `oauth2:` copy-paste escapes a URL-only guard; a lane added later escapes a list.
- The fetch-step check **counts** `CARGO_NET_OFFLINE: "false"` against `cargo fetch --locked` per file. `release.yml` has three fetch steps, and a file-level substring match stayed green with two of them left offline — a failure that surfaces only at tag time.
- The two **colliding contract tests are reconciled, not deleted**: the `windows-candle` step-**order** invariant keeps its anchor (renamed to `Fetch the pinned inference release`), and the macOS dispatch checkout keeps its repo/ref/token-scoping assertion. Only the positive `x-access-token` match became two negative asserts.

## Prose

Stale "private inference" claims swept from the ~10 workflow comments, `README.md`, and `.cargo/config.toml` — which still advised `gh auth setup-git` for a public repo. `PHASE_5_CUTOVER.md` keeps its historical record under a dated superseded banner rather than being falsified.

## Testing

`npm run check` (324 tests), `npm run check:compose`, `npm run check:docker:rust-api:self-test` — all green. No Rust source touched.

An adversarial review of the first draft found two mutation-proven false greens (the URL-only guard and the substring `CARGO_NET_OFFLINE` check) plus the missed `.cargo/config.toml` prose; all are fixed above and re-mutation-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
