### PR TITLE
fix(canary): retain watchdog failure reason (SC-19741)

### DIFF
--- a/scripts/run-ltx-safety-canary.mjs
+++ b/scripts/run-ltx-safety-canary.mjs
@@ -58,6 +58,45 @@ export function runtimeFreeFloor(memoryBytes) {
   return MIN_RUNTIME_FREE_BYTES + telemetryResolutionBytes(memoryBytes);
 }
 
+export function watchdogFailureSummary(status, eventBytes) {
+  let hardStopReason = null;
+  let validEvents = 0;
+  let malformed = false;
+  for (const line of eventBytes.trim() ? eventBytes.trim().split("\n") : []) {
+    try {
+      const event = JSON.parse(line);
+      validEvents += 1;
+      if (event?.event === "hard_stop" && typeof event.reason === "string"
+          && event.reason !== "") {
+        hardStopReason = event.reason;
+      }
+    } catch {
+      malformed = true;
+    }
+  }
+  let reason = "event_stream_unavailable";
+  if (hardStopReason !== null) {
+    reason = hardStopReason.replaceAll(/[\u0000-\u001f\u007f]/g, " ").slice(0, 512);
+    if (malformed) reason += ";event_stream_malformed";
+  } else if (malformed) {
+    reason = "event_stream_malformed";
+  } else if (validEvents > 0) {
+    reason = "hard_stop_event_absent";
+  }
+  return `watchdog failed closed: code=${status.code} signal=${status.signal} reason=${reason}`;
+}
+
+export function preservePrimaryFailure(primary, cleanup) {
+  if (primary === null) return cleanup;
+  if (cleanup === null) return primary;
+  const error = primary instanceof Error ? primary : new Error(String(primary));
+  const cleanupMessage = cleanup instanceof Error ? cleanup.message : String(cleanup);
+  error.message += `; scratch cleanup failed: ${cleanupMessage
+    .replaceAll(/[\u0000-\u001f\u007f]/g, " ").slice(0, 512)}`;
+  if (error.cause === undefined) error.cause = cleanup;
+  return error;
+}
+
 async function git(cwd, args, signal) {
   return (await execFileAsync("git", ["-C", cwd, ...args], {
     encoding: "utf8", signal,
@@ -344,6 +383,8 @@ export async function exactToolchain(scratch, signal) {
   if (!new RegExp(`^release: ${channel.replaceAll(".", "\\.")}$`, "m").test(version)) {
     fail(`resolved rustc does not match pinned channel ${channel}`);
   }
+  const privateTemp = path.join(scratch, "tmp");
+  await mkdir(privateTemp, { mode: 0o700 });
   return {
     cargo,
     channel,
@@ -354,7 +395,7 @@ export async function exactToolchain(scratch, signal) {
       CARGO_TARGET_DIR: path.join(scratch, "target"),
       CARGO_TERM_COLOR: "never",
       RUSTUP_TOOLCHAIN: channel,
-      TMPDIR: process.env.TMPDIR ?? tmpdir(),
+      TMPDIR: privateTemp,
     },
   };
 }
@@ -595,6 +636,7 @@ async function controller(argv) {
     process.on(signalName, handler);
   }
   let operationError = null;
+  let cleanupError = null;
   try {
     const { signal } = cancellation;
     const scratchDevice = (await stat(scratch, { bigint: true })).dev;
@@ -674,7 +716,10 @@ async function controller(argv) {
     });
     activeWatchdog = null;
     if (interruptedSignal !== null) throw new CanaryInterrupted(interruptedSignal);
-    if (status.code !== 0 || status.signal) fail(`watchdog failed closed: code=${status.code} signal=${status.signal}`);
+    if (status.code !== 0 || status.signal) {
+      const eventBytes = await readFile(eventsPath, "utf8").catch(() => "");
+      fail(watchdogFailureSummary(status, eventBytes));
+    }
     await assertAdapterIdentity(adapter, signal);
     assertInventory(
       await hashArtifactInventory(numericTierRoot, { signal }), numericTierInventory, "post-run q4",
@@ -757,13 +802,19 @@ async function controller(argv) {
   } catch (error) {
     operationError = error;
   } finally {
-    await cleanupCanaryScratch(scratch);
+    try {
+      await cleanupCanaryScratch(scratch);
+    } catch (error) {
+      cleanupError = error;
+    }
     for (const [signalName, handler] of Object.entries(signalHandlers)) {
       process.off(signalName, handler);
     }
   }
-  if (interruptedSignal !== null) throw new CanaryInterrupted(interruptedSignal);
-  if (operationError !== null) throw operationError;
+  const primaryError = interruptedSignal !== null
+    ? new CanaryInterrupted(interruptedSignal) : operationError;
+  const finalError = preservePrimaryFailure(primaryError, cleanupError);
+  if (finalError !== null) throw finalError;
 }
 
 try {

--- a/scripts/run-ltx-safety-canary.test.mjs
+++ b/scripts/run-ltx-safety-canary.test.mjs
@@ -20,11 +20,13 @@ import {
   inventoryAtRoot,
   parseMemoryFreePercent,
   parseSwapFreeBytes,
+  preservePrimaryFailure,
   preflightFreeFloor,
   repositoryToolchain,
   runtimeFreeFloor,
   telemetryResolutionBytes,
   validateCanaryResponse,
+  watchdogFailureSummary,
 } from "./run-ltx-safety-canary.mjs";
 
 const TEXT_ENCODER_INVENTORY = {
@@ -189,6 +191,47 @@ test("controller interruption preserves shell signal status after cleanup", () =
   assert.equal(new CanaryInterrupted("SIGTERM").exitCode, 143);
 });
 
+test("watchdog failures retain the exact hard-stop reason before scratch cleanup", () => {
+  const status = { code: 97, signal: null };
+  assert.equal(
+    watchdogFailureSummary(status, [
+      JSON.stringify({ event: "started" }),
+      JSON.stringify({ event: "hard_stop", reason: "child_attestation_failed:TimeoutError" }),
+      JSON.stringify({ event: "terminated" }),
+    ].join("\n")),
+    "watchdog failed closed: code=97 signal=null reason=child_attestation_failed:TimeoutError",
+  );
+  assert.match(watchdogFailureSummary(status, ""), /reason=event_stream_unavailable$/);
+  assert.match(watchdogFailureSummary(status, "not-json\n"), /reason=event_stream_malformed$/);
+  assert.match(
+    watchdogFailureSummary(status, JSON.stringify({ event: "hard_stop", reason: "line1\nline2" })),
+    /reason=line1 line2$/,
+  );
+  assert.match(
+    watchdogFailureSummary(status, [
+      JSON.stringify({ event: "hard_stop", reason: "physical_footprint_at_or_above_limit" }),
+      '{"event":"terminated"',
+    ].join("\n")),
+    /reason=physical_footprint_at_or_above_limit;event_stream_malformed$/,
+  );
+  assert.match(
+    watchdogFailureSummary(status, `${JSON.stringify({ event: "started" })}\n`),
+    /reason=hard_stop_event_absent$/,
+  );
+});
+
+test("scratch cleanup cannot mask the primary watchdog or signal failure", () => {
+  const primary = new CanaryInterrupted("SIGTERM");
+  const cleanup = new Error("permission denied\nwhile removing scratch");
+  const combined = preservePrimaryFailure(primary, cleanup);
+  assert.strictEqual(combined, primary);
+  assert.equal(combined.exitCode, 143);
+  assert.match(combined.message, /scratch cleanup failed: permission denied while removing scratch$/);
+  assert.strictEqual(combined.cause, cleanup);
+  assert.strictEqual(preservePrimaryFailure(primary, null), primary);
+  assert.strictEqual(preservePrimaryFailure(null, cleanup), cleanup);
+});
+
 test("the production runner can only launch through the identity-checked watchdog", async () => {
   const source = await readFile(new URL("./run-ltx-safety-canary.mjs", import.meta.url), "utf8");
   assert.match(source, /scripts\/memory-calibration-watchdog\.py/);
@@ -224,6 +267,8 @@ test("the production runner can only launch through the identity-checked watchdo
   assert.match(source, /RUSTUP_TOOLCHAIN: channel/);
   assert.match(source, /CARGO_HOME: path\.join\(scratch, "cargo-home"\)/);
   assert.match(source, /CARGO_TARGET_DIR: path\.join\(scratch, "target"\)/);
+  assert.match(source, /TMPDIR: privateTemp/);
+  assert.doesNotMatch(source, /TMPDIR: process\.env\.TMPDIR/);
   assert.match(source, /Cargo inference source tree differs from the verified checkout/);
   assert.match(source, /response\?\.inferenceRevision !== expectedInferenceRevision/);
   assert.match(source, /--require-child-attestation/);
@@ -231,6 +276,10 @@ test("the production runner can only launch through the identity-checked watchdo
   assert.match(source, /await chmod\(adapterDirectory, 0o500\)/);
   assert.match(source, /execFileAsync\("\/bin\/cp", \["-c", cloneSource, output\]/);
   assert.match(source, /await cleanupCanaryScratch\(scratch\)/);
+  const failureRead = source.indexOf("const eventBytes = await readFile(eventsPath");
+  const cleanup = source.indexOf("await cleanupCanaryScratch(scratch)");
+  assert.ok(failureRead >= 0 && cleanup > failureRead,
+    "watchdog failure reason must be read before scratch cleanup");
   assert.match(source, /cancellation\.abort\(new CanaryInterrupted\(signalName\)\)/);
   assert.match(source, /process\.exitCode = error instanceof CanaryInterrupted \? error\.exitCode : 1/);
 });
@@ -268,6 +317,8 @@ test("the runner binds the pinned toolchain and private same-volume artifact clo
       assert.equal(toolchain.channel, "1.97.1");
       assert.equal(toolchain.env.RUSTUP_TOOLCHAIN, toolchain.channel);
       assert.equal(toolchain.env.CARGO_HOME, path.join(scratch, "cargo-home"));
+      assert.equal(toolchain.env.TMPDIR, path.join(scratch, "tmp"));
+      assert.equal((await stat(toolchain.env.TMPDIR)).mode & 0o777, 0o700);
       assert.ok(path.isAbsolute(toolchain.cargo));
     }
 


### PR DESCRIPTION
## Summary
- preserve the exact watchdog hard-stop reason before scratch cleanup
- retain a valid persisted hard-stop even if a later JSONL line is truncated
- attach scratch-cleanup failures as secondary evidence without masking watchdog/signal status
- bind Cargo TMPDIR inside the removable private scratch

This does not change canary thresholds, tuple, attestation, admission, or campaign refusal.

## Validation
- `npm run check` — 535/535
- focused runner tests — 9/9
- watchdog process-group suite — 23/23
- independent rereview PASS, confidence 0.99
- `git diff --check`

No model, MLX device, weights, calibration, or NAX workload was run during this repair.