### PR TITLE
SC-18902: add LTX Eros Candle baseline capture

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -156,6 +156,11 @@ on:
         description: "Exact 40-hex Krea artifact revision"
         required: false
         type: string
+      run_ltx_eros_acceptance:
+        description: "Capture the fixed SC-18902 current-route LTX-2.3 10Eros CUDA baseline"
+        required: false
+        type: boolean
+        default: false
 
 # Cancel superseded PR runs, but never cancel a main-push run: this lane is the
 # ONLY thing that compiles the candle-gated worker code, so a main commit whose
@@ -275,7 +280,7 @@ jobs:
     # that box and starves every queued PR/main run on it until the cap fires
     # (sc-13603). Well above the healthy ~11-14 min build+test+clippy — a cold
     # candle-kernels (nvcc) rebuild still fits comfortably.
-    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && inputs.provision_krea_snapshot && 240 || github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && 120 || 45 }}
+    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && inputs.run_ltx_eros_acceptance && 360 || github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && inputs.provision_krea_snapshot && 240 || github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && 120 || 45 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # sc-13166: point this lane at the REAL rustup toolchain bin and prepend it to
@@ -592,3 +597,202 @@ jobs:
           :audio_restamped
           echo ::error::config/engine-capabilities/audio/capabilities.candle.json does not match a fresh dump at this pin. Either box re-dumps it - the audio registry is candle-native everywhere - then run npm run gen:preview-support from apps/web. If the macOS lane passes this same check while this one fails, the two lanes have stopped producing identical audio bytes, which is what the shared file assumes. Do NOT just rewrite the inferenceRevision line.
           exit /b 1
+      # SC-18902's product decision requires an actual Eros render, not source inference. These
+      # dispatch-only steps run after the ordinary PR verdicts so the capability dump remains last
+      # on the PR path. This captures only the current no-adapter Candle route. A candidate is
+      # intentionally absent: the published cond_safe LoRA has 3,320 keys while the current Candle
+      # adapter surface accepts only 768, so filtering it would not be an honest comparison.
+      - name: Validate the fixed LTX Eros acceptance dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_ltx_eros_acceptance }}
+        shell: powershell
+        run: |
+          $version = python --version
+          if ($LASTEXITCODE -ne 0 -or $version -notmatch '^Python 3\.(?<minor>\d+)\.') {
+            throw "the self-hosted CUDA runner requires Python 3.12 or newer, got: $version"
+          }
+          if ([int]$Matches.minor -lt 12) {
+            throw "the self-hosted CUDA runner requires Python 3.12 or newer, got: $version"
+          }
+          foreach ($command in @('nvidia-smi', 'ffmpeg', 'ffprobe')) {
+            if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
+              throw "the self-hosted CUDA runner is missing required command: $command"
+            }
+          }
+      - name: Provision exact public LTX Eros acceptance artifacts
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_ltx_eros_acceptance }}
+        shell: powershell
+        env:
+          EROS_REVISION: "84a05a13610d78dbe4340d1be23fd8185e10f697"
+          GEMMA_REVISION: "01df27d308466533aa09d251e3aebdcc627d07eb"
+          HF_HUB_DISABLE_IMPLICIT_TOKEN: "1"
+          HF_HUB_DISABLE_PROGRESS_BARS: "1"
+          HF_HUB_DISABLE_TELEMETRY: "1"
+          HF_HUB_VERBOSITY: "error"
+        run: |
+          $venv = Join-Path $env:RUNNER_TEMP 'ltx-eros-provision-venv'
+          python -m venv $venv
+          if ($LASTEXITCODE -ne 0) { throw 'failed to create the job-local LTX provisioning venv' }
+          $python = Join-Path $venv 'Scripts\python.exe'
+          & $python -m pip install --disable-pip-version-check --no-input 'huggingface_hub==0.36.0'
+          if ($LASTEXITCODE -ne 0) { throw 'failed to install the pinned huggingface_hub client' }
+          @'
+          import os
+          from pathlib import Path
+          from huggingface_hub import snapshot_download
+
+          cache_dir = os.path.join(os.environ["USERPROFILE"], ".cache", "huggingface", "hub")
+          eros_root = Path(snapshot_download(
+              repo_id="TenStrip/LTX2.3-10Eros",
+              repo_type="model",
+              revision=os.environ["EROS_REVISION"],
+              allow_patterns=["10Eros_v1.3_bf16.safetensors"],
+              cache_dir=cache_dir,
+              token=False,
+              max_workers=4,
+          ))
+          gemma_root = Path(snapshot_download(
+              repo_id="SceneWorks/ltx-2.3-mlx",
+              repo_type="model",
+              revision=os.environ["GEMMA_REVISION"],
+              allow_patterns=["gemma/**"],
+              cache_dir=cache_dir,
+              token=False,
+              max_workers=4,
+          ))
+
+          eros_file = eros_root / "10Eros_v1.3_bf16.safetensors"
+          gemma_dir = gemma_root / "gemma"
+          for path, label in [
+              (eros_file, "Eros checkpoint"),
+              (gemma_dir / "config.json", "public SceneWorks Gemma component"),
+          ]:
+              if not path.is_file():
+                  raise RuntimeError(f"{label} is missing after exact-revision provisioning: {path}")
+          output_dir = Path(os.environ["RUNNER_TEMP"]) / (
+              f"sc-18902-ltx-eros-{os.environ['GITHUB_RUN_ID']}-{os.environ['GITHUB_RUN_ATTEMPT']}"
+          )
+          if output_dir.exists():
+              raise RuntimeError(f"refusing a stale LTX acceptance output directory: {output_dir}")
+
+          exports = {
+              "LTX_EROS_DIR": str(eros_root),
+              "LTX_EROS_GEMMA_DIR": str(gemma_dir),
+              "LTX_EROS_OUT_DIR": str(output_dir),
+          }
+          with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env_file:
+              for key, value in exports.items():
+                  print(f"{key}={value}", file=env_file)
+          print("Exact public LTX Eros acceptance artifacts provisioned anonymously")
+          '@ | & $python -
+          if ($LASTEXITCODE -ne 0) { throw 'exact LTX Eros artifact provisioning failed' }
+      - name: Render the fixed LTX Eros CUDA acceptance artifact
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_ltx_eros_acceptance }}
+        shell: cmd
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          set NVCC_CCBIN=%VCToolsInstallDir%bin\Hostx64\x64
+          nvidia-smi
+          cargo test -p sceneworks-worker --features backend-candle --release ltx_eros_candle_gpu_smoke -- --ignored --nocapture --test-threads=1
+      - name: Encode and verify the LTX Eros evidence bundle
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_ltx_eros_acceptance }}
+        shell: powershell
+        run: |
+          $out = $env:LTX_EROS_OUT_DIR
+          if (-not (Test-Path -LiteralPath $out -PathType Container)) {
+            throw "the LTX Eros smoke wrote no output directory: $out"
+          }
+          $mp4 = Join-Path $out 'ltx_eros.mp4'
+          $videoOnly = Join-Path $out 'ltx_eros.video-only.mp4'
+          $frames = Join-Path $out 'frames\frame_%05d.png'
+          $audio = Join-Path $out 'audio.wav'
+          & ffmpeg -hide_banner -loglevel warning -nostdin -y -framerate 25 -start_number 0 -i $frames -c:v libx264 -preset slow -crf 18 -pix_fmt yuv420p -r 25 $videoOnly
+          if ($LASTEXITCODE -ne 0) { throw 'ffmpeg failed to encode the LTX Eros video stream' }
+          # Match the product's LTX mux contract: copy the encoded H.264 stream, encode the WAV as
+          # AAC, inherit metadata from the video input, and bound the container by the shorter input.
+          # The exact 153-frame assertion below makes any unintended `-shortest` truncation fatal.
+          & ffmpeg -hide_banner -loglevel warning -nostdin -y -i $videoOnly -i $audio -map 0:v:0 -map 1:a:0 -c:v copy -c:a aac -b:a 192k -shortest -map_metadata 0 -movflags +faststart $mp4
+          if ($LASTEXITCODE -ne 0) { throw 'ffmpeg failed to mux the LTX Eros evidence MP4' }
+          Remove-Item -LiteralPath $videoOnly -Force
+
+          $probePath = Join-Path $out 'ffprobe-mp4.json'
+          & ffprobe -v error -count_frames -show_entries 'stream=index,codec_name,codec_type,width,height,r_frame_rate,nb_read_frames,sample_rate,channels,duration:format=duration' -of json $mp4 | Out-File -LiteralPath $probePath -Encoding utf8
+          if ($LASTEXITCODE -ne 0) { throw 'ffprobe failed on the LTX Eros evidence MP4' }
+          $probe = Get-Content -Raw -LiteralPath $probePath | ConvertFrom-Json
+          $video = $probe.streams | Where-Object { $_.codec_type -eq 'video' } | Select-Object -First 1
+          $sound = $probe.streams | Where-Object { $_.codec_type -eq 'audio' } | Select-Object -First 1
+          if (-not $video -or $video.codec_name -ne 'h264' -or $video.width -ne 768 -or $video.height -ne 512) {
+            throw 'encoded LTX Eros MP4 must contain h264 768x512 video'
+          }
+          if ($video.r_frame_rate -ne '25/1' -or [int]$video.nb_read_frames -ne 153) {
+            throw "encoded LTX Eros MP4 must contain exactly 153 frames at 25 fps, got $($video.nb_read_frames) at $($video.r_frame_rate)"
+          }
+          if (-not $sound -or $sound.codec_name -ne 'aac') {
+            throw 'encoded LTX Eros MP4 must contain AAC audio'
+          }
+
+          $wavProbePath = Join-Path $out 'ffprobe-wav.json'
+          & ffprobe -v error -show_entries 'stream=index,codec_name,codec_type,sample_rate,channels,duration:format=duration' -of json $audio | Out-File -LiteralPath $wavProbePath -Encoding utf8
+          if ($LASTEXITCODE -ne 0) { throw 'ffprobe failed on the LTX Eros source WAV' }
+          $wavProbe = Get-Content -Raw -LiteralPath $wavProbePath | ConvertFrom-Json
+          $wavAudio = $wavProbe.streams | Where-Object { $_.codec_type -eq 'audio' } | Select-Object -First 1
+          if (-not $wavAudio -or $wavAudio.codec_name -ne 'pcm_s16le') {
+            throw 'LTX Eros source WAV must contain signed 16-bit little-endian PCM audio'
+          }
+
+          # One output frame (40 ms) is the maximum tolerated timestamp/container rounding error.
+          # This is wide enough for AAC packet/time-base rounding. Together with the exact frame
+          # assertion above, it rejects a missing frame and an audio track that represents the raw
+          # 6.00 s rather than all 153 duration-derived frames (153 / 25 = 6.12 s).
+          $expectedDurationSeconds = 153.0 / 25.0
+          $durationToleranceSeconds = 1.0 / 25.0
+          function Assert-DurationNear([string]$label, $actualValue) {
+            if ($null -eq $actualValue) { throw "$label duration is missing" }
+            $actualSeconds = [Convert]::ToDouble($actualValue, [Globalization.CultureInfo]::InvariantCulture)
+            if ([Math]::Abs($actualSeconds - $expectedDurationSeconds) -gt ($durationToleranceSeconds + 0.000001)) {
+              throw "$label duration $actualSeconds is not within $durationToleranceSeconds s of $expectedDurationSeconds s"
+            }
+          }
+          Assert-DurationNear 'source WAV container' $wavProbe.format.duration
+          Assert-DurationNear 'MP4 video stream' $video.duration
+          Assert-DurationNear 'MP4 audio stream' $sound.duration
+          Assert-DurationNear 'MP4 container' $probe.format.duration
+
+          $metadata = Get-Content -Raw -LiteralPath (Join-Path $out 'metadata.json') | ConvertFrom-Json
+          if ($metadata.captureKind -ne 'current-candle-route-baseline' -or $metadata.request.seed -ne 18902) {
+            throw 'LTX Eros metadata does not identify the fixed current-route baseline and seed'
+          }
+          if ($metadata.request.width -ne 768 -or $metadata.request.height -ne 512 -or $metadata.request.durationSeconds -ne 6 -or $metadata.request.fps -ne 25 -or $metadata.request.steps -ne 8) {
+            throw 'LTX Eros metadata drifted from the shipped manifest defaults'
+          }
+
+          $runnerMetadata = [ordered]@{
+            story = 'SC-18902'
+            captureKind = 'current-candle-route-baseline'
+            gitSha = (git rev-parse HEAD).Trim()
+            githubSha = $env:GITHUB_SHA
+            runId = $env:GITHUB_RUN_ID
+            runAttempt = $env:GITHUB_RUN_ATTEMPT
+            runnerName = $env:RUNNER_NAME
+            gpu = ((& nvidia-smi --query-gpu=name,uuid,driver_version,memory.total --format=csv,noheader | Out-String).Trim())
+            rustc = ((& rustc --version | Out-String).Trim())
+            cargo = ((& cargo --version | Out-String).Trim())
+            ffmpeg = ((& ffmpeg -version | Select-Object -First 1 | Out-String).Trim())
+          }
+          $runnerMetadata | ConvertTo-Json -Depth 4 | Out-File -LiteralPath (Join-Path $out 'runner.json') -Encoding utf8
+          $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $mp4).Hash.ToLowerInvariant()
+          "$hash  ltx_eros.mp4" | Out-File -LiteralPath (Join-Path $out 'sha256.txt') -Encoding ascii
+      - name: Upload the LTX Eros acceptance evidence
+        if: ${{ success() && github.event_name == 'workflow_dispatch' && inputs.run_ltx_eros_acceptance }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sc-18902-ltx-eros-baseline-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/ltx_eros.mp4
+            ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/audio.wav
+            ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/stills/*.png
+            ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/metadata.json
+            ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/ffprobe-mp4.json
+            ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/ffprobe-wav.json
+            ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/runner.json
+            ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/sha256.txt
+          if-no-files-found: error

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -359,6 +359,12 @@ mod anima_gpu_smoke;
 // the hardware evidence for the sc-13817 dense-force fix.
 #[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
 mod sensenova_gpu_smoke;
+// SC-18902's opt-in real-weight evidence harness for the shipped `ltx_2_3_eros` Candle route.
+// Test-only + candle-only, and itself #[ignore]d: an explicit Windows CUDA workflow dispatch fixes
+// the manifest-default request and captures the current no-distill baseline. It deliberately has no
+// candidate mode and does not alter product routing.
+#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
+mod ltx_eros_gpu_smoke;
 // Real-weight GPU smoke for the candle SANA 1600M lane (epic 8485, sc-11780). Test-only + candle-only;
 // drives the WORKER's `resolve_weights_dir("sana_1600m")` (the diffusers-snapshot-root resolution) +
 // `gen_core::load("sana_1600m")` against the whole `Efficient-Large-Model/Sana_1600M_1024px_diffusers`

--- a/crates/sceneworks-worker/src/ltx_eros_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/ltx_eros_gpu_smoke.rs
@@ -1,0 +1,378 @@
+//! SC-18902 evidence harness for the shipped Windows/CUDA `ltx_2_3_eros` route.
+//!
+//! This is deliberately an ignored, real-weight test rather than product routing. It captures the
+//! current Candle baseline (the Eros checkpoint with no distill adapter) at the shipped defaults.
+//! It does not offer a candidate: the complete cond_safe LoRA has 3,320 keys while the current
+//! Candle adapter surface accepts only 768, so filtering it would produce misleading evidence.
+//! The baseline artifact informs a later product decision; this harness does not pre-decide it.
+//!
+//! The workflow pins every remote artifact revision and fixes every request parameter here. Only
+//! local paths and the output directory come from the environment. In particular there is no
+//! prompt/seed/shape override that could change the evidence request.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use gen_core::{GenerationOutput, GenerationRequest, LoadSpec, Progress, WeightsSource};
+use serde_json::{json, Value};
+
+use super::smoke_support::{
+    image_mean, image_std, mean_abs_frame_delta, save_png, DEGENERATE_STD_FLOOR_DEFAULT,
+};
+use super::video_jobs::{write_wav_pcm16, AudioTrack};
+
+const STORY_ID: &str = "SC-18902";
+const MODEL_ID: &str = "ltx_2_3_eros";
+const ENGINE_ID: &str = "ltx_2_3_distilled";
+const BACKEND: &str = "candle-cuda";
+const CAPTURE_KIND: &str = "current-candle-route-baseline";
+
+const WIDTH: u32 = 768;
+const HEIGHT: u32 = 512;
+const DURATION_SECONDS: u32 = 6;
+const FPS: u32 = 25;
+const STEPS: u32 = 8;
+const RAW_FRAMES: u32 = DURATION_SECONDS * FPS;
+const RENDERED_FRAMES: u32 = 153;
+const SEED: u64 = 18_902;
+const PROMPT: &str = "A wide locked camera shot of a red fox walking steadily from left to right through a snowy pine clearing at sunrise. The same fox remains visible and anatomically consistent for the entire shot. Fine snow falls continuously; no cuts, no text.";
+
+const EROS_REPOSITORY: &str = "TenStrip/LTX2.3-10Eros";
+const EROS_REVISION: &str = "84a05a13610d78dbe4340d1be23fd8185e10f697";
+const EROS_FILE: &str = "10Eros_v1.3_bf16.safetensors";
+const GEMMA_REPOSITORY: &str = "SceneWorks/ltx-2.3-mlx";
+const GEMMA_REVISION: &str = "01df27d308466533aa09d251e3aebdcc627d07eb";
+const GEMMA_SUBDIR: &str = "gemma";
+
+fn required_env_path(name: &str) -> PathBuf {
+    let value = std::env::var(name).unwrap_or_else(|_| panic!("set ${name}"));
+    let trimmed = value.trim();
+    assert!(!trimmed.is_empty(), "${name} must not be empty");
+    PathBuf::from(trimmed)
+}
+
+fn assert_file(path: &Path, label: &str) {
+    assert!(
+        path.is_file(),
+        "{label} is not a file at {}",
+        path.display()
+    );
+}
+
+fn assert_dir(path: &Path, label: &str) {
+    assert!(
+        path.is_dir(),
+        "{label} is not a directory at {}",
+        path.display()
+    );
+}
+
+fn load_spec(eros_dir: PathBuf, gemma_dir: PathBuf) -> LoadSpec {
+    LoadSpec {
+        text_encoder: Some(WeightsSource::Dir(gemma_dir)),
+        ..LoadSpec::new(WeightsSource::Dir(eros_dir))
+    }
+}
+
+fn request() -> GenerationRequest {
+    GenerationRequest {
+        prompt: PROMPT.to_owned(),
+        width: WIDTH,
+        height: HEIGHT,
+        count: 1,
+        seed: Some(SEED),
+        steps: Some(STEPS),
+        frames: Some(RENDERED_FRAMES),
+        fps: Some(FPS),
+        ..Default::default()
+    }
+}
+
+fn audio_stats(audio: &gen_core::AudioTrack) -> Value {
+    assert!(audio.sample_rate > 0, "LTX returned zero audio sample rate");
+    assert!(audio.channels > 0, "LTX returned zero audio channels");
+    assert!(
+        !audio.samples.is_empty(),
+        "LTX returned an empty audio track"
+    );
+    assert!(
+        audio.samples.iter().all(|sample| sample.is_finite()),
+        "LTX audio contains a non-finite sample"
+    );
+    assert_eq!(
+        audio.samples.len() % audio.channels as usize,
+        0,
+        "LTX audio is not whole interleaved sample frames"
+    );
+    let mean = audio
+        .samples
+        .iter()
+        .map(|sample| *sample as f64)
+        .sum::<f64>()
+        / audio.samples.len() as f64;
+    let std = (audio
+        .samples
+        .iter()
+        .map(|sample| (*sample as f64 - mean).powi(2))
+        .sum::<f64>()
+        / audio.samples.len() as f64)
+        .sqrt();
+    let peak = audio
+        .samples
+        .iter()
+        .fold(0.0_f32, |current, sample| current.max(sample.abs()));
+    assert!(peak > 0.0, "LTX returned an all-zero audio track");
+    json!({
+        "present": true,
+        "sampleRate": audio.sample_rate,
+        "channels": audio.channels,
+        "sampleCount": audio.samples.len(),
+        "durationSeconds": audio.samples.len() as f64
+            / (audio.sample_rate as f64 * audio.channels as f64),
+        "mean": mean,
+        "std": std,
+        "peak": peak,
+    })
+}
+
+#[cfg(test)]
+mod contract_tests {
+    use super::*;
+
+    #[test]
+    fn manifest_default_request_is_fixed_and_ltx_lattice_correct() {
+        assert_eq!((WIDTH, HEIGHT), (768, 512));
+        assert_eq!((DURATION_SECONDS, FPS, STEPS), (6, 25, 8));
+        assert_eq!(RAW_FRAMES, 150);
+        assert_eq!(
+            sceneworks_core::video_request::ltx_frame_count(RAW_FRAMES),
+            RENDERED_FRAMES
+        );
+        assert_eq!(SEED, 18_902);
+        let request = request();
+        assert_eq!(request.prompt, PROMPT);
+        assert_eq!(request.frames, Some(153));
+        assert_eq!(request.fps, Some(25));
+        assert_eq!(request.steps, Some(8));
+        assert_eq!(request.sampler, None);
+        assert_eq!(request.guidance, None);
+        assert_eq!(request.negative_prompt, None);
+    }
+
+    #[test]
+    fn load_spec_is_the_current_product_neutral_no_adapter_baseline() {
+        let spec = load_spec(PathBuf::from("eros"), PathBuf::from("gemma"));
+        let WeightsSource::Dir(weights) = &spec.weights else {
+            panic!("baseline Eros weights must remain a snapshot directory")
+        };
+        assert_eq!(weights, &PathBuf::from("eros"));
+        let Some(WeightsSource::Dir(text_encoder)) = &spec.text_encoder else {
+            panic!("baseline Gemma weights must remain a snapshot directory")
+        };
+        assert_eq!(text_encoder, &PathBuf::from("gemma"));
+        assert!(spec.adapters.is_empty());
+    }
+}
+
+#[test]
+#[ignore = "real-weight SC-18902 acceptance; needs exact public Eros/Gemma artifacts and a Windows CUDA GPU"]
+fn ltx_eros_candle_gpu_smoke() {
+    let eros_dir = required_env_path("LTX_EROS_DIR");
+    let gemma_dir = required_env_path("LTX_EROS_GEMMA_DIR");
+    let out_dir = required_env_path("LTX_EROS_OUT_DIR");
+    let eros_file = eros_dir.join(EROS_FILE);
+    assert_dir(&eros_dir, "exact Eros snapshot");
+    assert_file(&eros_file, "Eros bf16 checkpoint");
+    assert_dir(&gemma_dir, "public SceneWorks Gemma component");
+    assert_file(&gemma_dir.join("config.json"), "Gemma config");
+
+    std::fs::create_dir_all(out_dir.join("frames")).expect("create frame output directory");
+    std::fs::create_dir_all(out_dir.join("stills")).expect("create still output directory");
+
+    println!(
+        "[sc-18902] capture={} model={} engine={} {}x{} duration={}s raw_frames={} rendered_frames={} fps={} steps={} seed={} prompt={:?}",
+        CAPTURE_KIND,
+        MODEL_ID,
+        ENGINE_ID,
+        WIDTH,
+        HEIGHT,
+        DURATION_SECONDS,
+        RAW_FRAMES,
+        RENDERED_FRAMES,
+        FPS,
+        STEPS,
+        SEED,
+        PROMPT
+    );
+
+    let load_started = Instant::now();
+    let generator = crate::inference_runtime::load(ENGINE_ID, &load_spec(eros_dir, gemma_dir))
+        .unwrap_or_else(|error| panic!("load Candle LTX Eros provider: {error}"));
+    let load_seconds = load_started.elapsed().as_secs_f64();
+    assert_eq!(generator.descriptor().id, ENGINE_ID);
+
+    let render_started = Instant::now();
+    let mut last_step = 0_u32;
+    let mut saw_decode = false;
+    let output = generator
+        .generate(&request(), &mut |progress| match progress {
+            Progress::Step { current, total } => {
+                assert!(current >= last_step, "LTX progress moved backwards");
+                assert!(current <= total, "LTX progress exceeded its total");
+                last_step = current;
+                println!("[sc-18902] denoise {current}/{total}");
+            }
+            Progress::Decoding => {
+                saw_decode = true;
+                println!("[sc-18902] decoding");
+            }
+            Progress::Loading(phase) => println!("[sc-18902] loading {phase:?}"),
+        })
+        .unwrap_or_else(|error| panic!("Candle LTX Eros render: {error}"));
+    let render_seconds = render_started.elapsed().as_secs_f64();
+    assert!(last_step > 0, "LTX emitted no denoise progress");
+    assert!(saw_decode, "LTX emitted no decode progress");
+
+    let GenerationOutput::Video { frames, fps, audio } = output else {
+        panic!("Candle LTX Eros returned a non-video output")
+    };
+    assert_eq!(fps, FPS, "Candle LTX changed the requested playback fps");
+    assert_eq!(
+        frames.len(),
+        RENDERED_FRAMES as usize,
+        "Candle LTX changed the duration-derived frame count"
+    );
+
+    let mut frame_stats = Vec::with_capacity(frames.len());
+    for (index, frame) in frames.iter().enumerate() {
+        assert_eq!(
+            (frame.width, frame.height),
+            (WIDTH, HEIGHT),
+            "frame {index} has the wrong dimensions"
+        );
+        assert_eq!(
+            frame.pixels.len(),
+            (WIDTH * HEIGHT * 3) as usize,
+            "frame {index} has an invalid RGB buffer"
+        );
+        let mean = image_mean(frame);
+        let std = image_std(frame);
+        assert!(
+            std > DEGENERATE_STD_FLOOR_DEFAULT,
+            "frame {index} is degenerate (std {std:.3})"
+        );
+        save_png(
+            frame,
+            &out_dir.join("frames").join(format!("frame_{index:05}.png")),
+        );
+        frame_stats.push(json!({ "index": index, "mean": mean, "std": std }));
+    }
+
+    let pair_deltas: Vec<f64> = frames
+        .windows(2)
+        .map(|pair| mean_abs_frame_delta(&pair[0], &pair[1]))
+        .collect();
+    let minimum_pair_delta = pair_deltas.iter().copied().fold(f64::INFINITY, f64::min);
+    assert!(
+        minimum_pair_delta > 0.0,
+        "Candle LTX returned at least one bit-identical consecutive frame pair"
+    );
+    let first_last_delta = mean_abs_frame_delta(&frames[0], &frames[frames.len() - 1]);
+
+    for (name, index) in [
+        ("first", 0_usize),
+        ("middle", frames.len() / 2),
+        ("last", frames.len() - 1),
+    ] {
+        save_png(
+            &frames[index],
+            &out_dir.join("stills").join(format!("{name}.png")),
+        );
+    }
+
+    let audio = audio.expect("Candle LTX Eros must return its synchronized audio track");
+    let audio_metadata = audio_stats(&audio);
+    write_wav_pcm16(
+        &AudioTrack {
+            samples: audio.samples,
+            sample_rate: audio.sample_rate,
+            channels: audio.channels,
+        },
+        &out_dir.join("audio.wav"),
+    )
+    .expect("write synchronized LTX audio");
+
+    let adapter_reports = generator
+        .adapter_apply_reports()
+        .into_iter()
+        .map(|report| {
+            json!({
+                "path": report.adapter_path,
+                "applied": report.applied,
+                "skipped": report.skipped,
+            })
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        adapter_reports.is_empty(),
+        "the current-route baseline must not install or apply an adapter"
+    );
+    let metadata = json!({
+        "schemaVersion": 1,
+        "story": STORY_ID,
+        "model": MODEL_ID,
+        "engine": ENGINE_ID,
+        "backend": BACKEND,
+        "captureKind": CAPTURE_KIND,
+        "request": {
+            "prompt": PROMPT,
+            "seed": SEED,
+            "width": WIDTH,
+            "height": HEIGHT,
+            "durationSeconds": DURATION_SECONDS,
+            "fps": FPS,
+            "steps": STEPS,
+            "sampler": null,
+            "guidance": null,
+            "negativePrompt": null,
+            "rawFrames": RAW_FRAMES,
+            "renderedFrames": RENDERED_FRAMES,
+            "encodedDurationSeconds": RENDERED_FRAMES as f64 / FPS as f64,
+        },
+        "artifacts": {
+            "checkpoint": {
+                "repository": EROS_REPOSITORY,
+                "revision": EROS_REVISION,
+                "file": EROS_FILE,
+            },
+            "textEncoder": {
+                "repository": GEMMA_REPOSITORY,
+                "revision": GEMMA_REVISION,
+                "subdir": GEMMA_SUBDIR,
+            },
+        },
+        "result": {
+            "frameCount": frames.len(),
+            "fps": fps,
+            "loadSeconds": load_seconds,
+            "renderSeconds": render_seconds,
+            "minimumPairDelta": minimum_pair_delta,
+            "firstLastDelta": first_last_delta,
+            "pairDeltas": pair_deltas,
+            "frameStats": frame_stats,
+            "audio": audio_metadata,
+            "adapterApplyReports": adapter_reports,
+        },
+    });
+    std::fs::write(
+        out_dir.join("metadata.json"),
+        serde_json::to_vec_pretty(&metadata).expect("serialize SC-18902 metadata"),
+    )
+    .expect("write SC-18902 metadata");
+
+    println!(
+        "[sc-18902] DONE capture={} load={load_seconds:.1}s render={render_seconds:.1}s min_pair_delta={minimum_pair_delta:.3} first_last_delta={first_last_delta:.3} out={}",
+        CAPTURE_KIND,
+        out_dir.display()
+    );
+}

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1880,3 +1880,312 @@ test("the MLX FLUX.2-dev calibration arm is bound to the direct reference-free T
   assert.match(arm, /loaded_contract != &contract/);
   assert.doesNotMatch(arm, /registered_dev_safety_check|FLUX2_CONTRACT_PROVIDER/);
 });
+
+// SC-18902. Source inspection cannot decide whether the current Eros Candle route is acceptable:
+// the decision starts with a real Windows/CUDA baseline artifact. The published cond_safe LoRA is
+// not a valid candidate for the current Candle adapter surface (3,320 source keys versus 768
+// accepted keys), so this pins a product-neutral baseline only. The mutation loop is load-bearing:
+// each historically plausible drift is injected into an in-memory copy and must make this same
+// validator fail, proving the positive assertions are sensitive rather than decorative.
+test("the LTX Eros CUDA baseline is fixed, anonymous, mux-faithful, and mutation-sensitive", async () => {
+  const documents = {
+    manifestText: await source("config/manifests/builtin.models.jsonc"),
+    workflow: await source(".github/workflows/windows-candle.yml"),
+    harness: await source("crates/sceneworks-worker/src/ltx_eros_gpu_smoke.rs"),
+    workerLib: await source("crates/sceneworks-worker/src/lib.rs"),
+  };
+
+  const validate = ({ manifestText, workflow, harness, workerLib }) => {
+    const manifest = JSON.parse(stripJsoncComments(manifestText));
+    const base = manifest.models.find((entry) => entry.id === "ltx_2_3");
+    const eros = manifest.models.find((entry) => entry.id === "ltx_2_3_eros");
+    assert.ok(base, "the base ltx_2_3 manifest route must remain present");
+    assert.ok(eros, "the ltx_2_3_eros manifest route must remain present");
+    const shippedDefaults = {
+      duration: 6,
+      fps: 25,
+      resolution: "768x512",
+      quality: "balanced",
+      steps: 8,
+    };
+    assert.deepEqual(eros.defaults, shippedDefaults, "Eros manifest defaults must stay fixed");
+    assert.deepEqual(base.defaults, shippedDefaults, "base LTX manifest defaults must stay untouched");
+    assert.equal(
+      base.mlx?.autoDistillLora,
+      undefined,
+      "the evidence harness must not add the Eros distill recipe to base ltx_2_3",
+    );
+    assert.deepEqual(
+      eros.mlx?.autoDistillLora,
+      { stage1Strength: 1, stage2Strength: 0.4 },
+      "the existing MLX-only two-pass recipe is context, not a Candle recipe to copy",
+    );
+
+    assert.match(
+      workflow,
+      /run_ltx_eros_acceptance:\s+description:[^\n]+\s+required: false\s+type: boolean\s+default: false/,
+      "the expensive real-weight capture must be explicit and off by default",
+    );
+    assert.doesNotMatch(
+      `${workflow}\n${harness}`,
+      /AdapterKind|AdapterSpec|LTX_EROS_RECIPE|LTX_EROS_DISTILL_LORA|ltx_eros_recipe|single-pass-distill|DISTILL_(?:REPOSITORY|REVISION|FILE)/,
+      "the baseline harness must not expose or construct an unsupported filtered-LoRA candidate",
+    );
+    assert.match(
+      workflow,
+      /timeout-minutes: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.run_ltx_eros_acceptance && 360 \|\|/,
+      "the real-weight render needs the guarded six-hour ceiling",
+    );
+    for (const [repository, revision] of [
+      ["TenStrip/LTX2.3-10Eros", "84a05a13610d78dbe4340d1be23fd8185e10f697"],
+      ["SceneWorks/ltx-2.3-mlx", "01df27d308466533aa09d251e3aebdcc627d07eb"],
+    ]) {
+      assert.ok(workflow.includes(`repo_id="${repository}"`), `${repository} must be exact`);
+      assert.ok(workflow.includes(revision), `${repository} must use its exact revision`);
+    }
+    const provisioning = workflow.slice(
+      workflow.indexOf("- name: Provision exact public LTX Eros acceptance artifacts"),
+      workflow.indexOf("- name: Render the fixed LTX Eros CUDA acceptance artifact"),
+    );
+    assert.equal(
+      provisioning.match(/token=False/g)?.length,
+      2,
+      "both HF downloads must explicitly refuse implicit credentials",
+    );
+    assert.match(provisioning, /HF_HUB_DISABLE_IMPLICIT_TOKEN: "1"/);
+    assert.doesNotMatch(
+      provisioning,
+      /secrets\.|HF_TOKEN|HUGGING_FACE_HUB_TOKEN|google\/gemma/,
+      "the harness must not use a secret or a gated Gemma source",
+    );
+    assert.match(
+      workflow,
+      /cargo test -p sceneworks-worker --features backend-candle --release ltx_eros_candle_gpu_smoke -- --ignored --nocapture --test-threads=1/,
+    );
+    assert.match(
+      workflow,
+      /ffmpeg [^\n]*-framerate 25[^\n]*-c:v libx264[^\n]*-r 25 \$videoOnly/,
+      "the source frames must first be encoded as the product's H.264 video stream",
+    );
+    assert.match(
+      workflow,
+      /ffmpeg [^\n]*-i \$videoOnly -i \$audio[^\n]*-c:v copy[^\n]*-c:a aac[^\n]*-shortest[^\n]*-map_metadata 0[^\n]*\$mp4/,
+      "the evidence MP4 must use the product's copy-video/AAC/-shortest mux contract",
+    );
+    assert.match(workflow, /stream=index,codec_name,codec_type[^'\n]+duration:format=duration/);
+    assert.match(
+      workflow,
+      /\$video\.codec_name -ne 'h264'/,
+      "the MP4 verifier must require the production H.264 video codec",
+    );
+    assert.match(
+      workflow,
+      /\$sound\.codec_name -ne 'aac'/,
+      "the MP4 verifier must require the production AAC audio codec",
+    );
+    assert.match(
+      workflow,
+      /\$wavAudio\.codec_name -ne 'pcm_s16le'/,
+      "the source audio verifier must require the worker's PCM16 WAV codec",
+    );
+    assert.match(workflow, /nb_read_frames -ne 153/);
+    assert.match(workflow, /\$expectedDurationSeconds = 153\.0 \/ 25\.0/);
+    assert.match(
+      workflow,
+      /\$durationToleranceSeconds = 1\.0 \/ 25\.0/,
+      "duration tolerance must remain exactly one output frame",
+    );
+    for (const label of [
+      "source WAV container",
+      "MP4 video stream",
+      "MP4 audio stream",
+      "MP4 container",
+    ]) {
+      assert.ok(
+        workflow.includes(`Assert-DurationNear '${label}'`),
+        `${label} duration must be checked against all 153 frames`,
+      );
+    }
+    assert.match(workflow, /ffprobe-mp4\.json/);
+    assert.match(workflow, /ffprobe-wav\.json/);
+    assert.match(
+      workflow,
+      /\$metadata\.captureKind -ne 'current-candle-route-baseline'/,
+      "uploaded metadata must identify the product-neutral current-route baseline",
+    );
+    assert.match(
+      workflow,
+      /if: \$\{\{ success\(\) && github\.event_name == 'workflow_dispatch' && inputs\.run_ltx_eros_acceptance \}\}\s+uses: actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a/,
+      "only a verified capture may publish the MP4/stills/metadata bundle",
+    );
+
+    for (const declaration of [
+      "const WIDTH: u32 = 768;",
+      "const HEIGHT: u32 = 512;",
+      "const DURATION_SECONDS: u32 = 6;",
+      "const FPS: u32 = 25;",
+      "const STEPS: u32 = 8;",
+      "const RENDERED_FRAMES: u32 = 153;",
+      "const SEED: u64 = 18_902;",
+      "assert_eq!(request.sampler, None);",
+      'const CAPTURE_KIND: &str = "current-candle-route-baseline";',
+    ]) {
+      assert.ok(harness.includes(declaration), `fixed harness contract missing: ${declaration}`);
+    }
+    assert.doesNotMatch(
+      harness,
+      /sampler:\s*Some\(/,
+      "the current-route baseline must preserve the manifest-default absent sampler",
+    );
+    assert.match(
+      harness,
+      /"sampler": null/,
+      "capture metadata must record the manifest-default absent sampler",
+    );
+    assert.match(harness, /const PROMPT: &str = "A wide locked camera shot of a red fox/);
+    assert.doesNotMatch(
+      `${workflow}\n${harness}`,
+      /LTX_EROS_(?:PROMPT|SEED|WIDTH|HEIGHT|DURATION|FPS|STEPS)/,
+      "evidence-defining request fields must not be environment-overridable",
+    );
+    assert.match(harness, /fn load_spec\(eros_dir: PathBuf, gemma_dir: PathBuf\) -> LoadSpec/);
+    assert.doesNotMatch(harness, /\.with_adapters\(/);
+    assert.match(harness, /assert!\(spec\.adapters\.is_empty\(\)\)/);
+    assert.match(harness, /"captureKind": CAPTURE_KIND/);
+    assert.match(harness, /adapter_reports\.is_empty\(\)/);
+    assert.match(harness, /"pairDeltas": pair_deltas/);
+    assert.match(harness, /"frameStats": frame_stats/);
+    assert.match(harness, /audio\.expect\("Candle LTX Eros must return its synchronized audio track"\)/);
+    assert.match(
+      workerLib,
+      /#\[cfg\(all\(test, not\(target_os = "macos"\), feature = "backend-candle"\)\)\]\s*\nmod ltx_eros_gpu_smoke;/,
+      "the ignored real-weight test must compile on the actual Windows Candle lane",
+    );
+  };
+
+  assert.doesNotThrow(() => validate(documents));
+
+  const manifestObject = JSON.parse(stripJsoncComments(documents.manifestText));
+  const manifestMutation = (mutate) => {
+    const copy = structuredClone(manifestObject);
+    mutate(copy);
+    return JSON.stringify(copy);
+  };
+  const mutations = [
+    {
+      name: "manifest duration drift",
+      expected: /Eros manifest defaults must stay fixed/,
+      documents: {
+        ...documents,
+        manifestText: manifestMutation((copy) => {
+          copy.models.find((entry) => entry.id === "ltx_2_3_eros").defaults.duration = 5;
+        }),
+      },
+    },
+    {
+      name: "base route contamination",
+      expected: /must not add the Eros distill recipe to base/,
+      documents: {
+        ...documents,
+        manifestText: manifestMutation((copy) => {
+          copy.models.find((entry) => entry.id === "ltx_2_3").mlx.autoDistillLora = {
+            stage1Strength: 1,
+            stage2Strength: 0.4,
+          };
+        }),
+      },
+    },
+    {
+      name: "auto-dispatch regression",
+      expected: /must be explicit and off by default/,
+      documents: {
+        ...documents,
+        workflow: documents.workflow.replace(
+          /(run_ltx_eros_acceptance:[\s\S]*?default:) false/,
+          "$1 true",
+        ),
+      },
+    },
+    {
+      name: "credentialed HF regression",
+      expected: /both HF downloads must explicitly refuse implicit credentials/,
+      documents: {
+        ...documents,
+        workflow: documents.workflow.replace(
+          /(repo_id="TenStrip\/LTX2\.3-10Eros"[\s\S]*?)token=False/,
+          "$1token=True",
+        ),
+      },
+    },
+    {
+      name: "unsupported candidate mode introduced",
+      expected: /must not expose or construct an unsupported filtered-LoRA candidate/,
+      documents: {
+        ...documents,
+        workflow: `${documents.workflow}\nltx_eros_recipe: single-pass-distill`,
+      },
+    },
+    {
+      name: "production shortest mux removed",
+      expected: /copy-video\/AAC\/-shortest mux contract/,
+      documents: {
+        ...documents,
+        workflow: documents.workflow.replace(
+          "-b:a 192k -shortest -map_metadata",
+          "-b:a 192k -map_metadata",
+        ),
+      },
+    },
+    {
+      name: "H.264 verification weakened",
+      expected: /must require the production H\.264 video codec/,
+      documents: {
+        ...documents,
+        workflow: documents.workflow.replace(
+          "$video.codec_name -ne 'h264'",
+          "$video.codec_name -ne 'hevc'",
+        ),
+      },
+    },
+    {
+      name: "duration tolerance widened",
+      expected: /duration tolerance must remain exactly one output frame/,
+      documents: {
+        ...documents,
+        workflow: documents.workflow.replace(
+          "$durationToleranceSeconds = 1.0 / 25.0",
+          "$durationToleranceSeconds = 2.0 / 25.0",
+        ),
+      },
+    },
+    {
+      name: "MP4 audio duration verification removed",
+      expected: /MP4 audio stream duration must be checked/,
+      documents: {
+        ...documents,
+        workflow: documents.workflow.replace(
+          "Assert-DurationNear 'MP4 audio stream' $sound.duration",
+          "",
+        ),
+      },
+    },
+    {
+      name: "explicit sampler alias reintroduced",
+      expected: /manifest-default absent sampler/,
+      documents: {
+        ...documents,
+        harness: documents.harness.replace(
+          "steps: Some(STEPS),",
+          'steps: Some(STEPS),\n        sampler: Some("rectified-flow".to_owned()),',
+        ),
+      },
+    },
+  ];
+  for (const mutation of mutations) {
+    assert.throws(
+      () => validate(mutation.documents),
+      mutation.expected,
+      `${mutation.name} must be killed by the acceptance contract`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add an opt-in, default-off Windows/CUDA capture for the shipped `ltx_2_3_eros` Candle route
- reproduce the manifest-default request exactly: 768×512, 6 seconds / 153 rendered frames at 25 fps, 8 steps, absent/default sampler, no adapters, fixed prompt and seed
- provision immutable public Eros and Gemma revisions anonymously and render through the real runtime registry
- upload a compact H.264/AAC evidence bundle with PCM16 source audio, three stills, timings, runner provenance, hashes, and exact A/V duration checks

## Scope decision
The published `cond_safe` distillation LoRA is not a valid current Candle candidate: only 768 of its 3,320 tensor keys are supported, and the provider hard-fails on the remainder. Silently filtering away 76.9% of the overlay would not be an honest comparison. This PR therefore adds the baseline prerequisite only; after the real artifact is inspected, SC-18902 will make and validate the product decision required by the story.

## Validation
- `npm run check`: 467/467 passed
- focused platform contract: passed, including sampler-identity mutation
- rustfmt and diff checks passed
- actionlint passed except the repository's known custom `cuda` runner-label diagnostic
- two adversarial reviews; final rereview clean, confidence 0.99

The actual CUDA render is intentionally not claimed here; it runs only after this reviewed harness reaches the feature branch.

Shortcut: https://app.shortcut.com/trefry/story/18902
