### PR TITLE
fix(sc-19741): attest exact LTX provider cache residue

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -150,6 +150,15 @@ const LTX_CANARY_TEXT_ENCODER_INVENTORY_FILES: u64 = 17;
 const LTX_CANARY_TEXT_ENCODER_INVENTORY_BYTES: u64 = 26_427_894_918;
 const LTX_CANARY_TEXT_ENCODER_INVENTORY_SHA256: &str =
     "abde2d155aa8991747cc2999d40688d29a50261c080c0d51fac20357653928d7";
+// The pinned mlx-gen-ltx `transformer::ONES_CACHE` retains one bf16 unit-weight Array for each
+// AvDiT stream's weightless RMSNorm dimension on the current thread. The exact LTX-2.3 config is
+// video 32 heads x 128 = 4096 and audio 32 x 64 = 2048. These six Ki elements intentionally
+// outlive the dropped generator so production denoise can reuse them; the diagnostic canary
+// accounts for this one named allocation by checked arithmetic, never by a tolerance.
+const LTX_CANARY_ONES_CACHE_IDENTITY: &str = "mlx-gen-ltx-transformer-ones-cache-av-bfloat16-v1";
+const LTX_CANARY_ONES_CACHE_VIDEO_DIMENSION: u64 = 4_096;
+const LTX_CANARY_ONES_CACHE_AUDIO_DIMENSION: u64 = 2_048;
+const BFLOAT16_BYTES_PER_ELEMENT: u64 = 2;
 const LTX_INCIDENT_FORBIDDEN: &str = "incident_forbidden";
 const LTX_ARITHMETIC_UNMEASURABLE: &str = "arithmetic_unmeasurable";
 const LTX_SAFETY_REFUSED_OPEN: &str = "safety_refused_open";
@@ -6781,11 +6790,59 @@ fn consume_ltx_canary_watchdog_attestation_stream(
 /// One deliberately tiny, non-ingestible real-weight probe for the permanent-pin tiled-release
 /// repair. This is not a campaign arm: it executes one render, never the six-render lifecycle
 /// sweep, and emits a status the calibration harness schema rejects.
+fn ltx_canary_ones_cache_bytes() -> Result<u64, String> {
+    LTX_CANARY_ONES_CACHE_VIDEO_DIMENSION
+        .checked_add(LTX_CANARY_ONES_CACHE_AUDIO_DIMENSION)
+        .and_then(|elements| elements.checked_mul(BFLOAT16_BYTES_PER_ELEMENT))
+        .ok_or_else(|| "LTX safety canary ONES_CACHE byte arithmetic overflowed".to_owned())
+}
+
+fn validate_ltx_canary_pre_provider(pre_provider: AllocatorState) -> Result<(), String> {
+    if pre_provider.cache != 0 {
+        return Err(format!(
+            "LTX safety canary preProviderCacheBytes {} did not attest the cleared cache 0",
+            pre_provider.cache
+        ));
+    }
+    Ok(())
+}
+
+fn validate_ltx_canary_cleanup(
+    pre_provider: AllocatorState,
+    post_cleanup: AllocatorState,
+    expected_persistent_active: u64,
+) -> Result<(), String> {
+    let expected_post_active = pre_provider
+        .active
+        .checked_add(expected_persistent_active)
+        .ok_or_else(|| "LTX safety canary cleanup active-byte arithmetic overflowed".to_owned())?;
+    if post_cleanup.active != expected_post_active {
+        return Err(format!(
+            "LTX safety canary postCleanupActiveBytes {} did not equal pre-provider active {} plus intentional persistent active {} = {}",
+            post_cleanup.active,
+            pre_provider.active,
+            expected_persistent_active,
+            expected_post_active
+        ));
+    }
+    if post_cleanup.cache != pre_provider.cache {
+        return Err(format!(
+            "LTX safety canary postCleanupCacheBytes {} did not return to preProviderCacheBytes {}",
+            post_cleanup.cache, pre_provider.cache
+        ));
+    }
+    Ok(())
+}
+
 fn run_ltx_canary(request: &Value) -> Result<Value, String> {
     let selection = validate_ltx_canary_plan(request)?;
     let mut watchdog = consume_ltx_canary_watchdog_attestation(request)?;
     let watchdog_lease = watchdog.start_lease()?;
     let limits = LtxCanaryLimits::install()?;
+    clear_cache();
+    let pre_provider = AllocatorState::capture_current();
+    validate_ltx_canary_pre_provider(pre_provider)?;
+    let expected_persistent_active = ltx_canary_ones_cache_bytes()?;
     let geometry = LtxGeometry {
         width: LTX_CANARY_WIDTH,
         height: LTX_CANARY_HEIGHT,
@@ -6895,6 +6952,7 @@ fn run_ltx_canary(request: &Value) -> Result<Value, String> {
     drop(generator);
     clear_cache();
     let cleanup = AllocatorState::capture_current();
+    validate_ltx_canary_cleanup(pre_provider, cleanup, expected_persistent_active)?;
     let planned_artifact = protocol::planned(request)?
         .get("_artifact")
         .cloned()
@@ -6943,6 +7001,16 @@ fn run_ltx_canary(request: &Value) -> Result<Value, String> {
             "wiredLimitBytes": limits.wired,
         },
         "observedMemory": {
+            "preProviderActiveBytes": pre_provider.active,
+            "preProviderCacheBytes": pre_provider.cache,
+            "expectedPersistentActive": {
+                "identity": LTX_CANARY_ONES_CACHE_IDENTITY,
+                "videoDimension": LTX_CANARY_ONES_CACHE_VIDEO_DIMENSION,
+                "audioDimension": LTX_CANARY_ONES_CACHE_AUDIO_DIMENSION,
+                "dtype": "bfloat16",
+                "bytesPerElement": BFLOAT16_BYTES_PER_ELEMENT,
+                "bytes": expected_persistent_active,
+            },
             "conditioning": conditioning.json(),
             "denoise": denoise.json(),
             "decode": decode.json(),
@@ -8546,6 +8614,86 @@ mod ltx_tests {
         let mut provider_override = ltx_canary_generation_request();
         provider_override.video_mode = Some("default".to_owned());
         assert!(restore_ltx_canary_no_audio_after_configuration(&mut provider_override).is_err());
+    }
+
+    #[test]
+    fn the_ltx_safety_canary_accounts_for_only_the_exact_av_bfloat16_ones_cache() {
+        let expected = ltx_canary_ones_cache_bytes().expect("checked ONES_CACHE arithmetic");
+        assert_eq!(
+            expected,
+            (LTX_CANARY_ONES_CACHE_VIDEO_DIMENSION + LTX_CANARY_ONES_CACHE_AUDIO_DIMENSION)
+                * BFLOAT16_BYTES_PER_ELEMENT
+        );
+        assert!(validate_ltx_canary_pre_provider(AllocatorState {
+            active: 0,
+            cache: 0,
+        })
+        .is_ok());
+        let pre_provider = AllocatorState {
+            active: 7,
+            cache: 0,
+        };
+        assert!(validate_ltx_canary_cleanup(
+            pre_provider,
+            AllocatorState {
+                active: pre_provider.active + expected,
+                cache: 0,
+            },
+            expected,
+        )
+        .is_ok());
+
+        let low = validate_ltx_canary_cleanup(
+            pre_provider,
+            AllocatorState {
+                active: pre_provider.active + expected - 1,
+                cache: 0,
+            },
+            expected,
+        )
+        .expect_err("one byte below the exact active identity must fail");
+        assert!(low.contains("intentional persistent active"));
+        let high = validate_ltx_canary_cleanup(
+            pre_provider,
+            AllocatorState {
+                active: pre_provider.active + expected + 1,
+                cache: 0,
+            },
+            expected,
+        )
+        .expect_err("one byte above the exact active identity must fail");
+        assert!(high.contains("intentional persistent active"));
+
+        let dirty_pre = validate_ltx_canary_pre_provider(AllocatorState {
+            active: 0,
+            cache: 1,
+        })
+        .expect_err("a non-empty baseline cache must fail");
+        assert!(dirty_pre.contains("preProviderCacheBytes 1"));
+        let dirty_post = validate_ltx_canary_cleanup(
+            pre_provider,
+            AllocatorState {
+                active: pre_provider.active + expected,
+                cache: 1,
+            },
+            expected,
+        )
+        .expect_err("a retained post-cleanup cache byte must fail");
+        assert!(dirty_post.contains("postCleanupCacheBytes 1"));
+
+        let overflow = validate_ltx_canary_cleanup(
+            AllocatorState {
+                active: u64::MAX,
+                cache: 0,
+            },
+            AllocatorState::default(),
+            expected,
+        )
+        .expect_err("pre-provider plus persistent active bytes must not wrap");
+        assert_eq!(
+            overflow,
+            "LTX safety canary cleanup active-byte arithmetic overflowed"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -8871,9 +8871,10 @@ mod ltx_tests {
 
     #[test]
     fn the_ltx_canary_process_global_limits_are_serialized_and_restore_memory() {
-        let previous = get_memory_limit();
+        let previous;
         {
             let mut limits = LtxCanaryLimits::install().expect("install exact canary limits");
+            previous = limits.previous_memory;
             assert_eq!(get_memory_limit(), LTX_CANARY_MAX_FOOTPRINT_BYTES as usize);
             limits.restore();
             assert_eq!(get_memory_limit(), previous);
@@ -8881,6 +8882,9 @@ mod ltx_tests {
             set_wired_limit(restored_wired);
             assert_eq!(restored_wired, limits.previous_wired);
         }
+        let _restoration_guard = LTX_MEMORY_LIMIT_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         assert_eq!(get_memory_limit(), previous);
     }
 

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -2006,7 +2006,28 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
     '"status": "diagnostic_canary_complete"',
     '"promotable": false',
     '"ingestible": false',
+    '"preProviderActiveBytes": pre_provider.active',
+    '"preProviderCacheBytes": pre_provider.cache',
+    '"identity": LTX_CANARY_ONES_CACHE_IDENTITY',
+    '"bytes": expected_persistent_active',
   ]) assert.ok(canary.includes(required), `canary must retain ${required}`);
+  const limitsInstalled = canary.indexOf("let limits = LtxCanaryLimits::install()?");
+  const baselineCaptured = canary.indexOf("let pre_provider = AllocatorState::capture_current()");
+  const providerLoadSpec = canary.indexOf("ltx_load_spec(request, \"q4\", &selection)?");
+  assert.ok(limitsInstalled >= 0 && limitsInstalled < baselineCaptured,
+    "the allocator baseline must be captured after canary limits are installed");
+  assert.ok(baselineCaptured < providerLoadSpec,
+    "the allocator baseline must be captured before provider/model resolution");
+  assert.match(canary, /clear_cache\(\);\n\s*let pre_provider = AllocatorState::capture_current\(\);/,
+    "the pre-provider baseline must exclude reclaimable allocator cache");
+  assert.match(canary, /validate_ltx_canary_pre_provider\(pre_provider\)\?;/);
+  assert.match(
+    canary,
+    /validate_ltx_canary_cleanup\(pre_provider, cleanup, expected_persistent_active\)\?;/,
+    "successful canary output must require the exact named persistent allocation",
+  );
+  assert.doesNotMatch(campaign, /validate_ltx_canary_(?:pre_provider|cleanup)/,
+    "production generation must not use the diagnostic canary residue exception");
 
   const generationRequest = adapter.slice(
     adapter.indexOf("fn ltx_canary_generation_request("),

--- a/scripts/run-ltx-safety-canary.mjs
+++ b/scripts/run-ltx-safety-canary.mjs
@@ -38,6 +38,17 @@ const Q4_INVENTORY_SHA256 = "4e811932e87bb258f642ada790525e36ef2a55959c520e755f1
 const TEXT_ENCODER_INVENTORY_FILES = 17;
 const TEXT_ENCODER_INVENTORY_BYTES = 26_427_894_918;
 const TEXT_ENCODER_INVENTORY_SHA256 = "abde2d155aa8991747cc2999d40688d29a50261c080c0d51fac20357653928d7";
+const LTX_ONES_CACHE_IDENTITY = "mlx-gen-ltx-transformer-ones-cache-av-bfloat16-v1";
+const LTX_ONES_CACHE_VIDEO_DIMENSION = 4_096;
+const LTX_ONES_CACHE_AUDIO_DIMENSION = 2_048;
+const BFLOAT16_BYTES_PER_ELEMENT = 2;
+
+function ltxOnesCacheBytes() {
+  const elements = LTX_ONES_CACHE_VIDEO_DIMENSION + LTX_ONES_CACHE_AUDIO_DIMENSION;
+  const bytes = elements * BFLOAT16_BYTES_PER_ELEMENT;
+  if (!Number.isSafeInteger(bytes)) fail("LTX ONES_CACHE byte arithmetic overflowed");
+  return bytes;
+}
 
 function fail(message) {
   throw new Error(message);
@@ -454,10 +465,47 @@ export function validateCanaryResponse(
       || !Number.isInteger(response?.mlxLimits?.wiredLimitBytes)
       || response.mlxLimits.wiredLimitBytes <= 0
       || response.mlxLimits.wiredLimitBytes > MAX_FOOTPRINT_BYTES
-      || response?.observedMemory?.postCleanupActiveBytes !== 0
-      || response?.observedMemory?.postCleanupCacheBytes !== 0
       || response?.output?.firstFrameNondegenerate !== true) {
     fail("adapter response did not attest the exact bounded canary execution");
+  }
+  for (const field of [
+    "preProviderActiveBytes",
+    "preProviderCacheBytes",
+    "postCleanupActiveBytes",
+    "postCleanupCacheBytes",
+  ]) {
+    const value = response?.observedMemory?.[field];
+    if (!Number.isSafeInteger(value) || value < 0) {
+      fail(`adapter response observedMemory.${field} must be a non-negative safe integer`);
+    }
+  }
+  if (response.observedMemory.preProviderCacheBytes !== 0) {
+    fail(`adapter response observedMemory.preProviderCacheBytes ${response.observedMemory.preProviderCacheBytes} did not attest the cleared pre-provider cache 0`);
+  }
+  const persistent = response?.observedMemory?.expectedPersistentActive;
+  for (const [field, expected] of [
+    ["identity", LTX_ONES_CACHE_IDENTITY],
+    ["videoDimension", LTX_ONES_CACHE_VIDEO_DIMENSION],
+    ["audioDimension", LTX_ONES_CACHE_AUDIO_DIMENSION],
+    ["dtype", "bfloat16"],
+    ["bytesPerElement", BFLOAT16_BYTES_PER_ELEMENT],
+    ["bytes", ltxOnesCacheBytes()],
+  ]) {
+    if (persistent?.[field] !== expected) {
+      fail(`adapter response observedMemory.expectedPersistentActive.${field} ${JSON.stringify(persistent?.[field])} did not equal ${JSON.stringify(expected)}`);
+    }
+  }
+  const expectedPostActive = response.observedMemory.preProviderActiveBytes
+    + persistent.bytes;
+  if (!Number.isSafeInteger(expectedPostActive)) {
+    fail("adapter response pre-provider plus persistent active-byte arithmetic overflowed");
+  }
+  if (response.observedMemory.postCleanupActiveBytes !== expectedPostActive) {
+    fail(`adapter response observedMemory.postCleanupActiveBytes ${response.observedMemory.postCleanupActiveBytes} did not equal pre-provider active ${response.observedMemory.preProviderActiveBytes} plus intentional persistent active ${persistent.bytes} = ${expectedPostActive}`);
+  }
+  if (response.observedMemory.postCleanupCacheBytes
+      !== response.observedMemory.preProviderCacheBytes) {
+    fail(`adapter response observedMemory.postCleanupCacheBytes ${response.observedMemory.postCleanupCacheBytes} did not return to observedMemory.preProviderCacheBytes ${response.observedMemory.preProviderCacheBytes}`);
   }
   return response;
 }

--- a/scripts/run-ltx-safety-canary.test.mjs
+++ b/scripts/run-ltx-safety-canary.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   chmod, mkdir, mkdtemp, readFile, readdir, stat, symlink, writeFile,
@@ -896,9 +897,31 @@ test("owned command cancellation terminates descendants before rejecting", async
   const childPid = Number((await readFile(pidFile, "utf8")).trim());
   cancellation.abort(new CanaryInterrupted("SIGTERM"));
   await assert.rejects(operation, CanaryInterrupted);
-  assert.throws(
-    () => process.kill(childPid, 0),
-    (error) => error.code === "ESRCH",
-    "owned descendant survived cancellation",
-  );
+  let childExists = true;
+  try {
+    process.kill(childPid, 0);
+  } catch (error) {
+    if (error.code !== "ESRCH") throw error;
+    childExists = false;
+  }
+  if (childExists) {
+    const childStatus = spawnSync("/bin/ps", ["-o", "stat=", "-p", String(childPid)], {
+      encoding: "utf8",
+    });
+    assert.equal(childStatus.error, undefined);
+    assert.equal(childStatus.signal, null);
+    assert.equal(childStatus.stderr, "");
+    const childStates = childStatus.stdout.split("\n").map((state) => state.trim()).filter(Boolean);
+    if (childStatus.status === 1 && childStates.length === 0) {
+      assert.throws(
+        () => process.kill(childPid, 0),
+        (error) => error.code === "ESRCH",
+        "owned descendant survived cancellation after ps reported no process",
+      );
+    } else {
+      assert.equal(childStatus.status, 0);
+      assert.equal(childStates.length, 1);
+      assert.match(childStates[0], /^Z/, `owned descendant survived cancellation: state=${childStates[0]}`);
+    }
+  }
 });

--- a/scripts/run-ltx-safety-canary.test.mjs
+++ b/scripts/run-ltx-safety-canary.test.mjs
@@ -208,7 +208,20 @@ test("the runner refuses promotable or identity-drifted adapter output", () => {
       memoryLimitBytes: MAX_FOOTPRINT_BYTES,
       wiredLimitBytes: MAX_FOOTPRINT_BYTES,
     },
-    observedMemory: { postCleanupActiveBytes: 0, postCleanupCacheBytes: 0 },
+    observedMemory: {
+      preProviderActiveBytes: 0,
+      preProviderCacheBytes: 0,
+      expectedPersistentActive: {
+        identity: "mlx-gen-ltx-transformer-ones-cache-av-bfloat16-v1",
+        videoDimension: 4_096,
+        audioDimension: 2_048,
+        dtype: "bfloat16",
+        bytesPerElement: 2,
+        bytes: (4_096 + 2_048) * 2,
+      },
+      postCleanupActiveBytes: (4_096 + 2_048) * 2,
+      postCleanupCacheBytes: 0,
+    },
     output: { firstFrameNondegenerate: true },
   };
   assert.deepEqual(
@@ -233,7 +246,6 @@ test("the runner refuses promotable or identity-drifted adapter output", () => {
     (value) => { value.watchdog.minMemoryFreeBytes -= 1; },
     (value) => { value.watchdog.minSwapFreeBytes = 1024 ** 3; },
     (value) => { value.mlxLimits.wiredLimitBytes = MAX_FOOTPRINT_BYTES + 1; },
-    (value) => { value.observedMemory.postCleanupActiveBytes = 1; },
     (value) => { value.output.firstFrameNondegenerate = false; },
     (value) => { value.inferenceRevision = "0".repeat(40); },
     (value) => { value.artifact.resolvedRevision = "0".repeat(40); },
@@ -247,6 +259,70 @@ test("the runner refuses promotable or identity-drifted adapter output", () => {
       changed, response.inferenceRevision, TEXT_ENCODER_INVENTORY,
       response.watchdog.hostMemoryBytes,
     ));
+  }
+  for (const [mutate, expected] of [
+    [
+      (value) => { delete value.observedMemory.preProviderActiveBytes; },
+      /preProviderActiveBytes must be a non-negative safe integer/,
+    ],
+    [
+      (value) => { value.observedMemory.preProviderActiveBytes = 1; },
+      /postCleanupActiveBytes 12288 did not equal pre-provider active 1 plus intentional persistent active 12288 = 12289/,
+    ],
+    [
+      (value) => {
+        value.observedMemory.preProviderActiveBytes = Number.MAX_SAFE_INTEGER;
+        value.observedMemory.postCleanupActiveBytes = Number.MAX_SAFE_INTEGER;
+      },
+      /pre-provider plus persistent active-byte arithmetic overflowed/,
+    ],
+    [
+      (value) => { value.observedMemory.postCleanupActiveBytes -= 1; },
+      /postCleanupActiveBytes 12287 did not equal pre-provider active 0 plus intentional persistent active 12288 = 12288/,
+    ],
+    [
+      (value) => { value.observedMemory.postCleanupActiveBytes += 1; },
+      /postCleanupActiveBytes 12289 did not equal pre-provider active 0 plus intentional persistent active 12288 = 12288/,
+    ],
+    [
+      (value) => { value.observedMemory.preProviderCacheBytes = 1; },
+      /preProviderCacheBytes 1 did not attest the cleared pre-provider cache 0/,
+    ],
+    [
+      (value) => { value.observedMemory.postCleanupCacheBytes = 1; },
+      /postCleanupCacheBytes 1 did not return to observedMemory\.preProviderCacheBytes 0/,
+    ],
+    [
+      (value) => { value.observedMemory.expectedPersistentActive.bytes += 1; },
+      /expectedPersistentActive\.bytes 12289 did not equal 12288/,
+    ],
+    [
+      (value) => { value.observedMemory.expectedPersistentActive.videoDimension -= 1; },
+      /expectedPersistentActive\.videoDimension 4095 did not equal 4096/,
+    ],
+    [
+      (value) => { value.observedMemory.expectedPersistentActive.audioDimension += 1; },
+      /expectedPersistentActive\.audioDimension 2049 did not equal 2048/,
+    ],
+    [
+      (value) => { value.observedMemory.expectedPersistentActive.dtype = "float32"; },
+      /expectedPersistentActive\.dtype "float32" did not equal "bfloat16"/,
+    ],
+    [
+      (value) => { value.observedMemory.expectedPersistentActive.bytesPerElement = 4; },
+      /expectedPersistentActive\.bytesPerElement 4 did not equal 2/,
+    ],
+    [
+      (value) => { value.observedMemory.expectedPersistentActive.identity = "generic-cache"; },
+      /expectedPersistentActive\.identity "generic-cache" did not equal/,
+    ],
+  ]) {
+    const changed = structuredClone(response);
+    mutate(changed);
+    assert.throws(() => validateCanaryResponse(
+      changed, response.inferenceRevision, TEXT_ENCODER_INVENTORY,
+      response.watchdog.hostMemoryBytes,
+    ), expected);
   }
 });
 


### PR DESCRIPTION
## Summary
- capture the clean allocator state after canary limits are installed and before provider/model resolution
- identify the pinned LTX provider's intentional thread-local bf16 RMSNorm cache by source dimensions: (4096 video + 2048 audio) * 2 bytes = 12,288 bytes
- require exact post-cleanup active bytes to equal pre-provider active plus that named cache, with cache bytes returning exactly to zero
- emit and independently validate the baseline, cache identity, dimensions, dtype, byte width, and post-cleanup state
- add field-specific diagnostics and mutation coverage for one-byte drift, cache retention, identity drift, and arithmetic overflow

## Why
The real canary completed its exact no-audio render but the runner rejected postCleanupActiveBytes=12,288. Pinned mlx-gen-ltx source proves those bytes are two intentional thread-local AvDiT RMSNorm unit weights: 4096 bf16 video elements and 2048 bf16 audio elements. No-audio still denoises both streams and skips only audio decode. This is production process-cache identity, not leaked generator or frame state.

This PR does not add a tolerance or clear the provider cache. It preserves production lifecycle behavior and rejects any active byte beyond the exact source-derived identity.

## Validation
- focused Node/platform: 71/71
- full npm run check: 559/559
- focused Rust cleanup contract: 1/1
- cargo fmt --all -- --check
- exact MLX adapter all-target Clippy with warnings denied
- independent adversarial rereview: PASS, no findings, confidence 0.99

No inference pin, campaign path, GPU/model/canary run, or calibration admission changed.