### PR TITLE
test(scripts): derive the stale-lane digest count from the locator's own comment-excluding scan (sc-18208)

### DIFF
--- a/scripts/backfill-closure-digests.mjs
+++ b/scripts/backfill-closure-digests.mjs
@@ -104,6 +104,28 @@ function maskLine(line) {
 }
 
 /**
+ * Every `"inferenceClosureDigest": "<64hex>"` occurrence outside a `//` comment tail, as
+ * `{ line, column }` (both zero-based), scanned per occurrence rather than per line.
+ *
+ * This is THE definition of "a digest the manifest carries": the orphan scan in `stampManifest`
+ * consumes it, and it is exported (sc-18208) so `stale-lane-report.test.mjs` can derive its
+ * population-coverage count from the gate's own predicate. The test used to re-count with a
+ * resembling regex over the raw body, which also matched digest shapes QUOTED IN COMMENTS — clean
+ * today, but one doc comment quoting the shape away from false-redding a required check.
+ */
+export function digestOccurrences(lines) {
+  const occurrences = [];
+  lines.forEach((line, index) => {
+    const limit = commentColumn(line);
+    for (const match of line.matchAll(new RegExp(DIGEST_KEY, "g"))) {
+      if (match.index >= limit) break;
+      occurrences.push({ line: index, column: match.index });
+    }
+  });
+  return occurrences;
+}
+
+/**
  * Refuse to touch a manifest containing `/* … *\/` block comments.
  *
  * Everything here is line-scoped, so a comment spanning lines would be read as code: its braces
@@ -352,16 +374,12 @@ export function stampManifest(body, digestFor) {
   // covers everything" being enforced and being asserted. Scanned per occurrence rather than per
   // line, for the same reason `claimed` is keyed by column.
   const orphans = [];
-  lines.forEach((line, index) => {
-    const limit = commentColumn(line);
-    for (const match of line.matchAll(new RegExp(DIGEST_KEY, "g"))) {
-      if (match.index >= limit) break;
-      if (claimed.has(`${index}:${match.index}`)) continue;
-      orphans.push(
-        `line ${index + 1}: an inferenceClosureDigest no inferenceRevision/provider pair reaches`,
-      );
-    }
-  });
+  for (const { line, column } of digestOccurrences(lines)) {
+    if (claimed.has(`${line}:${column}`)) continue;
+    orphans.push(
+      `line ${line + 1}: an inferenceClosureDigest no inferenceRevision/provider pair reaches`,
+    );
+  }
 
   return { body: lines.join("\n"), stamped, skipped, orphans, located };
 }

--- a/scripts/stale-lane-report.test.mjs
+++ b/scripts/stale-lane-report.test.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { digestOccurrences } from "./backfill-closure-digests.mjs";
 import { deriveMargins } from "./derive-ladder-margins.mjs";
 import { inferencePinFromCargo } from "./inference-closure-digest.mjs";
 import {
@@ -253,14 +254,38 @@ test("the located binding population covers every closure digest the manifest ca
   // `inferenceClosureDigest` occurrence, and a population walk that cannot see it reds here. Same
   // "derive coverage from the source" discipline the pre-push trigger test applies. A
   // `calibrations[]`-only walk fails this by two on the shipped manifest.
+  // The occurrence count comes from `digestOccurrences` — the SAME comment-excluding scan the
+  // locator's own orphan check consumes — not a resembling regex over the raw body (sc-18208). The
+  // manifest is JSONC and narrates digest provenance in prose, so a raw-body regex also counts a
+  // digest shape quoted inside a `//` comment and would false-red this check the day one lands.
   const manifestBody = await readFile(MANIFEST_PATH, "utf8");
   const { manifest } = await loadSources();
   const located = manifestBindings({ manifestBody, manifest });
-  const occurrences = [...manifestBody.matchAll(/"inferenceClosureDigest":\s*"[0-9a-f]{64}"/g)].length;
+  const occurrences = digestOccurrences(manifestBody.split("\n")).length;
   assert.ok(occurrences > 0, "the manifest carries closure digests at all");
   assert.equal(located.length, occurrences, "every manifest closure digest is in the population");
   assert.ok(located.every((item) => /^(mlx|candle):.+/.test(item.lane)));
   assert.ok(located.every((item) => item.digest === null || /^[0-9a-f]{64}$/.test(item.digest)));
+});
+
+test("a digest shape quoted in a // comment is not part of the population, nor of the derived count", () => {
+  // Regression guard for the sc-18208 fix above. The commented copy of the binding shape must be
+  // invisible to BOTH sides of the coverage equation: the locator (which would otherwise report an
+  // orphan and refuse) and the occurrence count (which would otherwise exceed the population and
+  // false-red the coverage test on a perfectly healthy manifest).
+  const models = [{ id: "alpha_model", mlx: { calibrations: [binding("alpha", OLD)] } }];
+  const body = JSON.stringify({ models }, null, 2);
+  const commented =
+    `// provenance prose quoting the shape: "inferenceClosureDigest": "${digest("f")}"\n${body}`;
+
+  assert.equal(digestOccurrences(commented.split("\n")).length, 1, "the commented digest is not counted");
+  const located = manifestBindings({ manifestBody: commented, manifest: { models } });
+  assert.equal(located.length, digestOccurrences(commented.split("\n")).length);
+  assert.deepEqual(located.map((item) => item.digest), [OLD]);
+
+  // The exact hazard the raw-body regex had: it sees 2 where the gate's own predicate sees 1.
+  const naive = [...commented.matchAll(/"inferenceClosureDigest":\s*"[0-9a-f]{64}"/g)].length;
+  assert.equal(naive, 2, "a resembling raw-body regex DOES count the commented digest");
 });
 
 test("the real corpus reports the margins the worker actually applies", async () => {


### PR DESCRIPTION
## Story

[sc-18208](https://app.shortcut.com/sceneworks/story/18208) — stale-lane-report derived-count regex should exclude comment regions (relates to sc-18098).

## Problem

`scripts/stale-lane-report.test.mjs`'s population-coverage test ("the located binding population covers every closure digest the manifest carries") counted `"inferenceClosureDigest": "<64hex>"` occurrences with a raw-body regex over `config/manifests/builtin.models.jsonc`. The manifest is JSONC and narrates digest provenance in `//` comments, so a future doc comment quoting that shape would inflate the count past the locator's population and false-red a required check on every PR. Today it happens to be clean (33 matches, 0 in comments) — this fixes it before it isn't.

## Fix

Per the repo principle that a derived constant inherits a gate only via the gate's OWN predicate:

- `scripts/backfill-closure-digests.mjs`: extracted the orphan scan's per-occurrence, `commentColumn`-limited digest walk into an exported `digestOccurrences(lines)`, and the orphan scan now consumes it. This makes it THE single definition of "a digest the manifest carries" — not a helper that merely resembles the gate.
- `scripts/stale-lane-report.test.mjs`: the coverage test now derives its occurrence count from `digestOccurrences` instead of its own regex, so the count and the locator's orphan check share one predicate by construction.
- New regression test: a digest shape quoted in a `//` comment changes neither the located population nor the derived count, and (documented in the same test) the old raw-body regex DOES count it — 2 where the gate sees 1.

Kept `located.length === occurrences` (rather than `located.filter((item) => item.digest).length`) deliberately: comparing the locator to itself would be circular, and the unfiltered form additionally reds if the shipped manifest ever carries a binding with no digest key.

## Mutation evidence

Temporarily removed the `commentColumn` limit from `digestOccurrences` (making it count comment-region matches). Result: 2 failures —
- `a digest shape quoted in a // comment is not part of the population, nor of the derived count` (the new test), and
- `a 64-hex value quoted inside a COMMENT is never mistaken for the digest key` (the existing backfill suite test, which now also flows through the shared helper — confirming the orphan scan and the derived count red together).

Restored; both suites green.

## Validation

- `node --test scripts/stale-lane-report.test.mjs scripts/backfill-closure-digests.test.mjs` — 50/50 pass
- `npm run check` — exit 0, 344/344 node tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)