### PR TITLE
docs: mark calibration-cost-model references retired by sc-18100 (sc-18231)

### DIFF
--- a/docs/calibration-invalidation-sc-17774.md
+++ b/docs/calibration-invalidation-sc-17774.md
@@ -174,7 +174,8 @@ that by default.
 
 The captured-half gate exists because grading only `config/inference-provider-closures.json` left the
 other side of every comparison — 65 record digests and 31 manifest bindings — checked by nothing. That
-was not hypothetical: a constant in `scripts/sc-15833-flux2-evidence.test.mjs` carried the comment
+was not hypothetical: a constant in `scripts/sc-15833-flux2-evidence.test.mjs` *(deleted in
+sc-18100 with its one-shot)* carried the comment
 "derive it with …" and had never been a real derivation, and it survived the whole of sc-17774
 unnoticed. A plain dry run reports drift and still exits 0, which is right for a pin-bump preview and
 useless as a gate, so `--verify` is a separate mode that fails on any drift and ignores `--restamp`.
@@ -205,15 +206,18 @@ reaches. The orphan check is what makes "every digest is graded" a fact: droppin
 checked by nothing, and the skipped-block check alone does not see either. Both are checked before
 drift, because "this digest is not covered" outranks "this covered digest moved".
 
-Two test-fixture constants were the same shape of hole and are now derived instead of transcribed:
+Two test-fixture constants were the same shape of hole and were re-derived instead of transcribed:
 `SUPERSEDED_KREA_CLOSURE_DIGEST` (`scripts/generate-memory-matrix.test.mjs`) and the sc-15833
-constant (`scripts/sc-15833-flux2-evidence.test.mjs`) are read out of the evidence bundle through
+constant (`scripts/sc-15833-flux2-evidence.test.mjs`) were read out of the evidence bundle through
 `recordsNeedingDigest` — the gate's own eligibility predicate — so they inherit the CI derivation
 rather than sitting beside it. A wrong value in either did not fail anything; it made the test assert
-the right verdict for the wrong reason, which is exactly how `820bf106…` hid. By contrast the two
-constants in `scripts/sc-15823-flux1-evidence.mjs` are deliberately left as they are: that script
-*feeds* the evidence bundle, so its values land in records the gate re-derives and a drift there
-already surfaces.
+the right verdict for the wrong reason, which is exactly how `820bf106…` hid. *(As of sc-18100 the
+sc-15833 evidence test no longer exists; the krea constant in
+`scripts/generate-memory-matrix.test.mjs` is the surviving instance of the pattern.)* By contrast the
+two constants in `scripts/sc-15823-flux1-evidence.mjs` were deliberately left as they were: that
+script *fed* the evidence bundle, so its values land in records the gate re-derives and a drift there
+already surfaced. *(That one-shot is also gone as of sc-18100; the records it wrote remain in the
+bundle and stay under `backfill-closure-digests.mjs --verify`.)*
 
 The CI re-derivation matters more than it looks. Without it the currency term is checked-in data
 that nothing grades — a hand-edited digest would pass. `SceneWorks/inference` is public, so the

--- a/docs/calibration-invalidation-sc-17774.md
+++ b/docs/calibration-invalidation-sc-17774.md
@@ -97,9 +97,10 @@ node scripts/inference-closure-digest.mjs --repo <inference clone> --write
 node scripts/backfill-closure-digests.mjs --repo <inference clone> --write
 ```
 
-Then regenerate the derived docs (`npm run generate:memory-matrix`,
-`npm run generate:calibration-cost-model`). `scripts/bump-inference.mjs` refuses a bump that would
-leave the closure config behind, and names both commands.
+Then regenerate the derived docs (`npm run generate:memory-matrix`). `scripts/bump-inference.mjs`
+refuses a bump that would leave the closure config behind, and names the command. *(sc-18100
+retired `generate:calibration-cost-model` along with the cost model itself; the staleness signal
+that table used to carry is read from `npm run report:stale-lanes` instead.)*
 
 **Lanes whose closure did not move stay `current` across the bump.** Only the ones that actually
 changed are demoted, and the regenerated files show which.
@@ -233,7 +234,7 @@ Three classes, and only the first would be re-measurement pressure:
 | --- | --- | --- |
 | **currency / re-measurement** | *(none)* | nothing in the composite demands a re-capture, and nothing may be added that does |
 | **integrity of the evidence and the table** | `check:memory-calibration` (schema + well-formedness of every record, `harnessVersion`, `evidenceSemantics`'s fail-closed "record carries no digest" / "lane is undeclared"); `inference-closure-digest.mjs --check` and `backfill-closure-digests.mjs --verify` in `check.yml`; `bump-inference.mjs`'s refusal of a pin bump that leaves `config/inference-provider-closures.json` un-regenerated | **stays.** These answer "is this data real and well-formed", never "is it recent" |
-| **derived-artifact consistency** | `check:rust-derived-docs` (`check:memory-matrix`, `check:calibration-cost-model`, `check:tier-integrity`) in `check`, `rust:check` and pre-push | **stays.** A closure digest that rotates changes the matrix's *source fingerprint* (and its content when a lane's currency actually flips); the remedy is `npm run generate:memory-matrix`, which is mechanical, sub-second, and needs no GPU, no weights and no capture |
+| **derived-artifact consistency** | `check:rust-derived-docs` (`check:memory-matrix`, `check:tier-integrity`; `check:calibration-cost-model` was a third member until sc-18100 retired it with its generator) in `check`, `rust:check` and pre-push | **stays.** A closure digest that rotates changes the matrix's *source fingerprint* (and its content when a lane's currency actually flips); the remedy is `npm run generate:memory-matrix`, which is mechanical, sub-second, and needs no GPU, no weights and no capture |
 
 Measured on the corpus at `40fa7583`: **every** measured lane is stale — 9 declared lanes, 8 of them
 carrying at least one binding or record, 0 of those closure-current, 1 declared but never captured;

--- a/docs/inference-artifact-audit-sc-17497.md
+++ b/docs/inference-artifact-audit-sc-17497.md
@@ -514,7 +514,8 @@ Moving the live pin at all — with or without a build — also means:
   every audited object is `capturedObject === compatibleObject` — true only on the free path;
 - `crates/sceneworks-worker/src/candle_memory_strategy.rs`'s binding test, which asserts the literal
   revision pair;
-- the evidence-classification test in `scripts/calibration-cost-model.test.mjs` and
+- the evidence-classification test in `scripts/generate-memory-matrix.test.mjs` (rehomed there by
+  sc-18100 from the deleted `scripts/calibration-cost-model.test.mjs`) and
   `tests/test_memory_matrix.py::test_calibration_evidence_is_schema_valid_and_matrix_ingested` on the
   parity lane.
 

--- a/docs/inference-artifact-audit-sc-17497.md
+++ b/docs/inference-artifact-audit-sc-17497.md
@@ -39,7 +39,7 @@ possibly have altered a single instruction.
 
 "The compiled code is identical" is the claim, so the audit hashes the thing that runs. Three
 candidate units were measured before choosing (fixture reproduced in
-`scripts/inference-artifact-audit.test.mjs`):
+`scripts/inference-artifact-audit.test.mjs`, deleted with the rest of the audit in sc-17774):
 
 | Unit | Doc-comment edit | `#[inline]` body `*7` → `*8` | Verdict |
 | --- | --- | --- | --- |
@@ -49,7 +49,8 @@ candidate units were measured before choosing (fixture reproduced in
 
 The binary hashed is the one that produced the measurements: the `candle-gen-flux2` **lib test
 binary** carrying `tests::flux2_dev_probed_generate_for_offload_ab` — the target named in the
-approved capture command that `scripts/sc-15833-flux2-evidence.mjs` prints.
+approved capture command that `scripts/sc-15833-flux2-evidence.mjs` printed *(a one-shot; as of
+sc-18100 it no longer exists, and nothing prints that command)*.
 
 Confirmed on the real closure at the real revisions, **on the Metal lane**: `277f4238` and
 `d2216f6b` — the pin bump the doc comment blocked — both produce
@@ -358,8 +359,9 @@ this is where it would appear.
 
 Two caveats on the field itself, so it is not read as more than it is. It is **descriptive, not
 gated**: it is outside the hashed text (folding it in would make a dev-dependency edit demand a
-re-capture) and neither validator checks it — for the shipped record it is pinned by
-`sc-15833-flux2-evidence.test.mjs`, and a future record's is not. And the tool reports a *change* in
+re-capture) and neither validator checks it — for the shipped record it was pinned by
+`sc-15833-flux2-evidence.test.mjs` *(deleted in sc-18100; no surviving test pins it)*, and a future
+record's is not. And the tool reports a *change* in
 it across the window only when the shipped witness held still: the delta is `measured − shipped`, so
 widening the shipped side widens the delta too, and reporting it there put the primary finding under
 the wrong name. Either way the record is still written and the run still exits 1.
@@ -509,8 +511,10 @@ Moving the live pin at all — with or without a build — also means:
 - the five `flux2_dev` `compatibleInferenceRevision` bindings in
   `config/manifests/builtin.models.jsonc`;
 - `SOURCE_PATHS.inferenceCompatibility` (`scripts/generate-memory-matrix.mjs`) and the same filename
-  hardcoded in `scripts/sc-15833-flux2-evidence.test.mjs`;
-- `LIVE_INFERENCE_REVISION` in `scripts/sc-15833-flux2-evidence.test.mjs`, and its assertion that
+  hardcoded in `scripts/sc-15833-flux2-evidence.test.mjs` *(the key left `SOURCE_PATHS` when
+  sc-17774 deleted the audit; the test went with its one-shot in sc-18100)*;
+- `LIVE_INFERENCE_REVISION` in `scripts/sc-15833-flux2-evidence.test.mjs` *(deleted in sc-18100)*,
+  and its assertion that
   every audited object is `capturedObject === compatibleObject` — true only on the free path;
 - `crates/sceneworks-worker/src/candle_memory_strategy.rs`'s binding test, which asserts the literal
   revision pair;

--- a/docs/memory-strategy-pipeline-target-design.md
+++ b/docs/memory-strategy-pipeline-target-design.md
@@ -882,7 +882,7 @@ would have left the contract half-named: `gen_core::registry::ImageMemoryRegistr
 | schemas | `packages/schemas/image-memory-{matrix,calibration}.schema.json` → `memory-{matrix,calibration}.schema.json` |
 | generated | `docs/generated/image-memory-{matrix.json,matrix.md,calibration-evidence.json}` → `memory-*` |
 | config | `config/image-memory-calibration-plan.json` → `config/memory-calibration-plan.json` |
-| scripts | `generate-image-memory-matrix.mjs`, `image-memory-calibration-harness.mjs`, their tests, the four `scripts/fixtures/image-memory-provider-*.mjs`, plus the path/identifier citations in `bump-inference.mjs`, `platform-review-contracts.test.mjs`, `split-memory-strategy-stories.mjs`, and the four `package.json` npm scripts |
+| scripts | `generate-image-memory-matrix.mjs`, `image-memory-calibration-harness.mjs`, their tests, the four `scripts/fixtures/image-memory-provider-*.mjs`, plus the path/identifier citations in `bump-inference.mjs`, `platform-review-contracts.test.mjs`, `split-memory-strategy-stories.mjs` *(one-shot, since deleted in sc-18100)*, and the four `package.json` npm scripts |
 | tests | `tests/test_image_memory_matrix.py` → `tests/test_memory_matrix.py` |
 | docs | `image-memory-strategy-contract.md`, `image-memory-calibration-harness.md`, this file |
 


### PR DESCRIPTION
## Summary
sc-18100 (PR #2201) deleted `scripts/calibration-cost-model.mjs`, its two committed artifacts, and the `generate:`/`check:calibration-cost-model` npm scripts. Three references survived; this PR reconciles each with the current mechanism rather than deleting the retained analysis docs.

Per-site disposition:
- **docs/calibration-invalidation-sc-17774.md "Bumping the pin"** — was a live instruction to run `npm run generate:calibration-cost-model` after a pin bump. Rewritten: the regen step is `generate:memory-matrix` alone, with a note that the staleness signal is now read via `npm run report:stale-lanes`.
- **docs/calibration-invalidation-sc-17774.md gate table** — listed `check:calibration-cost-model` as a current member of `check:rust-derived-docs`. Corrected to the actual composite (`check:memory-matrix`, `check:tier-integrity`), noting the third member was retired with its generator in sc-18100.
- **docs/inference-artifact-audit-sc-17497.md pin-move checklist** — cited the evidence-classification test in the deleted `scripts/calibration-cost-model.test.mjs`. Repointed at its rehomed location, `scripts/generate-memory-matrix.test.mjs`.

A repo-wide grep found four further mentions (`docs/calibration-runbook.md:541`, `scripts/bump-inference.mjs:274`, `scripts/generate-memory-matrix.test.mjs:2936`, `scripts/platform-review-contracts.test.mjs:523`) — all are deliberate sc-18100 provenance comments about the deletion itself and are left untouched. No live consumer of the deleted artifacts exists.

## Widened sweep (second commit)
An independent review of #2201 found more stale references to **other** one-shots that PR deleted (`sc-15833-flux2-evidence.{mjs,test.mjs}`, `sc-15823-flux1-evidence.mjs`, `split-memory-strategy-stories.mjs`). Same policy, each site verified deleted at `origin/main` and each surviving mechanism name-checked before being cited:

- **docs/inference-artifact-audit-sc-17497.md:52** — the capture-command sentence pointed the reader at the command `sc-15833-flux2-evidence.mjs` prints. Re-tensed with a note: the one-shot no longer exists and nothing prints that command.
- **docs/inference-artifact-audit-sc-17497.md:362** — claimed the shipped record's `featureWitness` "is pinned by" the deleted test. Corrected to past tense with an explicit "no surviving test pins it" (verified: no `featureWitness`/`LIVE_INFERENCE_REVISION` reference survives outside docs and the committed calibration records).
- **docs/inference-artifact-audit-sc-17497.md:512-513** — pin-move checklist items telling the reader to update constants in the deleted test. Marked deleted (and the `SOURCE_PATHS.inferenceCompatibility` key noted as having left with sc-17774's audit — verified absent from `generate-memory-matrix.mjs`).
- **docs/inference-artifact-audit-sc-17497.md:42** *(bonus, same class)* — the fixture citation of `scripts/inference-artifact-audit.test.mjs` is dated to its sc-17774 deletion.
- **docs/calibration-invalidation-sc-17774.md:177** — historical anecdote about the constant that hid in the sc-15833 test; short deleted-in-sc-18100 note.
- **docs/calibration-invalidation-sc-17774.md:209-216** — present-tense claim that two constants "are read" via `recordsNeedingDigest`. Re-tensed: the krea constant in `scripts/generate-memory-matrix.test.mjs` is the surviving instance (verified), and the sc-15823 feeder one-shot's records remain in the bundle under `backfill-closure-digests.mjs --verify` (verified: 20 sc-15823 mentions, 65 record digests in the shipped bundle).
- **docs/memory-strategy-pipeline-target-design.md:885** — rename-inventory table row citing `split-memory-strategy-stories.mjs`; marked as a since-deleted one-shot.

## Testing
- `node scripts/check-source-control-bytes.mjs` green; docs-only change, no script or CI gate scans these docs by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
