### PR TITLE
fix(worker): make candle deep-rung estimate floors composition-aware (sc-18253)

### DIFF
--- a/crates/sceneworks-worker/src/candle_memory_strategy.rs
+++ b/crates/sceneworks-worker/src/candle_memory_strategy.rs
@@ -479,7 +479,14 @@ fn estimate_floor_parameters(
 /// * Rungs 2–4 bound transients/residency the manifest has NOT measured for this cell, so they
 ///   take the STAGED floor unreduced — selectable without promising an unmeasured saving. (Where a
 ///   measured record for a rung exists it is a `verified_candidates` candidate and supersedes the
-///   floor in the selector.)
+///   floor in the selector.) The staged row prices the staged WORKING SET, so it is a sound floor
+///   only for a composition that actually engages `StagedResidency` (sc-18253). A provider may
+///   implement a deep rung whose engaged composition excludes staging
+///   (`gen_core::MemoryProviderContract::engaged_composition`) — such a request runs whole-model
+///   resident, so its floor clamps to the RESIDENT estimate instead: the candle mirror of the MLX
+///   floor's `engaged.contains(&StagedResidency)` max-vs-sum split
+///   (`mlx_fit_gate::estimate_floor_weights_bytes`), which keeps the rung selectable without ever
+///   under-predicting a resident working set behind the estimate margin.
 ///
 /// The candle estimate margin is NOT applied here — the selector owns margin widening
 /// (`crate::memory_strategy::select_strategy`), exactly as it owns the sc-18095 stale widening.
@@ -528,7 +535,14 @@ fn synthesize_estimate_floors(
         if contract.validate_selection(&selection).is_err() {
             continue;
         }
-        let predicted_peak_bytes = staged_floor_bytes;
+        // sc-18253: the staged row is only a sound floor for a composition that engages staging;
+        // a deep rung excluding `StagedResidency` runs whole-model resident and clamps to the
+        // resident estimate (see the doc comment above).
+        let predicted_peak_bytes = if engaged.contains(&MemoryStrategy::StagedResidency) {
+            staged_floor_bytes
+        } else {
+            resident_peak_bytes
+        };
         tracing::info!(
             route = engine_id,
             backend = "candle",
@@ -1627,6 +1641,263 @@ mod tests {
         assert_eq!(
             uncertified_roomy.context.selection.strategy,
             MemoryStrategy::Resident
+        );
+    }
+
+    /// A synthetic provider contract with every rung implemented and rungs 2-4 pinned to either
+    /// side of the staging composition split (sc-18253). `bind_deep_rungs_to_staging` mirrors the
+    /// shipped z-image contract's `additional_prerequisites` edges; without them the gen-core
+    /// default composition excludes `StagedResidency` from every deep rung. `staged_implemented`
+    /// false models the finding's contract — a provider implementing deep rungs with no staging
+    /// rung at all.
+    fn composition_probe_contract(
+        staged_implemented: bool,
+        bind_deep_rungs_to_staging: bool,
+    ) -> gen_core::MemoryProviderContract {
+        let mut contract = gen_core::MemoryProviderContract::compatibility_default(
+            "z_image_turbo",
+            gen_core::MemoryBackendRealization::CandleCuda {
+                device_residency: true,
+                host_backed_weights: true,
+                host_to_device_block_materialization: true,
+                block_materialization: gen_core::MemoryWindowMaterialization::DeviceFormatTransfer,
+            },
+        );
+        contract.strategies = MemoryStrategy::ALL
+            .into_iter()
+            .map(|strategy| gen_core::MemoryStrategyCapability {
+                strategy,
+                support: if strategy == MemoryStrategy::StagedResidency && !staged_implemented {
+                    gen_core::MemoryStrategySupport::Missing
+                } else {
+                    gen_core::MemoryStrategySupport::Implemented
+                },
+                parameters: match strategy {
+                    MemoryStrategy::BoundedDecode => gen_core::MemoryParameterRanges {
+                        decode_tile_edges: vec![512],
+                        decode_overlaps: vec![128],
+                        ..Default::default()
+                    },
+                    MemoryStrategy::BoundedAttention => gen_core::MemoryParameterRanges {
+                        attention_chunk_sizes: vec![1024],
+                        ..Default::default()
+                    },
+                    MemoryStrategy::BoundedTransformerResidency => {
+                        gen_core::MemoryParameterRanges {
+                            transformer_window_sizes: vec![1],
+                            ..Default::default()
+                        }
+                    }
+                    _ => Default::default(),
+                },
+            })
+            .collect();
+        contract.lifecycle = gen_core::MemoryLifecycleCapabilities {
+            phases: vec![
+                gen_core::MemoryPhase::Conditioning,
+                gen_core::MemoryPhase::Denoise,
+                gen_core::MemoryPhase::Decode,
+            ],
+            synchronized_phase_release: true,
+            decode_tiling: true,
+            attention_chunking: true,
+            transformer_window_materialization: true,
+        };
+        // Rung 4's SHARED prerequisite is the deferred load shape, not staged residency — which is
+        // exactly why a rung-4-without-staging contract is a legal shape.
+        contract.load_shape = gen_core::LoadShape::DeferredMaterialization;
+        contract.formula = gen_core::MemoryFormulaKind::AssetBytesPlusHeadroom;
+        contract.calibration = Some(gen_core::MemoryCalibrationIdentity::new(
+            "sc-18253-composition-probe-v1",
+            gen_core::LoadShape::DeferredMaterialization,
+        ));
+        if bind_deep_rungs_to_staging {
+            contract.additional_prerequisites = [
+                MemoryStrategy::BoundedDecode,
+                MemoryStrategy::BoundedAttention,
+                MemoryStrategy::BoundedTransformerResidency,
+            ]
+            .into_iter()
+            .map(|strategy| {
+                (
+                    strategy,
+                    gen_core::MemoryStrategyPrerequisite::Rung {
+                        rung: MemoryStrategy::StagedResidency,
+                        scope: gen_core::MemoryPrerequisiteScope::EngagedInSameRequest,
+                    },
+                )
+            })
+            .collect();
+        }
+        contract
+    }
+
+    /// sc-18253: the staged manifest row prices the staged WORKING SET, so it is only a sound
+    /// floor for a composition that actually engages `StagedResidency`. The gen-core engagement
+    /// mechanism permits a provider to implement a deep rung whose engaged composition excludes
+    /// staging — such a request runs whole-model resident, so its floor must clamp to the
+    /// RESIDENT estimate (the candle mirror of the MLX floor's
+    /// `engaged.contains(&StagedResidency)` max-vs-sum split) instead of under-predicting a whole
+    /// resident working set behind only the estimate margin.
+    ///
+    /// Both mutation directions are pinned:
+    ///  * deleting the composition check (every deep rung takes the staged row again) flips the
+    ///    staging-free contract's deep-rung assertions red;
+    ///  * inverting it (clamping every optimized floor to the resident row) flips the staged
+    ///    rung's own assertion and the staging-bound contract's deep-rung assertions red.
+    #[test]
+    fn deep_rung_floors_follow_the_engaged_composition_not_the_rung_ordinal() {
+        let manifest = json!({
+            "candle": {
+                "vramGbByTier": { "q4": 6.0 },
+                "sequentialPeakGb": { "q4": 2.5 },
+                "supportsSequentialOffload": true
+            }
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let geometry = MemoryGeometry {
+            width: 1024,
+            height: 1024,
+            batch: 1,
+            frames: 1,
+            reference_count: 0,
+        };
+        let resident_peak_bytes = (8.0 * BYTES_PER_GIB) as u64;
+        let staged_floor_bytes =
+            ((2.5 + crate::vram_gate::HEADROOM_GB) * BYTES_PER_GIB).ceil() as u64;
+        assert_ne!(
+            resident_peak_bytes, staged_floor_bytes,
+            "the two floor sources must be distinguishable for the assertions below to bite"
+        );
+        let floors = |contract: &gen_core::MemoryProviderContract| {
+            synthesize_estimate_floors(
+                "z_image_turbo",
+                contract,
+                &manifest,
+                "q4",
+                numeric_tier("q4").expect("q4 tier"),
+                &request_mode("z_image_turbo", "text_to_image"),
+                None,
+                geometry,
+                resident_peak_bytes,
+                0,
+                Z_IMAGE_REQUEST_EVIDENCE_REVISION,
+            )
+        };
+        let floor_of = |synthesized: &[(MemorySelection, MemoryEvidence)],
+                        strategy: MemoryStrategy| {
+            synthesized
+                .iter()
+                .find(|(selection, _)| selection.strategy == strategy)
+                .map(|(_, evidence)| evidence.predicted_peak_bytes)
+        };
+        const DEEP_RUNGS: [MemoryStrategy; 3] = [
+            MemoryStrategy::BoundedDecode,
+            MemoryStrategy::BoundedAttention,
+            MemoryStrategy::BoundedTransformerResidency,
+        ];
+
+        // Staging-free deep rungs (the gen-core default composition — no staged prerequisite
+        // edges): the staged row must not price them.
+        let synthesized = floors(&composition_probe_contract(true, false));
+        assert_eq!(
+            floor_of(&synthesized, MemoryStrategy::StagedResidency),
+            Some(staged_floor_bytes),
+            "the staged rung itself still takes the staged working-set row"
+        );
+        for deep in DEEP_RUNGS {
+            assert_eq!(
+                floor_of(&synthesized, deep),
+                Some(resident_peak_bytes),
+                "a {deep:?} composition that excludes staging runs whole-model resident and must \
+                 clamp to the resident estimate, not the staged working-set row"
+            );
+        }
+
+        // Control: a contract that binds every deep rung to staging (the shipped z-image shape)
+        // keeps the staged working-set floor on those rungs — clamping regardless of composition
+        // would flip these red.
+        let synthesized = floors(&composition_probe_contract(true, true));
+        for rung in [
+            MemoryStrategy::StagedResidency,
+            MemoryStrategy::BoundedDecode,
+            MemoryStrategy::BoundedAttention,
+            MemoryStrategy::BoundedTransformerResidency,
+        ] {
+            assert_eq!(
+                floor_of(&synthesized, rung),
+                Some(staged_floor_bytes),
+                "a {rung:?} composition that engages staging keeps the staged working-set floor"
+            );
+        }
+    }
+
+    /// The end-to-end arm of sc-18253: the exact contract the finding names — deep rungs
+    /// implemented, no staging rung at all — must NOT admit a request on the staged row. Its
+    /// floors clamp to the resident estimate, nothing fits below the resident peak, and the lane
+    /// hands back to the established legacy gates (`None`). Before the composition check the
+    /// staging-free `BoundedDecode` floor took the staged row and ADMITTED here at a
+    /// whole-model-resident working set behind only the 4% estimate margin — deleting the check
+    /// flips this arm red.
+    #[test]
+    fn a_staging_free_ladder_never_admits_on_the_staged_row() {
+        let manifest = json!({
+            "candle": {
+                "vramGbByTier": { "q4": 6.0 },
+                "sequentialPeakGb": { "q4": 2.5 },
+                "supportsSequentialOffload": true
+            }
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let spec = LoadSpec::new(WeightsSource::Dir(PathBuf::from("missing-z-image-q4")));
+        // A budget where the WIDENED staged-row floor fits but the resident estimate (8.0 GiB)
+        // does not — recomputed from the policy margin, never a frozen literal.
+        let staged_row_floor_gb = 2.5 + crate::vram_gate::HEADROOM_GB;
+        let free_gb = staged_row_floor_gb
+            * (1.0 + crate::ladder_margin_policy::CANDLE_ESTIMATE_MARGIN)
+            + crate::vram_gate::HEADROOM_GB
+            + 0.3;
+        assert!(
+            free_gb - crate::vram_gate::HEADROOM_GB < 8.0,
+            "the budget must stay below the resident estimate to discriminate"
+        );
+        let evaluation = evaluate_shared_bespoke_image(
+            "z_image_turbo",
+            "z_image_turbo",
+            &spec,
+            true,
+            &manifest,
+            "q4",
+            "text_to_image",
+            None,
+            MemoryGeometry {
+                width: 1024,
+                height: 1024,
+                batch: 1,
+                frames: 1,
+                reference_count: 0,
+            },
+            false,
+            false,
+            false,
+            Some(VramBudget {
+                free_gb,
+                total_gb: 96.0,
+            }),
+            Some(8.0),
+            0,
+            MemoryCacheState::Cold,
+            composition_probe_contract(false, false),
+        )
+        .expect("staging-free bespoke evaluation");
+        assert!(
+            evaluation.is_none(),
+            "a staging-free deep rung must be graded at the resident clamp, not admitted on the \
+             staged working-set row"
         );
     }
 

--- a/crates/sceneworks-worker/src/krea_control_fit.rs
+++ b/crates/sceneworks-worker/src/krea_control_fit.rs
@@ -576,8 +576,13 @@ fn fit_ladder_for_tier(
     // The control lane's mirror of the estimate ladder: manifest-row floors, never a promised
     // unmeasured saving. The resident floor is the measured `peakGbByTier` row (with adapters
     // already folded into `peak`); the staged floor is the measured `sequentialPeakGbByTier` row
-    // where present, else the resident floor; every deeper rung takes the staged floor UNREDUCED —
-    // selectable without promising an unmeasured saving. Where a rung's savings ARE measured, its
+    // where present, else the resident floor; every deeper rung whose engaged composition
+    // includes `StagedResidency` takes the staged floor UNREDUCED — selectable without promising
+    // an unmeasured saving. The staged row prices the staged WORKING SET, so a deep rung whose
+    // engaged composition EXCLUDES staging (sc-18253 — the `engagedRungs` mechanism permits it)
+    // runs whole-model resident and clamps to the resident floor instead, mirroring the MLX
+    // floor's `engaged.contains(&StagedResidency)` max-vs-sum split
+    // (`mlx_fit_gate::estimate_floor_weights_bytes`). Where a rung's savings ARE measured, its
     // measured candidate exists in `measured` above and supersedes the floor in the selector, so
     // the priced 1024² ladder is byte-for-byte unchanged.
     //
@@ -629,10 +634,16 @@ fn fit_ladder_for_tier(
             if contract.validate_selection(&selection).is_err() {
                 continue;
             }
-            let floor_gb = if strategy == MemoryStrategy::Resident {
-                resident_floor_gb
-            } else {
+            let engaged = contract.engaged_composition(strategy);
+            // sc-18253: the staged row is only a sound floor for a composition that actually
+            // engages staging; a rung excluding `StagedResidency` runs whole-model resident and
+            // clamps to the resident floor (see the header comment above).
+            let floor_gb = if strategy != MemoryStrategy::Resident
+                && engaged.contains(&MemoryStrategy::StagedResidency)
+            {
                 staged_floor_gb
+            } else {
+                resident_floor_gb
             };
             let predicted_peak_bytes = bytes(floor_gb);
             tracing::info!(
@@ -654,7 +665,7 @@ fn fit_ladder_for_tier(
                         overlay: Some(overlay.clone()),
                         geometry: request_geometry,
                         strategy,
-                        engaged_composition: contract.engaged_composition(strategy),
+                        engaged_composition: engaged,
                         parameters: selection.parameters,
                     },
                     conformance: MemoryConformanceState::ImplementedUnverified,
@@ -1597,6 +1608,107 @@ mod tests {
                 estimate_scoped: false,
             }
         );
+    }
+
+    /// sc-18253: the staged `sequentialPeakGbByTier` row prices the staged WORKING SET, so it is
+    /// only a sound floor for a composition that actually engages `StagedResidency`. The gen-core
+    /// engagement mechanism permits a contract to implement a deep rung while excluding staging
+    /// (the default composition when no staged prerequisite edge is declared); such a request runs
+    /// whole-model resident and its floor must clamp to the resident row — the mirror of the MLX
+    /// floor's `engaged.contains(&StagedResidency)` max-vs-sum split.
+    ///
+    /// The request runs at 512² — inside the measured envelope, so the floors are synthesized,
+    /// while every measured 1024² candidate is structurally out-of-envelope. That isolates the
+    /// FLOOR values in the outcome: admission below the resident row is possible only through a
+    /// floor. Both mutation directions are pinned: deleting the composition check re-admits the
+    /// staging-free arm on the staged row (red), and inverting it (always the resident floor)
+    /// strands the registered control arm's staged rung at the resident row (red).
+    #[test]
+    fn a_staging_free_deep_rung_floor_clamps_to_the_resident_row() {
+        let request_geometry = MemoryGeometry {
+            width: 512,
+            height: 512,
+            batch: 1,
+            frames: 1,
+            reference_count: 0,
+        };
+        let peak = 40.0;
+        let sequential = 30.0;
+        let staged_floor = sequential - HEADROOM_GB;
+        let resident_floor = peak - HEADROOM_GB;
+        let margin = crate::ladder_margin_policy::CANDLE_ESTIMATE_MARGIN;
+        // An effective budget between the WIDENED staged floor and the resident floor: a rung
+        // priced on the staged row admits here; one clamped to the resident row cannot. Recomputed
+        // from the policy margin, never a frozen literal.
+        let free = staged_floor * (1.0 + margin) + HEADROOM_GB + 0.5;
+        assert!(
+            free - HEADROOM_GB < resident_floor,
+            "the budget must stay below the resident floor to discriminate"
+        );
+        let run = |contract: &MemoryProviderContract| {
+            fit_ladder_for_tier(
+                Some(contract),
+                "q4",
+                request_geometry,
+                Some(peak),
+                Some(sequential),
+                Some(budget(free)),
+                None,
+                None,
+                true,
+                true,
+                0.0,
+                &live_test_closure_digest(),
+            )
+        };
+
+        // Control: the registered q4 contract binds its deep rungs to staging, so the staged
+        // working-set floor stands and the ladder admits sequential staging at 512². Clamping
+        // every floor to the resident row regardless of composition would flip this red.
+        let registered = registered_contract_for_tier("q4").expect("registered control contract");
+        assert_eq!(
+            run(&registered),
+            KreaControlFit::Fits {
+                offload_policy: OffloadPolicy::Sequential,
+                tile_vae_decode: false,
+                chunk_attention: false,
+                estimate_scoped: true,
+            },
+            "a staging-engaged composition keeps the staged working-set floor"
+        );
+
+        // The finding's contract shape: decode/attention implemented, staging not implemented and
+        // no staged prerequisite edges — every deep rung's engaged composition excludes
+        // `StagedResidency`, so the request runs whole-model resident. Before sc-18253 those
+        // rungs took the staged row and ADMITTED here behind only the estimate margin; the clamp
+        // makes the ladder refuse at the widened RESIDENT floor instead. Deleting the composition
+        // check flips this arm back to `Fits` and red.
+        let mut staging_free = registered.clone();
+        staging_free.additional_prerequisites.clear();
+        for capability in &mut staging_free.strategies {
+            if capability.strategy == MemoryStrategy::StagedResidency {
+                capability.support = gen_core::MemoryStrategySupport::Missing;
+            }
+        }
+        match run(&staging_free) {
+            KreaControlFit::TooBig {
+                needed_gb,
+                available_gb,
+            } => {
+                // The refusal quotes the widened resident clamp (byte-ceil wiggle tolerated),
+                // proving the deep-rung floors were re-priced rather than merely excluded.
+                let expected_needed = resident_floor * (1.0 + margin) + HEADROOM_GB;
+                assert!(
+                    (needed_gb - expected_needed).abs() < 1e-6,
+                    "the refusal must quote the widened RESIDENT clamp: got {needed_gb}, want \
+                     {expected_needed}"
+                );
+                assert!((available_gb - free).abs() < 1e-6);
+            }
+            other => panic!(
+                "a staging-free deep rung must not admit on the staged working-set row: {other:?}"
+            ),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Story

[sc-18253](https://app.shortcut.com/sceneworks/story/18253) (bug) — Candle deep-rung estimate floors are not composition-aware; a rung-4-without-staging contract would under-predict massively.

## Problem

Both candle estimate-floor synthesizers priced every deep rung (2–4) off the STAGED manifest row unconditionally:

- `crates/sceneworks-worker/src/candle_memory_strategy.rs` — `synthesize_estimate_floors` (`predicted_peak_bytes = staged_floor_bytes` for every optimized rung)
- `crates/sceneworks-worker/src/krea_control_fit.rs` — the control-lane floor loop (`strategy == Resident ? resident : staged`)

That assumes every implemented deep rung's engaged composition includes `StagedResidency`. The gen-core engagement mechanism (`MemoryProviderContract::engages` / `engaged_composition`, pinned inference rev) explicitly permits a provider to implement a deep rung while excluding staging — the shared cost-order default does NOT engage rung 1 from rungs 2–4; only a declared `additional_prerequisites` edge does. Such a contract would run **whole-model resident** against a **staged-working-set floor**, under-predicting behind only the 4% `CANDLE_ESTIMATE_MARGIN`. MLX's floor is already composition-aware (`mlx_fit_gate.rs`, `estimate_floor_weights_bytes`: `engaged.contains(&StagedResidency)` picks max-vs-sum); the candle floors were not.

## Fix — clamp, not skip (mirroring MLX)

A floor whose engaged composition excludes `StagedResidency` now clamps to the **RESIDENT** row instead of taking the staged row, at both sites. Clamp rather than skip because that is what MLX does: it keeps such rungs selectable, charging the full resident weights sum instead of the staged max. Candle has no per-component byte decomposition — only manifest rows — so the resident row (`vramGbByTier` / `peakGbByTier`) is its coarsest sound equivalent of MLX's sum branch: the rung stays selectable, and no unmeasured saving is ever promised (the module's standing floor philosophy).

**Shipped behavior is byte-for-byte unchanged:** the pinned z-image candle contract binds rungs 2–4 to staging via `additional_prerequisites`, and the Krea control contract binds rungs 2–3 the same way (rung 4 is structurally N/A) — verified at the pinned inference rev `40fa7583`. Every live composition contains `StagedResidency` and keeps the staged floor; the fix bites only a future/drifted contract, which is exactly the finding's scenario.

## Tests (mutation-checked both directions, per site)

Margins/headroom recomputed from `CANDLE_ESTIMATE_MARGIN` / `HEADROOM_GB`, never frozen literals.

- `candle_memory_strategy::tests::deep_rung_floors_follow_the_engaged_composition_not_the_rung_ordinal` — unit-level: a synthetic contract with staging-free deep rungs must get the resident clamp on rungs 2–4 while the staged rung keeps the staged row; a staging-bound control contract keeps the staged row on all four.
- `candle_memory_strategy::tests::a_staging_free_ladder_never_admits_on_the_staged_row` — end-to-end through `evaluate_shared_bespoke_image` + the shared selector: the finding's exact contract (deep rungs implemented, no staging rung) must NOT admit at a budget where the widened staged row fits but the resident estimate does not.
- `krea_control_fit::tests::a_staging_free_deep_rung_floor_clamps_to_the_resident_row` — a 512² request isolates the floors (measured 1024² cells are structurally out-of-envelope): the registered q4 contract (staging-bound) admits sequential staging on its staged floor; the staging-free mutant refuses with `TooBig` quoting the widened RESIDENT clamp.

### Mutation evidence (run on Linux/candle cfg in Docker, sc-16903 recipe)

**Mutation A — delete the composition check (revert to pre-fix `staged` floor):** all three new tests red, per site:
```
FAILED candle_memory_strategy::tests::deep_rung_floors_follow_the_engaged_composition_not_the_rung_ordinal
  left: Some(4831838208)  right: Some(8589934592)   (BoundedDecode got the staged row)
FAILED candle_memory_strategy::tests::a_staging_free_ladder_never_admits_on_the_staged_row
FAILED krea_control_fit::tests::a_staging_free_deep_rung_floor_clamps_to_the_resident_row
  got: Fits { Sequential, tile_vae_decode: true, estimate_scoped: true }   (the under-prediction, admitted)
```

**Mutation B — invert the check (clamp every floor to resident):** the control arms red, per site:
```
FAILED candle_memory_strategy::tests::deep_rung_floors_follow_the_engaged_composition_not_the_rung_ordinal
  "the staged rung itself still takes the staged working-set row"
FAILED krea_control_fit::tests::a_staging_free_deep_rung_floor_clamps_to_the_resident_row
  got: TooBig { needed_gb: 41.52.. }  want: Fits { Sequential, estimate_scoped: true }
```

Fix restored: `49 passed; 0 failed` across both modules.

## Verification on this Mac (the changed modules are cfg'd `all(not(macos), backend-candle)`)

- `npm run rust:check:candle` — cross-target Linux typecheck of the real candle cfg incl. test targets under `-D warnings`: **green** (after `cargo fmt --all`).
- Docker `rust:1.96` (Linux/aarch64, fake-nvcc + stub-CUDA-libs recipe): `cargo test -p sceneworks-worker --features backend-candle --lib candle_memory_strategy:: krea_control_fit::` → **49/49 green**; mutation runs above.
- Native `cargo check` (default members): green. `cargo check --workspace` fails only on the pre-existing `apps/desktop` Tauri build-script sidecar requirement in a fresh worktree (outside default-members, unrelated to this change).
- The windows-candle CI lane (`cargo test -p sceneworks-worker --features backend-candle`) is the authoritative runner for these tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)