### PR TITLE
ci(release): pin macOS release to signing runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,12 +55,20 @@ jobs:
   macos:
     # Self-hosted macOS 26.2 runner; same-repo only — never run fork code.
     if: ${{ github.repository == 'SceneWorks/SceneWorks' && startsWith(github.ref, 'refs/tags/v') }}
-    runs-on: [self-hosted, macOS, ARM64, nax]
+    # `signing`, not just `nax`. This job cannot run on any nax box — it needs the
+    # Developer ID cert in the runner's LOGIN KEYCHAIN and the notary .p8 on that
+    # runner's disk (see the APPLE_API_KEY_PATH note in this file's header). Those are
+    # host state, not repo secrets, so they do not travel with the label. The nax pool
+    # is now more than one Mac, and on plain `nax` this job would schedule onto
+    # whichever box was free, do the full cold MLX build, and then fail at
+    # codesign/notarize — a broken tag release, since this lane is tag-triggered with
+    # cancel-in-progress: false. `signing` is carried ONLY by the signing Mac.
+    runs-on: [self-hosted, macOS, ARM64, nax, signing]
     env:
       CARGO_NET_OFFLINE: "true"
     # Guardrail so a wedged step fails fast instead of riding GitHub's 6-hour
-    # default (sc-10420). Runs on the SOLE self-hosted nax box (shared with
-    # macos-mlx.yml), so a wedge holds that box against queued runs (sc-13603).
+    # default (sc-10420). Pinned by `signing` to the one signing Mac, so a wedge
+    # holds that box against queued runs (sc-13603).
     # Generous for the release path: a cold MLX-from-source rebuild plus Apple
     # notarization's variable network round-trip sit on top of the healthy
     # ~7-14 min.


### PR DESCRIPTION
## Summary

- require the signing capability label for the macOS release job
- prevent tagged releases from landing on non-signing nax runners
- update the timeout comment to reflect the dedicated signing runner

## Validation

- git diff --check
- actionlint passed with the repository custom runner labels allowed
- confirmed nax-macos is online and uniquely carries signing; nax-macos-2 does not

This is the minimal release/next backport of the runner-routing fix already present on main.