### PR TITLE
MiniMax-H3: per-tier completeness and shared-repo-safe delete (sc-19078)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1089,8 +1089,11 @@ pub(crate) async fn delete_model(
         state.settings.data_dir.join("models"),
         huggingface_hub_cache_dir(&state.settings.data_dir),
     ];
-    let removal = match remove_owned_artifacts(
-        model_artifact_paths(cleanup_source, &state.settings.data_dir),
+    let removal = match remove_whole_model_artifacts(
+        catalogs.models(&state).await?,
+        &model_id,
+        cleanup_source,
+        &state.settings.data_dir,
         &allowed_roots,
         permanent,
     )
@@ -1152,6 +1155,135 @@ pub(crate) async fn delete_model(
         "warnings": warnings,
         "policy": policy,
     })))
+}
+
+/// The file scopes `model` claims inside `repo` — the union of every one of its download entries
+/// (quant tiers AND co-requisites) that points at `repo`. `None` when ANY of them declares no `files`
+/// filter: that is a claim on the WHOLE repo, which cannot be expressed as a scoped removal, so the
+/// caller keeps the blanket path removal rather than silently reclaiming less than the user asked for.
+fn model_repo_file_scopes(model: &Value, repo: &str) -> Option<Vec<String>> {
+    let mut scopes = Vec::new();
+    for download in model
+        .get("downloads")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|entry| entry.get("repo").and_then(Value::as_str) == Some(repo))
+    {
+        let files = string_array_field(download, "files");
+        if files.is_empty() {
+            return None;
+        }
+        for file in files {
+            if !scopes.contains(&file) {
+                scopes.push(file);
+            }
+        }
+    }
+    (!scopes.is_empty()).then_some(scopes)
+}
+
+/// The file scopes every catalog entry OTHER than `model_id` claims inside `repo` (sc-19078).
+///
+/// Thirteen catalog groups put two or more entries in ONE Hugging Face repo, and a whole-model delete
+/// resolves that repo's cache path ([`model_artifact_paths`]) — so removing one entry took the SIBLING
+/// entry's bytes with it. For most of those groups the two entries name the same `files`, so the
+/// removal at least matched what both wanted. MiniMax-H3 is the group where it becomes destructive:
+/// `minimax_h3` owns `{tier}/transformer` and `minimax_h3_ref` owns `{tier}/transformer_ref` inside
+/// `SceneWorks/minimax-h3-mlx` — DIFFERENT weights, up to 66.3 GB per tier — so deleting the
+/// text-to-video entry wiped an installed reference model the user never asked to remove.
+///
+/// Co-requisite rows are included: a sibling's shared component living in the same repo is still bytes
+/// that sibling needs. Nothing here is conditioned on the sibling being INSTALLED — an installed
+/// sibling is exactly the case that matters, and for a sibling that is absent every one of these
+/// patterns matches no file on disk, so retaining them costs the delete nothing.
+fn other_entries_repo_file_scopes(catalog: &[Value], model_id: &str, repo: &str) -> Vec<String> {
+    let mut scopes = Vec::new();
+    for entry in catalog
+        .iter()
+        .filter(|entry| entry.get("id").and_then(Value::as_str) != Some(model_id))
+    {
+        for download in entry
+            .get("downloads")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter(|download| download.get("repo").and_then(Value::as_str) == Some(repo))
+        {
+            for file in string_array_field(download, "files") {
+                if !scopes.contains(&file) {
+                    scopes.push(file);
+                }
+            }
+        }
+    }
+    scopes
+}
+
+/// Remove a whole model's owned artifacts for [`delete_model`], keeping a shared-repo sibling's bytes.
+///
+/// The default path is unchanged: every path in [`model_artifact_paths`] is removed wholesale, which
+/// is right for the ~80 catalog entries that own their download repo outright. When the primary repo is
+/// ALSO claimed by another catalog entry, the repo's two storage locations (the app-managed mirror dir
+/// and the Hugging Face hub cache) are removed SCOPED instead — via the same
+/// [`remove_tier_artifacts`] machinery the per-tier delete uses, with the sibling's declared files as
+/// the retained set — so this entry's own subtrees and their exclusive blobs go and the sibling's stay.
+/// Every other artifact path (a manifest `paths.model`, an imported `source.path`) is entry-exclusive
+/// and still removed wholesale.
+///
+/// An entry that declares NO file scope inside a shared repo ([`model_repo_file_scopes`] → `None`)
+/// keeps the blanket removal: it claims the whole repo, so there is no honest narrower scope, and
+/// today's behavior is preserved rather than quietly reclaiming nothing.
+async fn remove_whole_model_artifacts(
+    catalog: &[Value],
+    model_id: &str,
+    cleanup_source: &Value,
+    data_dir: &FsPath,
+    allowed_roots: &[PathBuf],
+    permanent: bool,
+) -> Result<ArtifactRemoval, ApiError> {
+    let all_paths = model_artifact_paths(cleanup_source, data_dir);
+    let shared = model_download(cleanup_source)
+        .and_then(|download| {
+            download
+                .get("repo")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        })
+        .and_then(|repo| {
+            let siblings = other_entries_repo_file_scopes(catalog, model_id, &repo);
+            let own = model_repo_file_scopes(cleanup_source, &repo)?;
+            (!siblings.is_empty()).then_some((repo, own, siblings))
+        });
+    let Some((repo, own_files, sibling_files)) = shared else {
+        return remove_owned_artifacts(all_paths, allowed_roots, permanent).await;
+    };
+
+    let managed_dir = data_dir.join("models").join(safe_download_dir(&repo));
+    let repo_cache = huggingface_repo_cache_path(data_dir, &repo);
+    // Everything that is NOT the shared repo's storage: still this entry's alone, still removed whole.
+    let exclusive = all_paths
+        .into_iter()
+        .filter(|path| {
+            // `is_some_and` rather than `is_none_or`: the latter is stable only since 1.82 and the
+            // workspace MSRV is 1.80 (`clippy::incompatible_msrv` is denied).
+            path != &managed_dir && !repo_cache.as_ref().is_some_and(|cache| path == cache)
+        })
+        .collect::<Vec<_>>();
+    let mut removal = remove_owned_artifacts(exclusive, allowed_roots, permanent).await?;
+    let scoped = remove_tier_artifacts(
+        repo_cache,
+        Some(managed_dir),
+        &own_files,
+        &sibling_files,
+        allowed_roots,
+        permanent,
+    )
+    .await?;
+    removal.removed_paths.extend(scoped.removed_paths);
+    removal.retained_paths.extend(scoped.retained_paths);
+    removal.trash_failed_paths.extend(scoped.trash_failed_paths);
+    Ok(removal)
 }
 
 /// Delete ONE installed quant tier of a model and reclaim its disk, leaving the other tiers
@@ -3575,6 +3707,13 @@ fn no_model_index_family_predicate(family: &str, model_id: &str) -> Option<fn(&F
         // not the family — picks the predicate. Dispatched through the SHARED id list the worker's tier
         // resolver uses, so an id the worker would not tighten is not tightened here either.
         "sensenova-u1" => tc::sensenova_tier_predicate(model_id),
+        // sc-19078: the MiniMax-H3 tiers ship two DiT partition dirs (`{tier}/transformer` and
+        // `{tier}/transformer_ref`) and NO `model_index.json` at either level, so the coarse
+        // `q4/transformer/*` glob is satisfied by a single landed file out of fourteen shards. Like
+        // SenseNova the id — not the family — picks the predicate: the two catalog entries share the
+        // `minimax-h3` family but own DIFFERENT partitions of one repo, so a family-only predicate
+        // would have to demand both and report a reference-only install as torn forever.
+        "minimax-h3" => tc::minimax_h3_tier_predicate(model_id),
         _ => None,
     }
 }
@@ -7566,6 +7705,334 @@ mod variant_delete_tests {
         assert!(components
             .join("snapshots/rev/q4/text_encoder/model.safetensors")
             .exists());
+    }
+
+    /// The `SceneWorks/minimax-h3-mlx` shape (sc-17150 / sc-17158): ONE repo holding two DiT
+    /// partitions per tier, each owned by a DIFFERENT catalog entry. Seeds `tier`'s `transformer/`
+    /// (owned by `minimax_h3`) and `transformer_ref/` (owned by `minimax_h3_ref`).
+    ///
+    /// The two partitions ship a BYTE-IDENTICAL `config.json` (they carry the same architecture and
+    /// the same 638 tensor names; only the weights differ), so the hub cache stores it as ONE blob
+    /// that both snapshot entries symlink to. That shared blob is the trap: unlinking it with the base
+    /// partition would leave the reference partition's `config.json` dangling.
+    fn seed_minimax_tier(repo: &FsPath, tier: &str, base_etag: &str, ref_etag: &str, size: usize) {
+        let shared_config = blob(repo, &format!("{tier}-config"), b"{}");
+        link(
+            repo,
+            &format!("{tier}/transformer/config.json"),
+            &shared_config,
+        );
+        link(
+            repo,
+            &format!("{tier}/transformer_ref/config.json"),
+            &shared_config,
+        );
+        for partition in ["transformer", "transformer_ref"] {
+            let etag = if partition == "transformer" {
+                base_etag
+            } else {
+                ref_etag
+            };
+            seed(
+                repo,
+                &format!("{tier}/{partition}/diffusion_pytorch_model.safetensors.index.json"),
+                &format!("{etag}-index"),
+                1,
+            );
+            seed(
+                repo,
+                &format!("{tier}/{partition}/diffusion_pytorch_model-00001-of-00001.safetensors"),
+                etag,
+                size,
+            );
+        }
+    }
+
+    /// sc-19078 — a MiniMax-H3 per-tier delete reclaims that tier's own partition and NOTHING else.
+    ///
+    /// Mirrors `mage_flow_per_tier_delete_reclaims_only_that_tiers_dit`, which is the shipping
+    /// physical-per-tier precedent. H3 adds a dimension Mage does not have: the sibling that must
+    /// survive is not only another TIER of the same entry but another CATALOG ENTRY's partition inside
+    /// the same tier of the same repo — and the two partitions share a blob.
+    ///
+    /// Four things must hold at once, each a distinct way this could fail:
+    ///   - the deleted tier's own partition bytes are actually reclaimed (not 0);
+    ///   - the OTHER tier of the same entry survives (the tier predicates are disjoint);
+    ///   - the SIBLING ENTRY's partition in the SAME tier survives (the partition predicates are
+    ///     disjoint) — the case sc-17139's follow-ups flagged as reachable here for the first time;
+    ///   - the blob the two partitions SHARE survives, so the sibling's `config.json` still resolves.
+    #[tokio::test]
+    async fn minimax_h3_per_tier_delete_reclaims_only_that_entrys_partition() {
+        let tmp = tempfile::tempdir().unwrap();
+        let hub = tmp.path().join("hub");
+        let repo = hub.join("models--SceneWorks--minimax-h3-mlx");
+        // Real hosted per-partition sizes scaled down by 1e6 (18,780,109,783 B q4 / 35,302,064,357 B
+        // q8). The RATIO and the disjointness are what the assertions are about.
+        const Q4_DIT: usize = 18780;
+        const Q8_DIT: usize = 35302;
+        seed_minimax_tier(&repo, "q4", "q4dit", "q4refdit", Q4_DIT);
+        seed_minimax_tier(&repo, "q8", "q8dit", "q8refdit", Q8_DIT);
+
+        // Delete `minimax_h3`'s q4 tier. `retained` carries the surviving tiers of THAT entry, exactly
+        // as `delete_model_variant` builds it from the entry's own `downloads`.
+        let removal = remove_tier_artifacts(
+            Some(repo.clone()),
+            None,
+            &["q4/transformer/*".to_owned()],
+            &[
+                "q8/transformer/*".to_owned(),
+                "bf16/transformer/*".to_owned(),
+            ],
+            std::slice::from_ref(&hub),
+            true,
+        )
+        .await
+        .unwrap();
+
+        // 1. Real bytes: the q4 base partition's shard + its index, and nothing else. The shared
+        //    `config.json` blob is NOT counted — it never left disk.
+        assert_eq!(
+            removal.reclaimed_bytes,
+            (Q4_DIT + 1) as u64,
+            "a MiniMax-H3 tier delete must reclaim that entry's own partition bytes"
+        );
+        assert!(!repo.join("blobs/q4dit").exists());
+        assert!(!repo
+            .join("snapshots/rev/q4/transformer/diffusion_pytorch_model-00001-of-00001.safetensors")
+            .exists());
+
+        // 2. The same entry's OTHER tier is untouched.
+        assert!(repo.join("blobs/q8dit").exists());
+        assert!(repo
+            .join("snapshots/rev/q8/transformer/diffusion_pytorch_model-00001-of-00001.safetensors")
+            .exists());
+
+        // 3. The SIBLING ENTRY's partition inside the deleted tier is untouched — `minimax_h3_ref`
+        //    stays installed at q4 even though its bytes live in the tier just deleted.
+        assert!(repo.join("blobs/q4refdit").exists());
+        assert!(repo
+            .join(
+                "snapshots/rev/q4/transformer_ref/diffusion_pytorch_model-00001-of-00001.safetensors"
+            )
+            .exists());
+
+        // 4. The blob the two partitions SHARE survives and the sibling's link still resolves through
+        //    it — a dangling `config.json` would make the reference entry unloadable while still
+        //    reading installed.
+        assert!(repo.join("blobs/q4-config").exists());
+        let sibling_config = repo.join("snapshots/rev/q4/transformer_ref/config.json");
+        assert!(
+            std::fs::read(&sibling_config).is_ok(),
+            "sibling config resolves"
+        );
+    }
+
+    /// sc-19078 — the WHOLE-model delete is scoped when the download repo is shared.
+    ///
+    /// This is the destructive half. `model_artifact_paths` resolves the repo's cache dir, so before
+    /// this the blanket `remove_dir_all` on `models--SceneWorks--minimax-h3-mlx` took every
+    /// `transformer_ref/` tier with it — up to 132.6 GB of an installed model the user never asked to
+    /// delete. `remove_whole_model_artifacts` removes the entry's own `files` scopes instead, with the
+    /// sibling entry's scopes retained.
+    #[tokio::test]
+    async fn whole_model_delete_on_a_shared_repo_keeps_the_sibling_entrys_partitions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let repo_name = "SceneWorks/minimax-h3-mlx";
+        let repo = huggingface_repo_cache_path(data_dir, repo_name).unwrap();
+        seed_minimax_tier(&repo, "q4", "q4dit", "q4refdit", 18780);
+        seed_minimax_tier(&repo, "bf16", "bf16dit", "bf16refdit", 66280);
+
+        let downloads = |partition: &str| {
+            json!(["q4", "q8", "bf16"]
+                .iter()
+                .map(|tier| json!({
+                    "provider": "huggingface",
+                    "repo": repo_name,
+                    "variant": tier,
+                    "files": [format!("{tier}/{partition}/*")],
+                }))
+                .collect::<Vec<_>>())
+        };
+        let base = json!({ "id": "minimax_h3", "downloads": downloads("transformer") });
+        let reference =
+            json!({ "id": "minimax_h3_ref", "downloads": downloads("transformer_ref") });
+        let catalog = vec![base.clone(), reference];
+        let allowed_roots = vec![data_dir.join("models"), huggingface_hub_cache_dir(data_dir)];
+
+        let removal = remove_whole_model_artifacts(
+            &catalog,
+            "minimax_h3",
+            &base,
+            data_dir,
+            &allowed_roots,
+            true,
+        )
+        .await
+        .unwrap();
+
+        // Every tier of the deleted entry's own partition is gone…
+        assert!(!removal.removed_paths.is_empty());
+        for etag in ["q4dit", "bf16dit"] {
+            assert!(!repo.join("blobs").join(etag).exists(), "{etag} removed");
+        }
+        assert!(!repo.join("snapshots/rev/q4/transformer").exists());
+        assert!(!repo.join("snapshots/rev/bf16/transformer").exists());
+
+        // …and every tier of the SIBLING entry's partition survives, blobs and links alike.
+        for etag in ["q4refdit", "bf16refdit", "q4-config", "bf16-config"] {
+            assert!(repo.join("blobs").join(etag).exists(), "{etag} retained");
+        }
+        for tier in ["q4", "bf16"] {
+            let sibling = repo.join(format!("snapshots/rev/{tier}/transformer_ref"));
+            assert!(sibling.join("config.json").exists(), "{tier} ref config");
+            assert!(std::fs::read(sibling.join("config.json")).is_ok());
+            assert!(sibling
+                .join("diffusion_pytorch_model-00001-of-00001.safetensors")
+                .exists());
+        }
+        // The repo cache dir itself must NOT be pruned — the sibling still lives in it.
+        assert!(repo.is_dir(), "shared repo cache survives a scoped delete");
+    }
+
+    /// The exclusive-repo case is UNCHANGED: with no sibling claiming the repo, a whole-model delete
+    /// still removes the repo cache wholesale, including files no `files` scope names.
+    ///
+    /// This is the non-vacuity partner of the test above — without it, scoping could silently become
+    /// the universal path and quietly stop reclaiming the ~80 entries that own their repo outright.
+    #[tokio::test]
+    async fn whole_model_delete_on_an_exclusive_repo_still_removes_the_repo_cache() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let repo_name = "Org/solo-model";
+        let repo = huggingface_repo_cache_path(data_dir, repo_name).unwrap();
+        seed(&repo, "q4/transformer/model.safetensors", "q4dit", 100);
+        // A file NO declared scope names — only a blanket removal reaches it.
+        seed(&repo, "README.md", "readme", 10);
+
+        let model = json!({
+            "id": "solo_model",
+            "downloads": [{
+                "provider": "huggingface",
+                "repo": repo_name,
+                "variant": "q4",
+                "files": ["q4/transformer/*"],
+            }],
+        });
+        let allowed_roots = vec![data_dir.join("models"), huggingface_hub_cache_dir(data_dir)];
+
+        remove_whole_model_artifacts(
+            std::slice::from_ref(&model),
+            "solo_model",
+            &model,
+            data_dir,
+            &allowed_roots,
+            true,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !repo.exists(),
+            "an exclusively-owned repo cache is removed whole"
+        );
+    }
+
+    /// A shared-repo entry that declares NO `files` scope keeps the blanket removal (`SceneWorks/bernini`
+    /// is the shipping example — both entries claim the whole repo with `files: []`). There is no
+    /// honest narrower scope for a whole-repo claim, so the documented behavior is preserved rather
+    /// than quietly reclaiming nothing.
+    #[tokio::test]
+    async fn whole_model_delete_keeps_the_blanket_path_for_an_unscoped_shared_claim() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path();
+        let repo_name = "SceneWorks/whole-repo-pair";
+        let repo = huggingface_repo_cache_path(data_dir, repo_name).unwrap();
+        seed(&repo, "model.safetensors", "dit", 100);
+
+        let entry = |id: &str| {
+            json!({
+                "id": id,
+                "downloads": [{ "provider": "huggingface", "repo": repo_name, "files": [] }],
+            })
+        };
+        let first = entry("pair_a");
+        let catalog = vec![first.clone(), entry("pair_b")];
+        let allowed_roots = vec![data_dir.join("models"), huggingface_hub_cache_dir(data_dir)];
+
+        remove_whole_model_artifacts(&catalog, "pair_a", &first, data_dir, &allowed_roots, true)
+            .await
+            .unwrap();
+
+        assert!(!repo.exists());
+    }
+
+    #[test]
+    fn repo_file_scopes_union_tiers_and_reject_a_whole_repo_claim() {
+        let model = json!({
+            "id": "minimax_h3",
+            "downloads": [
+                { "repo": "SceneWorks/minimax-h3-mlx", "variant": "q4", "files": ["q4/transformer/*"] },
+                { "repo": "SceneWorks/minimax-h3-mlx", "variant": "q8", "files": ["q8/transformer/*"] },
+                { "repo": "MiniMaxAI/MiniMax-H3", "coRequisite": true, "files": ["vae/*"] },
+            ],
+        });
+        // Only the named repo's rows, unioned across tiers — the co-requisite repo is a different repo
+        // and contributes nothing to this repo's scope.
+        assert_eq!(
+            model_repo_file_scopes(&model, "SceneWorks/minimax-h3-mlx"),
+            Some(vec![
+                "q4/transformer/*".to_owned(),
+                "q8/transformer/*".to_owned()
+            ])
+        );
+        // A repo this entry does not claim at all has no scope.
+        assert_eq!(model_repo_file_scopes(&model, "Org/unrelated"), None);
+        // One unscoped row poisons the whole repo's scope: it is a claim on everything.
+        let unscoped = json!({
+            "id": "bernini",
+            "downloads": [{ "repo": "SceneWorks/bernini", "files": [] }],
+        });
+        assert_eq!(
+            model_repo_file_scopes(&unscoped, "SceneWorks/bernini"),
+            None
+        );
+        // …and it poisons it even when a SCOPED sibling row is present in the same repo. This is the
+        // case the empty-scopes fallback alone cannot express: without the early return the entry
+        // would scope its delete to `q4/*` and strand everything else the unscoped row claims.
+        let mixed = json!({
+            "id": "mixed_claim",
+            "downloads": [
+                { "repo": "Org/mixed", "variant": "q4", "files": ["q4/*"] },
+                { "repo": "Org/mixed", "files": [] },
+            ],
+        });
+        assert_eq!(model_repo_file_scopes(&mixed, "Org/mixed"), None);
+
+        // Sibling scopes exclude the entry itself and INCLUDE a sibling's co-requisite in that repo.
+        let sibling = json!({
+            "id": "minimax_h3_ref",
+            "downloads": [
+                { "repo": "SceneWorks/minimax-h3-mlx", "variant": "q4", "files": ["q4/transformer_ref/*"] },
+                { "repo": "SceneWorks/minimax-h3-mlx", "coRequisite": true, "files": ["shared/*"] },
+            ],
+        });
+        let catalog = vec![model.clone(), sibling];
+        assert_eq!(
+            other_entries_repo_file_scopes(&catalog, "minimax_h3", "SceneWorks/minimax-h3-mlx"),
+            vec!["q4/transformer_ref/*".to_owned(), "shared/*".to_owned()]
+        );
+        // Viewed from the sibling, the base entry's scopes are the ones retained.
+        assert_eq!(
+            other_entries_repo_file_scopes(&catalog, "minimax_h3_ref", "SceneWorks/minimax-h3-mlx"),
+            vec!["q4/transformer/*".to_owned(), "q8/transformer/*".to_owned()]
+        );
+        // A repo only this entry claims has no sibling scopes at all — the discriminator that keeps
+        // the blanket path in force for the entries that own their repo outright.
+        assert!(
+            other_entries_repo_file_scopes(&catalog, "minimax_h3", "MiniMaxAI/MiniMax-H3")
+                .is_empty()
+        );
     }
 
     // Convert-at-install (Anima) tiers are real `<converted>/<tier>/` dirs with a packed DiT plus

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -2997,6 +2997,427 @@ async fn quant_matrix_model_with_single_tier_reads_installed_not_incomplete() {
     }
 }
 
+/// The two MiniMax-H3 catalog entries (sc-17158) as the shipped manifest declares them: ONE repo,
+/// three tiers each, disjoint per-partition `files`, and the same three shared co-requisites. Written
+/// without `platforms` so the fixture is not stripped by `retain_downloads_for_os` on the candle CI
+/// lanes — the download/delete logic under test is OS-independent.
+#[cfg(test)]
+fn minimax_h3_manifest() -> String {
+    let tiers = |partition: &str| {
+        ["q4", "q8", "bf16"]
+            .iter()
+            .map(|tier| {
+                format!(
+                    r#"{{ "provider": "huggingface", "repo": "SceneWorks/minimax-h3-mlx", "revision": "f22bc294f46894584645aec59a513ee411450c96", "variant": "{tier}"{}, "files": ["{tier}/{partition}/*"] }}"#,
+                    if *tier == "q4" { ", \"default\": true" } else { "" }
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",\n")
+    };
+    let co_requisites = r#"
+        { "provider": "huggingface", "repo": "MiniMaxAI/MiniMax-H3", "revision": "939557dc319dd91227e30195a763f272ba7f8765", "coRequisite": true, "componentId": "text_encoder", "subdir": "text_encoder", "files": ["text_encoder/config.json", "text_encoder/model.safetensors.index.json"] },
+        { "provider": "huggingface", "repo": "MiniMaxAI/MiniMax-H3", "revision": "939557dc319dd91227e30195a763f272ba7f8765", "coRequisite": true, "componentId": "video_vae", "subdir": "vae", "files": ["vae/*"] },
+        { "provider": "huggingface", "repo": "MiniMaxAI/MiniMax-H3", "revision": "939557dc319dd91227e30195a763f272ba7f8765", "coRequisite": true, "componentId": "audio_vae", "subdir": "audio_vae", "files": ["audio_vae/*"] }"#;
+    format!(
+        r#"
+        {{
+          "schemaVersion": 1,
+          "models": [
+            {{
+              "id": "minimax_h3",
+              "name": "MiniMax-H3",
+              "type": "video",
+              "family": "minimax-h3",
+              "downloads": [
+{},
+{}
+              ]
+            }},
+            {{
+              "id": "minimax_h3_ref",
+              "name": "MiniMax-H3 References",
+              "type": "video",
+              "family": "minimax-h3",
+              "downloads": [
+{},
+{}
+              ]
+            }}
+          ]
+        }}
+        "#,
+        tiers("transformer"),
+        co_requisites,
+        tiers("transformer_ref"),
+        co_requisites
+    )
+}
+
+/// Seed ONE MiniMax-H3 DiT partition into a repo snapshot: `config.json`, the shard index, and the
+/// shards in `present`. Files are real (not blob symlinks) so the fixture is portable; the blob-level
+/// semantics are covered by the unix-gated `variant_delete_tests`.
+#[cfg(test)]
+fn seed_minimax_partition(
+    snapshot: &std::path::Path,
+    tier: &str,
+    partition: &str,
+    present: &[&str],
+) {
+    let dir = snapshot.join(tier).join(partition);
+    std::fs::create_dir_all(&dir).expect("partition dir creates");
+    std::fs::write(dir.join("config.json"), "{}").expect("config writes");
+    std::fs::write(
+        dir.join("diffusion_pytorch_model.safetensors.index.json"),
+        json!({
+            "weight_map": {
+                "blocks.0.weight": "diffusion_pytorch_model-00001-of-00002.safetensors",
+                "blocks.1.weight": "diffusion_pytorch_model-00002-of-00002.safetensors",
+            }
+        })
+        .to_string(),
+    )
+    .expect("index writes");
+    for shard in present {
+        std::fs::write(dir.join(shard), b"weights").expect("shard writes");
+    }
+}
+
+#[cfg(test)]
+const MINIMAX_SHARDS: [&str; 2] = [
+    "diffusion_pytorch_model-00001-of-00002.safetensors",
+    "diffusion_pytorch_model-00002-of-00002.safetensors",
+];
+
+/// Seed the three shared co-requisite components from `MiniMaxAI/MiniMax-H3` (the tier-agnostic
+/// weights floor a render needs regardless of which DiT tier is installed).
+#[cfg(test)]
+fn seed_minimax_shared_floor(data_dir: &std::path::Path) {
+    let snapshot =
+        data_dir.join("cache/huggingface/hub/models--MiniMaxAI--MiniMax-H3/snapshots/939557dc");
+    for (dir, files) in [
+        (
+            "text_encoder",
+            vec!["config.json", "model.safetensors.index.json"],
+        ),
+        ("vae", vec!["config.json"]),
+        ("audio_vae", vec!["config.json"]),
+    ] {
+        let component = snapshot.join(dir);
+        std::fs::create_dir_all(&component).expect("component dir creates");
+        for file in files {
+            std::fs::write(component.join(file), "{}").expect("component file writes");
+        }
+    }
+}
+
+#[tokio::test]
+async fn minimax_h3_tier_download_fetches_one_partition_plus_the_whole_shared_floor() {
+    // sc-19078 — the on-demand tier fetch, per entry and per tier. `SceneWorks/minimax-h3-mlx` is
+    // 240.7 GB in total, so a tier install must pull exactly ONE partition of ONE tier: q8 here is
+    // 35.3 GB against 240.7 GB for the repo. The three co-requisites are the tier-agnostic weights
+    // FLOOR — dense in every tier — and must be queued alongside it, at their own pinned revision;
+    // without them the entry installs as a model that cannot render.
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        minimax_h3_manifest(),
+    )
+    .expect("builtin models writes");
+    write_empty_sibling_manifests(&config_dir);
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, primary) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/models/minimax_h3/download",
+        json!({ "requestedGpu": "auto", "variant": "q8" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    // The primary job fetches THIS entry's partition of THAT tier — not the tier, not the repo.
+    assert_eq!(primary["payload"]["repo"], "SceneWorks/minimax-h3-mlx");
+    assert_eq!(primary["payload"]["variant"], "q8");
+    assert_eq!(primary["payload"]["files"], json!(["q8/transformer/*"]));
+    assert_eq!(
+        primary["payload"]["revision"], "f22bc294f46894584645aec59a513ee411450c96",
+        "the tier fetch is pinned, never main"
+    );
+
+    let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+    let download_jobs = jobs
+        .as_array()
+        .expect("jobs is an array")
+        .iter()
+        .filter(|job| job["type"] == "model_download")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        download_jobs.len(),
+        4,
+        "one partition job plus all three shared co-requisites: {download_jobs:?}"
+    );
+    let floor = download_jobs
+        .iter()
+        .filter(|job| job["payload"]["repo"] == "MiniMaxAI/MiniMax-H3")
+        .collect::<Vec<_>>();
+    assert_eq!(floor.len(), 3, "text encoder + both VAEs");
+    for component in floor {
+        // A DIFFERENT pin than the tier row's: the shared floor comes from MiniMax's own upstream
+        // snapshot, so asserting the tier's SHA here would have passed on a plain copy-through.
+        assert_eq!(
+            component["payload"]["revision"], "939557dc319dd91227e30195a763f272ba7f8765",
+            "a co-requisite carries its OWN pinned revision, not the tier row's"
+        );
+        assert!(
+            component["payload"]
+                .get("family")
+                .map_or(true, Value::is_null),
+            "a shared component is a different artifact than the DiT and must not carry its family"
+        );
+    }
+    // NOTHING pulls the sibling entry's partition or another tier — the whole point of per-tier fetch.
+    for job in download_jobs {
+        let files = job["payload"]["files"].to_string();
+        assert!(
+            !files.contains("transformer_ref"),
+            "a minimax_h3 install must not pull the reference checkpoint: {files}"
+        );
+        assert!(
+            !files.contains("q4/") && !files.contains("bf16/"),
+            "a q8 install must not pull another tier: {files}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn minimax_h3_tier_state_gates_on_every_shard_the_partition_index_names() {
+    // sc-19078: `SceneWorks/minimax-h3-mlx` ships no `model_index.json`, so the coarse
+    // `q4/transformer/*` glob is satisfied by a SINGLE landed file out of fourteen shards. Without the
+    // family predicate a torn tier read `installed` and then died at load — the "complete but
+    // unloadable" class. The two entries own disjoint partitions of one repo, so each must be judged
+    // on its OWN partition: here `minimax_h3`'s q4 is complete while `minimax_h3_ref`'s q4 is torn.
+    let _env = isolate_hf_cache();
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        minimax_h3_manifest(),
+    )
+    .expect("builtin models writes");
+    write_empty_sibling_manifests(&config_dir);
+
+    let data_dir = temp_dir.path().join("data");
+    let snapshot = data_dir
+        .join("cache/huggingface/hub/models--SceneWorks--minimax-h3-mlx/snapshots/f22bc294");
+    // `minimax_h3` q4: complete. `minimax_h3_ref` q4: index + config landed, ONE of two shards missing.
+    seed_minimax_partition(&snapshot, "q4", "transformer", &MINIMAX_SHARDS);
+    seed_minimax_partition(&snapshot, "q4", "transformer_ref", &MINIMAX_SHARDS[..1]);
+    seed_minimax_shared_floor(&data_dir);
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, models) = request(app, "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let entry = |id: &str| {
+        models
+            .as_array()
+            .expect("models array")
+            .iter()
+            .find(|model| model["id"] == id)
+            .unwrap_or_else(|| panic!("{id} present"))
+            .clone()
+    };
+    let tier_state = |model: &Value, name: &str| {
+        model["variants"]
+            .as_array()
+            .expect("variants array")
+            .iter()
+            .find(|variant| variant["variant"] == name)
+            .unwrap_or_else(|| panic!("variant {name} present"))
+            .clone()
+    };
+
+    let base = entry("minimax_h3");
+    assert_eq!(base["hasVariantMatrix"], true);
+    assert_eq!(base["installState"], "installed");
+    assert_eq!(tier_state(&base, "q4")["installState"], "installed");
+    for absent in ["q8", "bf16"] {
+        assert_eq!(
+            tier_state(&base, absent)["installState"],
+            "missing",
+            "{absent} was never fetched"
+        );
+    }
+
+    // The torn sibling: NOT installed, and flagged as repairable so the card offers a re-fetch rather
+    // than a green badge over a tier that cannot load.
+    let reference = entry("minimax_h3_ref");
+    assert_eq!(reference["installState"], "missing");
+    assert_eq!(reference["repairAvailable"], true);
+    let torn = tier_state(&reference, "q4");
+    assert_eq!(torn["installState"], "missing");
+    assert_eq!(torn["cacheState"], "incomplete");
+    assert!(
+        torn["missingRequiredFiles"]
+            .as_array()
+            .expect("missing files array")
+            .iter()
+            .any(|file| file.as_str() == Some("q4/ (incomplete: missing model components)")),
+        "the torn tier must name itself: {torn:?}"
+    );
+}
+
+#[tokio::test]
+async fn minimax_h3_is_not_installed_without_its_shared_component_floor() {
+    // A co-requisite is a WEIGHTS FLOOR, not an optional extra: the Qwen3-VL-32B text encoder and both
+    // VAEs are dense in every tier and must be present before any render, whatever tier is installed.
+    // A tier fetch that landed the DiT alone would otherwise advertise a model that cannot run.
+    let _env = isolate_hf_cache();
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        minimax_h3_manifest(),
+    )
+    .expect("builtin models writes");
+    write_empty_sibling_manifests(&config_dir);
+
+    let data_dir = temp_dir.path().join("data");
+    let snapshot = data_dir
+        .join("cache/huggingface/hub/models--SceneWorks--minimax-h3-mlx/snapshots/f22bc294");
+    seed_minimax_partition(&snapshot, "q4", "transformer", &MINIMAX_SHARDS);
+    // The floor is seeded, then the audio VAE is taken back out — one MISSING component of three.
+    seed_minimax_shared_floor(&data_dir);
+    std::fs::remove_dir_all(
+        data_dir.join(
+            "cache/huggingface/hub/models--MiniMaxAI--MiniMax-H3/snapshots/939557dc/audio_vae",
+        ),
+    )
+    .expect("audio vae removes");
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, models) = request(app, "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    let base = models
+        .as_array()
+        .expect("models array")
+        .iter()
+        .find(|model| model["id"] == "minimax_h3")
+        .expect("minimax_h3 present")
+        .clone();
+
+    // The q4 DiT tier itself is complete — this is specifically the co-requisite gate, not a torn tier.
+    let q4 = base["variants"]
+        .as_array()
+        .expect("variants array")
+        .iter()
+        .find(|variant| variant["variant"] == "q4")
+        .expect("q4 present")
+        .clone();
+    assert_eq!(
+        q4["installState"], "installed",
+        "the DiT tier itself landed"
+    );
+    // …yet the entry is not installed, and names the component repo it is still waiting on.
+    assert_eq!(base["installState"], "missing");
+    assert_eq!(base["repairAvailable"], true);
+    assert!(
+        base["missingRequiredFiles"]
+            .as_array()
+            .expect("missing files array")
+            .iter()
+            .any(|file| file
+                .as_str()
+                .is_some_and(|file| file.starts_with("MiniMaxAI/MiniMax-H3"))),
+        "the missing co-requisite must be named: {:?}",
+        base["missingRequiredFiles"]
+    );
+}
+
+#[tokio::test]
+async fn deleting_one_minimax_h3_entry_keeps_the_sibling_entrys_partitions() {
+    // sc-19078 — the shared-repo trap. Both entries live in ONE repo cache dir, and a whole-model
+    // delete resolves that dir, so the blanket `remove_dir_all` took `transformer_ref/` (a different
+    // checkpoint, up to 66.3 GB per tier) with it. After the delete `minimax_h3_ref` must still read
+    // installed at every tier it had.
+    let _env = isolate_hf_cache();
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        minimax_h3_manifest(),
+    )
+    .expect("builtin models writes");
+    write_empty_sibling_manifests(&config_dir);
+
+    let data_dir = temp_dir.path().join("data");
+    let snapshot = data_dir
+        .join("cache/huggingface/hub/models--SceneWorks--minimax-h3-mlx/snapshots/f22bc294");
+    // Both entries installed: `minimax_h3` at q4 + bf16, `minimax_h3_ref` at q4.
+    for tier in ["q4", "bf16"] {
+        seed_minimax_partition(&snapshot, tier, "transformer", &MINIMAX_SHARDS);
+    }
+    seed_minimax_partition(&snapshot, "q4", "transformer_ref", &MINIMAX_SHARDS);
+    seed_minimax_shared_floor(&data_dir);
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    // permanent=true keeps the assertions deterministic (the OS-trash path depends on the host).
+    let (status, deleted) = request(
+        app.clone(),
+        "DELETE",
+        "/api/v1/models/minimax_h3?permanent=true",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(deleted["removedLocalArtifacts"], true);
+    // A built-in entry stays catalogued; only its files go.
+    assert_eq!(deleted["removedManifestEntry"], false);
+
+    // The deleted entry's partitions are gone from EVERY tier…
+    for tier in ["q4", "bf16"] {
+        assert!(
+            !snapshot.join(tier).join("transformer").exists(),
+            "{tier}/transformer removed"
+        );
+    }
+    // …the sibling's partition survives, file for file…
+    let sibling = snapshot.join("q4/transformer_ref");
+    assert!(sibling.join("config.json").is_file());
+    for shard in MINIMAX_SHARDS {
+        assert!(sibling.join(shard).is_file(), "{shard} retained");
+    }
+    // …and the shared component floor is untouched (it is a co-requisite of BOTH entries).
+    assert!(data_dir
+        .join("cache/huggingface/hub/models--MiniMaxAI--MiniMax-H3/snapshots/939557dc/vae/config.json")
+        .is_file());
+
+    // The catalog agrees: the reference entry still reads installed at q4, the deleted one does not.
+    let (status, models) = request(app, "GET", "/api/v1/models", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    let state_of = |id: &str| {
+        models
+            .as_array()
+            .expect("models array")
+            .iter()
+            .find(|model| model["id"] == id)
+            .unwrap_or_else(|| panic!("{id} present"))["installState"]
+            .clone()
+    };
+    assert_eq!(state_of("minimax_h3_ref"), "installed");
+    assert_eq!(state_of("minimax_h3"), "missing");
+}
+
 #[tokio::test]
 async fn quant_matrix_empty_cache_skeleton_reads_missing_not_incomplete() {
     // sc-9909: a tier that isn't published upstream resolves ZERO files, leaving an empty HF cache

--- a/crates/sceneworks-core/src/mlx_tier_completeness.rs
+++ b/crates/sceneworks-core/src/mlx_tier_completeness.rs
@@ -1,5 +1,5 @@
 //! Per-family tier-completeness predicates for the MLX turnkeys that ship NO `model_index.json`
-//! (Anima / Boogu / SANA / Wan / SenseNova-U1).
+//! (Anima / Boogu / SANA / Wan / SenseNova-U1 / MiniMax-H3).
 //!
 //! These families lay their weights out in a bespoke tree rather than a diffusers `model_index.json`
 //! pipeline, so the generic `<tier>/*` presence checks — the worker's `tier_components_present`
@@ -152,21 +152,15 @@ fn sensenova_tokenizer_resolvable(dir: &Path) -> bool {
     })
 }
 
-/// Whether the SenseNova backbone under `dir` is fully on disk: either the packed single-file
-/// `model.safetensors` (every q4/q8 tier, and the `*-fast-mlx` bf16, which the packer emits pre-merged
-/// as one file) or a sharded `model.safetensors.index.json` with EVERY shard its `weight_map` names
-/// (the base/infographic bf16 tiers ship 8 shards / ~35 GB).
+/// Whether EVERY shard the safetensors index `index_file` in `dir` names is on disk, resolved against
+/// `dir` itself (the same rule `verify_model_snapshot.py` applies to an `expected_files` index).
 ///
 /// The shard set is read from the index rather than settling for "some `.safetensors` is here": the
-/// engine's `Weights::from_dir` merges whatever shards it finds WITHOUT consulting the index, then
-/// fails much later on missing tensor keys — so a download interrupted after 1 of 8 shards would
-/// otherwise read complete. A malformed / unreadable index is treated as incomplete.
-fn sensenova_backbone_present(dir: &Path) -> bool {
-    if dir.join("model.safetensors").is_file() {
-        return true;
-    }
-    let index = dir.join("model.safetensors.index.json");
-    let Ok(contents) = std::fs::read_to_string(&index) else {
+/// MLX loaders merge whatever shards they find WITHOUT consulting the index, then fail much later on
+/// missing tensor keys — so a download interrupted after 1 of N shards would otherwise read complete.
+/// An index naming no shards, or a malformed / unreadable one, is treated as incomplete.
+fn index_shards_present(dir: &Path, index_file: &str) -> bool {
+    let Ok(contents) = std::fs::read_to_string(dir.join(index_file)) else {
         return false;
     };
     let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&contents) else {
@@ -180,6 +174,15 @@ fn sensenova_backbone_present(dir: &Path) -> bool {
         .filter_map(serde_json::Value::as_str)
         .peekable();
     shards.peek().is_some() && shards.all(|shard| dir.join(shard).is_file())
+}
+
+/// Whether the SenseNova backbone under `dir` is fully on disk: either the packed single-file
+/// `model.safetensors` (every q4/q8 tier, and the `*-fast-mlx` bf16, which the packer emits pre-merged
+/// as one file) or a sharded `model.safetensors.index.json` with EVERY shard its `weight_map` names
+/// (the base/infographic bf16 tiers ship 8 shards / ~35 GB), per [`index_shards_present`].
+fn sensenova_backbone_present(dir: &Path) -> bool {
+    dir.join("model.safetensors").is_file()
+        || index_shards_present(dir, "model.safetensors.index.json")
 }
 
 /// Whether a SenseNova-U1 tier `dir` is COMPLETE and loadable. The `SceneWorks/sensenova-u1-8b*-mlx`
@@ -257,6 +260,66 @@ pub fn sensenova_tier_predicate(model_id: &str) -> Option<fn(&Path) -> bool> {
     } else {
         sensenova_tier_complete
     })
+}
+
+/// The DiT partition directory each MiniMax-H3 catalog entry owns inside a `SceneWorks/minimax-h3-mlx`
+/// tier (sc-19078). `minimax_h3` (t2va + fl2va) is the base `transformer/` checkpoint; `minimax_h3_ref`
+/// (Ref2VA) is `transformer_ref/`. The names mirror `DIT_COMPONENT` / `REFERENCE_DIT_PARTITION` in
+/// inference's `mlx-gen-minimax-h3::model`, which is what the loader actually opens.
+///
+/// The two partitions are the ONLY things a tier of that repo holds: the Qwen3-VL-32B text encoder,
+/// both VAEs and the tokenizer are dense in every tier and ship as shared co-requisites from upstream
+/// `MiniMaxAI/MiniMax-H3`, so they are deliberately NOT part of this predicate — the catalog gates them
+/// separately as co-requisites (`install_state_for`), which is what keeps a q4 install from demanding
+/// the bf16 tier's floor.
+pub const MINIMAX_H3_PARTITIONS: [(&str, &str); 2] = [
+    ("minimax_h3", "transformer"),
+    ("minimax_h3_ref", "transformer_ref"),
+];
+
+/// The sharded-weight index inference's `mlx-gen-minimax-h3::convert` writes into every MiniMax-H3 DiT
+/// partition. It is the file that makes a 14-shard partition checkable at all: without it the predicate
+/// would need fourteen hand-maintained shard names per partition and would silently stop covering a
+/// re-shard.
+const MINIMAX_H3_DIT_INDEX: &str = "diffusion_pytorch_model.safetensors.index.json";
+
+/// Whether ONE MiniMax-H3 DiT `partition` (`transformer` / `transformer_ref`) under tier dir `dir` is
+/// COMPLETE and loadable. `SceneWorks/minimax-h3-mlx` ships no `model_index.json` at either the tier
+/// root or inside a partition, so rust-api's coarse `<tier>/<partition>/*` glob is satisfied by a
+/// SINGLE landed file: a download interrupted after one of fourteen shards read `installed` and then
+/// died at load. A partition is complete when its `config.json` is present (the engine's config parse
+/// errors without it) and every shard its [`MINIMAX_H3_DIT_INDEX`] names is on disk.
+fn minimax_h3_partition_complete(dir: &Path, partition: &str) -> bool {
+    let partition = dir.join(partition);
+    partition.join("config.json").is_file()
+        && index_shards_present(&partition, MINIMAX_H3_DIT_INDEX)
+}
+
+/// Whether a `minimax_h3` (t2va + fl2va) tier `dir` is complete — its `transformer/` partition.
+pub fn minimax_h3_tier_complete(dir: &Path) -> bool {
+    minimax_h3_partition_complete(dir, MINIMAX_H3_PARTITIONS[0].1)
+}
+
+/// Whether a `minimax_h3_ref` (Ref2VA) tier `dir` is complete — its `transformer_ref/` partition.
+///
+/// Deliberately independent of [`minimax_h3_tier_complete`]: the two partitions are separate catalog
+/// entries with disjoint `files` predicates, so a user who installed only the reference checkpoint has
+/// a complete `minimax_h3_ref` tier and NO `transformer/` at all. Requiring both would report that
+/// working install as torn and prompt an endless repair.
+pub fn minimax_h3_ref_tier_complete(dir: &Path) -> bool {
+    minimax_h3_partition_complete(dir, MINIMAX_H3_PARTITIONS[1].1)
+}
+
+/// The per-tier completeness predicate for a MiniMax-H3 `model_id`, or `None` for an id outside
+/// [`MINIMAX_H3_PARTITIONS`]. Dispatched on the id rather than the shared `minimax-h3` family because
+/// the two entries own DIFFERENT partition dirs of the same repo — a family-only predicate could not
+/// tell them apart and would have to demand both, which is exactly the false-torn case above.
+pub fn minimax_h3_tier_predicate(model_id: &str) -> Option<fn(&Path) -> bool> {
+    match model_id {
+        id if id == MINIMAX_H3_PARTITIONS[0].0 => Some(minimax_h3_tier_complete),
+        id if id == MINIMAX_H3_PARTITIONS[1].0 => Some(minimax_h3_ref_tier_complete),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -686,6 +749,182 @@ mod tests {
         assert!(sensenova_tier_predicate("sana_1600m").is_none());
     }
 
+    /// Write ONE MiniMax-H3 DiT partition under tier dir `dir`: `config.json` plus a shard index naming
+    /// `shards`, of which only `present` actually land. The real repo ships 14 shards per partition; the
+    /// fixture keeps the COUNT small and the index-vs-disk relationship exact, which is what the
+    /// predicate reads.
+    fn seed_minimax_partition(dir: &Path, partition: &str, shards: &[&str], present: &[&str]) {
+        let partition = dir.join(partition);
+        let weight_map = shards
+            .iter()
+            .enumerate()
+            .map(|(index, shard)| {
+                (
+                    format!("blocks.{index}.attn.to_q.weight"),
+                    serde_json::Value::String((*shard).to_owned()),
+                )
+            })
+            .collect::<serde_json::Map<_, _>>();
+        fs::create_dir_all(&partition).unwrap();
+        fs::write(
+            partition.join(MINIMAX_H3_DIT_INDEX),
+            serde_json::json!({ "weight_map": weight_map }).to_string(),
+        )
+        .unwrap();
+        touch(&partition.join("config.json"));
+        for shard in present {
+            touch(&partition.join(shard));
+        }
+    }
+
+    const MINIMAX_SHARDS: [&str; 3] = [
+        "diffusion_pytorch_model-00001-of-00003.safetensors",
+        "diffusion_pytorch_model-00002-of-00003.safetensors",
+        "diffusion_pytorch_model-00003-of-00003.safetensors",
+    ];
+
+    /// Write a COMPLETE `minimax_h3` tier (the base `transformer/` partition only).
+    fn seed_minimax_h3(dir: &Path) {
+        seed_minimax_partition(dir, "transformer", &MINIMAX_SHARDS, &MINIMAX_SHARDS);
+    }
+
+    /// Write a COMPLETE `minimax_h3_ref` tier (the `transformer_ref/` partition only).
+    fn seed_minimax_h3_ref(dir: &Path) {
+        seed_minimax_partition(dir, "transformer_ref", &MINIMAX_SHARDS, &MINIMAX_SHARDS);
+    }
+
+    #[test]
+    fn minimax_h3_complete_true_each_file_load_bearing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("q4");
+        seed_minimax_h3(&dir);
+        assert!(
+            minimax_h3_tier_complete(&dir),
+            "fully-seeded transformer partition is complete"
+        );
+
+        // Mutation check, applied to EACH file on its own: the config, the index, and every one of the
+        // shards it names must independently flip the verdict. A tier that clears the coarse
+        // `q4/transformer/*` glob on a single landed file is exactly the "installed but unloadable"
+        // shape this predicate exists to catch.
+        let mut files = vec!["config.json".to_owned(), MINIMAX_H3_DIT_INDEX.to_owned()];
+        files.extend(MINIMAX_SHARDS.iter().map(|shard| (*shard).to_owned()));
+        for file in files {
+            let torn = tmp.path().join("torn");
+            seed_minimax_h3(&torn);
+            fs::remove_file(torn.join("transformer").join(&file)).unwrap();
+            assert!(
+                !minimax_h3_tier_complete(&torn),
+                "removing transformer/{file} must read incomplete"
+            );
+            fs::remove_dir_all(&torn).ok();
+        }
+    }
+
+    #[test]
+    fn minimax_h3_ref_complete_true_each_file_load_bearing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("q4");
+        seed_minimax_h3_ref(&dir);
+        assert!(minimax_h3_ref_tier_complete(&dir));
+
+        let mut files = vec!["config.json".to_owned(), MINIMAX_H3_DIT_INDEX.to_owned()];
+        files.extend(MINIMAX_SHARDS.iter().map(|shard| (*shard).to_owned()));
+        for file in files {
+            let torn = tmp.path().join("torn");
+            seed_minimax_h3_ref(&torn);
+            fs::remove_file(torn.join("transformer_ref").join(&file)).unwrap();
+            assert!(
+                !minimax_h3_ref_tier_complete(&torn),
+                "removing transformer_ref/{file} must read incomplete"
+            );
+            fs::remove_dir_all(&torn).ok();
+        }
+    }
+
+    #[test]
+    fn minimax_h3_partitions_are_judged_independently_of_each_other() {
+        // The two catalog entries own DISJOINT partition dirs of ONE repo, so each tier verdict must
+        // read only its own partition. A user who installed just the reference checkpoint has no
+        // `transformer/` at all; demanding both would report that working install as torn forever.
+        let tmp = tempfile::tempdir().unwrap();
+        let base_only = tmp.path().join("base-only");
+        seed_minimax_h3(&base_only);
+        assert!(minimax_h3_tier_complete(&base_only));
+        assert!(!minimax_h3_ref_tier_complete(&base_only));
+
+        let ref_only = tmp.path().join("ref-only");
+        seed_minimax_h3_ref(&ref_only);
+        assert!(minimax_h3_ref_tier_complete(&ref_only));
+        assert!(!minimax_h3_tier_complete(&ref_only));
+
+        // Both installed side by side in one tier — the shipped shape once a user owns both entries.
+        let both = tmp.path().join("both");
+        seed_minimax_h3(&both);
+        seed_minimax_h3_ref(&both);
+        assert!(minimax_h3_tier_complete(&both));
+        assert!(minimax_h3_ref_tier_complete(&both));
+    }
+
+    #[test]
+    fn minimax_h3_partition_needs_every_shard_the_index_names() {
+        // 2 of 3 shards landed: the coarse glob is satisfied, the index is not.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("bf16");
+        seed_minimax_partition(&dir, "transformer", &MINIMAX_SHARDS, &MINIMAX_SHARDS[..2]);
+        assert!(!minimax_h3_tier_complete(&dir));
+
+        // Mutation check: landing the last shard flips it, so the assertion above discriminates on the
+        // MISSING shard rather than on some unrelated absence.
+        touch(&dir.join("transformer").join(MINIMAX_SHARDS[2]));
+        assert!(minimax_h3_tier_complete(&dir));
+    }
+
+    #[test]
+    fn minimax_h3_ignores_appledouble_shard_sidecars_and_empty_indexes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("q8");
+        seed_minimax_partition(&dir, "transformer", &MINIMAX_SHARDS, &MINIMAX_SHARDS[..2]);
+        // A hidden `._` sidecar has a different name than the shard the index maps to, so an exact-path
+        // check rejects it (SceneWorks#1333).
+        touch(
+            &dir.join("transformer")
+                .join(format!("._{}", MINIMAX_SHARDS[2])),
+        );
+        assert!(!minimax_h3_tier_complete(&dir));
+
+        // An index whose `weight_map` names NOTHING is incomplete rather than vacuously complete: a
+        // truncated/placeholder index must never certify a partition with no weights at all.
+        let empty = tmp.path().join("empty-index");
+        seed_minimax_partition(&empty, "transformer", &[], &[]);
+        assert!(!minimax_h3_tier_complete(&empty));
+    }
+
+    #[test]
+    fn minimax_h3_predicate_dispatch_is_keyed_on_the_entry_id() {
+        // Behavioural probe (fn pointers don't compare reliably): a tier holding ONLY the base
+        // partition separates the two predicates the dispatcher can return.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("q4");
+        seed_minimax_h3(&dir);
+
+        let base = minimax_h3_tier_predicate("minimax_h3").expect("base id has a predicate");
+        assert!(base(&dir), "minimax_h3 must take the transformer predicate");
+        let reference =
+            minimax_h3_tier_predicate("minimax_h3_ref").expect("reference id has a predicate");
+        assert!(
+            !reference(&dir),
+            "minimax_h3_ref must take the transformer_ref predicate"
+        );
+
+        // Ids outside the pair get no predicate, so a future MiniMax entry with a different on-disk
+        // shape is left alone rather than mis-tightened. `minimax_h3_ref` is a PREFIX extension of
+        // `minimax_h3`, so a prefix match here would silently mis-dispatch — assert exact keying.
+        assert!(minimax_h3_tier_predicate("minimax_h3_2k").is_none());
+        assert!(minimax_h3_tier_predicate("minimax_h3_refiner").is_none());
+        assert!(minimax_h3_tier_predicate("wan_2_2").is_none());
+    }
+
     #[test]
     fn missing_tier_dir_is_incomplete_for_every_family() {
         // A tier subdir that does not exist at all (never converted / never downloaded) is incomplete,
@@ -697,5 +936,7 @@ mod tests {
         assert!(!sana_tier_complete(&absent));
         assert!(!wan_tier_complete(&absent));
         assert!(!sensenova_tier_complete(&absent));
+        assert!(!minimax_h3_tier_complete(&absent));
+        assert!(!minimax_h3_ref_tier_complete(&absent));
     }
 }


### PR DESCRIPTION
Story: [sc-19078](https://app.shortcut.com/trefry/story/19078) — MiniMax-H3: on-demand tier fetch + per-tier delete
Base: `feature/sc-17137-minimax-h3`

MiniMax-H3 (sc-17158) is the first catalog pair where two entries own **different weights inside one repo**: `minimax_h3` is `{tier}/transformer`, `minimax_h3_ref` is `{tier}/transformer_ref`, both in `SceneWorks/minimax-h3-mlx`, with the Qwen3-VL-32B text encoder and both VAEs shared as tier-agnostic co-requisites from `MiniMaxAI/MiniMax-H3`. That shape broke two things.

## 1. A torn tier read `installed` and then died at load

The repo carries no `model_index.json` at the tier root or inside a partition, so rust-api's coarse `q4/transformer/*` glob was satisfied by a **single landed file out of fourteen shards**.

`crates/sceneworks-core/src/mlx_tier_completeness.rs` gains `minimax_h3_tier_complete` / `minimax_h3_ref_tier_complete`: `config.json` present **plus every shard the partition's `diffusion_pytorch_model.safetensors.index.json` names**. Dispatch is by entry id (`minimax_h3_tier_predicate`), like SenseNova — the two entries share the `minimax-h3` family but own different partitions, so a family-only predicate would have to demand both and would report a reference-only install as torn forever.

`index_shards_present` is factored out of `sensenova_backbone_present` (identical semantics) so both read a shard index the same way. Wired into `no_model_index_family_predicate`, which is what `model_variant_states` and `install_state_for` consult.

## 2. Deleting one entry destroyed the other's weights

`model_artifact_paths` resolves the download repo's cache dir and `delete_model` removed it wholesale. Thirteen catalog groups put two or more entries in one repo, and for the five with **disjoint** `files` predicates that was real data loss:

| repo | entries | overlap |
| --- | --- | --- |
| `SceneWorks/minimax-h3-mlx` | `minimax_h3`, `minimax_h3_ref` | disjoint — up to **120.4 GB** |
| `SceneWorks/boogu-image-mlx` | base / turbo / edit | disjoint |
| `circlestone-labs/Anima` | base / aesthetic / turbo | disjoint DiTs, shared TE+VAE |
| `ResembleAI/chatterbox` | `chatterbox_tts`, `chatterbox_ve` | disjoint |
| `hkchengrex/MMAudio` | small_16k, large_44k | disjoint |

`remove_whole_model_artifacts` routes a **shared** repo through the same `remove_tier_artifacts` machinery the per-tier delete already uses, with every sibling entry's declared `files` as the retained set. Entry-exclusive paths (`paths.model`, an imported `source.path`) are still removed whole. Two deliberate non-changes, both pinned by tests:

- a repo **only this entry** claims keeps today's blanket removal (~80 catalog entries);
- an entry that claims a **whole repo** with `files: []` (`SceneWorks/bernini`) keeps it too — there is no honest narrower scope for a whole-repo claim.

## Per-tier fetch needed no code change — and now has a test

`create_model_download_job` already queues the selected tier's partition **plus all three co-requisites at their own pinned revision**. `minimax_h3_tier_download_fetches_one_partition_plus_the_whole_shared_floor` asserts a `variant: "q8"` install produces exactly 4 jobs (`q8/transformer/*` at `f22bc294…` + three components at `939557dc…`), and that nothing pulls `transformer_ref` or another tier. `minimax_h3_is_not_installed_without_its_shared_component_floor` pins the co-requisite gate: a complete q4 DiT with one VAE missing reads `installed: false` / `repairAvailable: true` and names the component repo — a co-requisite is a weights floor, not an extra.

## Mutation checks — nine, applied individually

| # | mutation | result |
| --- | --- | --- |
| M1 | drop `config.json` from the partition predicate | caught (2) |
| M2 | index no longer requires its shards on disk | caught (6) |
| M3 | an empty `weight_map` certifies a partition | caught (1) |
| M4 | prefix dispatch instead of exact id | caught (1) |
| M5 | whole-model delete removes the shared repo wholesale | caught (2) |
| M6 | sibling scopes stop excluding the entry itself | caught (4) |
| M7 | an unscoped whole-repo row stops forcing the blanket path | **missed first**, then caught (1) |
| M8 | scoped removal applies to exclusively-owned repos too | caught (1) |
| M9 | unwire the `minimax-h3` family-predicate arm | caught (1) |

M7 initially passed: `model_repo_file_scopes` also returns `None` when the collected scopes end up empty, so removing the early return was a no-op for a single unscoped row. The test now uses a **mixed** entry (one scoped row + one unscoped row in the same repo), which is the case only the early return can express.

## Verification

- `npm run rust:check` — exit 0; **3505 passed, 0 failed, 219 ignored** across 31 suites (clippy `-D warnings` caught an `is_none_or` MSRV violation, now `is_some_and`).
- `npm run check` — 410/411 node tests pass. The one failure, `check-docker-api-runtime.test.mjs::waitForHealth retries after a single request stalls`, is a wall-clock deadline (565 ms vs a 500 ms budget) that fails only under concurrent Rust compilation; it passes in isolation at 196 ms and this branch touches nothing under `scripts/`.
- `pytest -q tests/ -m "not e2e and not parity"` — 95 passed, 19 deselected.
- `pytest -q -m parity` — 14 passed, 100 deselected (contract snapshots unchanged).

## Not done here

- **sc-19506** — the tier-integrity ledger rows. The dense TE and both VAEs sit above tier on q4/q8, which the ledger's DECLARE threshold requires a row for, but `check-tier-integrity.mjs` validates `backends` against the router's lane oracle and treats an unrouted model as an ERROR. Neither MiniMax-H3 id appears in `crates/sceneworks-core/src/jobs_store/routing/`, so any row added today makes `npm run check` red. Also needs measured MLX-resident bytes, which only sc-17150's DiT figures cover.
- **sc-19507** — co-requisite repos are still never reclaimable (72.9 GB for this pair survives deleting both entries), and identical-predicate shared-repo groups still flip a sibling to not-installed with no warning.
- **The worker-side `ensure_minimax_h3_tier_present`** the story names: `mlx-gen-minimax-h3` is not at the pinned inference rev `014134e3`, there is no MiniMax-H3 video job module to call it from, and epic 17625 is actively removing job-time weight fetches — a new one would have to be registered in `job_time_download_guard::DOWNLOAD_SITES` as a 25th `JobTime` entry, against that epic's stated policy. Worth a decision on sc-18650 (the paired pin) rather than a quiet re-add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
