### PR TITLE
ci(check): fan parity out into four parallel jobs behind one aggregator

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,10 +2,12 @@ name: Check
 
 on:
   pull_request:
-  # The merge queue gates on this workflow's `web` + `parity` jobs, so they must
-  # run against the queue's speculative merge ref too. Without this trigger no
-  # run is ever created for `gh-readonly-queue/main/**`, the required checks stay
-  # pending forever, and every queued PR is evicted on timeout.
+  # RETAINED, though the merge queue was removed on 2026-08-11 (0 integration failures caught
+  # in 103 groups, +21m median tax, every group size 1). No `merge_group` event fires today, so
+  # this costs nothing — and it keeps re-enabling the queue a one-line ruleset change. A
+  # required lane with NO `merge_group:` trigger strands the group until
+  # `check_response_timeout_minutes` evicts its entries, which silently re-orders the queue
+  # rather than failing loudly, so this is the expensive half to have to rediscover.
   merge_group:
   push:
     branches:
@@ -34,18 +36,55 @@ jobs:
       - name: Build web production bundle
         run: npm --prefix apps/web run build
 
+  # `parity` IS THE REQUIRED STATUS CHECK, and it is an aggregator — the work fans out into
+  # the four `parity-*` jobs below. They are mutually independent, and running them serially
+  # in one job meant everything queued behind the Rust compile for no reason. Measured
+  # 2026-08-11 over 12 runs: rust 6.8m, closure digests 4.0m, scaffold 1.6m, docker smoke
+  # 6.8m when it fires (4/12) — a 14.2m median job whose longest single member is 6.8m.
+  #
+  # Keeping ONE required context (rather than promoting each split job to its own) means the
+  # ruleset needs no change, and there is no window in which a split-out check has stopped
+  # being covered by `parity` but is not yet required on its own.
   parity:
+    needs: [parity-rust, parity-digests, parity-scaffold, parity-docker]
+    # FAIL CLOSED. Without `if: always()` this job is SKIPPED whenever any `needs:` job fails
+    # or is skipped — and a skipped job reports **Success** to a required status check, which
+    # is exactly the false-green shape documented at the top of changed-paths.yml. So it runs
+    # unconditionally and asserts the results itself.
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Assert every parity job succeeded
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        # Iterates whatever is in `needs` rather than naming the four jobs, so adding a fifth
+        # `parity-*` job cannot silently go ungraded. The count floor is the other half of
+        # that: deleting a `needs:` entry would otherwise shrink the assertion to a green
+        # no-op instead of failing.
+        run: |
+          set -euo pipefail
+          jq -r 'to_entries[] | "\(.key): \(.value.result)"' <<<"$RESULTS"
+          count="$(jq -r 'length' <<<"$RESULTS")"
+          if [ "$count" -lt 4 ]; then
+            echo "::error::parity expects at least 4 upstream jobs, saw ${count} — a needs: entry was removed"
+            exit 1
+          fi
+          if [ "$(jq -r '[to_entries[] | select(.value.result != "success")] | length' <<<"$RESULTS")" != "0" ]; then
+            echo "::error::one or more parity jobs did not succeed"
+            exit 1
+          fi
+
+  parity-rust:
     runs-on: ubuntu-latest
     env:
       # Fetch the pinned inference source once, then force every build and build.rs process
       # offline so nothing else can reach the network mid-build.
       CARGO_NET_OFFLINE: "true"
-    # A stalled step (e.g. a transient `docker compose up --build` layer/registry
-    # hang in the Docker smoke) otherwise rides GitHub's 6-hour default timeout,
-    # blocking the PR and holding a runner for hours — this bit PR #1300 / sc-10354
-    # for ~4 h. Cap well above the healthy ~12-15 min parity duration so healthy
-    # runs are unaffected but a wedge fails in minutes with a clear timeout
-    # (sc-10420).
+    # A stalled step otherwise rides GitHub's 6-hour default timeout, blocking the PR and
+    # holding a runner for hours — this bit PR #1300 / sc-10354 for ~4 h. Cap well above the
+    # healthy duration so healthy runs are unaffected but a wedge fails in minutes with a
+    # clear timeout (sc-10420).
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -79,10 +118,102 @@ jobs:
         # are picked up automatically; e2e/parity-marked tests run in their own
         # later steps against the built Rust API (sc-4180).
         run: python -m pytest -q tests/ -m "not e2e and not parity" --strict-markers
+      - name: Guard against gen-core version skew (sc-4482, epic 3720)
+        # Fails if more than one distinct `sceneworks-gen-core` rev resolves in the worker's
+        # build graph (split contract types can invalidate explicit catalog wiring). `--target all`
+        # resolves the macOS-only mlx-gen transitive gen-core even on this Linux lane. The
+        # self-test proves the gate fires without a deliberately-broken pin checked in.
+        #
+        # Lives on THIS job because it shells out to `cargo tree`, so it needs the toolchain and
+        # the fetched registry above — it is not a Node guard like its former neighbours.
+        run: |
+          bash scripts/check-gen-core-skew.sh --self-test
+          bash scripts/check-gen-core-skew.sh
+      - name: Run Rust workspace checks
+        run: npm run rust:check
+      - name: Export prebuilt Rust binaries for the e2e/parity harnesses
+        # `npm run rust:check` ends in `cargo build`, which builds both default-member
+        # binaries into target/debug. Point the pytest harnesses at them so the ~30
+        # API + worker spawns across the e2e/parity steps launch the binary directly
+        # and skip `cargo run`'s per-launch freshness check over the whole workspace
+        # graph. This also replaces the old redundant `cargo build -p sceneworks-rust-api`
+        # step (the binary is already built above). See tests/test_rust_api_worker_smoke.py
+        # `_launch_command` and tests/test_rust_api_contract_snapshots.py (sc-10823).
+        run: |
+          echo "SCENEWORKS_RUST_API_BINARY=${{ github.workspace }}/target/debug/sceneworks-rust-api" >> "$GITHUB_ENV"
+          echo "SCENEWORKS_RUST_WORKER_BINARY=${{ github.workspace }}/target/debug/sceneworks-rust-worker" >> "$GITHUB_ENV"
+      - name: Run end-to-end job pipeline test
+        # tests/conftest.py fails this gate (via `require_tool` + an all-skipped
+        # session guard) if `CI` is set and every collected test skips -- e.g. a
+        # future change dropping the cargo toolchain would otherwise turn the gate
+        # into a silent green no-op. GitHub Actions sets CI=true automatically
+        # (sc-8935 / F-133).
+        run: python -m pytest -q -m e2e --strict-markers
+      - name: Run Rust API contract snapshot tests
+        # Same all-skipped guard as the e2e step: a parity run that exercised
+        # nothing fails instead of reporting success (sc-8935 / F-133).
+        run: python -m pytest -q -m parity --strict-markers
+
+  # Node-only: `npm run check` and its neighbours read Cargo.toml as TEXT (the pin regex in
+  # generate-memory-matrix.mjs) and never invoke cargo, so this needs no Rust toolchain and no
+  # rust-cache — which is what lets it run beside the compile instead of in front of it.
+  parity-scaffold:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
       - name: Run scaffold and compose checks
         run: |
           npm run check
           npm run check:compose
+      - name: Guard against NC model weights in a published artifact (sc-10526, epic 10512)
+        # SceneWorks converts weights at install and pulls them at runtime — it never
+        # redistributes them. Baking a Non-Commercial family's weights (Anima /
+        # CircleStone, FLUX NC, Ideogram, Krea, NVIDIA SANA, …) into an installer or
+        # image layer would make us a distributor of a Derivative and attach the NC
+        # obligations. The self-test proves the gate fires on a fake anima-*.safetensors
+        # before the real scan runs over the Docker build context / Tauri resource trees
+        # (config/, crates/, apps/). See docs/packaging-nc-weights-guard.md.
+        run: |
+          node scripts/check-no-nc-weights.mjs --self-test
+          npm run check:nc-weights
+      - name: Guard About→Licenses coverage for shipped models and embedded source
+        # The licenses page records the upstream license + attribution for every model
+        # whose weights SceneWorks downloads — including which ones are NON-COMMERCIAL.
+        # It had drifted to cover only the bundled binaries, Wan2.2/LTX and the audio
+        # models while ~30 image/video/utility primaries (SDXL, FLUX, Krea, Ideogram,
+        # SANA, SD3.5, Anima, the PiD decoders, …) shipped with no entry at all, because
+        # adding a catalog model had no mechanical link to the page. This fails the build
+        # if a downloading model is unclaimed, a claimed id no longer exists, or a
+        # document key is not wired into bundledLicenses.js (which would render an EMPTY
+        # license — worse than a missing one). The same executable guard also
+        # revision-locks the audited inventory of ported/embedded inference source
+        # (Cephes, CMUDICT), forcing every inference pin bump to re-audit upstream
+        # NOTICE/LICENSE-* and production include_str!/include_bytes! sites.
+        # It additionally fails CLOSED on any production-Rust crate in the pinned
+        # inference revision that is neither covered by a ported-source area nor given
+        # an explicit crateDispositions decision. The marker regex that finds ported
+        # FILES is only a heuristic, and a whole crate already slipped it once —
+        # mlx-gen-krea-realtime described its port in words the regex did not know and
+        # shipped unclassified on a false green (sc-15138 → sc-15191).
+        #
+        # It grades CHECKED-IN audit data against the Cargo pin, so unlike the digest job
+        # below it needs no inference clone.
+        run: |
+          node scripts/check-license-coverage.mjs --self-test
+          npm run check:license-coverage
+
+  parity-digests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
       - name: Verify the per-lane inference closure digests against real pinned source (sc-17774)
         # `npm run check` only asserts that config/inference-provider-closures.json is KEYED to the
         # live pin. It cannot tell a real digest from a hand-edited one, because the derivation needs
@@ -120,71 +251,22 @@ jobs:
             git -C "$RUNNER_TEMP/inference" fetch -q --depth=1 origin "$rev"
           done < <(node scripts/backfill-closure-digests.mjs --revisions)
           node scripts/backfill-closure-digests.mjs --repo "$RUNNER_TEMP/inference" --verify
-      - name: Guard against NC model weights in a published artifact (sc-10526, epic 10512)
-        # SceneWorks converts weights at install and pulls them at runtime — it never
-        # redistributes them. Baking a Non-Commercial family's weights (Anima /
-        # CircleStone, FLUX NC, Ideogram, Krea, NVIDIA SANA, …) into an installer or
-        # image layer would make us a distributor of a Derivative and attach the NC
-        # obligations. The self-test proves the gate fires on a fake anima-*.safetensors
-        # before the real scan runs over the Docker build context / Tauri resource trees
-        # (config/, crates/, apps/). See docs/packaging-nc-weights-guard.md.
-        run: |
-          node scripts/check-no-nc-weights.mjs --self-test
-          npm run check:nc-weights
-      - name: Guard About→Licenses coverage for shipped models and embedded source
-        # The licenses page records the upstream license + attribution for every model
-        # whose weights SceneWorks downloads — including which ones are NON-COMMERCIAL.
-        # It had drifted to cover only the bundled binaries, Wan2.2/LTX and the audio
-        # models while ~30 image/video/utility primaries (SDXL, FLUX, Krea, Ideogram,
-        # SANA, SD3.5, Anima, the PiD decoders, …) shipped with no entry at all, because
-        # adding a catalog model had no mechanical link to the page. This fails the build
-        # if a downloading model is unclaimed, a claimed id no longer exists, or a
-        # document key is not wired into bundledLicenses.js (which would render an EMPTY
-        # license — worse than a missing one). The same executable guard also
-        # revision-locks the audited inventory of ported/embedded inference source
-        # (Cephes, CMUDICT), forcing every inference pin bump to re-audit upstream
-        # NOTICE/LICENSE-* and production include_str!/include_bytes! sites.
-        # It additionally fails CLOSED on any production-Rust crate in the pinned
-        # inference revision that is neither covered by a ported-source area nor given
-        # an explicit crateDispositions decision. The marker regex that finds ported
-        # FILES is only a heuristic, and a whole crate already slipped it once —
-        # mlx-gen-krea-realtime described its port in words the regex did not know and
-        # shipped unclassified on a false green (sc-15138 → sc-15191).
-        run: |
-          node scripts/check-license-coverage.mjs --self-test
-          npm run check:license-coverage
-      - name: Guard against gen-core version skew (sc-4482, epic 3720)
-        # Fails if more than one distinct `sceneworks-gen-core` rev resolves in the worker's
-        # build graph (split contract types can invalidate explicit catalog wiring). `--target all`
-        # resolves the macOS-only mlx-gen transitive gen-core even on this Linux lane. The
-        # self-test proves the gate fires without a deliberately-broken pin checked in.
-        run: |
-          bash scripts/check-gen-core-skew.sh --self-test
-          bash scripts/check-gen-core-skew.sh
-      - name: Run Rust workspace checks
-        run: npm run rust:check
-      - name: Export prebuilt Rust binaries for the e2e/parity harnesses
-        # `npm run rust:check` ends in `cargo build`, which builds both default-member
-        # binaries into target/debug. Point the pytest harnesses at them so the ~30
-        # API + worker spawns across the e2e/parity steps launch the binary directly
-        # and skip `cargo run`'s per-launch freshness check over the whole workspace
-        # graph. This also replaces the old redundant `cargo build -p sceneworks-rust-api`
-        # step (the binary is already built above). See tests/test_rust_api_worker_smoke.py
-        # `_launch_command` and tests/test_rust_api_contract_snapshots.py (sc-10823).
-        run: |
-          echo "SCENEWORKS_RUST_API_BINARY=${{ github.workspace }}/target/debug/sceneworks-rust-api" >> "$GITHUB_ENV"
-          echo "SCENEWORKS_RUST_WORKER_BINARY=${{ github.workspace }}/target/debug/sceneworks-rust-worker" >> "$GITHUB_ENV"
-      - name: Run end-to-end job pipeline test
-        # tests/conftest.py fails this gate (via `require_tool` + an all-skipped
-        # session guard) if `CI` is set and every collected test skips -- e.g. a
-        # future change dropping the cargo toolchain would otherwise turn the gate
-        # into a silent green no-op. GitHub Actions sets CI=true automatically
-        # (sc-8935 / F-133).
-        run: python -m pytest -q -m e2e --strict-markers
-      - name: Run Rust API contract snapshot tests
-        # Same all-skipped guard as the e2e step: a parity run that exercised
-        # nothing fails instead of reporting success (sc-8935 / F-133).
-        run: python -m pytest -q -m parity --strict-markers
+
+  # Split out because the smoke recompiles the whole workspace inside BuildKit and shares
+  # nothing with the host's rust-cache — ~7m that used to land at the END of a 14m serial job,
+  # so its cost was fully additive to everything above it.
+  #
+  # The `if:` below is a STEP-level skip, so this job still reports success when the gate says
+  # no Docker input changed. That keeps the aggregator honest: it can demand `success` from
+  # every member with no skipped-counts-as-green special case to get wrong later.
+  parity-docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "20"
       - name: Decide whether to run the Docker runtime smoke
         id: docker_smoke_gate
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@
   branches, story PR targets, mirrored inference work, final merge ordering, and
   the CI protections required before using this workflow.
 - Read its *Current state* section before assuming anything about branch
-  protection. As of 2026-08-11 the repositories deliberately differ: SceneWorks
-  has no merge queue anywhere, inference still queues `main` and every feature
-  branch. Queue staging/activation/recovery procedures are inference-only.
+  protection. As of 2026-08-11 neither SceneWorks nor inference has a merge
+  queue; `main` is `strict: false` and `feature/*` is `strict: true` in both.
+  Queue staging/activation/recovery procedures are obsolete in both repositories.
 
 ## Pull Requests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@
 - Follow [FEATURE_DEVELOPMENT.md](FEATURE_DEVELOPMENT.md) for epic integration
   branches, story PR targets, mirrored inference work, final merge ordering, and
   the CI protections required before using this workflow.
+- Read its *Current state* section before assuming anything about branch
+  protection. As of 2026-08-11 the repositories deliberately differ: SceneWorks
+  has no merge queue anywhere, inference still queues `main` and every feature
+  branch. Queue staging/activation/recovery procedures are inference-only.
 
 ## Pull Requests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,12 @@ here.
   the current ruleset/CI state.
 
   Read its *Current state* section before acting on any branch protection
-  assumption. As of 2026-08-11 the two repositories deliberately differ:
-  **SceneWorks has no merge queue anywhere**, while **inference still queues
-  `main` and every feature branch**. Procedures that mention staging, activating,
-  or recovering a per-branch queue ruleset apply to inference only.
+  assumption. As of 2026-08-11 **neither SceneWorks nor inference has a merge
+  queue** — both were removed the same day after the queue was measured catching
+  zero integration failures in 103 groups while adding ~21m per merge. `main` is
+  `strict: false` in both; `feature/*` is `strict: true` in both. Any procedure
+  or memory that mentions staging, activating, or recovering a per-branch queue
+  ruleset is obsolete.
 
 - **[RELEASING.md](RELEASING.md)** — release, hotfix, inference-pin, publication,
   and failed-candidate recovery.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# SceneWorks
+
+Agent instructions for this repository live in **[AGENTS.md](AGENTS.md)** — read it
+first. This file exists so the `CLAUDE.md` convention resolves; AGENTS.md is the
+source of truth, and anything beyond the pointers below belongs there rather than
+here.
+
+## Workflows
+
+- **[FEATURE_DEVELOPMENT.md](FEATURE_DEVELOPMENT.md)** — epic integration
+  branches, story PR targets, mirrored inference work, final merge ordering, and
+  the current ruleset/CI state.
+
+  Read its *Current state* section before acting on any branch protection
+  assumption. As of 2026-08-11 the two repositories deliberately differ:
+  **SceneWorks has no merge queue anywhere**, while **inference still queues
+  `main` and every feature branch**. Procedures that mention staging, activating,
+  or recovering a per-branch queue ruleset apply to inference only.
+
+- **[RELEASING.md](RELEASING.md)** — release, hotfix, inference-pin, publication,
+  and failed-candidate recovery.

--- a/FEATURE_DEVELOPMENT.md
+++ b/FEATURE_DEVELOPMENT.md
@@ -75,19 +75,41 @@ Do not create an epic branch as a substitute for incomplete requirements.
 
 ## 2. Create the integration branches
 
-Use current remote state and a clean checkout. GitHub rejects a merge-queue rule
-whose condition is the wildcard `feature/*`, while an active exact queue rule
-rejects creation of its not-yet-existing ref. The bootstrap command must
-therefore treat the applicable exact queue ruleset and ref as one durable,
-recoverable transaction; when inference is in scope, that transaction covers
-both repositories' queue rulesets and refs.
+Use current remote state and a clean checkout.
 
 Run the complete read-only preflight for every applicable repository before the
 first mutation: capture the current `origin/main` SHA; verify both wildcard
 ruleset layers; and verify every configured required context on that exact
 commit is terminal `success`, `skipped`, or `neutral` from the expected GitHub
 Actions app. Pending, missing, wrong-app, or failed contexts are a stop
-condition. Persist the plan, then for each repository:
+condition. Persist the plan before mutating anything.
+
+The two repositories then diverge, because only inference still has merge
+queues. See *Current state* under **CI and repository configuration**.
+
+### SceneWorks: create the ref
+
+There is no queue rule and therefore no ordering constraint. Create the branch
+at the captured immutable SHA under the active wildcard base and deletion
+guards:
+
+```bash
+git fetch origin
+git switch -c feature/sc-<epic-id>-<epic-slug> origin/main
+git push -u origin feature/sc-<epic-id>-<epic-slug>
+```
+
+Then verify that **two** layers aggregate: the wildcard base policy and the
+wildcard deletion guard. Do not create a per-branch queue ruleset; SceneWorks
+has none by decision, and adding one back reintroduces a cost measured to buy
+nothing.
+
+### inference: stage the queue, create the ref, activate
+
+GitHub rejects a merge-queue rule whose condition is the wildcard `feature/*`,
+while an active exact queue rule rejects creation of its not-yet-existing ref.
+When inference is in scope, its exact queue ruleset and ref must therefore be
+treated as one durable, recoverable transaction:
 
 1. create or verify the exact queue ruleset in disabled mode and record its ID
    and payload digest;
@@ -96,9 +118,10 @@ condition. Persist the plan, then for each repository:
 3. immediately activate only the recorded exact queue ruleset; and
 4. query the effective rules and require the five-rule aggregate.
 
-Only after every repository reaches that state may bootstrap create a workspace
-or declare success. Do not loosen `do_not_enforce_on_create=false` or silently
-choose an older commit to make branch creation succeed.
+Step 2 uses the same commands shown for SceneWorks above, run against the
+inference remote — but only between the staged-disabled and activate steps, never
+before or after. Create the inference branch only when inference changes are part
+of the approved scope, and use the identical branch name as SceneWorks.
 
 Recovery resumes recognized durable states instead of blindly rolling back:
 
@@ -111,27 +134,20 @@ Recovery resumes recognized durable states instead of blindly rolling back:
 - missing queue/ref at the recorded SHA: create the recorded policy disabled,
   then activate it.
 
-An unexpected ref SHA, duplicate matching ref or ruleset, payload drift, or an
-unrecognized partial state fails closed. A partial success in one repository is
-resumed after revalidation; it is not force-deleted or rewritten. A ref whose
-queue rule is missing or disabled remains protected by the wildcard layers but
-is unsafe: expose no workspace and admit no story PR until recovery completes.
+An inference ref whose queue rule is missing or disabled remains protected by
+the wildcard layers but is unsafe: expose no workspace and admit no story PR
+until recovery completes.
 
-The equivalent manual ref creation is:
+### Both repositories
 
-```bash
-git fetch origin
-git switch -c feature/sc-<epic-id>-<epic-slug> origin/main
-git push -u origin feature/sc-<epic-id>-<epic-slug>
-```
-
-Create the inference branch only when inference changes are part of the approved
-scope. Use the identical command and branch name in that repository.
-
-Immediately verify that all three applicable active layers aggregate: the wildcard
-base policy, the wildcard deletion guard, and the exact-branch queue policy. Do
-not begin story merges while the branch allows unreviewed direct pushes, lacks
-required checks, can be deleted, or has no merge queue.
+Only after every applicable repository reaches its verified state may bootstrap
+create a workspace or declare success. Do not loosen
+`do_not_enforce_on_create=false` or silently choose an older commit to make
+branch creation succeed. An unexpected ref SHA, duplicate matching ref or
+ruleset, payload drift, or an unrecognized partial state fails closed. A partial
+success in one repository is resumed after revalidation; it is not force-deleted
+or rewritten. Do not begin story merges while a branch allows unreviewed direct
+pushes, lacks required checks, or can be deleted.
 
 Add the following to the Shortcut epic:
 
@@ -163,8 +179,12 @@ Treat each story as a small PR even though its base is an epic branch.
      --head story/sc-<story-id>-<story-slug>
    ```
 
-9. Merge through the feature branch's required checks and merge queue. Verify
-   the remote merge rather than treating queue entry as completion.
+9. Merge through the feature branch's required checks — and, in inference only,
+   its merge queue. SceneWorks feature branches have no queue; they require the
+   branch to be up to date with its base (`strict: true`), so merge `main` or the
+   feature head in and let the checks re-run rather than waiting for a queue to
+   do it for you. Verify the remote merge rather than treating queue entry or a
+   green check as completion.
 10. Validate the acceptance criteria against the new combined feature head.
 11. Add a Shortcut closeout comment containing the PR, merge commit, tests,
     runtime evidence, limitations, and tracked follow-ups.
@@ -267,7 +287,7 @@ Open one PR from the SceneWorks feature branch to `main`. Its body must contain:
 - independent-review verdicts; and
 - explicit limitations and separately tracked follow-ups.
 
-Before enqueueing, verify:
+Before merging, verify:
 
 - every required story is Done and no epic blocker remains;
 - both feature branches include current respective `main`;
@@ -276,9 +296,13 @@ Before enqueueing, verify:
 - required CI reports on the actual feature-to-main PR head; and
 - no unrelated changes entered through synchronization.
 
-Merge through the protected `main` merge queue. Afterward, re-fetch and verify
-the exact remote merge commit, post-merge state, and any required runtime or
-deployment evidence. Only then:
+Merge through the protected `main` ruleset. SceneWorks `main` has **no merge
+queue** and does **not** require the branch to be up to date (`strict: false`),
+so nothing re-verifies this PR against a `main` that moved after its checks went
+green — if `main` advanced while the final PR sat open, merge it in and let the
+required checks re-run before merging. Afterward, re-fetch and verify the exact
+remote merge commit, post-merge state, and any required runtime or deployment
+evidence. Only then:
 
 1. add the epic closeout comment;
 2. move the epic to Done;
@@ -305,50 +329,96 @@ publish a release.
 
 ## CI and repository configuration
 
-### Current state observed on 2026-08-08
+### Current state verified on 2026-08-11
 
-The process above is not yet fully enforced:
+**The two repositories no longer behave the same way. SceneWorks has no merge
+queue anywhere; inference still queues everything.** Read the repository-specific
+column before following any procedure below.
 
-- SceneWorks ruleset `Require MR` targets only the default branch.
-- Inference ruleset `Require MR` targets only the default branch.
-- Therefore `feature/*` branches in both repositories currently lack the PR,
-  required-check, merge-queue, non-fast-forward, and deletion rules applied to
-  `main`.
-- SceneWorks `check.yml`, `desktop-macos-check.yml`,
-  `desktop-linux-check.yml`, and `desktop-windows.yml` already trigger for
-  arbitrary pull-request bases and `merge_group` events.
-- SceneWorks `macos-mlx.yml` supports `merge_group` but restricts ordinary PRs
-  to `main`; its required macOS/MLX status would not report on a story PR whose
-  base is `feature/*`.
-- SceneWorks `windows-candle.yml` restricts ordinary PRs to `main` and does not
-  currently support `merge_group`; it cannot be made a feature-branch required
-  check without restructuring its triggers and path selection.
-- Inference `ci.yml` already supports arbitrary pull requests and
-  `merge_group`; its workflow trigger is suitable for feature branches, but no
-  feature-branch ruleset currently requires its `CI gate`.
+| | SceneWorks | inference |
+| --- | --- | --- |
+| `main` ruleset | `Require MR` (17708030) | `Require MR` (20481541) |
+| queue on `main` | **none** | `merge_queue` |
+| up-to-date required on `main` | no (`strict: false`) | — |
+| `feature/*` base policy | 20638194 | 20638200 |
+| queue on `feature/*` | **none** | per-branch exact rulesets, active |
+| `feature/*` up-to-date | yes (`strict: true`) | yes (`strict: true`) |
+| deletion guard | 20638197 | 20638201 |
+
+Both repositories' `feature/*` base policies carry `pull_request` (0 approvals;
+SceneWorks additionally requires code-owner review), `non_fast_forward`, and
+required status checks — the same seven contexts as SceneWorks `main`
+(`web`, `parity`, `candle`, `build-windows`, `check-linux`, `check-macos`,
+`macOS build, lint and workspace tests (hosted)`), and `CI gate` for inference.
+
+#### Why SceneWorks has no queue
+
+Removed 2026-08-11 after measurement, not preference. Over 5.4 days the queue
+produced **103 merge groups and caught zero integration failures**, while adding
+a median 21m (mean 35m, p90 43m) to every merge. Every group contained exactly
+one PR — `min_entries_to_merge: 1` forms a group the instant one entry arrives,
+so nothing was ever amortized and the entire cost was additive. Its only
+observable effects were two evictions, on PRs that then took 1h32m and 5h33m.
+
+Do not re-add it without new evidence. A merge queue earns its cost through
+batching under concurrency; at SceneWorks' merge rate it batched nothing. The
+`merge_group:` triggers remain in the workflows deliberately so re-enabling is a
+one-line ruleset change.
+
+#### Consequences for this document
+
+- Every SceneWorks bootstrap step that stages, activates, or recovers an exact
+  per-branch queue ruleset is obsolete. SceneWorks feature branches have **two**
+  layers, not three, and ref creation needs no transaction.
+- The inference procedures are unchanged and still correct.
+- `release/next` is covered by **no ruleset in either repository** — no required
+  checks, no PR requirement, no force-push or deletion guard. It is the least
+  protected branch in the hotfix path.
+
+Workflow triggers, verified the same day:
+
+- SceneWorks `check.yml`, `desktop-macos-check.yml`, `desktop-linux-check.yml`,
+  and `desktop-windows.yml` trigger for arbitrary pull-request bases and
+  `merge_group`.
+- SceneWorks `macos-mlx.yml` now targets `pull_request: branches: [main,
+  "feature/*"]` with no PR path filter, so its required status reports on
+  feature-target PRs. `platform-review-contracts.test.mjs` enforces this.
+- SceneWorks `windows-candle.yml` still restricts ordinary PRs to `main`, keeps
+  a PR path filter, and has no `merge_group` trigger. It is deliberately not a
+  required check; a contract test asserts it stays out of the required set.
+- Inference `ci.yml` supports arbitrary pull requests and `merge_group`, and its
+  `CI gate` is required on `feature/*`.
 
 Re-query live rules and workflow files before implementation; this section is a
-dated baseline, not a substitute for current inspection.
+dated snapshot, not a substitute for current inspection.
 
-### Required before the first feature branch
+### Ruleset and workflow requirements
 
-#### 1. Add feature-branch rulesets
+These layers already exist in both repositories (see *Current state* above); this
+section is the contract they must keep satisfying, and the recipe for any future
+repository or feature branch.
 
-Create three layers of `Feature integration` rulesets in each repository.
-GitHub rulesets use `fnmatch`, so the two durable wildcard layers target
-`feature/*`, which intentionally matches the one-slash branch format defined
-above. The third layer targets one exact feature branch.
+#### 1. Feature-branch rulesets
 
-GitHub's ruleset API rejects `merge_queue` when the condition contains a
-wildcard (`Invalid rule 'merge_queue': Wildcard ref names are not supported
-when merge queue is enabled`). An active exact queue rule also rejects initial
-creation of its matching ref with `Changes must be made through the merge
-queue`. Consequently the wildcard base policy must not contain the queue rule.
-Every bootstrap must create or verify a separate disabled exact queue ruleset
-for `feature/sc-<epic-id>-<epic-slug>`, create the checked ref under the active
-wildcard guards, immediately activate the exact rule, and verify the aggregate.
-A wildcard queue payload or a feature ref with a missing/disabled exact queue
-rule is a configuration error, not a degraded mode.
+GitHub rulesets use `fnmatch`, so the durable wildcard layers target `feature/*`,
+which intentionally matches the one-slash branch format defined above.
+
+**SceneWorks: two layers** — the wildcard base policy and the wildcard deletion
+guard. There is no queue layer, so there is no exact-branch ruleset, no staging
+transaction, and no per-epic ruleset lifecycle to manage.
+
+**inference: three layers** — the same two wildcard layers plus one exact-branch
+queue ruleset per feature branch. GitHub's ruleset API rejects `merge_queue`
+when the condition contains a wildcard (`Invalid rule 'merge_queue': Wildcard ref
+names are not supported when merge queue is enabled`). An active exact queue rule
+also rejects initial creation of its matching ref with `Changes must be made
+through the merge queue`. Consequently the wildcard base policy must not contain
+the queue rule. Every inference bootstrap must create or verify a separate
+disabled exact queue ruleset for `feature/sc-<epic-id>-<epic-slug>`, create the
+checked ref under the active wildcard guards, immediately activate the exact
+rule, and verify the aggregate. A wildcard queue payload, or an inference feature
+ref with a missing/disabled exact queue rule, is a configuration error rather
+than a degraded mode.
 
 SceneWorks must require at least the same integration contexts currently
 required on `main`:
@@ -372,23 +442,32 @@ must:
 - require current-head status checks;
 - use merge commits so story and synchronization provenance is retained.
 
-The exact-branch queue ruleset must also have no bypass actors. It contains the
-`merge_queue` rule for that one feature ref, uses merge commits, and uses merge
-groups of one entry unless deliberate batch validation is accepted. Persist its
-ID and payload digest while it is disabled, then activate only that exact
-recorded policy after ref creation. If the disposable proof shows that GitHub
-does not aggregate a queue-only exact ruleset with the wildcard pull-request
-and status rules, repeat those rules in the exact ruleset; never remove them
-from the wildcard layer. Record the final active state with the epic bootstrap
-evidence.
+The exact-branch queue ruleset — **inference only** — must also have no bypass
+actors. It contains the `merge_queue` rule for that one feature ref and uses
+merge commits. Persist its ID and payload digest while it is disabled, then
+activate only that exact recorded policy after ref creation. If the disposable
+proof shows that GitHub does not aggregate a queue-only exact ruleset with the
+wildcard pull-request and status rules, repeat those rules in the exact ruleset;
+never remove them from the wildcard layer. Record the final active state with the
+epic bootstrap evidence.
+
+Note the batch-size trap that removed SceneWorks' queues: `min_entries_to_merge:
+1` forms a group the instant a single entry arrives, so `max_entries_to_build`
+never engages, `min_entries_to_merge_wait_minutes` is inert, and the queue
+amortizes nothing while charging a full verification pass per PR. If an inference
+queue is ever measured behaving that way, fix the batching parameters or remove
+the queue — do not keep paying for a group of one.
 
 The wildcard deletion-guard ruleset must contain only the deletion rule and
 normally have no bypass actors. After every non-cleanup assertion passes on a
 disposable proof branch, or after the post-merge checklist succeeds, freeze the
-target branch and require no open PR or queue entry. First attempt the proof
-deletion with the exact queue still active. If GitHub's queue rule rejects
-deletion, disable only the recorded exact queue policy and re-verify that the
-wildcard base and deletion layers remain active before continuing.
+target branch and require no open PR or queue entry.
+
+In SceneWorks, deletion is then gated only by the deletion guard itself. In
+inference, first attempt the deletion with the exact queue still active; if
+GitHub's queue rule rejects it, disable only the recorded exact queue policy and
+re-verify that the wildcard base and deletion layers remain active before
+continuing.
 
 An administrator may then temporarily add one closed maintainer team or cleanup
 automation as the deletion guard's exact cleanup actor. If neither exists, one
@@ -396,18 +475,18 @@ explicitly named repository administrator may be the temporary actor; record
 its immutable actor ID, the approved proof-or-completed branch names, and the
 start/end of the cleanup window. Delete only those branches and restore
 `bypass_actors: []` immediately in a finally-style cleanup step, whether the
-deletion succeeds or fails. If deletion failed after the exact queue was
-disabled, reactivate that recorded queue policy and verify all five effective
-rules before releasing the freeze. If reactivation also fails, keep the branch
-explicitly unsafe, expose no workspace, admit no PR, and record an incident for
-recovery. Never leave deletion authority active during an epic. Bypass is
-ruleset-wide: never put the deletion rule and its cleanup bypass in the base
-policy or exact queue ruleset, because that would also let the cleanup actor
-bypass pull-request, status-check, non-fast-forward, or queue protections. If
-the ref is absent, audit the restored guard and then delete the obsolete exact
-queue ruleset. If activation failed during bootstrap, keep the disabled-queue
-ref as a fail-closed resumable state; use this same bounded cleanup only after
-an explicit abandonment decision.
+deletion succeeds or fails. In inference, if deletion failed after the exact
+queue was disabled, reactivate that recorded queue policy and verify all five
+effective rules before releasing the freeze; if reactivation also fails, keep the
+branch explicitly unsafe, expose no workspace, admit no PR, and record an
+incident for recovery. Never leave deletion authority active during an epic.
+Bypass is ruleset-wide: never put the deletion rule and its cleanup bypass in the
+base policy or an exact queue ruleset, because that would also let the cleanup
+actor bypass pull-request, status-check, non-fast-forward, or queue protections.
+For inference, if the ref is absent, audit the restored guard and then delete the
+obsolete exact queue ruleset; if activation failed during bootstrap, keep the
+disabled-queue ref as a fail-closed resumable state. Use this same bounded
+cleanup only after an explicit abandonment decision.
 
 Evaluate mode, when available, is an optional preview of matched refs and rule
 evaluations; it cannot prove enforced denials or merge-queue admission. Activate
@@ -429,15 +508,20 @@ At minimum:
 3. Ensure path-irrelevant required jobs report success through an always-created
    change-selection job. Do not use a workflow-level `paths` filter for a
    required check, because an absent workflow leaves the requirement pending.
-4. Ensure every required workflow includes `merge_group`. GitHub explicitly
-   requires that trigger for checks used by a merge queue; see
+4. Keep `merge_group` on every required workflow even though SceneWorks no
+   longer has a queue. The trigger costs nothing while no such event fires, and
+   it keeps re-enabling a queue a one-line ruleset change; a required lane
+   without it strands a queued group until `check_response_timeout_minutes`
+   evicts its entries, which re-orders the queue silently rather than failing.
+   GitHub requires that trigger for checks used by a merge queue; see
    [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group).
 5. Keep concurrency keyed so one PR or merge-group run cannot cancel another
    required verdict.
 
 Do not add duplicate `push: feature/*` builds merely because the branches are
-new. If the merge queue tests the exact speculative commit that lands, that run
-is the integration verdict. Add post-merge feature pushes only when they prove a
+new. With no SceneWorks queue, the integration verdict is the required-check run
+on the PR head itself, and `strict: true` on `feature/*` guarantees that head
+contains the current base. Add post-merge feature pushes only when they prove a
 separate property.
 
 #### 3. Decide the privileged runtime policy
@@ -449,11 +533,12 @@ policy:
 
 - feature-target story and synchronization PRs run the required hosted checks,
   including `macOS build, lint and workspace tests (hosted)`;
-- `nax-worker` does not auto-run for PRs targeting `feature/*` or for merge
-  groups; it continues to run for the final same-repo integration PR targeting
-  `main`;
-- `windows-candle.yml` remains limited to ordinary PRs targeting `main` and
-  stays out of the merge queue; and
+- `nax-worker` does not auto-run for PRs targeting `feature/*`, nor for merge
+  groups should a queue ever be re-enabled; it continues to run for the final
+  same-repo integration PR targeting `main`;
+- `windows-candle.yml` remains limited to ordinary PRs targeting `main`, keeps
+  its PR path filter, and carries no `merge_group` trigger, so it stays out of
+  the required set; and
 - at the frozen final feature head, explicitly dispatch both privileged
   workflows and record their exact head SHA and successful run URLs in the epic
   before opening the final PR to `main`.
@@ -479,9 +564,9 @@ After adding the inference ruleset:
 Implement small fail-closed automation rather than relying only on memory:
 
 - a feature bootstrap command or agent skill that creates and records mirrored
-  branches from exact main SHAs, verifies both wildcard layers, and safely
-  stages, activates, or recovers each exact-branch queue ruleset around creation
-  of its ref;
+  branches from exact main SHAs, verifies both wildcard layers in each
+  repository, and — for inference only — safely stages, activates, or recovers
+  its exact-branch queue ruleset around creation of the ref;
 - a PR policy check that rejects a feature story targeting `main` or the wrong
   epic branch;
 - a check that rejects a final SceneWorks feature PR while its inference pin is
@@ -504,14 +589,18 @@ feature branches and exercise all of the following:
    runtime evidence.
 5. An inference story PR produces `CI gate`, merges through its queue, and can be
    pinned by the SceneWorks feature branch.
-6. SceneWorks and inference merge queues validate their speculative commits and
-   do not cancel one another.
-7. The API refuses a wildcard queue payload and an active queue rejects initial
-   ref creation; disabled staging followed by ref creation and immediate queue
-   activation produces all five effective rules.
+6. A SceneWorks story PR whose base has moved is blocked as out-of-date
+   (`strict: true` on `feature/*`), and merges once the base is merged in and the
+   required checks re-run. There is no SceneWorks queue to validate a speculative
+   commit, so this is the only integration verdict.
+7. In inference, the API refuses a wildcard queue payload and an active queue
+   rejects initial ref creation; disabled staging followed by ref creation and
+   immediate queue activation produces all five effective rules. In SceneWorks,
+   creating a feature ref succeeds directly under the two wildcard layers.
 8. Direct and force pushes to feature branches fail.
 9. An unauthorized deletion fails, while the authorized post-epic cleanup path
-   succeeds without bypassing the base or exact queue policies.
+   succeeds without bypassing the base policy, or — in inference — the exact
+   queue policy.
 10. The final inference-first merge and SceneWorks pin transition succeed without
    leaving `main` dependent on a feature-only inference commit.
 

--- a/FEATURE_DEVELOPMENT.md
+++ b/FEATURE_DEVELOPMENT.md
@@ -84,14 +84,9 @@ commit is terminal `success`, `skipped`, or `neutral` from the expected GitHub
 Actions app. Pending, missing, wrong-app, or failed contexts are a stop
 condition. Persist the plan before mutating anything.
 
-The two repositories then diverge, because only inference still has merge
-queues. See *Current state* under **CI and repository configuration**.
-
-### SceneWorks: create the ref
-
-There is no queue rule and therefore no ordering constraint. Create the branch
-at the captured immutable SHA under the active wildcard base and deletion
-guards:
+Neither repository has a merge queue, so there is no per-branch queue ruleset to
+stage and no ordering constraint on ref creation. Create the branch at the
+captured immutable SHA under the active wildcard base and deletion guards:
 
 ```bash
 git fetch origin
@@ -99,48 +94,16 @@ git switch -c feature/sc-<epic-id>-<epic-slug> origin/main
 git push -u origin feature/sc-<epic-id>-<epic-slug>
 ```
 
-Then verify that **two** layers aggregate: the wildcard base policy and the
-wildcard deletion guard. Do not create a per-branch queue ruleset; SceneWorks
-has none by decision, and adding one back reintroduces a cost measured to buy
-nothing.
+Create the inference branch only when inference changes are part of the approved
+scope, using the identical commands and branch name against that remote.
 
-### inference: stage the queue, create the ref, activate
+Then verify that **two** layers aggregate in each applicable repository: the
+wildcard base policy and the wildcard deletion guard. Do not create a per-branch
+queue ruleset in either repository; both had one and both had it removed after
+measurement showed it bought nothing (see *Current state* under **CI and
+repository configuration**).
 
-GitHub rejects a merge-queue rule whose condition is the wildcard `feature/*`,
-while an active exact queue rule rejects creation of its not-yet-existing ref.
-When inference is in scope, its exact queue ruleset and ref must therefore be
-treated as one durable, recoverable transaction:
-
-1. create or verify the exact queue ruleset in disabled mode and record its ID
-   and payload digest;
-2. create the feature ref at the captured immutable SHA under the active
-   wildcard base and deletion guards;
-3. immediately activate only the recorded exact queue ruleset; and
-4. query the effective rules and require the five-rule aggregate.
-
-Step 2 uses the same commands shown for SceneWorks above, run against the
-inference remote — but only between the staged-disabled and activate steps, never
-before or after. Create the inference branch only when inference changes are part
-of the approved scope, and use the identical branch name as SceneWorks.
-
-Recovery resumes recognized durable states instead of blindly rolling back:
-
-- missing queue/no ref: create the recorded policy disabled, then continue;
-- disabled queue/no ref: create the ref, then activate;
-- disabled queue/ref at the recorded SHA: activate;
-- active queue/ref at the recorded SHA: verify the aggregate;
-- active queue/no ref: first disable that exact recorded, still-matching policy,
-  then create the ref and reactivate it; and
-- missing queue/ref at the recorded SHA: create the recorded policy disabled,
-  then activate it.
-
-An inference ref whose queue rule is missing or disabled remains protected by
-the wildcard layers but is unsafe: expose no workspace and admit no story PR
-until recovery completes.
-
-### Both repositories
-
-Only after every applicable repository reaches its verified state may bootstrap
+Only after every applicable repository reaches that verified state may bootstrap
 create a workspace or declare success. Do not loosen
 `do_not_enforce_on_create=false` or silently choose an older commit to make
 branch creation succeed. An unexpected ref SHA, duplicate matching ref or
@@ -179,12 +142,11 @@ Treat each story as a small PR even though its base is an epic branch.
      --head story/sc-<story-id>-<story-slug>
    ```
 
-9. Merge through the feature branch's required checks — and, in inference only,
-   its merge queue. SceneWorks feature branches have no queue; they require the
-   branch to be up to date with its base (`strict: true`), so merge `main` or the
-   feature head in and let the checks re-run rather than waiting for a queue to
-   do it for you. Verify the remote merge rather than treating queue entry or a
-   green check as completion.
+9. Merge through the feature branch's required checks. Neither repository has a
+   merge queue; `feature/*` requires the branch to be up to date with its base
+   (`strict: true`), so merge the feature head in and let the checks re-run
+   rather than waiting for a queue to do it for you. Verify the remote merge
+   rather than treating a green check as completion.
 10. Validate the acceptance criteria against the new combined feature head.
 11. Add a Shortcut closeout comment containing the PR, merge commit, tests,
     runtime evidence, limitations, and tracked follow-ups.
@@ -261,9 +223,11 @@ by exact commit SHA:
 4. Update SceneWorks to the final inference feature head and run the complete
    paired validation and final adversarial review.
 5. Open the inference feature PR against inference `main` and merge it through
-   the required CI and merge queue.
-6. Record the exact resulting inference `main` commit. A queue or open PR is not
-   a merged dependency.
+   the required CI. inference `main` is `strict: false` and has no queue, so if
+   inference `main` moved after those checks went green, merge it in and let them
+   re-run before merging.
+6. Record the exact resulting inference `main` commit. An open PR is not a merged
+   dependency.
 7. Update the SceneWorks feature branch to that inference-main commit with
    `bump-inference.mjs` and regenerate every derived artifact at the final pin.
 8. Rerun the complete SceneWorks validation matrix and final review. The pin
@@ -331,46 +295,55 @@ publish a release.
 
 ### Current state verified on 2026-08-11
 
-**The two repositories no longer behave the same way. SceneWorks has no merge
-queue anywhere; inference still queues everything.** Read the repository-specific
-column before following any procedure below.
+**Neither repository has a merge queue.** Both were removed on 2026-08-11 —
+SceneWorks first, inference the same day — and the two are now structurally
+identical.
 
 | | SceneWorks | inference |
 | --- | --- | --- |
 | `main` ruleset | `Require MR` (17708030) | `Require MR` (20481541) |
-| queue on `main` | **none** | `merge_queue` |
-| up-to-date required on `main` | no (`strict: false`) | — |
+| queue on `main` | **none** | **none** |
+| up-to-date required on `main` | no (`strict: false`) | no (`strict: false`) |
 | `feature/*` base policy | 20638194 | 20638200 |
-| queue on `feature/*` | **none** | per-branch exact rulesets, active |
+| queue on `feature/*` | **none** | **none** |
 | `feature/*` up-to-date | yes (`strict: true`) | yes (`strict: true`) |
 | deletion guard | 20638197 | 20638201 |
 
-Both repositories' `feature/*` base policies carry `pull_request` (0 approvals;
-SceneWorks additionally requires code-owner review), `non_fast_forward`, and
-required status checks — the same seven contexts as SceneWorks `main`
-(`web`, `parity`, `candle`, `build-windows`, `check-linux`, `check-macos`,
-`macOS build, lint and workspace tests (hosted)`), and `CI gate` for inference.
+Both `main` rulesets carry `deletion`, `non_fast_forward`, `pull_request`, and
+required status checks. Both `feature/*` base policies carry `non_fast_forward`,
+`pull_request`, and required status checks at `strict: true`.
 
-#### Why SceneWorks has no queue
+The deliberate remaining differences are policy, not structure: SceneWorks
+requires code-owner review and allows merge/squash/rebase; inference requires no
+code-owner review and allows merge commits only. Required contexts differ by
+repository — SceneWorks requires `web`, `parity`, `candle`, `build-windows`,
+`check-linux`, `check-macos`, and `macOS build, lint and workspace tests
+(hosted)`; inference requires `CI gate`. inference also retains a **disabled**
+`No Force-Push` ruleset (18886583) with no SceneWorks equivalent.
 
-Removed 2026-08-11 after measurement, not preference. Over 5.4 days the queue
+#### Why there is no queue
+
+Removed after measurement, not preference. Over 5.4 days the SceneWorks queue
 produced **103 merge groups and caught zero integration failures**, while adding
 a median 21m (mean 35m, p90 43m) to every merge. Every group contained exactly
 one PR — `min_entries_to_merge: 1` forms a group the instant one entry arrives,
-so nothing was ever amortized and the entire cost was additive. Its only
+so `max_entries_to_build` never engaged, `min_entries_to_merge_wait_minutes` was
+inert, nothing was ever amortized, and the entire cost was additive. Its only
 observable effects were two evictions, on PRs that then took 1h32m and 5h33m.
+inference ran the identical configuration, including the same
+`min_entries_to_merge: 1`, and was removed to match.
 
-Do not re-add it without new evidence. A merge queue earns its cost through
-batching under concurrency; at SceneWorks' merge rate it batched nothing. The
-`merge_group:` triggers remain in the workflows deliberately so re-enabling is a
-one-line ruleset change.
+Do not re-add a queue to either repository without new evidence. A merge queue
+earns its cost through batching under concurrency; at these merge rates it
+batched nothing. The `merge_group:` triggers remain in the workflows deliberately
+so re-enabling is a one-line ruleset change — and a required lane *without* that
+trigger strands a queued group until the response timeout evicts its entries.
 
 #### Consequences for this document
 
-- Every SceneWorks bootstrap step that stages, activates, or recovers an exact
-  per-branch queue ruleset is obsolete. SceneWorks feature branches have **two**
-  layers, not three, and ref creation needs no transaction.
-- The inference procedures are unchanged and still correct.
+- Every step that stages, activates, or recovers an exact per-branch queue
+  ruleset is obsolete in **both** repositories. Feature branches have **two**
+  layers, not three, and ref creation needs no transaction in either repo.
 - `release/next` is covered by **no ruleset in either repository** — no required
   checks, no PR requirement, no force-push or deletion guard. It is the least
   protected branch in the hotfix path.
@@ -403,22 +376,21 @@ repository or feature branch.
 GitHub rulesets use `fnmatch`, so the durable wildcard layers target `feature/*`,
 which intentionally matches the one-slash branch format defined above.
 
-**SceneWorks: two layers** — the wildcard base policy and the wildcard deletion
-guard. There is no queue layer, so there is no exact-branch ruleset, no staging
-transaction, and no per-epic ruleset lifecycle to manage.
+**Two layers in each repository** — the wildcard base policy and the wildcard
+deletion guard. There is no queue layer in either repository, so there is no
+exact-branch ruleset, no staging transaction, and no per-epic ruleset lifecycle
+to manage.
 
-**inference: three layers** — the same two wildcard layers plus one exact-branch
-queue ruleset per feature branch. GitHub's ruleset API rejects `merge_queue`
-when the condition contains a wildcard (`Invalid rule 'merge_queue': Wildcard ref
-names are not supported when merge queue is enabled`). An active exact queue rule
-also rejects initial creation of its matching ref with `Changes must be made
-through the merge queue`. Consequently the wildcard base policy must not contain
-the queue rule. Every inference bootstrap must create or verify a separate
-disabled exact queue ruleset for `feature/sc-<epic-id>-<epic-slug>`, create the
-checked ref under the active wildcard guards, immediately activate the exact
-rule, and verify the aggregate. A wildcard queue payload, or an inference feature
-ref with a missing/disabled exact queue rule, is a configuration error rather
-than a degraded mode.
+Should a queue ever be reintroduced, the constraint that shaped the old
+three-layer design still applies and is worth recording: GitHub's ruleset API
+rejects `merge_queue` when the condition contains a wildcard (`Invalid rule
+'merge_queue': Wildcard ref names are not supported when merge queue is
+enabled`), and an active exact queue rule rejects initial creation of its
+matching ref with `Changes must be made through the merge queue`. A queue
+therefore cannot live in the wildcard base policy, and its exact ruleset and ref
+have to be staged disabled, created, then activated as one recoverable
+transaction. Do not reintroduce that machinery without first fixing the batching
+parameters that made the queue worthless.
 
 SceneWorks must require at least the same integration contexts currently
 required on `main`:
@@ -442,32 +414,20 @@ must:
 - require current-head status checks;
 - use merge commits so story and synchronization provenance is retained.
 
-The exact-branch queue ruleset — **inference only** — must also have no bypass
-actors. It contains the `merge_queue` rule for that one feature ref and uses
-merge commits. Persist its ID and payload digest while it is disabled, then
-activate only that exact recorded policy after ref creation. If the disposable
-proof shows that GitHub does not aggregate a queue-only exact ruleset with the
-wildcard pull-request and status rules, repeat those rules in the exact ruleset;
-never remove them from the wildcard layer. Record the final active state with the
-epic bootstrap evidence.
-
-Note the batch-size trap that removed SceneWorks' queues: `min_entries_to_merge:
-1` forms a group the instant a single entry arrives, so `max_entries_to_build`
-never engages, `min_entries_to_merge_wait_minutes` is inert, and the queue
-amortizes nothing while charging a full verification pass per PR. If an inference
-queue is ever measured behaving that way, fix the batching parameters or remove
-the queue — do not keep paying for a group of one.
+Note the batch-size trap that removed both repositories' queues:
+`min_entries_to_merge: 1` forms a group the instant a single entry arrives, so
+`max_entries_to_build` never engages, `min_entries_to_merge_wait_minutes` is
+inert, and the queue amortizes nothing while charging a full verification pass
+per PR. Both repositories ran exactly that configuration. If a queue is ever
+reintroduced, set the batching parameters so a group can actually hold several
+entries, and measure group sizes before trusting it — do not pay for a group of
+one.
 
 The wildcard deletion-guard ruleset must contain only the deletion rule and
 normally have no bypass actors. After every non-cleanup assertion passes on a
 disposable proof branch, or after the post-merge checklist succeeds, freeze the
-target branch and require no open PR or queue entry.
-
-In SceneWorks, deletion is then gated only by the deletion guard itself. In
-inference, first attempt the deletion with the exact queue still active; if
-GitHub's queue rule rejects it, disable only the recorded exact queue policy and
-re-verify that the wildcard base and deletion layers remain active before
-continuing.
+target branch and require no open PR. With no queue in either repository,
+deletion is gated only by the deletion guard itself.
 
 An administrator may then temporarily add one closed maintainer team or cleanup
 automation as the deletion guard's exact cleanup actor. If neither exists, one
@@ -475,23 +435,18 @@ explicitly named repository administrator may be the temporary actor; record
 its immutable actor ID, the approved proof-or-completed branch names, and the
 start/end of the cleanup window. Delete only those branches and restore
 `bypass_actors: []` immediately in a finally-style cleanup step, whether the
-deletion succeeds or fails. In inference, if deletion failed after the exact
-queue was disabled, reactivate that recorded queue policy and verify all five
-effective rules before releasing the freeze; if reactivation also fails, keep the
-branch explicitly unsafe, expose no workspace, admit no PR, and record an
-incident for recovery. Never leave deletion authority active during an epic.
-Bypass is ruleset-wide: never put the deletion rule and its cleanup bypass in the
-base policy or an exact queue ruleset, because that would also let the cleanup
-actor bypass pull-request, status-check, non-fast-forward, or queue protections.
-For inference, if the ref is absent, audit the restored guard and then delete the
-obsolete exact queue ruleset; if activation failed during bootstrap, keep the
-disabled-queue ref as a fail-closed resumable state. Use this same bounded
-cleanup only after an explicit abandonment decision.
+deletion succeeds or fails. If deletion fails, keep the branch explicitly unsafe,
+expose no workspace, admit no PR, and record an incident for recovery. Never
+leave deletion authority active during an epic. Bypass is ruleset-wide: never put
+the deletion rule and its cleanup bypass in the base policy, because that would
+also let the cleanup actor bypass pull-request, status-check, or
+non-fast-forward protections. If the ref is absent, audit the restored guard. Use
+this same bounded cleanup only after an explicit abandonment decision.
 
 Evaluate mode, when available, is an optional preview of matched refs and rule
-evaluations; it cannot prove enforced denials or merge-queue admission. Activate
-the three layers on disposable branches before running those enforcement tests,
-and do not create the real epic branches until the complete proof matrix passes.
+evaluations; it cannot prove enforced denials. Activate both layers on disposable
+branches before running those enforcement tests, and do not create the real epic
+branches until the complete proof matrix passes.
 GitHub's ruleset pattern and bypass behavior is documented in
 [Creating rulesets for a repository](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository).
 
@@ -508,21 +463,21 @@ At minimum:
 3. Ensure path-irrelevant required jobs report success through an always-created
    change-selection job. Do not use a workflow-level `paths` filter for a
    required check, because an absent workflow leaves the requirement pending.
-4. Keep `merge_group` on every required workflow even though SceneWorks no
-   longer has a queue. The trigger costs nothing while no such event fires, and
-   it keeps re-enabling a queue a one-line ruleset change; a required lane
-   without it strands a queued group until `check_response_timeout_minutes`
-   evicts its entries, which re-orders the queue silently rather than failing.
+4. Keep `merge_group` on every required workflow even though neither repository
+   has a queue. The trigger costs nothing while no such event fires, and it keeps
+   re-enabling a queue a one-line ruleset change; a required lane without it
+   strands a queued group until `check_response_timeout_minutes` evicts its
+   entries, which re-orders the queue silently rather than failing.
    GitHub requires that trigger for checks used by a merge queue; see
    [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group).
 5. Keep concurrency keyed so one PR or merge-group run cannot cancel another
    required verdict.
 
 Do not add duplicate `push: feature/*` builds merely because the branches are
-new. With no SceneWorks queue, the integration verdict is the required-check run
-on the PR head itself, and `strict: true` on `feature/*` guarantees that head
-contains the current base. Add post-merge feature pushes only when they prove a
-separate property.
+new. With no queue in either repository, the integration verdict is the
+required-check run on the PR head itself, and `strict: true` on `feature/*`
+guarantees that head contains the current base. Add post-merge feature pushes
+only when they prove a separate property.
 
 #### 3. Decide the privileged runtime policy
 
@@ -534,7 +489,7 @@ policy:
 - feature-target story and synchronization PRs run the required hosted checks,
   including `macOS build, lint and workspace tests (hosted)`;
 - `nax-worker` does not auto-run for PRs targeting `feature/*`, nor for merge
-  groups should a queue ever be re-enabled; it continues to run for the final
+  groups should a queue ever be reintroduced; it continues to run for the final
   same-repo integration PR targeting `main`;
 - `windows-candle.yml` remains limited to ordinary PRs targeting `main`, keeps
   its PR path filter, and carries no `merge_group` trigger, so it stays out of
@@ -552,7 +507,8 @@ epic that requires real-weight evidence cannot close on a compile-only lane.
 After adding the inference ruleset:
 
 - prove that a story PR to `feature/*` produces `CI gate`;
-- prove that its merge queue produces and accepts the `merge_group` verdict;
+- prove that an out-of-date story PR is blocked until its base is merged in and
+  `CI gate` re-runs (`strict: true`, no queue);
 - prove that a SceneWorks PR can fetch an exact commit reachable only from the
   active private inference feature branch;
 - prove that `bump-inference.mjs` regenerates and validates all pin-derived
@@ -564,9 +520,8 @@ After adding the inference ruleset:
 Implement small fail-closed automation rather than relying only on memory:
 
 - a feature bootstrap command or agent skill that creates and records mirrored
-  branches from exact main SHAs, verifies both wildcard layers in each
-  repository, and — for inference only — safely stages, activates, or recovers
-  its exact-branch queue ruleset around creation of the ref;
+  branches from exact main SHAs and verifies both wildcard layers in each
+  repository;
 - a PR policy check that rejects a feature story targeting `main` or the wrong
   epic branch;
 - a check that rejects a final SceneWorks feature PR while its inference pin is
@@ -587,20 +542,17 @@ feature branches and exercise all of the following:
 3. An MLX-sensitive PR runs the required macOS/MLX context.
 4. A candle-sensitive PR produces the hosted candle verdict and the chosen CUDA
    runtime evidence.
-5. An inference story PR produces `CI gate`, merges through its queue, and can be
-   pinned by the SceneWorks feature branch.
-6. A SceneWorks story PR whose base has moved is blocked as out-of-date
-   (`strict: true` on `feature/*`), and merges once the base is merged in and the
-   required checks re-run. There is no SceneWorks queue to validate a speculative
-   commit, so this is the only integration verdict.
-7. In inference, the API refuses a wildcard queue payload and an active queue
-   rejects initial ref creation; disabled staging followed by ref creation and
-   immediate queue activation produces all five effective rules. In SceneWorks,
-   creating a feature ref succeeds directly under the two wildcard layers.
+5. An inference story PR produces `CI gate`, merges, and can be pinned by the
+   SceneWorks feature branch.
+6. A story PR whose base has moved is blocked as out-of-date (`strict: true` on
+   `feature/*`) in both repositories, and merges once the base is merged in and
+   the required checks re-run. With no queue validating a speculative commit,
+   this is the only integration verdict.
+7. Creating a feature ref succeeds directly under the two wildcard layers, in
+   both repositories, with no queue ruleset staged.
 8. Direct and force pushes to feature branches fail.
 9. An unauthorized deletion fails, while the authorized post-epic cleanup path
-   succeeds without bypassing the base policy, or — in inference — the exact
-   queue policy.
+   succeeds without bypassing the base policy.
 10. The final inference-first merge and SceneWorks pin transition succeed without
    leaving `main` dependent on a feature-only inference commit.
 


### PR DESCRIPTION
## Why

`parity` was a single serial job running four mutually independent things, so everything queued behind the ~7m Rust compile. `check.yml`'s duration **is** `parity`'s duration — `web` (2.6m) and `candle` (2.5m) already run in parallel and finish long before it.

Measured over 12 `pull_request` runs on 2026-08-11:

| step | median | runs |
|---|---|---|
| Run Rust workspace checks | 6.8m | 12/12 |
| Verify inference closure digests | 4.0m | 12/12 |
| Scaffold + compose checks | 1.6m | 12/12 |
| Docker runtime smoke | 6.8m | 4/12 (already gated) |
| **job total** | **14.2m median, 22.3m max** | |

Splitting them into concurrent jobs makes the critical path the longest single member instead of their sum: **~8m expected**, and ~8m on the runs where the Docker smoke fires rather than 22m.

## One required check, not four

`parity` stays a single required status context and becomes an aggregator over `parity-rust`, `parity-digests`, `parity-scaffold`, `parity-docker`. Promoting each to its own required context would have meant a ruleset change plus a window where a split-out check had left `parity` but was not yet required on its own.

**The aggregator fails closed.** Without `if: always()` it would be *skipped* whenever an upstream job failed or was skipped — and a skipped job reports Success to a required check, the exact false-green shape documented at the top of `changed-paths.yml`. It asserts over whatever is in `needs` rather than naming the jobs, so a fifth `parity-*` job cannot go ungraded, and it floors the count so deleting a `needs:` entry fails instead of shrinking the assertion to a no-op.

## Verification

- Command-set diff old vs new: **zero commands removed**; the only additions are the aggregator's own logic.
- Aggregator tested against `success` / `failure` / `skipped` / `cancelled` / short-list / empty inputs → exits 0 only on all-success.
- `platform-review-contracts.test.mjs`: 45/45 pass.
- `npm run check`: exit 0, 399/399 tests pass.
- `check:compose`, `check:nc-weights`, `check:license-coverage` and both self-tests run standalone with no Rust toolchain and no inference clone — confirming the placement below.

Placement is by real dependency, not by theme: gen-core skew shells out to `cargo tree` so it stays on the Rust job; `npm run check` reads `Cargo.toml` as text and never invokes cargo; the licence guard grades checked-in audit data against the Cargo pin and needs no inference clone, unlike the digest job which fetches one.

## Context

The `merge_group:` trigger is retained deliberately. The merge queue was removed on 2026-08-11 (0 integration failures caught in 103 groups, +21m median tax, every group size 1), so no such event fires today — but keeping the trigger makes re-enabling it a one-line ruleset change, and a required lane without it strands a queued group until the response timeout evicts it.

The real proof is this PR's own `check` run: compare it against the 15.6m workflow / 14.2m job baselines above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)