### PR TITLE
ci(candle): make CUDA weight provisioning independent of the compile chain (sc-18691)

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -334,87 +334,48 @@ jobs:
     timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && inputs.provision_snapshot && 240 || github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && 120 || 45 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # sc-13166: point this lane at the REAL rustup toolchain bin and prepend it to
-      # PATH, so cargo/rustc/clippy never dispatch through the fragile
-      # %USERPROFILE%\.cargo\bin proxies (0-byte symlinks -> rustup.exe that go dangling
-      # when rustup self-updates or its rustup.exe is deleted, or that fail to launch as
-      # symlinks in the runner's Windows-service context — both surface as the cryptic
-      # Windows ERROR_NO_ASSOCIATION at `cargo fetch` and turned every PR red, forcing
-      # admin-override merges). The action fails loudly with an actionable message if no
-      # usable toolchain is installed. See .github/actions/prepare-rust-runner.
-      - uses: ./.github/actions/prepare-rust-runner
-      # The shared runner exports RUSTC_WRAPPER=sccache. The prep action correctly clears a
-      # missing wrapper, but an installed daemon can still reset its local connection mid-build
-      # (Windows os error 10054), observed independently in both the backend-candle test and the
-      # sidecar check. This is the repository's heaviest Rust/CUDA lane, so make rustc direct and
-      # deterministic for this job only. Cargo registry/git/target caches remain intact; sibling
-      # workflows may continue using sccache.
-      - name: Disable unstable sccache wrapper for the heavy Candle lane
-        shell: powershell
-        run: |
-          Add-Content -Path $env:GITHUB_ENV -Value 'RUSTC_WRAPPER='
-          Remove-Item Env:RUSTC_WRAPPER -ErrorAction SilentlyContinue
-      # Multiple runner services share %USERPROFILE%\.cargo. A sibling job can replace
-      # that global git checkout while rustc is still reading vendored inference sources,
-      # which surfaces as an unrelated missing-path/os-error-267 failure. Keep dependency
-      # state job-local; the verified toolchain remains on PATH from the step above.
-      - name: Isolate Cargo dependency checkout
-        shell: powershell
-        run: |
-          $jobCargoHome = Join-Path $env:RUNNER_TEMP 'cargo-home'
-          New-Item -ItemType Directory -Force -Path $jobCargoHome | Out-Null
-          Add-Content -Path $env:GITHUB_ENV -Value "CARGO_HOME=$jobCargoHome"
-      - name: Fetch the pinned inference release
-        env:
-          CARGO_NET_OFFLINE: "false"
-        run: cargo fetch --locked
-      # No rust-toolchain action: the self-hosted box has rustup + the repo's
-      # `rust-toolchain.toml`-pinned toolchain (incl. clippy) pre-installed, and the
-      # action's bash step breaks here — `bash` resolves to the box's WSL stub, not
-      # Git Bash. cargo in-repo auto-selects the pinned toolchain.
-      # nvcc needs the MSVC 14.44 host compiler (NOT VS2026 14.51, which CUDA 12.9
-      # rejects). Load the BuildTools vcvars in-shell, then build+test in the same
-      # cmd invocation so the toolchain env survives (each step is a fresh shell).
-      - name: Test the candle GPU worker (backend-candle)
-        shell: cmd
-        run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          set NVCC_CCBIN=%VCToolsInstallDir%bin\Hostx64\x64
-          cargo test -p sceneworks-worker --features backend-candle
-      # PR guard for the desktop candle SIDECAR the hosted lane no longer builds on
-      # PRs (see header). `cargo check` runs the build scripts (incl. the nvcc kernel
-      # compile) and typechecks the full graph, so a candle sidecar build break is
-      # caught on the PR — cheap here on the warm, CUDA-equipped box.
+      # PROVISIONING RUNS BEFORE ANY CARGO INVOCATION (sc-18691). It used to sit BELOW the three
+      # compile steps with no guard, so an unrelated build break made landing weights on this box
+      # impossible rather than merely slow -- the fetch was never reached. That is not hypothetical
+      # for this epic: sc-17149 must provision `transformer_ref` (+66.28 GB, taking the resident set
+      # from 144.051 GB to 210.332 GB) onto this exact runner, and a red candle lane at that moment
+      # would block it for reasons that have nothing to do with the weights.
       #
-      # NB: `embed-web` is intentionally OMITTED. It embeds apps/web/dist via
-      # rust-embed (with `debug-embed`, so it embeds at compile time even under
-      # `cargo check`), which requires a built web bundle — this lane never runs a
-      # web build, so including it fails with "no `get` on WebAssets". embed-web is
-      # orthogonal to candle (static-serving glue) and is compiled on the push:main /
-      # release.yml package builds, where web/dist exists. (Release-only codegen/link
-      # breaks also still surface first in those builds.)
-      - name: Check the candle sidecar builds (rust-api, backend-candle)
-        shell: cmd
-        run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          set NVCC_CCBIN=%VCToolsInstallDir%bin\Hostx64\x64
-          cargo check -p sceneworks-rust-api --features backend-candle
-      # PR guard for the Candle memory-calibration adapter binary (epic 15448). Like the
-      # candle-gated worker code it is invisible to every other lane: `src/bin/candle.rs` is
-      # `compile_error!` on macOS, macos-mlx.yml builds only `--bin memory-mlx-adapter`, and the
-      # Linux candle lane is workflow_dispatch-only. Before this step a break in it stayed hidden
-      # until someone ran Candle calibration on a CUDA host — which is exactly where this epic's
-      # downstream Candle stories start (sc-15804 review: an exhaustive
-      # `MemoryStrategyParameters` literal here went stale against the inference contract with
-      # nothing to catch it). Keep both the production typecheck and the binary's CUDA-only unit
-      # tests here: the batching contamination guard cannot be compiled or exercised on macOS.
-      - name: Check and test the candle memory adapter (memory-candle-adapter)
-        shell: cmd
-        run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
-          set NVCC_CCBIN=%VCToolsInstallDir%bin\Hostx64\x64
-          cargo check -p sceneworks-memory-adapter --features candle --bin memory-candle-adapter
-          cargo test -p sceneworks-memory-adapter --features candle --bin memory-candle-adapter
+      # TWO changes make provisioning independent, and BOTH are load-bearing:
+      #   1. ORDER. This whole block moved above `Fetch the pinned inference release` -- above even
+      #      `prepare-rust-runner`, which fails loudly on a broken rustup, because a weights fetch
+      #      has no business depending on toolchain discovery either. Every step below needs only
+      #      the checkout and the box's Python.
+      #   2. SKIP. A weights-only dispatch (`provision_snapshot` without `run_five_rung_reference`)
+      #      now skips the compile chain entirely -- see the guard on `Fetch the pinned inference
+      #      release` below. Order ALONE would still drag a provision-only run red on an unrelated
+      #      break, and still burn the ~24m of box time this lane costs, which is the scarce
+      #      resource the whole story is about.
+      #
+      # WHAT DID NOT CHANGE, deliberately: there is no `continue-on-error`, no `if: always()` and no
+      # swallowed exit code anywhere in this block. sc-18677's whole point was that provisioning
+      # fails LOUDLY, and decoupling must not turn a genuine provisioning failure into a silent
+      # skip. Every `throw` below is still fatal, and platform-review-contracts.test.mjs COUNTS them
+      # per step, so a `throw` -> `Write-Warning` downgrade goes red instead of passing with the
+      # message string still present.
+      #
+      # Consequence worth knowing: a five-rung dispatch whose provisioning fails no longer runs the
+      # compile steps at all, since they are now downstream. That loses nothing -- those steps are
+      # PR/push guards, and a five-rung dispatch that cannot resolve its snapshot produces no
+      # capture either way.
+      #
+      # PYTHON HOSTING DECISION (sc-18691). The `huggingface_hub` body below stays inline Python on
+      # this lane, deliberately, and this comment is the record. Epic 3482 is Done and was
+      # macOS-runtime-scoped, so it gives this no home. Both alternatives are worse HERE
+      # specifically: a Rust downloader would have to be produced by the very compile chain this
+      # story just decoupled provisioning from, which reintroduces the coupling under a new name,
+      # and a vendored .py file still needs the same interpreter while moving the logic away from
+      # the step that owns it. `huggingface_hub` is also the reference implementation of the
+      # `models--<owner>--<name>\snapshots\<rev>` cache layout the resolve step asserts against, so
+      # replacing it means reimplementing the thing the proof is written in terms of. It is pinned
+      # exactly (`huggingface_hub==0.36.0`), anonymous (`token=False`), and its exit code is checked
+      # -- which is the whole of what a hosted implementation would buy. Revisit if a SECOND lane
+      # ever needs the same fetch; at that point a composite action is the move, not a rewrite.
       # Two independent validations, in one step because both are pure input checks.
       #
       # (1) PROVISIONING. `provision_snapshot` no longer requires `run_five_rung_reference`
@@ -709,6 +670,105 @@ jobs:
           if ($isKrea) {
             "SCENEWORKS_KREA_ROOT=$root" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           }
+      # sc-13166: point this lane at the REAL rustup toolchain bin and prepend it to
+      # PATH, so cargo/rustc/clippy never dispatch through the fragile
+      # %USERPROFILE%\.cargo\bin proxies (0-byte symlinks -> rustup.exe that go dangling
+      # when rustup self-updates or its rustup.exe is deleted, or that fail to launch as
+      # symlinks in the runner's Windows-service context — both surface as the cryptic
+      # Windows ERROR_NO_ASSOCIATION at `cargo fetch` and turned every PR red, forcing
+      # admin-override merges). The action fails loudly with an actionable message if no
+      # usable toolchain is installed. See .github/actions/prepare-rust-runner.
+      - uses: ./.github/actions/prepare-rust-runner
+      # The shared runner exports RUSTC_WRAPPER=sccache. The prep action correctly clears a
+      # missing wrapper, but an installed daemon can still reset its local connection mid-build
+      # (Windows os error 10054), observed independently in both the backend-candle test and the
+      # sidecar check. This is the repository's heaviest Rust/CUDA lane, so make rustc direct and
+      # deterministic for this job only. Cargo registry/git/target caches remain intact; sibling
+      # workflows may continue using sccache.
+      - name: Disable unstable sccache wrapper for the heavy Candle lane
+        shell: powershell
+        run: |
+          Add-Content -Path $env:GITHUB_ENV -Value 'RUSTC_WRAPPER='
+          Remove-Item Env:RUSTC_WRAPPER -ErrorAction SilentlyContinue
+      # Multiple runner services share %USERPROFILE%\.cargo. A sibling job can replace
+      # that global git checkout while rustc is still reading vendored inference sources,
+      # which surfaces as an unrelated missing-path/os-error-267 failure. Keep dependency
+      # state job-local; the verified toolchain remains on PATH from the step above.
+      - name: Isolate Cargo dependency checkout
+        shell: powershell
+        run: |
+          $jobCargoHome = Join-Path $env:RUNNER_TEMP 'cargo-home'
+          New-Item -ItemType Directory -Force -Path $jobCargoHome | Out-Null
+          Add-Content -Path $env:GITHUB_ENV -Value "CARGO_HOME=$jobCargoHome"
+      # THE COMPILE CHAIN, skipped for a weights-only dispatch (sc-18691). The condition names
+      # exactly one dispatch shape -- `provision_snapshot` true AND `run_five_rung_reference` false
+      # -- and excludes only that. Everything else is untouched: PR and push runs (`github.event_name`
+      # is not `workflow_dispatch`, so the inner conjunction is false), a plain no-input dispatch, and
+      # EVERY five-rung dispatch, which still runs this entire chain exactly as it did before.
+      #
+      # This is a SKIP, not a swallow. A skipped step cannot mask a failure the way
+      # `continue-on-error` can, so a weights-only dispatch's conclusion is decided solely by the
+      # provisioning steps above -- each of which still throws.
+      #
+      # The expression is repeated verbatim on each guarded step rather than hoisted into a job-level
+      # env, because platform-review-contracts.test.mjs asserts it PER STEP with `stepBody()`, and
+      # byte-identical neighbours are precisely why that scoping exists: sc-18677's third review
+      # round found three narrowing mutations green against a file-wide `assert.match`.
+      - name: Fetch the pinned inference release
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.provision_snapshot && !inputs.run_five_rung_reference) }}
+        env:
+          CARGO_NET_OFFLINE: "false"
+        run: cargo fetch --locked
+      # No rust-toolchain action: the self-hosted box has rustup + the repo's
+      # `rust-toolchain.toml`-pinned toolchain (incl. clippy) pre-installed, and the
+      # action's bash step breaks here — `bash` resolves to the box's WSL stub, not
+      # Git Bash. cargo in-repo auto-selects the pinned toolchain.
+      # nvcc needs the MSVC 14.44 host compiler (NOT VS2026 14.51, which CUDA 12.9
+      # rejects). Load the BuildTools vcvars in-shell, then build+test in the same
+      # cmd invocation so the toolchain env survives (each step is a fresh shell).
+      - name: Test the candle GPU worker (backend-candle)
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.provision_snapshot && !inputs.run_five_rung_reference) }}
+        shell: cmd
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          set NVCC_CCBIN=%VCToolsInstallDir%bin\Hostx64\x64
+          cargo test -p sceneworks-worker --features backend-candle
+      # PR guard for the desktop candle SIDECAR the hosted lane no longer builds on
+      # PRs (see header). `cargo check` runs the build scripts (incl. the nvcc kernel
+      # compile) and typechecks the full graph, so a candle sidecar build break is
+      # caught on the PR — cheap here on the warm, CUDA-equipped box.
+      #
+      # NB: `embed-web` is intentionally OMITTED. It embeds apps/web/dist via
+      # rust-embed (with `debug-embed`, so it embeds at compile time even under
+      # `cargo check`), which requires a built web bundle — this lane never runs a
+      # web build, so including it fails with "no `get` on WebAssets". embed-web is
+      # orthogonal to candle (static-serving glue) and is compiled on the push:main /
+      # release.yml package builds, where web/dist exists. (Release-only codegen/link
+      # breaks also still surface first in those builds.)
+      - name: Check the candle sidecar builds (rust-api, backend-candle)
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.provision_snapshot && !inputs.run_five_rung_reference) }}
+        shell: cmd
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          set NVCC_CCBIN=%VCToolsInstallDir%bin\Hostx64\x64
+          cargo check -p sceneworks-rust-api --features backend-candle
+      # PR guard for the Candle memory-calibration adapter binary (epic 15448). Like the
+      # candle-gated worker code it is invisible to every other lane: `src/bin/candle.rs` is
+      # `compile_error!` on macOS, macos-mlx.yml builds only `--bin memory-mlx-adapter`, and the
+      # Linux candle lane is workflow_dispatch-only. Before this step a break in it stayed hidden
+      # until someone ran Candle calibration on a CUDA host — which is exactly where this epic's
+      # downstream Candle stories start (sc-15804 review: an exhaustive
+      # `MemoryStrategyParameters` literal here went stale against the inference contract with
+      # nothing to catch it). Keep both the production typecheck and the binary's CUDA-only unit
+      # tests here: the batching contamination guard cannot be compiled or exercised on macOS.
+      - name: Check and test the candle memory adapter (memory-candle-adapter)
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.provision_snapshot && !inputs.run_five_rung_reference) }}
+        shell: cmd
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          set NVCC_CCBIN=%VCToolsInstallDir%bin\Hostx64\x64
+          cargo check -p sceneworks-memory-adapter --features candle --bin memory-candle-adapter
+          cargo test -p sceneworks-memory-adapter --features candle --bin memory-candle-adapter
       - name: Check out the exact inference reference source
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -748,6 +808,7 @@ jobs:
             ${{ runner.temp }}/sc-16059-candle-reuse-comparison.json
           if-no-files-found: error
       - name: Clippy (candle worker)
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.provision_snapshot && !inputs.run_five_rung_reference) }}
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
@@ -807,6 +868,7 @@ jobs:
       # at every pin bump with nothing red). Checking it on both lanes is what turns that argument
       # into a measurement, and it costs nothing either side: the same dumper run already writes it.
       - name: Verify capabilities.candle.json is a real dump, not a restamp
+        if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.provision_snapshot && !inputs.run_five_rung_reference) }}
         shell: cmd
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat" || exit /b 1

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -518,6 +518,204 @@ test("windows-candle validates every provisioning input that reaches a path", as
   assert.match(workflow, /\$env:PROVISION_CACHE_DIR_INPUT -notmatch '\^\[A-Za-z\]:\\\\'/);
 });
 
+// sc-18691: provisioning must be INDEPENDENT of the compile chain. It used to sit BELOW
+// `cargo test -p sceneworks-worker --features backend-candle` with no guard, so an unrelated build
+// break made landing weights on the CUDA box impossible rather than merely slow -- the fetch was
+// never reached. Epic 17137 hits that concretely at sc-17149, which must land `transformer_ref`
+// (+66.28 GB) onto a box whose resident set is already 144.051 GB.
+//
+// TWO properties, pinned by two separate tests because either alone is insufficient. ORDER without
+// SKIP still drags a weights-only run red on an unrelated break and still burns the lane's ~24m of
+// box time; SKIP without ORDER leaves a five-rung dispatch's provisioning downstream of the compile
+// chain. Both are DERIVED from the workflow's own cargo invocations rather than from a hand-written
+// step order, so a NEW compile step added above provisioning, or added unguarded, goes red.
+
+const PROVISIONING_STEPS = [
+  "Validate dispatch inputs",
+  "Resolve snapshot provisioning parameters",
+  "Validate runner Python for snapshot provisioning",
+  "Provision exact snapshot",
+  "Resolve exact snapshot",
+];
+
+const COMPILE_CHAIN_STEPS = [
+  "Fetch the pinned inference release",
+  "Test the candle GPU worker (backend-candle)",
+  "Check the candle sidecar builds (rust-api, backend-candle)",
+  "Check and test the candle memory adapter (memory-candle-adapter)",
+  "Clippy (candle worker)",
+  "Verify capabilities.candle.json is a real dump, not a restamp",
+];
+
+// The ORDERED view of the job's steps. `stepBody()` above finds one step by name; this keeps
+// position, and keeps the `uses:`-only steps (checkout, prepare-rust-runner) that have no name at
+// all and so are invisible to `stepBody`.
+function jobSteps(workflow) {
+  const start = workflow.indexOf("\n    steps:\n");
+  assert.ok(start >= 0, "windows-candle.yml must keep a steps: block");
+  const body = workflow.slice(start);
+  const steps = [];
+  const marker = "\n      - ";
+  for (let at = body.indexOf(marker); at !== -1; ) {
+    const next = body.indexOf(marker, at + 1);
+    const chunk = body.slice(at, next === -1 ? undefined : next);
+    const named = chunk.match(/^\n      - name: (.*)$/m);
+    const used = chunk.match(/^\n      - uses: (.*)$/m);
+    steps.push({
+      name: named ? named[1] : `uses:${used ? used[1].trim() : "?"}`,
+      body: chunk,
+      // A cargo COMMAND, line-initial, so an `echo`ed fix-it message that merely QUOTES
+      // `cargo run -p sceneworks-worker` (the restamp step has one) counts as the prose it is.
+      cargo: chunk.split("\n").some((line) => /^\s+(run: )?cargo\s/.test(line)),
+    });
+    at = next;
+  }
+  return steps;
+}
+
+// A step's body with comment lines removed. Both YAML and PowerShell comment with a leading `#`,
+// and the counts below must not be movable by editing prose -- in either direction. This file's own
+// header comments narrate `throw` and `continue-on-error` as history.
+function stepCode(workflow, name) {
+  return stepBody(workflow, name)
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+}
+
+test("windows-candle provisions before it compiles anything", async () => {
+  const workflow = await source(".github/workflows/windows-candle.yml");
+  const steps = jobSteps(workflow);
+  const indexOf = (name) => {
+    const at = steps.findIndex((step) => step.name === name);
+    assert.ok(at >= 0, `windows-candle.yml must keep a step named ${name}`);
+    return at;
+  };
+
+  const compiling = steps.map((step, at) => (step.cargo ? at : -1)).filter((at) => at >= 0);
+  // Anti-vacuity. If the derivation stops recognising cargo steps, "provisioning comes first" is
+  // trivially true and this whole test means nothing -- which is precisely how the sibling audit at
+  // the bottom of this file silently emptied itself when sc-18691 changed a guard's polarity.
+  assert.ok(
+    compiling.length >= COMPILE_CHAIN_STEPS.length,
+    `expected at least ${COMPILE_CHAIN_STEPS.length} cargo steps, derived ${compiling.length}`,
+  );
+  for (const name of COMPILE_CHAIN_STEPS) {
+    assert.ok(steps[indexOf(name)].cargo, `${name} must still be a cargo invocation`);
+  }
+
+  const firstCompile = Math.min(...compiling);
+  for (const name of PROVISIONING_STEPS) {
+    assert.ok(
+      indexOf(name) < firstCompile,
+      `${name} must run before the first cargo step (${steps[firstCompile].name}); a build ` +
+        "break must not be able to starve a weights dispatch",
+    );
+  }
+  // Stronger than "ahead of the compile chain": ahead of the Rust setup too. prepare-rust-runner
+  // fails loudly on a broken rustup, and a weights fetch has no business depending on toolchain
+  // discovery -- it needs the checkout and the box's Python, nothing else.
+  for (const name of PROVISIONING_STEPS) {
+    assert.ok(
+      indexOf(name) < indexOf("uses:./.github/actions/prepare-rust-runner"),
+      `${name} must not depend on toolchain discovery either`,
+    );
+  }
+  // ...but still after the checkout, which every one of them reads (INFERENCE_PIN lives in the
+  // worktree, and an unchecked-out repo has no workflow to run).
+  assert.ok(
+    steps[0].name.startsWith("uses:actions/checkout@"),
+    "the checkout must remain the job's first step",
+  );
+});
+
+test("a weights-only dispatch skips the entire compile chain, pinned per step", async () => {
+  const workflow = await source(".github/workflows/windows-candle.yml");
+
+  // The WHOLE expression. A weights-only dispatch is `provision_snapshot` true AND
+  // `run_five_rung_reference` false; every other shape must still compile. Half of this is not a
+  // weaker version of it -- dropping `&& !inputs.run_five_rung_reference` would strip the compile
+  // chain off Krea's five-rung capture too, which this story's scope guard forbids, and dropping
+  // `github.event_name == 'workflow_dispatch'` would strip it off every PR and push.
+  const skip =
+    /^        if: \$\{\{ !\(github\.event_name == 'workflow_dispatch' && inputs\.provision_snapshot && !inputs\.run_five_rung_reference\) \}\}$/m;
+
+  // SCOPED PER STEP. The expression is byte-identical on all six steps, so one file-wide
+  // `assert.match` is satisfied by any single survivor and a narrowing mutation on the other five
+  // stays green. That is not hypothetical -- it is trap 1 from sc-18677's third review round, which
+  // found three such mutations green against this same file.
+  for (const name of COMPILE_CHAIN_STEPS) {
+    assert.match(stepBody(workflow, name), skip, `${name} must carry the weights-only skip guard`);
+  }
+
+  // Derived backstop, so a NEW compile step cannot appear without a decision: every cargo step is
+  // either skipped for a weights-only dispatch, or gated on the five-rung capture -- which is not a
+  // weights-only dispatch and legitimately compiles its adapter.
+  for (const step of jobSteps(workflow).filter((candidate) => candidate.cargo)) {
+    assert.ok(
+      skip.test(step.body) || /if: \$\{\{[^\n]*inputs\.run_five_rung_reference/.test(step.body),
+      `${step.name} would compile on a weights-only dispatch; guard it or gate it`,
+    );
+  }
+});
+
+// sc-18691 AC2. Decoupling must not turn a genuine provisioning failure into a silent skip. With
+// the compile chain skipped, these five steps ARE the entire verdict of a weights-only dispatch, so
+// every failure mode they carry has to stay fatal.
+//
+// PIN THE THROW, NOT THE MESSAGE -- trap 2 from sc-18677's third review round, and it is live in
+// this file right now: "Windows Krea provisioning accepts supported newer Python 3 runtimes" above
+// asserts the string `Python 3.12 or newer`, which survives a `throw` -> `Write-Warning` downgrade
+// completely intact. Counting `throw`s is what makes a downgrade red, and the count is taken PER
+// STEP because a file-wide count is satisfied by adding a throw anywhere else.
+test("every failure mode a weights-only dispatch can hit is still fatal", async () => {
+  const workflow = await source(".github/workflows/windows-candle.yml");
+
+  const throwCounts = {
+    // repo-id shape, revision shape, empty allow-list, rooted pattern, the two containment guards
+    // (segment shape + canonical probe), subdir shape, subdir traversal, cache-dir newline,
+    // cache-dir absoluteness, and the three five-rung guards (inference_revision shape, the fixed
+    // Krea repository, INFERENCE_PIN agreement).
+    "Validate dispatch inputs": 13,
+    // Pure derivation: it writes GITHUB_ENV and throws nothing.
+    "Resolve snapshot provisioning parameters": 0,
+    // A non-zero `python --version`, and a minor version below 12.
+    "Validate runner Python for snapshot provisioning": 2,
+    // pip install, and the heredoc'd snapshot_download -- `@'...'@ | python -` does not propagate
+    // its exit code, so the explicit $LASTEXITCODE check is the only thing that fails the step.
+    "Provision exact snapshot": 2,
+    // Absent snapshot, canonical-suffix mismatch, escaping component, missing components. The
+    // suffix one is the dangerous downgrade: warned rather than thrown, a snapshot that does NOT
+    // match the requested repo+revision is exported as SCENEWORKS_PROVISIONED_ROOT and a per-tier
+    // VRAM measurement silently runs against the wrong weights.
+    "Resolve exact snapshot": 4,
+  };
+  for (const [name, expected] of Object.entries(throwCounts)) {
+    assert.equal(
+      (stepCode(workflow, name).match(/\bthrow /g) || []).length,
+      expected,
+      `${name} must keep exactly ${expected} fatal throw(s); a throw -> Write-Warning downgrade ` +
+        "leaves every message assertion in this file green",
+    );
+  }
+  // The Python body guards itself with a `raise`, which the count above cannot see.
+  assert.match(
+    stepCode(workflow, "Provision exact snapshot"),
+    /raise SystemExit\("provision_patterns resolved to an empty allow-list"\)/,
+  );
+
+  // Decoupling by SKIPPING is safe; decoupling by SWALLOWING is not. `continue-on-error` on any of
+  // these would let a weights-only dispatch report success with no weights on the box -- strictly
+  // worse than the coupling this story removed, because the coupling at least failed visibly.
+  for (const name of [...PROVISIONING_STEPS, ...COMPILE_CHAIN_STEPS]) {
+    assert.doesNotMatch(
+      stepCode(workflow, name),
+      /continue-on-error|always\(\)/,
+      `${name} must not degrade a failure into a warning`,
+    );
+  }
+});
+
 test("Windows CUDA runs the Candle adapter's platform-only unit tests", async () => {
   const workflow = await source(".github/workflows/windows-candle.yml");
   assert.match(
@@ -1300,12 +1498,23 @@ test("every workspace path a self-hosted lane watches maps to a package that lan
     // dispatch-only calibration build that reaches a member is not PR coverage of it, so
     // drop every step block gated on workflow_dispatch before scanning (same step-splitting
     // idiom as the capability-dump ordering check above).
-    const prSteps = lane
-      .split(/\n {6}- (?=name: |uses: )/)
-      .filter(
-        (block) => !/if: \$\{\{[^\n]*github\.event_name == 'workflow_dispatch'/.test(block),
-      )
-      .join("\n");
+    //
+    // POLARITY MATTERS, and it did not used to (sc-18691). This filter was a bare substring test
+    // for `github.event_name == 'workflow_dispatch'` inside the step's `if:`. sc-18691 added the
+    // opposite polarity to windows-candle.yml -- `!(github.event_name == 'workflow_dispatch' &&
+    // inputs.provision_snapshot && !inputs.run_five_rung_reference)`, which skips the compile chain
+    // for a weights-only dispatch and therefore RUNS on every PR and push. The substring test read
+    // those two forms as identical, dropped all six compile steps, and left this audit with zero
+    // cargo invocations to reason about -- it survived only because of the `invocations.length > 0`
+    // assertion below, which is exactly the vacuity backstop that case is for. Strip negated groups
+    // before looking for the positive requirement, so "requires a dispatch" means what it says.
+    const requiresDispatch = (block) => {
+      const gate = block.match(/^\s*if: ([^\n]*)$/m);
+      if (!gate) return false;
+      return /github\.event_name == 'workflow_dispatch'/.test(gate[1].replace(/!\([^)]*\)/g, ""));
+    };
+    const blocks = lane.split(/\n {6}- (?=name: |uses: )/);
+    const prSteps = blocks.filter((block) => !requiresDispatch(block)).join("\n");
     // Strip comment lines, then re-join backslash line continuations so a `-p <pkg>` split
     // across lines cannot degrade into a "package-less" invocation (which the rule below
     // would over-widen into the whole default-member set).


### PR DESCRIPTION
Closes sc-18691. Epic sc-17137.

## Problem

The provisioning steps in `.github/workflows/windows-candle.yml` sat **below** `cargo test -p sceneworks-worker --features backend-candle` with no guard. An unrelated build break therefore made landing weights on the CUDA runner *impossible* rather than merely slow — the fetch was never reached.

That is an operational risk this epic hits concretely: sc-17149 must provision `transformer_ref` (+66.28 GB) onto that runner, taking its resident set from 144.051 GB to 210.332 GB.

## Mechanism — two changes, both load-bearing

**1. ORDER.** The whole dispatch/provisioning block moves above every cargo invocation — above `prepare-rust-runner` too, which fails loudly on a broken rustup, because a weights fetch has no business depending on toolchain discovery. Those steps need only the checkout and the box's Python.

**2. SKIP.** A weights-only dispatch (`provision_snapshot` without `run_five_rung_reference`) now skips the compile chain entirely. Order *alone* would still drag a provision-only run red on an unrelated break and still burn the lane's ~24m of box time, which is the scarce resource here.

Only the provision-only dispatch shape changes. PR runs, push runs, a plain no-input dispatch and **every** five-rung dispatch behave exactly as before.

## Failure semantics are preserved, deliberately

No `continue-on-error`, no `if: always()`, no swallowed exit codes. This is a **skip**, not a swallow — a skipped step cannot mask a failure, and every `throw` stays fatal. sc-18677's whole point was that provisioning must fail loudly.

## Proof on the real runner

Manufactured the break deliberately on `proof/sc-18691-compile-break` @ `c8c7889bcd493dd737d339751bbeccaa4f1f31db` (a `compile_error!` in `sceneworks-worker`, which breaks the worker test, the sidecar check, clippy and the capability dump while leaving `cargo fetch --locked` intact). Run URLs are recorded on the story.

## Contract tests

Three new tests in `scripts/platform-review-contracts.test.mjs`, following this file's own rules:

- **Scoped per step** with `stepBody()`. The skip guard is byte-identical on all six steps, so a file-wide `assert.match` is satisfied by any survivor — measured: dropping one step's guard leaves 5 of 6 occurrences, so a file-wide match stays green.
- **Pins the THROW, not the message.** `throw`s are counted per step. The pre-existing "Python 3.12 or newer" test matches only the message and survives a `throw` -> `Write-Warning` downgrade completely intact — measured.
- **Derived, not hand-listed.** Both order and guard coverage derive from the workflow's own cargo invocations, so a *new* compile step added above provisioning, or added unguarded, goes red.

Seven mutations were each performed individually and observed red, then reverted with a byte-compare.

## Drive-by fix this change exposed

The sc-17703 path audit dropped any step whose `if:` merely *contained* `github.event_name == 'workflow_dispatch'` — which reads a **negated** guard as dispatch-only. My guard emptied its cargo-invocation set entirely; only its own vacuity backstop caught it. Fixed to strip negated groups before testing for the positive requirement.

## Python hosting decision (the story's lower-priority question)

Recorded in the workflow: **inline `huggingface_hub` stays.** Epic 3482 is Done and was macOS-runtime-scoped. Both alternatives are worse *here specifically* — a Rust downloader would be produced by the very compile chain this change just decoupled provisioning from, and `huggingface_hub` is the reference implementation of the `models--<owner>--<name>\snapshots\<rev>` cache layout the resolve step asserts against. It is pinned exactly, anonymous, and its exit code is checked.

## Gates

- `npm run check` — exit 0, 411 tests
- `node --test scripts/platform-review-contracts.test.mjs` — exit 0, 57 tests (54 pre-existing + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)