### PR TITLE
fix(api): let SCAIL-2 animate_character reach the queue (sc-17009)

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -3732,6 +3732,13 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
         // and ads2v (source video + reference video + reference images).
         "multi_video_to_video",
         "ads2v",
+        // SCAIL-2 standalone character animation (sc-5448 / sc-5449, epic 5439): reference
+        // character image + driving video → animated clip. It was wired end-to-end — catalog
+        // `capabilities`, `VIDEO_UI_MODES`, `video_mode_is_mlx_eligible`, the candle claim gate,
+        // the worker's `generate_scail2` — and offered in the Video Studio, but never added
+        // HERE, so every submission 400'd on "Unsupported video mode" and the mode was
+        // unreachable from the moment it shipped (GH #2074).
+        "animate_character",
     ]
     .contains(&payload.mode.as_str())
     {
@@ -3855,6 +3862,21 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
         "ads2v" if payload.reference_asset_ids.is_empty() => Err(ApiError::bad_request(
             "Source + Reference Video requires at least one reference image.",
         )),
+        // SCAIL-2 standalone character animation (sc-5449): the same required-media contract the
+        // worker's `resolve_scail2_conditioning` enforces — the character is `referenceAssetIds[0]`
+        // (preferred) or the i2v `sourceAssetId`, and the motion comes from `sourceClipAssetId`.
+        // Both are hard engine inputs (`Reference` + `ControlClip`), so a missing one is a rejected
+        // enqueue rather than a job that fails minutes later inside the worker.
+        "animate_character" if payload.source_clip_asset_id.is_none() => Err(
+            ApiError::bad_request("Animate Character requires a driving video."),
+        ),
+        "animate_character"
+            if payload.reference_asset_ids.is_empty() && payload.source_asset_id.is_none() =>
+        {
+            Err(ApiError::bad_request(
+                "Animate Character requires a reference character image.",
+            ))
+        }
         _ => Ok(()),
     }
 }

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -3588,6 +3588,113 @@ async fn bernini_video_modes_validate_required_media() {
     assert_eq!(ads2v_job["payload"]["referenceAssetIds"][0], "ref-1");
 }
 
+/// SCAIL-2 standalone character animation reaches the queue (GH #2074). `animate_character` was
+/// wired everywhere BUT this route's mode allow-list — catalog `capabilities`, `VIDEO_UI_MODES`,
+/// `video_mode_is_mlx_eligible`, the candle claim gate, the worker's `generate_scail2`, and the
+/// Video Studio mode picker all shipped it (sc-5448 / sc-5449), so the studio offered a mode the
+/// API answered with 400 "Unsupported video mode". The declaration being correct in every OTHER
+/// layer is exactly why nothing caught it; this test pins REACHABILITY, not declaration.
+///
+/// It also pins the required-media contract, which mirrors the worker's
+/// `resolve_scail2_conditioning`: a driving clip plus a character image (`referenceAssetIds[0]`
+/// preferred, `sourceAssetId` accepted) — both hard engine inputs, so an incomplete request is
+/// refused at enqueue instead of failing minutes into the render.
+#[tokio::test]
+async fn scail2_animate_character_reaches_the_queue_and_validates_media() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "SCAIL-2" }),
+    )
+    .await;
+
+    // The regression itself: a complete request is ACCEPTED, not "Unsupported video mode".
+    let (status, animate_job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "scail2_14b",
+            "mode": "animate_character",
+            "prompt": "the character dances",
+            "sourceClipAssetId": "clip-driving",
+            "referenceAssetIds": ["ref-character"]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    // The base video type, which is what `video_job_is_mlx_eligible` gates on for this mode.
+    assert_eq!(animate_job["type"], "video_generate");
+    assert_eq!(animate_job["payload"]["mode"], "animate_character");
+    assert_eq!(animate_job["payload"]["sourceClipAssetId"], "clip-driving");
+    assert_eq!(
+        animate_job["payload"]["referenceAssetIds"][0],
+        "ref-character"
+    );
+
+    // The worker also accepts the i2v `sourceAssetId` as the character.
+    let (status, source_asset_job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "scail2_14b",
+            "mode": "animate_character",
+            "prompt": "the character dances",
+            "sourceClipAssetId": "clip-driving",
+            "sourceAssetId": "ref-character"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(
+        source_asset_job["payload"]["sourceAssetId"],
+        "ref-character"
+    );
+
+    // No driving video, and no character image: each is refused on its own.
+    let incomplete = [
+        json!({ "referenceAssetIds": ["ref-character"] }),
+        json!({ "sourceClipAssetId": "clip-driving" }),
+    ];
+    for extra in incomplete {
+        let mut body = json!({
+            "projectId": "project-1",
+            "model": "scail2_14b",
+            "mode": "animate_character",
+            "prompt": "the character dances"
+        });
+        let object = body.as_object_mut().unwrap();
+        for (key, value) in extra.as_object().unwrap() {
+            object.insert(key.clone(), value.clone());
+        }
+        let (status, _) = request(app.clone(), "POST", "/api/v1/video/jobs", body).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    // An unknown mode still 400s — the allow-list widened by exactly one entry.
+    let (status, _) = request(
+        app,
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "scail2_14b",
+            "mode": "animate_creature",
+            "prompt": "the character dances",
+            "sourceClipAssetId": "clip-driving",
+            "referenceAssetIds": ["ref-character"]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
 #[tokio::test]
 async fn person_tracking_routes_match_contracts() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");


### PR DESCRIPTION
`validate_video_job`'s hard-coded video-mode allow-list never gained `animate_character`, so every SCAIL-2 "Animate character" submission was answered with HTTP 400 "Unsupported video mode" before anything else ran (GH #2074).

The mode was wired correctly in every other layer when it shipped on 2026-06-14 — the model manifest's `capabilities` (sc-5447), `VIDEO_UI_MODES` and `video_mode_is_mlx_eligible` (sc-5448), the candle claim gate (sc-6837), the worker's `generate_scail2` dispatch (sc-5448), and the Video Studio's mode picker, media slots and submit payload (sc-5449). Only this route's allow-list was missed, which left the studio offering a mode the API refused: the standalone animate flow has been unreachable since the day it shipped. Cross-identity `replace_person` on SCAIL-2 was unaffected because that mode predates the list.

Also adds the per-mode required-media guards, mirroring the worker's `resolve_scail2_conditioning`: a driving clip (`sourceClipAssetId`) plus a character image (`referenceAssetIds[0]` preferred, `sourceAssetId` accepted). Both are hard engine inputs, so an incomplete request is refused at enqueue rather than failing minutes into a render — the same shape every other conditioned video mode already has.

The regression test POSTs to `/api/v1/video/jobs` and asserts 201, pinning REACHABILITY rather than declaration; asserting the mode's presence in `VIDEO_UI_MODES` or `capabilities` is exactly what would have passed throughout the outage. Mutation-checked: reverting the allow-list entry fails it `left: 400, right: 201`, the reported symptom.

No worker, routing, manifest or web change — the rest of the path was already correct.

<!--
Thanks for contributing to SceneWorks! Please fill this out so reviewers have
the context they need. See CONTRIBUTING.md for the full process.
-->

## What does this PR do?

<!-- A clear description of the change and why it's needed. -->

## Related issue

<!-- e.g. "Closes #123". For anything non-trivial, please open an issue first. -->

Closes #

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

<!-- Describe how you verified the change. Which platform(s) did you test on? -->

- [ ] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [ ] Not platform-specific (web UI, docs, shared crate)

## Checklist

- [ ] I ran `npm run rust:check` (if I touched Rust) and it passed
- [ ] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build` (if I touched the web app)
- [ ] I ran `npm run check` (scaffold checks)
- [ ] I updated documentation where relevant
- [ ] All my commits are signed off (`git commit -s` — see the DCO section in CONTRIBUTING.md)
- [ ] My PR is focused on a single logical change
