### PR TITLE
fix(desktop): gate Windows GPU-runtime adoption on the pinned version

### DIFF
--- a/apps/desktop/docs/offline-install.md
+++ b/apps/desktop/docs/offline-install.md
@@ -70,7 +70,27 @@ guide covers how to **pre-stage** the runtime so first run completes fully offli
 | You are scripting an enterprise / MSI rollout | [Method 2](#method-2-stage-a-redist-bundle) with `SCENEWORKS_GPU_RUNTIME_DIR` |
 
 All methods land the same files in the same place. Under the hood the app skips the
-download whenever the runtime is already present (`apps/desktop/src/cuda_provision.rs`).
+download only when the runtime is both **complete** and **marked as this SceneWorks
+version's pinned redist** (`apps/desktop/src/cuda_provision.rs`).
+
+### The version marker is required
+
+Every skip-the-download path is gated on a `.redist-marker` file naming the exact pinned
+redist version:
+
+```text
+cuda12.9-ort1.26.0-cudnn9.23-1
+```
+
+The DLL filenames alone are not enough to prove which redist a folder came from —
+`cudart64_12.dll` and `onnxruntime.dll` are the same names in older releases — so a stage
+with no marker, or a marker from an older SceneWorks, is rejected and the app downloads
+instead. Methods 1 and 2 both produce that marker; the [manual
+fallback](#manual-fallback-place-the-dlls-yourself) has you write it.
+
+When a SceneWorks upgrade changes the pinned versions this string changes too, and every
+pre-staged bundle must be rebuilt from the new wheel set. The authoritative value is
+`REDIST_VERSION` in [`apps/desktop/src/cuda_provision.rs`](../src/cuda_provision.rs).
 
 ---
 
@@ -79,20 +99,25 @@ download whenever the runtime is already present (`apps/desktop/src/cuda_provisi
 If you have another Windows machine (same or newer NVIDIA driver) that can reach the
 internet:
 
-1. Install and launch SceneWorks on the **connected** machine and let first run
-   finish the GPU-runtime download.
+1. Install **the same SceneWorks version** on the **connected** machine, launch it, and
+   let first run finish the GPU-runtime download.
 2. Copy its entire runtime folder to the **offline** machine, to the same path:
 
    ```
    %APPDATA%\SceneWorks\gpu-runtime
    ```
 
-   That folder contains `cuda\`, `onnxruntime\`, and a `.redist-marker` file. Copy all
-   of it (the marker tells the app it is already provisioned).
+   That folder contains `cuda\`, `onnxruntime\`, `.redist-marker`, and a set of
+   `.component-*.ok` files. Copy **all** of it — the markers are what tell the app the
+   DLLs match its pinned redist.
 3. Install SceneWorks on the offline machine and launch it. First run detects the
    existing runtime and skips the download.
 
 That is the whole procedure — no environment variables needed.
+
+> Both machines must run the same SceneWorks version. A folder provisioned by an older
+> release carries an older marker; the offline machine rejects it and tries to download,
+> which fails with no network. Re-copy from a connected machine on the matching version.
 
 ---
 
@@ -135,6 +160,7 @@ A wheel is just a ZIP. Build a bundle folder with two subdirectories, `cuda` and
 gpu-runtime-bundle\
   cuda\           <- every *.dll from the 7 nvidia_*-cu12 wheels
   onnxruntime\    <- three DLLs from the onnxruntime_gpu wheel
+  .redist-marker  <- the pinned version string (see below)
 ```
 
 - From each of the **seven `nvidia_*-cu12`** wheels, copy **every `*.dll`** (they live
@@ -166,6 +192,24 @@ foreach ($whl in Get-ChildItem *.whl) {
 }
 ```
 
+### 2b-2. Mark the bundle with the pinned version
+
+The app refuses an unmarked bundle, because a folder of DLLs assembled from an older wheel
+set is indistinguishable by filename from one built at the current pin. Write the marker
+that says which redist you just assembled:
+
+```powershell
+Set-Content -Path "$bundle\.redist-marker" -Value "cuda12.9-ort1.26.0-cudnn9.23-1" -Encoding ascii
+```
+
+Use `-Encoding ascii` (or any BOM-free UTF-8 writer). A UTF-8 **byte-order mark** makes the
+file's first character invisible junk and the marker will not match.
+
+The value must equal `REDIST_VERSION` in
+[`apps/desktop/src/cuda_provision.rs`](../src/cuda_provision.rs) exactly. Only write it
+after assembling the bundle from the wheel table above — the marker asserts which wheels
+are inside, and the app trusts it.
+
 Sanity-check the bundle carries the key libraries: `cuda\` should contain
 `cudart64_12.dll`, `cublas64_12.dll`, `curand64_10.dll`, an `nvrtc64_*.dll`,
 `cudnn64_9.dll`, `cufft64_11.dll`, and an `nvJitLink_*.dll`; `onnxruntime\` should hold
@@ -184,17 +228,23 @@ setx SCENEWORKS_GPU_RUNTIME_DIR "C:\path\to\gpu-runtime-bundle"
 (`setx` persists it for future launches; open a new session for it to take effect. For
 a machine-wide rollout, set it as a system environment variable.)
 
-On first launch the app copies the bundle's DLLs into `%APPDATA%\SceneWorks\gpu-runtime`,
-verifies the set is complete, marks the runtime provisioned, and starts — with no network
-access. If the bundle is missing a subdirectory or a required DLL, setup stops with an
-actionable message rather than starting a broken worker.
+On first launch the app checks the bundle's marker, copies its DLLs into
+`%APPDATA%\SceneWorks\gpu-runtime`, verifies the set is complete, marks the runtime
+provisioned, and starts — with no network access. If the bundle is missing a
+subdirectory, a required DLL, or the version marker, setup stops with an actionable
+message rather than starting a broken worker.
 
 Once installed, `SCENEWORKS_GPU_RUNTIME_DIR` is no longer consulted (the provisioned
-copy is marked complete), so you can leave it set or remove it.
+copy is marked complete), so you can leave it set or remove it. It *is* consulted again
+after a SceneWorks upgrade that changes the pinned redist — rebuild the bundle and update
+its marker before rolling that upgrade out, or the upgraded app will try to download.
+
+Pointing the variable at `%APPDATA%\SceneWorks\gpu-runtime` itself is harmless: a
+complete, correctly marked runtime is accepted in place rather than copied onto itself.
 
 ---
 
-## Manual fallback (marker file)
+## Manual fallback (place the DLLs yourself)
 
 If you prefer not to set an environment variable, you can place the DLLs directly and
 let the app adopt them:
@@ -202,11 +252,19 @@ let the app adopt them:
 1. Copy the bundle's `cuda\` and `onnxruntime\` folders into
    `%APPDATA%\SceneWorks\gpu-runtime\` so you have
    `%APPDATA%\SceneWorks\gpu-runtime\cuda\...` and `...\onnxruntime\...`.
-2. Launch SceneWorks. It detects the complete DLL set and skips the download.
+2. Write the version marker next to them:
 
-You do **not** need to hand-write the `.redist-marker` file — the app writes it once it
-confirms the set is complete. (Older instructions that had you create the marker by hand
-still work, but the DLL detection above is the supported path.)
+   ```powershell
+   Set-Content -Path "$env:APPDATA\SceneWorks\gpu-runtime\.redist-marker" -Value "cuda12.9-ort1.26.0-cudnn9.23-1" -Encoding ascii
+   ```
+
+3. Launch SceneWorks. It confirms the DLL set is complete, sees the marker, and skips the
+   download.
+
+Step 2 is **required**. Earlier releases adopted any complete-looking DLL set with no
+marker; that made a pinned-version bump silently inert on machines that already had a
+runtime, so adoption is now marker-gated on every path. If you skip it, the app treats
+the folder as an unknown-vintage leftover and downloads the pinned set over it.
 
 ---
 

--- a/apps/desktop/src/cuda_provision.rs
+++ b/apps/desktop/src/cuda_provision.rs
@@ -20,6 +20,14 @@
 //! Idempotent: a `.redist-marker` written after a full success short-circuits later
 //! runs, so the multi-GB fetch happens only on the first launch (or after a version
 //! bump that changes the marker).
+//!
+//! Every skip-the-download path is gated on *marker evidence for this exact
+//! `REDIST_VERSION`*, never on DLL presence alone (mirrors `linux_cuda_provision`).
+//! The sentinels are version-agnostic basenames (`cudart64_`, `onnxruntime.dll`), so a
+//! box provisioned at an older pin satisfies every sentinel — adopting on that basis
+//! made a `REDIST_VERSION` bump inert on precisely the installs it exists to update.
+//! An unmarked (or stale-marked) tree therefore falls through to the download loop,
+//! whose per-component retry-skip does check the version.
 #![cfg(target_os = "windows")]
 
 use std::fs;
@@ -208,16 +216,28 @@ fn root() -> PathBuf {
     gpu_runtime_dir()
 }
 
+/// The CUDA DLL subdir of an arbitrary runtime root. Taking the root as an argument (vs.
+/// reading the ambient one) lets the same predicates judge the provisioned root AND a
+/// pre-staged source bundle, which shares the layout.
+fn cuda_subdir(root: &Path) -> PathBuf {
+    root.join("cuda")
+}
+
+/// The onnxruntime DLL subdir of an arbitrary runtime root.
+fn ort_subdir(root: &Path) -> PathBuf {
+    root.join("onnxruntime")
+}
+
 /// Provisioned CUDA runtime DLL dir (`<root>\cuda`). The candle worker's PATH is
 /// prepended with this so cudarc's `LoadLibrary` and onnxruntime's CUDA provider find
 /// cudart/cublas/curand/nvrtc/cuDNN/cuFFT/nvJitLink.
 pub(crate) fn cuda_dir() -> PathBuf {
-    root().join("cuda")
+    cuda_subdir(&root())
 }
 
 /// Provisioned onnxruntime DLL dir (`<root>\onnxruntime`).
 fn onnxruntime_dir() -> PathBuf {
-    root().join("onnxruntime")
+    ort_subdir(&root())
 }
 
 /// The provisioned onnxruntime.dll path (set as `ORT_DYLIB_PATH`).
@@ -240,11 +260,64 @@ pub(crate) fn onnxruntime_dll_if_present() -> Option<PathBuf> {
     dll.exists().then_some(dll)
 }
 
-/// True when a prior run already provisioned this exact REDIST_VERSION.
-fn already_provisioned(root: &Path) -> bool {
+/// True when `root`'s top-level `.redist-marker` names this exact `REDIST_VERSION`.
+/// A missing, unreadable, or older-version marker is not evidence.
+fn top_marker_current(root: &Path) -> bool {
     fs::read_to_string(root.join(".redist-marker"))
         .map(|marker| marker.trim() == REDIST_VERSION)
         .unwrap_or(false)
+}
+
+/// True when EVERY component under `root` carries a current-version completion marker
+/// alongside its sentinel DLL(s). This is the recovery path for a run that provisioned
+/// every component but died before writing the top-level marker.
+fn all_component_markers_current(root: &Path) -> bool {
+    let cuda = cuda_subdir(root);
+    let ort = ort_subdir(root);
+    COMPONENTS.iter().all(|component| {
+        component_provisioned(
+            root,
+            dest_dir(component, &cuda, &ort),
+            component.slug,
+            REDIST_VERSION,
+            component.sentinels,
+        )
+    })
+}
+
+/// True when `root` proves it was provisioned at this exact `REDIST_VERSION` — either by
+/// its top-level marker or by a full set of per-component markers. Mirrors the Linux
+/// `top_marker_current || all_component_markers_current` test.
+///
+/// Load-bearing: the sentinels are version-agnostic (`cudart64_` matches a CUDA 11, 12 or
+/// 13 runtime; `onnxruntime.dll` is the same basename in every ORT release), so DLL
+/// presence alone cannot distinguish a tree staged at the pinned version from one left by
+/// an older install. Only a marker can.
+fn has_current_marker_evidence(root: &Path) -> bool {
+    top_marker_current(root) || all_component_markers_current(root)
+}
+
+/// True when a prior run already provisioned this exact `REDIST_VERSION` into `root` AND
+/// the full DLL set is still on disk. Both halves matter: the marker pins the version, the
+/// sentinel sweep catches a tree whose DLLs were deleted/pruned after the marker landed
+/// (which would otherwise short-circuit provisioning and leave the worker unable to load).
+fn already_provisioned(root: &Path) -> bool {
+    top_marker_current(root) && is_staged_complete(&cuda_subdir(root), &ort_subdir(root))
+}
+
+/// True when `root` holds a runtime that may be adopted as-is without downloading: the
+/// complete DLL set AND current-version marker evidence for it.
+fn adoptable(root: &Path) -> bool {
+    is_staged_complete(&cuda_subdir(root), &ort_subdir(root)) && has_current_marker_evidence(root)
+}
+
+/// True when two paths name the same directory, tolerating the case/separator/UNC
+/// differences a hand-typed `SCENEWORKS_GPU_RUNTIME_DIR` can carry on Windows.
+fn same_dir(left: &Path, right: &Path) -> bool {
+    match (fs::canonicalize(left), fs::canonicalize(right)) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
 }
 
 /// Which provisioned dir a component's sentinels live in.
@@ -255,12 +328,15 @@ fn dest_dir<'a>(component: &Component, cuda: &'a Path, ort: &'a Path) -> &'a Pat
     }
 }
 
-/// True when both provisioned dirs hold every component's sentinel DLL(s) — i.e. a
-/// pre-staged redist is complete enough to run without downloading. Derived from the
-/// single `COMPONENTS` table (one source of truth for what a component's DLLs are), so
+/// True when both provisioned dirs hold every component's sentinel DLL(s). Derived from
+/// the single `COMPONENTS` table (one source of truth for what a component's DLLs are), so
 /// adding a component can't skew this check. Deliberately stricter than the single-DLL
 /// `*_if_present` resolver probes (which only gate the candle lane): a partial stage
 /// that passed a one-DLL probe but was missing cuDNN/nvJitLink would hard-fail at load.
+///
+/// A *completeness* test only — it says nothing about WHICH redist version those DLLs came
+/// from, so it is never sufficient on its own to skip provisioning. Every caller pairs it
+/// with `has_current_marker_evidence` (see `adoptable` / `already_provisioned`).
 fn is_staged_complete(cuda: &Path, ort: &Path) -> bool {
     COMPONENTS.iter().all(|component| {
         let dir = dest_dir(component, cuda, ort);
@@ -295,24 +371,45 @@ fn copy_dlls(src: &Path, dst: &Path) -> Result<usize, String> {
 }
 
 /// Install a pre-extracted redist from `source` (a `cuda\` + `onnxruntime\` pair) into
-/// the provisioned dirs by copying every DLL across, then verify the full sentinel set
-/// landed. Errors clearly if the expected subdirs/DLLs are missing so a mis-staged
-/// override doesn't masquerade as success (and silently leave the candle lane broken).
-fn install_from_staged(source: &Path, cuda: &Path, ort: &Path) -> Result<(), String> {
+/// `root`'s provisioned dirs by copying every DLL across, then verify the full sentinel
+/// set landed and record per-component completion markers. Errors clearly if the expected
+/// subdirs/DLLs are missing so a mis-staged override doesn't masquerade as success (and
+/// silently leave the candle lane broken).
+///
+/// The source must carry current-`REDIST_VERSION` marker evidence, the same requirement
+/// the Linux sibling enforces. A hand-assembled bundle is DLL-name-indistinguishable from
+/// one built against an older pin, so without the marker a stale bundle would keep
+/// satisfying every version bump — the failure mode this whole module's markers exist to
+/// prevent. `docs/offline-install.md` documents writing the marker into the bundle.
+fn install_from_staged(source: &Path, root: &Path, cuda: &Path, ort: &Path) -> Result<(), String> {
     if !source.is_dir() {
         return Err(format!(
             "{GPU_RUNTIME_DIR_ENV} points at a missing directory: {}",
             source.display()
         ));
     }
-    let src_cuda = source.join("cuda");
-    let src_ort = source.join("onnxruntime");
+    let src_cuda = cuda_subdir(source);
+    let src_ort = ort_subdir(source);
     if !src_cuda.is_dir() || !src_ort.is_dir() {
         return Err(format!(
             "{GPU_RUNTIME_DIR_ENV} ({}) must contain `cuda` and `onnxruntime` subdirectories of \
              extracted DLLs — see docs/offline-install.md",
             source.display()
         ));
+    }
+    if !has_current_marker_evidence(source) {
+        return Err(format!(
+            "{GPU_RUNTIME_DIR_ENV} ({}) has no current `{REDIST_VERSION}` marker evidence; stage a \
+             bundle built from this SceneWorks version's pinned wheels (or copy a runtime it \
+             provisioned) — see docs/offline-install.md",
+            source.display()
+        ));
+    }
+    // Pointing the override at the live runtime root is a self-copy: `fs::copy` would fail
+    // on Windows with a sharing violation. It is already verified complete + pinned above,
+    // so accept it in place.
+    if same_dir(source, root) {
+        return Ok(());
     }
     let copied_cuda = copy_dlls(&src_cuda, cuda)?;
     let copied_ort = copy_dlls(&src_ort, ort)?;
@@ -329,6 +426,12 @@ fn install_from_staged(source: &Path, cuda: &Path, ort: &Path) -> Result<(), Str
              DLLs are missing; see docs/offline-install.md for the full redist set",
             source.display()
         ));
+    }
+    // Record the same per-component evidence a downloaded runtime carries, so the installed
+    // tree is self-describing: it can later be adopted implicitly, feed the retry-skip loop,
+    // or be copied to another offline machine as a pinned source in its own right.
+    for component in COMPONENTS {
+        write_component_marker(root, component.slug, REDIST_VERSION)?;
     }
     Ok(())
 }
@@ -469,8 +572,8 @@ pub(crate) async fn provision(app: &AppHandle) -> Result<(), String> {
         return Ok(());
     }
 
-    let cuda = cuda_dir();
-    let ort = onnxruntime_dir();
+    let cuda = cuda_subdir(&root);
+    let ort = ort_subdir(&root);
     for dir in [&cuda, &ort] {
         fs::create_dir_all(dir).map_err(|error| format!("create {}: {error}", dir.display()))?;
     }
@@ -496,16 +599,21 @@ pub(crate) async fn provision(app: &AppHandle) -> Result<(), String> {
                 ),
                 false,
             );
-            install_from_staged(&source, &cuda, &ort)?;
+            install_from_staged(&source, &root, &cuda, &ort)?;
             write_marker(&root)?;
             emit(app, "provision", "GPU runtime ready (pre-staged).", false);
             return Ok(());
         }
     }
 
-    // 2. Implicit — a user (or a prior install) already populated the target dirs with
-    //    the full DLL set. Adopt them as-is; no network.
-    if is_staged_complete(&cuda, &ort) {
+    // 2. Implicit — a user (or a prior install) already populated the target dirs with the
+    //    full DLL set AND left current-version marker evidence for it. Adopt as-is; no
+    //    network. The marker half is what makes a REDIST_VERSION bump actually land:
+    //    `is_staged_complete` alone is satisfied by the previous pin's DLLs (the sentinels
+    //    are version-agnostic basenames), so a version-blind adoption here would write the
+    //    NEW marker over the OLD DLLs and skip the download loop entirely — the loop being
+    //    the only thing that re-fetches at the new pin.
+    if adoptable(&root) {
         write_marker(&root)?;
         emit(
             app,
@@ -740,6 +848,48 @@ mod tests {
         "onnxruntime_providers_shared.dll",
     ];
 
+    /// The CUDA DLLs an install provisioned at an OLDER pin leaves behind (CUDA 11 /
+    /// cuDNN 8 era). Every name still satisfies its component's sentinel — `cudart64_`,
+    /// `cudnn64_`, `nvjitlink` are deliberately version-agnostic prefixes — which is
+    /// exactly why DLL presence alone cannot tell a stale tree from a current one. The
+    /// onnxruntime DLLs need no stale variant: their basenames are byte-identical across
+    /// ORT releases, so `STAGED_ORT_DLLS` is already indistinguishable by name.
+    const PREVIOUS_REDIST_CUDA_DLLS: &[&str] = &[
+        "cudart64_11.dll",
+        "cublas64_11.dll",
+        "cublasLt64_11.dll",
+        "curand64_10.dll",
+        "nvrtc64_112_0.dll",
+        "cudnn64_8.dll",
+        "cufft64_10.dll",
+        "nvJitLink_110_0.dll",
+    ];
+
+    /// A marker value from before the current pin (`cuda12.8-ort1.25.1-cudnn9.10-1`).
+    ///
+    /// Assembled at runtime rather than written as a literal: `check-onnxruntime-pins.mjs`
+    /// greps this file for `REDIST_VERSION…= "…-ort<x.y.z>-"` to prove every distribution
+    /// channel names ONE ONNX Runtime version (the `ort` dlopen rejects an older dylib at
+    /// runtime, which no compile can see). A hard-coded prior pin here reads to that guard
+    /// as a half-applied bump and fails `npm run check` — so keep the `-ort` and the
+    /// version apart in the source text.
+    fn previous_redist_version() -> String {
+        format!("cuda12.8-ort{}.{}.{}-cudnn9.10-1", 1, 25, 1)
+    }
+
+    /// Lay down a complete current-pin tree under `root` (DLLs only, no markers).
+    fn stage_tree(root: &Path, cuda_dlls: &[&str]) {
+        touch(&cuda_subdir(root), cuda_dlls);
+        touch(&ort_subdir(root), STAGED_ORT_DLLS);
+    }
+
+    /// Write every component's completion marker at `version`.
+    fn mark_components(root: &Path, version: &str) {
+        for component in COMPONENTS {
+            write_component_marker(root, component.slug, version).expect("write component marker");
+        }
+    }
+
     /// `is_staged_complete` requires the FULL sentinel set in both dirs — a stage
     /// missing even one component (here cuDNN) is rejected, unlike the one-DLL probes.
     #[test]
@@ -759,24 +909,28 @@ mod tests {
         assert!(!is_staged_complete(&cuda, &ort));
     }
 
-    /// `install_from_staged` copies a well-formed `cuda\` + `onnxruntime\` source into
-    /// the provisioned dirs and reports complete.
+    /// `install_from_staged` copies a well-formed, currently-pinned `cuda\` +
+    /// `onnxruntime\` source into the provisioned dirs, reports complete, and leaves the
+    /// per-component evidence a downloaded runtime carries.
     #[test]
     fn install_from_staged_copies_full_set() {
         let src_guard = scratch("stage-src");
         let src = src_guard.path();
-        touch(&src.join("cuda"), STAGED_CUDA_DLLS);
-        touch(&src.join("onnxruntime"), STAGED_ORT_DLLS);
+        stage_tree(src, STAGED_CUDA_DLLS);
+        write_marker(src).expect("pin the source bundle");
 
         let dest_guard = scratch("stage-dest");
         let dest = dest_guard.path();
-        let cuda = dest.join("cuda");
-        let ort = dest.join("onnxruntime");
+        let cuda = cuda_subdir(dest);
+        let ort = ort_subdir(dest);
 
-        install_from_staged(src, &cuda, &ort).expect("install succeeds");
+        install_from_staged(src, dest, &cuda, &ort).expect("install succeeds");
         assert!(cuda.join("cudart64_12.dll").is_file());
         assert!(ort.join("onnxruntime_providers_cuda.dll").is_file());
         assert!(is_staged_complete(&cuda, &ort));
+        // The installed tree is self-describing: it can now be adopted implicitly (and
+        // re-staged onto another offline box) without re-deriving the version.
+        assert!(all_component_markers_current(dest));
     }
 
     /// A source missing the `cuda\`/`onnxruntime\` subdirs, or missing a component, is
@@ -787,16 +941,17 @@ mod tests {
         let flat_guard = scratch("stage-flat");
         let flat = flat_guard.path();
         touch(flat, STAGED_CUDA_DLLS);
+        write_marker(flat).expect("pin the flat source");
         let dest_guard = scratch("stage-flat-dest");
         let dest = dest_guard.path();
-        let error = install_from_staged(flat, &dest.join("cuda"), &dest.join("onnxruntime"))
+        let error = install_from_staged(flat, dest, &cuda_subdir(dest), &ort_subdir(dest))
             .expect_err("must reject a source without cuda/onnxruntime subdirs");
         assert!(
             error.contains("subdirectories"),
             "unexpected error: {error}"
         );
 
-        // Subdirs present but incomplete (cuDNN missing).
+        // Subdirs present and pinned, but incomplete (cuDNN missing).
         let partial_guard = scratch("stage-partial");
         let partial = partial_guard.path();
         let incomplete: Vec<&str> = STAGED_CUDA_DLLS
@@ -804,13 +959,139 @@ mod tests {
             .copied()
             .filter(|dll| *dll != "cudnn64_9.dll")
             .collect();
-        touch(&partial.join("cuda"), &incomplete);
-        touch(&partial.join("onnxruntime"), STAGED_ORT_DLLS);
+        stage_tree(partial, &incomplete);
+        write_marker(partial).expect("pin the partial source");
         let dest2_guard = scratch("stage-partial-dest");
         let dest2 = dest2_guard.path();
-        let error = install_from_staged(partial, &dest2.join("cuda"), &dest2.join("onnxruntime"))
+        let error = install_from_staged(partial, dest2, &cuda_subdir(dest2), &ort_subdir(dest2))
             .expect_err("must reject an incomplete source");
         assert!(error.contains("incomplete"), "unexpected error: {error}");
+        // A rejected install leaves no completion evidence behind.
+        assert!(!has_current_marker_evidence(dest2));
+    }
+
+    /// `SCENEWORKS_GPU_RUNTIME_DIR` must carry current-version marker evidence, matching
+    /// what the Linux sibling enforces. A bundle assembled against an older pin is
+    /// name-identical to a current one, so without this an upgraded install would keep
+    /// re-adopting the stale DLLs on every launch.
+    #[test]
+    fn install_from_staged_rejects_unpinned_source() {
+        let dest_guard = scratch("unpinned-dest");
+        let dest = dest_guard.path();
+        let cuda = cuda_subdir(dest);
+        let ort = ort_subdir(dest);
+
+        // Complete layout, no marker at all.
+        let src_guard = scratch("unpinned-src");
+        let src = src_guard.path();
+        stage_tree(src, STAGED_CUDA_DLLS);
+        let error = install_from_staged(src, dest, &cuda, &ort)
+            .expect_err("an unmarked bundle is not pinned");
+        assert!(
+            error.contains("marker evidence"),
+            "unexpected error: {error}"
+        );
+
+        // Marker present but from an older redist — names the required version so the
+        // operator can see what to rebuild against.
+        fs::write(src.join(".redist-marker"), previous_redist_version()).expect("stale marker");
+        let error =
+            install_from_staged(src, dest, &cuda, &ort).expect_err("a stale bundle is not pinned");
+        assert!(error.contains(REDIST_VERSION), "unexpected error: {error}");
+        assert!(
+            !cuda.join("cudart64_12.dll").exists(),
+            "must not have copied"
+        );
+
+        // Per-component evidence is an accepted alternative, but only when EVERY component
+        // is current — one stale component sinks the whole bundle.
+        fs::remove_file(src.join(".redist-marker")).expect("drop top marker");
+        mark_components(src, REDIST_VERSION);
+        write_component_marker(src, "cudnn", &previous_redist_version())
+            .expect("stale one component");
+        let error =
+            install_from_staged(src, dest, &cuda, &ort).expect_err("a mixed bundle is not pinned");
+        assert!(
+            error.contains("marker evidence"),
+            "unexpected error: {error}"
+        );
+
+        write_component_marker(src, "cudnn", REDIST_VERSION).expect("restore component marker");
+        install_from_staged(src, dest, &cuda, &ort).expect("a fully-marked bundle installs");
+    }
+
+    /// The version-blind-adoption regression: a runtime left by a PREVIOUS `REDIST_VERSION`
+    /// satisfies every sentinel (the prefixes are version-agnostic), so DLL presence alone
+    /// must never authorize the implicit skip-the-download branch. If it does, bumping
+    /// `REDIST_VERSION` writes the new marker over the old DLLs and updates nothing — the
+    /// exact case a bump exists to serve. Only current-version marker evidence adopts.
+    #[test]
+    fn stale_runtime_is_not_adopted_but_current_marker_is() {
+        let root_guard = scratch("adopt");
+        let root = root_guard.path();
+
+        // A complete tree of correctly-named DLLs from the previous pin.
+        stage_tree(root, PREVIOUS_REDIST_CUDA_DLLS);
+        assert!(
+            is_staged_complete(&cuda_subdir(root), &ort_subdir(root)),
+            "old DLLs still satisfy every sentinel — that is the trap"
+        );
+        assert!(!adoptable(root), "DLL presence alone must not adopt");
+        assert!(!already_provisioned(root));
+
+        // A marker from the previous redist is not evidence for this one.
+        fs::write(root.join(".redist-marker"), previous_redist_version())
+            .expect("stale top marker");
+        assert!(!adoptable(root), "a stale top marker must not adopt");
+        assert!(!already_provisioned(root));
+
+        // Neither are stale per-component markers.
+        mark_components(root, &previous_redist_version());
+        assert!(!adoptable(root), "stale component markers must not adopt");
+
+        // Current per-component markers alone DO adopt: that is a run which provisioned
+        // every component at this pin but died before writing the top-level marker.
+        mark_components(root, REDIST_VERSION);
+        assert!(adoptable(root));
+        // ...but it is not yet `already_provisioned` — the top marker is still stale, so
+        // the run re-derives it rather than short-circuiting on partial evidence.
+        assert!(!already_provisioned(root));
+
+        // A complete tree with a current top marker is adopted and short-circuits.
+        write_marker(root).expect("write current marker");
+        assert!(adoptable(root));
+        assert!(already_provisioned(root));
+
+        // Completeness is still required on top of the marker: a tree whose DLLs were
+        // pruned after the marker landed re-provisions instead of starting a broken worker.
+        fs::remove_file(cuda_subdir(root).join("cudnn64_8.dll")).expect("rm cudnn");
+        assert!(!adoptable(root));
+        assert!(!already_provisioned(root));
+    }
+
+    /// Pointing the override at the live runtime root is a self-copy; it is accepted in
+    /// place when complete + pinned rather than failing on a Windows sharing violation.
+    #[test]
+    fn install_from_staged_accepts_the_runtime_root_itself() {
+        let root_guard = scratch("self-stage");
+        let root = root_guard.path();
+        stage_tree(root, STAGED_CUDA_DLLS);
+        write_marker(root).expect("pin the runtime root");
+        install_from_staged(root, root, &cuda_subdir(root), &ort_subdir(root))
+            .expect("a complete, pinned root installs from itself");
+        assert!(is_staged_complete(&cuda_subdir(root), &ort_subdir(root)));
+    }
+
+    /// The offline guide tells operators to hand-write `.redist-marker` with the exact
+    /// pinned version, so a `REDIST_VERSION` bump that leaves the doc behind hands out a
+    /// string that no longer adopts. Fail the bump here instead of on an air-gapped box.
+    #[test]
+    fn offline_guide_documents_the_current_redist_version() {
+        let guide = include_str!("../docs/offline-install.md");
+        assert!(
+            guide.contains(REDIST_VERSION),
+            "docs/offline-install.md must document the current REDIST_VERSION ({REDIST_VERSION})"
+        );
     }
 
     /// End-to-end smoke of the download → sha256 → unzip path on the SMALLEST pinned


### PR DESCRIPTION
## The hole

`provision()`'s implicit-adoption branch skipped the download whenever `is_staged_complete()` found every component's sentinel DLL — **with no version check**. The sentinels are version-agnostic basenames (`cudart64_` matches a CUDA 11, 12 or 13 runtime; `onnxruntime.dll` is the same name in every ORT release), so a box provisioned at an older `REDIST_VERSION` satisfied all of them.

On such a box:

1. `already_provisioned()` correctly returns false (marker differs from the new `REDIST_VERSION`);
2. control reaches the implicit branch, the **old** DLLs pass, and the **new** marker is written;
3. the per-component retry-skip loop below — the only code that *does* compare against `REDIST_VERSION`, via `component_provisioned(..., REDIST_VERSION, ...)` — never runs.

Net effect: bumping `REDIST_VERSION` or the pinned wheel URLs **updated nothing on any machine that already had a runtime**, which is the exact population a version bump exists to serve. Latent today only because the `ort` API-mismatch fix in 83e04e080 deliberately avoided bumping the runtime.

## The fix

The Linux sibling already had the right shape, so this ports it rather than inventing one:

- `has_current_marker_evidence()` = `top_marker_current || all_component_markers_current`, mirroring `linux_cuda_provision`. Component evidence reuses the existing `component_provisioned(..., REDIST_VERSION, ...)`, so it checks marker *and* sentinels per component.
- Adoption (`adoptable()`) now requires that evidence **and** completeness. Without it the run falls through to the download loop, which re-fetches each component at the pinned version.
- `already_provisioned()` gains the completeness half it was missing (Linux: `top_marker_current && runtime_complete`), so a marked tree whose DLLs were later pruned re-provisions instead of starting a worker that cannot load.

**`SCENEWORKS_GPU_RUNTIME_DIR` gets the marker requirement too.** A hand-assembled bundle is filename-identical whether built from the current wheels or last year's, and unlike the provisioned root the override is re-consulted on *every* launch until provisioning succeeds — leaving it ungated would just relocate the hole from `%APPDATA%` to the env var, permanently. The error names the required version string so an operator can see what to rebuild against. `install_from_staged` also writes per-component markers on success (as Linux does), making an offline-provisioned tree valid as a source for the next machine, and short-circuits when the override points at the runtime root itself — that self-copy previously failed with a Windows sharing violation.

## Offline flows (sc-10354) — read this before merging

Method 1 (copy `%APPDATA%\SceneWorks\gpu-runtime`) still works untouched, because the marker travels with the tree. Two documented flows **do** lose a guarantee and are rewritten in `docs/offline-install.md`:

| Flow | Before | After |
| --- | --- | --- |
| Method 1 — copy a provisioned folder | any provisioned folder | both machines must be on the **same SceneWorks version** (an older marker is now rejected) |
| Method 2 — staged bundle + env var | DLLs only | bundle must carry a hand-written `.redist-marker` |
| Manual fallback | *"You do **not** need to hand-write the `.redist-marker` file"* | marker is now **required** |

That manual-fallback sentence was the documented face of this bug. The marker-writing command uses `-Encoding ascii` because a UTF-8 BOM survives `trim()` and would silently fail the match.

The version string is now duplicated into the guide, so `offline_guide_documents_the_current_redist_version` fails the build if a `REDIST_VERSION` bump leaves the doc handing out a string that no longer adopts.

## Tests

`stale_runtime_is_not_adopted_but_current_marker_is` uses a CUDA 11 / cuDNN 8 fixture (`cudart64_11.dll`, `cudnn64_8.dll`, …) plus the byte-identical ORT names, and **first asserts `is_staged_complete()` is TRUE on it** — that assertion is the point, since it is exactly what the old branch tested. Then: stale-no-marker, stale top marker, and stale component markers must all fail to adopt; current component markers alone adopt but don't count as `already_provisioned`; current top marker + complete tree does both; pruning a DLL revokes both. Plus `install_from_staged_rejects_unpinned_source` for markerless/stale/mixed bundles.

**Mutation-verified:** reverting `adoptable()` to bare `is_staged_complete()` fails the new test on `DLL presence alone must not adopt`, then restored.

These live in the Windows-gated `cuda_provision` module, and `desktop-windows.yml`'s required `build-windows` job runs `cargo test -p sceneworks-desktop` on hosted windows-2022 — so they do execute as a PR gate.

## Verification

Rebased onto current `origin/main` (clean; 83e04e080's `COMPONENTS` doc block is preserved), then re-run on the new base:

- `cargo test -p sceneworks-desktop` — 123 passed, 0 failed, 2 ignored (network)
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p sceneworks-desktop --all-targets -- -D warnings` — clean
- `node scripts/check-onnxruntime-pins.mjs` — exit 0

That last one is why the stale-pin test fixture is assembled at runtime rather than written as a literal: the guard main added in 83e04e080 greps this file for `REDIST_VERSION…= "…-ort<x.y.z>-"` to prove every distribution channel names one ONNX Runtime version, and a hard-coded prior pin in a test read to it as a half-applied bump. Caught by re-running the guard after the rebase — the Rust tests passed either way.

## Known gap, deliberately not in this PR

Re-fetching overwrites same-named DLLs, but a component whose filename carries the major version (`cudart64_12.dll` → `cudart64_13.dll`) would leave the old file beside the new one, and cudarc probes versioned names. Linux avoids this because `promote_component()` replaces the dest dir; the Windows path extracts in place. Purging needs its own handling for Windows sharing violations on a mapped DLL, so it is left for the first pin bump that renames a DLL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
