### PR TITLE
sc-17160: audio-reference payload field for video jobs + per-model reference caps

### DIFF
--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -952,6 +952,21 @@ pub(crate) struct VideoJobRequest {
     /// The worker pushes it as a second `Conditioning::VideoClip`.
     #[serde(default)]
     pub(crate) reference_clip_asset_id: Option<String>,
+    /// Reference **audio** clips for a multi-modal reference video mode (sc-17160,
+    /// MiniMax-H3 Ref2VA). The audio sibling of [`Self::reference_asset_ids`]: the worker
+    /// resolves each id through the project-scoped asset guard and pushes one
+    /// `Conditioning::ReferenceAudio` per entry.
+    ///
+    /// Serialized unconditionally, exactly like the two id lists above, so the enqueued
+    /// payload has one shape and a replay reader never has to distinguish "absent" from
+    /// "empty" (the sc-12345 lesson).
+    ///
+    /// Bounded twice: by the payload-sanity blanket `MAX_VIDEO_REFERENCE_AUDIO_ASSET_IDS`
+    /// in `validate_video_job`, and — the binding one — by the model's declared
+    /// `limits.maxReferenceAudioAssets`, which defaults to 0 so no already-shipped video
+    /// model accepts one.
+    #[serde(default)]
+    pub(crate) reference_audio_asset_ids: Vec<String>,
     #[serde(default = "default_requested_gpu")]
     pub(crate) requested_gpu: String,
     #[serde(default)]

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -608,6 +608,33 @@ pub(crate) async fn create_video_job(
     // resolved entry (reading either from the DTO is sc-12300). The RESOLVED rate is written back so
     // the enqueued payload records what was actually rendered — the worker re-resolves identically
     // from the same entry, but a recipe replay reads this row.
+    // The model's declared reference-media caps (sc-17160) — `limits.maxReferenceAssets` /
+    // `maxSourceClipAssets` / `maxReferenceAudioAssets` / `maxCombinedReferenceAssets`. This is the
+    // BINDING half of the caps; `validate_video_job`'s three constants are only the payload-sanity
+    // outer bound, for the same reason `1..=30` is for duration — that gate runs before the model is
+    // known, and a recipe preset can still replace it (sc-12300).
+    //
+    // It is what makes raising the image blanket 8 -> 9 for MiniMax-H3 safe for every OTHER video
+    // model: `reference_caps` defaults to 8 images / 8 clips / 0 audio / no combined ceiling, so a
+    // family that declares nothing behaves byte-for-byte as it did before this key had a reader — a
+    // 9th reference to bernini is still refused, just here instead of one layer up. A per-family cap
+    // rather than a global bump, which is what the "raising a shared constant affects every video
+    // model" warning on the story asks for.
+    //
+    // Same placement rationale as the duration and fps caps above: keyed off the post-preset
+    // `model_id` and the resolved entry. The counts come off the DTO, not `job_payload`, because no
+    // preset patches the id lists — they are the caller's media, verbatim.
+    if let Some(entry) = model_manifest_entry.as_object() {
+        if let Some(message) = reference_limit_error(
+            &model_id,
+            payload.reference_asset_ids.len(),
+            payload.source_clip_asset_ids.len(),
+            payload.reference_audio_asset_ids.len(),
+            entry,
+        ) {
+            return Err(ApiError::bad_request(message));
+        }
+    }
     if let Some(entry) = model_manifest_entry.as_object() {
         let fps = resolve_fps(job_payload.get("fps"), entry);
         if let Some(message) = fps_limit_error(&model_id, fps, entry) {

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -62,7 +62,8 @@ use sceneworks_core::training_store::{
     TrainingDatasetSummary, TrainingDatasetUpdateInput,
 };
 use sceneworks_core::video_request::{
-    default_resolution, duration_limit_error, fps_limit_error, resolve_duration, resolve_fps,
+    default_resolution, duration_limit_error, fps_limit_error, reference_limit_error,
+    resolve_duration, resolve_fps,
 };
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -4158,6 +4159,29 @@ fn validate_video_job(payload: &VideoJobRequest) -> Result<(), ApiError> {
             "sourceClipAssetIds must contain at most {MAX_VIDEO_SOURCE_CLIP_ASSET_IDS} ids"
         )));
     }
+    // The audio references (sc-17160), rejected blank-first and bounded exactly like the two
+    // id lists above — same order, same wording — because "consistent with the existing lists"
+    // is the contract a caller reads off one list and applies to the next.
+    if payload
+        .reference_audio_asset_ids
+        .iter()
+        .any(|id| id.trim().is_empty())
+    {
+        return Err(ApiError::bad_request(
+            "referenceAudioAssetIds must not contain blank ids",
+        ));
+    }
+    if payload.reference_audio_asset_ids.len() > MAX_VIDEO_REFERENCE_AUDIO_ASSET_IDS {
+        return Err(ApiError::bad_request(format!(
+            "referenceAudioAssetIds must contain at most {MAX_VIDEO_REFERENCE_AUDIO_ASSET_IDS} ids"
+        )));
+    }
+    // There is deliberately NO combined blanket here, only the three per-list ones above. 12 is
+    // MiniMax-H3's number, not a product-wide truth: today's caps admit 8 images AND 8 clips on
+    // one request, so a blanket 12 would refuse a 16-file shape this route accepts right now —
+    // narrowing every existing video model, which is precisely what the cap change must not do.
+    // The combined budget is a per-model fact and lives with the model, as
+    // `limits.maxCombinedReferenceAssets` (see `create_video_job`).
     // Only a *named* duration is bounded here, for the same reason as fps below: an omitted one is
     // resolved from the model's declared `defaults.duration` in `create_video_job`. This blanket
     // stays a payload-sanity check; the model's own `limits.hardMaxDuration` is enforced there
@@ -4494,8 +4518,32 @@ const MAX_IMAGE_DIMENSION: u32 = 4096;
 /// Upper bound for video width/height — a lower backstop than images, matching
 /// the cap enforced when validating a video job request.
 const MAX_VIDEO_DIMENSION: u32 = 1920;
-const MAX_VIDEO_REFERENCE_ASSET_IDS: usize = 8;
+// ---------------------------------------------------------------------------
+// Reference-media payload-sanity blankets (sc-17160).
+//
+// These three are the OUTER bound — "no video model in the product accepts more than
+// this" — and play exactly the role the `1..=30` duration and `1..=60` fps blankets do
+// a few lines up in `validate_video_job`: they run BEFORE the model is known (a recipe
+// preset can still replace it — sc-12300), so they cannot be the per-model answer.
+//
+// The BINDING per-model cap is `sceneworks_core::video_request::reference_limit_error`,
+// enforced in `create_video_job` against the resolved manifest entry, and mirrored in the
+// worker's `video_preflight`. Its defaults are 8 images / 8 clips / 0 audio / no combined
+// ceiling, so raising the image blanket from 8 to 9 here does NOT hand a 9th reference to
+// any already-shipped model — bernini and every other family still refuse it, one layer
+// down, on `limits.maxReferenceAssets`.
+//
+// The COMBINED cap has no blanket at all, only a per-model declaration, for the same reason
+// in the opposite direction: see the note where the per-list checks end.
+// ---------------------------------------------------------------------------
+
+/// 9 — MiniMax-H3 Ref2VA's image-reference ceiling, the largest of any shipped video model
+/// (every other family stops at [`sceneworks_core::video_request::DEFAULT_MAX_REFERENCE_ASSETS`]).
+const MAX_VIDEO_REFERENCE_ASSET_IDS: usize = 9;
 const MAX_VIDEO_SOURCE_CLIP_ASSET_IDS: usize = 8;
+/// 3 — Ref2VA's audio-reference ceiling. No model declares more; models that declare
+/// nothing take none at all (`DEFAULT_MAX_REFERENCE_AUDIO_ASSETS` is 0).
+const MAX_VIDEO_REFERENCE_AUDIO_ASSET_IDS: usize = 3;
 
 fn validate_dimension(value: u32, field: &'static str, max: u32) -> Result<(), ApiError> {
     if !(256..=max).contains(&value) {

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -3643,6 +3643,203 @@ async fn image_and_video_job_routes_normalize_payloads() {
     assert_eq!(queue["counts"]["queued"], 5);
 }
 
+/// THE regression test the cap change required: a video model that declares none of the four new
+/// `limits` keys keeps the exact reference budget it had before sc-17160.
+///
+/// The shape that matters is 8 images + 8 clips — SIXTEEN reference files on one request, which
+/// this route accepts today because the pre-story caps were per-list only. Introducing the combined
+/// cap as a payload-sanity BLANKET of 12 (the reading the story's wording invites) would have
+/// refused it, silently narrowing every already-shipped video model. That is why the combined cap
+/// is per-model declaration only, and why this test asserts an ACCEPT rather than a reject: the
+/// rejecting tests would all still pass with the regression in place.
+#[tokio::test]
+async fn existing_video_models_keep_their_pre_sc_17160_reference_budget() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Budget" }),
+    )
+    .await;
+
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "bernini",
+            "mode": "ads2v",
+            "prompt": "drive the edit",
+            "sourceClipAssetId": "clip-src",
+            "referenceClipAssetId": "clip-ref",
+            "referenceAssetIds": ["i1", "i2", "i3", "i4", "i5", "i6", "i7", "i8"],
+            "sourceClipAssetIds": ["c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8"],
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "16 reference files was legal before this story and must stay legal: {job}"
+    );
+    assert_eq!(
+        job["payload"]["referenceAssetIds"].as_array().map(Vec::len),
+        Some(8)
+    );
+    assert_eq!(
+        job["payload"]["sourceClipAssetIds"]
+            .as_array()
+            .map(Vec::len),
+        Some(8)
+    );
+}
+
+/// The story's acceptance pair at the ROUTE, against a model that declares the Ref2VA reference
+/// surface: 9 images + 3 clips + 3 audio is 15 reference files and must be refused; 9 + 2 + 1 is
+/// 12 and must be accepted, with all three lists on the enqueued payload.
+///
+/// Driven off a SEEDED manifest rather than a shipped model on purpose. The caps are per-model
+/// (`limits.maxReferenceAssets` / `maxSourceClipAssets` / `maxReferenceAudioAssets` /
+/// `maxCombinedReferenceAssets`), so the only honest way to exercise the accepting side today is a
+/// model that declares them — MiniMax-H3's own manifest entry is sc-17158. That separation is the
+/// point of the design: this test needs no engine and no weights to pin the contract.
+///
+/// The combined budget has NO payload-sanity blanket, only this per-model declaration — see the
+/// note in `validate_video_job`. 12 is MiniMax-H3's number and today's per-list caps already admit
+/// a 16-file request (8 images + 8 clips), so a blanket 12 would have narrowed every existing
+/// video model. `existing_video_models_keep_their_pre_sc_17160_reference_budget` holds that line.
+#[tokio::test]
+async fn ref2va_reference_caps_refuse_fifteen_files_and_admit_twelve() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "models": [
+            {
+              "id": "ref2va_probe",
+              "name": "Ref2VA Probe",
+              "family": "minimax-h3",
+              "type": "video",
+              "adapter": "stub",
+              "capabilities": ["text_to_video", "reference_to_video"],
+              "downloads": [],
+              "paths": {},
+              "defaults": {},
+              "limits": {
+                "maxReferenceAssets": 9,
+                "maxSourceClipAssets": 3,
+                "maxReferenceAudioAssets": 3,
+                "maxCombinedReferenceAssets": 12
+              },
+              "ui": {}
+            },
+            {
+              "id": "legacy_probe",
+              "name": "Legacy Probe",
+              "family": "ltx-video",
+              "type": "video",
+              "adapter": "stub",
+              "capabilities": ["text_to_video", "reference_to_video"],
+              "downloads": [],
+              "paths": {},
+              "defaults": {},
+              "limits": {},
+              "ui": {}
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Ref2VA" }),
+    )
+    .await;
+
+    let submit = |model: &str, images: usize, clips: usize, audio: usize| {
+        let app = app.clone();
+        let body = json!({
+            "projectId": "project-1",
+            "model": model,
+            "mode": "reference_to_video",
+            "prompt": "the subject speaks",
+            "referenceAssetIds": (0..images).map(|i| format!("img-{i}")).collect::<Vec<_>>(),
+            "sourceClipAssetIds": (0..clips).map(|i| format!("clip-{i}")).collect::<Vec<_>>(),
+            "referenceAudioAssetIds": (0..audio).map(|i| format!("aud-{i}")).collect::<Vec<_>>(),
+        });
+        async move { request(app, "POST", "/api/v1/video/jobs", body).await }
+    };
+
+    // 9 + 3 + 3 = 15 > 12. REFUSED, and the message decomposes the total so the caller knows how
+    // much to cut without counting three lists themselves. Nothing but the combined budget can
+    // decide this one: 9 <= 9, 3 <= 3 and 3 <= 3 all pass their own caps.
+    let (status, over) = submit("ref2va_probe", 9, 3, 3).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        over["detail"],
+        "ref2va_probe takes up to 12 reference files in total, but this request supplies 15 \
+         (9 reference images + 3 source clips + 3 audio references). Remove 3 of them."
+    );
+
+    // 9 + 2 + 1 = 12. ACCEPTED, at the cap, and every list reaches the enqueued payload.
+    let (status, job) = submit("ref2va_probe", 9, 2, 1).await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(job["type"], "video_generate");
+    assert_eq!(
+        job["payload"]["referenceAssetIds"].as_array().map(Vec::len),
+        Some(9)
+    );
+    assert_eq!(
+        job["payload"]["sourceClipAssetIds"]
+            .as_array()
+            .map(Vec::len),
+        Some(2)
+    );
+    assert_eq!(
+        job["payload"]["referenceAudioAssetIds"],
+        json!(["aud-0"]),
+        "the audio references must reach the worker verbatim, not just validate"
+    );
+
+    // A shape that clears the blanket but not what THIS model declares: 4 clips against its
+    // declared 3, only 8 files in total. Refused by the per-model gate, naming the model.
+    let (status, per_model) = submit("ref2va_probe", 4, 4, 0).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        per_model["detail"],
+        "ref2va_probe takes up to 3 source clips, but this request supplies 4. Reduce \
+         sourceClipAssetIds to 3 or fewer, or choose a model that takes more."
+    );
+
+    // The SAME 9 + 2 + 1 request against a model that declares nothing is refused — twice over,
+    // and the image cap is what it trips first. This is the per-family shape doing its job: the
+    // declaration travels with the model, not with the API constant.
+    let (status, legacy) = submit("legacy_probe", 9, 2, 1).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        legacy["detail"],
+        "legacy_probe takes up to 8 reference images, but this request supplies 9. Reduce \
+         referenceAssetIds to 8 or fewer, or choose a model that takes more."
+    );
+}
+
 #[tokio::test]
 async fn bernini_video_modes_validate_required_media() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
@@ -3718,7 +3915,14 @@ async fn bernini_video_modes_validate_required_media() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
 
     // Reference id lists are bounded before the worker has to encode them.
-    let (status, _) = request(
+    //
+    // THE REGRESSION ASSERTION FOR sc-17160. This 9-reference request 400'd before that story and
+    // must keep 400ing after it, even though the API's payload-sanity blanket was raised from 8 to
+    // 9 for MiniMax-H3 — bernini declares no `limits.maxReferenceAssets`, so the per-model gate in
+    // `create_video_job` holds it at the historical 8. The status alone would pass for the wrong
+    // reason (any 400 satisfies it), so the message is asserted too: it has to be bernini's own cap
+    // talking, not the blanket.
+    let (status, over_cap) = request(
         app.clone(),
         "POST",
         "/api/v1/video/jobs",
@@ -3732,6 +3936,82 @@ async fn bernini_video_modes_validate_required_media() {
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        over_cap["detail"],
+        "bernini takes up to 8 reference images, but this request supplies 9. Reduce \
+         referenceAssetIds to 8 or fewer, or choose a model that takes more."
+    );
+
+    // 8 is still admitted — the cap moved for nobody, in either direction.
+    let (status, at_cap) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "bernini",
+            "mode": "reference_to_video",
+            "prompt": "the subject dances",
+            "referenceAssetIds": ["ref-1", "ref-2", "ref-3", "ref-4", "ref-5", "ref-6", "ref-7", "ref-8"]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(
+        at_cap["payload"]["referenceAssetIds"]
+            .as_array()
+            .map(Vec::len),
+        Some(8)
+    );
+    // And the new list is present-but-empty on a model that has nothing to do with it, so a replay
+    // reader never has to tell "absent" from "empty" (sc-12345).
+    assert_eq!(at_cap["payload"]["referenceAudioAssetIds"], json!([]));
+
+    // The new audio list is INERT for every already-shipped video model: bernini declares no
+    // `limits.maxReferenceAudioAssets`, which defaults to 0, so a single audio reference is
+    // refused rather than accepted-and-silently-dropped by an engine that cannot consume it.
+    let (status, audio_refused) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "bernini",
+            "mode": "reference_to_video",
+            "prompt": "the subject dances",
+            "referenceAssetIds": ["ref-1"],
+            "referenceAudioAssetIds": ["voice-1"]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        audio_refused["detail"],
+        "bernini takes no audio references, but this request supplies 1. Remove \
+         referenceAudioAssetIds, or choose a model that conditions on audio references."
+    );
+
+    // Blank audio ids are rejected exactly as blank image and clip ids are, and by the blanket —
+    // so the refusal does not depend on the model declaring anything.
+    let (status, blank_audio) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "bernini",
+            "mode": "reference_to_video",
+            "prompt": "the subject dances",
+            "referenceAssetIds": ["ref-1"],
+            "referenceAudioAssetIds": ["  "]
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        blank_audio["detail"],
+        "referenceAudioAssetIds must not contain blank ids"
+    );
 
     // A complete video_to_video request creates a base video_generate job that
     // carries the source clip.

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -345,6 +345,11 @@ export function VideoStudio() {
   // Reference video for Bernini's ads2v mode (sc-5425): a second source clip distinct from the
   // edited source clip (sourceClipAssetId).
   const [referenceClipAssetId, setReferenceClipAssetId] = useState(saved.referenceClipAssetId ?? "");
+  // Reference AUDIO clips for a multi-modal reference mode (sc-17160). Held and replayed here so a
+  // re-run rebuilds the same conditioning; the picker that populates it is sc-17161's.
+  const [referenceAudioAssetIds, setReferenceAudioAssetIds] = useState(
+    saved.referenceAudioAssetIds ?? [],
+  );
   const [characterId, setCharacterId] = useState(saved.characterId ?? "");
   const [characterLookId, setCharacterLookId] = useState(saved.characterLookId ?? "");
   const [personTrackId, setPersonTrackId] = useState(saved.personTrackId ?? "");
@@ -852,6 +857,9 @@ export function VideoStudio() {
     setBridgeRightClipAssetId(settings.bridgeRightClipAssetId ?? "");
     setSourceClipAssetIds(Array.isArray(settings.sourceClipAssetIds) ? settings.sourceClipAssetIds : []);
     setReferenceAssetIds(Array.isArray(settings.referenceAssetIds) ? settings.referenceAssetIds : []);
+    setReferenceAudioAssetIds(
+      Array.isArray(settings.referenceAudioAssetIds) ? settings.referenceAudioAssetIds : [],
+    );
     setReferenceClipAssetId(settings.referenceClipAssetId ?? "");
     setFitMode(settings.fitMode ?? "crop");
     setCharacterId(settings.characterId ?? "");
@@ -1012,6 +1020,7 @@ export function VideoStudio() {
     sourceClipAssetId,
     bridgeRightClipAssetId,
     referenceAssetIds,
+    referenceAudioAssetIds,
     sourceClipAssetIds,
     referenceClipAssetId,
     characterId,
@@ -1293,6 +1302,12 @@ export function VideoStudio() {
         ].includes(mode)
           ? referenceAssetIds
           : [],
+        // Reference AUDIO clips (sc-17160). Deliberately NOT gated on a hardcoded mode list like
+        // the two above: which modes take audio references is a MODEL fact, declared as
+        // `limits.maxReferenceAudioAssets` and enforced server-side, and a model that takes none
+        // refuses a non-empty list at enqueue. Hardcoding a mode list here would have to be edited
+        // again the moment sc-17159 lands the modes.
+        referenceAudioAssetIds,
         // Bernini ads2v reference video (sc-5425).
         referenceClipAssetId: mode === "ads2v" ? referenceClipAssetId || null : null,
         personTrackId: mode === "replace_person" ? personTrackId || null : null,

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -603,6 +603,19 @@ describe("VideoStudio Bernini task modes", () => {
     expect(payload.referenceAssetIds).toEqual([]);
   });
 
+  // sc-17160: the audio-reference list is on every video job body, present-but-empty when the
+  // user picked none, so a replay reader never has to tell "absent" from "empty" and the picker
+  // (sc-17161) has a field to fill rather than a payload shape to invent.
+  it("carries the audio-reference list on the submitted payload", async () => {
+    const context = baseContext({ videoModels: [BERNINI], assets: [clip], selectedAsset: clip });
+    await render(context);
+    await click(modeButton("Video → Video"));
+    await click(buttonWithText(container, "Render clip"));
+
+    const payload = context.createVideoJob.mock.calls[0][0];
+    expect(payload.referenceAudioAssetIds).toEqual([]);
+  });
+
   it("submits all chosen reference images for reference_to_video", async () => {
     const context = baseContext({ videoModels: [BERNINI], assets: [refA, refB] });
     await render(context);

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -4787,7 +4787,14 @@ fn build_video_sidecar_parts(job_id: &str, fact: &Value) -> (Value, Value, Value
     // The list-valued source ids are parents too — mv2v's clips, the reference-driven modes'
     // subject images, and ads2v's reference video. Without them those modes' provenance names
     // only a subset of what the clip was actually derived from (sc-12345).
-    let list_source_keys = ["sourceClipAssetIds", "referenceAssetIds"];
+    // sc-17160 adds the audio references: media the clip was genuinely derived from, so leaving
+    // them out would name only a subset of its provenance — the same gap sc-12345 closed for the
+    // clip and image lists.
+    let list_source_keys = [
+        "sourceClipAssetIds",
+        "referenceAssetIds",
+        "referenceAudioAssetIds",
+    ];
     let parents: Vec<Value> = source_keys
         .iter()
         .chain(std::iter::once(&"referenceClipAssetId"))
@@ -4845,6 +4852,9 @@ fn build_video_sidecar_parts(job_id: &str, fact: &Value) -> (Value, Value, Value
         "fitMode": get("fitMode"),
         "sourceClipAssetIds": list_or_empty("sourceClipAssetIds"),
         "referenceAssetIds": list_or_empty("referenceAssetIds"),
+        // sc-17160. `list_or_empty` keeps the array shape on facts written before this key
+        // existed, so the replay reader never distinguishes "absent" from "empty".
+        "referenceAudioAssetIds": list_or_empty("referenceAudioAssetIds"),
         "referenceClipAssetId": get("referenceClipAssetId"),
         "characterId": get("characterId"),
         "characterLookId": get("characterLookId"),
@@ -9201,8 +9211,31 @@ mod tests {
         let old_normalized = &old["recipe"]["normalizedSettings"];
         assert_eq!(old_normalized["referenceAssetIds"], json!([]));
         assert_eq!(old_normalized["sourceClipAssetIds"], json!([]));
+        assert_eq!(old_normalized["referenceAudioAssetIds"], json!([]));
         assert_eq!(old_normalized["fitMode"], Value::Null);
         assert_eq!(old["lineage"]["parents"], json!([]));
+
+        // sc-17160: the audio references replay and count as parents for the same reason the
+        // image and clip lists do — a re-run that omits them renders the same prompt with its
+        // audio conditioning silently gone, which is invisible in the output.
+        let ref2va = json!({
+            "type": "video",
+            "assetId": "asset-ref2va",
+            "mediaPath": "assets/videos/ref2va.mp4",
+            "mimeType": "video/mp4",
+            "mode": "reference_to_video", "model": "minimax_h3",
+            "referenceAssetIds": ["ref-1"],
+            "referenceAudioAssetIds": ["voice-1", "music-1"],
+        });
+        let multimodal = build_generated_asset_sidecar("project-1", "job-4", "genset-1", &ref2va);
+        assert_eq!(
+            multimodal["recipe"]["normalizedSettings"]["referenceAudioAssetIds"],
+            json!(["voice-1", "music-1"])
+        );
+        assert_eq!(
+            multimodal["lineage"]["parents"],
+            json!(["ref-1", "voice-1", "music-1"])
+        );
     }
 
     #[test]

--- a/crates/sceneworks-core/src/video_request.rs
+++ b/crates/sceneworks-core/src/video_request.rs
@@ -106,6 +106,17 @@ pub struct VideoRequest {
     /// source video distinct from `source_clip_asset_id`. `generate_bernini` pushes
     /// it as a second `Conditioning::VideoClip` after the source clip.
     pub reference_clip_asset_id: Option<String>,
+    /// Reference **audio** clips for a multi-modal reference video mode (sc-17160,
+    /// MiniMax-H3 Ref2VA). The audio sibling of [`Self::reference_asset_ids`] (still
+    /// images) and [`Self::reference_clip_asset_id`] (a moving reference): the worker
+    /// resolves each id through the project-scoped asset guard, decodes the clip, and
+    /// pushes one `Conditioning::ReferenceAudio` per entry.
+    ///
+    /// Inert for every video model shipped before this field existed: the per-model cap
+    /// [`reference_caps`] resolves defaults to **0** audio references, so a payload that
+    /// carries any is refused at enqueue unless the model declares
+    /// `limits.maxReferenceAudioAssets`.
+    pub reference_audio_asset_ids: Vec<String>,
     /// Per-model advanced knobs (steps, guidanceScale, imageConditioningStrength,
     /// timelineContext, …), passed through.
     pub advanced: JsonObject,
@@ -155,6 +166,7 @@ impl VideoRequest {
             bridge_right_clip_asset_id: optional_id(payload, "bridgeRightClipAssetId"),
             reference_asset_ids: string_list(payload, "referenceAssetIds"),
             reference_clip_asset_id: optional_id(payload, "referenceClipAssetId"),
+            reference_audio_asset_ids: string_list(payload, "referenceAudioAssetIds"),
             advanced: object_or_empty(payload, "advanced"),
             model_manifest_entry,
         }
@@ -548,6 +560,140 @@ pub fn fps_limit_error(model: &str, fps: u32, model_manifest_entry: &JsonObject)
         format!(
             "{model} renders at {allowed} fps, but this request asks for {fps} fps. Set fps to \
              {allowed}, or choose a model that renders at {fps} fps."
+        )
+    })
+}
+
+/// The reference-image cap applied when a model declares no `limits.maxReferenceAssets` —
+/// the historical blanket, so every already-shipped video model keeps refusing a 9th
+/// reference exactly as it did before sc-17160 raised the API's payload-sanity ceiling.
+pub const DEFAULT_MAX_REFERENCE_ASSETS: usize = 8;
+/// The source-clip cap applied when a model declares no `limits.maxSourceClipAssets` —
+/// the historical blanket, unchanged for every already-shipped video model.
+pub const DEFAULT_MAX_SOURCE_CLIP_ASSETS: usize = 8;
+/// The reference-**audio** cap applied when a model declares no
+/// `limits.maxReferenceAudioAssets`.
+///
+/// **Zero, deliberately.** `referenceAudioAssetIds` is new surface (sc-17160) that no video
+/// model shipped before it could consume, and no engine silently ignores conditioning it was
+/// handed — it renders unconditioned, which is invisible in the output (the epic-1788 class).
+/// Defaulting to 0 means a model has to *declare* that it takes audio references before one
+/// can reach it, so the new field is inert for every existing family rather than accepted-and-
+/// dropped.
+pub const DEFAULT_MAX_REFERENCE_AUDIO_ASSETS: usize = 0;
+
+/// The per-model reference-media caps resolved from a manifest entry's `limits`.
+///
+/// Four independent facts, because a model's reference surface is not one number: MiniMax-H3's
+/// Ref2VA takes ≤9 images, ≤3 video clips and ≤3 audio clips but ≤12 **files in total**, so the
+/// per-list caps do not multiply out to the real ceiling and the combined cap is not derivable
+/// from them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReferenceCaps {
+    /// `limits.maxReferenceAssets` — still-image references (`referenceAssetIds`).
+    pub images: usize,
+    /// `limits.maxSourceClipAssets` — source/reference video clips (`sourceClipAssetIds`).
+    pub clips: usize,
+    /// `limits.maxReferenceAudioAssets` — audio references (`referenceAudioAssetIds`).
+    pub audio: usize,
+    /// `limits.maxCombinedReferenceAssets` — the ceiling on images + clips + audio together, or
+    /// `None` when the model declares none. Absent ⇒ no combined ceiling, so a model that
+    /// declares nothing behaves exactly as it did before this key had a reader.
+    pub combined: Option<usize>,
+}
+
+impl Default for ReferenceCaps {
+    fn default() -> Self {
+        Self {
+            images: DEFAULT_MAX_REFERENCE_ASSETS,
+            clips: DEFAULT_MAX_SOURCE_CLIP_ASSETS,
+            audio: DEFAULT_MAX_REFERENCE_AUDIO_ASSETS,
+            combined: None,
+        }
+    }
+}
+
+/// [`ReferenceCaps`] for a resolved manifest entry, falling back to the pre-sc-17160 defaults
+/// for every key the model does not declare.
+///
+/// Same never-block-without-evidence posture as [`hard_max_duration`]: a declared cap that is
+/// not a non-negative integer is not a constraint anyone could satisfy, so it falls back to the
+/// default rather than bricking the model.
+pub fn reference_caps(model_manifest_entry: &JsonObject) -> ReferenceCaps {
+    let limits = model_manifest_entry
+        .get("limits")
+        .and_then(Value::as_object);
+    let cap = |key: &str| -> Option<usize> {
+        limits
+            .and_then(|limits| limits.get(key))
+            .and_then(Value::as_u64)
+            .and_then(|cap| usize::try_from(cap).ok())
+    };
+    let defaults = ReferenceCaps::default();
+    ReferenceCaps {
+        images: cap("maxReferenceAssets").unwrap_or(defaults.images),
+        clips: cap("maxSourceClipAssets").unwrap_or(defaults.clips),
+        audio: cap("maxReferenceAudioAssets").unwrap_or(defaults.audio),
+        combined: cap("maxCombinedReferenceAssets"),
+    }
+}
+
+/// The actionable rejection for a request whose reference media exceeds what the model declares,
+/// or `None` to admit. The pure decision, so the API enqueue gate and the worker preflight assert
+/// on one message — the same shape as [`duration_limit_error`] / [`fps_limit_error`] (sc-17160).
+///
+/// **Per-model, not a global bump.** MiniMax-H3 accepts 9 images where every family before it
+/// accepted 8; raising the shared API constant alone would have handed every other video model a
+/// 9th reference its engine was never asked to encode. The manifest is the seam epic 12334
+/// established for exactly this: a model that takes more declares more, and one that declares
+/// nothing keeps the historical [`DEFAULT_MAX_REFERENCE_ASSETS`].
+///
+/// Per-list caps are checked before the combined one so the message names the list actually over
+/// budget; the combined cap is the only one that can reject a request in which every individual
+/// list fits.
+///
+/// Message follows the house convention (`mlx_fit_gate::too_big_error`): name the model, state
+/// what was asked and what the cap is, and give the lever.
+pub fn reference_limit_error(
+    model: &str,
+    images: usize,
+    clips: usize,
+    audio: usize,
+    model_manifest_entry: &JsonObject,
+) -> Option<String> {
+    let caps = reference_caps(model_manifest_entry);
+    for (count, cap, field, noun) in [
+        (images, caps.images, "referenceAssetIds", "reference images"),
+        (clips, caps.clips, "sourceClipAssetIds", "source clips"),
+        (
+            audio,
+            caps.audio,
+            "referenceAudioAssetIds",
+            "audio references",
+        ),
+    ] {
+        if count > cap {
+            return Some(if cap == 0 {
+                format!(
+                    "{model} takes no {noun}, but this request supplies {count}. Remove \
+                     {field}, or choose a model that conditions on {noun}."
+                )
+            } else {
+                format!(
+                    "{model} takes up to {cap} {noun}, but this request supplies {count}. \
+                     Reduce {field} to {cap} or fewer, or choose a model that takes more."
+                )
+            });
+        }
+    }
+    let combined = caps.combined?;
+    let total = images + clips + audio;
+    (total > combined).then(|| {
+        format!(
+            "{model} takes up to {combined} reference files in total, but this request supplies \
+             {total} ({images} reference images + {clips} source clips + {audio} audio \
+             references). Remove {} of them.",
+            total - combined
         )
     })
 }
@@ -1476,6 +1622,177 @@ mod tests {
         assert_eq!(duration_limit_error("mochi_1", 5.0, &mochi), None);
         assert_eq!(duration_limit_error("mochi_1", 1.0, &mochi), None);
         assert!(duration_limit_error("mochi_1", 5.5, &mochi).is_some());
+    }
+
+    // -----------------------------------------------------------------------
+    // Reference-media caps (sc-17160).
+    // -----------------------------------------------------------------------
+
+    /// THE regression test for the cap change. Raising the API's image blanket from 8 to 9 for
+    /// MiniMax-H3 must not hand a 9th reference to any other video model, and the new audio list
+    /// must not become quietly acceptable to a family whose engine cannot consume it.
+    ///
+    /// This is the "existing video models unaffected" assertion in its purest form: a model that
+    /// declares NOTHING (which is every video model shipped before this story — no builtin
+    /// declares any of the four keys) keeps 8 / 8 / 0 / no-combined-ceiling. Driven off a matrix
+    /// of the shapes a manifest entry actually takes in the wild, including the `{}` an
+    /// uncatalogued id resolves to.
+    #[test]
+    fn an_undeclared_model_keeps_the_pre_sc_17160_reference_caps() {
+        for empty in [json!({}), json!({ "limits": {} })] {
+            let entry = payload(empty.clone());
+            assert_eq!(
+                reference_caps(&entry),
+                ReferenceCaps {
+                    images: 8,
+                    clips: 8,
+                    audio: 0,
+                    combined: None,
+                },
+                "undeclared entry must keep the historical caps: {empty}"
+            );
+            // 8 images and 8 clips still admit — the exact pre-story ceiling, unchanged.
+            assert_eq!(reference_limit_error("bernini", 8, 8, 0, &entry), None);
+            // ...and a 9th image is still refused, one layer down from the raised blanket.
+            assert!(
+                reference_limit_error("bernini", 9, 0, 0, &entry).is_some(),
+                "the raised API blanket must not let a 9th reference through: {empty}"
+            );
+            // 16 files in total admit: an undeclared model has NO combined ceiling, so the new
+            // combined cap cannot retroactively narrow a shape bernini accepts today.
+            assert_eq!(reference_limit_error("bernini", 8, 8, 0, &entry), None);
+            // A single audio reference is refused outright — the new field is inert here.
+            let audio = reference_limit_error("bernini", 0, 0, 1, &entry)
+                .expect("an undeclared model takes no audio references");
+            assert!(audio.contains("bernini"), "names the model: {audio}");
+            assert!(
+                audio.contains("takes no audio references"),
+                "says the model takes none rather than quoting a cap of 0: {audio}"
+            );
+            assert!(
+                audio.contains("referenceAudioAssetIds"),
+                "names the field to remove: {audio}"
+            );
+        }
+    }
+
+    /// The story's acceptance pair, at the layer that owns the decision: 9 images + 3 clips +
+    /// 3 audio is 15 files against a declared 12 and must be REFUSED, while 9 + 2 + 1 is 12 and
+    /// must be ADMITTED.
+    ///
+    /// The combined cap is the only bound that can decide either of these — every individual list
+    /// in the rejected shape is within its own per-list cap — which is why it is a separate key
+    /// rather than something derived from the three.
+    #[test]
+    fn the_combined_cap_refuses_fifteen_files_and_admits_twelve() {
+        let ref2va = payload(json!({
+            "limits": {
+                "maxReferenceAssets": 9,
+                "maxSourceClipAssets": 3,
+                "maxReferenceAudioAssets": 3,
+                "maxCombinedReferenceAssets": 12,
+            }
+        }));
+        assert_eq!(
+            reference_caps(&ref2va),
+            ReferenceCaps {
+                images: 9,
+                clips: 3,
+                audio: 3,
+                combined: Some(12),
+            }
+        );
+
+        // Every list is within ITS OWN cap — 9 <= 9, 3 <= 3, 3 <= 3 — so nothing but the combined
+        // budget can refuse this. That is the whole point of the assertion.
+        assert_eq!(reference_limit_error("minimax_h3", 9, 0, 0, &ref2va), None);
+        assert_eq!(reference_limit_error("minimax_h3", 0, 3, 0, &ref2va), None);
+        assert_eq!(reference_limit_error("minimax_h3", 0, 0, 3, &ref2va), None);
+        let message = reference_limit_error("minimax_h3", 9, 3, 3, &ref2va)
+            .expect("15 files is past the 12-file combined cap");
+        assert!(message.contains("minimax_h3"), "names the model: {message}");
+        assert!(message.contains("12"), "states the cap: {message}");
+        assert!(message.contains("15"), "states what was asked: {message}");
+        assert!(
+            message.contains("Remove 3"),
+            "gives the lever, counted: {message}"
+        );
+
+        // 9 + 2 + 1 is exactly 12 — at the cap, which admits, matching every other bound in this
+        // module being `>` rather than `>=`.
+        assert_eq!(reference_limit_error("minimax_h3", 9, 2, 1, &ref2va), None);
+        // ...and 13 does not.
+        assert!(reference_limit_error("minimax_h3", 9, 3, 1, &ref2va).is_some());
+    }
+
+    /// A per-list overage names the list that is over, not the total. A caller told only
+    /// "12 files maximum" for a request of 4 images + 9 clips would have to work out which list to
+    /// cut; naming `sourceClipAssetIds` and its cap is the actionable form, and it is why the
+    /// per-list checks run before the combined one.
+    #[test]
+    fn a_per_list_overage_names_the_list_rather_than_the_total() {
+        let ref2va = payload(json!({
+            "limits": {
+                "maxReferenceAssets": 9,
+                "maxSourceClipAssets": 3,
+                "maxReferenceAudioAssets": 3,
+                "maxCombinedReferenceAssets": 12,
+            }
+        }));
+        // 4 + 5 + 0 = 9 files, well inside the combined budget, but 5 clips is past the 3 declared.
+        let message = reference_limit_error("minimax_h3", 4, 5, 0, &ref2va)
+            .expect("5 clips is past the declared 3");
+        assert!(
+            message.contains("sourceClipAssetIds"),
+            "names the offending list: {message}"
+        );
+        assert!(
+            message.contains("up to 3 source clips"),
+            "states that list's cap: {message}"
+        );
+        assert!(
+            !message.contains("in total"),
+            "must not report this as a combined-budget failure: {message}"
+        );
+    }
+
+    /// The infallibility contract [`hard_max_duration`] holds to, applied here: a declared cap that
+    /// is not a non-negative integer is not a constraint anyone could satisfy, so it falls back to
+    /// the default rather than bricking the model. A typo'd `"9"` must not turn a model that takes
+    /// nine references into one that takes none.
+    #[test]
+    fn an_unhonorable_declared_reference_cap_falls_back_to_the_default() {
+        for bad in [json!(-1), json!("9"), json!(null), json!(9.5), json!([9])] {
+            let entry = payload(json!({ "limits": { "maxReferenceAssets": bad } }));
+            assert_eq!(
+                reference_caps(&entry).images,
+                DEFAULT_MAX_REFERENCE_ASSETS,
+                "unhonorable cap {bad} must fall back, not brick the model"
+            );
+        }
+        // A declared 0 IS honorable — "this model takes no references" is a real statement — so it
+        // must NOT fall back to 8. This is the case that separates "unparseable" from "zero".
+        let none = payload(json!({ "limits": { "maxReferenceAssets": 0 } }));
+        assert_eq!(reference_caps(&none).images, 0);
+        assert!(reference_limit_error("t2v_only", 1, 0, 0, &none).is_some());
+    }
+
+    /// The payload parse: the new list arrives through the same `string_list` filter the two
+    /// existing id lists use, so blanks and non-strings are dropped identically and an absent key
+    /// yields an empty list rather than a missing one.
+    #[test]
+    fn from_payload_parses_reference_audio_asset_ids_like_the_other_id_lists() {
+        let request = VideoRequest::from_payload(&payload(json!({
+            "projectId": "p1",
+            "referenceAudioAssetIds": ["voice-a", "  ", "music-b", 7]
+        })));
+        assert_eq!(
+            request.reference_audio_asset_ids,
+            vec!["voice-a", "music-b"]
+        );
+
+        let bare = VideoRequest::from_payload(&payload(json!({ "projectId": "p1" })));
+        assert!(bare.reference_audio_asset_ids.is_empty());
     }
 
     /// A model that declares no cap is UNCONSTRAINED — the default-absent behavior that keeps

--- a/crates/sceneworks-core/src/workflow_share.rs
+++ b/crates/sceneworks-core/src/workflow_share.rs
@@ -187,6 +187,11 @@ pub const INPUT_KIND_SOURCE_CLIP: &str = "sourceClip";
 /// A reference CLIP a video run conditions on (`referenceClipAssetId`, Bernini's ads2v) —
 /// sc-15956. The moving counterpart of [`INPUT_KIND_REFERENCE`].
 pub const INPUT_KIND_REFERENCE_CLIP: &str = "referenceClip";
+/// A reference AUDIO clip a video run conditions on (`referenceAudioAssetIds`, MiniMax-H3's
+/// Ref2VA) — sc-17160. The audible counterpart of [`INPUT_KIND_REFERENCE`], and a separate kind
+/// for the same reason [`INPUT_KIND_SOURCE_CLIP`] is: "this recipe needs a voice or a piece of
+/// music" is a different ask of whoever replays it than "this recipe needs a picture".
+pub const INPUT_KIND_REFERENCE_AUDIO: &str = "referenceAudio";
 
 /// A LoRA the run applied, reduced to what another install can act on: the display name, the
 /// weight, the Hugging Face repo id when the catalog entry resolved to one, and (only when the
@@ -2299,6 +2304,18 @@ fn describe_inputs(job_payload: &JsonObject) -> Vec<WorkflowInput> {
             control_mode: None,
         });
     }
+    // The audio references (sc-17160), counted exactly as the still and clip references are.
+    // Without their own kind a shared multi-modal recipe would describe "9 reference images +
+    // 2 source clips" and say nothing about the audio it also needs — the recipient sees a
+    // complete-looking input list and reproduces an under-conditioned render.
+    let reference_audio = id_list_len("referenceAudioAssetIds");
+    if reference_audio > 0 {
+        inputs.push(WorkflowInput {
+            kind: INPUT_KIND_REFERENCE_AUDIO.to_owned(),
+            count: u32::try_from(reference_audio).unwrap_or(u32::MAX),
+            control_mode: None,
+        });
+    }
     let advanced = job_payload.get("advanced").and_then(Value::as_object);
     let control_image = advanced
         .and_then(|advanced| advanced.get("controlImage"))
@@ -2394,6 +2411,7 @@ pub const INPUT_KINDS: &[&str] = &[
     INPUT_KIND_CONTROL,
     INPUT_KIND_SOURCE_CLIP,
     INPUT_KIND_REFERENCE_CLIP,
+    INPUT_KIND_REFERENCE_AUDIO,
 ];
 
 // ---------------------------------------------------------------------------
@@ -4090,8 +4108,9 @@ mod tests {
         assert_eq!(MAX_SHARE_LORAS, crate::lora_family::MAX_JOB_LORAS);
         assert_eq!(MAX_SHARE_LORAS, 5);
         assert_eq!(MAX_SHARE_INPUTS, INPUT_KINDS.len());
-        // Four image kinds plus the video lane's two clip kinds (sc-15956).
-        assert_eq!(MAX_SHARE_INPUTS, 6);
+        // Four image kinds, the video lane's two clip kinds (sc-15956), and the audio reference
+        // (sc-17160).
+        assert_eq!(MAX_SHARE_INPUTS, 7);
         // The worker's `MAX_MULTIPHASE_PHASES`; pinned against its source by
         // `the_phase_cap_matches_the_multi_phase_validators` in tests/workflow_share.rs, which can
         // read the file this crate cannot import.

--- a/crates/sceneworks-core/tests/workflow_mp4.rs
+++ b/crates/sceneworks-core/tests/workflow_mp4.rs
@@ -15,9 +15,9 @@ use sceneworks_core::workflow_mp4::{
 };
 use sceneworks_core::workflow_share::{
     build_video_workflow_share_from, embeddable_video_workflow_share, parse_workflow_share_json,
-    WorkflowAssetFacts, WorkflowShareError, INPUT_KIND_REFERENCE, INPUT_KIND_REFERENCE_CLIP,
-    INPUT_KIND_SOURCE, INPUT_KIND_SOURCE_CLIP, WORKFLOW_KIND_IMAGE, WORKFLOW_KIND_VIDEO,
-    WORKFLOW_SHARE_MARKER_KEY, WORKFLOW_SHARE_MAX_BYTES,
+    WorkflowAssetFacts, WorkflowShareError, INPUT_KIND_REFERENCE, INPUT_KIND_REFERENCE_AUDIO,
+    INPUT_KIND_REFERENCE_CLIP, INPUT_KIND_SOURCE, INPUT_KIND_SOURCE_CLIP, WORKFLOW_KIND_IMAGE,
+    WORKFLOW_KIND_VIDEO, WORKFLOW_SHARE_MARKER_KEY, WORKFLOW_SHARE_MAX_BYTES,
 };
 
 // ---------------------------------------------------------------------------
@@ -653,6 +653,7 @@ fn clip_ids_become_shape_descriptors() {
             "sourceClipAssetIds": ["clip_a_1", "clip_b_2"],
             "referenceClipAssetId": "refclip_5566",
             "referenceAssetIds": ["ref_img_1", "ref_img_2", "ref_img_3"],
+            "referenceAudioAssetIds": ["ref_aud_1", "ref_aud_2"],
             "lastFrameAssetId": "still_4321",
         })),
     );
@@ -668,6 +669,10 @@ fn clip_ids_become_shape_descriptors() {
     assert_eq!(by_kind(INPUT_KIND_SOURCE_CLIP), Some(4));
     assert_eq!(by_kind(INPUT_KIND_REFERENCE_CLIP), Some(1));
     assert_eq!(by_kind(INPUT_KIND_REFERENCE), Some(3));
+    // sc-17160: the audio references get their OWN kind rather than folding into `reference`.
+    // Folded in, a recipient reading "5 reference images" would supply five stills and reproduce
+    // an under-conditioned render, with nothing in the envelope to tell them otherwise.
+    assert_eq!(by_kind(INPUT_KIND_REFERENCE_AUDIO), Some(2));
     // `lastFrameAssetId` is a STILL, so it counts as a source rather than a clip.
     assert_eq!(by_kind(INPUT_KIND_SOURCE), Some(1));
 
@@ -679,6 +684,7 @@ fn clip_ids_become_shape_descriptors() {
         "clip_b_2",
         "refclip_5566",
         "ref_img_1",
+        "ref_aud_1",
         "still_4321",
     ] {
         assert!(

--- a/crates/sceneworks-mcp/src/server.rs
+++ b/crates/sceneworks-mcp/src/server.rs
@@ -275,6 +275,13 @@ pub struct SubmitVideoJobArgs {
     pub source_clip_asset_id: Option<String>,
     #[schemars(description = "RIGHT video clip asset id for bridge mode.")]
     pub bridge_right_clip_asset_id: Option<String>,
+    /// sc-17160. Only models that DECLARE `limits.maxReferenceAudioAssets` accept these; every
+    /// other video model refuses a non-empty list at enqueue, which is why the description says
+    /// so rather than letting the caller discover it from a 400.
+    #[schemars(
+        description = "Audio clip asset ids to condition the render on (up to 3), for a model whose reference modes take audio as well as images. Every other video model rejects a non-empty list."
+    )]
+    pub reference_audio_asset_ids: Option<Vec<String>>,
     #[schemars(description = "Person track id to replace (person_replace mode).")]
     pub person_track_id: Option<String>,
     #[schemars(description = "person_replace scope: \"face_only\" (default) or \"full_body\".")]
@@ -1056,6 +1063,10 @@ pub(crate) fn video_job_body(args: &SubmitVideoJobArgs) -> Result<Value, String>
             args.bridge_right_clip_asset_id.as_ref().map(|v| json!(v)),
         ),
         (
+            "referenceAudioAssetIds",
+            args.reference_audio_asset_ids.as_ref().map(|v| json!(v)),
+        ),
+        (
             "personTrackId",
             args.person_track_id.as_ref().map(|v| json!(v)),
         ),
@@ -1781,6 +1792,34 @@ mod tests {
         assert_eq!(body["personTrackId"], "track_1");
         assert_eq!(body["characterId"], "char_1");
         assert_eq!(body["replacementMode"], "full_body");
+    }
+
+    /// sc-17160: the audio references reach the request body verbatim, and are OMITTED when the
+    /// caller names none rather than being sent as an empty array.
+    ///
+    /// The omission matters: `video_job_body` only inserts keys the caller supplied, and the API's
+    /// DTO defaults an absent `referenceAudioAssetIds` to empty. Sending `[]` unconditionally would
+    /// be indistinguishable in behaviour but would put a key on every MCP video request that names
+    /// no audio, which is not what the other optional fields do.
+    #[test]
+    fn video_job_body_carries_reference_audio_asset_ids() {
+        let args = video_args_from(json!({
+            "projectId": "p1",
+            "prompt": "the subject speaks",
+            "referenceAudioAssetIds": ["asset_voice", "asset_music"]
+        }));
+        let body = video_job_body(&args).expect("body builds");
+        assert_eq!(
+            body["referenceAudioAssetIds"],
+            json!(["asset_voice", "asset_music"])
+        );
+
+        let without = video_args_from(json!({ "projectId": "p1", "prompt": "a storm" }));
+        let body = video_job_body(&without).expect("body builds");
+        assert!(
+            body.get("referenceAudioAssetIds").is_none(),
+            "an unnamed optional field stays off the body: {body}"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/video_jobs/mod.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mod.rs
@@ -21,7 +21,7 @@ use std::f32::consts::PI;
 use std::path::Path;
 
 use sceneworks_core::video_request::{
-    duration_limit_error, fps_limit_error, is_ltx_model, VideoRequest,
+    duration_limit_error, fps_limit_error, is_ltx_model, reference_limit_error, VideoRequest,
 };
 
 // Used only by the video generation metrics builders below, which are themselves
@@ -407,7 +407,76 @@ fn video_preflight(request: &VideoRequest) -> WorkerResult<()> {
     {
         return Err(WorkerError::InvalidPayload(message));
     }
+    // The model's declared reference-media caps (sc-17160). Bounds a THIRD axis the two above do
+    // not touch: how much conditioning media the engine is handed. The API gate is the one that
+    // returns a caller a 400, but it only covers what IT enqueues — a job replayed from a
+    // pre-sc-17160 row, or produced by any future non-HTTP path, reaches the engine through here.
+    //
+    // It matters most for the audio references, whose default cap is 0: an engine handed
+    // `Conditioning::ReferenceAudio` it does not consume renders unconditioned, and an
+    // unconditioned render is invisible in the output rather than an error (epic 1788). Refusing
+    // at the funnel is what keeps "this model takes no audio references" from degrading into
+    // "this model quietly ignored them".
+    if let Some(message) = reference_limit_error(
+        &request.model,
+        request.reference_asset_ids.len(),
+        request.source_clip_asset_ids.len(),
+        request.reference_audio_asset_ids.len(),
+        &request.model_manifest_entry,
+    ) {
+        return Err(WorkerError::InvalidPayload(message));
+    }
     Ok(())
+}
+
+/// Resolve a video request's `referenceAudioAssetIds` (sc-17160) into the engine conditioning:
+/// one [`gen_core::Conditioning::ReferenceAudio`] per id, in submission order.
+///
+/// The audio sibling of [`bernini::resolve_bernini_conditioning`]'s reference-image handling, and
+/// deliberately built on the SAME two primitives the voice-clone reference uses
+/// ([`ltx::resolve_clip_media_path`] + [`crate::audio_jobs::read_wav_pcm16`]) rather than a second
+/// implementation of either.
+///
+/// **The path handling is the load-bearing part.** An asset id is not a filename: the id resolves
+/// through [`ProjectStore::get_asset`] to a PROJECT-RELATIVE `file.path` in the sidecar, which is
+/// then joined under the project root by `safe_project_path`. Reading the id as a bare name — or
+/// joining the sidecar path without the guard — is the sc-4278 / F-MLXW-14 escape, and the
+/// training-preview class of bug where a relative path was assumed absolute. Going through
+/// `resolve_clip_media_path` inherits both the lookup and the guard.
+///
+/// Ungated (compiled in every feature/target config) for the same reason
+/// `resolve_clip_media_path` is: the body depends only on cross-platform helpers, and the
+/// preflight caller below is itself cross-platform.
+pub(crate) fn resolve_reference_audio_conditioning(
+    settings: &Settings,
+    request: &VideoRequest,
+    project_path: &Path,
+) -> WorkerResult<Vec<gen_core::Conditioning>> {
+    request
+        .reference_audio_asset_ids
+        .iter()
+        .map(|asset_id| {
+            let asset_id = asset_id.trim();
+            if asset_id.is_empty() {
+                return Err(WorkerError::InvalidPayload(
+                    "referenceAudioAssetIds must not contain blank ids".to_owned(),
+                ));
+            }
+            let path = ltx::resolve_clip_media_path(
+                settings,
+                &request.project_id,
+                asset_id,
+                project_path,
+            )?;
+            Ok(gen_core::Conditioning::ReferenceAudio {
+                audio: crate::audio_jobs::read_wav_pcm16(&path)?,
+                // No per-reference strength knob today: the request carries one flat list, and
+                // inventing a weight the caller cannot set would be a knob that silently does
+                // nothing. `None` is what the voice-clone reference passes for the same reason.
+                strength: None,
+            })
+        })
+        .collect()
 }
 
 /// Dispatch handler for `JobType::VideoGenerate`: generate, encode, and stream a
@@ -422,6 +491,20 @@ pub(crate) async fn run_video_generate_job(
     let project =
         ProjectStore::new(settings.data_dir.clone(), "worker").get_project(&request.project_id)?;
     let project_path = PathBuf::from(project.path);
+    // Prove the audio references resolve BEFORE the job is marked Running — the same posture as
+    // `resolve_voice_clone_plan`, which resolves its reference up front so a missing or
+    // undecodable clip fails in the first second rather than deep inside a render that has
+    // already cost minutes of GPU time. This runs the whole path: project-scoped asset lookup,
+    // the `safe_project_path` guard, the WAV decode, and the `Conditioning::ReferenceAudio`
+    // construction.
+    //
+    // The vector is discarded here because no engine consumes audio references YET — MiniMax-H3
+    // Ref2VA is the first and its generation arm is sc-17149, which calls this same function and
+    // keeps the value. Until then the resolution's product value is the early, honest refusal;
+    // for every already-shipped model the list is empty (their `limits.maxReferenceAudioAssets`
+    // defaults to 0, so `video_preflight` above has already refused a non-empty one) and this is
+    // a no-op that touches no disk.
+    resolve_reference_audio_conditioning(settings, &request, &project_path)?;
     let plan = VideoPlan::new(&request, &project_path);
     if let Some(parent) = plan.media_path.parent() {
         tokio::fs::create_dir_all(parent).await?;
@@ -1612,6 +1695,11 @@ fn video_asset_fact(
         "fitMode": request.fit_mode,
         "sourceClipAssetIds": request.source_clip_asset_ids,
         "referenceAssetIds": request.reference_asset_ids,
+        // sc-17160: the audio references join the list-valued ids for exactly the sc-12345 reason
+        // — they are a top-level payload field, so the `advanced.clone()` every `*_raw_settings`
+        // builder starts with does not carry them, and a replay that omits them re-runs a
+        // multi-modal reference job with its audio conditioning silently missing.
+        "referenceAudioAssetIds": request.reference_audio_asset_ids,
         "referenceClipAssetId": request.reference_clip_asset_id,
         "characterId": request.character_id,
         "characterLookId": request.character_look_id,

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -439,6 +439,241 @@ fn video_preflight_refuses_a_clip_past_the_models_declared_hard_max_duration() {
     ));
 }
 
+/// sc-17160: the worker's backstop refuses reference media past what the model declares, BEFORE
+/// any weights load — pinned at the seam `run_video_generate_job` actually calls.
+///
+/// Kills the same mutation the two gates above do: deleting the `reference_limit_error` call from
+/// `video_preflight`. Every `sceneworks_core::video_request` test stays green through that — the
+/// function is still correct, it is simply no longer CALLED.
+///
+/// The audio arm is the one that matters most. An engine handed conditioning it does not consume
+/// renders UNCONDITIONED, and an unconditioned render is not an error — it is a plausible-looking
+/// clip that ignored the reference (the epic-1788 class). The API gate covers what it enqueues; a
+/// job replayed from a pre-sc-17160 row, or produced by any future non-HTTP path, reaches the
+/// engine through here.
+#[test]
+fn video_preflight_refuses_reference_media_past_what_the_model_declares() {
+    // An already-shipped model declares none of the four keys, so it keeps 8 / 8 / 0 — and a
+    // single audio reference is refused rather than silently dropped.
+    let legacy_audio = request(json!({
+        "projectId": "p", "model": "bernini", "mode": "reference_to_video", "prompt": "p",
+        "referenceAssetIds": ["ref-1"],
+        "referenceAudioAssetIds": ["voice-1"],
+        "modelManifestEntry": { "limits": {} }
+    }));
+    let Err(WorkerError::InvalidPayload(message)) = video_preflight(&legacy_audio) else {
+        panic!("a model declaring no audio-reference capability must refuse one");
+    };
+    assert!(message.contains("bernini"), "names the model: {message}");
+    assert!(
+        message.contains("takes no audio references"),
+        "says the model takes none: {message}"
+    );
+
+    // The same model still admits its historical 8 images + 8 clips: the cap change moved nothing
+    // for it, which is the regression this half exists to hold.
+    let legacy_at_cap = request(json!({
+        "projectId": "p", "model": "bernini", "mode": "reference_to_video", "prompt": "p",
+        "referenceAssetIds": ["a", "b", "c", "d", "e", "f", "g", "h"],
+        "sourceClipAssetIds": ["1", "2", "3", "4", "5", "6", "7", "8"],
+        "modelManifestEntry": { "limits": {} }
+    }));
+    assert!(
+        video_preflight(&legacy_at_cap).is_ok(),
+        "8 images + 8 clips is exactly what bernini accepted before this story"
+    );
+
+    // A model that DECLARES the Ref2VA surface: 9 + 2 + 1 = 12 admits, 9 + 3 + 3 = 15 does not.
+    let ref2va_limits = json!({
+        "limits": {
+            "maxReferenceAssets": 9,
+            "maxSourceClipAssets": 3,
+            "maxReferenceAudioAssets": 3,
+            "maxCombinedReferenceAssets": 12
+        }
+    });
+    let admitted = request(json!({
+        "projectId": "p", "model": "ref2va_probe", "mode": "reference_to_video", "prompt": "p",
+        "referenceAssetIds": ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+        "sourceClipAssetIds": ["1", "2"],
+        "referenceAudioAssetIds": ["voice-1"],
+        "modelManifestEntry": ref2va_limits
+    }));
+    assert!(
+        video_preflight(&admitted).is_ok(),
+        "9 + 2 + 1 is exactly the declared 12-file budget"
+    );
+
+    let over_budget = request(json!({
+        "projectId": "p", "model": "ref2va_probe", "mode": "reference_to_video", "prompt": "p",
+        "referenceAssetIds": ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+        "sourceClipAssetIds": ["1", "2", "3"],
+        "referenceAudioAssetIds": ["v1", "v2", "v3"],
+        "modelManifestEntry": ref2va_limits
+    }));
+    let Err(WorkerError::InvalidPayload(message)) = video_preflight(&over_budget) else {
+        panic!("15 files against a declared 12 must be refused before the load");
+    };
+    assert!(message.contains("12"), "states the cap: {message}");
+    assert!(message.contains("15"), "states what was asked: {message}");
+
+    // A job carrying no manifest entry at all (the stub lane, an uncatalogued id) keeps the
+    // defaults rather than becoming unconstrained — the audio list is new surface, so "no
+    // declaration" must mean "not supported", not "anything goes".
+    let no_entry = request(json!({
+        "projectId": "p", "model": "stub-model", "mode": "text_to_video", "prompt": "p",
+        "referenceAudioAssetIds": ["voice-1"]
+    }));
+    assert!(
+        video_preflight(&no_entry).is_err(),
+        "an undeclared model must not silently accept audio references"
+    );
+}
+
+/// sc-17160: the audio references resolve through the PROJECT-RELATIVE asset path, not a bare
+/// filename — the trap this story was explicitly warned about.
+///
+/// An asset id is not a path. It resolves through `ProjectStore::get_asset` to a project-relative
+/// `file.path` recorded in the sidecar, which `safe_project_path` then joins under the project
+/// root. This drives the whole chain on a real store with a real WAV on disk, and asserts the
+/// decoded samples come back — a resolver that returned the right count of empty tracks would
+/// pass a shape-only assertion.
+///
+/// The negative arms are the ones that pin the guard: an id that does not exist, and a project
+/// path that is not the asset's own, must both fail loudly rather than resolve to something.
+#[test]
+fn resolve_reference_audio_conditioning_resolves_project_relative_asset_paths() {
+    let data_dir = tempfile::tempdir().expect("temp dir creates");
+    let mut settings = Settings::from_env();
+    settings.data_dir = data_dir.path().to_path_buf();
+    let store = ProjectStore::new(settings.data_dir.clone(), "worker");
+    let project = store.create_project("sc17160").expect("project creates");
+    let project_path = PathBuf::from(&project.path);
+
+    // Two distinct clips, so an implementation that resolved one id and cloned it — or reordered
+    // the list — is caught: the sample counts differ.
+    //
+    // Registered through `persist_generated_asset`, the same entry point the Audio Studio lane
+    // writes its clips with. `import_asset` is the WRONG door here — it accepts image and video
+    // uploads only — and using it would have proved the resolution against an asset shape the
+    // audio references never actually have.
+    let mut asset_ids = Vec::new();
+    for (asset_id, name, samples) in [
+        ("asset_voice", "voice.wav", 4usize),
+        ("asset_music", "music.wav", 6usize),
+    ] {
+        let media_rel = format!("assets/audio/{name}");
+        let media_path = project_path.join(&media_rel);
+        std::fs::create_dir_all(media_path.parent().expect("audio dir"))
+            .expect("audio dir creates");
+        write_wav_pcm16(
+            &AudioTrack {
+                samples: vec![0.25; samples],
+                sample_rate: 32_000,
+                channels: 1,
+            },
+            &media_path,
+        )
+        .expect("wav writes");
+        store
+            .persist_generated_asset(
+                &project.id,
+                "job-sc17160",
+                "genset-sc17160",
+                &json!({
+                    "type": "audio",
+                    "assetId": asset_id,
+                    "mediaPath": media_rel,
+                    "mimeType": "audio/wav",
+                    "displayName": name,
+                    "createdAt": "2026-08-11T00:00:00Z",
+                }),
+            )
+            .expect("audio asset persists");
+        asset_ids.push(asset_id.to_owned());
+    }
+
+    // The recorded media path is PROJECT-RELATIVE — the fact the resolver has to honor. Asserted
+    // here so this test fails on the store's contract changing rather than silently starting to
+    // prove something weaker.
+    let recorded = store
+        .get_asset(&project.id, &asset_ids[0])
+        .expect("asset reads");
+    let rel = recorded["file"]["path"].as_str().expect("media path");
+    assert!(
+        !rel.starts_with('/') && !PathBuf::from(rel).is_absolute(),
+        "the sidecar records a project-relative path, not an absolute one: {rel}"
+    );
+
+    let request = request(json!({
+        "projectId": project.id,
+        "model": "ref2va_probe",
+        "mode": "reference_to_video",
+        "prompt": "p",
+        "referenceAudioAssetIds": asset_ids
+    }));
+    let conditioning = resolve_reference_audio_conditioning(&settings, &request, &project_path)
+        .expect("both references resolve");
+    assert_eq!(conditioning.len(), 2);
+    let lengths: Vec<usize> = conditioning
+        .iter()
+        .map(|item| match item {
+            gen_core::Conditioning::ReferenceAudio { audio, strength } => {
+                assert_eq!(*strength, None, "no per-reference strength knob exists yet");
+                assert_eq!(audio.sample_rate, 32_000);
+                audio.samples.len()
+            }
+            other => panic!("expected ReferenceAudio, got {other:?}"),
+        })
+        .collect();
+    assert_eq!(
+        lengths,
+        vec![4, 6],
+        "each id decodes to ITS OWN clip, in submission order"
+    );
+
+    // An empty request resolves to no conditioning and touches no disk — the shape every
+    // already-shipped video model takes through this call.
+    let bare = noop_request(&project.id);
+    assert!(
+        resolve_reference_audio_conditioning(&settings, &bare, &project_path)
+            .expect("no references resolves cleanly")
+            .is_empty()
+    );
+
+    // An unknown id fails loudly rather than resolving to nothing.
+    let missing = request_with_audio(&project.id, &["not-an-asset"]);
+    assert!(matches!(
+        resolve_reference_audio_conditioning(&settings, &missing, &project_path),
+        Err(WorkerError::InvalidPayload(_))
+    ));
+
+    // ...and so does a real id resolved against a DIFFERENT project root: the project-relative
+    // path only means anything under the project it came from, and `safe_project_path` is what
+    // keeps a sidecar path from reaching outside it (sc-4278 / F-MLXW-14).
+    let elsewhere = tempfile::tempdir().expect("temp dir creates");
+    assert!(matches!(
+        resolve_reference_audio_conditioning(&settings, &request, elsewhere.path()),
+        Err(WorkerError::InvalidPayload(_))
+    ));
+}
+
+/// A [`VideoRequest`] carrying only a project id — the shape every video job that predates
+/// sc-17160 has.
+fn noop_request(project_id: &str) -> VideoRequest {
+    request(json!({
+        "projectId": project_id, "model": "bernini", "mode": "text_to_video", "prompt": "p"
+    }))
+}
+
+/// A [`VideoRequest`] carrying the given audio reference ids.
+fn request_with_audio(project_id: &str, ids: &[&str]) -> VideoRequest {
+    request(json!({
+        "projectId": project_id, "model": "ref2va_probe", "mode": "reference_to_video",
+        "prompt": "p", "referenceAudioAssetIds": ids
+    }))
+}
+
 /// sc-12347: the same backstop on the fps axis — refuses a rate the model does not advertise,
 /// and admits a payload that names no rate at all.
 ///

--- a/docs/workflow-share-envelope.md
+++ b/docs/workflow-share-envelope.md
@@ -522,6 +522,7 @@ times larger.
 | `control` | A pre-made control map, with the conditioning it feeds in `controlMode`. |
 | `sourceClip` | **Video.** A clip the run continues, re-times or bridges from. Separate from `source` because "needs a still to start from" and "needs a clip to continue" are different asks of whoever replays it. |
 | `referenceClip` | **Video.** A reference clip the run conditions on — the moving counterpart of `reference`. |
+| `referenceAudio` | **Video.** A reference audio clip the run conditions on — the audible counterpart of `reference`. |
 
 <!-- END PINNED: input-kinds -->
 
@@ -580,7 +581,7 @@ measurement found a new way to spend what they left.
 | `PROSE_MAX_BYTES` | 16,384 | Each authored prose field, in bytes. | Truncated at a whole character. Prose still means what it said after its tail is cut. |
 | `LABEL_MAX_CHARS` | 200 | Each non-prose label (model slug, style id, LoRA name, producer block), in characters. | **Dropped**, not truncated — a slug's spelling is its identity. |
 | `MAX_SHARE_LORAS` | 5 | Entries in `loras`. | The list is dropped whole and `omitted` gains `loras`. |
-| `MAX_SHARE_INPUTS` | 6 | Entries in `inputs` — one per kind, and the kinds are closed. | The list is dropped whole and `omitted` gains `inputs`. |
+| `MAX_SHARE_INPUTS` | 7 | Entries in `inputs` — one per kind, and the kinds are closed. | The list is dropped whole and `omitted` gains `inputs`. |
 | `MAX_SHARE_PHASES` | 8 | Entries in `advanced.phases`. | The key is dropped and `omitted` gains `advanced.phases`. |
 | `MAX_SHARE_POSES` | 64 | Entries in `advanced.poses`. | The key is dropped and `omitted` gains `advanced.poses`. |
 | `MAX_SHARE_POSE_SLOTS` | 6,144 | Coordinate slots across the whole `advanced.poses` array — a number, or a `null` standing in for one. | The key is dropped and `omitted` gains `advanced.poses`. |

--- a/packages/schemas/model-manifest.schema.json
+++ b/packages/schemas/model-manifest.schema.json
@@ -683,6 +683,34 @@
                 "x-sceneworks-readers": [{ "path": "apps/web/src/screens/VideoStudio.jsx", "anchor": "selectedModel.limits.recommendedMaxDuration" }],
                 "description": "Non-blocking UI recommendation; intentionally not enforced."
               },
+              "maxReferenceAssets": {
+                "type": "integer", "minimum": 0,
+                "x-sceneworks-contract": "binding",
+                "x-sceneworks-allow-undeclared": true,
+                "x-sceneworks-readers": [{ "path": "crates/sceneworks-core/src/video_request.rs", "anchor": "pub fn reference_caps(" }, { "path": "apps/rust-api/src/generation.rs", "anchor": "if let Some(message) = reference_limit_error(" }, { "path": "crates/sceneworks-worker/src/video_jobs/mod.rs", "anchor": "if let Some(message) = reference_limit_error(" }],
+                "description": "Maximum still-image references (`referenceAssetIds`) this model conditions on; API and worker reject an over-cap request rather than dropping the extras. ABSENT MEANS 8, the ceiling every video family shipped before sc-17160 enforced, so an undeclared model is byte-for-byte unchanged. Declared only by a family whose real cap differs (MiniMax-H3 Ref2VA takes 9) — no builtin model needs it yet; sc-17158 is the first."
+              },
+              "maxSourceClipAssets": {
+                "type": "integer", "minimum": 0,
+                "x-sceneworks-contract": "binding",
+                "x-sceneworks-allow-undeclared": true,
+                "x-sceneworks-readers": [{ "path": "crates/sceneworks-core/src/video_request.rs", "anchor": "pub fn reference_caps(" }, { "path": "apps/rust-api/src/generation.rs", "anchor": "if let Some(message) = reference_limit_error(" }, { "path": "crates/sceneworks-worker/src/video_jobs/mod.rs", "anchor": "if let Some(message) = reference_limit_error(" }],
+                "description": "Maximum source/reference video clips (`sourceClipAssetIds`) this model conditions on. ABSENT MEANS 8, the pre-sc-17160 ceiling. Declared by a family whose real cap differs (MiniMax-H3 Ref2VA takes 3) — no builtin model needs it yet; sc-17158 is the first."
+              },
+              "maxReferenceAudioAssets": {
+                "type": "integer", "minimum": 0,
+                "x-sceneworks-contract": "binding",
+                "x-sceneworks-allow-undeclared": true,
+                "x-sceneworks-readers": [{ "path": "crates/sceneworks-core/src/video_request.rs", "anchor": "pub fn reference_caps(" }, { "path": "apps/rust-api/src/generation.rs", "anchor": "if let Some(message) = reference_limit_error(" }, { "path": "crates/sceneworks-worker/src/video_jobs/mod.rs", "anchor": "if let Some(message) = reference_limit_error(" }],
+                "description": "Maximum AUDIO references (`referenceAudioAssetIds`, sc-17160) this model conditions on. ABSENT MEANS 0 — unlike the two caps above, the default is a refusal, because the payload field is newer than every shipped video family and an engine handed conditioning it cannot consume renders unconditioned, which is invisible in the output. A model must declare that it takes audio references before one can reach it. No builtin model needs it yet; sc-17158 is the first."
+              },
+              "maxCombinedReferenceAssets": {
+                "type": "integer", "minimum": 0,
+                "x-sceneworks-contract": "binding",
+                "x-sceneworks-allow-undeclared": true,
+                "x-sceneworks-readers": [{ "path": "crates/sceneworks-core/src/video_request.rs", "anchor": "pub fn reference_caps(" }, { "path": "apps/rust-api/src/generation.rs", "anchor": "if let Some(message) = reference_limit_error(" }, { "path": "crates/sceneworks-worker/src/video_jobs/mod.rs", "anchor": "if let Some(message) = reference_limit_error(" }],
+                "description": "Maximum reference FILES in total across `referenceAssetIds` + `sourceClipAssetIds` + `referenceAudioAssetIds` (sc-17160). NOT derivable from the three per-list caps — MiniMax-H3 Ref2VA takes 9 + 3 + 3 per list but only 12 files together — which is why it is its own key: it is the only cap that can refuse a request in which every individual list fits. ABSENT MEANS NO COMBINED CEILING, so an undeclared model is unchanged. No builtin model needs it yet; sc-17158 is the first."
+              },
               "samplers": {
                 "type": "array",
                 "minItems": 1,

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -2672,6 +2672,7 @@
       "prompt": "hero walks through rain",
       "quality": "balanced",
       "referenceAssetIds": [],
+      "referenceAudioAssetIds": [],
       "referenceClipAssetId": null,
       "replacementMode": "face_only",
       "seed": null,


### PR DESCRIPTION
Closes sc-17160 (epic sc-17137).

## What

Adds `referenceAudioAssetIds` to the video job payload — genuinely new API surface — and moves reference-media caps off three global constants and onto per-model manifest declarations.

## End to end

| Layer | Where |
| --- | --- |
| DTO | `apps/rust-api/src/dto.rs` — `VideoJobRequest::reference_audio_asset_ids`, serialized unconditionally like the two existing id lists |
| Blanket validation | `apps/rust-api/src/lib.rs` — blank rejection + `MAX_VIDEO_REFERENCE_AUDIO_ASSET_IDS = 3`, in the same order and wording as the image/clip lists |
| Binding per-model gate | `apps/rust-api/src/generation.rs` — `reference_limit_error` against the resolved manifest entry |
| Job payload → request | `crates/sceneworks-core/src/video_request.rs` — `VideoRequest::reference_audio_asset_ids` |
| Worker backstop | `crates/sceneworks-worker/src/video_jobs/mod.rs` — `video_preflight` mirrors the same gate |
| Worker → engine | `resolve_reference_audio_conditioning` → one `gen_core::Conditioning::ReferenceAudio` per id |

`run_video_generate_job` resolves the references **before** the job is marked Running, so a missing or undecodable clip fails in the first second rather than deep inside a render. The returned vector is discarded until an engine consumes it — MiniMax-H3 Ref2VA is the first, and its arm is sc-17149, which calls the same function and keeps the value.

**Project-relative path handling** (the trap this story was warned about) is inherited rather than reimplemented: resolution goes through `ltx::resolve_clip_media_path`, the same primitive the voice-clone reference uses, so an asset id resolves via `ProjectStore::get_asset` to a project-relative `file.path` and then through `safe_project_path`. Never a bare filename, and a poisoned sidecar cannot escape the project (sc-4278 / F-MLXW-14).

## Caps: per-model, not a global bump

Four new `limits` keys (`packages/schemas/model-manifest.schema.json`), resolved by `reference_caps` and enforced by `reference_limit_error` — the same shape as `duration_limit_error` / `fps_limit_error`:

| key | default when undeclared |
| --- | --- |
| `maxReferenceAssets` | 8 |
| `maxSourceClipAssets` | 8 |
| `maxReferenceAudioAssets` | **0** |
| `maxCombinedReferenceAssets` | no combined ceiling |

Raising the API's image blanket 8 → 9 for H3 therefore hands **no** other model a 9th reference — bernini still refuses it, one layer down. The audio default of 0 is deliberate: an engine handed conditioning it cannot consume renders unconditioned, which is invisible in the output rather than an error, so a model must *declare* audio references before one can reach it.

**There is deliberately no combined blanket.** 12 is H3's number, not a product-wide truth: today's per-list caps admit 8 images AND 8 clips on one request, so a blanket 12 would have refused a 16-file shape the route accepts right now. `existing_video_models_keep_their_pre_sc_17160_reference_budget` holds that line with an ACCEPT assertion — every rejecting test would still pass with the regression in place.

## Also carried

- Recipe replay: `video_asset_fact`, `normalizedSettings`, and lineage parents, so a re-run cannot silently drop the audio conditioning (the sc-12345 class).
- MCP `submit_video_job` argument + body mapping.
- Video Studio submit body and replay hydration. The picker control is sc-17161's.
- A `referenceAudio` workflow-share input kind, so a shared multi-modal recipe reports the audio it needs instead of describing only its stills.

## Out of scope (per the epic's slicing)

Ref2VA engine behaviour (sc-17149), mode reachability across the six surfaces (sc-17159), the Video Studio picker (sc-17161), and H3's own manifest entry declaring these four keys (sc-17158). No builtin model declares them yet, hence `x-sceneworks-allow-undeclared` on all four.

## Gates

| gate | result |
| --- | --- |
| `cargo test` (core / worker / rust-api / mcp) | green — 565 rust-api, 868 core lib, worker + mcp suites |
| `cargo clippy --all-targets -- -D warnings` (macOS) | exit 0 |
| `npm run rust:check:neither` (the `parity` lane) | exit 0 |
| `npm run rust:check:candle` | exit 0 |
| `cargo fmt --all -- --check` | clean |
| `npm run check` | exit 0, 408 node tests |
| `python -m pytest -m "not e2e and not parity"` | 95 passed (incl. the manifest contract audit) |
| `python -m pytest -m parity` | 14 passed after snapshot regen |
| web `npm run test` / `npm run lint` | 3598 passed / exit 0 |

API contract snapshots regenerated with `UPDATE_SNAPSHOTS=1`; the diff is a single line — the new `referenceAudioAssetIds: []` payload key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)