### PR TITLE
fix(report): clarify stale-lane operator guidance (sc-18212, sc-18252)

### DIFF
--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -48,7 +48,8 @@ Verified output shape (run on the sc-18212 branch at inference pin `40fa7583`):
 
 ```
 9 declared lanes: 8 stale, 0 current, 0 pending capture; 6 lanes (declared or planned) have no adapter arm, and 2 planned lanes were never declared.
-33 shipped calibration bindings and 65 evidence records are serving under a widened margin.
+33 shipped calibration bindings are serving under a widened margin; 65 eligible evidence records
+are stale corpus debt, not runtime inputs.
 
 #  LANE                         BINDINGS  RECORDS  MARGIN  ESTIMATE  IMPACT  CAPTURE  MODELS
 1  mlx:qwen_image               9/9       41/41    5.00%   10.00%    0.450   yes      qwen_image
@@ -57,8 +58,9 @@ Verified output shape (run on the sc-18212 branch at inference pin `40fa7583`):
 4  candle:flux1_dev             5/5       5/5      2.00%   4.00%     0.100   NO ARM   flux_dev
 ...
 DECLARED/PLANNED BUT UNCAPTURABLE — no adapter arm can serve these; a capture host booked for
-one is wasted (docs/calibration-runbook.md §2c). This is missing-adapter work, not measurement work:
-  candle:z_image  declared=yes  plan=90 entries (90 authoritative)  evidence=no evidence  status=uncapturable
+one is wasted (docs/calibration-runbook.md §2c). A declared lane needs adapter work before
+measurement; a planned-but-undeclared lane needs both an adapter arm and a closure declaration:
+  candle:z_image  declared=yes  plan=90 entries (90 authoritative)  bindings=0 shipped  records=0 eligible  status=uncapturable
   ...
 ```
 

--- a/scripts/stale-lane-report.mjs
+++ b/scripts/stale-lane-report.mjs
@@ -711,8 +711,8 @@ export function formatReport(report) {
       `planned) have no adapter arm, and ${totals.undeclaredLanes} planned lanes were never declared.`,
   );
   out.push(
-    `${totals.staleBindings} shipped calibration bindings and ${totals.staleRecords} evidence records ` +
-      "are serving under a widened margin.",
+    `${totals.staleBindings} shipped calibration bindings are serving under a widened margin; ` +
+      `${totals.staleRecords} eligible evidence records are stale corpus debt, not runtime inputs.`,
   );
   out.push("");
 
@@ -770,16 +770,16 @@ export function formatReport(report) {
       "DECLARED/PLANNED BUT UNCAPTURABLE — no adapter arm can serve these; a capture host booked for",
     );
     out.push(
-      "one is wasted (docs/calibration-runbook.md §2c). This is missing-adapter work, not measurement work:",
+      "one is wasted (docs/calibration-runbook.md §2c). A declared lane needs adapter work before",
+    );
+    out.push(
+      "measurement; a planned-but-undeclared lane needs both an adapter arm and a closure declaration:",
     );
     for (const lane of report.uncapturableLanes) {
-      const evidence =
-        (lane.bindings.total ?? 0) + (lane.records.total ?? 0) > 0
-          ? `${lane.bindings.total} bindings + ${lane.records.total} records captured by a retired arm`
-          : "no evidence";
       out.push(
         `  ${lane.lane}  declared=${lane.declared ? "yes" : "NO"}  plan=${lane.plan.entries} entries ` +
-          `(${lane.plan.authoritative} authoritative)  evidence=${evidence}  status=${lane.status}`,
+          `(${lane.plan.authoritative} authoritative)  bindings=${lane.bindings.total ?? 0} shipped  ` +
+          `records=${lane.records.total ?? 0} eligible  status=${lane.status}`,
       );
     }
   }

--- a/scripts/stale-lane-report.test.mjs
+++ b/scripts/stale-lane-report.test.mjs
@@ -681,16 +681,54 @@ test("a non-eligible record neither counts as stale nor flips a lane out of pend
 
 test("the human report separates pending capture from uncapturable, and prints the derivation", () => {
   const fixture = twoLaneFixture({
-    extraLanes: [["candle:gamma", digest("d")], ["candle:delta", digest("e")]],
-    plan: { providers: [planEntry("candle", "gamma"), planEntry("candle", "delta"), planEntry("candle", "epsilon", "candidate")] },
+    extraModels: [
+      // An armless lane with a shipped binding but no corpus record: the binding proves current
+      // admission state, not that a retired adapter arm captured anything.
+      { id: "theta_model", candle: { calibrations: [binding("theta", OLD)] } },
+    ],
+    extraLanes: [
+      ["candle:gamma", digest("d")],
+      ["candle:delta", digest("e")],
+      ["candle:theta", digest("f")],
+    ],
+    plan: {
+      providers: [
+        planEntry("candle", "gamma"),
+        planEntry("candle", "delta"),
+        planEntry("candle", "epsilon", "candidate"),
+        // Undeclared AND armless: the report must name both missing prerequisites, not imply that
+        // adding an adapter arm alone would make the lane measurable.
+        planEntry("candle", "zeta", "candidate"),
+      ],
+    },
     // No "beta" arm: the stale candle:beta lane doubles as the measured-but-armless case, so the
     // ranked table's CAPTURE column shows both values at once.
     adapterSources: { mlx: adapterSource(["alpha"]), candle: adapterSource(["gamma", "epsilon"]) },
   });
   const text = formatReport(buildStaleLaneReport(fixture));
+  assert.match(
+    text,
+    /9 shipped calibration bindings are serving under a widened margin; 3 eligible evidence records are stale corpus debt, not runtime inputs\./,
+  );
   assert.match(text, /PENDING CAPTURE \(declared, adapter arm exists, no measurement yet\): candle:gamma \(1 plan entries, 1 authoritative\)/);
   assert.match(text, /DECLARED\/PLANNED BUT UNCAPTURABLE/);
-  assert.match(text, /candle:delta\s+declared=yes\s+plan=1 entries \(1 authoritative\)\s+evidence=no evidence\s+status=uncapturable/);
+  assert.match(
+    text,
+    /candle:theta\s+declared=yes\s+plan=0 entries \(0 authoritative\)\s+bindings=1 shipped\s+records=0 eligible\s+status=stale/,
+  );
+  assert.match(
+    text,
+    /candle:delta\s+declared=yes\s+plan=1 entries \(1 authoritative\)\s+bindings=0 shipped\s+records=0 eligible\s+status=uncapturable/,
+  );
+  assert.match(
+    text,
+    /candle:zeta\s+declared=NO\s+plan=1 entries \(0 authoritative\)\s+bindings=0 shipped\s+records=0 eligible\s+status=undeclared/,
+  );
+  assert.match(
+    text,
+    /planned-but-undeclared lane needs both an adapter arm and a closure declaration/,
+  );
+  assert.doesNotMatch(text, /captured by a retired arm|evidence=.*bindings/);
   assert.match(text, /PLANNED BUT NEVER DECLARED/);
   assert.match(text, /candle:epsilon\s+plan=1 entries \(0 authoritative\)/);
   assert.match(text, /CAPTURE/);


### PR DESCRIPTION
## Summary

Follow-up to #2209 for sc-18212 and sc-18252. The stale-lane report's calculations and classifications were correct, but three operator-facing statements blurred distinct source-of-truth populations or implied incomplete remediation.

- Report shipped bindings and eligible corpus records as separate facts; never infer that a retired adapter arm captured a lane merely because a manifest binding exists.
- State that an uncapturable, undeclared planned lane needs both an adapter arm and a closure declaration before it can produce current evidence.
- Describe stale manifest bindings as the runtime admission surface and eligible evidence records as corpus debt, not runtime inputs.
- Keep the runbook's verified output sample byte-for-byte aligned with the report vocabulary.

## Regression coverage

The human-output fixture now includes:

- an armless lane with one shipped binding and zero records, proving a binding cannot turn into a claim about capture history;
- an armless, planned-but-undeclared lane, proving both missing prerequisites remain visible;
- exact positive assertions for the binding/corpus distinction and negative assertions against the retired-arm wording.

## Validation

- `node --test scripts/stale-lane-report.test.mjs` — 24 passed, 0 failed.
- `npm run report:stale-lanes` — output inspected; 33 serving bindings and 65 eligible corpus-debt records remain unchanged.
- `npm run check` — 370 passed, 0 failed; all repository checks green.
- `git diff --check` — clean.

Tracking: sc-18212, sc-18252.
