### PR TITLE
SC-20169: add bounded product-envelope LTX canary

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -142,6 +142,12 @@ const LTX_CANARY_SEED: u64 = 1234;
 const LTX_CANARY_TILE_EDGE: u32 = 192;
 const LTX_CANARY_OVERLAP: u32 = 64;
 const LTX_CANARY_FIXTURE: &str = "ltx-2-3-mlx-q4-256x256-f9-fps24-seed1234-safety-canary";
+const LTX_PRODUCT_CANARY_WIDTH: u32 = 768;
+const LTX_PRODUCT_CANARY_HEIGHT: u32 = 512;
+const LTX_PRODUCT_CANARY_FRAMES: u32 = 97;
+const LTX_PRODUCT_CANARY_FPS: u32 = 24;
+const LTX_PRODUCT_CANARY_FIXTURE: &str =
+    "ltx-2-3-mlx-q4-768x512-f97-fps24-seed1234-product-envelope-canary";
 const LTX_CANARY_ARTIFACT_REVISION: &str = "01df27d308466533aa09d251e3aebdcc627d07eb";
 const LTX_CANARY_Q4_INVENTORY_FILES: u64 = 11;
 const LTX_CANARY_Q4_INVENTORY_SHA256: &str =
@@ -164,6 +170,93 @@ const LTX_ARITHMETIC_UNMEASURABLE: &str = "arithmetic_unmeasurable";
 const LTX_SAFETY_REFUSED_OPEN: &str = "safety_refused_open";
 const LTX_INCIDENT_PREDICTED_DECODE_BYTES: u64 =
     3_300_000_000 + 40 * (1280 * 704 * 305) + 300 * 384 * 384 * 96;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LtxCanaryProfile {
+    Safety,
+    ProductEnvelope,
+}
+
+impl LtxCanaryProfile {
+    fn action(self) -> &'static str {
+        match self {
+            Self::Safety => "canary",
+            Self::ProductEnvelope => "product_envelope_canary",
+        }
+    }
+
+    fn width(self) -> u32 {
+        match self {
+            Self::Safety => LTX_CANARY_WIDTH,
+            Self::ProductEnvelope => LTX_PRODUCT_CANARY_WIDTH,
+        }
+    }
+
+    fn height(self) -> u32 {
+        match self {
+            Self::Safety => LTX_CANARY_HEIGHT,
+            Self::ProductEnvelope => LTX_PRODUCT_CANARY_HEIGHT,
+        }
+    }
+
+    fn frames(self) -> u32 {
+        match self {
+            Self::Safety => LTX_CANARY_FRAMES,
+            Self::ProductEnvelope => LTX_PRODUCT_CANARY_FRAMES,
+        }
+    }
+
+    fn fps(self) -> u32 {
+        match self {
+            Self::Safety => LTX_CANARY_FPS,
+            Self::ProductEnvelope => LTX_PRODUCT_CANARY_FPS,
+        }
+    }
+
+    fn fixture(self) -> &'static str {
+        match self {
+            Self::Safety => LTX_CANARY_FIXTURE,
+            Self::ProductEnvelope => LTX_PRODUCT_CANARY_FIXTURE,
+        }
+    }
+
+    fn prompt(self) -> &'static str {
+        match self {
+            Self::Safety => "a sunlit pine branch, static camera",
+            Self::ProductEnvelope => {
+                "a slow dolly through a sunlit pine forest, drifting motes of pollen, cinematic"
+            }
+        }
+    }
+
+    fn video_mode(self) -> Option<&'static str> {
+        match self {
+            Self::Safety => Some("no_audio"),
+            Self::ProductEnvelope => None,
+        }
+    }
+
+    fn video_mode_identity(self) -> &'static str {
+        match self {
+            Self::Safety => "no_audio",
+            Self::ProductEnvelope => "default_av",
+        }
+    }
+
+    fn completion_status(self) -> &'static str {
+        match self {
+            Self::Safety => "diagnostic_canary_complete",
+            Self::ProductEnvelope => "diagnostic_product_envelope_canary_complete",
+        }
+    }
+
+    fn identity(self) -> &'static str {
+        match self {
+            Self::Safety => "sc-19741-safety",
+            Self::ProductEnvelope => "sc-20169-product-envelope",
+        }
+    }
+}
 /// LTX's video VAE is x32 spatial and **x8 causal temporal**, so `out_f = 1 + (t_lat - 1) * 8` and
 /// the engine's `validate_request` hard-rejects any `num_frames` that is not `1 + 8k`. Latent
 /// temporal depth — not raw frame count — is the physically motivated regressor for a frames-aware
@@ -5502,20 +5595,20 @@ fn ltx_request(geometry: LtxGeometry, fps: u32, seed: u64) -> GenerationRequest 
     }
 }
 
-/// The non-promotable safety canary. This is intentionally outside the product calibration
-/// envelope: it reuses the inference provider's historical 256x256x9 q4 residency baseline, skips
-/// only the downstream audio decoder/vocoder, then forces the smallest shipped spatial decode
-/// carrier so the permanent-pin per-tile release path executes without a campaign geometry.
-fn ltx_canary_generation_request() -> GenerationRequest {
+/// One non-promotable diagnostic request. The safety profile is intentionally outside the product
+/// envelope and skips only downstream audio decode. The product-envelope profile is the smallest
+/// shipped four-second geometry and leaves `video_mode` unset so it follows the ordinary full-A/V
+/// provider path. Both force the same bounded-decode carrier without admitting a campaign row.
+fn ltx_canary_generation_request_for(profile: LtxCanaryProfile) -> GenerationRequest {
     GenerationRequest {
-        prompt: "a sunlit pine branch, static camera".to_owned(),
-        width: LTX_CANARY_WIDTH,
-        height: LTX_CANARY_HEIGHT,
+        prompt: profile.prompt().to_owned(),
+        width: profile.width(),
+        height: profile.height(),
         count: 1,
         seed: Some(LTX_CANARY_SEED),
-        frames: Some(LTX_CANARY_FRAMES),
-        fps: Some(LTX_CANARY_FPS),
-        video_mode: Some("no_audio".to_owned()),
+        frames: Some(profile.frames()),
+        fps: Some(profile.fps()),
+        video_mode: profile.video_mode().map(str::to_owned),
         memory: Some(GenerationMemory {
             tile_vae_decode: true,
             decode_tile_edge: Some(LTX_CANARY_TILE_EDGE),
@@ -5524,6 +5617,14 @@ fn ltx_canary_generation_request() -> GenerationRequest {
         }),
         ..Default::default()
     }
+}
+
+fn ltx_canary_generation_request() -> GenerationRequest {
+    ltx_canary_generation_request_for(LtxCanaryProfile::Safety)
+}
+
+fn ltx_product_envelope_canary_generation_request() -> GenerationRequest {
+    ltx_canary_generation_request_for(LtxCanaryProfile::ProductEnvelope)
 }
 
 fn ltx_canary_request_for_provider_admission(
@@ -5990,6 +6091,34 @@ impl LtxDecodePlan {
             .and_then(|config| config.spatial)
             .map_or(0, |spatial| u64::from(spatial.overlap_px.max(0) as u32))
     }
+
+    /// Count physical spatial decode tiles from the same shared plan geometry the provider executes.
+    /// A configured tiling object alone is insufficient evidence: a carrier smaller than its tile
+    /// edge can still produce a one-tile plan.
+    fn spatial_tile_count(self, geometry: LtxGeometry) -> Result<u64, String> {
+        let Some(config) = self.tiling else {
+            return Ok(1);
+        };
+        let spatial_scale = u32::try_from(VaeTiling::LTX.spatial_scale)
+            .map_err(|_| "LTX spatial scale must fit u32".to_owned())?;
+        let latent_height = i32::try_from(geometry.height / spatial_scale)
+            .map_err(|_| "LTX latent height must fit i32".to_owned())?;
+        let latent_width = i32::try_from(geometry.width / spatial_scale)
+            .map_err(|_| "LTX latent width must fit i32".to_owned())?;
+        let latent_frames = i32::try_from(geometry.latent_frames)
+            .map_err(|_| "LTX latent frames must fit i32".to_owned())?;
+        let plan = config.plan(VaeTiling::LTX, latent_frames, latent_height, latent_width);
+        [plan.h.len(), plan.w.len()]
+            .into_iter()
+            .try_fold(1_u64, |count, axis| {
+                count
+                    .checked_mul(
+                        u64::try_from(axis)
+                            .map_err(|_| "LTX decode tile-axis count must fit u64".to_owned())?,
+                    )
+                    .ok_or_else(|| "LTX decode tile-count arithmetic overflowed".to_owned())
+            })
+    }
 }
 
 /// Bind the plan to the provider contract's actual engaged composition. SC-19109 made bounded
@@ -6030,6 +6159,63 @@ fn video_frames(output: GenerationOutput) -> Result<(Vec<Image>, u32, bool), Str
         GenerationOutput::Audio(_) => {
             Err("MLX LTX-2.3 render returned an audio track, not a video clip".to_owned())
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DiagnosticAudioIdentity {
+    samples: u64,
+    sample_rate: u32,
+    channels: u16,
+}
+
+/// Extract a diagnostic clip while retaining enough audio identity to prove the full default-A/V
+/// decoder returned a non-empty track. The samples themselves drop here, before provider cleanup.
+fn diagnostic_video_frames(
+    output: GenerationOutput,
+) -> Result<(Vec<Image>, u32, Option<DiagnosticAudioIdentity>), String> {
+    match output {
+        GenerationOutput::Video { frames, fps, audio } => {
+            if frames.is_empty() {
+                return Err("MLX LTX-2.3 render returned no frames".to_owned());
+            }
+            let audio = audio
+                .map(|track| {
+                    Ok::<_, String>(DiagnosticAudioIdentity {
+                        samples: u64::try_from(track.samples.len()).map_err(|_| {
+                            "LTX diagnostic audio sample count must fit u64".to_owned()
+                        })?,
+                        sample_rate: track.sample_rate,
+                        channels: track.channels,
+                    })
+                })
+                .transpose()?;
+            Ok((frames, fps, audio))
+        }
+        GenerationOutput::Images(_) => {
+            Err("MLX LTX-2.3 render returned images, not a video clip".to_owned())
+        }
+        GenerationOutput::Audio(_) => {
+            Err("MLX LTX-2.3 render returned an audio track, not a video clip".to_owned())
+        }
+    }
+}
+
+fn validate_diagnostic_audio(
+    profile: LtxCanaryProfile,
+    audio: Option<DiagnosticAudioIdentity>,
+) -> Result<(), String> {
+    match (profile, audio) {
+        (LtxCanaryProfile::Safety, None) => Ok(()),
+        (LtxCanaryProfile::ProductEnvelope, Some(audio))
+            if audio.samples > 0 && audio.sample_rate > 0 && audio.channels > 0 =>
+        {
+            Ok(())
+        }
+        _ => Err(format!(
+            "LTX diagnostic canary returned invalid {:?} audio identity {audio:?}",
+            profile
+        )),
     }
 }
 
@@ -6447,7 +6633,16 @@ fn verify_ltx_lifecycle(
     Ok(metrics)
 }
 
-fn validate_ltx_canary_plan(request: &Value) -> Result<MemorySelection, String> {
+fn validate_ltx_canary_plan_for(
+    request: &Value,
+    profile: LtxCanaryProfile,
+) -> Result<MemorySelection, String> {
+    if protocol::action(request)? != profile.action() {
+        return Err(format!(
+            "LTX diagnostic canary action must be {:?}",
+            profile.action()
+        ));
+    }
     let planned = protocol::planned(request)?;
     if planned.get("_diagnosticOnly").and_then(Value::as_bool) != Some(true) {
         return Err("LTX safety canary requires planned._diagnosticOnly == true".to_owned());
@@ -6495,10 +6690,10 @@ fn validate_ltx_canary_plan(request: &Value) -> Result<MemorySelection, String> 
         .and_then(Value::as_object)
         .ok_or_else(|| "planned.target.geometry must be an object".to_owned())?;
     let exact_geometry = [
-        ("width", u64::from(LTX_CANARY_WIDTH)),
-        ("height", u64::from(LTX_CANARY_HEIGHT)),
+        ("width", u64::from(profile.width())),
+        ("height", u64::from(profile.height())),
         ("batch", 1),
-        ("frames", u64::from(LTX_CANARY_FRAMES)),
+        ("frames", u64::from(profile.frames())),
     ];
     for (field, expected) in exact_geometry {
         if geometry.get(field).and_then(Value::as_u64) != Some(expected) {
@@ -6507,9 +6702,10 @@ fn validate_ltx_canary_plan(request: &Value) -> Result<MemorySelection, String> 
             ));
         }
     }
-    if planned.get("fixture").and_then(Value::as_str) != Some(LTX_CANARY_FIXTURE) {
+    if planned.get("fixture").and_then(Value::as_str) != Some(profile.fixture()) {
         return Err(format!(
-            "LTX safety canary fixture must be {LTX_CANARY_FIXTURE:?}"
+            "LTX safety canary fixture must be {:?}",
+            profile.fixture()
         ));
     }
     if planned
@@ -6535,12 +6731,16 @@ fn validate_ltx_canary_plan(request: &Value) -> Result<MemorySelection, String> 
         .get("_canary")
         .and_then(Value::as_object)
         .ok_or_else(|| "LTX safety canary requires planned._canary".to_owned())?;
-    if canary.get("videoMode").and_then(Value::as_str) != Some("no_audio")
-        || canary.get("fps").and_then(Value::as_u64) != Some(u64::from(LTX_CANARY_FPS))
+    if canary.get("identity").and_then(Value::as_str) != Some(profile.identity())
+        || canary.get("videoMode").and_then(Value::as_str) != Some(profile.video_mode_identity())
+        || canary.get("fps").and_then(Value::as_u64) != Some(u64::from(profile.fps()))
         || canary.get("seed").and_then(Value::as_u64) != Some(LTX_CANARY_SEED)
     {
         return Err(format!(
-            "LTX safety canary requires the no-audio route, fps {LTX_CANARY_FPS}, seed {LTX_CANARY_SEED}"
+            "LTX safety canary requires identity {:?}, video mode {:?}, fps {}, seed {LTX_CANARY_SEED}",
+            profile.identity(),
+            profile.video_mode_identity(),
+            profile.fps(),
         ));
     }
     let artifact = planned
@@ -6603,6 +6803,16 @@ fn validate_ltx_canary_plan(request: &Value) -> Result<MemorySelection, String> 
         ));
     }
     Ok(selection)
+}
+
+#[cfg(test)]
+fn validate_ltx_canary_plan(request: &Value) -> Result<MemorySelection, String> {
+    validate_ltx_canary_plan_for(request, LtxCanaryProfile::Safety)
+}
+
+#[cfg(test)]
+fn validate_ltx_product_envelope_canary_plan(request: &Value) -> Result<MemorySelection, String> {
+    validate_ltx_canary_plan_for(request, LtxCanaryProfile::ProductEnvelope)
 }
 
 #[derive(Debug)]
@@ -6834,8 +7044,8 @@ fn validate_ltx_canary_cleanup(
     Ok(())
 }
 
-fn run_ltx_canary(request: &Value) -> Result<Value, String> {
-    let selection = validate_ltx_canary_plan(request)?;
+fn run_ltx_canary_for(request: &Value, profile: LtxCanaryProfile) -> Result<Value, String> {
+    let selection = validate_ltx_canary_plan_for(request, profile)?;
     let mut watchdog = consume_ltx_canary_watchdog_attestation(request)?;
     let watchdog_lease = watchdog.start_lease()?;
     let limits = LtxCanaryLimits::install()?;
@@ -6844,10 +7054,10 @@ fn run_ltx_canary(request: &Value) -> Result<Value, String> {
     validate_ltx_canary_pre_provider(pre_provider)?;
     let expected_persistent_active = ltx_canary_ones_cache_bytes()?;
     let geometry = LtxGeometry {
-        width: LTX_CANARY_WIDTH,
-        height: LTX_CANARY_HEIGHT,
-        frames: LTX_CANARY_FRAMES,
-        latent_frames: 1 + (LTX_CANARY_FRAMES - 1) / LTX_TEMPORAL_SCALE,
+        width: profile.width(),
+        height: profile.height(),
+        frames: profile.frames(),
+        latent_frames: 1 + (profile.frames() - 1) / LTX_TEMPORAL_SCALE,
     };
     let (repository, revision, root, text_encoder_root, spec) =
         ltx_load_spec(request, "q4", &selection)?;
@@ -6885,6 +7095,10 @@ fn run_ltx_canary(request: &Value) -> Result<Value, String> {
             "LTX safety canary did not resolve the exact multi-tile decode carrier".to_owned(),
         );
     }
+    let spatial_decode_tile_count = decode_plan.spatial_tile_count(geometry)?;
+    if spatial_decode_tile_count <= 1 {
+        return Err("LTX safety canary resolved no physical multi-tile decode".to_owned());
+    }
     let generator = registry
         .load(LTX_PROVIDER, &spec)
         .map_err(|error| format!("load real LTX-2.3 q4 canary provider: {error}"))?;
@@ -6915,29 +7129,42 @@ fn run_ltx_canary(request: &Value) -> Result<Value, String> {
         active: 0,
         cache: 0,
     };
-    let (frames, fps, has_audio) = video_frames(scoped_generate_ltx_no_audio_canary(
-        generator.as_ref(),
-        ltx_canary_generation_request(),
-        &context,
-        &mut |progress| match progress {
-            Progress::Step { current: 1, .. } => {
-                conditioning = PhaseMemory::capture();
-                reset_peak_memory();
-            }
-            Progress::Decoding => {
-                denoise = PhaseMemory::capture();
-                reset_peak_memory();
-            }
-            _ => {}
-        },
-    )?)?;
+    let mut observe_progress = |progress| match progress {
+        Progress::Step { current: 1, .. } => {
+            conditioning = PhaseMemory::capture();
+            reset_peak_memory();
+        }
+        Progress::Decoding => {
+            denoise = PhaseMemory::capture();
+            reset_peak_memory();
+        }
+        _ => {}
+    };
+    let generated = match profile {
+        LtxCanaryProfile::Safety => scoped_generate_ltx_no_audio_canary(
+            generator.as_ref(),
+            ltx_canary_generation_request(),
+            &context,
+            &mut observe_progress,
+        ),
+        LtxCanaryProfile::ProductEnvelope => scoped_generate(
+            generator.as_ref(),
+            ltx_product_envelope_canary_generation_request(),
+            &context,
+            None,
+            &mut observe_progress,
+        ),
+    }?;
+    let (frames, fps, audio) = diagnostic_video_frames(generated)?;
     let decode = PhaseMemory::capture();
-    if frames.len() != LTX_CANARY_FRAMES as usize || fps != LTX_CANARY_FPS || has_audio {
+    let expected_audio = profile == LtxCanaryProfile::ProductEnvelope;
+    if frames.len() != profile.frames() as usize || fps != profile.fps() {
         return Err(format!(
-            "LTX safety canary returned frames={}, fps={fps}, audio={has_audio}",
-            frames.len()
+            "LTX safety canary returned frames={}, fps={fps}, audio={audio:?}",
+            frames.len(),
         ));
     }
+    validate_diagnostic_audio(profile, audio)?;
     let first = frames
         .first()
         .ok_or_else(|| "LTX safety canary returned no frames".to_owned())?;
@@ -6957,9 +7184,12 @@ fn run_ltx_canary(request: &Value) -> Result<Value, String> {
         .get("_artifact")
         .cloned()
         .ok_or_else(|| "LTX safety canary lost planned._artifact".to_owned())?;
+    let mut strategy = ltx_attested_strategy(request, &context.selection, &contract)?;
+    strategy["spatialDecodeTiles"] = json!(spatial_decode_tile_count);
     watchdog_lease.complete()?;
     Ok(json!({
-        "status": "diagnostic_canary_complete",
+        "status": profile.completion_status(),
+        "canaryIdentity": profile.identity(),
         "diagnosticOnly": true,
         "promotable": false,
         "ingestible": false,
@@ -6978,14 +7208,15 @@ fn run_ltx_canary(request: &Value) -> Result<Value, String> {
             "provider": LTX_PROVIDER,
             "tier": "q4",
             "geometry": {
-                "width": LTX_CANARY_WIDTH,
-                "height": LTX_CANARY_HEIGHT,
-                "frames": LTX_CANARY_FRAMES,
-                "fps": LTX_CANARY_FPS,
+                "width": profile.width(),
+                "height": profile.height(),
+                "frames": profile.frames(),
+                "fps": profile.fps(),
             },
-            "audio": false,
+            "videoMode": profile.video_mode_identity(),
+            "audio": expected_audio,
         },
-        "strategy": ltx_attested_strategy(request, &context.selection, &contract)?,
+        "strategy": strategy,
         "watchdog": {
             "required": true,
             "protocol": LTX_CANARY_WATCHDOG_PROTOCOL,
@@ -7019,12 +7250,27 @@ fn run_ltx_canary(request: &Value) -> Result<Value, String> {
             "postCleanupCacheBytes": cleanup.cache,
         },
         "output": {
-            "frames": LTX_CANARY_FRAMES,
-            "fps": LTX_CANARY_FPS,
+            "frames": profile.frames(),
+            "fps": profile.fps(),
+            "audio": {
+                "present": audio.is_some(),
+                "samples": audio.map_or(0, |value| value.samples),
+                "sampleRate": audio.map_or(0, |value| value.sample_rate),
+                "channels": audio.map_or(0, |value| value.channels),
+            },
+            "frameTimelineSeconds": f64::from(profile.frames() - 1) / f64::from(profile.fps()),
             "firstFrameNondegenerate": true,
         },
         "capturedAt": protocol::captured_at(),
     }))
+}
+
+fn run_ltx_canary(request: &Value) -> Result<Value, String> {
+    run_ltx_canary_for(request, LtxCanaryProfile::Safety)
+}
+
+fn run_ltx_product_envelope_canary(request: &Value) -> Result<Value, String> {
+    run_ltx_canary_for(request, LtxCanaryProfile::ProductEnvelope)
 }
 
 /// The `mlx:ltx_2_3` SC-18946 arm. SC-19109 moved strategy ownership into the provider: this path
@@ -7406,6 +7652,7 @@ fn main() {
         "probe" => probe(),
         "run" => run(&request),
         "canary" => run_ltx_canary(&request),
+        "product_envelope_canary" => run_ltx_product_envelope_canary(&request),
         "assess_batch" => assess_z_image_batch(&request),
         other => Err(format!("unsupported action {other:?}")),
     }
@@ -8553,6 +8800,7 @@ mod ltx_tests {
                     "maxFootprintBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES,
                 },
                 "_canary": {
+                    "identity": LtxCanaryProfile::Safety.identity(),
                     "videoMode": "no_audio",
                     "fps": LTX_CANARY_FPS,
                     "seed": LTX_CANARY_SEED,
@@ -8575,6 +8823,25 @@ mod ltx_tests {
         })
     }
 
+    fn ltx_product_envelope_canary_request_json() -> Value {
+        let mut request = ltx_canary_request_json();
+        request["action"] = json!("product_envelope_canary");
+        request["planned"]["target"]["geometry"] = json!({
+            "width": LTX_PRODUCT_CANARY_WIDTH,
+            "height": LTX_PRODUCT_CANARY_HEIGHT,
+            "batch": 1,
+            "frames": LTX_PRODUCT_CANARY_FRAMES,
+        });
+        request["planned"]["fixture"] = json!(LTX_PRODUCT_CANARY_FIXTURE);
+        request["planned"]["_canary"] = json!({
+            "identity": LtxCanaryProfile::ProductEnvelope.identity(),
+            "videoMode": "default_av",
+            "fps": LTX_PRODUCT_CANARY_FPS,
+            "seed": LTX_CANARY_SEED,
+        });
+        request
+    }
+
     #[test]
     fn the_ltx_safety_canary_is_an_exact_non_promotable_multi_tile_tuple() {
         let request = ltx_canary_request_json();
@@ -8590,6 +8857,7 @@ mod ltx_tests {
             Some(LTX_CANARY_OVERLAP)
         );
         let generated = ltx_canary_generation_request();
+        assert_eq!(generated.prompt, "a sunlit pine branch, static camera");
         assert_eq!(
             (generated.width, generated.height, generated.frames),
             (LTX_CANARY_WIDTH, LTX_CANARY_HEIGHT, Some(LTX_CANARY_FRAMES))
@@ -8614,6 +8882,84 @@ mod ltx_tests {
         let mut provider_override = ltx_canary_generation_request();
         provider_override.video_mode = Some("default".to_owned());
         assert!(restore_ltx_canary_no_audio_after_configuration(&mut provider_override).is_err());
+    }
+
+    #[test]
+    fn the_ltx_product_envelope_canary_is_exact_full_av_and_physically_multi_tile() {
+        let request = ltx_product_envelope_canary_request_json();
+        let selection = validate_ltx_product_envelope_canary_plan(&request)
+            .expect("exact product-envelope canary tuple");
+        assert_eq!(selection.strategy, MemoryStrategy::BoundedDecode);
+        let generated = ltx_product_envelope_canary_generation_request();
+        assert_eq!(
+            (
+                generated.width,
+                generated.height,
+                generated.frames,
+                generated.fps
+            ),
+            (
+                LTX_PRODUCT_CANARY_WIDTH,
+                LTX_PRODUCT_CANARY_HEIGHT,
+                Some(LTX_PRODUCT_CANARY_FRAMES),
+                Some(LTX_PRODUCT_CANARY_FPS),
+            )
+        );
+        assert_eq!(
+            generated.prompt,
+            "a slow dolly through a sunlit pine forest, drifting motes of pollen, cinematic"
+        );
+        assert_eq!(generated.video_mode, None, "default A/V must stay unset");
+        let geometry = LtxGeometry {
+            width: LTX_PRODUCT_CANARY_WIDTH,
+            height: LTX_PRODUCT_CANARY_HEIGHT,
+            frames: LTX_PRODUCT_CANARY_FRAMES,
+            latent_frames: 1 + (LTX_PRODUCT_CANARY_FRAMES - 1) / LTX_TEMPORAL_SCALE,
+        };
+        let decode = LtxDecodePlan::resolve_for_selection(&selection, geometry)
+            .expect("exact bounded decode plan");
+        assert_eq!(decode.spatial_tile_count(geometry).unwrap(), 24);
+        assert!(validate_diagnostic_audio(
+            LtxCanaryProfile::ProductEnvelope,
+            Some(DiagnosticAudioIdentity {
+                samples: 1,
+                sample_rate: 24_000,
+                channels: 2,
+            }),
+        )
+        .is_ok());
+        for audio in [
+            None,
+            Some(DiagnosticAudioIdentity {
+                samples: 0,
+                sample_rate: 24_000,
+                channels: 2,
+            }),
+            Some(DiagnosticAudioIdentity {
+                samples: 1,
+                sample_rate: 0,
+                channels: 2,
+            }),
+            Some(DiagnosticAudioIdentity {
+                samples: 1,
+                sample_rate: 24_000,
+                channels: 0,
+            }),
+        ] {
+            assert!(validate_diagnostic_audio(LtxCanaryProfile::ProductEnvelope, audio).is_err());
+        }
+        assert!(validate_diagnostic_audio(
+            LtxCanaryProfile::Safety,
+            Some(DiagnosticAudioIdentity {
+                samples: 1,
+                sample_rate: 24_000,
+                channels: 2,
+            }),
+        )
+        .is_err());
+        let direct = run_ltx_product_envelope_canary(&request)
+            .expect_err("product-envelope canary must refuse without the external watchdog");
+        assert!(direct.contains("live external watchdog channel"));
     }
 
     #[test]
@@ -8799,7 +9145,10 @@ mod ltx_tests {
     #[test]
     fn the_ltx_safety_canary_rejects_every_identity_or_safety_mutation_before_load() {
         type CanaryMutation = (&'static str, fn(&mut Value));
-        let mutations: [CanaryMutation; 15] = [
+        let mutations: [CanaryMutation; 16] = [
+            ("wrong canary identity", |request| {
+                request["planned"]["_canary"]["identity"] = json!("sc-20169-product-envelope")
+            }),
             ("promotable scope", |request| {
                 request["planned"]["evidenceScope"] = json!("authoritative")
             }),
@@ -8856,6 +9205,53 @@ mod ltx_tests {
             mutate(&mut request);
             assert!(
                 validate_ltx_canary_plan(&request).is_err(),
+                "{name} must fail before environment/provider/model access"
+            );
+        }
+    }
+
+    #[test]
+    fn the_ltx_product_envelope_canary_rejects_every_tuple_mutation_before_load() {
+        type CanaryMutation = (&'static str, fn(&mut Value));
+        let mutations: [CanaryMutation; 10] = [
+            ("wrong action", |request| {
+                request["action"] = json!("canary")
+            }),
+            ("no audio", |request| {
+                request["planned"]["_canary"]["videoMode"] = json!("no_audio")
+            }),
+            ("wrong width", |request| {
+                request["planned"]["target"]["geometry"]["width"] = json!(512)
+            }),
+            ("wrong height", |request| {
+                request["planned"]["target"]["geometry"]["height"] = json!(768)
+            }),
+            ("wrong frames", |request| {
+                request["planned"]["target"]["geometry"]["frames"] = json!(89)
+            }),
+            ("wrong fps", |request| {
+                request["planned"]["_canary"]["fps"] = json!(30)
+            }),
+            ("wrong carrier", |request| {
+                request["planned"]["strategy"]["parameters"]["decodeTileEdge"] = json!(384)
+            }),
+            ("campaign scope", |request| {
+                request["planned"]["evidenceScope"] = json!("campaign")
+            }),
+            ("watchdog threshold", |request| {
+                request["planned"]["_watchdog"]["maxFootprintBytes"] =
+                    json!(LTX_CANARY_MAX_FOOTPRINT_BYTES - 1)
+            }),
+            ("artifact drift", |request| {
+                request["planned"]["_artifact"]["numericTierInventory"]["sha256"] =
+                    json!("0".repeat(64))
+            }),
+        ];
+        for (name, mutate) in mutations {
+            let mut request = ltx_product_envelope_canary_request_json();
+            mutate(&mut request);
+            assert!(
+                validate_ltx_product_envelope_canary_plan(&request).is_err(),
                 "{name} must fail before environment/provider/model access"
             );
         }

--- a/scripts/memory-calibration-harness.test.mjs
+++ b/scripts/memory-calibration-harness.test.mjs
@@ -30,14 +30,15 @@ const stubClosureDigest = async (provider) =>
 const execFileAsync = promisify(execFile);
 
 test("diagnostic LTX safety canary output is structurally non-ingestible", () => {
-  assert.throws(
-    () => validateRecord({
-      id: "ltx-safety-canary",
-      logicalCaseId: "ltx-safety-canary",
-      status: "diagnostic_canary_complete",
-    }),
-    /invalid status/,
-  );
+  for (const [id, status] of [
+    ["ltx-safety-canary", "diagnostic_canary_complete"],
+    ["ltx-product-envelope-canary", "diagnostic_product_envelope_canary_complete"],
+  ]) {
+    assert.throws(
+      () => validateRecord({ id, logicalCaseId: id, status }),
+      /invalid status/,
+    );
+  }
 });
 
 async function cleanFixtureRepo() {

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -3,6 +3,7 @@ import { readFile, readdir } from "node:fs/promises";
 import test from "node:test";
 
 import { SOURCE_PATHS } from "./generate-memory-matrix.mjs";
+import { buildPlans as buildLtxPlans } from "./generate-ltx-sc18946-plan.mjs";
 import { stripJsoncComments } from "./lib/jsonc.mjs";
 
 async function source(path) {
@@ -1948,6 +1949,36 @@ test("the MLX LTX arm's manifest constants match the shipped ltx_2_3 limits", as
   const reachable = limits.durations.flatMap((duration) =>
     limits.fps.map((fps) => snap(duration * fps)),
   );
+  const productWidth = Number(rustConst("LTX_PRODUCT_CANARY_WIDTH"));
+  const productHeight = Number(rustConst("LTX_PRODUCT_CANARY_HEIGHT"));
+  const productFrames = Number(rustConst("LTX_PRODUCT_CANARY_FRAMES"));
+  const productFps = Number(rustConst("LTX_PRODUCT_CANARY_FPS"));
+  const productResolution = `${productWidth}x${productHeight}`;
+  assert.equal(
+    model.defaults.resolution,
+    productResolution,
+    "the product-envelope canary must use the shipped default resolution",
+  );
+  assert.ok(
+    limits.resolutions.includes(productResolution),
+    "the product-envelope resolution must remain inside the shipped envelope",
+  );
+  const defaultDownloads = model.downloads.filter((download) => download.default === true);
+  assert.equal(defaultDownloads.length, 1, "LTX must retain exactly one default artifact variant");
+  assert.equal(
+    defaultDownloads[0].variant,
+    "q4",
+    "the product-envelope canary must measure the default product artifact variant",
+  );
+  const productDuration = (productFrames - 1) / productFps;
+  assert.ok(Number.isInteger(productDuration), "the product tuple must span an exact duration");
+  assert.ok(limits.durations.includes(productDuration), "the product duration must remain shipped");
+  assert.ok(limits.fps.includes(productFps), "the product FPS must remain shipped");
+  assert.equal(
+    snap(productDuration * productFps),
+    productFrames,
+    "the shipped duration/FPS snap must resolve to the exact product frame count",
+  );
   assert.match(
     adapter,
     /const LTX_FRAME_ENVELOPE: \(u32, u32\) = ltx_frame_envelope\(\);/,
@@ -1988,24 +2019,38 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
     campaign.indexOf("refuse_unsafe_ltx_capture(") < campaign.indexOf("ltx_load_spec("),
     "the campaign must still refuse before model-path/provider/weights access",
   );
-  assert.doesNotMatch(campaign, /LTX_CANARY_FIXTURE|diagnostic_canary_complete/);
+  const campaignRows = Object.values(buildLtxPlans()).flatMap((plan) => plan.providers);
+  assert.equal(campaignRows.length, 70, "the frozen SC-18946 campaign must retain all 70 rows");
+  for (const row of campaignRows) {
+    assert.ok(
+      ["incident_forbidden", "arithmetic_unmeasurable", "safety_refused_open"]
+        .includes(row._measurementSafety.disposition),
+      `${row.name} must retain an explicit refusal disposition`,
+    );
+  }
+  assert.doesNotMatch(
+    campaign,
+    /LTX_(?:CANARY|PRODUCT_CANARY)_FIXTURE|diagnostic_(?:product_envelope_)?canary_complete/,
+  );
 
   const canary = adapter.slice(
-    adapter.indexOf("fn validate_ltx_canary_plan("),
+    adapter.indexOf("fn validate_ltx_canary_plan_for("),
     adapter.indexOf("/// The `mlx:ltx_2_3` SC-18946 arm"),
   );
   for (const required of [
     "_diagnosticOnly",
     'Some("fixture")',
-    "LTX_CANARY_WIDTH",
-    "LTX_CANARY_HEIGHT",
-    "LTX_CANARY_FRAMES",
+    "profile.width()",
+    "profile.height()",
+    "profile.frames()",
     "LTX_CANARY_TILE_EDGE",
     "LTX_CANARY_OVERLAP",
-    'Some("no_audio")',
-    '"status": "diagnostic_canary_complete"',
+    "profile.video_mode_identity()",
+    '"status": profile.completion_status()',
+    '"canaryIdentity": profile.identity()',
     '"promotable": false',
     '"ingestible": false',
+    'strategy["spatialDecodeTiles"]',
     '"preProviderActiveBytes": pre_provider.active',
     '"preProviderCacheBytes": pre_provider.cache',
     '"identity": LTX_CANARY_ONES_CACHE_IDENTITY',
@@ -2029,13 +2074,25 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
   assert.doesNotMatch(campaign, /validate_ltx_canary_(?:pre_provider|cleanup)/,
     "production generation must not use the diagnostic canary residue exception");
 
+  const profiles = adapter.slice(
+    adapter.indexOf("enum LtxCanaryProfile"),
+    adapter.indexOf("/// LTX's video VAE"),
+  );
+  for (const required of [
+    'Self::Safety => Some("no_audio")',
+    "Self::ProductEnvelope => None",
+    'Self::Safety => "diagnostic_canary_complete"',
+    'Self::ProductEnvelope => "diagnostic_product_envelope_canary_complete"',
+    'Self::Safety => "a sunlit pine branch, static camera"',
+    'Self::ProductEnvelope => "sc-20169-product-envelope"',
+  ]) assert.ok(profiles.includes(required), `diagnostic profiles must retain ${required}`);
   const generationRequest = adapter.slice(
-    adapter.indexOf("fn ltx_canary_generation_request("),
+    adapter.indexOf("fn ltx_canary_generation_request_for("),
     adapter.indexOf("fn ltx_load_spec("),
   );
   assert.match(
     generationRequest,
-    /video_mode: Some\("no_audio"\.to_owned\(\)\)/,
+    /video_mode: profile\.video_mode\(\)\.map\(str::to_owned\)/,
     "the canary must skip the downstream audio decoder and vocoder",
   );
   const admissionBridge = adapter.slice(
@@ -2068,6 +2125,26 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
   for (const lifecycle of ["enter_phase", "leave_phase", "scope.finish", "settle_scoped_generation"]) {
     assert.ok(configuredScope.includes(lifecycle), `canary scope must retain ${lifecycle}`);
   }
+  const diagnosticRun = adapter.slice(
+    adapter.indexOf("fn run_ltx_canary_for("),
+    adapter.indexOf("/// The `mlx:ltx_2_3` SC-18946 arm"),
+  );
+  assert.match(
+    diagnosticRun,
+    /LtxCanaryProfile::ProductEnvelope => scoped_generate\(/,
+    "the product-envelope canary must use the ordinary provider request-scope lifecycle",
+  );
+  assert.doesNotMatch(
+    diagnosticRun,
+    /LtxCanaryProfile::ProductEnvelope => scoped_generate_ltx_no_audio_canary/,
+  );
+  for (const required of [
+    "LTX_PRODUCT_CANARY_WIDTH",
+    "LTX_PRODUCT_CANARY_HEIGHT",
+    "LTX_PRODUCT_CANARY_FRAMES",
+    "spatial_tile_count",
+    "validate_diagnostic_audio",
+  ]) assert.ok(adapter.includes(required), `product-envelope canary must retain ${required}`);
 
   const limitsLifecycle = adapter.slice(
     adapter.indexOf("impl LtxCanaryLimits"),

--- a/scripts/run-ltx-safety-canary.mjs
+++ b/scripts/run-ltx-safety-canary.mjs
@@ -30,7 +30,40 @@ export const MIN_PREFLIGHT_FREE_BYTES = MAX_FOOTPRINT_BYTES * 2;
 export const MIN_RUNTIME_FREE_BYTES = MAX_FOOTPRINT_BYTES;
 const PROVIDER = "ltx_2_3";
 const FINGERPRINT = "sc-19109-ltx-2-3-mlx-memory-ladder-v1";
-const FIXTURE = "ltx-2-3-mlx-q4-256x256-f9-fps24-seed1234-safety-canary";
+export const SAFETY_CANARY_PROFILE = "safety";
+export const PRODUCT_ENVELOPE_CANARY_PROFILE = "product-envelope";
+const CANARY_PROFILES = Object.freeze({
+  [SAFETY_CANARY_PROFILE]: Object.freeze({
+    action: "canary",
+    identity: "sc-19741-safety",
+    story: "sc-19741",
+    status: "diagnostic_canary_complete",
+    fixture: "ltx-2-3-mlx-q4-256x256-f9-fps24-seed1234-safety-canary",
+    width: 256,
+    height: 256,
+    frames: 9,
+    fps: 24,
+    videoMode: "no_audio",
+    audio: false,
+    spatialDecodeTiles: 4,
+    frameTimelineSeconds: 1 / 3,
+  }),
+  [PRODUCT_ENVELOPE_CANARY_PROFILE]: Object.freeze({
+    action: "product_envelope_canary",
+    identity: "sc-20169-product-envelope",
+    story: "sc-20169",
+    status: "diagnostic_product_envelope_canary_complete",
+    fixture: "ltx-2-3-mlx-q4-768x512-f97-fps24-seed1234-product-envelope-canary",
+    width: 768,
+    height: 512,
+    frames: 97,
+    fps: 24,
+    videoMode: "default_av",
+    audio: true,
+    spatialDecodeTiles: 24,
+    frameTimelineSeconds: 4,
+  }),
+});
 const ARTIFACT_REPOSITORY = "SceneWorks/ltx-2.3-mlx";
 const ARTIFACT_REVISION = "01df27d308466533aa09d251e3aebdcc627d07eb";
 const Q4_INVENTORY_BYTES = 20_467_690_460;
@@ -52,6 +85,12 @@ function ltxOnesCacheBytes() {
 
 function fail(message) {
   throw new Error(message);
+}
+
+function canaryProfile(name) {
+  const profile = CANARY_PROFILES[name];
+  if (profile === undefined) fail(`unsupported canary profile ${JSON.stringify(name)}`);
+  return profile;
 }
 
 export class CanaryInterrupted extends Error {
@@ -335,14 +374,19 @@ async function cleanCargoSourceHead(cwd, signal) {
   return head;
 }
 
-export function canaryRequest(memoryBytes, textEncoderInventory) {
+export function canaryRequest(
+  memoryBytes,
+  textEncoderInventory,
+  profileName = SAFETY_CANARY_PROFILE,
+) {
+  const profile = canaryProfile(profileName);
   assertInventory(textEncoderInventory, {
     files: TEXT_ENCODER_INVENTORY_FILES,
     bytes: TEXT_ENCODER_INVENTORY_BYTES,
     sha256: TEXT_ENCODER_INVENTORY_SHA256,
   }, "immutable text-encoder");
   return {
-    action: "canary",
+    action: profile.action,
     hardware: { memoryBytes },
     planned: {
       _diagnosticOnly: true,
@@ -353,7 +397,9 @@ export function canaryRequest(memoryBytes, textEncoderInventory) {
         tier: "q4",
         mode: "text_to_video",
         overlay: "none",
-        geometry: { width: 256, height: 256, batch: 1, frames: 9 },
+        geometry: {
+          width: profile.width, height: profile.height, batch: 1, frames: profile.frames,
+        },
       },
       backend: "mlx",
       loadShape: "eager_materialization",
@@ -363,9 +409,11 @@ export function canaryRequest(memoryBytes, textEncoderInventory) {
         parameters: { decodeTileEdge: 192, decodeOverlap: 64 },
       },
       calibrationFingerprint: FINGERPRINT,
-      fixture: FIXTURE,
+      fixture: profile.fixture,
       _watchdog: { maxFootprintBytes: MAX_FOOTPRINT_BYTES },
-      _canary: { videoMode: "no_audio", fps: 24, seed: 1234 },
+      _canary: {
+        identity: profile.identity, videoMode: profile.videoMode, fps: profile.fps, seed: 1234,
+      },
       _artifact: {
         repository: ARTIFACT_REPOSITORY,
         revision: ARTIFACT_REVISION,
@@ -410,8 +458,10 @@ export function validateCanaryResponse(
   expectedInferenceRevision,
   expectedTextEncoderInventory,
   expectedHostMemoryBytes,
+  profileName = SAFETY_CANARY_PROFILE,
 ) {
-  if (response?.status !== "diagnostic_canary_complete"
+  const profile = canaryProfile(profileName);
+  if (response?.status !== profile.status
       || response?.diagnosticOnly !== true
       || response?.promotable !== false
       || response?.ingestible !== false) {
@@ -420,14 +470,32 @@ export function validateCanaryResponse(
   if (response?.calibrationFingerprint !== FINGERPRINT
       || (expectedInferenceRevision !== undefined
         && response?.inferenceRevision !== expectedInferenceRevision)
+      || response?.canaryIdentity !== profile.identity
       || response?.target?.provider !== PROVIDER
       || response?.target?.tier !== "q4"
-      || response?.target?.geometry?.width !== 256
-      || response?.target?.geometry?.height !== 256
-      || response?.target?.geometry?.frames !== 9
-      || response?.target?.geometry?.fps !== 24
-      || response?.target?.audio !== false) {
+      || response?.target?.geometry?.width !== profile.width
+      || response?.target?.geometry?.height !== profile.height
+      || response?.target?.geometry?.frames !== profile.frames
+      || response?.target?.geometry?.fps !== profile.fps
+      || response?.target?.videoMode !== profile.videoMode
+      || response?.target?.audio !== profile.audio
+      || response?.output?.frames !== profile.frames
+      || response?.output?.fps !== profile.fps
+      || response?.output?.frameTimelineSeconds !== profile.frameTimelineSeconds) {
     fail("adapter response changed the exact canary identity");
+  }
+  const outputAudio = response?.output?.audio;
+  if (outputAudio?.present !== profile.audio
+      || (profile.audio && (!Number.isSafeInteger(outputAudio?.samples)
+        || outputAudio.samples <= 0
+        || !Number.isSafeInteger(outputAudio?.sampleRate)
+        || outputAudio.sampleRate <= 0
+        || !Number.isSafeInteger(outputAudio?.channels)
+        || outputAudio.channels <= 0))
+      || (!profile.audio && (outputAudio?.samples !== 0
+        || outputAudio?.sampleRate !== 0
+        || outputAudio?.channels !== 0))) {
+    fail("adapter response did not attest the exact canary audio output");
   }
   if (response?.artifact?.repository !== ARTIFACT_REPOSITORY
       || response?.artifact?.resolvedRevision !== ARTIFACT_REVISION
@@ -448,6 +516,8 @@ export function validateCanaryResponse(
         !== JSON.stringify(["resident", "staged_residency", "bounded_decode"])
       || response?.strategy?.parameters?.decodeTileEdge !== 192
       || response?.strategy?.parameters?.decodeOverlap !== 64
+      || response?.strategy?.spatialDecodeTiles !== profile.spatialDecodeTiles
+      || response.strategy.spatialDecodeTiles <= 1
       || response?.watchdog?.required !== true
       || response?.watchdog?.protocol !== "sceneworks-memory-watchdog-v1"
       || response?.watchdog?.maxFootprintBytes !== MAX_FOOTPRINT_BYTES
@@ -467,6 +537,24 @@ export function validateCanaryResponse(
       || response.mlxLimits.wiredLimitBytes > MAX_FOOTPRINT_BYTES
       || response?.output?.firstFrameNondegenerate !== true) {
     fail("adapter response did not attest the exact bounded canary execution");
+  }
+  const phaseActive = [];
+  for (const phaseName of ["conditioning", "denoise", "decode"]) {
+    const phase = response?.observedMemory?.[phaseName];
+    for (const field of ["activeBytes", "allocatorBytes", "reclaimableBytes"]) {
+      if (!Number.isSafeInteger(phase?.[field]) || phase[field] < 0) {
+        fail(`adapter response observedMemory.${phaseName}.${field} must be a non-negative safe integer`);
+      }
+    }
+    if (phase.activeBytes <= 0
+        || phase.allocatorBytes !== phase.activeBytes + phase.reclaimableBytes
+        || !Number.isSafeInteger(phase.allocatorBytes)) {
+      fail(`adapter response observedMemory.${phaseName} is not an exact phase-memory attestation`);
+    }
+    phaseActive.push(phase.activeBytes);
+  }
+  if (response?.observedMemory?.peakActiveBytes !== Math.max(...phaseActive)) {
+    fail("adapter response observedMemory.peakActiveBytes did not equal the maximum phase active bytes");
   }
   for (const field of [
     "preProviderActiveBytes",
@@ -1284,8 +1372,12 @@ async function controller(argv) {
   for (const name of ["inference-repo", "output"]) {
     if (!options[name]) fail(`--${name} is required`);
   }
-  const unexpected = Object.keys(options).filter((name) => !["inference-repo", "output"].includes(name));
+  const unexpected = Object.keys(options).filter(
+    (name) => !["inference-repo", "output", "profile"].includes(name),
+  );
   if (unexpected.length) fail(`unsupported option(s): ${unexpected.join(", ")}`);
+  const profileName = options.profile ?? SAFETY_CANARY_PROFILE;
+  const profile = canaryProfile(profileName);
   const inferenceRepo = path.resolve(options["inference-repo"]);
   const output = path.resolve(options.output);
   const relativeOutput = path.relative(ROOT, output);
@@ -1422,7 +1514,7 @@ async function controller(argv) {
     );
     const runRoot = path.join(path.dirname(output), "runs");
     await mkdir(runRoot, { recursive: true, mode: 0o700 });
-    runScratch = await mkdtemp(path.join(runRoot, "sc19741-run-"));
+    runScratch = await mkdtemp(path.join(runRoot, `${profile.story}-run-`));
     const runtimeHome = path.join(runScratch, "home");
     await mkdir(runtimeHome, { mode: 0o700 });
     await exactMetadata(runtimeHome, "directory", 0o700);
@@ -1430,7 +1522,7 @@ async function controller(argv) {
     const requestPath = path.join(runScratch, "request.json");
     const responsePath = path.join(runScratch, "response.json");
     const eventsPath = path.join(runScratch, "watchdog.jsonl");
-    const request = canaryRequest(memoryBytes, textEncoderInventory);
+    const request = canaryRequest(memoryBytes, textEncoderInventory, profileName);
     await writeFile(requestPath, `${JSON.stringify(request)}\n`, { flag: "wx" });
     const launchPrepared = await validatePreparedCache(
       preparationRoot, preparationKey, identity, signal,
@@ -1455,7 +1547,7 @@ async function controller(argv) {
       "--require-child-attestation",
       "--",
       "/bin/sh", "-c", 'set -C; exec "$1" <"$2" >"$3"',
-      "sc19741-canary", adapter.path, requestPath, responsePath,
+      `${profile.story}-canary`, adapter.path, requestPath, responsePath,
     ];
     const watchdogEnv = canaryWatchdogEnvironment(
       process.env,
@@ -1502,6 +1594,7 @@ async function controller(argv) {
       inferenceRevision,
       textEncoderInventory,
       memoryBytes,
+      profileName,
     );
     const events = (await readFile(eventsPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
     const attestedIndex = events.findIndex((event) => event.event === "child_attested");
@@ -1525,7 +1618,8 @@ async function controller(argv) {
     if (maxObservedFootprintBytes >= MAX_FOOTPRINT_BYTES) fail("successful watchdog stream crossed its stop boundary");
     const receipt = {
     schemaVersion: 1,
-    story: "sc-19741",
+    story: profile.story,
+    canaryIdentity: profile.identity,
     diagnosticOnly: true,
     promotable: false,
     ingestible: false,

--- a/scripts/run-ltx-safety-canary.test.mjs
+++ b/scripts/run-ltx-safety-canary.test.mjs
@@ -18,6 +18,7 @@ import {
   MIN_PREFLIGHT_FREE_BYTES,
   MIN_RUNTIME_FREE_BYTES,
   PREPARATION_SCHEMA_VERSION,
+  PRODUCT_ENVELOPE_CANARY_PROFILE,
   acquirePreparationLock,
   canaryWatchdogEnvironment,
   canaryRequest,
@@ -128,7 +129,7 @@ test("the runner freezes the exact tiny bounded-decode canary", () => {
     decodeTileEdge: 192, decodeOverlap: 64,
   });
   assert.deepEqual(request.planned._canary, {
-    videoMode: "no_audio", fps: 24, seed: 1234,
+    identity: "sc-19741-safety", videoMode: "no_audio", fps: 24, seed: 1234,
   });
   assert.equal(request.planned._watchdog.maxFootprintBytes, 53_347_146_863);
   assert.deepEqual(request.planned._artifact.numericTierInventory, {
@@ -137,6 +138,27 @@ test("the runner freezes the exact tiny bounded-decode canary", () => {
     sha256: "4e811932e87bb258f642ada790525e36ef2a55959c520e755f1807caf6fa225a",
   });
   assert.throws(() => canaryRequest(128 * 1024 ** 3));
+});
+
+test("the runner freezes the distinct full-A/V product-envelope canary", () => {
+  const request = canaryRequest(
+    128 * 1024 ** 3, TEXT_ENCODER_INVENTORY, PRODUCT_ENVELOPE_CANARY_PROFILE,
+  );
+  assert.equal(request.action, "product_envelope_canary");
+  assert.equal(request.planned.fixture,
+    "ltx-2-3-mlx-q4-768x512-f97-fps24-seed1234-product-envelope-canary");
+  assert.deepEqual(request.planned.target.geometry, {
+    width: 768, height: 512, batch: 1, frames: 97,
+  });
+  assert.deepEqual(request.planned._canary, {
+    identity: "sc-20169-product-envelope", videoMode: "default_av", fps: 24, seed: 1234,
+  });
+  assert.deepEqual(request.planned.strategy.parameters, {
+    decodeTileEdge: 192, decodeOverlap: 64,
+  });
+  assert.throws(() => canaryRequest(
+    128 * 1024 ** 3, TEXT_ENCODER_INVENTORY, "campaign",
+  ), /unsupported canary profile/);
 });
 
 test("private artifact clones preserve the canonical immutable snapshot roots", async () => {
@@ -163,6 +185,7 @@ test("private artifact clones preserve the canonical immutable snapshot roots", 
 test("the runner refuses promotable or identity-drifted adapter output", () => {
   const response = {
     status: "diagnostic_canary_complete",
+    canaryIdentity: "sc-19741-safety",
     inferenceRevision: "6f3a84ef4ad4f858c6fe199e14925a01a7943f97",
     diagnosticOnly: true,
     promotable: false,
@@ -172,6 +195,7 @@ test("the runner refuses promotable or identity-drifted adapter output", () => {
       provider: "ltx_2_3",
       tier: "q4",
       geometry: { width: 256, height: 256, frames: 9, fps: 24 },
+      videoMode: "no_audio",
       audio: false,
     },
     artifact: {
@@ -195,6 +219,7 @@ test("the runner refuses promotable or identity-drifted adapter output", () => {
       rung: "bounded_decode",
       engagedRungs: ["resident", "staged_residency", "bounded_decode"],
       parameters: { decodeTileEdge: 192, decodeOverlap: 64 },
+      spatialDecodeTiles: 4,
     },
     watchdog: {
       required: true,
@@ -212,6 +237,10 @@ test("the runner refuses promotable or identity-drifted adapter output", () => {
     observedMemory: {
       preProviderActiveBytes: 0,
       preProviderCacheBytes: 0,
+      conditioning: { activeBytes: 10, reclaimableBytes: 2, allocatorBytes: 12 },
+      denoise: { activeBytes: 20, reclaimableBytes: 3, allocatorBytes: 23 },
+      decode: { activeBytes: 30, reclaimableBytes: 4, allocatorBytes: 34 },
+      peakActiveBytes: 30,
       expectedPersistentActive: {
         identity: "mlx-gen-ltx-transformer-ones-cache-av-bfloat16-v1",
         videoDimension: 4_096,
@@ -223,7 +252,13 @@ test("the runner refuses promotable or identity-drifted adapter output", () => {
       postCleanupActiveBytes: (4_096 + 2_048) * 2,
       postCleanupCacheBytes: 0,
     },
-    output: { firstFrameNondegenerate: true },
+    output: {
+      frames: 9,
+      fps: 24,
+      audio: { present: false, samples: 0, sampleRate: 0, channels: 0 },
+      frameTimelineSeconds: 1 / 3,
+      firstFrameNondegenerate: true,
+    },
   };
   assert.deepEqual(
     validateCanaryResponse(
@@ -247,6 +282,8 @@ test("the runner refuses promotable or identity-drifted adapter output", () => {
     (value) => { value.watchdog.minMemoryFreeBytes -= 1; },
     (value) => { value.watchdog.minSwapFreeBytes = 1024 ** 3; },
     (value) => { value.mlxLimits.wiredLimitBytes = MAX_FOOTPRINT_BYTES + 1; },
+    (value) => { value.observedMemory.decode.allocatorBytes += 1; },
+    (value) => { value.observedMemory.peakActiveBytes -= 1; },
     (value) => { value.output.firstFrameNondegenerate = false; },
     (value) => { value.inferenceRevision = "0".repeat(40); },
     (value) => { value.artifact.resolvedRevision = "0".repeat(40); },
@@ -324,6 +361,118 @@ test("the runner refuses promotable or identity-drifted adapter output", () => {
       changed, response.inferenceRevision, TEXT_ENCODER_INVENTORY,
       response.watchdog.hostMemoryBytes,
     ), expected);
+  }
+});
+
+test("the runner requires exact non-ingestible full-A/V product-envelope evidence", () => {
+  const hostMemoryBytes = 128 * 1024 ** 3;
+  const response = {
+    status: "diagnostic_product_envelope_canary_complete",
+    canaryIdentity: "sc-20169-product-envelope",
+    inferenceRevision: "6f3a84ef4ad4f858c6fe199e14925a01a7943f97",
+    diagnosticOnly: true,
+    promotable: false,
+    ingestible: false,
+    calibrationFingerprint: "sc-19109-ltx-2-3-mlx-memory-ladder-v1",
+    target: {
+      provider: "ltx_2_3",
+      tier: "q4",
+      geometry: { width: 768, height: 512, frames: 97, fps: 24 },
+      videoMode: "default_av",
+      audio: true,
+    },
+    artifact: {
+      repository: "SceneWorks/ltx-2.3-mlx",
+      resolvedRevision: "01df27d308466533aa09d251e3aebdcc627d07eb",
+      numericTierInventory: {
+        files: 11,
+        bytes: 20_467_690_460,
+        sha256: "4e811932e87bb258f642ada790525e36ef2a55959c520e755f1807caf6fa225a",
+      },
+      textEncoderInventory: { ...TEXT_ENCODER_INVENTORY },
+    },
+    strategy: {
+      rung: "bounded_decode",
+      engagedRungs: ["resident", "staged_residency", "bounded_decode"],
+      parameters: { decodeTileEdge: 192, decodeOverlap: 64 },
+      spatialDecodeTiles: 24,
+    },
+    watchdog: {
+      required: true,
+      protocol: "sceneworks-memory-watchdog-v1",
+      maxFootprintBytes: MAX_FOOTPRINT_BYTES,
+      maxRuntimeSeconds: MAX_RUNTIME_SECONDS,
+      hostMemoryBytes,
+      minInitialMemoryFreeBytes: preflightFreeFloor(hostMemoryBytes),
+      minMemoryFreeBytes: runtimeFreeFloor(hostMemoryBytes),
+    },
+    mlxLimits: {
+      memoryLimitBytes: MAX_FOOTPRINT_BYTES,
+      wiredLimitBytes: MAX_FOOTPRINT_BYTES,
+    },
+    observedMemory: {
+      preProviderActiveBytes: 0,
+      preProviderCacheBytes: 0,
+      conditioning: { activeBytes: 10, reclaimableBytes: 2, allocatorBytes: 12 },
+      denoise: { activeBytes: 20, reclaimableBytes: 3, allocatorBytes: 23 },
+      decode: { activeBytes: 30, reclaimableBytes: 4, allocatorBytes: 34 },
+      peakActiveBytes: 30,
+      expectedPersistentActive: {
+        identity: "mlx-gen-ltx-transformer-ones-cache-av-bfloat16-v1",
+        videoDimension: 4_096,
+        audioDimension: 2_048,
+        dtype: "bfloat16",
+        bytesPerElement: 2,
+        bytes: 12_288,
+      },
+      postCleanupActiveBytes: 12_288,
+      postCleanupCacheBytes: 0,
+    },
+    output: {
+      frames: 97,
+      fps: 24,
+      audio: { present: true, samples: 192_000, sampleRate: 48_000, channels: 2 },
+      frameTimelineSeconds: 4,
+      firstFrameNondegenerate: true,
+    },
+  };
+  assert.deepEqual(validateCanaryResponse(
+    structuredClone(response), response.inferenceRevision, TEXT_ENCODER_INVENTORY,
+    hostMemoryBytes, PRODUCT_ENVELOPE_CANARY_PROFILE,
+  ), response);
+
+  const mutations = [
+    (value) => { value.status = "diagnostic_canary_complete"; },
+    (value) => { value.canaryIdentity = "sc-19741-safety"; },
+    (value) => { value.promotable = true; },
+    (value) => { value.ingestible = true; },
+    (value) => { value.target.geometry.width = 256; },
+    (value) => { value.target.geometry.height = 768; },
+    (value) => { value.target.geometry.frames = 89; },
+    (value) => { value.target.geometry.fps = 30; },
+    (value) => { value.target.videoMode = "no_audio"; },
+    (value) => { value.target.audio = false; },
+    (value) => { value.output.audio.present = false; },
+    (value) => { value.output.audio.samples = 0; },
+    (value) => { value.output.audio.sampleRate = 0; },
+    (value) => { value.output.audio.channels = 0; },
+    (value) => { value.output.frameTimelineSeconds = 97 / 24; },
+    (value) => { value.strategy.parameters.decodeTileEdge = 384; },
+    (value) => { value.strategy.spatialDecodeTiles = 1; },
+    (value) => { value.strategy.spatialDecodeTiles = 23; },
+    (value) => { value.watchdog.maxFootprintBytes -= 1; },
+    (value) => { value.mlxLimits.memoryLimitBytes -= 1; },
+    (value) => { value.observedMemory.peakActiveBytes -= 1; },
+    (value) => { value.observedMemory.postCleanupActiveBytes += 1; },
+    (value) => { value.artifact.numericTierInventory.sha256 = "0".repeat(64); },
+  ];
+  for (const mutate of mutations) {
+    const changed = structuredClone(response);
+    mutate(changed);
+    assert.throws(() => validateCanaryResponse(
+      changed, response.inferenceRevision, TEXT_ENCODER_INVENTORY,
+      hostMemoryBytes, PRODUCT_ENVELOPE_CANARY_PROFILE,
+    ));
   }
 });
 


### PR DESCRIPTION
## Summary

- add a distinct q4 768x512 f97 24fps full-A/V product-envelope diagnostic
- reuse the sealed preparation, exact watchdog, MLX limits, and allocator cleanup contract
- attest 24 physical spatial decode tiles and non-empty audio output
- keep the receipt non-promotable and non-ingestible; all 70 SC-18946 campaign rows remain refused before load
- preserve the SC-19741 safety canary contract unchanged

## Validation

- npm run check: 561/561 passed
- focused runner/platform/harness: 135/135 passed
- platform contracts: 53/53 passed
- pure Rust product tests: 2/2 passed
- pure Rust safety regression: 1/1 passed
- cargo check, exact MLX adapter Clippy with -D warnings, cargo fmt, and diff checks passed
- independent adversarial review passed with no remaining findings

## Runtime scope

No model, GPU, MLX, or real-weight workload was run in this PR. After merge and exact-head verification, SC-20169 authorizes exactly one diagnostic product-envelope canary. It does not admit or promote a calibration row.