### PR TITLE
ci: consume ffmpeg version output before selection (sc-18902)

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -790,6 +790,12 @@ jobs:
           Assert-DurationNear 'product MP4 audio stream' $sound.duration $productBoundarySeconds
           Assert-DurationNear 'product MP4 container' $probe.format.duration $productBoundarySeconds
 
+          # Consume the native process completely before selecting one line. Piping ffmpeg directly
+          # into `Select-Object -First 1` closes stdout early on Windows, leaves LASTEXITCODE=1, and
+          # makes the otherwise-successful evidence step fail when the Actions wrapper exits.
+          $ffmpegVersionLines = @(& ffmpeg -version)
+          if ($LASTEXITCODE -ne 0) { throw 'ffmpeg version probe failed' }
+          $ffmpegVersion = ($ffmpegVersionLines | Select-Object -First 1).Trim()
           $runnerMetadata = [ordered]@{
             story = 'SC-18902'
             captureKind = 'current-candle-route-baseline'
@@ -801,7 +807,7 @@ jobs:
             gpu = ((& nvidia-smi --query-gpu=name,uuid,driver_version,memory.total --format=csv,noheader | Out-String).Trim())
             rustc = ((& rustc --version | Out-String).Trim())
             cargo = ((& cargo --version | Out-String).Trim())
-            ffmpeg = ((& ffmpeg -version | Select-Object -First 1 | Out-String).Trim())
+            ffmpeg = $ffmpegVersion
           }
           $runnerMetadata | ConvertTo-Json -Depth 4 | Out-File -LiteralPath (Join-Path $out 'runner.json') -Encoding utf8
           $productHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $mp4).Hash.ToLowerInvariant()

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -2096,6 +2096,17 @@ test("the LTX Eros CUDA baseline keeps renderer and product timelines distinct",
     );
     assert.match(
       workflow,
+      /\$ffmpegVersionLines = @\(& ffmpeg -version\)\s+if \(\$LASTEXITCODE -ne 0\) \{ throw 'ffmpeg version probe failed' \}\s+\$ffmpegVersion = \(\$ffmpegVersionLines \| Select-Object -First 1\)\.Trim\(\)/,
+      "the runner probe must consume ffmpeg output before selecting its version line",
+    );
+    assert.doesNotMatch(
+      workflow,
+      /ffmpeg -version \| Select-Object -First 1/,
+      "an early-closing native pipeline must not leak exit code 1 into the Actions wrapper",
+    );
+    assert.match(workflow, /ffmpeg = \$ffmpegVersion/);
+    assert.match(
+      workflow,
       /if: \$\{\{ success\(\) && github\.event_name == 'workflow_dispatch' && inputs\.run_ltx_eros_acceptance \}\}\s+uses: actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a/,
       "only a verified capture may publish the MP4/stills/metadata bundle",
     );
@@ -2273,6 +2284,16 @@ test("the LTX Eros CUDA baseline keeps renderer and product timelines distinct",
           "Assert-DurationNear 'product MP4 container' $probe.format.duration $productBoundarySeconds",
           "Assert-DurationNear 'product MP4 container' $probe.format.duration $renderedDurationSeconds",
         ),
+      },
+    },
+    {
+      name: "early-closing ffmpeg version pipeline restored",
+      expected: /must consume ffmpeg output before selecting its version line|must not leak exit code 1/,
+      documents: {
+        ...documents,
+        workflow: documents.workflow
+          .replace("$ffmpegVersionLines = @(& ffmpeg -version)", "$ffmpegVersionLines = & ffmpeg -version | Select-Object -First 1")
+          .replace("$ffmpegVersion = ($ffmpegVersionLines | Select-Object -First 1).Trim()", "$ffmpegVersion = $ffmpegVersionLines.Trim()"),
       },
     },
     {


### PR DESCRIPTION
## Summary

- consume the complete native ffmpeg version output before selecting its first line
- fail explicitly when the version probe itself fails
- mutation-pin the safe PowerShell shape and reject the early-closing pipeline that leaked exit code 1

## Evidence

Windows/CUDA run 31758460547 completed the real LTX Eros render and every verifier assertion, then the evidence step exited generically with code 1 because the final native ffmpeg pipeline was closed early. Upload was skipped. This repair leaves render and product contracts unchanged and removes only that post-verification exit leak.

## Validation

- node --test scripts/platform-review-contracts.test.mjs: 50 passed
- npm run check: 486 passed
- git diff --check
- actionlint: only the repository-known custom cuda runner-label warning
- stable patch-id preserved across exact rebase onto feature head 541c2da2

Shortcut: SC-18902