### PR TITLE
fix(web): add direct uploads to Video Studio media pickers (sc-18115)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -2736,7 +2736,12 @@ export function App() {
           body,
         });
         setAssets((items) => [imported, ...items.filter((item) => item.id !== imported.id)]);
-        setSelectedAssetId(imported.id);
+        // Field-scoped pickers select the imported asset in their own local value. Let them opt
+        // out of changing the app-wide Library selection, which studios also observe as a request
+        // to replace their PRIMARY source (for example First frame / Left clip).
+        if (options.select !== false) {
+          setSelectedAssetId(imported.id);
+        }
         setError("");
         return imported;
       } catch (err) {

--- a/apps/web/src/components/AssetPicker.jsx
+++ b/apps/web/src/components/AssetPicker.jsx
@@ -12,7 +12,7 @@ const categoryOptions = [
   ["render", "Renders"],
 ];
 
-const sourceImageTabs = [
+const sourceMediaTabs = [
   ["assets", "Assets"],
   ["upload", "File Upload"],
   ["character", "Character"],
@@ -230,6 +230,7 @@ export function ImageEditSourcePickerField({
   assets,
   buttonLabel = "Select image",
   characters = [],
+  changeLabel = "Change",
   // clearable=true renders a "Remove" control next to "Change" that resets the
   // selection to "" (onChange("")). Opt-in because some callers (e.g. the edit
   // Source image) require a picked asset; enable it where the source is optional
@@ -237,21 +238,106 @@ export function ImageEditSourcePickerField({
   // once-picked image can actually be un-picked rather than sticking until reload.
   clearable = false,
   emptyLabel = "No source image selected",
+  eyebrow = "Image Edit",
   importAsset,
   label = "Source image",
+  multiple = false,
   onChange,
   projectId,
   value = "",
+  values = [],
+}) {
+  return (
+    <MediaSourcePickerField
+      assets={assets}
+      buttonLabel={buttonLabel}
+      characters={characters}
+      changeLabel={changeLabel}
+      clearable={clearable}
+      emptyLabel={emptyLabel}
+      eyebrow={eyebrow}
+      importAsset={importAsset}
+      label={label}
+      mediaKind="image"
+      multiple={multiple}
+      onChange={onChange}
+      projectId={projectId}
+      value={value}
+      values={values}
+    />
+  );
+}
+
+export function VideoSourcePickerField({
+  assets,
+  buttonLabel = "Select clip",
+  characters = [],
+  changeLabel = "Change",
+  clearable = false,
+  emptyLabel = "No source clip selected",
+  importAsset,
+  label = "Source clip",
+  multiple = false,
+  onChange,
+  projectId,
+  value = "",
+  values = [],
+}) {
+  return (
+    <MediaSourcePickerField
+      assets={assets}
+      buttonLabel={buttonLabel}
+      characters={characters}
+      changeLabel={changeLabel}
+      clearable={clearable}
+      emptyLabel={emptyLabel}
+      eyebrow="Video Studio"
+      importAsset={importAsset}
+      label={label}
+      mediaKind="video"
+      multiple={multiple}
+      onChange={onChange}
+      projectId={projectId}
+      value={value}
+      values={values}
+    />
+  );
+}
+
+function MediaSourcePickerField({
+  assets,
+  buttonLabel,
+  characters,
+  changeLabel,
+  clearable,
+  emptyLabel,
+  eyebrow = "Image Edit",
+  importAsset,
+  label,
+  mediaKind,
+  multiple,
+  onChange,
+  projectId,
+  value,
+  values,
 }) {
   const [open, setOpen] = useState(false);
   const selectableAssets = useMemo(
-    () => assets.filter((asset) => activeProjectImageAsset(asset, projectId)),
-    [assets, projectId],
+    () =>
+      assets.filter((asset) =>
+        mediaKind === "video"
+          ? activeProjectVideoAsset(asset, projectId)
+          : activeProjectImageAsset(asset, projectId),
+      ),
+    [assets, mediaKind, projectId],
   );
-  const selectedAsset = selectableAssets.find((asset) => asset.id === value) ?? assets.find((asset) => asset.id === value);
+  const selectedIds = multiple ? values : value ? [value] : [];
+  const selectedAssets = selectedIds
+    .map((id) => selectableAssets.find((asset) => asset.id === id) ?? assets.find((asset) => asset.id === id))
+    .filter(Boolean);
 
-  function confirm(id) {
-    onChange(id ?? "");
+  function confirm(ids) {
+    onChange(multiple ? ids : ids[0] ?? "");
     setOpen(false);
   }
 
@@ -260,45 +346,78 @@ export function ImageEditSourcePickerField({
       <div className="asset-picker-head">
         <span className="asset-picker-label">{label}</span>
         <div className="asset-picker-actions">
-          {/* Gate on `value`, not `selectedAsset`: a still-sent id that no longer
+          {/* Gate on the value, not the resolved asset: a still-sent id that no longer
               resolves (asset trashed/filtered out) must still be clearable. */}
-          {clearable && value ? (
-            <button className="asset-picker-clear" onClick={() => onChange("")} type="button">
+          {clearable && selectedIds.length ? (
+            <button className="asset-picker-clear" onClick={() => onChange(multiple ? [] : "")} type="button">
               Remove
             </button>
           ) : null}
           <button aria-haspopup="dialog" onClick={() => setOpen(true)} type="button">
-            {selectedAsset ? "Change" : buttonLabel}
+            {selectedAssets.length ? changeLabel : buttonLabel}
           </button>
         </div>
       </div>
-      <AssetPreviewChips assets={selectedAsset ? [selectedAsset] : []} emptyLabel={emptyLabel} />
+      <AssetPreviewChips assets={selectedAssets} emptyLabel={emptyLabel} />
       {open ? (
-        <ImageEditSourcePickerModal
+        <MediaSourcePickerModal
           assets={selectableAssets}
           characters={characters}
+          eyebrow={eyebrow}
           importAsset={importAsset}
-          initialSelectedId={value}
+          initialSelectedIds={selectedIds}
+          mediaKind={mediaKind}
+          multiple={multiple}
           onCancel={() => setOpen(false)}
           onConfirm={confirm}
+          title={label}
         />
       ) : null}
     </div>
   );
 }
 
-function ImageEditSourcePickerModal({ assets, characters, importAsset, initialSelectedId, onCancel, onConfirm }) {
+function fileMatchesMediaKind(file, mediaKind) {
+  const mime = String(file?.type ?? "").toLowerCase();
+  if (mime.startsWith("image/") || mime.startsWith("video/")) {
+    return mime.startsWith(`${mediaKind}/`);
+  }
+  const name = String(file?.name ?? "").toLowerCase();
+  return mediaKind === "video"
+    ? /\.(mp4|m4v|mov|webm|mkv|avi|ogv|mpeg|mpg|wmv|flv|3gp|3g2)$/i.test(name)
+    : /\.(png|jpe?g|webp|gif|bmp|tiff?|avif|heic|heif)$/i.test(name);
+}
+
+function assetMatchesMediaKind(asset, mediaKind) {
+  return mediaKind === "video"
+    ? assetCanRenderAsVideo(asset)
+    : assetCanRenderAsImage(asset) || asset?.type === "frame";
+}
+
+function MediaSourcePickerModal({
+  assets,
+  characters,
+  eyebrow,
+  importAsset,
+  initialSelectedIds,
+  mediaKind,
+  multiple,
+  onCancel,
+  onConfirm,
+  title,
+}) {
   const [tab, setTab] = useState("assets");
   const [query, setQuery] = useState("");
-  const [selectedId, setSelectedId] = useState(() => (assets.some((asset) => asset.id === initialSelectedId) ? initialSelectedId : ""));
+  const [selectedIds, setSelectedIds] = useState(() => normalizeSelection(initialSelectedIds, assets, multiple));
   const [characterId, setCharacterId] = useState(characters[0]?.id ?? "");
   const [dragActive, setDragActive] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState("");
+  const mediaLabel = mediaKind === "video" ? "video" : "image";
 
   useEffect(() => {
-    setSelectedId((id) => (id && assets.some((asset) => asset.id === id) ? id : ""));
-  }, [assets]);
+    setSelectedIds((ids) => normalizeSelection(ids, assets, multiple));
+  }, [assets, multiple]);
 
   useEffect(() => {
     if (characterId && characters.some((character) => character.id === characterId)) {
@@ -316,7 +435,7 @@ function ImageEditSourcePickerModal({ assets, characters, importAsset, initialSe
       ),
     [assets, characterId, selectedCharacter, characterReferenceIds],
   );
-  // The Assets tab shows the project library *minus* images that already belong
+  // The Assets tab shows the project library minus media that already belongs
   // to a character — those live on the Character tab. Splitting the library this
   // way is the whole point of the two tabs; without this exclusion every
   // character asset appeared on both tabs, so "Assets" looked unfiltered.
@@ -335,23 +454,46 @@ function ImageEditSourcePickerModal({ assets, characters, importAsset, initialSe
   const searchIndex = useMemo(() => assetSearchIndex(tabAssets), [tabAssets]);
   const visibleAssets = useMemo(() => filterPickerAssets(tabAssets, query, searchIndex), [tabAssets, query, searchIndex]);
 
-  async function handleUpload(file) {
-    if (!file || uploading) {
+  async function handleUpload(files) {
+    const selectedFiles = Array.from(files ?? []);
+    if (!selectedFiles.length || uploading) {
       return;
     }
     if (!importAsset) {
       setUploadError("File upload is unavailable in this context.");
       return;
     }
+    if (selectedFiles.some((file) => !fileMatchesMediaKind(file, mediaKind))) {
+      setUploadError(`Choose ${mediaLabel} files only.`);
+      return;
+    }
     setUploading(true);
     setUploadError("");
     try {
-      const imported = await importAsset(file, { throwOnError: true });
-      if (imported?.id) {
-        onConfirm(imported.id);
+      const outcomes = await Promise.allSettled(
+        (multiple ? selectedFiles : selectedFiles.slice(0, 1)).map((file) =>
+          importAsset(file, { select: false, throwOnError: true }),
+        ),
+      );
+      const importedIds = outcomes
+        .filter((outcome) => outcome.status === "fulfilled" && outcome.value?.id && assetMatchesMediaKind(outcome.value, mediaKind))
+        .map((outcome) => outcome.value.id);
+      const failureCount = outcomes.length - importedIds.length;
+      const nextIds = multiple ? [...new Set([...selectedIds, ...importedIds])] : importedIds.slice(0, 1);
+      if (failureCount) {
+        setSelectedIds(nextIds);
+        setUploadError(
+          importedIds.length
+            ? `Imported ${importedIds.length} ${mediaLabel}${importedIds.length === 1 ? "" : "s"}; ${failureCount} failed.`
+            : `Could not import the selected ${mediaLabel}${outcomes.length === 1 ? "" : "s"}.`,
+        );
+        return;
+      }
+      if (importedIds.length) {
+        onConfirm(nextIds);
       }
     } catch (err) {
-      setUploadError(err.message);
+      setUploadError(err?.message ?? `Could not import the ${mediaLabel}.`);
     } finally {
       setUploading(false);
     }
@@ -360,7 +502,7 @@ function ImageEditSourcePickerModal({ assets, characters, importAsset, initialSe
   function handleDrop(event) {
     event.preventDefault();
     setDragActive(false);
-    handleUpload(event.dataTransfer?.files?.[0] ?? null);
+    handleUpload(event.dataTransfer?.files);
   }
 
   function switchTab(nextTab) {
@@ -370,24 +512,33 @@ function ImageEditSourcePickerModal({ assets, characters, importAsset, initialSe
   }
 
   function renderAssetGrid(emptyLabel) {
+    function toggleAsset(asset) {
+      setSelectedIds((ids) => {
+        if (multiple) {
+          return ids.includes(asset.id) ? ids.filter((id) => id !== asset.id) : [...ids, asset.id];
+        }
+        return [asset.id];
+      });
+    }
+
     return (
       <PickerCardGrid
-        ariaMultiselectable={undefined}
+        ariaMultiselectable={multiple || undefined}
         assets={visibleAssets}
         emptyLabel={emptyLabel}
-        isSelected={(asset) => selectedId === asset.id}
-        onActivate={(asset) => onConfirm(asset.id)}
-        onSelect={(asset) => setSelectedId(asset.id)}
+        isSelected={(asset) => selectedIds.includes(asset.id)}
+        onActivate={multiple ? undefined : (asset) => onConfirm([asset.id])}
+        onSelect={toggleAsset}
       />
     );
   }
 
   return (
-    <Modal className="asset-picker-modal image-edit-source-modal" labelledBy="asset-picker-title" onClose={onCancel}>
+    <Modal className="asset-picker-modal image-edit-source-modal media-source-modal" labelledBy="asset-picker-title" onClose={onCancel}>
       <header className="asset-picker-modal-head">
         <div>
-          <p className="eyebrow">Image Edit</p>
-          <h2 id="asset-picker-title">Choose source image</h2>
+          <p className="eyebrow">{eyebrow}</p>
+          <h2 id="asset-picker-title">Choose {title.toLowerCase()}</h2>
         </div>
         <button className="modal-close" onClick={onCancel} type="button">
           Close
@@ -395,8 +546,8 @@ function ImageEditSourcePickerModal({ assets, characters, importAsset, initialSe
       </header>
 
       <div className="asset-picker-toolbar">
-        <div className="segmented-control compact-segment" role="tablist" aria-label="Source image source">
-          {sourceImageTabs.map(([key, label]) => (
+        <div className="segmented-control compact-segment" role="tablist" aria-label={`Source ${mediaLabel} source`}>
+          {sourceMediaTabs.map(([key, label]) => (
             <button
               aria-selected={tab === key}
               className={tab === key ? "active" : ""}
@@ -413,7 +564,7 @@ function ImageEditSourcePickerModal({ assets, characters, importAsset, initialSe
         </div>
         {tab === "upload" ? null : (
           <input
-            aria-label="Search source images"
+            aria-label={`Search source ${mediaLabel}s`}
             onChange={(event) => setQuery(event.target.value)}
             placeholder={tab === "character" ? "Search character assets" : "Search project assets"}
             value={query}
@@ -421,17 +572,18 @@ function ImageEditSourcePickerModal({ assets, characters, importAsset, initialSe
         )}
       </div>
 
-      {tab === "assets" ? renderAssetGrid("No active project images match this view") : null}
+      {tab === "assets" ? renderAssetGrid(`No active project ${mediaLabel}s match this view`) : null}
 
       {tab === "upload" ? (
         <FileDropzone
-          accept="image/*"
+          accept={`${mediaKind}/*`}
           active={dragActive}
           busy={uploading}
-          hint={uploading ? "Importing image..." : "Drop an image here, or"}
+          hint={uploading ? `Importing ${mediaLabel}${multiple ? "s" : ""}...` : `Drop ${multiple ? `${mediaLabel}s` : `a ${mediaLabel}`} here, or`}
+          multiple={multiple}
           onActiveChange={setDragActive}
           onDrop={handleDrop}
-          onFiles={(files) => handleUpload(files?.[0] ?? null)}
+          onFiles={handleUpload}
         />
       ) : null}
       {tab === "upload" && uploadError ? <p className="inline-warning">{uploadError}</p> : null}
@@ -449,17 +601,23 @@ function ImageEditSourcePickerModal({ assets, characters, importAsset, initialSe
               ))}
             </select>
           </label>
-          {renderAssetGrid(characterId ? "No active images for this character" : "Select a character")}
+          {renderAssetGrid(characterId ? `No active ${mediaLabel}s for this character` : "Select a character")}
         </div>
       ) : null}
 
       <footer className="asset-picker-footer">
-        <span>{selectedId ? "1 selected" : tab === "upload" ? "Upload an image to use it" : "No selection"}</span>
+        <span>
+          {selectedIds.length
+            ? `${selectedIds.length} selected`
+            : tab === "upload"
+              ? `Upload ${multiple ? `${mediaLabel}s` : `a ${mediaLabel}`} to use ${multiple ? "them" : "it"}`
+              : "No selection"}
+        </span>
         <div className="detail-actions">
           <button onClick={onCancel} type="button">
             Cancel
           </button>
-          <button disabled={!selectedId} onClick={() => onConfirm(selectedId)} type="button">
+          <button disabled={!selectedIds.length} onClick={() => onConfirm(selectedIds)} type="button">
             Use Selection
           </button>
         </div>

--- a/apps/web/src/components/AssetPicker.test.jsx
+++ b/apps/web/src/components/AssetPicker.test.jsx
@@ -2,7 +2,7 @@ import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ImageEditSourcePickerField } from "./AssetPicker.jsx";
+import { ImageEditSourcePickerField, VideoSourcePickerField } from "./AssetPicker.jsx";
 
 // The picker was previously "Change"/"Select"-only: once an optional source (img2img reference,
 // control image, second edit image) was picked there was no way to un-pick it, so it kept driving
@@ -146,5 +146,226 @@ describe("ImageEditSourcePickerField Assets tab excludes character assets", () =
     );
     await click(characterTab);
     expect(gridTitles().sort()).toEqual(["Hero Gen", "Hero Ref"]);
+  });
+});
+
+describe("VideoSourcePickerField video-only sources", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  const click = async (el) =>
+    act(async () => el.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+  const gridTitles = () =>
+    [...document.body.querySelectorAll('.asset-picker-grid [role="option"] strong')].map((el) =>
+      el.textContent.trim(),
+    );
+  const tab = (label) =>
+    [...document.body.querySelectorAll('[role="tab"]')].find((button) =>
+      button.textContent.startsWith(label),
+    );
+
+  const assets = [
+    { id: "plain-video", type: "video", projectId: "p1", displayName: "Library Video" },
+    {
+      id: "hero-video",
+      type: "video",
+      projectId: "p1",
+      displayName: "Hero Video",
+      recipe: { normalizedSettings: { characterId: "hero" } },
+    },
+    { id: "plain-image", type: "image", projectId: "p1", displayName: "Library Image" },
+    { id: "other-video", type: "video", projectId: "p2", displayName: "Other Project Video" },
+  ];
+  const characters = [{ id: "hero", name: "Hero", references: [], approvedReferences: [] }];
+
+  it("shows project videos and selected-character videos in separate tabs", async () => {
+    await act(async () => {
+      root.render(
+        <VideoSourcePickerField
+          assets={assets}
+          characters={characters}
+          label="Source clip"
+          onChange={() => {}}
+          projectId="p1"
+        />,
+      );
+    });
+
+    await click(container.querySelector('button[aria-haspopup="dialog"]'));
+    expect(gridTitles()).toEqual(["Library Video"]);
+    expect(tab("Assets").querySelector("span").textContent).toBe("1");
+    expect(tab("Character").querySelector("span").textContent).toBe("1");
+
+    await click(tab("Character"));
+    expect(gridTitles()).toEqual(["Hero Video"]);
+    expect(document.body.textContent).not.toContain("Library Image");
+    expect(document.body.textContent).not.toContain("Other Project Video");
+  });
+
+  it("uploads a video and selects the imported asset immediately", async () => {
+    const onChange = vi.fn();
+    const importAsset = vi.fn(async () => ({ id: "uploaded-video", type: "video", projectId: "p1" }));
+    await act(async () => {
+      root.render(
+        <VideoSourcePickerField
+          assets={assets}
+          characters={characters}
+          importAsset={importAsset}
+          label="Source clip"
+          onChange={onChange}
+          projectId="p1"
+        />,
+      );
+    });
+
+    await click(container.querySelector('button[aria-haspopup="dialog"]'));
+    await click(tab("File Upload"));
+    const input = document.body.querySelector('input[type="file"]');
+    expect(input.accept).toBe("video/*");
+    const file = new File(["video"], "source.mp4", { type: "video/mp4" });
+    Object.defineProperty(input, "files", { configurable: true, value: [file] });
+    await act(async () => input.dispatchEvent(new Event("change", { bubbles: true })));
+
+    expect(importAsset).toHaveBeenCalledWith(file, { select: false, throwOnError: true });
+    expect(onChange).toHaveBeenCalledWith("uploaded-video");
+    expect(document.body.querySelector('[role="dialog"]')).toBeFalsy();
+  });
+
+  it("rejects a non-video file before import", async () => {
+    const importAsset = vi.fn();
+    await act(async () => {
+      root.render(
+        <VideoSourcePickerField
+          assets={assets}
+          characters={characters}
+          importAsset={importAsset}
+          label="Source clip"
+          onChange={() => {}}
+          projectId="p1"
+        />,
+      );
+    });
+
+    await click(container.querySelector('button[aria-haspopup="dialog"]'));
+    await click(tab("File Upload"));
+    const input = document.body.querySelector('input[type="file"]');
+    const file = new File(["image"], "not-a-video.png", { type: "image/png" });
+    Object.defineProperty(input, "files", { configurable: true, value: [file] });
+    await act(async () => input.dispatchEvent(new Event("change", { bubbles: true })));
+
+    expect(importAsset).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Choose video files only.");
+  });
+
+  it("accepts a backend-supported video extension when the browser reports a generic MIME", async () => {
+    const onChange = vi.fn();
+    const importAsset = vi.fn(async () => ({ id: "uploaded-wmv", type: "video", projectId: "p1" }));
+    await act(async () => {
+      root.render(
+        <VideoSourcePickerField
+          assets={assets}
+          importAsset={importAsset}
+          onChange={onChange}
+          projectId="p1"
+        />,
+      );
+    });
+
+    await click(container.querySelector('button[aria-haspopup="dialog"]'));
+    await click(tab("File Upload"));
+    const input = document.body.querySelector('input[type="file"]');
+    const file = new File(["video"], "legacy.wmv", { type: "application/octet-stream" });
+    Object.defineProperty(input, "files", { configurable: true, value: [file] });
+    await act(async () => input.dispatchEvent(new Event("change", { bubbles: true })));
+
+    expect(importAsset).toHaveBeenCalledWith(file, { select: false, throwOnError: true });
+    expect(onChange).toHaveBeenCalledWith("uploaded-wmv");
+  });
+
+  it("imports multiple images and returns their ids with the existing selection", async () => {
+    const onChange = vi.fn();
+    const importAsset = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "uploaded-image-1", type: "image", projectId: "p1" })
+      .mockResolvedValueOnce({ id: "uploaded-image-2", type: "image", projectId: "p1" });
+    await act(async () => {
+      root.render(
+        <ImageEditSourcePickerField
+          assets={assets}
+          characters={characters}
+          importAsset={importAsset}
+          label="Reference images"
+          multiple
+          onChange={onChange}
+          projectId="p1"
+          values={["plain-image"]}
+        />,
+      );
+    });
+
+    await click(container.querySelector('button[aria-haspopup="dialog"]'));
+    await click(tab("File Upload"));
+    const input = document.body.querySelector('input[type="file"]');
+    expect(input.accept).toBe("image/*");
+    expect(input.multiple).toBe(true);
+    const files = [
+      new File(["one"], "one.png", { type: "image/png" }),
+      new File(["two"], "two.jpg", { type: "image/jpeg" }),
+    ];
+    Object.defineProperty(input, "files", { configurable: true, value: files });
+    await act(async () => input.dispatchEvent(new Event("change", { bubbles: true })));
+
+    expect(importAsset).toHaveBeenCalledTimes(2);
+    expect(onChange).toHaveBeenCalledWith(["plain-image", "uploaded-image-1", "uploaded-image-2"]);
+  });
+
+  it("keeps successful multi-file imports selected when a sibling fails", async () => {
+    const onChange = vi.fn();
+    const importAsset = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "uploaded-image-1", type: "image", projectId: "p1" })
+      .mockRejectedValueOnce(new Error("second upload failed"));
+    await act(async () => {
+      root.render(
+        <ImageEditSourcePickerField
+          assets={assets}
+          importAsset={importAsset}
+          label="Reference images"
+          multiple
+          onChange={onChange}
+          projectId="p1"
+          values={["plain-image"]}
+        />,
+      );
+    });
+
+    await click(container.querySelector('button[aria-haspopup="dialog"]'));
+    await click(tab("File Upload"));
+    const input = document.body.querySelector('input[type="file"]');
+    const files = [
+      new File(["one"], "one.png", { type: "image/png" }),
+      new File(["two"], "two.jpg", { type: "image/jpeg" }),
+    ];
+    Object.defineProperty(input, "files", { configurable: true, value: files });
+    await act(async () => input.dispatchEvent(new Event("change", { bubbles: true })));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Imported 1 image; 1 failed.");
+    expect(document.body.textContent).toContain("2 selected");
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Use Selection"));
+    expect(onChange).toHaveBeenCalledWith(["plain-image", "uploaded-image-1"]);
   });
 });

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -535,7 +535,7 @@ describe("ImageStudio edit source picker", () => {
     await act(async () => setFileInput(dialog.querySelector('input[type="file"]'), [file]));
     await act(async () => {});
 
-    expect(importAsset).toHaveBeenCalledWith(file, { throwOnError: true });
+    expect(importAsset).toHaveBeenCalledWith(file, { select: false, throwOnError: true });
     expect(document.body.querySelector('[role="dialog"]')).toBeNull();
 
     await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Generate"));

--- a/apps/web/src/screens/ReplacePersonPanel.jsx
+++ b/apps/web/src/screens/ReplacePersonPanel.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { API_BASE_URL, withMediaTicket } from "../api.js";
-import { AssetPickerField } from "../components/AssetPicker.jsx";
+import { VideoSourcePickerField } from "../components/AssetPicker.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
 import { StudioUpdateBadge, StudioUpdateNotice, updateOptionLabel } from "../components/StudioUpdateNotice.jsx";
 
@@ -427,9 +427,11 @@ function PersonTrackCorrections({ track, sourceClip, saveTrackCorrections }) {
 }
 
 export function ReplacePersonPanel({
+  characters = [],
   createPersonDetectionJob,
   createPersonTrackJob,
   detectionResult,
+  importAsset,
   matchingTracks,
   representativeFrame,
   selectedDetection,
@@ -449,6 +451,7 @@ export function ReplacePersonPanel({
   model,
   setModel,
   personReadiness = {},
+  projectId,
   createModelDownloadJob,
 }) {
   // The replacement backend = the replace-capable video models. The user picks one here (it drives
@@ -499,12 +502,15 @@ export function ReplacePersonPanel({
 
   return (
     <div className="replace-person-panel">
-      <AssetPickerField
+      <VideoSourcePickerField
         assets={videoAssets}
         buttonLabel="Select clip"
+        characters={characters}
         emptyLabel="No source clip selected"
+        importAsset={importAsset}
         label="Source clip"
         onChange={setSourceClipAssetId}
+        projectId={projectId}
         value={sourceClipAssetId}
       />
 

--- a/apps/web/src/screens/ReplacePersonPanel.test.jsx
+++ b/apps/web/src/screens/ReplacePersonPanel.test.jsx
@@ -33,7 +33,7 @@ describe("ReplacePersonPanel track corrections drafts (sc-11966)", () => {
 
   // Only the props PersonTrackCorrections needs to mount and re-render; the rest
   // of ReplacePersonPanel's surface is inert with these safe defaults.
-  const renderPanel = (selectedTrack, saveTrackCorrections = vi.fn()) =>
+  const renderPanel = (selectedTrack, saveTrackCorrections = vi.fn(), overrides = {}) =>
     act(() => {
       root.render(
         <ReplacePersonPanel
@@ -54,6 +54,7 @@ describe("ReplacePersonPanel track corrections drafts (sc-11966)", () => {
           trackName=""
           videoAssets={[]}
           videoModels={[]}
+          {...overrides}
         />,
       );
     });
@@ -79,6 +80,25 @@ describe("ReplacePersonPanel track corrections drafts (sc-11966)", () => {
     // First render of a track shows its saved corrections (acceptance #3).
     expect(field(container, "Box x").value).toBe("0.65");
     expect(container.textContent).toContain("1 saved");
+  });
+
+  it("uses the direct-upload video source picker for the Replace Person source clip", async () => {
+    await renderPanel(track("track-1", []), vi.fn(), {
+      importAsset: vi.fn(),
+      projectId: "project-1",
+      videoAssets: [{ id: "clip-1", type: "video", projectId: "project-1", displayName: "Source Clip" }],
+    });
+
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Select clip").click();
+    });
+    const modal = document.body.querySelector(".media-source-modal");
+    expect(modal).toBeTruthy();
+    expect([...modal.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent.trim())).toEqual([
+      "Assets1",
+      "File Upload",
+      "Character0",
+    ]);
   });
 
   it("keeps dirty per-frame drafts when a same-track corrections refresh arrives", async () => {

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { parseResolution, pickClosestResolution } from "../resolutionMatch.js";
-import { AssetPickerField } from "../components/AssetPicker.jsx";
+import { ImageEditSourcePickerField, VideoSourcePickerField } from "../components/AssetPicker.jsx";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
 import { AssetMedia } from "../components/assetMedia.jsx";
@@ -127,6 +127,7 @@ export function VideoStudio() {
     deleteAsset,
     purgeAsset,
     gpuOptions,
+    importAsset,
     latestVideoAssets,
     recentVideoAssets,
     studioLaunch,
@@ -1477,23 +1478,31 @@ export function VideoStudio() {
           {mode !== "text_to_video" ? (
           <div className="studio-source-band">
             {mode === "image_to_video" || mode === "first_last_frame" ? (
-              <AssetPickerField
+              <ImageEditSourcePickerField
                 assets={imageAssets}
                 buttonLabel="Select image"
+                characters={characters}
                 emptyLabel="No first frame selected"
+                eyebrow="Video Studio"
+                importAsset={importAsset}
                 label="First frame"
                 onChange={setSourceAssetId}
+                projectId={activeProject?.id}
                 value={sourceAssetId}
               />
             ) : null}
 
             {mode === "first_last_frame" ? (
-              <AssetPickerField
+              <ImageEditSourcePickerField
                 assets={imageAssets}
                 buttonLabel="Select image"
+                characters={characters}
                 emptyLabel="No last frame selected"
+                eyebrow="Video Studio"
+                importAsset={importAsset}
                 label="Last frame"
                 onChange={setLastFrameAssetId}
+                projectId={activeProject?.id}
                 value={lastFrameAssetId}
               />
             ) : null}
@@ -1507,104 +1516,133 @@ export function VideoStudio() {
             ) : null}
 
             {mode === "extend_clip" ? (
-              <AssetPickerField
+              <VideoSourcePickerField
                 assets={videoAssets}
                 buttonLabel="Select clip"
+                characters={characters}
                 emptyLabel="No source clip selected"
+                importAsset={importAsset}
                 label="Source clip"
                 onChange={setSourceClipAssetId}
+                projectId={activeProject?.id}
                 value={sourceClipAssetId}
               />
             ) : null}
 
             {mode === "video_bridge" ? (
               <>
-                <AssetPickerField
+                <VideoSourcePickerField
                   assets={videoAssets}
                   buttonLabel="Select clip"
+                  characters={characters}
                   emptyLabel="No left clip selected"
+                  importAsset={importAsset}
                   label="Left clip"
                   onChange={setSourceClipAssetId}
+                  projectId={activeProject?.id}
                   value={sourceClipAssetId}
                 />
-                <AssetPickerField
+                <VideoSourcePickerField
                   assets={videoAssets}
                   buttonLabel="Select clip"
+                  characters={characters}
                   emptyLabel="No right clip selected"
+                  importAsset={importAsset}
                   label="Right clip"
                   onChange={setBridgeRightClipAssetId}
+                  projectId={activeProject?.id}
                   value={bridgeRightClipAssetId}
                 />
               </>
             ) : null}
 
             {["video_to_video", "reference_video_to_video", "ads2v"].includes(mode) ? (
-              <AssetPickerField
+              <VideoSourcePickerField
                 assets={videoAssets}
                 buttonLabel="Select clip"
+                characters={characters}
                 emptyLabel="No source clip selected"
+                importAsset={importAsset}
                 label="Source clip"
                 onChange={setSourceClipAssetId}
+                projectId={activeProject?.id}
                 value={sourceClipAssetId}
               />
             ) : null}
 
             {mode === "multi_video_to_video" ? (
-              <AssetPickerField
+              <VideoSourcePickerField
                 assets={videoAssets}
                 buttonLabel="Select clips"
+                characters={characters}
                 changeLabel="Edit clips"
                 emptyLabel="No source clips selected"
+                importAsset={importAsset}
                 label="Source clips"
                 multiple
                 onChange={setSourceClipAssetIds}
+                projectId={activeProject?.id}
                 values={sourceClipAssetIds}
               />
             ) : null}
 
             {mode === "ads2v" ? (
-              <AssetPickerField
+              <VideoSourcePickerField
                 assets={videoAssets}
                 buttonLabel="Select clip"
+                characters={characters}
                 emptyLabel="No reference video selected"
+                importAsset={importAsset}
                 label="Reference video"
                 onChange={setReferenceClipAssetId}
+                projectId={activeProject?.id}
                 value={referenceClipAssetId}
               />
             ) : null}
 
             {["reference_to_video", "reference_video_to_video", "ads2v"].includes(mode) ? (
-              <AssetPickerField
+              <ImageEditSourcePickerField
                 assets={imageAssets}
                 buttonLabel="Select images"
+                characters={characters}
                 changeLabel="Edit references"
                 emptyLabel="No reference images selected"
+                eyebrow="Video Studio"
+                importAsset={importAsset}
                 label="Reference images"
                 multiple
                 onChange={setReferenceAssetIds}
+                projectId={activeProject?.id}
                 values={referenceAssetIds}
               />
             ) : null}
 
             {mode === "animate_character" ? (
               <>
-                <AssetPickerField
+                <VideoSourcePickerField
                   assets={videoAssets}
                   buttonLabel="Select clip"
+                  characters={characters}
                   emptyLabel="No driving video selected"
+                  importAsset={importAsset}
                   label="Driving video"
                   onChange={setSourceClipAssetId}
+                  projectId={activeProject?.id}
                   value={sourceClipAssetId}
                 />
                 {/* One character today; the worker reads the first reference. Multi-reference is
                     experimental and tracked separately (sc-5583), so this stays a single image. */}
-                <AssetPickerField
+                <ImageEditSourcePickerField
                   assets={imageAssets}
                   buttonLabel="Select image"
+                  characters={characters}
                   changeLabel="Change character"
                   emptyLabel="No reference character selected"
+                  eyebrow="Video Studio"
+                  importAsset={importAsset}
                   label="Reference character"
                   onChange={(id) => setReferenceAssetIds(id ? [id] : [])}
+                  projectId={activeProject?.id}
                   value={referenceAssetIds[0] ?? ""}
                 />
               </>
@@ -1612,10 +1650,13 @@ export function VideoStudio() {
 
             {mode === "replace_person" ? (
               <ReplacePersonPanel
+                characters={characters}
                 createPersonDetectionJob={createPersonDetectionJob}
                 createPersonTrackJob={createPersonTrackJob}
                 createModelDownloadJob={createModelDownloadJob}
+                importAsset={importAsset}
                 personReadiness={personReadiness}
+                projectId={activeProject?.id}
                 detectionResult={detectionResult}
                 matchingTracks={matchingTracks}
                 personTrackId={personTrackId}
@@ -2122,13 +2163,16 @@ export function VideoStudio() {
                   previously lived in the render rail this layout removes. It operates on a
                   selected existing asset, independent of the current generation payload. */}
               <VideoUpscalePanel
+                characters={characters}
                 createVideoUpscaleJob={createVideoUpscaleJob}
+                importAsset={importAsset}
                 macCapabilities={macCapabilities}
                 onSubmitted={(job) => {
                   onLocalJobCreated(job);
                   onOpenQueue();
                 }}
                 selectedAsset={selectedAsset}
+                projectId={activeProject?.id}
                 videoAssets={videoAssets}
               />
             </div>

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -45,6 +45,7 @@ function baseContext(overrides = {}) {
     deleteAsset: vi.fn(),
     purgeAsset: vi.fn(),
     gpuOptions: [],
+    importAsset: vi.fn(),
     latestVideoAssets: [],
     recentVideoAssets: [],
     studioLaunch: null,
@@ -399,6 +400,56 @@ describe("VideoStudio fit mode (sc-6139)", () => {
     expect(context.createVideoJob.mock.calls[1][0].fitMode).toBe("pad");
   });
 
+  it("keeps a secondary-field upload from overwriting the primary source selection", async () => {
+    let importOptions;
+    function Host() {
+      const [assets, setAssets] = React.useState([source]);
+      const [selectedAssetId, setSelectedAssetId] = React.useState(source.id);
+      const selectedAsset = assets.find((asset) => asset.id === selectedAssetId) ?? null;
+      const importAsset = async (_file, options) => {
+        importOptions = options;
+        const imported = {
+          id: "img_last",
+          type: "image",
+          projectId: "project_1",
+          displayName: "Uploaded Last Frame",
+        };
+        setAssets((items) => [imported, ...items]);
+        if (options.select !== false) {
+          setSelectedAssetId(imported.id);
+        }
+        return imported;
+      };
+      return (
+        <AppContext.Provider
+          value={baseContext({ assets, importAsset, selectedAsset, selectedAssetId })}
+        >
+          <VideoStudio />
+        </AppContext.Provider>
+      );
+    }
+
+    await act(async () => root.render(<Host />));
+    await act(async () => {});
+    await click(modeButton("First → Last"));
+    const fieldByLabel = (label) =>
+      [...container.querySelectorAll(".asset-picker-field")].find(
+        (field) => field.querySelector(".asset-picker-label")?.textContent === label,
+      );
+    await click(buttonWithText(fieldByLabel("Last frame"), "Select image"));
+    const modal = document.querySelector(".media-source-modal");
+    await click([...modal.querySelectorAll('[role="tab"]')].find((tab) => tab.textContent.includes("File Upload")));
+    const input = modal.querySelector('input[type="file"]');
+    const file = new File(["last"], "last.png", { type: "image/png" });
+    Object.defineProperty(input, "files", { configurable: true, value: [file] });
+    await act(async () => input.dispatchEvent(new Event("change", { bubbles: true })));
+
+    expect(importOptions).toEqual({ select: false, throwOnError: true });
+    expect(fieldByLabel("First frame").textContent).toContain("Source");
+    expect(fieldByLabel("First frame").textContent).not.toContain("Uploaded Last Frame");
+    expect(fieldByLabel("Last frame").textContent).toContain("Uploaded Last Frame");
+  });
+
   it("omits fitMode for non-image-conditioned modes", async () => {
     const context = baseContext({ assets: [source], selectedAsset: source });
     await render(context);
@@ -496,6 +547,31 @@ describe("VideoStudio Bernini task modes", () => {
     expect(pickerLabels()).toEqual(
       expect.arrayContaining(["Source clip", "Reference video", "Reference images"]),
     );
+  });
+
+  it("uses the Image Studio source flow for both clip and image pickers", async () => {
+    const context = baseContext({ videoModels: [BERNINI], assets: [clip, refA] });
+    await render(context);
+
+    await click(modeButton("Video → Video"));
+    await click(buttonWithText(container, "Select clip"));
+    let modal = document.querySelector(".media-source-modal");
+    expect([...modal.querySelectorAll('[role="tab"]')].map((el) => el.textContent.trim())).toEqual([
+      "Assets1",
+      "File Upload",
+      "Character0",
+    ]);
+    await click([...modal.querySelectorAll('[role="tab"]')].find((el) => el.textContent.includes("File Upload")));
+    expect(modal.querySelector('input[type="file"]').accept).toBe("video/*");
+    await click(buttonWithText(modal, "Cancel"));
+
+    await click(modeButton("Reference → Video"));
+    await click(buttonWithText(container, "Select images"));
+    modal = document.querySelector(".media-source-modal");
+    await click([...modal.querySelectorAll('[role="tab"]')].find((el) => el.textContent.includes("File Upload")));
+    const imageInput = modal.querySelector('input[type="file"]');
+    expect(imageInput.accept).toBe("image/*");
+    expect(imageInput.multiple).toBe(true);
   });
 
   it("keeps Render disabled until the required reference image is selected", async () => {

--- a/apps/web/src/screens/VideoUpscalePanel.jsx
+++ b/apps/web/src/screens/VideoUpscalePanel.jsx
@@ -5,7 +5,7 @@
 // clip, NOT a generation mode, so it lives in its own card rather than the mode picker.
 import React, { useMemo, useState } from "react";
 
-import { AssetPickerField } from "../components/AssetPicker.jsx";
+import { VideoSourcePickerField } from "../components/AssetPicker.jsx";
 import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock } from "../macGating.js";
 
 // SeedVR2 is the only Mac engine (no torch path). 7B (sc-5197) / int8 (sc-5198) are
@@ -13,11 +13,14 @@ import { DEFAULT_MAC_CAPABILITIES, macFeatureBlock } from "../macGating.js";
 const VIDEO_UPSCALE_ENGINES = [{ id: "seedvr2", label: "SeedVR2", model: "seedvr2_3b", factors: [2, 4] }];
 
 export function VideoUpscalePanel({
+  characters = [],
   videoAssets = [],
   selectedAsset = null,
   createVideoUpscaleJob,
+  importAsset,
   macCapabilities = DEFAULT_MAC_CAPABILITIES,
   onSubmitted,
+  projectId,
 }) {
   const engine = VIDEO_UPSCALE_ENGINES[0];
   const [sourceAssetId, setSourceAssetId] = useState(
@@ -62,12 +65,15 @@ export function VideoUpscalePanel({
       <h3>Upscale video</h3>
       <p className="upscale-card-sub">{engine.label} · one-step super-resolution (Mac / MLX)</p>
       {block ? <p className="mac-feature-block">{block.text}</p> : null}
-      <AssetPickerField
+      <VideoSourcePickerField
         assets={videoAssets}
         buttonLabel="Select clip"
+        characters={characters}
         emptyLabel="No source clip selected"
+        importAsset={importAsset}
         label="Source clip"
         onChange={setSourceAssetId}
+        projectId={projectId}
         value={sourceAssetId}
       />
       <div className="upscale-field">

--- a/apps/web/src/screens/VideoUpscalePanel.test.jsx
+++ b/apps/web/src/screens/VideoUpscalePanel.test.jsx
@@ -8,6 +8,7 @@ import { VideoUpscalePanel } from "./VideoUpscalePanel.jsx";
 const VIDEO = {
   id: "vid_1",
   type: "video",
+  projectId: "project_1",
   displayName: "Clip A",
   file: { width: 512, height: 384 },
 };
@@ -79,5 +80,24 @@ describe("VideoUpscalePanel", () => {
     expect(button.disabled).toBe(true);
     await click(button);
     expect(createVideoUpscaleJob).not.toHaveBeenCalled();
+  });
+
+  it("uses the direct-upload video source picker", async () => {
+    await renderPanel(
+      <VideoUpscalePanel
+        importAsset={vi.fn()}
+        projectId="project_1"
+        videoAssets={[VIDEO]}
+      />,
+    );
+
+    await click(findButton("Select clip"));
+    const modal = document.body.querySelector(".media-source-modal");
+    expect(modal).toBeTruthy();
+    expect([...modal.querySelectorAll('[role="tab"]')].map((tab) => tab.textContent.trim())).toEqual([
+      "Assets1",
+      "File Upload",
+      "Character0",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- replace every Video Studio clip and image picker with the shared Assets / File Upload / Character source flow
- keep video and image assets strictly separated, including selected-character filtering and backend-supported upload formats
- preserve single and multi-selection payload shapes, partial multi-upload successes, and secondary-field isolation from the global asset selection
- cover Replace Person and Video Upscale as well as every generation mode

## Validation
- npm run check (15/15)
- npm --prefix apps/web run lint
- npm --prefix apps/web run test (209 files, 2,902 tests)
- npm --prefix apps/web run build
- git diff --check
- independent adversarial review: PASS, high confidence

## Acceptance mapping
- Clip dialogs: Assets / File Upload / Character, video-only
- Image dialogs: Assets / File Upload / Character, image-only
- Character assets excluded from general Assets and scoped by selected character
- Single uploads immediately select; plural uploads preserve ID arrays and successful partial imports
- First/Last and Left/Right secondary uploads do not overwrite the primary source

Shortcut: https://app.shortcut.com/trefry/story/18115