### PR TITLE
fix(canary): shorten watchdog socket path (SC-19741)

### DIFF
--- a/scripts/memory-calibration-watchdog.py
+++ b/scripts/memory-calibration-watchdog.py
@@ -502,11 +502,28 @@ def guard(args: argparse.Namespace) -> int:
     attestation_directory = None
     attestation_path = None
     if args.require_child_attestation:
-        attestation_directory = Path(tempfile.mkdtemp(prefix="sceneworks-watchdog-attestation-"))
-        attestation_path = attestation_directory / "watchdog.sock"
-        attestation_listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        attestation_listener.bind(str(attestation_path))
-        attestation_listener.listen(1)
+        try:
+            # Darwin's sockaddr_un path is capped at 104 bytes. The caller may
+            # put TMPDIR on a deliberately long external-volume path for large
+            # build artifacts, so keep this tiny, mode-0700 rendezvous under the
+            # system's short temporary root.
+            short_temp_root = Path("/tmp")
+            if not short_temp_root.is_dir():
+                short_temp_root = Path(tempfile.gettempdir())
+            attestation_directory = Path(tempfile.mkdtemp(
+                prefix="sceneworks-watchdog-attestation-", dir=short_temp_root))
+            attestation_path = attestation_directory / "watchdog.sock"
+            attestation_listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            attestation_listener.bind(str(attestation_path))
+            attestation_listener.listen(1)
+        except BaseException:
+            if attestation_listener is not None:
+                attestation_listener.close()
+            if attestation_path is not None:
+                attestation_path.unlink(missing_ok=True)
+            if attestation_directory is not None:
+                attestation_directory.rmdir()
+            raise
     previous_handlers = {
         signum: signal.getsignal(signum) for signum in (signal.SIGINT, signal.SIGTERM)
     }

--- a/scripts/memory-calibration-watchdog.test.mjs
+++ b/scripts/memory-calibration-watchdog.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile, spawn } from "node:child_process";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -141,6 +141,7 @@ async function runWithMockedProductionTelemetry(files, childCommand, options = {
     telemetryTimeout = 0.5, actualHostMemory = 1000, requestedHostMemory = 1000,
     memoryFreePercent = 90, memoryFreeBytes = 900, swapFreeBytes = 900,
     pressureSamples = [[memoryFreePercent, memoryFreeBytes, swapFreeBytes]],
+    environment = process.env,
   } = options;
   const launcher = `${files.program}.production-watchdog.py`;
   await writeFile(launcher, String.raw`import importlib.util, sys
@@ -169,7 +170,7 @@ sys.argv = [${JSON.stringify(WATCHDOG)},
     "--require-child-attestation", "--", *${JSON.stringify(childCommand)}]
 raise SystemExit(module.guard(module.parse_args()))
 `);
-  return execFileAsync("python3", [launcher], { timeout: 10_000 });
+  return execFileAsync("python3", [launcher], { timeout: 10_000, env: environment });
 }
 
 test("physical-footprint hard stop terminates the responsive owned group with no residue", async () => {
@@ -321,6 +322,48 @@ while True:
   assert.ok(events.slice(0, attested).some((event) =>
     event.event === "sample" && event.phase === "child_attested_before_allocation"));
   assert.ok(events.some((event) => event.event === "child_completed"));
+});
+
+test("child attestation uses a short socket path when TMPDIR is a long external path", async (t) => {
+  if (process.platform !== "darwin") {
+    t.skip("the production safety canary is categorically Darwin-only");
+    return;
+  }
+  const files = await fixture();
+  const longTmpRoot = await mkdtemp(path.join(tmpdir(), "sc19741-long-external-tmp-"));
+  t.after(() => rm(longTmpRoot, { recursive: true, force: true }));
+  const longTmp = path.join(
+    longTmpRoot,
+    "nested-external-campaign-directory".repeat(4),
+  );
+  await mkdir(longTmp, { recursive: true });
+  const attester = `${files.program}.long-tmp-attest.py`;
+  const socketRecord = `${files.pids}.socket`;
+  await writeFile(attester, String.raw`import json, os, socket, sys
+socket_path = os.environ["SCENEWORKS_MEMORY_WATCHDOG_SOCKET"]
+open(sys.argv[1], "w").write(socket_path + "\n")
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect(socket_path)
+def line():
+    data = b""
+    while not data.endswith(b"\n"): data += sock.recv(1)
+    return data.decode().strip()
+payload = json.loads(line()); nonce = payload["nonce"]
+sock.sendall(f"ACK {nonce}\n".encode())
+assert line() == f"GO {nonce}"
+sock.sendall(f"DONE {nonce}\n".encode())
+while True:
+    message = line()
+    if message == f"BYE {nonce}": break
+    assert message == f"PING {nonce}"
+`);
+  await runWithMockedProductionTelemetry(files, ["python3", attester, socketRecord], {
+    environment: { ...process.env, TMPDIR: longTmp },
+  });
+  const socketPath = (await readFile(socketRecord, "utf8")).trim();
+  assert.equal(path.dirname(path.dirname(socketPath)), "/tmp");
+  assert.ok(socketPath.length < 104, `socket path is ${socketPath.length} bytes`);
+  assert.equal(socketPath.startsWith(longTmp), false);
 });
 
 test("a child that cannot attest is terminated with no owned residue", async () => {


### PR DESCRIPTION
## Summary
- keep the child-attestation AF_UNIX rendezvous under a short mode-0700 `/tmp` directory even when the canary uses a long external `TMPDIR`
- clean partial socket setup on bind/listen failure
- add a Darwin long-external-TMPDIR regression test

The first bounded canary attempt failed closed before provider/model load with `AF_UNIX path too long`; no receipt was emitted. This patch does not change thresholds, tuple, admission, telemetry, or campaign refusal.

## Validation
- `npm run check` — 533/533
- watchdog suite — 23/23
- long-TMPDIR mutation reproduces the old AF_UNIX failure and passes with this patch
- `python3 -m py_compile scripts/memory-calibration-watchdog.py`
- `git diff --check`
- independent review PASS, confidence 0.98

No model, MLX device, weights, calibration, or NAX workload was run during the repair.