### PR TITLE
fix(loras): forward-port the LoRA install-badge and family-gate fixes to main [sc-18196, sc-18200]

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -38,10 +38,10 @@ use sceneworks_core::jobs_store::{
     RetryJob, RouteDecision, StaleSweep, UnsupportedReason, WorkerHeartbeat, JOB_STATUSES,
 };
 use sceneworks_core::lora_family::{
-    apply_adapter_metadata_to_manifest_entry, apply_model_manifest_defaults, canonical_lora_family,
-    detect_lora_family, detect_model_family, first_safetensors_path, read_adapter_metadata,
-    read_safetensors_header, reconcile_detected_family, AdapterFileMetadata,
-    SafetensorsHeaderError,
+    accepted_lora_families, apply_adapter_metadata_to_manifest_entry,
+    apply_model_manifest_defaults, canonical_lora_family, detect_lora_family, detect_model_family,
+    first_safetensors_path, read_adapter_metadata, read_safetensors_header,
+    reconcile_detected_family, AdapterFileMetadata, SafetensorsHeaderError,
 };
 use sceneworks_core::lora_url::{lora_source_url_file_stem, parse_lora_source_url, LoraUrlError};
 use sceneworks_core::project_store::{

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -42,7 +42,18 @@ pub(crate) async fn create_lora_download_job(
     if lora.get("installState").and_then(Value::as_str) == Some("installed")
         && lora.get("updateAvailable").and_then(Value::as_bool) != Some(true)
     {
-        return Err(ApiError::bad_request("LoRA is already installed"));
+        // `installState` is probed live from the HF cache on every catalog read, but a
+        // client's rendered badge is a snapshot from its last fetch. Anything that fills
+        // the cache out-of-band — the on-demand pull at first generation, another client,
+        // a manual `hf download` — flips the server to "installed" while an open catalog
+        // view still reads "Not Installed". Tag the rejection so the client can tell this
+        // benign disagreement apart from a real failure and resync instead of surfacing a
+        // message that contradicts the badge it is showing.
+        return Err(ApiError {
+            status: StatusCode::BAD_REQUEST,
+            detail: "LoRA is already installed".to_owned(),
+            code: Some("lora_already_installed"),
+        });
     }
     let source = lora.get("source").and_then(Value::as_object);
     let provider = source

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -1405,7 +1405,34 @@ pub(crate) fn validate_lora_specs_for_model(
             // same canonical form before the membership test, else a krea_2 LoRA is falsely
             // rejected against a `krea-2`-normalized model surface (sc-8185).
             let detected_family = normalize_lora_family(&detected_family);
-            if !model_families
+            // The detected family is the LoRA file's *base architecture*, which is not always the
+            // model's own family token. A model whose weights ARE some base architecture loads that
+            // architecture's LoRAs — Krea Realtime is Wan 2.1 T2V 14B weight-for-weight, SCAIL-2 is
+            // Wan2.1-I2V-derived — and that one-directional relation is registered in
+            // `extra_compatible_lora_families`, deliberately kept OUT of the manifest's
+            // `loraCompatibility.families` so it does not leak into the other family-keyed gates.
+            // This test previously read the manifest list alone, so it was blind to that registry
+            // and rejected exactly the cross-architecture LoRAs the engines are built to load
+            // (sc-18200). Widen it to the model's full accepted set: its declared families plus
+            // whatever each of those may additionally load.
+            // Strictly ADDITIVE: keep `model_families` verbatim and append only the registry
+            // extras. Replacing the list instead would silently re-spell it — `model_families` is
+            // in `normalize_lora_family` space (which canonicalizes `krea-2` -> `krea_2`) while
+            // `accepted_lora_families` normalizes to model space (`krea-2`), so round-tripping the
+            // declared families through it turns a passing `krea_2` match into a rejection
+            // (sc-8185's regression). The extras come back through `normalize_lora_family` for the
+            // same reason, so both sides of the comparison stay in one canonical space.
+            let accepted_families = model_families
+                .iter()
+                .cloned()
+                .chain(
+                    model_families
+                        .iter()
+                        .flat_map(|family| accepted_lora_families(family))
+                        .map(|family| normalize_lora_family(&family)),
+                )
+                .collect::<Vec<_>>();
+            if !accepted_families
                 .iter()
                 .any(|model_family| model_family == &detected_family)
             {
@@ -2376,6 +2403,132 @@ mod base_model_gating_tests {
         });
         validate_lora_specs_for_model(&models, &[], "krea_2_turbo", &[lora], true, "LoRA")
             .expect("krea_2 detected family must pass against a krea_2 (→krea-2) model surface");
+    }
+
+    /// A lightx2v Wan2.1-I2V step-distill ("lightning") adapter, keyed exactly like the real
+    /// `Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors`: `diffusion_model.`
+    /// namespace, per-block `lora_down`/`lora_up` factors, full-rank `.diff_b` bias deltas, and the
+    /// I2V-only `k_img`/`v_img` cross-attention targets. It carries NO metadata blob, so detection
+    /// is purely key-based — the same path the real file takes.
+    fn write_wan_i2v_lightning_lora(dir: &std::path::Path) {
+        use std::io::Write;
+        let mut entries = Vec::new();
+        let mut offset = 0_usize;
+        let push = |name: String, len: usize, entries: &mut Vec<String>, offset: &mut usize| {
+            entries.push(format!(
+                r#""{name}":{{"dtype":"F32","shape":[1],"data_offsets":[{},{}]}}"#,
+                *offset,
+                *offset + len
+            ));
+            *offset += len;
+        };
+        for block in 0..2 {
+            for target in [
+                "self_attn.q",
+                "cross_attn.k_img",
+                "cross_attn.v_img",
+                "ffn.0",
+            ] {
+                for suffix in ["lora_down.weight", "lora_up.weight", "diff_b"] {
+                    push(
+                        format!("diffusion_model.blocks.{block}.{target}.{suffix}"),
+                        4,
+                        &mut entries,
+                        &mut offset,
+                    );
+                }
+            }
+        }
+        let header = format!("{{{}}}", entries.join(","));
+        let mut bytes = (header.len() as u64).to_le_bytes().to_vec();
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(&vec![0u8; offset]);
+        std::fs::File::create(dir.join("wan_lightning.safetensors"))
+            .unwrap()
+            .write_all(&bytes)
+            .unwrap();
+    }
+
+    /// sc-18200: the bundled `scail2_lightning` speed toggle IS a lightx2v Wan2.1-I2V LoRA, applied
+    /// to SCAIL-2 cross-architecture on purpose. `detect_lora_family` therefore reports `wan-video`
+    /// — correctly — while the model surface declares `scail2`. The gate used to compare the
+    /// detected family against the manifest list ALONE, so it rejected the transplant the engine
+    /// exists to perform ("appears to be a wan-video LoRA, which is not compatible with model
+    /// scail2_14b"). It must consult the model's full accepted set (`extra_compatible_lora_families`).
+    #[test]
+    fn wan_lightning_lora_passes_detected_family_check_on_scail2() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_wan_i2v_lightning_lora(tmp.path());
+        // The fixture is only meaningful if it really detects as wan-video — pin that, so a change
+        // in the detector turns into a clear failure here rather than a vacuous pass.
+        let header =
+            read_safetensors_header(&tmp.path().join("wan_lightning.safetensors")).unwrap();
+        assert_eq!(detect_lora_family(&header).as_deref(), Some("wan-video"));
+
+        let models = vec![json!({
+            "id": "scail2_14b",
+            "family": "scail2",
+            "loraCompatibility": { "families": ["scail2"] }
+        })];
+        let lora = json!({
+            "id": "scail2_lightning",
+            "installState": "installed",
+            "installedPath": tmp.path().to_str().unwrap(),
+            "families": ["scail2"],
+        });
+        validate_lora_specs_for_model(&models, &[], "scail2_14b", &[lora], true, "LoRA")
+            .expect("a wan-video-detected lightning LoRA must be accepted on a scail2 model");
+    }
+
+    /// The same defect, second instance: Krea Realtime's DiT is Wan 2.1 T2V 14B weight-for-weight,
+    /// and its manifest deliberately keeps `wan-video` OUT of `loraCompatibility.families` so the
+    /// token does not leak into the other family-keyed gates — the relation lives in
+    /// `extra_compatible_lora_families` instead. That left this gate blind to it too.
+    #[test]
+    fn wan_lora_passes_detected_family_check_on_krea_realtime() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_wan_i2v_lightning_lora(tmp.path());
+        let models = vec![json!({
+            "id": "krea_realtime_14b",
+            "family": "krea-realtime",
+            "loraCompatibility": { "families": ["krea-realtime"] }
+        })];
+        let lora = json!({
+            "id": "some_wan_motion_lora",
+            "installState": "installed",
+            "installedPath": tmp.path().to_str().unwrap(),
+            "families": ["krea-realtime"],
+        });
+        validate_lora_specs_for_model(&models, &[], "krea_realtime_14b", &[lora], true, "LoRA")
+            .expect("a wan-video LoRA must be accepted on krea-realtime");
+    }
+
+    /// The widening must stay narrow: a model with no extra-compatible relation still rejects a
+    /// foreign detected architecture. Without this, "accept the registry" could silently become
+    /// "accept anything" and the gate would stop catching genuinely wrong files.
+    #[test]
+    fn wan_lora_still_rejected_on_an_unrelated_model_family() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_wan_i2v_lightning_lora(tmp.path());
+        let models = vec![json!({
+            "id": "z_image_turbo",
+            "family": "z-image",
+            "loraCompatibility": { "families": ["z-image"] }
+        })];
+        let lora = json!({
+            "id": "mislabelled",
+            "installState": "installed",
+            "installedPath": tmp.path().to_str().unwrap(),
+            "families": ["z-image"],
+        });
+        let error =
+            validate_lora_specs_for_model(&models, &[], "z_image_turbo", &[lora], true, "LoRA")
+                .expect_err("a wan-video LoRA must still be rejected on an unrelated family");
+        assert!(
+            error.detail.contains("wan-video"),
+            "unexpected rejection detail: {}",
+            error.detail
+        );
     }
 
     // sc-10214: the id (and thus the on-disk folder) is family-scoped so two variants of

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -1204,6 +1204,17 @@ async fn lora_download_endpoint_queues_hf_download_for_builtin_lora() {
                   "family": "z-image",
                   "compatibility": { "families": ["z-image"] },
                   "source": { "provider": "local", "path": "loras/local.safetensors" }
+                },
+                {
+                  "id": "already_cached",
+                  "name": "Already Cached",
+                  "family": "ltx-video",
+                  "compatibility": { "families": ["ltx-video"] },
+                  "source": {
+                    "provider": "huggingface",
+                    "repo": "Test/lora-install-probe",
+                    "file": "cached.safetensors"
+                  }
                 }
               ]
             }
@@ -1237,6 +1248,30 @@ async fn lora_download_endpoint_queues_hf_download_for_builtin_lora() {
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // A LoRA already present in the HF cache is rejected with a machine-readable code. The
+    // web client keys the "my badge is stale, resync" path off `code` rather than the prose
+    // detail, so the code is load-bearing contract, not decoration: a client rendering a
+    // pre-download catalog snapshot would otherwise show "Not Installed" next to an error
+    // saying it IS installed. Guarded here so the code can't be dropped or renamed silently.
+    let repo_dir =
+        huggingface_repo_cache_path(&temp_dir.path().join("data"), "Test/lora-install-probe")
+            .expect("repo cache path");
+    std::fs::create_dir_all(repo_dir.join("refs")).expect("create refs");
+    std::fs::write(repo_dir.join("refs").join("main"), "rev1").expect("write refs/main");
+    let snapshot = repo_dir.join("snapshots").join("rev1");
+    std::fs::create_dir_all(&snapshot).expect("create snapshot");
+    std::fs::write(snapshot.join("cached.safetensors"), b"").expect("write adapter");
+
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/loras/already_cached/download",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(body["code"], "lora_already_installed");
 
     // An unknown LoRA id is a 404.
     let (status, _) = request(app, "POST", "/api/v1/loras/missing/download", json!({})).await;

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -364,11 +364,22 @@ export function useModelsAndLoras({
         setLoraError("");
         return job;
       } catch (err) {
+        // The server probes installState live from the HF cache; our badge is a snapshot
+        // from the last catalog fetch. When the cache is filled out-of-band (the on-demand
+        // pull at first generation, another client) the row is already "installed" server-
+        // side while we still render "Not Installed", so the click lands on a Download
+        // button that cannot succeed. That disagreement is benign and self-correcting:
+        // resync the catalog so the badge flips, rather than showing an error that
+        // contradicts what the user is looking at.
+        if (err?.code === "lora_already_installed") {
+          await refreshLoras();
+          return null;
+        }
         setLoraError(err.message);
         return null;
       }
     },
-    [token, setJobs, setLoraError],
+    [token, setJobs, setLoraError, refreshLoras],
   );
 
   return {

--- a/apps/web/src/hooks/useModelsAndLoras.loraDownloadResync.test.jsx
+++ b/apps/web/src/hooks/useModelsAndLoras.loraDownloadResync.test.jsx
@@ -1,0 +1,107 @@
+// A LoRA row's install badge is a snapshot from the last catalog fetch, but the API probes
+// `installState` live from the HF cache on every request. Anything that fills the cache
+// out-of-band — the on-demand pull at first generation, a second client, a manual fetch —
+// flips the server to "installed" while an open catalog view still renders "Not Installed".
+// Clicking Download then 400s, and the old code surfaced that detail verbatim, so the user
+// saw "LoRA is already installed" sitting next to a "Not Installed" badge.
+//
+// The fix keys off the API's `lora_already_installed` code (not the prose detail) and
+// resyncs the catalog so the badge corrects itself. These tests pin both halves: the
+// benign-disagreement path refetches and stays silent, and an ordinary failure still
+// surfaces its error and does NOT refetch.
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiFetchMock } = vi.hoisted(() => ({ apiFetchMock: vi.fn() }));
+vi.mock("../api.js", () => ({
+  apiFetch: (...args) => apiFetchMock(...args),
+  isAbortError: () => false,
+}));
+
+import { useModelsAndLoras } from "./useModelsAndLoras.js";
+
+let container;
+let root;
+let hookApi;
+let loraErrors;
+
+function Harness() {
+  hookApi = useModelsAndLoras({
+    token: "tok",
+    activeProject: { id: "proj-1" },
+    activeProjectRef: { current: { id: "proj-1" } },
+    setError: () => {},
+    setLoraError: (value) => loraErrors.push(value),
+    setJobs: () => {},
+    setActiveView: () => {},
+    refreshData: async () => {},
+    refreshDataWithLoraOverlay: async () => {},
+  });
+  return null;
+}
+
+/** The download POST paths this hook issues, so a test can count catalog refetches. */
+const downloadCalls = (calls) => calls.filter(([path]) => path.endsWith("/download"));
+const catalogCalls = (calls) => calls.filter(([path]) => path.startsWith("/api/v1/loras?") || path === "/api/v1/loras");
+
+beforeEach(async () => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+  apiFetchMock.mockReset();
+  loraErrors = [];
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(<Harness />);
+  });
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("createLoraDownloadJob stale-badge resync", () => {
+  it("refetches the catalog and stays silent when the server says it is already installed", async () => {
+    const alreadyInstalled = Object.assign(new Error("LoRA is already installed"), {
+      status: 400,
+      detail: "LoRA is already installed",
+      code: "lora_already_installed",
+    });
+    apiFetchMock.mockImplementation(async (path) => {
+      if (path.endsWith("/download")) throw alreadyInstalled;
+      // The resync refetch: the row now carries the server's real state.
+      return [{ id: "scail2_lightning", installState: "installed" }];
+    });
+
+    let result;
+    await act(async () => {
+      result = await hookApi.createLoraDownloadJob({ id: "scail2_lightning" });
+    });
+
+    expect(result).toBe(null);
+    expect(downloadCalls(apiFetchMock.mock.calls)).toHaveLength(1);
+    // The badge only corrects if the catalog is actually refetched.
+    expect(catalogCalls(apiFetchMock.mock.calls)).toHaveLength(1);
+    // The contradiction must never reach the user as an error.
+    expect(loraErrors).not.toContain("LoRA is already installed");
+  });
+
+  it("still surfaces an ordinary download failure without refetching", async () => {
+    const boom = Object.assign(new Error("disk full"), { status: 500, detail: "disk full" });
+    apiFetchMock.mockImplementation(async (path) => {
+      if (path.endsWith("/download")) throw boom;
+      return [];
+    });
+
+    let result;
+    await act(async () => {
+      result = await hookApi.createLoraDownloadJob({ id: "scail2_lightning" });
+    });
+
+    expect(result).toBe(null);
+    expect(loraErrors).toContain("disk full");
+    expect(catalogCalls(apiFetchMock.mock.calls)).toHaveLength(0);
+  });
+});

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -148,6 +148,11 @@ export const EXTRA_COMPATIBLE_LORA_FAMILIES = {
   "flux2-klein": ["flux2"],
   "flux2-dev": ["flux2"],
   "krea-realtime": ["wan-video"],
+  // sc-18200: SCAIL-2's DiT is Wan2.1-I2V-14B-derived and ships the raw I2V module names, so Wan
+  // LoRAs resolve against it — the bundled `scail2_lightning` speed toggle IS a lightx2v Wan2.1-I2V
+  // adapter. Mirrored here for the same reason as the entries above: without it the picker would be
+  // stricter than the backend and hide a Wan LoRA the job-creation gate now accepts on SCAIL-2.
+  scail2: ["wan-video"],
 };
 
 // Every LoRA family `model` can load: the families it declares plus their

--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -2096,6 +2096,20 @@ fn extra_compatible_lora_families(normalized_family: &str) -> &'static [&'static
         "chroma" => &["flux"],
         "flux2-klein" | "flux2-dev" => &["flux2"],
         "krea-realtime" => &["wan-video"],
+        // SCAIL-2's DiT is Wan2.1-I2V-14B-derived and ships the raw I2V module names — the same
+        // `blocks.{i}.self_attn.{q,k,v,o}` / `ffn` / qk-norm targets — so a Wan2.1-I2V LoRA's tensor
+        // keys resolve against it. That is not incidental: the bundled `scail2_lightning` speed
+        // toggle IS a lightx2v Wan2.1-I2V step-distill LoRA, applied cross-architecture on purpose
+        // (the engine merges every compatible target and deliberately skips the one that differs,
+        // the in_dim-36 `patch_embedding` vs SCAIL-2's in_dim 20). Because the file is a genuine Wan
+        // LoRA, `detect_lora_family` reports `wan-video` — correctly — so without this entry the
+        // job-creation gate rejects the very transplant the engine exists to perform (sc-18200).
+        // Declared HERE rather than as `wan-video` in the model's own `loraCompatibility.families`
+        // for the same reason as krea-realtime above: family membership is read by every other
+        // family-keyed gate too (tier/repo resolution, adapter routing, training bases), and SCAIL-2
+        // is not a Wan model for any of those. One-directional as usual — a Wan LoRA loads on
+        // SCAIL-2; a SCAIL-2 LoRA is not thereby declared loadable on a Wan model.
+        "scail2" => &["wan-video"],
         _ => &[],
     }
 }
@@ -2229,7 +2243,34 @@ pub fn base_model_satisfies_gate(model_family: &str, model_id: &str, base: &str)
     extra_compatible_lora_families(&normalized_family).contains(&"wan-video")
         && is_wan_14b_class_id(model_id)
         && is_wan_14b_class_id(base)
-        && !is_wan_i2v_id(base)
+        && (extra_compatible_backbone_is_image_conditioned(&normalized_family)
+            || !is_wan_i2v_id(base))
+}
+
+/// Whether a model riding the `wan-video` extra-compatible arm has an **image-conditioned** (I2V)
+/// backbone, i.e. one that actually carries the `cross_attn.k_img`/`v_img` projections an I2V LoRA
+/// targets.
+///
+/// This exists because the I2V exclusion in [`base_model_satisfies_gate`] is not a property of Wan
+/// LoRAs — it is a property of the *host*. sc-15017 introduced it for Krea Realtime, whose DiT is Wan
+/// 2.1 **T2V** 14B: it has no `k_img`/`v_img` at any width, so an I2V-stamped LoRA cannot apply and
+/// the exclusion is right. Applying that same rule to every extra-compatible family inverts it for an
+/// image-conditioned host — SCAIL-2's DiT IS Wan2.1-**I2V**-14B-derived and does carry `k_img`/`v_img`
+/// (they are adaptable targets, and the bundled `scail2_lightning` adapter patches them), so an I2V
+/// base is the *exact* architectural match while a T2V base is the lossy one. Without this split,
+/// forward-porting sc-18200 to a tree containing sc-15017 would refuse precisely the right LoRAs on
+/// SCAIL-2 and admit the weaker ones (sc-18200 forward-port).
+///
+/// Both size classes still gate: `is_wan_14b_class_id` keeps the 5B TI2V base out either way, which
+/// is the split the base-model gate was written for.
+fn extra_compatible_backbone_is_image_conditioned(normalized_family: &str) -> bool {
+    match normalized_family {
+        // Wan2.1-I2V-14B-derived: 40 blocks × dim 5120 with the I2V cross-attention stack intact.
+        "scail2" => true,
+        // Wan 2.1 T2V 14B weight-for-weight — no image cross-attention at any width.
+        "krea-realtime" => false,
+        _ => false,
+    }
 }
 
 /// A LoRA id for error messages: `id` / `loraId` / `lora_<n>`.
@@ -4857,9 +4898,11 @@ mod tests {
             "the 5B TI2V base has 48 latent channels — admitting it would garble the render"
         );
         // A model with no extra-compatible entry gets no relaxation, even between two 14B ids.
+        // (This used to name `scail2`, which gained a `wan-video` entry in sc-18200 — so it now
+        // legitimately DOES relax, and is asserted separately below. `ltx-video` has no entry.)
         assert!(!base_model_satisfies_gate(
-            "scail2",
-            "scail2_14b",
+            "ltx-video",
+            "ltx_2_3_14b",
             "wan_2_2_t2v_14b"
         ));
         // 🔴 …and REFUSES an I2V base, even though it is the same 14B size class. Krea Realtime is a
@@ -4925,6 +4968,70 @@ mod tests {
             Some("wan_2_2"),
         )
         .is_ok());
+    }
+
+    /// sc-18200: SCAIL-2's DiT is Wan2.1-I2V-derived and ships the raw I2V module names, and the
+    /// bundled `scail2_lightning` toggle IS a lightx2v Wan2.1-I2V LoRA — so a Wan LoRA must load on
+    /// a SCAIL-2 model. Same shape as the krea-realtime entry above, and asserted the same way so
+    /// it DISCRIMINATES: dropping the registry entry leaves `[scail2]` (and the job-creation gate
+    /// then rejects the lightning LoRA outright), while declaring `wan-video` as SCAIL-2's own
+    /// family would make the FIRST element `wan-video`, which this pins against.
+    /// The base-model half, which only exists on this line (sc-15017). The `wan-video` registry entry
+    /// is read by `base_model_satisfies_gate` too, so sc-18200 gained a SECOND meaning when forward-
+    /// ported here — and the I2V axis sc-15017 wrote for Krea Realtime is INVERTED for SCAIL-2.
+    /// Krea Realtime is a T2V backbone with no `cross_attn.k_img`/`v_img`, so an I2V stamp must be
+    /// refused there. SCAIL-2 is Wan2.1-**I2V**-derived and carries those projections — the bundled
+    /// lightning adapter patches them — so an I2V base is its EXACT match. Ported naively, SCAIL-2
+    /// would have refused the right LoRAs and admitted the weaker ones, silently.
+    #[test]
+    fn scail2_base_model_gate_admits_i2v_unlike_the_t2v_backbone() {
+        // The exact architectural match: a Wan I2V 14B base on SCAIL-2.
+        assert!(
+            base_model_satisfies_gate("scail2", "scail2_14b", "wan_2_2_i2v_14b"),
+            "SCAIL-2 is I2V-derived and has k_img/v_img — an I2V base is its exact match"
+        );
+        // The same stamp stays refused on the T2V backbone, unchanged by this split.
+        assert!(
+            !base_model_satisfies_gate("krea-realtime", "krea_realtime_14b", "wan_2_2_i2v_14b"),
+            "Krea Realtime has no image cross-attention; sc-15017's exclusion still holds there"
+        );
+        // A T2V base is still admitted on SCAIL-2 (same 40×5120 block layout, minus the img stack).
+        assert!(base_model_satisfies_gate(
+            "scail2",
+            "scail2_14b",
+            "wan_2_2_t2v_14b"
+        ));
+        // The size class still gates on BOTH: the 5B TI2V base is refused either way.
+        assert!(
+            !base_model_satisfies_gate("scail2", "scail2_14b", "wan_2_2"),
+            "the 5B TI2V base is a different latent geometry — the relaxation is size-classed"
+        );
+    }
+
+    #[test]
+    fn scail2_accepts_wan_loras_one_directionally() {
+        assert_eq!(
+            accepted_lora_families("scail2"),
+            vec!["scail2".to_owned(), "wan-video".to_owned()]
+        );
+        // Not symmetric: a Wan model does not thereby accept a scail2 LoRA.
+        assert!(!accepted_lora_families("wan-video").contains(&"scail2".to_owned()));
+        // The pre-flight accepts a Wan-declared LoRA on a SCAIL-2 job.
+        assert!(validate_lora_compatibility(
+            &[json!({ "id": "scail2_lightning", "family": "wan-video" })],
+            Some("scail2"),
+            "scail2",
+            Some("scail2_14b"),
+        )
+        .is_ok());
+        // ...and still refuses an unrelated architecture.
+        assert!(validate_lora_compatibility(
+            &[json!({ "id": "wrong", "family": "flux" })],
+            Some("scail2"),
+            "scail2",
+            Some("scail2_14b"),
+        )
+        .is_err());
     }
 
     #[test]


### PR DESCRIPTION
Forward-port to `main` of two hotfixes already merged into `release/next`, as required by `RELEASING.md` invariant 5. Both defects are present on `main` today.

Stories: [sc-18196](https://app.shortcut.com/trefry/story/18196) · [sc-18200](https://app.shortcut.com/trefry/story/18200)
Sources: #2193 (`9591b174`) and #2195 (`30430277`). One PR because both touch `apps/rust-api/src/loras.rs` and would conflict as separate branches.

## sc-18196 — stale install badge (clean cherry-pick)

The API probes `installState` live from the HF cache on every request; the client's badge is a snapshot from its last catalog fetch. Anything filling the cache out-of-band flips the server to `installed` while an open Model Manager still reads "Not Installed", so Download 400s with a message contradicting the badge on screen. Tagged with a `lora_already_installed` code; the client keys off the **code** (not the prose) and resyncs.

This matters more than it looks: Model Manager's Download is the **only** install path, because both studio shells filter uninstalled LoRAs out of the picker entirely.

## sc-18200 — cross-architecture LoRAs rejected at job creation

`scail2_lightning` is a lightx2v Wan2.1-I2V LoRA applied to SCAIL-2 on purpose. Detection correctly reports `wan-video`, but the gate compared it against `loraCompatibility.families` alone and never consulted `extra_compatible_lora_families` — the registry that exists for exactly this relation. Also fixes the same latent bug for Krea Realtime.

## ⚠️ This half is NOT a clean cherry-pick — please read

`main` carries **sc-15017**, which `release/next` does not. `base_model_satisfies_gate` reads the **same registry**, so the new entry acquires a second meaning here:

```rust
extra_compatible_lora_families(&family).contains(&"wan-video")
    && is_wan_14b_class_id(model_id)
    && is_wan_14b_class_id(base)
    && !is_wan_i2v_id(base)          // written for Krea Realtime
```

That last axis is **inverted for SCAIL-2**. Its own rationale says why: *"an I2V LoRA targets `cross_attn.k_img`/`v_img`, which a text-to-video backbone does not have."* True of Krea Realtime. SCAIL-2 is Wan2.1-**I2V**-derived and **does** carry those projections — they're adaptable targets, and the lightning adapter patches them.

Ported naively, SCAIL-2 would have:

| Wan base stamped on the LoRA | Naive port | Correct |
|---|---|---|
| `wan_2_2_i2v_14b` | refused | **admit** — exact architectural match |
| `wan_2_2_t2v_14b` | admitted | admit (same block layout, minus the img stack) |
| `wan_2_2` (5B) | refused | refused — different latent geometry |

So the I2V exclusion is now a property of the **host**, not of every extra-compatible family: `extra_compatible_backbone_is_image_conditioned` splits SCAIL-2 (image-conditioned) from Krea Realtime (text-only). Krea Realtime's behavior is unchanged. Both size classes still gate.

Scope note: the base-model gate only fires when a LoRA **records** a `baseModel`. The lightning catalog entry doesn't, so `scail2_lightning` is unaffected either way — this is about user-imported, base-stamped Wan LoRAs on SCAIL-2.

The sc-15017 test that used `scail2` as its example of a family with *no* extra-compatible entry now names `ltx-video`, since scail2 legitimately has one.

## Verification

- `sceneworks-core` 858 tests, `sceneworks-rust-api` 559 tests, web `src/hooks/` 186 tests — all pass.
- `cargo fmt --all --check` clean; `cargo clippy -p sceneworks-core -p sceneworks-rust-api --all-targets` zero warnings.
- Mutation-checked: treating `scail2` as a T2V backbone fails `scail2_base_model_gate_admits_i2v_unlike_the_t2v_backbone` and nothing else.

## Not included

The inference-pin bump (#2198) is release-line-specific — `main` tracks its own inference revision — so it is deliberately not forward-ported. The inference fix itself needs a separate port to inference `main`, tracked under sc-18198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)