### PR TITLE
fix(image): stop the reference aspect snap clobbering the user's resolution (sc-18255)

### DIFF
--- a/apps/web/src/App.imageStudioReferenceSnap.test.jsx
+++ b/apps/web/src/App.imageStudioReferenceSnap.test.jsx
@@ -1,0 +1,314 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withImageStudioContext, FakeEventSource, response, settle } from "./main.testSupport.jsx";
+
+// sc-18255: picking an img2img reference auto-presets the Aspect to the bucket closest to the
+// reference's own aspect (sc-10195). That snap must fire ONCE per picked reference — the effect
+// also depends on the asset list, whose array identity changes on every refresh (a generation
+// completing, an SSE asset update, submitting a job). An unguarded re-run re-probed the reference
+// and clobbered the Aspect the user had since chosen, so a Krea 2 Turbo job configured at
+// 768x1024 was submitted at 1152x2048 (the 1080x1920 reference's closest bucket).
+const REFERENCE_ASSET = {
+  id: "asset-reference",
+  projectId: "project-1",
+  type: "image",
+  displayName: "Portrait reference",
+  file: { path: "assets/uploads/portrait.jpg", mimeType: "image/jpeg", width: 1080, height: 1920 },
+  status: { favorite: false, rating: 0, rejected: false, trashed: false },
+};
+
+const KREA_MODEL = {
+  id: "krea_2_turbo",
+  name: "Krea 2 Turbo",
+  type: "image",
+  family: "krea_2",
+  installed: true,
+  defaults: { resolution: "1024x1024", steps: 8 },
+  limits: { resolutions: ["1024x1024", "768x1024", "1152x2048"] },
+  // Both capabilities, like the real entry — the mode round-trip below needs the model to keep
+  // serving Edit mode so the option set stays stable across the trip.
+  capabilities: ["text_to_image", "edit_image"],
+  ui: { img2img: true, img2imgStrength: { default: 0.5, min: 0, max: 1, step: 0.05 } },
+};
+
+// A second img2img model with its OWN bucket list, for the model-switch case: the snap key is the
+// option set, so switching here must re-snap the reference onto this model's closest bucket rather
+// than leaving the model-defaults reset (1024x1024) standing against a 9:16 reference.
+const OTHER_MODEL = {
+  ...KREA_MODEL,
+  id: "z_image_turbo",
+  name: "Z-Image",
+  family: "z-image",
+  limits: { resolutions: ["1024x1024", "832x1216", "896x1600"] },
+};
+
+// A model with NO img2img panel. `img2imgReferenceAssetId` is never cleared on a model change, so a
+// reference armed elsewhere must stop steering the Aspect the moment the panel is gone.
+const NO_IMG2IMG_MODEL = {
+  ...OTHER_MODEL,
+  id: "flux2_klein_9b",
+  name: "FLUX.2 klein",
+  family: "flux2",
+  ui: {},
+};
+
+// jsdom's Image never loads, so probeImageDimensions would never fire. Stand in a version that
+// reports the reference's natural size on the next microtask, like a real decode would.
+function stubImageDecode(naturalWidth, naturalHeight) {
+  class ProbeImage {
+    constructor() {
+      this.naturalWidth = 0;
+      this.naturalHeight = 0;
+      this.onload = null;
+      this.onerror = null;
+    }
+    set src(value) {
+      this._src = value;
+      if (!value) return;
+      Promise.resolve().then(() => {
+        this.naturalWidth = naturalWidth;
+        this.naturalHeight = naturalHeight;
+        this.onload?.();
+      });
+    }
+    get src() {
+      return this._src;
+    }
+  }
+  global.Image = ProbeImage;
+}
+
+describe("Image Studio img2img reference aspect snap", () => {
+  let container;
+  let root;
+  const originalImage = global.Image;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+    global.fetch = vi.fn(() => Promise.resolve(response([])));
+    stubImageDecode(1080, 1920);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    container.remove();
+    global.Image = originalImage;
+    vi.restoreAllMocks();
+  });
+
+  // The prompt-tool tiles concatenate a title and a description into one button, so match on the
+  // leading title rather than the whole node.
+  const buttonByText = (text) =>
+    [...document.body.querySelectorAll("button")].find((button) =>
+      button.textContent.trim().startsWith(text),
+    );
+  const aspectSelect = () => document.body.querySelector(".settings-field-aspect select");
+
+  async function pickReference() {
+    await act(async () => {
+      buttonByText("Select reference image").click();
+    });
+    await settle();
+    await act(async () => {
+      document.body.querySelector(".asset-picker-modal .asset-picker-card").click();
+    });
+    await settle();
+    await act(async () => {
+      buttonByText("Use Selection").click();
+    });
+    await settle();
+  }
+
+  function studio(assets, imageModels = [KREA_MODEL]) {
+    return withImageStudioContext({
+      activeProject: { id: "project-1", name: "Noir" },
+      assets,
+      characters: [],
+      createImageJob: () => {},
+      deleteAsset: () => {},
+      purgeAsset: () => {},
+      gpuOptions: ["auto"],
+      imageModels,
+      latestAssets: [],
+      localJobs: [],
+      loras: [],
+      onPreview: () => {},
+      requestedGpu: "auto",
+      selectedAsset: null,
+      setRequestedGpu: () => {},
+      updateAssetStatus: () => {},
+    });
+  }
+
+  it("snaps once on pick, then keeps the user's Aspect across asset-list refreshes (sc-18255)", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(studio([REFERENCE_ASSET]));
+    });
+    await settle();
+
+    await act(async () => {
+      buttonByText("Image reference").click();
+    });
+    await settle();
+    await pickReference();
+
+    // The 1080x1920 reference snaps the Aspect to its closest declared bucket.
+    expect(aspectSelect().value).toBe("1152x2048");
+
+    // The user then picks a different Aspect for this render.
+    await act(async () => {
+      const select = aspectSelect();
+      select.value = "768x1024";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await settle();
+    expect(aspectSelect().value).toBe("768x1024");
+
+    // An asset-list refresh (new array identity, same reference still picked) must not re-snap.
+    await act(async () => {
+      root.render(studio([{ ...REFERENCE_ASSET }]));
+    });
+    await settle();
+    expect(aspectSelect().value).toBe("768x1024");
+
+    // Nor may any number of further refreshes.
+    await act(async () => {
+      root.render(studio([{ ...REFERENCE_ASSET }, { ...REFERENCE_ASSET, id: "asset-generated" }]));
+    });
+    await settle();
+    expect(aspectSelect().value).toBe("768x1024");
+  });
+
+  it("re-snaps when the reference is cleared and re-picked (sc-18255)", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(studio([REFERENCE_ASSET]));
+    });
+    await settle();
+
+    await act(async () => {
+      buttonByText("Image reference").click();
+    });
+    await settle();
+    await pickReference();
+    expect(aspectSelect().value).toBe("1152x2048");
+
+    await act(async () => {
+      const select = aspectSelect();
+      select.value = "768x1024";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await settle();
+
+    await act(async () => {
+      buttonByText("Remove").click();
+    });
+    await settle();
+    await pickReference();
+
+    // Re-picking is a deliberate user action, so the aspect preset applies again.
+    expect(aspectSelect().value).toBe("1152x2048");
+  });
+
+  it("re-snaps when the resolution options themselves change (sc-18255)", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(studio([REFERENCE_ASSET]));
+    });
+    await settle();
+
+    await act(async () => {
+      buttonByText("Image reference").click();
+    });
+    await settle();
+    await pickReference();
+    expect(aspectSelect().value).toBe("1152x2048");
+
+    // Switching models resets the Aspect to the new model's default (1024x1024). The reference is
+    // still armed, so the snap must run again on the NEW bucket list — otherwise a 9:16 reference
+    // would silently render square, the wrong-shaped-latent failure sc-10195 exists to prevent.
+    const select = document.body.querySelector(".settings-field-model select");
+    await act(async () => {
+      root.render(studio([REFERENCE_ASSET], [KREA_MODEL, OTHER_MODEL]));
+    });
+    await settle();
+    await act(async () => {
+      select.value = "z_image_turbo";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await settle();
+
+    expect(aspectSelect().value).toBe("896x1600");
+  });
+
+  it("stops steering the Aspect on a model with no img2img panel (sc-18255)", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(studio([REFERENCE_ASSET], [KREA_MODEL, NO_IMG2IMG_MODEL]));
+    });
+    await settle();
+
+    await act(async () => {
+      buttonByText("Image reference").click();
+    });
+    await settle();
+    await pickReference();
+    expect(aspectSelect().value).toBe("1152x2048");
+
+    // The armed reference is not cleared by a model change, but the panel that owns it is gone, so
+    // the model's own default must stand rather than an invisible reference's closest bucket.
+    const select = document.body.querySelector(".settings-field-model select");
+    await act(async () => {
+      select.value = "flux2_klein_9b";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await settle();
+
+    expect(aspectSelect().value).toBe("1024x1024");
+  });
+
+  it("keeps the user's Aspect across a Text → Edit → Text round-trip (sc-18255)", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(studio([REFERENCE_ASSET]));
+    });
+    await settle();
+
+    await act(async () => {
+      buttonByText("Image reference").click();
+    });
+    await settle();
+    await pickReference();
+    expect(aspectSelect().value).toBe("1152x2048");
+
+    await act(async () => {
+      const select = aspectSelect();
+      select.value = "768x1024";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    await settle();
+
+    // Krea 2 Turbo serves both text_to_image and edit_image, so this changes neither the model nor
+    // the resolution options. The img2img panel is inoperative in Edit mode — but the reference is
+    // still armed, and coming back must NOT re-snap over the Aspect the user chose.
+    await act(async () => {
+      buttonByText("Edit").click();
+    });
+    await settle();
+    await act(async () => {
+      buttonByText("Text").click();
+    });
+    await settle();
+
+    expect(aspectSelect().value).toBe("768x1024");
+  });
+});

--- a/apps/web/src/components/ReferenceCaptionPicker.jsx
+++ b/apps/web/src/components/ReferenceCaptionPicker.jsx
@@ -12,11 +12,10 @@
 // parent supplies `onCaption(assetId)` (run the job + parse) and `onApply(result)` (apply
 // the result to its own state). C1: the image is captioning-only — never sent to generation.
 
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { AssetPickerField, ImageEditSourcePickerField } from "./AssetPicker.jsx";
-import { assetUrl } from "./assetMedia.jsx";
 import { ModelAvailabilityGate } from "./ModelAvailabilityGate.jsx";
-import { probeImageDimensions } from "../imageDimensions.js";
+import { useReferenceAspectSnap } from "../hooks/useReferenceAspectSnap.js";
 
 export default function ReferenceCaptionPicker({
   // Run the vision job for the picked asset and resolve to a result (the parent parses:
@@ -28,6 +27,10 @@ export default function ReferenceCaptionPicker({
   // sc-8109 seam: invoked with the uploaded image's natural (width, height) so the parent
   // can auto-preset the generation resolution to the nearest aspect.
   onReferenceImageLoaded,
+  // The parent's resolution-option set as a VALUE (sc-18255) — see useReferenceAspectSnap. Snapping
+  // is deduped per (reference, snapKey) pair so an asset-list refresh cannot re-snap over an Aspect
+  // the user has since chosen, while a real option-set change still re-snaps.
+  referenceSnapKey = "",
   referenceAssets = [],
   referenceCharacters = [],
   importAsset,
@@ -74,14 +77,16 @@ export default function ReferenceCaptionPicker({
 
   // Run the auto-preset from an effect on the SELECTED id rather than the picker's onChange: a freshly
   // imported/dragged reference lands in `referenceAssets` a render AFTER its id is set, so the
-  // onChange-time `find` missed it and the Aspect stayed at the 1:1 default (sc-8220). Keying on both
-  // the id and the list re-runs once the asset resolves, covering select / import / drag / character
-  // paths uniformly.
-  useEffect(() => {
-    if (!referenceAssetId) return undefined;
-    const asset = referenceAssets.find((item) => item.id === referenceAssetId);
-    return probeImageDimensions(asset && assetUrl(asset), onReferenceImageLoaded);
-  }, [onReferenceImageLoaded, referenceAssetId, referenceAssets]);
+  // onChange-time `find` missed it and the Aspect stayed at the 1:1 default (sc-8220). The hook keys
+  // on both the id and the list so it re-runs once the asset resolves — covering select / import /
+  // drag / character paths uniformly — while deduping per (reference, snapKey) pair so a plain
+  // asset-list refresh cannot re-snap over the user's own Aspect pick (sc-18255).
+  useReferenceAspectSnap({
+    referenceId: referenceAssetId,
+    assets: referenceAssets,
+    onReferenceImageLoaded,
+    snapKey: referenceSnapKey,
+  });
 
   async function handleCaption() {
     if (typeof onCaption !== "function" || !referenceAssetId || busy) return;

--- a/apps/web/src/components/ReferenceCaptionPicker.snap.test.jsx
+++ b/apps/web/src/components/ReferenceCaptionPicker.snap.test.jsx
@@ -1,0 +1,136 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ReferenceCaptionPicker from "./ReferenceCaptionPicker.jsx";
+
+// sc-18255: the describe/caption picker shares the reference aspect auto-preset seam with Image
+// Studio's img2img panel. Its probe is keyed on the asset LIST as well as the reference id, and the
+// list gets a new array identity on every asset refresh — so an unguarded re-run re-snapped the
+// Aspect over whatever the user had chosen since. The snap must fire once per (reference, snapKey).
+const REFERENCE_ASSET = {
+  id: "asset-reference",
+  projectId: "project-1",
+  type: "image",
+  displayName: "Portrait reference",
+  file: { path: "assets/uploads/portrait.jpg", mimeType: "image/jpeg" },
+  status: { favorite: false, rating: 0, rejected: false, trashed: false },
+};
+
+// jsdom's Image never loads, so probeImageDimensions would never fire its callback.
+function stubImageDecode(naturalWidth, naturalHeight) {
+  class ProbeImage {
+    constructor() {
+      this.naturalWidth = 0;
+      this.naturalHeight = 0;
+      this.onload = null;
+      this.onerror = null;
+    }
+    set src(value) {
+      this._src = value;
+      if (!value) return;
+      Promise.resolve().then(() => {
+        this.naturalWidth = naturalWidth;
+        this.naturalHeight = naturalHeight;
+        this.onload?.();
+      });
+    }
+    get src() {
+      return this._src;
+    }
+  }
+  global.Image = ProbeImage;
+}
+
+describe("ReferenceCaptionPicker aspect snap", () => {
+  let container;
+  let root;
+  const originalImage = global.Image;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    stubImageDecode(1080, 1920);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    global.Image = originalImage;
+    vi.restoreAllMocks();
+  });
+
+  const buttonByText = (text) =>
+    [...container.querySelectorAll("button")].find((button) => button.textContent.trim() === text);
+
+  function picker(assets, onReferenceImageLoaded, snapKey) {
+    return (
+      <ReferenceCaptionPicker
+        onCaption={() => Promise.resolve("")}
+        onApply={() => {}}
+        onReferenceImageLoaded={onReferenceImageLoaded}
+        referenceSnapKey={snapKey}
+        referenceAssets={assets}
+        projectId="project-1"
+      />
+    );
+  }
+
+  // The picker's modal renders into document.body, outside the container.
+  const modalButtonByText = (text) =>
+    [...document.body.querySelectorAll(".asset-picker-modal button")].find(
+      (button) => button.textContent.trim() === text,
+    );
+
+  async function pick() {
+    await act(async () =>
+      buttonByText("Select reference image").dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
+    await act(async () =>
+      document.body
+        .querySelector(".asset-picker-modal .asset-picker-card")
+        .dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
+    await act(async () =>
+      modalButtonByText("Use Selection").dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
+  }
+
+  it("snaps once per reference, not on every asset-list refresh (sc-18255)", async () => {
+    const onReferenceImageLoaded = vi.fn();
+    await act(async () => root.render(picker([REFERENCE_ASSET], onReferenceImageLoaded, "1024x1024,768x1024")));
+    await pick();
+    expect(onReferenceImageLoaded).toHaveBeenCalledTimes(1);
+    expect(onReferenceImageLoaded).toHaveBeenCalledWith(1080, 1920);
+
+    // Two asset-list refreshes with the same reference still picked: no further snaps.
+    await act(async () =>
+      root.render(picker([{ ...REFERENCE_ASSET }], onReferenceImageLoaded, "1024x1024,768x1024")),
+    );
+    await act(async () =>
+      root.render(
+        picker(
+          [{ ...REFERENCE_ASSET }, { ...REFERENCE_ASSET, id: "asset-generated" }],
+          onReferenceImageLoaded,
+          "1024x1024,768x1024",
+        ),
+      ),
+    );
+    expect(onReferenceImageLoaded).toHaveBeenCalledTimes(1);
+  });
+
+  it("snaps again when the caller's option set changes (sc-18255)", async () => {
+    const onReferenceImageLoaded = vi.fn();
+    await act(async () => root.render(picker([REFERENCE_ASSET], onReferenceImageLoaded, "1024x1024,768x1024")));
+    await pick();
+    expect(onReferenceImageLoaded).toHaveBeenCalledTimes(1);
+
+    // A real option-set change (the user switched models) must re-snap onto the new buckets.
+    await act(async () =>
+      root.render(picker([REFERENCE_ASSET], onReferenceImageLoaded, "1024x1024,896x1600")),
+    );
+    expect(onReferenceImageLoaded).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/components/StructuredPromptBuilder.jsx
+++ b/apps/web/src/components/StructuredPromptBuilder.jsx
@@ -106,6 +106,9 @@ export default function StructuredPromptBuilder({
   // reference image so the parent can auto-preset the generation resolution to the
   // nearest aspect (the caption's bboxes are normalized 0–1000 to the frame).
   onReferenceImageLoaded,
+  // The parent's resolution-option set as a value (sc-18255) — passed straight through to the
+  // shared picker, which dedupes the aspect snap per (reference, key) pair.
+  referenceSnapKey = "",
   // Reference-image → JSON caption (epic 8102, sc-8108). When `onImageCaption` is supplied
   // (Ideogram 4 + text-to-image only — the parent gates it), the Plain-text tab also offers a
   // reference-image picker + "Generate JSON from image" button. `onImageCaption(assetId)` runs
@@ -399,6 +402,7 @@ export default function StructuredPromptBuilder({
               onCaption={onImageCaption}
               onApply={applyImageCaption}
               onReferenceImageLoaded={onReferenceImageLoaded}
+              referenceSnapKey={referenceSnapKey}
               referenceAssets={referenceAssets}
               referenceCharacters={referenceCharacters}
               importAsset={importAsset}

--- a/apps/web/src/hooks/useReferenceAspectSnap.js
+++ b/apps/web/src/hooks/useReferenceAspectSnap.js
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from "react";
+
+import { assetUrl } from "../components/assetMedia.jsx";
+import { probeImageDimensions } from "../imageDimensions.js";
+
+// The `snapKey` a resolution-bucket caller should pass: which model's option UNIVERSE we are in.
+// Deliberately derived from the model's DECLARED buckets and nothing else — NOT from the
+// memory-gated list the picker actually shows. That gated list also varies with the picked quant
+// tier (sc-16020), and a tier switch re-snapping over the user's Aspect is the same clobber
+// sc-18255 fixes. If the gate trims the selected bucket, the caller's own validity effect re-picks
+// it. Returns a VALUE, so a model-catalog refetch that hands back an equal-but-new object is inert.
+export function resolutionUniverseKey(model, fallbackResolutions = []) {
+  const declared = model?.limits?.resolutions?.length ? model.limits.resolutions : fallbackResolutions;
+  return `${model?.id ?? ""}|${declared.join(",")}`;
+}
+
+// Shared reference-image aspect auto-preset (sc-8109 / sc-8220 / sc-10195): probe the picked
+// reference's natural size and hand it to `onReferenceImageLoaded`, which snaps the Aspect picker to
+// the declared bucket closest to that aspect. Keeping the composition's aspect matters because a
+// reference grounded for 9:16 but rendered at 1:1 comes out wrong-shaped.
+//
+// The probe stays keyed on the asset LIST as well as the id, because a freshly imported / dragged
+// reference lands in the list a render after its id is set (sc-8220) and the snap must still happen
+// once it resolves. But the list gets a NEW ARRAY IDENTITY on every asset refresh — and the worker
+// emits a generationSetId on the first denoise step, so clicking Generate refreshes the list within
+// a second. Re-running the snap there overwrote whatever Aspect the user had chosen since (sc-18255:
+// a 768x1024 Krea job submitted at 1152x2048, the 1080x1920 reference's closest bucket).
+//
+// So the snap fires at most once per (reference, snapKey) pair. `snapKey` is the caller's option set
+// as a VALUE, not an identity — the option list is memoized on the selected model, whose identity
+// churns on every model-catalog refetch, while a genuine change (switching models, or the catalog
+// resolving for the first time) changes the value and legitimately re-snaps.
+// `enabled` is deliberately SEPARATE from an empty `referenceId`: only an empty id means "the user
+// cleared the reference", which re-arms the snap. A caller that is merely inoperative right now (the
+// img2img panel is hidden because the mode or model changed) must suppress the snap WITHOUT re-arming
+// it — collapsing the two would re-snap on the way back and clobber the Aspect all over again.
+export function useReferenceAspectSnap({
+  referenceId,
+  assets = [],
+  onReferenceImageLoaded,
+  snapKey = "",
+  enabled = true,
+}) {
+  const snapped = useRef("");
+  useEffect(() => {
+    // Wrapping the callback below defeats probeImageDimensions' own callable check, and a throw
+    // from an image onload lands outside React's tree where no boundary catches it.
+    if (typeof onReferenceImageLoaded !== "function") return undefined;
+    if (!referenceId) {
+      // Cleared: re-picking is a fresh user action and snaps again.
+      snapped.current = "";
+      return undefined;
+    }
+    if (!enabled) return undefined;
+    // "|" separates safely: asset ids and resolution buckets never contain one.
+    const pairKey = `${referenceId}|${snapKey}`;
+    if (snapped.current === pairKey) return undefined;
+    const asset = assets.find((item) => item.id === referenceId);
+    // Mark only on a SUCCESSFUL probe: an id whose asset has not resolved yet never reaches this
+    // callback, so it stays eligible and snaps on the render where the asset appears.
+    return probeImageDimensions(asset && assetUrl(asset), (width, height) => {
+      snapped.current = pairKey;
+      onReferenceImageLoaded(width, height);
+    });
+  }, [referenceId, assets, onReferenceImageLoaded, snapKey, enabled]);
+}

--- a/apps/web/src/hooks/useReferenceAspectSnap.test.jsx
+++ b/apps/web/src/hooks/useReferenceAspectSnap.test.jsx
@@ -1,0 +1,183 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resolutionUniverseKey, useReferenceAspectSnap } from "./useReferenceAspectSnap.js";
+
+// Unit coverage for the shared guard behind Image Studio's img2img panel and the describe picker.
+// The screen-level tests (App.imageStudioReferenceSnap, ReferenceCaptionPicker.snap) drive it
+// through the UI; these pin the cases the UI cannot stage — a reference whose asset resolves a
+// render later (sc-8220), a probe that never loads, and a missing callback.
+const ASSET = {
+  id: "asset-reference",
+  projectId: "project-1",
+  type: "image",
+  displayName: "Portrait reference",
+  file: { path: "assets/uploads/portrait.jpg", mimeType: "image/jpeg" },
+  status: { favorite: false, rating: 0, rejected: false, trashed: false },
+};
+
+// jsdom's Image never loads. `loads` false models a reference whose URL never decodes.
+function stubImageDecode({ width = 1080, height = 1920, loads = true } = {}) {
+  class ProbeImage {
+    constructor() {
+      this.naturalWidth = 0;
+      this.naturalHeight = 0;
+      this.onload = null;
+      this.onerror = null;
+    }
+    set src(value) {
+      this._src = value;
+      if (!value || !loads) return;
+      Promise.resolve().then(() => {
+        this.naturalWidth = width;
+        this.naturalHeight = height;
+        this.onload?.();
+      });
+    }
+    get src() {
+      return this._src;
+    }
+  }
+  global.Image = ProbeImage;
+}
+
+function Probe(props) {
+  useReferenceAspectSnap(props);
+  return null;
+}
+
+describe("resolutionUniverseKey", () => {
+  const MODEL = { id: "krea_2_turbo", limits: { resolutions: ["1024x1024", "768x1024", "2048x2048"] } };
+
+  it("is a value, so an equal-but-new catalog object is inert", () => {
+    expect(resolutionUniverseKey(MODEL)).toBe(
+      resolutionUniverseKey({ ...MODEL, limits: { resolutions: [...MODEL.limits.resolutions] } }),
+    );
+  });
+
+  it("changes when the model changes", () => {
+    expect(resolutionUniverseKey(MODEL)).not.toBe(
+      resolutionUniverseKey({ ...MODEL, id: "z_image_turbo" }),
+    );
+    // Same id, different declared buckets (a manifest update) is also a real change.
+    expect(resolutionUniverseKey(MODEL)).not.toBe(
+      resolutionUniverseKey({ ...MODEL, limits: { resolutions: ["1024x1024"] } }),
+    );
+  });
+
+  it("reflects the DECLARED buckets, so gating cannot reach it", () => {
+    // The regression guard for the sc-16020 tier axis: the key names the model's declared universe,
+    // so switching quant tier — which re-gates the picker's visible list, trimming >1536² buckets —
+    // leaves the key untouched and cannot re-fire the snap over the user's Aspect.
+    expect(resolutionUniverseKey(MODEL)).toBe("krea_2_turbo|1024x1024,768x1024,2048x2048");
+    // A gated list would have dropped 2048x2048; the key keeps it.
+    expect(resolutionUniverseKey(MODEL)).toContain("2048x2048");
+  });
+
+  it("falls back to the caller's default list when the model declares none", () => {
+    expect(resolutionUniverseKey(undefined, ["1024x1024"])).toBe("|1024x1024");
+    expect(resolutionUniverseKey({ id: "m" }, ["1024x1024"])).toBe("m|1024x1024");
+  });
+});
+
+describe("useReferenceAspectSnap", () => {
+  let container;
+  let root;
+  const originalImage = global.Image;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    stubImageDecode();
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    global.Image = originalImage;
+    vi.restoreAllMocks();
+  });
+
+  const render = (props) => act(async () => root.render(<Probe {...props} />));
+
+  it("snaps once the asset resolves a render later, and not again (sc-8220 import/drag path)", async () => {
+    const onReferenceImageLoaded = vi.fn();
+    // The id is set a render BEFORE the asset lands in the list — the import/drag shape.
+    await render({ referenceId: ASSET.id, assets: [], onReferenceImageLoaded, snapKey: "a" });
+    expect(onReferenceImageLoaded).not.toHaveBeenCalled();
+
+    await render({ referenceId: ASSET.id, assets: [ASSET], onReferenceImageLoaded, snapKey: "a" });
+    expect(onReferenceImageLoaded).toHaveBeenCalledTimes(1);
+    expect(onReferenceImageLoaded).toHaveBeenCalledWith(1080, 1920);
+
+    // Further list churn must not re-snap.
+    await render({ referenceId: ASSET.id, assets: [{ ...ASSET }], onReferenceImageLoaded, snapKey: "a" });
+    expect(onReferenceImageLoaded).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays eligible when the probe never loads", async () => {
+    stubImageDecode({ loads: false });
+    const onReferenceImageLoaded = vi.fn();
+    await render({ referenceId: ASSET.id, assets: [ASSET], onReferenceImageLoaded, snapKey: "a" });
+    expect(onReferenceImageLoaded).not.toHaveBeenCalled();
+
+    // A failed probe must not consume the pick: once decoding works, the snap still happens.
+    stubImageDecode();
+    await render({ referenceId: ASSET.id, assets: [{ ...ASSET }], onReferenceImageLoaded, snapKey: "a" });
+    expect(onReferenceImageLoaded).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-snaps for a new snapKey but not for a repeated one", async () => {
+    const onReferenceImageLoaded = vi.fn();
+    await render({ referenceId: ASSET.id, assets: [ASSET], onReferenceImageLoaded, snapKey: "a" });
+    expect(onReferenceImageLoaded).toHaveBeenCalledTimes(1);
+
+    await render({ referenceId: ASSET.id, assets: [ASSET], onReferenceImageLoaded, snapKey: "b" });
+    expect(onReferenceImageLoaded).toHaveBeenCalledTimes(2);
+
+    await render({ referenceId: ASSET.id, assets: [ASSET], onReferenceImageLoaded, snapKey: "b" });
+    expect(onReferenceImageLoaded).toHaveBeenCalledTimes(2);
+  });
+
+  it("suppresses while disabled without re-arming", async () => {
+    const onReferenceImageLoaded = vi.fn();
+    const props = { referenceId: ASSET.id, assets: [ASSET], onReferenceImageLoaded, snapKey: "a" };
+    await render(props);
+    expect(onReferenceImageLoaded).toHaveBeenCalledTimes(1);
+
+    // Inoperative, not cleared — the caller's panel is hidden. Going back must not re-snap: that is
+    // the Text -> Edit -> Text round-trip that re-clobbered the user's Aspect.
+    await render({ ...props, enabled: false });
+    await render(props);
+    expect(onReferenceImageLoaded).toHaveBeenCalledTimes(1);
+  });
+
+  it("clearing the reference re-arms it", async () => {
+    const onReferenceImageLoaded = vi.fn();
+    await render({ referenceId: ASSET.id, assets: [ASSET], onReferenceImageLoaded, snapKey: "a" });
+    await render({ referenceId: "", assets: [ASSET], onReferenceImageLoaded, snapKey: "a" });
+    await render({ referenceId: ASSET.id, assets: [ASSET], onReferenceImageLoaded, snapKey: "a" });
+    expect(onReferenceImageLoaded).toHaveBeenCalledTimes(2);
+  });
+
+  it("does nothing without a callback instead of throwing out of an image onload", async () => {
+    // The hook wraps the callback, which defeats probeImageDimensions' own callable check, and a
+    // throw from onload lands outside React's tree where no error boundary catches it.
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    const uncaught = vi.fn();
+    process.on("uncaughtException", uncaught);
+    try {
+      await render({ referenceId: ASSET.id, assets: [ASSET], snapKey: "a" });
+      await act(async () => {});
+    } finally {
+      process.off("unhandledRejection", unhandled);
+      process.off("uncaughtException", uncaught);
+    }
+    expect(unhandled).not.toHaveBeenCalled();
+    expect(uncaught).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AssetPickerField, ImageEditSourcePickerField } from "../components/AssetPicker.jsx";
 import { AssetCard } from "../components/assetPanels.jsx";
-import { AssetMedia, assetUrl } from "../components/assetMedia.jsx";
+import { AssetMedia } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { AdvancedSection } from "../components/AdvancedSection.jsx";
 import { StudioLoraImportPanel } from "../components/StudioLoraImportPanel.jsx";
@@ -177,7 +177,7 @@ import {
   macModelFeatureBlock,
 } from "../macGating.js";
 import { loadStudioSettings, useStudioSettingsWriter } from "../hooks/useStudioSettings.js";
-import { probeImageDimensions } from "../imageDimensions.js";
+import { resolutionUniverseKey, useReferenceAspectSnap } from "../hooks/useReferenceAspectSnap.js";
 import { resolveJobResultAssets } from "../jobResultAssets.js";
 import {
   availableUpscaleEngines as upscaleEnginesForPlatform,
@@ -1211,16 +1211,30 @@ export function ImageStudio() {
     },
     [resolutionOptions],
   );
-  // Auto-preset the Aspect from the picked img2img reference (sc-10195): matching the reference's
-  // aspect keeps the latent-init composition valid (a 4:5 reference rendered at 16:9 comes out
-  // wrong-shaped). Mirrors the describe picker's probe (sc-8109/8220) — keyed on the id AND the asset
-  // list so a freshly imported reference re-runs once it resolves. User Aspect override still wins.
-  useEffect(() => {
-    if (!img2imgReferenceAssetId) return;
-    const asset = editImageAssets.find((item) => item.id === img2imgReferenceAssetId);
-    const src = asset && assetUrl(asset);
-    return probeImageDimensions(src, onReferenceImageLoaded);
-  }, [img2imgReferenceAssetId, editImageAssets, onReferenceImageLoaded]);
+  // The reference snap's dedupe key, shared with the describe picker. It names which model's option
+  // UNIVERSE we are in — deliberately the DECLARED buckets, not the memory-gated `resolutionOptions`
+  // above. The gate also varies with the picked quant tier (sc-16020), and a tier switch re-snapping
+  // over the user's Aspect is the very clobber sc-18255 fixes. If the gate ever trims the selected
+  // bucket, the validity effect below re-picks it. A VALUE, not an identity: `selectedModel`'s
+  // identity churns on every model-catalog refetch (see useReferenceAspectSnap).
+  const resolutionSnapKey = useMemo(
+    () => resolutionUniverseKey(selectedModel, DEFAULT_RESOLUTION_OPTIONS),
+    [selectedModel],
+  );
+  // Auto-preset the Aspect from the picked img2img reference (sc-10195), through the same guarded
+  // hook the describe picker uses. Gated on the SAME condition that renders the tile (below), because
+  // `img2imgReferenceAssetId` is never cleared on a model or mode change: without the gate, a
+  // reference armed on Krea would keep steering the Aspect on a model that has no img2img panel at
+  // all. This rides `enabled`, NOT an emptied id — an emptied id re-arms the snap, which would
+  // re-clobber the Aspect on a mode round-trip (Text → Edit → Text with the reference still armed).
+  const img2imgSnapEligible = supportsImg2img && mode === "text_to_image";
+  useReferenceAspectSnap({
+    referenceId: img2imgReferenceAssetId,
+    assets: editImageAssets,
+    onReferenceImageLoaded,
+    snapKey: resolutionSnapKey,
+    enabled: img2imgSnapEligible,
+  });
   // Sampler / scheduler menus declared by the model, gated to the ACTIVE backend
   // (epic 7114 P5): `macGatingActive` is the worker `mlx_required` master switch, so
   // it picks the manifest's `mlx.limits` override on Mac/MLX and the `candle.limits`
@@ -2754,6 +2768,7 @@ export function ImageStudio() {
                 // sc-8109 seam: the reference-image picker calls this with the uploaded image's
                 // natural dimensions to auto-preset the resolution to the nearest aspect.
                 onReferenceImageLoaded={onReferenceImageLoaded}
+                referenceSnapKey={resolutionSnapKey}
                 // Reference-image → JSON caption (epic 8102, sc-8108). Gated to text-to-image ONLY:
                 // edit/character modes condition on their own source/identity image, so a fresh
                 // scene caption written from a different reference would conflict. The image is
@@ -2874,7 +2889,9 @@ export function ImageStudio() {
                 <div className="structured-reference">
                   <p className="structured-hint">
                     Pick an image to guide the render (image-to-image). A higher reference strength
-                    stays closer to it; lower lets the prompt take over.
+                    stays closer to it; lower lets the prompt take over. Any strength above 0 starts
+                    the denoise partway through the schedule, so progress counts only the remaining
+                    steps — a stronger reference runs fewer than the Steps you set.
                   </p>
                   <ImageEditSourcePickerField
                     assets={editImageAssets}
@@ -2970,6 +2987,7 @@ export function ImageStudio() {
                       onCaption={onImageDescribe}
                       onApply={(text) => setPromptFromUser(text)}
                       onReferenceImageLoaded={onReferenceImageLoaded}
+                      referenceSnapKey={resolutionSnapKey}
                       referenceAssets={editImageAssets}
                       referenceCharacters={characters}
                       importAsset={importAsset}


### PR DESCRIPTION
Forward-port of the [sc-18255](https://app.shortcut.com/trefry/story/18255) hotfix landing on `release/next` in #2217. `main` carries both unguarded effects, so this is a real port, not a no-op.

## The bug

Picking an img2img reference auto-presets the Aspect to the declared bucket closest to the reference's own aspect (sc-10195, so a 9:16 reference doesn't render square). That effect also depends on the asset list, because a freshly imported reference lands in the list a render after its id is set (sc-8220). But the list gets a **new array identity on every refresh** — and the worker emits a `generationSetId` on the first denoise step, so clicking Generate refreshes it within a second. The snap re-ran and overwrote whatever Aspect the user had chosen since.

Reported against Krea 2 Turbo: a job configured at 768x1024 was **submitted** with `width:1152, height:2048` — the 1080x1920 reference's closest bucket.

## The fix

A shared `useReferenceAspectSnap` hook that dedupes the snap per `(reference, option-universe)` pair, used by both callers: the img2img panel and the describe/caption picker, which carried the identical unguarded effect on the same seam.

Three things the guard deliberately does **not** do:

- **The key is the model's DECLARED buckets, not the memory-gated list.** On `main` the gated list also varies with the picked quant tier (sc-16020), so keying on it would let a tier switch re-snap over the user's Aspect — the same clobber. Extracted as `resolutionUniverseKey` so the invariant is directly unit-tested rather than implied by a dependency array.
- **It is a value, not an identity.** `selectedModel`'s identity churns on every model-catalog refetch.
- **`enabled` is separate from an emptied reference id.** Only an empty id means the user cleared the reference, which re-arms the snap. A caller that is merely inoperative (the img2img panel is hidden in Edit mode) suppresses *without* re-arming — collapsing the two re-snapped on the way back, so `Text → Edit → Text` clobbered the Aspect again.

## Relationship to #2217

The hook, both test files for it, and the studio's key derivation are **byte-identical** on the two branches (verified by `shasum`), so the release line and `main` cannot drift on this fix. The tier-axis input is `main`-only, but the derivation is shared because the gated list is the wrong input on both.

## Coverage

16 tests across three files. Every guard is mutation-checked on **this** branch, not inherited from the release-line run:

| Mutation | Tests that fail |
|---|---|
| delete the `snapped.current === pairKey` return | 5 |
| `pairKey` → `referenceId` alone | 3 |
| drop `enabled: img2imgSnapEligible` | 2 |
| revert `ReferenceCaptionPicker` to its unguarded effect | 1 |
| remove the `typeof` callback guard | 1 (real `uncaughtException`) |

The hook tests also pin what the UI cannot stage: an asset that resolves a render later (sc-8220 import/drag) and a probe that never loads — both must leave the reference eligible rather than consuming the pick.

## Validation on this branch

- `npm --prefix apps/web run test` — 240 files / 3559 tests pass
- `npm --prefix apps/web run lint` — clean
- `npm run build --prefix apps/web` — succeeds
- `npm run check` — passes
- `git diff --check origin/main...HEAD` — clean

Independently reviewed for fit against current `main` architecture: confirmed the auto-merge landed the hook call after every symbol it uses, no orphaned or dropped imports, and `main` has exactly two call sites of this seam — Simple UI has no aspect snap, and Video Studio's i2v snap already carries its own guard and does not share this code.

## Related

[sc-18328](https://app.shortcut.com/trefry/story/18328): `sana_1600m` / `sana_sprint_1600m` declare `ui.img2img` but `candle-gen-sana` has no img2img conditioning at the pin — pre-existing, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
