### PR TITLE
fix(loras): honor extra-compatible families in the detected-family gate [sc-18200]

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -38,10 +38,10 @@ use sceneworks_core::jobs_store::{
     RetryJob, RouteDecision, StaleSweep, UnsupportedReason, WorkerHeartbeat, JOB_STATUSES,
 };
 use sceneworks_core::lora_family::{
-    apply_adapter_metadata_to_manifest_entry, apply_model_manifest_defaults, canonical_lora_family,
-    detect_lora_family, detect_model_family, first_safetensors_path, read_adapter_metadata,
-    read_safetensors_header, reconcile_detected_family, AdapterFileMetadata,
-    SafetensorsHeaderError,
+    accepted_lora_families, apply_adapter_metadata_to_manifest_entry,
+    apply_model_manifest_defaults, canonical_lora_family, detect_lora_family, detect_model_family,
+    first_safetensors_path, read_adapter_metadata, read_safetensors_header,
+    reconcile_detected_family, AdapterFileMetadata, SafetensorsHeaderError,
 };
 use sceneworks_core::lora_url::{lora_source_url_file_stem, parse_lora_source_url, LoraUrlError};
 use sceneworks_core::project_store::{

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -1292,7 +1292,34 @@ pub(crate) fn validate_lora_specs_for_model(
             // same canonical form before the membership test, else a krea_2 LoRA is falsely
             // rejected against a `krea-2`-normalized model surface (sc-8185).
             let detected_family = normalize_lora_family(&detected_family);
-            if !model_families
+            // The detected family is the LoRA file's *base architecture*, which is not always the
+            // model's own family token. A model whose weights ARE some base architecture loads that
+            // architecture's LoRAs — Krea Realtime is Wan 2.1 T2V 14B weight-for-weight, SCAIL-2 is
+            // Wan2.1-I2V-derived — and that one-directional relation is registered in
+            // `extra_compatible_lora_families`, deliberately kept OUT of the manifest's
+            // `loraCompatibility.families` so it does not leak into the other family-keyed gates.
+            // This test previously read the manifest list alone, so it was blind to that registry
+            // and rejected exactly the cross-architecture LoRAs the engines are built to load
+            // (sc-18200). Widen it to the model's full accepted set: its declared families plus
+            // whatever each of those may additionally load.
+            // Strictly ADDITIVE: keep `model_families` verbatim and append only the registry
+            // extras. Replacing the list instead would silently re-spell it — `model_families` is
+            // in `normalize_lora_family` space (which canonicalizes `krea-2` -> `krea_2`) while
+            // `accepted_lora_families` normalizes to model space (`krea-2`), so round-tripping the
+            // declared families through it turns a passing `krea_2` match into a rejection
+            // (sc-8185's regression). The extras come back through `normalize_lora_family` for the
+            // same reason, so both sides of the comparison stay in one canonical space.
+            let accepted_families = model_families
+                .iter()
+                .cloned()
+                .chain(
+                    model_families
+                        .iter()
+                        .flat_map(|family| accepted_lora_families(family))
+                        .map(|family| normalize_lora_family(&family)),
+                )
+                .collect::<Vec<_>>();
+            if !accepted_families
                 .iter()
                 .any(|model_family| model_family == &detected_family)
             {
@@ -1977,6 +2004,132 @@ mod base_model_gating_tests {
         });
         validate_lora_specs_for_model(&models, &[], "krea_2_turbo", &[lora], true, "LoRA")
             .expect("krea_2 detected family must pass against a krea_2 (→krea-2) model surface");
+    }
+
+    /// A lightx2v Wan2.1-I2V step-distill ("lightning") adapter, keyed exactly like the real
+    /// `Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors`: `diffusion_model.`
+    /// namespace, per-block `lora_down`/`lora_up` factors, full-rank `.diff_b` bias deltas, and the
+    /// I2V-only `k_img`/`v_img` cross-attention targets. It carries NO metadata blob, so detection
+    /// is purely key-based — the same path the real file takes.
+    fn write_wan_i2v_lightning_lora(dir: &std::path::Path) {
+        use std::io::Write;
+        let mut entries = Vec::new();
+        let mut offset = 0_usize;
+        let push = |name: String, len: usize, entries: &mut Vec<String>, offset: &mut usize| {
+            entries.push(format!(
+                r#""{name}":{{"dtype":"F32","shape":[1],"data_offsets":[{},{}]}}"#,
+                *offset,
+                *offset + len
+            ));
+            *offset += len;
+        };
+        for block in 0..2 {
+            for target in [
+                "self_attn.q",
+                "cross_attn.k_img",
+                "cross_attn.v_img",
+                "ffn.0",
+            ] {
+                for suffix in ["lora_down.weight", "lora_up.weight", "diff_b"] {
+                    push(
+                        format!("diffusion_model.blocks.{block}.{target}.{suffix}"),
+                        4,
+                        &mut entries,
+                        &mut offset,
+                    );
+                }
+            }
+        }
+        let header = format!("{{{}}}", entries.join(","));
+        let mut bytes = (header.len() as u64).to_le_bytes().to_vec();
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(&vec![0u8; offset]);
+        std::fs::File::create(dir.join("wan_lightning.safetensors"))
+            .unwrap()
+            .write_all(&bytes)
+            .unwrap();
+    }
+
+    /// sc-18200: the bundled `scail2_lightning` speed toggle IS a lightx2v Wan2.1-I2V LoRA, applied
+    /// to SCAIL-2 cross-architecture on purpose. `detect_lora_family` therefore reports `wan-video`
+    /// — correctly — while the model surface declares `scail2`. The gate used to compare the
+    /// detected family against the manifest list ALONE, so it rejected the transplant the engine
+    /// exists to perform ("appears to be a wan-video LoRA, which is not compatible with model
+    /// scail2_14b"). It must consult the model's full accepted set (`extra_compatible_lora_families`).
+    #[test]
+    fn wan_lightning_lora_passes_detected_family_check_on_scail2() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_wan_i2v_lightning_lora(tmp.path());
+        // The fixture is only meaningful if it really detects as wan-video — pin that, so a change
+        // in the detector turns into a clear failure here rather than a vacuous pass.
+        let header =
+            read_safetensors_header(&tmp.path().join("wan_lightning.safetensors")).unwrap();
+        assert_eq!(detect_lora_family(&header).as_deref(), Some("wan-video"));
+
+        let models = vec![json!({
+            "id": "scail2_14b",
+            "family": "scail2",
+            "loraCompatibility": { "families": ["scail2"] }
+        })];
+        let lora = json!({
+            "id": "scail2_lightning",
+            "installState": "installed",
+            "installedPath": tmp.path().to_str().unwrap(),
+            "families": ["scail2"],
+        });
+        validate_lora_specs_for_model(&models, &[], "scail2_14b", &[lora], true, "LoRA")
+            .expect("a wan-video-detected lightning LoRA must be accepted on a scail2 model");
+    }
+
+    /// The same defect, second instance: Krea Realtime's DiT is Wan 2.1 T2V 14B weight-for-weight,
+    /// and its manifest deliberately keeps `wan-video` OUT of `loraCompatibility.families` so the
+    /// token does not leak into the other family-keyed gates — the relation lives in
+    /// `extra_compatible_lora_families` instead. That left this gate blind to it too.
+    #[test]
+    fn wan_lora_passes_detected_family_check_on_krea_realtime() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_wan_i2v_lightning_lora(tmp.path());
+        let models = vec![json!({
+            "id": "krea_realtime_14b",
+            "family": "krea-realtime",
+            "loraCompatibility": { "families": ["krea-realtime"] }
+        })];
+        let lora = json!({
+            "id": "some_wan_motion_lora",
+            "installState": "installed",
+            "installedPath": tmp.path().to_str().unwrap(),
+            "families": ["krea-realtime"],
+        });
+        validate_lora_specs_for_model(&models, &[], "krea_realtime_14b", &[lora], true, "LoRA")
+            .expect("a wan-video LoRA must be accepted on krea-realtime");
+    }
+
+    /// The widening must stay narrow: a model with no extra-compatible relation still rejects a
+    /// foreign detected architecture. Without this, "accept the registry" could silently become
+    /// "accept anything" and the gate would stop catching genuinely wrong files.
+    #[test]
+    fn wan_lora_still_rejected_on_an_unrelated_model_family() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_wan_i2v_lightning_lora(tmp.path());
+        let models = vec![json!({
+            "id": "z_image_turbo",
+            "family": "z-image",
+            "loraCompatibility": { "families": ["z-image"] }
+        })];
+        let lora = json!({
+            "id": "mislabelled",
+            "installState": "installed",
+            "installedPath": tmp.path().to_str().unwrap(),
+            "families": ["z-image"],
+        });
+        let error =
+            validate_lora_specs_for_model(&models, &[], "z_image_turbo", &[lora], true, "LoRA")
+                .expect_err("a wan-video LoRA must still be rejected on an unrelated family");
+        assert!(
+            error.detail.contains("wan-video"),
+            "unexpected rejection detail: {}",
+            error.detail
+        );
     }
 
     // sc-10214: the id (and thus the on-disk folder) is family-scoped so two variants of

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -2096,6 +2096,20 @@ fn extra_compatible_lora_families(normalized_family: &str) -> &'static [&'static
         "chroma" => &["flux"],
         "flux2-klein" | "flux2-dev" => &["flux2"],
         "krea-realtime" => &["wan-video"],
+        // SCAIL-2's DiT is Wan2.1-I2V-14B-derived and ships the raw I2V module names — the same
+        // `blocks.{i}.self_attn.{q,k,v,o}` / `ffn` / qk-norm targets — so a Wan2.1-I2V LoRA's tensor
+        // keys resolve against it. That is not incidental: the bundled `scail2_lightning` speed
+        // toggle IS a lightx2v Wan2.1-I2V step-distill LoRA, applied cross-architecture on purpose
+        // (the engine merges every compatible target and deliberately skips the one that differs,
+        // the in_dim-36 `patch_embedding` vs SCAIL-2's in_dim 20). Because the file is a genuine Wan
+        // LoRA, `detect_lora_family` reports `wan-video` — correctly — so without this entry the
+        // job-creation gate rejects the very transplant the engine exists to perform (sc-18200).
+        // Declared HERE rather than as `wan-video` in the model's own `loraCompatibility.families`
+        // for the same reason as krea-realtime above: family membership is read by every other
+        // family-keyed gate too (tier/repo resolution, adapter routing, training bases), and SCAIL-2
+        // is not a Wan model for any of those. One-directional as usual — a Wan LoRA loads on
+        // SCAIL-2; a SCAIL-2 LoRA is not thereby declared loadable on a Wan model.
+        "scail2" => &["wan-video"],
         _ => &[],
     }
 }
@@ -4743,6 +4757,38 @@ mod tests {
             Some("krea_realtime_14b"),
         )
         .is_ok());
+    }
+
+    /// sc-18200: SCAIL-2's DiT is Wan2.1-I2V-derived and ships the raw I2V module names, and the
+    /// bundled `scail2_lightning` toggle IS a lightx2v Wan2.1-I2V LoRA — so a Wan LoRA must load on
+    /// a SCAIL-2 model. Same shape as the krea-realtime entry above, and asserted the same way so
+    /// it DISCRIMINATES: dropping the registry entry leaves `[scail2]` (and the job-creation gate
+    /// then rejects the lightning LoRA outright), while declaring `wan-video` as SCAIL-2's own
+    /// family would make the FIRST element `wan-video`, which this pins against.
+    #[test]
+    fn scail2_accepts_wan_loras_one_directionally() {
+        assert_eq!(
+            accepted_lora_families("scail2"),
+            vec!["scail2".to_owned(), "wan-video".to_owned()]
+        );
+        // Not symmetric: a Wan model does not thereby accept a scail2 LoRA.
+        assert!(!accepted_lora_families("wan-video").contains(&"scail2".to_owned()));
+        // The pre-flight accepts a Wan-declared LoRA on a SCAIL-2 job.
+        assert!(validate_lora_compatibility(
+            &[json!({ "id": "scail2_lightning", "family": "wan-video" })],
+            Some("scail2"),
+            "scail2",
+            Some("scail2_14b"),
+        )
+        .is_ok());
+        // ...and still refuses an unrelated architecture.
+        assert!(validate_lora_compatibility(
+            &[json!({ "id": "wrong", "family": "flux" })],
+            Some("scail2"),
+            "scail2",
+            Some("scail2_14b"),
+        )
+        .is_err());
     }
 
     #[test]


### PR DESCRIPTION
Hotfix off `release/next`. Story: [sc-18200](https://app.shortcut.com/trefry/story/18200)

## Symptom

Attaching **SCAIL-2 Lightning (8-step, fast)** to a SCAIL-2 job fails:

> LoRA scail2_lightning appears to be a wan-video LoRA, which is not compatible with model scail2_14b (scail2)

The adapter is **unusable end to end**. It is catalogued, wired in the worker (`resolve_scail2_adapters`, the auto step-distill recipe) and unit-tested there — but job creation rejects it before the worker ever sees it.

## Root cause

The detection is *correct*: the file genuinely is a lightx2v Wan2.1-I2V LoRA. Applying it to SCAIL-2 cross-architecture is the entire point — the engine merges every compatible target and deliberately skips the one that differs (in_dim-36 `patch_embedding` vs SCAIL-2's in_dim 20).

The **gate** was wrong. It tested the detected family against the manifest's `loraCompatibility.families` alone, so it never consulted `extra_compatible_lora_families` — the registry that exists precisely to record "this model's weights ARE that base architecture, so it loads that architecture's LoRAs."

Two compatibility systems had drifted apart:

| | Reads | Consults the registry? |
|---|---|---|
| `validate_lora_compatibility` (core) | LoRA's **declared** families | yes |
| rust-api gate (`loras.rs`) | **detected** family from the header | **no** |

## Fix

1. Register `"scail2" => &["wan-video"]`. Kept **out** of the manifest's families for the reason the krea-realtime entry documents: that token also drives tier/repo resolution and adapter routing, and SCAIL-2 is not a Wan model for those.
2. Widen the gate to consult the registry.

### The widening is strictly additive — and that matters

My first version *replaced* the family list with `accepted_lora_families(...)`. That silently re-spells it: `model_families` is in `normalize_lora_family` space (which canonicalizes `krea-2` → `krea_2`), while `accepted_lora_families` normalizes to model space (`krea-2`). Round-tripping the declared families through it **regressed sc-8185 and rejected Krea 2 image LoRAs**.

Caught by the full suite, not the targeted run. The landed version keeps `model_families` verbatim and appends only the extras, normalized back into the same space.

## Also fixes a second, reachable instance

Krea Realtime's DiT is Wan 2.1 T2V 14B weight-for-weight and it took the same registry route, so a Wan LoRA on `krea_realtime_14b` hit the identical 400. I had called this "likely" from code reading — the new test **fails without the gate change**, which demonstrates it was reachable, not theoretical.

## Verification

Every test mutation-checked, each half independently:

- **Gate reverted** → both new tests fail, negative control still passes.
- **Registry entry removed** → scail2 tests fail, krea-realtime still passes (its entry intact).
- **Extras neutralized in the additive version** → both new tests fail, sc-8185 passes — proving the extras are the load-bearing part and the base path is untouched.

Includes a negative control (`wan_lora_still_rejected_on_an_unrelated_model_family`) so "consult the registry" cannot silently become "accept anything". The Wan fixture is keyed exactly like the real `Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors` (`diffusion_model.` namespace, `lora_down`/`lora_up`, `.diff_b`, I2V-only `k_img`/`v_img`) and self-validates that it detects as `wan-video`.

`cargo fmt --all --check` clean, `cargo clippy -p sceneworks-rust-api -p sceneworks-core --all-targets` zero warnings, 503 rust-api lib tests and 117 core `lora_family` tests pass.

## Not covered

This unblocks attaching Lightning. It does **not** make it work on the pre-quantized q4/q8 tiers — that is a separate engine-side gate tracked in sc-18198. On the bf16 tier it should now run end to end; I have not executed a render.

## Follow-up owed

Originated on `release/next`, so per `RELEASING.md` it owes a forward-port PR to `main`. Same defect exists there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)