### PR TITLE
chore(release): 0.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-core"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "directories",
  "fs2",
@@ -6344,7 +6344,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-desktop"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -6379,7 +6379,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-image-quality"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "image",
  "image_hasher",
@@ -6391,7 +6391,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-mcp"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -6408,7 +6408,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-rust-api"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "axum",
  "fs2",
@@ -6445,7 +6445,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-rust-worker"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "sceneworks-worker",
  "tokio",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-worker"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "axum",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 rust-version = "1.80"
 license-file = "LICENSE"

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/desktop",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/desktop",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "devDependencies": {
         "@tauri-apps/cli": "^2",
         "ajv": "8.20.0"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/desktop",
   "private": true,
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "SceneWorks desktop shell (Tauri).",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SceneWorks",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "identifier": "net.trefry.sceneworks",
   "build": {
     "frontendDist": "ui",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/web",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/web",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "dependencies": {
         "konva": "^9.3.22",
         "react": "18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/web",
   "private": true,
-  "version": "0.8.3",
+  "version": "0.8.4",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sceneworks",
   "private": true,
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Local AI image and video generation studio runtime skeleton.",
   "license": "AGPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump SceneWorks from 0.8.3 to 0.8.4 across root, web, desktop, Tauri, and Cargo version metadata
- preserve the existing immutable inference pin
- prepare the reviewed release/next candidate for the next patch release

## Validation
- git diff --check origin/release/next...HEAD
- cargo metadata --locked --no-deps --format-version 1
- npm run check (15/15)
- version diff audited: 8 expected files only