### PR TITLE
SC-18621: allow safe adopted story refresh

### DIFF
--- a/FEATURE_DEVELOPMENT.md
+++ b/FEATURE_DEVELOPMENT.md
@@ -201,7 +201,9 @@ adopted heads, verifies the recorded wildcard and exact active/effective policy
 IDs and digests, and binds the SceneWorks inference pin to both inference
 baselines by ancestry. Adoption never creates or updates a ref or ruleset;
 `bootstrap` only revalidates that frozen evidence and clones the exact adopted
-heads. Any drift requires a new plan.
+heads. Any drift requires a new plan. These immutable repository baselines do
+not freeze Shortcut scope: additive live stories may still be journaled until
+final integration begins.
 
 Record every already-merged PR needed to explain pre-automation history with an
 explicit immutable disposition:
@@ -235,10 +237,12 @@ npm run feature:epic -- refresh-stories \
 ```
 
 The refresh journals the previous and next inventory digests, every added or
-removed id, and every workflow-state-map change. Removals and cross-epic moves
-fail closed. Any live or recorded PR from the feature branch freezes the
-inventory permanently; post-freeze drift remains visible as a failed audit
-gate rather than being adopted.
+removed id, every workflow-state-map change, and any legacy adoption-freeze
+migration. Removals and cross-epic moves fail closed. Any open or closed
+final-integration PR whose head is the canonical feature branch, or its recorded
+PR intent, freezes the inventory permanently. Story and sync PRs do not freeze
+additive scope. Post-freeze drift remains visible as a failed audit gate rather
+than being adopted.
 
 Every command that reads or writes the state/report transaction holds an
 exclusive sibling lock for its full lifetime. A crashed same-host lock is

--- a/scripts/feature-epic.mjs
+++ b/scripts/feature-epic.mjs
@@ -50,7 +50,7 @@ const USAGE = `Usage:
 
 Safety properties:
   * plan reads the complete live Shortcut epic and is otherwise read-only except for atomically creating the explicit state file.
-  * refresh-stories adopts additive live scope only before any final-integration PR intent.
+  * refresh-stories adopts additive live scope only before any live or recorded final-integration PR intent.
   * state/report commands hold an exclusive owner-recorded lock; stale recovery is explicit unless a same-host PID is dead.
   * create-mode bootstrap stages both state-owned queues, then creates, activates, and verifies each repository.
   * adopt-existing validates immutable heads, checks, pins, and active/effective policies without remote mutation.

--- a/scripts/feature-epic.test.mjs
+++ b/scripts/feature-epic.test.mjs
@@ -805,6 +805,7 @@ test("inventory refresh journals additive live scope and freezes on final-PR int
 
   f.shortcut.storyValues = f.shortcut.storyValues.filter(({ id }) => id !== 18418);
   f.shortcut.epicValue.stats.num_stories_total = f.shortcut.storyValues.length;
+  const beforeRemoval = readFileSync(f.statePath, "utf8");
   assert.throws(
     () => refreshStoryInventory(
       f.statePath,
@@ -813,6 +814,7 @@ test("inventory refresh journals additive live scope and freezes on final-PR int
     ),
     /additive-only.*sc-18418/,
   );
+  assert.equal(readFileSync(f.statePath, "utf8"), beforeRemoval);
   assert.deepEqual(loadState(f.statePath).expectedStories, refreshed.expectedStories);
 
   f.shortcut.storyValues.unshift({
@@ -836,6 +838,7 @@ test("inventory refresh journals additive live scope and freezes on final-PR int
     },
     base: { ref: "main", repo: { full_name: REPOSITORIES.sceneworks.slug } },
   });
+  const beforeFreeze = readFileSync(f.statePath, "utf8");
   assert.throws(
     () => refreshStoryInventory(
       f.statePath,
@@ -844,6 +847,7 @@ test("inventory refresh journals additive live scope and freezes on final-PR int
     ),
     /inventory is frozen.*final-integration PR intent/,
   );
+  assert.equal(readFileSync(f.statePath, "utf8"), beforeFreeze);
   const drifted = auditState(
     f.statePath,
     f.reportPath,
@@ -852,6 +856,279 @@ test("inventory refresh journals additive live scope and freezes on final-PR int
   assert.equal(drifted.gates.shortcutInventoryMatches, false);
   assert.equal(drifted.gates.noOpenTrainPullRequests, false);
   assert.equal(drifted.cleanup.eligible, false);
+});
+
+test("adopted inventory refresh migrates the legacy sentinel without changing immutable evidence", (t) => {
+  const f = fixture(t);
+  const state = adoptionPlanFixture(f);
+  const laterClock = () => new Date("2026-08-10T18:00:00Z");
+  mergedAdoptionPr(f, state, {
+    number: 2500,
+    head: "story/sc-18418-feature-epic-ci",
+    base: "main",
+  });
+  adoptPullRequest(
+    f.statePath,
+    { repo: "sceneworks", number: 2500, disposition: "precanonical-story" },
+    { github: f.github, clock: laterClock },
+  );
+  for (const [number, head] of [
+    [2501, "story/sc-18419-epic-18304-pipeline-flexibility-mlx-perf"],
+    [2502, "sync/sc-18304-main-2026-08-10-2"],
+  ]) {
+    f.github.prs.set(`sceneworks:${number}`, {
+      html_url: `https://github.com/SceneWorks/SceneWorks/pull/${number}`,
+      state: "closed",
+      head: {
+        ref: head,
+        sha: state.repositories.sceneworks.adoptedFeatureSha,
+        repo: { full_name: REPOSITORIES.sceneworks.slug },
+      },
+      base: {
+        ref: state.featureBranch,
+        repo: { full_name: REPOSITORIES.sceneworks.slug },
+      },
+      merged_at: "2026-08-10T17:00:00Z",
+      merge_commit_sha: state.repositories.sceneworks.adoptedFeatureSha,
+    });
+    recordEvidence(
+      f.statePath,
+      { repo: "sceneworks", number },
+      { github: f.github, clock: laterClock },
+    );
+  }
+
+  const legacy = loadState(f.statePath);
+  delete legacy.shortcut.inventoryFreezePolicy;
+  legacy.shortcut.inventoryFrozenAt = legacy.createdAt;
+  writeJsonAtomic(f.statePath, legacy);
+  const before = loadState(f.statePath);
+  const immutableEvidence = (value) => ({
+    createdAt: value.createdAt,
+    repositories: value.repositories,
+    policies: value.policies,
+    inferencePin: value.inferencePin,
+    requiredContexts: value.requiredContexts,
+    pullRequests: value.pullRequests,
+    adoptedPullRequests: value.adoptedPullRequests,
+    finalPullRequests: value.finalPullRequests,
+    privilegedRuns: value.privilegedRuns,
+    deployments: value.deployments,
+    transaction: value.transaction,
+  });
+
+  f.shortcut.storyValues.push({
+    ...structuredClone(f.shortcut.storyValues[0]),
+    id: 19000,
+    name: "Added to an adopted train",
+    workflow_state_id: 999,
+  });
+  f.shortcut.epicValue.stats.num_stories_total = f.shortcut.storyValues.length;
+  const beforeInvalidRefresh = readFileSync(f.statePath, "utf8");
+  assert.throws(
+    () => refreshStoryInventory(
+      f.statePath,
+      { apply: true },
+      { github: f.github, shortcut: f.shortcut, clock: laterClock },
+    ),
+    /unknown workflow state/,
+  );
+  assert.equal(readFileSync(f.statePath, "utf8"), beforeInvalidRefresh);
+
+  f.shortcut.storyValues.at(-1).workflow_state_id = 30;
+  const { state: refreshed, refresh } = refreshStoryInventory(
+    f.statePath,
+    { apply: true },
+    { github: f.github, shortcut: f.shortcut, clock: laterClock },
+  );
+  assert.equal(refreshed.shortcut.inventoryFreezePolicy, "final-pr-intent-v1");
+  assert.equal(refreshed.shortcut.inventoryFrozenAt, null);
+  assert.equal(refresh.inventoryFreezeMigration, "adoption-created-at-v0");
+  assert.deepEqual(refresh.added, ["sc-19000"]);
+  assert.deepEqual(immutableEvidence(refreshed), immutableEvidence(before));
+
+  const report = auditState(
+    f.statePath,
+    f.reportPath,
+    { github: f.github, shortcut: f.shortcut, clock: laterClock },
+  );
+  assert.equal(report.expectedStories["sc-19000"], false);
+  assert.equal(report.gates.allExpectedStoriesMerged, false);
+  assert.equal(report.gates.allAdoptedReceiptsExact, true);
+  assert.equal(report.gates.adoptedBaselineVerified, true);
+});
+
+test("inventory refresh fails byte-identically when a closed final PR appears before save", (t) => {
+  const f = fixture(t);
+  const state = planFixture(f);
+  f.shortcut.storyValues.push({
+    ...structuredClone(f.shortcut.storyValues[0]),
+    id: 19000,
+    name: "Raced by final integration",
+  });
+  f.shortcut.epicValue.stats.num_stories_total = f.shortcut.storyValues.length;
+  const before = readFileSync(f.statePath, "utf8");
+  const originalPullRequests = f.github.pullRequests.bind(f.github);
+  let sceneWorksFinalScans = 0;
+  f.github.pullRequests = (slug, query = {}) => {
+    if (slug === REPOSITORIES.sceneworks.slug && query.head) {
+      sceneWorksFinalScans += 1;
+      if (sceneWorksFinalScans === 2) {
+        f.github.prs.set("sceneworks:2999", {
+          html_url: "https://github.com/SceneWorks/SceneWorks/pull/2999",
+          state: "closed",
+          head: {
+            ref: state.featureBranch,
+            sha: state.repositories.sceneworks.plannedMainSha,
+            repo: { full_name: REPOSITORIES.sceneworks.slug },
+          },
+          base: { ref: "main", repo: { full_name: REPOSITORIES.sceneworks.slug } },
+        });
+      }
+    }
+    return originalPullRequests(slug, query);
+  };
+  assert.throws(
+    () => refreshStoryInventory(
+      f.statePath,
+      { apply: true },
+      { github: f.github, shortcut: f.shortcut, clock },
+    ),
+    /inventory is frozen.*final-integration PR intent/,
+  );
+  assert.equal(sceneWorksFinalScans, 2);
+  assert.equal(readFileSync(f.statePath, "utf8"), before);
+});
+
+test("final receipts canonicalize a legacy adopted freeze to the earliest intent", (t) => {
+  const f = fixture(t);
+  const state = adoptionPlanFixture(f);
+  const legacy = loadState(f.statePath);
+  delete legacy.shortcut.inventoryFreezePolicy;
+  legacy.shortcut.inventoryFrozenAt = legacy.createdAt;
+  writeJsonAtomic(f.statePath, legacy);
+  const finalNumber = 2600;
+  f.github.prs.set(`sceneworks:${finalNumber}`, {
+    html_url: `https://github.com/SceneWorks/SceneWorks/pull/${finalNumber}`,
+    state: "open",
+    head: {
+      ref: state.featureBranch,
+      sha: state.repositories.sceneworks.adoptedFeatureSha,
+      repo: { full_name: REPOSITORIES.sceneworks.slug },
+    },
+    base: { ref: "main", repo: { full_name: REPOSITORIES.sceneworks.slug } },
+  });
+  const finalClock = () => new Date("2026-08-10T19:00:00Z");
+  const receipt = recordEvidence(
+    f.statePath,
+    { repo: "sceneworks", number: finalNumber },
+    { github: f.github, clock: finalClock },
+  );
+  const frozen = loadState(f.statePath);
+  assert.equal(frozen.shortcut.inventoryFreezePolicy, "final-pr-intent-v1");
+  assert.equal(frozen.shortcut.inventoryFrozenAt, receipt.recordedAt);
+
+  delete frozen.shortcut.inventoryFreezePolicy;
+  frozen.shortcut.inventoryFrozenAt = frozen.createdAt;
+  writeJsonAtomic(f.statePath, frozen);
+  assert.equal(loadState(f.statePath).shortcut.inventoryFrozenAt, frozen.createdAt);
+  const pairedFinalNumber = 2601;
+  f.github.prs.set(`inference:${pairedFinalNumber}`, {
+    html_url: `https://github.com/SceneWorks/inference/pull/${pairedFinalNumber}`,
+    state: "open",
+    head: {
+      ref: state.featureBranch,
+      sha: state.repositories.inference.adoptedFeatureSha,
+      repo: { full_name: REPOSITORIES.inference.slug },
+    },
+    base: { ref: "main", repo: { full_name: REPOSITORIES.inference.slug } },
+  });
+  const pairedFinalClock = () => new Date("2026-08-10T20:00:00Z");
+  const pairedReceipt = recordEvidence(
+    f.statePath,
+    { repo: "inference", number: pairedFinalNumber },
+    { github: f.github, clock: pairedFinalClock },
+  );
+  const pairedFrozen = loadState(f.statePath);
+  assert.notEqual(pairedReceipt.recordedAt, receipt.recordedAt);
+  assert.equal(pairedFrozen.shortcut.inventoryFreezePolicy, "final-pr-intent-v1");
+  assert.equal(pairedFrozen.shortcut.inventoryFrozenAt, receipt.recordedAt);
+
+  f.github.prs.delete(`sceneworks:${finalNumber}`);
+  f.github.prs.delete(`inference:${pairedFinalNumber}`);
+  f.shortcut.storyValues.push({
+    ...structuredClone(f.shortcut.storyValues[0]),
+    id: 19000,
+    name: "Too late after a recorded final PR",
+  });
+  f.shortcut.epicValue.stats.num_stories_total = f.shortcut.storyValues.length;
+  const before = readFileSync(f.statePath, "utf8");
+  assert.throws(
+    () => refreshStoryInventory(
+      f.statePath,
+      { apply: true },
+      { github: f.github, shortcut: f.shortcut, clock: pairedFinalClock },
+    ),
+    /inventory is frozen.*final-integration PR intent/,
+  );
+  assert.equal(readFileSync(f.statePath, "utf8"), before);
+});
+
+test("state validation limits legacy adoption-freeze compatibility to its exact shape", async (t) => {
+  await t.test("unknown freeze policy", (t) => {
+    const f = fixture(t);
+    adoptionPlanFixture(f);
+    const state = loadState(f.statePath);
+    state.shortcut.inventoryFreezePolicy = "unknown-policy";
+    writeJsonAtomic(f.statePath, state);
+    assert.throws(() => loadState(f.statePath), /Shortcut inventory evidence/);
+  });
+  await t.test("markerless null-frozen adoption state", (t) => {
+    const f = fixture(t);
+    adoptionPlanFixture(f);
+    const state = loadState(f.statePath);
+    delete state.shortcut.inventoryFreezePolicy;
+    writeJsonAtomic(f.statePath, state);
+    assert.throws(() => loadState(f.statePath), /lacks its freeze policy or exact legacy sentinel/);
+  });
+  await t.test("create-mode adoption sentinel", (t) => {
+    const f = fixture(t);
+    planFixture(f);
+    const state = loadState(f.statePath);
+    delete state.shortcut.inventoryFreezePolicy;
+    state.shortcut.inventoryFrozenAt = state.createdAt;
+    writeJsonAtomic(f.statePath, state);
+    assert.throws(() => loadState(f.statePath), /freeze policy|final-integration PR intent/);
+  });
+  await t.test("adoption sentinel after a refresh", (t) => {
+    const f = fixture(t);
+    adoptionPlanFixture(f);
+    f.shortcut.storyValues.push({
+      ...structuredClone(f.shortcut.storyValues[0]),
+      id: 19000,
+      name: "First additive refresh",
+    });
+    f.shortcut.epicValue.stats.num_stories_total = f.shortcut.storyValues.length;
+    refreshStoryInventory(
+      f.statePath,
+      { apply: true },
+      { github: f.github, shortcut: f.shortcut, clock },
+    );
+    const state = loadState(f.statePath);
+    delete state.shortcut.inventoryFreezePolicy;
+    state.shortcut.inventoryFrozenAt = state.createdAt;
+    writeJsonAtomic(f.statePath, state);
+    assert.throws(() => loadState(f.statePath), /freeze policy|final-integration PR intent/);
+  });
+  await t.test("arbitrary adoption freeze time", (t) => {
+    const f = fixture(t);
+    adoptionPlanFixture(f);
+    const state = loadState(f.statePath);
+    delete state.shortcut.inventoryFreezePolicy;
+    state.shortcut.inventoryFrozenAt = "2026-08-10T11:00:00.000Z";
+    writeJsonAtomic(f.statePath, state);
+    assert.throws(() => loadState(f.statePath), /freeze policy|final-integration PR intent/);
+  });
 });
 
 test("state validation rejects a tampered Shortcut inventory-refresh chain", (t) => {
@@ -1138,7 +1415,8 @@ test("adopt-existing plans immutable protected heads and bootstraps without remo
   const f = fixture(t);
   const state = adoptionPlanFixture(f);
   assert.equal(state.mode, "adopt-existing");
-  assert.equal(state.shortcut.inventoryFrozenAt, new Date(EPOCH).toISOString());
+  assert.equal(state.shortcut.inventoryFreezePolicy, "final-pr-intent-v1");
+  assert.equal(state.shortcut.inventoryFrozenAt, null);
   for (const key of Object.keys(REPOSITORIES)) {
     assert.equal(state.repositories[key].adoptedFeatureSha, state.repositories[key].plannedMainSha);
     assert.equal(

--- a/scripts/lib/feature-epic.mjs
+++ b/scripts/lib/feature-epic.mjs
@@ -79,6 +79,8 @@ const SHORTCUT_WORKFLOW_STATE_TYPES = new Set(["backlog", "unstarted", "started"
 const PULL_REQUEST_LIST_JQ =
   '.[] | {number, state, html_url, head: {ref: .head.ref}, base: {ref: .base.ref}} | @base64';
 const PLAN_MODES = new Set(["create", "adopt-existing"]);
+const INVENTORY_FREEZE_POLICY = "final-pr-intent-v1";
+const LEGACY_ADOPTION_FREEZE_MIGRATION = "adoption-created-at-v0";
 const ADOPTION_DISPOSITIONS = new Set([
   "precanonical-story",
   "historical-train",
@@ -723,6 +725,23 @@ function validateAdoptedPullRequestReceipt(state, receipt) {
   );
 }
 
+function finalInventoryFreezeAt(state) {
+  return state.pullRequests
+    .filter(({ kind }) => kind === "final")
+    .map(({ recordedAt }) => recordedAt)
+    .sort((left, right) => evidenceTimestamp(left) - evidenceTimestamp(right))[0] ?? null;
+}
+
+function hasLegacyAdoptionInventoryFreeze(state) {
+  return (
+    state.mode === "adopt-existing" &&
+    state.shortcut?.inventoryFreezePolicy === undefined &&
+    state.shortcut?.inventoryFrozenAt === state.createdAt &&
+    Array.isArray(state.shortcut?.refreshes) &&
+    state.shortcut.refreshes.length === 0
+  );
+}
+
 export function validateState(state) {
   if (!state || state.schemaVersion !== STATE_VERSION) {
     refuse(`unsupported or missing state schema version`, "INVALID_STATE");
@@ -757,6 +776,8 @@ export function validateState(state) {
     !state.shortcut.workflowStates ||
     typeof state.shortcut.workflowStates !== "object" ||
     Array.isArray(state.shortcut.workflowStates) ||
+    (state.shortcut.inventoryFreezePolicy !== undefined &&
+      state.shortcut.inventoryFreezePolicy !== INVENTORY_FREEZE_POLICY) ||
     (state.shortcut.inventoryFrozenAt !== null &&
       (typeof state.shortcut.inventoryFrozenAt !== "string" ||
         !Number.isFinite(evidenceTimestamp(state.shortcut.inventoryFrozenAt)))) ||
@@ -773,6 +794,16 @@ export function validateState(state) {
       refuse("state contains malformed Shortcut workflow-state evidence", "STATE_SHORTCUT_CONFLICT");
     }
   }
+  if (
+    state.mode === "adopt-existing" &&
+    state.shortcut.inventoryFreezePolicy !== INVENTORY_FREEZE_POLICY &&
+    !hasLegacyAdoptionInventoryFreeze(state)
+  ) {
+    refuse(
+      "state adopted Shortcut inventory lacks its freeze policy or exact legacy sentinel",
+      "STATE_SHORTCUT_CONFLICT",
+    );
+  }
   let inventoryCursor = [...state.expectedStories];
   let workflowStateCursor = structuredClone(state.shortcut.workflowStates);
   let laterRefreshAt = Number.POSITIVE_INFINITY;
@@ -788,6 +819,12 @@ export function validateState(state) {
       !Array.isArray(refresh.removed) ||
       refresh.removed.length !== 0 ||
       !Array.isArray(refresh.workflowStateChanges) ||
+      (refresh.inventoryFreezeMigration !== undefined &&
+        refresh.inventoryFreezeMigration !== null &&
+        (refresh.inventoryFreezeMigration !== LEGACY_ADOPTION_FREEZE_MIGRATION ||
+          state.mode !== "adopt-existing" ||
+          state.shortcut.inventoryFreezePolicy !== INVENTORY_FREEZE_POLICY ||
+          index !== 0)) ||
       (refresh.epicUpdatedAt !== null &&
         (typeof refresh.epicUpdatedAt !== "string" ||
           !Number.isFinite(evidenceTimestamp(refresh.epicUpdatedAt))))
@@ -987,16 +1024,13 @@ export function validateState(state) {
     }
     pullRequestKeys.add(key);
   }
-  const finalIntentTimes = state.pullRequests
-    .filter(({ kind }) => kind === "final")
-    .map(({ recordedAt }) => recordedAt)
-    .sort((left, right) => evidenceTimestamp(left) - evidenceTimestamp(right));
-  const expectedInventoryFreeze = state.mode === "adopt-existing"
-    ? state.createdAt
-    : finalIntentTimes[0] ?? null;
-  if (state.shortcut.inventoryFrozenAt !== expectedInventoryFreeze) {
+  const expectedInventoryFreeze = finalInventoryFreezeAt(state);
+  if (
+    !hasLegacyAdoptionInventoryFreeze(state) &&
+    state.shortcut.inventoryFrozenAt !== expectedInventoryFreeze
+  ) {
     refuse(
-      "state Shortcut inventory freeze does not match immutable adoption/final intent",
+      "state Shortcut inventory freeze does not match final-integration PR intent",
       "STATE_SHORTCUT_CONFLICT",
     );
   }
@@ -2177,14 +2211,15 @@ export function inspectShortcutEpic(shortcut, epic, expectedStories) {
   };
 }
 
-function plannedShortcutRecord(snapshot, inventoryFrozenAt = null) {
+function plannedShortcutRecord(snapshot) {
   return {
     epicId: snapshot.epic.id,
     epicUrl: snapshot.epic.appUrl,
     epicUpdatedAt: snapshot.epic.updatedAt,
     inventoryDigest: snapshot.inventory.digest,
     workflowStates: snapshot.workflowStates,
-    inventoryFrozenAt,
+    inventoryFreezePolicy: INVENTORY_FREEZE_POLICY,
+    inventoryFrozenAt: null,
     refreshes: [],
   };
 }
@@ -2458,10 +2493,7 @@ function createPlanUnlocked(
     expectedStories: stories,
     workspaceParent,
     deploymentRequired: Boolean(deploymentRequired),
-    shortcut: plannedShortcutRecord(
-      shortcutSnapshot,
-      mode === "adopt-existing" ? createdAt : null,
-    ),
+    shortcut: plannedShortcutRecord(shortcutSnapshot),
     createdAt,
     updatedAt: createdAt,
     phase: "planned",
@@ -2543,17 +2575,12 @@ function liveFinalIntegrationPullRequests(github, state) {
   });
 }
 
-function refreshStoryInventoryUnlocked(
-  statePath,
-  { apply = false } = {},
-  { github = new GitHubClient(), shortcut = new ShortcutClient(), clock = () => new Date() } = {},
-) {
-  if (!apply) refuse("refresh-stories is read-only unless --apply is explicit", "APPLY_REQUIRED");
-  const state = loadState(statePath);
+function assertShortcutInventoryMutable(state, github) {
   const finalPrEvidence = state.pullRequests.filter(({ kind }) => kind === "final");
   const liveFinalPrs = liveFinalIntegrationPullRequests(github, state);
+  const legacyAdoptionFreeze = hasLegacyAdoptionInventoryFreeze(state);
   if (
-    state.shortcut.inventoryFrozenAt !== null ||
+    (state.shortcut.inventoryFrozenAt !== null && !legacyAdoptionFreeze) ||
     Object.values(state.finalPullRequests).some(Boolean) ||
     finalPrEvidence.length > 0 ||
     liveFinalPrs.length > 0
@@ -2563,6 +2590,17 @@ function refreshStoryInventoryUnlocked(
       "SHORTCUT_INVENTORY_FROZEN",
     );
   }
+  return { legacyAdoptionFreeze };
+}
+
+function refreshStoryInventoryUnlocked(
+  statePath,
+  { apply = false } = {},
+  { github = new GitHubClient(), shortcut = new ShortcutClient(), clock = () => new Date() } = {},
+) {
+  if (!apply) refuse("refresh-stories is read-only unless --apply is explicit", "APPLY_REQUIRED");
+  const state = loadState(statePath);
+  const { legacyAdoptionFreeze } = assertShortcutInventoryMutable(state, github);
 
   const snapshot = inspectShortcutEpic(shortcut, state.epic, undefined);
   if (!snapshot.gates.epicNotArchived) {
@@ -2592,6 +2630,9 @@ function refreshStoryInventoryUnlocked(
     state.shortcut.workflowStates,
     snapshot.workflowStates,
   );
+  // Shortcut enumeration can be slow. Re-scan GitHub immediately before the
+  // atomic state write so a final PR created during that window fails closed.
+  assertShortcutInventoryMutable(state, github);
   const refresh = {
     at: nowIso(clock),
     previousDigest: state.shortcut.inventoryDigest,
@@ -2599,6 +2640,9 @@ function refreshStoryInventoryUnlocked(
     added,
     removed,
     workflowStateChanges,
+    inventoryFreezeMigration: legacyAdoptionFreeze
+      ? LEGACY_ADOPTION_FREEZE_MIGRATION
+      : null,
     epicUpdatedAt: snapshot.epic.updatedAt,
   };
   state.expectedStories = next;
@@ -2606,6 +2650,8 @@ function refreshStoryInventoryUnlocked(
   state.shortcut.epicUpdatedAt = snapshot.epic.updatedAt;
   state.shortcut.inventoryDigest = snapshot.inventory.digest;
   state.shortcut.workflowStates = snapshot.workflowStates;
+  state.shortcut.inventoryFreezePolicy = INVENTORY_FREEZE_POLICY;
+  if (legacyAdoptionFreeze) state.shortcut.inventoryFrozenAt = null;
   state.shortcut.refreshes.push(refresh);
   saveState(statePath, state, clock);
   return { state, refresh };
@@ -3910,7 +3956,8 @@ function recordEvidenceUnlocked(
       refuse(`${fixed.slug} final PR merge evidence changed`, "FINAL_PR_CONFLICT");
     }
     state.finalPullRequests[repo] = existingPointer?.mergeCommit ? existingPointer : pointer;
-    state.shortcut.inventoryFrozenAt ??= receipt.recordedAt;
+    state.shortcut.inventoryFrozenAt = finalInventoryFreezeAt(state);
+    state.shortcut.inventoryFreezePolicy = INVENTORY_FREEZE_POLICY;
   }
 
   if (runReceipts.length > 0) {


### PR DESCRIPTION
## Summary

- allow additive Shortcut story inventory refresh for adopted feature trains until actual final-PR intent exists
- migrate exact schema-3 adoption sentinels through an append-only digest journal without weakening immutable adoption baselines or PR receipts
- scan live feature-head PR evidence before enumeration and immediately before save, including closed PRs
- make final receipts canonicalize the freeze to the earliest intent across both repositories
- include newly added stories in audit coverage immediately

## Validation

- `node --test scripts/feature-epic.test.mjs` (153/153)
- `node --test scripts/platform-review-contracts.test.mjs` (48/48)
- focused migration/race matrix (12/12)
- `git diff --check`
- independent adversarial review: clean, confidence 0.97

## Self-hosting evidence

The reviewed exact branch CLI successfully migrated epic 18304's live operation state through the supported command. It adopted SC-18602 through SC-18610 and SC-18621, recorded the previous and next inventory digests, preserved all immutable baselines and PR receipts, and left final-PR freeze unset because no feature-to-main PR intent exists.

Shortcut: SC-18621
