### PR TITLE
fix(release): include calibration evidence in Candle image

### DIFF
--- a/docker/rust.Dockerfile
+++ b/docker/rust.Dockerfile
@@ -215,6 +215,8 @@ COPY apps/desktop/Cargo.toml ./apps/desktop/Cargo.toml
 COPY apps/desktop/build.rs ./apps/desktop/build.rs
 # The builtin catalog, embedded via include_str! by sceneworks-core (see above).
 COPY config ./config
+# Keep the Candle builder on the same compile-time calibration input as the plain builder.
+COPY docs/generated/memory-calibration-evidence.json ./docs/generated/
 
 # nvcc compiles every candle provider's CUDA kernels here (compiling needs no GPU).
 # The general Candle kernels retain compute_80 PTX, but the GGUF/MoE kernels in

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -266,6 +266,18 @@ test("both Rust Docker builders carry the mechanically digested web capability s
   }
 });
 
+test("both Rust Docker builders carry the compiled memory-calibration evidence", async () => {
+  const dockerfile = await source("docker/rust.Dockerfile");
+  assert.equal(
+    (
+      dockerfile.match(
+        /^COPY docs\/generated\/memory-calibration-evidence\.json \.\/docs\/generated\/$/gm,
+      ) ?? []
+    ).length,
+    2,
+  );
+});
+
 test("all three manifest scripts import the shared JSONC parser", async () => {
   for (const scriptPath of [
     "scripts/check-scaffold.mjs",


### PR DESCRIPTION
## Summary
- copy the compiled memory-calibration evidence into the Candle Docker builder
- add a regression contract requiring both Rust Docker builders to carry that file

## Release recovery
The first unpublished v0.8.7 RunPod candidate failed because `sceneworks-core` could not resolve `docs/generated/memory-calibration-evidence.json` in the Candle builder. The old desktop run was canceled and the provisional draft/tag/release branch were removed before this PR.

## Validation
- `node --test scripts/platform-review-contracts.test.mjs`
- `npm run check` (401 tests)
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`