### PR TITLE
MiniMax-H3: re-point the 21:9 caveat at the pin bump, and give ui.description a Simple reader (sc-17162)

### DIFF
--- a/apps/web/public/prompt-guides/minimax-h3.md
+++ b/apps/web/public/prompt-guides/minimax-h3.md
@@ -79,7 +79,7 @@ budget. Ratios between 1:4 and 4:1 are accepted.
 | 1024x768 / 768x1024 | 4:3 and 3:4. |
 | 768x768 | Square. |
 | 1344x768 / 768x1344 | Full size, 16:9 and 9:16. The default, and the expensive one. |
-| 1536x672 / 672x1536 | 21:9 and its transpose. Same pixel budget as full size, same cost. **Pending an engine change — see below.** |
+| 1536x672 / 672x1536 | 21:9 and its transpose. Same pixel budget as full size, same cost. **Not renderable yet — see below.** |
 
 Every bucket in the table is the same fixed area budget or less — the 21:9 pair is 1,032,192 px,
 byte for byte what 1344x768 is. **The bound is the area, not the long edge**, which is why a wider
@@ -87,12 +87,15 @@ canvas is not automatically a bigger one.
 
 > **The 21:9 pair is not renderable yet.** The area budget already accommodates it, but the engine
 > *also* caps each edge independently, and that per-edge ceiling currently sits below this pair's
-> long edge — so a 21:9 request is refused today even though the menu offers it. **inference PR
-> #640** raises the per-edge ceiling to the widest canvas the resolver can itself produce, which is
-> what makes this pair reachable. Until it lands, treat **1344x768** as the widest canvas that
-> actually renders; every other bucket above works now. **This row and #640 must not be separated at
-> merge** — shipping this table without that engine change re-advertises a canvas the engine
-> refuses.
+> long edge — so a 21:9 request is refused today even though the menu offers it. Treat **1344x768**
+> as the widest canvas that actually renders; every other bucket above works now.
+>
+> The engine-side fix exists and is **already merged** — inference PR #640 raised the per-edge
+> ceiling to the widest canvas the resolver can itself produce. That is not the same as SceneWorks
+> having it: this app runs a **pinned** engine revision, and the pinned revision predates #640, so
+> the refusal stands here today regardless. **What discharges this caveat is the inference pin bump
+> (sc-18650), not #640 being merged.** Do not delete this note on the strength of that PR being
+> closed — that is how the catalog goes back to advertising a canvas the pinned engine refuses.
 
 A keyframe is **stretched** onto the canvas, not letterboxed — crop your reference to the target
 shape first or the subject will distort.

--- a/apps/web/src/minimaxH3CatalogCopy.test.jsx
+++ b/apps/web/src/minimaxH3CatalogCopy.test.jsx
@@ -301,24 +301,51 @@ describe("MiniMax-H3 prompt guide (sc-17162)", () => {
     }
   });
 
-  it("marks the 21:9 pair as pending its engine change, and cites it in the repo it lives in", () => {
+  it("ties the 21:9 caveat to the PIN BUMP, not to the already-merged engine PR", () => {
     // The 21:9 pair is ADVERTISED in `limits.resolutions` and satisfies the area budget, but the
     // engine bounds each EDGE independently and that ceiling currently sits below 1536, so the
-    // bucket is offered and refused. The unblocking change is `inference` PR #640
-    // (`story/sc-17152-h3-max-size-1536`), which raises the per-edge ceiling to the widest canvas
-    // `resolve_canvas_size` itself emits.
+    // bucket is offered and refused.
     //
-    // Cite the INFERENCE PR, not a SceneWorks branch. I looked for `story/sc-17152-h3-max-size-1536`
-    // on the SceneWorks origin, found nothing, and concluded the dependency did not exist — it lives
-    // in the engine repo, correctly, because it is an engine change. A bare `sc-17152` would have
-    // repeated that error for the next reader: the story's own title is about dense-attention cost
-    // at long duration, and the branch borrows its number for the geometry-gate lineage rather than
-    // being that story's deliverable. The PR number is the unambiguous handle.
-    expect(/inference PR\s*\n?>?\s*#640/.test(guide), "guide must cite inference PR #640 by number").toBe(true);
+    // This assertion previously demanded the guide cite `inference` PR #640 as PENDING. **#640 is
+    // now MERGED** — `75d66db5`, the head merge commit on the engine's `feature/sc-17137-minimax-h3`
+    // — so that framing became a live trap rather than a citation. A reader following it finds a
+    // closed PR, concludes the caveat is discharged, deletes it, and SceneWorks goes back to
+    // advertising a canvas the engine refuses.
+    //
+    // The refusal did NOT end when #640 merged, because SceneWorks does not run the engine's branch
+    // head; it runs a PINNED revision. `Cargo.toml` pins `014134e3`, and `75d66db5` is not an
+    // ancestor of it (`git merge-base --is-ancestor 75d66db5 014134e3` exits 1). So the caveat is
+    // still substantively correct, for a DIFFERENT reason, and the citation has to name the event
+    // that actually ends it: **sc-18650's inference pin bump**.
+    //
+    // The three assertions below are the three ways this can go wrong: the discharging event goes
+    // unnamed; #640 gets named without saying it is already merged (re-arming the trap); or someone
+    // re-points the caveat back at #640 as the thing being waited on.
     expect(
-      /must not be separated at\s*\n?>?\s*merge/.test(guide),
-      "guide must say the row and the engine change ship together — this table alone re-advertises a refused canvas",
+      /\bsc-18650\b/.test(guide),
+      "guide must cite the inference pin bump (sc-18650) as what discharges the caveat",
     ).toBe(true);
+    // MEASURED, not assumed: the first form of this assertion was
+    // `/#640[^.]{0,120}\bmerged\b|\bmerged\b[^.]{0,120}#640/`, and deleting "already merged" from
+    // the sentence that actually makes the claim left it GREEN — because the guide says "#640" and
+    // "merged" a second time in the NEGATED clause below ("not #640 being merged"), and the regex
+    // matched those leftovers. Same defect the duration-range assertion had twice on this story.
+    // So it is sentence-scoped and the negated clause is excluded explicitly: what must exist is a
+    // sentence that names #640 and asserts its merged status AFFIRMATIVELY.
+    const sentences = guide.split(/(?<=[.!?])\s+/);
+    expect(
+      sentences.some(
+        (sentence) =>
+          /#640/.test(sentence) &&
+          /\bmerged\b/i.test(sentence) &&
+          !/\bnot\b[^.]{0,40}\bmerged\b/i.test(sentence),
+      ),
+      "guide names #640, so some sentence must affirmatively say it is already merged — a bare citation sends the reader to a closed PR",
+    ).toBe(true);
+    expect(
+      /\b(?:pending|awaiting|until|once|when|blocked (?:on|by))\b[^.]{0,120}#640/is.test(guide),
+      "guide must not frame #640 as the thing still being waited on — it is merged; the PIN is what is outstanding",
+    ).toBe(false);
     // NO NUMERIC PER-EDGE CEILING IN CATALOG COPY. The resolver's widest output is an engine
     // internal a user never sees, and writing it down dates the page the moment the resolver moves.
     // 1536 was also the plausible-but-wrong value — a 1536 ceiling would still refuse a canvas the

--- a/apps/web/src/simple/SimpleAudioStudio.jsx
+++ b/apps/web/src/simple/SimpleAudioStudio.jsx
@@ -7,7 +7,7 @@ import { buildSimpleAudioRequest } from "./simpleJobs.js";
 import { SimpleAudioDeck, SimpleTakeCard, takeGridColumns } from "./simpleAudioParts.jsx";
 import { useSimpleUi } from "./SimpleUiContext.js";
 import { useStudioState } from "./useStudioState.js";
-import { Chips, SheetSelect, StudioRunStatus, jobIsRunning, newestLocalJob } from "./studioParts.jsx";
+import { Chips, ModelDescription, SheetSelect, StudioRunStatus, jobIsRunning, newestLocalJob } from "./studioParts.jsx";
 
 // Simple Audio Studio (design handoff → Audio Studio redesign, epic 14361 / sc-14365).
 //
@@ -196,6 +196,9 @@ export function SimpleAudioStudio() {
           }))}
           value={selectedModel?.name ?? selectedModel?.id ?? "No audio model installed"}
         />
+        {/* sc-17162 — see the note in `studioParts.jsx`. `ui.description` had one reader in the
+            whole app (the advanced Models card), so Simple identified a model by NAME ALONE. */}
+        <ModelDescription model={selectedModel} />
         {mode === "speech" && voices.length ? (
           <SheetSelect
             label="Voice"

--- a/apps/web/src/simple/SimpleImageStudio.jsx
+++ b/apps/web/src/simple/SimpleImageStudio.jsx
@@ -24,6 +24,7 @@ import { SimpleLoraField, promptWithKeyword } from "./SimpleLoraField.jsx";
 import { SimpleLoraSheet } from "./SimpleLoraSheet.jsx";
 import {
   Chips,
+  ModelDescription,
   RefinePanel,
   ReferenceTile,
   SheetSelect,
@@ -391,6 +392,9 @@ export function SimpleImageStudio() {
             }))}
             value={selectedModel?.name ?? selectedModel?.id ?? "No image model installed"}
           />
+          {/* sc-17162 — see the note in `studioParts.jsx`. `ui.description` had one reader in the
+              whole app (the advanced Models card), so Simple identified a model by NAME ALONE. */}
+          <ModelDescription model={selectedModel} />
           <SheetSelect
             kind="grid"
             label="Resolution"

--- a/apps/web/src/simple/SimpleShell.test.jsx
+++ b/apps/web/src/simple/SimpleShell.test.jsx
@@ -174,6 +174,72 @@ describe("SimpleShell", () => {
     expect(container.querySelector(".su-nav-footer .su-switch")).toBeTruthy();
   });
 
+  // sc-17162 — `ui.description` had exactly ONE reader in the app: the advanced Models screen's
+  // card. Simple's only route there is "Manage", which switches the SHELL out from under the user,
+  // so a Simple user identified every model by NAME ALONE. That is a reachability gap, not a
+  // styling one: for MiniMax-H3 the string is the withheld-component disclosure, and a disclosure
+  // that renders only on a screen the reduced shell hands off to is not discharged for that shell's
+  // users.
+  //
+  // Driven through the REAL shell across all THREE studios, because the wiring is per-studio (three
+  // separate call sites of `ModelDescription`) and a test that only covered Video — where
+  // MiniMax-H3 lives — would have left Image and Audio silently unwired. Asserted against the
+  // fixture's own string rather than a literal, so it is the model's declared copy that is proven
+  // to reach the DOM.
+  it("renders the selected model's description in every Simple studio (sc-17162)", async () => {
+    // Eligibility is load-bearing here, not decoration: each studio picks its model out of the
+    // catalog on its own terms, and a fixture that fails that filter selects NOTHING, so the studio
+    // renders no model field and the assertion reads `undefined` for a reason that has nothing to
+    // do with the wiring under test. Both legs failed exactly that way in draft — Video needs video
+    // `capabilities`, and Audio resolves per MODE through `audioModelServesMode`, whose default
+    // "music" mode requires a declared `audio.editModes`. That is the argument for driving all
+    // three studios rather than extrapolating from whichever one happened to be green.
+    const described = (type, description, extra) => ({
+      ...IMAGE_MODEL,
+      id: `${type}_described`,
+      type,
+      ui: { ...IMAGE_MODEL.ui, description },
+      ...extra,
+    });
+    const image = described("image", "Image model. Declares what it does and does not do.", {
+      capabilities: ["text_to_image"],
+    });
+    const video = described("video", "Video model. Not the hosted product; 2K is unreachable.", {
+      capabilities: ["text_to_video", "image_to_video"],
+    });
+    const audio = described("audio", "Audio model. Mono only, and no voice cloning.", {
+      capabilities: ["text_to_audio"],
+      audio: { editModes: ["generate"], sampleRates: [44100] },
+    });
+    const context = baseContext({
+      imageModels: [image],
+      videoModels: [video],
+      audioModels: [audio],
+      models: [image, video, audio],
+    });
+
+    await renderShell(root, context);
+    expect(container.querySelector(".su-model-desc")?.textContent).toBe(image.ui.description);
+
+    await click(navButton(container, "Video"));
+    expect(container.querySelector(".su-topbar-title strong").textContent).toBe("Video Studio");
+    expect(container.querySelector(".su-model-desc")?.textContent).toBe(video.ui.description);
+
+    await click(navButton(container, "Audio"));
+    expect(container.querySelector(".su-topbar-title strong").textContent).toBe("Audio Studio");
+    expect(container.querySelector(".su-model-desc")?.textContent).toBe(audio.ui.description);
+  });
+
+  it("renders nothing where a model declares no description (sc-17162)", async () => {
+    // Rendering nothing is always correct — a model that declares no description owes none — and
+    // this is the anti-vacuity guard for the assertion above: without it, a `ModelDescription` that
+    // emitted an empty <p> for every model would still satisfy a querySelector-is-truthy check.
+    // `IMAGE_MODEL` declares `ui` but no `description`, which is the common catalog shape.
+    expect(IMAGE_MODEL.ui.description).toBeUndefined();
+    await renderShell(root, baseContext());
+    expect(container.querySelector(".su-model-desc")).toBeNull();
+  });
+
   it("navigates between screens from the sidebar", async () => {
     await renderShell(root, baseContext());
     await click(navButton(container, "Queue"));

--- a/apps/web/src/simple/SimpleVideoStudio.jsx
+++ b/apps/web/src/simple/SimpleVideoStudio.jsx
@@ -16,6 +16,7 @@ import { SimpleLoraField, promptWithKeyword } from "./SimpleLoraField.jsx";
 import { SimpleLoraSheet } from "./SimpleLoraSheet.jsx";
 import {
   Chips,
+  ModelDescription,
   RefinePanel,
   ReferenceTile,
   SheetSelect,
@@ -308,6 +309,12 @@ export function SimpleVideoStudio() {
               shell, not a subset view, so a licence obligation discharged only in Advanced would
               be undischarged for every Simple user. */}
           <ModelAttribution model={selectedModel} />
+          {/* sc-17162 — the model's own `ui.description`, which until now rendered ONLY on the
+              advanced Models screen. For MiniMax-H3 that string is the withheld-component
+              disclosure (not the hosted Hailuo product, 2K unreachable, dense attention ⇒ a ~2
+              hour render at full canvas), so a Simple user picked the model on its name alone.
+              Below the attribution, which is a licence obligation and outranks it. */}
+          <ModelDescription model={selectedModel} />
           <SheetSelect
             kind="grid"
             label="Resolution"

--- a/apps/web/src/simple/SimpleVideoStudio.minimaxH3.test.jsx
+++ b/apps/web/src/simple/SimpleVideoStudio.minimaxH3.test.jsx
@@ -176,6 +176,33 @@ describe("SimpleVideoStudio with MiniMax-H3 (sc-17161)", () => {
     expect(hint.textContent).toContain("15s is refused");
   });
 
+  it("renders the model's declared description, not just its name (sc-17162)", async () => {
+    // `ui.description` had ONE reader in the whole app — the advanced Models screen's card. Simple's
+    // only route there is "Manage", which switches the SHELL, so a Simple user identified the model
+    // by NAME ALONE and never met the withheld-component disclosure the string carries: not the
+    // hosted Hailuo product, 2K unreachable, dense attention. Same gap and same fix as the duration
+    // hint above.
+    //
+    // Read back out of the DOM and compared against the MANIFEST string, not a typed literal, so
+    // copy edits travel and a description that renders empty is red. The two extra assertions pin
+    // the load-bearing halves of the disclosure specifically: a rewrite that keeps the field
+    // non-empty but drops what the withheld components cost would otherwise stay green.
+    await openVideo(baseContext());
+    const description = container.querySelector(".su-model-desc");
+    expect(description, "Simple must carry the model's description, not only its name").toBeTruthy();
+    expect(description.textContent).toBe(MINIMAX.ui.description);
+    expect(description.textContent).toContain("H3-Regenerate-2K");
+    expect(description.textContent).toContain("not the hosted Hailuo product");
+    // It must sit BELOW the licence attribution, which is an obligation to display prominently and
+    // outranks descriptive copy. Asserted by document order rather than by CSS.
+    const attribution = container.querySelector(".model-attribution");
+    expect(attribution, "the licence attribution must still render").toBeTruthy();
+    expect(
+      attribution.compareDocumentPosition(description) & Node.DOCUMENT_POSITION_FOLLOWING,
+      "the description must follow the licence attribution, not precede it",
+    ).toBeTruthy();
+  });
+
   it("sends the exact declared duration, not the rounded label", async () => {
     const context = baseContext();
     await openVideo(context);

--- a/apps/web/src/simple/simple.css
+++ b/apps/web/src/simple/simple.css
@@ -979,6 +979,18 @@
   color: var(--text-muted);
 }
 
+/* The model's declared `ui.description` under the Model field (sc-17162). Muted, like
+   `.model-card-description` on the advanced Models card and unlike `.model-attribution`
+   immediately above it — the attribution is a licence obligation that must read prominently,
+   this is context about the model. Wraps: descriptions are full sentences (~300 characters
+   median across the catalog), so no ellipsis and no nowrap. */
+.su-model-desc {
+  margin: 2px 0 0;
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
 /* Context, not a warning — so no border, no danger/warm tint. */
 .su-lora-hint {
   display: flex;

--- a/apps/web/src/simple/studioParts.jsx
+++ b/apps/web/src/simple/studioParts.jsx
@@ -175,6 +175,32 @@ export function SheetSelect({ label, value, options, onSelect, title, kind = "li
   );
 }
 
+// sc-17162 — the model's declared `ui.description`, under the Model field it describes.
+//
+// `ui.description` had exactly ONE reader in the whole app: the advanced Models screen's card
+// (`ModelManagerScreen.jsx`). Simple is an alternative shell, not a subset view, and its only route
+// to that screen is "Manage", which switches the shell out from under the user — so a Simple user
+// who never leaves Simple met the model by NAME ALONE. That is the same reachability gap sc-17227
+// closed for `ui.attribution` and 28b5fea6d closed for `ui.durationHint`, and it is the expensive
+// one here: `description` is where the withheld-component disclosure lives (H3-Context-IR and
+// H3-Regenerate-2K are unreleased, so this is not the hosted Hailuo product and 2K is unreachable;
+// sparse attention is unreleased, so the shortest clip at full canvas is a ~2 hour render). A
+// disclosure that only renders on a screen the reduced shell hands off to is not discharged for
+// the users of that shell.
+//
+// Read off the SELECTED model rather than special-cased, so every model with a declared description
+// gets one and a family added later needs no change here. Rendering nothing is always correct: a
+// model that declares no description owes none. Deliberately NOT falling back to `family`/`id` the
+// way the advanced card does — the card needs a non-empty body, whereas here the name is already on
+// the field directly above, so a fallback would just repeat it.
+export function ModelDescription({ model = null, className = "su-model-desc" }) {
+  const description = model?.ui?.description;
+  if (typeof description !== "string" || !description.trim()) {
+    return null;
+  }
+  return <p className={className}>{description.trim()}</p>;
+}
+
 // `label` doubles as the visible field label and the group's accessible name. A caller
 // that already has a heading above the row (Settings' "Default quality" card) passes only
 // `ariaLabel`, so no empty <label> is emitted.

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -13387,12 +13387,21 @@
         //      BELOW this entry's advertised 21:9 pair. So `1536x672` / `672x1536` are ADVERTISED
         //      BUT NOT YET RENDERABLE: the area check passes and the edge check refuses.
         //
-        //      ⚠️ THE UNBLOCKING CHANGE IS IN THE ENGINE REPO, NOT THIS ONE — inference PR #640
-        //      (`story/sc-17152-h3-max-size-1536`), which raises the per-edge ceiling to the widest
-        //      canvas `resolve_canvas_size` itself emits. **This entry's 21:9 buckets and #640 must
-        //      not be separated at merge**: shipping these two `resolutions` values without that
-        //      engine change advertises a canvas the engine refuses. The prompt guide's *Sizes*
-        //      section carries the same caveat for the user and is pinned by
+        //      ⚠️ #640 IS MERGED, AND THIS CAVEAT STILL STANDS — DO NOT DELETE IT ON THAT NEWS.
+        //      inference PR #640 (`story/sc-17152-h3-max-size-1536`) raised the per-edge ceiling to
+        //      the widest canvas `resolve_canvas_size` itself emits, and merged into the engine's
+        //      `feature/sc-17137-minimax-h3` as `75d66db5`. That is not the same as SceneWorks
+        //      HAVING it: `Cargo.toml` pins inference at `014134e3`, and `75d66db5` is not an
+        //      ancestor of that pin (`git merge-base --is-ancestor 75d66db5 014134e3` exits 1), so
+        //      the engine this app actually runs still refuses the pair.
+        //
+        //      **WHAT DISCHARGES THIS CAVEAT IS THE PIN BUMP (sc-18650), NOT #640 BEING MERGED.**
+        //      This note previously read "pending inference PR #640", which is now a trap: a reader
+        //      who checks that PR finds it closed, concludes the caveat is obsolete, deletes it, and
+        //      SceneWorks re-advertises a canvas the pinned engine refuses — the exact failure the
+        //      note exists to prevent. It is re-pointed at the pin bump so the citation ends when
+        //      the refusal does. The prompt guide's *Sizes* section carries the same caveat for the
+        //      user, names the same discharging event, and is pinned by
         //      `minimaxH3CatalogCopy.test.jsx`.
         //
         //      Do NOT write the new ceiling's VALUE here or in the copy. It is an engine internal


### PR DESCRIPTION
Two decision-free remainders of sc-17162, batched into one PR because they are small and both are the same shape: **the copy names something the user cannot reach.**

The two open product calls on sc-17162 — whether a 2K upscale path is offered, and whether prompt refinement is offered as an opt-in control — are **untouched**. Neither the 2K paragraph's routing stance nor the Refine control is modified here.

---

## 1. The 21:9 caveat cited a MERGED PR (time-sensitive)

`apps/web/public/prompt-guides/minimax-h3.md:82,88-98` and the mirrored manifest comment at `config/manifests/builtin.models.jsonc:13390-13405` both told the reader the 21:9 pair was *"pending inference PR #640"*.

**#640 is merged** — `75d66db50543ac288deb278853d0f0b432f92c5c`, the head merge commit on `SceneWorks/inference` `feature/sc-17137-minimax-h3`. Left alone, the next reader follows the citation, finds a closed PR, concludes the caveat is obsolete, deletes it, and SceneWorks re-advertises a canvas the engine refuses.

**The caveat is still substantively correct, for a different reason.** SceneWorks does not run the engine's branch head; it runs a **pinned** revision. `Cargo.toml:148` pins `014134e3035ad7e4eca5c2ed7bded2375dc3c071`, and `75d66db5` is **not** an ancestor of it:

```
git merge-base --is-ancestor 75d66db50 014134e3035ad7e4eca5c2ed7bded2375dc3c071  →  exit 1
```

So the pinned engine still refuses the pair today, and what ends the refusal is **sc-18650's pin bump**. Both surfaces are re-pointed there, and both now state that #640 is *already merged* rather than citing it bare — the merged status is the half that stops the next reader repeating the mistake in either direction.

The second partition (`minimax_h3_ref`) needs no change: its `limits` comment defers to this entry by cross-reference rather than restating the caveat.

### The guarding assertion had the epic's recurring defect

`minimaxH3CatalogCopy.test.jsx` is re-pointed with the copy. Worth flagging: my **first replacement form survived its own mutation**. It was

```js
/#640[^.]{0,120}\bmerged\b|\bmerged\b[^.]{0,120}#640/is
```

and deleting *"already merged"* from the sentence that actually makes the claim left it **green** — because the guide says "#640" and "merged" a second time in the **negated** clause below (*"not #640 being merged"*), and the regex matched those leftovers. That is the same defect the duration-range assertion had twice earlier on this story. It is now sentence-scoped with the negated clause excluded, so what it pins is an *affirmative* claim.

---

## 2. `ui.description` had exactly one reader in the whole app

`apps/web/src/screens/ModelManagerScreen.jsx:1267`, the advanced Models card. Simple's only route there is **"Manage"**, which switches the *shell* out from under the user — so a Simple user identified every model by **name alone**.

That is a reachability gap, not a styling one. For MiniMax-H3 the string *is* the withheld-component disclosure this story exists to write (not the hosted Hailuo product, 2K unreachable, dense attention ⇒ a ~2 hour render at full canvas). A disclosure that renders only on a screen the reduced shell hands off to is not discharged for that shell's users. Same gap and same argument as `ui.durationHint` in 28b5fea6d, and as `ui.attribution` in sc-17227.

`ModelDescription` (`simple/studioParts.jsx`) follows the `ModelAttribution` precedent: read off the selected model, renders nothing when none is declared, no family special-cased, muted register so it does not compete with the licence attribution above it (which is an obligation to display *prominently* and outranks it — asserted by document order).

Wired into **all three** Simple studios. `description` is model-generic where `durationHint` was video-only, so covering Video alone would have left Image and Audio silently unwired — which is exactly how the first draft of the test failed.

---

## Verification (every command unpiped, real exit codes)

| Command | Exit |
|---|---|
| `npx vitest run --environment jsdom` (full web suite, 254 files / 3718 tests) | **0** |
| `npm run check` (438 node:test assertions) | **0** |
| `npm run lint` (`eslint src`) | **0** |
| `npm run build` (vite) | **0** |
| `cargo test -p sceneworks-core --lib builtin_manifests` (26 passed) | **0** |
| `node scripts/generate-memory-matrix.mjs --check` | **0**, unchanged |

The memory matrix did **not** need regenerating: the manifest edit is comment-only, so no fingerprinted *parsed* content moved. (A `description` string edit does rotate hashes — a comment edit does not.) **No Rust file is touched by this PR.**

`origin/feature/sc-17137-minimax-h3` was re-fetched before and after the work; the branch base is `dfe3ef5e4` and the tip has not moved, so there was nothing to merge.

## Mutation evidence — 8 mutations, each applied and restored INDIVIDUALLY, all red, no survivors

| # | Mutation | Result |
|---|---|---|
| M1 | re-point the guide back to "pending inference PR #640" | red — pin-bump assertion |
| M2 | delete the `sc-18650` citation | red — pin-bump assertion |
| M3 | drop "already merged" from the #640 sentence | red — affirmative-merged assertion *(this is the one that survived the first form)* |
| M4 | re-arm the "pending #640" framing while **keeping** sc-18650 | red — negative assertion, alone |
| M5 | delete the **Video** studio render site | red |
| M6 | delete the **Image** studio render site | red |
| M7 | delete the **Audio** studio render site | red |
| M8 | make `ModelDescription` emit a vacuous `<p>` instead of nothing | red — anti-vacuity guard only |

Baseline green before and after the full mutation run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)