### PR TITLE
chore(release): 0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "directories",
  "fs2",
@@ -6344,7 +6344,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-desktop"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -6379,7 +6379,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-image-quality"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "image",
  "image_hasher",
@@ -6391,7 +6391,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-mcp"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -6408,7 +6408,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-rust-api"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "axum",
  "fs2",
@@ -6445,7 +6445,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-rust-worker"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "sceneworks-worker",
  "tokio",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-worker"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "axum",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 rust-version = "1.80"
 license-file = "LICENSE"

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/desktop",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/desktop",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "devDependencies": {
         "@tauri-apps/cli": "^2",
         "ajv": "8.20.0"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/desktop",
   "private": true,
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "SceneWorks desktop shell (Tauri).",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SceneWorks",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "identifier": "net.trefry.sceneworks",
   "build": {
     "frontendDist": "ui",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/web",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/web",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "konva": "^9.3.22",
         "react": "18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/web",
   "private": true,
-  "version": "0.8.2",
+  "version": "0.8.3",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sceneworks",
   "private": true,
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Local AI image and video generation studio runtime skeleton.",
   "license": "AGPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare SceneWorks 0.8.3 from the validated release/next line.

Release contents requested for this test:

- #1876: already present in release/next through squash commit 050ca59d; exact patch ID verified and 116 LoRA-family tests passed
- #1877: already present in release/next through squash commit 049ab25e; exact patch ID verified and all 5 focused tier tests passed
- #2156: backported through #2177 as exact patch commit 68dbb7e76; local and hosted gates passed

## Version synchronization

The release script updated only the expected version-bearing files:

- root package.json
- Cargo.toml and the seven workspace package entries in Cargo.lock
- desktop package.json/package-lock.json and tauri.conf.json
- web package.json/package-lock.json

The pinned inference revision remains 1ee443884925242e9f261c6dbdb11289d47780ee, protected by inference/release/0.8.1.

## Validation

- git diff --check
- cargo metadata --locked --no-deps --format-version 1
- npm run check
- verified every synchronized version is 0.8.3
- verified the macOS release workflow requires the signing label