### PR TITLE
fix(sc-19741): bind canary to built metallib

### DIFF
--- a/scripts/run-ltx-safety-canary.mjs
+++ b/scripts/run-ltx-safety-canary.mjs
@@ -20,7 +20,7 @@ export const MAX_FOOTPRINT_BYTES = 53_347_146_863;
 export const MAX_RUNTIME_SECONDS = 1_800;
 export const CHILD_ATTESTATION_TIMEOUT_SECONDS = 30;
 export const CARGO_METADATA_TIMEOUT_MS = 15 * 60 * 1000;
-export const PREPARATION_SCHEMA_VERSION = 2;
+export const PREPARATION_SCHEMA_VERSION = 3;
 export const PREPARATION_LOCK_POLL_MS = 50;
 export const PREPARATION_LOCK_ORPHAN_GRACE_MS = 30_000;
 // Free swap capacity is not a safety margin: the prelaunch free-memory floor is already more than
@@ -543,12 +543,13 @@ export async function repositoryToolchain() {
 
 export async function exactToolchain(scratch, signal) {
   const home = process.env.HOME ?? fail("HOME is required to resolve the pinned rustup toolchain");
+  const resolvedRustupHome = path.resolve(process.env.RUSTUP_HOME ?? path.join(home, ".rustup"));
   const resolutionEnv = Object.fromEntries([
-    "HOME", "RUSTUP_HOME", "SSL_CERT_FILE", "SSL_CERT_DIR",
+    "HOME", "SSL_CERT_FILE", "SSL_CERT_DIR",
   ].flatMap((name) => process.env[name] === undefined ? [] : [[name, process.env[name]]]));
-  resolutionEnv.PATH = [
-    path.join(home, ".cargo/bin"), "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin",
-  ].join(":");
+  resolutionEnv.RUSTUP_HOME = resolvedRustupHome;
+  const systemPath = ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"].join(":");
+  resolutionEnv.PATH = [path.join(home, ".cargo/bin"), systemPath].join(":");
   const rustup = (await runOwnedCommand("/usr/bin/which", ["rustup"], {
     cwd: ROOT, env: resolutionEnv, timeout: 2_000, signal,
   })).stdout.trim();
@@ -571,17 +572,30 @@ export async function exactToolchain(scratch, signal) {
   if (!new RegExp(`^release: ${channel.replaceAll(".", "\\.")}$`, "m").test(version)) {
     fail(`resolved rustc does not match pinned channel ${channel}`);
   }
+  const privateHome = path.join(scratch, "home");
   const privateTemp = path.join(scratch, "tmp");
-  await mkdir(privateTemp, { recursive: true, mode: 0o700 });
+  const privateCargoHome = path.join(scratch, "cargo-home");
+  const privateTarget = path.join(scratch, "target");
+  await Promise.all([
+    mkdir(privateHome, { recursive: true, mode: 0o700 }),
+    mkdir(privateTemp, { recursive: true, mode: 0o700 }),
+    mkdir(privateCargoHome, { recursive: true, mode: 0o700 }),
+    mkdir(privateTarget, { recursive: true, mode: 0o700 }),
+  ]);
+  await exactMetadata(privateHome, "directory", 0o700);
+  await exactEntries(privateHome, []);
   return {
     cargo,
     channel,
     env: {
       ...resolutionEnv,
+      HOME: privateHome,
+      PATH: systemPath,
       CARGO_BUILD_JOBS: "2",
-      CARGO_HOME: path.join(scratch, "cargo-home"),
-      CARGO_TARGET_DIR: path.join(scratch, "target"),
+      CARGO_HOME: privateCargoHome,
+      CARGO_TARGET_DIR: privateTarget,
       CARGO_TERM_COLOR: "never",
+      RUSTC: rustc,
       RUSTUP_TOOLCHAIN: channel,
       TMPDIR: privateTemp,
     },
@@ -711,16 +725,16 @@ async function exactEntries(directory, expected) {
   }
 }
 
-function adapterManifestIdentity(adapter) {
+function preparedFileManifestIdentity(file) {
   return {
-    sha256: adapter.sha256,
-    size: adapter.size,
+    sha256: file.sha256,
+    size: file.size,
     seal: {
-      device: adapter.device,
-      inode: adapter.inode,
-      mtimeNs: adapter.mtimeNs,
-      ctimeNs: adapter.ctimeNs,
-      mode: adapter.mode,
+      device: file.device,
+      inode: file.inode,
+      mtimeNs: file.mtimeNs,
+      ctimeNs: file.ctimeNs,
+      mode: file.mode,
     },
   };
 }
@@ -743,7 +757,7 @@ async function validatePreparedStructure(preparationRoot) {
   await exactEntries(modelDirectory, ["snapshots"]);
   await exactEntries(snapshotsDirectory, [ARTIFACT_REVISION]);
   await exactEntries(revisionDirectory, ["gemma", "q4"]);
-  await exactEntries(adapterDirectory, ["memory-mlx-adapter"]);
+  await exactEntries(adapterDirectory, ["memory-mlx-adapter", "mlx.metallib"]);
   return roots;
 }
 
@@ -786,10 +800,15 @@ export async function validatePreparedCache(preparationRoot, key, identity, sign
   }
   const adapterPath = path.join(preparationRoot, "adapter", "memory-mlx-adapter");
   const adapter = await adapterIdentity(adapterPath, signal);
-  if (!sameJson(adapterManifestIdentity(adapter), manifest?.adapter)) {
+  if (!sameJson(preparedFileManifestIdentity(adapter), manifest?.adapter)) {
     fail("prepared canary adapter changed");
   }
-  return { manifest, roots, adapter, reused: true };
+  const metallibPath = path.join(preparationRoot, "adapter", "mlx.metallib");
+  const metallib = await metallibIdentity(metallibPath, signal);
+  if (!sameJson(preparedFileManifestIdentity(metallib), manifest?.metallib)) {
+    fail("prepared canary metallib changed");
+  }
+  return { manifest, roots, adapter, metallib, reused: true };
 }
 
 async function sealPreparationDirectories(directory) {
@@ -817,13 +836,15 @@ async function writePreparedManifest(stage, key, identity, preparedFrom, builtAr
     };
   }
   const adapter = await adapterIdentity(path.join(stage, "adapter", "memory-mlx-adapter"), signal);
+  const metallib = await metallibIdentity(path.join(stage, "adapter", "mlx.metallib"), signal);
   const manifest = {
     schemaVersion: PREPARATION_SCHEMA_VERSION,
     key,
     identity,
     preparedFrom,
     artifacts,
-    adapter: adapterManifestIdentity(adapter),
+    adapter: preparedFileManifestIdentity(adapter),
+    metallib: preparedFileManifestIdentity(metallib),
   };
   const bytes = `${JSON.stringify(manifest, null, 2)}\n`;
   const manifestPath = path.join(stage, "prepared.json");
@@ -1063,15 +1084,15 @@ export async function inferenceCargoSource(
   return cargoSource;
 }
 
-async function adapterIdentity(adapterPath, signal) {
-  const metadata = await lstat(adapterPath, { bigint: true });
+async function preparedFileIdentity(filePath, expectedMode, label, signal) {
+  const metadata = await lstat(filePath, { bigint: true });
   if (!metadata.isFile() || metadata.isSymbolicLink()
-      || Number(metadata.mode & 0o777n) !== 0o500) {
-    fail("prepared canary adapter must be a read-only executable regular file");
+      || Number(metadata.mode & 0o777n) !== expectedMode) {
+    fail(`prepared canary ${label} must be a read-only regular file with mode ${expectedMode.toString(8)}`);
   }
   return {
-    path: adapterPath,
-    sha256: await sha256(adapterPath, signal),
+    path: filePath,
+    sha256: await sha256(filePath, signal),
     device: metadata.dev.toString(),
     inode: metadata.ino.toString(),
     size: Number(metadata.size),
@@ -1081,11 +1102,55 @@ async function adapterIdentity(adapterPath, signal) {
   };
 }
 
+async function adapterIdentity(adapterPath, signal) {
+  return preparedFileIdentity(adapterPath, 0o500, "adapter executable", signal);
+}
+
+async function metallibIdentity(metallibPath, signal) {
+  return preparedFileIdentity(metallibPath, 0o400, "metallib", signal);
+}
+
 async function assertAdapterIdentity(expected, signal) {
   const actual = await adapterIdentity(expected.path, signal);
   if (JSON.stringify(actual) !== JSON.stringify(expected)) {
     fail("canary adapter identity changed after its exact build");
   }
+}
+
+async function assertMetallibIdentity(expected, signal) {
+  const actual = await metallibIdentity(expected.path, signal);
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    fail("canary metallib identity changed after its exact build");
+  }
+}
+
+async function assertRuntimeAssetIdentities(adapter, metallib, signal) {
+  await Promise.all([
+    assertAdapterIdentity(adapter, signal),
+    assertMetallibIdentity(metallib, signal),
+  ]);
+}
+
+export async function locateBuiltMetallib(target) {
+  const buildDirectory = path.join(target, "release", "build");
+  const metallibs = [];
+  for (const entry of await readdir(buildDirectory, { withFileTypes: true })) {
+    if (!entry.name.startsWith("pmetal-mlx-sys-") || !entry.isDirectory()) continue;
+    const candidate = path.join(buildDirectory, entry.name, "out", "build", "lib", "mlx.metallib");
+    const metadata = await lstat(candidate).catch((error) => {
+      if (error.code === "ENOENT") return null;
+      throw error;
+    });
+    if (metadata === null) continue;
+    if (!metadata.isFile() || metadata.isSymbolicLink()) {
+      fail(`built pmetal metallib is not a regular file: ${candidate}`);
+    }
+    metallibs.push(candidate);
+  }
+  if (metallibs.length !== 1) {
+    fail(`exactly one built pmetal metallib is required, found ${metallibs.length}`);
+  }
+  return metallibs[0];
 }
 
 async function buildExactAdapter(
@@ -1120,13 +1185,38 @@ async function buildExactAdapter(
   }
   await inferenceCargoSource(cargo, cargoEnv, inferenceRepo, inferenceRevision, signal);
   const built = path.join(target, "release/memory-mlx-adapter");
+  const builtMetallib = await locateBuiltMetallib(target);
   const adapterDirectory = path.join(preparationRoot, "adapter");
   const adapterPath = path.join(adapterDirectory, "memory-mlx-adapter");
+  const metallibPath = path.join(adapterDirectory, "mlx.metallib");
   await mkdir(adapterDirectory, { mode: 0o700 });
   await copyFile(built, adapterPath, fsConstants.COPYFILE_EXCL);
+  await copyFile(builtMetallib, metallibPath, fsConstants.COPYFILE_EXCL);
   await chmod(adapterPath, 0o500);
+  await chmod(metallibPath, 0o400);
   await chmod(adapterDirectory, 0o500);
-  return adapterIdentity(adapterPath, signal);
+  return Promise.all([
+    adapterIdentity(adapterPath, signal),
+    metallibIdentity(metallibPath, signal),
+  ]);
+}
+
+export function canaryWatchdogEnvironment(baseEnvironment, roots, metallibPath, privateHome) {
+  if (!path.isAbsolute(metallibPath)) fail("prepared canary metallib path must be absolute");
+  if (!path.isAbsolute(privateHome)) fail("private canary runtime HOME must be absolute");
+  const environment = { ...baseEnvironment };
+  for (const name of ["HOME", "PMETAL_METALLIB_PATH", "PMETAL_CACHE_DIR", "XDG_CACHE_HOME"]) {
+    delete environment[name];
+  }
+  return {
+    ...environment,
+    HOME: privateHome,
+    // The pinned pmetal resolver reads this before its mutable user cache. Keep the override after
+    // the inherited environment so a concurrent build can never redirect this prepared adapter.
+    PMETAL_METALLIB_PATH: metallibPath,
+    SCENEWORKS_LTX_ROOT: roots.numericTier,
+    SCENEWORKS_LTX_TEXT_ENCODER_ROOT: roots.textEncoder,
+  };
 }
 
 function parseArgs(argv) {
@@ -1278,12 +1368,17 @@ async function controller(argv) {
       textEncoder: privateTextEncoderRoot,
     } = prepared.roots;
     const adapter = prepared.adapter;
+    const metallib = prepared.metallib;
     const textEncoderInventory = inventoryAtRoot(
       identity.artifact.textEncoder, privateTextEncoderRoot,
     );
     const runRoot = path.join(path.dirname(output), "runs");
     await mkdir(runRoot, { recursive: true, mode: 0o700 });
     runScratch = await mkdtemp(path.join(runRoot, "sc19741-run-"));
+    const runtimeHome = path.join(runScratch, "home");
+    await mkdir(runtimeHome, { mode: 0o700 });
+    await exactMetadata(runtimeHome, "directory", 0o700);
+    await exactEntries(runtimeHome, []);
     const requestPath = path.join(runScratch, "request.json");
     const responsePath = path.join(runScratch, "response.json");
     const eventsPath = path.join(runScratch, "watchdog.jsonl");
@@ -1293,7 +1388,9 @@ async function controller(argv) {
       preparationRoot, preparationKey, identity, signal,
     );
     if (launchPrepared === null) fail("prepared canary cache disappeared before launch");
-    await assertAdapterIdentity(launchPrepared.adapter, signal);
+    await assertRuntimeAssetIdentities(
+      launchPrepared.adapter, launchPrepared.metallib, signal,
+    );
     const watchdog = path.join(ROOT, "scripts/memory-calibration-watchdog.py");
     const runtimeMemoryFreeFloor = runtimeFreeFloor(memoryBytes);
     const watchdogArgs = [
@@ -1312,11 +1409,12 @@ async function controller(argv) {
       "/bin/sh", "-c", 'set -C; exec "$1" <"$2" >"$3"',
       "sc19741-canary", adapter.path, requestPath, responsePath,
     ];
-    const watchdogEnv = {
-      ...process.env,
-      SCENEWORKS_LTX_ROOT: privateNumericTierRoot,
-      SCENEWORKS_LTX_TEXT_ENCODER_ROOT: privateTextEncoderRoot,
-    };
+    const watchdogEnv = canaryWatchdogEnvironment(
+      process.env,
+      { numericTier: privateNumericTierRoot, textEncoder: privateTextEncoderRoot },
+      metallib.path,
+      runtimeHome,
+    );
     if (await cleanHead(ROOT, "SceneWorks", signal) !== sceneWorksRevision
         || await cleanHead(inferenceRepo, "inference", signal) !== inferenceRevision
         || await git(ROOT, ["rev-parse", "HEAD^{tree}"], signal) !== sceneWorksTree
@@ -1343,7 +1441,7 @@ async function controller(argv) {
       const eventBytes = await readFile(eventsPath, "utf8").catch(() => "");
       fail(watchdogFailureSummary(status, eventBytes));
     }
-    await assertAdapterIdentity(adapter, signal);
+    await assertRuntimeAssetIdentities(adapter, metallib, signal);
     if (await validatePreparedCache(preparationRoot, preparationKey, identity, signal) === null) {
       fail("prepared canary cache disappeared after the run");
     }
@@ -1386,6 +1484,7 @@ async function controller(argv) {
     sceneWorksRevision,
     inferenceRevision,
     adapter,
+    metallib,
     preparation: {
       key: preparationKey,
       root: preparationRoot,

--- a/scripts/run-ltx-safety-canary.test.mjs
+++ b/scripts/run-ltx-safety-canary.test.mjs
@@ -16,7 +16,9 @@ import {
   MAX_RUNTIME_SECONDS,
   MIN_PREFLIGHT_FREE_BYTES,
   MIN_RUNTIME_FREE_BYTES,
+  PREPARATION_SCHEMA_VERSION,
   acquirePreparationLock,
+  canaryWatchdogEnvironment,
   canaryRequest,
   cargoSourceStatusIsClean,
   cleanupCanaryScratch,
@@ -24,6 +26,7 @@ import {
   exactToolchain,
   foreignHeavyProcesses,
   inventoryAtRoot,
+  locateBuiltMetallib,
   parseMemoryFreePercent,
   parseSwapFreeBytes,
   preparationCacheKey,
@@ -91,7 +94,9 @@ async function cacheFixture(t) {
     const adapterDirectory = path.join(stage, "adapter");
     await mkdir(adapterDirectory, { mode: 0o700 });
     await writeFile(path.join(adapterDirectory, "memory-mlx-adapter"), "adapter\n", { mode: 0o500 });
+    await writeFile(path.join(adapterDirectory, "mlx.metallib"), "metallib\n", { mode: 0o400 });
     await chmod(path.join(adapterDirectory, "memory-mlx-adapter"), 0o500);
+    await chmod(path.join(adapterDirectory, "mlx.metallib"), 0o400);
     await chmod(adapterDirectory, 0o500);
     return {
       artifacts: { numericTier: preparedNumeric, textEncoder: preparedText },
@@ -352,10 +357,11 @@ test("the production runner can only launch through the identity-checked watchdo
   assert.doesNotMatch(source, /memory-mlx-adapter[^\n]*spawn\(/);
   assert.doesNotMatch(source, /--child-adapter|async function child\(/);
   assert.match(source, /buildExactAdapter\(/);
+  assert.match(source, /locateBuiltMetallib\(target\)/);
   assert.match(source, /inferenceCargoSource\(/);
   assert.equal(CARGO_METADATA_TIMEOUT_MS, 15 * 60 * 1000);
   assert.match(source, /timeout: CARGO_METADATA_TIMEOUT_MS/);
-  assert.match(source, /await assertAdapterIdentity\(adapter, signal\)/);
+  assert.match(source, /await assertRuntimeAssetIdentities\(adapter, metallib, signal\)/);
   assert.match(source, /validatePreparedCache\(preparationRoot, preparationKey, identity, signal\)/);
   assert.match(source, /sealedArtifactIdentity\(root\)/);
   const reuseValidation = source.slice(
@@ -365,9 +371,13 @@ test("the production runner can only launch through the identity-checked watchdo
   assert.doesNotMatch(reuseValidation, /hashArtifactInventory\(/,
     "cache reuse must not repeat the 46.9 GB content hash");
   assert.match(source, /const resolutionEnv = Object\.fromEntries/);
+  assert.match(source, /const resolvedRustupHome = path\.resolve/);
+  assert.match(source, /HOME: privateHome/);
+  assert.match(source, /RUSTUP_HOME = resolvedRustupHome/);
   assert.match(source, /RUSTUP_TOOLCHAIN: channel/);
-  assert.match(source, /CARGO_HOME: path\.join\(scratch, "cargo-home"\)/);
-  assert.match(source, /CARGO_TARGET_DIR: path\.join\(scratch, "target"\)/);
+  assert.match(source, /CARGO_HOME: privateCargoHome/);
+  assert.match(source, /CARGO_TARGET_DIR: privateTarget/);
+  assert.match(source, /RUSTC: rustc/);
   assert.match(source, /TMPDIR: privateTemp/);
   assert.doesNotMatch(source, /TMPDIR: process\.env\.TMPDIR/);
   assert.match(source, /Cargo inference source tree differs from the verified checkout/);
@@ -377,6 +387,12 @@ test("the production runner can only launch through the identity-checked watchdo
   assert.match(source, /--child-attestation-timeout", String\(CHILD_ATTESTATION_TIMEOUT_SECONDS\)/);
   assert.match(source, /event\.event === "child_attested"/);
   assert.match(source, /await chmod\(adapterDirectory, 0o500\)/);
+  assert.match(source, /await chmod\(metallibPath, 0o400\)/);
+  assert.match(source, /PMETAL_METALLIB_PATH: metallibPath/);
+  assert.match(source, /const runtimeHome = path\.join\(runScratch, "home"\)/);
+  assert.match(source, /await exactEntries\(runtimeHome, \[\]\)/);
+  assert.doesNotMatch(source, /\.cache\/pmetal\/lib\/mlx\.metallib/,
+    "the canary must never name the mutable global metallib cache");
   assert.match(source, /runOwnedCommand\("\/bin\/cp", \["-c", cloneSource, output\]/);
   assert.match(source, /await cleanupCanaryScratch\(runScratch\)/);
   const failureRead = source.indexOf("const eventBytes = await readFile(eventsPath");
@@ -441,10 +457,41 @@ test("the runner binds the pinned toolchain and private same-volume artifact clo
       const toolchain = await exactToolchain(scratch);
       assert.equal(toolchain.channel, "1.97.1");
       assert.equal(toolchain.env.RUSTUP_TOOLCHAIN, toolchain.channel);
+      assert.equal(toolchain.env.RUSTUP_HOME,
+        path.resolve(process.env.RUSTUP_HOME ?? path.join(process.env.HOME, ".rustup")));
+      assert.equal(toolchain.env.HOME, path.join(scratch, "home"));
+      assert.notEqual(toolchain.env.HOME, process.env.HOME);
+      assert.equal(toolchain.env.PATH,
+        ["/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin"].join(":"));
       assert.equal(toolchain.env.CARGO_HOME, path.join(scratch, "cargo-home"));
+      assert.equal(toolchain.env.CARGO_TARGET_DIR, path.join(scratch, "target"));
       assert.equal(toolchain.env.TMPDIR, path.join(scratch, "tmp"));
-      assert.equal((await stat(toolchain.env.TMPDIR)).mode & 0o777, 0o700);
+      assert.ok(path.isAbsolute(toolchain.env.RUSTC));
+      assert.equal(path.dirname(toolchain.env.RUSTC), path.dirname(toolchain.cargo));
+      for (const directory of [
+        toolchain.env.HOME, toolchain.env.CARGO_HOME,
+        toolchain.env.CARGO_TARGET_DIR, toolchain.env.TMPDIR,
+      ]) assert.equal((await stat(directory)).mode & 0o777, 0o700);
+      assert.deepEqual(await readdir(toolchain.env.HOME), []);
       assert.ok(path.isAbsolute(toolchain.cargo));
+      const probe = path.join(root, "cargo-rustc-probe");
+      await mkdir(path.join(probe, "src"), { recursive: true });
+      await writeFile(path.join(probe, "Cargo.toml"), [
+        "[package]", 'name = "sc19741-cargo-rustc-probe"', 'version = "0.0.0"',
+        'edition = "2024"', "",
+      ].join("\n"));
+      await writeFile(path.join(probe, "src/main.rs"), "fn main() {}\n");
+      const probeArgs = [
+        "check", "--offline", "--manifest-path", path.join(probe, "Cargo.toml"),
+      ];
+      await assert.rejects(() => runOwnedCommand(toolchain.cargo, probeArgs, {
+        cwd: probe,
+        env: { ...toolchain.env, RUSTC: path.join(root, "missing-rustc") },
+        timeout: 30_000,
+      }));
+      await runOwnedCommand(toolchain.cargo, probeArgs, {
+        cwd: probe, env: toolchain.env, timeout: 30_000,
+      });
     }
 
     const disposable = path.join(root, "disposable");
@@ -458,7 +505,53 @@ test("the runner binds the pinned toolchain and private same-volume artifact clo
   }
 });
 
+test("the exact Cargo build metallib is uniquely selected and overrides every global cache", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "sc19741-metallib-test-"));
+  t.after(() => cleanupCanaryScratch(root));
+  const target = path.join(root, "target");
+  const first = path.join(
+    target, "release", "build", "pmetal-mlx-sys-first", "out", "build", "lib", "mlx.metallib",
+  );
+  await mkdir(path.dirname(first), { recursive: true });
+  await writeFile(first, "exact build metallib\n");
+  assert.equal(await locateBuiltMetallib(target), first);
+
+  const prepared = path.join(root, "prepared", "adapter", "mlx.metallib");
+  const runtimeHome = path.join(root, "runtime-home");
+  await mkdir(runtimeHome, { mode: 0o700 });
+  const roots = { numericTier: "/prepared/q4", textEncoder: "/prepared/gemma" };
+  const environment = canaryWatchdogEnvironment({
+    HOME: "/Users/test",
+    PMETAL_METALLIB_PATH: "/Users/test/.cache/pmetal/lib/mlx.metallib",
+    PMETAL_CACHE_DIR: "/Users/test/.cache/pmetal",
+    XDG_CACHE_HOME: "/Users/test/.cache",
+  }, roots, prepared, runtimeHome);
+  assert.equal((await stat(runtimeHome)).mode & 0o777, 0o700);
+  assert.deepEqual(await readdir(runtimeHome), []);
+  assert.equal(environment.HOME, runtimeHome);
+  assert.notEqual(environment.HOME, "/Users/test");
+  assert.equal(environment.PMETAL_METALLIB_PATH, prepared);
+  assert.equal(Object.hasOwn(environment, "PMETAL_CACHE_DIR"), false);
+  assert.equal(Object.hasOwn(environment, "XDG_CACHE_HOME"), false);
+  assert.equal(environment.SCENEWORKS_LTX_ROOT, roots.numericTier);
+  assert.equal(environment.SCENEWORKS_LTX_TEXT_ENCODER_ROOT, roots.textEncoder);
+  assert.notEqual(environment.PMETAL_METALLIB_PATH,
+    "/Users/test/.cache/pmetal/lib/mlx.metallib");
+  assert.throws(() => canaryWatchdogEnvironment(
+    {}, roots, "relative/mlx.metallib", runtimeHome,
+  ));
+  assert.throws(() => canaryWatchdogEnvironment({}, roots, prepared, "relative/home"));
+
+  const second = path.join(
+    target, "release", "build", "pmetal-mlx-sys-second", "out", "build", "lib", "mlx.metallib",
+  );
+  await mkdir(path.dirname(second), { recursive: true });
+  await writeFile(second, "ambiguous metallib\n");
+  await assert.rejects(() => locateBuiltMetallib(target), /exactly one.*found 2/);
+});
+
 test("preparation identity and cache keys change for every canonical input", () => {
+  assert.equal(PREPARATION_SCHEMA_VERSION, 3);
   const identity = preparationIdentity("1".repeat(40), "2".repeat(40), "1.97.1");
   const key = preparationCacheKey(identity);
   for (const mutate of [
@@ -490,6 +583,10 @@ test("a completed cache is atomically reused without rebuilding or rehashing fil
   assert.equal(fixture.builds(), 1);
   assert.deepEqual(second.manifest.artifacts.numericTier.content, fixture.identity.artifact.numericTier);
   assert.deepEqual(second.manifest.artifacts.textEncoder.content, fixture.identity.artifact.textEncoder);
+  assert.match(second.manifest.metallib.sha256, /^[0-9a-f]{64}$/);
+  assert.equal(second.manifest.metallib.seal.mode, 0o400);
+  assert.equal(second.metallib.path,
+    path.join(fixture.preparationRoot, "adapter", "mlx.metallib"));
   assert.equal((await stat(fixture.preparationRoot)).mode & 0o777, 0o500);
   assert.equal(
     (await stat(path.join(fixture.preparationRoot, "prepared.json"))).mode & 0o777,
@@ -497,6 +594,9 @@ test("a completed cache is atomically reused without rebuilding or rehashing fil
   );
   assert.deepEqual((await readdir(fixture.preparationRoot)).sort(), [
     "adapter", "artifacts", "prepared.json", "prepared.sha256",
+  ]);
+  assert.deepEqual((await readdir(path.join(fixture.preparationRoot, "adapter"))).sort(), [
+    "memory-mlx-adapter", "mlx.metallib",
   ]);
 });
 
@@ -546,7 +646,18 @@ test("cache validation rejects canonical identity, completion, permission and me
   await chmod(adapterPath, 0o700);
   await assert.rejects(
     () => validatePreparedCache(adapter.preparationRoot, adapter.key, adapter.identity),
-    /read-only executable regular file/,
+    /adapter executable.*mode 500/,
+  );
+
+  const metallib = await cacheFixture(t);
+  await prepareCanaryCache(metallib.options);
+  const metallibPath = path.join(metallib.preparationRoot, "adapter", "mlx.metallib");
+  await chmod(metallibPath, 0o600);
+  await writeFile(metallibPath, "drifted global-cache candidate\n");
+  await chmod(metallibPath, 0o400);
+  await assert.rejects(
+    () => validatePreparedCache(metallib.preparationRoot, metallib.key, metallib.identity),
+    /metallib changed/,
   );
 
   const metadata = await cacheFixture(t);


### PR DESCRIPTION
## Summary
- copy the exact pmetal mlx.metallib produced by the canary adapter build into the sealed preparation cache
- validate and attest the adapter and metallib together before and after execution
- isolate build and runtime HOME directories and force PMETAL_METALLIB_PATH to the sealed artifact so the mutable user cache cannot be read or overwritten
- bump the preparation schema so older binary-only caches cannot be reused

## Why
The first real canary reached provider execution and failed loading implicit_gemm_conv_3d_bfloat16_bm32_bn64_bk16_wm2_wn2_filter_s. The prepared binary's compiled metallib path had been deleted with build scratch, so pmetal fell through to a mutable global cache. That cache did not export the requested symbol and changed afterward, confirming the race.

## Validation
- focused runner and platform tests: 71/71
- full npm run check: 559/559
- cargo fmt --all -- --check
- exact MLX adapter all-target Clippy with warnings denied
- independent adversarial review: PASS, no findings

No GPU, model, canary, or SC-18946 campaign run was performed by this PR.