### PR TITLE
ci: save Rust caches only on main so PR lanes start warm

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -100,7 +100,32 @@ jobs:
         with:
           toolchain: "1.97.1"
           components: clippy,rustfmt
+      # SAVE ONLY ON `main`. This is the canonical note; every other rust-cache step in this repo
+      # carries the same input and points here.
+      #
+      # GitHub scopes an Actions cache to the ref that wrote it: a `refs/pull/N/merge` entry is
+      # readable only from inside PR N, while a `refs/heads/main` entry is readable from every
+      # branch and every PR. Left at the default (`save-if: true`) each PR job writes its own copy,
+      # so the repo accumulates one cache per lane per open PR and almost nothing another PR can
+      # use. Measured 2026-08-15, before this change: 12 of 12 SceneWorks caches were PR-scoped,
+      # ZERO were on main, and the repo sat at 14.3 GB of its 16 GB ceiling. Every PR job started
+      # cold, every time.
+      #
+      # The failure is a RATCHET, not a steady state. Eviction is LRU and fires on the PEAK, so a
+      # burst of concurrent PRs pushes the repo over the ceiling and drops the least-recently-read
+      # entries. A main baseline that PRs still read has its access time refreshed and survives; one
+      # that gets dropped can never come back, because refreshing it requires a read and the entry
+      # is gone. It stays dead until the next successful push to main, which is days apart here.
+      # Demonstrated in the sibling inference repo: main's `candle-cpu` baseline was full-matched at
+      # 2026-08-14T23:33 and gone by the next morning, after which every PR rebuilt the whole candle
+      # dependency graph inside its test step — ~18 minutes of a ~20-minute step, on every run.
+      #
+      # Restricting saves to main keeps exactly one baseline per lane, which is the only kind a PR
+      # can read anyway. A PR whose Cargo.lock differs from main's gets rust-cache's prefix restore
+      # instead of a full match: partial, and far better than cold.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
@@ -347,6 +372,8 @@ jobs:
           # A distinct key from `parity`'s: this job compiles the same crates under a different
           # feature set, so sharing one cache would thrash both.
           key: candle
+          # Save only on `main` — see the note on the `parity-rust` cache step above.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"

--- a/.github/workflows/desktop-linux-check.yml
+++ b/.github/workflows/desktop-linux-check.yml
@@ -93,7 +93,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
           toolchain: "1.97.1"
+      # Save only on `main` — see the note on the `parity-rust` cache step in check.yml.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # The Tauri/WebKitGTK prerequisites desktop-linux.yml installs, minus the
       # packaging-only ones: libfuse2/patchelf serve AppImage bundling and

--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -34,6 +34,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
           toolchain: "1.97.1"
+      # DELIBERATELY NOT `save-if: main`, unlike the PR and release lanes (see the note on the
+      # `parity-rust` cache step in check.yml). This workflow is `workflow_dispatch:` only, so its
+      # runs are manual packaging iterations on whatever branch the operator is working from —
+      # a branch-scoped cache is the point here, not waste. It also never runs on `main`, so a
+      # main-only save would leave it with nothing to restore and cold on every dispatch. The
+      # 2026-08-15 cache inventory carried no entry from this lane at all, so it is not what was
+      # starving the PR lanes. Do not re-symmetrise this with the lanes above.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
 
       # Tauri v2's Ubuntu/WebKitGTK build prerequisites. gstreamer1.0-libav

--- a/.github/workflows/desktop-macos-check.yml
+++ b/.github/workflows/desktop-macos-check.yml
@@ -121,7 +121,10 @@ jobs:
         with:
           toolchain: "1.97.1"
           components: clippy
+      # Save only on `main` — see the note on the `parity-rust` cache step in check.yml.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Fetch the pinned inference release
         env:

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -136,7 +136,10 @@ jobs:
         with:
           toolchain: "1.97.1"
           components: clippy
+      # Save only on `main` — see the note on the `parity-rust` cache step in check.yml.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"

--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -351,7 +351,10 @@ jobs:
       # `<workspace>/target` — the path this action derives and stores. See the block above
       # `jobs:`; pointing the two at different directories caches nothing and says nothing,
       # which is exactly what the first version of this step did.
+      # Save only on `main` — see the note on the `parity-rust` cache step in check.yml.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Ensure Metal compiler
         # The hosted image ships Xcode but not necessarily the Metal toolchain component,
         # and mlx-sys's build script shells out to `xcrun metal`. Same step the inference

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,7 +400,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
           toolchain: "1.97.1"
+      # Save only on `main` — see the note on the `parity-rust` cache step in check.yml. This lane
+      # runs on `refs/tags/v*`, and a tag-scoped cache is readable from no other ref at all, so
+      # saving here only ever consumed budget that the PR lanes needed.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Match the manual Linux packaging lane. gstreamer1.0-libav supplies H.264
       # decoding for WebKitGTK media playback on stock Ubuntu.

--- a/.github/workflows/server-candle-linux.yml
+++ b/.github/workflows/server-candle-linux.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           toolchain: "1.97.1"
           components: clippy
+      # DELIBERATELY NOT `save-if: main` — same reasoning as desktop-linux.yml: this lane is
+      # `workflow_dispatch:` only, never runs on `main`, and contributed no entry to the 2026-08-15
+      # cache inventory. Do not re-symmetrise it with the PR lanes.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 (v2.9.1+1)
       - name: Fetch the pinned inference release
         env:


### PR DESCRIPTION
## What

Adds `save-if: ${{ github.ref == 'refs/heads/main' }}` to every `Swatinem/rust-cache` step on a PR or release lane. No lane, job, step, or command changes.

## Why

Every cache step was at the default `save-if: true`, so each PR job wrote its own `refs/pull/N/merge` cache — an entry **no other PR can read**. Only `refs/heads/main` entries are readable from every branch and PR.

Measured 2026-08-15, before this change:

```
14.3 GB used of a 16 GB ceiling · 12 caches · caches on refs/heads/main: 0
```

All twelve belonged to just **two open PRs** (#2332 and #2335) — #2332 alone held ~10.1 GB. With zero baselines on main, every PR job started cold, every time.

The failure is a **ratchet**, not a steady state. Eviction is LRU and fires on the peak, so a burst of concurrent PRs drops the least-recently-read entries. A main baseline that PRs still read has its access time refreshed and survives; one that gets dropped can never come back, because refreshing it requires a read and PRs cannot read what is gone. It stays dead until the next successful push to main.

Demonstrated in the sibling `inference` repo, where the same shape had left exactly one surviving baseline: main's `candle-cpu` entry was full-matched at `2026-08-14T23:33`, was gone by the next morning, and the PR run at `10:20` logged `No cache found` and then spent ~18 of its test step's 20 minutes compiling `candle-core` and its dependents.

## Scope

| lane | change |
|---|---|
| `check.yml` (`parity-rust`, `candle`), `macos-mlx`, `desktop-windows`, `desktop-macos-check`, `desktop-linux-check`, `release` | save only on `main` |
| `desktop-linux`, `server-candle-linux` | **unchanged** — `workflow_dispatch`-only manual iteration lanes that never run on `main` and contributed no entry to the measured inventory. Both carry a note against re-symmetrising them. |

A PR whose `Cargo.lock` differs from main's gets rust-cache's prefix restore rather than a full match: partial, and far better than cold.

## Cold start — expected

There are no baselines on main yet, so **this PR runs cold, and so does the first PR after it merges.** The first main run after merge populates the baselines; the speedup appears on the second PR after merge.

## Conflict

#2286 (dependabot) bumps the `Swatinem/rust-cache` pin on the same `uses:` lines this PR edits. Whichever lands first, the other needs a merge from main.

## Verification

- `node --test scripts/platform-review-contracts.test.mjs` — 47/47
- `node --test "scripts/**/*.test.mjs"` — 401/401
- all 11 workflow files parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)