### PR TITLE
fix(ltx): make bf16 tier downloadable (sc-18853)

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -7778,6 +7778,11 @@
         // tier(s) the user picks, tracked once, excluded from the tier matrix, and NOT double-counted in
         // the per-tier footprint. The worker still fetches a toggled-but-not-downloaded tier on demand
         // (ensure_ltx_{q8,bf16}_present, video_jobs.rs), so advanced.mlxQuantize works without a pre-pick.
+        //
+        // sc-18853: keep all four rows at the first immutable revision that contains `bf16/`.
+        // The former `254989c3…` pin predates that directory; `01df27d3…` is its direct child and adds
+        // only the ten bf16 files, so q4/q8/gemma remain byte-identical. Keep these rows aligned with
+        // the worker's LTX_BUNDLE_REVISION so first-install and on-demand downloads populate one pin.
         {
           "provider": "huggingface",
           "repo": "SceneWorks/ltx-2.3-mlx",
@@ -7791,7 +7796,7 @@
           // LoadSpec::text_encoder (no $LTX_GEMMA_DIR / HF-cache fallback), so it MUST be provisioned;
           // pinning keeps it reproducible + offline-resolvable.
           "coRequisite": true,
-          "revision": "254989c3ca7ee691187647f350b112c0c448789d",
+          "revision": "01df27d308466533aa09d251e3aebdcc627d07eb",
           "files": ["gemma/*"],
           "platforms": ["macos", "windows", "linux"],
           "estimatedSizeBytes": 26427894918
@@ -7799,7 +7804,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/ltx-2.3-mlx",
-          "revision": "254989c3ca7ee691187647f350b112c0c448789d",
+          "revision": "01df27d308466533aa09d251e3aebdcc627d07eb",
           "variant": "q4",
           "default": true,
           "files": ["q4/*"],
@@ -7810,7 +7815,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/ltx-2.3-mlx",
-          "revision": "254989c3ca7ee691187647f350b112c0c448789d",
+          "revision": "01df27d308466533aa09d251e3aebdcc627d07eb",
           "variant": "q8",
           "files": ["q8/*"],
           "platforms": ["macos"],
@@ -7820,7 +7825,7 @@
         {
           "provider": "huggingface",
           "repo": "SceneWorks/ltx-2.3-mlx",
-          "revision": "254989c3ca7ee691187647f350b112c0c448789d",
+          "revision": "01df27d308466533aa09d251e3aebdcc627d07eb",
           "variant": "bf16",
           "files": ["bf16/*"],
           "platforms": ["macos"],

--- a/crates/sceneworks-worker/src/video_jobs/ltx.rs
+++ b/crates/sceneworks-worker/src/video_jobs/ltx.rs
@@ -45,8 +45,19 @@ pub(super) const LTX_BUNDLE_REPO: &str = "SceneWorks/ltx-2.3-mlx";
 /// Pin the exact commit for defense-in-depth (mirrors the SeedVR2/Real-ESRGAN pins, sc-8879/sc-9682).
 /// The native downloader still verifies each file's own hash on download. Bumped in sc-13870 to the
 /// packed-q4 + Gemma revision validated by the candle training and inference round-trip.
+///
+/// Bumped again in sc-18853 to the direct-child revision that adds the dense `bf16/` tier. The old
+/// pin predates that directory, so its `bf16/*` fetch resolved no files. The newer revision changes
+/// no q4/q8/gemma paths and must stay aligned with every `ltx_2_3` manifest download row.
 #[cfg(target_os = "macos")]
-pub(super) const LTX_BUNDLE_REVISION: &str = "254989c3ca7ee691187647f350b112c0c448789d";
+pub(super) const LTX_BUNDLE_REVISION: &str = "01df27d308466533aa09d251e3aebdcc627d07eb";
+
+/// The only older LTX bundle snapshot whose contents are allowed to complement the current pin.
+/// [`LTX_BUNDLE_REVISION`] is a proven strict superset of this direct parent: its only additions are
+/// the ten `bf16/` files. Keeping the parent explicit prevents an unrelated cached revision from
+/// bypassing the immutable product pin during the split-cache compatibility scan (sc-18853).
+#[cfg(target_os = "macos")]
+pub(super) const LTX_BUNDLE_PRE_BF16_REVISION: &str = "254989c3ca7ee691187647f350b112c0c448789d";
 
 /// Whether `dir` is a converted LTX snapshot **complete for the current engine** — it must
 /// carry the audio `vocoder` + I2V `vae_encoder` + single `upsampler`/`vae_decoder` the
@@ -142,6 +153,36 @@ pub(super) fn ltx_bundle_subdir(root: &Path, order: &[&str]) -> Option<PathBuf> 
         .find(|dir| ltx_dir_is_complete(dir))
 }
 
+/// Search the two proven-compatible Hugging Face bundle revisions while keeping tier preference
+/// dominant (sc-18853). An existing install can retain q4/q8 in the old snapshot and place bf16 in
+/// the bumped one; selecting only one snapshot would silently downgrade a bf16 request to q8.
+///
+/// Do not enumerate arbitrary sibling snapshots here. A cache can contain manually downloaded or
+/// future revisions; letting one of those satisfy a preferred tier would bypass the immutable
+/// [`LTX_BUNDLE_REVISION`] pin. The only admitted fallback is its direct parent, whose old paths were
+/// verified byte-identical before this hotfix. The current pin wins a same-tier tie.
+#[cfg(target_os = "macos")]
+pub(super) fn ltx_bundle_subdir_across_revisions(
+    selected: &Path,
+    order: &[&str],
+) -> Option<PathBuf> {
+    let Some(snapshots) = selected
+        .parent()
+        .filter(|parent| parent.file_name().and_then(|name| name.to_str()) == Some("snapshots"))
+    else {
+        return ltx_bundle_subdir(selected, order);
+    };
+    let roots = [
+        snapshots.join(LTX_BUNDLE_REVISION),
+        snapshots.join(LTX_BUNDLE_PRE_BF16_REVISION),
+    ];
+    order.iter().find_map(|sub| {
+        roots
+            .iter()
+            .find_map(|root| ltx_bundle_subdir(root, &[sub]))
+    })
+}
+
 /// Resolve the converted LTX MLX snapshot dir. Env override (`SCENEWORKS_MLX_LTX_DIR` /
 /// `…_EROS_DIR`) → `<data>/models/mlx/<candidate>` → (base only) the turnkey SceneWorks bundle
 /// [`LTX_BUNDLE_REPO`], descending into its `q4/`/`q8/` subdir. Only a dir **complete for the
@@ -191,7 +232,9 @@ pub(super) fn resolve_ltx_model_dir(
     // load.
     if !eros {
         if let Some(root) = huggingface_snapshot_dir(&settings.data_dir, LTX_BUNDLE_REPO) {
-            if let Some(dir) = ltx_bundle_subdir(&root, ltx_bundle_tier_order(request)) {
+            if let Some(dir) =
+                ltx_bundle_subdir_across_revisions(&root, ltx_bundle_tier_order(request))
+            {
                 return Ok(dir);
             }
         }
@@ -497,7 +540,7 @@ pub(super) async fn ensure_ltx_q8_present(
     let Some(root) = huggingface_snapshot_dir(&settings.data_dir, LTX_BUNDLE_REPO) else {
         return Ok(());
     };
-    if ltx_dir_is_complete(&root.join("q8")) {
+    if ltx_bundle_subdir_across_revisions(&root, &["q8"]).is_some() {
         return Ok(());
     }
     let files = vec!["q8/*".to_owned()];
@@ -518,7 +561,7 @@ pub(super) async fn ensure_ltx_q8_present(
 /// `bf16/*` from the FIXED [`LTX_BUNDLE_REVISION`] the first time it is requested. No-op for eros, for
 /// non-bf16 jobs, or when `bf16/` is already complete. Mirrors [`ensure_ltx_q8_present`].
 #[cfg(target_os = "macos")]
-async fn ensure_ltx_bf16_present(
+pub(super) async fn ensure_ltx_bf16_present(
     api: &ApiClient,
     settings: &Settings,
     job: &JobSnapshot,
@@ -530,7 +573,7 @@ async fn ensure_ltx_bf16_present(
     let Some(root) = huggingface_snapshot_dir(&settings.data_dir, LTX_BUNDLE_REPO) else {
         return Ok(());
     };
-    if ltx_dir_is_complete(&root.join("bf16")) {
+    if ltx_bundle_subdir_across_revisions(&root, &["bf16"]).is_some() {
         return Ok(());
     }
     let files = vec!["bf16/*".to_owned()];

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -4290,6 +4290,10 @@ fn wan_lightning_subdir_is_canonical_for_fetch_and_resolution() {
 #[cfg(target_os = "macos")]
 #[test]
 fn ltx_bundle_revision_is_pinned_commit_not_main() {
+    assert_eq!(
+        LTX_BUNDLE_REVISION, "01df27d308466533aa09d251e3aebdcc627d07eb",
+        "the LTX pin must name the first revision that contains bf16/ (sc-18853)"
+    );
     assert_ne!(
         LTX_BUNDLE_REVISION, "main",
         "LTX q8 bundle must pin a fixed revision"
@@ -4305,6 +4309,48 @@ fn ltx_bundle_revision_is_pinned_commit_not_main() {
             .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
         "the pinned revision must be lowercase hex"
     );
+}
+
+/// The Models-screen install and generation-time tier fetch are two entry points into the same
+/// bundle. Every LTX row must therefore use the worker pin, and the bf16 row must request the
+/// directory that exists at that pin (sc-18853).
+#[cfg(target_os = "macos")]
+#[test]
+fn ltx_bundle_manifest_rows_match_the_worker_pin() {
+    use sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS;
+    use sceneworks_core::jsonc::strip_jsonc_comments;
+
+    let raw = BUILTIN_MANIFESTS
+        .iter()
+        .find(|(name, _)| *name == "builtin.models.jsonc")
+        .map(|(_, contents)| *contents)
+        .expect("builtin.models.jsonc present");
+    let manifest: Value =
+        serde_json::from_str(&strip_jsonc_comments(raw)).expect("builtin models parses as JSON");
+    let model = manifest["models"]
+        .as_array()
+        .expect("models array")
+        .iter()
+        .find(|model| model["id"].as_str() == Some("ltx_2_3"))
+        .expect("ltx_2_3 present in the builtin catalog");
+    let downloads = model["downloads"]
+        .as_array()
+        .expect("ltx_2_3 declares downloads");
+
+    assert_eq!(downloads.len(), 4, "gemma plus q4/q8/bf16 rows");
+    for download in downloads {
+        assert_eq!(download["repo"].as_str(), Some(LTX_BUNDLE_REPO));
+        assert_eq!(
+            download["revision"].as_str(),
+            Some(LTX_BUNDLE_REVISION),
+            "manifest and on-demand fetches must populate the same snapshot"
+        );
+    }
+    let bf16 = downloads
+        .iter()
+        .find(|download| download["variant"].as_str() == Some("bf16"))
+        .expect("bf16 tier row");
+    assert_eq!(bf16["files"], json!(["bf16/*"]));
 }
 
 // sc-8828 (F-026): `resolve_video_route` is the extracted native (MLX) dispatch decision — the
@@ -7942,6 +7988,251 @@ fn ltx_bundle_subdir_picks_quant_and_finds_gemma() {
 
     let _ = std::fs::remove_dir_all(&root);
     let _ = std::fs::remove_dir_all(&bare);
+}
+
+/// A pre-hotfix install keeps q4/q8 in the old snapshot while bf16 lands in the bumped snapshot.
+/// The requested tier must win across revisions; otherwise a bf16 request silently runs q8.
+#[cfg(target_os = "macos")]
+#[test]
+fn ltx_bundle_subdir_across_revisions_prefers_tier_over_revision() {
+    fn write_complete_ltx_dir(dir: &Path) {
+        std::fs::create_dir_all(dir).unwrap();
+        for file in [
+            "connector.safetensors",
+            "transformer.safetensors",
+            "upsampler.safetensors",
+            "vae_decoder.safetensors",
+            "vae_encoder.safetensors",
+            "audio_vae.safetensors",
+            "vocoder.safetensors",
+        ] {
+            std::fs::write(dir.join(file), b"x").unwrap();
+        }
+    }
+
+    let cache = tempfile::tempdir().expect("temp cache");
+    let snapshots = cache.path().join("snapshots");
+    let old = snapshots.join(LTX_BUNDLE_PRE_BF16_REVISION);
+    let bumped = snapshots.join(LTX_BUNDLE_REVISION);
+    write_complete_ltx_dir(&old.join("q4"));
+    write_complete_ltx_dir(&old.join("q8"));
+    write_complete_ltx_dir(&bumped.join("bf16"));
+
+    assert_eq!(
+        ltx_bundle_subdir(&old, &["bf16", "q8", "q4"]).as_deref(),
+        Some(old.join("q8").as_path()),
+        "precondition: a single-snapshot lookup downgrades bf16 to q8"
+    );
+    assert_eq!(
+        ltx_bundle_subdir_across_revisions(&old, &["bf16", "q8", "q4"]).as_deref(),
+        Some(bumped.join("bf16").as_path()),
+        "bf16 in a sibling revision must beat q8 in the selected revision"
+    );
+    assert_eq!(
+        ltx_bundle_subdir_across_revisions(&bumped, &["q4", "q8"]).as_deref(),
+        Some(old.join("q4").as_path()),
+        "the default tier remains reachable in the pre-hotfix snapshot"
+    );
+
+    write_complete_ltx_dir(&bumped.join("q4"));
+    assert_eq!(
+        ltx_bundle_subdir_across_revisions(&old, &["q4"]).as_deref(),
+        Some(bumped.join("q4").as_path()),
+        "the immutable current pin wins when both compatible revisions contain the tier"
+    );
+
+    let unrelated = snapshots.join("ffffffffffffffffffffffffffffffffffffffff");
+    write_complete_ltx_dir(&unrelated.join("bf16"));
+    std::fs::remove_file(bumped.join("bf16/vocoder.safetensors")).unwrap();
+    assert_eq!(
+        ltx_bundle_subdir_across_revisions(&unrelated, &["bf16", "q8", "q4"]).as_deref(),
+        Some(old.join("q8").as_path()),
+        "an arbitrary cached revision must never bypass the immutable pin or its proven parent"
+    );
+
+    let flat = tempfile::tempdir().expect("flat cache");
+    write_complete_ltx_dir(&flat.path().join("sibling").join("bf16"));
+    write_complete_ltx_dir(&flat.path().join("selected").join("q4"));
+    assert_eq!(
+        ltx_bundle_subdir_across_revisions(&flat.path().join("selected"), &["bf16", "q8", "q4"])
+            .as_deref(),
+        Some(flat.path().join("selected").join("q4").as_path()),
+        "legacy flat layouts must not scan unrelated sibling directories"
+    );
+}
+
+/// Build the exact split cache created when an existing install downloads bf16 after the pin bump.
+/// No refs/main is written, so the real resolver's most-files fallback selects the old snapshot.
+#[cfg(target_os = "macos")]
+fn ltx_split_revision_hub(tag: &str) -> tempfile::TempDir {
+    fn write_complete_ltx_dir(dir: &Path) {
+        std::fs::create_dir_all(dir).unwrap();
+        for file in [
+            "connector.safetensors",
+            "transformer.safetensors",
+            "upsampler.safetensors",
+            "vae_decoder.safetensors",
+            "vae_encoder.safetensors",
+            "audio_vae.safetensors",
+            "vocoder.safetensors",
+        ] {
+            std::fs::write(dir.join(file), b"x").unwrap();
+        }
+    }
+
+    let hub = tempfile::Builder::new()
+        .prefix(&format!("sw_ltx_hub_{tag}_"))
+        .tempdir()
+        .expect("temp hub");
+    let snapshots = hub
+        .path()
+        .join(format!(
+            "models--{}",
+            sceneworks_core::hf_home::safe_repo_dir_name(LTX_BUNDLE_REPO).expect("LTX repo slug")
+        ))
+        .join("snapshots");
+    let old = snapshots.join(LTX_BUNDLE_PRE_BF16_REVISION);
+    write_complete_ltx_dir(&old.join("q4"));
+    write_complete_ltx_dir(&old.join("q8"));
+    write_complete_gemma_dir(&old.join("gemma"));
+    write_complete_ltx_dir(&snapshots.join(LTX_BUNDLE_REVISION).join("bf16"));
+    hub
+}
+
+#[cfg(target_os = "macos")]
+fn ltx_with_hermetic_cache<T>(hub: &Path, body: impl FnOnce() -> T) -> T {
+    temp_env_vars(
+        &[
+            ("HF_HUB_CACHE", hub.to_str().expect("utf-8 hub")),
+            ("HUGGINGFACE_HUB_CACHE", ""),
+            ("HF_HOME", ""),
+            ("SCENEWORKS_MLX_LTX_DIR", ""),
+            ("SCENEWORKS_MLX_LTX_EROS_DIR", ""),
+            ("LTX_GEMMA_DIR", ""),
+        ],
+        body,
+    )
+}
+
+/// Drive the production resolver over the split cache, rather than only testing its helper.
+#[cfg(target_os = "macos")]
+#[test]
+fn resolve_ltx_model_dir_reaches_bf16_in_a_sibling_revision() {
+    let hub = ltx_split_revision_hub("resolve");
+    let data = tempfile::tempdir().expect("temp data");
+    let settings = Settings {
+        data_dir: data.path().to_path_buf(),
+        ..offline_settings()
+    };
+    let request_for = |bits: Option<i64>| {
+        let advanced = bits.map_or_else(|| json!({}), |bits| json!({ "mlxQuantize": bits }));
+        request(json!({
+            "projectId": "p", "model": "ltx_2_3", "prompt": "x", "advanced": advanced
+        }))
+    };
+    let snapshots = hub
+        .path()
+        .join(format!(
+            "models--{}",
+            sceneworks_core::hf_home::safe_repo_dir_name(LTX_BUNDLE_REPO).expect("slug")
+        ))
+        .join("snapshots");
+
+    let (bf16, q8, default) = ltx_with_hermetic_cache(hub.path(), || {
+        (
+            resolve_ltx_model_dir(&settings, &request_for(Some(0))),
+            resolve_ltx_model_dir(&settings, &request_for(Some(8))),
+            resolve_ltx_model_dir(&settings, &request_for(None)),
+        )
+    });
+
+    assert_eq!(
+        bf16.expect("bf16 resolves"),
+        snapshots.join(LTX_BUNDLE_REVISION).join("bf16")
+    );
+    let old = snapshots.join(LTX_BUNDLE_PRE_BF16_REVISION);
+    assert_eq!(q8.expect("q8 resolves"), old.join("q8"));
+    assert_eq!(default.expect("default resolves"), old.join("q4"));
+}
+
+/// A complete tier in any revision is already provisioned. Presence checks must not contact the Hub
+/// for it, while a tier missing from every revision must still attempt the fetch.
+#[cfg(target_os = "macos")]
+#[test]
+fn ensure_ltx_tier_present_skips_fetch_for_a_sibling_revision() {
+    fn block_on<F: std::future::Future>(future: F) -> F::Output {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime")
+            .block_on(future)
+    }
+
+    let hub = ltx_split_revision_hub("ensure");
+    let data = tempfile::tempdir().expect("temp data");
+    let settings = Settings {
+        data_dir: data.path().to_path_buf(),
+        ..offline_settings()
+    };
+    let api = ApiClient::new(&settings);
+    let job: JobSnapshot = serde_json::from_value(json!({
+        "id": "job-ltx-tier-1",
+        "type": "video_generate",
+        "status": "running",
+        "projectId": "p",
+        "projectName": "P",
+        "payload": { "model": "ltx_2_3" },
+        "result": {},
+        "requestedGpu": "auto",
+        "assignedGpu": null,
+        "workerId": "test-worker",
+        "progress": 0,
+        "stage": "queued",
+        "message": "",
+        "error": null,
+        "etaSeconds": null,
+        "attempts": 1,
+        "cancelRequested": false,
+        "createdAt": "2026-08-13T00:00:00Z",
+        "updatedAt": "2026-08-13T00:00:00Z"
+    }))
+    .expect("job snapshot");
+    let ltx = |bits: i64| {
+        request(json!({
+            "projectId": "p", "model": "ltx_2_3", "prompt": "x",
+            "advanced": { "mlxQuantize": bits }
+        }))
+    };
+
+    let (bf16, q8) = ltx_with_hermetic_cache(hub.path(), || {
+        (
+            block_on(ensure_ltx_bf16_present(&api, &settings, &job, &ltx(0))),
+            block_on(ensure_ltx_q8_present(&api, &settings, &job, &ltx(8))),
+        )
+    });
+    assert!(
+        bf16.is_ok(),
+        "bf16 in a sibling must not dial the Hub: {bf16:?}"
+    );
+    assert!(q8.is_ok(), "q8 in the selected snapshot is present: {q8:?}");
+
+    let bare = tempfile::tempdir().expect("bare hub");
+    let bare_snapshot = bare
+        .path()
+        .join(format!(
+            "models--{}",
+            sceneworks_core::hf_home::safe_repo_dir_name(LTX_BUNDLE_REPO).expect("slug")
+        ))
+        .join("snapshots")
+        .join(LTX_BUNDLE_PRE_BF16_REVISION);
+    write_complete_gemma_dir(&bare_snapshot.join("gemma"));
+    let missing = ltx_with_hermetic_cache(bare.path(), || {
+        block_on(ensure_ltx_bf16_present(&api, &settings, &job, &ltx(0)))
+    });
+    assert!(
+        missing.is_err(),
+        "bf16 absent from every revision must still attempt a fetch"
+    );
 }
 
 /// Lay down a complete Gemma-3 text-encoder snapshot at `dir`: config, tokenizer, a two-shard


### PR DESCRIPTION
## Summary

- move every LTX-2.3 bundle download and the worker to the first immutable revision containing `bf16/`
- resolve q4/q8/bf16 across only the proven current + legacy snapshot pair, preserving split-cache installs without allowing arbitrary cached revisions to bypass the pin
- cover manifest/worker alignment, tier-first split-cache resolution, current-pin precedence, unrelated-revision exclusion, and offline presence probes

Shortcut: https://app.shortcut.com/trefry/story/18853

## Verification

- Old pin `254989c3ca7ee691187647f350b112c0c448789d` + `bf16/*`: zero files
- New pin `01df27d308466533aa09d251e3aebdcc627d07eb` + `bf16/*`: 10 files / 47,092,811,992 bytes, including `bf16/transformer.safetensors`
- Hugging Face history proves the new pin is the old pin's direct child and adds only those 10 `bf16/` files; q4/q8/gemma are byte-identical
- production Models-screen snapshot installer resolved the new commit and integrity-accepted/materialized `bf16/transformer.safetensors` (1 passed, 1635.54s)
- real MLX LTX bf16 engine video-with-audio smoke passed (1 passed, 15.82s)
- `cargo test --locked -p sceneworks-worker --lib ltx_ -- --nocapture` (21 passed, 2 real-weight tests ignored in the focused run)
- `npm run check`
- `npm run rust:lint`
- `npm run rust:check:candle`
- manifest audit (59 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

The release-line `check-download-patterns` script also passes, but it is revision-blind; the direct revision-qualified Hugging Face and product-installer evidence above is the pin proof. The local Docker-only neither-backend lane was unavailable because Docker Desktop was stopped; required GitHub CI supplies that lane.

## Scope

This is the smallest complete extraction from the feature fix. It intentionally excludes Eros-Gemma changes, calibration docs, generated memory-matrix artifacts, and the separate SC-18854 revision-aware CI-gate work.

Independent adversarial review: PASS, high confidence, no remaining issues, scope gaps, or code-validation gaps after restricting the compatibility scan to the two proven revisions.
