### PR TITLE
fix(desktop): gate the window on API readiness, not liveness (sc-15591)

### DIFF
--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -50,7 +50,25 @@ pub fn get_session_logs(
     })
 }
 
+/// How long to wait for the API process to answer at all. This is a *liveness*
+/// budget: a sidecar that never binds is broken, and 30 s is generous for that.
 const HEALTH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long to wait, after the API has answered, for its readiness-critical
+/// startup to finish (sc-15591).
+///
+/// sc-14788 moved the TCP bind ahead of readiness-critical initialization, so
+/// "the port answers" and "the app can render" became different events. The work
+/// in between is proportional to library size — a jobs-DB retention pass, then an
+/// orphaned-asset sweep that opens every project's `project.db` and stats every
+/// asset row — so a large library on a slow disk legitimately needs minutes where
+/// `HEALTH_TIMEOUT` allows seconds. Gating on readiness under the liveness budget
+/// would just trade GH #1937's raw JSON for a spurious "did not start in time".
+const READINESS_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+
+/// How often the splash message is refreshed while readiness-critical startup
+/// runs, so a long pass reads as progress rather than a frozen window.
+const READINESS_NOTICE_INTERVAL: Duration = Duration::from_secs(15);
 
 /// Process handles + run guards shared across the app.
 #[derive(Default)]
@@ -641,15 +659,33 @@ fn parse_listening_port(line: &str) -> Option<u16> {
     None
 }
 
-/// Health check that also confirms the responder is genuinely the SceneWorks API
-/// (HTTP 200 with the expected service/runtime in the JSON body) before we
-/// navigate the privileged Tauri window to it — a foreign service that grabbed
-/// the port must not be trusted.
-fn health_is_sceneworks(port: u16) -> bool {
+/// What a health probe says about whatever is listening on the API port.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HealthVerdict {
+    /// Nothing usable answered: a connect/read failure, a non-200 status, an
+    /// unparseable body, or a responder that isn't SceneWorks (a foreign service
+    /// that grabbed the port — never navigate the privileged window to that).
+    Unavailable,
+    /// Genuinely our API, but still running readiness-critical startup. Only the
+    /// bootstrap health/access surface exists; every other path — `/` included,
+    /// which is where the SPA lives — is answered by the pre-readiness fallback.
+    Starting,
+    /// Readiness-critical startup finished and the real application router is
+    /// installed. Only now is there an app to navigate to.
+    Ready,
+}
+
+/// Probe `/api/v1/health` and classify the responder.
+///
+/// Trust first: a 200 whose body carries the expected service/runtime is our API,
+/// and nothing else may receive the privileged window. Then readiness: since
+/// sc-14788 the API binds its port *before* readiness-critical startup, so a 200
+/// no longer implies there is an app to show (sc-15591, GH #1937).
+fn probe_health(port: u16) -> HealthVerdict {
     use std::io::Read;
     use std::net::TcpStream;
     let Ok(mut stream) = TcpStream::connect(("127.0.0.1", port)) else {
-        return false;
+        return HealthVerdict::Unavailable;
     };
     let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
     let _ = stream.set_write_timeout(Some(Duration::from_secs(2)));
@@ -657,17 +693,76 @@ fn health_is_sceneworks(port: u16) -> bool {
         "GET /api/v1/health HTTP/1.0\r\nHost: 127.0.0.1:{port}\r\nConnection: close\r\n\r\n"
     );
     if stream.write_all(request.as_bytes()).is_err() {
-        return false;
+        return HealthVerdict::Unavailable;
     }
     let mut response = String::new();
+    // A read timeout leaves a partial body behind; classification parses the body,
+    // so a truncated read lands on `Unavailable` and the caller simply polls again.
     let _ = stream.read_to_string(&mut response);
+    classify_health_response(&response)
+}
+
+/// Pure classification of a raw HTTP health response, split out so the gate's
+/// decision is testable without a socket.
+fn classify_health_response(response: &str) -> HealthVerdict {
     let ok_status = response
         .lines()
         .next()
         .is_some_and(|status_line| status_line.contains(" 200"));
-    ok_status
-        && response.contains("\"service\":\"sceneworks-api\"")
-        && response.contains("\"runtime\":\"rust\"")
+    if !ok_status {
+        return HealthVerdict::Unavailable;
+    }
+    // Body follows the header terminator. Tolerate a bare-LF terminator so a
+    // relay that rewrote line endings can't strand the window on the splash.
+    let Some(body) = response
+        .split_once("\r\n\r\n")
+        .or_else(|| response.split_once("\n\n"))
+        .map(|(_, body)| body)
+    else {
+        return HealthVerdict::Unavailable;
+    };
+    let Ok(health) = serde_json::from_str::<serde_json::Value>(body.trim()) else {
+        return HealthVerdict::Unavailable;
+    };
+    if health.get("service").and_then(serde_json::Value::as_str) != Some("sceneworks-api")
+        || health.get("runtime").and_then(serde_json::Value::as_str) != Some("rust")
+    {
+        return HealthVerdict::Unavailable;
+    }
+    if health_is_ready(&health) {
+        HealthVerdict::Ready
+    } else {
+        HealthVerdict::Starting
+    }
+}
+
+/// The bootstrap surface reports `status:"starting"` with
+/// `readiness.status:"initializing"`; the ready router reports `status:"ok"` with
+/// `readiness.status:"ready"`. Prefer the explicit readiness field, and fall back
+/// to the top-level status so an API that never grew (or later drops) the nested
+/// field is still judged correctly rather than wedging the window on the splash —
+/// only the ready router ever reports `ok`.
+fn health_is_ready(health: &serde_json::Value) -> bool {
+    match health
+        .get("readiness")
+        .and_then(|readiness| readiness.get("status"))
+        .and_then(serde_json::Value::as_str)
+    {
+        Some(status) => status == "ready",
+        None => health.get("status").and_then(serde_json::Value::as_str) == Some("ok"),
+    }
+}
+
+/// Splash text while readiness-critical startup runs. The elapsed count only
+/// appears once the wait is long enough to look stuck, so a normal launch shows a
+/// plain message (or nothing at all — it is usually over within one poll).
+fn readiness_message(elapsed: Duration) -> String {
+    let seconds = elapsed.as_secs();
+    if seconds < READINESS_NOTICE_INTERVAL.as_secs() {
+        "Preparing your library…".to_owned()
+    } else {
+        format!("Preparing your library… ({seconds}s)")
+    }
 }
 
 /// Resolve the ffmpeg binary the Rust worker shells out to (frame sampling,
@@ -1317,22 +1412,57 @@ fn handle_api_exit(app: &AppHandle) {
     );
 }
 
-/// Health-gate the window on a background thread: wait for the API's
-/// OS-assigned port, confirm the responder is genuinely SceneWorks, then
-/// navigate and start the platform inference worker(s) — the MLX GPU worker on
-/// macOS (MLX-only, sc-3492), the Python torch worker elsewhere; show an error
-/// after the timeout.
+/// Health-gate the window on a background thread: wait for the API's OS-assigned
+/// port, confirm the responder is genuinely SceneWorks, wait for its
+/// readiness-critical startup to finish, then navigate and start the platform
+/// inference worker(s) — the MLX GPU worker on macOS (MLX-only, sc-3492), the
+/// candle worker off-Mac; show an error after the timeout.
+///
+/// The readiness wait is the sc-15591 fix for GH #1937. sc-14788 moved the TCP
+/// bind ahead of readiness-critical startup, and this gate navigated on the first
+/// 200 — which the bootstrap surface answers within milliseconds of the bind,
+/// while `/` still resolves to the pre-readiness fallback. The window therefore
+/// rendered `{"code":"api_initializing"}` as text and stayed there, because
+/// nothing re-navigates a webview. Deterministic for anyone whose readiness pass
+/// outlasts one poll — i.e. anyone with a real library.
 fn gate_window(app: AppHandle) {
     std::thread::spawn(move || {
-        let deadline = Instant::now() + HEALTH_TIMEOUT;
+        let started = Instant::now();
+        let liveness_deadline = started + HEALTH_TIMEOUT;
+        let readiness_deadline = started + READINESS_TIMEOUT;
+        // Sticky: once the API has genuinely answered, we are no longer waiting on
+        // a process to come up, so the wait moves to the readiness budget.
+        let mut answered = false;
+        let mut next_notice = Instant::now();
         loop {
             let port = *app
                 .state::<Managed>()
                 .api_port
                 .lock()
                 .expect("api port lock");
+            if answered && port.is_none() {
+                // `handle_api_exit` cleared the port: the sidecar died and has
+                // already put its recoverable error screen up, and its Retry runs a
+                // fresh `gate_window`. Leave now rather than lingering for the rest
+                // of the readiness budget and then clobbering that UI — or a
+                // successful retry's — with a stale timeout error.
+                return;
+            }
             if let Some(port) = port {
-                if health_is_sceneworks(port) {
+                let verdict = probe_health(port);
+                if verdict != HealthVerdict::Unavailable {
+                    answered = true;
+                }
+                if verdict == HealthVerdict::Starting && Instant::now() >= next_notice {
+                    next_notice = Instant::now() + READINESS_NOTICE_INTERVAL;
+                    emit(
+                        &app,
+                        "starting",
+                        readiness_message(started.elapsed()),
+                        false,
+                    );
+                }
+                if verdict == HealthVerdict::Ready {
                     if let Ok(url) = format!("http://127.0.0.1:{port}").parse() {
                         if let Some(window) = app.get_webview_window("main") {
                             let _ = window.navigate(url);
@@ -1392,8 +1522,25 @@ fn gate_window(app: AppHandle) {
                     return;
                 }
             }
+            let deadline = if answered {
+                readiness_deadline
+            } else {
+                liveness_deadline
+            };
             if Instant::now() >= deadline {
-                emit(&app, "error", "The local API did not start in time.", true);
+                let message = if answered {
+                    // The API is alive and still initializing. Retry can't help
+                    // here (`run_startup` spawns the API once), so point at the
+                    // action that can.
+                    format!(
+                        "The local API is still preparing your library after {} minutes. Restart \
+                         SceneWorks, and check the API log if it happens again.",
+                        READINESS_TIMEOUT.as_secs() / 60
+                    )
+                } else {
+                    "The local API did not start in time.".to_owned()
+                };
+                emit(&app, "error", message, true);
                 return;
             }
             std::thread::sleep(Duration::from_millis(300));
@@ -3625,6 +3772,146 @@ mod bind_tests {
                 r#"{"event":"utility_worker_inprocess","apiUrl":"http://127.0.0.1:60294"}"#
             ),
             None
+        );
+    }
+}
+
+/// sc-15591 (GH #1937): what the window gate is allowed to navigate to.
+///
+/// sc-14788 moved the API's TCP bind ahead of its readiness-critical startup, so
+/// a 200 from `/api/v1/health` stopped meaning "there is an app at `/`". The gate
+/// still navigated on the first 200, landing the window on the bootstrap
+/// fallback's `{"code":"api_initializing"}` — permanently, since nothing
+/// re-navigates a webview. These tests pin the classification as pure logic, with
+/// no socket and no thread.
+#[cfg(test)]
+mod health_gate_tests {
+    use super::{
+        classify_health_response, readiness_message, HealthVerdict, READINESS_NOTICE_INTERVAL,
+    };
+    use std::time::Duration;
+
+    /// Verbatim shape of the pre-readiness bootstrap body (`bootstrap_dispatch`).
+    const BOOTSTRAP_HEALTH: &str = concat!(
+        r#"{"status":"starting","service":"sceneworks-api","runtime":"rust","version":"0.8.1","#,
+        r#""authRequired":false,"interruptedJobsOnStartup":0,"#,
+        r#""readiness":{"status":"initializing","criticality":"readiness-critical"},"#,
+        r#""startupMaintenance":{"phase":"stale_upload_sweeps","criticality":"background-safe","#,
+        r#""status":"pending","removedUploads":0,"failureCount":0}}"#,
+    );
+
+    /// …and of the ready router's (`health`).
+    const READY_HEALTH: &str = concat!(
+        r#"{"status":"ok","service":"sceneworks-api","runtime":"rust","version":"0.8.1","#,
+        r#""authRequired":false,"interruptedJobsOnStartup":0,"#,
+        r#""readiness":{"status":"ready","criticality":"readiness-critical"},"#,
+        r#""startupMaintenance":{"phase":"stale_upload_sweeps","criticality":"background-safe","#,
+        r#""status":"complete","removedUploads":0,"failureCount":0}}"#,
+    );
+
+    fn response(body: &str) -> String {
+        format!("HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\r\n{body}")
+    }
+
+    /// The discriminating test. Both bodies pass the old gate's whole check —
+    /// 200 + `sceneworks-api` + `rust` — so the old code navigated on the
+    /// bootstrap one and produced GH #1937. Only `Ready` may navigate.
+    #[test]
+    fn bootstrap_health_is_starting_and_only_ready_health_is_ready() {
+        assert_eq!(
+            classify_health_response(&response(BOOTSTRAP_HEALTH)),
+            HealthVerdict::Starting,
+            "an API that is still initializing must hold the window on the splash"
+        );
+        assert_eq!(
+            classify_health_response(&response(READY_HEALTH)),
+            HealthVerdict::Ready
+        );
+    }
+
+    /// Trust is unchanged by the readiness split: a foreign service that grabbed
+    /// the port, a non-200, and an unreadable body all stay `Unavailable`, so the
+    /// privileged window is never navigated to them.
+    #[test]
+    fn only_a_genuine_sceneworks_api_is_trusted() {
+        for (label, raw) in [
+            (
+                "a foreign service on our port",
+                response(r#"{"status":"ok","service":"some-other-app","runtime":"rust"}"#),
+            ),
+            (
+                "our fields but a foreign runtime",
+                response(r#"{"status":"ok","service":"sceneworks-api","runtime":"python"}"#),
+            ),
+            (
+                "a non-200 status",
+                format!("HTTP/1.1 503 Service Unavailable\r\n\r\n{BOOTSTRAP_HEALTH}"),
+            ),
+            (
+                "a body that isn't JSON",
+                response("<html>gateway error</html>"),
+            ),
+            (
+                // A read timeout leaves a partial body behind.
+                "a truncated read",
+                response(&BOOTSTRAP_HEALTH[..40]),
+            ),
+            ("no response at all", String::new()),
+        ] {
+            assert_eq!(
+                classify_health_response(&raw),
+                HealthVerdict::Unavailable,
+                "{label} must not be trusted with the window"
+            );
+        }
+    }
+
+    /// The nested `readiness` field is authoritative when present, but a body
+    /// without one is judged by the top-level `status` — only the ready router
+    /// ever reports `ok`. Without this fallback, dropping the field later would
+    /// wedge every launch on the splash until the readiness timeout fired.
+    #[test]
+    fn readiness_falls_back_to_the_top_level_status() {
+        assert_eq!(
+            classify_health_response(&response(
+                r#"{"status":"ok","service":"sceneworks-api","runtime":"rust"}"#
+            )),
+            HealthVerdict::Ready
+        );
+        assert_eq!(
+            classify_health_response(&response(
+                r#"{"status":"starting","service":"sceneworks-api","runtime":"rust"}"#
+            )),
+            HealthVerdict::Starting
+        );
+    }
+
+    /// Header parsing must not be the thing that strands the window: a bare-LF
+    /// terminator classifies exactly like the CRLF form.
+    #[test]
+    fn bare_lf_header_terminator_still_classifies() {
+        assert_eq!(
+            classify_health_response(&format!("HTTP/1.1 200 OK\n\n{READY_HEALTH}")),
+            HealthVerdict::Ready
+        );
+    }
+
+    /// The splash stays quiet for a normal launch and only starts counting once
+    /// the wait is long enough that a static message would read as a hang.
+    #[test]
+    fn readiness_message_shows_elapsed_only_once_the_wait_looks_stuck() {
+        assert_eq!(readiness_message(Duration::ZERO), "Preparing your library…");
+        assert_eq!(
+            readiness_message(READINESS_NOTICE_INTERVAL - Duration::from_secs(1)),
+            "Preparing your library…"
+        );
+        assert_eq!(
+            readiness_message(READINESS_NOTICE_INTERVAL),
+            "Preparing your library… (15s)"
+        );
+        assert_eq!(
+            readiness_message(Duration::from_secs(90)),
+            "Preparing your library… (90s)"
         );
     }
 }

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -25,8 +25,8 @@ use std::time::Duration;
 
 use axum::body::Body;
 use axum::extract::State;
-use axum::http::{Request, StatusCode};
-use axum::response::{IntoResponse, Response};
+use axum::http::{header, HeaderMap, Request, StatusCode};
+use axum::response::{Html, IntoResponse, Response};
 use axum::{Json, Router};
 use parking_lot::Mutex;
 use serde_json::json;
@@ -390,7 +390,66 @@ struct BootstrapState {
     startup_maintenance: StartupMaintenance,
 }
 
-fn bootstrap_router(
+/// Self-refreshing holding page served to browser navigations that arrive before
+/// readiness-critical startup finishes (sc-15591). The SPA lives at `/` on the
+/// ready router, so until that router is installed a navigation lands on the
+/// fallback below — and rendering the raw `api_initializing` JSON leaves the tab
+/// permanently parked on machine-readable text that never re-navigates itself.
+/// The `<meta http-equiv="refresh">` costs nothing while starting and turns into
+/// the app on the first poll after `api_ready`.
+const INITIALIZING_PAGE: &str = r#"<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="refresh" content="2" />
+    <title>Starting SceneWorks…</title>
+    <style>
+      :root { color-scheme: dark; font-family: -apple-system, "Segoe UI", system-ui, sans-serif; }
+      html, body { margin: 0; height: 100%; }
+      body { display: grid; place-items: center; background: #0f1117; color: #e7e9ee; }
+      main { width: min(32rem, 88vw); padding: 2rem; text-align: center; }
+      h1 { margin: 0 0 0.5rem; font-size: 1.5rem; letter-spacing: -0.01em; font-weight: 600; }
+      p { margin: 0; color: #9aa1ad; font-size: 0.95rem; line-height: 1.5; }
+      .spinner {
+        width: 1.4rem; height: 1.4rem; margin: 0 auto 1.25rem;
+        border: 2px solid #2a2f3a; border-top-color: #6c8cff; border-radius: 50%;
+        animation: spin 0.8s linear infinite;
+      }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      @media (prefers-reduced-motion: reduce) { .spinner { animation: none; } }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="spinner"></div>
+      <h1>Starting SceneWorks…</h1>
+      <p>Preparing your library. This page loads the app automatically when startup finishes.</p>
+    </main>
+  </body>
+</html>
+"#;
+
+/// Whether the caller is a browser navigating to a page rather than an API client
+/// reading JSON. Only an explicit `text/html` in `Accept` counts: a `*/*`-only
+/// client (curl, the worker, a health probe) keeps the machine-readable 503.
+fn accepts_html(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::ACCEPT)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|accept| {
+            accept.split(',').any(|entry| {
+                entry
+                    .split(';')
+                    .next()
+                    .is_some_and(|media| media.trim().eq_ignore_ascii_case("text/html"))
+            })
+        })
+}
+
+/// `pub(crate)` so the startup tests can drive the pre-readiness surface directly
+/// (an empty `ready_app` is exactly the window this router exists to cover).
+pub(crate) fn bootstrap_router(
     settings: Settings,
     ready_app: Arc<OnceLock<Router>>,
     startup_maintenance: StartupMaintenance,
@@ -454,6 +513,18 @@ async fn bootstrap_dispatch(
             "tokenHeader": "X-SceneWorks-Token",
         }))
         .into_response(),
+        // Everything else — including `/`, where the SPA lives once the ready
+        // router is installed. A browser gets the self-refreshing holding page so
+        // the tab becomes the app on its own; API clients get the unchanged
+        // machine-readable 503 with `retry-after`.
+        _ if accepts_html(request.headers()) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            // `no-store`: the holding page must never be what a later navigation
+            // replays from cache once the app is up. `Html` sets the content type.
+            [("retry-after", "1"), ("cache-control", "no-store")],
+            Html(INITIALIZING_PAGE),
+        )
+            .into_response(),
         _ => (
             StatusCode::SERVICE_UNAVAILABLE,
             [("retry-after", "1")],

--- a/apps/rust-api/src/tests/startup.rs
+++ b/apps/rust-api/src/tests/startup.rs
@@ -1,5 +1,45 @@
 use super::support::*;
 
+/// The pre-readiness surface: a bootstrap router whose `ready_app` is never set,
+/// i.e. the exact window between `api_listening` and `api_ready` (sc-14788).
+fn bootstrap_app(settings: Settings) -> axum::Router {
+    crate::server::bootstrap_router(
+        settings,
+        std::sync::Arc::new(std::sync::OnceLock::new()),
+        crate::startup::StartupMaintenance::pending(),
+    )
+}
+
+/// Like `request_with_headers`, but returns the raw body + content type instead of
+/// parsing JSON — the holding page is HTML, so a JSON-parsing helper would panic.
+async fn raw_request(
+    app: axum::Router,
+    uri: &str,
+    headers: &[(&str, &str)],
+) -> (StatusCode, String, String) {
+    let mut builder = Request::builder().method("GET").uri(uri);
+    for (name, value) in headers {
+        builder = builder.header(*name, *value);
+    }
+    let request = builder.body(Body::empty()).expect("request builds");
+    let response = app.oneshot(request).await.expect("response returns");
+    let status = response.status();
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_owned();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body buffers");
+    (
+        status,
+        content_type,
+        String::from_utf8(bytes.to_vec()).expect("body is utf-8"),
+    )
+}
+
 fn write_stale_asset_upload(data_dir: &std::path::Path) -> std::path::PathBuf {
     let upload_root = data_dir.join("cache/uploads");
     std::fs::create_dir_all(&upload_root).expect("upload root creates");
@@ -222,4 +262,95 @@ async fn deferred_upload_sweeps_preserve_orphan_first_list_and_asset_mutation() 
     assert_eq!(after_mutation.as_array().expect("assets array").len(), 1);
     assert_eq!(after_mutation[0]["id"], "current");
     hook.release();
+}
+
+/// sc-15591 (GH #1937). A browser that navigates to the app root before readiness
+/// finishes must get a page that becomes the app on its own. Before this, `/`
+/// answered the `api_initializing` JSON to everyone — so the desktop window (and
+/// any LAN/Compose tab) rendered that JSON as text and stayed there forever, since
+/// nothing re-navigates a webview.
+#[tokio::test]
+async fn browser_navigation_before_readiness_gets_a_self_refreshing_page() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = bootstrap_app(test_settings(&temp_dir));
+
+    for uri in ["/", "/projects/some-deep-link"] {
+        let (status, content_type, body) = raw_request(
+            app.clone(),
+            uri,
+            // What Chromium/WebView2 actually sends on a top-level navigation.
+            &[(
+                "accept",
+                "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            )],
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "{uri} stays a 503");
+        assert!(
+            content_type.starts_with("text/html"),
+            "{uri} is rendered as a page, not as text: {content_type}"
+        );
+        assert!(
+            body.contains(r#"http-equiv="refresh""#),
+            "{uri} retries on its own, so the tab becomes the app once startup ends"
+        );
+        assert!(
+            !body.contains("api_initializing"),
+            "{uri} never shows the raw error payload to a human"
+        );
+    }
+}
+
+/// The other half of the negotiation: an API client is unchanged. A `*/*`-only
+/// caller (curl, the GPU worker, a health probe) must keep the machine-readable
+/// 503 + `retry-after` rather than being handed a page it cannot parse.
+#[tokio::test]
+async fn api_clients_before_readiness_keep_the_machine_readable_error() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = bootstrap_app(test_settings(&temp_dir));
+
+    for accept in [None, Some("*/*"), Some("application/json")] {
+        // `None` sends no Accept header at all.
+        let headers: Vec<(&str, &str)> =
+            accept.into_iter().map(|value| ("accept", value)).collect();
+        let (status, content_type, body) =
+            raw_request(app.clone(), "/api/v1/projects", &headers).await;
+
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "accept={accept:?}");
+        assert!(
+            content_type.starts_with("application/json"),
+            "accept={accept:?} keeps JSON: {content_type}"
+        );
+        let payload: Value = serde_json::from_str(&body).expect("json body parses");
+        assert_eq!(payload["code"], "api_initializing", "accept={accept:?}");
+    }
+}
+
+/// The bootstrap health body is what the desktop's window gate classifies, so it
+/// has to be distinguishable from the ready router's. `status`/`readiness.status`
+/// are the two markers `probe_health` reads; if either stopped moving, the gate
+/// would navigate early again and land on the holding page instead of the app.
+#[tokio::test]
+async fn bootstrap_health_is_distinguishable_from_ready_health() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let settings = test_settings(&temp_dir);
+    let bootstrap = bootstrap_app(settings.clone());
+
+    let (status, starting) = request(bootstrap, "GET", "/api/v1/health", Value::Null).await;
+    assert_eq!(status, StatusCode::OK, "the trust probe still gets a 200");
+    // The three fields the desktop uses to decide the responder is genuinely ours.
+    assert_eq!(starting["service"], "sceneworks-api");
+    assert_eq!(starting["runtime"], "rust");
+    // …and the two that say it is not ready to be rendered yet.
+    assert_eq!(starting["status"], "starting");
+    assert_eq!(starting["readiness"]["status"], "initializing");
+
+    let (ready_app, _state) = create_app_with_state(settings).expect("ready app creates");
+    let (status, ready) = request(ready_app, "GET", "/api/v1/health", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(ready["service"], "sceneworks-api");
+    assert_eq!(ready["runtime"], "rust");
+    assert_eq!(ready["status"], "ok");
+    assert_eq!(ready["readiness"]["status"], "ready");
 }


### PR DESCRIPTION
GH #1937: on 0.8.1 the desktop window renders

  {"detail":"SceneWorks API readiness-critical startup is still running",
   "code":"api_initializing"}

instead of the app, permanently — nothing re-navigates a webview, and the next launch loses the same race.

sc-14788 moved the API's TCP bind ahead of readiness-critical startup. The port now opens, logs api_listening, and serves a bootstrap router whose fallback answers every non-health path with that 503 — including `/`, where the SPA lives once the ready router is installed. But gate_window still navigated on the first successful health probe, and health_is_sceneworks only asserted 200 + "service":"sceneworks-api" + "runtime":"rust", all three of which the bootstrap health surface satisfies while reporting "status":"starting" / readiness.status:"initializing". So ~300 ms after the bind the window navigated to `/` and landed on the raw JSON.

Whether that race is lost is decided by the bind->ready gap, which is the readiness-critical block in create_app_with_state_mode: jobs-DB init, retention purge, interrupt marking, then prune_all_orphaned_assets, which opens every project's project.db and stats every asset row against disk. An empty library finishes in milliseconds and the ready router wins; a real library on Windows takes seconds to minutes and the JSON always wins. That is why this reads as "the new version doesn't start" for upgraders while fresh installs and CI are unaffected. (sc-14788 did update the Python parity harness to wait for status "ok" + readiness "ready" — the desktop shell was the one caller that kept the old liveness gate.)

Desktop: probe_health replaces health_is_sceneworks and returns a verdict — Unavailable / Starting / Ready. Trust is unchanged (a foreign service that grabbed the port still never receives the privileged window); only Ready navigates. The two waits get separate budgets, because "the process came up" and "the app can render" are now different events: HEALTH_TIMEOUT (30 s) still bounds liveness, and READINESS_TIMEOUT (15 min) bounds readiness, so gating on readiness cannot trade #1937's JSON for a spurious "did not start in time" on a large library. While readiness runs the splash reports progress instead of freezing, and the gate exits quietly if handle_api_exit clears the port, so a dead sidecar's own error screen (or a successful Retry) is never clobbered by a stale timeout from the previous gate thread.

API: bootstrap_dispatch content-negotiates. A browser navigation (Accept: text/html) gets a small self-refreshing holding page, so any tab pointed at a starting API — LAN, Compose, RunPod, or a desktop that navigates early anyway — becomes the app on its own instead of dead-ending on JSON. API clients (*/*, application/json, no Accept) keep the unchanged 503 + retry-after payload.

Tests: desktop health_gate_tests pin the classification as pure logic — the verbatim bootstrap body must classify Starting and the ready body Ready (both pass the old check in full), plus the trust cases and the splash message. rust-api startup tests cover the HTML/JSON negotiation on the bootstrap fallback and assert the two health bodies stay distinguishable in exactly the fields the gate reads.

<!--
Thanks for contributing to SceneWorks! Please fill this out so reviewers have
the context they need. See CONTRIBUTING.md for the full process.
-->

## What does this PR do?

<!-- A clear description of the change and why it's needed. -->

## Related issue

<!-- e.g. "Closes #123". For anything non-trivial, please open an issue first. -->

Closes #

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

<!-- Describe how you verified the change. Which platform(s) did you test on? -->

- [ ] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [ ] Not platform-specific (web UI, docs, shared crate)

## Checklist

- [ ] I ran `npm run rust:check` (if I touched Rust) and it passed
- [ ] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build` (if I touched the web app)
- [ ] I ran `npm run check` (scaffold checks)
- [ ] I updated documentation where relevant
- [ ] All my commits are signed off (`git commit -s` — see the DCO section in CONTRIBUTING.md)
- [ ] My PR is focused on a single logical change
