### PR TITLE
fix(rust-api): make the parked cache-stage candidate deterministic (sc-19806)

### DIFF
--- a/apps/rust-api/src/catalogs.rs
+++ b/apps/rust-api/src/catalogs.rs
@@ -203,15 +203,6 @@ impl CatalogCacheStageTestSignal {
 #[cfg(test)]
 struct CatalogCacheStageTestHook {
     claimed: std::sync::atomic::AtomicBool,
-    /// Set the first time the shortened candidate budget is handed out, so
-    /// EXACTLY ONE candidate ever gets it — the one this hook parks. It used to
-    /// be handed to every candidate for as long as the hook was installed,
-    /// including the replacement candidate the hook test needs to SUCCEED; on a
-    /// loaded runner that replacement blew the 100 ms budget too and signalled a
-    /// second, unexpected timeout. Keying off `claimed` instead would still
-    /// race, because the claim happens inside the verifier, after the budget has
-    /// already been chosen.
-    short_budget_issued: std::sync::atomic::AtomicBool,
     /// Stall injected into the staging verifier BEFORE it claims the hook, so a
     /// test can put the candidate budget's expiry ahead of the `before_stage`
     /// meeting point deterministically. That is the ordering a loaded CI runner
@@ -303,7 +294,6 @@ pub(crate) fn install_catalog_cache_stage_test_hook(
 ) -> CatalogCacheStageTestControl {
     let hook = std::sync::Arc::new(CatalogCacheStageTestHook {
         claimed: std::sync::atomic::AtomicBool::new(false),
-        short_budget_issued: std::sync::atomic::AtomicBool::new(false),
         verifier_delay,
         before_stage: CatalogCacheStageTestRendezvous::new("before_stage"),
         release_stage: CatalogCacheStageTestRendezvous::new("release_stage"),
@@ -775,7 +765,7 @@ pub(crate) async fn materialize_catalog_results(
                 break 'pages;
             }
             let acquired = tokio::time::timeout(
-                remaining.min(materialization_candidate_timeout()),
+                remaining.min(materialization_candidate_timeout(staging_token)),
                 acquire_materialization_source(
                     &catalog_root,
                     staging.path(),
@@ -1043,11 +1033,15 @@ fn verified_cached_source(
     let content_hash = verified.content_hash;
     verify_record_content_hash(record, &content_hash)?;
     #[cfg(test)]
-    sleep_catalog_cache_stage_test_verifier_delay();
-    #[cfg(test)]
-    let claimed_test_hook = claim_catalog_cache_stage_test_hook();
+    let claimed_test_hook = claim_catalog_cache_stage_test_hook(index);
     #[cfg(test)]
     if let Some(hook) = &claimed_test_hook {
+        // Stall AFTER claiming, never before. Sleeping first put a 400 ms
+        // scheduler-dependent gap between the two verifiers' claims, which is
+        // how the parked candidate stopped being deterministic (sc-19806).
+        if !hook.verifier_delay.is_zero() {
+            std::thread::sleep(hook.verifier_delay);
+        }
         hook.before_stage.wait();
         hook.release_stage.wait();
     }
@@ -1081,50 +1075,52 @@ fn verify_record_content_hash(record: &CatalogRecord, actual: &str) -> Result<()
     Ok(())
 }
 
-fn materialization_candidate_timeout() -> std::time::Duration {
-    // The shortened budget belongs to the ONE candidate the cache-stage hook
-    // parks, not to every candidate for as long as the hook is installed. The
-    // hook test needs its *replacement* candidate to succeed, and on a loaded
-    // runner that replacement blew the short budget too (sc-19764).
-    #[cfg(test)]
-    if catalog_cache_stage_test_hook()
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .as_ref()
-        .is_some_and(|hook| {
-            hook.short_budget_issued
-                .compare_exchange(
-                    false,
-                    true,
-                    std::sync::atomic::Ordering::SeqCst,
-                    std::sync::atomic::Ordering::SeqCst,
-                )
-                .is_ok()
-        })
+/// The shortened budget, and the staging park, belong to this candidate and no
+/// other.
+///
+/// Both used to be first-come: whichever verifier thread reached the CAS first
+/// won. The two verifiers reach it only ~166 ms apart (measured: candidate 1 at
+/// t=406 ms, candidate 2 at t=572 ms), each after a `thread::sleep` whose
+/// wake-up is at the scheduler's discretion, so on a slower host candidate 2
+/// could win — and when it did, the hook parked the replacement candidate that
+/// the test needs to SUCCEED. The request then blocked forever awaiting that
+/// parked verifier, `before_project_copy` and `release_stage` were each left
+/// without a partner, and the test failed at the 120 s rendezvous bound
+/// (sc-19806, seen on the hosted macOS runner). Keying on the candidate index
+/// makes it deterministic on any host, at any speed.
+#[cfg(test)]
+const CATALOG_CACHE_STAGE_TEST_PARKED_CANDIDATE: usize = 1;
+
+#[cfg(test)]
+fn materialization_candidate_timeout(candidate_index: usize) -> std::time::Duration {
+    // Only the parked candidate gets the short budget. Every other candidate —
+    // including the replacement this test needs to succeed — keeps the
+    // production budget (sc-19764).
+    if candidate_index == CATALOG_CACHE_STAGE_TEST_PARKED_CANDIDATE
+        && catalog_cache_stage_test_hook()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_some()
     {
         return CATALOG_CACHE_STAGE_TEST_CANDIDATE_TIMEOUT;
     }
     MATERIALIZATION_CANDIDATE_TIMEOUT
 }
 
-/// Runs on the staging verifier's `spawn_blocking` thread, so the stall never
-/// touches a test's runtime thread.
-#[cfg(test)]
-fn sleep_catalog_cache_stage_test_verifier_delay() {
-    let delay = catalog_cache_stage_test_hook()
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .as_ref()
-        .map_or(std::time::Duration::ZERO, |hook| hook.verifier_delay);
-    if !delay.is_zero() {
-        std::thread::sleep(delay);
-    }
+#[cfg(not(test))]
+fn materialization_candidate_timeout(_candidate_index: usize) -> std::time::Duration {
+    MATERIALIZATION_CANDIDATE_TIMEOUT
 }
 
 #[cfg(test)]
-fn claim_catalog_cache_stage_test_hook() -> Option<std::sync::Arc<CatalogCacheStageTestHook>> {
+fn claim_catalog_cache_stage_test_hook(
+    candidate_index: usize,
+) -> Option<std::sync::Arc<CatalogCacheStageTestHook>> {
     use std::sync::atomic::Ordering;
 
+    if candidate_index != CATALOG_CACHE_STAGE_TEST_PARKED_CANDIDATE {
+        return None;
+    }
     let hook = catalog_cache_stage_test_hook()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)


### PR DESCRIPTION
Fixes the hosted-macOS red introduced by #2354's own regression test. **Fix-forward — do not revert #2354**, whose root-cause fix is proven (`parity-rust` went from cancelled-at-30m to passing in 8m39s).

## The failure

`tests::dataset_catalogs::timed_out_cache_verifier_survives_a_budget_that_expires_before_the_stage_rendezvous`, hosted macOS runner, PR #2342 head `1a86877fe`, run 31919160091 job 95096087066 — 603 passed / 1 failed in 218.95 s:

```
panicked at apps/rust-api/src/catalogs.rs:133:13:
catalog cache stage test rendezvous `before_project_copy` had no partner within 120s
catalog cache stage test rendezvous `release_stage` had no partner within 120s
panicked at apps/rust-api/src/catalogs.rs:254:14: JoinError::Panic(...)
```

## Hypothesis (A), established causally

Two hypotheses were on the table: (A) the choreography genuinely mispairs on slower hardware, or (B) the 120 s partner bound is too tight. **It is (A).** The detector was reporting a real defect.

Both the shortened candidate budget and the staging park were **first-come**: whichever verifier thread reached the CAS first won. Measured locally with a timestamped probe:

```
PROBE t=125ns          index=1 entered
PROBE t=138.155917ms   index=2 entered
PROBE t=406.218292ms   index=1 claim=true
PROBE t=572.638542ms   index=2 claim=true(forced)
```

The two claims are only **~166 ms apart**, and each is preceded by a `thread::sleep(400ms)` whose wake-up is at the scheduler's discretion. On a slower host candidate 2 can win. When it does, the hook parks the **replacement** candidate the test needs to *succeed*; the request then blocks forever awaiting that parked verifier, leaving `before_project_copy` and `release_stage` each without a partner.

Proven by **forcing** candidate 2 to win the claim, which reproduces the CI failure exactly — same two rendezvous, same panic sites (`:133` and `:254`), same `JoinError::Panic` wrapper. That is causation, not correlation.

Note this defect is in the **test scaffolding sc-19764 added**, not in the production hook. Pre-#2354 the hook test used no verifier delay, so candidate 1 claimed ~100 ms before candidate 2's verifier even started and the race was unreachable.

## Ancestry — answered

The failing tree **did** contain #2354. The test named in the failure was introduced by `ec638c97c` (#2354) and exists nowhere else, so the tree that failed necessarily included the fix. (`git log -S` on the test name returns exactly that commit.) A direct `merge-base --is-ancestor d359ad70c 1a86877fe` reads NO only because `1a86877fe` is the PR *head*; `pull_request` events test the head+base **merge ref**, and base included #2354 from `01:13:34Z`, two minutes before the run was created at `01:15:35Z`. Both lines agree.

## Fix

Key both decisions on the candidate index (`CATALOG_CACHE_STAGE_TEST_PARKED_CANDIDATE`) rather than on which thread arrives first, and stall the verifier **after** claiming rather than before, so no sleep sits between entry and the claim. Deterministic on any host at any speed. The `short_budget_issued` CAS becomes dead and is removed.

The 120 s rendezvous bound is **unchanged** and the detector keeps naming the mispairing — the report was correct and should stay loud. No bound was raised, no gate added.

## Verification

| command | exit |
|---|---|
| forced-inversion repro (index 2 claims) | `101` — reproduces the CI signature exactly |
| both hook cases, after fix | `0` — 2 passed in 1.15 s |
| `cargo test -p sceneworks-rust-api --lib --no-run` | `0` |

**Not yet run on this branch: full `cargo test`, clippy, fmt-check.** Session is winding down; CI on this PR is the gate. Flagging that explicitly rather than implying broader local verification than I did.

## Open, for the next session

The five sibling `dataset_catalogs` tests failing with `catalog scan supervisor becomes idle: Elapsed(())` at `dataset_catalogs.rs:36` are a **separate** bound (the flat 60 s idle cap), tracked as sc-19801 with a work-derived replacement already drafted on `claude/sc-scan-idle-stall-bound`. Whether this PR also resolves those is the discriminator described on sc-19764 — if they keep flaking after this lands, they are the 60 s cap and not the choreography.

Shortcut: sc-19806

🤖 Generated with [Claude Code](https://claude.com/claude-code)