### PR TITLE
chore(release): 0.8.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-core"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "directories",
  "fs2",
@@ -6344,7 +6344,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-desktop"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -6379,7 +6379,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-image-quality"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "image",
  "image_hasher",
@@ -6391,7 +6391,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-mcp"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -6408,7 +6408,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-rust-api"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "axum",
  "fs2",
@@ -6445,7 +6445,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-rust-worker"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "sceneworks-worker",
  "tokio",
@@ -6453,7 +6453,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-worker"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "axum",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 rust-version = "1.80"
 license-file = "LICENSE"

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/desktop",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/desktop",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "devDependencies": {
         "@tauri-apps/cli": "^2",
         "ajv": "8.20.0"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/desktop",
   "private": true,
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "SceneWorks desktop shell (Tauri).",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SceneWorks",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "identifier": "net.trefry.sceneworks",
   "build": {
     "frontendDist": "ui",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/web",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/web",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "dependencies": {
         "konva": "^9.3.22",
         "react": "18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/web",
   "private": true,
-  "version": "0.8.4",
+  "version": "0.8.5",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sceneworks",
   "private": true,
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Local AI image and video generation studio runtime skeleton.",
   "license": "AGPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
Version bump to `0.8.5` on the release line.

Synced by `scripts/release.mjs` / `scripts/sync-version.mjs`:
root `package.json`, `apps/desktop` + `apps/web` (package.json + package-lock.json),
`apps/desktop/tauri.conf.json`, `Cargo.toml` `[workspace.package]`, and `Cargo.lock`.

Version-only diff — no inference pin change. The pin stays at
`5ed990bd302cbc868c73dcbb17f2a5296843267e` (inference `release/next`, sc-18229).

Release content since `release/0.8.4`:

- sc-18229 — pin inference for the SCAIL-2 decode-tiling fix (#2203)
- sc-18198 — pin inference for the SCAIL-2 lightning q4/q8 fix (#2198)
- sc-18200 — honor extra-compatible families in the detected-family gate (#2195)
- sc-18196 — resync the LoRA catalog when the install badge is stale (#2193)
- sc-18182 — surface an OOM-killed Mac worker instead of freezing the UI (#2189)

After this merges, `release/0.8.5` and `v0.8.5` are cut from `release/next`
per [RELEASING.md](../blob/main/RELEASING.md).