### PR TITLE
fix: an inference pin bump no longer invalidates capability dumps

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -580,7 +580,7 @@ jobs:
           echo ::error::git could not compare the checked-in capabilities.candle.json against the fresh dump. This is a tooling or missing-file failure, NOT a restamp - read the git error above.
           exit /b 1
           :restamped
-          echo ::error::config/engine-capabilities/capabilities.candle.json does not match a fresh dump at this pin. Re-dump it on a CUDA box with: cargo run -p sceneworks-worker --bin dump-engine-capabilities --no-default-features --features backend-candle - then run npm run gen:preview-support from apps/web. Do NOT just rewrite the inferenceRevision line.
+          echo ::error::config/engine-capabilities/capabilities.candle.json does not match a fresh dump. DOWNLOAD the backend-capability-facts-candle artifact from this run and commit its capabilities.candle.json - this job already produced the authoritative file, so there is no reason to re-dump by hand on a CUDA box. Then run npm run gen:preview-support from apps/web. Do NOT just rewrite the inferenceRevision line.
           exit /b 1
           :no_audio_file
           echo ::error::the dumper wrote capabilities.candle.json but no audio/capabilities.candle.json. This build links no audio registry, so every audio route is unverified here - both runtime bundles carry the audio lane default-on, so reconcile the build features with SCENEWORKS_AUDIO_BACKENDS.
@@ -589,7 +589,7 @@ jobs:
           echo ::error::git could not compare the checked-in audio/capabilities.candle.json against the fresh dump. This is a tooling or missing-file failure, NOT a restamp - read the git error above.
           exit /b 1
           :audio_restamped
-          echo ::error::config/engine-capabilities/audio/capabilities.candle.json does not match a fresh dump at this pin. Either box re-dumps it - the audio registry is candle-native everywhere - then run npm run gen:preview-support from apps/web. If the macOS lane passes this same check while this one fails, the two lanes have stopped producing identical audio bytes, which is what the shared file assumes. Do NOT just rewrite the inferenceRevision line.
+          echo ::error::config/engine-capabilities/audio/capabilities.candle.json does not match a fresh dump. DOWNLOAD the backend-capability-facts-candle artifact from this run and commit its audio/capabilities.candle.json - either box can produce it, the audio registry is candle-native everywhere, but this job already did. Then run npm run gen:preview-support from apps/web. If the macOS lane passes this same check while this one fails, the two lanes have stopped producing identical audio bytes, which is what the shared file assumes. Do NOT just rewrite the inferenceRevision line.
           exit /b 1
           :no_runtime_file
           echo ::error::the dumper wrote legacy facts but no runtime/capabilities.candle.json. The rich inference descriptor snapshot required by the backend matrix was not captured.

--- a/apps/web/src/data/previewSupportCatalog.test.js
+++ b/apps/web/src/data/previewSupportCatalog.test.js
@@ -237,21 +237,26 @@ describe("preview-support catalog: the stage-1 facts files are non-vacuous", () 
     },
   );
 
-  // The assertion `bump-inference.mjs` makes at bump time, made again where CI can actually see it.
-  // Without this, a pin edited outside the sanctioned script leaves every facts file — and therefore
-  // the entire served catalog — describing the PREVIOUS revision's descriptors, silently.
-  it.each(factsEntries.map((entry) => [entry.name, entry.facts]))(
-    "%s was dumped at the revision the worker currently pins",
-    (name, facts) => {
-      expect(facts.generatedFrom.inferenceRevision, `${name} vs crates/sceneworks-worker/Cargo.toml`)
-        .toBe(inferencePin);
-    },
-  );
-
-  it("the manifest stamps each backend's dump revision, and it is the current pin", () => {
+  // A capability dump is NOT invalidated by a pin bump.
+  //
+  // These two suites used to require every facts file, and every backend in the manifest, to carry
+  // the revision the worker currently pins. That made an ordinary pin bump invalidate the declared
+  // capabilities of both backends at once — and since a dump can only be produced on a lane that
+  // LINKS that backend, refreshing them meant a round trip to a second machine before CI could go
+  // green. Pins change constantly; declared capabilities almost never do. A dump goes stale when a
+  // provider gains or loses a capability, which is a property of the dump's CONTENT, not of the
+  // revision label attached to it.
+  //
+  // So the revision is recorded and no longer enforced. What still holds is the shape: each dump
+  // names a backend matching its filename, is not truncated, and carries a well-formed 40-hex
+  // revision (asserted above), and the manifest still stamps one per backend so the served catalog
+  // says which checkout produced it. Fourth instance of the same defect class — see sc-19728
+  // (decode-quality fingerprints), sc-19751 (license/provenance audits), sc-19758 (closure digests).
+  it("the manifest stamps a well-formed dump revision for each backend", () => {
     const manifest = JSON.parse(previewSupportManifestRaw);
+    expect(manifest.backends.length).toBeGreaterThan(0);
     for (const backend of manifest.backends) {
-      expect(manifest.generatedFrom[backend].inferenceRevision, backend).toBe(inferencePin);
+      expect(manifest.generatedFrom[backend].inferenceRevision, backend).toMatch(/^[0-9a-f]{40}$/);
     }
   });
 
@@ -533,14 +538,26 @@ describe("preview-support catalog: the audio registry is dumped too", () => {
     }
   });
 
-  it("refuses a media and audio dump of one backend at different revisions", () => {
-    // `candle` is dumped twice — once per registry — and the two must describe one checkout, or
-    // `generatedFrom` claims a state that never existed.
-    expect(() =>
-      derivePreviewSupport(rows, factsFiles, [
-        syntheticAudioFacts({ inferenceRevision: "0".repeat(40) }),
-      ]),
-    ).toThrow(/two different inference revisions/);
+  it("records both revisions when a backend's media and audio dumps disagree", () => {
+    // This used to THROW. `candle` is dumped once per registry, and the two were required to
+    // describe one checkout on the reasoning that anything else claims a state that never existed.
+    //
+    // But the two halves come off different machines: the media candle dump needs a lane that links
+    // the candle media engines (off-Mac), while the audio registry is candle-native everywhere and
+    // is rewritten by the macOS dump. Requiring agreement meant a Mac-side pin bump produced a tree
+    // this function rejected outright, and the derived catalog could not regenerate until a second
+    // machine had run. That is the ordinary mid-bump state of a two-lane repo, not a fiction.
+    //
+    // Inverted rather than deleted, so it is the observable proof of the removal: restoring the
+    // refusal turns this red.
+    const audioRevision = "0".repeat(40);
+    const derivedSplit = derivePreviewSupport(rows, factsFiles, [
+      syntheticAudioFacts({ inferenceRevision: audioRevision }),
+    ]);
+    expect(derivedSplit.generatedFrom.candle.audioInferenceRevision).toBe(audioRevision);
+    // The media half keeps the plain key, so consumers reading `.inferenceRevision` are unaffected.
+    expect(derivedSplit.generatedFrom.candle.inferenceRevision).toMatch(/^[0-9a-f]{40}$/);
+    expect(derivedSplit.generatedFrom.candle.inferenceRevision).not.toBe(audioRevision);
   });
 
   it("still derives when no audio dump is supplied, so the argument stays optional", () => {

--- a/apps/web/src/data/previewSupportDerivation.js
+++ b/apps/web/src/data/previewSupportDerivation.js
@@ -699,20 +699,34 @@ export function derivePreviewSupport(rows, factsFiles, audioFactsFiles = [], bes
   const sortedModels = {};
   for (const id of Object.keys(models).sort()) sortedModels[id] = models[id];
 
+  // `generatedFrom` records what produced each half. It used to REFUSE when a backend's media and
+  // audio dumps disagreed, on the reasoning that `candle` is both on every platform so a mismatch
+  // meant one was not re-dumped.
+  //
+  // That reasoning missed where the two come FROM. The media candle dump can only be produced on a
+  // lane that links the candle media engines — off-Mac — while the audio registry is candle-native
+  // everywhere, so the macOS dump rewrites the audio half and nothing else. Requiring them to agree
+  // therefore required BOTH machines to have run before the derived catalog could regenerate at all,
+  // and a Mac-side pin bump would leave the tree in a state this function rejected outright. That is
+  // not a checkout that never existed; it is the ordinary state of a two-lane repo mid-bump.
+  //
+  // Recording both revisions truthfully serves the original goal better than forcing them equal. A
+  // reader can now see exactly which checkout produced the media facts and which produced the audio
+  // facts, and a stale half is visible rather than fatal.
   const generatedFrom = {};
-  for (const entry of [...indexed, ...audioIndexed]) {
-    const existing = generatedFrom[entry.backend];
-    // The media and audio dumps of ONE backend must come from one revision — `candle` is both, on
-    // every platform. A disagreement means one of the two was not re-dumped at the current pin, and
-    // silently keeping either would make `generatedFrom` describe a checkout that never existed.
-    if (existing && existing.inferenceRevision !== entry.inferenceRevision) {
-      throw new Error(
-        `derivePreviewSupport: backend ${entry.backend} was dumped at two different inference ` +
-          `revisions (${existing.inferenceRevision} and ${entry.inferenceRevision}). Re-dump both ` +
-          "its media and audio facts at the pin the worker currently carries.",
-      );
-    }
+  for (const entry of indexed) {
     generatedFrom[entry.backend] = { inferenceRevision: entry.inferenceRevision };
+  }
+  for (const entry of audioIndexed) {
+    const existing = generatedFrom[entry.backend];
+    generatedFrom[entry.backend] = {
+      ...(existing ?? {}),
+      // Only carried separately when the two halves actually disagree, so the common single-revision
+      // case keeps its existing shape and consumers reading `.inferenceRevision` are unaffected.
+      ...(existing && existing.inferenceRevision !== entry.inferenceRevision
+        ? { audioInferenceRevision: entry.inferenceRevision }
+        : { inferenceRevision: entry.inferenceRevision }),
+    };
   }
 
   return {

--- a/scripts/bump-inference.mjs
+++ b/scripts/bump-inference.mjs
@@ -623,16 +623,22 @@ function verifyEngineCapabilityFacts(sha, root = repoRoot) {
     }
   }
   if (stale.length) {
-    throw new Error(
-      `engine-capability facts are stale for ${sha}:\n  ${stale.join("\n  ")}\n` +
-        "Each file must be re-dumped on the lane that owns it — one file per backend, so no lane " +
-        "overwrites another's:\n" +
-        "  macOS  : cargo run -p sceneworks-worker --bin dump-engine-capabilities\n" +
-        "  off-Mac: cargo run -p sceneworks-worker --bin dump-engine-capabilities " +
+    // REPORTED, not refused. A pin bump does not invalidate a capability dump: pins change
+    // constantly, declared capabilities almost never do. A dump goes stale when a provider gains or
+    // loses a capability — a property of its CONTENT, not of the revision label on it — and the only
+    // way to learn that is to re-dump on a lane that links the backend.
+    //
+    // Refusing here made every pin bump wait on a second machine, because the candle media dump can
+    // only be produced off-Mac. Landing a bump and re-dumping when that lane next runs leaves the
+    // catalog describing the previous revision's descriptors in the meantime, which is a stale
+    // label on accurate data far more often than it is a wrong capability.
+    console.warn(
+      `bump-inference: engine-capability facts still at an older revision (NOT blocking):\n  ${stale.join("\n  ")}\n` +
+        "  Re-dump on the lane that owns each file when convenient — one file per backend:\n" +
+        "    macOS  : cargo run -p sceneworks-worker --bin dump-engine-capabilities\n" +
+        "    off-Mac: cargo run -p sceneworks-worker --bin dump-engine-capabilities " +
         "--no-default-features --features backend-candle\n" +
-        "Either command also rewrites audio/ — the audio registry is candle-native on both lanes.\n" +
-        "then regenerate the derived catalog: (cd apps/web && npm run gen:preview-support). " +
-        "The pin itself is already written.",
+        "  then (cd apps/web && npm run gen:preview-support).",
     );
   }
   // Silent when driven from `--self-test`, which runs in `npm run check`: the fixture tree is a
@@ -947,23 +953,20 @@ source = "git+${INFERENCE_GIT}?rev=${SHA}#${CURRENT_COMMIT}"
       /audio engine-capability facts are missing/.test(missingAudio) &&
       /dump-engine-capabilities/.test(missingAudio),
   );
-  // Staleness must reach into the subdirectory too: an audio dump left at the previous pin describes
-  // descriptors that may have moved, exactly as a stale media dump does.
+  // Staleness is now WARNED about, not refused (see verifyEngineCapabilityFacts): a pin bump does
+  // not invalidate a capability dump, and blocking on one meant waiting for a second machine. What
+  // must survive is that a MISSING dump still fails — absence is a real coverage hole, whereas an
+  // older revision is a stale label on data that is usually still accurate.
   const staleAudio = verifyFacts({ revision: "b".repeat(40) });
-  check(
-    "a stale audio dump is reported, named by its subdirectory path",
-    !!staleAudio && /audio\/capabilities\.candle\.json/.test(staleAudio),
-  );
+  check("a stale audio dump no longer blocks the bump", staleAudio === null);
   const missingRuntime = verifyFacts({ runtime: false });
   check(
     "a missing rich runtime descriptor dump fails coverage",
     !!missingRuntime && /rich runtime descriptor facts are missing/.test(missingRuntime),
   );
+  // Same reasoning as the audio dump above: an older revision is warned about, not refused.
   const staleRuntime = verifyFacts({ runtimeRevision: "b".repeat(40) });
-  check(
-    "a stale rich runtime descriptor dump is reported by exact path",
-    !!staleRuntime && /runtime\/capabilities\.candle\.json/.test(staleRuntime),
-  );
+  check("a stale rich runtime descriptor dump no longer blocks the bump", staleRuntime === null);
   const narrowRuntime = verifyFacts({ narrowRuntime: true });
   check(
     "a narrow runtime projection without parity axes is refused",


### PR DESCRIPTION
> "These fucking PINS!!! Pins SHOULD NOT INVALIDATE CAPABILITIES OR MEASUREMENTS!!! PINS CHANGE CONSTANTLY" — Michael, 2026-08-16

He's right, and this is the fourth instance of the same defect in one day.

## The defect

A capability dump records what a backend's engines can do. It goes stale when a provider **gains or loses a capability** — a property of the dump's *content*. Three places instead treated the *revision label* as the thing, so every unrelated pin move invalidated both backends' capabilities at once:

| Where | What it did |
|---|---|
| `previewSupportCatalog.test.js` | required every facts file + every manifest backend to carry the current pin |
| `previewSupportDerivation.js:703` | **threw** when a backend's media and audio dumps disagreed |
| `bump-inference.mjs` | failed the bump closed on any stale facts file |

## Why the middle one cost a machine

The media candle dump can only be produced on a lane that **links the candle media engines** — off-Mac. The audio registry is candle-native *everywhere*, so the macOS dump rewrites the audio half and nothing else. Both report `backend: "candle"`, and `generatedFrom` was keyed by backend name alone, so they were forced to agree.

The consequence: **both machines had to have run before the derived catalog could regenerate at all.** An ordinary Mac-side pin bump produced a tree that `gen:preview-support` rejected outright —

```
derivePreviewSupport: backend candle was dumped at two different inference
revisions (e58fb08d… and 5ca75016…)
```

— which is not a checkout that never existed. It's the ordinary mid-bump state of a two-lane repo. That put a Windows/CUDA runner on the critical path of every pin bump.

## What changed

`generatedFrom` now **records what produced each half** instead of forcing them equal, which serves its own stated goal — not describing a checkout that never existed — better than the refusal did. The plain `inferenceRevision` key is unchanged in the common single-revision case, so consumers are unaffected; a disagreement adds `audioInferenceRevision` beside it.

## What still fails

Absence is a real coverage hole and stays fatal — a **missing** dump, a truncated one (<40 engines), a dump whose `backend` disagrees with its filename, or a revision that isn't well-formed 40-hex. An older label is usually a stale name on accurate data; a missing file is nothing at all.

## Evidence

Two tests are **inverted rather than deleted**, so each removal is observable — restoring either refusal turns them red:
- `records both revisions when a backend's media and audio dumps disagree` (was: `refuses a media and audio dump…`)
- the bump self-test's two stale-dump cases (now assert non-blocking; the **missing**-dump cases are untouched and still assert failure)

`node suite: 411 passed` · `web suite: 3647 passed` · `bump-inference --self-test: PASS`

## Series

- [sc-19728](https://app.shortcut.com/trefry/story/19728) decode-quality fingerprints — stamp, don't gate
- [sc-19751](https://app.shortcut.com/trefry/story/19751) license/provenance audits — report, don't gate
- [sc-19758](https://app.shortcut.com/trefry/story/19758) closure digests + the 11-step pin bump
- **this** — capability dumps

Same shape every time: a digest or label keyed to a whole revision, refusing on any change, re-derived by hand each time it fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)