### PR TITLE
fix(web): make the error notice band dismissible

### DIFF
--- a/apps/web/src/App.auth.test.jsx
+++ b/apps/web/src/App.auth.test.jsx
@@ -635,4 +635,59 @@ describe("SceneWorks app shell", () => {
     expect(noticeTexts.some((text) => text.includes("Failed without additional worker detail."))).toBe(true);
   });
 
+  // A failed job's notice is pushed once and never re-pushed (the terminal-revision dedupe
+  // in useJobEvents drops the replay), so before the dismiss control it sat above every
+  // screen until the app was restarted. Clicking the X must clear it and leave it cleared.
+  it("dismisses a notice from its X and keeps unrelated kinds", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<App />);
+    });
+    await settle();
+
+    async function failJob(job) {
+      await act(async () => {
+        FakeEventSource.instances[0].listeners["job.updated"]({ data: JSON.stringify(job) });
+      });
+      await settle();
+    }
+
+    const poseFailure = {
+      id: "job-pose-fail",
+      type: "pose_detect",
+      status: "failed",
+      projectId: "project-default",
+      createdAt: "2026-08-10T00:00:00Z",
+      revision: 4,
+      error: "task 1287 panicked",
+    };
+    await failJob(poseFailure);
+    // A second kind, so the dismiss is proven to be per-kind rather than a blanket clear.
+    await failJob({
+      id: "job-import-fail",
+      type: "lora_import",
+      status: "failed",
+      projectId: "project-default",
+      createdAt: "2026-08-10T00:00:01Z",
+      revision: 2,
+      error: "bad adapter",
+    });
+
+    const noticeOf = (text) =>
+      [...document.body.querySelectorAll(".notice.error")].find((node) => node.textContent.includes(text));
+    expect(noticeOf("task 1287 panicked")).toBeTruthy();
+
+    await act(async () => {
+      noticeOf("task 1287 panicked").querySelector(".notice-dismiss").click();
+    });
+    await settle();
+
+    expect(noticeOf("task 1287 panicked")).toBeUndefined();
+    expect(noticeOf("bad adapter")).toBeTruthy();
+
+    // The same SSE row replayed (reconnect/snapshot) must not resurrect what was dismissed.
+    await failJob(poseFailure);
+    expect(noticeOf("task 1287 panicked")).toBeUndefined();
+  });
+
 });

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -3653,8 +3653,24 @@ export function App() {
           ) : null}
         </header>
 
+        {/* Every notice is dismissible. Most kinds clear themselves (a retry succeeds, the
+            next run completes), but a terminal one — a failed job's panic message — is
+            pushed once and never re-pushed, so without an X it sat above every screen for
+            the rest of the session. Dismissing removes only this kind; the same kind
+            failing again re-raises it. */}
         {notices.map((notice) => (
-          <p className="notice error" key={notice.kind}>{notice.message}</p>
+          <div className="notice error" key={notice.kind} role="alert">
+            <span className="notice-message">{notice.message}</span>
+            <button
+              aria-label="Dismiss this message"
+              className="notice-dismiss"
+              onClick={() => dismissNoticeKind(notice.kind)}
+              title="Dismiss"
+              type="button"
+            >
+              <Icon.Close size={15} />
+            </button>
+          </div>
         ))}
 
         {workflowEmbedNoticeOpen ? (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1783,7 +1783,13 @@ button:focus-visible {
   margin-bottom: 30px;
 }
 
+/* Flex so a dismiss button can sit at the top-right of a message that wraps to several
+   lines. Notices rendered as a bare <p> (the access gate, screen-level errors) have a
+   single anonymous text item and lay out exactly as they did as a block. */
 .notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
   padding: 10px 14px;
   border: 1px solid color-mix(in oklch, var(--danger) 35%, var(--border));
   border-radius: var(--r-md);
@@ -1796,6 +1802,41 @@ button:focus-visible {
 .notice.error {
   background: var(--danger-soft);
   border-color: color-mix(in oklch, var(--danger) 45%, transparent);
+}
+
+/* Worker panics carry unbroken Windows paths with no spaces to wrap at; without this
+   the message forces the whole band wider than the workspace. */
+.notice-message {
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.notice-dismiss {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  /* Pull into the band's padding so the glyph lines up with the first text line. */
+  margin: -2px -6px 0 0;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.notice-dismiss:hover {
+  background: color-mix(in oklch, var(--danger) 18%, transparent);
+  color: var(--text);
+}
+
+.notice-dismiss:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
 }
 
 /* Remote-access blocker (sc-15102): the ONLY thing on screen until the host password


### PR DESCRIPTION
## What does this PR do?

The red band at the top of the workspace had no way to close it. A failed job's
notice is pushed once by the SSE handler and never re-pushed (`useJobEvents`
dedupes terminal effects by job revision), so a terminal failure — e.g. a
pose-detect worker panicking on a bad `onnxruntime.dll` — sat above every screen
until the app was restarted.

The notices store has had per-kind dismissal since sc-4198 (`dismissNoticeKind`),
but it was only ever called internally when a retry succeeded; nothing in the UI
exposed it. This wires it to an X in the corner of each notice.

- `App.jsx` — each notice renders as a flex row: message + a `Icon.Close` button
  calling `dismissNoticeKind(notice.kind)`. Dismissal is per-kind, so an
  unrelated LoRA-import failure survives, and the same kind failing again
  re-raises it. The dismissal also sticks across SSE reconnects, because the
  replayed terminal row is dropped by the existing revision dedupe.
- `styles.css` — `.notice` becomes a flex row so the X sits top-right of a
  message that wraps; `.notice-message` gets `overflow-wrap: anywhere` (worker
  panics carry unbroken Windows paths with nothing to wrap at, which otherwise
  force the band wider than the workspace); `.notice-dismiss` is a 22px
  transparent icon button with hover and `:focus-visible` states.
- `App.auth.test.jsx` — regression test: raise two failed-job notices of
  different kinds, click one X, assert that one is gone, the other survives, and
  that replaying the same SSE row does not resurrect it.

## Related issue

n/a — reported directly (screenshot of a stuck `pose detect:` panic on the Pose
Library screen).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

- Full web suite: 242 files / 3568 tests pass. (The `chunk unavailable` text in
  the output is an intentional error-path log from `LazyScreen.test.jsx`, not a
  failure.)
- `npm --prefix apps/web run lint` clean; `npm --prefix apps/web run build`
  succeeds.
- `npm run check` passes. Note for Windows reviewers: run it from Git Bash — under
  PowerShell the shell-script gate resolves `bash` to WSL and fails 4 scripts
  with `execvpe(/bin/bash) failed`, unrelated to any change here.
- Rendered the new markup against the real CSS and measured the geometry: the
  22×22 button sits 9px in from the top-right corner, vertically centered on the
  first text line, and the long `onnxruntime.dll` path wraps to two lines with no
  horizontal page scroll.

- [ ] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (web UI, docs, shared crate)

## Reviewer notes

The access gate's notices ([AccessGate.jsx](apps/web/src/components/AccessGate.jsx))
are deliberately left as plain paragraphs. Its three kinds (`access-probe`,
`access-verify`, `media-ticket`) are re-pushed by the retry loop every few
seconds, so an X there would flicker rather than dismiss — they are not the stuck
class this fixes.

## Checklist

- [ ] I ran `npm run rust:check` (if I touched Rust) and it passed — n/a, no Rust changes
- [x] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build`
- [x] I ran `npm run check` (scaffold checks)
- [ ] I updated documentation where relevant — n/a
- [x] All my commits are signed off
- [x] My PR is focused on a single logical change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
