### PR TITLE
fix(canary): preserve private snapshot roots (sc-19741)

### DIFF
--- a/scripts/run-ltx-safety-canary.mjs
+++ b/scripts/run-ltx-safety-canary.mjs
@@ -58,6 +58,20 @@ export function runtimeFreeFloor(memoryBytes) {
   return MIN_RUNTIME_FREE_BYTES + telemetryResolutionBytes(memoryBytes);
 }
 
+export function privateArtifactRoots(scratch) {
+  const snapshotRoot = path.join(
+    scratch,
+    "artifacts",
+    `models--${ARTIFACT_REPOSITORY.replaceAll("/", "--")}`,
+    "snapshots",
+    ARTIFACT_REVISION,
+  );
+  return {
+    numericTier: path.join(snapshotRoot, "q4"),
+    textEncoder: path.join(snapshotRoot, "gemma"),
+  };
+}
+
 export function watchdogFailureSummary(status, eventBytes) {
   let hardStopReason = null;
   let validEvents = 0;
@@ -640,9 +654,11 @@ async function controller(argv) {
   try {
     const { signal } = cancellation;
     const scratchDevice = (await stat(scratch, { bigint: true })).dev;
-    const privateNumericTierRoot = path.join(scratch, "artifacts/q4");
-    const privateTextEncoderRoot = path.join(scratch, "artifacts/gemma");
-    await mkdir(path.dirname(privateNumericTierRoot), { mode: 0o700 });
+    const {
+      numericTier: privateNumericTierRoot,
+      textEncoder: privateTextEncoderRoot,
+    } = privateArtifactRoots(scratch);
+    await mkdir(path.dirname(privateNumericTierRoot), { recursive: true, mode: 0o700 });
     await cloneArtifactTree(numericTierRoot, privateNumericTierRoot, scratchDevice, signal);
     await cloneArtifactTree(textEncoderRoot, privateTextEncoderRoot, scratchDevice, signal);
     assertInventory(

--- a/scripts/run-ltx-safety-canary.test.mjs
+++ b/scripts/run-ltx-safety-canary.test.mjs
@@ -20,6 +20,7 @@ import {
   inventoryAtRoot,
   parseMemoryFreePercent,
   parseSwapFreeBytes,
+  privateArtifactRoots,
   preservePrimaryFailure,
   preflightFreeFloor,
   repositoryToolchain,
@@ -57,6 +58,27 @@ test("the runner freezes the exact tiny bounded-decode canary", () => {
     sha256: "4e811932e87bb258f642ada790525e36ef2a55959c520e755f1807caf6fa225a",
   });
   assert.throws(() => canaryRequest(128 * 1024 ** 3));
+});
+
+test("private artifact clones preserve the canonical immutable snapshot roots", async () => {
+  const scratch = "/private/canary-scratch";
+  const roots = privateArtifactRoots(scratch);
+  const snapshotRoot = path.join(
+    scratch,
+    "artifacts/models--SceneWorks--ltx-2.3-mlx/snapshots",
+    "01df27d308466533aa09d251e3aebdcc627d07eb",
+  );
+  assert.deepEqual(roots, {
+    numericTier: path.join(snapshotRoot, "q4"),
+    textEncoder: path.join(snapshotRoot, "gemma"),
+  });
+  assert.notEqual(roots.numericTier, path.join(scratch, "artifacts/q4"));
+  assert.notEqual(roots.textEncoder, path.join(scratch, "artifacts/gemma"));
+  assert.equal(path.relative(scratch, roots.numericTier).startsWith(".."), false);
+  assert.equal(path.relative(scratch, roots.textEncoder).startsWith(".."), false);
+  const runnerSource = await readFile(new URL("./run-ltx-safety-canary.mjs", import.meta.url), "utf8");
+  assert.match(runnerSource,
+    /mkdir\(path\.dirname\(privateNumericTierRoot\), \{ recursive: true, mode: 0o700 \}\)/);
 });
 
 test("the runner refuses promotable or identity-drifted adapter output", () => {
@@ -308,6 +330,19 @@ test("the runner binds the pinned toolchain and private same-volume artifact clo
     await cloneArtifactTree(linked, resolved, device);
     assert.equal(await readFile(path.join(resolved, "weights.safetensors"), "utf8"), "immutable\n");
     assert.equal((await stat(path.join(resolved, "weights.safetensors"))).isFile(), true);
+
+    const privateRoots = privateArtifactRoots(root);
+    await mkdir(path.dirname(privateRoots.numericTier), { recursive: true, mode: 0o700 });
+    await cloneArtifactTree(source, privateRoots.numericTier, device);
+    await cloneArtifactTree(source, privateRoots.textEncoder, device);
+    assert.equal(
+      await readFile(path.join(privateRoots.numericTier, "weights.safetensors"), "utf8"),
+      "immutable\n",
+    );
+    assert.equal(
+      await readFile(path.join(privateRoots.textEncoder, "weights.safetensors"), "utf8"),
+      "immutable\n",
+    );
 
     assert.equal(await repositoryToolchain(), "1.97.1");
     if (process.platform === "darwin") {


### PR DESCRIPTION
## Summary
- preserve the immutable Hugging Face repository/snapshot suffix for private q4 and Gemma clones
- recursively create the nested private snapshot parent before APFS cloning
- add mutation-sensitive coverage for the rejected shallow paths and both nested clones

## Validation
- `node --test scripts/run-ltx-safety-canary.test.mjs` (10/10)
- `npm run check` (536/536)
- `git diff --check`
- independent adversarial review PASS, confidence 0.99

No model, weights, provider, calibration, NAX, or device execution. The bounded canary remains stopped until this exact head merges and is read back.