### PR TITLE
fix(calibration): use calibrated LTX canary route

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -5471,7 +5471,9 @@ fn ltx_canary_generation_request() -> GenerationRequest {
         seed: Some(LTX_CANARY_SEED),
         frames: Some(LTX_CANARY_FRAMES),
         fps: Some(LTX_CANARY_FPS),
-        video_mode: Some("no_audio".to_owned()),
+        // The provider's calibrated contract has no video-mode variant axis. Keep the production
+        // default A/V path instead of asking the memory scope to configure an unsupported variant.
+        video_mode: None,
         memory: Some(GenerationMemory {
             tile_vae_decode: true,
             decode_tile_edge: Some(LTX_CANARY_TILE_EDGE),
@@ -6430,12 +6432,12 @@ fn validate_ltx_canary_plan(request: &Value) -> Result<MemorySelection, String> 
         .get("_canary")
         .and_then(Value::as_object)
         .ok_or_else(|| "LTX safety canary requires planned._canary".to_owned())?;
-    if canary.get("videoMode").and_then(Value::as_str) != Some("no_audio")
+    if canary.get("videoMode").and_then(Value::as_str) != Some("default")
         || canary.get("fps").and_then(Value::as_u64) != Some(u64::from(LTX_CANARY_FPS))
         || canary.get("seed").and_then(Value::as_u64) != Some(LTX_CANARY_SEED)
     {
         return Err(format!(
-            "LTX safety canary requires no_audio, fps {LTX_CANARY_FPS}, seed {LTX_CANARY_SEED}"
+            "LTX safety canary requires the default A/V route, fps {LTX_CANARY_FPS}, seed {LTX_CANARY_SEED}"
         ));
     }
     let artifact = planned
@@ -6794,7 +6796,7 @@ fn run_ltx_canary(request: &Value) -> Result<Value, String> {
         },
     )?)?;
     let decode = PhaseMemory::capture();
-    if frames.len() != LTX_CANARY_FRAMES as usize || fps != LTX_CANARY_FPS || has_audio {
+    if frames.len() != LTX_CANARY_FRAMES as usize || fps != LTX_CANARY_FPS || !has_audio {
         return Err(format!(
             "LTX safety canary returned frames={}, fps={fps}, audio={has_audio}",
             frames.len()
@@ -6844,7 +6846,7 @@ fn run_ltx_canary(request: &Value) -> Result<Value, String> {
                 "frames": LTX_CANARY_FRAMES,
                 "fps": LTX_CANARY_FPS,
             },
-            "audio": false,
+            "audio": true,
         },
         "strategy": ltx_attested_strategy(request, &context.selection, &contract)?,
         "watchdog": {
@@ -8406,7 +8408,7 @@ mod ltx_tests {
                     "maxFootprintBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES,
                 },
                 "_canary": {
-                    "videoMode": "no_audio",
+                    "videoMode": "default",
                     "fps": LTX_CANARY_FPS,
                     "seed": LTX_CANARY_SEED,
                 },
@@ -8447,7 +8449,7 @@ mod ltx_tests {
             (generated.width, generated.height, generated.frames),
             (LTX_CANARY_WIDTH, LTX_CANARY_HEIGHT, Some(LTX_CANARY_FRAMES))
         );
-        assert_eq!(generated.video_mode.as_deref(), Some("no_audio"));
+        assert_eq!(generated.video_mode, None);
         let memory = generated.memory.expect("bounded decode carrier");
         assert!(memory.tile_vae_decode);
         assert_eq!(memory.decode_tile_edge, Some(LTX_CANARY_TILE_EDGE));
@@ -8559,8 +8561,8 @@ mod ltx_tests {
             ("wrong overlap", |request| {
                 request["planned"]["strategy"]["parameters"]["decodeOverlap"] = json!(32)
             }),
-            ("audio enabled", |request| {
-                request["planned"]["_canary"]["videoMode"] = json!("default")
+            ("audio-suppressed variant", |request| {
+                request["planned"]["_canary"]["videoMode"] = json!("no_audio")
             }),
             ("ceiling drift", |request| {
                 request["planned"]["_watchdog"]["maxFootprintBytes"] =

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -2000,11 +2000,21 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
     "LTX_CANARY_FRAMES",
     "LTX_CANARY_TILE_EDGE",
     "LTX_CANARY_OVERLAP",
-    'Some("no_audio")',
+    'Some("default")',
     '"status": "diagnostic_canary_complete"',
     '"promotable": false',
     '"ingestible": false',
   ]) assert.ok(canary.includes(required), `canary must retain ${required}`);
+
+  const generationRequest = adapter.slice(
+    adapter.indexOf("fn ltx_canary_generation_request("),
+    adapter.indexOf("fn ltx_load_spec("),
+  );
+  assert.match(
+    generationRequest,
+    /video_mode: None/,
+    "the canary must stay on the provider contract's default A/V route",
+  );
 
   const limitsLifecycle = adapter.slice(
     adapter.indexOf("impl LtxCanaryLimits"),

--- a/scripts/run-ltx-safety-canary.mjs
+++ b/scripts/run-ltx-safety-canary.mjs
@@ -173,7 +173,7 @@ export function canaryRequest(memoryBytes, textEncoderInventory) {
       calibrationFingerprint: FINGERPRINT,
       fixture: FIXTURE,
       _watchdog: { maxFootprintBytes: MAX_FOOTPRINT_BYTES },
-      _canary: { videoMode: "no_audio", fps: 24, seed: 1234 },
+      _canary: { videoMode: "default", fps: 24, seed: 1234 },
       _artifact: {
         repository: ARTIFACT_REPOSITORY,
         revision: ARTIFACT_REVISION,
@@ -234,7 +234,7 @@ export function validateCanaryResponse(
       || response?.target?.geometry?.height !== 256
       || response?.target?.geometry?.frames !== 9
       || response?.target?.geometry?.fps !== 24
-      || response?.target?.audio !== false) {
+      || response?.target?.audio !== true) {
     fail("adapter response changed the exact canary identity");
   }
   if (response?.artifact?.repository !== ARTIFACT_REPOSITORY

--- a/scripts/run-ltx-safety-canary.test.mjs
+++ b/scripts/run-ltx-safety-canary.test.mjs
@@ -51,7 +51,7 @@ test("the runner freezes the exact tiny bounded-decode canary", () => {
     decodeTileEdge: 192, decodeOverlap: 64,
   });
   assert.deepEqual(request.planned._canary, {
-    videoMode: "no_audio", fps: 24, seed: 1234,
+    videoMode: "default", fps: 24, seed: 1234,
   });
   assert.equal(request.planned._watchdog.maxFootprintBytes, 53_347_146_863);
   assert.deepEqual(request.planned._artifact.numericTierInventory, {
@@ -95,7 +95,7 @@ test("the runner refuses promotable or identity-drifted adapter output", () => {
       provider: "ltx_2_3",
       tier: "q4",
       geometry: { width: 256, height: 256, frames: 9, fps: 24 },
-      audio: false,
+      audio: true,
     },
     artifact: {
       repository: "SceneWorks/ltx-2.3-mlx",
@@ -146,7 +146,7 @@ test("the runner refuses promotable or identity-drifted adapter output", () => {
   );
   const mutations = [
     (value) => { value.promotable = true; },
-    (value) => { value.target.audio = true; },
+    (value) => { value.target.audio = false; },
     (value) => { value.target.geometry.frames = 97; },
     (value) => { value.strategy.parameters.decodeTileEdge = 384; },
     (value) => { value.strategy.engagedRungs = ["resident", "bounded_decode"]; },


### PR DESCRIPTION
## Summary

- keep the safety canary on LTX's contract-admitted default A/V request instead of the unsupported `no_audio` variant
- require the real result and diagnostic receipt to contain the default audio track
- mutation-pin the request, receipt, and platform contract without relaxing campaign refusal

## Evidence

- the prior permanent-head attempt failed closed at provider `configure_request`: calibrated route has no `video_mode` variant axis
- pinned provider source confirms `None` is full default A/V; f9@24 uses nine audio latent frames and drops AvDiT before video/audio decode
- independent adversarial review PASS, confidence 0.98, no findings
- MLX adapter: 84/84
- platform + runner: 63/63
- `npm run check`: 541/541
- no campaign or promotable evidence

Shortcut: SC-19741