### PR TITLE
chore(release): 0.8.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6319,7 +6319,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-core"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "directories",
  "fs2",
@@ -6344,7 +6344,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-desktop"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -6380,7 +6380,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-image-quality"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "image",
  "image_hasher",
@@ -6392,7 +6392,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-mcp"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -6409,7 +6409,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-rust-api"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "axum",
  "fs2",
@@ -6446,7 +6446,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-rust-worker"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "sceneworks-worker",
  "tokio",
@@ -6454,7 +6454,7 @@ dependencies = [
 
 [[package]]
 name = "sceneworks-worker"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "axum",
  "fs2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 rust-version = "1.80"
 license-file = "LICENSE"

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/desktop",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/desktop",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "devDependencies": {
         "@tauri-apps/cli": "^2",
         "ajv": "8.20.0"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/desktop",
   "private": true,
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "SceneWorks desktop shell (Tauri).",
   "scripts": {
     "dev": "tauri dev",

--- a/apps/desktop/tauri.conf.json
+++ b/apps/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SceneWorks",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "identifier": "net.trefry.sceneworks",
   "build": {
     "frontendDist": "ui",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sceneworks/web",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sceneworks/web",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "dependencies": {
         "konva": "^9.3.22",
         "react": "18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sceneworks/web",
   "private": true,
-  "version": "0.8.5",
+  "version": "0.8.6",
   "type": "module",
   "scripts": {
     "dev": "vite --host 0.0.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sceneworks",
   "private": true,
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Local AI image and video generation studio runtime skeleton.",
   "license": "AGPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
## Summary

- bump SceneWorks from 0.8.5 to 0.8.6 across npm, Tauri, Cargo workspace, and lockfiles
- preserve the exact inference pin at `6d29a83dd7a97e22dc5dce0a57fdef1521d02ed6`

## Validation

- `git diff --check HEAD^`
- `cargo metadata --locked --no-deps --format-version 1`
- `npm run check`
- reviewed all eight changed manifests and lockfiles; version-only changes