### PR TITLE
fix(calibration): allow cold metadata resolution

### DIFF
--- a/scripts/run-ltx-safety-canary.mjs
+++ b/scripts/run-ltx-safety-canary.mjs
@@ -19,6 +19,7 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 export const MAX_FOOTPRINT_BYTES = 53_347_146_863;
 export const MAX_RUNTIME_SECONDS = 1_800;
 export const CHILD_ATTESTATION_TIMEOUT_SECONDS = 30;
+export const CARGO_METADATA_TIMEOUT_MS = 15 * 60 * 1000;
 export const MIN_MEMORY_FREE_PERCENT = 70;
 export const MIN_SWAP_FREE_BYTES = 1024 ** 3;
 export const MIN_PREFLIGHT_FREE_BYTES = MAX_FOOTPRINT_BYTES * 2;
@@ -485,7 +486,7 @@ export async function inferenceCargoSource(
   const metadata = JSON.parse((await execFileAsync(cargo, [
     "metadata", "--locked", "--format-version", "1",
   ], {
-    cwd: ROOT, encoding: "utf8", env: cargoEnv, timeout: 5 * 60 * 1000,
+    cwd: ROOT, encoding: "utf8", env: cargoEnv, timeout: CARGO_METADATA_TIMEOUT_MS,
     maxBuffer: 50 * 1024 * 1024, signal,
   })).stdout);
   const packages = metadata.packages.filter((pkg) =>

--- a/scripts/run-ltx-safety-canary.test.mjs
+++ b/scripts/run-ltx-safety-canary.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  CARGO_METADATA_TIMEOUT_MS,
   CHILD_ATTESTATION_TIMEOUT_SECONDS,
   CanaryInterrupted,
   MAX_FOOTPRINT_BYTES,
@@ -281,6 +282,8 @@ test("the production runner can only launch through the identity-checked watchdo
   assert.doesNotMatch(source, /--child-adapter|async function child\(/);
   assert.match(source, /buildExactAdapter\(/);
   assert.match(source, /inferenceCargoSource\(/);
+  assert.equal(CARGO_METADATA_TIMEOUT_MS, 15 * 60 * 1000);
+  assert.match(source, /timeout: CARGO_METADATA_TIMEOUT_MS/);
   assert.match(source, /await assertAdapterIdentity\(adapter, signal\)/);
   assert.match(source, /pre-launch q4/);
   assert.match(source, /post-run q4/);


### PR DESCRIPTION
## Summary

- extend only the locked Cargo metadata resolution timeout from 5 to 15 minutes
- keep the adapter build timeout and 30-minute watched canary runtime unchanged
- freeze the new bound and callsite with mutation-sensitive source assertions

## Evidence

- real cold canary setup exceeded the old 5-minute metadata timeout while indexing the exact pinned inference fetch; it failed before adapter build/model allocation
- independent adversarial review PASS, confidence 0.99, no findings
- `npm run check`: 541/541
- focused watchdog + runner: 38/38
- no weights/model/device execution in this patch validation

Shortcut: SC-19741