### PR TITLE
Fix monitored startup for the LTX safety canary

### DIFF
--- a/scripts/memory-calibration-watchdog.py
+++ b/scripts/memory-calibration-watchdog.py
@@ -660,25 +660,151 @@ def guard(args: argparse.Namespace) -> int:
                 "minSwapFreeBytes": args.min_swap_free_bytes,
             }
             try:
-                attestation_listener.settimeout(bounded_telemetry_timeout())
-                attestation_stream, _ = attestation_listener.accept()
-                attestation_stream.settimeout(bounded_telemetry_timeout())
-                attestation_stream.sendall((json.dumps(attestation, separators=(",", ":")) + "\n").encode())
-                if recv_line(attestation_stream) != f"ACK {nonce}":
-                    raise RuntimeError("guarded child returned an invalid watchdog acknowledgement")
-                _, footprint, pressure, _ = observe_group(
-                    group, sampler, host_sampler, bounded_telemetry_timeout(),
+                child_attestation_deadline = (
+                    time.monotonic() + args.child_attestation_timeout
                 )
-                hard_stop = check_initial_observation(footprint, pressure)
+                startup_deadline = min(runtime_deadline, child_attestation_deadline)
+
+                def startup_deadline_reason() -> str | None:
+                    if time.monotonic() < startup_deadline:
+                        return None
+                    if runtime_deadline <= child_attestation_deadline:
+                        return f"runtime_at_or_above_{args.max_runtime_seconds}s"
+                    return (
+                        "child_attestation_timeout_at_or_above_"
+                        f"{args.child_attestation_timeout}s"
+                    )
+
+                def observe_startup() -> tuple[
+                        str | None, int | None, HostPressure | None]:
+                    stopped = startup_deadline_reason()
+                    if stopped is not None:
+                        return stopped, None, None
+                    status = group.child.poll()
+                    if status is not None:
+                        if status < 0:
+                            return f"launch_sentinel_lost:status_{status}", None, None
+                        return (
+                            "child_attestation_failed:guarded_child_exited:"
+                            f"status_{status}", None, None,
+                        )
+                    remaining = startup_deadline - time.monotonic()
+                    if remaining <= 0:
+                        return startup_deadline_reason(), None, None
+                    try:
+                        _, current_footprint, current_pressure, _ = observe_group(
+                            group, sampler, host_sampler,
+                            min(
+                                args.telemetry_timeout,
+                                remaining,
+                            ),
+                        )
+                    except MonitorSignal:
+                        raise
+                    except Exception as error:
+                        failed_at_or_after_startup_deadline = (
+                            time.monotonic() >= startup_deadline
+                        )
+                        status = group.child.poll()
+                        if status is not None and status < 0:
+                            return f"launch_sentinel_lost:status_{status}", None, None
+                        if status is not None:
+                            return (
+                                "child_attestation_failed:guarded_child_exited:"
+                                f"status_{status}", None, None,
+                            )
+                        if failed_at_or_after_startup_deadline:
+                            return startup_deadline_reason(), None, None
+                        return (
+                            "child_attestation_telemetry_lost:"
+                            f"{type(error).__name__}:{error}", None, None,
+                        )
+                    stopped = startup_deadline_reason()
+                    if stopped is None:
+                        stopped = check_initial_observation(
+                            current_footprint, current_pressure,
+                        )
+                    return stopped, current_footprint, current_pressure
+
+                def pause_startup() -> None:
+                    remaining = startup_deadline - time.monotonic()
+                    if remaining > 0:
+                        time.sleep(min(args.sample_interval, remaining))
+
+                attestation_listener.setblocking(False)
+                while attestation_stream is None and hard_stop is None:
+                    try:
+                        attestation_stream, _ = attestation_listener.accept()
+                        break
+                    except BlockingIOError:
+                        pass
+                    hard_stop, footprint, pressure = observe_startup()
+                    if footprint is not None:
+                        emit_sample(footprint, pressure, "awaiting_child_attestation")
+                    if hard_stop is None:
+                        pause_startup()
                 if hard_stop is None:
-                    emit_sample(footprint, pressure, "child_attested_before_allocation")
-                    emit(args.event_file, {"event": "child_attested"})
-                    attestation_stream.sendall(f"GO {nonce}\n".encode())
+                    remaining = startup_deadline - time.monotonic()
+                    if remaining <= 0:
+                        hard_stop = startup_deadline_reason()
+                    else:
+                        attestation_stream.settimeout(min(args.telemetry_timeout, remaining))
+                if hard_stop is None:
+                    attestation_stream.sendall((
+                        json.dumps(attestation, separators=(",", ":")) + "\n"
+                    ).encode())
                     attestation_stream.setblocking(False)
+                    acknowledgement = bytearray()
+                    while hard_stop is None and b"\n" not in acknowledgement:
+                        try:
+                            chunk = attestation_stream.recv(4096)
+                        except BlockingIOError:
+                            chunk = None
+                        if chunk == b"":
+                            hard_stop = (
+                                "child_attestation_failed:channel_closed_before_ack"
+                            )
+                            break
+                        if chunk:
+                            acknowledgement.extend(chunk)
+                            if len(acknowledgement) > 4096:
+                                hard_stop = (
+                                    "child_attestation_failed:ack_exceeded_size_bound"
+                                )
+                                break
+                        if b"\n" in acknowledgement:
+                            line, remainder = bytes(acknowledgement).split(b"\n", 1)
+                            if remainder or line.decode() != f"ACK {nonce}":
+                                hard_stop = (
+                                    "child_attestation_failed:invalid_acknowledgement"
+                                )
+                            break
+                        hard_stop, footprint, pressure = observe_startup()
+                        if footprint is not None:
+                            emit_sample(footprint, pressure, "awaiting_child_ack")
+                        if hard_stop is None:
+                            pause_startup()
+                if hard_stop is None:
+                    hard_stop, footprint, pressure = observe_startup()
+                    if hard_stop is None:
+                        emit_sample(footprint, pressure, "child_attested_before_allocation")
+                        emit(args.event_file, {"event": "child_attested"})
+                        remaining = startup_deadline - time.monotonic()
+                        if remaining <= 0:
+                            hard_stop = startup_deadline_reason()
+                if hard_stop is None:
+                    attestation_stream.settimeout(min(args.telemetry_timeout, remaining))
+                    try:
+                        attestation_stream.sendall(f"GO {nonce}\n".encode())
+                    finally:
+                        attestation_stream.setblocking(False)
             except MonitorSignal:
                 raise
             except Exception as error:
-                hard_stop = f"child_attestation_failed:{type(error).__name__}:{error}"
+                if hard_stop is None:
+                    hard_stop = (
+                        f"child_attestation_failed:{type(error).__name__}:{error}"
+                    )
         while True:
             if hard_stop is not None:
                 break
@@ -810,6 +936,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--min-swap-free-bytes", type=int)
     parser.add_argument("--sample-interval", type=float, default=0.25)
     parser.add_argument("--telemetry-timeout", type=float, default=1.0)
+    parser.add_argument("--child-attestation-timeout", type=float, default=5.0)
     parser.add_argument("--term-grace", type=float, default=0.5)
     parser.add_argument("--event-file", type=Path)
     parser.add_argument("--telemetry-file", type=Path)
@@ -824,7 +951,9 @@ def parse_args() -> argparse.Namespace:
         args.command = args.command[1:]
     if not args.command:
         parser.error("a guarded command is required after --")
-    for name in ["max_footprint_bytes", "sample_interval", "telemetry_timeout", "term_grace"]:
+    for name in [
+            "max_footprint_bytes", "sample_interval", "telemetry_timeout",
+            "child_attestation_timeout", "term_grace"]:
         if getattr(args, name) <= 0:
             parser.error(f"--{name.replace('_', '-')} must be positive")
     if args.max_runtime_seconds is not None and args.max_runtime_seconds <= 0:

--- a/scripts/memory-calibration-watchdog.test.mjs
+++ b/scripts/memory-calibration-watchdog.test.mjs
@@ -394,7 +394,7 @@ while True:
 `);
   await runWithMockedProductionTelemetry(files, ["python3", attester], {
     telemetryTimeout: 0.1,
-    childAttestationTimeout: 1,
+    childAttestationTimeout: 3,
   });
   const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
   const waiting = events.filter((event) =>

--- a/scripts/memory-calibration-watchdog.test.mjs
+++ b/scripts/memory-calibration-watchdog.test.mjs
@@ -139,10 +139,13 @@ function assertGone(pid) {
 async function runWithMockedProductionTelemetry(files, childCommand, options = {}) {
   const {
     telemetryTimeout = 0.5, actualHostMemory = 1000, requestedHostMemory = 1000,
+    childAttestationTimeout = 1,
     memoryFreePercent = 90, memoryFreeBytes = 900, swapFreeBytes = 900,
     pressureSamples = [[memoryFreePercent, memoryFreeBytes, swapFreeBytes]],
+    pressureFailureAt = null,
     environment = process.env,
   } = options;
+  const pressureFailureAtPython = pressureFailureAt === null ? "None" : String(pressureFailureAt);
   const launcher = `${files.program}.production-watchdog.py`;
   await writeFile(launcher, String.raw`import importlib.util, sys
 spec = importlib.util.spec_from_file_location("watchdog", ${JSON.stringify(WATCHDOG)})
@@ -152,6 +155,8 @@ class Footprint:
 class Pressure:
     def __init__(self, host_memory_bytes): self.index = 0
     def sample(self, timeout):
+        if self.index == ${pressureFailureAtPython}:
+            raise RuntimeError("injected startup pressure failure")
         samples = ${JSON.stringify(pressureSamples)}
         values = samples[min(self.index, len(samples) - 1)]
         self.index += 1
@@ -166,6 +171,7 @@ sys.argv = [${JSON.stringify(WATCHDOG)},
     "--min-memory-free-bytes", "100",
     "--min-swap-free-bytes", "100", "--sample-interval", "0.02",
     "--telemetry-timeout", ${JSON.stringify(String(telemetryTimeout))},
+    "--child-attestation-timeout", ${JSON.stringify(String(childAttestationTimeout))},
     "--term-grace", "0.1", "--event-file", ${JSON.stringify(files.events)},
     "--require-child-attestation", "--", *${JSON.stringify(childCommand)}]
 raise SystemExit(module.guard(module.parse_args()))
@@ -366,21 +372,156 @@ while True:
   assert.equal(socketPath.startsWith(longTmp), false);
 });
 
-test("a child that cannot attest is terminated with no owned residue", async () => {
+test("a cold child gets a separately bounded startup window while strict telemetry continues", async () => {
   const files = await fixture();
+  const attester = `${files.program}.delayed-attest.py`;
+  await writeFile(attester, String.raw`import json, os, socket, time
+time.sleep(0.35)
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect(os.environ["SCENEWORKS_MEMORY_WATCHDOG_SOCKET"])
+def line():
+    data = b""
+    while not data.endswith(b"\n"): data += sock.recv(1)
+    return data.decode().strip()
+payload = json.loads(line()); nonce = payload["nonce"]
+sock.sendall(f"ACK {nonce}\n".encode())
+assert line() == f"GO {nonce}"
+sock.sendall(f"DONE {nonce}\n".encode())
+while True:
+    message = line()
+    if message == f"BYE {nonce}": break
+    assert message == f"PING {nonce}"
+`);
+  await runWithMockedProductionTelemetry(files, ["python3", attester], {
+    telemetryTimeout: 0.1,
+    childAttestationTimeout: 1,
+  });
+  const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
+  const waiting = events.filter((event) =>
+    event.event === "sample" && event.phase === "awaiting_child_attestation");
+  assert.ok(waiting.length >= 2, `expected repeated startup samples, saw ${waiting.length}`);
+  assert.ok(events.some((event) => event.event === "child_attested"));
+  assert.ok(events.some((event) => event.event === "child_completed"));
+});
+
+test("child startup never weakens the strict pre-allocation pressure floor", async () => {
+  const files = await fixture();
+  const attester = `${files.program}.pressured-delayed-attest.py`;
+  await writeFile(attester, String.raw`import os, socket, time
+time.sleep(0.35)
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect(os.environ["SCENEWORKS_MEMORY_WATCHDOG_SOCKET"])
+time.sleep(60)
+`);
   let status = 0;
   try {
-    await runWithMockedProductionTelemetry(files, [
-      "python3", files.program, "hold", files.pids, files.telemetry, files.events,
-    ], { telemetryTimeout: 0.2 });
+    await runWithMockedProductionTelemetry(files, ["python3", attester], {
+      telemetryTimeout: 0.1,
+      childAttestationTimeout: 1,
+      pressureSamples: [[90, 900, 900], [69, 900, 900]],
+    });
   } catch (error) {
     status = error.code;
   }
   assert.equal(status, 97);
   const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
-  assert.ok(events.some((event) => event.reason?.includes("child_attestation_failed")));
+  assert.ok(events.some((event) =>
+    event.reason?.includes("initial_host_memory_free_percent_below_70")));
+  assert.equal(events.some((event) => event.event === "child_attested"), false);
+});
+
+test("a child that cannot attest is terminated with no owned residue", async () => {
+  const files = await fixture();
+  const started = Date.now();
+  let status = 0;
+  try {
+    await runWithMockedProductionTelemetry(files, [
+      "python3", files.program, "hold", files.pids, files.telemetry, files.events,
+    ], { telemetryTimeout: 0.2, childAttestationTimeout: 0.25 });
+  } catch (error) {
+    status = error.code;
+  }
+  assert.equal(status, 97);
+  const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
+  assert.ok(events.some((event) =>
+    event.reason === "child_attestation_timeout_at_or_above_0.25s"));
+  assert.ok(Date.now() - started < 1_500, "startup timeout drifted toward the runtime deadline");
   const pids = (await readFile(files.pids, "utf8")).trim().split("\n").map(Number);
   pids.forEach(assertGone);
+});
+
+test("a connected child that stalls before ACK remains monitored until the hard startup deadline", async () => {
+  const files = await fixture();
+  const staller = `${files.program}.stall-before-ack.py`;
+  await writeFile(staller, String.raw`import os, signal, socket, sys, time
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+open(sys.argv[1], "w").write(f"{os.getpid()}\n")
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect(os.environ["SCENEWORKS_MEMORY_WATCHDOG_SOCKET"])
+while not sock.recv(4096).endswith(b"\n"): pass
+time.sleep(60)
+`);
+  const started = Date.now();
+  let status = 0;
+  try {
+    await runWithMockedProductionTelemetry(files, ["python3", staller, files.pids], {
+      telemetryTimeout: 0.1,
+      childAttestationTimeout: 0.3,
+    });
+  } catch (error) {
+    status = error.code;
+  }
+  assert.equal(status, 97);
+  const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
+  assert.ok(events.some((event) => event.phase === "awaiting_child_ack"));
+  assert.ok(events.some((event) =>
+    event.reason === "child_attestation_timeout_at_or_above_0.3s"));
+  assert.ok(Date.now() - started < 1_500, "ACK stall exceeded the startup bound");
+  assertGone(Number((await readFile(files.pids, "utf8")).trim()));
+});
+
+test("telemetry loss during child startup preserves its exact forensic category", async () => {
+  const files = await fixture();
+  const delayed = `${files.program}.telemetry-loss-startup.py`;
+  await writeFile(delayed, "import time; time.sleep(60)\n");
+  let status = 0;
+  try {
+    await runWithMockedProductionTelemetry(files, ["python3", delayed], {
+      telemetryTimeout: 0.1,
+      childAttestationTimeout: 1,
+      pressureFailureAt: 1,
+    });
+  } catch (error) {
+    status = error.code;
+  }
+  assert.equal(status, 97);
+  const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
+  assert.ok(events.some((event) => event.reason?.startsWith(
+    "child_attestation_telemetry_lost:RuntimeError:injected startup pressure failure")));
+});
+
+test("sentinel loss during child startup preserves the launch-sentinel category", async () => {
+  const files = await fixture();
+  const killer = `${files.program}.kill-sentinel-during-startup.py`;
+  await writeFile(killer, String.raw`import os, signal, sys, time
+open(sys.argv[1], "w").write(f"{os.getpid()}\n")
+time.sleep(0.08)
+os.kill(os.getppid(), signal.SIGKILL)
+time.sleep(60)
+`);
+  let status = 0;
+  try {
+    await runWithMockedProductionTelemetry(files, ["python3", killer, files.pids], {
+      telemetryTimeout: 0.1,
+      childAttestationTimeout: 1,
+    });
+  } catch (error) {
+    status = error.code;
+  }
+  assert.equal(status, 97);
+  const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
+  assert.ok(events.some((event) => event.reason?.startsWith("launch_sentinel_lost:status_-")));
+  assertGone(Number((await readFile(files.pids, "utf8")).trim()));
 });
 
 test("loss of the held attestation lease after GO hard-stops the owned group", async () => {

--- a/scripts/memory-calibration-watchdog.test.mjs
+++ b/scripts/memory-calibration-watchdog.test.mjs
@@ -466,7 +466,7 @@ time.sleep(60)
   try {
     await runWithMockedProductionTelemetry(files, ["python3", staller, files.pids], {
       telemetryTimeout: 0.1,
-      childAttestationTimeout: 0.3,
+      childAttestationTimeout: 1.5,
     });
   } catch (error) {
     status = error.code;
@@ -475,8 +475,8 @@ time.sleep(60)
   const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
   assert.ok(events.some((event) => event.phase === "awaiting_child_ack"));
   assert.ok(events.some((event) =>
-    event.reason === "child_attestation_timeout_at_or_above_0.3s"));
-  assert.ok(Date.now() - started < 1_500, "ACK stall exceeded the startup bound");
+    event.reason === "child_attestation_timeout_at_or_above_1.5s"));
+  assert.ok(Date.now() - started < 2_800, "ACK stall exceeded the startup bound");
   assertGone(Number((await readFile(files.pids, "utf8")).trim()));
 });
 

--- a/scripts/run-ltx-safety-canary.mjs
+++ b/scripts/run-ltx-safety-canary.mjs
@@ -18,6 +18,7 @@ const execFileAsync = promisify(execFile);
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 export const MAX_FOOTPRINT_BYTES = 53_347_146_863;
 export const MAX_RUNTIME_SECONDS = 1_800;
+export const CHILD_ATTESTATION_TIMEOUT_SECONDS = 30;
 export const MIN_MEMORY_FREE_PERCENT = 70;
 export const MIN_SWAP_FREE_BYTES = 1024 ** 3;
 export const MIN_PREFLIGHT_FREE_BYTES = MAX_FOOTPRINT_BYTES * 2;
@@ -711,6 +712,7 @@ async function controller(argv) {
       "--min-swap-free-bytes", String(MIN_SWAP_FREE_BYTES),
       "--sample-interval", "0.25",
       "--telemetry-timeout", "1",
+      "--child-attestation-timeout", String(CHILD_ATTESTATION_TIMEOUT_SECONDS),
       "--term-grace", "1",
       "--event-file", eventsPath,
       "--require-child-attestation",

--- a/scripts/run-ltx-safety-canary.test.mjs
+++ b/scripts/run-ltx-safety-canary.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  CHILD_ATTESTATION_TIMEOUT_SECONDS,
   CanaryInterrupted,
   MAX_FOOTPRINT_BYTES,
   MAX_RUNTIME_SECONDS,
@@ -294,6 +295,8 @@ test("the production runner can only launch through the identity-checked watchdo
   assert.match(source, /Cargo inference source tree differs from the verified checkout/);
   assert.match(source, /response\?\.inferenceRevision !== expectedInferenceRevision/);
   assert.match(source, /--require-child-attestation/);
+  assert.equal(CHILD_ATTESTATION_TIMEOUT_SECONDS, 30);
+  assert.match(source, /--child-attestation-timeout", String\(CHILD_ATTESTATION_TIMEOUT_SECONDS\)/);
   assert.match(source, /event\.event === "child_attested"/);
   assert.match(source, /await chmod\(adapterDirectory, 0o500\)/);
   assert.match(source, /execFileAsync\("\/bin\/cp", \["-c", cloneSource, output\]/);


### PR DESCRIPTION
## Summary
- separate the cold adapter attestation allowance from the one-second telemetry freshness bound
- continuously enforce the strict pre-allocation footprint, memory, and swap gates through connection and ACK
- retain exact startup timeout, telemetry-loss, and sentinel-loss reasons
- freeze the production startup allowance at 30 seconds

## Validation
- independent review PASS, confidence 0.98, no findings
- `node --test scripts/memory-calibration-watchdog.test.mjs scripts/run-ltx-safety-canary.test.mjs` (38/38)
- timeout boundary repeated 20/20
- `npm run check` (541/541)
- `python3 -m py_compile scripts/memory-calibration-watchdog.py`
- `git diff --check`

No model, weights, MLX, device, calibration, or NAX workload was run. This repair does not authorize a canary retry; that remains a separately coordinated execution window.
