### PR TITLE
[sc-18418] Enable protected feature integration checks

### DIFF
--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -25,9 +25,11 @@ name: macOS MLX worker
 # all external contributors' workflows" enabled in the repo Actions settings as
 # defense in depth.
 
-# Epic-3018 stories merged to main via PR #456 and `rust-mlx-integration` was
-# deleted; epic work now branches off and PRs into main (sc-4177 re-pointed the
-# lane after it sat dead on the deleted branch).
+# Ordinary work still PRs into `main`, while substantial epics PR their story
+# branches into protected `feature/*` integration branches. The hosted required
+# check must report on both targets. The self-hosted NAX job below deliberately
+# remains limited to final integration PRs targeting `main` and explicit
+# dispatches so feature-story traffic does not consume the two-Mac pool.
 on:
   # THE MERGE QUEUE'S SPECULATIVE MERGE. Without this trigger the queue's `gh-readonly-queue/main/**`
   # ref is validated only by check.yml's hosted Linux jobs, and this lane — the ONLY compiler of
@@ -107,7 +109,7 @@ on:
   # replaces it: a job skipped by `if:` reports Success, which a required check accepts. The `push:`
   # trigger above keeps its filter, since nothing gates on main pushes.
   pull_request:
-    branches: [main]
+    branches: [main, "feature/*"]
   workflow_dispatch:
     inputs:
       run_memory_calibration:
@@ -390,6 +392,12 @@ jobs:
   nax-worker:
     # Same-repo only — never execute untrusted fork code on the self-hosted runner.
     #
+    # FEATURE-TARGET STORY PRS ARE HOSTED-ONLY. `macos-checks` is required on
+    # `feature/*`, but automatically running this job for every story would turn
+    # the two-Mac NAX pool into feature-branch queue capacity. NAX evidence is
+    # instead captured by an explicit dispatch at the frozen feature head; this
+    # job also continues to run on the final same-repo integration PR to `main`.
+    #
     # AND NEVER ON A MERGE GROUP, deliberately. The pool is two hand-registered Macs, one of them a
     # developer's daily driver, and PR runs there already compete with real-weight jobs for unified
     # memory badly enough to have produced six jetsam kills on 2026-08-04. A merge group is an
@@ -401,8 +409,9 @@ jobs:
     # job skips. Everything else this lane proves — the whole workspace suite, both clippy scopes,
     # the MLX-linked build — is `macos-checks` above, which DOES gate the queue. And `nax_guard`
     # asserts a property of the M5 matrix-unit kernels, not of how two PRs compose, so it is a poor
-    # fit for the class the merge queue exists to catch. It still runs on every PR and on the
-    # post-merge main push, which is where a NAX regression would surface anyway.
+    # fit for the class the merge queue exists to catch. It still runs on final integration PRs
+    # targeting `main`, explicit final-head dispatches, and the post-merge main push, which are
+    # the points where authoritative NAX evidence is required.
     #
     # `needs: changes` IS LOAD-BEARING HERE, not just an optimisation. sc-17014 dropped the
     # `paths:` filter from this workflow's pull_request trigger so `macos-checks` could become a
@@ -419,7 +428,7 @@ jobs:
     # level up. A gate that did not succeed must therefore RUN the lane, matching
     # merge-group-relevance.mjs's own internal fallback. Do not "simplify" this back to a bare
     # `needs.changes.outputs.relevant == 'true'`.
-    if: ${{ !cancelled() && github.event_name != 'merge_group' && (needs.changes.result != 'success' || needs.changes.outputs.relevant == 'true') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ !cancelled() && github.event_name != 'merge_group' && (needs.changes.result != 'success' || needs.changes.outputs.relevant == 'true') && (github.event_name != 'pull_request' || (github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.full_name == github.repository)) }}
     # The PR/main path needs only `nax`. The workflow_dispatch calibration paths
     # additionally need the HF snapshots, and those are HOST STATE that does not travel
     # with a label — the same defect class this repo just fixed for release.yml's signing

--- a/FEATURE_DEVELOPMENT.md
+++ b/FEATURE_DEVELOPMENT.md
@@ -319,14 +319,19 @@ must:
 - use a merge queue after every required workflow supports `merge_group`;
 - use merge groups of one entry unless deliberate batch validation is accepted.
 
-The second ruleset must contain only the deletion rule. Give only a closed
-maintainer team or cleanup automation a bypass on that deletion-only ruleset for
-branch removal after verified epic completion. Bypass is ruleset-wide: never
-put the deletion rule and its cleanup bypass in the core merge-policy ruleset,
-because that would also let the cleanup actor bypass pull-request, status-check,
-and non-fast-forward protections. Matching rulesets aggregate, so the no-bypass
-core policy remains enforced while the authorized actor deletes a completed
-feature branch.
+The second ruleset must contain only the deletion rule and normally have no
+bypass actors. After a disposable ruleset proof succeeds, or after the
+post-merge checklist succeeds, an administrator may temporarily add one closed
+maintainer team or cleanup automation as its exact cleanup actor. If neither
+exists, one explicitly named repository administrator may be the temporary
+actor; record its immutable actor ID, the approved proof-or-completed branch
+names, and the start/end of the cleanup window. Delete only those branches and
+immediately restore the no-bypass deletion guard. Never leave deletion
+authority active during an epic. Bypass is ruleset-wide: never put the
+deletion rule and its cleanup bypass in the core merge-policy ruleset, because
+that would also let the cleanup actor bypass pull-request, status-check, and
+non-fast-forward protections. Matching rulesets aggregate, so the no-bypass
+core policy remains enforced during that bounded cleanup window.
 
 Start the rulesets in Evaluate mode if available, prove them with disposable
 branches, and activate them only after the check matrix is complete. GitHub's

--- a/FEATURE_DEVELOPMENT.md
+++ b/FEATURE_DEVELOPMENT.md
@@ -291,9 +291,9 @@ dated baseline, not a substitute for current inspection.
 
 #### 1. Add feature-branch rulesets
 
-Create a `Feature integration` branch ruleset in each repository targeting
-`feature/*`. GitHub rulesets use `fnmatch`; this pattern intentionally matches
-the one-slash branch format defined above.
+Create two layered `Feature integration` branch rulesets in each repository,
+both targeting `feature/*`. GitHub rulesets use `fnmatch`; this pattern
+intentionally matches the one-slash branch format defined above.
 
 SceneWorks must require at least the same integration contexts currently
 required on `main`:
@@ -308,7 +308,8 @@ required on `main`:
 
 Inference must require `CI gate`.
 
-Both rulesets must:
+The core merge-policy ruleset in each repository must have no bypass actors and
+must:
 
 - require pull requests;
 - block force pushes and non-fast-forward updates;
@@ -316,10 +317,16 @@ Both rulesets must:
 - require current-head status checks;
 - use merge commits so story and synchronization provenance is retained;
 - use a merge queue after every required workflow supports `merge_group`;
-- use merge groups of one entry unless deliberate batch validation is accepted;
-  and
-- restrict deletion while giving only a maintainer team or cleanup automation a
-  narrow bypass for branch removal after verified epic completion.
+- use merge groups of one entry unless deliberate batch validation is accepted.
+
+The second ruleset must contain only the deletion rule. Give only a closed
+maintainer team or cleanup automation a bypass on that deletion-only ruleset for
+branch removal after verified epic completion. Bypass is ruleset-wide: never
+put the deletion rule and its cleanup bypass in the core merge-policy ruleset,
+because that would also let the cleanup actor bypass pull-request, status-check,
+and non-fast-forward protections. Matching rulesets aggregate, so the no-bypass
+core policy remains enforced while the authorized actor deletes a completed
+feature branch.
 
 Start the rulesets in Evaluate mode if available, prove them with disposable
 branches, and activate them only after the check matrix is complete. GitHub's
@@ -330,8 +337,9 @@ ruleset pattern and bypass behavior is documented in
 
 At minimum:
 
-1. Extend `macos-mlx.yml` ordinary PR targeting from `main` to `main` plus
-   `feature/*`.
+1. Keep `macos-mlx.yml` ordinary PR targeting on both `main` and `feature/*`.
+   Repository contract tests must reject a required workflow whose base filter
+   would prevent its status from reporting on a feature-target PR.
 2. Audit every required workflow and job condition for assumptions about
    `main`, `pull_request.base.sha`, or `github.event.before`. A merge-group run
    must use `github.event.merge_group.base_sha` where a base is required.
@@ -351,15 +359,21 @@ separate property.
 
 #### 3. Decide the privileged runtime policy
 
-`windows-candle.yml` supplies real CUDA-linked runtime coverage but is not part
-of the current required-status set and is limited to PRs targeting `main`.
-Choose and document one policy before feature work begins:
+`windows-candle.yml` and `macos-mlx.yml`'s `nax-worker` supply authoritative
+CUDA-linked and Apple matrix-unit runtime coverage, but they run on scarce,
+self-hosted hardware and are not feature-branch required checks. Use this
+policy:
 
-- **Recommended:** extend its PR support to `feature/*`, add a merge-group-safe
-  change-selection pattern, and require the relevant successful job for changes
-  selected by its paths; or
-- require an operator-dispatched run at the final feature head and record its
-  URL in the epic before the final PR to `main`.
+- feature-target story and synchronization PRs run the required hosted checks,
+  including `macOS build, lint and workspace tests (hosted)`;
+- `nax-worker` does not auto-run for PRs targeting `feature/*` or for merge
+  groups; it continues to run for the final same-repo integration PR targeting
+  `main`;
+- `windows-candle.yml` remains limited to ordinary PRs targeting `main` and
+  stays out of the merge queue; and
+- at the frozen final feature head, explicitly dispatch both privileged
+  workflows and record their exact head SHA and successful run URLs in the epic
+  before opening the final PR to `main`.
 
 Apply the same rule to privileged inference real-weight lanes: ordinary CI may
 select their impact without having authority or hardware to execute them. An

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1098,6 +1098,353 @@ const REQUIRED_LANES = [
   { path: ".github/workflows/desktop-macos-check.yml", anchor: "desktop_macos_check_paths" },
 ];
 
+const REQUIRED_WORKFLOWS = [
+  ".github/workflows/check.yml",
+  ...REQUIRED_LANES.map(({ path }) => path),
+];
+
+function stripYamlComment(line) {
+  let quote;
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (quote === '"' && char === "\\") {
+      i += 1;
+    } else if (quote === "'" && char === "'" && line[i + 1] === "'") {
+      i += 1;
+    } else if (quote && char === quote) {
+      quote = undefined;
+    } else if (!quote && (char === '"' || char === "'")) {
+      quote = char;
+    } else if (!quote && char === "#" && (i === 0 || /\s/.test(line[i - 1]))) {
+      return line.slice(0, i).trimEnd();
+    }
+  }
+  return line;
+}
+
+function yamlScalar(value, context) {
+  const scalar = value.trim();
+  assert.ok(scalar.length > 0, `${context}: empty branch pattern`);
+  if (scalar.startsWith('"')) {
+    assert.ok(scalar.endsWith('"'), `${context}: unterminated double-quoted branch pattern`);
+    return JSON.parse(scalar);
+  }
+  if (scalar.startsWith("'")) {
+    assert.ok(scalar.endsWith("'"), `${context}: unterminated single-quoted branch pattern`);
+    return scalar.slice(1, -1).replaceAll("''", "'");
+  }
+  assert.doesNotMatch(
+    scalar,
+    /[\[\]{},]/,
+    `${context}: unsupported branch-pattern syntax; refusing to assume feature PR coverage`,
+  );
+  return scalar;
+}
+
+function splitFlowItems(value, context) {
+  const items = [];
+  let quote;
+  let squareDepth = 0;
+  let curlyDepth = 0;
+  let start = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+    if (quote === '"' && char === "\\") {
+      i += 1;
+    } else if (quote === "'" && char === "'" && value[i + 1] === "'") {
+      i += 1;
+    } else if (quote && char === quote) {
+      quote = undefined;
+    } else if (!quote && (char === '"' || char === "'")) {
+      quote = char;
+    } else if (!quote && char === "[") {
+      squareDepth += 1;
+    } else if (!quote && char === "]") {
+      squareDepth -= 1;
+    } else if (!quote && char === "{") {
+      curlyDepth += 1;
+    } else if (!quote && char === "}") {
+      curlyDepth -= 1;
+    } else if (!quote && char === "," && squareDepth === 0 && curlyDepth === 0) {
+      items.push(value.slice(start, i).trim());
+      start = i + 1;
+    }
+    assert.ok(squareDepth >= 0 && curlyDepth >= 0, `${context}: unbalanced flow collection`);
+  }
+  assert.ok(!quote && squareDepth === 0 && curlyDepth === 0, `${context}: unclosed flow collection`);
+  items.push(value.slice(start).trim());
+  return items.filter(Boolean);
+}
+
+function branchSequence(value, context) {
+  const sequence = value.trim();
+  assert.match(
+    sequence,
+    /^\[.*\]$/,
+    `${context}: branch filters must use an explicit sequence; refusing to guess`,
+  );
+  return splitFlowItems(sequence.slice(1, -1), context).map((item) => yamlScalar(item, context));
+}
+
+function flowPullRequestFilters(value, context) {
+  assert.match(
+    value,
+    /^\{.*\}$/,
+    `${context}: unsupported pull_request value; refusing to assume feature PR coverage`,
+  );
+  let branches;
+  let hasBranchesIgnore = false;
+  for (const item of splitFlowItems(value.slice(1, -1), context)) {
+    const separator = item.indexOf(":");
+    assert.ok(separator > 0, `${context}: malformed pull_request flow mapping`);
+    const key = yamlScalar(item.slice(0, separator), context);
+    const rawValue = item.slice(separator + 1);
+    if (key === "<<") {
+      assert.fail(`${context}: inherited pull_request filters cannot prove feature PR coverage`);
+    } else if (key === "branches") {
+      assert.equal(branches, undefined, `${context}: duplicate branches filter`);
+      branches = branchSequence(rawValue, `${context} branches`);
+    } else if (key === "branches-ignore") {
+      hasBranchesIgnore = true;
+    }
+  }
+  return { branches, hasBranchesIgnore };
+}
+
+// This is deliberately a narrow reader, not a general YAML parser. It accepts the block and
+// single-line flow forms used by Actions, strips real comments without stripping quoted `#`, and
+// throws on aliases or syntax it cannot prove safe. A required check must fail closed here: treating
+// an unknown shape as unfiltered could leave every feature-target PR permanently Pending.
+function pullRequestBranchFilters(workflow, context) {
+  const lines = workflow.split(/\r?\n/).map(stripYamlComment);
+  const onDeclarations = lines
+    .map((line, index) => (/^on\s*:/.test(line) ? index : -1))
+    .filter((index) => index >= 0);
+  assert.equal(
+    onDeclarations.length,
+    1,
+    `${context}: required workflow must declare one top-level on mapping`,
+  );
+  const [onAt] = onDeclarations;
+  const onDeclaration = /^on\s*:\s*(.*)$/.exec(lines[onAt]);
+  assert.equal(
+    onDeclaration[1].trim(),
+    "",
+    `${context}: flow-style top-level on mappings are unsupported; refusing to guess`,
+  );
+
+  let onEnd = lines.length;
+  for (let i = onAt + 1; i < lines.length; i += 1) {
+    if (lines[i].trim() && /^\S/.test(lines[i])) {
+      onEnd = i;
+      break;
+    }
+  }
+  const eventLines = lines.slice(onAt + 1, onEnd).filter((line) => line.trim());
+  assert.ok(eventLines.length > 0, `${context}: top-level on mapping is empty`);
+  const eventIndent = Math.min(...eventLines.map((line) => /^ */.exec(line)[0].length));
+  assert.ok(eventIndent > 0, `${context}: malformed top-level on mapping`);
+
+  const pullRequestDeclarations = [];
+  for (let i = onAt + 1; i < onEnd; i += 1) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    const indent = /^ */.exec(line)[0].length;
+    assert.ok(indent >= eventIndent, `${context}: inconsistent event indentation`);
+    if (indent !== eventIndent) continue;
+    const declaration = /^\s*((?:"[^"]*"|'[^']*'|[A-Za-z0-9_-]+))\s*:\s*(.*)$/.exec(line);
+    assert.ok(declaration, `${context}: unrecognized event declaration: ${line.trim()}`);
+    if (yamlScalar(declaration[1], context) === "pull_request") {
+      pullRequestDeclarations.push({ index: i, inline: declaration[2].trim() });
+    }
+  }
+  assert.equal(
+    pullRequestDeclarations.length,
+    1,
+    `${context}: top-level on mapping must declare pull_request exactly once`,
+  );
+  const [{ index: pullRequestAt, inline }] = pullRequestDeclarations;
+  if (inline) return flowPullRequestFilters(inline, context);
+
+  let pullRequestEnd = onEnd;
+  for (let i = pullRequestAt + 1; i < onEnd; i += 1) {
+    if (!lines[i].trim()) continue;
+    const indent = /^ */.exec(lines[i])[0].length;
+    if (indent === eventIndent) {
+      pullRequestEnd = i;
+      break;
+    }
+    assert.ok(indent > eventIndent, `${context}: inconsistent pull_request indentation`);
+  }
+  const childLines = lines.slice(pullRequestAt + 1, pullRequestEnd).filter((line) => line.trim());
+  if (childLines.length === 0) return { branches: undefined, hasBranchesIgnore: false };
+  const childIndent = Math.min(...childLines.map((line) => /^ */.exec(line)[0].length));
+  assert.ok(childIndent > eventIndent, `${context}: malformed pull_request mapping`);
+
+  let branches;
+  let hasBranchesIgnore = false;
+  for (let i = pullRequestAt + 1; i < pullRequestEnd; i += 1) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    const indent = /^ */.exec(line)[0].length;
+    assert.equal(
+      indent,
+      childIndent,
+      `${context}: unrecognized pull_request child line: ${line.trim()}`,
+    );
+    const keyMatch = /^((?:"[^"]*"|'[^']*'|[A-Za-z0-9_-]+|<<))\s*:\s*(.*)$/.exec(
+      line.slice(childIndent),
+    );
+    assert.ok(keyMatch, `${context}: unrecognized pull_request child line: ${line.trim()}`);
+    const key = yamlScalar(keyMatch[1], context);
+    if (key === "<<") {
+      assert.fail(`${context}: inherited pull_request filters cannot prove feature PR coverage`);
+    }
+
+    const values = [];
+    if (keyMatch[2].trim()) {
+      if (key === "branches" || key === "branches-ignore") {
+        values.push(...branchSequence(keyMatch[2], `${context} ${key}`));
+      }
+    } else {
+      let nestedIndent;
+      for (let j = i + 1; j < pullRequestEnd; j += 1) {
+        if (!lines[j].trim()) continue;
+        const indent = /^ */.exec(lines[j])[0].length;
+        if (indent <= childIndent) break;
+        nestedIndent ??= indent;
+        assert.equal(
+          indent,
+          nestedIndent,
+          `${context}: inconsistent indentation under pull_request ${key}`,
+        );
+        const item = /^-\s+(.+)$/.exec(lines[j].slice(nestedIndent));
+        assert.ok(item, `${context}: unrecognized value under pull_request ${key}`);
+        if (key === "branches" || key === "branches-ignore") {
+          values.push(yamlScalar(item[1], `${context} ${key}`));
+        }
+        i = j;
+      }
+    }
+
+    if (key === "branches") {
+      assert.equal(branches, undefined, `${context}: duplicate branches filter`);
+      branches = values;
+    } else if (key === "branches-ignore") {
+      hasBranchesIgnore = true;
+    }
+  }
+  return { branches, hasBranchesIgnore };
+}
+
+function assertFeaturePullRequestCoverage(workflow, context) {
+  const { branches, hasBranchesIgnore } = pullRequestBranchFilters(workflow, context);
+  assert.equal(
+    hasBranchesIgnore,
+    false,
+    `${context}: branches-ignore is not allowed on a required workflow because it can exclude ` +
+      "feature integration PRs",
+  );
+  if (!branches) return;
+  assert.ok(branches.includes("main"), `${context}: its PR base filter must retain main`);
+  assert.ok(
+    branches.includes("feature/*"),
+    `${context}: its PR base filter must include feature/* so the required check reports on ` +
+      "story PRs into a feature integration branch",
+  );
+  assert.equal(
+    branches.some((pattern) => pattern.startsWith("!")),
+    false,
+    `${context}: negative branch filters cannot prove coverage of every feature integration PR`,
+  );
+}
+
+test("every required workflow reports on feature-target pull requests", async () => {
+  for (const path of REQUIRED_WORKFLOWS) {
+    assertFeaturePullRequestCoverage(await source(path), path);
+  }
+});
+
+test("feature-target coverage rejects inline and multiline branches-ignore filters", () => {
+  for (const workflow of [
+    'on:\n  pull_request:\n    branches-ignore: ["feature/*"]\n',
+    'on:\n  pull_request:\n    branches-ignore:\n      - "feature/*"\n',
+    'on:\n  pull_request: { branches-ignore: ["feature/*"] }\n',
+  ]) {
+    assert.throws(
+      () => assertFeaturePullRequestCoverage(workflow, "mutated workflow"),
+      /branches-ignore/,
+    );
+  }
+});
+
+test("feature-target coverage ignores comments and rejects negative or main-only filters", () => {
+  for (const [workflow, error] of [
+    ['on:\n  pull_request:\n    branches: [main] # "feature/*"\n', /must include feature\/\*/],
+    [
+      'on:\n  pull_request:\n    # branches: [main, "feature/*"]\n    branches: [main]\n',
+      /must include feature\/\*/,
+    ],
+    [
+      'on:\n  pull_request:\n    branches: [main, "feature/*", "!feature/*"]\n',
+      /negative branch filters/,
+    ],
+    ['on:\n  pull_request: { branches: [main] } # "feature/*"\n', /must include feature\/\*/],
+  ]) {
+    assert.throws(() => assertFeaturePullRequestCoverage(workflow, "mutated workflow"), error);
+  }
+});
+
+test("feature-target coverage cannot be supplied by a job named pull_request", () => {
+  const workflow = [
+    "on:",
+    "  push:",
+    "jobs:",
+    "  pull_request:",
+    '    branches: [main, "feature/*"]',
+  ].join("\n");
+  assert.throws(
+    () => assertFeaturePullRequestCoverage(workflow, "mutated workflow"),
+    /top-level on mapping must declare pull_request exactly once/,
+  );
+});
+
+test("feature-target coverage parses arbitrary child indentation and rejects malformed children", () => {
+  assert.throws(
+    () =>
+      assertFeaturePullRequestCoverage(
+        "on:\n  pull_request:\n   branches: [main]\n",
+        "three-space mutation",
+      ),
+    /must include feature\/\*/,
+  );
+  assert.doesNotThrow(() =>
+    assertFeaturePullRequestCoverage(
+      'on:\n  pull_request:\n   branches: [main, "feature/*"]\n',
+      "three-space workflow",
+    ),
+  );
+  assert.throws(
+    () =>
+      assertFeaturePullRequestCoverage(
+        'on:\n  pull_request:\n   branches [main, "feature/*"]\n',
+        "malformed workflow",
+      ),
+    /unrecognized pull_request child line/,
+  );
+});
+
+test("feature-target coverage accepts unfiltered, block, and flow branch declarations", () => {
+  for (const workflow of [
+    "on:\n  pull_request:\n  push:\n    branches: [main]\n",
+    'on:\n  pull_request:\n    branches:\n      - main\n      - "feature/*"\n',
+    'on:\n  pull_request:\n    branches: [main, "feature/*"]\n    types: [opened, synchronize]\n',
+    'on:\n  pull_request: { branches: [main, "feature/*"], types: [opened] }\n',
+  ]) {
+    assert.doesNotThrow(() => assertFeaturePullRequestCoverage(workflow, "valid workflow"));
+  }
+});
+
 test("every required lane reports on the merge queue and drops its PR path filter", async () => {
   for (const { path } of REQUIRED_LANES) {
     const lane = await source(path);
@@ -1171,6 +1518,12 @@ test("dropping the PR path filter did not expose the self-hosted pools", async (
     "nax-worker must consult the `changes` gate — without it, every docs-only PR now wakes the " +
       "two-Mac nax pool, because the pull_request path filter that used to do this is gone.",
   );
+  assert.match(
+    naxCondition,
+    /github\.event\.pull_request\.base\.ref == 'main'/,
+    "nax-worker must not auto-run for story PRs targeting feature/*; capture NAX evidence with " +
+      "an explicit dispatch at the frozen feature head, then run it again on the final PR to main.",
+  );
 
   const desktop = await source(".github/workflows/desktop-windows.yml");
   // package-windows is main + dispatch only. Before merge_group existed, `!= 'pull_request'`
@@ -1196,11 +1549,26 @@ test("windows-candle stays out of the queue and out of the required set", async 
   // on the self-hosted `cuda` pool. Its merge-time stand-in is check.yml's hosted `candle`
   // typecheck. Making candle-worker required would force a merge_group: trigger here, and p90
   // queue wait (18m) + p90 run already reaches ~50m of the 60m budget.
+  const candle = await source(".github/workflows/windows-candle.yml");
   assert.doesNotMatch(
-    await source(".github/workflows/windows-candle.yml"),
+    candle,
     /^ {2}merge_group:$/m,
     "windows-candle.yml must stay out of the merge queue; check.yml's `candle` job is its " +
       "merge-time stand-in. See sc-17014 for the (A)/(B)/(C) decision if this changes.",
+  );
+  const prAt = candle.indexOf("\n  pull_request:");
+  assert.ok(prAt > 0, "windows-candle.yml must retain its pull_request trigger for final main PRs");
+  const prBlock = candle.slice(prAt + 1).split(/\n {2}(?=[a-z_]+:)/)[0];
+  assert.match(prBlock, /^ {4}branches: \[main\]$/m);
+  assert.doesNotMatch(
+    prBlock,
+    /feature\/\*/,
+    "windows-candle must not auto-run on feature story PRs; dispatch it at the frozen feature head.",
+  );
+  assert.match(
+    candle.slice(0, candle.indexOf("\njobs:")),
+    /^ {2}workflow_dispatch:$/m,
+    "windows-candle must remain dispatchable for authoritative final-head evidence.",
   );
 });
 


### PR DESCRIPTION
## Summary

- run the required hosted macOS check for pull requests targeting either `main` or `feature/*`
- keep feature-story PRs off the scarce NAX pool while preserving explicit final-head dispatches and final integration PR coverage
- make the required-workflow contract fail closed on branch exclusions, negative filters, misleading comments, malformed/aliased YAML, nested job names, and indentation variants
- document the hosted-vs-privileged runtime matrix and layered no-bypass merge/deletion ruleset design

## Tracker

- [sc-18418](https://app.shortcut.com/trefry/story/18418)

## Validation

- `node --test scripts/platform-review-contracts.test.mjs scripts/merge-group-relevance.test.mjs` — 52/52 passed
- `node scripts/check-source-control-bytes.mjs` — passed across 1,456 tracked source files
- `git diff --check` — passed
- `actionlint .github/workflows/macos-mlx.yml` — only the same two pre-existing diagnostics reproduced from `origin/main` (the externally consumed YAML anchor and existing SC2016 notice)

## Review

A fresh adversarial review found two fail-open parser classes in the first draft: branch exclusions/comment-only matches, then a nested job named `pull_request`/nonstandard valid indentation. Both were reproduced, fixed, and pinned with mutation tests. Final re-review reported no actionable findings.

## Live acceptance after merge

This PR is the source prerequisite for sc-18418. After it merges, the story still requires active layered `feature/*` rulesets in SceneWorks and inference, disposable branch/PR/merge-queue proof, direct/force/deletion denial evidence, and creation of the mirrored epic integration branches from exact post-merge main heads.
