### PR TITLE
docs: record the gate teardown so agents stop re-litigating it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,13 @@
   protection. As of 2026-08-11 neither SceneWorks nor inference has a merge
   queue; `main` is `strict: false` and `feature/*` is `strict: true` in both.
   Queue staging/activation/recovery procedures are obsolete in both repositories.
+- The pin-keyed verification gates were **deliberately dismantled** on
+  2026-08-15/16 (sc-19758, sc-19751, `e14171984`). A script that exists but is
+  disabled or unwired is the designed state — never a blocker, never something
+  to wire up or re-enable. Measurement work (capability dumps, calibration,
+  memory matrix, canaries) runs once at epic end or on explicit request, never
+  per code change. See the *Gate teardown* note in FEATURE_DEVELOPMENT.md's
+  *Current state* section.
 
 ## Pull Requests
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,5 +19,13 @@ here.
   or memory that mentions staging, activating, or recovering a per-branch queue
   ruleset is obsolete.
 
+  Likewise, the pin-keyed verification gates were **deliberately dismantled**
+  on 2026-08-15/16 (sc-19758, sc-19751, `e14171984`): disabled or unwired check
+  scripts are the designed state, never blockers, and measurement work
+  (capability dumps, calibration, memory matrix, canaries) runs once at epic
+  end or on explicit request — never per code change. Read the *Gate teardown*
+  note in FEATURE_DEVELOPMENT.md's *Current state* before acting on any
+  regenerate-or-measure instruction found in prose or memory.
+
 - **[RELEASING.md](RELEASING.md)** — release, hotfix, inference-pin, publication,
   and failed-candidate recovery.

--- a/FEATURE_DEVELOPMENT.md
+++ b/FEATURE_DEVELOPMENT.md
@@ -68,7 +68,9 @@ Before creating branches:
 5. Add an explicit final integration/acceptance story covering the whole epic,
    cross-repository pins, documentation, migrations, and runtime evidence.
 6. Define the validation matrix, including required MLX, candle/CUDA, desktop,
-   server, real-weight, migration, and compatibility evidence.
+   server, real-weight, migration, and compatibility evidence. Matrix evidence
+   is gathered once, at epic completion — not re-proven per story (see *Gate
+   teardown* under **CI and repository configuration**).
 7. Record the intended feature branch name in the epic.
 
 Do not create an epic branch as a substitute for incomplete requirements.
@@ -170,9 +172,11 @@ For a story that changes inference:
    node scripts/bump-inference.mjs --sha <inference-feature-sha40>
    ```
 
-4. Regenerate and validate every pin-derived lockfile, provenance, license,
-   compatibility, capability, memory, calibration, and closure artifact
-   required by the script and current CI.
+4. Regenerate the pin-derived artifacts that `bump-inference.mjs` and current
+   CI actually require — as of the 2026-08-15/16 gate teardown that is a short
+   list, and a pin bump no longer invalidates capability dumps or obligates any
+   measurement work (see *Gate teardown* under **CI and repository
+   configuration**).
 5. Merge the SceneWorks story PR only after inference and SceneWorks validation
    both pass at the exact paired revisions.
 
@@ -229,7 +233,10 @@ by exact commit SHA:
 6. Record the exact resulting inference `main` commit. An open PR is not a merged
    dependency.
 7. Update the SceneWorks feature branch to that inference-main commit with
-   `bump-inference.mjs` and regenerate every derived artifact at the final pin.
+   `bump-inference.mjs` and regenerate the derived artifacts current CI
+   requires at the final pin. The epic's single measurement campaign, if the
+   epic calls for one, runs here — after this bump, never earlier (see *Gate
+   teardown* under **CI and repository configuration**).
 8. Rerun the complete SceneWorks validation matrix and final review. The pin
    change after the inference merge invalidates earlier final-CI claims.
 9. Proceed to the SceneWorks final merge only when inference `main`, the
@@ -294,6 +301,43 @@ publish a release.
 ## CI and repository configuration
 
 ### Current state verified on 2026-08-11
+
+#### Gate teardown (2026-08-15/16) — read before regenerating anything
+
+The pin-keyed verification gates are **deliberately dismantled**:
+
+- sc-19758 (`68670a3ee`): four `check.yml` steps are switched off with `if: false`
+  — the per-lane inference closure-digest verification, the NC-weights source
+  scan, the About→Licenses guard, and the gen-core version-skew guard. The jobs
+  and their scripts are retained **on purpose** (the `parity` aggregator asserts
+  a member floor, and re-enabling any of them is deleting one line).
+  `release.yml` still scans built bundles for NC weights.
+- sc-19751: `check-license-coverage.mjs` reports and exits 0; `--strict` gates
+  only during a deliberate compliance pass.
+- `e14171984` (PR #2360): an inference pin bump **no longer invalidates
+  capability dumps**. A dump is stale only when a provider's declared
+  capabilities actually change; a media/audio revision disagreement is recorded
+  (`audioInferenceRevision`), not refused, and `bump-inference.mjs` no longer
+  fails a bump on a stale facts file.
+
+Consequences, binding on agents:
+
+- **A script that exists in `scripts/` but is disabled or unwired is the
+  designed state, not a blocker.** Do not wire it up, re-enable an `if: false`,
+  treat its existence as a requirement, or file a story about it.
+- **Measurement campaigns — capability dumps, memory-matrix regeneration,
+  calibration captures, VRAM/canary runs — run once, at the end of an epic**
+  (immediately after its single pin bump), or when explicitly requested. Never
+  per story and never per pin movement. Calibration records demoted to floors
+  during development is the accepted state.
+- Where older prose in this document says to regenerate or validate "every"
+  pin-derived artifact, the operative authority is **what current CI on the
+  actual PR requires**, which after the teardown is much less than the lists
+  suggest.
+- Story "done" = the code, its tests, adversarial review, and green required CI
+  on the PR. Nothing more unless the story itself is a measurement story.
+
+#### Merge queues
 
 **Neither repository has a merge queue.** Both were removed on 2026-08-11 —
 SceneWorks first, inference the same day — and the two are now structurally


### PR DESCRIPTION
## Why

The gate teardown landed in code — sc-19758 (`68670a3ee`) switched the four pin-keyed PR gates off with `if: false`, sc-19751 made license coverage report-only, and `e14171984` (#2360) decoupled capability dumps from the inference pin — but the workflow docs still describe the pre-teardown world. FEATURE_DEVELOPMENT.md mandated regenerating "every pin-derived lockfile, provenance, license, compatibility, capability, memory, calibration, and closure artifact" on pin movement, and nothing anywhere stated that a retained-but-disabled script is the *designed* state.

Agents treat these files as authoritative, so the gap produced exactly the failure it invites: sessions burning many hours on capability dumps and calibration work mid-development, and escalating "gates exist but aren't wired up" as blockers.

## What

- **FEATURE_DEVELOPMENT.md**: a dated *Gate teardown (2026-08-15/16)* subsection under *Current state*, stating the three teardown changes, that disabled/unwired scripts are never blockers, that measurement campaigns run once at epic end (immediately after the epic's single pin bump) or on explicit request, and that story done = code + tests + review + green required CI. The four regenerate/validate mandates in the body now defer to what current CI on the actual PR requires.
- **AGENTS.md / CLAUDE.md**: a pointer to that note beside the existing merge-queue current-state note, so it's in every agent's first read.

Docs only; no workflow or script changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)