### PR TITLE
docs: pinned corpus populations are frozen-corpus gates — assert shape instead

### DIFF
--- a/FEATURE_DEVELOPMENT.md
+++ b/FEATURE_DEVELOPMENT.md
@@ -336,6 +336,16 @@ Consequences, binding on agents:
   suggest.
 - Story "done" = the code, its tests, adversarial review, and green required CI
   on the PR. Nothing more unless the story itself is a measurement story.
+- **Tests over measured corpora** (calibration records and evidence, capability
+  dumps, session logs, survey populations) **assert shape and invariants —
+  schema validity, non-emptiness, resolving cross-references, per-item
+  properties — never exact populations, pinned ids, or historical counts.** A
+  pinned count over a corpus that is supposed to churn cannot fail on a bug and
+  is guaranteed to fail on every legitimate re-capture; it is a gate on
+  measurement wearing a test's clothes. When a re-capture trips one, the defect
+  is in the test: rewrite that assertion and its siblings to shape in the same
+  PR rather than hand-updating the numbers. (Golden/parity fixtures that pin a
+  fixed input's output are a different, legitimate class.)
 
 #### Merge queues
 


### PR DESCRIPTION
Follow-up to #2363, which merged while this commit was in flight.

Measured on #2356 (sc-19721): seven consecutive test fixes, each a pinned count — record ids, session ids, status counts, load-shape counts, historical populations — that a legitimate new calibration capture invalidated. None caught a defect. A test pinning the exact population of a corpus that is supposed to churn cannot fail on a bug and must fail on every re-capture: it is a gate on measurement wearing a test's clothes.

This records the rule beside the gate-teardown note in FEATURE_DEVELOPMENT.md: assert shape and invariants over measured corpora (schema, non-emptiness, resolving cross-references, per-item properties), never exact populations or pinned ids; when a re-capture trips a pinned count, rewrite the assertion class in the same PR rather than hand-updating the numbers. Golden/parity fixtures pinning a fixed input's output remain a legitimate, separate class.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)