### PR TITLE
fix(catalog): repoint lora:ltx_2_3_ic_lipdub at the renamed DubIt repo and pin it (sc-18917)

### DIFF
--- a/config/download-pattern-evidence.json
+++ b/config/download-pattern-evidence.json
@@ -104,6 +104,20 @@
       ]
     },
     {
+      "key": "Lightricks/LTX-2.3-22b-IC-LoRA-DubIt@1456334c3d69924de5083e553733b108ed1147f2",
+      "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-DubIt",
+      "revision": "1456334c3d69924de5083e553733b108ed1147f2",
+      "resolvedSha": "1456334c3d69924de5083e553733b108ed1147f2",
+      "servedRepo": "Lightricks/LTX-2.3-22b-IC-LoRA-DubIt",
+      "gated": "auto",
+      "files": [
+        ".gitattributes",
+        "LICENSE",
+        "README.md",
+        "ltx-2.3-22b-ic-lora-dubit-0.9.safetensors"
+      ]
+    },
+    {
       "key": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR@main",
       "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
       "revision": null,
@@ -115,20 +129,6 @@
         "README.md",
         "ltx-2.3-22b-ic-lora-hdr-0.9.safetensors",
         "ltx-2.3-22b-ic-lora-hdr-scene-emb.safetensors"
-      ]
-    },
-    {
-      "key": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub@main",
-      "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
-      "revision": null,
-      "resolvedSha": "1456334c3d69924de5083e553733b108ed1147f2",
-      "servedRepo": "Lightricks/LTX-2.3-22b-IC-LoRA-DubIt",
-      "gated": "auto",
-      "files": [
-        ".gitattributes",
-        "LICENSE",
-        "README.md",
-        "ltx-2.3-22b-ic-lora-dubit-0.9.safetensors"
       ]
     },
     {

--- a/config/manifests/builtin.loras.jsonc
+++ b/config/manifests/builtin.loras.jsonc
@@ -48,6 +48,18 @@
       }
     },
     {
+      // sc-18917: upstream renamed BOTH the repo (LTX-2.3-22b-IC-LoRA-LipDub -> …-DubIt) and the
+      // weight file (…-lipdub-0.9 -> …-dubit-0.9). The old repo name still answers 200 through HF's
+      // 307 rename redirect, so the listing looked healthy while the declared FILE matched nothing
+      // — the worker's sc-12288 zero-file check turned that into a failed download for anyone who
+      // selected it. `revision` is pinned here (and was not before) because an unrevisioned entry
+      // reads a moving default branch, which is exactly how the rename went unnoticed; the
+      // remaining 12 unrevisioned keys are sc-18924's scope, not this entry's.
+      //
+      // `id` and `name` deliberately keep the LipDub spelling: `id` is the stable catalog key the
+      // picker, job payloads, compatibility checks and the on-disk install probe all key on, so
+      // renaming it would orphan saved selections and installed weights for no functional gain,
+      // and "LipDub" names what the adapter DOES. DubIt is upstream's product branding.
       "id": "ltx_2_3_ic_lipdub",
       "name": "LTX-2.3 IC-LoRA LipDub",
       "family": "ltx-video",
@@ -58,8 +70,9 @@
       "defaultWeight": 0.8,
       "source": {
         "provider": "huggingface",
-        "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
-        "file": "ltx-2.3-22b-ic-lora-lipdub-0.9.safetensors"
+        "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-DubIt",
+        "file": "ltx-2.3-22b-ic-lora-dubit-0.9.safetensors",
+        "revision": "1456334c3d69924de5083e553733b108ed1147f2"
       }
     },
     {

--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -341,11 +341,16 @@ Two things follow, and both are now enforced rather than remembered:
     the last record reds this way harmlessly, and so does a hand edit.
 
   🔴 **In this mode the exit code carries that verdict and nothing else** (sc-18854 review). The
-  live zero-match / access-gated / redirect / untranslatable lists still print *above* the banner,
-  and today's tree prints a tracked `ZERO-MATCH PATTERNS (1)` for LipDub on every clean run — but
-  they deliberately do not move the exit status, because an anti-tamper mode that reds
-  unconditionally signals nothing. Grade those lists with
-  `npm run check:download-patterns:offline`; that is the gate CI runs.
+  live zero-match / access-gated / redirect / untranslatable lists still print *above* the banner —
+  today's tree prints `ACCESS-GATED (2)` and `SERVED BY A DIFFERENT REPO (1)` on every clean run,
+  and since sc-18917 no `ZERO-MATCH PATTERNS` line at all — but they deliberately do not move the
+  exit status, because an anti-tamper mode that reds unconditionally signals nothing. Grade those
+  lists with `npm run check:download-patterns:offline`; that is the gate CI runs.
+
+  Do **not** read the absent zero-match line as the two modes having converged. They answer
+  different questions, and `scripts/check-download-patterns.test.mjs` no longer relies on a live
+  catalog defect to prove it: the collision case now injects a bogus declared pattern into a
+  throwaway copy of the catalog, which moves a live verdict without moving the artifact.
 
   `--dry-run` is rejected outright when it is not paired with `--write`, including in combination
   with `--check` or `--self-test` (both of which ignore it — they never touch the network or the
@@ -358,12 +363,12 @@ Two things follow, and both are now enforced rather than remembered:
   Forgetting the re-record is not a silent pass: adding or re-pinning an entry changes its
   `repo@revision` key, and a claim with no recorded listing reds the gate with the exact command to
   run. The recorder never evaluates a pattern — it only transcribes — so you cannot record your way
-  out of a real zero-match. 83 of the 96 keys are pinned to immutable 40-hex revisions, whose
-  listings cannot go stale. **The other 13 are unrevisioned and that immutability argument does not
+  out of a real zero-match. 84 of the 96 keys are pinned to immutable 40-hex revisions, whose
+  listings cannot go stale. **The other 12 are unrevisioned and that immutability argument does not
   cover them** — they read a moving default branch, and while each records the `resolvedSha` it
   actually read so drift is visible in a re-record diff, nothing forces a re-record. **sc-18924
-  tracks pinning all 13**, which is what closes that window; sc-18917 and sc-18923 each pin one as a
-  side effect of their own fixes.
+  tracks pinning the rest**, which is what closes that window; sc-18917 already pinned one as a side
+  effect of its own fix (it was 13 before) and sc-18923 owns another.
 
   Each recorded key also carries `gated` and `servedRepo`, and the gate hard-fails on both
   (`evidence-gated`, `evidence-repo-id-mismatch`) with tracked waivers in `KNOWN_REPO_CONDITIONS`.

--- a/scripts/check-download-patterns.mjs
+++ b/scripts/check-download-patterns.mjs
@@ -46,17 +46,17 @@
 // The usual objection to a recorded fixture is decay. It does not apply here, for two
 // structural reasons:
 //
-//  1. **83 of 96 keys are pinned to an immutable 40-hex revision.** A git SHA's file listing
+//  1. **84 of 96 keys are pinned to an immutable 40-hex revision.** A git SHA's file listing
 //     is timeless — re-reading it in a year returns the same bytes. There is nothing to
 //     decay.
 //
-//     The other **13 keys are unrevisioned** and this argument does NOT cover them. They read a
+//     The other **12 keys are unrevisioned** and this argument does NOT cover them. They read a
 //     moving default branch, and while each records the `resolvedSha` it actually read — so drift
 //     is VISIBLE in a re-record diff — nothing forces anyone to re-record. That is a real
-//     stale-green window, and it is 13 keys wide, not one. **sc-18924 tracks pinning all 13**,
-//     which is what converts them onto the immutability argument above. sc-18917 pins exactly one
-//     of them (the LipDub/DubIt rename) as a side effect of fixing that entry, and sc-18923 owns
-//     another; the remaining eleven have no other owner and are sc-18924's alone.
+//     stale-green window, and it is 12 keys wide, not one. **sc-18924 tracks pinning all of them**,
+//     which is what converts them onto the immutability argument above. sc-18917 already pinned one
+//     (the LipDub/DubIt rename, as a side effect of fixing that entry — it was 13 before) and
+//     sc-18923 owns another; the remaining eleven have no other owner and are sc-18924's alone.
 //  2. **Coverage is graded as a set, in both directions.** Adding an entry, or re-pinning
 //     one, changes its `repo@revision` key, and a key with no recorded listing is a hard
 //     failure naming the re-record command. Conversely a recorded key that nothing claims
@@ -97,8 +97,9 @@
 // The cost of that false claim was a live catalog entry grading green while being unfetchable.
 // Measured across all 96 recorded keys, TWO are gated:
 //
-//   Lightricks/LTX-2.3-22b-IC-LoRA-HDR@main      gated:"auto"   (sc-18923)
-//   Lightricks/LTX-2.3-22b-IC-LoRA-LipDub@main   gated:"auto"   (sc-18917)
+//   Lightricks/LTX-2.3-22b-IC-LoRA-HDR@main       gated:"auto"   (sc-18923)
+//   Lightricks/LTX-2.3-22b-IC-LoRA-DubIt@1456334c gated:"auto"   (sc-18923; was LipDub@main until
+//                                                                 sc-18917 repointed and pinned it)
 //
 // For HDR: `HEAD .../resolve/main/ltx-2.3-22b-ic-lora-hdr-0.9.safetensors` returns **401**
 // unauthenticated, and this gate graded it green. `gated:"auto"` means terms are auto-approved ON
@@ -114,17 +115,20 @@
 //
 // The same body also carries `id` — the repo HF ACTUALLY served. `fetch` follows the 307 a renamed
 // repo issues, so an entry naming a dead repo resolves silently; `evidence-repo-id-mismatch`
-// catches that. Both live instances are waived and tracked (sc-18917, sc-18926).
+// catches that. ONE live instance remains, waived and tracked (sc-18926); the other — LipDub ->
+// DubIt — was fixed at the source by sc-18917 rather than waived onward.
 //
 // What a green run still does NOT prove: that the token's account has accepted the licence, or
 // that the bytes download. Those need a real authenticated fetch. The ceiling is real — it is just
 // one rung higher than this header used to claim.
 //
-// The LIVE modes deliberately ignore `KNOWN_ZERO_MATCHES` and report the raw truth, so
-// `--write` currently exits 1 on the tracked lipdub gap (sc-18917). Policy lives in the
-// gate; the pre-flight is for a human who wants the unfiltered picture. Do not "fix" that
-// exit code by teaching the recorder about waivers — a recorder that knows which failures
-// are acceptable is one step from a recorder that records them as passing.
+// The LIVE modes deliberately ignore `KNOWN_ZERO_MATCHES` and report the raw truth, so `--write`
+// exits 1 on any tracked zero-match gap. There is none today — sc-18917 fixed the last one — so
+// `--write` currently exits 0, but do NOT read that as the modes agreeing: the gated and redirect
+// lists still print above and are still waived in `--check`. Policy lives in the gate; the
+// pre-flight is for a human who wants the unfiltered picture. Do not "fix" that exit code by
+// teaching the recorder about waivers — a recorder that knows which failures are acceptable is one
+// step from a recorder that records them as passing.
 
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -157,21 +161,13 @@ const STORY_REF_PATTERN = /^sc-\d+$/;
 // changed, which is the same "required context reds for a reason unrelated to this PR"
 // failure mode this design exists to avoid. Structural expiry fires exactly when the
 // underlying fact changes, which is the only moment the entry is actually wrong.
-export const KNOWN_ZERO_MATCHES = [
-  {
-    label: "lora:ltx_2_3_ic_lipdub",
-    repo: "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
-    revision: null,
-    pattern: "ltx-2.3-22b-ic-lora-lipdub-0.9.safetensors",
-    story: "sc-18917",
-    reason:
-      "Upstream renamed the repo LipDub -> DubIt and the weight file with it; the old path " +
-      "still resolves through HF's rename redirect, so the listing returns 200 but holds " +
-      "ltx-2.3-22b-ic-lora-dubit-0.9.safetensors instead. The DubIt repo is also access-gated, " +
-      "so correcting the filename alone may not make it fetchable. Fixing the manifest entry " +
-      "is sc-18917; it must delete this waiver in the same change.",
-  },
-];
+// EMPTY, and that is a verdict rather than an oversight: the catalog currently declares no
+// pattern that matches zero files. The list's only entry was the LipDub/DubIt rename, deleted by
+// sc-18917 when it repointed the manifest entry — the gate forced it, reporting
+// `waiver-stale-unclaimed` the moment the waived tuple stopped being claimed. Keep the list (and
+// this comment) rather than deleting the mechanism: the next real zero-match needs somewhere with
+// an owner to go, and an empty list is the honest statement that today there is none.
+export const KNOWN_ZERO_MATCHES = [];
 
 // Known, TRACKED repo-level defects: the repo is access-gated, or HF served a DIFFERENT repo than
 // the manifest names. Same discipline as `KNOWN_ZERO_MATCHES` — a reason, an `sc-NNNN` owner, and
@@ -215,24 +211,19 @@ export const KNOWN_REPO_CONDITIONS = [
   },
   {
     kind: "evidence-gated",
-    repo: "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
-    revision: null,
-    story: "sc-18917",
+    repo: "Lightricks/LTX-2.3-22b-IC-LoRA-DubIt",
+    revision: "1456334c3d69924de5083e553733b108ed1147f2",
+    story: "sc-18923",
     reason:
-      "Same posture as HDR (gated:\"auto\", 401 on the weight file), reached through the LipDub -> " +
-      "DubIt rename redirect. sc-18917 owns the rename fix and inherits the gating question with " +
-      "it; note its activity-18919 argued gating was a non-issue BECAUSE HDR already ships this " +
-      "way, which was circular — HDR is broken too, and is now sc-18923.",
-  },
-  {
-    kind: "evidence-repo-id-mismatch",
-    repo: "Lightricks/LTX-2.3-22b-IC-LoRA-LipDub",
-    revision: null,
-    story: "sc-18917",
-    reason:
-      "Upstream renamed the repo LipDub -> DubIt. The declared name still resolves through HF's " +
-      "307 rename redirect, so the listing is served by Lightricks/LTX-2.3-22b-IC-LoRA-DubIt. " +
-      "sc-18917 repoints the manifest entry and deletes this waiver with it.",
+      "Re-keyed by sc-18917 from Lightricks/LTX-2.3-22b-IC-LoRA-LipDub@main when that entry was " +
+      "repointed onto the renamed repo and pinned; the gate forced it, reporting " +
+      "repo-waiver-stale-unclaimed on the old key. The rename is fixed and the GATING is not: " +
+      "the pinned revision answers 200 with gated:\"auto\" while HEAD on " +
+      "ltx-2.3-22b-ic-lora-dubit-0.9.safetensors returns 401 unauthenticated — the identical " +
+      "posture as the HDR sibling above. It is deliberately owned by sc-18923 rather than by " +
+      "sc-18917: sc-18917 fixed a rename and is done, so naming it here would leave a waiver whose " +
+      "owner is closed. sc-18923 owns the gated-IC-LoRA class (surface licence acceptance, re-host, " +
+      "or withdraw) and must delete BOTH its waivers — HDR's and this one — in the same change.",
   },
   {
     kind: "evidence-repo-id-mismatch",

--- a/scripts/check-download-patterns.test.mjs
+++ b/scripts/check-download-patterns.test.mjs
@@ -7,7 +7,8 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import test from "node:test";
@@ -222,35 +223,77 @@ test("evidence-gated: the real HDR entry reds without its waiver and is tracked 
 });
 
 // The repo-id guard's reason for existing: it catches what the sha check structurally cannot.
-test("evidence-repo-id-mismatch catches both live redirects, including the one the sha check cannot", async () => {
+//
+// This used to loop over TWO live redirects. sc-18917 fixed one of them at the source (the manifest
+// entry that named the dead `…IC-LoRA-LipDub` repo now names `…IC-LoRA-DubIt` directly), so only
+// the mmaudio DFN5B entry is still redirected. That deletion costs a shape the loop used to cover
+// — an UNREVISIONED redirected key, where `claim.revision &&` makes the sha guard inert outright
+// rather than merely satisfied — so the second half of this test rebuilds that shape from the same
+// real listing instead of letting the coverage quietly lapse with the fix.
+test("evidence-repo-id-mismatch catches the live redirect, in both the pinned and unrevisioned shapes", async () => {
   const { claims, evidence } = await realInputs();
 
-  for (const [repo, servedBy] of [
-    ["apple/DFN5B-CLIP-ViT-H-14-384", "apple/DFN5B-CLIP-ViT-H-14-378"],
-    ["Lightricks/LTX-2.3-22b-IC-LoRA-LipDub", "Lightricks/LTX-2.3-22b-IC-LoRA-DubIt"],
-  ]) {
-    const claim = claims.find((row) => row.repo === repo);
-    assert.ok(claim, `a manifest entry must still declare ${repo}`);
-    const entry = evidence.repos.find((row) => row.key === claimKey(claim.repo, claim.revision));
-    assert.ok(entry, `${repo} must have a recorded listing`);
-    assert.equal(entry.servedRepo, servedBy, `${repo} must genuinely still be served by ${servedBy}`);
+  const repo = "apple/DFN5B-CLIP-ViT-H-14-384";
+  const servedBy = "apple/DFN5B-CLIP-ViT-H-14-378";
+  const claim = claims.find((row) => row.repo === repo);
+  assert.ok(claim, `a manifest entry must still declare ${repo}`);
+  assert.ok(claim.revision, `${repo} must still be the PINNED shape for the first half to bind`);
+  const entry = evidence.repos.find((row) => row.key === claimKey(claim.repo, claim.revision));
+  assert.ok(entry, `${repo} must have a recorded listing`);
+  assert.equal(entry.servedRepo, servedBy, `${repo} must genuinely still be served by ${servedBy}`);
 
-    // The sha check passes on BOTH — which is the point. An HF rename redirect preserves the sha,
-    // and for the unrevisioned LipDub key `claim.revision &&` makes that guard inert outright.
-    // Without the repo-id guard these two are invisible.
-    const problems = gradeRecordedEvidence({
-      claims: [claim],
-      evidence: { repos: [entry] },
+  // Shape 1 — PINNED. The sha check passes, because an HF rename redirect preserves the sha. So
+  // the redirect is invisible without the repo-id guard even when the entry IS pinned.
+  const pinned = gradeRecordedEvidence({
+    claims: [claim],
+    evidence: { repos: [entry] },
+    waivers: [],
+    repoConditions: [],
+  }).problems;
+  assert.ok(
+    pinned.some((problem) => problem.kind === "evidence-repo-id-mismatch"),
+    `expected evidence-repo-id-mismatch for ${repo}, got ${JSON.stringify(pinned)}`,
+  );
+  assert.ok(
+    !pinned.some((problem) => problem.kind === "evidence-revision-mismatch"),
+    `${repo}: the sha check must NOT fire — that is why the repo-id guard is needed`,
+  );
+
+  // Shape 2 — UNREVISIONED, which is where renames actually bite (nothing forces a re-record of a
+  // moving default branch). Same real listing, re-keyed to `@main`. Here the sha guard is not just
+  // satisfied, it is unreachable: `claim.revision &&` short-circuits before it can look.
+  const unrevisionedKey = claimKey(repo, null);
+  assert.notEqual(unrevisionedKey, entry.key, "the re-key must actually change the key");
+  const unrevisioned = gradeRecordedEvidence({
+    claims: [{ ...claim, revision: null }],
+    evidence: { repos: [{ ...entry, key: unrevisionedKey, revision: null }] },
+    waivers: [],
+    repoConditions: [],
+  }).problems;
+  assert.ok(
+    unrevisioned.some((problem) => problem.kind === "evidence-repo-id-mismatch"),
+    `expected evidence-repo-id-mismatch unrevisioned, got ${JSON.stringify(unrevisioned)}`,
+  );
+  assert.ok(
+    !unrevisioned.some((problem) => problem.kind === "evidence-revision-mismatch"),
+    "unrevisioned: the sha guard is inert, so only the repo-id guard can see this",
+  );
+
+  // The other direction, on both shapes: a listing served by the repo it names must NOT fire.
+  // Without this the two assertions above would still pass if the guard fired unconditionally.
+  for (const [name, graded] of [
+    ["pinned", { claim, entry }],
+    ["unrevisioned", { claim: { ...claim, revision: null }, entry: { ...entry, key: unrevisionedKey, revision: null } }],
+  ]) {
+    const honest = gradeRecordedEvidence({
+      claims: [graded.claim],
+      evidence: { repos: [{ ...graded.entry, servedRepo: graded.claim.repo }] },
       waivers: [],
       repoConditions: [],
     }).problems;
     assert.ok(
-      problems.some((problem) => problem.kind === "evidence-repo-id-mismatch"),
-      `expected evidence-repo-id-mismatch for ${repo}, got ${JSON.stringify(problems)}`,
-    );
-    assert.ok(
-      !problems.some((problem) => problem.kind === "evidence-revision-mismatch"),
-      `${repo}: the sha check must NOT fire — that is why the repo-id guard is needed`,
+      !honest.some((problem) => problem.kind === "evidence-repo-id-mismatch"),
+      `${name}: a repo serving its own listing must not fire, got ${JSON.stringify(honest)}`,
     );
   }
 });
@@ -418,7 +461,7 @@ test("the CLI rejects those combinations before any mode runs, not after", () =>
 // tree that DOES have a live zero-match (the tracked LipDub row) — without that the test would be
 // vacuous, since it is the collision that has to not happen.
 const PERTURBED_KEY = "SceneWorks/ltx-2.3-mlx@01df27d308466533aa09d251e3aebdcc627d07eb";
-const runReplayed = (args, env = {}) => {
+const runReplayed = (args, env = {}, cwd = root) => {
   const result = spawnSync(
     process.execPath,
     [
@@ -427,26 +470,125 @@ const runReplayed = (args, env = {}) => {
       "scripts/check-download-patterns.mjs",
       ...args,
     ],
-    { cwd: root, encoding: "utf8", env: { ...process.env, ...env } },
+    { cwd, encoding: "utf8", env: { ...process.env, ...env } },
   );
   return { status: result.status, output: `${result.stdout}${result.stderr}` };
 };
 const runDryRun = (env = {}) => runReplayed(["--write", "--dry-run"], env);
 
-test("--write --dry-run: the exit code carries the artifact verdict and only that", () => {
-  const clean = runDryRun();
-  // Anti-vacuity: prove the live verdicts really did fire on this run. If the catalog ever grades
-  // clean live, this assertion fails loudly rather than letting the test pass for the wrong reason.
-  assert.match(
-    clean.output,
-    /ZERO-MATCH PATTERNS \(\d+\)/,
-    "a live zero-match must be present, or this test proves nothing about the collision",
+// A COMPLETE temporary catalog — the recorder, its one local import, the replay fixture, both
+// manifests and the committed evidence — with ONE deliberate defect injected into a manifest entry.
+//
+// WHY THIS EXISTS (sc-18917). The collision test below needs a run in which a LIVE verdict fires
+// while the recorded artifact is still byte-identical to a re-record. Until sc-18917 that
+// combination was supplied for free by a real catalog defect — the LipDub row declared a file
+// upstream had renamed away — and the test leaned on it, saying so in its own comment. Repointing
+// that entry removes it, and it cannot simply be re-borrowed elsewhere: a live zero-match can only
+// come from a listing that lacks a declared pattern, and that is the very listing the recorder
+// transcribes, so ANY perturbation of the replayed network moves the artifact as well.
+//
+// The one input that moves a live verdict WITHOUT moving the artifact is the MANIFEST — a declared
+// pattern matching nothing leaves every listing untouched — and the manifest path is fixed relative
+// to the script, hence a temporary root. The result is a collision proof that holds permanently
+// rather than one that expires the moment the catalog is healthy.
+const INJECT_TARGET_ID = "ltx_2_3_ic_lipdub";
+const INJECTED_PATTERN = "sw-injected-zero-match-sc-18917.safetensors";
+
+async function withInjectedZeroMatch(run) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "sw-download-patterns-"));
+  try {
+    await mkdir(path.join(dir, "scripts", "lib"), { recursive: true });
+    await mkdir(path.join(dir, "scripts", "fixtures"), { recursive: true });
+    await mkdir(path.join(dir, "config", "manifests"), { recursive: true });
+    // `copyFile` for the evidence specifically: the whole point is that it stays byte-identical, so
+    // a re-record inside the temp root reproduces it and the UP-TO-DATE branch is reachable.
+    for (const rel of [
+      "scripts/check-download-patterns.mjs",
+      "scripts/lib/jsonc.mjs",
+      "scripts/fixtures/replay-download-pattern-network.mjs",
+      "config/download-pattern-evidence.json",
+    ]) {
+      await copyFile(path.join(root, rel), path.join(dir, rel));
+    }
+
+    const models = await readJsonc("config/manifests/builtin.models.jsonc");
+    const loras = await readJsonc("config/manifests/builtin.loras.jsonc");
+    const target = loras.loras.find((lora) => lora.id === INJECT_TARGET_ID);
+    assert.ok(target, `${INJECT_TARGET_ID} must exist in the LoRA manifest`);
+    const declared = target.source?.file;
+    assert.ok(declared, `${INJECT_TARGET_ID} must declare a single source.file to widen`);
+    // `source.files` is the manifest's own multi-pattern shape, so the injected catalog is still a
+    // LEGAL one: the real declared file, plus one pattern that cannot match. Nothing about the
+    // repo@revision key changes, so the replayed listing — and therefore the artifact — does not.
+    delete target.source.file;
+    target.source.files = [declared, INJECTED_PATTERN];
+    // Written as plain JSON: `readManifests` strips JSONC comments before parsing, and comment-free
+    // JSON is a fixed point of that. Comments carry no meaning to the script.
+    await writeFile(
+      path.join(dir, "config/manifests/builtin.models.jsonc"),
+      JSON.stringify(models),
+      "utf8",
+    );
+    await writeFile(
+      path.join(dir, "config/manifests/builtin.loras.jsonc"),
+      JSON.stringify(loras),
+      "utf8",
+    );
+    return await run({ dir, declaredFile: declared });
+  } finally {
+    // In a `finally` because a failed assertion inside `run` is the likeliest exit path, and that
+    // is exactly the path a leaked temp dir hides on.
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+// The injection is only meaningful if the pattern genuinely matches nothing while the entry's REAL
+// declared file genuinely matches. Assert both against the committed listing, so a stale fixture
+// cannot turn the collision test into a run with two zero-matches or none.
+test("the injected zero-match pattern is absent and the real declared file is present", async () => {
+  const { claims, evidence } = await realInputs();
+  const claim = claims.find((row) => row.label === `lora:${INJECT_TARGET_ID}`);
+  assert.ok(claim, `lora:${INJECT_TARGET_ID} must exist for the injection to bind`);
+  const entry = evidence.repos.find((row) => row.key === claimKey(claim.repo, claim.revision));
+  assert.ok(entry, `${INJECT_TARGET_ID} must have a recorded listing`);
+  assert.ok(!entry.files.includes(INJECTED_PATTERN), "the injected pattern must match nothing");
+  assert.deepEqual(
+    claim.declared.filter((pattern) => !entry.files.includes(pattern)),
+    [],
+    `every declared pattern of ${INJECT_TARGET_ID} must be present at its pinned revision`,
   );
+});
+
+test("--write --dry-run: the exit code carries the artifact verdict and only that", async () => {
+  // Direction 1 — THE COLLISION ITSELF. A live zero-match fires while the artifact is unchanged,
+  // so the exit code must be 0. This is the assertion the whole temp-root construction exists for.
+  await withInjectedZeroMatch(async ({ dir }) => {
+    const collided = runReplayed(["--write", "--dry-run"], {}, dir);
+    assert.match(
+      collided.output,
+      /ZERO-MATCH PATTERNS \(1\)/,
+      `the injected live zero-match must fire, or this proves nothing: ${collided.output}`,
+    );
+    assert.ok(
+      collided.output.includes(INJECTED_PATTERN),
+      "the zero-match must be the injected pattern, not some unrelated catalog drift",
+    );
+    assert.match(collided.output, /ARTIFACT VERDICT: UP TO DATE \(\d+ key\(s\)\) — exit 0/);
+    assert.doesNotMatch(collided.output, /WOULD CHANGE/);
+    assert.equal(
+      collided.status,
+      0,
+      `a live zero-match must not move this mode's exit code: ${collided.output}`,
+    );
+  });
+
+  // Direction 2 — the real tree, which sc-18917 left with no live zero-match at all.
+  const clean = runDryRun();
   assert.match(clean.output, /ARTIFACT VERDICT: UP TO DATE \(\d+ key\(s\)\) — exit 0/);
   assert.doesNotMatch(clean.output, /WOULD CHANGE/);
-  assert.equal(clean.status, 0, `a clean artifact must exit 0 despite the live zero-match above`);
+  assert.equal(clean.status, 0, `a clean artifact must exit 0: ${clean.output}`);
 
-  // Direction 2: one appended file in one replayed listing — the smallest possible divergence
+  // Direction 3: one appended file in one replayed listing — the smallest possible divergence
   // between the committed artifact and a re-record — must red.
   const tampered = runDryRun({ REPLAY_EXTRA_FILE: PERTURBED_KEY });
   assert.match(tampered.output, /ARTIFACT VERDICT: WOULD CHANGE — exit 1/);
@@ -457,14 +599,25 @@ test("--write --dry-run: the exit code carries the artifact verdict and only tha
 // The counterpart of the test above: routing the live verdicts through a flag must not have
 // DROPPED them. Same replayed network, plain live mode (no --write, so no dry-run verdict owns the
 // exit code), each verdict isolated to a single catalog entry and asserted in both directions.
-test("plain live mode still reds on a zero-match and on an unreachable repo, and greens otherwise", () => {
+test("plain live mode still reds on a zero-match and on an unreachable repo, and greens otherwise", async () => {
   const clean = runReplayed(["--model", "ltx_2_3"]);
   assert.match(clean.output, /Every declared download pattern matches at least one file\./);
   assert.equal(clean.status, 0, `a fully matching entry must exit 0: ${clean.output}`);
 
-  const zeroMatch = runReplayed(["--model", "ltx_2_3_ic_lipdub"]);
-  assert.match(zeroMatch.output, /ZERO-MATCH PATTERNS \(1\)/);
-  assert.equal(zeroMatch.status, 1, "a zero-match must still red the live mode");
+  await withInjectedZeroMatch(async ({ dir }) => {
+    const zeroMatch = runReplayed(["--model", INJECT_TARGET_ID], {}, dir);
+    // Exactly ONE: the injected pattern. Two would mean the entry's real declared file stopped
+    // matching, which is the sc-18917 defect coming back.
+    assert.match(zeroMatch.output, /ZERO-MATCH PATTERNS \(1\)/);
+    assert.ok(zeroMatch.output.includes(INJECTED_PATTERN));
+    assert.equal(zeroMatch.status, 1, "a zero-match must still red the live mode");
+
+    // Same temp root, a different entry: still green. Without this the red above could be caused
+    // by the temporary catalog being broken rather than by the injected pattern.
+    const greenInTemp = runReplayed(["--model", "ltx_2_3"], {}, dir);
+    assert.match(greenInTemp.output, /Every declared download pattern matches at least one file\./);
+    assert.equal(greenInTemp.status, 0, `the temp root must otherwise be healthy: ${greenInTemp.output}`);
+  });
 
   // Same entry as the green run, with only its listing made unreadable.
   const outage = runReplayed(["--model", "ltx_2_3"], { REPLAY_ERROR_KEY: PERTURBED_KEY });


### PR DESCRIPTION
Closes the rename half of [sc-18917](https://app.shortcut.com/trefry/story/18917). Catalog + gate only — no Rust in this diff.

## The defect

`config/manifests/builtin.loras.jsonc` declared `Lightricks/LTX-2.3-22b-IC-LoRA-LipDub` / `ltx-2.3-22b-ic-lora-lipdub-0.9.safetensors`, unrevisioned. Upstream renamed **both** the repo and the file:

| probe (unauthenticated, re-verified against live HF at implementation time) | result |
|---|---|
| `GET /api/models/…-IC-LoRA-LipDub?blobs=false` | **307** → `…-IC-LoRA-DubIt` |
| `GET /api/models/…-IC-LoRA-DubIt?blobs=false` | 200, `id` = `…-DubIt`, sha `1456334c3d69924de5083e553733b108ed1147f2`, `gated: "auto"`, 4 files |
| declared `…-lipdub-0.9.safetensors` in that listing | **absent** — upstream ships `…-dubit-0.9.safetensors` |
| `HEAD /…-DubIt/resolve/1456334c…/ltx-2.3-22b-ic-lora-dubit-0.9.safetensors` | **401** |

The 307 is why this looked healthy for so long: the metadata call resolved against a real repo that simply lacked the declared file. **Following the redirect alone does not fix it** — the file moved too. At download time the worker's sc-12288 zero-file check turns that into a hard failure for any user who selects the LoRA.

## What changed

`source.repo` → `Lightricks/LTX-2.3-22b-IC-LoRA-DubIt`, `source.file` → `ltx-2.3-22b-ic-lora-dubit-0.9.safetensors`, and **`source.revision` pinned to `1456334c…`** where there was none. The pin is enforcement, not decoration: `apps/rust-api/src/loras.rs:123-130` forwards `source.revision` into the download job payload and `lora_huggingface_cached_file` resolves `snapshots/<revision>`.

`id` and `name` deliberately keep the LipDub spelling. `id` is the stable catalog key the picker, job payloads, compatibility checks and the install probe all key on, so renaming it orphans saved selections and installed weights for no functional gain. The reasoning is recorded in the manifest so the id/repo divergence does not read as a second bug.

**Not** pinning the other 12 unrevisioned keys — that is sc-18924's entire scope.

## Waiver cleanup — the gate forced every step

This is the first real end-to-end exercise of sc-18854's download-pattern gate. Three waivers covered this one row, and all three self-expired the moment the manifest moved:

```
[waiver-stale-unclaimed]       lora:ltx_2_3_ic_lipdub  ltx-2.3-22b-ic-lora-lipdub-0.9.safetensors
                               no manifest entry declares this any more — delete the sc-18917 waiver
[repo-waiver-stale-unclaimed]  evidence-repo-id-mismatch  …-IC-LoRA-LipDub@main
                               no manifest entry claims this key any more — re-key or delete …
[repo-waiver-stale-unclaimed]  evidence-gated             …-IC-LoRA-LipDub@main
                               no manifest entry claims this key any more — re-key or delete …
```

- **`KNOWN_ZERO_MATCHES`** — deleted; the pattern matches now. The list is left in place but **empty**, with a comment saying so: that is a verdict about today's catalog, not a dead mechanism.
- **`evidence-repo-id-mismatch`** — deleted; pointing directly at DubIt means there is no redirect to waive.
- **`evidence-gated`** — **re-keyed, not deleted.** DubIt is still `gated: "auto"` and still 401s unauthenticated. Re-owned by **sc-18923**, which owns the gated-IC-LoRA class (surface licence acceptance, re-host, or withdraw) and must now delete *two* waivers. It is deliberately **not** sc-18917: this story fixed a rename and closes, so naming it here would leave a waiver whose owner is closed — precisely what the `story` field exists to prevent.

## Tests

Fixing the catalog broke two tests that were leaning on the defect, and that had to be repaired honestly rather than relaxed.

The `--write --dry-run` collision test used a live `ZERO-MATCH PATTERNS` line as its anti-vacuity guard, and a healthy catalog prints none. It cannot simply be re-borrowed: a live zero-match requires a listing that lacks a declared pattern, and that is the same listing the recorder transcribes, so **any** perturbation of the replayed network moves the artifact too and collapses the two verdicts back together. The one input that moves a live verdict *without* moving the artifact is the **manifest**. So both tests now build a throwaway catalog (recorder + its one import + the replay fixture + both manifests + the committed evidence, copied byte-for-byte) and inject one declared pattern that cannot match. The collision proof now holds permanently instead of expiring the moment the catalog is healthy.

Every new assertion was mutation-proven individually, both directions:

| mutation | result |
|---|---|
| fold `liveFailure` back into the dry-run exit code (re-introduce the sc-18854 collision) | ✅ reds: `a live zero-match must not move this mode's exit code` |
| …the **same** mutation against the real tree | exits **0** — confirming the old, catalog-dependent guard would no longer have caught it |
| drop the injected pattern (temp root becomes a plain copy) | ✅ reds: `the injected live zero-match must fire, or this proves nothing` |
| revert `source.file` to the pre-fix lipdub name | ✅ reds: `every declared pattern of ltx_2_3_ic_lipdub must be present at its pinned revision` |
| point `INJECTED_PATTERN` at a file that exists | ✅ reds: `the injected pattern must match nothing` |
| gate `evidence-repo-id-mismatch` behind `claim.revision &&` | ✅ reds on the unrevisioned shape only |
| make `evidence-repo-id-mismatch` fire unconditionally | ✅ reds: `a repo serving its own listing must not fire` |
| delete the new DubIt `evidence-gated` waiver | ✅ `--check` exits 1 with `[evidence-gated] … DubIt@1456334c…` |
| keep that waiver but on the old `LipDub@main` key | ✅ `--check` exits 1 with **both** `evidence-gated` and `repo-waiver-stale-unclaimed` |

`evidence-repo-id-mismatch` also lost a shape when LipDub left the catalog — an *unrevisioned* redirected key, where `claim.revision &&` makes the sha guard unreachable rather than merely satisfied. That coverage is rebuilt from the same real DFN5B listing instead of being allowed to lapse silently, and both shapes now assert the negative direction too.

## Verification

- `node scripts/check-download-patterns.mjs --write` → 96 keys, `Every declared download pattern matches at least one file`, exit 0 (it exited 1 before this change)
- `node scripts/check-download-patterns.mjs --check` → exit 0, `WAIVED (3)`, zero problems
- `node scripts/check-download-patterns.mjs --write --dry-run` → `=== ARTIFACT VERDICT: UP TO DATE (96 key(s)) — exit 0 ===`, **exit 0**
- `node --test scripts/check-download-patterns.test.mjs` → 16/16
- `npm run check` → exit 0, 432/432
- Evidence diff is one key replaced (LipDub@main → DubIt@1456334c…) plus a re-sort; HDR and the other 94 are byte-identical.

**What is NOT verified, stated plainly:** the bytes do not download. `gated: "auto"` needs a token whose account has accepted the Lightricks licence, and none is available here — an unauthenticated `HEAD` on the pinned weight file returns 401. So this PR proves the file is *declared correctly at an immutable revision*, not that a user can fetch it; that gap is sc-18923's, and the waiver keeps it tracked. No render was run and no cargo build was performed (a sibling agent holds the GPU). The IC-LoRA injection path is untouched by construction — `lora_looks_like_ic_lora` short-circuits on `icLora: true`, and every text haystack it falls back to (`id`, `source.repo`, `source.file`) still carries an `ic-lora` / `ltx-2-3-ic-` marker after the rename, verified individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)