### PR TITLE
fix(loras): resync the catalog when the install badge is stale [sc-18196]

### DIFF
--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -42,7 +42,18 @@ pub(crate) async fn create_lora_download_job(
     if lora.get("installState").and_then(Value::as_str) == Some("installed")
         && lora.get("updateAvailable").and_then(Value::as_bool) != Some(true)
     {
-        return Err(ApiError::bad_request("LoRA is already installed"));
+        // `installState` is probed live from the HF cache on every catalog read, but a
+        // client's rendered badge is a snapshot from its last fetch. Anything that fills
+        // the cache out-of-band — the on-demand pull at first generation, another client,
+        // a manual `hf download` — flips the server to "installed" while an open catalog
+        // view still reads "Not Installed". Tag the rejection so the client can tell this
+        // benign disagreement apart from a real failure and resync instead of surfacing a
+        // message that contradicts the badge it is showing.
+        return Err(ApiError {
+            status: StatusCode::BAD_REQUEST,
+            detail: "LoRA is already installed".to_owned(),
+            code: Some("lora_already_installed"),
+        });
     }
     let source = lora.get("source").and_then(Value::as_object);
     let provider = source

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -1096,6 +1096,17 @@ async fn lora_download_endpoint_queues_hf_download_for_builtin_lora() {
                   "family": "z-image",
                   "compatibility": { "families": ["z-image"] },
                   "source": { "provider": "local", "path": "loras/local.safetensors" }
+                },
+                {
+                  "id": "already_cached",
+                  "name": "Already Cached",
+                  "family": "ltx-video",
+                  "compatibility": { "families": ["ltx-video"] },
+                  "source": {
+                    "provider": "huggingface",
+                    "repo": "Test/lora-install-probe",
+                    "file": "cached.safetensors"
+                  }
                 }
               ]
             }
@@ -1129,6 +1140,30 @@ async fn lora_download_endpoint_queues_hf_download_for_builtin_lora() {
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // A LoRA already present in the HF cache is rejected with a machine-readable code. The
+    // web client keys the "my badge is stale, resync" path off `code` rather than the prose
+    // detail, so the code is load-bearing contract, not decoration: a client rendering a
+    // pre-download catalog snapshot would otherwise show "Not Installed" next to an error
+    // saying it IS installed. Guarded here so the code can't be dropped or renamed silently.
+    let repo_dir =
+        huggingface_repo_cache_path(&temp_dir.path().join("data"), "Test/lora-install-probe")
+            .expect("repo cache path");
+    std::fs::create_dir_all(repo_dir.join("refs")).expect("create refs");
+    std::fs::write(repo_dir.join("refs").join("main"), "rev1").expect("write refs/main");
+    let snapshot = repo_dir.join("snapshots").join("rev1");
+    std::fs::create_dir_all(&snapshot).expect("create snapshot");
+    std::fs::write(snapshot.join("cached.safetensors"), b"").expect("write adapter");
+
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/loras/already_cached/download",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["code"], "lora_already_installed");
 
     // An unknown LoRA id is a 404.
     let (status, _) = request(app, "POST", "/api/v1/loras/missing/download", json!({})).await;

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -364,11 +364,22 @@ export function useModelsAndLoras({
         setLoraError("");
         return job;
       } catch (err) {
+        // The server probes installState live from the HF cache; our badge is a snapshot
+        // from the last catalog fetch. When the cache is filled out-of-band (the on-demand
+        // pull at first generation, another client) the row is already "installed" server-
+        // side while we still render "Not Installed", so the click lands on a Download
+        // button that cannot succeed. That disagreement is benign and self-correcting:
+        // resync the catalog so the badge flips, rather than showing an error that
+        // contradicts what the user is looking at.
+        if (err?.code === "lora_already_installed") {
+          await refreshLoras();
+          return null;
+        }
         setLoraError(err.message);
         return null;
       }
     },
-    [token, setJobs, setLoraError],
+    [token, setJobs, setLoraError, refreshLoras],
   );
 
   return {

--- a/apps/web/src/hooks/useModelsAndLoras.loraDownloadResync.test.jsx
+++ b/apps/web/src/hooks/useModelsAndLoras.loraDownloadResync.test.jsx
@@ -1,0 +1,107 @@
+// A LoRA row's install badge is a snapshot from the last catalog fetch, but the API probes
+// `installState` live from the HF cache on every request. Anything that fills the cache
+// out-of-band — the on-demand pull at first generation, a second client, a manual fetch —
+// flips the server to "installed" while an open catalog view still renders "Not Installed".
+// Clicking Download then 400s, and the old code surfaced that detail verbatim, so the user
+// saw "LoRA is already installed" sitting next to a "Not Installed" badge.
+//
+// The fix keys off the API's `lora_already_installed` code (not the prose detail) and
+// resyncs the catalog so the badge corrects itself. These tests pin both halves: the
+// benign-disagreement path refetches and stays silent, and an ordinary failure still
+// surfaces its error and does NOT refetch.
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiFetchMock } = vi.hoisted(() => ({ apiFetchMock: vi.fn() }));
+vi.mock("../api.js", () => ({
+  apiFetch: (...args) => apiFetchMock(...args),
+  isAbortError: () => false,
+}));
+
+import { useModelsAndLoras } from "./useModelsAndLoras.js";
+
+let container;
+let root;
+let hookApi;
+let loraErrors;
+
+function Harness() {
+  hookApi = useModelsAndLoras({
+    token: "tok",
+    activeProject: { id: "proj-1" },
+    activeProjectRef: { current: { id: "proj-1" } },
+    setError: () => {},
+    setLoraError: (value) => loraErrors.push(value),
+    setJobs: () => {},
+    setActiveView: () => {},
+    refreshData: async () => {},
+    refreshDataWithLoraOverlay: async () => {},
+  });
+  return null;
+}
+
+/** The download POST paths this hook issues, so a test can count catalog refetches. */
+const downloadCalls = (calls) => calls.filter(([path]) => path.endsWith("/download"));
+const catalogCalls = (calls) => calls.filter(([path]) => path.startsWith("/api/v1/loras?") || path === "/api/v1/loras");
+
+beforeEach(async () => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+  apiFetchMock.mockReset();
+  loraErrors = [];
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(<Harness />);
+  });
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("createLoraDownloadJob stale-badge resync", () => {
+  it("refetches the catalog and stays silent when the server says it is already installed", async () => {
+    const alreadyInstalled = Object.assign(new Error("LoRA is already installed"), {
+      status: 400,
+      detail: "LoRA is already installed",
+      code: "lora_already_installed",
+    });
+    apiFetchMock.mockImplementation(async (path) => {
+      if (path.endsWith("/download")) throw alreadyInstalled;
+      // The resync refetch: the row now carries the server's real state.
+      return [{ id: "scail2_lightning", installState: "installed" }];
+    });
+
+    let result;
+    await act(async () => {
+      result = await hookApi.createLoraDownloadJob({ id: "scail2_lightning" });
+    });
+
+    expect(result).toBe(null);
+    expect(downloadCalls(apiFetchMock.mock.calls)).toHaveLength(1);
+    // The badge only corrects if the catalog is actually refetched.
+    expect(catalogCalls(apiFetchMock.mock.calls)).toHaveLength(1);
+    // The contradiction must never reach the user as an error.
+    expect(loraErrors).not.toContain("LoRA is already installed");
+  });
+
+  it("still surfaces an ordinary download failure without refetching", async () => {
+    const boom = Object.assign(new Error("disk full"), { status: 500, detail: "disk full" });
+    apiFetchMock.mockImplementation(async (path) => {
+      if (path.endsWith("/download")) throw boom;
+      return [];
+    });
+
+    let result;
+    await act(async () => {
+      result = await hookApi.createLoraDownloadJob({ id: "scail2_lightning" });
+    });
+
+    expect(result).toBe(null);
+    expect(loraErrors).toContain("disk full");
+    expect(catalogCalls(apiFetchMock.mock.calls)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Hotfix off `release/next`. Story: [sc-18196](https://app.shortcut.com/trefry/story/18196)

> Supersedes #2192, which GitHub auto-closed when the branch was renamed to follow the `hotfix/<tracker-id>` convention in `RELEASING.md`. Same commit (`9591b174`), unchanged; CI was already green on it (`web`, `parity`, `build-windows` all passed).

## Symptom

Clicking Download on a built-in LoRA (found on **SCAIL-2 Lightning (8-step, fast)**) shows the error "LoRA is already installed" while the badge right next to it still reads **Not Installed**.

## Root cause

Neither side is wrong — they read the state at different times.

- The API probes `installState` **live from the HF cache on every request** (`normalize_lora_entry` → `lora_huggingface_cached_file`).
- The client's badge is a **snapshot from its last catalog fetch**.

Anything that fills the cache out-of-band flips the server to `installed` while an open Model Manager view keeps rendering `Not Installed`. The POST then correctly 400s, and `createLoraDownloadJob` surfaced that detail verbatim — producing an error that contradicts the badge on screen.

This is reachable in normal use, and it matters more than it first looks: the Model Manager Download button is the **only** install path, because both studio shells filter uninstalled LoRAs out of the picker entirely (`generationStudio.jsx:478`, `useSimpleLoras.js:53`). A badge that wrongly reads "Not Installed" next to a Download that refuses to run is the difference between a usable LoRA and one the studio never offers.

Confirmed against the running app — `GET /api/v1/loras` returned `scail2_lightning | installState=installed` with a resolved `installedPath` while the UI showed Not Installed.

## Fix

- **API** — tag the rejection with `code: "lora_already_installed"`. The crate already has a `code` convention; `bad_request` leaves it `None`.
- **Web** — `createLoraDownloadJob` keys off that **code**, not the prose detail (string-matching an error message is the brittle version of this), and calls `refreshLoras()` so the badge self-corrects. Ordinary failures still surface their error and do not refetch.

## Verification

Both tests were **mutation-checked** — a green test that would also pass without the fix proves nothing:

- `catalog.rs` — the endpoint test's comment already claimed to cover the already-installed rejection but never asserted it. It now does, including the code. Reverting the tag fails it (`left: Null, right: "lora_already_installed"`).
- `useModelsAndLoras.loraDownloadResync.test.jsx` — pins both halves. Disabling the branch fails the resync test while the control test still passes.

`cargo fmt --all --check`, `cargo clippy -p sceneworks-rust-api --all-targets`, `eslint`, and the full `src/hooks/` vitest suite (136 tests, incl. `hookStability`) are clean.

## Follow-up owed

This fix originated on `release/next`, not `main`, so per `RELEASING.md` it owes a forward-port PR to `main`. The same defect exists there. Not yet opened.

## Scope

Model downloads use a different guard and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)