### PR TITLE
feat(loras): enforce the declared-partition pairing for MiniMax-H3 [sc-19563]

### DIFF
--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -1485,12 +1485,42 @@ pub(crate) fn validate_lora_specs_for_model(
                 "LoRA {lora_id} is not compatible with model {model_id}"
             )));
         }
+        // ── Declared-partition gating (sc-19563), the FAMILY-AGNOSTIC arm ──────────────────────
+        //
+        // The gate below this one is hardcoded to `wan-video`. This one deliberately is not, and
+        // that is the whole point of the story: it fires on the LoRA's own `modelIds` declaration,
+        // whatever family it belongs to, so closing the next family's version of this gap is a
+        // manifest edit rather than a third hardcoded arm here.
+        //
+        // What it closes: `family` cannot express a partition. MiniMax-H3 publishes `minimax_h3`
+        // (t2va/fl2va) and `minimax_h3_ref` (ref2va) as ONE DiT architecture with ONE geometry, so
+        // both declare `family: minimax-h3` and family detection cannot separate them — correctly,
+        // because they really are the same architecture. But lightx2v distils the fl2v and ref2v
+        // turbo adapters for one partition each, and cross-selecting one folds CLEANLY: no shape
+        // error, no refusal, just a quality mismatch. That is what makes it easy to ship and hard
+        // to notice.
+        //
+        // Absent `modelIds` means family gating alone, so no existing entry is tightened.
+        let declared_model_ids = lora_model_ids(lora);
+        if !declared_model_ids.is_empty() && !declared_model_ids.iter().any(|id| id == model_id) {
+            return Err(ApiError::bad_request(format!(
+                "LoRA {lora_id} is declared for model {}, not {model_id}. These are separate \
+                 partitions of the same model family, so the adapter would attach and fold \
+                 cleanly at the wrong quality rather than fail — which is why the pairing is \
+                 enforced here rather than left to the family check.",
+                declared_model_ids.join(" or ")
+            )));
+        }
         // Base-model gating: for families where a matching family is insufficient
         // (Wan 5B vs 14B both declare `wan-video` but have incompatible
         // architectures — 48 vs 16 latent channels), a LoRA that records its
         // trained base model only loads on that exact model. LoRAs without a
         // recorded base model fall back to family gating (legacy/imported), so this
         // never tightens behavior for existing LoRAs.
+        //
+        // Kept alongside the declared-partition gate above rather than merged into it: this one
+        // reads what an adapter RECORDS about its own training, that one reads what a catalog
+        // author DECLARES. An imported Wan LoRA has the former and no catalog entry at all.
         if families.iter().any(|family| family == "wan-video") {
             if let Some(base_model) = lora_base_model(lora) {
                 // Shared with the worker's own gate (sc-15017): exact-id equality, plus the
@@ -1963,6 +1993,40 @@ pub(crate) fn lora_families(lora: &Value) -> Vec<String> {
         &["families", "compatibleFamilies", "modelFamilies"],
         Some("compatibility"),
     )
+}
+
+/// The exact model ids a catalog entry **declares** this adapter is for (sc-19563), or empty when
+/// it declares none.
+///
+/// The generalisation of the base-model gate below. Two things distinguish it from
+/// [`lora_base_model`], and both are why it is a separate reader rather than another spelling of
+/// the same one:
+///
+/// * **Direction.** `baseModel` is a value a trained or imported adapter *records about itself*;
+///   `modelIds` is a catalog author *declaring* which partitions an adapter may attach to.
+/// * **Arity.** A recorded base model is one id. A declaration can legitimately name several, so
+///   this is a list.
+///
+/// Absent means family gating alone, exactly as before — so adding the key tightens nothing for any
+/// entry that does not declare it. Not normalized: model ids are exact strings, like
+/// [`lora_base_model`]'s. `model_ids` is accepted alongside `modelIds` for the same reason
+/// `lora_base_model` accepts `base_model` — an inline spec may arrive in either casing.
+pub(crate) fn lora_model_ids(lora: &Value) -> Vec<String> {
+    for key in ["modelIds", "model_ids"] {
+        if let Some(items) = lora.get(key).and_then(Value::as_array) {
+            let ids: Vec<String> = items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(str::to_owned)
+                .collect();
+            if !ids.is_empty() {
+                return ids;
+            }
+        }
+    }
+    Vec::new()
 }
 
 /// The specific base model a LoRA records it was trained for (e.g. `wan_2_2`,
@@ -2583,6 +2647,180 @@ mod base_model_gating_tests {
                 panic!("the turbo accelerator must be accepted on {model_id}: {error:?}")
             });
         }
+    }
+
+    /// sc-19563 — **the declared-partition gate**, both directions, with the control that makes it
+    /// attributable.
+    ///
+    /// The family check cannot see this: `minimax_h3` and `minimax_h3_ref` are one architecture and
+    /// one family, so before this gate the ref2v adapter attached to `minimax_h3` and **folded
+    /// cleanly** — no shape error, no refusal, just a quality mismatch, which is what made it easy
+    /// to ship and hard to notice.
+    ///
+    /// Four arms, and the two `Ok` ones are load-bearing: without them a gate that refused
+    /// *everything* would pass the two `Err` arms.
+    #[test]
+    fn a_declared_partition_gates_the_lora_to_that_model_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_minimax_h3_turbo_lora(
+            tmp.path(),
+            "minimax_h3_ref2v_turbo_4step_v0.1_bf16.safetensors",
+        );
+        let models = vec![
+            json!({
+                "id": "minimax_h3",
+                "family": "minimax-h3",
+                "loraCompatibility": { "families": ["minimax-h3"] }
+            }),
+            json!({
+                "id": "minimax_h3_ref",
+                "family": "minimax-h3",
+                "loraCompatibility": { "families": ["minimax-h3"] }
+            }),
+        ];
+        let ref2v = json!({
+            "id": "minimax_h3_ref2v_turbo_4step",
+            "installState": "installed",
+            "installedPath": tmp.path().to_str().unwrap(),
+            "families": ["minimax-h3"],
+            "modelIds": ["minimax_h3_ref"],
+        });
+        let fl2v = json!({
+            "id": "minimax_h3_turbo_8step",
+            "installState": "installed",
+            "installedPath": tmp.path().to_str().unwrap(),
+            "families": ["minimax-h3"],
+            "modelIds": ["minimax_h3"],
+        });
+
+        // ── the two refusals, each naming BOTH the LoRA and the partition.
+        for (lora, model_id, declared) in [
+            (&ref2v, "minimax_h3", "minimax_h3_ref"),
+            (&fl2v, "minimax_h3_ref", "minimax_h3"),
+        ] {
+            let error = validate_lora_specs_for_model(
+                &models,
+                &[],
+                model_id,
+                std::slice::from_ref(lora),
+                true,
+                "LoRA",
+            )
+            .expect_err("a cross-selected partition adapter must be refused");
+            let message = format!("{error:?}");
+            let lora_id = lora["id"].as_str().unwrap();
+            assert!(
+                message.contains(lora_id),
+                "the refusal must name the LoRA; got {message}"
+            );
+            assert!(
+                message.contains(model_id),
+                "the refusal must name the model it was refused ON; got {message}"
+            );
+            // **The exact phrase, not a substring search.** `minimax_h3_ref2v_turbo_4step`
+            // CONTAINS `minimax_h3_ref`, so a bare `message.contains(declared)` is satisfied by
+            // the LoRA id already in the message and asserts nothing — mutation testing caught
+            // exactly that: blanking the declared-partition interpolation left this green.
+            assert!(
+                message.contains(&format!("is declared for model {declared}")),
+                "the refusal must name the partition it IS for; got {message}"
+            );
+        }
+
+        // ── the controls: each adapter is accepted on its OWN partition. Without these the test
+        //    would pass against a gate that refused every H3 LoRA outright.
+        for (lora, model_id) in [(&ref2v, "minimax_h3_ref"), (&fl2v, "minimax_h3")] {
+            validate_lora_specs_for_model(
+                &models,
+                &[],
+                model_id,
+                std::slice::from_ref(lora),
+                true,
+                "LoRA",
+            )
+            .unwrap_or_else(|error| panic!("must be accepted on its own partition: {error:?}"));
+        }
+    }
+
+    /// The gate is **not** hardcoded to a family — that was the whole point of sc-19563, whose
+    /// predecessor gate reads `families.iter().any(|f| f == "wan-video")`.
+    ///
+    /// A `modelIds` declaration on an invented family with no in-tree special-casing must gate just
+    /// as hard. If someone later re-hardcodes this to `minimax-h3`, this arm reds and the H3 arms
+    /// above do not.
+    #[test]
+    fn the_declared_partition_gate_is_family_agnostic() {
+        let models = vec![
+            json!({
+                "id": "acme_alpha",
+                "family": "acme",
+                "loraCompatibility": { "families": ["acme"] }
+            }),
+            json!({
+                "id": "acme_beta",
+                "family": "acme",
+                "loraCompatibility": { "families": ["acme"] }
+            }),
+        ];
+        // No `installedPath`, so no header is read and no family detection runs — this isolates the
+        // declared-partition gate from the detected-family one.
+        let lora = json!({
+            "id": "acme_style",
+            "installState": "installed",
+            "families": ["acme"],
+            "modelIds": ["acme_beta"],
+        });
+        validate_lora_specs_for_model(
+            &models,
+            &[],
+            "acme_beta",
+            std::slice::from_ref(&lora),
+            true,
+            "LoRA",
+        )
+        .expect("accepted on the partition it declares");
+        let error = validate_lora_specs_for_model(
+            &models,
+            &[],
+            "acme_alpha",
+            std::slice::from_ref(&lora),
+            true,
+            "LoRA",
+        )
+        .expect_err("a family with no in-tree special-casing must still be gated");
+        assert!(format!("{error:?}").contains("acme_beta"), "{error:?}");
+    }
+
+    /// **A LoRA that declares NO `modelIds` is untouched.** The key is optional, so the gate must
+    /// not tighten a single existing catalog entry — every LoRA in the tree today declares none.
+    #[test]
+    fn a_lora_without_declared_model_ids_is_not_gated() {
+        let models = vec![json!({
+            "id": "minimax_h3_ref",
+            "family": "minimax-h3",
+            "loraCompatibility": { "families": ["minimax-h3"] }
+        })];
+        let lora = json!({
+            "id": "legacy_h3_style",
+            "installState": "installed",
+            "families": ["minimax-h3"],
+        });
+        validate_lora_specs_for_model(&models, &[], "minimax_h3_ref", &[lora], true, "LoRA")
+            .expect("an undeclared LoRA keeps family gating alone");
+        // ...and the reader itself agrees there is nothing to gate on.
+        assert!(lora_model_ids(&json!({ "id": "x" })).is_empty());
+        assert!(lora_model_ids(&json!({ "modelIds": [] })).is_empty());
+        assert!(lora_model_ids(&json!({ "modelIds": ["  ", ""] })).is_empty());
+        assert_eq!(
+            lora_model_ids(&json!({ "modelIds": [" minimax_h3_ref "] })),
+            vec!["minimax_h3_ref".to_string()],
+            "ids are trimmed, matching lora_base_model"
+        );
+        assert_eq!(
+            lora_model_ids(&json!({ "model_ids": ["minimax_h3"] })),
+            vec!["minimax_h3".to_string()],
+            "the snake_case alias is read too, like base_model"
+        );
     }
 
     /// The detected-family gate is a REAL gate for this family, not a formality: a LoRA from another

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -8148,3 +8148,205 @@ fn a_fractional_resolved_duration_keeps_the_manifests_own_decimal() {
     assert_eq!(crate::generation::contract_number(6.0), json!(6));
     assert!(crate::generation::contract_number(4.0).is_i64());
 }
+
+/// **sc-19563 — the declared-partition refusal is reachable from a REAL request.**
+///
+/// The unit tests in `loras.rs` call `validate_lora_specs_for_model` directly. That proves the
+/// function refuses; it does not prove a user can ever reach it. This one goes through the actual
+/// route — `POST /api/v1/video/jobs` — with the manifests on disk, the adapter file on disk and the
+/// app assembled by `create_app`, and asserts the exact body a client receives.
+///
+/// The epic's own rule is why this arm exists at all: **declaration ≠ enforcement ≠ reachability.**
+/// `loraCompatibility` declared the relationship, the validator enforces it, and only a submission
+/// shows the enforcement is on the path a request takes.
+///
+/// Both directions, plus both positive controls. The controls are load-bearing twice over: they
+/// prove the gate is not refusing every H3 LoRA, and they prove the fixture is well-formed enough to
+/// reach the LoRA check at all.
+#[tokio::test]
+async fn cross_selecting_a_minimax_h3_partition_lora_is_refused_by_the_video_job_route() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    // Both H3 partitions, declared exactly as `builtin.models.jsonc` declares them: ONE family,
+    // ONE architecture. That identity is the point — the family check passes both ways, so the
+    // refusal below can only come from the declared-partition gate.
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "models": [
+            {
+              "id": "minimax_h3",
+              "name": "MiniMax-H3",
+              "family": "minimax-h3",
+              "type": "video",
+              "adapter": "minimax_h3",
+              "capabilities": ["text_to_video", "image_to_video", "first_last_frame"],
+              "downloads": [],
+              "paths": {},
+              "defaults": {},
+              "limits": {},
+              "loraCompatibility": { "families": ["minimax-h3"] },
+              "ui": {}
+            },
+            {
+              "id": "minimax_h3_ref",
+              "name": "MiniMax-H3 References",
+              "family": "minimax-h3",
+              "type": "video",
+              "adapter": "minimax_h3",
+              "capabilities": ["text_to_video", "reference_to_video"],
+              "downloads": [],
+              "paths": {},
+              "defaults": {},
+              "limits": {},
+              "loraCompatibility": { "families": ["minimax-h3"] },
+              "ui": {}
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+    // The two adapters, each declaring the ONE partition it is distilled for — the same shape
+    // `builtin.loras.jsonc` now ships.
+    std::fs::write(
+        config_dir.join("builtin.loras.jsonc"),
+        r#"
+        {
+          "schemaVersion": 1,
+          "loras": [
+            {
+              "id": "minimax_h3_turbo_8step",
+              "name": "MiniMax-H3 Turbo (8-step)",
+              "family": "minimax-h3",
+              "modelIds": ["minimax_h3"],
+              "triggerWords": [],
+              "compatibility": { "families": ["minimax-h3"] },
+              "source": { "provider": "local", "path": "loras/h3_fl2v.safetensors" }
+            },
+            {
+              "id": "minimax_h3_ref2v_turbo_4step",
+              "name": "MiniMax-H3 Ref2VA Turbo (4-step)",
+              "family": "minimax-h3",
+              "modelIds": ["minimax_h3_ref"],
+              "triggerWords": [],
+              "compatibility": { "families": ["minimax-h3"] },
+              "source": { "provider": "local", "path": "loras/h3_ref2v.safetensors" }
+            }
+          ]
+        }
+        "#,
+    )
+    .expect("builtin loras writes");
+    std::fs::write(
+        config_dir.join("user.loras.jsonc"),
+        r#"{ "schemaVersion": 1, "loras": [] }"#,
+    )
+    .expect("user loras writes");
+
+    let lora_dir = temp_dir.path().join("data/loras");
+    std::fs::create_dir_all(&lora_dir).expect("lora dir creates");
+    // Real MiniMax-H3 diffusers keys, so `detect_lora_family` reports `minimax-h3` and the
+    // detected-family check is exercised rather than skipped on a `None`.
+    let keys: Vec<String> = ["attn.to_q", "attn.to_out.0", "ff.net.0.proj", "ff.net.2"]
+        .iter()
+        .flat_map(|target| {
+            ["lora_A.default.weight", "lora_B.default.weight"]
+                .iter()
+                .flat_map(move |suffix| {
+                    [
+                        format!("transformer_blocks.0.{target}.{suffix}"),
+                        format!("token_refiner.refiner_blocks.0.{target}.{suffix}"),
+                    ]
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+    write_test_safetensors_with_keys(&lora_dir.join("h3_fl2v.safetensors"), &keys);
+    write_test_safetensors_with_keys(&lora_dir.join("h3_ref2v.safetensors"), &keys);
+
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "H3 partitions" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id");
+
+    let submit = |model: &'static str, lora: &'static str| {
+        let app = app.clone();
+        let project_id = project_id.to_owned();
+        async move {
+            request(
+                app,
+                "POST",
+                "/api/v1/video/jobs",
+                json!({
+                    "projectId": project_id,
+                    "mode": "text_to_video",
+                    "prompt": "a cellist on a rooftop",
+                    "model": model,
+                    "loras": [{ "id": lora, "weight": 1.0 }]
+                }),
+            )
+            .await
+        }
+    };
+
+    // ── the ref2v adapter on the fl2v partition.
+    let (status, body) = submit("minimax_h3", "minimax_h3_ref2v_turbo_4step").await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "cross-selecting must be refused at submit; got {body:?}"
+    );
+    let detail = body["detail"].as_str().unwrap_or_default();
+    assert!(
+        detail.contains("minimax_h3_ref2v_turbo_4step"),
+        "the message must name the LoRA; got {detail}"
+    );
+    // The exact phrase, not a substring search: `minimax_h3_ref2v_turbo_4step` CONTAINS
+    // `minimax_h3_ref`, so `detail.contains("minimax_h3_ref")` is satisfied by the LoRA id already
+    // in the message and asserts nothing about the partition.
+    assert!(
+        detail.contains("is declared for model minimax_h3_ref"),
+        "the message must name the partition it IS for; got {detail}"
+    );
+
+    // ── and the reverse.
+    let (status, body) = submit("minimax_h3_ref", "minimax_h3_turbo_8step").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "got {body:?}");
+    let detail = body["detail"].as_str().unwrap_or_default();
+    assert!(detail.contains("minimax_h3_turbo_8step"), "{detail}");
+    assert!(
+        detail.contains("is declared for model minimax_h3,"),
+        "{detail}"
+    );
+
+    // ── the controls. Each adapter on its OWN partition must NOT be refused for a LoRA reason.
+    //    A later gate in `create_video_job` (the sc-19504 no-lane check) may still stop a job in a
+    //    test environment with no worker, so the assertion is on the REASON rather than on a 201:
+    //    what this proves is that the LoRA gate let it past, which is exactly the control needed.
+    for (model, lora) in [
+        ("minimax_h3", "minimax_h3_turbo_8step"),
+        ("minimax_h3_ref", "minimax_h3_ref2v_turbo_4step"),
+    ] {
+        let (status, body) = submit(model, lora).await;
+        let detail = body["detail"].as_str().unwrap_or_default().to_owned();
+        assert!(
+            !detail.contains("is declared for model"),
+            "{lora} on its OWN partition {model} must not trip the partition gate; got \
+             {status} {detail}"
+        );
+    }
+}

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -227,7 +227,42 @@ export function loraMatchesModel(lora, model) {
   if (!modelFamilies.length) {
     return true;
   }
-  return families.length > 0 && families.some((family) => modelFamilies.includes(family));
+  if (!families.some((family) => modelFamilies.includes(family))) {
+    return false;
+  }
+  // The DECLARED-PARTITION gate (sc-19563), mirroring `validate_lora_specs_for_model`'s. A LoRA
+  // may name the exact model ids it is for, which is the case `family` cannot express: MiniMax-H3's
+  // `minimax_h3` and `minimax_h3_ref` are one architecture and one family, so the family test above
+  // passes both ways, and lightx2v's fl2v and ref2v turbo adapters are distilled for one partition
+  // each. Without this the picker keeps offering the mismatched adapter and the API 400s on it —
+  // the dead-end selection the sc-10509 comment above describes.
+  //
+  // Absent `modelIds` means family gating alone, so no existing LoRA is affected. Gated on the
+  // model actually having an id: with no model selected there is nothing to compare against, and
+  // the permissive branch above already covers that case.
+  const declaredModelIds = loraModelIds(lora);
+  if (declaredModelIds.length && model?.id) {
+    return declaredModelIds.includes(model.id);
+  }
+  return true;
+}
+
+// The exact model ids a LoRA declares it is for (sc-19563), or `[]` when it declares none.
+// Mirrors the API's `lora_model_ids`, including the snake_case alias an inline spec may carry.
+export function loraModelIds(lora) {
+  for (const key of ['modelIds', 'model_ids']) {
+    const raw = lora?.[key];
+    if (Array.isArray(raw)) {
+      const ids = raw
+        .filter((id) => typeof id === 'string')
+        .map((id) => id.trim())
+        .filter(Boolean);
+      if (ids.length) {
+        return ids;
+      }
+    }
+  }
+  return [];
 }
 
 // Resolve an edit-capable model whose family matches the asset's generating model.

--- a/apps/web/src/presetUtils.test.jsx
+++ b/apps/web/src/presetUtils.test.jsx
@@ -118,6 +118,35 @@ describe("loraMatchesModel", () => {
     expect(loraMatchesModel(sdxlLora, { ...sdxlModel, loraCompatibility: { families: ["sdxl"], supported: true } })).toBe(true);
   });
 
+  it("gates a LoRA to the partitions it DECLARES, within one family (sc-19563)", () => {
+    // MiniMax-H3 publishes `minimax_h3` (t2va/fl2va) and `minimax_h3_ref` (ref2va) as ONE DiT
+    // architecture with ONE geometry, so both declare `family: minimax-h3` and the family test
+    // above passes BOTH WAYS. lightx2v distils the fl2v and ref2v turbo adapters for one partition
+    // each; cross-selecting folds cleanly at the wrong quality, and the API now 400s on it — so
+    // without this the picker keeps offering a dead-end selection.
+    const h3 = { id: "minimax_h3", family: "minimax-h3", loraCompatibility: { families: ["minimax-h3"] } };
+    const h3Ref = { id: "minimax_h3_ref", family: "minimax-h3", loraCompatibility: { families: ["minimax-h3"] } };
+    const fl2v = { id: "minimax_h3_turbo_8step", family: "minimax-h3", modelIds: ["minimax_h3"] };
+    const ref2v = { id: "minimax_h3_ref2v_turbo_4step", family: "minimax-h3", modelIds: ["minimax_h3_ref"] };
+
+    // Each on its OWN partition — the controls, without which a gate that hid everything passes.
+    expect(loraMatchesModel(fl2v, h3)).toBe(true);
+    expect(loraMatchesModel(ref2v, h3Ref)).toBe(true);
+    // ...and each cross-selected.
+    expect(loraMatchesModel(fl2v, h3Ref)).toBe(false);
+    expect(loraMatchesModel(ref2v, h3)).toBe(false);
+
+    // A LoRA declaring NO modelIds is untouched — the key is optional, so no existing entry is
+    // tightened. This is the arm that proves the gate is not "hide every minimax-h3 LoRA".
+    const undeclared = { id: "legacy_h3_style", family: "minimax-h3" };
+    expect(loraMatchesModel(undeclared, h3)).toBe(true);
+    expect(loraMatchesModel(undeclared, h3Ref)).toBe(true);
+
+    // Multiple declared partitions, and the snake_case alias an inline spec may carry.
+    expect(loraMatchesModel({ ...fl2v, modelIds: ["minimax_h3", "minimax_h3_ref"] }, h3Ref)).toBe(true);
+    expect(loraMatchesModel({ id: "l", family: "minimax-h3", model_ids: ["minimax_h3_ref"] }, h3)).toBe(false);
+  });
+
   it("normalizes separators/underscores on both sides before comparing", () => {
     expect(loraMatchesModel({ id: "l", family: "Z_Image" }, { id: "z", loraCompatibility: { families: ["z-image"] } })).toBe(true);
   });

--- a/config/manifests/builtin.loras.jsonc
+++ b/config/manifests/builtin.loras.jsonc
@@ -208,6 +208,7 @@
       "id": "minimax_h3_turbo_4step_768p",
       "name": "MiniMax-H3 Turbo (4-step, 768p)",
       "family": "minimax-h3",
+      "modelIds": ["minimax_h3"],
       "triggerWords": [],
       "compatibility": { "families": ["minimax-h3"] },
       "role": "accelerator",
@@ -226,6 +227,7 @@
       "id": "minimax_h3_turbo_8step",
       "name": "MiniMax-H3 Turbo (8-step)",
       "family": "minimax-h3",
+      "modelIds": ["minimax_h3"],
       "triggerWords": [],
       "compatibility": { "families": ["minimax-h3"] },
       "role": "accelerator",
@@ -246,6 +248,7 @@
       "id": "minimax_h3_turbo_4step_v01",
       "name": "MiniMax-H3 Turbo (4-step, v0.1)",
       "family": "minimax-h3",
+      "modelIds": ["minimax_h3"],
       "triggerWords": [],
       "compatibility": { "families": ["minimax-h3"] },
       "role": "accelerator",
@@ -259,16 +262,19 @@
     },
     {
       // The Ref2VA variant — it distils the REFERENCE-conditioned path, so it pairs with the
-      // `minimax_h3_ref` catalog entry rather than the `minimax_h3` (t2va/fl2va) one. That pairing is
-      // NOT enforced today and this entry does not pretend otherwise: both partitions share
-      // `family: minimax-h3` (they are one DiT architecture, one geometry), the LoRA schema has no
-      // per-model-id field, and the API's base-model gate is hardcoded to `wan-video`. Cross-selecting
-      // an fl2v file onto Ref2VA (or this onto t2va) is shape-valid and folds cleanly — it is a
-      // quality mismatch, not a failure. Enforcing the pairing needs a new per-model-id gate on both
-      // the LoRA schema and `validate_lora_specs_for_model`; tracked on sc-19563 (epic 17137).
+      // `minimax_h3_ref` catalog entry rather than the `minimax_h3` (t2va/fl2va) one. sc-19563
+      // ENFORCES that pairing: the `modelIds` below is read by `validate_lora_specs_for_model`,
+      // which refuses this adapter on `minimax_h3` and the three fl2v ones on `minimax_h3_ref`.
+      //
+      // The enforcement lives on a declared key rather than in family detection because it CANNOT
+      // live there: both partitions are one DiT architecture with one geometry, so both declare
+      // `family: minimax-h3` and `detect_unique_key_family` correctly cannot separate them.
+      // Cross-selecting used to be shape-valid and fold cleanly — a quality mismatch, not a
+      // failure, which is exactly why nothing caught it.
       "id": "minimax_h3_ref2v_turbo_4step",
       "name": "MiniMax-H3 Ref2VA Turbo (4-step)",
       "family": "minimax-h3",
+      "modelIds": ["minimax_h3_ref"],
       "triggerWords": [],
       "compatibility": { "families": ["minimax-h3"] },
       "role": "accelerator",

--- a/crates/sceneworks-core/src/builtin_manifests.rs
+++ b/crates/sceneworks-core/src/builtin_manifests.rs
@@ -1229,6 +1229,63 @@ mod tests {
         }
     }
 
+    /// sc-19563 — **every MiniMax-H3 turbo entry declares the ONE partition it is distilled for**,
+    /// and the ref2v one is the odd one out.
+    ///
+    /// This reads the embedded manifest, so it is the guard on the declaration itself; the gate that
+    /// reads it lives in `apps/rust-api/src/loras.rs::validate_lora_specs_for_model` and is proved
+    /// reachable from a real submission by
+    /// `jobs::cross_selecting_a_minimax_h3_partition_lora_is_refused_by_the_video_job_route`.
+    ///
+    /// The `assert_ne!` at the end is the half that matters. Family membership cannot express this
+    /// pairing — both partitions are one architecture and both declare `family: minimax-h3` — so a
+    /// table that gave all four the same `modelIds` would be exactly as wrong as declaring none, and
+    /// would sail past a test that only checked the key was present.
+    #[test]
+    fn every_minimax_h3_turbo_lora_declares_its_partition() {
+        // The expected pairing, spelled out rather than derived from the filename, so a manifest
+        // edit that pointed the ref2v adapter at the fl2v partition reds here.
+        const EXPECTED: [(&str, &str); 4] = [
+            ("minimax_h3_turbo_4step_768p", "minimax_h3"),
+            ("minimax_h3_turbo_8step", "minimax_h3"),
+            ("minimax_h3_turbo_4step_v01", "minimax_h3"),
+            ("minimax_h3_ref2v_turbo_4step", "minimax_h3_ref"),
+        ];
+        let mut seen = 0;
+        for lora in builtin_loras() {
+            if lora["family"] != serde_json::json!("minimax-h3") {
+                continue;
+            }
+            let id = lora["id"].as_str().expect("a LoRA entry has an id");
+            let want = EXPECTED
+                .iter()
+                .find(|(known, _)| *known == id)
+                .unwrap_or_else(|| panic!("unlisted minimax-h3 LoRA {id}; add it to EXPECTED"))
+                .1;
+            let declared: Vec<&str> = lora["modelIds"]
+                .as_array()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{id} declares no `modelIds`. Both H3 partitions share \
+                         `family: minimax-h3`, so without this the adapter attaches to either and \
+                         folds CLEANLY at the wrong quality — a mismatch, not a failure (sc-19563)."
+                    )
+                })
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .collect();
+            assert_eq!(declared, vec![want], "{id} names the wrong partition");
+            seen += 1;
+        }
+        assert_eq!(seen, EXPECTED.len(), "every listed entry must be present");
+        // The two partitions really are addressed differently — a uniform table would be as wrong
+        // as no table at all, and would pass a mere presence check.
+        assert_ne!(
+            EXPECTED[0].1, EXPECTED[3].1,
+            "the fl2v and ref2v adapters must name DIFFERENT partitions"
+        );
+    }
+
     #[test]
     fn no_minimax_h3_lora_declares_an_alpha() {
         // 🔴 sc-18724 / sc-18725. Alpha differs PER FILE inside this one repo — 128, 8, 8, and absent

--- a/packages/schemas/lora-manifest.schema.json
+++ b/packages/schemas/lora-manifest.schema.json
@@ -60,6 +60,12 @@
             "minLength": 1,
             "description": "Human-facing display name shown in the LoRA picker."
           },
+          "modelIds": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 },
+            "description": "The exact model ids this adapter may attach to (sc-19563). OPTIONAL, and absent means family gating alone \u2014 so this never tightens an existing entry. When present, validate_lora_specs_for_model refuses the LoRA on any model id outside this list, EVEN WITHIN THE SAME FAMILY. That is the case `family` cannot express: MiniMax-H3 publishes `minimax_h3` (t2va/fl2va) and `minimax_h3_ref` (ref2va) as one DiT architecture with one geometry, so both declare `family: minimax-h3` and both accept `minimax-h3` LoRAs \u2014 yet lightx2v distils the fl2v and ref2v turbo adapters for one partition each. Cross-selecting is shape-valid and folds cleanly, which is what made it a quality mismatch rather than a failure. Deliberately a LIST, not the singular `baseModel` the Wan gate reads: `baseModel` is a value a trained or imported adapter RECORDS about itself, while this is a catalog author DECLARING which partitions an adapter is for, and one adapter can legitimately serve several."
+          },
           "family": {
             "type": "string",
             "description": "Model family this adapter is compatible with (the compatibility gate reads this and `compatibility.families`)."

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -2101,6 +2101,69 @@ def test_lora_source_guard_is_live_against_the_real_catalog():
     )
 
 
+def test_lora_schema_accepts_a_declared_model_id_list():
+    """sc-19563: the entry is additionalProperties:false, so a per-model-id key is an
+    explicit schema addition rather than a free-form one. Pin that it is accepted at
+    all — reverting the property would turn every shipped `modelIds` into an
+    authoring error."""
+    entry = _sample_lora_entry()
+    entry["modelIds"] = ["minimax_h3_ref"]
+    errors = _schema_errors({"schemaVersion": 1, "loras": [entry]}, LORA_SCHEMA_PATH)
+    assert not errors, "a declared modelIds list must be schema-valid:\n" + _format_errors(errors)
+
+
+def test_lora_schema_rejects_a_malformed_model_id_list():
+    """`modelIds` is typed, not free-form: a bare string, an empty list, a non-string
+    element and an empty id are each rejected. Without the typing an author could
+    write `"modelIds": "minimax_h3_ref"` and the gate would read nothing — the key
+    present, the constraint absent, which is worse than declaring none at all."""
+    for value, keyword in (
+        ("minimax_h3_ref", "type"),
+        ([], "minItems"),
+        ([123], "type"),
+        ([""], "minLength"),
+    ):
+        entry = _sample_lora_entry()
+        entry["modelIds"] = value
+        errors = _schema_errors({"schemaVersion": 1, "loras": [entry]}, LORA_SCHEMA_PATH)
+        assert any(
+            error.validator == keyword
+            and list(error.absolute_path)[:3] == ["loras", 0, "modelIds"]
+            for error in errors
+        ), f"modelIds={value!r} must be rejected by `{keyword}`; got {_format_errors(errors)}"
+
+
+def test_every_minimax_h3_lora_declares_its_partition_in_the_real_catalog():
+    """sc-19563, against the SHIPPED manifest rather than a sample entry.
+
+    Both H3 partitions are one architecture and declare one family, so family
+    membership cannot express which of `minimax_h3` / `minimax_h3_ref` an adapter is
+    distilled for; cross-selecting used to fold cleanly at the wrong quality.
+
+    The final inequality is the load-bearing half: a catalog that gave all four the
+    same `modelIds` would pass a presence check and enforce nothing."""
+    manifest = _load_jsonc(LORA_MANIFEST_PATH)
+    declared = {
+        entry["id"]: entry.get("modelIds")
+        for entry in manifest["loras"]
+        if entry.get("family") == "minimax-h3"
+    }
+    assert declared, "no minimax-h3 LoRAs found; this guard would be vacuous"
+    for lora_id, model_ids in declared.items():
+        assert model_ids, f"{lora_id} declares no modelIds (sc-19563)"
+    assert declared["minimax_h3_ref2v_turbo_4step"] == ["minimax_h3_ref"]
+    fl2v = [
+        ids for lora_id, ids in declared.items() if lora_id != "minimax_h3_ref2v_turbo_4step"
+    ]
+    assert all(
+        ids == ["minimax_h3"] for ids in fl2v
+    ), f"the fl2v adapters must name minimax_h3; got {fl2v}"
+    assert declared["minimax_h3_ref2v_turbo_4step"] != fl2v[0], (
+        "the ref2v and fl2v adapters must name DIFFERENT partitions, or the declaration "
+        "enforces nothing"
+    )
+
+
 # --- Control-overlay catalog (builtin.control_overlays.jsonc) ---------------
 
 


### PR DESCRIPTION
The SceneWorks half of a three-story batch. The other two — **sc-18728** (candle turbo LoRA parity) and **sc-19443** (ComfyUI key-space conversion) — are engine-side and ship in [inference#627](https://github.com/SceneWorks/inference/pull/627). Two repos, so two PRs; there is no code overlap.

## The gap

`fl2v` and `ref2v` turbo LoRAs were distinguished only by filename convention. Nothing enforced the pairing:

- both partitions share `family: minimax-h3` — one DiT, one geometry — so family detection cannot separate them, and **correctly does not try**;
- the LoRA schema had **no per-model-id field**, and the entry is `additionalProperties: false`, so an entry literally could not say "this one is for `minimax_h3_ref` only";
- the API's base-model gate is hardcoded to `wan-video`, so it did not constrain H3 at all.

A `ref2v` LoRA selected against `minimax_h3` therefore **folded cleanly** — no error, no refusal. A quality mismatch rather than a failure, which is what made it easy to ship and hard to notice.

## Acceptance criteria

| # | Criterion | Status |
|---|---|---|
| 1 | `lora-manifest.schema.json` gains a per-model-id constraint; an explicit addition, since the entry is `additionalProperties: false` | **done** — entry-level `modelIds`, a typed array (`minItems: 1`, string items, `minLength: 1`) |
| 2 | `validate_lora_specs_for_model` enforces it, **not** hardcoded to one family — generalise rather than adding a second hardcoded arm | **done** — see below |
| 3 | The refusal is **reachable from a real request**, proved with an actual submission | **done** — `cross_selecting_a_minimax_h3_partition_lora_is_refused_by_the_video_job_route` |
| 4 | Cross-selecting `ref2v` against `minimax_h3` (and the reverse) is refused with a message naming both the LoRA and the partition | **done** — both directions, both controls |
| 5 | Mutate each new guard individually and record which test went red and which stayed blind | **done** — 15 mutations, table below, **including one that stayed blind and was fixed** |

## How criterion 2 was met

The existing gate is `families.iter().any(|family| family == "wan-video")`. The new one deliberately reads **no family at all** — it fires on the LoRA's own `modelIds` declaration whatever family it belongs to, so closing the next family's version of this gap is a manifest edit rather than a third hardcoded arm in this function.

`the_declared_partition_gate_is_family_agnostic` is the guard on that: it uses an invented `acme` family with no in-tree special-casing anywhere, and asserts the gate still fires. Re-hardcoding the check to `minimax-h3` reds that test and leaves the H3 tests green — which is exactly what makes it a real guard rather than a restatement.

The `wan-video` `baseModel` gate is **left in place** rather than merged into the new one. They are different facts: `baseModel` is a value a trained or imported adapter *records about itself* (an imported Wan LoRA has one and no catalog entry at all), while `modelIds` is a catalog author *declaring* which partitions an adapter may attach to. Arity differs too — one recorded base, potentially several declared partitions.

**Absent `modelIds` means family gating alone**, so not one existing catalog entry is tightened. `a_lora_without_declared_model_ids_is_not_gated` pins that, and the "gate over-fires" mutation below proves the pin bites.

## Also changed

- `apps/web/src/presetUtils.js::loraMatchesModel` mirrors the gate. Without it the picker keeps offering the mismatched adapter and the API 400s on submit — the dead-end selection the sc-10509 comment in that same function already describes.
- `config/manifests/builtin.loras.jsonc`: the four turbo entries declare their partition (three fl2v → `minimax_h3`, ref2v → `minimax_h3_ref`), and the comment that documented the gap and named this story is rewritten to describe the enforcement.

## ⚠️ The alpha guard

sc-18725 pinned that `lora-manifest.schema.json` declares **no** alpha, because the engine resolves alpha per checkpoint and a declared one produces a 16×/128× overshoot that is invisible in output. Relaxing `additionalProperties: false` is a one-line edit, so this was the thing most at risk here.

Nothing was relaxed: `modelIds` is an explicit typed property alongside the existing ones, and `no_minimax_h3_lora_declares_an_alpha` — which also scans `source.*` and `compatibility.*` for six alpha spellings including `scale` — is **green**. `cargo test -p sceneworks-core --lib builtin_manifests`: 26 passed.

## Validation

- `cargo test -p sceneworks-rust-api --lib` — 599 passed, 0 failed.
- `cargo test -p sceneworks-core --lib` — 905 passed, 0 failed.
- `python -m pytest -q tests/test_builtin_manifest_audit.py` — 81 passed.
- `vitest run src/presetUtils.test.jsx` — 62 passed.
- `node scripts/check-scaffold.mjs` — passed.
- `cargo fmt --all`.

### Mutation testing — 15 mutations, each applied INDIVIDUALLY

All-at-once proves the set, not each member. Each restore was followed by a `touch` so cargo could not reuse the mutated binary.

| Mutation | Test that went red |
|---|---|
| gate deleted: declared `modelIds` no longer refuse | `a_declared_partition_gates_the_lora_to_that_model_id` |
| gate re-hardcoded to the `minimax-h3` family | `the_declared_partition_gate_is_family_agnostic` |
| gate inverted: refuses the partition it IS for | `a_declared_partition_gates_the_lora_to_that_model_id` |
| gate over-fires: an UNDECLARED LoRA is refused too | `a_lora_without_declared_model_ids_is_not_gated` |
| reader: the snake_case `model_ids` alias dropped | `a_lora_without_declared_model_ids_is_not_gated` |
| refusal message no longer names the declared partition | `a_declared_partition_gates_the_lora_to_that_model_id` |
| …same, through the HTTP route | `cross_selecting_a_minimax_h3_partition_lora_is_refused_by_the_video_job_route` |
| gate deleted, through the HTTP route | `cross_selecting_a_minimax_h3_partition_lora_is_refused_by_the_video_job_route` |
| manifest: the ref2v adapter points at the fl2v partition | `every_minimax_h3_turbo_lora_declares_its_partition` |
| manifest: the ref2v declaration removed entirely | `every_minimax_h3_turbo_lora_declares_its_partition` |
| manifest: ref2v repointed (pytest arm) | `test_every_minimax_h3_lora_declares_its_partition_in_the_real_catalog` |
| schema: `modelIds` untyped, so a bare string would pass | `test_lora_schema_rejects_a_malformed_model_id_list` |
| schema: the `modelIds` property removed | `test_lora_schema_accepts_a_declared_model_id_list` |
| picker: the declared-partition branch deleted | `presetUtils.test.jsx` |
| picker: over-fires on an undeclared LoRA | `presetUtils.test.jsx` |

**15/15 caught — but only after fixing a guard that stayed blind.** Criterion 5 asks which test went red *and which stayed blind*, so: on the first sweep, "refusal message no longer names the declared partition" **survived**. The reason is worth recording, because it is a trap any similar test can fall into — `minimax_h3_ref2v_turbo_4step` *contains* the substring `minimax_h3_ref`, so `message.contains(declared)` was satisfied by the LoRA id already present in the message and asserted nothing at all about the partition. Both the unit and the HTTP assertions now pin the exact phrase `is declared for model {declared}`, and the mutation reds in both.

The other guard worth naming as deliberately narrow: `every_minimax_h3_turbo_lora_declares_its_partition` ends with an `assert_ne!` between the fl2v and ref2v declarations. A catalog that gave all four entries the *same* `modelIds` would pass a presence check and enforce nothing; the inequality is what makes the guard non-vacuous.

## Related, deliberately out of scope

- A hypothetical DiT-only H3 LoRA that omitted the token refiner would not be detected by `detect_unique_key_family`'s `token_refiner.refiner_blocks.` marker. Not reachable today — all four published files carry the 24 refiner tensors, which sc-18724 established are load-bearing.
- `crates/sceneworks-core/src/lora_family.rs::is_base_model_gated_family` still hardcodes `wan-video`. It is the **worker's** mirror of the `baseModel` gate, not of this one, and this story's gate is enforced at the API boundary where every job is admitted. Left untouched rather than half-ported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
