### PR TITLE
SC-20191: contain the first canonical LTX campaign entry

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -148,6 +148,14 @@ const LTX_PRODUCT_CANARY_FRAMES: u32 = 97;
 const LTX_PRODUCT_CANARY_FPS: u32 = 24;
 const LTX_PRODUCT_CANARY_FIXTURE: &str =
     "ltx-2-3-mlx-q4-768x512-f97-fps24-seed1234-product-envelope-canary";
+const LTX_CAMPAIGN_ENTRY_ACTION: &str = "campaign_entry";
+const LTX_CAMPAIGN_ENTRY_IDENTITY: &str = "sc-20191-q4-768x512-f121-fps30-staged-v1";
+const LTX_CAMPAIGN_ENTRY_LOGICAL_CASE_ID: &str = "implan-9b107d4d1ca0d61d4faa";
+const LTX_CAMPAIGN_ENTRY_FIXTURE: &str = "ltx-2-3-mlx-q4-768x512-f121-fps30-seed18946";
+const LTX_CAMPAIGN_ENTRY_WIDTH: u32 = 768;
+const LTX_CAMPAIGN_ENTRY_HEIGHT: u32 = 512;
+const LTX_CAMPAIGN_ENTRY_FRAMES: u32 = 121;
+const LTX_CAMPAIGN_ENTRY_FPS: u32 = 30;
 const LTX_CANARY_ARTIFACT_REVISION: &str = "01df27d308466533aa09d251e3aebdcc627d07eb";
 const LTX_CANARY_Q4_INVENTORY_FILES: u64 = 11;
 const LTX_CANARY_Q4_INVENTORY_SHA256: &str =
@@ -5488,12 +5496,12 @@ fn planned_ltx_capture(
 /// row is refused; only rows supported by incident or monotonic evidence are called unmeasurable,
 /// while the rest remain explicitly safety-refused/open. External polling is defense in depth,
 /// not admission.
-fn refuse_unsafe_ltx_capture(
+fn validate_ltx_safety_evidence(
     request: &Value,
     tier: &str,
     geometry: LtxGeometry,
     selection: &MemorySelection,
-) -> Result<(), String> {
+) -> Result<(&'static str, u64, u64), String> {
     let inventory_bytes = match tier {
         "q4" => LTX_Q4_INVENTORY_BYTES,
         "q8" => LTX_Q8_INVENTORY_BYTES,
@@ -5570,10 +5578,138 @@ fn refuse_unsafe_ltx_capture(
     let projection = u64::try_from(projection)
         .map_err(|_| "SC-18946 incident-calibrated projection must fit u64".to_owned())?;
     exact_u64("incidentCalibratedProjectionBytes", projection)?;
+    Ok((expected_disposition, inventory_bytes, projection))
+}
+
+fn refuse_unsafe_ltx_capture(
+    request: &Value,
+    tier: &str,
+    geometry: LtxGeometry,
+    selection: &MemorySelection,
+) -> Result<(), String> {
+    let (expected_disposition, inventory_bytes, projection) =
+        validate_ltx_safety_evidence(request, tier, geometry, selection)?;
     Err(format!(
         "SC-19642 pre-load safety refusal: SC-18946 {tier} is {expected_disposition}; exact tier inventory={inventory_bytes} bytes, incident q4 f305 physical footprint={} bytes, incident-calibrated projection={projection} bytes, and every geometry shares the complete tier plus Gemma load without a proved safe upper bound",
         LTX_Q4_F305_CRASH_FOOTPRINT_BYTES
     ))
+}
+
+/// The sole supervised entry into SC-18946. The ordinary `run` action continues through
+/// [`refuse_unsafe_ltx_capture`]; this private action additionally requires the live watchdog
+/// channel and may reach only the first frozen q4 staged row. The runner injects the two private
+/// objects after the canonical harness has constructed the row, so neither object participates in
+/// the campaign logical-case identity.
+fn validate_ltx_campaign_entry(
+    request: &Value,
+    tier: &str,
+    geometry: LtxGeometry,
+    selection: &MemorySelection,
+) -> Result<(), String> {
+    if protocol::action(request)? != LTX_CAMPAIGN_ENTRY_ACTION {
+        return Err("SC-20191 campaign entry action changed".to_owned());
+    }
+    let planned = protocol::planned(request)?;
+    let exact = |pointer: &str, expected: &Value| -> Result<(), String> {
+        let actual = planned.pointer(pointer);
+        if actual == Some(expected) {
+            Ok(())
+        } else {
+            Err(format!(
+                "SC-20191 campaign entry {pointer} must be {expected}, got {actual:?}"
+            ))
+        }
+    };
+    exact("/logicalCaseId", &json!(LTX_CAMPAIGN_ENTRY_LOGICAL_CASE_ID))?;
+    exact("/evidenceScope", &json!("authoritative"))?;
+    exact("/backend", &json!("mlx"))?;
+    exact("/loadShape", &json!("eager_materialization"))?;
+    exact("/target/provider", &json!(LTX_PROVIDER))?;
+    exact("/target/modelId", &json!(LTX_PROVIDER))?;
+    exact("/target/tier", &json!("q4"))?;
+    exact("/target/mode", &json!("text_to_video"))?;
+    exact("/target/overlay", &json!("none"))?;
+    exact("/target/geometry/width", &json!(LTX_CAMPAIGN_ENTRY_WIDTH))?;
+    exact("/target/geometry/height", &json!(LTX_CAMPAIGN_ENTRY_HEIGHT))?;
+    exact("/target/geometry/batch", &json!(1))?;
+    exact("/target/geometry/frames", &json!(LTX_CAMPAIGN_ENTRY_FRAMES))?;
+    exact("/strategy/rung", &json!("staged_residency"))?;
+    exact(
+        "/strategy/engagedRungs",
+        &json!(["resident", "staged_residency"]),
+    )?;
+    exact("/strategy/parameters", &json!({}))?;
+    exact(
+        "/calibrationFingerprint",
+        &json!(LTX_CALIBRATION_FINGERPRINT),
+    )?;
+    exact("/fixture", &json!(LTX_CAMPAIGN_ENTRY_FIXTURE))?;
+    exact("/negative", &json!(false))?;
+    exact("/expectedResult", &json!("passed"))?;
+    exact("/modelLoadPolicy", &json!("fresh_per_case"))?;
+    exact("/modelLoadGroup", &Value::Null)?;
+    exact(
+        "/_watchdog",
+        &json!({ "maxFootprintBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES }),
+    )?;
+    exact(
+        "/_campaignEntry",
+        &json!({
+            "identity": LTX_CAMPAIGN_ENTRY_IDENTITY,
+            "artifact": {
+                "repository": protocol::LTX_REPOSITORY,
+                "revision": LTX_CANARY_ARTIFACT_REVISION,
+                "numericTierInventory": {
+                    "files": LTX_CANARY_Q4_INVENTORY_FILES,
+                    "bytes": LTX_Q4_INVENTORY_BYTES,
+                    "sha256": LTX_CANARY_Q4_INVENTORY_SHA256,
+                },
+                "textEncoderInventory": {
+                    "files": LTX_CANARY_TEXT_ENCODER_INVENTORY_FILES,
+                    "bytes": LTX_CANARY_TEXT_ENCODER_INVENTORY_BYTES,
+                    "sha256": LTX_CANARY_TEXT_ENCODER_INVENTORY_SHA256,
+                },
+            },
+        }),
+    )?;
+    exact(
+        "/_measurementSafety",
+        &json!({
+            "disposition": LTX_SAFETY_REFUSED_OPEN,
+            "tierInventoryBytes": LTX_Q4_INVENTORY_BYTES,
+            "incidentCrashFootprintBytes": LTX_Q4_F305_CRASH_FOOTPRINT_BYTES,
+            "incidentCase": "mlx-ltx-2-3-q4-1280x704-f305-fps30-bounded_decode",
+            "commonLoad": "complete numeric tier plus shared Gemma stack before geometry-specific work",
+            "predictedDecodeBytes": 19_476_906_240_u64,
+            "incidentPredictedDecodeBytes": LTX_INCIDENT_PREDICTED_DECODE_BYTES,
+            "incidentCalibratedProjectionBytes": 97_906_593_920_u64,
+            "projectionAssumptions": [
+                "pinned provider decode cost is the only geometry-varying term used",
+                "immutable tier inventory delta is added byte-for-byte",
+                "incident binding phase is unknown, so the projection is not a physical-footprint bound and cannot admit execution",
+            ],
+            "reason": "incident-calibrated projection is diagnostic only; no proved bound or hard containment admits this row",
+        }),
+    )?;
+    if tier != "q4"
+        || geometry.width != LTX_CAMPAIGN_ENTRY_WIDTH
+        || geometry.height != LTX_CAMPAIGN_ENTRY_HEIGHT
+        || geometry.frames != LTX_CAMPAIGN_ENTRY_FRAMES
+        || selection.strategy != MemoryStrategy::StagedResidency
+        || selection.parameters.decode_tile_edge.is_some()
+        || selection.parameters.decode_overlap.is_some()
+    {
+        return Err("SC-20191 campaign entry resolved a non-canonical tuple or carrier".to_owned());
+    }
+    let (fps, seed) = planned_ltx_capture(request, tier, geometry)?;
+    if fps != LTX_CAMPAIGN_ENTRY_FPS || seed != LTX_SEED {
+        return Err("SC-20191 campaign entry fps or seed changed".to_owned());
+    }
+    let (disposition, _, _) = validate_ltx_safety_evidence(request, tier, geometry, selection)?;
+    if disposition != LTX_SAFETY_REFUSED_OPEN {
+        return Err("SC-20191 campaign entry safety disposition changed".to_owned());
+    }
+    Ok(())
 }
 
 /// The production A/V request. `video_mode` is deliberately left unset so the arm measures the same
@@ -7276,7 +7412,13 @@ fn run_ltx_product_envelope_canary(request: &Value) -> Result<Value, String> {
 /// The `mlx:ltx_2_3` SC-18946 arm. SC-19109 moved strategy ownership into the provider: this path
 /// reads the exact registry contract, proves the loaded generator exposes the same contract, drives
 /// the selected request scope, and executes every runtime-complete admission/lifecycle scenario.
-fn run_ltx(request: &Value) -> Result<Value, String> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LtxRunAdmission {
+    Ordinary,
+    CampaignEntry,
+}
+
+fn run_ltx_with_admission(request: &Value, admission: LtxRunAdmission) -> Result<Value, String> {
     let geometry = validate_ltx_target(request)?;
     protocol::validate_plain_overlay_target(request, LTX_PLAIN_EXECUTION_PATH)?;
     let load_shape = planned_load_shape(request)?;
@@ -7307,7 +7449,14 @@ fn run_ltx(request: &Value) -> Result<Value, String> {
              implements {LTX_CALIBRATION_FINGERPRINT}"
         ));
     }
-    refuse_unsafe_ltx_capture(request, tier, geometry, &selection)?;
+    match admission {
+        LtxRunAdmission::Ordinary => {
+            refuse_unsafe_ltx_capture(request, tier, geometry, &selection)?
+        }
+        LtxRunAdmission::CampaignEntry => {
+            validate_ltx_campaign_entry(request, tier, geometry, &selection)?
+        }
+    }
     let (repository, revision, root, text_encoder_root, spec) =
         ltx_load_spec(request, tier, &selection)?;
     // Read BEFORE the load so the staging bound below is grounded in the artifact on disk rather
@@ -7418,7 +7567,7 @@ fn run_ltx(request: &Value) -> Result<Value, String> {
     reset_peak_memory();
     let pre_rung_active = get_active_memory() as u64;
     let pre_rung_cache = get_cache_memory() as u64;
-    let (measured, output_fps, has_audio) = video_frames(scoped_generate(
+    let (measured, output_fps, audio) = diagnostic_video_frames(scoped_generate(
         generator.as_ref(),
         ltx_request(geometry, fps, seed),
         &context,
@@ -7463,6 +7612,17 @@ fn run_ltx(request: &Value) -> Result<Value, String> {
         return Err(format!(
             "LTX-2.3 returned fps {output_fps} for a {fps} fps request"
         ));
+    }
+    let audio = audio
+        .filter(|audio| audio.samples > 0 && audio.sample_rate > 0 && audio.channels > 0)
+        .ok_or_else(|| {
+            "LTX-2.3 full-A/V campaign render returned no non-empty audio track".to_owned()
+        })?;
+    let first = measured
+        .first()
+        .ok_or_else(|| "LTX-2.3 campaign render returned no first frame".to_owned())?;
+    if first.pixels.is_empty() || first.pixels.iter().all(|pixel| *pixel == first.pixels[0]) {
+        return Err("LTX-2.3 campaign render returned a degenerate first frame".to_owned());
     }
     let overall = PhaseMemory::overall(&[conditioning, denoise, decode]);
 
@@ -7563,6 +7723,17 @@ fn run_ltx(request: &Value) -> Result<Value, String> {
             "result": "passed",
             "resolvedPathFingerprint": format!("{repository}@{revision}:{tier}+gemma"),
         },
+        "output": {
+            "frames": geometry.frames,
+            "fps": fps,
+            "audio": {
+                "present": true,
+                "samples": audio.samples,
+                "sampleRate": audio.sample_rate,
+                "channels": audio.channels,
+            },
+            "firstFrameNondegenerate": true,
+        },
         "diagnostics": protocol::diagnostics(
             "memory-mlx-adapter:ltx-2-3-provider-contract-video",
             "executed",
@@ -7601,7 +7772,7 @@ fn run_ltx(request: &Value) -> Result<Value, String> {
                 ("latentTemporalDepth", "count", u64::from(geometry.latent_frames)),
                 ("latentTokens", "count", u64::from(geometry.latent_frames) * u64::from(geometry.width / 32) * u64::from(geometry.height / 32)),
                 ("outputFps", "count", u64::from(fps)),
-                ("audioTrackDecoded", "count", u64::from(has_audio)),
+                ("audioTrackDecoded", "count", 1),
                 ("decodeTilingEngaged", "count", u64::from(decode_plan.tiling_engaged())),
                 ("decodeWritableFrameCap", "count", decode_plan.writable_frame_cap.max(0) as u64),
                 ("decodeTileSpatialPx", "count", decode_plan.spatial_tile_px()),
@@ -7616,6 +7787,151 @@ fn run_ltx(request: &Value) -> Result<Value, String> {
     });
     protocol::settle_plain_overlay_scenario(request, &mut fragment, LTX_PLAIN_EXECUTION_PATH)?;
     Ok(fragment)
+}
+
+fn campaign_entry_diagnostic(fragment: &Value, name: &str) -> Result<u64, String> {
+    fragment
+        .pointer("/diagnostics/measurements")
+        .and_then(Value::as_array)
+        .and_then(|measurements| {
+            measurements
+                .iter()
+                .find(|measurement| measurement.get("name").and_then(Value::as_str) == Some(name))
+        })
+        .and_then(|measurement| measurement.get("value"))
+        .and_then(Value::as_u64)
+        .ok_or_else(|| format!("SC-20191 campaign entry omitted diagnostic {name}"))
+}
+
+fn validate_ltx_campaign_entry_fragment(fragment: &Value) -> Result<(), String> {
+    for (name, expected) in [
+        ("renderedFrames", u64::from(LTX_CAMPAIGN_ENTRY_FRAMES)),
+        ("outputFps", u64::from(LTX_CAMPAIGN_ENTRY_FPS)),
+        ("audioTrackDecoded", 1),
+        ("decodeTilingEngaged", 0),
+        ("decodeTileSpatialPx", 0),
+        ("decodeTileOverlapPx", 0),
+        ("latentTemporalDepth", 16),
+        ("latentTokens", 6_144),
+    ] {
+        let actual = campaign_entry_diagnostic(fragment, name)?;
+        if actual != expected {
+            return Err(format!(
+                "SC-20191 campaign entry diagnostic {name} must be {expected}, got {actual}"
+            ));
+        }
+    }
+    if fragment.pointer("/strategy/rung").and_then(Value::as_str) != Some("staged_residency")
+        || fragment.pointer("/strategy/engagedRungs")
+            != Some(&json!(["resident", "staged_residency"]))
+        || fragment.pointer("/strategy/parameters") != Some(&json!({}))
+        || fragment.pointer("/output/frames").and_then(Value::as_u64)
+            != Some(u64::from(LTX_CAMPAIGN_ENTRY_FRAMES))
+        || fragment.pointer("/output/fps").and_then(Value::as_u64)
+            != Some(u64::from(LTX_CAMPAIGN_ENTRY_FPS))
+        || fragment
+            .pointer("/output/audio/present")
+            .and_then(Value::as_bool)
+            != Some(true)
+        || fragment
+            .pointer("/output/audio/samples")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+            == 0
+        || fragment
+            .pointer("/output/audio/sampleRate")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+            == 0
+        || fragment
+            .pointer("/output/audio/channels")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+            == 0
+        || fragment
+            .pointer("/output/firstFrameNondegenerate")
+            .and_then(Value::as_bool)
+            != Some(true)
+    {
+        return Err(
+            "SC-20191 campaign entry response changed the exact untiled full-A/V carrier"
+                .to_owned(),
+        );
+    }
+    Ok(())
+}
+
+fn prevalidate_ltx_campaign_entry(request: &Value) -> Result<(), String> {
+    let geometry = validate_ltx_target(request)?;
+    protocol::validate_plain_overlay_target(request, LTX_PLAIN_EXECUTION_PATH)?;
+    if planned_load_shape(request)? != LoadShape::EagerMaterialization {
+        return Err("SC-20191 campaign entry requires eager materialization".to_owned());
+    }
+    let selection = planned_selection(request)?;
+    let tier = planned_qwen_tier(request)?;
+    let planned_fingerprint = protocol::planned(request)?
+        .get("calibrationFingerprint")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "planned.calibrationFingerprint must be a string".to_owned())?;
+    if planned_fingerprint != LTX_CALIBRATION_FINGERPRINT {
+        return Err("SC-20191 campaign entry calibration fingerprint changed".to_owned());
+    }
+    validate_ltx_campaign_entry(request, tier, geometry, &selection)
+}
+
+fn run_ltx_campaign_entry(request: &Value) -> Result<Value, String> {
+    // Every request identity check precedes the live watchdog handshake, process-global limits,
+    // model-path resolution and provider registry construction.
+    prevalidate_ltx_campaign_entry(request)?;
+    let mut watchdog = consume_ltx_canary_watchdog_attestation(request)?;
+    let watchdog_lease = watchdog.start_lease()?;
+    let limits = LtxCanaryLimits::install()?;
+    clear_cache();
+    let pre_provider = AllocatorState::capture_current();
+    validate_ltx_canary_pre_provider(pre_provider)?;
+    let expected_persistent_active = ltx_canary_ones_cache_bytes()?;
+    let mut fragment = run_ltx_with_admission(request, LtxRunAdmission::CampaignEntry)?;
+    validate_ltx_campaign_entry_fragment(&fragment)?;
+    clear_cache();
+    let post_cleanup = AllocatorState::capture_current();
+    validate_ltx_canary_cleanup(pre_provider, post_cleanup, expected_persistent_active)?;
+    fragment["_campaignEntry"] = json!({
+        "identity": LTX_CAMPAIGN_ENTRY_IDENTITY,
+        "inferenceRevision": protocol::INFERENCE_PIN,
+        "watchdog": {
+            "required": true,
+            "protocol": LTX_CANARY_WATCHDOG_PROTOCOL,
+            "maxFootprintBytes": watchdog.max_footprint_bytes,
+            "maxRuntimeSeconds": watchdog.max_runtime_seconds,
+            "hostMemoryBytes": watchdog.host_memory_bytes,
+            "minInitialMemoryFreeBytes": watchdog.min_initial_memory_free_bytes,
+            "minMemoryFreeBytes": watchdog.min_memory_free_bytes,
+        },
+        "mlxLimits": {
+            "memoryLimitBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES,
+            "wiredLimitBytes": limits.wired,
+        },
+        "cleanup": {
+            "preProviderActiveBytes": pre_provider.active,
+            "preProviderCacheBytes": pre_provider.cache,
+            "expectedPersistentActive": {
+                "identity": LTX_CANARY_ONES_CACHE_IDENTITY,
+                "videoDimension": LTX_CANARY_ONES_CACHE_VIDEO_DIMENSION,
+                "audioDimension": LTX_CANARY_ONES_CACHE_AUDIO_DIMENSION,
+                "dtype": "bfloat16",
+                "bytesPerElement": BFLOAT16_BYTES_PER_ELEMENT,
+                "bytes": expected_persistent_active,
+            },
+            "postCleanupActiveBytes": post_cleanup.active,
+            "postCleanupCacheBytes": post_cleanup.cache,
+        },
+    });
+    watchdog_lease.complete()?;
+    Ok(fragment)
+}
+
+fn run_ltx(request: &Value) -> Result<Value, String> {
+    run_ltx_with_admission(request, LtxRunAdmission::Ordinary)
 }
 
 fn run(request: &Value) -> Result<Value, String> {
@@ -7653,6 +7969,7 @@ fn main() {
         "run" => run(&request),
         "canary" => run_ltx_canary(&request),
         "product_envelope_canary" => run_ltx_product_envelope_canary(&request),
+        LTX_CAMPAIGN_ENTRY_ACTION => run_ltx_campaign_entry(&request),
         "assess_batch" => assess_z_image_batch(&request),
         other => Err(format!("unsupported action {other:?}")),
     }
@@ -8840,6 +9157,144 @@ mod ltx_tests {
             "seed": LTX_CANARY_SEED,
         });
         request
+    }
+
+    fn ltx_campaign_entry_request_json() -> Value {
+        let mut request = ltx_request_json(
+            LTX_CAMPAIGN_ENTRY_WIDTH,
+            LTX_CAMPAIGN_ENTRY_HEIGHT,
+            LTX_CAMPAIGN_ENTRY_FRAMES,
+        );
+        request["action"] = json!(LTX_CAMPAIGN_ENTRY_ACTION);
+        request["hardware"] = json!({ "memoryBytes": 128_u64 * 1024 * 1024 * 1024 });
+        request["planned"]["logicalCaseId"] = json!(LTX_CAMPAIGN_ENTRY_LOGICAL_CASE_ID);
+        request["planned"]["evidenceScope"] = json!("authoritative");
+        request["planned"]["target"]["tier"] = json!("q4");
+        request["planned"]["fixture"] = json!(LTX_CAMPAIGN_ENTRY_FIXTURE);
+        request["planned"]["negative"] = json!(false);
+        request["planned"]["expectedResult"] = json!("passed");
+        request["planned"]["modelLoadPolicy"] = json!("fresh_per_case");
+        request["planned"]["modelLoadGroup"] = Value::Null;
+        request["planned"]["_watchdog"] =
+            json!({ "maxFootprintBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES });
+        request["planned"]["_campaignEntry"] = json!({
+            "identity": LTX_CAMPAIGN_ENTRY_IDENTITY,
+            "artifact": {
+                "repository": protocol::LTX_REPOSITORY,
+                "revision": LTX_CANARY_ARTIFACT_REVISION,
+                "numericTierInventory": {
+                    "files": LTX_CANARY_Q4_INVENTORY_FILES,
+                    "bytes": LTX_Q4_INVENTORY_BYTES,
+                    "sha256": LTX_CANARY_Q4_INVENTORY_SHA256,
+                },
+                "textEncoderInventory": {
+                    "files": LTX_CANARY_TEXT_ENCODER_INVENTORY_FILES,
+                    "bytes": LTX_CANARY_TEXT_ENCODER_INVENTORY_BYTES,
+                    "sha256": LTX_CANARY_TEXT_ENCODER_INVENTORY_SHA256,
+                },
+            },
+        });
+        request["planned"]["_measurementSafety"] = json!({
+            "disposition": LTX_SAFETY_REFUSED_OPEN,
+            "tierInventoryBytes": LTX_Q4_INVENTORY_BYTES,
+            "incidentCrashFootprintBytes": LTX_Q4_F305_CRASH_FOOTPRINT_BYTES,
+            "incidentCase": "mlx-ltx-2-3-q4-1280x704-f305-fps30-bounded_decode",
+            "commonLoad": "complete numeric tier plus shared Gemma stack before geometry-specific work",
+            "predictedDecodeBytes": 19_476_906_240_u64,
+            "incidentPredictedDecodeBytes": LTX_INCIDENT_PREDICTED_DECODE_BYTES,
+            "incidentCalibratedProjectionBytes": 97_906_593_920_u64,
+            "projectionAssumptions": [
+                "pinned provider decode cost is the only geometry-varying term used",
+                "immutable tier inventory delta is added byte-for-byte",
+                "incident binding phase is unknown, so the projection is not a physical-footprint bound and cannot admit execution",
+            ],
+            "reason": "incident-calibrated projection is diagnostic only; no proved bound or hard containment admits this row",
+        });
+        request
+    }
+
+    #[test]
+    fn sc_20191_admits_only_the_exact_private_campaign_row_before_weight_work() {
+        let request = ltx_campaign_entry_request_json();
+        prevalidate_ltx_campaign_entry(&request).expect("the exact canonical row is admissible");
+
+        for (pointer, value) in [
+            ("/action", json!("run")),
+            ("/planned/logicalCaseId", json!("implan-mutated")),
+            ("/planned/target/tier", json!("q8")),
+            ("/planned/target/geometry/frames", json!(97)),
+            (
+                "/planned/fixture",
+                json!("ltx-2-3-mlx-q4-768x512-f121-fps30-seed1"),
+            ),
+            (
+                "/planned/strategy/parameters",
+                json!({ "decodeTileEdge": 192 }),
+            ),
+            ("/planned/evidenceScope", json!("fixture")),
+            ("/planned/modelLoadPolicy", json!("batch_rungs")),
+            (
+                "/planned/_watchdog/maxFootprintBytes",
+                json!(LTX_CANARY_MAX_FOOTPRINT_BYTES - 1),
+            ),
+            (
+                "/planned/_campaignEntry/identity",
+                json!("sc-20191-mutated"),
+            ),
+            (
+                "/planned/_measurementSafety/predictedDecodeBytes",
+                json!(19_476_906_239_u64),
+            ),
+        ] {
+            let mut mutated = request.clone();
+            *mutated.pointer_mut(pointer).expect("mutation pointer") = value;
+            let error = prevalidate_ltx_campaign_entry(&mutated)
+                .expect_err("every campaign-entry identity mutation must fail closed");
+            assert!(
+                error.contains("SC-20191") || error.contains("SC-18946"),
+                "{pointer}: {error}"
+            );
+        }
+
+        let direct = run_ltx_campaign_entry(&request)
+            .expect_err("canonical JSON alone cannot bypass the live watchdog");
+        assert!(
+            direct.contains("live external watchdog channel"),
+            "{direct}"
+        );
+    }
+
+    #[test]
+    fn sc_20191_requires_the_exact_untiled_full_av_response_carrier() {
+        let diagnostics = |name: &str, value: u64| json!({ "name": name, "value": value });
+        let mut fragment = json!({
+            "strategy": {
+                "rung": "staged_residency",
+                "engagedRungs": ["resident", "staged_residency"],
+                "parameters": {},
+            },
+            "output": {
+                "frames": 121,
+                "fps": 30,
+                "audio": { "present": true, "samples": 1, "sampleRate": 48_000, "channels": 2 },
+                "firstFrameNondegenerate": true,
+            },
+            "diagnostics": { "measurements": [
+                diagnostics("renderedFrames", 121),
+                diagnostics("outputFps", 30),
+                diagnostics("audioTrackDecoded", 1),
+                diagnostics("decodeTilingEngaged", 0),
+                diagnostics("decodeTileSpatialPx", 0),
+                diagnostics("decodeTileOverlapPx", 0),
+                diagnostics("latentTemporalDepth", 16),
+                diagnostics("latentTokens", 6_144),
+            ] },
+        });
+        validate_ltx_campaign_entry_fragment(&fragment).expect("exact carrier");
+        fragment["diagnostics"]["measurements"][3]["value"] = json!(1);
+        let tiled = validate_ltx_campaign_entry_fragment(&fragment)
+            .expect_err("a tiled carrier cannot publish the untiled canonical row");
+        assert!(tiled.contains("decodeTilingEngaged"), "{tiled}");
     }
 
     #[test]

--- a/packages/schemas/memory-calibration.schema.json
+++ b/packages/schemas/memory-calibration.schema.json
@@ -650,9 +650,24 @@
                   { "contains": { "properties": { "name": { "const": "exact_fit" }, "result": { "const": "passed" } }, "required": ["name", "result"] } },
                   { "contains": { "properties": { "name": { "const": "unknown_budget" }, "result": { "const": "passed" } }, "required": ["name", "result"] } },
                   { "contains": { "properties": { "name": { "const": "stale_evidence" }, "result": { "const": "passed" } }, "required": ["name", "result"] } },
-                  { "contains": { "properties": { "name": { "const": "warm_repeat" }, "result": { "const": "not_run" } }, "required": ["name", "result", "reason"] } },
-                  { "contains": { "properties": { "name": { "const": "cancel" }, "result": { "const": "not_run" } }, "required": ["name", "result", "reason"] } },
-                  { "contains": { "properties": { "name": { "const": "error" }, "result": { "const": "not_run" } }, "required": ["name", "result", "reason"] } },
+                  {
+                    "oneOf": [
+                      {
+                        "allOf": [
+                          { "contains": { "properties": { "name": { "const": "warm_repeat" }, "result": { "const": "not_run" } }, "required": ["name", "result", "reason"] } },
+                          { "contains": { "properties": { "name": { "const": "cancel" }, "result": { "const": "not_run" } }, "required": ["name", "result", "reason"] } },
+                          { "contains": { "properties": { "name": { "const": "error" }, "result": { "const": "not_run" } }, "required": ["name", "result", "reason"] } }
+                        ]
+                      },
+                      {
+                        "allOf": [
+                          { "contains": { "properties": { "name": { "const": "warm_repeat" }, "result": { "const": "passed" } }, "required": ["name", "result", "reason"] } },
+                          { "contains": { "properties": { "name": { "const": "cancel" }, "result": { "const": "passed" }, "cleanupVerified": { "const": true }, "warmFollowUpPassed": { "const": true } }, "required": ["name", "result", "reason", "cleanupVerified", "warmFollowUpPassed"] } },
+                          { "contains": { "properties": { "name": { "const": "error" }, "result": { "const": "passed" }, "cleanupVerified": { "const": true }, "warmFollowUpPassed": { "const": true } }, "required": ["name", "result", "reason", "cleanupVerified", "warmFollowUpPassed"] } }
+                        ]
+                      }
+                    ]
+                  },
                   { "contains": { "properties": { "name": { "const": "loadability" }, "result": { "const": "passed" } }, "required": ["name", "result"] } },
                   { "contains": { "properties": { "name": { "const": "overlay" }, "result": { "const": "not_applicable" } }, "required": ["name", "result", "reason"] } }
                 ]

--- a/scripts/memory-calibration-harness.mjs
+++ b/scripts/memory-calibration-harness.mjs
@@ -649,10 +649,16 @@ function validateRuntimeComplete(record) {
   for (const name of ["exact_fit", "unknown_budget", "stale_evidence", "loadability"]) {
     if (scenarios.get(name)?.result !== "passed") fail(`${record.id}: ${name} must pass for runtime activation`);
   }
-  for (const name of ["warm_repeat", "cancel", "error"]) {
-    const scenario = scenarios.get(name);
-    if (scenario?.result !== "not_run") fail(`${record.id}: ${name} must remain explicitly not_run`);
-    text(scenario.reason, `${record.id}.${name}.reason`);
+  const lifecycle = ["warm_repeat", "cancel", "error"].map((name) => scenarios.get(name));
+  const lifecycleNotRun = lifecycle.every((scenario) => scenario?.result === "not_run");
+  const lifecyclePassed = lifecycle.every((scenario) => scenario?.result === "passed")
+    && lifecycle.slice(1).every((scenario) =>
+      scenario.cleanupVerified === true && scenario.warmFollowUpPassed === true);
+  if (!lifecycleNotRun && !lifecyclePassed) {
+    fail(`${record.id}: runtime lifecycle must be entirely not_run or fully passed with cleanup and recovery`);
+  }
+  for (const [index, name] of ["warm_repeat", "cancel", "error"].entries()) {
+    text(lifecycle[index].reason, `${record.id}.${name}.reason`);
   }
   const exact = scenarios.get("exact_fit");
   number(exact.predictedBytes, `${record.id}.exact_fit.predictedBytes`);
@@ -1362,6 +1368,9 @@ export async function runProviderPlan({
   // sc-17774: injectable so the runner's own tests can drive synthetic repositories, which have no
   // inference crate layout to derive a real closure from. Production always uses the default.
   closureDigestFor = null,
+  // SC-20191 keeps the canonical request/record assembly here while allowing the one contained
+  // campaign entry to transport the provider request through its sealed watchdog wrapper.
+  executeProvider = execute,
 }) {
   if (!Array.isArray(providerCommand) || !providerCommand.length) fail("provider command must be a JSON argv array");
   if (Boolean(rawLogDir) !== Boolean(sourcePathPrefix)) {
@@ -1475,7 +1484,7 @@ export async function runProviderPlan({
   if (backends.size !== 1) {
     fail(`provider run must select exactly one backend; pass --backend mlx|candle (selected: ${[...backends].join(", ")})`);
   }
-  const probe = JSON.parse(await execute(
+  const probe = JSON.parse(await executeProvider(
     providerCommand[0],
     providerCommand.slice(1),
     canonicalJson({ action: "probe", repositories }),
@@ -1563,7 +1572,7 @@ export async function runProviderPlan({
       repositoryPaths: { sceneWorks: sceneWorksRepo, inference: inferenceRepo },
       hardware: probe.hardware,
     });
-    const providerOutput = await execute(
+    const providerOutput = await executeProvider(
       providerCommand[0],
       providerCommand.slice(1),
       providerRequest,

--- a/scripts/memory-calibration-harness.test.mjs
+++ b/scripts/memory-calibration-harness.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -521,14 +521,38 @@ test("complete status fails closed on scenario, quality, mutation, memory and lo
 // sc-18100: rehomed from `sc-15823-flux1-evidence.test.mjs`, which was the ONLY coverage of these
 // three `validateRuntimeComplete` rejection paths. They gate the SURVIVING harness, not the deleted
 // one-shot, so deleting that file without this test would have dropped the gates silently.
-test("runtime-complete fails closed on promoted lifecycle scenarios, overlay targets and extra cases", () => {
-  // A runtime-complete record attests only that the rung ran. Promoting an unexercised lifecycle
-  // scenario to `passed` is the overclaim the status exists to prevent.
+test("runtime-complete requires lifecycle scenarios to be wholly deferred or fully proven", () => {
+  const proven = runtimeComplete();
   for (const name of ["warm_repeat", "cancel", "error"]) {
-    const record = runtimeComplete();
-    record.scenarios.find((scenario) => scenario.name === name).result = "passed";
+    const scenario = proven.scenarios.find((entry) => entry.name === name);
+    scenario.result = "passed";
+    scenario.reason = `${name} executed under the selected request scope`;
+    if (name !== "warm_repeat") {
+      scenario.cleanupVerified = true;
+      scenario.warmFollowUpPassed = true;
+    }
+  }
+  proven.id = recordId(proven);
+  assert.equal(validateRecord(proven), proven);
+  validateBundle({
+    schemaVersion: SCHEMA_VERSION, harnessVersion: HARNESS_VERSION,
+    sourceSessions: [], records: [proven],
+  });
+
+  for (const mutate of [
+    (record) => { record.scenarios.find((entry) => entry.name === "warm_repeat").result = "not_run"; },
+    (record) => { record.scenarios.find((entry) => entry.name === "cancel").cleanupVerified = false; },
+    (record) => { delete record.scenarios.find((entry) => entry.name === "error").warmFollowUpPassed; },
+    (record) => { record.scenarios.find((entry) => entry.name === "warm_repeat").reason = ""; },
+  ]) {
+    const record = structuredClone(proven);
+    mutate(record);
     record.id = recordId(record);
-    assert.throws(() => validateRecord(record), new RegExp(`${name} must remain explicitly not_run`));
+    assert.throws(() => validateRecord(record), /lifecycle|non-empty/);
+    assert.throws(() => validateBundle({
+      schemaVersion: SCHEMA_VERSION, harnessVersion: HARNESS_VERSION,
+      sourceSessions: [], records: [record],
+    }), /schema validation failed|non-empty/);
   }
 
   // Runtime-complete evidence is base-only: an overlay coordinate may never be attested this way.
@@ -1664,6 +1688,27 @@ test("executable runner handles fragmented responses across provider processes",
       ],
     }],
   };
+  const actions = [];
+  const executeProvider = async (command, args, input) => {
+    const request = JSON.parse(input);
+    actions.push(request.action);
+    if (request.action === "run") {
+      assert.equal(typeof request.planned.logicalCaseId, "string");
+      assert.equal(Object.hasOwn(request.planned, "_campaignEntry"), false);
+    }
+    return new Promise((resolve, reject) => {
+      const child = spawn(command, args, { stdio: ["pipe", "pipe", "pipe"] });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (chunk) => { stdout += chunk; });
+      child.stderr.on("data", (chunk) => { stderr += chunk; });
+      child.on("error", reject);
+      child.on("close", (code) => code === 0
+        ? resolve(stdout)
+        : reject(new Error(`provider exited ${code}: ${stderr}`)));
+      child.stdin.end(input);
+    });
+  };
   const result = await runProviderPlan({
     closureDigestFor: stubClosureDigest,
     config,
@@ -1673,6 +1718,7 @@ test("executable runner handles fragmented responses across provider processes",
     ],
     sceneWorksRepo: fileURLToPath(new URL("..", import.meta.url)),
     inferenceRepo: fileURLToPath(new URL("..", import.meta.url)),
+    executeProvider,
   });
   const clean = result.records.every((record) =>
     !record.repositories.sceneWorks.dirty && !record.repositories.inference.dirty
@@ -1681,6 +1727,7 @@ test("executable runner handles fragmented responses across provider processes",
   assert.equal(expandPlan(config, result.records).length, clean ? 0 : 2);
   assert.equal(result.records[0].hardware.deviceId, "fixture:0");
   assert.match(result.records[0].repositories.sceneWorks.revision, /^[0-9a-f]{40}$/);
+  assert.deepEqual(actions, ["probe", "run", ...(clean ? [] : ["run"])]);
 });
 
 function physicalMlxConfig() {

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -2011,9 +2011,14 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
   );
 
   const campaign = adapter.slice(
+    adapter.indexOf("fn run_ltx_with_admission("),
+    adapter.indexOf("fn campaign_entry_diagnostic("),
+  );
+  const ordinary = adapter.slice(
     adapter.indexOf("fn run_ltx(request:"),
     adapter.indexOf("fn run(request:"),
   );
+  assert.match(ordinary, /run_ltx_with_admission\(request, LtxRunAdmission::Ordinary\)/);
   assert.ok(campaign.indexOf("refuse_unsafe_ltx_capture(") >= 0);
   assert.ok(
     campaign.indexOf("refuse_unsafe_ltx_capture(") < campaign.indexOf("ltx_load_spec("),
@@ -2029,8 +2034,27 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
     );
   }
   assert.doesNotMatch(
-    campaign,
+    ordinary,
     /LTX_(?:CANARY|PRODUCT_CANARY)_FIXTURE|diagnostic_(?:product_envelope_)?canary_complete/,
+  );
+  const campaignEntry = adapter.slice(
+    adapter.indexOf("fn prevalidate_ltx_campaign_entry("),
+    adapter.indexOf("fn run_ltx(request:"),
+  );
+  for (const required of [
+    "prevalidate_ltx_campaign_entry(request)?",
+    "consume_ltx_canary_watchdog_attestation(request)?",
+    "LtxCanaryLimits::install()?",
+    "LtxRunAdmission::CampaignEntry",
+    "validate_ltx_campaign_entry_fragment(&fragment)?",
+    "validate_ltx_canary_cleanup(",
+    '"_campaignEntry"',
+    "watchdog_lease.complete()?",
+  ]) assert.ok(campaignEntry.includes(required), `campaign entry must retain ${required}`);
+  assert.ok(
+    campaignEntry.indexOf("prevalidate_ltx_campaign_entry(request)?")
+      < campaignEntry.indexOf("consume_ltx_canary_watchdog_attestation(request)?"),
+    "the exact campaign row must be validated before the watchdog releases model allocation",
   );
 
   const canary = adapter.slice(

--- a/scripts/run-ltx-safety-canary.mjs
+++ b/scripts/run-ltx-safety-canary.mjs
@@ -13,6 +13,9 @@ import { isDeepStrictEqual, promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 
 import { hashArtifactInventory } from "./hash-artifact-inventory.mjs";
+import {
+  canonicalJson, expandPlan, runProviderPlan, validateBundle,
+} from "./memory-calibration-harness.mjs";
 
 const execFileAsync = promisify(execFile);
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -32,6 +35,31 @@ const PROVIDER = "ltx_2_3";
 const FINGERPRINT = "sc-19109-ltx-2-3-mlx-memory-ladder-v1";
 export const SAFETY_CANARY_PROFILE = "safety";
 export const PRODUCT_ENVELOPE_CANARY_PROFILE = "product-envelope";
+export const CAMPAIGN_ENTRY_PROFILE = "campaign-entry";
+export const CAMPAIGN_ENTRY_PROVIDER =
+  "mlx-ltx-2-3-q4-768x512-f121-fps30-staged_residency";
+export const CAMPAIGN_ENTRY_FIXTURE =
+  "ltx-2-3-mlx-q4-768x512-f121-fps30-seed18946";
+export const CAMPAIGN_ENTRY_LOGICAL_CASE_ID = "implan-9b107d4d1ca0d61d4faa";
+export const CAMPAIGN_ENTRY_IDENTITY = "sc-20191-q4-768x512-f121-fps30-staged-v1";
+const CAMPAIGN_ENTRY_ACTION = "campaign_entry";
+const CAMPAIGN_ENTRY_PLAN = "docs/calibration/sc-18946/ltx-mlx-single-pass-sweep.json";
+const CAMPAIGN_ENTRY_SAFETY = Object.freeze({
+  disposition: "safety_refused_open",
+  tierInventoryBytes: 20_467_690_460,
+  incidentCrashFootprintBytes: 96_970_084_480,
+  incidentCase: "mlx-ltx-2-3-q4-1280x704-f305-fps30-bounded_decode",
+  commonLoad: "complete numeric tier plus shared Gemma stack before geometry-specific work",
+  predictedDecodeBytes: 19_476_906_240,
+  incidentPredictedDecodeBytes: 18_540_396_800,
+  incidentCalibratedProjectionBytes: 97_906_593_920,
+  projectionAssumptions: Object.freeze([
+    "pinned provider decode cost is the only geometry-varying term used",
+    "immutable tier inventory delta is added byte-for-byte",
+    "incident binding phase is unknown, so the projection is not a physical-footprint bound and cannot admit execution",
+  ]),
+  reason: "incident-calibrated projection is diagnostic only; no proved bound or hard containment admits this row",
+});
 const CANARY_PROFILES = Object.freeze({
   [SAFETY_CANARY_PROFILE]: Object.freeze({
     action: "canary",
@@ -424,6 +452,346 @@ export function canaryRequest(
       },
     },
   };
+}
+
+export function campaignEntryPlan(config) {
+  const matches = config?.providers?.filter((provider) =>
+    provider.name === CAMPAIGN_ENTRY_PROVIDER) ?? [];
+  if (matches.length !== 1) fail("SC-20191 requires exactly one frozen campaign-entry provider");
+  const provider = matches[0];
+  const exactProvider = {
+    name: CAMPAIGN_ENTRY_PROVIDER,
+    _role: "fit",
+    _campaignPhase: "original_fit",
+    _coverageExpectation: "captured_or_attempted_or_arithmetic_unmeasurable",
+    _latentTokens: 6_144,
+    _writableFrameCap: 682,
+    _outputVoxels: 47_579_136,
+    _measurementSafety: structuredClone(CAMPAIGN_ENTRY_SAFETY),
+    evidenceScope: "authoritative",
+    backend: "mlx",
+    loadShape: "eager_materialization",
+    target: {
+      provider: PROVIDER,
+      modelId: PROVIDER,
+      tier: "q4",
+      mode: "text_to_video",
+      overlay: "none",
+      geometry: { width: 768, height: 512, batch: 1, frames: 121 },
+    },
+    rung: "staged_residency",
+    engagedRungs: ["resident", "staged_residency"],
+    calibrationFingerprint: FINGERPRINT,
+    fixture: CAMPAIGN_ENTRY_FIXTURE,
+    cases: [{ parameters: {}, expectedResult: "passed" }],
+  };
+  if (!isDeepStrictEqual(provider, exactProvider)) {
+    fail("SC-20191 frozen campaign-entry provider changed");
+  }
+  const planned = expandPlan({ providers: [provider] });
+  if (planned.length !== 1
+      || planned[0].logicalCaseId !== CAMPAIGN_ENTRY_LOGICAL_CASE_ID
+      || planned[0].modelLoadPolicy !== "fresh_per_case"
+      || planned[0].modelLoadGroup !== null) {
+    fail("SC-20191 campaign-entry logical identity changed");
+  }
+  return { provider, planned: planned[0] };
+}
+
+export function validateCampaignEntryHarnessRequest(request, expectedPlanned, {
+  sceneWorksRevision, inferenceRevision, sceneWorksRepo, inferenceRepo,
+} = {}) {
+  if (request?.action !== "run"
+      || !isDeepStrictEqual(request?.planned, expectedPlanned)
+      || request.planned.logicalCaseId !== CAMPAIGN_ENTRY_LOGICAL_CASE_ID
+      || request.planned.evidenceScope !== "authoritative"
+      || request.planned.fixture !== CAMPAIGN_ENTRY_FIXTURE
+      || request.planned.negative !== false
+      || request.planned.expectedResult !== "passed"
+      || request.planned.modelLoadPolicy !== "fresh_per_case"
+      || request.planned.modelLoadGroup !== null
+      || request.repositories?.sceneWorks?.dirty !== false
+      || request.repositories?.inference?.dirty !== false
+      || (sceneWorksRevision !== undefined
+        && request.repositories.sceneWorks.revision !== sceneWorksRevision)
+      || (inferenceRevision !== undefined
+        && request.repositories.inference.revision !== inferenceRevision)
+      || (sceneWorksRepo !== undefined && request.repositoryPaths?.sceneWorks !== sceneWorksRepo)
+      || (inferenceRepo !== undefined && request.repositoryPaths?.inference !== inferenceRepo)
+      || !Number.isSafeInteger(request.hardware?.memoryBytes)
+      || request.hardware.memoryBytes <= 0) {
+    fail("SC-20191 provider wrapper received a non-canonical harness request");
+  }
+  for (const privateField of ["_watchdog", "_campaignEntry", "_measurementSafety"]) {
+    if (Object.hasOwn(request.planned, privateField)) {
+      fail(`canonical SC-18946 request unexpectedly contains ${privateField}`);
+    }
+  }
+  return request;
+}
+
+export function campaignEntryAdapterRequest(request, expectedPlanned, expectedSource) {
+  validateCampaignEntryHarnessRequest(request, expectedPlanned, expectedSource);
+  const transformed = structuredClone(request);
+  transformed.action = CAMPAIGN_ENTRY_ACTION;
+  transformed.planned._watchdog = { maxFootprintBytes: MAX_FOOTPRINT_BYTES };
+  transformed.planned._measurementSafety = structuredClone(CAMPAIGN_ENTRY_SAFETY);
+  transformed.planned._campaignEntry = {
+    identity: CAMPAIGN_ENTRY_IDENTITY,
+    artifact: {
+      repository: ARTIFACT_REPOSITORY,
+      revision: ARTIFACT_REVISION,
+      numericTierInventory: {
+        files: 11, bytes: Q4_INVENTORY_BYTES, sha256: Q4_INVENTORY_SHA256,
+      },
+      textEncoderInventory: {
+        files: TEXT_ENCODER_INVENTORY_FILES,
+        bytes: TEXT_ENCODER_INVENTORY_BYTES,
+        sha256: TEXT_ENCODER_INVENTORY_SHA256,
+      },
+    },
+  };
+  return transformed;
+}
+
+function diagnosticMeasurements(response) {
+  const measurements = response?.diagnostics?.measurements;
+  if (!Array.isArray(measurements)) fail("SC-20191 response omitted typed diagnostics");
+  const values = new Map();
+  for (const measurement of measurements) {
+    if (typeof measurement?.name !== "string" || !Number.isSafeInteger(measurement?.value)
+        || measurement.value < 0 || values.has(measurement.name)) {
+      fail("SC-20191 response diagnostics are malformed or duplicated");
+    }
+    values.set(measurement.name, measurement.value);
+  }
+  return values;
+}
+
+export function validateCampaignEntryAdapterResponse(response, {
+  inferenceRevision, hostMemoryBytes,
+} = {}) {
+  const diagnostics = diagnosticMeasurements(response);
+  for (const [name, expected] of [
+    ["renderedFrames", 121], ["outputFps", 30], ["audioTrackDecoded", 1],
+    ["decodeTilingEngaged", 0], ["decodeTileSpatialPx", 0],
+    ["decodeTileOverlapPx", 0], ["latentTemporalDepth", 16], ["latentTokens", 6_144],
+  ]) {
+    if (diagnostics.get(name) !== expected) {
+      fail(`SC-20191 response diagnostic ${name} must be ${expected}`);
+    }
+  }
+  const sidecar = response?._campaignEntry;
+  if (response?.status !== "runtime_complete"
+      || response?.loadShape !== "eager_materialization"
+      || response?.artifact?.repository !== ARTIFACT_REPOSITORY
+      || response?.artifact?.resolvedRevision !== ARTIFACT_REVISION
+      || response?.artifact?.variant !== "q4"
+      || !isDeepStrictEqual(response?.strategy, {
+        rung: "staged_residency", engagedRungs: ["resident", "staged_residency"], parameters: {},
+      })
+      || response?.output?.frames !== 121
+      || response?.output?.fps !== 30
+      || response?.output?.audio?.present !== true
+      || !Number.isSafeInteger(response?.output?.audio?.samples)
+      || response.output.audio.samples <= 0
+      || !Number.isSafeInteger(response?.output?.audio?.sampleRate)
+      || response.output.audio.sampleRate <= 0
+      || !Number.isSafeInteger(response?.output?.audio?.channels)
+      || response.output.audio.channels <= 0
+      || response?.output?.firstFrameNondegenerate !== true
+      || sidecar?.identity !== CAMPAIGN_ENTRY_IDENTITY
+      || (inferenceRevision !== undefined && sidecar?.inferenceRevision !== inferenceRevision)
+      || sidecar?.watchdog?.required !== true
+      || sidecar?.watchdog?.protocol !== "sceneworks-memory-watchdog-v1"
+      || sidecar?.watchdog?.maxFootprintBytes !== MAX_FOOTPRINT_BYTES
+      || sidecar?.watchdog?.maxRuntimeSeconds !== MAX_RUNTIME_SECONDS
+      || (hostMemoryBytes !== undefined && sidecar?.watchdog?.hostMemoryBytes !== hostMemoryBytes)
+      || sidecar?.watchdog?.minInitialMemoryFreeBytes
+        !== preflightFreeFloor(sidecar?.watchdog?.hostMemoryBytes)
+      || sidecar?.watchdog?.minMemoryFreeBytes
+        !== runtimeFreeFloor(sidecar?.watchdog?.hostMemoryBytes)
+      || Object.hasOwn(sidecar?.watchdog ?? {}, "minSwapFreeBytes")
+      || Object.hasOwn(sidecar?.watchdog ?? {}, "minInitialMemoryFreePercent")
+      || sidecar?.mlxLimits?.memoryLimitBytes !== MAX_FOOTPRINT_BYTES
+      || !Number.isSafeInteger(sidecar?.mlxLimits?.wiredLimitBytes)
+      || sidecar.mlxLimits.wiredLimitBytes <= 0
+      || sidecar.mlxLimits.wiredLimitBytes > MAX_FOOTPRINT_BYTES) {
+    fail("SC-20191 adapter response changed the exact contained campaign entry");
+  }
+  const cleanup = sidecar.cleanup;
+  for (const field of [
+    "preProviderActiveBytes", "preProviderCacheBytes",
+    "postCleanupActiveBytes", "postCleanupCacheBytes",
+  ]) {
+    if (!Number.isSafeInteger(cleanup?.[field]) || cleanup[field] < 0) {
+      fail(`SC-20191 cleanup ${field} must be a non-negative safe integer`);
+    }
+  }
+  if (cleanup.preProviderCacheBytes !== 0
+      || !isDeepStrictEqual(cleanup.expectedPersistentActive, {
+        identity: LTX_ONES_CACHE_IDENTITY,
+        videoDimension: LTX_ONES_CACHE_VIDEO_DIMENSION,
+        audioDimension: LTX_ONES_CACHE_AUDIO_DIMENSION,
+        dtype: "bfloat16",
+        bytesPerElement: BFLOAT16_BYTES_PER_ELEMENT,
+        bytes: ltxOnesCacheBytes(),
+      })) {
+    fail("SC-20191 cleanup changed the exact named ONES_CACHE contract");
+  }
+  const expectedPostActive = cleanup.preProviderActiveBytes + cleanup.expectedPersistentActive.bytes;
+  if (!Number.isSafeInteger(expectedPostActive)) fail("SC-20191 cleanup active-byte arithmetic overflowed");
+  if (cleanup.postCleanupActiveBytes !== expectedPostActive
+      || cleanup.postCleanupCacheBytes !== cleanup.preProviderCacheBytes) {
+    fail("SC-20191 cleanup did not return to the exact intentional persistent baseline");
+  }
+  return response;
+}
+
+export function validateCampaignEntryWatchdogEvents(events, hostMemoryBytes) {
+  if (!Array.isArray(events) || events.length === 0) fail("SC-20191 watchdog stream is empty");
+  const startedIndex = events.findIndex((event) => event.event === "started");
+  const attestedIndex = events.findIndex((event) => event.event === "child_attested");
+  const completedIndex = events.findIndex((event) => event.event === "child_completed");
+  const samples = events.filter((event) => event.event === "sample");
+  const runtimeFloor = runtimeFreeFloor(hostMemoryBytes);
+  if (events.filter((event) => event.event === "started").length !== 1
+      || events.filter((event) => event.event === "child_attested").length !== 1
+      || events.filter((event) => event.event === "child_completed").length !== 1
+      || startedIndex < 0
+      || attestedIndex < 0
+      || completedIndex < 0
+      || startedIndex >= attestedIndex
+      || completedIndex <= attestedIndex
+      || !events.slice(0, attestedIndex).some((event) =>
+        event.event === "sample" && event.phase === "before_child_release")
+      || !events.slice(0, attestedIndex).some((event) =>
+        event.event === "sample" && event.phase === "child_attested_before_allocation")
+      || !events.slice(attestedIndex + 1, completedIndex).some((event) =>
+        event.event === "sample")
+      || samples.length === 0
+      || samples.some((event) =>
+        !Number.isSafeInteger(event.physicalFootprintBytes)
+        || event.physicalFootprintBytes < 0
+        || event.physicalFootprintBytes >= MAX_FOOTPRINT_BYTES
+        || !Number.isSafeInteger(event.memoryFreeBytes)
+        || event.memoryFreeBytes < runtimeFloor
+        || !Number.isSafeInteger(event.swapFreeBytes)
+        || event.swapFreeBytes < 0)
+      || events.some((event) => event.event === "hard_stop" || event.event === "terminated")) {
+    fail("SC-20191 watchdog stream is incomplete or crossed a safety boundary");
+  }
+  return Math.max(...samples.map((event) => event.physicalFootprintBytes));
+}
+
+export function campaignEntryCanonicalFragment(response, maxObservedFootprintBytes) {
+  if (!Number.isSafeInteger(maxObservedFootprintBytes)
+      || maxObservedFootprintBytes < 0
+      || maxObservedFootprintBytes >= MAX_FOOTPRINT_BYTES) {
+    fail("SC-20191 canonical fragment requires a contained physical-footprint maximum");
+  }
+  const canonical = structuredClone(response);
+  const sidecar = canonical._campaignEntry;
+  const output = canonical.output;
+  if (!sidecar || !output) fail("SC-20191 canonical fragment omitted private validated evidence");
+  delete canonical._campaignEntry;
+  delete canonical.output;
+  const measurements = canonical.diagnostics?.measurements;
+  if (!Array.isArray(measurements)) fail("SC-20191 canonical fragment omitted diagnostics");
+  const existing = new Set(measurements.map((measurement) => measurement.name));
+  const append = (name, unit, value) => {
+    if (existing.has(name) || !Number.isSafeInteger(value) || value < 0) {
+      fail(`SC-20191 canonical diagnostic ${name} is duplicated or invalid`);
+    }
+    existing.add(name);
+    measurements.push({ name, unit, value });
+  };
+  append("campaignWatchdogMaxFootprintBytes", "bytes", sidecar.watchdog.maxFootprintBytes);
+  append("campaignWatchdogMaxObservedFootprintBytes", "bytes", maxObservedFootprintBytes);
+  append("campaignWatchdogMaxRuntimeSeconds", "seconds", sidecar.watchdog.maxRuntimeSeconds);
+  append("campaignWatchdogHostMemoryBytes", "bytes", sidecar.watchdog.hostMemoryBytes);
+  append("campaignWatchdogMinInitialMemoryFreeBytes", "bytes",
+    sidecar.watchdog.minInitialMemoryFreeBytes);
+  append("campaignWatchdogMinMemoryFreeBytes", "bytes", sidecar.watchdog.minMemoryFreeBytes);
+  append("campaignMlxMemoryLimitBytes", "bytes", sidecar.mlxLimits.memoryLimitBytes);
+  append("campaignMlxWiredLimitBytes", "bytes", sidecar.mlxLimits.wiredLimitBytes);
+  append("campaignPreProviderActiveBytes", "bytes", sidecar.cleanup.preProviderActiveBytes);
+  append("campaignPreProviderCacheBytes", "bytes", sidecar.cleanup.preProviderCacheBytes);
+  append("campaignExpectedPersistentActiveBytes", "bytes",
+    sidecar.cleanup.expectedPersistentActive.bytes);
+  append("campaignPostCleanupActiveBytes", "bytes", sidecar.cleanup.postCleanupActiveBytes);
+  append("campaignPostCleanupCacheBytes", "bytes", sidecar.cleanup.postCleanupCacheBytes);
+  append("campaignOutputAudioSamples", "count", output.audio.samples);
+  append("campaignOutputAudioSampleRate", "hertz", output.audio.sampleRate);
+  append("campaignOutputAudioChannels", "count", output.audio.channels);
+  append("campaignFirstFrameNondegenerate", "boolean", output.firstFrameNondegenerate ? 1 : 0);
+  append("campaignOwnedProcessGroupResidue", "count", 0);
+  append("campaignProviderContainmentComplete", "boolean", 1);
+  return canonical;
+}
+
+export function validateCampaignEntryBundle(bundle) {
+  validateBundle(bundle);
+  if (bundle.records.length !== 1 || (bundle.sourceSessions?.length ?? 0) !== 0) {
+    fail("SC-20191 must publish exactly one canonical record and no synthetic source session");
+  }
+  const record = bundle.records[0];
+  if (record.logicalCaseId !== CAMPAIGN_ENTRY_LOGICAL_CASE_ID
+      || record.status !== "runtime_complete"
+      || record.evidenceScope !== "authoritative"
+      || record.fixture !== CAMPAIGN_ENTRY_FIXTURE
+      || !isDeepStrictEqual(record.target, {
+        provider: PROVIDER, modelId: PROVIDER, tier: "q4", mode: "text_to_video",
+        overlay: "none", geometry: { width: 768, height: 512, batch: 1, frames: 121 },
+      })
+      || !isDeepStrictEqual(record.strategy, {
+        rung: "staged_residency", engagedRungs: ["resident", "staged_residency"], parameters: {},
+      })) {
+    fail("SC-20191 canonical bundle changed identity");
+  }
+  const diagnostics = diagnosticMeasurements(record);
+  for (const [name, expected] of [
+    ["renderedFrames", 121], ["outputFps", 30], ["audioTrackDecoded", 1],
+    ["decodeTilingEngaged", 0], ["decodeTileSpatialPx", 0],
+    ["decodeTileOverlapPx", 0], ["latentTemporalDepth", 16], ["latentTokens", 6_144],
+    ["campaignWatchdogMaxFootprintBytes", MAX_FOOTPRINT_BYTES],
+    ["campaignWatchdogMaxRuntimeSeconds", MAX_RUNTIME_SECONDS],
+    ["campaignMlxMemoryLimitBytes", MAX_FOOTPRINT_BYTES],
+    ["campaignPreProviderCacheBytes", 0],
+    ["campaignExpectedPersistentActiveBytes", ltxOnesCacheBytes()],
+    ["campaignPostCleanupCacheBytes", 0],
+    ["campaignFirstFrameNondegenerate", 1],
+    ["campaignOwnedProcessGroupResidue", 0],
+    ["campaignProviderContainmentComplete", 1],
+  ]) {
+    if (diagnostics.get(name) !== expected) {
+      fail(`SC-20191 canonical bundle diagnostic ${name} must be ${expected}`);
+    }
+  }
+  const pre = diagnostics.get("campaignPreProviderActiveBytes");
+  const post = diagnostics.get("campaignPostCleanupActiveBytes");
+  const observed = diagnostics.get("campaignWatchdogMaxObservedFootprintBytes");
+  const hostMemory = diagnostics.get("campaignWatchdogHostMemoryBytes");
+  for (const name of [
+    "campaignOutputAudioSamples", "campaignOutputAudioSampleRate", "campaignOutputAudioChannels",
+    "campaignMlxWiredLimitBytes", "campaignWatchdogHostMemoryBytes",
+    "campaignWatchdogMinInitialMemoryFreeBytes", "campaignWatchdogMinMemoryFreeBytes",
+  ]) {
+    if (!Number.isSafeInteger(diagnostics.get(name)) || diagnostics.get(name) <= 0) {
+      fail(`SC-20191 canonical bundle diagnostic ${name} must be positive`);
+    }
+  }
+  if (!Number.isSafeInteger(pre) || !Number.isSafeInteger(post)
+      || post !== pre + ltxOnesCacheBytes()
+      || hostMemory !== record.hardware.memoryBytes
+      || diagnostics.get("campaignWatchdogMinInitialMemoryFreeBytes")
+        !== preflightFreeFloor(hostMemory)
+      || diagnostics.get("campaignWatchdogMinMemoryFreeBytes") !== runtimeFreeFloor(hostMemory)
+      || diagnostics.get("campaignMlxWiredLimitBytes") > MAX_FOOTPRINT_BYTES
+      || !Number.isSafeInteger(observed) || observed < 0 || observed >= MAX_FOOTPRINT_BYTES) {
+    fail("SC-20191 canonical bundle cleanup or footprint attestation changed");
+  }
+  return bundle;
 }
 
 function sameInventory(left, right) {
@@ -1355,6 +1723,235 @@ export function canaryWatchdogEnvironment(baseEnvironment, roots, metallibPath, 
   };
 }
 
+async function readStandardInput() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function runProtocolCommand(executable, input, { env, signal, cwd = ROOT } = {}) {
+  signal?.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    let spawnError = null;
+    let stdinError = null;
+    const child = spawn(executable, [], {
+      cwd, env, detached: true, stdio: ["pipe", "pipe", "pipe"],
+    });
+    const terminate = () => killProcessGroup(child, "SIGKILL");
+    const onAbort = () => terminate();
+    if (signal) signal.addEventListener("abort", onAbort, { once: true });
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", (error) => { spawnError = error; terminate(); });
+    child.stdin.on("error", (error) => { stdinError = error; });
+    child.on("close", (code, childSignal) => {
+      if (signal) signal.removeEventListener("abort", onAbort);
+      if (spawnError) return reject(spawnError);
+      if (stdinError) return reject(stdinError);
+      if (signal?.aborted) return reject(signal.reason ?? new Error("protocol command aborted"));
+      return code === 0 && childSignal === null
+        ? resolve(stdout)
+        : reject(new Error(
+          `campaign adapter failed: code=${code} signal=${childSignal}: ${stderr.trim() || "no stderr"}`,
+        ));
+    });
+    child.stdin.end(input);
+  });
+}
+
+export function ownedProcessGroupResidue(processTable, pgid) {
+  if (!Number.isSafeInteger(pgid) || pgid <= 0) fail("watchdog PGID must be a positive integer");
+  return processTable.split("\n").map((line) => line.trim()).filter(Boolean).filter((line) => {
+    const match = line.match(/^(\d+)\s+(\d+)\s+(.+)$/);
+    return match !== null && Number(match[2]) === pgid;
+  });
+}
+
+async function assertRunRootEmpty(runRoot) {
+  const entries = await readdir(runRoot).catch((error) => {
+    if (error.code === "ENOENT") return [];
+    throw error;
+  });
+  if (entries.length !== 0) fail(`SC-20191 run scratch retained residue: ${entries.join(", ")}`);
+}
+
+async function assertCampaignSourceState(options, signal) {
+  const pairs = [
+    [ROOT, "SceneWorks", options["scene-revision"], options["scene-tree"]],
+    [options["inference-repo"], "inference", options["inference-revision"], options["inference-tree"]],
+  ];
+  for (const [repo, label, revision, tree] of pairs) {
+    if (await cleanHead(repo, label, signal) !== revision
+        || await git(repo, ["rev-parse", "HEAD^{tree}"], signal) !== tree) {
+      fail(`${label} source changed during SC-20191 campaign entry`);
+    }
+  }
+}
+
+function campaignProviderOptions(argv) {
+  const options = parseArgs(argv);
+  for (const name of [
+    "inference-repo", "preparation-root", "preparation-key", "run-root",
+    "scene-revision", "scene-tree", "inference-revision", "inference-tree",
+  ]) {
+    if (!options[name]) fail(`campaign provider requires --${name}`);
+  }
+  const unexpected = Object.keys(options).filter((name) => ![
+    "inference-repo", "preparation-root", "preparation-key", "run-root",
+    "scene-revision", "scene-tree", "inference-revision", "inference-tree",
+  ].includes(name));
+  if (unexpected.length) fail(`unsupported campaign provider option(s): ${unexpected.join(", ")}`);
+  for (const name of ["inference-repo", "preparation-root", "run-root"]) {
+    options[name] = path.resolve(options[name]);
+  }
+  return options;
+}
+
+async function campaignProviderInvocation(options, input, {
+  signal, setActiveWatchdog = () => {},
+} = {}) {
+  signal?.throwIfAborted();
+  const request = JSON.parse(input);
+  const config = JSON.parse(await readFile(path.join(ROOT, CAMPAIGN_ENTRY_PLAN), "utf8"));
+  const { planned } = campaignEntryPlan(config);
+  const toolchainChannel = await repositoryToolchain();
+  const identity = preparationIdentity(
+    options["scene-tree"], options["inference-tree"], toolchainChannel,
+  );
+  if (preparationCacheKey(identity) !== options["preparation-key"]) {
+    fail("SC-20191 campaign provider preparation key changed");
+  }
+  await assertCampaignSourceState(options, signal);
+  const prepared = await validatePreparedCache(
+    options["preparation-root"], options["preparation-key"], identity, signal,
+  );
+  if (prepared === null) fail("SC-20191 prepared cache disappeared before provider invocation");
+  await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal);
+  await mkdir(options["run-root"], { recursive: true, mode: 0o700 });
+  await assertRunRootEmpty(options["run-root"]);
+  const runScratch = await mkdtemp(path.join(options["run-root"], "sc-20191-run-"));
+  let operationError = null;
+  let cleanupError = null;
+  let output = null;
+  try {
+    const runtimeHome = path.join(runScratch, "home");
+    await mkdir(runtimeHome, { mode: 0o700 });
+    await exactMetadata(runtimeHome, "directory", 0o700);
+    await exactEntries(runtimeHome, []);
+    const environment = canaryWatchdogEnvironment(
+      process.env, prepared.roots, prepared.metallib.path, runtimeHome,
+    );
+    if (request.action === "probe") {
+      const probeOutput = await runProtocolCommand(prepared.adapter.path, input, {
+        env: environment, signal,
+      });
+      JSON.parse(probeOutput);
+      await assertCampaignSourceState(options, signal);
+      await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal);
+      if (await validatePreparedCache(
+        options["preparation-root"], options["preparation-key"], identity, signal,
+      ) === null) fail("SC-20191 prepared cache disappeared after provider probe");
+      output = probeOutput;
+    } else {
+      const adapterRequest = campaignEntryAdapterRequest(request, planned, {
+        sceneWorksRevision: options["scene-revision"],
+        inferenceRevision: options["inference-revision"],
+        sceneWorksRepo: ROOT,
+        inferenceRepo: options["inference-repo"],
+      });
+      const requestPath = path.join(runScratch, "request.json");
+      const responsePath = path.join(runScratch, "response.json");
+      const eventsPath = path.join(runScratch, "watchdog.jsonl");
+      await writeFile(requestPath, canonicalJson(adapterRequest), { flag: "wx" });
+      const hostMemoryBytes = request.hardware.memoryBytes;
+      const runtimeMemoryFreeFloor = runtimeFreeFloor(hostMemoryBytes);
+      const watchdogArgs = [
+        path.join(ROOT, "scripts/memory-calibration-watchdog.py"),
+        "--max-footprint-bytes", String(MAX_FOOTPRINT_BYTES),
+        "--max-runtime-seconds", String(MAX_RUNTIME_SECONDS),
+        "--host-memory-bytes", String(hostMemoryBytes),
+        "--min-memory-free-bytes", String(runtimeMemoryFreeFloor),
+        "--sample-interval", "0.25",
+        "--telemetry-timeout", "1",
+        "--child-attestation-timeout", String(CHILD_ATTESTATION_TIMEOUT_SECONDS),
+        "--term-grace", "1",
+        "--event-file", eventsPath,
+        "--require-child-attestation",
+        "--",
+        "/bin/sh", "-c", 'set -C; exec "$1" <"$2" >"$3"',
+        "sc-20191-campaign-entry", prepared.adapter.path, requestPath, responsePath,
+      ];
+      await assertCampaignSourceState(options, signal);
+      await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal);
+      if (await validatePreparedCache(
+        options["preparation-root"], options["preparation-key"], identity, signal,
+      ) === null) fail("SC-20191 prepared cache disappeared before model release");
+      // This immediate actual-GPU-owner and two-boundary pressure check is deliberately the final
+      // operation before the watchdog takes ownership of the model process.
+      await assertHostPreflight(hostMemoryBytes, signal);
+      const status = await new Promise((resolve, reject) => {
+        const child = spawn("/usr/bin/python3", watchdogArgs, {
+          stdio: "inherit", env: environment,
+        });
+        setActiveWatchdog(child);
+        const onAbort = () => child.kill(signal.reason?.signalName ?? "SIGTERM");
+        if (signal) signal.addEventListener("abort", onAbort, { once: true });
+        child.on("error", reject);
+        child.on("close", (code, childSignal) => {
+          if (signal) signal.removeEventListener("abort", onAbort);
+          setActiveWatchdog(null);
+          resolve({ code, signal: childSignal });
+        });
+      });
+      signal?.throwIfAborted();
+      const eventBytes = await readFile(eventsPath, "utf8").catch(() => "");
+      if (status.code !== 0 || status.signal) fail(watchdogFailureSummary(status, eventBytes));
+      const response = JSON.parse(await readFile(responsePath, "utf8"));
+      const events = eventBytes.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+      validateCampaignEntryAdapterResponse(response, {
+        inferenceRevision: options["inference-revision"], hostMemoryBytes,
+      });
+      const maxObservedFootprintBytes = validateCampaignEntryWatchdogEvents(
+        events, hostMemoryBytes,
+      );
+      const started = events.find((event) => event.event === "started");
+      const processTable = (await execFileAsync(
+        "/bin/ps", ["-ww", "-axo", "pid=,pgid=,command="],
+        { encoding: "utf8", timeout: 2_000 },
+      )).stdout;
+      const residue = ownedProcessGroupResidue(processTable, started?.pgid);
+      if (residue.length) fail(`SC-20191 watchdog process group retained residue:\n${residue.join("\n")}`);
+      await assertCampaignSourceState(options, signal);
+      await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal);
+      if (await validatePreparedCache(
+        options["preparation-root"], options["preparation-key"], identity, signal,
+      ) === null) fail("SC-20191 prepared cache disappeared after campaign entry");
+      output = canonicalJson(campaignEntryCanonicalFragment(response, maxObservedFootprintBytes));
+    }
+  } catch (error) {
+    operationError = error;
+  } finally {
+    try {
+      await cleanupCanaryScratch(runScratch);
+      await assertRunRootEmpty(options["run-root"]);
+    } catch (error) {
+      cleanupError = error;
+    }
+  }
+  const finalError = preservePrimaryFailure(operationError, cleanupError);
+  if (finalError !== null) throw finalError;
+  return output;
+}
+
+async function campaignProvider(argv) {
+  const output = await campaignProviderInvocation(
+    campaignProviderOptions(argv), await readStandardInput(),
+  );
+  process.stdout.write(output);
+}
+
 function parseArgs(argv) {
   const options = {};
   for (let index = 0; index < argv.length; index += 2) {
@@ -1364,6 +1961,107 @@ function parseArgs(argv) {
     options[name.slice(2)] = value;
   }
   return options;
+}
+
+async function publishExclusiveJson(output, value, signal) {
+  await mkdir(path.dirname(output), { recursive: true });
+  signal?.throwIfAborted();
+  const temporary = `${output}.tmp-${process.pid}-${randomUUID()}`;
+  try {
+    await writeFile(temporary, canonicalJson(value), { flag: "wx" });
+    signal?.throwIfAborted();
+    await link(temporary, output);
+  } finally {
+    await unlink(temporary).catch((error) => { if (error.code !== "ENOENT") throw error; });
+  }
+}
+
+async function assertPreparationHasNoTransientResidue(preparationRoot) {
+  const parent = path.dirname(preparationRoot);
+  const key = path.basename(preparationRoot);
+  const entries = await readdir(parent).catch((error) => {
+    if (error.code === "ENOENT") return [];
+    throw error;
+  });
+  const residue = entries.filter((name) =>
+    name === `.${key}.lock`
+    || name.startsWith(`.${key}.stage-`)
+    || name.startsWith(`.${key}.build-`)
+    || name.startsWith(`.${key}.tmp-`));
+  if (residue.length) fail(`SC-20191 preparation retained transient residue: ${residue.join(", ")}`);
+}
+
+async function runCampaignEntryController({
+  output, inferenceRepo, sceneWorksRevision, inferenceRevision,
+  sceneWorksTree, inferenceTree, identity, preparationKey, preparationRoot,
+  prepared, signal, setActiveWatchdog,
+}) {
+  const config = JSON.parse(await readFile(path.join(ROOT, CAMPAIGN_ENTRY_PLAN), "utf8"));
+  campaignEntryPlan(config);
+  const runRoot = path.join(path.dirname(output), "runs");
+  await mkdir(runRoot, { recursive: true, mode: 0o700 });
+  await assertRunRootEmpty(runRoot);
+  const providerOptions = {
+    "inference-repo": inferenceRepo,
+    "preparation-root": preparationRoot,
+    "preparation-key": preparationKey,
+    "run-root": runRoot,
+    "scene-revision": sceneWorksRevision,
+    "scene-tree": sceneWorksTree,
+    "inference-revision": inferenceRevision,
+    "inference-tree": inferenceTree,
+  };
+  const providerCommand = [fileURLToPath(import.meta.url), "--campaign-provider"];
+  let operationError = null;
+  let cleanupError = null;
+  let bundle = null;
+  try {
+    bundle = await runProviderPlan({
+      config,
+      providerCommand,
+      sceneWorksRepo: ROOT,
+      inferenceRepo,
+      backend: "mlx",
+      providerName: CAMPAIGN_ENTRY_PROVIDER,
+      onProviderInvocation: ({ action, cases }) => {
+        if (action !== "run" || cases.length !== 1
+            || cases[0].logicalCaseId !== CAMPAIGN_ENTRY_LOGICAL_CASE_ID) {
+          fail("SC-20191 attempted a batch or a foreign logical case");
+        }
+      },
+      // No checkpoint callback: no partial or pre-validation bundle may reach the output path.
+      executeProvider: async (command, args, input) => {
+        if (command !== providerCommand[0]
+            || !isDeepStrictEqual(args, providerCommand.slice(1))) {
+          fail("SC-20191 harness attempted a foreign provider command");
+        }
+        return campaignProviderInvocation(providerOptions, input, {
+          signal, setActiveWatchdog,
+        });
+      },
+    });
+    signal.throwIfAborted();
+    await cleanupCanaryScratch(runRoot);
+    await assertCampaignSourceState(providerOptions, signal);
+    await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal);
+    if (await validatePreparedCache(
+      preparationRoot, preparationKey, identity, signal,
+    ) === null) fail("SC-20191 prepared cache disappeared before publication");
+    await assertPreparationHasNoTransientResidue(preparationRoot);
+    validateCampaignEntryBundle(bundle);
+    await publishExclusiveJson(output, bundle, signal);
+  } catch (error) {
+    operationError = error;
+  } finally {
+    try {
+      if (await pathExists(runRoot)) await cleanupCanaryScratch(runRoot);
+    } catch (error) {
+      cleanupError = error;
+    }
+  }
+  const finalError = preservePrimaryFailure(operationError, cleanupError);
+  if (finalError !== null) throw finalError;
+  process.stdout.write(`${output}\n`);
 }
 
 async function controller(argv) {
@@ -1377,7 +2075,8 @@ async function controller(argv) {
   );
   if (unexpected.length) fail(`unsupported option(s): ${unexpected.join(", ")}`);
   const profileName = options.profile ?? SAFETY_CANARY_PROFILE;
-  const profile = canaryProfile(profileName);
+  const campaignEntry = profileName === CAMPAIGN_ENTRY_PROFILE;
+  const profile = campaignEntry ? { story: "sc-20191" } : canaryProfile(profileName);
   const inferenceRepo = path.resolve(options["inference-repo"]);
   const output = path.resolve(options.output);
   const relativeOutput = path.relative(ROOT, output);
@@ -1512,6 +2211,23 @@ async function controller(argv) {
     const textEncoderInventory = inventoryAtRoot(
       identity.artifact.textEncoder, privateTextEncoderRoot,
     );
+    if (campaignEntry) {
+      await runCampaignEntryController({
+        output,
+        inferenceRepo,
+        sceneWorksRevision,
+        inferenceRevision,
+        sceneWorksTree,
+        inferenceTree,
+        identity,
+        preparationKey,
+        preparationRoot,
+        prepared,
+        signal,
+        setActiveWatchdog: (child) => { activeWatchdog = child; },
+      });
+      return;
+    }
     const runRoot = path.join(path.dirname(output), "runs");
     await mkdir(runRoot, { recursive: true, mode: 0o700 });
     runScratch = await mkdtemp(path.join(runRoot, `${profile.story}-run-`));
@@ -1678,7 +2394,11 @@ async function controller(argv) {
 
 try {
   if (process.argv[1] === fileURLToPath(import.meta.url)) {
-    await controller(process.argv.slice(2));
+    if (process.argv[2] === "--campaign-provider") {
+      await campaignProvider(process.argv.slice(3));
+    } else {
+      await controller(process.argv.slice(2));
+    }
   }
 } catch (error) {
   process.stderr.write(`${error.stack ?? error}\n`);

--- a/scripts/run-ltx-safety-canary.test.mjs
+++ b/scripts/run-ltx-safety-canary.test.mjs
@@ -11,6 +11,10 @@ import { setTimeout as delay } from "node:timers/promises";
 
 import {
   CARGO_METADATA_TIMEOUT_MS,
+  CAMPAIGN_ENTRY_FIXTURE,
+  CAMPAIGN_ENTRY_IDENTITY,
+  CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
+  CAMPAIGN_ENTRY_PROVIDER,
   CHILD_ATTESTATION_TIMEOUT_SECONDS,
   CanaryInterrupted,
   MAX_FOOTPRINT_BYTES,
@@ -20,6 +24,9 @@ import {
   PREPARATION_SCHEMA_VERSION,
   PRODUCT_ENVELOPE_CANARY_PROFILE,
   acquirePreparationLock,
+  campaignEntryAdapterRequest,
+  campaignEntryCanonicalFragment,
+  campaignEntryPlan,
   canaryWatchdogEnvironment,
   canaryRequest,
   cargoSourceStatusIsClean,
@@ -43,12 +50,17 @@ import {
   runOwnedCommand,
   sealedArtifactIdentity,
   telemetryResolutionBytes,
+  validateCampaignEntryAdapterResponse,
+  validateCampaignEntryBundle,
+  validateCampaignEntryHarnessRequest,
+  validateCampaignEntryWatchdogEvents,
   validateCanaryResponse,
   validatePreparedCache,
   watchdogFailureSummary,
 } from "./run-ltx-safety-canary.mjs";
 
 import { hashArtifactInventory } from "./hash-artifact-inventory.mjs";
+import { canonicalJson, runProviderPlan } from "./memory-calibration-harness.mjs";
 
 const TEXT_ENCODER_INVENTORY = {
   root: "/models/gemma",
@@ -56,6 +68,151 @@ const TEXT_ENCODER_INVENTORY = {
   bytes: 26_427_894_918,
   sha256: "abde2d155aa8991747cc2999d40688d29a50261c080c0d51fac20357653928d7",
 };
+
+async function campaignEntryFixture() {
+  const config = JSON.parse(await readFile(new URL(
+    "../docs/calibration/sc-18946/ltx-mlx-single-pass-sweep.json",
+    import.meta.url,
+  ), "utf8"));
+  const { provider, planned } = campaignEntryPlan(config);
+  const request = {
+    action: "run",
+    planned,
+    repositories: {
+      sceneWorks: {
+        revision: "1".repeat(40), dirty: false, matrixSourceRevision: "1".repeat(40),
+      },
+      inference: { revision: "2".repeat(40), dirty: false, closureDigest: "3".repeat(64) },
+    },
+    repositoryPaths: { sceneWorks: "/scene", inference: "/inference" },
+    hardware: { probe: "mlx", memoryBytes: 128 * 1024 ** 3 },
+  };
+  return { config, provider, planned, request };
+}
+
+function campaignEntryResponse(hostMemoryBytes = 128 * 1024 ** 3) {
+  const diagnostics = [
+    ["renderedFrames", 121], ["outputFps", 30], ["audioTrackDecoded", 1],
+    ["decodeTilingEngaged", 0], ["decodeTileSpatialPx", 0],
+    ["decodeTileOverlapPx", 0], ["latentTemporalDepth", 16], ["latentTokens", 6_144],
+  ].map(([name, value]) => ({ name, unit: "count", value }));
+  return {
+    status: "runtime_complete",
+    loadShape: "eager_materialization",
+    artifact: {
+      repository: "SceneWorks/ltx-2.3-mlx",
+      resolvedRevision: "01df27d308466533aa09d251e3aebdcc627d07eb",
+      variant: "q4",
+    },
+    strategy: {
+      rung: "staged_residency", engagedRungs: ["resident", "staged_residency"], parameters: {},
+    },
+    output: {
+      frames: 121, fps: 30,
+      audio: { present: true, samples: 48_000, sampleRate: 48_000, channels: 2 },
+      firstFrameNondegenerate: true,
+    },
+    diagnostics: {
+      adapter: "memory-mlx-adapter:ltx-2-3-provider-contract-video",
+      execution: "executed",
+      blockers: [],
+      measurements: diagnostics,
+    },
+    _campaignEntry: {
+      identity: CAMPAIGN_ENTRY_IDENTITY,
+      inferenceRevision: "2".repeat(40),
+      watchdog: {
+        required: true,
+        protocol: "sceneworks-memory-watchdog-v1",
+        maxFootprintBytes: MAX_FOOTPRINT_BYTES,
+        maxRuntimeSeconds: MAX_RUNTIME_SECONDS,
+        hostMemoryBytes,
+        minInitialMemoryFreeBytes: preflightFreeFloor(hostMemoryBytes),
+        minMemoryFreeBytes: runtimeFreeFloor(hostMemoryBytes),
+      },
+      mlxLimits: { memoryLimitBytes: MAX_FOOTPRINT_BYTES, wiredLimitBytes: MAX_FOOTPRINT_BYTES },
+      cleanup: {
+        preProviderActiveBytes: 0,
+        preProviderCacheBytes: 0,
+        expectedPersistentActive: {
+          identity: "mlx-gen-ltx-transformer-ones-cache-av-bfloat16-v1",
+          videoDimension: 4_096,
+          audioDimension: 2_048,
+          dtype: "bfloat16",
+          bytesPerElement: 2,
+          bytes: 12_288,
+        },
+        postCleanupActiveBytes: 12_288,
+        postCleanupCacheBytes: 0,
+      },
+    },
+  };
+}
+
+function campaignEntryRuntimeResponse(hostMemoryBytes = 128 * 1024 ** 3) {
+  const response = campaignEntryResponse(hostMemoryBytes);
+  const phase = (value) => ({
+    activeBytes: value, allocatorBytes: value + 10, reclaimableBytes: 10,
+  });
+  return {
+    ...response,
+    sweep: { axes: [], cases: [{ parameters: {}, result: "passed" }], rangeVerified: true },
+    scenarios: [
+      { name: "exact_fit", result: "passed", predictedBytes: 200, effectiveBudgetBytes: 200 },
+      { name: "unknown_budget", result: "passed", reason: "unknown budget rejected" },
+      { name: "stale_evidence", result: "passed", reason: "stale evidence rejected" },
+      { name: "warm_repeat", result: "passed", reason: "warm repeat stayed deterministic" },
+      {
+        name: "cancel", result: "passed", reason: "cancel cleaned and recovered",
+        cleanupVerified: true, warmFollowUpPassed: true,
+      },
+      {
+        name: "error", result: "passed", reason: "error cleaned and recovered",
+        cleanupVerified: true, warmFollowUpPassed: true,
+      },
+      { name: "loadability", result: "passed" },
+      { name: "overlay", result: "not_applicable", reason: "base-only runtime record" },
+    ],
+    predictedPeakBytes: { conditioning: 100, denoise: 200, decode: 150, overall: 200 },
+    observedMemory: {
+      conditioning: phase(100), denoise: phase(200), decode: phase(150), overall: phase(200),
+    },
+    quality: {
+      contract: "exact campaign-entry repeat determinism",
+      identicalInputs: true,
+      result: "passed",
+      maximumError: 0,
+      meanError: 0,
+      rootMeanSquareError: 0,
+      maximumErrorThreshold: 0.08,
+      meanErrorThreshold: 0.01,
+      rootMeanSquareErrorThreshold: 0.02,
+    },
+    negativeMutation: null,
+    loadability: { result: "passed", resolvedPathFingerprint: "exact@campaign-entry:q4" },
+    capturedAt: "2026-08-17T12:00:00Z",
+  };
+}
+
+async function cleanCampaignHarnessRepo(t) {
+  const root = await mkdtemp(path.join(tmpdir(), "sc20191-harness-repo-"));
+  t.after(() => cleanupCanaryScratch(root));
+  await mkdir(path.join(root, "docs/generated"), { recursive: true });
+  await writeFile(path.join(root, "docs/generated/memory-matrix.json"), JSON.stringify({
+    generatedFrom: { sceneWorksRevision: `source-tree:${"a".repeat(64)}` },
+  }));
+  for (const args of [
+    ["init", root],
+    ["-C", root, "config", "user.email", "fixture@example.invalid"],
+    ["-C", root, "config", "user.name", "Fixture"],
+    ["-C", root, "add", "docs/generated/memory-matrix.json"],
+    ["-C", root, "commit", "-m", "fixture"],
+  ]) {
+    const result = spawnSync("git", args, { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+  }
+  return root;
+}
 
 async function cacheFixture(t) {
   const root = await mkdtemp(path.join(tmpdir(), "sc19741-cache-test-"));
@@ -138,6 +295,184 @@ test("the runner freezes the exact tiny bounded-decode canary", () => {
     sha256: "4e811932e87bb258f642ada790525e36ef2a55959c520e755f1807caf6fa225a",
   });
   assert.throws(() => canaryRequest(128 * 1024 ** 3));
+});
+
+test("SC-20191 transforms only the exact canonical harness row without changing its identity", async () => {
+  const { config, provider, planned, request } = await campaignEntryFixture();
+  assert.equal(planned.logicalCaseId, CAMPAIGN_ENTRY_LOGICAL_CASE_ID);
+  assert.equal(planned.fixture, CAMPAIGN_ENTRY_FIXTURE);
+  assert.equal(provider.name, CAMPAIGN_ENTRY_PROVIDER);
+  assert.deepEqual(planned.target.geometry, {
+    width: 768, height: 512, batch: 1, frames: 121,
+  });
+  assert.deepEqual(planned.strategy, {
+    rung: "staged_residency", engagedRungs: ["resident", "staged_residency"], parameters: {},
+  });
+  const original = structuredClone(request);
+  const expectedSource = {
+    sceneWorksRevision: "1".repeat(40),
+    inferenceRevision: "2".repeat(40),
+    sceneWorksRepo: "/scene",
+    inferenceRepo: "/inference",
+  };
+  validateCampaignEntryHarnessRequest(request, planned, expectedSource);
+  const adapter = campaignEntryAdapterRequest(request, planned, expectedSource);
+  assert.deepEqual(request, original, "the canonical harness request must remain untouched");
+  assert.equal(adapter.action, "campaign_entry");
+  assert.equal(adapter.planned.logicalCaseId, CAMPAIGN_ENTRY_LOGICAL_CASE_ID);
+  assert.equal(adapter.planned._campaignEntry.identity, CAMPAIGN_ENTRY_IDENTITY);
+  assert.equal(adapter.planned._watchdog.maxFootprintBytes, MAX_FOOTPRINT_BYTES);
+  const mutatedConfig = structuredClone(config);
+  mutatedConfig.providers.find((entry) => entry.name === CAMPAIGN_ENTRY_PROVIDER)
+    .target.geometry.frames = 97;
+  assert.throws(() => campaignEntryPlan(mutatedConfig), /frozen campaign-entry provider changed/);
+
+  for (const mutate of [
+    (value) => { value.action = "run_batch"; },
+    (value) => { value.planned.logicalCaseId = "implan-mutated"; },
+    (value) => { value.planned.target.geometry.frames = 97; },
+    (value) => { value.planned.target.tier = "q8"; },
+    (value) => { value.planned.fixture = CAMPAIGN_ENTRY_FIXTURE.replace("seed18946", "seed1"); },
+    (value) => { value.planned.strategy.parameters = { decodeTileEdge: 192 }; },
+    (value) => { value.planned.evidenceScope = "fixture"; },
+    (value) => { value.planned.modelLoadPolicy = "batch_rungs"; },
+    (value) => { value.repositories.sceneWorks.dirty = true; },
+    (value) => { value.repositories.inference.revision = "4".repeat(40); },
+    (value) => { value.repositoryPaths.sceneWorks = "/foreign"; },
+    (value) => { value.hardware.memoryBytes = 0; },
+    (value) => { value.planned._watchdog = {}; },
+  ]) {
+    const mutated = structuredClone(request);
+    mutate(mutated);
+    assert.throws(
+      () => campaignEntryAdapterRequest(mutated, planned, expectedSource),
+      /SC-20191|canonical SC-18946/,
+    );
+  }
+});
+
+test("SC-20191 rejects carrier, cleanup and watchdog mutations", () => {
+  const hostMemoryBytes = 128 * 1024 ** 3;
+  const response = campaignEntryResponse(hostMemoryBytes);
+  validateCampaignEntryAdapterResponse(response, {
+    inferenceRevision: "2".repeat(40), hostMemoryBytes,
+  });
+  for (const mutate of [
+    (value) => { value.output.audio.present = false; },
+    (value) => { value.output.audio.samples = 0; },
+    (value) => { value.output.frames = 120; },
+    (value) => { value.strategy.parameters = { decodeTileEdge: 192 }; },
+    (value) => { value.diagnostics.measurements.find((entry) =>
+      entry.name === "decodeTilingEngaged").value = 1; },
+    (value) => { value.diagnostics.measurements.find((entry) =>
+      entry.name === "latentTokens").value = 6_143; },
+    (value) => { value._campaignEntry.watchdog.maxFootprintBytes -= 1; },
+    (value) => { value._campaignEntry.watchdog.minSwapFreeBytes = 1; },
+    (value) => { value._campaignEntry.mlxLimits.memoryLimitBytes -= 1; },
+    (value) => { value._campaignEntry.cleanup.expectedPersistentActive.bytes += 1; },
+    (value) => { value._campaignEntry.cleanup.postCleanupActiveBytes += 1; },
+    (value) => { value._campaignEntry.cleanup.postCleanupCacheBytes = 1; },
+  ]) {
+    const mutated = structuredClone(response);
+    mutate(mutated);
+    assert.throws(
+      () => validateCampaignEntryAdapterResponse(mutated, {
+        inferenceRevision: "2".repeat(40), hostMemoryBytes,
+      }),
+      /SC-20191/,
+    );
+  }
+
+  const runtimeFloor = runtimeFreeFloor(hostMemoryBytes);
+  const validEvents = [
+    { event: "started" },
+    {
+      event: "sample", phase: "before_child_release", physicalFootprintBytes: 1,
+      memoryFreeBytes: runtimeFloor, swapFreeBytes: 0,
+    },
+    {
+      event: "sample", phase: "child_attested_before_allocation", physicalFootprintBytes: 2,
+      memoryFreeBytes: runtimeFloor, swapFreeBytes: 0,
+    },
+    { event: "child_attested" },
+    {
+      event: "sample", phase: "running", physicalFootprintBytes: 3,
+      memoryFreeBytes: runtimeFloor, swapFreeBytes: 0,
+    },
+    { event: "child_completed" },
+  ];
+  assert.equal(validateCampaignEntryWatchdogEvents(validEvents, hostMemoryBytes), 3);
+  for (const events of [
+    validEvents.filter((event) => event.event !== "child_completed"),
+    validEvents.filter((event) => event.phase !== "running"),
+    [validEvents[0], ...validEvents.slice(1).reverse()],
+    [...validEvents, { event: "hard_stop" }],
+    validEvents.map((event) => event.phase === "before_child_release"
+      ? { ...event, physicalFootprintBytes: MAX_FOOTPRINT_BYTES } : event),
+    validEvents.map((event) => event.phase === "before_child_release"
+      ? { ...event, memoryFreeBytes: runtimeFloor - 1 } : event),
+  ]) assert.throws(() => validateCampaignEntryWatchdogEvents(events, hostMemoryBytes), /SC-20191/);
+});
+
+test("SC-20191 publishes one schema-valid canonical runtime record after stripping private evidence", async (t) => {
+  const { provider } = await campaignEntryFixture();
+  const repo = await cleanCampaignHarnessRepo(t);
+  let runRequests = 0;
+  const result = await runProviderPlan({
+    config: { providers: [provider] },
+    providerCommand: ["synthetic-contained-provider"],
+    sceneWorksRepo: repo,
+    inferenceRepo: repo,
+    backend: "mlx",
+    providerName: CAMPAIGN_ENTRY_PROVIDER,
+    closureDigestFor: async () => "b".repeat(64),
+    executeProvider: async (_command, _args, input) => {
+      const request = JSON.parse(input);
+      if (request.action === "probe") {
+        return canonicalJson({
+          hardware: {
+            probe: "synthetic contained MLX provider",
+            memoryBytes: 128 * 1024 ** 3,
+            model: "MacFixture",
+            chip: "Apple Fixture",
+            osVersion: "macOS fixture",
+            metalDevice: "Apple Fixture",
+            mlxMemoryLimitBytes: 96 * 1024 ** 3,
+            wiredLimitBytes: 64 * 1024 ** 3,
+          },
+        });
+      }
+      assert.equal(request.action, "run");
+      runRequests += 1;
+      const response = campaignEntryRuntimeResponse(request.hardware.memoryBytes);
+      response._campaignEntry.inferenceRevision = request.repositories.inference.revision;
+      validateCampaignEntryAdapterResponse(response, {
+        inferenceRevision: request.repositories.inference.revision,
+        hostMemoryBytes: request.hardware.memoryBytes,
+      });
+      return canonicalJson(campaignEntryCanonicalFragment(response, 1_234));
+    },
+  });
+  assert.equal(runRequests, 1);
+  validateCampaignEntryBundle(result);
+  assert.equal(result.records.length, 1);
+  assert.equal(result.records[0].status, "runtime_complete");
+  assert.equal(Object.hasOwn(result.records[0], "output"), false);
+  assert.equal(Object.hasOwn(result.records[0], "containment"), false);
+  assert.equal(Object.hasOwn(result.records[0], "_campaignEntry"), false);
+
+  for (const mutate of [
+    (record) => { record.scenarios.find((entry) => entry.name === "cancel").cleanupVerified = false; },
+    (record) => { record.scenarios.find((entry) => entry.name === "error").result = "not_run"; },
+    (record) => { record.diagnostics.measurements.find((entry) =>
+      entry.name === "campaignOwnedProcessGroupResidue").value = 1; },
+    (record) => { record.diagnostics.measurements.find((entry) =>
+      entry.name === "campaignWatchdogMaxObservedFootprintBytes").value = MAX_FOOTPRINT_BYTES; },
+  ]) {
+    const changed = structuredClone(result);
+    mutate(changed.records[0]);
+    assert.throws(() => validateCampaignEntryBundle(changed), /runtime lifecycle|schema|SC-20191/);
+  }
 });
 
 test("the runner freezes the distinct full-A/V product-envelope canary", () => {
@@ -625,15 +960,37 @@ test("the production runner can only launch through the identity-checked watchdo
   const cleanup = source.indexOf("await cleanupCanaryScratch(runScratch)");
   assert.ok(failureRead >= 0 && cleanup > failureRead,
     "watchdog failure reason must be read before scratch cleanup");
-  assert.equal(source.match(/await assertHostPreflight\(/g)?.length, 1,
-    "foreign-heavy work is checked only at model release");
+  assert.equal(source.match(/await assertHostPreflight\(/g)?.length, 2,
+    "each contained execution profile has one immediate model-release check");
   assert.doesNotMatch(source, /300_000|5 \* 60 \* 1_000/);
   assert.match(
     source,
     /const preLaunchHost = await assertHostPreflight\(memoryBytes, signal\);\n\s*const status = await new Promise\(\(resolve, reject\) => \{\n\s*const childProcess = spawn/,
     "the fresh host gate must be the final operation before watchdog launch",
   );
+  assert.match(
+    source,
+    /await assertHostPreflight\(hostMemoryBytes, signal\);\n\s*const status = await new Promise\(\(resolve, reject\) => \{\n\s*const child = spawn/,
+    "the campaign entry host gate must also be the final operation before watchdog launch",
+  );
   assert.match(source, /sourceAfterRun: \{ sceneWorks: sceneWorksAfterRun, inference: inferenceAfterRun \}/);
+  const campaignController = source.slice(
+    source.indexOf("async function runCampaignEntryController("),
+    source.indexOf("async function controller("),
+  );
+  assert.doesNotMatch(campaignController, /onProviderCheckpoint/,
+    "the one-row campaign entry must never publish a partial harness checkpoint");
+  for (const operation of [
+    "await cleanupCanaryScratch(runRoot)",
+    "await assertCampaignSourceState(providerOptions, signal)",
+    "await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal)",
+    "await assertPreparationHasNoTransientResidue(preparationRoot)",
+    "validateCampaignEntryBundle(bundle)",
+  ]) {
+    assert.ok(campaignController.indexOf(operation) >= 0
+      && campaignController.indexOf(operation) < campaignController.indexOf("await publishExclusiveJson("),
+    `${operation} must precede atomic canonical publication`);
+  }
   assert.match(source, /cancellation\.abort\(new CanaryInterrupted\(signalName\)\)/);
   assert.match(source, /process\.exitCode = error instanceof CanaryInterrupted \? error\.exitCode : 1/);
 });


### PR DESCRIPTION
## Summary

- add one exact watchdog-contained entry for the frozen q4 768x512 f121 30fps staged/full-A/V row
- preserve ordinary pre-load refusal for all 70 SC-18946 rows
- keep canonical request, logical-case, record, and runtime_complete assembly in runProviderPlan
- require live untiled carrier evidence, the full warm/cancel/error/recovery lifecycle, exact allocator cleanup, sealed assets, and zero process/scratch residue
- publish the canonical bundle only after outer watchdog/source/asset/cleanup validation; failure publishes nothing
- evolve runtime lifecycle validation narrowly so it accepts either wholly deferred evidence or a fully passed cleanup/recovery set

## Validation

- npm run check: 564/564 passed
- focused runner/harness/platform: 138/138 passed
- SC-20191 Rust adapter contracts: 2/2 passed
- exact MLX all-targets Clippy with -D warnings passed
- formatting, Node syntax, and diff checks passed
- independent adversarial review passed with high confidence after two P1 pre-publication/schema findings were fixed

## Runtime scope

No model, GPU, MLX, or real-weight workload was run in this PR. After merge and permanent-head verification, this change authorizes exactly one contained execution of the named canonical row. It does not admit or extrapolate to the other 69 rows.