### PR TITLE
MiniMax-H3: per-variant turbo sampling recipe + a drivable Video Studio control (sc-18726, sc-18727)

### DIFF
--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -596,9 +596,15 @@ pub(crate) async fn create_video_job(
     // three gates around it bound how long the clip is and how much conditioning media it carries,
     // never how it is SAMPLED — so a MiniMax-H3 request at exactly its 5.1667s floor and its one
     // advertised 24 fps, with no references at all, clears every one of them carrying
-    // `advanced.steps = 1`, and then fails in the scheduler, which needs at least two sigma grid
-    // points to have a single model evaluation between them. Until this key existed the constraint
-    // could only be written as a manifest comment, and a comment enforces nothing.
+    // `advanced.steps = 1` — a single Euler jump from pure noise, which is not a fast draft. Until
+    // this key existed the constraint could only be written as a manifest comment, and a comment
+    // enforces nothing.
+    //
+    // The unit is MODEL EVALUATIONS everywhere on this seam — `advanced.steps`, `defaults.steps`,
+    // `limits.hardMinSteps`, `limits.steps`, and each turbo adapter's declared `sampling.steps`. The
+    // MiniMax-H3 engine appends its own terminal sigma grid point (`evaluations + 1`), so no ±1 is
+    // applied on this side of the boundary (sc-18726). A gate that read grid points while the worker
+    // passed evaluations would be off by one on every model in the family.
     //
     // Rejected, never clamped, for the duration cap's reason: raising the step count for the caller
     // doubles the compute they asked for with no error and no signal.

--- a/apps/web/public/prompt-guides/minimax-h3.md
+++ b/apps/web/public/prompt-guides/minimax-h3.md
@@ -189,11 +189,49 @@ it a guess.
 Unlike a first/last frame, **references do not set the canvas shape** — they are encoded at their own
 resolution and the output falls back to 16:9 unless you choose a size.
 
+## Turbo — The Control That Changes The Cost Table
+
+The **Turbo** control in the Advanced panel swaps in a step-distilled adapter and switches the render
+to the schedule that adapter was trained on. It is **on by default**, and the reason is the table
+above: at 1344x768 a measured base render took **2 h 25 m**, and the same shot with the 4-step 768p
+adapter took **12.6 minutes**. On a matched 576x320 pair the measured floor was 7x.
+
+Turbo is not "the same picture, faster". It is a **different sample** of the same prompt and seed —
+on the validated shot it carried *more* detail and *more* motion than the 50-step base, but the
+adapters are distilled at 544p/768p and MiniMax's own roadmap lists improving Turbo's fine detail as
+open work. Turn it off for the reference schedule; leave it on for everything else.
+
+Each published adapter carries its own schedule, which is why the control is a menu rather than a
+switch:
+
+| Variant | Steps | Trained for |
+|---|---|---|
+| **Turbo (4-step, 768p)** | 4 | The default 1344x768 canvas. The validated one, and the default pick. |
+| **Turbo (8-step)** | 8 | 544p, mixed aspect ratios. Two more steps of headroom. |
+| **Turbo (4-step, v0.1)** | 4 | 544p, the earlier release. |
+| **Ref2VA Turbo (4-step)** | 4 | The **References** entry — it distils the reference-conditioned path. |
+
+Two notes worth knowing:
+
+- The menu only lists adapters you have **installed**. If it says none are installed, fetch one from
+  the LoRA library — nothing else about the model changes.
+- Selecting a Turbo adapter from the ordinary **LoRA picker** does exactly the same thing. They are
+  one selection shown in two places, not two settings that can disagree.
+
 ## Steps
 
 Fifty steps is the reference default and what the timings above assume. Fewer steps scale the cost
 almost linearly, so 25 steps roughly halves the render — a reasonable trade while you are drafting.
-Below about 20 the motion starts to smear and the audio loses definition.
+Below about 20 the motion starts to smear and the audio loses definition — **unless** a Turbo adapter
+is on, which is the whole point of it: those weights are distilled to land in 4 or 8.
+
+Leaving the Steps box blank runs the model's own 50, or the selected Turbo adapter's own count. You
+can still type a number over either. The 8-step adapter is documented to work at 4 as well, so that
+override is a real option rather than a way to break it; the *sigma shift* is not overridable while
+Turbo is on, because sampling a distilled checkpoint on a schedule it was not distilled for is
+precisely what makes it look wrong.
+
+The count is **model evaluations**. "4 steps" means the transformer runs four times.
 
 ## Quant Tiers
 

--- a/apps/web/src/minimaxH3Turbo.js
+++ b/apps/web/src/minimaxH3Turbo.js
@@ -1,0 +1,110 @@
+// MiniMax-H3 turbo variant selection for the Video Studio (sc-18727, epic 17137).
+//
+// The turbo control is NOT a second way to say "accelerate". It selects a catalog LoRA — the exact
+// same thing the generic LoRA picker does — so both entry points converge on one payload field
+// (`loras`) and one server-side resolver (`sceneworks_core::minimax_h3_turbo::resolve_turbo_recipe`).
+// sc-18727 asked for exactly that: "either route both through one resolver or hide it from the
+// generic picker". Routing both is the better half of that choice, because hiding an installed
+// adapter from the picker would make it un-deselectable from the surface that shows it selected.
+//
+// Everything here is DERIVED from the LoRA catalog the API already serves. There is deliberately no
+// mirrored table of variants, step counts or shifts on this side: `builtin.loras.jsonc` declares the
+// `sampling` block, the API passes it through unmodified, and the Rust resolver reads the same
+// declaration. A web-side copy would be a fourth place for the numbers to drift and the first place
+// nothing would notice.
+
+/// Whether `lora` is a step-distill accelerator carrying a declared sampling recipe — the pair of
+/// facts that makes selecting it change the SCHEDULE rather than just stack a residual.
+///
+/// Both halves are required. `role: accelerator` alone is what the Krea 2 turbo adapter carries and
+/// means only "this adapter's intent is a different sampler regime"; without a `sampling` block the
+/// worker has nothing to apply and the file loads as a plain residual, so offering it in a control
+/// labelled "turbo" would promise a speedup nothing delivers.
+export function isTurboVariant(lora) {
+  const role = typeof lora?.role === "string" ? lora.role.trim().toLowerCase().replace(/-/g, "_") : null;
+  if (role !== "accelerator") return false;
+  const sampling = lora?.sampling;
+  return (
+    Boolean(sampling) &&
+    Number.isInteger(sampling.steps) &&
+    sampling.steps > 0 &&
+    Number.isFinite(sampling.schedulerShift) &&
+    sampling.schedulerShift > 0
+  );
+}
+
+/// The turbo variants offerable for `selectedModel`, given the studio's already-filtered
+/// `compatibleLoras` (installed + family-compatible + not preset-managed).
+///
+/// Built on `compatibleLoras` rather than the raw catalog so the control can never offer a variant
+/// the picker would refuse, or one whose weights are not on disk — an uninstalled adapter would
+/// produce a selection the enqueue gate rejects ("LoRA is not installed"), which is the shape of
+/// unreachable control this story exists to avoid.
+///
+/// Non-MiniMax-H3 models get an empty list even if some other family ships an accelerator, because
+/// the worker's turbo resolver returns "no recipe" off this family: the control must not appear
+/// where flipping it would change nothing.
+export function turboVariantsForModel(selectedModel, compatibleLoras = []) {
+  if (!modelIsMinimaxH3(selectedModel)) return [];
+  return compatibleLoras.filter(isTurboVariant);
+}
+
+/// Whether `selectedModel` is a MiniMax-H3 catalog entry. Mirrors
+/// `sceneworks_core::video_request::is_minimax_h3_model` (an `id` prefix test), which is what every
+/// MiniMax-H3 gate in the Rust half already keys on — both catalog partitions (`minimax_h3` and
+/// `minimax_h3_ref`) are in scope, since both load the same DiT architecture and both have a
+/// published turbo adapter.
+export function modelIsMinimaxH3(selectedModel) {
+  return typeof selectedModel?.id === "string" && selectedModel.id.startsWith("minimax_h3");
+}
+
+/// The variant a fresh MiniMax-H3 studio defaults to, or `null` when none is installed.
+///
+/// **Default-on**, matching the Wan Lightning precedent (sc-10048) and for a much larger reason:
+/// sc-18729 measured a 1344x768 base render at 2.42 h against 12.6 min with the 768p turbo adapter.
+/// A default-off control would make the shipped default experience a two-and-a-half-hour render,
+/// which is not a default anyone would choose on purpose.
+///
+/// The preference order is the checkpoint pairing, not the step count: the reference partition takes
+/// the ref2v adapter (it distils the reference-conditioned path), and the base partition takes the
+/// 768p 4-step file — the one variant sc-18729 validated end to end, and the one trained at the
+/// model's own default canvas. Anything else installed is a fallback rather than a default, so a
+/// user who has only the 8-step file still gets accelerated instead of silently getting nothing.
+///
+/// Returns `null` — not a variant — when nothing is installed. Selecting an uninstalled adapter
+/// would 400 at enqueue, so "no turbo" is the honest default state on a fresh install, and the
+/// control says so rather than pretending.
+export function defaultTurboVariant(selectedModel, variants = []) {
+  if (!variants.length) return null;
+  const preferred =
+    selectedModel?.id === "minimax_h3_ref"
+      ? ["minimax_h3_ref2v_turbo_4step"]
+      : ["minimax_h3_turbo_4step_768p", "minimax_h3_turbo_8step", "minimax_h3_turbo_4step_v01"];
+  for (const id of preferred) {
+    const match = variants.find((variant) => variant.id === id);
+    if (match) return match;
+  }
+  return variants[0];
+}
+
+/// The turbo variant currently selected, given the studio's selected LoRA ids. `null` = the base
+/// 50-step regime.
+///
+/// Reads the SELECTION, not a separate toggle state, so the control and the LoRA picker cannot
+/// disagree: deselecting the adapter in the picker turns the control off, and vice versa, because
+/// there is only one piece of state.
+export function selectedTurboVariant(variants = [], selectedLoraIds = []) {
+  return variants.find((variant) => selectedLoraIds.includes(variant.id)) ?? null;
+}
+
+/// The one-line schedule summary shown under the control: the recipe the selected variant actually
+/// applies, in the same units the worker records on the asset.
+///
+/// Spells out the audio shift as well as the video one because MiniMax-H3 runs two schedulers, and a
+/// control that reported only the video half would be describing half the render.
+export function turboRecipeSummary(variant) {
+  if (!variant) return null;
+  const { steps, schedulerShift, audioSchedulerShift } = variant.sampling ?? {};
+  const audio = Number.isFinite(audioSchedulerShift) ? `, audio shift ${audioSchedulerShift}` : "";
+  return `${steps} steps, video shift ${schedulerShift}${audio}`;
+}

--- a/apps/web/src/minimaxH3Turbo.test.js
+++ b/apps/web/src/minimaxH3Turbo.test.js
@@ -1,0 +1,110 @@
+// sc-18727 — the turbo-variant derivation, unit-level.
+//
+// The studio tests next door prove the CHAIN (control → payload). These prove the three predicates
+// that chain rests on, against inputs the shipped catalog cannot currently produce: a non-MiniMax
+// family that ships an accelerator, an accelerator with no recipe, and a recipe-bearing entry that
+// is not an accelerator. Without these the guards would be real but untestable — the shipped catalog
+// happens to make every one of them redundant with some other check, which is exactly how a
+// defence-in-depth guard rots into a no-op nobody notices.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultTurboVariant,
+  isTurboVariant,
+  modelIsMinimaxH3,
+  selectedTurboVariant,
+  turboRecipeSummary,
+  turboVariantsForModel,
+} from "./minimaxH3Turbo.js";
+
+const accelerator = (id, steps, schedulerShift, extra = {}) => ({
+  id,
+  name: id,
+  family: "minimax-h3",
+  role: "accelerator",
+  sampling: { steps, schedulerShift, audioSchedulerShift: 3.0 },
+  ...extra,
+});
+
+const MINIMAX = { id: "minimax_h3" };
+const MINIMAX_REF = { id: "minimax_h3_ref" };
+
+describe("minimaxH3Turbo", () => {
+  it("claims an accelerator only when it also declares a usable recipe", () => {
+    expect(isTurboVariant(accelerator("a", 4, 6.0))).toBe(true);
+    // `role` alone is the Krea 2 turbo adapter's shape: intent, no numbers. The worker has nothing
+    // to apply, so offering it under a control labelled "turbo" would promise a speedup that never
+    // arrives.
+    expect(isTurboVariant({ id: "b", role: "accelerator" })).toBe(false);
+    // A recipe on a non-accelerator is equally not a turbo variant — the two keys mean different
+    // things and only the pair is a claim.
+    expect(
+      isTurboVariant({ id: "c", sampling: { steps: 4, schedulerShift: 6.0 } }),
+    ).toBe(false);
+    // Degenerate recipes are refused rather than clamped: a 0-step or 0-shift schedule is not a
+    // fast render, it is an unrenderable one.
+    expect(isTurboVariant(accelerator("d", 0, 6.0))).toBe(false);
+    expect(isTurboVariant(accelerator("e", 4, 0))).toBe(false);
+    // The `role` spelling is normalised the way the worker's own reader normalises it.
+    expect(isTurboVariant({ ...accelerator("f", 4, 6.0), role: " Accelerator " })).toBe(true);
+    expect(isTurboVariant(null)).toBe(false);
+  });
+
+  it("offers nothing on a family whose accelerators this app cannot apply", () => {
+    // No shipped non-MiniMax family declares a `sampling` block today, so this is the ONLY place
+    // the family gate is observable. It is not decoration: the worker's turbo resolver returns "no
+    // recipe" off this family, so a control offered here would be a knob whose every setting does
+    // the same thing.
+    const foreign = accelerator("some_other_turbo", 4, 6.0, { family: "wan-video" });
+    expect(turboVariantsForModel({ id: "wan_2_2_t2v_14b" }, [foreign])).toEqual([]);
+    expect(turboVariantsForModel(null, [foreign])).toEqual([]);
+    // …and the same adapter list on a MiniMax-H3 model is offered, so the empty results above are
+    // the MODEL gate rather than the adapter being rejected for some other reason.
+    expect(turboVariantsForModel(MINIMAX, [foreign])).toEqual([foreign]);
+  });
+
+  it("recognises both catalog partitions", () => {
+    expect(modelIsMinimaxH3(MINIMAX)).toBe(true);
+    expect(modelIsMinimaxH3(MINIMAX_REF)).toBe(true);
+    expect(modelIsMinimaxH3({ id: "mochi_1" })).toBe(false);
+    expect(modelIsMinimaxH3(undefined)).toBe(false);
+  });
+
+  it("defaults to the checkpoint-paired variant, falling back rather than to nothing", () => {
+    const p768 = accelerator("minimax_h3_turbo_4step_768p", 4, 6.0);
+    const eight = accelerator("minimax_h3_turbo_8step", 8, 12.0);
+    const ref2v = accelerator("minimax_h3_ref2v_turbo_4step", 4, 12.0);
+    // Order in the list must not decide it: the 8-step file is FIRST here and must still lose to
+    // the validated 768p one.
+    expect(defaultTurboVariant(MINIMAX, [eight, p768])).toBe(p768);
+    // The reference partition takes the ref2v adapter even when an fl2v one is available — the two
+    // are one family and nothing else stops a Ref2VA job from folding a checkpoint it was not
+    // trained against.
+    expect(defaultTurboVariant(MINIMAX_REF, [p768, ref2v])).toBe(ref2v);
+    // A user who installed only the 8-step file still gets accelerated.
+    expect(defaultTurboVariant(MINIMAX, [eight])).toBe(eight);
+    // Nothing installed is an honest null, not a variant that would 400 at enqueue.
+    expect(defaultTurboVariant(MINIMAX, [])).toBeNull();
+  });
+
+  it("reads the active variant out of the LoRA selection, not a separate flag", () => {
+    const p768 = accelerator("minimax_h3_turbo_4step_768p", 4, 6.0);
+    const eight = accelerator("minimax_h3_turbo_8step", 8, 12.0);
+    expect(selectedTurboVariant([p768, eight], ["some_style", "minimax_h3_turbo_8step"])).toBe(
+      eight,
+    );
+    expect(selectedTurboVariant([p768, eight], ["some_style"])).toBeNull();
+    expect(selectedTurboVariant([], ["minimax_h3_turbo_8step"])).toBeNull();
+  });
+
+  it("summarises BOTH schedulers, not just the video one", () => {
+    // MiniMax-H3 denoises video and audio against two schedules. A summary naming only the video
+    // shift would describe half the render — and the audio half is the one the request cannot move,
+    // so it is the half a user has no other way to learn.
+    expect(turboRecipeSummary(accelerator("x", 4, 6.0))).toBe(
+      "4 steps, video shift 6, audio shift 3",
+    );
+    expect(turboRecipeSummary(null)).toBeNull();
+  });
+});

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { parseResolution, pickClosestResolution } from "../resolutionMatch.js";
 import { AssetPickerField, ImageEditSourcePickerField, VideoSourcePickerField } from "../components/AssetPicker.jsx";
 import { FitModeControl, effectiveFitMode } from "../components/FitModeControl.jsx";
@@ -64,6 +64,13 @@ import { videoGenerateValidation } from "../videoStudioValidation.js";
 import { useValidation } from "../validation/useValidation.js";
 import { ValidationSummary } from "../validation/Validation.jsx";
 import { VIDEO_MODES, downloadOffersFor, videoModelUsable } from "../modelEligibility.js";
+import {
+  defaultTurboVariant,
+  modelIsMinimaxH3,
+  selectedTurboVariant,
+  turboRecipeSummary,
+  turboVariantsForModel,
+} from "../minimaxH3Turbo.js";
 import { PROMPT_REFINE_MODEL_ID, WAN_A14B_LIGHTNING_MODEL_IDS } from "../constants.js";
 import {
   DEFAULT_MAC_CAPABILITIES,
@@ -316,6 +323,19 @@ export function VideoStudio() {
   // native multi-step CFG default). Only the two A14B engines honor it (see showLightning),
   // so the dense 5B and non-Wan models never see the control. Persisted per-workspace.
   const [lightning, setLightning] = useState(saved.lightning ?? true);
+  // Which MiniMax-H3 models have already had the default-on turbo variant applied (sc-18727).
+  //
+  // Turbo IS a LoRA selection — the control and the generic LoRA picker write the same
+  // `selectedLoraIds`, which is the only way the two entry points can't disagree (sc-18727's "route
+  // both through one resolver"). That makes "default on" a ONE-SHOT seed rather than a default
+  // value: without this marker, re-selecting the default every time the studio saw an empty
+  // selection would silently undo a deliberate "Off", and undo it identically whether the user
+  // turned it off in the turbo control or deselected the adapter in the picker.
+  //
+  // Persisted in the studio snapshot (mirrored to server ui-preferences, so it survives a desktop
+  // relaunch — a localStorage-only marker would re-seed on every launch and re-defeat "Off").
+  // Per-model because the two partitions take different adapters.
+  const [turboSeededModels, setTurboSeededModels] = useState(saved.turboSeededModels ?? []);
   // LTX-2.3 native guidance knobs (epic 1753 sc-1769). The native ltx-core
   // path has no diffusers scheduler to swap — these three values (cfg + STG +
   // rescale) drive its sealed MultiModalGuiderParams instead.
@@ -530,6 +550,59 @@ export function VideoStudio() {
     initialLoraWeights: saved.loraWeights ?? {},
     initialGeneralStackIds: saved.generalStackIds ?? [],
   });
+  // ── MiniMax-H3 turbo (sc-18726 / sc-18727) ────────────────────────────────────────────────
+  //
+  // Every value below is derived from the LoRA catalog and the live selection; there is no separate
+  // turbo state to keep in sync. `turboVariants` is already narrowed to installed + compatible by
+  // `compatibleLoras`, so the control can only ever offer an adapter that would actually enqueue.
+  const turboVariants = useMemo(
+    () => turboVariantsForModel(selectedModel, compatibleLoras),
+    [selectedModel, compatibleLoras],
+  );
+  const activeTurboVariant = selectedTurboVariant(turboVariants, selectedLoraIds);
+  // Shown whenever the model is MiniMax-H3, even with nothing installed: an absent control would
+  // answer "why is this render two and a half hours?" with silence. With no variant installed the
+  // control renders the reason and the Model Manager pointer instead of an empty menu.
+  const showTurbo = modelIsMinimaxH3(selectedModel);
+  // Default-on seed. Runs once per model (see `turboSeededModels`) and only once the LoRA catalog
+  // has actually resolved — seeding against an empty `turboVariants` during the restart-restore
+  // window would mark the model seeded and leave turbo permanently off, the same sc-11962 trap the
+  // preset/LoRA prunes above guard.
+  useEffect(() => {
+    if (!showTurbo || !turboVariants.length) return;
+    if (turboSeededModels.includes(model)) return;
+    setTurboSeededModels((seeded) => (seeded.includes(model) ? seeded : [...seeded, model]));
+    // A variant already selected — a replayed recipe, a restored snapshot, a preset — is the
+    // caller's choice and the seed must not stack a SECOND accelerator on top of it. Two adapters
+    // asking for different schedules is refused by the worker, so seeding blind here would turn
+    // "replay this render" into a hard enqueue failure.
+    if (selectedTurboVariant(turboVariants, selectedLoraIds)) return;
+    const preferred = defaultTurboVariant(selectedModel, turboVariants);
+    if (!preferred) return;
+    setSelectedLoraIds((ids) => (ids.includes(preferred.id) ? ids : [...ids, preferred.id]));
+  }, [
+    showTurbo,
+    turboVariants,
+    turboSeededModels,
+    model,
+    selectedModel,
+    selectedLoraIds,
+    setSelectedLoraIds,
+  ]);
+  // Selecting a variant REPLACES any other turbo adapter rather than stacking: two accelerators ask
+  // for two different schedules and the worker refuses the pair by name
+  // (`resolve_turbo_recipe`), so letting the control build that payload would offer a selection that
+  // can only fail. Plain (non-accelerator) LoRAs are untouched — a style LoRA rides alongside turbo.
+  const selectTurboVariant = useCallback(
+    (id) => {
+      const turboIds = new Set(turboVariants.map((variant) => variant.id));
+      setSelectedLoraIds((ids) => {
+        const withoutTurbo = ids.filter((existing) => !turboIds.has(existing));
+        return id ? [...withoutTurbo, id] : withoutTurbo;
+      });
+    },
+    [turboVariants, setSelectedLoraIds],
+  );
   // Sampler / scheduler menus declared by the model. Video Wan torch
   // declares the full menu; sealed paths (LTX native, MLX) drop to
   // default-only and the picker hides. Gated to the ACTIVE backend (epic 7114 P5):
@@ -1058,6 +1131,10 @@ export function VideoStudio() {
     steps: stepsOverride,
     guidanceScale: guidanceOverride,
     lightning,
+    // The MiniMax-H3 turbo default-on one-shot marker (sc-18727). The SELECTION itself already
+    // persists through `selectedLoraIds`; this records only that the seed has fired, so a
+    // deliberate "Off" is not re-seeded on the next mount or the next relaunch.
+    turboSeededModels,
     videoCfgGuidanceScale: ltxVideoCfg,
     videoStgGuidanceScale: ltxVideoStg,
     videoRescaleScale: ltxVideoRescale,
@@ -2042,6 +2119,39 @@ export function VideoStudio() {
                   </p>
                 </div>
               ) : null}
+              {/* MiniMax-H3 turbo (sc-18727). A VARIANT selector, not a toggle: the three published
+                  fl2v adapters carry three different (NFE, video shift) pairs, so "on" is not one
+                  state. Writes the SAME `selectedLoraIds` the LoRA picker writes — the control and
+                  the picker are two views of one selection, which is why they cannot disagree.
+                  Default-on (seeded once per model): sc-18729 measured 2.42 h against 12.6 min at
+                  the model's default canvas. */}
+              {showTurbo ? (
+                <div className="lightning-toggle">
+                  <label>
+                    Turbo (step-distilled)
+                    <select
+                      aria-label="Turbo (step-distilled)"
+                      disabled={!turboVariants.length}
+                      onChange={(event) => selectTurboVariant(event.target.value)}
+                      value={activeTurboVariant?.id ?? ""}
+                    >
+                      <option value="">Off — {selectedModel?.defaults?.steps ?? 50} steps</option>
+                      {turboVariants.map((variant) => (
+                        <option key={variant.id} value={variant.id}>
+                          {variant.name} — {variant.sampling.steps} steps
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <p className="helper-copy">
+                    {!turboVariants.length
+                      ? "No turbo adapter installed for this model. Install one from the LoRA library to render in 4–8 steps instead of the full schedule."
+                      : activeTurboVariant
+                        ? `On: ${turboRecipeSummary(activeTurboVariant)}. Roughly 7–12× faster (measured 12.6 min against 2.42 h at 1344×768). The distilled checkpoints are trained at 544p/768p and upstream is still improving their detail, so this is a different sample rather than the same one faster — turn it off for the reference schedule.`
+                        : "Off: the full schedule at the model's own sigma shift. Slow — a default-canvas clip measured 2.42 h."}
+                  </p>
+                </div>
+              ) : null}
               {model === ltxVideoModelId ? (
                 <>
                   <label>
@@ -2320,16 +2430,27 @@ export function VideoStudio() {
                         ? "4 (Lightning)"
                         : stepsPinned
                           ? `${stepsPinnedValue} (fixed schedule)`
-                          : String(stepsDefaultFromModel(selectedModel) ?? "")
+                          : /* Turbo supplies a step count but does NOT seize the control, unlike
+                               Lightning above: upstream's own spec table lists the 8-step MiniMax-H3
+                               adapter as "8 / 4", so a caller who knows the checkpoint may run it
+                               shorter, and `minimax_h3_sampling` honours an explicit
+                               `advanced.steps` over the variant's default for exactly that reason.
+                               So the placeholder REPORTS the recipe's count while the box stays
+                               editable — a knob honoured rather than rejected. */
+                            activeTurboVariant
+                            ? `${activeTurboVariant.sampling.steps} (Turbo)`
+                            : String(stepsDefaultFromModel(selectedModel) ?? "")
                     }
                     title={
                       lightningActive
                         ? "Governed by Lightning (fast 4-step). Turn Lightning off to set steps."
                         : stepsPinned
                           ? `${selectedModel?.ui?.label ?? selectedModel?.name ?? "This model"} is distilled: it runs a fixed ${stepsPinnedValue}-step schedule baked into its weights and cannot render any other step count.`
-                          : minSteps > 1
-                            ? `${selectedModel?.name ?? "This model"} needs at least ${minSteps} steps.`
-                            : undefined
+                          : activeTurboVariant
+                            ? `${activeTurboVariant.name} is distilled for ${activeTurboVariant.sampling.steps} steps, which is what runs when this is blank. You can still set your own count.`
+                            : minSteps > 1
+                              ? `${selectedModel?.name ?? "This model"} needs at least ${minSteps} steps.`
+                              : undefined
                     }
                     type="number"
                     value={lightningActive || stepsPinned ? "" : stepsOverride}

--- a/apps/web/src/screens/VideoStudio.minimaxH3Turbo.test.jsx
+++ b/apps/web/src/screens/VideoStudio.minimaxH3Turbo.test.jsx
@@ -1,0 +1,338 @@
+// sc-18727 — the MiniMax-H3 turbo control in the Advanced Video Studio.
+//
+// The defect class this file exists for is "declared but undrivable": a control that renders, holds
+// state, and never reaches the job. sc-17160 shipped `referenceAudioAssetIds` with no control that
+// could set it; sc-19502 found `limits.hardMinSteps` with no web reader at all. So nothing here
+// asserts that the control EXISTS — every test follows the value into the payload
+// `createVideoJob` actually receives, which is the last thing the web owns.
+//
+// The LoRA fixtures are the SHIPPED `builtin.loras.jsonc` entries, read at test time, for the same
+// reason the model fixtures in the sibling file are: the whole point of the `sampling` block is
+// that the four published variants disagree, and a retyped fixture would let the control and the
+// catalog drift into agreeing about numbers neither of them holds.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import React, { act } from "react";
+import JSON5 from "json5";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click, mountRoot, setInput, setSelect, unmountRoot } from "../testUtils/dom.js";
+
+vi.mock("../api.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, apiFetch: vi.fn(async () => ({})) };
+});
+
+import { AppContext } from "../context/AppContext.js";
+import { VideoStudio } from "./VideoStudio.jsx";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MANIFESTS = resolve(HERE, "../../../../config/manifests");
+const readManifest = (file, key) => {
+  const parsed = JSON5.parse(readFileSync(resolve(MANIFESTS, file), "utf8"));
+  return Array.isArray(parsed) ? parsed : parsed[key];
+};
+
+const shippedModel = (id) => {
+  const entry = readManifest("builtin.models.jsonc", "models").find((model) => model.id === id);
+  if (!entry) throw new Error(`manifest has no model ${id}`);
+  return { ...entry, installState: "installed", usable: true };
+};
+/// The shipped LoRA entry as the catalog route serves it: the manifest entry plus the install state
+/// `normalize_lora_entry` probes. `installedPath` matters — an uninstalled adapter is filtered out
+/// of `compatibleLoras`, which is exactly the state the "nothing installed" test asserts.
+const shippedLora = (id) => {
+  const entry = readManifest("builtin.loras.jsonc", "loras").find((lora) => lora.id === id);
+  if (!entry) throw new Error(`manifest has no lora ${id}`);
+  return {
+    ...entry,
+    scope: "builtin",
+    installState: "installed",
+    installedPath: `/data/loras/${id}.safetensors`,
+  };
+};
+
+const MINIMAX = shippedModel("minimax_h3");
+const MINIMAX_REF = shippedModel("minimax_h3_ref");
+// The control leg for every "only where it does something" gate below. Bernini is a video model
+// with no accelerator adapter at all, so a change that showed the turbo control globally rather
+// than per-family fails here.
+const BERNINI = shippedModel("bernini");
+
+const TURBO_768P = shippedLora("minimax_h3_turbo_4step_768p");
+const TURBO_8STEP = shippedLora("minimax_h3_turbo_8step");
+const TURBO_4STEP_V01 = shippedLora("minimax_h3_turbo_4step_v01");
+const TURBO_REF2V = shippedLora("minimax_h3_ref2v_turbo_4step");
+const ALL_TURBO = [TURBO_768P, TURBO_8STEP, TURBO_4STEP_V01, TURBO_REF2V];
+// A plain style LoRA on the same family — the "turbo is not just any LoRA" control.
+const PLAIN_LORA = {
+  id: "user_minimax_style",
+  name: "A user style LoRA",
+  family: "minimax-h3",
+  compatibility: { families: ["minimax-h3"] },
+  defaultWeight: 0.8,
+  scope: "global",
+  installState: "installed",
+  installedPath: "/data/loras/user_minimax_style.safetensors",
+};
+
+function baseContext(overrides = {}) {
+  return {
+    token: "test-token",
+    activeProject: { id: "project_1", name: "My Project" },
+    assets: [],
+    characters: [],
+    createPersonDetectionJob: vi.fn(),
+    createPersonTrackJob: vi.fn(),
+    createVideoJob: vi.fn(),
+    createPreset: vi.fn(async (payload) => ({ id: payload.id })),
+    refinePrompt: vi.fn(),
+    deleteAsset: vi.fn(),
+    purgeAsset: vi.fn(),
+    gpuOptions: [],
+    importAsset: vi.fn(),
+    latestVideoAssets: [],
+    recentVideoAssets: [],
+    studioLaunch: null,
+    loras: ALL_TURBO,
+    jobs: [],
+    videoLocalJobs: [],
+    jobAction: vi.fn(),
+    rememberLocalGenerationJob: vi.fn(),
+    setActiveView: vi.fn(),
+    setSelectedAssetId: vi.fn(),
+    setPreviewAsset: vi.fn(),
+    personTracks: [],
+    personReadiness: {},
+    presets: [],
+    requestedGpu: "",
+    saveTrackCorrections: vi.fn(),
+    selectedAsset: null,
+    setRequestedGpu: vi.fn(),
+    updateAssetStatus: vi.fn(),
+    models: [],
+    videoModels: [MINIMAX],
+    ...overrides,
+  };
+}
+
+describe("MiniMax-H3 turbo control (sc-18726 / sc-18727)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <VideoStudio />
+        </AppContext.Provider>,
+      );
+    });
+  }
+
+  const labelStartingWith = (text) =>
+    [...container.querySelectorAll("label")].find((label) =>
+      label.textContent.trim().startsWith(text),
+    );
+  const turboSelect = () => container.querySelector('select[aria-label="Turbo (step-distilled)"]');
+  const openAdvanced = async () => {
+    const toggle = container.querySelector(".advanced-section-toggle");
+    if (toggle && container.querySelector(".advanced-panel") === null) await click(toggle);
+  };
+  const generate = async () => {
+    await click(
+      [...container.querySelectorAll("button")].find((b) => b.textContent.includes("Render clip")),
+    );
+  };
+  const lastJob = (context) => context.createVideoJob.mock.calls.at(-1)[0];
+  const jobLoraIds = (context) => (lastJob(context).loras ?? []).map((lora) => lora.id);
+  // The GENERIC picker's own controls — the second entry point this story has to keep in agreement
+  // with the turbo control. Selecting goes through "Add LoRA" → a `.lora-pick-row`; deselecting
+  // goes through the selected slot's own Remove button.
+  const addFromPicker = async (name) => {
+    await click(container.querySelector("button.lora-add"));
+    const row = [...container.querySelectorAll("button.lora-pick-row")].find((node) =>
+      node.textContent.includes(name),
+    );
+    if (!row) throw new Error(`the generic picker does not offer ${name}`);
+    await click(row);
+  };
+  const removeFromPicker = async (name) => {
+    const remove = container.querySelector(`button[aria-label="Remove ${name}"]`);
+    if (!remove) throw new Error(`${name} is not shown as selected in the generic picker`);
+    await click(remove);
+  };
+
+  // ------------------------------------------------------------------ the chain
+
+  it("puts the selected variant's LoRA in the submitted payload", async () => {
+    // THE reachability assertion. The recipe itself lives server-side (the worker resolves it from
+    // the catalog id, so the web cannot forge a step count) — which makes "the id reaches `loras`"
+    // exactly the whole of the web's contribution to the chain, and the only thing worth asserting
+    // here. Anything less follows the value into React state and stops.
+    const context = baseContext();
+    await render(context);
+    await openAdvanced();
+    await act(async () => setSelect(turboSelect(), TURBO_8STEP.id));
+    await generate();
+
+    expect(jobLoraIds(context)).toContain(TURBO_8STEP.id);
+    const submitted = lastJob(context).loras.find((lora) => lora.id === TURBO_8STEP.id);
+    // 8 is NOT the model default (50), NOT the seeded 768p variant's 4, and NOT the other two
+    // variants' 4 — so this cannot pass against a control wired to a constant.
+    expect(TURBO_8STEP.sampling.steps).toBe(8);
+    expect(submitted.role).toBe("accelerator");
+  });
+
+  it("defaults on with the validated 768p variant and can be turned off", async () => {
+    // Default-on is the sc-18727 posture: sc-18729 measured 2.42 h against 12.6 min at the model's
+    // own default canvas, so shipping default-off would make the out-of-the-box experience a
+    // two-and-a-half-hour render.
+    const context = baseContext();
+    await render(context);
+    await openAdvanced();
+    expect(turboSelect().value).toBe(TURBO_768P.id);
+    await generate();
+    expect(jobLoraIds(context)).toContain(TURBO_768P.id);
+
+    // …and Off is a real state, not a label: the adapter leaves the payload entirely, so the worker
+    // resolves no recipe and the base 50-step schedule runs.
+    await act(async () => setSelect(turboSelect(), ""));
+    await generate();
+    expect(jobLoraIds(context)).not.toContain(TURBO_768P.id);
+    expect(lastJob(context).loras ?? []).toHaveLength(0);
+  });
+
+  it("pairs the reference partition with the ref2v adapter, not an fl2v one", async () => {
+    // The four adapters are one family and the API's compatibility gate cannot tell them apart, so
+    // nothing but this default stops a Ref2VA job from seeding the fl2v 768p file — shape-valid,
+    // folds cleanly, and quietly wrong (a quality mismatch with no error).
+    const context = baseContext({ videoModels: [MINIMAX_REF] });
+    await render(context);
+    await openAdvanced();
+    expect(turboSelect().value).toBe(TURBO_REF2V.id);
+    expect(turboSelect().value).not.toBe(TURBO_768P.id);
+  });
+
+  // ------------------------------------------------------- one selection, two views
+
+  it("selecting a variant replaces any other accelerator but keeps plain LoRAs", async () => {
+    // Two accelerators ask for two different schedules and the worker refuses the pair by name, so
+    // a control that STACKED would offer a selection that can only 400. A plain style LoRA is
+    // untouched — turbo is not a mode that evicts the picker.
+    const context = baseContext({ loras: [...ALL_TURBO, PLAIN_LORA] });
+    await render(context);
+    await openAdvanced();
+    await addFromPicker(PLAIN_LORA.name);
+
+    await act(async () => setSelect(turboSelect(), TURBO_4STEP_V01.id));
+    await generate();
+    const ids = jobLoraIds(context);
+    expect(ids).toContain(TURBO_4STEP_V01.id);
+    expect(ids).not.toContain(TURBO_768P.id);
+    expect(ids.filter((id) => ALL_TURBO.some((variant) => variant.id === id))).toHaveLength(1);
+    expect(ids).toContain(PLAIN_LORA.id);
+  });
+
+  it("reflects a variant selected from the generic LoRA picker", async () => {
+    // sc-18727's "the two entry points must not silently disagree". They cannot, because they are
+    // one piece of state: the control READS `selectedLoraIds`. Driven from the picker side here —
+    // deselecting the seeded variant there has to turn the control off, not leave it stale.
+    const context = baseContext();
+    await render(context);
+    await openAdvanced();
+    expect(turboSelect().value).toBe(TURBO_768P.id);
+
+    // Deselect from the PICKER side: the control must follow.
+    await removeFromPicker(TURBO_768P.name);
+    expect(turboSelect().value).toBe("");
+    await generate();
+    expect(jobLoraIds(context)).not.toContain(TURBO_768P.id);
+
+    // …and re-select a DIFFERENT variant from the picker side: the control must show that one, so
+    // a user who never opens the turbo menu still gets the recipe their pick implies.
+    await addFromPicker(TURBO_8STEP.name);
+    expect(turboSelect().value).toBe(TURBO_8STEP.id);
+    await generate();
+    expect(jobLoraIds(context)).toContain(TURBO_8STEP.id);
+  });
+
+  // --------------------------------------------------------------- reachability edges
+
+  it("offers only installed variants and says so when none are", async () => {
+    // An uninstalled adapter would 400 at enqueue ("LoRA is not installed"), so offering it would be
+    // a control whose only outcome is an error. With none installed the control still renders — the
+    // alternative answers "why is this render two and a half hours?" with silence.
+    const context = baseContext({ loras: [] });
+    await render(context);
+    await openAdvanced();
+    expect(turboSelect()).toBeTruthy();
+    expect(turboSelect().disabled).toBe(true);
+    expect([...turboSelect().querySelectorAll("option")]).toHaveLength(1);
+    expect(labelStartingWith("Turbo").parentElement.textContent).toContain(
+      "No turbo adapter installed",
+    );
+
+    // One installed alongside three the catalog advertises but the user has NOT fetched: exactly
+    // the installed one is offered. This is the arm that discriminates — a control built on the raw
+    // catalog rather than the installed set would offer all four and every extra option would 400.
+    const partial = baseContext({
+      loras: [
+        { ...TURBO_768P, installState: "missing", installedPath: null },
+        TURBO_8STEP,
+        { ...TURBO_4STEP_V01, installState: "missing", installedPath: null },
+        { ...TURBO_REF2V, installState: "missing", installedPath: null },
+      ],
+    });
+    await render(partial);
+    await openAdvanced();
+    expect([...turboSelect().querySelectorAll("option")].map((o) => o.value)).toEqual([
+      "",
+      TURBO_8STEP.id,
+    ]);
+    // …and the default-on seed lands on the one that is actually installed, rather than on the
+    // preferred-but-absent 768p file.
+    expect(turboSelect().value).toBe(TURBO_8STEP.id);
+  });
+
+  it("is absent on a model with no accelerator", async () => {
+    const context = baseContext({ videoModels: [BERNINI], loras: ALL_TURBO });
+    await render(context);
+    await openAdvanced();
+    expect(turboSelect()).toBeNull();
+  });
+
+  it("reports the recipe's step count while leaving Steps editable", async () => {
+    // Upstream lists the 8-step adapter as "8 / 4", and the worker honours an explicit
+    // `advanced.steps` over the variant's own — so the control REPORTS the count rather than
+    // seizing the input, which is the Lightning precedent's opposite call and deliberately so.
+    const context = baseContext();
+    await render(context);
+    await openAdvanced();
+    await act(async () => setSelect(turboSelect(), TURBO_768P.id));
+    const steps = labelStartingWith("Steps").querySelector("input");
+    expect(steps.disabled).toBe(false);
+    expect(steps.placeholder).toBe(`${TURBO_768P.sampling.steps} (Turbo)`);
+    expect(steps.placeholder).not.toBe(String(MINIMAX.defaults.steps));
+
+    await act(async () => setInput(steps, "6"));
+    await generate();
+    // 6 is neither the variant's 4 nor the model's default 50, so a payload carrying it proves the
+    // override survived the turbo selection rather than being swallowed by it.
+    expect(lastJob(context).advanced.steps).toBe(6);
+    expect(jobLoraIds(context)).toContain(TURBO_768P.id);
+  });
+});

--- a/apps/web/src/screens/VideoStudio.minimaxH3Turbo.test.jsx
+++ b/apps/web/src/screens/VideoStudio.minimaxH3Turbo.test.jsx
@@ -315,6 +315,80 @@ describe("MiniMax-H3 turbo control (sc-18726 / sc-18727)", () => {
     expect(turboSelect()).toBeNull();
   });
 
+  // ------------------------------------------------------------ the Off that has to survive
+
+  it("does not re-seed turbo when the persisted snapshot already lists the model", async () => {
+    // The DURABLE half of the one-shot marker. `turboSeededModels` is in the studio snapshot
+    // (localStorage cache + the server ui-preferences copy `seedStudioSettingsFromServer` restores),
+    // and dropping it from that object is invisible in-session: the in-memory marker still stops the
+    // re-seed until the studio unmounts. It only bites on the NEXT mount — a nav away and back, or a
+    // desktop relaunch — at which point a deliberate Off silently becomes On again, on a control
+    // whose two states are a 12.6 min render and a 2 h 25 m one.
+    //
+    // `preferencesHydrated` is required, not decoration: `useStudioSettingsWriter`'s `ready` gate is
+    // `preferencesHydrated && videoModels.length > 0`, so a context without it never writes at all
+    // and this test would assert nothing (sc-15425's window).
+    const context = baseContext({ preferencesHydrated: true });
+    await render(context);
+    await openAdvanced();
+    expect(turboSelect().value).toBe(TURBO_768P.id);
+
+    // A deliberate Off.
+    await act(async () => setSelect(turboSelect(), ""));
+    await generate();
+    expect(jobLoraIds(context)).not.toContain(TURBO_768P.id);
+
+    // What the next mount will read back. Both fields matter: the SELECTION alone cannot express
+    // "already seeded", which is why the marker is persisted separately.
+    const stored = JSON.parse(window.localStorage.getItem("sceneworks-studio-video-project_1"));
+    expect(stored.turboSeededModels, "the marker must reach the persisted snapshot").toContain(
+      MINIMAX.id,
+    );
+    expect(stored.selectedLoraIds ?? []).not.toContain(TURBO_768P.id);
+
+    // Relaunch: a brand-new studio restoring that snapshot, catalog and all.
+    await unmountRoot(root, container);
+    ({ container, root } = mountRoot());
+    const relaunched = baseContext({ preferencesHydrated: true });
+    await render(relaunched);
+    await openAdvanced();
+    expect(turboSelect().value, "a stored Off must not be re-seeded on the next mount").toBe("");
+    await generate();
+    expect(jobLoraIds(relaunched)).not.toContain(TURBO_768P.id);
+  });
+
+  // ------------------------------------------------------------ turbo × the partition gate
+
+  it("offers each partition only its own adapter once the declared-partition gate applies", async () => {
+    // sc-19563 narrowed `loraMatchesModel` with the LoRAs' declared `modelIds`, and the turbo
+    // control is built on `compatibleLoras` — so the two features compose rather than merely
+    // coexisting: the fl2v variants become unofferable on the reference partition and the ref2v one
+    // unofferable on the base partition, instead of being merely non-default. Asserted because
+    // "the default is right" and "the wrong one cannot be chosen at all" are different claims, and
+    // only the second closes the quality mismatch the ref2v test above describes.
+    const base = baseContext({ videoModels: [MINIMAX], loras: ALL_TURBO });
+    await render(base);
+    await openAdvanced();
+    expect([...turboSelect().querySelectorAll("option")].map((option) => option.value)).toEqual([
+      "",
+      TURBO_768P.id,
+      TURBO_8STEP.id,
+      TURBO_4STEP_V01.id,
+    ]);
+
+    const reference = baseContext({ videoModels: [MINIMAX_REF], loras: ALL_TURBO });
+    await render(reference);
+    await openAdvanced();
+    expect([...turboSelect().querySelectorAll("option")].map((option) => option.value)).toEqual([
+      "",
+      TURBO_REF2V.id,
+    ]);
+    // The declarations these two lists are derived from — retyped here so a manifest edit that
+    // erased `modelIds` (and re-collapsed both lists to all four) can't leave this test green.
+    expect(TURBO_768P.modelIds).toEqual([MINIMAX.id]);
+    expect(TURBO_REF2V.modelIds).toEqual([MINIMAX_REF.id]);
+  });
+
   it("reports the recipe's step count while leaving Steps editable", async () => {
     // Upstream lists the 8-step adapter as "8 / 4", and the worker honours an explicit
     // `advanced.steps` over the variant's own — so the control REPORTS the count rather than

--- a/apps/web/src/simple/SimpleVideoStudio.minimaxH3.test.jsx
+++ b/apps/web/src/simple/SimpleVideoStudio.minimaxH3.test.jsx
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppContext } from "../context/AppContext.js";
 import { SimpleShell } from "./SimpleShell.jsx";
 import { click, mountRoot, unmountRoot } from "../testUtils/dom.js";
+import { readSimpleStudioSnapshot } from "../simpleStudioStore.js";
 
 vi.mock("../api.js", async (importOriginal) => {
   const actual = await importOriginal();
@@ -42,6 +43,20 @@ const MINIMAX = {
   installState: "installed",
   usable: true,
 };
+
+/// The shipped 768p turbo entry as the catalog route serves it — the manifest entry (so the step
+/// count and the declared `modelIds` partition are the real ones) plus the install state
+/// `normalize_lora_entry` probes.
+function turboFixture() {
+  return {
+    ...JSON5.parse(
+      readFileSync(resolve(HERE, "../../../../config/manifests/builtin.loras.jsonc"), "utf8"),
+    ).loras.find((lora) => lora.id === "minimax_h3_turbo_4step_768p"),
+    scope: "builtin",
+    installState: "installed",
+    installedPath: "/data/loras/minimax_h3_turbo_4step_768p.safetensors",
+  };
+}
 
 function baseContext() {
   return {
@@ -180,14 +195,7 @@ describe("SimpleVideoStudio with MiniMax-H3 (sc-17161)", () => {
   // Asserted on the PAYLOAD, not on any control: there is nothing to click, so the only observable
   // difference between "seeded" and "not seeded" is the job that gets submitted.
   it("seeds the turbo adapter into the submitted job, with no control to set it", async () => {
-    const turbo = {
-      ...JSON5.parse(
-        readFileSync(resolve(HERE, "../../../../config/manifests/builtin.loras.jsonc"), "utf8"),
-      ).loras.find((lora) => lora.id === "minimax_h3_turbo_4step_768p"),
-      scope: "builtin",
-      installState: "installed",
-      installedPath: "/data/loras/minimax_h3_turbo_4step_768p.safetensors",
-    };
+    const turbo = turboFixture();
     // 4 against the model's own 50 — a non-default recipe, so this cannot pass against a shell that
     // simply forwards the model defaults.
     expect(turbo.sampling.steps).toBe(4);
@@ -214,5 +222,64 @@ describe("SimpleVideoStudio with MiniMax-H3 (sc-17161)", () => {
     // …and it is not counted against the user's own LoRA budget: it is a builtin, which is the one
     // slot of headroom MAX_USER_JOB_LORAS (4) leaves inside MAX_JOB_LORAS_TOTAL (5).
     expect(payload.loras.find((lora) => lora.id === turbo.id).scope).toBe("builtin");
+  });
+
+  // sc-18727 — the other half of a default-on seed: it has to be turn-off-able.
+  //
+  // Simple ships NO turbo control, so deselecting the adapter in the LoRA picker is the only way a
+  // Simple user can decline it. The seed effect re-runs on every `selectedLoraIds` change, so
+  // without the one-shot marker (`turboSeededModels`) the removal would re-fire the seed and put
+  // the adapter straight back — turbo would be literally un-turn-off-able from this shell, with no
+  // error and no control to explain it. Nothing about that is visible in the seeding test above,
+  // which is why it needs its own.
+  //
+  // Both halves of the marker are exercised: the IN-SESSION half (the effect must not re-add on the
+  // very next render) and the DURABLE half (Simple's studio snapshot is mirrored to server
+  // ui-preferences, so a relaunch that read back only `selectedLoraIds` would re-seed on every
+  // launch and re-defeat the same "Off").
+  it("does not re-add the turbo adapter after it is removed from the picker, across a relaunch", async () => {
+    const turbo = turboFixture();
+    const generate = async (context) => {
+      const textarea = container.querySelector("textarea");
+      await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLTextAreaElement.prototype,
+          "value",
+        ).set;
+        setter.call(textarea, "a lighthouse in a storm");
+        textarea.dispatchEvent(new window.Event("input", { bubbles: true }));
+      });
+      await click(
+        [...container.querySelectorAll("button")].find((node) =>
+          /generate|create|render/i.test(node.textContent.trim()),
+        ),
+      );
+      return (context.createVideoJob.mock.calls.at(-1)[0].loras ?? []).map((lora) => lora.id);
+    };
+
+    const context = { ...baseContext(), loras: [turbo] };
+    await openVideo(context);
+    // Seeded, and shown as a normal selected LoRA — which is what makes the picker's own Remove
+    // button the off switch.
+    const remove = container.querySelector(`button[aria-label="Remove ${turbo.name}"]`);
+    expect(remove, "the seeded adapter must be visible as a removable selection").toBeTruthy();
+    await click(remove);
+    expect(container.querySelector(`button[aria-label="Remove ${turbo.name}"]`)).toBeNull();
+    expect(await generate(context)).not.toContain(turbo.id);
+
+    // The snapshot the next launch reads. `writeSimpleStudioSnapshot` is debounced, so the unmount
+    // flush is what makes the stored value observable (same rule as useStudioState.test.jsx).
+    await unmountRoot(root, container);
+    const stored = readSimpleStudioSnapshot("project-1");
+    expect(stored.video.turboSeededModels).toContain(MINIMAX.id);
+    expect(stored.video.selectedLoraIds ?? []).not.toContain(turbo.id);
+
+    // Relaunch: a brand-new shell restoring that snapshot. The marker is what stops the seed from
+    // firing again against an empty selection.
+    ({ container, root } = mountRoot());
+    const relaunched = { ...baseContext(), loras: [turbo] };
+    await openVideo(relaunched);
+    expect(container.querySelector(`button[aria-label="Remove ${turbo.name}"]`)).toBeNull();
+    expect(await generate(relaunched)).not.toContain(turbo.id);
   });
 });

--- a/apps/web/src/simple/SimpleVideoStudio.minimaxH3.test.jsx
+++ b/apps/web/src/simple/SimpleVideoStudio.minimaxH3.test.jsx
@@ -171,4 +171,48 @@ describe("SimpleVideoStudio with MiniMax-H3 (sc-17161)", () => {
     expect(payload.duration).toBe(MINIMAX.defaults.duration);
     expect(MINIMAX.limits.durations).toContain(payload.duration);
   });
+
+  // sc-18727 — the turbo DEFAULT reaches Simple, even though the turbo CONTROL deliberately does
+  // not. Simple exposes no advanced sampler knobs, so a user here can never turn turbo on by hand;
+  // if the seed did not run, every Simple MiniMax-H3 render would be the 2 h 25 m one that
+  // sc-18729 measured, with nothing on screen explaining why.
+  //
+  // Asserted on the PAYLOAD, not on any control: there is nothing to click, so the only observable
+  // difference between "seeded" and "not seeded" is the job that gets submitted.
+  it("seeds the turbo adapter into the submitted job, with no control to set it", async () => {
+    const turbo = {
+      ...JSON5.parse(
+        readFileSync(resolve(HERE, "../../../../config/manifests/builtin.loras.jsonc"), "utf8"),
+      ).loras.find((lora) => lora.id === "minimax_h3_turbo_4step_768p"),
+      scope: "builtin",
+      installState: "installed",
+      installedPath: "/data/loras/minimax_h3_turbo_4step_768p.safetensors",
+    };
+    // 4 against the model's own 50 — a non-default recipe, so this cannot pass against a shell that
+    // simply forwards the model defaults.
+    expect(turbo.sampling.steps).toBe(4);
+    expect(MINIMAX.defaults.steps).toBe(50);
+
+    const context = { ...baseContext(), loras: [turbo] };
+    await openVideo(context);
+    const textarea = container.querySelector("textarea");
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        "value",
+      ).set;
+      setter.call(textarea, "a lighthouse in a storm");
+      textarea.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+    await click(
+      [...container.querySelectorAll("button")].find((node) =>
+        /generate|create|render/i.test(node.textContent.trim()),
+      ),
+    );
+    const payload = context.createVideoJob.mock.calls[0][0];
+    expect((payload.loras ?? []).map((lora) => lora.id)).toContain(turbo.id);
+    // …and it is not counted against the user's own LoRA budget: it is a builtin, which is the one
+    // slot of headroom MAX_USER_JOB_LORAS (4) leaves inside MAX_JOB_LORAS_TOTAL (5).
+    expect(payload.loras.find((lora) => lora.id === turbo.id).scope).toBe("builtin");
+  });
 });

--- a/apps/web/src/simple/useSimpleLoras.js
+++ b/apps/web/src/simple/useSimpleLoras.js
@@ -7,6 +7,7 @@ import {
   serializeLora,
 } from "../presetUtils.js";
 import { terminalStatuses } from "../jobTypes.js";
+import { defaultTurboVariant, turboVariantsForModel } from "../minimaxH3Turbo.js";
 import { useStudioState } from "./useStudioState.js";
 
 // Module-level so the "first time this key is seen" initial is referentially stable — a
@@ -103,6 +104,47 @@ export function useSimpleLoras({ loras = [], selectedModel, jobs = [], excludeLo
       return kept.length === ids.length ? ids : kept;
     });
   }, [loras.length, selectedModel, compatibleLoraKey, compatibleLoras, setSelectedLoraIds]);
+
+  // MiniMax-H3 turbo, default-on (sc-18727). Simple deliberately shows no turbo CONTROL — the
+  // adapter is already in its picker like any other LoRA, and adding a second surface for it would
+  // be exactly the advanced knob this shell exists to leave out. What Simple must not inherit is the
+  // DEFAULT, because "no turbo" here means a measured 2 h 25 m render where the advanced studio
+  // ships 12.6 min. So the seed runs identically in both shells and only the control differs.
+  //
+  // One-shot per model, marked even when a variant is already selected, for the reason the advanced
+  // copy documents: without the marker, re-seeding on every empty selection would silently undo a
+  // deliberate removal from the picker.
+  const [turboSeededModels, setTurboSeededModels] = useStudioState(
+    scope,
+    "turboSeededModels",
+    EMPTY_IDS,
+  );
+  useEffect(() => {
+    const modelId = selectedModel?.id;
+    if (!modelId || turboSeededModels.includes(modelId)) {
+      return;
+    }
+    const variants = turboVariantsForModel(selectedModel, compatibleLoras);
+    if (!variants.length) {
+      return;
+    }
+    setTurboSeededModels((seeded) => (seeded.includes(modelId) ? seeded : [...seeded, modelId]));
+    if (selectedLoraIds.some((id) => variants.some((variant) => variant.id === id))) {
+      return;
+    }
+    const preferred = defaultTurboVariant(selectedModel, variants);
+    if (!preferred) {
+      return;
+    }
+    setSelectedLoraIds((ids) => (ids.includes(preferred.id) ? ids : [...ids, preferred.id]));
+  }, [
+    selectedModel,
+    compatibleLoras,
+    turboSeededModels,
+    selectedLoraIds,
+    setTurboSeededModels,
+    setSelectedLoraIds,
+  ]);
 
   const effectiveLoraWeight = useCallback(
     (lora) => {

--- a/config/manifests/builtin.loras.jsonc
+++ b/config/manifests/builtin.loras.jsonc
@@ -212,6 +212,10 @@
       "compatibility": { "families": ["minimax-h3"] },
       "role": "accelerator",
       "defaultWeight": 1.0,
+      // sc-18726 — the recipe sc-18729 MEASURED end to end: 4 NFE, video shift 6, audio shift 3.
+      // This is the ONLY published variant whose video shift is not 12, which is exactly why the
+      // shift is declared per entry rather than once per family.
+      "sampling": { "steps": 4, "schedulerShift": 6.0, "audioSchedulerShift": 3.0 },
       "source": {
         "provider": "huggingface",
         "repo": "lightx2v/Minimax-h3-Turbo",
@@ -230,6 +234,10 @@
       "compatibility": { "families": ["minimax-h3"] },
       "role": "accelerator",
       "defaultWeight": 1.0,
+      // sc-18726 — 8 NFE at the checkpoint's own published 12/3 pair. The shift equalling the base
+      // 12.0 is NOT a reason to omit it: an absent value would mean "engine default", which is the
+      // same number today and would silently follow the base if that ever moved.
+      "sampling": { "steps": 8, "schedulerShift": 12.0, "audioSchedulerShift": 3.0 },
       "source": {
         "provider": "huggingface",
         "repo": "lightx2v/Minimax-h3-Turbo",
@@ -250,6 +258,10 @@
       "compatibility": { "families": ["minimax-h3"] },
       "role": "accelerator",
       "defaultWeight": 1.0,
+      // sc-18726 — 4 NFE at 12/3. Same NFE as the 768p file and a DIFFERENT shift, which is the pair
+      // that makes "one recipe per family" impossible: the two 4-step files disagree on the shift and
+      // the 8-step one agrees with this file on the shift while disagreeing on the NFE.
+      "sampling": { "steps": 4, "schedulerShift": 12.0, "audioSchedulerShift": 3.0 },
       "source": {
         "provider": "huggingface",
         "repo": "lightx2v/Minimax-h3-Turbo",
@@ -273,6 +285,12 @@
       "compatibility": { "families": ["minimax-h3"] },
       "role": "accelerator",
       "defaultWeight": 1.0,
+      // sc-18726 — 4 NFE at 12/3. Upstream's model-specs table publishes per-variant shifts for the
+      // fl2v files only (12/3 for the 544p ones, 6/3 for the 768p one) and carries NO separate ref2v
+      // row, so this v0.1 file takes the 544p v0.1 pair rather than the 768p one: same version, same
+      // training canvas, same declared alpha 8. If upstream later publishes a ref2v-specific shift,
+      // this is the one line that changes.
+      "sampling": { "steps": 4, "schedulerShift": 12.0, "audioSchedulerShift": 3.0 },
       "source": {
         "provider": "huggingface",
         "repo": "lightx2v/Minimax-h3-Turbo",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -13240,12 +13240,22 @@
         // the default canvas is already two hours. Recommending a shorter scalar would falsely
         // imply long clips are infeasible everywhere (sc-17152).
         "recommendedMaxDuration": 14.375,
-        // The scheduler's sigma grid is `linspace(1, 0, num_inference_steps)` and the terminal 0 is
-        // a GRID POINT, not a sentinel appended afterwards — so N steps drive N-1 model evaluations
-        // and a single point is a schedule with nothing between its ends. `set_timesteps` raises
-        // "`num_inference_steps` >= 2, got 1" (diffusers `MiniMaxH3Scheduler`), so 1 step is not a
-        // fast draft here, it is unrenderable, and it is REFUSED rather than quietly raised to 2 —
-        // the same reject-never-clamp posture the duration bounds take (sc-19426).
+        // 🔴 THE UNIT IS MODEL EVALUATIONS (NFE), and it is the same unit everywhere: `defaults.steps`
+        // above, `advanced.steps`, this floor, and the `sampling.steps` each turbo adapter declares
+        // in builtin.loras.jsonc. The engine builds the sigma grid as `linspace(1, 0, steps + 1)` —
+        // it appends the terminal 0 ITSELF (`JointSchedule::with_shifts(evaluations + 1, ..)`) — so
+        // `defaults.steps: 50` really is 50 evaluations and nothing in SceneWorks adds or subtracts
+        // one. sc-18726 asked for that call to be made once and tested; it is pinned by
+        // `minimax_h3_turbo_steps_are_model_evaluations_not_grid_points` (sceneworks-core) and by
+        // the arm-level `a_selected_turbo_variant_changes_the_job_that_reaches_the_engine`.
+        //
+        // ⚠️ This comment previously read "N steps drive N-1 model evaluations" and concluded that
+        // `steps: 1` is unrenderable. That describes diffusers' `num_inference_steps`, which is NOT
+        // what this key carries: at 1 NFE the engine builds a legal 2-point grid and renders. So the
+        // floor is a PRODUCT judgement, not an engine limit — a 1-evaluation schedule is a single
+        // Euler jump from pure noise, which is not a fast draft, it is noise. 2 is the smallest
+        // schedule with an intermediate sigma. REFUSED rather than quietly raised, the same
+        // reject-never-clamp posture the duration bounds take (sc-19426, corrected sc-18726).
         "hardMinSteps": 2,
         // One cadence. The lattice, the duration window and every measured render are 24 fps.
         "fps": [24],
@@ -13557,7 +13567,9 @@
         "hardMinDuration": 5.1667,
         "hardMaxDuration": 14.375,
         "recommendedMaxDuration": 14.375,
-        // Same scheduler, same two-grid-point floor as `minimax_h3` — see that entry (sc-19426).
+        // Same scheduler, same two-EVALUATION floor as `minimax_h3` — see that entry for the unit
+        // (NFE, not sigma grid points) and for why 2 is a product judgement rather than an engine
+        // limit (sc-19426, corrected sc-18726).
         "hardMinSteps": 2,
         "fps": [24],
         "maxPixels": 1032192,

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod lora_family;
 pub mod lora_url;
 pub mod media_convert;
 pub mod memory_calibration;
+pub mod minimax_h3_turbo;
 pub mod mlx_tier_completeness;
 pub mod observability;
 pub mod payload_util;

--- a/crates/sceneworks-core/src/minimax_h3_turbo.rs
+++ b/crates/sceneworks-core/src/minimax_h3_turbo.rs
@@ -1,0 +1,452 @@
+//! The MiniMax-H3 turbo sampling recipe (epic 17137, sc-18726) — the ONE resolver that turns a
+//! selected step-distill adapter into the `(steps, video shift, audio shift)` triple a job actually
+//! renders with.
+//!
+//! # Why this exists at all
+//!
+//! sc-18725 put four `lightx2v/Minimax-h3-Turbo` adapters in the catalog with `role: accelerator`,
+//! and that marker is **weight-load only**: selecting one stacked a 692M-parameter residual and
+//! still ran the base 50 steps at the base video shift 12.0 — slower than the base render (the LoRA
+//! is pure overhead at 50 steps) *and* off-distribution, because a distilled checkpoint sampled on
+//! the schedule it was distilled AWAY from is not the model anyone trained. sc-18729 measured what
+//! the right recipe buys: **12.6 min against 2.42 h** at 1344x768 (11.57x), with a matched-geometry
+//! floor of 7.05x.
+//!
+//! # Why the recipe is per FILE and lives in the catalog
+//!
+//! The four published files disagree with each other:
+//!
+//! | adapter | NFE | video shift | audio shift |
+//! | --- | --- | --- | --- |
+//! | `minimax_h3_turbo_4step_768p` | 4 | **6.0** | 3.0 |
+//! | `minimax_h3_turbo_8step` | **8** | 12.0 | 3.0 |
+//! | `minimax_h3_turbo_4step_v01` | 4 | 12.0 | 3.0 |
+//! | `minimax_h3_ref2v_turbo_4step` | 4 | 12.0 | 3.0 |
+//!
+//! No pair of axes separates them, so no family-wide constant is right for more than one, and — the
+//! part that rules out the SCAIL-2 approach — the files are **format-identical**, so a
+//! `has_diff_patch_keys`-style sniff cannot tell them apart either. The discriminator that exists is
+//! the catalog id, so the recipe is declared per catalog entry (`sampling` in
+//! `builtin.loras.jsonc`) and resolved from the id here.
+//!
+//! Resolution reads the **embedded** builtin manifest rather than the payload's own `sampling`
+//! block. A job payload is caller-supplied: reading a recipe out of it would let any HTTP client
+//! name its own step count and shift under an adapter that was not distilled for them, bypassing
+//! `steps_limit_error` entirely. Reading it from the id means the worst a forged payload can do is
+//! name a real adapter, which is identical to selecting it.
+//!
+//! # The step-count contract — decided ONCE, here
+//!
+//! `steps` is the **number of model evaluations (NFE)**, everywhere: `advanced.steps`,
+//! `limits.hardMinSteps`, `defaults.steps: 50`, the `sampling.steps` declared above, and the
+//! engine's `req.steps`. `mlx-gen-minimax-h3` appends the terminal sigma = 0 grid point ITSELF
+//! (`JointSchedule::with_shifts(evaluations + 1, ..)`), so there is **no +1 anywhere in
+//! SceneWorks** and every number above is comparable to every other one without adjustment. sc-18726
+//! flagged this as the design call that makes "every step count in the product off by one" if it is
+//! made twice; [`crate::video_request::steps_limit_error`] is the gate that reads the same unit, and
+//! `minimax_h3_turbo_steps_are_model_evaluations_not_grid_points` is the guard that pins it.
+//!
+//! # The audio shift is DECLARED, RECORDED and GUARDED — but not a request knob
+//!
+//! MiniMax-H3 denoises video and audio against two separate sigma schedules, and the audio one is a
+//! real axis of the recipe, so it is declared per variant and recorded on the asset as
+//! `effectiveAudioSchedulerShift`. It is not forwarded, because there is nothing to forward it to:
+//! `GenerationRequest` carries one `scheduler_shift` and the engine applies it to VIDEO ONLY,
+//! holding audio at its own `AUDIO_SIGMA_SHIFT` constant — deliberately, since every published
+//! variant trains at 3.0 and applying one shift to both modalities is a known defect class.
+//! [`ENGINE_AUDIO_SIGMA_SHIFT`] mirrors that constant and
+//! `every_turbo_variant_declares_the_audio_shift_the_engine_is_fixed_at` fails the moment a declared
+//! variant diverges from it — which turns "the engine cannot express this" from a silent wrong
+//! render into a red test at the moment the catalog gains such a variant.
+
+use std::sync::OnceLock;
+
+use serde_json::Value;
+
+use crate::video_request::is_minimax_h3_model;
+
+/// The audio sigma shift `mlx-gen-minimax-h3` is hard-wired at (`AUDIO_SIGMA_SHIFT`), and therefore
+/// the only audio shift a SceneWorks job can actually render at.
+///
+/// Mirrored here rather than imported because `sceneworks-core` builds on every platform and the
+/// MLX engine crate is macOS-only — and because the mirror is the point: a declared variant that
+/// disagrees with this number is a variant this app cannot render correctly, and the guard that
+/// compares the two is the only thing that would say so.
+pub const ENGINE_AUDIO_SIGMA_SHIFT: f32 = 3.0;
+
+/// One published turbo adapter's sampling recipe, as declared on its catalog entry.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TurboRecipe {
+    /// The catalog LoRA id this recipe belongs to — the discriminator, since the files themselves
+    /// are format-identical.
+    pub lora_id: String,
+    /// Display name, for the message a conflicting selection produces.
+    pub name: String,
+    /// Model evaluations (NFE). See the module header: no +1 lives on this side.
+    pub steps: u32,
+    /// The video flow-matching sigma shift → `GenerationRequest::scheduler_shift`.
+    pub video_shift: f32,
+    /// The audio sigma shift. Recorded on the asset; the engine is fixed at
+    /// [`ENGINE_AUDIO_SIGMA_SHIFT`].
+    pub audio_shift: f32,
+}
+
+static TURBO_RECIPES: OnceLock<Vec<TurboRecipe>> = OnceLock::new();
+
+/// Every `family: minimax-h3` accelerator in the EMBEDDED builtin LoRA catalog that declares a
+/// `sampling` block, in catalog order.
+///
+/// Derived from the shipped manifest rather than retyped, so adding a fifth published variant is a
+/// manifest edit and nothing else — the studio control, the worker recipe and the guards below all
+/// read this one list. A malformed manifest yields an EMPTY list rather than a panic: the catalog is
+/// compile-time embedded and validated by the tests below, so an empty list at runtime can only mean
+/// a build that shipped a broken manifest, and degrading to "no turbo available" beats taking the
+/// worker down on a video job.
+pub fn turbo_recipes() -> &'static [TurboRecipe] {
+    TURBO_RECIPES.get_or_init(|| {
+        let contents = crate::builtin_manifests::BUILTIN_MANIFESTS
+            .iter()
+            .find(|(name, _)| *name == "builtin.loras.jsonc")
+            .map(|(_, contents)| *contents)
+            .unwrap_or("");
+        parse_turbo_recipes(contents)
+    })
+}
+
+/// Parse the turbo recipes out of a `builtin.loras.jsonc` body. Split out so the tests can drive it
+/// on synthetic catalogs as well as the shipped one.
+fn parse_turbo_recipes(contents: &str) -> Vec<TurboRecipe> {
+    let stripped = crate::jsonc::strip_jsonc_comments(contents);
+    let Ok(manifest) = serde_json::from_str::<Value>(&stripped) else {
+        return Vec::new();
+    };
+    let Some(loras) = manifest.get("loras").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    loras
+        .iter()
+        .filter(|lora| lora.get("family").and_then(Value::as_str) == Some("minimax-h3"))
+        .filter(|lora| lora.get("role").and_then(Value::as_str) == Some("accelerator"))
+        .filter_map(|lora| {
+            let sampling = lora.get("sampling")?.as_object()?;
+            let steps = u32::try_from(sampling.get("steps")?.as_u64()?).ok()?;
+            let video_shift = sampling.get("schedulerShift")?.as_f64()? as f32;
+            let audio_shift = sampling.get("audioSchedulerShift")?.as_f64()? as f32;
+            let lora_id = lora.get("id")?.as_str()?.to_owned();
+            let name = lora
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or(&lora_id)
+                .to_owned();
+            (steps > 0 && video_shift > 0.0 && audio_shift > 0.0).then_some(TurboRecipe {
+                lora_id,
+                name,
+                steps,
+                video_shift,
+                audio_shift,
+            })
+        })
+        .collect()
+}
+
+/// The recipe declared for catalog LoRA `id`, or `None` when the id names no turbo adapter.
+pub fn turbo_recipe_for_lora_id(id: &str) -> Option<&'static TurboRecipe> {
+    turbo_recipes().iter().find(|recipe| recipe.lora_id == id)
+}
+
+/// The turbo recipe a MiniMax-H3 request runs under, resolved from the job's own selected LoRAs.
+///
+/// `Ok(None)` is the base regime — the 50-step / shift-12.0 checkpoint default, byte-identical to
+/// what shipped before this story, which is what makes "turbo off" a real state rather than a
+/// different set of numbers.
+///
+/// This is the SINGLE resolver sc-18727 asks for: the Video Studio's turbo control and the generic
+/// LoRA picker are two ways of putting the same catalog id in `request.loras`, and both land here.
+/// Nothing else may derive the recipe, or the two entry points can disagree.
+///
+/// Two adapters carrying DIFFERENT recipes is an error, not a silent first-wins: they are
+/// contradictory sampling regimes and picking one would render at a schedule the user can see they
+/// did not choose. Two selections of the SAME recipe (possible via a project-scoped copy of a
+/// builtin id) resolve normally.
+///
+/// Returns `Ok(None)` unconditionally for a non-MiniMax-H3 model, so a turbo file cross-selected
+/// onto some other family loads as the plain residual it is rather than reshaping that family's
+/// schedule.
+pub fn resolve_turbo_recipe(
+    model: &str,
+    loras: &[Value],
+) -> Result<Option<&'static TurboRecipe>, String> {
+    if !is_minimax_h3_model(model) {
+        return Ok(None);
+    }
+    let mut resolved: Option<&'static TurboRecipe> = None;
+    for lora in loras {
+        let Some(id) = lora.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(recipe) = turbo_recipe_for_lora_id(id) else {
+            continue;
+        };
+        match resolved {
+            None => resolved = Some(recipe),
+            Some(current) if current.lora_id == recipe.lora_id => {}
+            Some(current) if current.recipe_eq(recipe) => {}
+            Some(current) => {
+                return Err(format!(
+                    "{model}: \"{}\" and \"{}\" are both step-distill accelerators and ask for \
+                     different schedules ({} steps at video shift {} vs {} steps at video shift \
+                     {}). A render has one schedule — select one of them.",
+                    current.name,
+                    recipe.name,
+                    current.steps,
+                    current.video_shift,
+                    recipe.steps,
+                    recipe.video_shift
+                ));
+            }
+        }
+    }
+    Ok(resolved)
+}
+
+impl TurboRecipe {
+    /// Whether two recipes ask for the same schedule (ignoring identity).
+    fn recipe_eq(&self, other: &Self) -> bool {
+        self.steps == other.steps
+            && self.video_shift.to_bits() == other.video_shift.to_bits()
+            && self.audio_shift.to_bits() == other.audio_shift.to_bits()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::video_request::steps_limit_error;
+    use serde_json::json;
+
+    fn lora(id: &str) -> Value {
+        json!({ "id": id })
+    }
+
+    /// The shipped catalog carries EXACTLY the four published turbo adapters, each with the recipe
+    /// upstream's model-specs table publishes.
+    ///
+    /// Every triple is spelled out rather than derived, because the whole point of the per-entry
+    /// declaration is that the four disagree: an implementation that returned one constant for all
+    /// of them, or that read the shift off the family, fails at least two arms here.
+    #[test]
+    fn the_shipped_catalog_declares_every_published_turbo_variant() {
+        let recipes = turbo_recipes();
+        let actual: Vec<(&str, u32, f32, f32)> = recipes
+            .iter()
+            .map(|recipe| {
+                (
+                    recipe.lora_id.as_str(),
+                    recipe.steps,
+                    recipe.video_shift,
+                    recipe.audio_shift,
+                )
+            })
+            .collect();
+        assert_eq!(
+            actual,
+            vec![
+                ("minimax_h3_turbo_4step_768p", 4, 6.0, 3.0),
+                ("minimax_h3_turbo_8step", 8, 12.0, 3.0),
+                ("minimax_h3_turbo_4step_v01", 4, 12.0, 3.0),
+                ("minimax_h3_ref2v_turbo_4step", 4, 12.0, 3.0),
+            ],
+            "the shipped turbo recipes"
+        );
+        // The set is not uniform on EITHER axis — the property that makes a per-entry declaration
+        // necessary rather than decorative. Asserted so a future edit that flattens the catalog to
+        // one recipe cannot pass the arm above by rewriting it.
+        assert!(
+            recipes.iter().any(|r| r.steps == 4) && recipes.iter().any(|r| r.steps == 8),
+            "the published set spans two step counts"
+        );
+        assert!(
+            recipes.iter().any(|r| r.video_shift == 6.0)
+                && recipes.iter().any(|r| r.video_shift == 12.0),
+            "the published set spans two video shifts"
+        );
+    }
+
+    /// 🔴 The declared audio shift must equal the ONE the engine can render at.
+    ///
+    /// `mlx-gen-minimax-h3` reads `req.scheduler_shift` as the VIDEO shift and holds audio at its own
+    /// `AUDIO_SIGMA_SHIFT = 3.0` with no request-level override. So a catalog variant declaring any
+    /// other audio shift would be recorded on the asset as what the user asked for and rendered at
+    /// 3.0 anyway — a silent divergence with no shape and no error. This is the guard that makes
+    /// that loud: it fails at the moment such a variant is added, which is the moment the engine
+    /// needs a second shift knob.
+    #[test]
+    fn every_turbo_variant_declares_the_audio_shift_the_engine_is_fixed_at() {
+        for recipe in turbo_recipes() {
+            assert_eq!(
+                recipe.audio_shift, ENGINE_AUDIO_SIGMA_SHIFT,
+                "{}: the engine has no audio-shift request knob, so a variant declaring {} would \
+                 render at {ENGINE_AUDIO_SIGMA_SHIFT} regardless. Adding one needs an engine-side \
+                 audio shift on GenerationRequest first.",
+                recipe.lora_id, recipe.audio_shift
+            );
+        }
+    }
+
+    /// Every recipe's step count must clear the paired model's own step gate, or selecting the
+    /// adapter would build a job `steps_limit_error` refuses — a control that 400s the render it
+    /// exists to start.
+    ///
+    /// Reads the SHIPPED model manifest (not a fixture) and the SAME gate the API and worker call,
+    /// so a manifest edit that tightens `limits.hardMinSteps` above 4, or that pins
+    /// `limits.steps: [50]`, goes red here rather than at enqueue.
+    #[test]
+    fn every_turbo_recipe_step_count_clears_the_model_step_gate() {
+        let contents = crate::builtin_manifests::BUILTIN_MANIFESTS
+            .iter()
+            .find(|(name, _)| *name == "builtin.models.jsonc")
+            .map(|(_, contents)| *contents)
+            .expect("builtin.models.jsonc is embedded");
+        let stripped = crate::jsonc::strip_jsonc_comments(contents);
+        let manifest: Value = serde_json::from_str(&stripped).expect("the model catalog parses");
+        let models = manifest["models"].as_array().expect("a models array");
+        for model_id in ["minimax_h3", "minimax_h3_ref"] {
+            let entry = models
+                .iter()
+                .find(|model| model["id"].as_str() == Some(model_id))
+                .and_then(Value::as_object)
+                .unwrap_or_else(|| panic!("{model_id} is in the shipped catalog"));
+            for recipe in turbo_recipes() {
+                assert_eq!(
+                    steps_limit_error(model_id, recipe.steps, entry),
+                    None,
+                    "{model_id} refuses {}'s {} steps",
+                    recipe.lora_id,
+                    recipe.steps
+                );
+            }
+        }
+    }
+
+    /// 🔴 sc-18726's "decide the +1 once" call, pinned as a value rather than a comment.
+    ///
+    /// `steps` is model EVALUATIONS on this side of the seam. The engine builds
+    /// `evaluations + 1` sigma grid points itself, so a SceneWorks-side +1 would render 5 and 9
+    /// evaluations for the "4-step" and "8-step" adapters. Asserting the declared numbers are the
+    /// PUBLISHED NFE — not NFE+1 — is what keeps a future "fix" from adding the engine's increment a
+    /// second time.
+    #[test]
+    fn minimax_h3_turbo_steps_are_model_evaluations_not_grid_points() {
+        let four =
+            turbo_recipe_for_lora_id("minimax_h3_turbo_4step_768p").expect("the 768p recipe");
+        let eight = turbo_recipe_for_lora_id("minimax_h3_turbo_8step").expect("the 8-step recipe");
+        assert_eq!(four.steps, 4, "the file upstream calls 4-step runs 4 NFE");
+        assert_eq!(eight.steps, 8, "the file upstream calls 8-step runs 8 NFE");
+    }
+
+    /// The resolver: no accelerator ⇒ the base regime, one ⇒ its own recipe, and the recipe follows
+    /// the ID rather than the position in the list.
+    #[test]
+    fn resolves_the_selected_variants_own_recipe() {
+        assert_eq!(resolve_turbo_recipe("minimax_h3", &[]), Ok(None));
+        assert_eq!(
+            resolve_turbo_recipe("minimax_h3", &[lora("some_style_lora")]),
+            Ok(None),
+            "a plain LoRA leaves the base regime alone"
+        );
+        // A NON-DEFAULT pair on purpose: 4 differs from the model's `defaults.steps: 50` and 6.0
+        // from the engine's own 12.0, so this cannot pass against an implementation that returns
+        // the defaults.
+        let turbo = resolve_turbo_recipe("minimax_h3", &[lora("minimax_h3_turbo_4step_768p")])
+            .expect("one accelerator resolves")
+            .expect("a recipe");
+        assert_eq!((turbo.steps, turbo.video_shift), (4, 6.0));
+        // The 8-step file, selected SECOND, must still win its own recipe — the resolver keys on the
+        // id, not on the order or the count.
+        let eight = resolve_turbo_recipe(
+            "minimax_h3",
+            &[lora("some_style_lora"), lora("minimax_h3_turbo_8step")],
+        )
+        .expect("resolves")
+        .expect("a recipe");
+        assert_eq!((eight.steps, eight.video_shift), (8, 12.0));
+    }
+
+    /// Two accelerators asking for different schedules is refused by name, not silently first-wins.
+    #[test]
+    fn two_conflicting_accelerators_are_refused_by_name() {
+        let error = resolve_turbo_recipe(
+            "minimax_h3",
+            &[
+                lora("minimax_h3_turbo_4step_768p"),
+                lora("minimax_h3_turbo_8step"),
+            ],
+        )
+        .expect_err("two different schedules cannot both govern one render");
+        assert!(
+            error.contains("MiniMax-H3 Turbo (4-step, 768p)")
+                && error.contains("MiniMax-H3 Turbo (8-step)"),
+            "the refusal names both adapters: {error}"
+        );
+        // The same id twice is not a conflict.
+        assert!(resolve_turbo_recipe(
+            "minimax_h3",
+            &[
+                lora("minimax_h3_turbo_8step"),
+                lora("minimax_h3_turbo_8step"),
+            ],
+        )
+        .is_ok());
+        // Nor are two DISTINCT adapters that happen to declare the same schedule — the 544p 4-step
+        // pair, which is exactly the shape a Ref2VA job selecting both would produce.
+        assert!(resolve_turbo_recipe(
+            "minimax_h3_ref",
+            &[
+                lora("minimax_h3_turbo_4step_v01"),
+                lora("minimax_h3_ref2v_turbo_4step"),
+            ],
+        )
+        .is_ok());
+    }
+
+    /// A turbo file cross-selected onto some OTHER family must not reshape that family's schedule.
+    #[test]
+    fn a_turbo_adapter_on_a_non_minimax_model_changes_nothing() {
+        assert_eq!(
+            resolve_turbo_recipe("wan_2_2_t2v_14b", &[lora("minimax_h3_turbo_4step_768p")]),
+            Ok(None)
+        );
+    }
+
+    /// The parser reads the declared block and drops a malformed one rather than inventing values —
+    /// the difference between "this adapter has no recipe" (loads as a plain residual) and "this
+    /// adapter renders at a number nobody declared".
+    #[test]
+    fn a_malformed_or_absent_sampling_block_yields_no_recipe() {
+        let catalog = r#"{
+          "schemaVersion": 1,
+          "loras": [
+            { "id": "no_block", "family": "minimax-h3", "role": "accelerator" },
+            { "id": "zero_steps", "family": "minimax-h3", "role": "accelerator",
+              "sampling": { "steps": 0, "schedulerShift": 6.0, "audioSchedulerShift": 3.0 } },
+            { "id": "no_shift", "family": "minimax-h3", "role": "accelerator",
+              "sampling": { "steps": 4, "audioSchedulerShift": 3.0 } },
+            { "id": "not_an_accelerator", "family": "minimax-h3",
+              "sampling": { "steps": 4, "schedulerShift": 6.0, "audioSchedulerShift": 3.0 } },
+            { "id": "other_family", "family": "wan-video", "role": "accelerator",
+              "sampling": { "steps": 4, "schedulerShift": 6.0, "audioSchedulerShift": 3.0 } },
+            { "id": "good", "family": "minimax-h3", "role": "accelerator",
+              "sampling": { "steps": 8, "schedulerShift": 12.0, "audioSchedulerShift": 3.0 } }
+          ]
+        }"#;
+        let recipes = parse_turbo_recipes(catalog);
+        assert_eq!(
+            recipes
+                .iter()
+                .map(|r| r.lora_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["good"]
+        );
+        assert!(parse_turbo_recipes("not json at all").is_empty());
+    }
+}

--- a/crates/sceneworks-mcp/src/server.rs
+++ b/crates/sceneworks-mcp/src/server.rs
@@ -261,11 +261,16 @@ pub struct SubmitVideoJobArgs {
     /// at the default canvas; the cheap draft an agent would reach for was unreachable.
     /// Per-model floors are real (`limits.hardMinSteps`), so `list_models` reports them.
     #[schemars(
-        description = "Denoise steps. Omit for the model's own default. Fewer steps render proportionally faster; a model may declare a minimum (minSteps from list_models) below which the request is refused rather than raised."
+        description = "Denoise steps. Omit for the model's own default. Fewer steps render proportionally faster; a model may declare a minimum (minSteps from list_models) below which the request is refused rather than raised. If a step-distill adapter is attached (see loras), omitting this runs that adapter's own trained step count; setting it overrides that count."
     )]
     pub steps: Option<u32>,
+    /// sc-18727. The turbo variant selector IS this field — a step-distill adapter is selected the
+    /// same way any other LoRA is, which is what keeps the MCP surface, the Video Studio control and
+    /// the generic picker on one payload key and one server-side resolver. The description says so
+    /// explicitly because the effect is not guessable from an id: attaching
+    /// `minimax_h3_turbo_4step_768p` changes the schedule, not just the weights.
     #[schemars(
-        description = "LoRA adapters to apply: [{\"id\": <from list_loras>, \"weight\": 0.0-2.0}]."
+        description = "LoRA adapters to apply: [{\"id\": <from list_loras>, \"weight\": 0.0-2.0}]. An adapter whose list_loras entry carries role=\"accelerator\" and a sampling block is a step-distill accelerator: attaching it also switches the render to that adapter's trained schedule (its sampling.steps and sampling.schedulerShift), which is how a MiniMax-H3 job renders in 4-8 steps instead of 50. Attach at most one accelerator per job — two asking for different schedules are refused."
     )]
     pub loras: Option<Vec<Value>>,
     #[schemars(
@@ -1508,6 +1513,16 @@ pub(crate) fn compact_loras(loras: &Value) -> Value {
                 "triggerWords",
                 "defaultWeight",
                 "installState",
+                // sc-18727 — the sampling-regime marker and the recipe it carries. Without these an
+                // agent listing LoRAs sees "MiniMax-H3 Turbo (4-step)" as a name and nothing else:
+                // it cannot tell that selecting it takes the render from the model's `defaults.steps`
+                // of 50 to 4 (a measured 2.42 h to 12.6 min), nor which of the three published
+                // variants runs which schedule. That is the same class of gap sc-17161 closed for
+                // `steps` — a knob reachable through `generate_video`'s `loras` field but invisible
+                // in the catalog that is supposed to describe it. `role` alone is not enough,
+                // because the numbers differ per adapter and no naming convention carries the shift.
+                "role",
+                "sampling",
             ],
             &mut out,
         );
@@ -1598,6 +1613,42 @@ mod tests {
                 "defaultWeight": 0.8,
                 "installState": "missing",
                 "compatibleFamilies": ["ltx-video"]
+            }])
+        );
+    }
+
+    /// sc-18727 — a step-distill adapter's REGIME (`role`) and its RECIPE (`sampling`) survive the
+    /// compaction, because an agent that cannot see them cannot tell a 4-step render from a 50-step
+    /// one before submitting it.
+    ///
+    /// Asserted with a NON-DEFAULT recipe (4 steps at video shift 6.0, against the model's
+    /// `defaults.steps: 50` and the engine's own shift 12.0) so the arm cannot pass against a
+    /// mapper that emits placeholder or default values. The negative half is the arm above: a plain
+    /// LoRA carries neither key and gains neither.
+    #[test]
+    fn compact_loras_keeps_the_accelerator_role_and_its_sampling_recipe() {
+        let full = json!([{
+            "id": "minimax_h3_turbo_4step_768p",
+            "name": "MiniMax-H3 Turbo (4-step, 768p)",
+            "family": "minimax-h3",
+            "role": "accelerator",
+            "sampling": { "steps": 4, "schedulerShift": 6.0, "audioSchedulerShift": 3.0 },
+            "defaultWeight": 1.0,
+            "installState": "installed",
+            "compatibility": { "families": ["minimax-h3"] },
+            "source": { "provider": "huggingface", "repo": "lightx2v/Minimax-h3-Turbo" }
+        }]);
+        assert_eq!(
+            compact_loras(&full),
+            json!([{
+                "id": "minimax_h3_turbo_4step_768p",
+                "name": "MiniMax-H3 Turbo (4-step, 768p)",
+                "family": "minimax-h3",
+                "defaultWeight": 1.0,
+                "installState": "installed",
+                "role": "accelerator",
+                "sampling": { "steps": 4, "schedulerShift": 6.0, "audioSchedulerShift": 3.0 },
+                "compatibleFamilies": ["minimax-h3"]
             }])
         );
     }

--- a/crates/sceneworks-worker/src/video_jobs/minimax_h3.rs
+++ b/crates/sceneworks-worker/src/video_jobs/minimax_h3.rs
@@ -420,6 +420,90 @@ pub(super) fn ensure_minimax_h3_renderable(
     Ok(())
 }
 
+/// Build the adapter specs for a MiniMax-H3 generation (sc-18726).
+///
+/// MiniMax-H3 is a single **dense** DiT — no MoE experts, no Lightning distill pair to prepend — so
+/// this is the shared [`super::resolve_dense_adapters`] the Wan-VACE and SCAIL-2 arms use, with the
+/// same `MAX_JOB_LORAS` cap and the same confinement of the resolved path.
+///
+/// 🔴 Until this existed the arm passed `adapters: Vec::new()` unconditionally, so a selected
+/// MiniMax-H3 LoRA — turbo or otherwise — was accepted by the API's family gate, round-tripped
+/// through the payload, shown as selected in the picker, and then **silently dropped** on the way to
+/// the engine. That is the whole reason the recipe below is not enough on its own: switching the
+/// schedule to 4 steps without the distilled residual actually loading renders the base checkpoint
+/// at 4 steps, which sc-18729 measured as visibly undercooked (motion 1.117 against 5.612).
+///
+/// The engine (`mlx-gen-minimax-h3`, `supports_lora: true`) resolves each file's rank from the factor
+/// shapes and its alpha from the file — per-target `.alpha`, then PEFT metadata, then the bare
+/// top-level `__metadata__["alpha"]` string, then `DEFAULT_LORA_ALPHA = 8`, never the rank. Nothing
+/// about that fold belongs on this side: `defaultWeight` is the runtime `lora_scale` MULTIPLIER and
+/// the catalog leaves it at 1.0 so the file's own alpha/rank fold lands unmodified.
+#[cfg(target_os = "macos")]
+pub(super) fn resolve_minimax_h3_adapters(
+    settings: &Settings,
+    request: &VideoRequest,
+) -> WorkerResult<Vec<AdapterSpec>> {
+    super::resolve_dense_adapters(settings, request, MAX_JOB_LORAS)
+}
+
+/// The MiniMax-H3 sampling recipe `(steps, video scheduler shift)` for this request, plus the turbo
+/// variant that produced it (`None` ⇒ the base regime).
+///
+/// The twin of [`super::wan::scail2_sampling`], and it diverges from it in exactly the three ways
+/// sc-18726 identified:
+///
+/// 1. **The recipe is per VARIANT, read from the catalog.** SCAIL-2 has one lightning recipe and can
+///    sniff it from the file format; MiniMax-H3's four published adapters carry three different
+///    `(NFE, video shift)` pairs in a byte-identical format, so the discriminator is the catalog id
+///    and the values live in `builtin.loras.jsonc` (`sampling`). Resolution goes through
+///    [`sceneworks_core::minimax_h3_turbo::resolve_turbo_recipe`] — the ONE resolver both entry
+///    points (the studio's turbo control and the generic LoRA picker) reach, because both do the
+///    same thing: put a catalog id in `request.loras`.
+///
+/// 2. **Guidance is not part of the recipe.** SCAIL-2's lightning invariants include CFG-off, because
+///    SCAIL-2 has CFG to turn off. This checkpoint is guidance-distilled — there is no unconditional
+///    branch in it, the manifest declares `video.supportsGuidance: false`, and the engine REJECTS a
+///    guidance scale — so the turbo LoRA changes the schedule and nothing else.
+///
+/// 3. **The audio shift is recorded, not forwarded.** See
+///    [`sceneworks_core::minimax_h3_turbo`]: the engine holds audio at its own `AUDIO_SIGMA_SHIFT`,
+///    every published variant trains at 3.0, and the core guard goes red if a catalog variant ever
+///    declares otherwise.
+///
+/// An explicit `advanced.steps` wins over the variant's own count, exactly as `scail2_sampling`
+/// lets it — upstream's spec table lists the 8-step file as "8 / 4", so a caller who knows the
+/// checkpoint can run it shorter. The shift is NOT overridable the same way: `advanced.schedulerShift`
+/// still reaches the base regime (it is the pre-existing knob this arm already read), but under a
+/// turbo variant the trained shift wins, because a distilled checkpoint sampled at a shift it was
+/// not distilled for is the off-distribution render the recipe exists to prevent.
+#[cfg(target_os = "macos")]
+pub(super) fn minimax_h3_sampling(
+    request: &VideoRequest,
+) -> WorkerResult<(
+    Option<u32>,
+    Option<f32>,
+    Option<&'static sceneworks_core::minimax_h3_turbo::TurboRecipe>,
+)> {
+    let recipe =
+        sceneworks_core::minimax_h3_turbo::resolve_turbo_recipe(&request.model, &request.loras)
+            .map_err(WorkerError::InvalidPayload)?;
+    let Some(recipe) = recipe else {
+        // Base regime — byte-identical to what this arm did before sc-18726: `None` ⇒ the engine's
+        // own DEFAULT_STEPS (50) and VIDEO_SIGMA_SHIFT (12.0), with the pre-existing `advanced`
+        // overrides still honored.
+        return Ok((
+            advanced_opt_u32(request, "steps"),
+            advanced_opt_f32(request, "schedulerShift"),
+            None,
+        ));
+    };
+    Ok((
+        advanced_opt_u32(request, "steps").or(Some(recipe.steps)),
+        Some(recipe.video_shift),
+        Some(recipe),
+    ))
+}
+
 /// The `rawSettings` recorded on a real MiniMax-H3 asset.
 ///
 /// `minimaxH3Tier` names the tier that actually LOADED, not the one the request asked for — the
@@ -430,14 +514,56 @@ pub(super) fn ensure_minimax_h3_renderable(
 /// partitions — actually denoised. It is the one field that makes a wrong-checkpoint render
 /// visible after the fact: the output of a t2va job on `transformer_ref/` is plausible video, so
 /// the asset record is the only place the truth can live.
+///
+/// The `effective*` block is the sc-18726 half — the `wan_raw_settings` / `scail2_raw_settings`
+/// convention, and the only place the schedule a render ACTUALLY ran is inspectable. `minimaxH3Turbo`
+/// names the variant (or `"off"`), `effectiveSteps` is the model-evaluation count that reached the
+/// engine, `effectiveSchedulerShift` the video shift, and `effectiveAudioSchedulerShift` the audio
+/// one.
+///
+/// `effectiveAudioSchedulerShift` is recorded from the DECLARED recipe (or, in the base regime, from
+/// the engine constant it is pinned to) rather than from a request field, because there is no request
+/// field: the engine holds audio at `AUDIO_SIGMA_SHIFT` on every path. Writing the number anyway is
+/// how the asset states the WHOLE schedule instead of the video half of it, and
+/// `sceneworks_core::minimax_h3_turbo` carries the guard that the declared and rendered values cannot
+/// silently diverge.
+///
+/// `effectiveSteps` / `effectiveSchedulerShift` record `null` when the arm passed `None` — "the
+/// engine picked its own default" is a fact about the render, and mirroring the engine's 50 / 12.0
+/// here would create a second place for those constants to drift. `scail2_raw_settings` omits its
+/// `effective*` keys off-recipe for the same reason it never has to answer that question; this arm
+/// answers it explicitly so `minimaxH3Turbo: "off"` and a null step count read as one statement.
 #[cfg(target_os = "macos")]
-pub(super) fn minimax_h3_raw_settings(request: &VideoRequest, tier: &str, task: &str) -> Value {
+pub(super) fn minimax_h3_raw_settings(
+    request: &VideoRequest,
+    tier: &str,
+    task: &str,
+    steps: Option<u32>,
+    scheduler_shift: Option<f32>,
+    turbo: Option<&sceneworks_core::minimax_h3_turbo::TurboRecipe>,
+) -> Value {
     let mut raw = request.advanced.clone();
     raw.insert("realModelInference".to_owned(), Value::Bool(true));
     raw.insert("model".to_owned(), Value::String(request.model.clone()));
     raw.insert("fps".to_owned(), json!(request.fps));
     raw.insert("minimaxH3Tier".to_owned(), Value::String(tier.to_owned()));
     raw.insert("minimaxH3Task".to_owned(), Value::String(task.to_owned()));
+    raw.insert(
+        "minimaxH3Turbo".to_owned(),
+        Value::String(
+            turbo
+                .map(|recipe| recipe.lora_id.clone())
+                .unwrap_or_else(|| "off".to_owned()),
+        ),
+    );
+    raw.insert("effectiveSteps".to_owned(), json!(steps));
+    raw.insert("effectiveSchedulerShift".to_owned(), json!(scheduler_shift));
+    raw.insert(
+        "effectiveAudioSchedulerShift".to_owned(),
+        json!(turbo
+            .map(|recipe| recipe.audio_shift)
+            .unwrap_or(sceneworks_core::minimax_h3_turbo::ENGINE_AUDIO_SIGMA_SHIFT)),
+    );
     Value::Object(raw)
 }
 
@@ -621,7 +747,12 @@ pub(super) async fn generate_minimax_h3_using(
     let conditioning = resolve_minimax_h3_conditioning(settings, request, project_path)?;
     let load = resolve_minimax_h3_load(settings, request)?;
     let task = minimax_h3_task(&conditioning);
-    let raw_settings = minimax_h3_raw_settings(request, load.tier, task);
+    // The turbo recipe (sc-18726) is resolved BEFORE the adapters so a contradictory pair of
+    // accelerators is refused by name rather than after a LoRA file has been opened and classified.
+    let (steps, scheduler_shift, turbo) = minimax_h3_sampling(request)?;
+    let adapters = resolve_minimax_h3_adapters(settings, request)?;
+    let raw_settings =
+        minimax_h3_raw_settings(request, load.tier, task, steps, scheduler_shift, turbo);
     let input = VideoGenInput {
         sampler: None,
         scheduler: None,
@@ -631,7 +762,10 @@ pub(super) async fn generate_minimax_h3_using(
         model_dir: load.root,
         dit_component_dir: Some(load.dit_dir),
         quant: load.quant,
-        adapters: Vec::new(),
+        // sc-18726. Was an unconditional `Vec::new()`: every selected MiniMax-H3 LoRA was dropped
+        // between the payload and the engine, so the turbo adapters sc-18725 catalogued could be
+        // picked and never loaded. See [`resolve_minimax_h3_adapters`].
+        adapters,
         conditioning,
         prompt: request.prompt.clone(),
         // Guidance-distilled: the checkpoint has no unconditional branch and the engine REJECTS
@@ -646,11 +780,14 @@ pub(super) async fn generate_minimax_h3_using(
         // engine an off-lattice count it hard-rejects (the engine never refits).
         frames: video_frame_count(&request.model, request.raw_frame_count()),
         fps: request.fps,
-        // `None` ⇒ the engine's own DEFAULT_STEPS (50).
-        steps: advanced_opt_u32(request, "steps"),
+        // MODEL EVALUATIONS, not sigma grid points — the engine appends the terminal σ = 0 itself
+        // (`JointSchedule::with_shifts(evaluations + 1, ..)`), so this number is passed through with
+        // no ±1 anywhere on this side. `None` ⇒ the engine's own DEFAULT_STEPS (50); a selected turbo
+        // variant supplies its own 4 or 8 ([`minimax_h3_sampling`]).
+        steps,
         // The video sigma shift (sc-18729). `None` ⇒ the engine's own VIDEO_SIGMA_SHIFT; the turbo
         // 4-step recipe wants a lower one, so it is a real per-request axis rather than a constant.
-        scheduler_shift: advanced_opt_f32(request, "schedulerShift"),
+        scheduler_shift,
         seed: resolve_video_seed(request) as u64,
         ..VideoGenInput::default()
     };

--- a/crates/sceneworks-worker/src/video_jobs/mod.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mod.rs
@@ -460,8 +460,13 @@ fn video_preflight(request: &VideoRequest) -> WorkerResult<()> {
     // because `steps_limit_error` owns both). Bounds the SAMPLING axis, which neither
     // bound above touches: `frames = duration × fps` says nothing about how many denoise steps run
     // over those frames, so a request legal on both can still hand the engine a schedule it cannot
-    // build. MiniMax-H3's sigma grid is `linspace(1, 0, steps)` and one grid point yields zero model
-    // evaluations, so its scheduler raises rather than rendering.
+    // build (LTX-2.3 bakes an 8-step sigma table and refuses anything else) or one that is legal but
+    // useless (MiniMax-H3 at 1 evaluation is a single Euler jump from pure noise — see that entry's
+    // `hardMinSteps` note for why its floor is a product judgement rather than an engine limit).
+    //
+    // The unit read here is MODEL EVALUATIONS, matching `advanced.steps`, `defaults.steps` and each
+    // turbo adapter's declared `sampling.steps`. No ±1 is applied anywhere on this side; the
+    // MiniMax-H3 engine appends its own terminal sigma grid point (sc-18726).
     //
     // The API gate is the one that returns a caller a 400, but it only covers what IT enqueues — a
     // job replayed from a pre-sc-19426 row, or produced by any future non-HTTP path, reaches the

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -12296,6 +12296,15 @@ fn minimax_h3_job_snapshot() -> JobSnapshot {
     .expect("the minimax-h3 job snapshot deserializes")
 }
 
+/// The `data_dir` [`drive_minimax_h3_arm`] runs under. Named rather than inlined because the LoRA
+/// confinement (`normalize_app_managed_lora_path`) admits only paths UNDER the data dir, so a test
+/// that stages an adapter for the arm has to stage it here — anywhere else and the arm rejects the
+/// file for the confinement reason rather than exercising the recipe (sc-18726).
+#[cfg(target_os = "macos")]
+fn minimax_h3_data_dir(tier_root: &Path) -> PathBuf {
+    tier_root.join("arm-data-dir")
+}
+
 /// Drive the REAL `generate_minimax_h3_using` against `probe`, with both roots pointed at fixtures.
 ///
 /// Every network field is unroutable (`offline_settings`) and `HF_HUB_CACHE` is pinned at an empty
@@ -12310,7 +12319,7 @@ fn drive_minimax_h3_arm(
     request: &VideoRequest,
 ) -> WorkerResult<(DecodedVideo, Value)> {
     let settings = Settings {
-        data_dir: tier_root.join("unused-data-dir"),
+        data_dir: minimax_h3_data_dir(tier_root),
         ..offline_settings()
     };
     let job = minimax_h3_job_snapshot();
@@ -13155,4 +13164,299 @@ fn generate_minimax_h3_using_refuses_a_wrong_partition_shape_before_loading() {
         "the shape check must run BEFORE the load — a wrong-partition job must never pay for a \
          53 GB text encoder, let alone render from the wrong DiT"
     );
+}
+
+// ---------------------------------------------------------------------------
+// MiniMax-H3 turbo recipe — the DRIVABLE CHAIN (epic 17137, sc-18726 / sc-18727).
+//
+// The failure these guard against is not "the control does not render". It is the one this epic has
+// shipped three times: a control that exists, a payload field that carries its value, and a worker
+// that never reads it. So every test below drives the REAL arm and asserts on what reached the
+// ENGINE — the step count, the video shift, and the adapter file itself — rather than on any
+// intermediate state.
+//
+// Every asserted value is NON-DEFAULT on purpose. The model's `defaults.steps` is 50 and the
+// engine's own `VIDEO_SIGMA_SHIFT` is 12.0, so an arm that forwarded nothing could not pass.
+// ---------------------------------------------------------------------------
+
+/// Stage a turbo adapter file under the arm's data dir and return the payload `loras` entry naming
+/// it — the shape `serialize_job_lora` produces for a catalog-backed selection (`id` + `path` +
+/// `weight`).
+///
+/// The `id` is what the recipe resolves from, and it is a REAL catalog id: the resolver reads the
+/// embedded builtin manifest, so a made-up id resolves to no recipe and every assertion below would
+/// silently be asserting the base regime.
+#[cfg(target_os = "macos")]
+fn minimax_h3_turbo_lora(tier_root: &Path, lora_id: &str) -> Value {
+    let dir = minimax_h3_data_dir(tier_root).join("loras");
+    std::fs::create_dir_all(&dir).expect("lora dir");
+    let file = dir.join(format!("{lora_id}.safetensors"));
+    write_lora_fixture(&file, None);
+    json!({ "id": lora_id, "path": file.to_string_lossy(), "weight": 1.0 })
+}
+
+/// 🔴 **THE CHAIN.** A selected turbo variant reaches the engine as its own `(steps, video shift)`
+/// AND as a loaded adapter, and the base regime is byte-identical to what shipped before.
+///
+/// Both halves are required and neither is sufficient:
+///
+/// * **the recipe without the adapter** renders the BASE checkpoint on a 4-step schedule, which
+///   sc-18729 measured as visibly undercooked (motion 1.117 against the LoRA's 5.612) — a fast
+///   render of the wrong thing;
+/// * **the adapter without the recipe** is what sc-18725 actually shipped: a 692M-parameter residual
+///   stacked onto a 50-step render, slower than the base and off-distribution.
+///
+/// The `off` arm is the control. Without it, an arm that unconditionally forced `(4, 6.0)` would
+/// pass the `on` arm and destroy every non-turbo MiniMax-H3 render.
+#[cfg(target_os = "macos")]
+#[test]
+fn a_selected_turbo_variant_changes_the_job_that_reaches_the_engine() {
+    let tiers = minimax_h3_tier_root("mm_turbo_", &["q4"], &["transformer", "transformer_ref"]);
+    let base = minimax_h3_base_root("mm_turbo_base_");
+
+    // --- turbo OFF: the base regime, unchanged ------------------------------------------------
+    let off_probe = ArmProbe::default();
+    let off = minimax_h3_request("minimax_h3", json!({}));
+    let (_decoded, off_raw) = drive_minimax_h3_arm(tiers.path(), base.path(), &off_probe, &off)
+        .expect("a plain t2va job runs");
+    let off_request = off_probe
+        .request
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("the arm reached the engine");
+    assert_eq!(
+        (off_request.steps, off_request.scheduler_shift),
+        (None, None),
+        "with no accelerator the arm must pass NOTHING, so the engine's own 50 steps / shift 12.0 \
+         stand exactly as they did before sc-18726"
+    );
+    let off_spec = off_probe.spec.lock().unwrap().clone().expect("a load ran");
+    assert!(
+        off_spec.adapters.is_empty(),
+        "a job with no LoRAs must load none"
+    );
+    assert_eq!(off_raw["minimaxH3Turbo"], json!("off"));
+    assert_eq!(off_raw["effectiveSteps"], Value::Null);
+    assert_eq!(off_raw["effectiveSchedulerShift"], Value::Null);
+
+    // --- turbo ON: the 768p variant's OWN recipe ----------------------------------------------
+    let on_probe = ArmProbe::default();
+    let lora = minimax_h3_turbo_lora(tiers.path(), "minimax_h3_turbo_4step_768p");
+    let lora_path = lora["path"].as_str().expect("a staged path").to_owned();
+    let on = minimax_h3_request("minimax_h3", json!({ "loras": [lora] }));
+    let (_decoded, on_raw) = drive_minimax_h3_arm(tiers.path(), base.path(), &on_probe, &on)
+        .expect("a t2va job carrying the turbo adapter runs");
+    let on_request = on_probe
+        .request
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("the arm reached the engine");
+    assert_eq!(
+        on_request.steps,
+        Some(4),
+        "the variant's own NFE must reach the engine — 4, not the model's default 50, and not the \
+         5 a SceneWorks-side +1 would produce (the engine appends the terminal sigma itself)"
+    );
+    assert_eq!(
+        on_request.scheduler_shift,
+        Some(6.0),
+        "the variant's own VIDEO shift must reach the engine — 6.0, the one published variant that \
+         differs from the base 12.0, so this cannot pass against a hardcoded default"
+    );
+    let on_spec = on_probe.spec.lock().unwrap().clone().expect("a load ran");
+    assert_eq!(
+        on_spec
+            .adapters
+            .iter()
+            .map(|adapter| adapter.path.clone())
+            .collect::<Vec<_>>(),
+        vec![std::fs::canonicalize(&lora_path).expect("the staged adapter canonicalizes")],
+        "the adapter itself must reach the LOAD — before sc-18726 the arm passed `Vec::new()` and \
+         every selected MiniMax-H3 LoRA was silently dropped here"
+    );
+    assert_eq!(
+        on_raw["minimaxH3Turbo"],
+        json!("minimax_h3_turbo_4step_768p")
+    );
+    assert_eq!(on_raw["effectiveSteps"], json!(4));
+    assert_eq!(on_raw["effectiveSchedulerShift"], json!(6.0));
+    assert_eq!(
+        on_raw["effectiveAudioSchedulerShift"],
+        json!(3.0),
+        "the asset records the WHOLE schedule — the audio shift the engine is fixed at, not just \
+         the video half the request can move"
+    );
+}
+
+/// Each published variant carries its OWN recipe to the engine — the property a single constant, a
+/// format sniff, or a `role: accelerator` boolean could not have.
+///
+/// The four files disagree pairwise: the two 4-step fl2v ones share an NFE and differ on shift, the
+/// 8-step one shares the shift with `4step_v01` and differs on NFE. Any implementation that
+/// collapses the set to one recipe fails at least one arm.
+#[cfg(target_os = "macos")]
+#[test]
+fn every_turbo_variant_drives_its_own_recipe_to_the_engine() {
+    let tiers = minimax_h3_tier_root("mm_variants_", &["q4"], &["transformer", "transformer_ref"]);
+    let base = minimax_h3_base_root("mm_variants_base_");
+    for (model, lora_id, steps, shift) in [
+        ("minimax_h3", "minimax_h3_turbo_4step_768p", 4u32, 6.0f32),
+        ("minimax_h3", "minimax_h3_turbo_8step", 8, 12.0),
+        ("minimax_h3", "minimax_h3_turbo_4step_v01", 4, 12.0),
+        ("minimax_h3_ref", "minimax_h3_ref2v_turbo_4step", 4, 12.0),
+    ] {
+        let lora = minimax_h3_turbo_lora(tiers.path(), lora_id);
+        // The reference partition needs a reference, or the SHAPE validator refuses before the
+        // recipe is ever consulted.
+        let extra = if model == "minimax_h3_ref" {
+            json!({ "loras": [lora], "referenceAssetIds": ["r1"] })
+        } else {
+            json!({ "loras": [lora] })
+        };
+        let request = minimax_h3_request(model, extra);
+        if model == "minimax_h3_ref" {
+            // Ref2VA resolves a real reference image off disk, which these fixtures have none of,
+            // so the arm legitimately stops in the media resolve. Assert on the pure sampling
+            // function the arm calls — the same code path, one frame earlier.
+            let (steps_out, shift_out, recipe) =
+                crate::video_jobs::minimax_h3::minimax_h3_sampling(&request)
+                    .expect("one accelerator resolves");
+            assert_eq!(
+                (steps_out, shift_out),
+                (Some(steps), Some(shift)),
+                "{lora_id}"
+            );
+            assert_eq!(recipe.expect("a recipe").lora_id, lora_id);
+            continue;
+        }
+        let probe = ArmProbe::default();
+        drive_minimax_h3_arm(tiers.path(), base.path(), &probe, &request)
+            .unwrap_or_else(|error| panic!("{lora_id} renders: {error}"));
+        let engine = probe
+            .request
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("the arm reached the engine");
+        assert_eq!(
+            (engine.steps, engine.scheduler_shift),
+            (Some(steps), Some(shift)),
+            "{lora_id} must drive its OWN (steps, video shift) to the engine"
+        );
+    }
+}
+
+/// An explicit `advanced.steps` beats the variant's own count; the trained SHIFT does not yield.
+///
+/// Upstream lists the 8-step adapter as "8 / 4", so a caller who knows the checkpoint may run it
+/// shorter — honouring the knob rather than seizing it, exactly as `scail2_sampling` does. The shift
+/// is the opposite call and is asserted here so the asymmetry is a decision rather than an accident:
+/// a distilled checkpoint sampled at a shift it was not distilled for is the off-distribution render
+/// the recipe exists to prevent, so `advanced.schedulerShift` loses to the variant.
+#[cfg(target_os = "macos")]
+#[test]
+fn an_explicit_step_override_wins_over_the_variants_count_but_the_shift_does_not() {
+    let tiers = minimax_h3_tier_root("mm_override_", &["q4"], &["transformer", "transformer_ref"]);
+    let base = minimax_h3_base_root("mm_override_base_");
+    let probe = ArmProbe::default();
+    let lora = minimax_h3_turbo_lora(tiers.path(), "minimax_h3_turbo_8step");
+    // 6 is neither the variant's 8, nor the model default 50, nor the other variants' 4 — so no
+    // value elsewhere in the system can produce this number by accident. 9.0 is likewise not the
+    // variant's/engine's 12.0 nor the 768p variant's 6.0.
+    let request = minimax_h3_request(
+        "minimax_h3",
+        json!({ "loras": [lora], "advanced": { "steps": 6, "schedulerShift": 9.0 } }),
+    );
+
+    drive_minimax_h3_arm(tiers.path(), base.path(), &probe, &request).expect("the job runs");
+    let engine = probe
+        .request
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("the arm reached the engine");
+    assert_eq!(
+        engine.steps,
+        Some(6),
+        "an explicit step count must win over the variant's own"
+    );
+    assert_eq!(
+        engine.scheduler_shift,
+        Some(12.0),
+        "the variant's TRAINED shift must win over an explicit one — 9.0 must not reach the engine"
+    );
+}
+
+/// Two accelerators asking for different schedules are refused BEFORE anything loads.
+///
+/// A render has one schedule; silently picking the first would run a job at numbers the user can see
+/// they did not choose. `probe.loaded()` makes this a pre-load assertion — the refusal must not cost
+/// a 53 GB text-encoder load.
+#[cfg(target_os = "macos")]
+#[test]
+fn two_conflicting_turbo_variants_are_refused_before_the_load() {
+    let tiers = minimax_h3_tier_root("mm_conflict_", &["q4"], &["transformer", "transformer_ref"]);
+    let base = minimax_h3_base_root("mm_conflict_base_");
+    let probe = ArmProbe::default();
+    let request = minimax_h3_request(
+        "minimax_h3",
+        json!({
+            "loras": [
+                minimax_h3_turbo_lora(tiers.path(), "minimax_h3_turbo_4step_768p"),
+                minimax_h3_turbo_lora(tiers.path(), "minimax_h3_turbo_8step"),
+            ]
+        }),
+    );
+
+    let message = drive_minimax_h3_arm(tiers.path(), base.path(), &probe, &request)
+        .err()
+        .expect("two different schedules cannot both govern one render")
+        .to_string();
+    assert!(
+        message.contains("MiniMax-H3 Turbo (4-step, 768p)")
+            && message.contains("MiniMax-H3 Turbo (8-step)"),
+        "the refusal names both adapters: {message}"
+    );
+    assert!(
+        !probe.loaded(),
+        "a contradictory selection must be refused before the load"
+    );
+}
+
+/// A plain (non-accelerator) MiniMax-H3 LoRA loads its weights and leaves the schedule alone.
+///
+/// The complement of the chain test: it proves the adapter plumbing is genuinely general rather than
+/// a turbo-only special case, and that the recipe keys on the catalog id rather than on "any LoRA is
+/// present".
+#[cfg(target_os = "macos")]
+#[test]
+fn a_plain_minimax_h3_lora_loads_without_changing_the_schedule() {
+    let tiers = minimax_h3_tier_root("mm_plain_", &["q4"], &["transformer", "transformer_ref"]);
+    let base = minimax_h3_base_root("mm_plain_base_");
+    let probe = ArmProbe::default();
+    let lora = minimax_h3_turbo_lora(tiers.path(), "some_user_style_lora");
+    let request = minimax_h3_request("minimax_h3", json!({ "loras": [lora] }));
+
+    let (_decoded, raw) = drive_minimax_h3_arm(tiers.path(), base.path(), &probe, &request)
+        .expect("a job carrying a plain LoRA runs");
+    let engine = probe
+        .request
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("the arm reached the engine");
+    assert_eq!(
+        (engine.steps, engine.scheduler_shift),
+        (None, None),
+        "a LoRA with no declared recipe must not move the schedule"
+    );
+    let spec = probe.spec.lock().unwrap().clone().expect("a load ran");
+    assert_eq!(
+        spec.adapters.len(),
+        1,
+        "…and must still be LOADED — the plumbing is general, not turbo-only"
+    );
+    assert_eq!(raw["minimaxH3Turbo"], json!("off"));
 }

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -12318,6 +12318,26 @@ fn drive_minimax_h3_arm(
     probe: &ArmProbe,
     request: &VideoRequest,
 ) -> WorkerResult<(DecodedVideo, Value)> {
+    // The t2va/fl2va arms resolve no media, so the project root is never read and a placeholder is
+    // honest. The Ref2VA arms DO read it — they take `drive_minimax_h3_arm_in_project`.
+    let project_path = tier_root.join("unused-project");
+    drive_minimax_h3_arm_in_project(tier_root, base_root, probe, request, &project_path)
+}
+
+/// [`drive_minimax_h3_arm`] with the project root supplied — the Ref2VA form.
+///
+/// A reference asset id resolves through `ProjectStore::get_asset` to a PROJECT-RELATIVE
+/// `file.path`, which `safe_project_path` joins under this root. So an arm carrying references only
+/// reaches the engine when the root is the staged project's own
+/// ([`stage_minimax_h3_reference_project`]).
+#[cfg(target_os = "macos")]
+fn drive_minimax_h3_arm_in_project(
+    tier_root: &Path,
+    base_root: &Path,
+    probe: &ArmProbe,
+    request: &VideoRequest,
+    project_path: &Path,
+) -> WorkerResult<(DecodedVideo, Value)> {
     let settings = Settings {
         data_dir: minimax_h3_data_dir(tier_root),
         ..offline_settings()
@@ -12325,7 +12345,7 @@ fn drive_minimax_h3_arm(
     let job = minimax_h3_job_snapshot();
     let loader = probe.loader();
     let hf_cache = tier_root.join("unused-hf-cache");
-    let project_path = tier_root.join("unused-project");
+    let project_path = project_path.to_path_buf();
     crate::test_env::temp_env_vars(
         &[
             ("HF_HUB_CACHE", hf_cache.to_str().expect("utf-8 hub")),
@@ -13195,6 +13215,53 @@ fn minimax_h3_turbo_lora(tier_root: &Path, lora_id: &str) -> Value {
     json!({ "id": lora_id, "path": file.to_string_lossy(), "weight": 1.0 })
 }
 
+/// Stage a real image reference for the Ref2VA arms: a project in the arm's own `ProjectStore`, a
+/// decodable PNG under it, and the indexed asset record `load_reference_image` resolves.
+///
+/// Returns `(project_id, project_path, asset_id)`. Both are needed by the caller: the id goes in the
+/// request (`minimax_h3_request`'s default `projectId` is a placeholder no store has heard of) and
+/// the path goes to [`drive_minimax_h3_arm_in_project`].
+///
+/// Registered through `persist_generated_asset` — the same door the image lane writes its own
+/// outputs with — rather than by hand-writing a sidecar, so this proves the resolution against the
+/// asset shape references actually have.
+#[cfg(target_os = "macos")]
+fn stage_minimax_h3_reference_project(data_dir: &Path) -> (String, PathBuf, String) {
+    let store = ProjectStore::new(data_dir.to_path_buf(), "worker");
+    let project = store
+        .create_project("sc18726_ref")
+        .expect("project creates");
+    let project_path = PathBuf::from(&project.path);
+    let asset_id = "mm_h3_ref_1";
+    let media_rel = "assets/images/reference.png";
+    let media_path = project_path.join(media_rel);
+    std::fs::create_dir_all(media_path.parent().expect("image dir")).expect("image dir creates");
+    // A real decodable PNG, not a touched file: `load_reference_image` runs `decode_image_any` and
+    // an empty file would fail there — which would leave this arm stopping one frame later than the
+    // fallback it replaces rather than reaching the engine.
+    image::RgbImage::from_pixel(64, 64, image::Rgb([32u8, 96, 200]))
+        .save(&media_path)
+        .expect("reference png writes");
+    store
+        .persist_generated_asset(
+            &project.id,
+            "job-sc18726",
+            "genset-sc18726",
+            &json!({
+                "type": "image",
+                "assetId": asset_id,
+                "mediaPath": media_rel,
+                "mimeType": "image/png",
+                "width": 64,
+                "height": 64,
+                "displayName": "reference.png",
+                "createdAt": "2026-08-15T00:00:00Z",
+            }),
+        )
+        .expect("reference asset persists");
+    (project.id, project_path, asset_id.to_owned())
+}
+
 /// 🔴 **THE CHAIN.** A selected turbo variant reaches the engine as its own `(steps, video shift)`
 /// AND as a loaded adapter, and the base regime is byte-identical to what shipped before.
 ///
@@ -13301,6 +13368,13 @@ fn a_selected_turbo_variant_changes_the_job_that_reaches_the_engine() {
 fn every_turbo_variant_drives_its_own_recipe_to_the_engine() {
     let tiers = minimax_h3_tier_root("mm_variants_", &["q4"], &["transformer", "transformer_ref"]);
     let base = minimax_h3_base_root("mm_variants_base_");
+    // The ref2v arm is driven at the ENGINE SEAM like the other three, not through the pure sampling
+    // function: the ref2v adapter is the one variant paired with the OTHER DiT partition, so the
+    // partition it is unique to is exactly the one a function-level assertion would leave unproved.
+    // That takes a real reference on disk, because `resolve_minimax_h3_conditioning` decodes one
+    // before the arm ever builds a `GenerationRequest`.
+    let (project_id, project_path, reference_id) =
+        stage_minimax_h3_reference_project(&minimax_h3_data_dir(tiers.path()));
     for (model, lora_id, steps, shift) in [
         ("minimax_h3", "minimax_h3_turbo_4step_768p", 4u32, 6.0f32),
         ("minimax_h3", "minimax_h3_turbo_8step", 8, 12.0),
@@ -13311,28 +13385,17 @@ fn every_turbo_variant_drives_its_own_recipe_to_the_engine() {
         // The reference partition needs a reference, or the SHAPE validator refuses before the
         // recipe is ever consulted.
         let extra = if model == "minimax_h3_ref" {
-            json!({ "loras": [lora], "referenceAssetIds": ["r1"] })
+            json!({
+                "loras": [lora],
+                "projectId": project_id,
+                "referenceAssetIds": [reference_id],
+            })
         } else {
             json!({ "loras": [lora] })
         };
         let request = minimax_h3_request(model, extra);
-        if model == "minimax_h3_ref" {
-            // Ref2VA resolves a real reference image off disk, which these fixtures have none of,
-            // so the arm legitimately stops in the media resolve. Assert on the pure sampling
-            // function the arm calls — the same code path, one frame earlier.
-            let (steps_out, shift_out, recipe) =
-                crate::video_jobs::minimax_h3::minimax_h3_sampling(&request)
-                    .expect("one accelerator resolves");
-            assert_eq!(
-                (steps_out, shift_out),
-                (Some(steps), Some(shift)),
-                "{lora_id}"
-            );
-            assert_eq!(recipe.expect("a recipe").lora_id, lora_id);
-            continue;
-        }
         let probe = ArmProbe::default();
-        drive_minimax_h3_arm(tiers.path(), base.path(), &probe, &request)
+        drive_minimax_h3_arm_in_project(tiers.path(), base.path(), &probe, &request, &project_path)
             .unwrap_or_else(|error| panic!("{lora_id} renders: {error}"));
         let engine = probe
             .request
@@ -13345,6 +13408,20 @@ fn every_turbo_variant_drives_its_own_recipe_to_the_engine() {
             (Some(steps), Some(shift)),
             "{lora_id} must drive its OWN (steps, video shift) to the engine"
         );
+        // The ref2v arm additionally has to have gone through the REFERENCE path to get here, or
+        // the partition this variant is distilled for is still unproved at the seam. The
+        // conditioning the arm built is what discriminates.
+        if model == "minimax_h3_ref" {
+            assert!(
+                engine
+                    .conditioning
+                    .iter()
+                    .any(|item| matches!(item, gen_core::Conditioning::Reference { .. })),
+                "the ref2v arm must reach the engine carrying its reference, not as a bare t2va \
+                 request that happened to resolve the same recipe: {:?}",
+                engine.conditioning
+            );
+        }
     }
 }
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -324,6 +324,15 @@ Expected failure modes: no/wrong token → `401` with
    frame lattice at 24 fps, so nothing between them renders, and the 15 s its own
    documentation advertises is between the last rung and the next. `minSteps` is
    the same shape — below it the request is refused, not raised.
+
+   ⚡ **A `loras` entry whose `list_loras` row carries `role: "accelerator"` and a
+   `sampling` block is a step-distill accelerator, and attaching it changes the
+   SCHEDULE as well as the weights** (sc-18726): the render switches to that
+   adapter's own `sampling.steps` and `sampling.schedulerShift`. This is the
+   difference between a two-and-a-half-hour MiniMax-H3 render and a twelve-minute
+   one, and there is no separate "turbo" parameter — the adapter *is* the switch.
+   Omit `steps` to take the adapter's trained count; set it to override. Attach at
+   most one accelerator per job: two asking for different schedules are refused.
 5. Poll `get_job_status` until `"status": "completed"`, then `get_job_result`
    → download each asset URL within the ticket TTL (300 s; re-call for fresh
    links). If the absolute URL host is not reachable from your machine, apply

--- a/packages/schemas/lora-manifest.schema.json
+++ b/packages/schemas/lora-manifest.schema.json
@@ -98,6 +98,29 @@
             "description": "Sampling-regime role marker (the sibling of 'conditioningRole', which is about how a job is CONDITIONED). 'accelerator' = a step-distill / turbo LoRA (e.g. the Krea 2 turbo adapter, sc-13882) whose weights load additively like any other LoRA but whose intent is to change the sampler regime — fewer steps, CFG off. Selecting one auto-switching the model to that regime is separately wired per model; absent that wiring the weights still stack as a plain residual.",
             "enum": ["accelerator"]
           },
+          "sampling": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["steps", "schedulerShift", "audioSchedulerShift"],
+            "description": "The sampling recipe a `role: accelerator` adapter was DISTILLED AGAINST — the values that make selecting it change the job rather than merely stack a residual (sc-18726). Declared here, per adapter, because a step-distill family's recipe differs per FILE: lightx2v's four MiniMax-H3 turbo checkpoints publish (4, 6.0), (8, 12.0), (4, 12.0) and (4, 12.0), and the four files are format-identical, so no sniff can tell them apart and a family-wide constant would be wrong for three of them. Read by `sceneworks_core::minimax_h3_turbo::turbo_recipes` (which resolves the selected job LoRA's catalog id against the EMBEDDED builtin manifest, so a forged payload cannot invent a recipe) and applied by `video_jobs::minimax_h3::minimax_h3_sampling`. Meaningful only alongside `role: accelerator`; an adapter with no `sampling` block still loads as a plain additive residual, which is exactly what `role` alone meant before this key existed.",
+            "properties": {
+              "steps": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "The denoise step count the adapter was distilled for, in MODEL EVALUATIONS (NFE) — the same unit `advanced.steps` carries and the same unit the engine's `req.steps` carries. The engine appends the terminal sigma = 0 grid point itself (`JointSchedule::with_shifts(evaluations + 1, ..)`), so there is NO +1 anywhere in SceneWorks and this number is passed through verbatim. Must satisfy the paired model's own `limits.hardMinSteps` / `limits.steps` gate, or the recipe would build a job the enqueue gate refuses; pinned by `every_turbo_recipe_step_count_clears_the_model_step_gate`."
+              },
+              "schedulerShift": {
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "description": "The VIDEO flow-matching sigma shift the adapter was trained against, forwarded as `GenerationRequest::scheduler_shift`. It is a real per-variant axis, not a constant: lightx2v's model-specs table publishes shift 6 for the 768p 4-step file and 12 for the 544p files, and rendering a turbo checkpoint on the base 12.0 is off-distribution (sc-18729 measured the 768p one at 6)."
+              },
+              "audioSchedulerShift": {
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "description": "The AUDIO sigma shift the adapter was trained against. MiniMax-H3 runs dual schedulers and the audio one is a genuinely separate axis, so it is declared per variant and recorded on the asset as `effectiveAudioSchedulerShift`. ⚠️ It is NOT a request knob: `mlx-gen-minimax-h3` holds audio at its own `AUDIO_SIGMA_SHIFT` constant and exposes no override, because every published variant trains at 3.0 (12/3 and 6/3 are the two published pairs). Declaring it anyway is what makes a future variant that moves it LOUD instead of silently rendering on 3.0 — `every_turbo_variant_declares_the_audio_shift_the_engine_is_fixed_at` fails the moment a declared value diverges."
+              }
+            }
+          },
           "source": { "$ref": "#/$defs/loraSource" }
         }
       }

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -2133,6 +2133,56 @@ def test_lora_schema_rejects_a_malformed_model_id_list():
         ), f"modelIds={value!r} must be rejected by `{keyword}`; got {_format_errors(errors)}"
 
 
+def test_lora_schema_accepts_a_declared_sampling_recipe():
+    """sc-18726: `sampling` is an explicit schema addition on an
+    additionalProperties:false entry, so pin that a well-formed block is accepted at
+    all — reverting the property would turn every shipped turbo entry into an
+    authoring error."""
+    entry = _sample_lora_entry()
+    entry["role"] = "accelerator"
+    entry["sampling"] = {"steps": 4, "schedulerShift": 6.0, "audioSchedulerShift": 3.0}
+    errors = _schema_errors({"schemaVersion": 1, "loras": [entry]}, LORA_SCHEMA_PATH)
+    assert not errors, "a declared sampling recipe must be schema-valid:\n" + _format_errors(errors)
+
+
+def test_lora_schema_rejects_a_malformed_sampling_recipe():
+    """The negative arm, and the one that carries the weight (sc-18726).
+
+    `parse_turbo_recipes` DROPS a block it cannot read rather than failing — a
+    silently recipe-less accelerator renders 50 steps at the base shift, which is the
+    2 h 25 m render this whole feature exists to avoid, with no error anywhere. So
+    every way of writing the block wrong has to be an authoring-time red: a partial
+    block (each of the three keys is load-bearing and none has a safe default), an
+    out-of-band step count, a zero shift, a string where a number belongs, a typo'd
+    key, and a non-object.
+    """
+    good = {"steps": 4, "schedulerShift": 6.0, "audioSchedulerShift": 3.0}
+    cases = [
+        ({key: value for key, value in good.items() if key != missing}, "required")
+        for missing in good
+    ]
+    cases += [
+        ({**good, "steps": 0}, "minimum"),
+        ({**good, "steps": 4.5}, "type"),
+        ({**good, "schedulerShift": 0}, "exclusiveMinimum"),
+        ({**good, "audioSchedulerShift": "3.0"}, "type"),
+        # The sc-12288 field class, one level in: a typo'd key is silently ignored by a
+        # permissive object, and `required` alone would not catch a MISSPELLED extra.
+        ({**good, "schedulerShifts": 6.0}, "additionalProperties"),
+        (4, "type"),
+    ]
+    for value, keyword in cases:
+        entry = _sample_lora_entry()
+        entry["role"] = "accelerator"
+        entry["sampling"] = value
+        errors = _schema_errors({"schemaVersion": 1, "loras": [entry]}, LORA_SCHEMA_PATH)
+        assert any(
+            error.validator == keyword
+            and list(error.absolute_path)[:3] == ["loras", 0, "sampling"]
+            for error in errors
+        ), f"sampling={value!r} must be rejected by `{keyword}`; got {_format_errors(errors)}"
+
+
 def test_every_minimax_h3_lora_declares_its_partition_in_the_real_catalog():
     """sc-19563, against the SHIPPED manifest rather than a sample entry.
 


### PR DESCRIPTION
Closes **sc-18726** (per-variant sampling recipe) and **sc-18727** (Video Studio control + reachability). They are the two halves of one feature — the recipe and the control that drives it — so they ship together or the control is inert.

## The state before this

sc-18725 catalogued four `lightx2v/Minimax-h3-Turbo` adapters with `role: accelerator`, and that marker is **weight-load only**. Selecting one:

1. stacked a 692M-parameter residual and still ran the base **50 steps at video shift 12.0** — slower than not selecting it, and off-distribution, because a distilled checkpoint sampled on the schedule it was distilled *away* from is not the model anyone trained; and
2. never reached the engine at all — `generate_minimax_h3_using` passed `adapters: Vec::new()` unconditionally, so **every** MiniMax-H3 LoRA was accepted by the API's family gate, round-tripped through the payload, shown as selected in the picker, and silently dropped.

## The drivable chain

Every link, in order:

| link | where |
|---|---|
| control | `apps/web/src/screens/VideoStudio.jsx:2133` — the Turbo `<select>` |
| → selection | `VideoStudio.jsx:596` `selectTurboVariant` writes `selectedLoraIds` |
| → payload | `VideoStudio.jsx:1494` `loras: selectedLoras.map(serializeLora)` |
| → API gate | `apps/rust-api/src/generation.rs:706` `validate_job_lora_compatibility_with` (catalog-backed, family-gated) |
| → worker recipe | `crates/sceneworks-worker/src/video_jobs/minimax_h3.rs:480` `minimax_h3_sampling` |
| → resolver | `crates/sceneworks-core/src/minimax_h3_turbo.rs:175` `resolve_turbo_recipe` |
| → engine request | `minimax_h3.rs:787` `steps` / `:790` `scheduler_shift` / `:768` `adapters` |
| → asset record | `minimax_h3.rs:552` `minimaxH3Turbo` / `effectiveSteps` / `effectiveSchedulerShift` / `effectiveAudioSchedulerShift` |

The proof that a flip changes the job is `a_selected_turbo_variant_changes_the_job_that_reaches_the_engine` (`video_jobs/tests.rs`): it drives the real arm and asserts the captured `GenerationRequest` carries `steps: Some(4)` and `scheduler_shift: Some(6.0)` with the adapter file in `LoadSpec::adapters`, against an `off` control arm asserting `(None, None)` and no adapters. 4 and 6.0 are both **non-default** (the model's `defaults.steps` is 50; the engine's own shift is 12.0), so it cannot pass against an arm that forwards nothing.

## Why the recipe is per adapter, and in the catalog

The four published files disagree pairwise and are **byte-format-identical**, so neither a family constant nor a SCAIL-2-style format sniff can serve:

| adapter | NFE | video shift | audio shift |
|---|---|---|---|
| `minimax_h3_turbo_4step_768p` | 4 | **6.0** | 3.0 |
| `minimax_h3_turbo_8step` | **8** | 12.0 | 3.0 |
| `minimax_h3_turbo_4step_v01` | 4 | 12.0 | 3.0 |
| `minimax_h3_ref2v_turbo_4step` | 4 | 12.0 | 3.0 |

So each entry in `builtin.loras.jsonc` gains a `sampling` block (new, `additionalProperties: false`, in `lora-manifest.schema.json`), and `sceneworks-core`'s new `minimax_h3_turbo` module resolves it **from the catalog id against the EMBEDDED manifest** — not from the payload. A payload-carried recipe would let any HTTP client name its own step count under an adapter that was not distilled for it, bypassing `steps_limit_error`; reading it from the id means the worst a forged payload can do is name a real adapter, which is identical to selecting it.

`every_turbo_recipe_step_count_clears_the_model_step_gate` reads the shipped model manifest and the same `steps_limit_error` the API and worker call, so a recipe whose count the enqueue gate would refuse is red at the source rather than at enqueue.

## One resolver, two entry points

sc-18727 asked to "either route both through one resolver or hide it from the generic picker". Routing both is the better half: hiding an installed adapter from the picker would make it un-deselectable from the surface that shows it selected. The Turbo control and the LoRA picker write the **same `selectedLoraIds`** — they are two views of one selection, so they cannot disagree. `reflects a variant selected from the generic LoRA picker` drives it from the picker side in both directions.

**Default-on**, seeded once per model and persisted (server ui-preferences, so a deliberate "Off" survives a desktop relaunch): sc-18729 measured **2 h 25 m against 12.6 min** at the model's own default canvas, so default-off would make the shipped default experience a two-and-a-half-hour render. The reference partition seeds the **ref2v** adapter rather than an fl2v one — the two are one family and nothing else stops a Ref2VA job folding a checkpoint it was not trained against.

The Simple shell gets the same seed and **no** new control (the adapter is already in its picker; a second surface would be exactly the advanced knob that shell exists to omit). Asserted on the payload, since there is nothing to click.

## Steps stays editable

Unlike Wan Lightning, Turbo **reports** its count rather than seizing the input: upstream lists the 8-step adapter as "8 / 4", and `minimax_h3_sampling` honours an explicit `advanced.steps` over the variant's default. The *shift* is the opposite call, asserted so the asymmetry is a decision: sampling a distilled checkpoint at a shift it was not distilled for is the off-distribution render the recipe exists to prevent.

## The step-count contract, decided once

sc-18726 flagged the `+1` as the call that makes "every step count in the product off by one" if made twice. It is made once, here: **`steps` is MODEL EVALUATIONS everywhere** — `advanced.steps`, `defaults.steps`, `limits.hardMinSteps`, `sampling.steps`, and the engine's `req.steps`. `mlx-gen-minimax-h3` appends the terminal σ = 0 grid point itself (`JointSchedule::with_shifts(evaluations + 1, ..)`), so **no ±1 exists on the SceneWorks side**.

Three shipped comments (the two manifest entries, `video_jobs/mod.rs`, `generation.rs`) described the diffusers `num_inference_steps` semantics instead and concluded `steps: 1` is unrenderable. It is renderable (1 evaluation, a legal 2-point grid) and merely useless, so `hardMinSteps: 2` is restated as the product judgement it actually is rather than an engine limit it is not. Value unchanged.

## The audio shift: declared, recorded, guarded — deliberately not a knob

MiniMax-H3 runs dual schedulers and the audio shift is a real axis of the recipe, so it is declared per variant and recorded on the asset as `effectiveAudioSchedulerShift`. It is **not forwarded**, because there is nothing to forward it to: `GenerationRequest` carries one `scheduler_shift`, the engine applies it to video only, and every published variant trains at 3.0. Adding a request field the engine ignores would be the "declared but undrivable" defect in a new place.

Instead, `ENGINE_AUDIO_SIGMA_SHIFT` mirrors the engine constant and `every_turbo_variant_declares_the_audio_shift_the_engine_is_fixed_at` fails the moment a catalog variant diverges — turning an inexpressible axis from a silently-wrong render into a red test at the moment the engine would need a second knob.

## Also fixed in passing

- **MCP `list_loras` dropped `role` and `sampling`**: an agent could attach an accelerator through `generate_video`'s existing `loras` field but had no way to learn that doing so takes the render from 50 steps to 4. Both keys now survive compaction, and the `loras` / `steps` tool descriptions say what an accelerator does.
- Prompt guide gains the variant table, the measured cost, the "different sample, not a degraded one" framing, and the override semantics.

## Tests

`cargo fmt --all --check` clean · `cargo clippy --all-targets -D warnings` clean · `cargo test` (default members) **3583 passed / 0 failed** · `npm run check` **424 passed** · web vitest **3696 passed / 0 failed across 253 files** (+ 15 new).

`cargo test --workspace` is not the gate here and is not green on this branch or on the base: `apps/desktop` is outside `default-members` and its Tauri build script requires a staged `binaries/sceneworks-api-aarch64-apple-darwin`, which a worktree has no reason to carry. `npm run rust:test` runs `cargo test` (default members) for that reason.

Every new guard was mutated **individually** and confirmed to fail on its own values — 12 Rust mutations and 12 web mutations, each killing a distinct, disjoint subset. Notably: reverting `adapters` to `Vec::new()` kills exactly the two adapter arms; flipping the 768p shift to 12.0 kills the shift arms but not the step-gate or audio guards; raising `hardMinSteps` to 5 kills only the step-gate guard.

**Verified against the branch pin (`014134e3`).** No pin bump — the MiniMax-H3 engine is not registered at this revision, so `minimax_h3_never_degrades_to_a_fake_video` still holds and the arm tests run through the injected-loader seam. The engine-side contract this builds on (`req.steps` = NFE, `req.scheduler_shift` = video shift only, `AUDIO_SIGMA_SHIFT` constant, `supports_lora: true`) was read directly from `origin/feature/sc-17137-minimax-h3` in the inference repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
