### PR TITLE
sc-18677: provision MiniMax-H3 on the CUDA runner, generalize the hardcoded Krea snapshot path

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -327,7 +327,8 @@ jobs:
     #
     # Provisioning now keys the 240m budget on its OWN input rather than on the five-rung
     # conjunction (sc-18677): a provision-only dispatch is a supported mode, and H3's
-    # component set is ~210 GB against Krea q4's ~14 GB, so it is the branch that most
+    # component set is 144.051 GB (210.332 GB once transformer_ref joins in sc-17149) against
+    # Krea q4's ~14 GB, so it is the branch that most
     # needs the long budget. Krea's two dispatch shapes keep their exact previous values --
     # five-rung + provision 240, five-rung alone 120, everything else 45.
     timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && inputs.provision_snapshot && 240 || github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && 120 || 45 }}
@@ -446,8 +447,15 @@ jobs:
           PROVISION_REVISION: ${{ inputs.provision_revision }}
           PROVISION_PATTERNS: ${{ inputs.provision_patterns }}
           PROVISION_SUBDIR: ${{ inputs.provision_subdir }}
+          PROVISION_CACHE_DIR_INPUT: ${{ inputs.provision_cache_dir }}
         run: |
-          if ($env:PROVISION_SNAPSHOT -eq 'true') {
+          # Gate on the SAME condition as the steps that consume these values (the params and
+          # resolve steps run on `run_five_rung_reference || provision_snapshot`), not on
+          # provision_snapshot alone. Scoping the containment checks to the provisioning branch
+          # left them unreachable for a five-rung-only dispatch, which consumes provision_subdir
+          # and provision_patterns just the same -- it failed closed downstream on the EndsWith
+          # assertion, but reported a confusing path mismatch instead of the real reason.
+          if ($env:PROVISION_SNAPSHOT -eq 'true' -or $env:RUN_FIVE_RUNG_REFERENCE -eq 'true') {
             if ($env:PROVISION_REPOSITORY -notmatch '^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$') {
               throw 'provision_repository must be a Hugging Face owner/name repo id'
             }
@@ -458,7 +466,21 @@ jobs:
             if ($patterns.Count -eq 0) {
               throw 'provision_patterns must name at least one allow-pattern; an empty list would fetch the whole repository'
             }
+            # Each pattern's leading literal segment is joined onto the snapshot root by the
+            # resolve step's component-presence assertion. Without this, `../../foo/*` would let
+            # that assertion be satisfied by a directory outside the snapshot entirely -- which
+            # is the one assertion that makes a root-resolved model's proof real.
+            foreach ($pattern in $patterns) {
+              if ($pattern -match '^[\\/]' -or $pattern -match '^[A-Za-z]:') {
+                throw "provision_patterns entries must be relative to the snapshot root: $pattern"
+              }
+              if (($pattern -split '[\\/]') -contains '..') {
+                throw "provision_patterns entries must not traverse out of the snapshot: $pattern"
+              }
+            }
             if ($env:PROVISION_SUBDIR) {
+              # The shape regex alone is NOT containment: '.' is inside the character class, so
+              # '..' matches it. The -contains check below is load-bearing.
               if ($env:PROVISION_SUBDIR -notmatch '^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$') {
                 throw 'provision_subdir must be a relative path of [A-Za-z0-9._-] segments'
               }
@@ -466,13 +488,20 @@ jobs:
                 throw 'provision_subdir must not traverse out of the snapshot'
               }
             }
+            if ($env:PROVISION_CACHE_DIR_INPUT) {
+              # This value is written verbatim into $GITHUB_ENV, where a newline would inject
+              # arbitrary job-scoped variables into every later step.
+              if ($env:PROVISION_CACHE_DIR_INPUT -match '[\r\n]') {
+                throw 'provision_cache_dir must be a single line'
+              }
+              if (-not [System.IO.Path]::IsPathRooted($env:PROVISION_CACHE_DIR_INPUT)) {
+                throw 'provision_cache_dir must be an absolute path'
+              }
+            }
           }
           if ($env:RUN_FIVE_RUNG_REFERENCE -ne 'true') { exit 0 }
           if ($env:INFERENCE_REVISION -notmatch '^[0-9a-f]{40}$') {
             throw 'inference_revision must be an exact lowercase 40-hex commit'
-          }
-          if ($env:PROVISION_REVISION -notmatch '^[0-9a-f]{40}$') {
-            throw 'provision_revision must be an exact lowercase 40-hex artifact revision'
           }
           if ($env:PROVISION_REPOSITORY -ne 'SceneWorks/krea-2-turbo-mlx') {
             throw 'provision_repository must be the fixed SceneWorks/krea-2-turbo-mlx reference artifact for a five-rung capture'
@@ -527,10 +556,11 @@ jobs:
             throw "the self-hosted CUDA runner requires Python 3.12 or newer, got: $version"
           }
       # ONE allow-pattern per component, never a bare repo fetch. MiniMaxAI/MiniMax-H3 is
-      # ~498 GB because it ships the root (modular) layout plus FL2VA/ and Ref2VA/ partition
+      # 498.475 GB because it ships the root (modular) layout plus FL2VA/ and Ref2VA/ partition
       # re-packagings of the same components; only the root layout is referenced by
       # `modular_model_index.json` and only it is the conversion source (sc-17139 section 2).
-      # Fetching by component takes that to ~210 GB. Note this is the OPPOSITE of the rule for
+      # Fetching by component takes that to 210.332 GB, and to 144.051 GB for the set sc-18677
+      # actually provisions (transformer_ref is sc-17149's, deferred). Note this is the OPPOSITE of the rule for
       # `config/manifests` download rows, where an empty `files` list (whole repo) is correct --
       # those name SceneWorks-built artifacts that contain only what a user needs, whereas this
       # provisions a third-party repo with three overlapping copies of every component.
@@ -547,6 +577,7 @@ jobs:
           HF_HUB_VERBOSITY: "error"
         run: |
           python -m pip install --disable-pip-version-check --no-input 'huggingface_hub==0.36.0'
+          if ($LASTEXITCODE -ne 0) { throw "installing huggingface_hub failed with exit code $LASTEXITCODE" }
           @'
           import os
           from huggingface_hub import snapshot_download
@@ -620,6 +651,10 @@ jobs:
             throw "provisioned snapshot is missing declared components under ${snapshotRoot}: $($missing -join ', ')"
           }
           Write-Host "resolved snapshot root: $root"
+          # The model-neutral handle. Nothing in the repo reads it YET -- it is the seam
+          # sc-17153/sc-17156 need, since SCENEWORKS_KREA_ROOT is a Krea-shaped name their
+          # MiniMax measurement steps cannot reuse. Exported unconditionally so a provision-only
+          # dispatch still names its snapshot to any step added after it.
           "SCENEWORKS_PROVISIONED_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           if ($isKrea) {
             "SCENEWORKS_KREA_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -184,7 +184,7 @@ on:
         type: string
         default: "q4/**"
       provision_subdir:
-        description: "Tier/subdirectory under the snapshot the resolve step must prove. Empty resolves the snapshot root."
+        description: "Tier/subdirectory under the snapshot the resolve step must prove. Use '.' for a model whose components sit at the snapshot ROOT (H3); an empty value cannot override this default."
         required: false
         type: string
         default: "q4"
@@ -532,8 +532,17 @@ jobs:
           $cache = $env:PROVISION_CACHE_DIR_INPUT
           if (-not $cache) { $cache = Join-Path $env:USERPROFILE '.cache\huggingface\hub' }
           $folder = 'models--' + $env:PROVISION_REPOSITORY.Replace('/', '--')
+          # '.' is the ROOT sentinel, and it is load-bearing rather than cosmetic. GitHub applies
+          # an input's `default` whenever the dispatch supplies an empty value, so
+          # `-f provision_subdir=` does NOT mean "no subdir" -- it silently becomes `q4`. Run
+          # 31509409586 proved it: H3 provisioned correctly, then the resolve step looked for
+          # ...\snapshots\939557dc...\q4 and threw. Because the default has to stay `q4` to keep a
+          # Krea dispatch identical, a model whose components sit at the snapshot root is
+          # otherwise INEXPRESSIBLE. Empty is still honored for any caller that can send it.
           $subdirTail = ''
-          if ($env:PROVISION_SUBDIR) { $subdirTail = '\' + $env:PROVISION_SUBDIR.Replace('/', '\') }
+          if ($env:PROVISION_SUBDIR -and $env:PROVISION_SUBDIR -ne '.') {
+            $subdirTail = '\' + $env:PROVISION_SUBDIR.Replace('/', '\')
+          }
           $suffix = '\' + $folder + '\snapshots\' + $env:PROVISION_REVISION + $subdirTail
           Add-Content -Path $env:GITHUB_ENV -Value "PROVISION_CACHE_DIR=$cache"
           Add-Content -Path $env:GITHUB_ENV -Value "PROVISION_SNAPSHOT_SUFFIX=$suffix"

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -467,14 +467,42 @@ jobs:
               throw 'provision_patterns must name at least one allow-pattern; an empty list would fetch the whole repository'
             }
             # Each pattern's leading literal segment is joined onto the snapshot root by the
-            # resolve step's component-presence assertion. Without this, `../../foo/*` would let
+            # resolve step's component-presence assertion. Without containment, `../../foo/*` lets
             # that assertion be satisfied by a directory outside the snapshot entirely -- which
             # is the one assertion that makes a root-resolved model's proof real.
+            #
+            # Validate the HEAD, computed with the identical expression the resolve step uses, and
+            # decide containment by CANONICALIZING rather than by matching path segments. Textual
+            # segment-equality is the wrong tool on Windows and was demonstrably bypassable two
+            # ways: `..*` yields head `..` while the pattern itself contains no `..` segment
+            # (moving the wildcard one character left defeats a check on `$pattern`), and `.. `
+            # survives `-contains '..'` yet Win32 strips trailing spaces and dots from path
+            # components, so it resolves to the parent anyway. GetFullPath collapses every such
+            # spelling, including the ones nobody has thought of yet.
+            $probe = Join-Path 'C:\__sw_containment_probe__' 'snapshot'
             foreach ($pattern in $patterns) {
               if ($pattern -match '^[\\/]' -or $pattern -match '^[A-Za-z]:') {
                 throw "provision_patterns entries must be relative to the snapshot root: $pattern"
               }
-              if (($pattern -split '[\\/]') -contains '..') {
+              $head = (($pattern -split '[\*\?\[]')[0]).TrimEnd('/')
+              if (-not $head) { continue }
+              # TWO checks, because neither alone is sufficient.
+              #
+              # (a) Segment shape. Win32 strips trailing spaces and dots from every path
+              # component, so `.. ` names the parent while comparing equal to nothing -- and
+              # [System.IO.Path]::GetFullPath does NOT strip it, so (b) alone accepts it. Any
+              # segment that is empty once trailing dots and spaces are removed is a disguised
+              # `.`/`..` and has no legitimate use in a component name.
+              foreach ($segment in ($head -split '[\\/]')) {
+                if (-not $segment.TrimEnd(' ', '.')) {
+                  throw "provision_patterns entries must not traverse out of the snapshot: $pattern"
+                }
+              }
+              # (b) Canonical containment, which catches every ordinary spelling including the
+              # wildcard-adjacent ones a check on `$pattern` misses (`..*` has head `..` while the
+              # pattern itself contains no `..` segment).
+              $full = [System.IO.Path]::GetFullPath((Join-Path $probe $head.Replace('/', '\')))
+              if (-not $full.StartsWith($probe + '\', [StringComparison]::OrdinalIgnoreCase)) {
                 throw "provision_patterns entries must not traverse out of the snapshot: $pattern"
               }
             }
@@ -494,8 +522,11 @@ jobs:
               if ($env:PROVISION_CACHE_DIR_INPUT -match '[\r\n]') {
                 throw 'provision_cache_dir must be a single line'
               }
-              if (-not [System.IO.Path]::IsPathRooted($env:PROVISION_CACHE_DIR_INPUT)) {
-                throw 'provision_cache_dir must be an absolute path'
+              # NOT IsPathRooted: it accepts `\foo` and `C:foo`, which are rooted but not
+              # absolute, so the check would not mean what its message says. .NET Framework 4.x
+              # (PowerShell 5.1) has no IsPathFullyQualified, hence the explicit drive pattern.
+              if ($env:PROVISION_CACHE_DIR_INPUT -notmatch '^[A-Za-z]:\\') {
+                throw 'provision_cache_dir must be an absolute path with a drive letter'
               }
             }
           }
@@ -654,6 +685,13 @@ jobs:
             $head = $head.TrimEnd('/')
             if (-not $head) { continue }
             $component = Join-Path $snapshotRoot $head.Replace('/', '\')
+            # Canonical containment, independently of the validation step. -LiteralPath suppresses
+            # globbing, NOT Win32 path normalization, so a probe must be proven to land inside the
+            # snapshot before its existence means anything.
+            $full = [System.IO.Path]::GetFullPath($component)
+            if (-not $full.StartsWith($snapshotRoot + '\', [StringComparison]::OrdinalIgnoreCase)) {
+              throw "declared component escapes the snapshot root: $pattern"
+            }
             if (-not (Test-Path -LiteralPath $component)) { $missing += $head }
           }
           if ($missing.Count -gt 0) {
@@ -662,7 +700,7 @@ jobs:
           Write-Host "resolved snapshot root: $root"
           # The model-neutral handle. Nothing in the repo reads it YET -- it is the seam
           # sc-17153/sc-17156 need, since SCENEWORKS_KREA_ROOT is a Krea-shaped name their
-          # MiniMax measurement steps cannot reuse. Exported unconditionally so a provision-only
+          # MiniMax measurement steps cannot reuse. Exported without an $isKrea guard so a provision-only
           # dispatch still names its snapshot to any step added after it.
           "SCENEWORKS_PROVISIONED_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           if ($isKrea) {

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -299,7 +299,20 @@ jobs:
   candle-worker:
     # Same-repo only — never execute untrusted fork code on the self-hosted runner.
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: [self-hosted, Windows, X64, cuda]
+    # A provisioning or five-rung dispatch additionally requires `real-weights`; ordinary PR and
+    # push runs keep the full `cuda` pool (sc-18677). This mirrors macos-mlx.yml:450 exactly, which
+    # adds `weights` for `run_memory_calibration || run_five_rung_reference` and is the convention
+    # this lane was missing -- the asymmetry epic 17137 recorded as "no weights label and no HF
+    # provisioning input, unlike the Mac lane".
+    #
+    # It matters because the `cuda` pool is FOUR runners across TWO registration levels: org-level
+    # `cuda-windows` / `cuda-windows-2` carry `real-weights`, repo-level `cuda-windows-3` /
+    # `cuda-windows-4` do NOT. All four happen to be listener processes on the same physical box
+    # today, so this narrowing changes nothing observable right now. It is what keeps a weights job
+    # correct the day a `cuda` runner is added on a second machine: without it the job lands on a
+    # box with no snapshot and fails at the resolve step, which is loud but wasteful; with it the
+    # job simply queues for a box that has the weights.
+    runs-on: ${{ (github.event_name == 'workflow_dispatch' && (inputs.provision_snapshot || inputs.run_five_rung_reference)) && fromJSON('["self-hosted","Windows","X64","cuda","real-weights"]') || fromJSON('["self-hosted","Windows","X64","cuda"]') }}
     env:
       # Native sm_120 (Blackwell) — this runner IS the RTX PRO 6000 box; nvcc emits
       # SASS directly (no load-time JIT). compute_80 PTX would also forward-JIT.

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -575,9 +575,12 @@ jobs:
             $subdirTail = '\' + $env:PROVISION_SUBDIR.Replace('/', '\')
           }
           $suffix = '\' + $folder + '\snapshots\' + $env:PROVISION_REVISION + $subdirTail
-          Add-Content -Path $env:GITHUB_ENV -Value "PROVISION_CACHE_DIR=$cache"
-          Add-Content -Path $env:GITHUB_ENV -Value "PROVISION_SNAPSHOT_SUFFIX=$suffix"
-          Add-Content -Path $env:GITHUB_ENV -Value "PROVISION_SUBDIR_TAIL=$subdirTail"
+          # -Encoding utf8 is not cosmetic: Windows PowerShell 5.1's Add-Content defaults to the
+          # ANSI code page, and these three values carry operator-supplied paths. The resolve step
+          # writes the same file with `Out-File -Encoding utf8 -Append`; both halves must agree.
+          Add-Content -Path $env:GITHUB_ENV -Encoding utf8 -Value "PROVISION_CACHE_DIR=$cache"
+          Add-Content -Path $env:GITHUB_ENV -Encoding utf8 -Value "PROVISION_SNAPSHOT_SUFFIX=$suffix"
+          Add-Content -Path $env:GITHUB_ENV -Encoding utf8 -Value "PROVISION_SUBDIR_TAIL=$subdirTail"
           Write-Host "cache dir       : $cache"
           Write-Host "snapshot suffix : $suffix"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -131,6 +131,28 @@ on:
   pull_request:
     branches: [main]
     paths: *candle_paths
+  # PROVISIONING IS MODEL-PARAMETERIZED (sc-18677). It used to be hardcoded to the Krea q4
+  # reference: a `provision_krea_snapshot` boolean, a `snapshot_download` literal naming
+  # `SceneWorks/krea-2-turbo-mlx` with `allow_patterns=["q4/**"]`, and a resolve step that
+  # rebuilt `models--SceneWorks--krea-2-turbo-mlx\snapshots\<rev>\q4` by hand. The machinery
+  # was sound; only the model was welded in. Epic 17137 needs the same machinery pointed at
+  # `MiniMaxAI/MiniMax-H3` so sc-17153/sc-17156 can measure per-tier VRAM on real weights.
+  #
+  # The Krea inputs were RENAMED, not duplicated, so there is exactly one provisioning path:
+  #   provision_krea_snapshot -> provision_snapshot
+  #   krea_repository         -> provision_repository   (same default)
+  #   krea_revision           -> provision_revision
+  # A Krea five-rung dispatch that sets only run_five_rung_reference / provision_snapshot /
+  # provision_revision / inference_revision leaves every provision_* default in place and
+  # resolves byte-identically to the old hardcoded path. `platform-review-contracts.test.mjs`
+  # pins that equivalence field by field so it cannot rot.
+  #
+  # The `SCENEWORKS_KREA_*` env names below are NOT renamed: they are the memory-adapter
+  # binary's contract (`crates/sceneworks-memory-adapter/src/bin/{candle,mlx}.rs` read them
+  # via `required_env`), so renaming them would break the five-rung capture at runtime.
+  #
+  # GitHub caps workflow_dispatch at 10 inputs. Renaming rather than adding a parallel
+  # provision_* family is what keeps this at 8 with room for the epic's later stories.
   workflow_dispatch:
     inputs:
       run_five_rung_reference:
@@ -138,8 +160,8 @@ on:
         required: false
         type: boolean
         default: false
-      provision_krea_snapshot:
-        description: "Provision the exact public Krea q4 snapshot before capture"
+      provision_snapshot:
+        description: "Provision the exact snapshot named by the provision_* inputs (defaults to the Krea q4 reference)"
         required: false
         type: boolean
         default: false
@@ -147,13 +169,27 @@ on:
         description: "Exact 40-hex inference revision pinned by the adapter"
         required: false
         type: string
-      krea_repository:
-        description: "Published Krea MLX artifact repository identity"
+      provision_repository:
+        description: "Hugging Face repo id to provision, owner/name (was krea_repository)"
         required: false
         type: string
         default: "SceneWorks/krea-2-turbo-mlx"
-      krea_revision:
-        description: "Exact 40-hex Krea artifact revision"
+      provision_revision:
+        description: "Exact 40-hex artifact revision to provision (was krea_revision)"
+        required: false
+        type: string
+      provision_patterns:
+        description: "Allow-patterns, one component per line or comma-separated (e.g. transformer/*). Default is the Krea q4 tier."
+        required: false
+        type: string
+        default: "q4/**"
+      provision_subdir:
+        description: "Tier/subdirectory under the snapshot the resolve step must prove. Empty resolves the snapshot root."
+        required: false
+        type: string
+        default: "q4"
+      provision_cache_dir:
+        description: "Hub cache dir. Empty uses %USERPROFILE%\\.cache\\huggingface\\hub, the historical Krea location."
         required: false
         type: string
 
@@ -275,7 +311,13 @@ jobs:
     # that box and starves every queued PR/main run on it until the cap fires
     # (sc-13603). Well above the healthy ~11-14 min build+test+clippy — a cold
     # candle-kernels (nvcc) rebuild still fits comfortably.
-    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && inputs.provision_krea_snapshot && 240 || github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && 120 || 45 }}
+    #
+    # Provisioning now keys the 240m budget on its OWN input rather than on the five-rung
+    # conjunction (sc-18677): a provision-only dispatch is a supported mode, and H3's
+    # component set is ~210 GB against Krea q4's ~14 GB, so it is the branch that most
+    # needs the long budget. Krea's two dispatch shapes keep their exact previous values --
+    # five-rung + provision 240, five-rung alone 120, everything else 45.
+    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && inputs.provision_snapshot && 240 || github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && 120 || 45 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # sc-13166: point this lane at the REAL rustup toolchain bin and prepend it to
@@ -359,39 +401,109 @@ jobs:
           set NVCC_CCBIN=%VCToolsInstallDir%bin\Hostx64\x64
           cargo check -p sceneworks-memory-adapter --features candle --bin memory-candle-adapter
           cargo test -p sceneworks-memory-adapter --features candle --bin memory-candle-adapter
-      - name: Validate five-rung reference inputs
+      # Two independent validations, in one step because both are pure input checks.
+      #
+      # (1) PROVISIONING. `provision_snapshot` no longer requires `run_five_rung_reference`
+      # (sc-18677). The old throw existed because provisioning had exactly one consumer -- the
+      # Krea capture -- so provisioning without it was necessarily a mistake. Epic 17137 makes
+      # provisioning a first-class outcome: sc-17153/sc-17156 need H3 weights resident on this
+      # box, and there is no H3 five-rung fixture to run. Everything the old guard actually
+      # protected is still enforced, just against the generalized inputs.
+      #
+      # `provision_subdir` is validated for CONTAINMENT here, not merely for shape. The resolve
+      # step joins it onto the cache path, and the same trap sc-17139 documented for the
+      # manifest `subdir` key applies verbatim: `..` is spelled entirely from characters a
+      # naive path pattern allows. The EndsWith assertion downstream already fails closed on a
+      # traversal (Resolve-Path normalizes `..` away, so the suffix stops matching), but a
+      # rejected input gives the operator the real reason instead of a confusing path mismatch.
+      #
+      # (2) FIVE-RUNG. Unchanged in substance -- still an exact 40-hex inference revision, an
+      # exact 40-hex artifact revision, the fixed Krea repository, and an INFERENCE_PIN match.
+      # Only the input NAMES moved (krea_revision -> provision_revision, krea_repository ->
+      # provision_repository), so a five-rung dispatch is rejected under exactly the same
+      # conditions as before.
+      - name: Validate dispatch inputs
         if: ${{ github.event_name == 'workflow_dispatch' }}
         shell: powershell
         env:
           RUN_FIVE_RUNG_REFERENCE: ${{ inputs.run_five_rung_reference }}
-          PROVISION_KREA_SNAPSHOT: ${{ inputs.provision_krea_snapshot }}
+          PROVISION_SNAPSHOT: ${{ inputs.provision_snapshot }}
           INFERENCE_REVISION: ${{ inputs.inference_revision }}
-          KREA_REPOSITORY: ${{ inputs.krea_repository }}
-          KREA_REVISION: ${{ inputs.krea_revision }}
+          PROVISION_REPOSITORY: ${{ inputs.provision_repository }}
+          PROVISION_REVISION: ${{ inputs.provision_revision }}
+          PROVISION_PATTERNS: ${{ inputs.provision_patterns }}
+          PROVISION_SUBDIR: ${{ inputs.provision_subdir }}
         run: |
-          if ($env:PROVISION_KREA_SNAPSHOT -eq 'true' -and $env:RUN_FIVE_RUNG_REFERENCE -ne 'true') {
-            throw 'provision_krea_snapshot requires run_five_rung_reference=true'
+          if ($env:PROVISION_SNAPSHOT -eq 'true') {
+            if ($env:PROVISION_REPOSITORY -notmatch '^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$') {
+              throw 'provision_repository must be a Hugging Face owner/name repo id'
+            }
+            if ($env:PROVISION_REVISION -notmatch '^[0-9a-f]{40}$') {
+              throw 'provision_revision must be an exact lowercase 40-hex artifact revision'
+            }
+            $patterns = @($env:PROVISION_PATTERNS -split '[,\r\n]' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+            if ($patterns.Count -eq 0) {
+              throw 'provision_patterns must name at least one allow-pattern; an empty list would fetch the whole repository'
+            }
+            if ($env:PROVISION_SUBDIR) {
+              if ($env:PROVISION_SUBDIR -notmatch '^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$') {
+                throw 'provision_subdir must be a relative path of [A-Za-z0-9._-] segments'
+              }
+              if (($env:PROVISION_SUBDIR -split '/') -contains '..') {
+                throw 'provision_subdir must not traverse out of the snapshot'
+              }
+            }
           }
           if ($env:RUN_FIVE_RUNG_REFERENCE -ne 'true') { exit 0 }
           if ($env:INFERENCE_REVISION -notmatch '^[0-9a-f]{40}$') {
             throw 'inference_revision must be an exact lowercase 40-hex commit'
           }
-          if ($env:KREA_REVISION -notmatch '^[0-9a-f]{40}$') {
-            throw 'krea_revision must be an exact lowercase 40-hex artifact revision'
+          if ($env:PROVISION_REVISION -notmatch '^[0-9a-f]{40}$') {
+            throw 'provision_revision must be an exact lowercase 40-hex artifact revision'
           }
-          if ($env:KREA_REPOSITORY -ne 'SceneWorks/krea-2-turbo-mlx') {
-            throw 'krea_repository must be the fixed SceneWorks/krea-2-turbo-mlx reference artifact'
+          if ($env:PROVISION_REPOSITORY -ne 'SceneWorks/krea-2-turbo-mlx') {
+            throw 'provision_repository must be the fixed SceneWorks/krea-2-turbo-mlx reference artifact for a five-rung capture'
           }
           $pinLine = Select-String -Path 'crates/sceneworks-memory-adapter/src/lib.rs' -Pattern '^pub const INFERENCE_PIN: &str = "([0-9a-f]{40})";$'
           if (-not $pinLine -or $pinLine.Matches[0].Groups[1].Value -ne $env:INFERENCE_REVISION) {
             throw "input inference_revision does not match the adapter's compiled INFERENCE_PIN"
           }
+      # Derives the cache dir and the exact snapshot suffix ONCE, so the provisioning step and
+      # the resolve step below cannot drift apart on where the snapshot is meant to land. That
+      # drift is the concrete failure this centralizes away: before sc-18677 the cache path
+      # `%USERPROFILE%\.cache\huggingface\hub` was written out twice, in two different
+      # languages (a Python `os.path.join` and a PowerShell `Join-Path`), and nothing tied them.
+      #
+      # The empty-input default reproduces the old hardcoded location EXACTLY, and deliberately
+      # ignores HF_HOME even though this box sets it (E:\huggingface). Honoring HF_HOME would
+      # silently relocate Krea's cache and break the "behaves identically" contract; a caller
+      # that wants another cache passes provision_cache_dir explicitly.
+      - name: Resolve snapshot provisioning parameters
+        if: ${{ github.event_name == 'workflow_dispatch' && (inputs.run_five_rung_reference || inputs.provision_snapshot) }}
+        shell: powershell
+        env:
+          PROVISION_REPOSITORY: ${{ inputs.provision_repository }}
+          PROVISION_REVISION: ${{ inputs.provision_revision }}
+          PROVISION_SUBDIR: ${{ inputs.provision_subdir }}
+          PROVISION_CACHE_DIR_INPUT: ${{ inputs.provision_cache_dir }}
+        run: |
+          $cache = $env:PROVISION_CACHE_DIR_INPUT
+          if (-not $cache) { $cache = Join-Path $env:USERPROFILE '.cache\huggingface\hub' }
+          $folder = 'models--' + $env:PROVISION_REPOSITORY.Replace('/', '--')
+          $subdirTail = ''
+          if ($env:PROVISION_SUBDIR) { $subdirTail = '\' + $env:PROVISION_SUBDIR.Replace('/', '\') }
+          $suffix = '\' + $folder + '\snapshots\' + $env:PROVISION_REVISION + $subdirTail
+          Add-Content -Path $env:GITHUB_ENV -Value "PROVISION_CACHE_DIR=$cache"
+          Add-Content -Path $env:GITHUB_ENV -Value "PROVISION_SNAPSHOT_SUFFIX=$suffix"
+          Add-Content -Path $env:GITHUB_ENV -Value "PROVISION_SUBDIR_TAIL=$subdirTail"
+          Write-Host "cache dir       : $cache"
+          Write-Host "snapshot suffix : $suffix"
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference }}
         with:
           node-version: 22
-      - name: Validate runner Python for Krea provisioning
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && inputs.provision_krea_snapshot }}
+      - name: Validate runner Python for snapshot provisioning
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.provision_snapshot }}
         shell: powershell
         run: |
           $version = python --version
@@ -401,11 +513,21 @@ jobs:
           if ([int]$Matches.minor -lt 12) {
             throw "the self-hosted CUDA runner requires Python 3.12 or newer, got: $version"
           }
-      - name: Provision exact public Krea reference snapshot
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && inputs.provision_krea_snapshot }}
+      # ONE allow-pattern per component, never a bare repo fetch. MiniMaxAI/MiniMax-H3 is
+      # ~498 GB because it ships the root (modular) layout plus FL2VA/ and Ref2VA/ partition
+      # re-packagings of the same components; only the root layout is referenced by
+      # `modular_model_index.json` and only it is the conversion source (sc-17139 section 2).
+      # Fetching by component takes that to ~210 GB. Note this is the OPPOSITE of the rule for
+      # `config/manifests` download rows, where an empty `files` list (whole repo) is correct --
+      # those name SceneWorks-built artifacts that contain only what a user needs, whereas this
+      # provisions a third-party repo with three overlapping copies of every component.
+      - name: Provision exact snapshot
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.provision_snapshot }}
         shell: powershell
         env:
-          KREA_REVISION: ${{ inputs.krea_revision }}
+          PROVISION_REPOSITORY: ${{ inputs.provision_repository }}
+          PROVISION_REVISION: ${{ inputs.provision_revision }}
+          PROVISION_PATTERNS: ${{ inputs.provision_patterns }}
           HF_HUB_DISABLE_IMPLICIT_TOKEN: "1"
           HF_HUB_DISABLE_PROGRESS_BARS: "1"
           HF_HUB_DISABLE_TELEMETRY: "1"
@@ -416,38 +538,79 @@ jobs:
           import os
           from huggingface_hub import snapshot_download
 
-          snapshot_download(
-              repo_id="SceneWorks/krea-2-turbo-mlx",
+          patterns = [p.strip() for p in os.environ["PROVISION_PATTERNS"].replace(",", "\n").splitlines() if p.strip()]
+          if not patterns:
+              raise SystemExit("provision_patterns resolved to an empty allow-list")
+
+          repo = os.environ["PROVISION_REPOSITORY"]
+          revision = os.environ["PROVISION_REVISION"]
+          path = snapshot_download(
+              repo_id=repo,
               repo_type="model",
-              revision=os.environ["KREA_REVISION"],
-              allow_patterns=["q4/**"],
-              cache_dir=os.path.join(os.environ["USERPROFILE"], ".cache", "huggingface", "hub"),
+              revision=revision,
+              allow_patterns=patterns,
+              cache_dir=os.environ["PROVISION_CACHE_DIR"],
               token=False,
               max_workers=4,
           )
-          print("Exact public Krea reference snapshot provisioned")
+          print(f"Exact public snapshot provisioned: {repo}@{revision}")
+          print(f"  path: {path}")
+          for pattern in patterns:
+              print(f"  allow-pattern: {pattern}")
           '@ | python -
-      - name: Resolve exact Krea reference snapshot
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference }}
+          if ($LASTEXITCODE -ne 0) { throw "snapshot provisioning failed with exit code $LASTEXITCODE" }
+      # Proves the EXACT snapshot path and fails loudly if absent. Three assertions, not one:
+      #   1. the resolved directory exists;
+      #   2. its canonical path ends with \models--<owner>--<name>\snapshots\<revision>[\<subdir>],
+      #      so a stale cache entry, a different revision or a lookalike repo cannot satisfy it;
+      #   3. every provisioned component directory is present under the SNAPSHOT root.
+      # (3) is what makes this a real proof for a root-resolved model. With provision_subdir
+      # empty the snapshot directory exists as soon as ANY file is fetched -- a README alone
+      # would pass assertions 1 and 2 while every weight was missing. Checking the leading
+      # literal segment of each allow-pattern closes that. For Krea it is exactly equivalent to
+      # the pre-existing check (the sole pattern `q4/**` yields `<snapshot>\q4`, which IS the
+      # resolved root), so it adds no new way for a Krea dispatch to fail.
+      - name: Resolve exact snapshot
+        if: ${{ github.event_name == 'workflow_dispatch' && (inputs.run_five_rung_reference || inputs.provision_snapshot) }}
         shell: powershell
         env:
-          KREA_REVISION: ${{ inputs.krea_revision }}
+          PROVISION_REPOSITORY: ${{ inputs.provision_repository }}
+          PROVISION_PATTERNS: ${{ inputs.provision_patterns }}
           KREA_ROOT_OVERRIDE: ${{ secrets.SCENEWORKS_KREA_ROOT }}
         run: |
-          if ($env:KREA_ROOT_OVERRIDE) {
+          $isKrea = $env:PROVISION_REPOSITORY -eq 'SceneWorks/krea-2-turbo-mlx'
+          if ($isKrea -and $env:KREA_ROOT_OVERRIDE) {
             $root = $env:KREA_ROOT_OVERRIDE
           } else {
-            $root = Join-Path $env:USERPROFILE ".cache\huggingface\hub\models--SceneWorks--krea-2-turbo-mlx\snapshots\$env:KREA_REVISION\q4"
+            $root = Join-Path $env:PROVISION_CACHE_DIR $env:PROVISION_SNAPSHOT_SUFFIX.TrimStart('\')
           }
           if (-not (Test-Path -LiteralPath $root -PathType Container)) {
-            throw 'the exact Krea reference snapshot is not available on this runner'
+            throw "the exact snapshot is not available on this runner: $root"
           }
           $root = (Resolve-Path -LiteralPath $root).Path
-          $suffix = "\models--SceneWorks--krea-2-turbo-mlx\snapshots\$env:KREA_REVISION\q4"
-          if (-not $root.EndsWith($suffix, [StringComparison]::OrdinalIgnoreCase)) {
-            throw 'the Krea reference root does not match the fixed repository and exact revision'
+          if (-not $root.EndsWith($env:PROVISION_SNAPSHOT_SUFFIX, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "the resolved root does not match the requested repository and exact revision: $root"
           }
-          "SCENEWORKS_KREA_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          $snapshotRoot = $root
+          if ($env:PROVISION_SUBDIR_TAIL) {
+            $snapshotRoot = $root.Substring(0, $root.Length - $env:PROVISION_SUBDIR_TAIL.Length)
+          }
+          $missing = @()
+          foreach ($pattern in ($env:PROVISION_PATTERNS -split '[,\r\n]' | ForEach-Object { $_.Trim() } | Where-Object { $_ })) {
+            $head = ($pattern -split '[\*\?\[]')[0]
+            $head = $head.TrimEnd('/')
+            if (-not $head) { continue }
+            $component = Join-Path $snapshotRoot $head.Replace('/', '\')
+            if (-not (Test-Path -LiteralPath $component)) { $missing += $head }
+          }
+          if ($missing.Count -gt 0) {
+            throw "provisioned snapshot is missing declared components under ${snapshotRoot}: $($missing -join ', ')"
+          }
+          Write-Host "resolved snapshot root: $root"
+          "SCENEWORKS_PROVISIONED_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          if ($isKrea) {
+            "SCENEWORKS_KREA_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          }
       - name: Check out the exact inference reference source
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -461,8 +624,10 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference }}
         shell: cmd
         env:
-          SCENEWORKS_KREA_REPOSITORY: ${{ inputs.krea_repository }}
-          SCENEWORKS_KREA_REVISION: ${{ inputs.krea_revision }}
+          # Env names are the memory-adapter binary's contract and are deliberately NOT
+          # renamed alongside the dispatch inputs; see the workflow_dispatch header.
+          SCENEWORKS_KREA_REPOSITORY: ${{ inputs.provision_repository }}
+          SCENEWORKS_KREA_REVISION: ${{ inputs.provision_revision }}
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
           set NVCC_CCBIN=%VCToolsInstallDir%bin\Hostx64\x64

--- a/docs/sc-18677-minimax-h3-runner-provisioning.md
+++ b/docs/sc-18677-minimax-h3-runner-provisioning.md
@@ -17,10 +17,20 @@ spend a self-hosted lane discovering it.
 
 ## 1. The runner (AC2)
 
-Both `cuda`-labelled runners registered to `SceneWorks/SceneWorks` — `cuda-windows-3` (agent 23)
-and `cuda-windows-4` (agent 24) — are listener processes on **one physical box**,
-`MICHAEL-TRX50`, running as `MICHAEL-TRX50\Michael`. So "the runner's GPU" is this box's GPU, and
-two concurrent jobs share it.
+The `cuda` pool is **four** runners across **two registration levels**, and they are all listener
+processes on **one physical box**, `MICHAEL-TRX50`, running as `MICHAEL-TRX50\Michael`. So "the
+runner's GPU" is this box's GPU, and concurrent jobs share it.
+
+| Runner | Level | Install | Labels |
+| --- | --- | --- | --- |
+| `cuda-windows` (2313) | **org** | `D:\actions-runner` | `self-hosted, Windows, X64, cuda, `**`real-weights`** |
+| `cuda-windows-2` (2619) | **org** | `D:\actions-runner-2` | `self-hosted, Windows, X64, cuda, `**`real-weights`** |
+| `cuda-windows-3` (23) | repo | `D:\actions-runner-3` | `self-hosted, Windows, X64, cuda` |
+| `cuda-windows-4` (24) | repo | `D:\actions-runner-4` | `self-hosted, Windows, X64, cuda` |
+
+`gh api repos/SceneWorks/SceneWorks/actions/runners` reports only the repo-level pair, which is how
+this pool gets undercounted — the org-level pair is where a `real-weights` job belongs and is the
+half this lane never asked for. That is fixed here (§4.1).
 
 | Fact | Value |
 | --- | --- |
@@ -202,7 +212,31 @@ One coupling was removed on purpose: `provision_snapshot` no longer requires
 provisioning alone was necessarily a mistake. This epic makes it a first-class outcome — H3 weights
 must land on the box and there is no H3 five-rung fixture to run.
 
-### 4.1 How "identical" was proven
+### 4.1 One deliberate behaviour change: weights dispatches now request `real-weights`
+
+This is the single place the change does **not** preserve prior behaviour, and it is intentional.
+
+`runs-on` was the flat list `[self-hosted, Windows, X64, cuda]`, so a five-rung capture could be
+scheduled onto any of the four runners in §1 — including the repo-level pair that does not carry
+`real-weights`. It is now conditional, exactly mirroring `macos-mlx.yml:450`:
+
+```yaml
+runs-on: ${{ (github.event_name == 'workflow_dispatch' && (inputs.provision_snapshot || inputs.run_five_rung_reference))
+             && fromJSON('["self-hosted","Windows","X64","cuda","real-weights"]')
+             || fromJSON('["self-hosted","Windows","X64","cuda"]') }}
+```
+
+The Mac lane has done this since it grew a weights dispatch; this lane's lack of it is the
+asymmetry epic 17137 recorded as *"no `weights` label and no HF provisioning input — unlike the Mac
+lane"*. Ordinary PR and push runs are untouched and keep the full four-runner pool, so the ~24m
+lane loses no throughput.
+
+**Observable effect today: none.** All four runners are on the same box and share the same caches,
+so a Krea dispatch resolves the same snapshot either way. It matters the day a `cuda` runner joins
+on a second machine: without the label the job lands somewhere with no snapshot and dies at the
+resolve step; with it the job queues for a box that has the weights.
+
+### 4.2 How "identical" was proven
 
 **Executed, not asserted.** The PowerShell step bodies were extracted from the YAML and run locally
 against the real caches, with a simulated `GITHUB_ENV` carried between steps exactly as Actions does.
@@ -262,6 +296,30 @@ tier.
 - **bf16 — reachable ONLY sequentially.** Co-resident is not a measurement question: the weights
   alone overrun the card by 26.19 GB before a single activation is allocated, so sc-17153 should not
   spend a lane on it. Sequential fits at 77.32 GB with 25.32 GB for activations.
+
+### 5.1 The AdaLN evict makes the bf16 sequential verdict comfortable, not marginal
+
+The sequential table above is deliberately conservative: it assumes both VAEs are co-resident with a
+*whole* DiT. The epic's headline memory lever changes that. `adaln_proj` is **26.021 GB of the
+66.280 GB DiT (39.3%)** and is a function of timestep only, so sc-17145 precomputes all 18
+modulation vectors for the entire schedule and then evicts those weights; sc-18665 makes that evict
+a typed memory-resident exclusion so the ladder's arithmetic can actually see it.
+
+With the phases ordered TE → (evict) → DiT load + AdaLN precompute → (evict AdaLN) → denoise → VAE
+decode, the bf16 stage peaks are:
+
+| Stage | Resident | GB |
+| --- | --- | ---: |
+| text encode | TE alone | 51.506 |
+| DiT load + AdaLN precompute | full DiT | **66.280** |
+| denoise | DiT − AdaLN | 40.260 |
+| VAE decode | DiT − AdaLN + VAEs | 51.303 |
+
+Peak **66.280 GB — 64.6% of the card, 36.36 GB of headroom.** That is the number that matters for
+whether bf16 is worth measuring, and it is comfortable rather than marginal. The 77.324 GB figure in
+§5 remains the correct *conservative* bound for a provider that has not implemented the evict, and
+the 25.32 GB headroom there is still positive — so bf16-sequential is reachable either way. Neither
+number changes the resident verdict: co-resident bf16 is out by 26.19 GB.
 
 **These are weights floors, not peaks.** `vramGbByTier` is the max across the whole generate and
 "the denoise peak dominates"; for a joint audio+video model at video sequence lengths, attention

--- a/docs/sc-18677-minimax-h3-runner-provisioning.md
+++ b/docs/sc-18677-minimax-h3-runner-provisioning.md
@@ -447,7 +447,27 @@ So the correct consequences are:
 | Run | Head SHA | Runner | Outcome |
 | --- | --- | --- | --- |
 | [31509409586](https://github.com/SceneWorks/SceneWorks/actions/runs/31509409586) | `ad072c06` | `cuda-windows-2` | **provisioned, resolve failed** — found the §8.1 bug |
-| [_pending_](#) | — | — | — |
+| [31511147004](https://github.com/SceneWorks/SceneWorks/actions/runs/31511147004) | `62410075` | `cuda-windows` | **success, every step** — the `.` sentinel fix |
+| [31512848344](https://github.com/SceneWorks/SceneWorks/actions/runs/31512848344) | `06ebcf53` | — | re-run at the merge head, after the containment rework |
+
+Run **31511147004 is the AC4 evidence**: every step green, including `Clippy (candle worker)` and
+`Verify capabilities.candle.json is a real dump, not a restamp`. What it printed:
+
+```
+cache dir       : E:\huggingface\hub
+snapshot suffix : \models--MiniMaxAI--MiniMax-H3\snapshots\939557dc319dd91227e30195a763f272ba7f8765
+Exact public snapshot provisioned: MiniMaxAI/MiniMax-H3@939557dc319dd91227e30195a763f272ba7f8765
+  path: E:\huggingface\hub\models--MiniMaxAI--MiniMax-H3\snapshots\939557dc319dd91227e30195a763f272ba7f8765
+resolved snapshot root: E:\huggingface\hub\models--MiniMaxAI--MiniMax-H3\snapshots\939557dc319dd91227e30195a763f272ba7f8765
+```
+
+The suffix carries no tier segment — the `.` sentinel resolved to the snapshot root, which is the
+whole point of §8.1 — and the resolve step's component-presence assertion passed against all
+thirteen declared patterns. It also landed on `cuda-windows`, the *other* org-level `real-weights`
+runner, so both halves of that pool are now demonstrated.
+
+Run 31512848344 re-runs the same dispatch at the merge head, because the containment logic in the
+validate and resolve steps was reworked after 31511147004 (§8.2).
 
 Run 31509409586 confirmed the substance and found a real defect, which is the outcome worth having.
 What it established:
@@ -497,7 +517,32 @@ Two things are worth recording about how this was missed, because both are reusa
 - The contract tests could not have caught it either: they assert the default **is** `q4`, which was
   true and correct. The gap was between two things that were each individually right.
 
-The lesson is now generalized rather than patched: a test walks every **optional** `provision_*`
+### 8.2 Containment is decided by canonicalizing, not by matching path segments
+
+The first attempt validated `provision_patterns` by splitting each entry on separators and
+rejecting a `..` segment. Adversarial review broke it twice, and both breaks are worth recording
+because they generalize:
+
+- **`..*`** — the resolve step joins the pattern's *head* (the text before the first `*`, `?` or
+  `[`), not the pattern. Moving the wildcard one character left yields head `..` from a pattern
+  containing no `..` segment at all, so any check on the pattern string misses it.
+- **`.. `** — survives `-contains '..'` because `'.. '` ≠ `'..'`, but Win32 strips trailing spaces
+  and dots from path components, so it names the parent anyway. `-LiteralPath` suppresses globbing,
+  **not** normalization.
+
+Both are now closed by two complementary checks, because neither alone is sufficient:
+`[System.IO.Path]::GetFullPath` collapses every ordinary spelling (including the wildcard-adjacent
+ones) but does *not* strip a trailing space; a segment check rejecting anything empty after
+`TrimEnd(' ', '.')` covers exactly what it misses. The resolve step canonicalizes independently, so
+the proof does not rest on validation having run. All eight demonstrated bypasses are rejected and
+the legitimate thirteen-pattern H3 set still passes, exercised against the shipped step body.
+
+The general lesson: **segment-equality is the wrong tool for Windows path containment.** Canonicalize
+and compare prefixes.
+
+### 8.3 The sentinel lesson, generalized
+
+A test walks every **optional** `provision_*`
 input — optionality derived from the validation step wrapping its checks in `if ($env:NAME)`, not
 from a hand-maintained list — and requires that any such input with a non-empty default be handled
 by a sentinel in the params step. The next input to hit this cannot ship without making the same

--- a/docs/sc-18677-minimax-h3-runner-provisioning.md
+++ b/docs/sc-18677-minimax-h3-runner-provisioning.md
@@ -450,7 +450,7 @@ So the correct consequences are:
 | --- | --- | --- | --- |
 | [31509409586](https://github.com/SceneWorks/SceneWorks/actions/runs/31509409586) | `ad072c06` | `cuda-windows-2` | **provisioned, resolve failed** — found the §8.1 bug |
 | [31511147004](https://github.com/SceneWorks/SceneWorks/actions/runs/31511147004) | `62410075` | `cuda-windows` | **success, every step** — the `.` sentinel fix |
-| [31512848344](https://github.com/SceneWorks/SceneWorks/actions/runs/31512848344) | `06ebcf53` | — | re-run at the merge head, after the containment rework |
+| [31512848344](https://github.com/SceneWorks/SceneWorks/actions/runs/31512848344) | `06ebcf53` | `cuda-windows` | **success, every step** — re-run after the containment rework |
 
 Run **31511147004 is the AC4 evidence**: every step green, including `Clippy (candle worker)` and
 `Verify capabilities.candle.json is a real dump, not a restamp`. What it printed:
@@ -468,8 +468,9 @@ whole point of §8.1 — and the resolve step's component-presence assertion pas
 thirteen declared patterns. It also landed on `cuda-windows`, the *other* org-level `real-weights`
 runner, so both halves of that pool are now demonstrated.
 
-Run 31512848344 re-runs the same dispatch at the merge head, because the containment logic in the
-validate and resolve steps was reworked after 31511147004 (§8.2).
+Run 31512848344 re-ran the same dispatch after the validate and resolve steps' containment logic was
+reworked (§8.2), and is green on every step too. Only docs changed after its SHA, so it exercises
+all shipped code.
 
 Run 31509409586 confirmed the substance and found a real defect, which is the outcome worth having.
 What it established:

--- a/docs/sc-18677-minimax-h3-runner-provisioning.md
+++ b/docs/sc-18677-minimax-h3-runner-provisioning.md
@@ -244,6 +244,13 @@ so a Krea dispatch resolves the same snapshot either way. It matters the day a `
 on a second machine: without the label the job lands somewhere with no snapshot and dies at the
 resolve step; with it the job queues for a box that has the weights.
 
+One further delta, smaller: provisioning-input validation now runs on
+`run_five_rung_reference || provision_snapshot` rather than on `provision_snapshot` alone, because
+both steps that *consume* those values run on the wider condition. A five-rung dispatch that
+explicitly clears `provision_patterns` or `provision_subdir` therefore now throws where it
+previously did not. Every historical Krea shape leaves those defaults in place, so no real dispatch
+changes.
+
 ### 4.2 How "identical" was proven
 
 **Executed, not asserted.** The PowerShell step bodies were extracted from the YAML and run locally
@@ -457,6 +464,20 @@ What it established:
   q4/q8 measurement on this box can be trusted.
 - `Resolve exact snapshot` **failed**, correctly and loudly, for the reason in §8.1.
 
+### 8.0 Operational caveat: provisioning is gated behind a green candle build
+
+Worth knowing before anyone relies on this to land weights. The heavy chain — `Fetch the pinned
+inference release`, `Test the candle GPU worker`, the rust-api sidecar check, the memory-adapter
+check — runs **before** the provisioning steps, and a failure in any of it aborts the job. There is
+no `continue-on-error` and no `if: always()` escape. So an unrelated compile break on the branch
+makes it *impossible* to land weights on the box at all, not merely slow.
+
+The ~24 minutes that chain costs on the scarce `cuda` pool is the lesser point. Reordering was
+considered and deliberately not done here: the capability-dump verify is last by design (a contract
+test enforces that placement, so a missing dump cannot suppress unrelated coverage), and rearranging
+a lane whose ordering carries documented rationale belongs in its own change. Read a partially-red
+dispatch at the step level, as §8 does, rather than by the run's overall conclusion.
+
 ### 8.1 The bug it found: an empty input cannot override a non-empty default
 
 The dispatch passed `-f provision_subdir=`, intending "this model's components are at the snapshot
@@ -475,3 +496,9 @@ Two things are worth recording about how this was missed, because both are reusa
   reproducing this exact failure is now in the set.
 - The contract tests could not have caught it either: they assert the default **is** `q4`, which was
   true and correct. The gap was between two things that were each individually right.
+
+The lesson is now generalized rather than patched: a test walks every **optional** `provision_*`
+input — optionality derived from the validation step wrapping its checks in `if ($env:NAME)`, not
+from a hand-maintained list — and requires that any such input with a non-empty default be handled
+by a sentinel in the params step. The next input to hit this cannot ship without making the same
+decision consciously.

--- a/docs/sc-18677-minimax-h3-runner-provisioning.md
+++ b/docs/sc-18677-minimax-h3-runner-provisioning.md
@@ -1,0 +1,344 @@
+# MiniMax-H3 — CUDA runner provisioning and per-tier VRAM reachability (sc-18677)
+
+Epic [sc-17137](https://app.shortcut.com/trefry/epic/17137) · story
+[sc-18677](https://app.shortcut.com/trefry/story/18677) · measured **2026-08-11**.
+
+This story unblocks [sc-17153](https://app.shortcut.com/trefry/story/17153) and
+[sc-17156](https://app.shortcut.com/trefry/story/17156), which need **measured** per-tier VRAM on
+real H3 weights with each tier in its own process. It does three things: it lands the weights on
+the CUDA runner, it generalizes `windows-candle.yml`'s Krea-hardcoded provisioning so it can point
+at any model, and it records what this hardware can and cannot physically hold.
+
+It measures no generate peak. §5 is a *necessary-condition* screen — it says which tiers are worth
+sending a measurement job at, and rules one configuration out arithmetically so sc-17153 does not
+spend a self-hosted lane discovering it.
+
+---
+
+## 1. The runner (AC2)
+
+Both `cuda`-labelled runners registered to `SceneWorks/SceneWorks` — `cuda-windows-3` (agent 23)
+and `cuda-windows-4` (agent 24) — are listener processes on **one physical box**,
+`MICHAEL-TRX50`, running as `MICHAEL-TRX50\Michael`. So "the runner's GPU" is this box's GPU, and
+two concurrent jobs share it.
+
+| Fact | Value |
+| --- | --- |
+| GPU | 2 × **NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition** |
+| VRAM per card | **97,887 MiB** = 102.642 GB = 95.593 GiB |
+| Free per card (idle) | GPU0 97,420 MiB (102.152 GB) · GPU1 96,686 MiB (101.383 GB) |
+| Compute capability | **12.0** (sm_120, Blackwell) |
+| Driver | 596.36 |
+| `display_active` | Disabled on both — no desktop VRAM tax |
+| Lane's `CUDA_COMPUTE_CAP` | `"120"` — matches the hardware, so nvcc emits native SASS |
+
+**The budget is ONE card, not the pair — 102.642 GB.** A generation is bounded by a single device:
+`runtime_cuda::media::default_device()` is a hardcoded `new_cuda(0)`, and under the `auto`
+supervisor each per-GPU child is spawned with `CUDA_VISIBLE_DEVICES=<its gpu id>` so device 0 *is*
+that child's card (`crates/sceneworks-worker/src/lib.rs:1030-1034`). There is no tensor-parallel
+path, so the two cards do not sum into a 205 GB budget for one job.
+
+### 1.1 Disk headroom
+
+| Volume | Used | Free |
+| --- | ---: | ---: |
+| C: | 3,061.4 GB | **663.6 GB** |
+| D: | 2,390.8 GB | **1,335.2 GB** |
+| E: | 7,192 GB | **3,983 GB** |
+
+The story flags that ~200 GB of provisioning competes with CI disk on this box. **It cost nothing.**
+The full 498 GB upstream repo was already resident in `E:\huggingface\hub` before this story, and the
+revision this epic pins differs from the cached one *only in `README.md`* (§2.2) — so provisioning
+re-links existing blobs rather than downloading. Nothing was stranded and no CI check was starved.
+
+### 1.2 The quantized-matmul patch (scope item 4)
+
+Confirmed present and in lockstep. The root `Cargo.toml` carries
+
+```toml
+[patch."https://github.com/huggingface/candle"]
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "b965641e388f4db646e4c60ab3f75219737e2cc8" }
+```
+
+and that rev equals the worker's `sceneworks-gen-core` / `runtime-cuda` pins
+(`crates/sceneworks-worker/Cargo.toml:40,99`). This matters more here than anywhere else in the
+repo: without the vendored multi-arch kernels, `libmoe.a` is an Ampere-only cubin with no PTX and
+**every quantized matmul silently returns zeros on sm_120** — which would turn a q4/q8 VRAM
+measurement into a confident wrong number rather than an error. Two guards keep it honest, and both
+run on this lane: `candle_kernels_patch_guard.rs` (file-only, proves the patch is live and in
+lockstep from `Cargo.lock`) and `cuda_quant_smoke.rs` (deliberately not `#[ignore]`d, exercises the
+patched kernels on the real GPU every run).
+
+---
+
+## 2. What is resident, and where (AC1)
+
+### 2.1 The cache is on E:, not in the profile
+
+The box sets `HF_HOME=E:\huggingface` as a user environment variable, which the runner listeners
+inherit. The workflow's provisioning step, however, passes an explicit `cache_dir` and therefore
+**ignores `HF_HOME`**. The two caches hold different things:
+
+| Cache | Holds |
+| --- | --- |
+| `C:\Users\Michael\.cache\huggingface\hub` | the Krea reference artifact (`models--SceneWorks--krea-2-turbo-mlx`), plus small LLMs |
+| `E:\huggingface\hub` | **`models--MiniMaxAI--MiniMax-H3`**, and the rest of the app's weights |
+
+This is why the generalization added a `provision_cache_dir` input rather than switching the default
+to `HF_HOME`: honoring `HF_HOME` would silently relocate Krea's cache and break the "Krea behaves
+identically" contract (§4).
+
+### 2.2 The pinned revision
+
+**`939557dc319dd91227e30195a763f272ba7f8765`** — current upstream `main`, and the exact snapshot
+sc-17139's sizing table was derived from.
+
+The cache already held an *older* snapshot, `6818f6c32d12b210915e44ad56a4228c2608f160`. Comparing
+LFS OIDs across the two revisions over all 280 files:
+
+- **210,331,731,510 bytes of component weights are byte-identical**;
+- the only difference is `README.md` (38,479 B → 38,391 B).
+
+Hugging Face keys `blobs/` by etag, so provisioning the pinned revision re-links the existing blobs
+and downloads ~38 KB. Pinning the revision sc-17139 measured therefore costs nothing, and keeps this
+epic's sizing table and its resident weights on the same commit.
+
+### 2.3 The component set
+
+Fetched by component, one `allow_patterns` entry each. The repo totals 498.475 GB only because
+`FL2VA/` and `Ref2VA/` re-package the same components; only the root layout is referenced by
+`modular_model_index.json` and only it is the conversion source (sc-17139 §2).
+
+| Pattern | Files | GB | GiB |
+| --- | ---: | ---: | ---: |
+| `transformer/*` | 16 | 66.281 | 61.729 |
+| `text_encoder/*` | 23 | 66.727 | 62.144 |
+| `vae/*` | 5 | 10.416 | 9.700 |
+| `audio_vae/*` | 2 | 0.605 | 0.564 |
+| `tokenizer/*` | 4 | 0.011 | 0.011 |
+| `processor/*` | 7 | 0.011 | 0.011 |
+| `scheduler/*`, `audio_scheduler/*` | 2 | 0.000 | 0.000 |
+| `model_index.json`, `modular_model_index.json`, `LICENSE` | 3 | 0.000 | 0.000 |
+| `FL2VA/model_index.json`, `Ref2VA/model_index.json` | 2 | 0.000 | 0.000 |
+| **selected** | **64** | **144.051** | **134.158** |
+| *whole repo, for contrast* | *280* | *498.475* | *464.241* |
+| **avoided** | **216** | **354.424** | **330.083** |
+
+Notes on the selection:
+
+- **`transformer_ref` is deliberately excluded.** The story defers it ("later, 66.3 GB"), and it is
+  sc-17149's entry. Adding it takes the set to the full 210.332 GB distinct total.
+- The two partition `model_index.json` files are included at a cost of ~2 KB. sc-17139 §2 identifies
+  them as the only place `sigma_shift_scales` and the task map live, so sc-17150 needs them; leaving
+  them out would mean re-dispatching a provisioning run for two kilobytes.
+- Patterns are matched with `fnmatch`, whose `*` **crosses `/`**. A lazy `*.json` would therefore
+  have dragged in `FL2VA/**/*.json` and `Ref2VA/**/*.json` too. The root files are named
+  individually for that reason, and the selection was verified to have zero partition leakage.
+
+> **Unit warning.** The story text mixes units: its "`vae` 9.7 GB, `audio_vae` 0.6 GB,
+> `text_encoder` 62 GB, `transformer` 62 GB" are **GiB**, while its "`transformer_ref` 66.3 GB" is
+> decimal GB. Both describe the same components. Every figure in this document is decimal GB unless
+> a column says GiB.
+
+---
+
+## 3. The exact snapshot path (AC1)
+
+```
+E:\huggingface\hub\models--MiniMaxAI--MiniMax-H3\snapshots\939557dc319dd91227e30195a763f272ba7f8765
+```
+
+The resolve step proves it with **three** assertions, not one, and throws on each:
+
+1. the resolved directory exists;
+2. its *canonical* path ends with `\models--<owner>--<name>\snapshots\<revision>[\<subdir>]`, so a
+   stale cache entry, a different revision, or a lookalike repo cannot satisfy it;
+3. every declared component's literal path prefix is present under the snapshot root.
+
+(3) is what makes this a real proof for H3. Krea resolves a *tier subdirectory* (`…\<rev>\q4`), so
+its directory cannot exist unless the tier was fetched. H3 resolves the snapshot **root**, which
+exists the moment any single file lands — a `README.md` alone would satisfy (1) and (2) while every
+weight was missing. For Krea, (3) is exactly equivalent to the pre-existing check: the sole pattern
+`q4/**` yields `<snapshot>\q4`, which *is* the resolved root. So it adds no new way for a Krea
+dispatch to fail.
+
+---
+
+## 4. The generalization, and the Krea invariance proof (AC3)
+
+`windows-candle.yml`'s provisioning was hardcoded to Krea in four places: the
+`provision_krea_snapshot` input, a `snapshot_download` literal naming `SceneWorks/krea-2-turbo-mlx`
+with `allow_patterns=["q4/**"]`, a `cache_dir` built from `USERPROFILE`, and a resolve step that
+re-spelled `models--SceneWorks--krea-2-turbo-mlx\snapshots\<rev>\q4` by hand.
+
+The inputs were **renamed, not duplicated**, so exactly one provisioning path exists:
+
+| Was | Now | Default |
+| --- | --- | --- |
+| `provision_krea_snapshot` | `provision_snapshot` | `false` |
+| `krea_repository` | `provision_repository` | `SceneWorks/krea-2-turbo-mlx` |
+| `krea_revision` | `provision_revision` | — |
+| — | `provision_patterns` | `q4/**` |
+| — | `provision_subdir` | `q4` |
+| — | `provision_cache_dir` | *(empty → `%USERPROFILE%\.cache\huggingface\hub`)* |
+
+Renaming rather than adding a parallel family is what keeps the workflow at **8 inputs** against
+GitHub's hard cap of 10, leaving headroom for the epic's later stories.
+
+Three things deliberately did **not** change:
+
+- **`SCENEWORKS_KREA_ROOT` / `_REPOSITORY` / `_REVISION` keep their names.** They are the
+  memory-adapter binaries' runtime contract, read via `required_env` in
+  `crates/sceneworks-memory-adapter/src/bin/{candle,mlx}.rs`. Renaming them would break the
+  five-rung capture at run time, not at lint time. `SCENEWORKS_KREA_ROOT` is now exported only when
+  the resolved repository *is* Krea, so an H3 dispatch cannot hand the adapter a MiniMax root under
+  a Krea-shaped name.
+- **Every five-rung guard survives** — exact 40-hex inference revision, exact 40-hex artifact
+  revision, the fixed Krea repository, and the `INFERENCE_PIN` match — just keyed on the new names.
+- **The default cache dir still ignores `HF_HOME`** (§2.1).
+
+One coupling was removed on purpose: `provision_snapshot` no longer requires
+`run_five_rung_reference`. The old throw existed because provisioning had exactly one consumer, so
+provisioning alone was necessarily a mistake. This epic makes it a first-class outcome — H3 weights
+must land on the box and there is no H3 five-rung fixture to run.
+
+### 4.1 How "identical" was proven
+
+**Executed, not asserted.** The PowerShell step bodies were extracted from the YAML and run locally
+against the real caches, with a simulated `GITHUB_ENV` carried between steps exactly as Actions does.
+A Krea dispatch leaving every `provision_*` input at its default resolves to
+
+```
+C:\Users\Michael\.cache\huggingface\hub\models--SceneWorks--krea-2-turbo-mlx\snapshots\d009674080cc1bccf2b629d834c34bf5eccdb723\q4
+```
+
+— character-for-character the path the hardcoded step produced. Eight cases pass: the historical
+five-rung + provision dispatch, five-rung without provisioning, H3 provision-only, and five negative
+cases (non-40-hex revision, `provision_subdir` traversal, empty allow-list, absent snapshot,
+declared-but-missing component) each failing at the intended step.
+
+**Pinned so it cannot rot.** Four tests in `scripts/platform-review-contracts.test.mjs` (inside
+`npm run check`) assert the input defaults, the path-construction expressions, the surviving
+five-rung guards, and the never-a-whole-repo-fetch guards. They are structural rather than
+prose-matching: the defaults and the suffix expression together *determine* the resolved path. All
+ten mutations tried against them go red — including flipping `provision_subdir` to `q8`, switching
+the cache default to `HF_HOME`, exporting `SCENEWORKS_KREA_ROOT` unconditionally, dropping the
+snapshots path segment, deleting either loud-failure guard, and pushing the input count over 10.
+
+---
+
+## 5. Per-tier reachability (AC2)
+
+Component bytes are sc-17139's; the tier factors are its validated MLX-affine model
+(`group_size: 64` → q8 = 8.5/16 = 53.125% of bf16, q4 = 4.5/16 = 28.125%), which held to +0.03% /
++0.48% against six shipped artifacts. The VAEs stay dense in every tier, so
+**11.044 GB is a fixed floor**.
+
+Against **one card = 102.642 GB**, using the *trimmed* text encoder (what sc-17150 will host):
+
+| Tier | DiT | TE | VAEs | **Resident total** | % of card | Headroom | Verdict |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| q4 | 18.641 | 14.486 | 11.044 | **44.171** | 43.0% | +58.471 | **fits** |
+| q8 | 35.211 | 27.363 | 11.044 | **73.618** | 71.7% | +29.024 | **fits** |
+| bf16 | 66.280 | 51.506 | 11.044 | **128.830** | 125.5% | **−26.188** | **exceeds** |
+
+Under **sequential** residency — the phase order the schema describes, text encoder dropped before
+the DiT — the peak is `max(TE, DiT + VAEs)`:
+
+| Tier | TE stage | DiT+VAEs stage | **Sequential peak** | % of card | Headroom |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| q4 | 14.486 | 29.685 | **29.685** | 28.9% | +72.957 |
+| q8 | 27.363 | 46.255 | **46.255** | 45.1% | +56.387 |
+| bf16 | 51.506 | 77.324 | **77.324** | 75.3% | +25.318 |
+
+With the **untrimmed** TE currently on the box, resident bf16 is 144.039 GB (140.3%) and resident q8
+is 81.697 GB (79.6%); the sequential peaks are unchanged, because the DiT stage dominates at every
+tier.
+
+### Verdicts
+
+- **q4 — reachable.** 43.0% of the card resident. Ample activation headroom.
+- **q8 — reachable.** 71.7% resident, 29.02 GB spare. Comfortable resident, trivially fine sequential.
+- **bf16 — reachable ONLY sequentially.** Co-resident is not a measurement question: the weights
+  alone overrun the card by 26.19 GB before a single activation is allocated, so sc-17153 should not
+  spend a lane on it. Sequential fits at 77.32 GB with 25.32 GB for activations.
+
+**These are weights floors, not peaks.** `vramGbByTier` is the max across the whole generate and
+"the denoise peak dominates"; for a joint audio+video model at video sequence lengths, attention
+scales as B·H·S²·2·bytes and can be large. So a "fits" verdict is a *necessary* condition that
+justifies sending a measurement job — the real ceiling is sc-17153/sc-17156's to measure. Only the
+bf16-resident row is a *sufficient* rejection.
+
+---
+
+## 6. Manifest consequences for sc-17150 / sc-17158 (AC5)
+
+The story asks that an unreachable tier be recorded as "must not be advertised on the candle lane".
+**Both premises behind that instruction are wrong, and the correct consequence is different.**
+
+**Premise 1 — "the largest `candle.vramGbByTier` in the manifest today is `bf16: 40.7`".** It is
+**128.0** (`flux2_dev`). Eleven entries already exceed 40.7:
+
+| id | q4 | q8 | bf16 | `minMemoryGb` | seq-capable |
+| --- | ---: | ---: | ---: | ---: | --- |
+| `flux2_dev` | 44.0 | 70.7 | **128.0** | 56 | yes |
+| `qwen_image_edit_2511_lightning` | 57.0 | 65.8 | 87.4 | 59 | yes |
+| `qwen_image` | 53.7 | 65.3 | 82.5 | 56 | yes |
+| `qwen_image_edit_2511` | 56.7 | 69.0 | 81.7 | 59 | yes |
+| `flux2_klein_9b` | 46.2 | 50.6 | 75.5 | 25 | yes |
+
+**Premise 2 — "a tier that cannot run on the candle lane must not be advertised there".** That is
+not the repo's convention. `flux2_dev` advertises `bf16: 128.0`, which **exceeds this very box's
+card**, and ships. The manifest does not encode "runnable here"; it encodes *measured cost*, and the
+runtime decides:
+
+- `minMemoryGb` gates the **default (lightest) tier only** — the schema says so explicitly, and
+  heavier hosted tiers are expected to exceed it (`model-manifest.schema.json:1040`).
+- `vramGbByTier` is the **resident** peak "that the fit-gate compares against free VRAM to pick
+  sequential offload vs reject" (`:1044`).
+- `sequentialPeakGb` is the **second-stage** check: when the resident peak forces sequential offload
+  but the measured sequential peak still exceeds free VRAM, reject before load instead of running
+  into a reactive OOM (`:1054`, sc-10856).
+
+So the correct consequences are:
+
+1. **Do not drop bf16 from the H3 manifest entry on VRAM grounds.** Hosting it (sc-17150) and
+   advertising it (sc-17158) stays correct and matches five shipped entries that are heavier than
+   H3's bf16 resident total.
+2. **bf16 on candle requires sequential residency**, and that is now a hard requirement rather than
+   an optimization: 128.830 GB against a 102.642 GB card. sc-17158 must declare
+   `supportsSequentialOffload: true` **and** populate `sequentialPeakGb` for bf16. Without the
+   second-stage number the gate keeps its best-effort behaviour — run sequentially, reactive-OOM
+   backstop — which on a tier that cannot possibly fit resident is a guaranteed bad experience.
+3. **If sc-17154/sc-17155 finds the candle H3 provider does not honor `LoadSpec` sequential
+   residency, then bf16 genuinely is unreachable on candle** and *that* is when the platform arrays
+   must exclude it. This is the real decision point the story was reaching for, and it is a provider
+   capability question, not a VRAM one.
+4. `minMemoryGb` must be derived from the measured **q4** peak, not from any bf16 figure.
+5. The `11.044 GB` dense VAE floor is tier-invariant, so it lifts every tier's number equally; do
+   not model it as part of the tier ladder.
+
+---
+
+## 7. Evidence
+
+| Claim | How it was established |
+| --- | --- |
+| GPU model, VRAM, free, compute cap, driver | `nvidia-smi --query-gpu` on the runner box |
+| Both `cuda` runners are one box | `gh api …/actions/runners` + `Win32_Process` owner of each `Runner.Listener.exe` |
+| Single-device budget | `lib.rs:1030-1034`, `runtime_cuda::media::default_device()` = `new_cuda(0)` |
+| Disk headroom | `Get-PSDrive -PSProvider FileSystem` |
+| candle-kernels patch in lockstep | root `Cargo.toml` `[patch]` rev vs `sceneworks-worker/Cargo.toml:40,99`; `candle_kernels_patch_guard.rs` |
+| 498 GB already cached; per-component bytes | symlink-resolving walk of the cache snapshot |
+| Two revisions differ only in `README.md` | `HfApi.model_info(files_metadata=True)` LFS-OID diff over all 280 files |
+| Pattern set selects 64 files / 144.051 GB, no leakage | `filter_repo_objects` against the live file list |
+| Krea path is character-identical | step bodies executed locally with a simulated `GITHUB_ENV` |
+| Contract tests cannot rot | 10/10 mutations go red |
+| Dispatch provisions and resolves H3 | §8 |
+
+---
+
+## 8. Dispatch run (AC4)
+
+<!-- sc-18677:dispatch-evidence -->
+_Recorded on the story and filled in here once the dispatch completes._

--- a/docs/sc-18677-minimax-h3-runner-provisioning.md
+++ b/docs/sc-18677-minimax-h3-runner-provisioning.md
@@ -160,6 +160,12 @@ Notes on the selection:
 E:\huggingface\hub\models--MiniMaxAI--MiniMax-H3\snapshots\939557dc319dd91227e30195a763f272ba7f8765
 ```
 
+**Written by run [31509409586](https://github.com/SceneWorks/SceneWorks/actions/runs/31509409586)
+and verified present on disk afterwards** — ten component directories (`transformer`,
+`text_encoder`, `vae`, `audio_vae`, `tokenizer`, `processor`, `scheduler`, `audio_scheduler`,
+`FL2VA`, `Ref2VA`) plus `LICENSE`, `model_index.json` and `modular_model_index.json`. This is an
+observation, not a projection; before that run the cache held only the older `6818f6c3…` snapshot.
+
 The resolve step proves it with **three** assertions, not one, and throws on each:
 
 1. the resolved directory exists;
@@ -421,11 +427,51 @@ So the correct consequences are:
 | Pattern set selects 64 files / 144.051 GB, no leakage | `filter_repo_objects` against the live file list |
 | Krea path is character-identical | step bodies executed locally with a simulated `GITHUB_ENV` |
 | Contract tests cannot rot | 10/10 mutations go red |
-| Dispatch provisions and resolves H3 | §8 |
+| Snapshot written at the pinned revision, then verified on disk | run 31509409586's `Provision exact snapshot` step; directory listing after it |
+| Patched quant kernels really work on sm_120 | `cuda_quant_smoke` (un-`#[ignore]`d) passing in run 31509409586 |
+| Dispatch resolves the snapshot | §8 — **see §8.1; the first run failed and why** |
 
 ---
 
-## 8. Dispatch run (AC4)
+## 8. Dispatch runs (AC4)
 
 <!-- sc-18677:dispatch-evidence -->
-_Recorded on the story and filled in here once the dispatch completes._
+
+| Run | Head SHA | Runner | Outcome |
+| --- | --- | --- | --- |
+| [31509409586](https://github.com/SceneWorks/SceneWorks/actions/runs/31509409586) | `ad072c06` | `cuda-windows-2` | **provisioned, resolve failed** — found the §8.1 bug |
+| [_pending_](#) | — | — | — |
+
+Run 31509409586 confirmed the substance and found a real defect, which is the outcome worth having.
+What it established:
+
+- The conditional `runs-on` works: the job landed on `cuda-windows-2`, an **org-level** runner
+  carrying `real-weights` (§4.1), rather than the repo-level half.
+- `Provision exact snapshot` **succeeded**, writing
+  `E:\huggingface\hub\models--MiniMaxAI--MiniMax-H3\snapshots\939557dc319dd91227e30195a763f272ba7f8765`
+  with all 13 allow-patterns, in **3.5 seconds** — the blob-dedup prediction in §2.2 holding exactly.
+  All ten component directories plus the three root files are present.
+- `Test the candle GPU worker (backend-candle)` passed, which runs the un-`#[ignore]`d
+  `cuda_quant_smoke` against the patched candle-kernels on the real sm_120 GPU. That is the §1.2
+  claim measured rather than argued: quantized matmul does not silently return zeros here, so a
+  q4/q8 measurement on this box can be trusted.
+- `Resolve exact snapshot` **failed**, correctly and loudly, for the reason in §8.1.
+
+### 8.1 The bug it found: an empty input cannot override a non-empty default
+
+The dispatch passed `-f provision_subdir=`, intending "this model's components are at the snapshot
+root". **GitHub substitutes an input's `default` for any empty dispatch value**, so
+`provision_subdir` arrived as `q4`, the suffix became
+`…\snapshots\939557dc…\q4`, and the resolve step threw because no such directory exists.
+
+The default cannot simply become empty — it has to stay `q4` for a Krea dispatch to resolve
+identically (§4.2). So without a sentinel, **a root-resolved model is inexpressible**, and this
+story's own model is one. `.` now means the snapshot root.
+
+Two things are worth recording about how this was missed, because both are reusable:
+
+- The local harness (§4.2) injected `provision_subdir: ""` straight into the step environment,
+  bypassing GitHub's default substitution entirely. It has since been taught that rule, and a case
+  reproducing this exact failure is now in the set.
+- The contract tests could not have caught it either: they assert the default **is** `q4`, which was
+  true and correct. The gap was between two things that were each individually right.

--- a/docs/sc-18677-minimax-h3-runner-provisioning.md
+++ b/docs/sc-18677-minimax-h3-runner-provisioning.md
@@ -263,18 +263,43 @@ A Krea dispatch leaving every `provision_*` input at its default resolves to
 C:\Users\Michael\.cache\huggingface\hub\models--SceneWorks--krea-2-turbo-mlx\snapshots\d009674080cc1bccf2b629d834c34bf5eccdb723\q4
 ```
 
-— character-for-character the path the hardcoded step produced. Eight cases pass: the historical
-five-rung + provision dispatch, five-rung without provisioning, H3 provision-only, and five negative
-cases (non-40-hex revision, `provision_subdir` traversal, empty allow-list, absent snapshot,
-declared-but-missing component) each failing at the intended step.
+— character-for-character the path the hardcoded step produced. Twenty-five cases pass: the
+historical five-rung + provision dispatch, five-rung without provisioning, H3 provision-only at the
+pinned revision, the eight containment bypasses of §8.2, and the other negative cases (non-40-hex
+revision, `provision_subdir` traversal, empty allow-list, absent snapshot, declared-but-missing
+component among them) each failing at the intended step.
 
-**Pinned so it cannot rot.** Four tests in `scripts/platform-review-contracts.test.mjs` (inside
-`npm run check`) assert the input defaults, the path-construction expressions, the surviving
-five-rung guards, and the never-a-whole-repo-fetch guards. They are structural rather than
-prose-matching: the defaults and the suffix expression together *determine* the resolved path. All
-ten mutations tried against them go red — including flipping `provision_subdir` to `q8`, switching
-the cache default to `HF_HOME`, exporting `SCENEWORKS_KREA_ROOT` unconditionally, dropping the
-snapshots path segment, deleting either loud-failure guard, and pushing the input count over 10.
+**Pinned so it cannot rot.** Nine tests in `scripts/platform-review-contracts.test.mjs` (inside
+`npm run check`; the file runs 54 tests in total) assert the input defaults and the 10-input cap,
+the path-construction expressions, the timeout budgets, the surviving five-rung guards, the
+`real-weights` routing, the never-a-whole-repo-fetch guards, the anonymous fetch, the sentinel rule,
+and the containment validation. They are structural rather than prose-matching: the defaults and the
+suffix expression together *determine* the resolved path.
+
+**Thirty mutations, all red — but five of them only after a third review round.** Twenty-five went
+red as written, including flipping `provision_subdir` to `q8`, switching the cache default to
+`HF_HOME`, exporting `SCENEWORKS_KREA_ROOT` unconditionally, dropping the snapshots path segment,
+deleting a loud-failure guard, and pushing the input count over 10. A third round then found **five
+that stayed green at 54/54**, which supersedes this PR's earlier "25/25 mutations red" claim:
+
+| Mutation that stayed green | Why the suite missed it | What catches it now |
+| --- | --- | --- |
+| `throw` → `Write-Warning` on `the exact snapshot is not available on this runner` | only the *condition* was pinned (`Test-Path -LiteralPath $root -PathType Container`), never the fatality | `assert.match(resolve, /throw "the exact snapshot is not available on this runner/)` |
+| `throw` → `Write-Warning` on `the resolved root does not match the requested repository` | same shape — the `EndsWith` expression was pinned, not the fatality | `assert.match(resolve, /throw "the resolved root does not match the requested repository/)` |
+| `Resolve exact snapshot` `if:` narrowed to five-rung-only | the `if:` assertion was file-wide, and the byte-identical string on the params step satisfied it | the assertion is now sliced with `stepBody(workflow, "Resolve exact snapshot")` |
+| `Resolve exact snapshot` `if:` narrowed to provision-only | same file-wide match | same slice |
+| `Resolve snapshot provisioning parameters` `if:` narrowed to provision-only | same file-wide match, satisfied by the resolve step instead | a second assertion sliced with `stepBody(workflow, "Resolve snapshot provisioning parameters")` |
+
+The second row is the dangerous one. Downgraded, a snapshot whose canonical path does *not* match
+the requested repo and revision is accepted and exported as `SCENEWORKS_PROVISIONED_ROOT` /
+`SCENEWORKS_KREA_ROOT`, so a five-rung capture or a per-tier VRAM measurement runs silently against
+the **wrong weights** — the failure mode AC1's "fails loudly" exists to prevent. The third row is the
+same class one level up: narrowed to five-rung-only, a provision-only dispatch — exactly the shape
+this story adds — skips AC1's entire proof step, with the suite green.
+
+Both are one lesson, already recorded as comments in the test file: **pin the `throw`, not the
+message, and slice every step assertion to its own step.** A file-wide `assert.match` is a claim
+about the file, not about the step you meant.
 
 ---
 
@@ -314,11 +339,14 @@ tier.
 
 ### Verdicts
 
-- **q4 — reachable.** 43.0% of the card resident. Ample activation headroom.
-- **q8 — reachable.** 71.7% resident, 29.02 GB spare. Comfortable resident, trivially fine sequential.
-- **bf16 — reachable ONLY sequentially.** Co-resident is not a measurement question: the weights
-  alone overrun the card by 26.19 GB before a single activation is allocated, so sc-17153 should not
-  spend a lane on it. Sequential fits at 77.32 GB with 25.32 GB for activations.
+- **q4 — reachable.** 44.378 GB resident, 43.2% of the card, +58.264 GB spare. Ample activation
+  headroom.
+- **q8 — reachable.** 73.753 GB resident, 71.9% of the card, +28.889 GB spare. Comfortable resident,
+  trivially fine sequential (46.262 GB, 45.1%).
+- **bf16 — reachable ONLY sequentially.** Co-resident is not a measurement question: at 128.830 GB
+  the weights alone overrun the card by 26.188 GB before a single activation is allocated, so
+  sc-17153 should not spend a lane on it. Sequential fits at 77.324 GB with 25.318 GB for
+  activations.
 
 ### 5.1 The AdaLN evict makes the bf16 sequential verdict comfortable, not marginal
 
@@ -435,7 +463,7 @@ So the correct consequences are:
 | Two revisions differ only in `README.md` | `HfApi.model_info(files_metadata=True)` LFS-OID diff over all 280 files |
 | Pattern set selects 64 files / 144.051 GB, no leakage | `filter_repo_objects` against the live file list |
 | Krea path is character-identical | step bodies executed locally with a simulated `GITHUB_ENV` |
-| Contract tests cannot rot | 10/10 mutations go red |
+| Contract tests cannot rot | 30/30 mutations go red — the five a third review round found still-green are now caught (§4.2) |
 | Snapshot written at the pinned revision, then verified on disk | run 31509409586's `Provision exact snapshot` step; directory listing after it |
 | Patched quant kernels really work on sm_120 | `cuda_quant_smoke` (un-`#[ignore]`d) passing in run 31509409586 |
 | Dispatch resolves the snapshot | §8 — **see §8.1; the first run failed and why** |

--- a/docs/sc-18677-minimax-h3-runner-provisioning.md
+++ b/docs/sc-18677-minimax-h3-runner-provisioning.md
@@ -220,9 +220,11 @@ One coupling was removed on purpose: `provision_snapshot` no longer requires
 provisioning alone was necessarily a mistake. This epic makes it a first-class outcome — H3 weights
 must land on the box and there is no H3 five-rung fixture to run.
 
-### 4.1 One deliberate behaviour change: weights dispatches now request `real-weights`
+### 4.1 The two deliberate behaviour changes
 
-This is the single place the change does **not** preserve prior behaviour, and it is intentional.
+These are the only places the change does **not** preserve prior behaviour, and both are intentional.
+
+**(a) Weights dispatches now request `real-weights`.**
 
 `runs-on` was the flat list `[self-hosted, Windows, X64, cuda]`, so a five-rung capture could be
 scheduled onto any of the four runners in §1 — including the repo-level pair that does not carry
@@ -244,7 +246,7 @@ so a Krea dispatch resolves the same snapshot either way. It matters the day a `
 on a second machine: without the label the job lands somewhere with no snapshot and dies at the
 resolve step; with it the job queues for a box that has the weights.
 
-One further delta, smaller: provisioning-input validation now runs on
+**(b) Validation covers the five-rung-only path.** Provisioning-input validation now runs on
 `run_five_rung_reference || provision_snapshot` rather than on `provision_snapshot` alone, because
 both steps that *consume* those values run on the wider condition. A five-rung dispatch that
 explicitly clears `provision_patterns` or `provision_subdir` therefore now throws where it

--- a/docs/sc-18677-minimax-h3-runner-provisioning.md
+++ b/docs/sc-18677-minimax-h3-runner-provisioning.md
@@ -52,9 +52,9 @@ path, so the two cards do not sum into a 205 GB budget for one job.
 
 | Volume | Used | Free |
 | --- | ---: | ---: |
-| C: | 3,061.4 GB | **663.6 GB** |
-| D: | 2,390.8 GB | **1,335.2 GB** |
-| E: | 7,192 GB | **3,983 GB** |
+| C: | 3,289.1 GB | **710.6 GB** |
+| D: | 2,494.5 GB | **1,506.2 GB** |
+| E: | 7,722.4 GB | **4,276.7 GB** |
 
 The story flags that ~200 GB of provisioning competes with CI disk on this box. **It cost nothing.**
 The full 498 GB upstream repo was already resident in `E:\huggingface\hub` before this story, and the
@@ -67,11 +67,13 @@ Confirmed present and in lockstep. The root `Cargo.toml` carries
 
 ```toml
 [patch."https://github.com/huggingface/candle"]
-candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "b965641e388f4db646e4c60ab3f75219737e2cc8" }
+candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "014134e3035ad7e4eca5c2ed7bded2375dc3c071" }
 ```
 
 and that rev equals the worker's `sceneworks-gen-core` / `runtime-cuda` pins
-(`crates/sceneworks-worker/Cargo.toml:40,99`). This matters more here than anywhere else in the
+(`crates/sceneworks-worker/Cargo.toml:40,99`). This is the pin **on this epic's feature branch**,
+which is the rev the story asks about; `main` has since moved to `b965641e…`, so read the branch
+you are on rather than assuming. This matters more here than anywhere else in the
 repo: without the vendored multi-arch kernels, `libmoe.a` is an Ampere-only cubin with no PTX and
 **every quantized matmul silently returns zeros on sm_120** — which would turn a q4/q8 VRAM
 measurement into a confident wrong number rather than an error. Two guards keep it honest, and both
@@ -263,17 +265,19 @@ snapshots path segment, deleting either loud-failure guard, and pushing the inpu
 
 ## 5. Per-tier reachability (AC2)
 
-Component bytes are sc-17139's; the tier factors are its validated MLX-affine model
-(`group_size: 64` → q8 = 8.5/16 = 53.125% of bf16, q4 = 4.5/16 = 28.125%), which held to +0.03% /
-+0.48% against six shipped artifacts. The VAEs stay dense in every tier, so
-**11.044 GB is a fixed floor**.
+Component figures are taken **directly from sc-17139 §5.2**, not recomputed. That matters: a flat
+`(bits + 0.5)/16` factor applied to a whole component's bf16 bytes understates each quantized tier
+by ~0.2 GB, because ~0.02% of the DiT (the AdaLN biases and `proj_in.weight`, whose in-features 96
+is not a multiple of 64) cannot be packed and stays dense. sc-17139's per-component numbers already
+carry that dense remainder, so using them keeps the two epic documents on one set of totals. The
+VAEs stay dense in every tier, so **11.044 GB is a fixed floor**.
 
 Against **one card = 102.642 GB**, using the *trimmed* text encoder (what sc-17150 will host):
 
 | Tier | DiT | TE | VAEs | **Resident total** | % of card | Headroom | Verdict |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| q4 | 18.641 | 14.486 | 11.044 | **44.171** | 43.0% | +58.471 | **fits** |
-| q8 | 35.211 | 27.363 | 11.044 | **73.618** | 71.7% | +29.024 | **fits** |
+| q4 | 18.651 | 14.683 | 11.044 | **44.378** | 43.2% | +58.264 | **fits** |
+| q8 | 35.218 | 27.491 | 11.044 | **73.753** | 71.9% | +28.889 | **fits** |
 | bf16 | 66.280 | 51.506 | 11.044 | **128.830** | 125.5% | **−26.188** | **exceeds** |
 
 Under **sequential** residency — the phase order the schema describes, text encoder dropped before
@@ -281,12 +285,16 @@ the DiT — the peak is `max(TE, DiT + VAEs)`:
 
 | Tier | TE stage | DiT+VAEs stage | **Sequential peak** | % of card | Headroom |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| q4 | 14.486 | 29.685 | **29.685** | 28.9% | +72.957 |
-| q8 | 27.363 | 46.255 | **46.255** | 45.1% | +56.387 |
+| q4 | 14.683 | 29.695 | **29.695** | 28.9% | +72.947 |
+| q8 | 27.491 | 46.262 | **46.262** | 45.1% | +56.380 |
 | bf16 | 51.506 | 77.324 | **77.324** | 75.3% | +25.318 |
 
+The resident column matches sc-17139 §5.3's install totals to the 0.001 GB its rounding allows
+(44.378 / 73.752 / 128.830 there — that table adds the 0.023 GB of configs, which the 11.044 GB
+floor here already includes).
+
 With the **untrimmed** TE currently on the box, resident bf16 is 144.039 GB (140.3%) and resident q8
-is 81.697 GB (79.6%); the sequential peaks are unchanged, because the DiT stage dominates at every
+is 81.832 GB (79.7%); the sequential peaks are unchanged, because the DiT stage dominates at every
 tier.
 
 ### Verdicts
@@ -335,7 +343,12 @@ The story asks that an unreachable tier be recorded as "must not be advertised o
 **Both premises behind that instruction are wrong, and the correct consequence is different.**
 
 **Premise 1 — "the largest `candle.vramGbByTier` in the manifest today is `bf16: 40.7`".** It is
-**128.0** (`flux2_dev`). Eleven entries already exceed 40.7:
+**128.0** (`flux2_dev`). Of the 35 entries carrying a `candle.vramGbByTier`, **fifteen** have a
+ladder whose maximum exceeds 40.7 — `flux2_dev` 128, `qwen_image_edit_2511_lightning` 87.4,
+`qwen_image` 82.5, `qwen_image_edit_2511` 81.7, `flux2_klein_9b` 75.5, `ideogram_4` 74.1, `kolors`
+63.7, `ideogram_4_turbo` 56.3, `boogu_image_turbo` 54.5, `boogu_image` 54.4, `lens_turbo` 52,
+`krea_2_turbo` 47.2, `krea_2_raw` 46.4, `sd3_5_large` 41.3, `sd3_5_large_turbo` 41.3. The five
+heaviest, with their gates:
 
 | id | q4 | q8 | bf16 | `minMemoryGb` | seq-capable |
 | --- | ---: | ---: | ---: | ---: | --- |
@@ -357,6 +370,22 @@ runtime decides:
 - `sequentialPeakGb` is the **second-stage** check: when the resident peak forces sequential offload
   but the measured sequential peak still exceeds free VRAM, reject before load instead of running
   into a reactive OOM (`:1054`, sc-10856).
+
+**`flux2_dev` is the structural template, and it is almost exactly H3's situation:**
+
+```jsonc
+"candle": {
+  "minMemoryGb": 56,                                        // gates the DEFAULT (q4) tier
+  "vramGbByTier":      { "q4": 44,   "q8": 70.7, "bf16": 128 },  // bf16 EXCEEDS this box's card
+  "sequentialPeakGb":  { "q4": 35.6, "q8": 64.9, "bf16": 97 },   // ...and fits sequentially
+  "supportsSequentialOffload": true
+}
+```
+
+A shipped entry already advertises a bf16 resident peak 25 GB above this card's capacity, and
+carries the measured sequential number that makes it runnable anyway. H3 bf16 is *less* extreme:
+128.830 GB resident versus flux2_dev's 128, and a sequential peak of 77.324 GB (66.280 GB
+post-AdaLN-evict) versus flux2_dev's 97.
 
 So the correct consequences are:
 

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -162,7 +162,10 @@ function dispatchInputs(workflow) {
   const defaults = {};
   let current = null;
   for (const line of workflow.slice(start, end).split("\n")) {
-    const header = line.match(/^ {6}([a-z_]+):$/);
+    // Deliberately permissive: GitHub allows digits, case and hyphens in an input name, and this
+    // helper backs the "at most 10 inputs" cap check. A narrower pattern would silently skip an
+    // input and let a workflow GitHub rejects sail through as 10-or-fewer.
+    const header = line.match(/^ {6}([A-Za-z0-9_-]+):$/);
     if (header) {
       current = header[1];
       names.push(current);
@@ -235,6 +238,17 @@ test("windows-candle rebuilds the exact Krea snapshot path from the generalized 
     /\$root\.EndsWith\(\$env:PROVISION_SNAPSHOT_SUFFIX, \[StringComparison\]::OrdinalIgnoreCase\)/,
   );
 
+  // The PYTHON half of the cache binding, not just the PowerShell half. Centralizing the cache
+  // path exists because it was previously spelled twice in two languages with nothing tying
+  // them; pinning only the PowerShell side leaves a re-hardcoded `os.path.join(USERPROFILE...)`
+  // green, which downloads the whole component set to C: before the resolve step throws.
+  assert.match(workflow, /cache_dir=os\.environ\["PROVISION_CACHE_DIR"\],/);
+  assert.doesNotMatch(
+    workflow,
+    /cache_dir=os\.path\.join\(os\.environ\["USERPROFILE"\]/,
+    "the provisioning cache dir must come from the shared resolved value, not a second hardcoding",
+  );
+
   // The memory-adapter binaries read these env names via required_env; renaming the dispatch
   // inputs must not rename the runtime contract (bin/candle.rs, bin/mlx.rs).
   assert.match(workflow, /"SCENEWORKS_KREA_ROOT=\$root" \| Out-File/);
@@ -244,6 +258,21 @@ test("windows-candle rebuilds the exact Krea snapshot path from the generalized 
   // five-rung adapter a MiniMax root under a Krea-shaped name.
   assert.match(workflow, /\$isKrea = \$env:PROVISION_REPOSITORY -eq 'SceneWorks\/krea-2-turbo-mlx'/);
   assert.match(workflow, /if \(\$isKrea\) \{\n\s*"SCENEWORKS_KREA_ROOT=\$root"/);
+  // The CONSUMPTION side too, not just the export side. `secrets.SCENEWORKS_KREA_ROOT` is a
+  // Krea-specific override; dropping the `$isKrea -and` would let it redirect an H3 resolve.
+  assert.match(workflow, /if \(\$isKrea -and \$env:KREA_ROOT_OVERRIDE\) \{/);
+});
+
+// sc-18677: the provisioning branch's timeout is the whole point of the change (a 144 GB fetch
+// under the ordinary 45m cap dies mid-download), and the doc claims Krea's two dispatch shapes
+// keep their exact previous budgets. Pin the whole expression the way the macOS twin above pins
+// its lane's -- otherwise a revert to a flat `timeout-minutes: 45` passes every other test here.
+test("windows-candle keeps the provisioning and five-rung timeout budgets", async () => {
+  const workflow = await source(".github/workflows/windows-candle.yml");
+  assert.match(
+    workflow,
+    /timeout-minutes: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.provision_snapshot && 240 \|\| github\.event_name == 'workflow_dispatch' && inputs\.run_five_rung_reference && 120 \|\| 45 \}\}/,
+  );
 });
 
 test("windows-candle keeps the five-rung guards while decoupling provisioning", async () => {
@@ -302,8 +331,9 @@ test("windows-candle routes weights dispatches to a real-weights runner, like th
 test("windows-candle provisioning can never degrade into a whole-repo fetch", async () => {
   const workflow = await source(".github/workflows/windows-candle.yml");
   // MiniMaxAI/MiniMax-H3 is ~498 GB because FL2VA/ and Ref2VA/ re-package the same components;
-  // the component set is ~210 GB. snapshot_download treats allow_patterns=[] as "everything",
-  // so an empty list is a 288 GB accident on a box that shares its disk with CI. Both the
+  // the set sc-18677 provisions is 144.051 GB. snapshot_download treats allow_patterns=[] as
+  // "everything", so an empty list is a 354.424 GB accident on a box that shares its disk with
+  // CI -- FL2VA/ and Ref2VA/ alone are 288.102 GB of it. Both the
   // validation step and the Python body must refuse it.
   assert.match(
     workflow,
@@ -315,9 +345,48 @@ test("windows-candle provisioning can never degrade into a whole-repo fetch", as
   // A non-zero pip/python exit must fail the step: `@'...'@ | python -` does not propagate.
   assert.match(workflow, /if \(\$LASTEXITCODE -ne 0\) \{ throw "snapshot provisioning failed with exit code \$LASTEXITCODE" \}/);
 
+  assert.match(
+    workflow,
+    /if \(\$LASTEXITCODE -ne 0\) \{ throw "installing huggingface_hub failed with exit code \$LASTEXITCODE" \}/,
+  );
+
   // With provision_subdir empty the snapshot directory exists as soon as ANY file lands, so
   // existence alone is not proof. Every declared component's literal prefix must be present.
+  //
+  // Pin the LOOP BODY, not just the throw string: replacing the `if (-not $head) { continue }`
+  // guard with an unconditional `continue` makes the assertion vacuous while leaving the error
+  // message -- and every other assertion in this file -- untouched.
   assert.match(workflow, /provisioned snapshot is missing declared components under/);
+  assert.match(workflow, /\$head = \(\$pattern -split '\[\\\*\\\?\\\[\]'\)\[0\]/);
+  assert.match(workflow, /if \(-not \$head\) \{ continue \}/);
+  assert.match(workflow, /\$component = Join-Path \$snapshotRoot \$head\.Replace\('\/', '\\'\)/);
+  assert.match(workflow, /if \(-not \(Test-Path -LiteralPath \$component\)\) \{ \$missing \+= \$head \}/);
+});
+
+// sc-18677: the containment checks around the two operator inputs that reach the filesystem.
+// `provision_subdir` is joined onto the cache path; each `provision_patterns` entry's literal
+// head is joined onto the snapshot root by the component-presence assertion above. Both are
+// validated on the SAME condition as the steps that consume them, not on provision_snapshot
+// alone -- a five-rung-only dispatch consumes both just the same.
+test("windows-candle validates every provisioning input that reaches a path", async () => {
+  const workflow = await source(".github/workflows/windows-candle.yml");
+  assert.match(
+    workflow,
+    /if \(\$env:PROVISION_SNAPSHOT -eq 'true' -or \$env:RUN_FIVE_RUNG_REFERENCE -eq 'true'\) \{/,
+    "provisioning-input validation must cover the five-rung-only path that also consumes them",
+  );
+  assert.match(workflow, /throw 'provision_subdir must not traverse out of the snapshot'/);
+  assert.match(
+    workflow,
+    /throw "provision_patterns entries must not traverse out of the snapshot: \$pattern"/,
+  );
+  assert.match(
+    workflow,
+    /throw "provision_patterns entries must be relative to the snapshot root: \$pattern"/,
+  );
+  // provision_cache_dir is written verbatim into $GITHUB_ENV.
+  assert.match(workflow, /throw 'provision_cache_dir must be a single line'/);
+  assert.match(workflow, /throw 'provision_cache_dir must be an absolute path'/);
 });
 
 test("Windows CUDA runs the Candle adapter's platform-only unit tests", async () => {

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -376,6 +376,20 @@ test("windows-candle validates every provisioning input that reaches a path", as
     "provisioning-input validation must cover the five-rung-only path that also consumes them",
   );
   assert.match(workflow, /throw 'provision_subdir must not traverse out of the snapshot'/);
+  // The root sentinel. GitHub substitutes an input's `default` for any empty dispatch value, so
+  // `-f provision_subdir=` resolves to `q4`, not to "no subdir" (proved by run 31509409586).
+  // The default must stay `q4` to keep a Krea dispatch identical, so without '.' a
+  // root-resolved model like MiniMax-H3 cannot be expressed at all.
+  assert.match(
+    workflow,
+    /if \(\$env:PROVISION_SUBDIR -and \$env:PROVISION_SUBDIR -ne '\.'\) \{/,
+    "'.' must mean the snapshot root; an empty input cannot override a non-empty default",
+  );
+  assert.match(
+    workflow,
+    /description: "Tier\/subdirectory under the snapshot the resolve step must prove\. Use '\.' for a model whose components sit at the snapshot ROOT/,
+    "the sentinel must be documented on the input the operator actually reads",
+  );
   assert.match(
     workflow,
     /throw "provision_patterns entries must not traverse out of the snapshot: \$pattern"/,

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -142,6 +142,161 @@ test("Windows Krea provisioning accepts supported newer Python 3 runtimes", asyn
   );
 });
 
+// sc-18677 generalized windows-candle.yml's provisioning from "the Krea q4 snapshot" to "the
+// snapshot named by the provision_* inputs", so epic 17137 can land MiniMax-H3 weights on the
+// CUDA box for sc-17153/sc-17156's per-tier VRAM measurement. The story's acceptance criterion
+// is that a Krea dispatch "still behaves identically -- proven, not assumed". These tests are
+// that proof, and they are structural rather than prose-matching: they pin the input DEFAULTS
+// and the path-construction EXPRESSIONS, which together determine the resolved snapshot path.
+//
+// The path the old hardcoded step produced, verbatim:
+//   %USERPROFILE%\.cache\huggingface\hub\models--SceneWorks--krea-2-turbo-mlx\snapshots\<rev>\q4
+// Every fragment below is a factor of that string. Change any one and a Krea five-rung capture
+// silently reads another directory -- or, if it is lucky, throws.
+function dispatchInputs(workflow) {
+  const start = workflow.indexOf("  workflow_dispatch:\n    inputs:\n");
+  assert.ok(start >= 0, "windows-candle.yml must keep a workflow_dispatch inputs block");
+  const end = workflow.indexOf("\nconcurrency:", start);
+  assert.ok(end > start, "could not find the end of the workflow_dispatch block");
+  const names = [];
+  const defaults = {};
+  let current = null;
+  for (const line of workflow.slice(start, end).split("\n")) {
+    const header = line.match(/^ {6}([a-z_]+):$/);
+    if (header) {
+      current = header[1];
+      names.push(current);
+      defaults[current] = undefined;
+      continue;
+    }
+    const def = current && line.match(/^ {8}default: (.*)$/);
+    if (def) defaults[current] = def[1].trim().replace(/^"|"$/g, "");
+  }
+  return { names, defaults };
+}
+
+test("windows-candle provisioning is model-parameterized, not Krea-hardcoded", async () => {
+  const workflow = await source(".github/workflows/windows-candle.yml");
+  const { names, defaults } = dispatchInputs(workflow);
+
+  // GitHub rejects a workflow_dispatch with more than 10 inputs. The Krea inputs were RENAMED
+  // rather than shadowed by a parallel provision_* family precisely to stay under that cap;
+  // a future story that adds an input needs the headroom this preserves.
+  assert.ok(names.length <= 10, `workflow_dispatch allows at most 10 inputs, found ${names.length}`);
+
+  for (const gone of ["provision_krea_snapshot", "krea_repository", "krea_revision"]) {
+    assert.ok(!names.includes(gone), `${gone} was renamed; two provisioning paths must not coexist`);
+  }
+  for (const required of [
+    "provision_snapshot",
+    "provision_repository",
+    "provision_revision",
+    "provision_patterns",
+    "provision_subdir",
+    "provision_cache_dir",
+  ]) {
+    assert.ok(names.includes(required), `missing generalized input ${required}`);
+  }
+
+  // The defaults ARE the Krea dispatch. With these values and no other input set, the
+  // generalized steps must reconstruct the old hardcoded path exactly.
+  assert.equal(defaults.provision_repository, "SceneWorks/krea-2-turbo-mlx");
+  assert.equal(defaults.provision_patterns, "q4/**");
+  assert.equal(defaults.provision_subdir, "q4");
+  assert.equal(defaults.provision_cache_dir, undefined, "an empty cache dir must mean the historical location");
+});
+
+test("windows-candle rebuilds the exact Krea snapshot path from the generalized inputs", async () => {
+  const workflow = await source(".github/workflows/windows-candle.yml");
+
+  // cache dir: %USERPROFILE%\.cache\huggingface\hub when provision_cache_dir is empty. This box
+  // sets HF_HOME=E:\huggingface, and honoring it here would relocate Krea's cache -- so the
+  // default deliberately ignores HF_HOME. A caller that wants another cache passes it in.
+  assert.match(workflow, /\$cache = Join-Path \$env:USERPROFILE '\.cache\\huggingface\\hub'/);
+  assert.doesNotMatch(
+    workflow,
+    /^\s*\$cache = .*HF_HOME/m,
+    "the default cache dir must not be derived from HF_HOME",
+  );
+
+  // models--<owner>--<name>\snapshots\<revision>[\<subdir>]
+  assert.match(workflow, /\$folder = 'models--' \+ \$env:PROVISION_REPOSITORY\.Replace\('\/', '--'\)/);
+  assert.match(workflow, /\$subdirTail = '\\' \+ \$env:PROVISION_SUBDIR\.Replace\('\/', '\\'\)/);
+  assert.match(
+    workflow,
+    /\$suffix = '\\' \+ \$folder \+ '\\snapshots\\' \+ \$env:PROVISION_REVISION \+ \$subdirTail/,
+  );
+
+  // The resolve step still asserts existence AND that the canonical path ends with that exact
+  // suffix, so a stale cache entry or a lookalike repo cannot satisfy it.
+  assert.match(workflow, /Test-Path -LiteralPath \$root -PathType Container/);
+  assert.match(
+    workflow,
+    /\$root\.EndsWith\(\$env:PROVISION_SNAPSHOT_SUFFIX, \[StringComparison\]::OrdinalIgnoreCase\)/,
+  );
+
+  // The memory-adapter binaries read these env names via required_env; renaming the dispatch
+  // inputs must not rename the runtime contract (bin/candle.rs, bin/mlx.rs).
+  assert.match(workflow, /"SCENEWORKS_KREA_ROOT=\$root" \| Out-File/);
+  assert.match(workflow, /SCENEWORKS_KREA_REPOSITORY: \$\{\{ inputs\.provision_repository \}\}/);
+  assert.match(workflow, /SCENEWORKS_KREA_REVISION: \$\{\{ inputs\.provision_revision \}\}/);
+  // ...and SCENEWORKS_KREA_ROOT stays scoped to Krea, so an H3 dispatch cannot hand the
+  // five-rung adapter a MiniMax root under a Krea-shaped name.
+  assert.match(workflow, /\$isKrea = \$env:PROVISION_REPOSITORY -eq 'SceneWorks\/krea-2-turbo-mlx'/);
+  assert.match(workflow, /if \(\$isKrea\) \{\n\s*"SCENEWORKS_KREA_ROOT=\$root"/);
+});
+
+test("windows-candle keeps the five-rung guards while decoupling provisioning", async () => {
+  const workflow = await source(".github/workflows/windows-candle.yml");
+
+  // Provisioning is now a first-class outcome: sc-17153/sc-17156 need H3 weights resident and
+  // there is no H3 five-rung fixture. The old coupling throw must be gone...
+  assert.doesNotMatch(workflow, /requires run_five_rung_reference=true/);
+  assert.match(
+    workflow,
+    /if: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.provision_snapshot \}\}/,
+  );
+  // ...but every five-rung guard it used to sit beside must survive, keyed on the new names.
+  assert.match(workflow, /throw 'inference_revision must be an exact lowercase 40-hex commit'/);
+  assert.match(
+    workflow,
+    /\$env:PROVISION_REVISION -notmatch '\^\[0-9a-f\]\{40\}\$'/,
+  );
+  assert.match(
+    workflow,
+    /\$env:PROVISION_REPOSITORY -ne 'SceneWorks\/krea-2-turbo-mlx'/,
+    "a five-rung capture is still only valid against the fixed Krea reference artifact",
+  );
+  assert.match(workflow, /does not match the adapter's compiled INFERENCE_PIN/);
+
+  // The resolve step must still run for a five-rung dispatch that does NOT provision.
+  assert.match(
+    workflow,
+    /if: \$\{\{ github\.event_name == 'workflow_dispatch' && \(inputs\.run_five_rung_reference \|\| inputs\.provision_snapshot\) \}\}/,
+  );
+});
+
+test("windows-candle provisioning can never degrade into a whole-repo fetch", async () => {
+  const workflow = await source(".github/workflows/windows-candle.yml");
+  // MiniMaxAI/MiniMax-H3 is ~498 GB because FL2VA/ and Ref2VA/ re-package the same components;
+  // the component set is ~210 GB. snapshot_download treats allow_patterns=[] as "everything",
+  // so an empty list is a 288 GB accident on a box that shares its disk with CI. Both the
+  // validation step and the Python body must refuse it.
+  assert.match(
+    workflow,
+    /throw 'provision_patterns must name at least one allow-pattern; an empty list would fetch the whole repository'/,
+  );
+  assert.match(workflow, /raise SystemExit\("provision_patterns resolved to an empty allow-list"\)/);
+  assert.match(workflow, /allow_patterns=patterns,/);
+
+  // A non-zero pip/python exit must fail the step: `@'...'@ | python -` does not propagate.
+  assert.match(workflow, /if \(\$LASTEXITCODE -ne 0\) \{ throw "snapshot provisioning failed with exit code \$LASTEXITCODE" \}/);
+
+  // With provision_subdir empty the snapshot directory exists as soon as ANY file lands, so
+  // existence alone is not proof. Every declared component's literal prefix must be present.
+  assert.match(workflow, /provisioned snapshot is missing declared components under/);
+});
+
 test("Windows CUDA runs the Candle adapter's platform-only unit tests", async () => {
   const workflow = await source(".github/workflows/windows-candle.yml");
   assert.match(

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -276,6 +276,29 @@ test("windows-candle keeps the five-rung guards while decoupling provisioning", 
   );
 });
 
+test("windows-candle routes weights dispatches to a real-weights runner, like the MLX lane", async () => {
+  const candle = await source(".github/workflows/windows-candle.yml");
+  const mlx = await source(".github/workflows/macos-mlx.yml");
+
+  // The MLX lane is the template: base labels for ordinary runs, plus a weights label for a
+  // dispatch that needs real weights on disk. Assert the template still looks like that, so this
+  // guard cannot outlive the convention it mirrors.
+  assert.match(mlx, /runs-on: \$\{\{ \(github\.event_name == 'workflow_dispatch' && \(inputs\.run_memory_calibration \|\| inputs\.run_five_rung_reference\)\) && fromJSON\('\["self-hosted","macOS","ARM64","nax","weights"\]'\)/);
+
+  // The `cuda` pool spans two registration levels and only the org-level half carries
+  // `real-weights`; a provisioning job on the other half finds no snapshot.
+  assert.match(
+    candle,
+    /runs-on: \$\{\{ \(github\.event_name == 'workflow_dispatch' && \(inputs\.provision_snapshot \|\| inputs\.run_five_rung_reference\)\) && fromJSON\('\["self-hosted","Windows","X64","cuda","real-weights"\]'\) \|\| fromJSON\('\["self-hosted","Windows","X64","cuda"\]'\) \}\}/,
+  );
+  // Ordinary PR/push runs must NOT be narrowed to the real-weights half: that would cut the
+  // available pool for this ~24m lane in half for no coverage.
+  assert.doesNotMatch(
+    candle,
+    /^\s*runs-on: \[self-hosted, Windows, X64, cuda, real-weights\]/m,
+  );
+});
+
 test("windows-candle provisioning can never degrade into a whole-repo fetch", async () => {
   const workflow = await source(".github/workflows/windows-candle.yml");
   // MiniMaxAI/MiniMax-H3 is ~498 GB because FL2VA/ and Ref2VA/ re-package the same components;

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -312,11 +312,18 @@ test("windows-candle keeps the five-rung guards while decoupling provisioning", 
   );
   assert.match(workflow, /does not match the adapter's compiled INFERENCE_PIN/);
 
-  // The resolve step must still run for a five-rung dispatch that does NOT provision.
-  assert.match(
-    workflow,
-    /if: \$\{\{ github\.event_name == 'workflow_dispatch' && \(inputs\.run_five_rung_reference \|\| inputs\.provision_snapshot\) \}\}/,
-  );
+  // The resolve step must still run for a five-rung dispatch that does NOT provision, and the
+  // params step that FEEDS it (PROVISION_CACHE_DIR / _SNAPSHOT_SUFFIX / _SUBDIR_TAIL) must run on
+  // the same wider condition. Scoped per step for the reason at the top of this block: the two
+  // `if:` strings are byte-identical, so one file-wide match is satisfied by EITHER step and three
+  // mutations stayed green -- narrowing the resolve step to five-rung-only (a provision-only
+  // dispatch then exports no snapshot root at all, skipping AC1's whole proof step), narrowing it
+  // to provision-only (a five-rung-without-provisioning dispatch loses it), and narrowing the
+  // params step (the resolve step then joins two empty env vars and throws, or worse, matches).
+  const resolveGate =
+    /if: \$\{\{ github\.event_name == 'workflow_dispatch' && \(inputs\.run_five_rung_reference \|\| inputs\.provision_snapshot\) \}\}/;
+  assert.match(stepBody(workflow, "Resolve exact snapshot"), resolveGate);
+  assert.match(stepBody(workflow, "Resolve snapshot provisioning parameters"), resolveGate);
 });
 
 test("windows-candle routes weights dispatches to a real-weights runner, like the MLX lane", async () => {
@@ -374,6 +381,16 @@ test("windows-candle provisioning can never degrade into a whole-repo fetch", as
   // Pin the THROW, not the message. Every other assertion here survives `throw` ->
   // `Write-Warning`: the head computation, the guard, the Join-Path, the Test-Path and the string
   // all still match, while "fails loudly if absent" quietly becomes a log line.
+  //
+  // All THREE of the resolve step's assertions need that treatment, not just the component one.
+  // The existence check and the canonical-suffix check are pinned elsewhere in this file as
+  // EXPRESSIONS (`Test-Path -LiteralPath $root -PathType Container`, `$root.EndsWith(...)`), which
+  // a `throw` -> `Write-Warning` downgrade leaves untouched. The suffix one is the dangerous case:
+  // downgraded, a snapshot whose canonical path does not match the requested repo+revision is
+  // accepted and exported as SCENEWORKS_PROVISIONED_ROOT / SCENEWORKS_KREA_ROOT, so a five-rung
+  // capture or a per-tier VRAM measurement silently runs against the WRONG weights.
+  assert.match(resolve, /throw "the exact snapshot is not available on this runner/);
+  assert.match(resolve, /throw "the resolved root does not match the requested repository/);
   assert.match(resolve, /throw "provisioned snapshot is missing declared components under/);
   assert.match(resolve, /\$head = \(\$pattern -split '\[\\\*\\\?\\\[\]'\)\[0\]/);
   assert.match(resolve, /if \(-not \$head\) \{ continue \}/);

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -153,6 +153,17 @@ test("Windows Krea provisioning accepts supported newer Python 3 runtimes", asyn
 //   %USERPROFILE%\.cache\huggingface\hub\models--SceneWorks--krea-2-turbo-mlx\snapshots\<rev>\q4
 // Every fragment below is a factor of that string. Change any one and a Krea five-rung capture
 // silently reads another directory -- or, if it is lucky, throws.
+// Assertions about a step must be scoped TO that step. A bare `assert.match(workflow, ...)` is
+// satisfied by an identical string anywhere in the file, which is not hypothetical: dropping
+// `inputs.provision_snapshot` from the Provision step's `if:` left the suite green because the
+// neighbouring "Validate runner Python" step carries the byte-identical condition. Slice first.
+function stepBody(workflow, name) {
+  const at = workflow.indexOf(`      - name: ${name}\n`);
+  assert.ok(at >= 0, `windows-candle.yml must keep a step named ${name}`);
+  const next = workflow.indexOf("\n      - ", at + 1);
+  return workflow.slice(at, next === -1 ? undefined : next);
+}
+
 function dispatchInputs(workflow) {
   const start = workflow.indexOf("  workflow_dispatch:\n    inputs:\n");
   assert.ok(start >= 0, "windows-candle.yml must keep a workflow_dispatch inputs block");
@@ -281,8 +292,11 @@ test("windows-candle keeps the five-rung guards while decoupling provisioning", 
   // Provisioning is now a first-class outcome: sc-17153/sc-17156 need H3 weights resident and
   // there is no H3 five-rung fixture. The old coupling throw must be gone...
   assert.doesNotMatch(workflow, /requires run_five_rung_reference=true/);
+  // Scoped to the Provision step itself: the identical `if:` string also appears on the
+  // "Validate runner Python" step, so a file-wide match would stay green if this step's gate were
+  // dropped -- and an ungated Provision step re-downloads the snapshot on every five-rung run.
   assert.match(
-    workflow,
+    stepBody(workflow, "Provision exact snapshot"),
     /if: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.provision_snapshot \}\}/,
   );
   // ...but every five-rung guard it used to sit beside must survive, keyed on the new names.
@@ -356,11 +370,60 @@ test("windows-candle provisioning can never degrade into a whole-repo fetch", as
   // Pin the LOOP BODY, not just the throw string: replacing the `if (-not $head) { continue }`
   // guard with an unconditional `continue` makes the assertion vacuous while leaving the error
   // message -- and every other assertion in this file -- untouched.
-  assert.match(workflow, /provisioned snapshot is missing declared components under/);
-  assert.match(workflow, /\$head = \(\$pattern -split '\[\\\*\\\?\\\[\]'\)\[0\]/);
-  assert.match(workflow, /if \(-not \$head\) \{ continue \}/);
-  assert.match(workflow, /\$component = Join-Path \$snapshotRoot \$head\.Replace\('\/', '\\'\)/);
-  assert.match(workflow, /if \(-not \(Test-Path -LiteralPath \$component\)\) \{ \$missing \+= \$head \}/);
+  const resolve = stepBody(workflow, "Resolve exact snapshot");
+  // Pin the THROW, not the message. Every other assertion here survives `throw` ->
+  // `Write-Warning`: the head computation, the guard, the Join-Path, the Test-Path and the string
+  // all still match, while "fails loudly if absent" quietly becomes a log line.
+  assert.match(resolve, /throw "provisioned snapshot is missing declared components under/);
+  assert.match(resolve, /\$head = \(\$pattern -split '\[\\\*\\\?\\\[\]'\)\[0\]/);
+  assert.match(resolve, /if \(-not \$head\) \{ continue \}/);
+  assert.match(resolve, /foreach \(\$pattern in \(\$env:PROVISION_PATTERNS -split/);
+  assert.match(resolve, /\$component = Join-Path \$snapshotRoot \$head\.Replace\('\/', '\\'\)/);
+  assert.match(resolve, /if \(-not \(Test-Path -LiteralPath \$component\)\) \{ \$missing \+= \$head \}/);
+  // Without Resolve-Path the EndsWith below compares the raw Join-Path output against the suffix
+  // it was just built from -- a tautology -- and nothing normalizes a traversal before it.
+  assert.match(resolve, /\$root = \(Resolve-Path -LiteralPath \$root\)\.Path/);
+});
+
+// sc-18677: provisioning must stay anonymous. This box sets HF_HOME=E:\huggingface, which can hold
+// a credential; with an implicit token a gated repo turns a "not entitled" failure into a silent
+// success on whoever's token the runner happens to carry. macos-mlx.yml pins both of these for its
+// own provisioning block and this lane pinned neither.
+test("windows-candle provisioning stays anonymous", async () => {
+  const provision = stepBody(await source(".github/workflows/windows-candle.yml"), "Provision exact snapshot");
+  assert.match(provision, /HF_HUB_DISABLE_IMPLICIT_TOKEN: "1"/);
+  assert.match(provision, /^\s+token=False,$/m);
+});
+
+// sc-18677 section 8.1, generalized. GitHub substitutes an input's `default` for any empty dispatch
+// value, so a non-empty default makes "the absence of this thing" INEXPRESSIBLE unless the step
+// body understands a sentinel. That cost run 31509409586. Any future provision_* input with a
+// non-empty default has to make the same decision consciously.
+test("every OPTIONAL provision_* input with a non-empty default has a sentinel", async () => {
+  const workflow = await source(".github/workflows/windows-candle.yml");
+  const { names, defaults } = dispatchInputs(workflow);
+  const validate = stepBody(workflow, "Validate dispatch inputs");
+  const params = stepBody(workflow, "Resolve snapshot provisioning parameters");
+
+  let checked = 0;
+  for (const name of names.filter((n) => n.startsWith("provision_"))) {
+    const def = defaults[name];
+    if (def === undefined || def === "" || def === "false") continue;
+    // "Optional" is derived, not listed: the validation step wraps an optional input's checks in
+    // `if ($env:NAME)`. A required input (provision_repository, provision_patterns) is checked
+    // unconditionally, and "unset" is not a state it can meaningfully have.
+    const env = name.toUpperCase();
+    const optional = new RegExp(`if \\(\\$env:${env}(_INPUT)?\\) \\{`).test(validate);
+    if (!optional) continue;
+    checked += 1;
+    assert.match(
+      params,
+      new RegExp(`\\$env:${env}(_INPUT)? -ne '\\.'`),
+      `${name} is optional and defaults to ${JSON.stringify(def)}, so an empty dispatch value ` +
+        "cannot unset it; the params step must honor a '.' sentinel or the default must be empty",
+    );
+  }
+  assert.ok(checked > 0, "this guard must actually examine an input, or it is vacuous");
 });
 
 // sc-18677: the containment checks around the two operator inputs that reach the filesystem.
@@ -398,9 +461,44 @@ test("windows-candle validates every provisioning input that reaches a path", as
     workflow,
     /throw "provision_patterns entries must be relative to the snapshot root: \$pattern"/,
   );
+  // Containment is decided by CANONICALIZING, not by matching path segments against '..'.
+  // Segment-equality was bypassable two ways: `..*` yields head `..` while the pattern contains
+  // no `..` segment, and `.. ` survives -contains yet Win32 strips the trailing space. The
+  // GetFullPath probe kills the first class; the TrimEnd(' ', '.') segment check kills the
+  // second, which GetFullPath does NOT normalize.
+  const validate = stepBody(workflow, "Validate dispatch inputs");
+  assert.match(validate, /\$head = \(\(\$pattern -split '\[\\\*\\\?\\\[\]'\)\[0\]\)\.TrimEnd\('\/'\)/);
+  assert.match(validate, /if \(-not \$segment\.TrimEnd\(' ', '\.'\)\) \{/);
+  // The validate step has its own loop and its own head guard, distinct from the resolve step's.
+  // Pin BOTH, scoped: `foreach ($pattern in @($patterns[0]))` checks only the first of thirteen
+  // H3 patterns, and `if ($true) { continue }` skips every one, while every other assertion in
+  // this file keeps matching because the resolve step still spells them correctly.
+  assert.match(validate, /foreach \(\$pattern in \$patterns\) \{/);
+  assert.match(validate, /if \(-not \$head\) \{ continue \}/);
+  // Both containment guards must stay FATAL. There are two throws with this message -- the
+  // segment check and the canonical probe -- and turning either into a Write-Host leaves the
+  // string present, so presence alone is not the property worth asserting.
+  assert.equal(
+    (validate.match(/throw "provision_patterns entries must not traverse out of the snapshot: \$pattern"/g) || []).length,
+    2,
+    "both the segment check and the canonical-containment probe must throw",
+  );
+  assert.match(
+    validate,
+    /\$full\.StartsWith\(\$probe \+ '\\', \[StringComparison\]::OrdinalIgnoreCase\)/,
+  );
+  // ...and the resolve step canonicalizes independently, so the proof does not rest on
+  // validation having run.
+  assert.match(
+    stepBody(workflow, "Resolve exact snapshot"),
+    /throw "declared component escapes the snapshot root: \$pattern"/,
+  );
   // provision_cache_dir is written verbatim into $GITHUB_ENV.
   assert.match(workflow, /throw 'provision_cache_dir must be a single line'/);
-  assert.match(workflow, /throw 'provision_cache_dir must be an absolute path'/);
+  assert.match(workflow, /throw 'provision_cache_dir must be an absolute path with a drive letter'/);
+  // IsPathRooted accepts `\foo` and `C:foo` -- rooted, but not absolute -- so the check would not
+  // mean what its message says. PowerShell 5.1's .NET has no IsPathFullyQualified.
+  assert.match(workflow, /\$env:PROVISION_CACHE_DIR_INPUT -notmatch '\^\[A-Za-z\]:\\\\'/);
 });
 
 test("Windows CUDA runs the Candle adapter's platform-only unit tests", async () => {


### PR DESCRIPTION
Story: [sc-18677](https://app.shortcut.com/trefry/story/18677) · Epic: [sc-17137](https://app.shortcut.com/trefry/epic/17137)
Base: `feature/sc-17137-minimax-h3` per [FEATURE_DEVELOPMENT.md](FEATURE_DEVELOPMENT.md) §3.

Unblocks [sc-17153](https://app.shortcut.com/trefry/story/17153) and [sc-17156](https://app.shortcut.com/trefry/story/17156), which need measured per-tier VRAM on real H3 weights. Closes the gap epic comment 18649 recorded as finding #5: *"There is no CUDA real-weight CI lane… no `weights` label and no HF provisioning input — unlike the Mac lane."*

Full write-up: [`docs/sc-18677-minimax-h3-runner-provisioning.md`](docs/sc-18677-minimax-h3-runner-provisioning.md).

## What changed

`windows-candle.yml`'s real-weight provisioning worked but was welded to Krea in four places. It is now model-parameterized, with the Krea inputs **renamed rather than duplicated** so exactly one provisioning path exists:

| Was | Now | Default |
| --- | --- | --- |
| `provision_krea_snapshot` | `provision_snapshot` | `false` |
| `krea_repository` | `provision_repository` | `SceneWorks/krea-2-turbo-mlx` |
| `krea_revision` | `provision_revision` | — |
| — | `provision_patterns` | `q4/**` |
| — | `provision_subdir` | `q4` (`.` means the snapshot root) |
| — | `provision_cache_dir` | *(empty → `%USERPROFILE%\.cache\huggingface\hub`)* |

Renaming keeps the workflow at **8 inputs** against GitHub's cap of 10. A new step derives the cache dir and snapshot suffix **once**, so provisioning and resolve cannot drift on where the snapshot lands — that path was previously spelled twice, in two languages, with nothing tying them.

Deliberately **not** changed: `SCENEWORKS_KREA_{ROOT,REPOSITORY,REVISION}` keep their names (the memory-adapter binaries' `required_env` contract), with `SCENEWORKS_KREA_ROOT` now exported only when the resolved repo *is* Krea; every five-rung guard survives; the default cache dir still ignores `HF_HOME` even though this box sets it.

One coupling removed on purpose: `provision_snapshot` no longer requires `run_five_rung_reference`. H3 must land on the box and has no five-rung fixture.

**Two deliberate behaviour changes**, both argued in docs §4.1:
1. `runs-on` now adds `real-weights` for a provisioning/five-rung dispatch, mirroring `macos-mlx.yml:450`. The `cuda` pool is **four** runners across two registration levels and only the org-level pair carries that label. Ordinary PR/push runs keep the full pool.
2. Provisioning-input validation runs on `run_five_rung_reference || provision_snapshot` — the same condition as the steps that consume those values.

## Acceptance criteria

| AC | Evidence |
| --- | --- |
| 1 — components resident; resolve proves the exact path, fails loudly | Snapshot written by run 31509409586, verified on disk; resolve makes **three** assertions (exists / canonical suffix / every declared component present) |
| 2 — GPU + VRAM recorded, per-tier verdict with arithmetic | docs §1, §5 |
| 3 — model-parameterized; Krea identical, **proven** | Step bodies executed locally, 25 cases; contract tests; **30/30 mutations red** (was 25/25 - superseded, see Correction below) |
| 4 — dispatch provisions and resolves | [31511147004](https://github.com/SceneWorks/SceneWorks/actions/runs/31511147004) green on every step |
| 5 — manifest consequence for sc-17150 / sc-17158 | docs §6 — **premises corrected** |

## AC5: both premises in the story are wrong

1. *"the largest `candle.vramGbByTier` today is `bf16: 40.7`"* — it is **128.0** (`flux2_dev`); fifteen entries exceed 40.7.
2. *"a tier that cannot run on the candle lane must not be advertised there"* — not the convention. `flux2_dev` ships `bf16: 128.0`, which exceeds this box's own card, alongside `sequentialPeakGb.bf16: 97` and `minMemoryGb: 56`. `minMemoryGb` gates the **default tier only** (schema :1040); `vramGbByTier` is the resident peak the fit-gate compares against free VRAM (:1044); `sequentialPeakGb` is the second-stage reject (:1054).

**The consequence is inverted: do not drop bf16 on VRAM grounds.** What bf16 requires is sequential residency — 128.830 GB resident against a 102.642 GB card — so sc-17158 must declare `supportsSequentialOffload: true` **and** populate `sequentialPeakGb`. Only if sc-17154/sc-17155 finds the provider does not honor `LoadSpec` sequential residency does bf16 become genuinely unreachable, and *that* is when the platform arrays exclude it.

## Per-tier verdict (one card = 102.642 GB, trimmed TE)

| Tier | Resident | % card | Verdict | Sequential peak |
| --- | ---: | ---: | --- | ---: |
| q4 | 44.378 | 43.2% | reachable | 29.695 |
| q8 | 73.753 | 71.9% | reachable | 46.262 |
| bf16 | 128.830 | 125.5% | **resident impossible** (−26.188) | 77.324 → **66.280** post-AdaLN-evict |

Weights floors, not generate peaks: a "reachable" verdict is the *necessary* condition that justifies sending a measurement job. Only the bf16-resident row is a sufficient rejection, and it needs no measurement.

## Review

Two adversarial review rounds (independent context). Round 1 returned DO NOT SHIP and found a wrong fact — the doc quoted `main`'s `candle-kernels` rev, not this branch's — plus four unpinned behaviour changes and two containment gaps. Round 2 found M5 still open with two working bypasses, and six further mutations passing green. Everything is fixed; notable ones:

- `throw` → `Write-Warning` on the component assertion passed every test, because they pinned the *message* not the *fatality*. AC1's "fails loudly" was one word from being a log line.
- Dropping the Provision step's `if:` stayed green because a neighbouring step carries a byte-identical condition — assertions are now sliced to the step.
- `token=False` and `HF_HUB_DISABLE_IMPLICIT_TOKEN` were unpinned. On a box whose `HF_HOME` may hold a credential, flipping either turns a gated repo's "not entitled" failure into a silent success on someone's token.
- Windows path containment by segment-equality was bypassable via `..*` (wildcard-adjacent) and `.. ` (Win32 strips trailing spaces). Now decided by canonicalizing.

## Testing

- `node --test scripts/platform-review-contracts.test.mjs` — **54 pass / 0 fail**
- `check-source-control-bytes.mjs`, `check-scaffold.mjs`, `check-evidence-corpus.mjs` — pass
- 25 local cases against the shipped PowerShell step bodies with a simulated `GITHUB_ENV`: the historical Krea dispatch resolving character-for-character, H3 at the pinned revision, and 8 containment bypasses + 9 other negatives all failing at the intended step
- **30/30 mutation cases turn the suite red**

> **Correction.** This PR previously claimed *25/25 mutations red*. A third adversarial-review round (`e611116f`) found **five** further mutations that left the suite at 54/54 green, so that claim was incomplete when made: `throw` -> `Write-Warning` on the resolve step's snapshot-absent and suffix-mismatch assertions (both pinned only as *expressions* elsewhere in the file), plus three step-scoping narrowings of the `run_five_rung_reference || provision_snapshot` gate, whose `if:` string is byte-identical on two steps. The suffix-mismatch one is the dangerous case: downgraded, a snapshot whose canonical path does not match the requested repo+revision is accepted and exported as `SCENEWORKS_KREA_ROOT`, so a five-rung capture or a per-tier VRAM measurement runs against the **wrong weights**. All five are now red; the battery is 30 cases.
- Dispatch runs: [31509409586](https://github.com/SceneWorks/SceneWorks/actions/runs/31509409586) (found the sentinel bug), [31511147004](https://github.com/SceneWorks/SceneWorks/actions/runs/31511147004) (**green, every step**), [31512848344](https://github.com/SceneWorks/SceneWorks/actions/runs/31512848344) (re-run at the merge head after the containment rework)

`npm run check` is not runnable in this worktree (no `node_modules`); the hosted `parity` lane runs it. The final commit is docs-only, so run 31512848344 exercises all shipped code.

## Limitations

- **`transformer_ref` is not provisioned** — the story defers it and it is sc-17149's entry. Adding it takes the set from 144.051 GB to the full 210.332 GB.
- **Provisioning sits behind the heavy compile chain** with no `continue-on-error`, so an unrelated build break makes it impossible to land weights at all, not merely slow (docs §8.0). Reordering belongs in its own change: the capability-dump verify is last by design and a contract test enforces that placement.
- **The provisioning step is still Python** (`huggingface_hub`). Pre-existing, and kept deliberately — rewriting it natively would have put AC3 at risk.
- §5 reports weights floors. The real ceilings are sc-17153/sc-17156's to measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


