### PR TITLE
SC-18923: rehost LTX IC LoRAs publicly

### DIFF
--- a/apps/desktop/licenses/ltx-2.3-ic-loras/NOTICE.txt
+++ b/apps/desktop/licenses/ltx-2.3-ic-loras/NOTICE.txt
@@ -1,0 +1,42 @@
+LTX-2.3 IC-LoRA HDR and LipDub/DubIt — redistribution notice
+
+SceneWorks redistributes the following unmodified artifacts at the immutable
+public Hugging Face revision
+SceneWorks/ltx-2.3-ic-loras@ca287bbae91f939481b3b36764d1e8b2cfb6160b:
+
+  ltx-2.3-22b-ic-lora-hdr-0.9.safetensors
+    Official source: Lightricks/LTX-2.3-22b-IC-LoRA-HDR
+    Official revision: 577ab50f447358d00ba68ef204648dfe05646300
+    SHA-256: c56bfa0f2e4461a8b2f318f494c61c5bf97f462f2220e31ece93ea7851ca871e
+
+  ltx-2.3-22b-ic-lora-hdr-scene-emb.safetensors
+    Official source: Lightricks/LTX-2.3-22b-IC-LoRA-HDR
+    Official revision: 577ab50f447358d00ba68ef204648dfe05646300
+    SHA-256: 78bffa6049bae2649a4365ec8769db88052c21348d643e8fc1ce6d483d994c5b
+
+  ltx-2.3-22b-ic-lora-dubit-0.9.safetensors
+    Official source: Lightricks/LTX-2.3-22b-IC-LoRA-DubIt
+    Official revision: 1456334c3d69924de5083e553733b108ed1147f2
+    SHA-256: fc415b12cb639e78511bc264f85080c2f7b188e334c1d9fade76b310e2bc419c
+
+The DubIt revision renamed the original LipDub file without changing its
+content. SceneWorks retains the stable ltx_2_3_ic_lipdub catalog identifier.
+
+The bytes were obtained without accepting the official repositories'
+marketing/contact-information access terms, through the publicly downloadable
+checksum-identical mirror
+asmae2003/LTX2.3@10254b25072ce77437b608b1b675343107afd12c, and verified against
+the SHA-256 values above before upload. No weight file was modified.
+
+The artifacts are derivatives of LTX-2.x and remain subject to the complete
+LTX-2 Community License Agreement displayed with this notice. The bundled
+agreement is the January 5, 2026 text from the official Lightricks/LTX-2
+repository at commit 4dbd99e628410c2b389a15d771240f182b3dacd2, which governed
+the two official artifact revisions. Original models and artifacts are by
+Lightricks Ltd. This redistribution is not endorsed by Lightricks and grants
+no trademark rights.
+
+The agreement includes the complete use restrictions in Attachment A. It also
+requires an entity with annual revenue of at least USD 10,000,000 to obtain the
+paid license described by the agreement before commercial use. Recipients are
+responsible for determining and maintaining their own compliance.

--- a/apps/desktop/licenses/manifest.json
+++ b/apps/desktop/licenses/manifest.json
@@ -152,6 +152,30 @@
       ]
     },
     {
+      "id": "ltx-2.3-ic-loras",
+      "models": [],
+      "name": "LTX-2.3 IC-LoRA HDR and LipDub",
+      "publisher": "Lightricks Ltd. (redistributed unmodified by SceneWorks)",
+      "license": "LTX-2 Community License",
+      "homepage": "https://huggingface.co/SceneWorks/ltx-2.3-ic-loras",
+      "platforms": [
+        "macos",
+        "windows",
+        "linux"
+      ],
+      "usage": "LTX-2.3 HDR and LipDub/DubIt IC-LoRA adapters downloaded on first use from the immutable public SceneWorks/ltx-2.3-ic-loras rehost. The rehost contains the exact unmodified upstream HDR adapter, its companion scene embedding, and the LipDub/DubIt adapter; SceneWorks currently downloads the two adapters and does not consume the scene embedding. These derivatives remain subject to the complete LTX-2 Community License, including its use restrictions and paid-license requirement for entities at or above its annual-revenue threshold.",
+      "documents": [
+        {
+          "label": "LTX-2 Community License",
+          "key": "ltx-2.3-license"
+        },
+        {
+          "label": "SceneWorks redistribution notice and immutable provenance",
+          "key": "ltx-2.3-ic-loras-notice"
+        }
+      ]
+    },
+    {
       "id": "kokoro-82m",
       "models": [
         "kokoro_82m"

--- a/apps/web/src/data/bundledLicenses.js
+++ b/apps/web/src/data/bundledLicenses.js
@@ -22,6 +22,7 @@ import wanI2vA14bApache from "../../../desktop/licenses/wan2.2-i2v-a14b/Apache-2
 import wanT2vA14bApache from "../../../desktop/licenses/wan2.2-t2v-a14b/Apache-2.0.txt?raw";
 import ltxLicense from "../../../desktop/licenses/ltx-2.3/LTX-2-Community-License.txt?raw";
 import ltxGemma from "../../../desktop/licenses/ltx-2.3/Gemma-Terms.txt?raw";
+import ltx23IcLorasNotice from "../../../desktop/licenses/ltx-2.3-ic-loras/NOTICE.txt?raw";
 // Audio model weights (epic 13400, sc-13402). All permissive (Apache-2.0 / MIT) —
 // downloaded on first use from the upstream Hugging Face repos and run natively
 // (Candle) on every platform.
@@ -125,6 +126,7 @@ const DOCUMENT_TEXT = {
   "wan2.2-t2v-a14b-apache": wanT2vA14bApache,
   "ltx-2.3-license": ltxLicense,
   "ltx-2.3-gemma": ltxGemma,
+  "ltx-2.3-ic-loras-notice": ltx23IcLorasNotice,
   "kokoro-82m-apache": kokoroApache,
   "moss-soundeffect-v2-apache": mossApache,
   "acestep-v15-turbo-mit": acestepMit,

--- a/apps/web/src/screens/LicensesScreen.test.jsx
+++ b/apps/web/src/screens/LicensesScreen.test.jsx
@@ -122,6 +122,29 @@ describe("LicensesScreen", () => {
     );
   });
 
+  it("binds the public LTX IC-LoRA rehost to its full license and immutable provenance", async () => {
+    await render();
+    const loras = [...container.querySelectorAll(".licenses-item")].find((button) =>
+      button.textContent.includes("LTX-2.3 IC-LoRA HDR and LipDub"),
+    );
+    expect(loras).toBeTruthy();
+    await act(async () => loras.click());
+    expect(container.querySelector(".licenses-text").textContent).toContain(
+      "LTX-2 Community License Agreement",
+    );
+
+    const noticeTab = [...container.querySelectorAll(".segmented-control button")].find((button) =>
+      button.textContent.includes("immutable provenance"),
+    );
+    expect(noticeTab).toBeTruthy();
+    await act(async () => noticeTab.click());
+    const notice = container.querySelector(".licenses-text").textContent;
+    expect(notice).toContain("ca287bbae91f939481b3b36764d1e8b2cfb6160b");
+    expect(notice).toContain("ltx-2.3-22b-ic-lora-hdr-0.9.safetensors");
+    expect(notice).toContain("ltx-2.3-22b-ic-lora-hdr-scene-emb.safetensors");
+    expect(notice).toContain("ltx-2.3-22b-ic-lora-dubit-0.9.safetensors");
+  });
+
   it("switches between a component's license documents", async () => {
     await render();
     // ffmpeg has two docs (notice + GPL text); pick the GPL tab.

--- a/config/download-pattern-evidence.json
+++ b/config/download-pattern-evidence.json
@@ -104,34 +104,6 @@
       ]
     },
     {
-      "key": "Lightricks/LTX-2.3-22b-IC-LoRA-DubIt@1456334c3d69924de5083e553733b108ed1147f2",
-      "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-DubIt",
-      "revision": "1456334c3d69924de5083e553733b108ed1147f2",
-      "resolvedSha": "1456334c3d69924de5083e553733b108ed1147f2",
-      "servedRepo": "Lightricks/LTX-2.3-22b-IC-LoRA-DubIt",
-      "gated": "auto",
-      "files": [
-        ".gitattributes",
-        "LICENSE",
-        "README.md",
-        "ltx-2.3-22b-ic-lora-dubit-0.9.safetensors"
-      ]
-    },
-    {
-      "key": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR@main",
-      "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
-      "revision": null,
-      "resolvedSha": "577ab50f447358d00ba68ef204648dfe05646300",
-      "servedRepo": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
-      "gated": "auto",
-      "files": [
-        ".gitattributes",
-        "README.md",
-        "ltx-2.3-22b-ic-lora-hdr-0.9.safetensors",
-        "ltx-2.3-22b-ic-lora-hdr-scene-emb.safetensors"
-      ]
-    },
-    {
       "key": "Lightricks/LTX-2.3-22b-IC-LoRA-Motion-Track-Control@main",
       "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-Motion-Track-Control",
       "revision": null,
@@ -2338,6 +2310,22 @@
         "q8/transformer/diffusion_pytorch_model.safetensors",
         "q8/vae/config.json",
         "q8/vae/diffusion_pytorch_model.safetensors"
+      ]
+    },
+    {
+      "key": "SceneWorks/ltx-2.3-ic-loras@ca287bbae91f939481b3b36764d1e8b2cfb6160b",
+      "repo": "SceneWorks/ltx-2.3-ic-loras",
+      "revision": "ca287bbae91f939481b3b36764d1e8b2cfb6160b",
+      "resolvedSha": "ca287bbae91f939481b3b36764d1e8b2cfb6160b",
+      "servedRepo": "SceneWorks/ltx-2.3-ic-loras",
+      "gated": false,
+      "files": [
+        ".gitattributes",
+        "LICENSE.md",
+        "README.md",
+        "ltx-2.3-22b-ic-lora-dubit-0.9.safetensors",
+        "ltx-2.3-22b-ic-lora-hdr-0.9.safetensors",
+        "ltx-2.3-22b-ic-lora-hdr-scene-emb.safetensors"
       ]
     },
     {

--- a/config/manifests/builtin.loras.jsonc
+++ b/config/manifests/builtin.loras.jsonc
@@ -43,8 +43,15 @@
       "defaultWeight": 0.8,
       "source": {
         "provider": "huggingface",
-        "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
-        "file": "ltx-2.3-22b-ic-lora-hdr-0.9.safetensors"
+        // sc-18923: the official repository requires a per-account marketing/contact-information
+        // consent and returns 401 to an unauthenticated install. SceneWorks redistributes the exact,
+        // unmodified HDR weights under the same LTX-2 Community License; the pinned rehost also
+        // carries the complete frozen agreement, attribution, provenance, and the upstream companion
+        // scene embedding. The primary LoRA remains the only requested file because the current
+        // SceneWorks runtime does not consume that embedding.
+        "repo": "SceneWorks/ltx-2.3-ic-loras",
+        "file": "ltx-2.3-22b-ic-lora-hdr-0.9.safetensors",
+        "revision": "ca287bbae91f939481b3b36764d1e8b2cfb6160b"
       }
     },
     {
@@ -54,7 +61,7 @@
       // — the worker's sc-12288 zero-file check turned that into a failed download for anyone who
       // selected it. `revision` is pinned here (and was not before) because an unrevisioned entry
       // reads a moving default branch, which is exactly how the rename went unnoticed; the
-      // remaining 12 unrevisioned keys are sc-18924's scope, not this entry's.
+      // remaining unrevisioned keys are sc-18924's scope, not this entry's.
       //
       // `id` and `name` deliberately keep the LipDub spelling: `id` is the stable catalog key the
       // picker, job payloads, compatibility checks and the on-disk install probe all key on, so
@@ -70,9 +77,11 @@
       "defaultWeight": 0.8,
       "source": {
         "provider": "huggingface",
-        "repo": "Lightricks/LTX-2.3-22b-IC-LoRA-DubIt",
+        // sc-18923: same immutable public rehost and license/provenance posture as the HDR sibling.
+        // The stable catalog id intentionally remains `lipdub`; only the source channel changed.
+        "repo": "SceneWorks/ltx-2.3-ic-loras",
         "file": "ltx-2.3-22b-ic-lora-dubit-0.9.safetensors",
-        "revision": "1456334c3d69924de5083e553733b108ed1147f2"
+        "revision": "ca287bbae91f939481b3b36764d1e8b2cfb6160b"
       }
     },
     {

--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -342,8 +342,8 @@ Two things follow, and both are now enforced rather than remembered:
 
   🔴 **In this mode the exit code carries that verdict and nothing else** (sc-18854 review). The
   live zero-match / access-gated / redirect / untranslatable lists still print *above* the banner —
-  today's tree prints `ACCESS-GATED (2)` and `SERVED BY A DIFFERENT REPO (1)` on every clean run,
-  and since sc-18917 no `ZERO-MATCH PATTERNS` line at all — but they deliberately do not move the
+  today's tree prints `SERVED BY A DIFFERENT REPO (1)` on every clean run, with no
+  `ACCESS-GATED` or `ZERO-MATCH PATTERNS` line — but they deliberately do not move the
   exit status, because an anti-tamper mode that reds unconditionally signals nothing. Grade those
   lists with `npm run check:download-patterns:offline`; that is the gate CI runs.
 
@@ -363,18 +363,19 @@ Two things follow, and both are now enforced rather than remembered:
   Forgetting the re-record is not a silent pass: adding or re-pinning an entry changes its
   `repo@revision` key, and a claim with no recorded listing reds the gate with the exact command to
   run. The recorder never evaluates a pattern — it only transcribes — so you cannot record your way
-  out of a real zero-match. 84 of the 96 keys are pinned to immutable 40-hex revisions, whose
-  listings cannot go stale. **The other 12 are unrevisioned and that immutability argument does not
+  out of a real zero-match. 84 of the 95 keys are pinned to immutable 40-hex revisions, whose
+  listings cannot go stale. **The other 11 are unrevisioned and that immutability argument does not
   cover them** — they read a moving default branch, and while each records the `resolvedSha` it
   actually read so drift is visible in a re-record diff, nothing forces a re-record. **sc-18924
-  tracks pinning the rest**, which is what closes that window; sc-18917 already pinned one as a side
-  effect of its own fix (it was 13 before) and sc-18923 owns another.
+  tracks pinning the rest**, which is what closes that window; sc-18917 pinned the renamed
+  LipDub/DubIt entry and sc-18923 pinned/rehosted HDR plus DubIt.
 
   Each recorded key also carries `gated` and `servedRepo`, and the gate hard-fails on both
   (`evidence-gated`, `evidence-repo-id-mismatch`) with tracked waivers in `KNOWN_REPO_CONDITIONS`.
   A green metadata listing does **not** mean a repo is fetchable: `gated: "auto"` answers 200 and
-  then 401s the actual download unless the token's account has accepted that repo's licence. Two
-  catalog entries are in that state today (sc-18923, sc-18917).
+  then 401s the actual download unless the token's account has accepted that repo's licence.
+  sc-18923 removed the two catalog instances by pinning checksum-identical public rehosts; any new
+  gated source fails the offline gate unless it receives an explicit tracked waiver.
 - **A tier that lands at a different revision is a resolution problem too.** The cache then holds two
   `snapshots/<rev>/` dirs with the tiers split across them, and `huggingface_snapshot_dir` selects
   exactly one. `ltx_bundle_subdir_across_revisions` (sc-18809) scans siblings with tier preference

--- a/scripts/check-download-patterns.mjs
+++ b/scripts/check-download-patterns.mjs
@@ -46,17 +46,17 @@
 // The usual objection to a recorded fixture is decay. It does not apply here, for two
 // structural reasons:
 //
-//  1. **84 of 96 keys are pinned to an immutable 40-hex revision.** A git SHA's file listing
+//  1. **84 of 95 keys are pinned to an immutable 40-hex revision.** A git SHA's file listing
 //     is timeless — re-reading it in a year returns the same bytes. There is nothing to
 //     decay.
 //
-//     The other **12 keys are unrevisioned** and this argument does NOT cover them. They read a
+//     The other **11 keys are unrevisioned** and this argument does NOT cover them. They read a
 //     moving default branch, and while each records the `resolvedSha` it actually read — so drift
 //     is VISIBLE in a re-record diff — nothing forces anyone to re-record. That is a real
-//     stale-green window, and it is 12 keys wide, not one. **sc-18924 tracks pinning all of them**,
-//     which is what converts them onto the immutability argument above. sc-18917 already pinned one
-//     (the LipDub/DubIt rename, as a side effect of fixing that entry — it was 13 before) and
-//     sc-18923 owns another; the remaining eleven have no other owner and are sc-18924's alone.
+//     stale-green window, and it is 11 keys wide, not one. **sc-18924 tracks pinning all of them**,
+//     which is what converts them onto the immutability argument above. sc-18917 pinned the renamed
+//     LipDub/DubIt entry and sc-18923 pinned/rehosted HDR plus DubIt; the remaining eleven are
+//     sc-18924's scope.
 //  2. **Coverage is graded as a set, in both directions.** Adding an entry, or re-pinning
 //     one, changes its `repo@revision` key, and a key with no recorded listing is a hard
 //     failure naming the re-record command. Conversely a recorded key that nothing claims
@@ -94,39 +94,31 @@
 // `repoFiles` was already parsing that body — it simply kept `sha` and `siblings` and threw the
 // rest away. The impossibility was an artefact of what we chose to record, not of the API.
 //
-// The cost of that false claim was a live catalog entry grading green while being unfetchable.
-// Measured across all 96 recorded keys, TWO are gated:
-//
-//   Lightricks/LTX-2.3-22b-IC-LoRA-HDR@main       gated:"auto"   (sc-18923)
-//   Lightricks/LTX-2.3-22b-IC-LoRA-DubIt@1456334c gated:"auto"   (sc-18923; was LipDub@main until
-//                                                                 sc-18917 repointed and pinned it)
-//
-// For HDR: `HEAD .../resolve/main/ltx-2.3-22b-ic-lora-hdr-0.9.safetensors` returns **401**
-// unauthenticated, and this gate graded it green. `gated:"auto"` means terms are auto-approved ON
-// ACCEPTANCE — it still needs a per-repo licence acceptance by the token's account, and the token
-// is optional in the first place (`resolve_hf_token(&Settings) -> Option<String>`,
-// credentials_ipc.rs:127). There is no gated-repo handling anywhere in the worker or core, so the
-// user gets a bare 401 on a LoRA the catalog offered them — exactly the "cost lands on the user as
-// a failed download" failure this script's header (above) exists to prevent.
+// The cost of that false claim was two live catalog entries grading green while being unfetchable:
+// the Lightricks HDR and DubIt IC-LoRA repos answered `gated:"auto"` and returned 401 to an
+// unauthenticated weight fetch. sc-18923 removed both instances by publishing the exact unmodified
+// files, complete frozen license, attribution and provenance at the immutable public
+// `SceneWorks/ltx-2.3-ic-loras` rehost, then repointing both manifest entries. The gate now proves
+// those replacements are ungated instead of carrying either historical waiver.
 //
 // So `gated` is now RECORDED per key and `evidence-gated` is a HARD FAILURE by default, waivable
-// through `KNOWN_REPO_CONDITIONS` on the same terms as a zero-match. See that list for why the
-// two existing instances are waived rather than red.
+// through `KNOWN_REPO_CONDITIONS` on the same terms as a zero-match.
 //
 // The same body also carries `id` — the repo HF ACTUALLY served. `fetch` follows the 307 a renamed
 // repo issues, so an entry naming a dead repo resolves silently; `evidence-repo-id-mismatch`
 // catches that. ONE live instance remains, waived and tracked (sc-18926); the other — LipDub ->
 // DubIt — was fixed at the source by sc-18917 rather than waived onward.
 //
-// What a green run still does NOT prove: that the token's account has accepted the licence, or
-// that the bytes download. Those need a real authenticated fetch. The ceiling is real — it is just
-// one rung higher than this header used to claim.
+// What a green run still does NOT prove is that the bytes download. Public replacements such as
+// sc-18923's rehost need a real ANONYMOUS fetch at the exact revision; a deliberately gated source
+// would instead need an authenticated fetch by an account that accepted its terms. The ceiling is
+// real — it is just one rung higher than this header used to claim.
 //
 // The LIVE modes deliberately ignore `KNOWN_ZERO_MATCHES` and report the raw truth, so `--write`
 // exits 1 on any tracked zero-match gap. There is none today — sc-18917 fixed the last one — so
-// `--write` currently exits 0, but do NOT read that as the modes agreeing: the gated and redirect
-// lists still print above and are still waived in `--check`. Policy lives in the gate; the
-// pre-flight is for a human who wants the unfiltered picture. Do not "fix" that exit code by
+// `--write` currently exits 0, but do NOT read that as the modes agreeing: the remaining redirect
+// condition still prints above and is waived only by the offline gate. Policy lives in the gate;
+// the pre-flight is for a human who wants the unfiltered picture. Do not "fix" that exit code by
 // teaching the recorder about waivers — a recorder that knows which failures are acceptable is one
 // step from a recorder that records them as passing.
 
@@ -181,50 +173,18 @@ export const KNOWN_ZERO_MATCHES = [];
 // that is the last moment the cost is cheap. What is waived is only the instances that ALREADY
 // SHIP.
 //
-// The alternative — make them unconditionally fatal — was considered and rejected. HDR, LipDub and
-// the mmaudio DFN5B entry are in the catalog today, so an unconditional failure would red the
-// required `parity` lane on every PR in flight for a defect none of them introduced. That is the
-// identical "a required context reds for a reason unrelated to this PR" failure mode that the
-// KNOWN_ZERO_MATCHES comment above rejects date-based expiry for, and it would push people toward
-// deleting the guard rather than fixing the entries.
+// The alternative — make known instances unconditionally fatal — was considered and rejected. It
+// would red the required `parity` lane on every unrelated PR while a defect was being repaired,
+// which pushes people toward deleting the guard rather than fixing its source.
 //
 // Waiving costs nothing in detection: the semantics land on "green means no NEW gated repo and no
 // NEW redirect", which is exactly the guarantee zero-match already provides. And unlike a silent
 // pass, each instance now has an owner, a reason, and a story that CANNOT be closed without
 // deleting its waiver — the gate reds if the condition clears and reds if the entry moves.
 //
-// The counter-argument is real and worth stating: a waiver keeps shipping a LoRA that returns 401
-// to users who have not accepted its licence. Waiving is a decision to track that, not to accept
-// it — sc-18923 owns making it work or withdrawing it. If it stalls, the honest escalation is to
-// pull the entry from the catalog, not to widen this list.
+// sc-18923 paid both gated-LoRA debts, so no `evidence-gated` waiver remains. New gated catalog
+// sources hard-fail unless a new live owner and explicit rationale are added here.
 export const KNOWN_REPO_CONDITIONS = [
-  {
-    kind: "evidence-gated",
-    repo: "Lightricks/LTX-2.3-22b-IC-LoRA-HDR",
-    revision: null,
-    story: "sc-18923",
-    reason:
-      "Ships today and is unfetchable without a token whose account has accepted the licence: " +
-      "the metadata API answers 200 with gated:\"auto\" while HEAD on the weight file returns 401. " +
-      "Was invisible until this gate started recording `gated`. sc-18923 must surface licence " +
-      "acceptance, re-host, or withdraw the LoRA — and delete this waiver in the same change.",
-  },
-  {
-    kind: "evidence-gated",
-    repo: "Lightricks/LTX-2.3-22b-IC-LoRA-DubIt",
-    revision: "1456334c3d69924de5083e553733b108ed1147f2",
-    story: "sc-18923",
-    reason:
-      "Re-keyed by sc-18917 from Lightricks/LTX-2.3-22b-IC-LoRA-LipDub@main when that entry was " +
-      "repointed onto the renamed repo and pinned; the gate forced it, reporting " +
-      "repo-waiver-stale-unclaimed on the old key. The rename is fixed and the GATING is not: " +
-      "the pinned revision answers 200 with gated:\"auto\" while HEAD on " +
-      "ltx-2.3-22b-ic-lora-dubit-0.9.safetensors returns 401 unauthenticated — the identical " +
-      "posture as the HDR sibling above. It is deliberately owned by sc-18923 rather than by " +
-      "sc-18917: sc-18917 fixed a rename and is done, so naming it here would leave a waiver whose " +
-      "owner is closed. sc-18923 owns the gated-IC-LoRA class (surface licence acceptance, re-host, " +
-      "or withdraw) and must delete BOTH its waivers — HDR's and this one — in the same change.",
-  },
   {
     kind: "evidence-repo-id-mismatch",
     repo: "apple/DFN5B-CLIP-ViT-H-14-384",
@@ -761,10 +721,10 @@ async function runLive({ only, write, dryRun }) {
 
   // The live verdicts below accumulate into a flag instead of writing straight to
   // `process.exitCode`, because `--write --dry-run` publishes an ANTI-TAMPER verdict and has to
-  // own its exit code outright (sc-18854 review). Folding the live verdicts in made the mode
-  // exit 1 on a clean tree — the tracked LipDub zero-match fires on every run — so a reviewer
-  // following the runbook would see a non-zero exit, find no re-record diff to explain it, and
-  // conclude the artifact had been hand-edited. A tamper detector that reds unconditionally
+  // own its exit code outright (sc-18854 review). Folding the live verdicts in historically made
+  // the mode exit 1 whenever a tracked live defect was present even if the re-record was exact, so a
+  // reviewer would see a non-zero exit, find no artifact diff to explain it, and conclude the
+  // artifact had been hand-edited. A tamper detector whose result is masked by a different verdict
   // detects nothing.
   let liveFailure = false;
   let dryRunVerdict = null;

--- a/scripts/check-download-patterns.test.mjs
+++ b/scripts/check-download-patterns.test.mjs
@@ -174,52 +174,66 @@ test("the recorded evidence carries servedRepo and gated on every key", async ()
   }
 });
 
-// THE sc-18923 REGRESSION TEST, on real data, in both directions.
+// THE sc-18923 REGRESSION TEST, on the real immutable public rehost.
 //
-// The whole MAJOR finding was that a gated repo graded green. This asserts the opposite verdict on
-// the real recorded HDR entry with the waiver removed, and the waived verdict with it present — so
-// the guard cannot quietly stop firing, and the waiver cannot quietly stop absorbing.
-test("evidence-gated: the real HDR entry reds without its waiver and is tracked with it", async () => {
+// The original defect was two gated repos grading green behind waivers. Both manifest claims must
+// now resolve to the same exact public revision, each declared file must exist, and there must be
+// no waiver capable of absorbing a future gate. Mutating that real listing back to gated must red.
+test("the HDR and LipDub claims share one ungated immutable rehost with no gating waiver", async () => {
   const { claims, evidence } = await realInputs();
 
   const hdr = claims.find((claim) => claim.label === "lora:ltx_2_3_ic_hdr");
+  const lipdub = claims.find((claim) => claim.label === "lora:ltx_2_3_ic_lipdub");
   assert.ok(hdr, "lora:ltx_2_3_ic_hdr must exist for this regression test to mean anything");
+  assert.ok(lipdub, "lora:ltx_2_3_ic_lipdub must exist for this regression test to mean anything");
+  assert.equal(hdr.repo, "SceneWorks/ltx-2.3-ic-loras");
+  assert.equal(lipdub.repo, hdr.repo);
+  assert.match(hdr.revision, /^[0-9a-f]{40}$/u);
+  assert.equal(lipdub.revision, hdr.revision);
   const entry = evidence.repos.find((row) => row.key === claimKey(hdr.repo, hdr.revision));
-  assert.ok(entry, "the HDR entry must have a recorded listing");
-  // Guard the fixture: a flip must come from the guard, not from the data being the wrong shape.
-  assert.equal(entry.gated, "auto", "upstream HDR must genuinely still be gated for this to bind");
-  assert.ok(
-    entry.files.includes(hdr.declared[0]),
-    "HDR's declared file must genuinely be present — the point is that it 401s ANYWAY",
+  assert.ok(entry, "the shared IC-LoRA rehost must have a recorded listing");
+  assert.equal(entry.servedRepo, hdr.repo, "the public rehost must not resolve through a rename");
+  assert.equal(entry.resolvedSha, hdr.revision, "the recorded listing must bind the manifest SHA");
+  assert.equal(entry.gated, false, "the replacement must remain publicly downloadable");
+  for (const claim of [hdr, lipdub]) {
+    assert.ok(entry.files.includes(claim.declared[0]), `${claim.label} file must exist at the pin`);
+  }
+  for (const file of [
+    "ltx-2.3-22b-ic-lora-hdr-0.9.safetensors",
+    "ltx-2.3-22b-ic-lora-hdr-scene-emb.safetensors",
+    "ltx-2.3-22b-ic-lora-dubit-0.9.safetensors",
+    "LICENSE.md",
+    "README.md",
+  ]) {
+    assert.ok(entry.files.includes(file), `the immutable public rehost must retain ${file}`);
+  }
+  assert.equal(
+    KNOWN_REPO_CONDITIONS.filter(
+      (waiver) => waiver.kind === "evidence-gated" && waiver.repo === hdr.repo,
+    ).length,
+    0,
+    "the public replacement must never carry forward a gating waiver",
   );
 
-  // Direction 1 — the defect: no waiver, so it is a hard failure.
-  const unwaived = gradeRecordedEvidence({
-    claims: [hdr],
+  const clean = gradeRecordedEvidence({
+    claims: [hdr, lipdub],
     evidence: { repos: [entry] },
     waivers: [],
     repoConditions: [],
   });
-  assert.deepEqual(
-    unwaived.problems.map((problem) => problem.kind),
-    ["evidence-gated"],
-    `expected exactly evidence-gated, got ${JSON.stringify(unwaived.problems)}`,
-  );
+  assert.deepEqual(clean.problems, []);
 
-  // Direction 2 — the shipped posture: waived, tracked, zero problems.
-  const gradedWaiver = KNOWN_REPO_CONDITIONS.filter(
-    (waiver) => waiver.kind === "evidence-gated" && waiver.repo === hdr.repo,
-  );
-  assert.equal(gradedWaiver.length, 1, "HDR must carry exactly one evidence-gated waiver");
-  const waivedRun = gradeRecordedEvidence({
-    claims: [hdr],
-    evidence: { repos: [entry] },
+  const regated = gradeRecordedEvidence({
+    claims: [hdr, lipdub],
+    evidence: { repos: [{ ...entry, gated: "auto" }] },
     waivers: [],
-    repoConditions: gradedWaiver,
+    repoConditions: [],
   });
-  assert.deepEqual(waivedRun.problems, []);
-  assert.equal(waivedRun.waived.length, 1);
-  assert.match(waivedRun.waived[0], /sc-18923/);
+  assert.deepEqual(
+    regated.problems.map((problem) => problem.kind),
+    ["evidence-gated"],
+    `expected exactly evidence-gated, got ${JSON.stringify(regated.problems)}`,
+  );
 });
 
 // The repo-id guard's reason for existing: it catches what the sha check structurally cannot.


### PR DESCRIPTION
## Summary
- repoint both shipped LTX-2.3 IC-LoRAs to one immutable public SceneWorks rehost
- preserve exact official artifact bytes, frozen license, attribution, and provenance
- remove the obsolete gating waivers and make the anonymous download evidence load-bearing
- expose the license and provenance notice in About → Licenses

## Validation
- `npm run check` (467/467)
- complete web suite (3,598/3,598)
- focused Licenses screen (9/9)
- web ESLint
- license coverage + self-test
- anonymous HEAD 200 and Range GET 206 for all three rehosted artifacts
- live download evidence dry-run byte-identical
- `git diff --check`

Shortcut: [SC-18923](https://app.shortcut.com/trefry/story/18923)