### PR TITLE
SC-18902: preserve complete CUDA evidence after product mux

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -702,17 +702,29 @@ jobs:
             throw "the LTX Eros smoke wrote no output directory: $out"
           }
           $mp4 = Join-Path $out 'ltx_eros.mp4'
-          $videoOnly = Join-Path $out 'ltx_eros.video-only.mp4'
+          $videoOnly = Join-Path $out 'ltx_eros.rendered-frames.mp4'
           $frames = Join-Path $out 'frames\frame_%05d.png'
           $audio = Join-Path $out 'audio.wav'
           & ffmpeg -hide_banner -loglevel warning -nostdin -y -framerate 25 -start_number 0 -i $frames -c:v libx264 -preset slow -crf 18 -pix_fmt yuv420p -r 25 $videoOnly
           if ($LASTEXITCODE -ne 0) { throw 'ffmpeg failed to encode the LTX Eros video stream' }
-          # Match the product's LTX mux contract: copy the encoded H.264 stream, encode the WAV as
-          # AAC, inherit metadata from the video input, and bound the container by the shorter input.
-          # The exact 153-frame assertion below makes any unintended `-shortest` truncation fatal.
+          # Preserve the full 153-frame renderer output above, then separately match the product's
+          # LTX mux contract: copy H.264, encode the WAV as AAC, and bound the user-visible file by
+          # the shorter input. The 6-second audio is intentionally shorter than the 153-frame LTX
+          # lattice (6.12 seconds), so `-shortest` trims the product-faithful MP4 at that boundary.
           & ffmpeg -hide_banner -loglevel warning -nostdin -y -i $videoOnly -i $audio -map 0:v:0 -map 1:a:0 -c:v copy -c:a aac -b:a 192k -shortest -map_metadata 0 -movflags +faststart $mp4
           if ($LASTEXITCODE -ne 0) { throw 'ffmpeg failed to mux the LTX Eros evidence MP4' }
-          Remove-Item -LiteralPath $videoOnly -Force
+
+          $renderedProbePath = Join-Path $out 'ffprobe-rendered-frames.json'
+          & ffprobe -v error -count_frames -show_entries 'stream=index,codec_name,codec_type,width,height,r_frame_rate,nb_read_frames,duration:format=duration' -of json $videoOnly | Out-File -LiteralPath $renderedProbePath -Encoding utf8
+          if ($LASTEXITCODE -ne 0) { throw 'ffprobe failed on the complete LTX Eros rendered-frame video' }
+          $renderedProbe = Get-Content -Raw -LiteralPath $renderedProbePath | ConvertFrom-Json
+          $renderedVideo = $renderedProbe.streams | Where-Object { $_.codec_type -eq 'video' } | Select-Object -First 1
+          if (-not $renderedVideo -or $renderedVideo.codec_name -ne 'h264' -or $renderedVideo.width -ne 768 -or $renderedVideo.height -ne 512) {
+            throw 'complete LTX Eros rendered-frame video must contain h264 768x512 video'
+          }
+          if ($renderedVideo.r_frame_rate -ne '25/1' -or [int]$renderedVideo.nb_read_frames -ne 153) {
+            throw "complete LTX Eros rendered-frame video must contain exactly 153 frames at 25 fps, got $($renderedVideo.nb_read_frames) at $($renderedVideo.r_frame_rate)"
+          }
 
           $probePath = Join-Path $out 'ffprobe-mp4.json'
           & ffprobe -v error -count_frames -show_entries 'stream=index,codec_name,codec_type,width,height,r_frame_rate,nb_read_frames,sample_rate,channels,duration:format=duration' -of json $mp4 | Out-File -LiteralPath $probePath -Encoding utf8
@@ -723,8 +735,9 @@ jobs:
           if (-not $video -or $video.codec_name -ne 'h264' -or $video.width -ne 768 -or $video.height -ne 512) {
             throw 'encoded LTX Eros MP4 must contain h264 768x512 video'
           }
-          if ($video.r_frame_rate -ne '25/1' -or [int]$video.nb_read_frames -ne 153) {
-            throw "encoded LTX Eros MP4 must contain exactly 153 frames at 25 fps, got $($video.nb_read_frames) at $($video.r_frame_rate)"
+          $productFrames = [int]$video.nb_read_frames
+          if ($video.r_frame_rate -ne '25/1' -or $productFrames -lt 150 -or $productFrames -gt 151) {
+            throw "product-faithful LTX Eros MP4 must retain 150 or 151 frames at the 6-second audio boundary, got $productFrames at $($video.r_frame_rate)"
           }
           if (-not $sound -or $sound.codec_name -ne 'aac') {
             throw 'encoded LTX Eros MP4 must contain AAC audio'
@@ -740,22 +753,25 @@ jobs:
           }
 
           # One output frame (40 ms) is the maximum tolerated timestamp/container rounding error.
-          # This is wide enough for AAC packet/time-base rounding. Together with the exact frame
-          # assertion above, it rejects a missing frame and an audio track that represents the raw
-          # 6.00 s rather than all 153 duration-derived frames (153 / 25 = 6.12 s).
-          $expectedDurationSeconds = 153.0 / 25.0
+          # The complete renderer output is 153 / 25 = 6.12 seconds. The manifest-default request,
+          # source audio, and product-faithful `-shortest` MP4 are 6 seconds; checking the two
+          # timelines independently prevents a valid product mux from masquerading as frame loss.
+          $renderedDurationSeconds = 153.0 / 25.0
+          $productDurationSeconds = 6.0
           $durationToleranceSeconds = 1.0 / 25.0
-          function Assert-DurationNear([string]$label, $actualValue) {
+          function Assert-DurationNear([string]$label, $actualValue, [double]$expectedDurationSeconds) {
             if ($null -eq $actualValue) { throw "$label duration is missing" }
             $actualSeconds = [Convert]::ToDouble($actualValue, [Globalization.CultureInfo]::InvariantCulture)
             if ([Math]::Abs($actualSeconds - $expectedDurationSeconds) -gt ($durationToleranceSeconds + 0.000001)) {
               throw "$label duration $actualSeconds is not within $durationToleranceSeconds s of $expectedDurationSeconds s"
             }
           }
-          Assert-DurationNear 'source WAV container' $wavProbe.format.duration
-          Assert-DurationNear 'MP4 video stream' $video.duration
-          Assert-DurationNear 'MP4 audio stream' $sound.duration
-          Assert-DurationNear 'MP4 container' $probe.format.duration
+          Assert-DurationNear 'complete rendered-frame video stream' $renderedVideo.duration $renderedDurationSeconds
+          Assert-DurationNear 'complete rendered-frame container' $renderedProbe.format.duration $renderedDurationSeconds
+          Assert-DurationNear 'source WAV container' $wavProbe.format.duration $productDurationSeconds
+          Assert-DurationNear 'product MP4 video stream' $video.duration $productDurationSeconds
+          Assert-DurationNear 'product MP4 audio stream' $sound.duration $productDurationSeconds
+          Assert-DurationNear 'product MP4 container' $probe.format.duration $productDurationSeconds
 
           $metadata = Get-Content -Raw -LiteralPath (Join-Path $out 'metadata.json') | ConvertFrom-Json
           if ($metadata.captureKind -ne 'current-candle-route-baseline' -or $metadata.request.seed -ne 18902) {
@@ -779,8 +795,12 @@ jobs:
             ffmpeg = ((& ffmpeg -version | Select-Object -First 1 | Out-String).Trim())
           }
           $runnerMetadata | ConvertTo-Json -Depth 4 | Out-File -LiteralPath (Join-Path $out 'runner.json') -Encoding utf8
-          $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $mp4).Hash.ToLowerInvariant()
-          "$hash  ltx_eros.mp4" | Out-File -LiteralPath (Join-Path $out 'sha256.txt') -Encoding ascii
+          $productHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $mp4).Hash.ToLowerInvariant()
+          $renderedHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $videoOnly).Hash.ToLowerInvariant()
+          @(
+            "$productHash  ltx_eros.mp4"
+            "$renderedHash  ltx_eros.rendered-frames.mp4"
+          ) | Out-File -LiteralPath (Join-Path $out 'sha256.txt') -Encoding ascii
       - name: Upload the LTX Eros acceptance evidence
         if: ${{ success() && github.event_name == 'workflow_dispatch' && inputs.run_ltx_eros_acceptance }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -788,10 +808,12 @@ jobs:
           name: sc-18902-ltx-eros-baseline-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/ltx_eros.mp4
+            ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/ltx_eros.rendered-frames.mp4
             ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/audio.wav
             ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/stills/*.png
             ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/metadata.json
             ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/ffprobe-mp4.json
+            ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/ffprobe-rendered-frames.json
             ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/ffprobe-wav.json
             ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/runner.json
             ${{ runner.temp }}/sc-18902-ltx-eros-${{ github.run_id }}-${{ github.run_attempt }}/sha256.txt

--- a/crates/sceneworks-worker/src/ltx_eros_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/ltx_eros_gpu_smoke.rs
@@ -337,7 +337,8 @@ fn ltx_eros_candle_gpu_smoke() {
             "negativePrompt": null,
             "rawFrames": RAW_FRAMES,
             "renderedFrames": RENDERED_FRAMES,
-            "encodedDurationSeconds": RENDERED_FRAMES as f64 / FPS as f64,
+            "renderedFramesDurationSeconds": RENDERED_FRAMES as f64 / FPS as f64,
+            "productDurationSeconds": DURATION_SECONDS,
         },
         "artifacts": {
             "checkpoint": {

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1887,7 +1887,7 @@ test("the MLX FLUX.2-dev calibration arm is bound to the direct reference-free T
 // accepted keys), so this pins a product-neutral baseline only. The mutation loop is load-bearing:
 // each historically plausible drift is injected into an in-memory copy and must make this same
 // validator fail, proving the positive assertions are sensitive rather than decorative.
-test("the LTX Eros CUDA baseline is fixed, anonymous, mux-faithful, and mutation-sensitive", async () => {
+test("the LTX Eros CUDA baseline keeps renderer and product timelines distinct", async () => {
   const documents = {
     manifestText: await source("config/manifests/builtin.models.jsonc"),
     workflow: await source(".github/workflows/windows-candle.yml"),
@@ -1972,6 +1972,11 @@ test("the LTX Eros CUDA baseline is fixed, anonymous, mux-faithful, and mutation
       /ffmpeg [^\n]*-i \$videoOnly -i \$audio[^\n]*-c:v copy[^\n]*-c:a aac[^\n]*-shortest[^\n]*-map_metadata 0[^\n]*\$mp4/,
       "the evidence MP4 must use the product's copy-video/AAC/-shortest mux contract",
     );
+    assert.match(
+      workflow,
+      /\$videoOnly = Join-Path \$out 'ltx_eros\.rendered-frames\.mp4'/,
+      "the complete 153-frame renderer output must survive beside the product-faithful MP4",
+    );
     assert.match(workflow, /stream=index,codec_name,codec_type[^'\n]+duration:format=duration/);
     assert.match(
       workflow,
@@ -1988,26 +1993,56 @@ test("the LTX Eros CUDA baseline is fixed, anonymous, mux-faithful, and mutation
       /\$wavAudio\.codec_name -ne 'pcm_s16le'/,
       "the source audio verifier must require the worker's PCM16 WAV codec",
     );
-    assert.match(workflow, /nb_read_frames -ne 153/);
-    assert.match(workflow, /\$expectedDurationSeconds = 153\.0 \/ 25\.0/);
+    assert.match(
+      workflow,
+      /\$renderedVideo\.r_frame_rate -ne '25\/1' -or \[int\]\$renderedVideo\.nb_read_frames -ne 153/,
+      "the complete renderer output must still prove all 153 frames",
+    );
+    assert.match(
+      workflow,
+      /\$productFrames -lt 150 -or \$productFrames -gt 151/,
+      "the product-faithful mux must end at the six-second audio boundary",
+    );
+    assert.match(workflow, /\$renderedDurationSeconds = 153\.0 \/ 25\.0/);
+    assert.match(workflow, /\$productDurationSeconds = 6\.0/);
     assert.match(
       workflow,
       /\$durationToleranceSeconds = 1\.0 \/ 25\.0/,
       "duration tolerance must remain exactly one output frame",
     );
-    for (const label of [
-      "source WAV container",
-      "MP4 video stream",
-      "MP4 audio stream",
-      "MP4 container",
+    for (const invocation of [
+      "Assert-DurationNear 'complete rendered-frame video stream' $renderedVideo.duration $renderedDurationSeconds",
+      "Assert-DurationNear 'complete rendered-frame container' $renderedProbe.format.duration $renderedDurationSeconds",
+      "Assert-DurationNear 'source WAV container' $wavProbe.format.duration $productDurationSeconds",
+      "Assert-DurationNear 'product MP4 video stream' $video.duration $productDurationSeconds",
+      "Assert-DurationNear 'product MP4 audio stream' $sound.duration $productDurationSeconds",
+      "Assert-DurationNear 'product MP4 container' $probe.format.duration $productDurationSeconds",
     ]) {
-      assert.ok(
-        workflow.includes(`Assert-DurationNear '${label}'`),
-        `${label} duration must be checked against all 153 frames`,
-      );
+      assert.ok(workflow.includes(invocation), `${invocation} must remain exact`);
     }
     assert.match(workflow, /ffprobe-mp4\.json/);
+    assert.match(workflow, /ffprobe-rendered-frames\.json/);
     assert.match(workflow, /ffprobe-wav\.json/);
+    assert.match(
+      workflow,
+      /sc-18902-ltx-eros-\$\{\{ github\.run_id \}\}-\$\{\{ github\.run_attempt \}\}\/ltx_eros\.rendered-frames\.mp4/,
+      "the inspected artifact must include the untrimmed renderer output",
+    );
+    assert.match(
+      workflow,
+      /"\$productHash  ltx_eros\.mp4"\s+"\$renderedHash  ltx_eros\.rendered-frames\.mp4"/,
+      "the checksum manifest must bind both inspectable MP4s",
+    );
+    assert.match(
+      workflow,
+      /\$productHash = \(Get-FileHash -Algorithm SHA256 -LiteralPath \$mp4\)\.Hash\.ToLowerInvariant\(\)/,
+      "the product checksum must hash the product-faithful MP4",
+    );
+    assert.match(
+      workflow,
+      /\$renderedHash = \(Get-FileHash -Algorithm SHA256 -LiteralPath \$videoOnly\)\.Hash\.ToLowerInvariant\(\)/,
+      "the renderer checksum must hash the complete rendered-frame MP4",
+    );
     assert.match(
       workflow,
       /\$metadata\.captureKind -ne 'current-candle-route-baseline'/,
@@ -2055,6 +2090,9 @@ test("the LTX Eros CUDA baseline is fixed, anonymous, mux-faithful, and mutation
     assert.match(harness, /adapter_reports\.is_empty\(\)/);
     assert.match(harness, /"pairDeltas": pair_deltas/);
     assert.match(harness, /"frameStats": frame_stats/);
+    assert.match(harness, /"renderedFramesDurationSeconds": RENDERED_FRAMES as f64 \/ FPS as f64/);
+    assert.match(harness, /"productDurationSeconds": DURATION_SECONDS/);
+    assert.doesNotMatch(harness, /"encodedDurationSeconds"/);
     assert.match(harness, /audio\.expect\("Candle LTX Eros must return its synchronized audio track"\)/);
     assert.match(
       workerLib,
@@ -2159,13 +2197,79 @@ test("the LTX Eros CUDA baseline is fixed, anonymous, mux-faithful, and mutation
       },
     },
     {
-      name: "MP4 audio duration verification removed",
-      expected: /MP4 audio stream duration must be checked/,
+      name: "product MP4 audio duration verification removed",
+      expected: /product MP4 audio stream.*must remain exact/,
       documents: {
         ...documents,
         workflow: documents.workflow.replace(
-          "Assert-DurationNear 'MP4 audio stream' $sound.duration",
+          "Assert-DurationNear 'product MP4 audio stream' $sound.duration $productDurationSeconds",
           "",
+        ),
+      },
+    },
+    {
+      name: "renderer duration wired to the product timeline",
+      expected: /complete rendered-frame video stream.*must remain exact/,
+      documents: {
+        ...documents,
+        workflow: documents.workflow.replace(
+          "Assert-DurationNear 'complete rendered-frame video stream' $renderedVideo.duration $renderedDurationSeconds",
+          "Assert-DurationNear 'complete rendered-frame video stream' $renderedVideo.duration $productDurationSeconds",
+        ),
+      },
+    },
+    {
+      name: "product duration wired to the renderer timeline",
+      expected: /product MP4 container.*must remain exact/,
+      documents: {
+        ...documents,
+        workflow: documents.workflow.replace(
+          "Assert-DurationNear 'product MP4 container' $probe.format.duration $productDurationSeconds",
+          "Assert-DurationNear 'product MP4 container' $probe.format.duration $renderedDurationSeconds",
+        ),
+      },
+    },
+    {
+      name: "renderer checksum omitted",
+      expected: /checksum manifest must bind both inspectable MP4s/,
+      documents: {
+        ...documents,
+        workflow: documents.workflow.replace(
+          '            "$renderedHash  ltx_eros.rendered-frames.mp4"\n',
+          "",
+        ),
+      },
+    },
+    {
+      name: "renderer checksum hashes the product MP4",
+      expected: /renderer checksum must hash the complete rendered-frame MP4/,
+      documents: {
+        ...documents,
+        workflow: documents.workflow.replace(
+          "$renderedHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $videoOnly)",
+          "$renderedHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $mp4)",
+        ),
+      },
+    },
+    {
+      name: "complete renderer frame assertion weakened",
+      expected: /must still prove all 153 frames/,
+      documents: {
+        ...documents,
+        workflow: documents.workflow.replace(
+          "[int]$renderedVideo.nb_read_frames -ne 153",
+          "[int]$renderedVideo.nb_read_frames -lt 150",
+        ),
+      },
+    },
+    {
+      name: "product mux accepts the untrimmed lattice",
+      expected: /must end at the six-second audio boundary/,
+      documents: {
+        ...documents,
+        workflow: documents.workflow.replace(
+          "$productFrames -gt 151",
+          "$productFrames -gt 153",
         ),
       },
     },


### PR DESCRIPTION
## Summary
- separate the complete 153-frame renderer output from the product-faithful six-second `-shortest` A/V MP4
- verify and upload both timelines with exact ffprobe and checksum evidence
- mutation-pin duration wiring, frame bounds, uploads, and hash sources

## Diagnosis
Windows/CUDA run 31735479741 rendered exactly 153 nondegenerate frames successfully. The harness then used the production `-shortest` mux with a six-second synchronized WAV, yielding the expected 151-frame product MP4, but incorrectly required that final mux to retain the full 6.12-second LTX lattice. This follow-up fixes that contradictory evidence contract; it does not make a product quality decision.

## Validation
- `npm run check` (467/467)
- `node --test scripts/platform-review-contracts.test.mjs` (49/49 after final review fixes)
- `cargo fmt --check --all`
- `git diff --check`
- `actionlint .github/workflows/windows-candle.yml` (only the repository-known custom `cuda` runner-label warning)
- independent adversarial review: PASS, high confidence

Shortcut: https://app.shortcut.com/trefry/story/18902