### PR TITLE
fix(sc-18315): route all creation gates through one backend derivation and mirror them at retry/duplicate

### DIFF
--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -1,9 +1,30 @@
 use super::*;
 
+/// The single backend this API instance can actually enqueue for — the one authority every
+/// enqueue-time capability gate must key off.
+///
+/// macOS runs the MLX worker, *unless* the operator forced the Candle one
+/// (`SCENEWORKS_CANDLE_REQUIRED` → [`Settings::candle_required`]); every other platform is
+/// Candle-only. A bare `cfg!(target_os = "macos")` is wrong in precisely the mode the setting
+/// exists for: the gate would validate the request against MLX's capability lists while the job
+/// executes on Candle, so an MLX-only choice is admitted and then fails on the worker, and a
+/// Candle-valid choice is 400'd (sc-18420). One derivation, one place.
+pub(crate) fn enqueue_backend(state: &AppState) -> &'static str {
+    if !cfg!(target_os = "macos") || state.settings.candle_required {
+        "candle"
+    } else {
+        "mlx"
+    }
+}
+
 /// Validate `advanced.decoder` against the descriptor-derived options on the exact post-preset model
 /// row. This is an enqueue-time fail-closed gate: z48/video/unknown models have no compatible option,
 /// and a soft donor that is not installed cannot produce a job that will fail later on the worker.
-fn validate_selected_decoder_for_manifest(
+///
+/// `active_backend` must come from [`enqueue_backend`] — never a hand-rolled `cfg!` — so the list
+/// consulted here is the list the worker that runs this job will actually offer.
+pub(crate) fn validate_selected_decoder_for_manifest(
+    active_backend: &str,
     job_payload: &JsonObject,
     model_manifest_entry: &Value,
 ) -> Result<(), ApiError> {
@@ -37,13 +58,8 @@ fn validate_selected_decoder_for_manifest(
     }
 
     // The catalog carries capability facts for every deployable backend, but this API instance can
-    // enqueue only for the backend used on its platform. Looking across every list would let a Linux
+    // enqueue only for the backend it actually routes to. Looking across every list would let a Linux
     // candle deployment accept an MLX-only choice and defer the rejection to the worker.
-    let active_backend = if cfg!(target_os = "macos") {
-        "mlx"
-    } else {
-        "candle"
-    };
     let matching: Vec<&Value> = model_manifest_entry
         .get(sceneworks_core::decoder_support::DECODERS_FIELD)
         .and_then(|decoders| decoders.get(sceneworks_core::decoder_support::BY_BACKEND_FIELD))
@@ -138,7 +154,11 @@ pub(crate) async fn create_image_job(
     // against the same server-owned entry.
     resolve_selected_image_text_encoder(&state, &job_payload, &model_id, &mut model_manifest_entry)
         .await?;
-    validate_selected_decoder_for_manifest(&job_payload, &model_manifest_entry)?;
+    validate_selected_decoder_for_manifest(
+        enqueue_backend(&state),
+        &job_payload,
+        &model_manifest_entry,
+    )?;
     job_payload.insert(
         "modelManifestEntry".to_owned(),
         model_manifest_entry.clone(),
@@ -227,7 +247,7 @@ pub(crate) async fn create_image_job(
 /// Refuse every imported request shape that the selected backend cannot execute. The exact stamped
 /// source shape and operation select one provider registration; family identity alone never admits
 /// a request. Builtins retain their id-keyed routing and are out of this family gate.
-fn validate_imported_submission(
+pub(crate) fn validate_imported_submission(
     state: &AppState,
     model_id: &str,
     payload: &JsonObject,
@@ -240,12 +260,12 @@ fn validate_imported_submission(
     {
         return Ok(());
     }
-    let candle_required = !cfg!(target_os = "macos") || state.settings.candle_required;
     let has_material_control = payload
         .get("advanced")
         .and_then(Value::as_object)
         .is_some_and(sceneworks_core::jobs_store::imported_control_intent_is_material);
-    let backend = if candle_required { "candle" } else { "mlx" };
+    let backend = enqueue_backend(state);
+    let candle_required = backend == "candle";
     let family = entry
         .get("family")
         .and_then(Value::as_str)
@@ -732,7 +752,11 @@ pub(crate) async fn create_video_job(
         .unwrap_or(payload.model.as_str())
         .to_owned();
     let model_manifest_entry = resolve_model_manifest_entry(&state, &model_id).await?;
-    validate_selected_decoder_for_manifest(&job_payload, &model_manifest_entry)?;
+    validate_selected_decoder_for_manifest(
+        enqueue_backend(&state),
+        &job_payload,
+        &model_manifest_entry,
+    )?;
     // The model's declared `limits.hardMaxDuration`, enforced at enqueue (sc-12297). It had ten
     // declarations and zero readers, so `validate_video_job`'s blanket `1..=30` was the ONLY
     // ceiling: a raw API/MCP/preset-replay caller could ask mochi_1 (cap 5) for 30s @ 30fps, and
@@ -983,44 +1007,103 @@ mod decoder_selection_tests {
         })
     }
 
+    /// A row whose `mlx` and `candle` lists advertise DIFFERENT installed decoders, so which list
+    /// the gate consulted is observable from the error alone. The shipped facts happen to declare
+    /// no candle decoders at all today, which would make "consulted candle" and "consulted nothing"
+    /// indistinguishable — this fixture keeps the assertion about the backend selection itself.
+    fn split_manifest() -> Value {
+        json!({
+            "id": "qwen_image",
+            "decoders": { "byBackend": {
+                "mlx": [{ "id": "mlx_only_vae", "componentId": "vae", "available": true }],
+                "candle": [{ "id": "candle_only_vae", "componentId": "vae", "available": true }]
+            } }
+        })
+    }
+
     fn payload(value: Value) -> JsonObject {
         value.as_object().expect("payload object").clone()
     }
 
     #[test]
     fn decoder_submission_is_default_off_and_fails_closed() {
-        assert!(
-            validate_selected_decoder_for_manifest(&payload(json!({})), &manifest(false)).is_ok()
-        );
         assert!(validate_selected_decoder_for_manifest(
+            "mlx",
+            &payload(json!({})),
+            &manifest(false)
+        )
+        .is_ok());
+        assert!(validate_selected_decoder_for_manifest(
+            "mlx",
             &payload(json!({ "advanced": { "decoder": "native" } })),
             &manifest(false),
         )
         .is_ok());
         assert!(validate_selected_decoder_for_manifest(
+            "mlx",
             &payload(json!({ "advanced": { "decoder": "wan_2_1_vae" } })),
             &manifest(false),
         )
         .is_err());
-        let selected = validate_selected_decoder_for_manifest(
+        assert!(validate_selected_decoder_for_manifest(
+            "mlx",
             &payload(json!({ "advanced": { "decoder": "wan_2_1_vae" } })),
             &manifest(true),
-        );
-        if cfg!(target_os = "macos") {
-            assert!(selected.is_ok());
-        } else {
-            assert!(selected.is_err());
-        }
+        )
+        .is_ok());
+        // The same installed MLX option on the candle lane: the shipped facts declare no candle
+        // decoders, so it fails closed rather than deferring the rejection to the worker.
         assert!(validate_selected_decoder_for_manifest(
+            "candle",
+            &payload(json!({ "advanced": { "decoder": "wan_2_1_vae" } })),
+            &manifest(true),
+        )
+        .is_err());
+        assert!(validate_selected_decoder_for_manifest(
+            "mlx",
             &payload(json!({ "advanced": { "decoder": "wan_2_1_vae" } })),
             &json!({ "id": "wan_2_2_t2v_a14b" }),
         )
         .is_err());
     }
 
+    /// Both directions of the backend selection, against one row that advertises a different
+    /// installed decoder per lane. This is the half a bare `cfg!(target_os = "macos")` got wrong
+    /// (sc-18420): under `SCENEWORKS_CANDLE_REQUIRED` on macOS the gate consulted the MLX list
+    /// while the job ran on candle, admitting the MLX-only id and refusing the candle-valid one.
+    #[test]
+    fn the_gate_consults_only_the_executing_backends_option_list() {
+        for (backend, valid, foreign) in [
+            ("mlx", "mlx_only_vae", "candle_only_vae"),
+            ("candle", "candle_only_vae", "mlx_only_vae"),
+        ] {
+            assert!(
+                validate_selected_decoder_for_manifest(
+                    backend,
+                    &payload(json!({ "advanced": { "decoder": valid } })),
+                    &split_manifest(),
+                )
+                .is_ok(),
+                "{backend} must admit its own installed option {valid}"
+            );
+            let error = validate_selected_decoder_for_manifest(
+                backend,
+                &payload(json!({ "advanced": { "decoder": foreign } })),
+                &split_manifest(),
+            )
+            .expect_err("the other lane's option must not be admitted")
+            .detail;
+            assert!(
+                error.contains("is not compatible with qwen_image"),
+                "{backend} got: {error}"
+            );
+        }
+    }
+
     #[test]
     fn alternate_decoder_and_pid_are_mutually_exclusive() {
         let error = validate_selected_decoder_for_manifest(
+            "mlx",
             &payload(json!({
                 "advanced": { "decoder": "wan_2_1_vae", "usePid": true }
             })),

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -9,6 +9,33 @@ use super::*;
 /// exists for: the gate would validate the request against MLX's capability lists while the job
 /// executes on Candle, so an MLX-only choice is admitted and then fails on the worker, and a
 /// Candle-valid choice is 400'd (sc-18420). One derivation, one place.
+///
+/// ## Scope: enqueue gates only — NOT the catalog advertisement lanes
+///
+/// `models.rs`'s `apply_imported_lora_advertisement`, `apply_imported_provider_surface` and the
+/// `mlx_catalog_status` probe keep their own bare `cfg!(target_os = "macos")` deliberately. They
+/// answer a DIFFERENT question: *which engines does this BUILD link* (macOS links MLX and no candle
+/// engine; Windows/Linux/Docker link candle and no MLX), and the MLX tier probe additionally reads
+/// convert-output directories that only exist on macOS. This function answers *which single backend
+/// does this INSTANCE route a job to*, which `candle_required` can move at runtime.
+///
+/// Three reasons not to unify them:
+/// 1. Those sites need a LANE PAIR, consulted ASYMMETRICALLY — a withdrawal crosses lanes, a
+///    positive advertisement never does. Collapsing that into this one-hot routing answer would
+///    break the invariant `apply_imported_lora_advertisement` documents.
+/// 2. A macOS build links no candle engine, so deriving the advertisement from `candle_required`
+///    would publish verdicts for an engine this binary cannot run.
+/// 3. Routing the `mlx_catalog_status` probe through here would HIDE `mlxTiers` and its per-tier
+///    state from the Studio on macOS under `candle_required`, for tier directories that are
+///    genuinely on disk — a regression, not a unification.
+///
+/// The residual skew is real but unshipped: on macOS the desktop wrapper sets
+/// `SCENEWORKS_CANDLE_REQUIRED` only under `cfg(not(target_os = "macos"))` and
+/// [`Settings::candle_required`] is documented "Absent on macOS", so reaching it takes a manual
+/// operator override. Under that override the catalog still advertises MLX-derived imported verdicts
+/// while these gates refuse against candle. Closing it properly means making the advertisement lane
+/// pair a runtime DEPLOYMENT fact (including remote candle workers registered with this API), not
+/// re-pointing it at this function.
 pub(crate) fn enqueue_backend(state: &AppState) -> &'static str {
     if !cfg!(target_os = "macos") || state.settings.candle_required {
         "candle"

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -456,7 +456,53 @@ async fn validate_and_canonicalize_merged_generation_payload(
                 .to_owned();
             resolve_selected_image_text_encoder(state, &merged, &model_id, &mut manifest_entry)
                 .await?;
+            // The two remaining `create_image_job` capability gates, run on the SAME merged object
+            // the queue transaction will persist (sc-18420). `payload_changes` is a SHALLOW merge,
+            // so `advanced` arrives replaced wholesale: without these, a retry/duplicate could
+            // enqueue a decoder+`usePid` pair, an uninstalled or wrong-backend decoder, or an
+            // imported request shape the create path 400s — the exact combinations this boundary's
+            // own doc comment claims it re-validates. Order mirrors `create_image_job`: the decoder
+            // gate reads the rebuilt entry directly, then the entry is stamped so the imported gate
+            // sees the server-owned row rather than anything the caller sent.
+            crate::generation::validate_selected_decoder_for_manifest(
+                crate::generation::enqueue_backend(state),
+                &merged,
+                &manifest_entry,
+            )?;
             merged.insert("modelManifestEntry".to_owned(), manifest_entry);
+            crate::generation::validate_imported_submission(state, &model_id, &merged)?;
+        }
+    } else if matches!(
+        job_type,
+        JobType::VideoGenerate
+            | JobType::VideoExtend
+            | JobType::VideoBridge
+            | JobType::PersonReplace
+    ) {
+        // The video half of the same bypass. `canonicalize_image_model_payload` is image-only, so
+        // there is no rebuilt entry to gate against here; resolve the catalog row for the merged
+        // model exactly as `create_video_job` does and gate on that. Read-only on purpose — this
+        // closes the decoder bypass without taking on video's separate entry-canonicalization
+        // question.
+        //
+        // Keyed off an actually-present `advanced.decoder`, which is precisely when the gate stops
+        // being a no-op, so the overwhelmingly common decoder-less replay costs no extra catalog
+        // resolution.
+        let selects_decoder = merged
+            .get("advanced")
+            .and_then(Value::as_object)
+            .is_some_and(|advanced| advanced.contains_key("decoder"));
+        if let Some(model_id) = merged
+            .get("model")
+            .and_then(Value::as_str)
+            .filter(|_| selects_decoder)
+        {
+            let entry = crate::models::resolve_model_manifest_entry(state, model_id).await?;
+            crate::generation::validate_selected_decoder_for_manifest(
+                crate::generation::enqueue_backend(state),
+                &merged,
+                &entry,
+            )?;
         }
     }
     Ok(merged)

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -408,6 +408,58 @@ pub(crate) async fn duplicate_job(
     Ok((StatusCode::CREATED, Json(public_job_snapshot(job))))
 }
 
+/// Whether a job's PERSISTED payload carries the character route's inline LoRA links, i.e. whether
+/// re-validating its adapters must use `allow_inline_loras = true`.
+///
+/// `characters.rs`'s test-job route is the one image-generation boundary that validates with inline
+/// LoRAs allowed. A character's attached adapters are inline links, not catalog rows:
+/// `character_store::attach_lora` mints `id: "character_lora_<hex>"` with `category: "character"` and
+/// a `sourcePath`/`projectPath`, copies the file into the project, and registers it in NO LoRA
+/// catalog. Re-validating that set as catalog-backed refuses it with "LoRA not found" — which broke
+/// even a no-op retry of a character test job when this boundary's gate was first mirrored.
+///
+/// ## Why the link SHAPE and not the `characterId` / `mode` markers
+///
+/// Both of those look server-stamped but are caller-settable: `ImageJobRequest` exposes
+/// `character_id` and `mode`, so `POST /api/v1/image/jobs { mode: "character_image", loras: [] }` is
+/// an ordinary image job that create admits (the LoRA gate no-ops on an empty set) while bearing
+/// both markers. Deriving permission from them would let that job's retry attach an arbitrary
+/// path-bearing adapter and have it accepted as "inline".
+///
+/// The link shape cannot be forged the same way, because it can only have been PERSISTED by a
+/// boundary that already allowed inline LoRAs:
+/// - `create_image_job` / `create_video_job` validate with `allow_inline_loras = false`, so a
+///   non-catalog adapter is refused before any job row exists.
+/// - `POST /api/v1/jobs` refuses image/video generation job types outright (`typed_generation_route`).
+/// - retry/duplicate reach this function, which is where the permission is being decided.
+///
+/// So the only way a persisted `image_generate` payload holds a character link is the character
+/// route. Requiring a non-empty `characterId` as well costs nothing (that route stamps it onto the
+/// same payload it writes the links into) and keeps the predicate honest about what it identifies.
+///
+/// An empty persisted set deliberately yields `false`: the gate no-ops on it anyway, and a character
+/// job whose character had no adapters must not become a hole through which a retry can add inline
+/// ones — attaching them to the character is the supported path.
+fn job_carries_character_inline_loras(persisted_payload: &JsonObject) -> bool {
+    let has_character = persisted_payload
+        .get("characterId")
+        .and_then(Value::as_str)
+        .is_some_and(|id| !id.trim().is_empty());
+    has_character
+        && persisted_payload
+            .get("loras")
+            .and_then(Value::as_array)
+            .is_some_and(|loras| {
+                loras.iter().any(|lora| {
+                    lora.get("category").and_then(Value::as_str) == Some("character")
+                        || lora
+                            .get("id")
+                            .and_then(Value::as_str)
+                            .is_some_and(|id| id.starts_with("character_lora_"))
+                })
+            })
+}
+
 /// Validate and canonicalize the exact payload a retry/duplicate will enqueue. Existing job
 /// payloads are immutable, so reading and merging before the create transaction cannot race with a
 /// payload update. Returning the complete merged payload is intentional: the store's shallow merge
@@ -423,6 +475,10 @@ async fn validate_and_canonicalize_merged_generation_payload(
     let job_type = job.job_type.clone();
     let project_id = job.project_id.clone();
     let mut merged = job.payload;
+    // Resolved from the PERSISTED payload, BEFORE the merge below, because inline-LoRA permission is
+    // a property of how the job was originally created and `payload_changes` must not be able to
+    // mint it. See [`job_carries_character_inline_loras`].
+    let allow_inline_loras = job_carries_character_inline_loras(&merged);
     merged.extend(payload_changes.clone());
     if generation_job_model_is_path_backed(&job_type) {
         validate_payload_model(&merged)?;
@@ -435,6 +491,13 @@ async fn validate_and_canonicalize_merged_generation_payload(
         if let Some(advanced) = merged.get("advanced").and_then(Value::as_object) {
             validate_image_pose_count(advanced)?;
         }
+        // PRECEDENCE DIVERGENCE, deliberate: `create_image_job` resolves the control overlay AFTER
+        // its LoRA gate, this boundary resolves it BEFORE. Acceptance is equivalent — the two read
+        // disjoint fields (`advanced.controlWeights.overlayId` vs the top-level `loras` array) and
+        // neither can change the other's verdict — so no payload is admitted here that create would
+        // refuse, or vice versa. Only the FIRST error reported for a payload that is invalid on both
+        // axes differs. Left as-is rather than reordered: this call predates the gate mirror and the
+        // existing ordering is pinned by the sc-13639 control-weights reauthorization tests.
         crate::control_overlays::resolve_control_overlay_selection(
             state,
             project_id.as_deref(),
@@ -476,8 +539,13 @@ async fn validate_and_canonicalize_merged_generation_payload(
                 &manifest_entry,
             )?;
             merged.insert("modelManifestEntry".to_owned(), manifest_entry);
-            validate_job_lora_compatibility(state, project_id.as_deref(), &mut merged, false)
-                .await?;
+            validate_job_lora_compatibility(
+                state,
+                project_id.as_deref(),
+                &mut merged,
+                allow_inline_loras,
+            )
+            .await?;
             crate::generation::validate_imported_submission(state, &model_id, &merged)?;
         }
     } else if matches!(
@@ -513,7 +581,13 @@ async fn validate_and_canonicalize_merged_generation_payload(
                 &entry,
             )?;
         }
-        validate_job_lora_compatibility(state, project_id.as_deref(), &mut merged, false).await?;
+        validate_job_lora_compatibility(
+            state,
+            project_id.as_deref(),
+            &mut merged,
+            allow_inline_loras,
+        )
+        .await?;
     }
     Ok(merged)
 }

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -456,20 +456,28 @@ async fn validate_and_canonicalize_merged_generation_payload(
                 .to_owned();
             resolve_selected_image_text_encoder(state, &merged, &model_id, &mut manifest_entry)
                 .await?;
-            // The two remaining `create_image_job` capability gates, run on the SAME merged object
-            // the queue transaction will persist (sc-18420). `payload_changes` is a SHALLOW merge,
-            // so `advanced` arrives replaced wholesale: without these, a retry/duplicate could
-            // enqueue a decoder+`usePid` pair, an uninstalled or wrong-backend decoder, or an
-            // imported request shape the create path 400s — the exact combinations this boundary's
-            // own doc comment claims it re-validates. Order mirrors `create_image_job`: the decoder
-            // gate reads the rebuilt entry directly, then the entry is stamped so the imported gate
-            // sees the server-owned row rather than anything the caller sent.
+            // The `create_image_job` capability gates this boundary did not run, applied to the
+            // SAME merged object the queue transaction will persist (sc-18420). `payload_changes`
+            // is a SHALLOW merge, so both `advanced` and the top-level `loras` array arrive
+            // REPLACED WHOLESALE: without these, a retry/duplicate could enqueue a decoder+`usePid`
+            // pair, an uninstalled or wrong-backend decoder, a family-incompatible or uninstalled
+            // LoRA set, or an imported request shape — every one of which the create path 400s, and
+            // all of them exactly the combinations this boundary's own doc comment claims it
+            // re-validates.
+            //
+            // Order mirrors `create_image_job`: the decoder gate reads the rebuilt entry directly,
+            // the entry is then stamped, the LoRA gate runs (it also NORMALIZES `loras` in place,
+            // and the canonical object returned from here is what gets persisted), and the imported
+            // gate runs last so it sees the server-owned row and the normalized adapter list rather
+            // than anything the caller sent.
             crate::generation::validate_selected_decoder_for_manifest(
                 crate::generation::enqueue_backend(state),
                 &merged,
                 &manifest_entry,
             )?;
             merged.insert("modelManifestEntry".to_owned(), manifest_entry);
+            validate_job_lora_compatibility(state, project_id.as_deref(), &mut merged, false)
+                .await?;
             crate::generation::validate_imported_submission(state, &model_id, &merged)?;
         }
     } else if matches!(
@@ -479,15 +487,16 @@ async fn validate_and_canonicalize_merged_generation_payload(
             | JobType::VideoBridge
             | JobType::PersonReplace
     ) {
-        // The video half of the same bypass. `canonicalize_image_model_payload` is image-only, so
-        // there is no rebuilt entry to gate against here; resolve the catalog row for the merged
-        // model exactly as `create_video_job` does and gate on that. Read-only on purpose — this
-        // closes the decoder bypass without taking on video's separate entry-canonicalization
-        // question.
+        // The video half of the same bypass — `create_video_job` runs both of these too.
+        // `canonicalize_image_model_payload` is image-only, so there is no rebuilt entry to gate
+        // against here; resolve the catalog row for the merged model exactly as `create_video_job`
+        // does and gate on that. Read-only on purpose — this closes the bypass without taking on
+        // video's separate entry-canonicalization question.
         //
-        // Keyed off an actually-present `advanced.decoder`, which is precisely when the gate stops
-        // being a no-op, so the overwhelmingly common decoder-less replay costs no extra catalog
-        // resolution.
+        // The decoder gate is keyed off an actually-present `advanced.decoder`, which is precisely
+        // when it stops being a no-op, so the overwhelmingly common decoder-less replay costs no
+        // extra catalog resolution. The LoRA gate needs no such guard: it returns before touching a
+        // catalog when `loras` is absent or empty.
         let selects_decoder = merged
             .get("advanced")
             .and_then(Value::as_object)
@@ -504,6 +513,7 @@ async fn validate_and_canonicalize_merged_generation_payload(
                 &entry,
             )?;
         }
+        validate_job_lora_compatibility(state, project_id.as_deref(), &mut merged, false).await?;
     }
     Ok(merged)
 }

--- a/apps/rust-api/src/jobs.rs
+++ b/apps/rust-api/src/jobs.rs
@@ -408,8 +408,8 @@ pub(crate) async fn duplicate_job(
     Ok((StatusCode::CREATED, Json(public_job_snapshot(job))))
 }
 
-/// Whether a job's PERSISTED payload carries the character route's inline LoRA links, i.e. whether
-/// re-validating its adapters must use `allow_inline_loras = true`.
+/// The character-route inline LoRA links a job's PERSISTED payload already carried — the ONLY
+/// adapters a retry/duplicate of that job may re-validate as inline. Empty for every other job.
 ///
 /// `characters.rs`'s test-job route is the one image-generation boundary that validates with inline
 /// LoRAs allowed. A character's attached adapters are inline links, not catalog rows:
@@ -437,27 +437,131 @@ pub(crate) async fn duplicate_job(
 /// route. Requiring a non-empty `characterId` as well costs nothing (that route stamps it onto the
 /// same payload it writes the links into) and keeps the predicate honest about what it identifies.
 ///
-/// An empty persisted set deliberately yields `false`: the gate no-ops on it anyway, and a character
-/// job whose character had no adapters must not become a hole through which a retry can add inline
-/// ones — attaching them to the character is the supported path.
-fn job_carries_character_inline_loras(persisted_payload: &JsonObject) -> bool {
+/// An empty persisted set deliberately yields an empty permit: the gate no-ops on it anyway, and a
+/// character job whose character had no adapters must not become a hole through which a retry can add
+/// inline ones — attaching them to the character is the supported path.
+fn persisted_character_inline_loras(persisted_payload: &JsonObject) -> Vec<Value> {
     let has_character = persisted_payload
         .get("characterId")
         .and_then(Value::as_str)
         .is_some_and(|id| !id.trim().is_empty());
-    has_character
-        && persisted_payload
+    if !has_character {
+        return Vec::new();
+    }
+    persisted_payload
+        .get("loras")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|lora| {
+            lora.get("category").and_then(Value::as_str) == Some("character")
+                || lora
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .is_some_and(|id| id.starts_with("character_lora_"))
+        })
+        .cloned()
+        .collect()
+}
+
+/// Whether `candidate` IS one of the persisted character links in `permitted`, and therefore may be
+/// hydrated inline.
+///
+/// Identity is the link id AND agreement on every path field the candidate carries. Matching on the
+/// id alone would leave the narrowing hollow: `normalize_inline_job_lora` passes a caller's object
+/// through almost verbatim, so replaying a persisted link id with a swapped `sourcePath` would carry
+/// an arbitrary file into the enqueued payload. A candidate that omits a path field is still a match
+/// — it is asking for the persisted link, not redirecting it.
+fn matches_permitted_inline_lora(candidate: &Value, permitted: &[Value]) -> bool {
+    let Some(candidate_id) = job_lora_id(candidate) else {
+        return false;
+    };
+    permitted.iter().any(|link| {
+        if job_lora_id(link) != Some(candidate_id) {
+            return false;
+        }
+        ["sourcePath", "projectPath"].iter().all(|field| {
+            match (
+                candidate.get(*field).and_then(Value::as_str),
+                link.get(*field).and_then(Value::as_str),
+            ) {
+                (Some(requested), Some(persisted)) => requested == persisted,
+                // The candidate names no path for this field, so it cannot redirect it.
+                (None, _) => true,
+                // The candidate names a path the persisted link does not have at all.
+                (Some(_), None) => false,
+            }
+        })
+    })
+}
+
+/// Re-validate a merged retry/duplicate payload's `loras`, granting inline hydration ONLY to the
+/// adapters the persisted payload already carried (`permitted_inline`) and requiring catalog backing
+/// for everything else — including any ADDITION to a genuine character job's set.
+///
+/// A single `allow_inline_loras = true` would have covered the whole merged array, so a retry of a
+/// real character job could swap in arbitrary inline path-bearing adapters. Splitting the array is
+/// verdict-preserving: `validate_lora_specs_for_model` decides each attached adapter independently
+/// (no cross-adapter state), so validating two sub-arrays yields exactly the per-adapter verdicts one
+/// pass over the whole array would, and the original order is restored afterwards.
+async fn validate_merged_job_loras(
+    state: &AppState,
+    project_id: Option<&str>,
+    merged: &mut JsonObject,
+    permitted_inline: &[Value],
+) -> Result<(), ApiError> {
+    // No inline permit (every job but a character test job's replay): one catalog-only pass, which
+    // is the create path's own posture.
+    if permitted_inline.is_empty() {
+        return validate_job_lora_compatibility(state, project_id, merged, false).await;
+    }
+    let Some(loras) = merged
+        .get("loras")
+        .and_then(Value::as_array)
+        .filter(|loras| !loras.is_empty())
+        .cloned()
+    else {
+        return Ok(());
+    };
+
+    // Partition, remembering each adapter's slot so the normalized array keeps the caller's order.
+    let mut inline_slots = Vec::new();
+    let mut catalog_slots = Vec::new();
+    for (slot, lora) in loras.iter().enumerate() {
+        if matches_permitted_inline_lora(lora, permitted_inline) {
+            inline_slots.push((slot, lora.clone()));
+        } else {
+            catalog_slots.push((slot, lora.clone()));
+        }
+    }
+
+    let mut normalized = vec![Value::Null; loras.len()];
+    for (allow_inline, slots) in [(true, inline_slots), (false, catalog_slots)] {
+        if slots.is_empty() {
+            continue;
+        }
+        let mut probe = merged.clone();
+        probe.insert(
+            "loras".to_owned(),
+            Value::Array(slots.iter().map(|(_, lora)| lora.clone()).collect()),
+        );
+        validate_job_lora_compatibility(state, project_id, &mut probe, allow_inline).await?;
+        let validated = probe
             .get("loras")
             .and_then(Value::as_array)
-            .is_some_and(|loras| {
-                loras.iter().any(|lora| {
-                    lora.get("category").and_then(Value::as_str) == Some("character")
-                        || lora
-                            .get("id")
-                            .and_then(Value::as_str)
-                            .is_some_and(|id| id.starts_with("character_lora_"))
-                })
-            })
+            .ok_or_else(|| ApiError::internal("LoRA validation dropped the adapter array"))?;
+        // `validate_lora_specs_for_model` may legitimately SKIP an entry (an unusable spec that
+        // `hydrate_lora_spec` returns `None` for), so pair by position over what came back rather
+        // than assuming a 1:1 mapping.
+        for ((slot, _), value) in slots.iter().zip(validated) {
+            normalized[*slot] = value.clone();
+        }
+    }
+    merged.insert(
+        "loras".to_owned(),
+        Value::Array(normalized.into_iter().filter(|v| !v.is_null()).collect()),
+    );
+    Ok(())
 }
 
 /// Validate and canonicalize the exact payload a retry/duplicate will enqueue. Existing job
@@ -477,8 +581,9 @@ async fn validate_and_canonicalize_merged_generation_payload(
     let mut merged = job.payload;
     // Resolved from the PERSISTED payload, BEFORE the merge below, because inline-LoRA permission is
     // a property of how the job was originally created and `payload_changes` must not be able to
-    // mint it. See [`job_carries_character_inline_loras`].
-    let allow_inline_loras = job_carries_character_inline_loras(&merged);
+    // mint it. Carries the specific adapters permitted, not a blanket flag — see
+    // [`persisted_character_inline_loras`] and [`validate_merged_job_loras`].
+    let permitted_inline_loras = persisted_character_inline_loras(&merged);
     merged.extend(payload_changes.clone());
     if generation_job_model_is_path_backed(&job_type) {
         validate_payload_model(&merged)?;
@@ -539,11 +644,11 @@ async fn validate_and_canonicalize_merged_generation_payload(
                 &manifest_entry,
             )?;
             merged.insert("modelManifestEntry".to_owned(), manifest_entry);
-            validate_job_lora_compatibility(
+            validate_merged_job_loras(
                 state,
                 project_id.as_deref(),
                 &mut merged,
-                allow_inline_loras,
+                &permitted_inline_loras,
             )
             .await?;
             crate::generation::validate_imported_submission(state, &model_id, &merged)?;
@@ -581,11 +686,11 @@ async fn validate_and_canonicalize_merged_generation_payload(
                 &entry,
             )?;
         }
-        validate_job_lora_compatibility(
+        validate_merged_job_loras(
             state,
             project_id.as_deref(),
             &mut merged,
-            allow_inline_loras,
+            &permitted_inline_loras,
         )
         .await?;
     }

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -4273,6 +4273,10 @@ fn tier_subdir_has_weights(tier_dir: &FsPath) -> bool {
 /// The lane split is a ONE-LINE binding here and a parameter below precisely so the behaviour is
 /// testable on both lanes from either platform.
 fn apply_imported_lora_advertisement(object: &mut JsonObject) {
+    // Deliberately the BUILD's linked engines, not `generation::enqueue_backend` — see that
+    // function's "Scope" note. The pair is consulted asymmetrically below (a withdrawal crosses
+    // lanes, a positive advertisement never does), which a one-hot routing answer cannot express,
+    // and a macOS build links no candle engine to derive a positive candle verdict from.
     let mlx_lane = cfg!(target_os = "macos");
     // Resolved as a VERDICT rather than by checking whether the first pass wrote anything:
     // `apply_model_manifest_defaults` can already have synthesized a `loraCompatibility` object, so
@@ -4402,6 +4406,8 @@ fn write_imported_lora_advertisement(object: &mut JsonObject, serves_loras: bool
 /// are never unioned: a Krea transformer file, SDXL fused checkpoint, Mage directory, and external
 /// ComfyUI tree each see only registrations for their structural loader.
 fn apply_imported_provider_surface(object: &mut JsonObject) {
+    // The BUILD's linked engines, like its `apply_imported_lora_advertisement` sibling — not
+    // `generation::enqueue_backend`. See that function's "Scope" note.
     let mlx_lane = cfg!(target_os = "macos");
     apply_imported_provider_surface_for_lanes(object, mlx_lane, !mlx_lane);
 }
@@ -4656,6 +4662,9 @@ fn apply_mac_and_mlx_fields(object: &mut JsonObject, data_dir: &FsPath) {
     if let Ok(mac_support) = serde_json::to_value(mac_support) {
         object.insert("macSupport".to_owned(), mac_support);
     }
+    // A LOCAL DISK probe for MLX convert-output tier dirs, so it is a platform fact and must NOT go
+    // through `generation::enqueue_backend`: keying it off `candle_required` would hide `mlxTiers`
+    // and its per-tier state from the Studio on macOS for directories that are genuinely present.
     let mlx_status = if cfg!(target_os = "macos") {
         mlx_catalog_status(object, data_dir)
     } else {

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -2599,6 +2599,384 @@ async fn candle_required_rejects_unsupported_import_before_creating_a_job() {
     assert_eq!(count, 0, "a preflight refusal must not create a queued job");
 }
 
+/// The pinned soft VAE donor the `wan_2_1_vae` decoder option depends on, mirroring the shipped
+/// `qwen_image` co-requisite row. Written into a test manifest so a tempdir catalog can advertise a
+/// genuinely SELECTABLE decoder option rather than only the "not installed" refusal.
+const DECODER_DONOR_REPO: &str = "SceneWorks/krea-realtime-14b-mlx";
+const DECODER_DONOR_REVISION: &str = "e68e9a3d98187fdf6936838ffcf6df5aa48d6626";
+const DECODER_DONOR_FILE: &str = "q4/vae.safetensors";
+
+/// A catalog holding the real `qwen_image` id — the id the checked-in engine decoder facts key on,
+/// so `decoders.byBackend` is stamped onto the resolved entry — plus that row's pinned soft VAE
+/// donor, with the donor's exact snapshot file seeded under `data_dir` so the descriptor-derived
+/// MLX option resolves `available: true`.
+///
+/// Installing the donor is what makes the backend selection observable: with it absent, both lanes
+/// refuse (candle for "no such option", MLX for "not installed") and the two are indistinguishable.
+fn write_decoder_capable_catalog(temp_dir: &tempfile::TempDir) {
+    let manifest_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&manifest_dir).expect("manifest dir creates");
+    write_empty_sibling_manifests(&manifest_dir);
+    std::fs::write(
+        manifest_dir.join("builtin.models.jsonc"),
+        format!(
+            r#"{{ "schemaVersion": 1, "models": [{{
+                "id": "qwen_image", "name": "Qwen Image", "type": "image", "family": "test",
+                "downloads": [
+                  {{ "provider": "huggingface", "repo": "SceneWorks/qwen-image-mlx" }},
+                  {{
+                    "provider": "huggingface",
+                    "repo": "{DECODER_DONOR_REPO}",
+                    "revision": "{DECODER_DONOR_REVISION}",
+                    "coRequisite": true,
+                    "required": "soft",
+                    "componentId": "vae",
+                    "files": ["{DECODER_DONOR_FILE}"],
+                    "estimatedSizeBytes": 507591212
+                  }}
+                ]
+            }}] }}"#
+        ),
+    )
+    .expect("builtin models writes");
+
+    let data_dir = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_dir).expect("data dir creates");
+    let repo_cache =
+        huggingface_repo_cache_path(&data_dir, DECODER_DONOR_REPO).expect("donor cache path");
+    let snapshot = repo_cache.join("snapshots").join(DECODER_DONOR_REVISION);
+    let donor = snapshot.join(DECODER_DONOR_FILE);
+    std::fs::create_dir_all(donor.parent().expect("donor parent")).expect("donor dir creates");
+    std::fs::write(&donor, b"pinned donor").expect("donor writes");
+}
+
+fn decoder_image_job(decoder: Value) -> Value {
+    json!({
+        "projectId": "project-1",
+        "model": "qwen_image",
+        "mode": "text_to_image",
+        "prompt": "mist over hills",
+        "count": 1,
+        "advanced": { "decoder": decoder },
+    })
+}
+
+/// sc-18420: the alternate-decoder gate must consult the option list of the backend this API
+/// instance actually routes to. It derived that with a bare `cfg!(target_os = "macos")`, so under
+/// `SCENEWORKS_CANDLE_REQUIRED` on macOS — a real, supported mode — it validated `advanced.decoder`
+/// against MLX's list while the job executed on Candle: an MLX-only decoder was admitted and then
+/// failed on the worker, and a Candle-valid one would have been 400'd.
+///
+/// Both directions of the same catalog row and the same request: only `candle_required` differs.
+#[tokio::test]
+async fn candle_required_moves_the_decoder_gate_onto_the_candle_option_list() {
+    let _env = isolate_hf_cache();
+
+    // Candle lane: the shipped facts declare no candle decoder for this row, so the MLX-only
+    // selection must be refused at enqueue rather than deferred to a worker that cannot run it.
+    let candle_dir = tempfile::tempdir().expect("temp dir creates");
+    write_decoder_capable_catalog(&candle_dir);
+    let mut candle_settings = test_settings(&candle_dir);
+    candle_settings.candle_required = true;
+    let candle_app = create_app(candle_settings).expect("app creates");
+    let (status, error) = request(
+        candle_app,
+        "POST",
+        "/api/v1/image/jobs",
+        decoder_image_job(json!("wan_2_1_vae")),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{error}");
+    let detail = error["detail"].as_str().unwrap_or_default();
+    assert!(
+        detail.contains("is not compatible with qwen_image"),
+        "candle_required must reject an MLX-only decoder as incompatible, not merely uninstalled: \
+         {error}"
+    );
+
+    // Native lane: the same request against the same row, with candle_required off. On macOS the
+    // MLX option is installed and selectable, so it is accepted — which is what proves the
+    // refusal above came from the backend swap and not from the option being unusable.
+    let native_dir = tempfile::tempdir().expect("temp dir creates");
+    write_decoder_capable_catalog(&native_dir);
+    let native_app = create_app(test_settings(&native_dir)).expect("app creates");
+    let (status, body) = request(
+        native_app,
+        "POST",
+        "/api/v1/image/jobs",
+        decoder_image_job(json!("wan_2_1_vae")),
+    )
+    .await;
+    if cfg!(target_os = "macos") {
+        assert_eq!(status, StatusCode::CREATED, "{body}");
+        assert_eq!(
+            body["payload"]["advanced"]["decoder"], "wan_2_1_vae",
+            "the accepted selection must reach the worker verbatim"
+        );
+    } else {
+        // Candle everywhere else regardless of the setting — same refusal as above.
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+        assert!(body["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("is not compatible with qwen_image")));
+    }
+}
+
+/// sc-18420: retry/duplicate re-run the text-encoder gate but skipped the decoder gate entirely,
+/// and `payloadChanges` is a SHALLOW merge — `advanced` arrives replaced wholesale. A retry could
+/// therefore enqueue exactly the decoder shapes the create path 400s.
+#[tokio::test]
+async fn retry_and_duplicate_gate_a_merged_decoder_selection_the_create_path_refuses() {
+    let _env = isolate_hf_cache();
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_decoder_capable_catalog(&temp_dir);
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    // The original job selects no decoder, so it is admitted on either lane.
+    let (status, original) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        decoder_image_job(Value::Null),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{original}");
+    let job_id = original["id"].as_str().expect("job id").to_owned();
+
+    let (_, before) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+    let before = before.as_array().expect("jobs array").len();
+
+    for (label, advanced) in [
+        // Mutually exclusive with usePid — refused on every lane, before any list lookup.
+        (
+            "exactly one decoder",
+            json!({ "decoder": "wan_2_1_vae", "usePid": true }),
+        ),
+        // Not an option on any backend for this row.
+        (
+            "is not compatible with qwen_image",
+            json!({ "decoder": "no_such_decoder" }),
+        ),
+        // The typed shape guard the create path applies to the same field.
+        (
+            "advanced.decoder must be a decoder id string",
+            json!({ "decoder": 7 }),
+        ),
+    ] {
+        for operation in ["retry", "duplicate"] {
+            let (status, error) = request(
+                app.clone(),
+                "POST",
+                &format!("/api/v1/jobs/{job_id}/{operation}"),
+                json!({ "payloadChanges": { "advanced": advanced } }),
+            )
+            .await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{operation}: {error}");
+            assert!(
+                error["detail"]
+                    .as_str()
+                    .is_some_and(|detail| detail.contains(label)),
+                "{operation} must fail with the create path's own refusal ({label}): {error}"
+            );
+        }
+    }
+
+    // A refused retry/duplicate must not have enqueued anything, and the boundary must still admit
+    // the selection the create path admits — the gate is not a blanket refusal of `advanced`.
+    let (_, after) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+    assert_eq!(
+        after.as_array().expect("jobs array").len(),
+        before,
+        "a refused retry/duplicate must not persist a job"
+    );
+
+    let (status, replayed) = request(
+        app,
+        "POST",
+        &format!("/api/v1/jobs/{job_id}/duplicate"),
+        json!({ "payloadChanges": { "advanced": { "decoder": "wan_2_1_vae" } } }),
+    )
+    .await;
+    if cfg!(target_os = "macos") {
+        assert_eq!(status, StatusCode::CREATED, "{replayed}");
+        assert_eq!(replayed["payload"]["advanced"]["decoder"], "wan_2_1_vae");
+    } else {
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{replayed}");
+    }
+}
+
+/// sc-18420, video half: `create_video_job` runs the same decoder gate, and the merged
+/// retry/duplicate boundary skipped it there too. No video provider advertises an alternate
+/// decoder, so every selection must fail closed at enqueue rather than reach a worker that has no
+/// such option.
+#[tokio::test]
+async fn retry_and_duplicate_gate_a_merged_video_decoder_selection() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (status, original) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": "project-1",
+            "mode": "text_to_video",
+            "prompt": "a drone shot",
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{original}");
+    let job_id = original["id"].as_str().expect("job id").to_owned();
+
+    let (_, before) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+    let before = before.as_array().expect("jobs array").len();
+
+    for (label, advanced) in [
+        (
+            "is not compatible with",
+            json!({ "decoder": "wan_2_1_vae" }),
+        ),
+        (
+            "exactly one decoder",
+            json!({ "decoder": "wan_2_1_vae", "usePid": true }),
+        ),
+    ] {
+        for operation in ["retry", "duplicate"] {
+            let (status, error) = request(
+                app.clone(),
+                "POST",
+                &format!("/api/v1/jobs/{job_id}/{operation}"),
+                json!({ "payloadChanges": { "advanced": advanced } }),
+            )
+            .await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{operation}: {error}");
+            assert!(
+                error["detail"]
+                    .as_str()
+                    .is_some_and(|detail| detail.contains(label)),
+                "{operation} must reproduce the video create path's refusal ({label}): {error}"
+            );
+        }
+    }
+
+    let (_, after) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+    assert_eq!(
+        after.as_array().expect("jobs array").len(),
+        before,
+        "a refused retry/duplicate must not persist a job"
+    );
+
+    // A replay that selects no decoder is untouched by the new gate.
+    let (status, replayed) = request(
+        app,
+        "POST",
+        &format!("/api/v1/jobs/{job_id}/duplicate"),
+        json!({ "payloadChanges": { "prompt": "a slower drone shot" } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{replayed}");
+}
+
+/// sc-18420: the same retry/duplicate bypass for the imported-submission gate. The create path
+/// refuses an imported request shape the resolved provider registration cannot execute; the merged
+/// boundary never ran that check, so a retry could swap `advanced` for one carrying a shape the
+/// backend has no route for.
+#[tokio::test]
+async fn retry_and_duplicate_gate_a_merged_imported_shape_the_create_path_refuses() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let manifest_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&manifest_dir).expect("manifest dir creates");
+    write_empty_sibling_manifests(&manifest_dir);
+    std::fs::write(
+        manifest_dir.join("builtin.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("builtin manifest writes");
+    std::fs::write(
+        manifest_dir.join("user.models.jsonc"),
+        r#"{
+          "schemaVersion": 1,
+          "models": [{
+            "id": "user_krea",
+            "name": "User Krea",
+            "type": "image",
+            "family": "krea_2",
+            "importSourceShape": "transformer_file",
+            "paths": { "model": "/probe/user-krea.safetensors" }
+          }]
+        }"#,
+    )
+    .expect("user manifest writes");
+    let mut settings = test_settings(&temp_dir);
+    // Candle declares krea_2/transformer_file for `generate` but NOT for `pose`, so the plain
+    // request is admitted and the pose replay is the shape with no route.
+    settings.candle_required = true;
+    let app = create_app(settings).expect("app creates");
+
+    let (status, original) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": "project-1",
+            "model": "user_krea",
+            "mode": "text_to_image",
+            "prompt": "mist over hills",
+            "count": 1,
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "the plain imported generate shape has a candle route: {original}"
+    );
+    let job_id = original["id"].as_str().expect("job id").to_owned();
+
+    let (_, before) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+    let before = before.as_array().expect("jobs array").len();
+
+    for advanced in [
+        json!({ "poses": [{ "id": "pose-1", "keypoints": [] }] }),
+        json!({ "controlImage": "control-1" }),
+        json!({ "controlMode": "pose" }),
+    ] {
+        for operation in ["retry", "duplicate"] {
+            let (status, error) = request(
+                app.clone(),
+                "POST",
+                &format!("/api/v1/jobs/{job_id}/{operation}"),
+                json!({ "payloadChanges": { "advanced": advanced } }),
+            )
+            .await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{operation}: {error}");
+            assert!(
+                error["detail"]
+                    .as_str()
+                    .is_some_and(|detail| detail.contains("candle_unsupported")),
+                "{operation} must reproduce the create path's imported refusal: {error}"
+            );
+        }
+    }
+
+    let (_, after) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+    assert_eq!(
+        after.as_array().expect("jobs array").len(),
+        before,
+        "a refused retry/duplicate must not persist a job"
+    );
+
+    // The gate must still pass a merged shape the create path accepts — a prompt-only replay keeps
+    // the admitted generate operation.
+    let (status, replayed) = request(
+        app,
+        "POST",
+        &format!("/api/v1/jobs/{job_id}/duplicate"),
+        json!({ "payloadChanges": { "prompt": "fog over hills" } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{replayed}");
+}
+
 #[cfg(target_os = "macos")]
 #[tokio::test]
 async fn native_imported_control_requires_pose_but_preserves_krea_pose_user_map() {

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -3200,6 +3200,90 @@ async fn retry_honours_character_inline_lora_provenance_without_letting_others_b
     assert_eq!(status, StatusCode::CREATED, "{replayed}");
     assert_eq!(replayed["payload"]["prompt"], "portrait, side light");
 
+    // The permit is PER-ADAPTER, not a blanket flag on the merged array: a genuine character job may
+    // replay its own links, but may not use that standing to introduce a foreign inline adapter.
+    let foreign = temp_dir.path().join("data/loras/foreign.safetensors");
+    write_test_safetensors(&foreign);
+    for (label, loras) in [
+        // Swap the persisted set for an entirely foreign inline adapter.
+        (
+            "LoRA not found: character_lora_foreign",
+            json!([{
+                "id": "character_lora_foreign",
+                "name": "Foreign",
+                "category": "character",
+                "sourcePath": foreign.display().to_string(),
+                "compatibility": { "families": ["z-image"] }
+            }]),
+        ),
+        // Keep the persisted link AND smuggle a foreign one alongside it: the permit must not
+        // launder its companion.
+        (
+            "LoRA not found: character_lora_foreign",
+            json!([
+                inline_lora.clone(),
+                {
+                    "id": "character_lora_foreign",
+                    "name": "Foreign",
+                    "category": "character",
+                    "sourcePath": foreign.display().to_string(),
+                    "compatibility": { "families": ["z-image"] }
+                }
+            ]),
+        ),
+        // Replay the persisted link's OWN id with a REDIRECTED path — the case an id-only match
+        // would wave through, carrying an arbitrary file into the enqueued payload.
+        (
+            &format!("LoRA not found: {inline_lora_id}"),
+            json!([{
+                "id": inline_lora_id,
+                "name": "Character Style",
+                "category": "character",
+                "sourcePath": foreign.display().to_string(),
+                "compatibility": { "families": ["z-image"] }
+            }]),
+        ),
+    ] {
+        for operation in ["retry", "duplicate"] {
+            let (status, error) = request(
+                app.clone(),
+                "POST",
+                &format!("/api/v1/jobs/{character_job_id}/{operation}"),
+                json!({ "payloadChanges": { "loras": loras } }),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "{operation} must not extend the character permit beyond the PERSISTED links: \
+                 {error}"
+            );
+            assert_eq!(error["detail"], label);
+        }
+    }
+
+    // A CATALOG adapter added alongside the persisted inline set is admitted — the narrowing must
+    // not turn a character job into one that can never gain an adapter — and both survive, in order.
+    let (status, widened) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/jobs/{character_job_id}/duplicate"),
+        json!({
+            "payloadChanges": {
+                "loras": [inline_lora.clone(), { "id": "good_style" }]
+            }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{widened}");
+    assert_eq!(widened["payload"]["loras"][0]["id"], inline_lora_id);
+    assert_eq!(widened["payload"]["loras"][1]["id"], "good_style");
+    assert!(
+        widened["payload"]["loras"][1].get("name").is_some(),
+        "the added catalog adapter must be hydrated from the catalog, not passed through inline: \
+         {widened}"
+    );
+
     // DIRECTION 2: an ORDINARY image job that wears both caller-settable markers must not borrow
     // that permission. Create is happy to make it — the LoRA gate no-ops on an empty set — which is
     // exactly why provenance cannot be read from the markers.

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -3097,6 +3097,188 @@ async fn retry_and_duplicate_gate_a_merged_lora_set_the_create_path_refuses() {
     );
 }
 
+/// sc-18420: the retry/duplicate LoRA gate must honour the ORIGINAL job's inline-LoRA provenance.
+///
+/// `characters.rs`'s test-job route creates `image_generate` jobs with `allow_inline_loras = true`,
+/// and a character's adapters are inline links (`character_lora_<hex>`, `category: "character"`,
+/// path-bearing) that `character_store::attach_lora` registers in NO catalog. Mirroring the gate
+/// with a hard-coded `false` refused that persisted set with "LoRA not found" — breaking even a
+/// retry with EMPTY `payloadChanges`.
+///
+/// Both directions, because the obvious fix opens a hole: `characterId` and `mode` are
+/// caller-settable (`ImageJobRequest` exposes both), so permission must come from the persisted
+/// LINK SHAPE, which only the character route can have put there. An ordinary image job wearing
+/// those markers must NOT be able to smuggle an inline path-bearing adapter through
+/// `payloadChanges`.
+#[tokio::test]
+async fn retry_honours_character_inline_lora_provenance_without_letting_others_borrow_it() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_lora_gate_catalog(&temp_dir);
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Character Retry" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+    let (_, character) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/projects/{project_id}/characters"),
+        json!({ "name": "Mira", "type": "person" }),
+    )
+    .await;
+    let character_id = character["id"].as_str().expect("character id").to_owned();
+    let source = temp_dir.path().join("data/loras/character.safetensors");
+    write_test_safetensors(&source);
+    let (status, attached) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/projects/{project_id}/characters/{character_id}/loras"),
+        json!({
+            "name": "Character Style",
+            "sourcePath": source.display().to_string(),
+            // Compatible with `gate_image` so the test-job itself is admitted; the family gate is
+            // pinned elsewhere and is not what this test is about.
+            "compatibility": { "families": ["z-image"] }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{attached}");
+
+    let (status, character_job) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/projects/{project_id}/characters/{character_id}/test-jobs"),
+        json!({ "prompt": "portrait", "model": "gate_image" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{character_job}");
+    let character_job_id = character_job["id"].as_str().expect("job id").to_owned();
+    let inline_lora = character_job["payload"]["loras"][0].clone();
+    assert_eq!(
+        inline_lora["category"], "character",
+        "the fixture must really be an inline character link, or this test proves nothing: \
+         {character_job}"
+    );
+    let inline_lora_id = inline_lora["id"].as_str().expect("link id").to_owned();
+    assert!(
+        inline_lora_id.starts_with("character_lora_"),
+        "got: {inline_lora_id}"
+    );
+
+    // DIRECTION 1: the character job's own inline set survives retry AND duplicate, including the
+    // no-op replay that the hard-coded `false` broke.
+    for operation in ["retry", "duplicate"] {
+        let (status, replayed) = request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/jobs/{character_job_id}/{operation}"),
+            json!({ "payloadChanges": {} }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "{operation} of a character test job must not refuse its own inline links: {replayed}"
+        );
+        assert_eq!(
+            replayed["payload"]["loras"][0]["id"], inline_lora_id,
+            "{operation} must preserve the character link"
+        );
+    }
+    // And a real change alongside them still works.
+    let (status, replayed) = request(
+        app.clone(),
+        "POST",
+        &format!("/api/v1/jobs/{character_job_id}/retry"),
+        json!({ "payloadChanges": { "prompt": "portrait, side light" } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{replayed}");
+    assert_eq!(replayed["payload"]["prompt"], "portrait, side light");
+
+    // DIRECTION 2: an ORDINARY image job that wears both caller-settable markers must not borrow
+    // that permission. Create is happy to make it — the LoRA gate no-ops on an empty set — which is
+    // exactly why provenance cannot be read from the markers.
+    let smuggler = temp_dir.path().join("data/loras/smuggled.safetensors");
+    write_test_safetensors(&smuggler);
+    let (status, ordinary) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "character_image",
+            "characterId": "character_not_really_mine",
+            "prompt": "mist over hills",
+            "model": "gate_image",
+            "count": 1,
+            "referenceAssetIds": [],
+            "loras": [],
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "the marker-wearing decoy must be creatable for the smuggle attempt to be meaningful: \
+         {ordinary}"
+    );
+    let ordinary_id = ordinary["id"].as_str().expect("job id").to_owned();
+
+    let (_, before) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+    let before = before.as_array().expect("jobs array").len();
+
+    for operation in ["retry", "duplicate"] {
+        let (status, error) = request(
+            app.clone(),
+            "POST",
+            &format!("/api/v1/jobs/{ordinary_id}/{operation}"),
+            json!({
+                "payloadChanges": {
+                    "loras": [{
+                        "id": "character_lora_forged",
+                        "name": "Forged",
+                        "category": "character",
+                        "sourcePath": smuggler.display().to_string(),
+                        "compatibility": { "families": ["z-image"] }
+                    }]
+                }
+            }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{operation} must not accept an inline adapter for a job whose PERSISTED set had none: \
+             {error}"
+        );
+        assert_eq!(error["detail"], "LoRA not found: character_lora_forged");
+    }
+
+    let (_, after) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+    assert_eq!(
+        after.as_array().expect("jobs array").len(),
+        before,
+        "a refused smuggle must not persist a job"
+    );
+
+    // The decoy still validates a CATALOG adapter normally, so the refusal above is about inline
+    // permission and not about the job being unable to take adapters at all.
+    let (status, replayed) = request(
+        app,
+        "POST",
+        &format!("/api/v1/jobs/{ordinary_id}/duplicate"),
+        json!({ "payloadChanges": { "loras": [{ "id": "good_style" }] } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{replayed}");
+    assert_eq!(replayed["payload"]["loras"][0]["id"], "good_style");
+}
+
 /// The video half of the same LoRA bypass — `create_video_job` runs the identical gate.
 #[tokio::test]
 async fn retry_and_duplicate_gate_a_merged_video_lora_set_the_create_path_refuses() {

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -2690,8 +2690,13 @@ async fn candle_required_moves_the_decoder_gate_onto_the_candle_option_list() {
     let detail = error["detail"].as_str().unwrap_or_default();
     assert!(
         detail.contains("is not compatible with qwen_image"),
-        "candle_required must reject an MLX-only decoder as incompatible, not merely uninstalled: \
-         {error}"
+        "candle_required must reject an MLX-only decoder as incompatible, not merely uninstalled. \
+         NOTE: this exact branch is coupled to the SHIPPED decoder facts declaring ZERO candle \
+         options for qwen_image — if `capabilities.candle.json` ever gains a decoderOption for this \
+         row, the correct refusal becomes 'is not installed' (or the selection becomes valid) and \
+         this assertion must be re-stated against the new facts, NOT deleted. The backend-selection \
+         claim itself lives in the platform-free unit test \
+         `the_gate_consults_only_the_executing_backends_option_list`: {error}"
     );
 
     // Native lane: the same request against the same row, with candle_required off. On macOS the
@@ -2874,6 +2879,322 @@ async fn retry_and_duplicate_gate_a_merged_video_decoder_selection() {
     )
     .await;
     assert_eq!(status, StatusCode::CREATED, "{replayed}");
+}
+
+/// One image model and one video model, each declaring its own LoRA family, plus the four adapters
+/// the retry/duplicate LoRA-gate tests need: a wrong-family one, a right-family-but-absent-on-disk
+/// one, and a compatible installed one per lane. Mirrors the fixture
+/// `generation_job_routes_reject_incompatible_loras` uses on the create path, so both boundaries are
+/// asserted against the SAME catalog and therefore the same refusal strings.
+fn write_lora_gate_catalog(temp_dir: &tempfile::TempDir) {
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"{
+          "schemaVersion": 1,
+          "models": [
+            {
+              "id": "gate_image",
+              "name": "Gate Image",
+              "family": "z-image",
+              "type": "image",
+              "adapter": "z_image_diffusers",
+              "capabilities": ["text_to_image", "edit_image", "character_image"],
+              "downloads": [], "paths": {}, "defaults": {}, "limits": {},
+              "loraCompatibility": { "families": ["z-image"] },
+              "ui": {}
+            },
+            {
+              "id": "gate_video",
+              "name": "Gate Video",
+              "family": "ltx-video",
+              "type": "video",
+              "adapter": "ltx_video",
+              "capabilities": ["text_to_video", "image_to_video", "first_last_frame", "extend_clip", "video_bridge", "replace_person"],
+              "downloads": [], "paths": {}, "defaults": {}, "limits": {},
+              "loraCompatibility": { "families": ["ltx-video"] },
+              "ui": {}
+            }
+          ]
+        }"#,
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("user models writes");
+    std::fs::write(
+        config_dir.join("builtin.loras.jsonc"),
+        r#"{ "schemaVersion": 1, "loras": [] }"#,
+    )
+    .expect("builtin loras writes");
+    std::fs::write(
+        config_dir.join("user.loras.jsonc"),
+        r#"{
+          "schemaVersion": 1,
+          "loras": [
+            {
+              "id": "qwen_style", "name": "Qwen Style", "family": "qwen-image",
+              "triggerWords": [], "compatibility": { "families": ["qwen-image"] },
+              "source": { "provider": "local", "path": "loras/qwen.safetensors" }
+            },
+            {
+              "id": "deleted_style", "name": "Deleted Style", "family": "z-image",
+              "triggerWords": [], "compatibility": { "families": ["z-image"] },
+              "source": { "provider": "local", "path": "loras/deleted.safetensors" }
+            },
+            {
+              "id": "good_style", "name": "Good Style", "family": "z-image",
+              "triggerWords": [], "compatibility": { "families": ["z-image"] },
+              "source": { "provider": "local", "path": "loras/good.safetensors" }
+            },
+            {
+              "id": "motion_style", "name": "Motion Style", "family": "ltx-video",
+              "triggerWords": [], "compatibility": { "families": ["ltx-video"] },
+              "source": { "provider": "local", "path": "loras/motion.safetensors" }
+            }
+          ]
+        }"#,
+    )
+    .expect("user loras writes");
+    for file in ["builtin.recipe-presets.jsonc", "user.recipe-presets.jsonc"] {
+        std::fs::write(
+            config_dir.join(file),
+            r#"{ "schemaVersion": 1, "presets": [] }"#,
+        )
+        .expect("preset manifest writes");
+    }
+    let lora_dir = temp_dir.path().join("data/loras");
+    std::fs::create_dir_all(&lora_dir).expect("lora dir creates");
+    // `deleted.safetensors` is deliberately NOT written: a catalog-backed adapter whose file is gone
+    // resolves to a non-installed state, which is the create path's "is not installed" refusal.
+    for name in ["qwen.safetensors", "good.safetensors", "motion.safetensors"] {
+        write_test_safetensors(&lora_dir.join(name));
+    }
+}
+
+/// sc-18420: `validate_job_lora_compatibility_with` runs at BOTH create boundaries
+/// (`create_image_job`, `create_video_job`) and at neither retry/duplicate one. `loras` is a
+/// TOP-LEVEL key, so the shallow `payload_changes` merge replaces the whole array — a retry could
+/// swap a validated adapter set for a wrong-family, uninstalled, or entirely unknown one and enqueue
+/// it, deferring the failure to a worker that cannot load the file.
+///
+/// Every refusal string here is the create path's own, asserted verbatim against the same catalog.
+#[tokio::test]
+async fn retry_and_duplicate_gate_a_merged_lora_set_the_create_path_refuses() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_lora_gate_catalog(&temp_dir);
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    // The LoRA catalog is project-scoped, so the gate needs a real project to resolve against.
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "LoRA Gate" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+
+    // Baseline: created with a COMPATIBLE adapter, so the refusals below are about the merged set
+    // and not about the route rejecting adapters at all.
+    let (status, original) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_image",
+            "prompt": "mist over hills",
+            "model": "gate_image",
+            "count": 1,
+            "loras": [{ "id": "good_style" }],
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{original}");
+    let job_id = original["id"].as_str().expect("job id").to_owned();
+
+    let (_, before) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+    let before = before.as_array().expect("jobs array").len();
+
+    for (expected, loras) in [
+        (
+            "LoRA qwen_style is not compatible with model gate_image",
+            json!([{ "id": "qwen_style" }]),
+        ),
+        (
+            "LoRA is not installed: deleted_style",
+            json!([{ "id": "deleted_style" }]),
+        ),
+        (
+            "LoRA not found: no_such_lora",
+            json!([{ "id": "no_such_lora" }]),
+        ),
+        // A mixed set must be refused for its bad member, not silently pruned to the good one.
+        (
+            "LoRA qwen_style is not compatible with model gate_image",
+            json!([{ "id": "good_style" }, { "id": "qwen_style" }]),
+        ),
+    ] {
+        // The create path's own verdict on the identical set, so the two boundaries are compared
+        // rather than the retry refusal being asserted in isolation.
+        let (create_status, create_error) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/image/jobs",
+            json!({
+                "projectId": project_id,
+                "mode": "text_to_image",
+                "prompt": "mist over hills",
+                "model": "gate_image",
+                "count": 1,
+                "loras": loras,
+            }),
+        )
+        .await;
+        assert_eq!(create_status, StatusCode::BAD_REQUEST, "{create_error}");
+        assert_eq!(create_error["detail"], expected);
+
+        for operation in ["retry", "duplicate"] {
+            let (status, error) = request(
+                app.clone(),
+                "POST",
+                &format!("/api/v1/jobs/{job_id}/{operation}"),
+                json!({ "payloadChanges": { "loras": loras } }),
+            )
+            .await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{operation}: {error}");
+            assert_eq!(
+                error["detail"], expected,
+                "{operation} must reproduce the create path's LoRA refusal verbatim"
+            );
+        }
+    }
+
+    let (_, after) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+    assert_eq!(
+        after.as_array().expect("jobs array").len(),
+        before,
+        "a refused retry/duplicate must not persist a job"
+    );
+
+    // The gate must still admit — and NORMALIZE — a set the create path accepts, so the canonical
+    // object this boundary returns carries the hydrated catalog spec rather than the bare id.
+    let (status, replayed) = request(
+        app,
+        "POST",
+        &format!("/api/v1/jobs/{job_id}/duplicate"),
+        json!({ "payloadChanges": { "loras": [{ "id": "good_style" }] } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{replayed}");
+    assert_eq!(replayed["payload"]["loras"][0]["id"], "good_style");
+    assert!(
+        replayed["payload"]["loras"][0].get("name").is_some(),
+        "the admitted set must be the normalized catalog spec, not the caller's bare id: {replayed}"
+    );
+}
+
+/// The video half of the same LoRA bypass — `create_video_job` runs the identical gate.
+#[tokio::test]
+async fn retry_and_duplicate_gate_a_merged_video_lora_set_the_create_path_refuses() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    write_lora_gate_catalog(&temp_dir);
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    // The LoRA catalog is project-scoped, so the gate needs a real project to resolve against.
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "LoRA Gate" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+
+    let (status, original) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/video/jobs",
+        json!({
+            "projectId": project_id,
+            "mode": "text_to_video",
+            "prompt": "a drone shot",
+            "model": "gate_video",
+            "loras": [{ "id": "motion_style" }],
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{original}");
+    let job_id = original["id"].as_str().expect("job id").to_owned();
+
+    let (_, before) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+    let before = before.as_array().expect("jobs array").len();
+
+    for (expected, loras) in [
+        (
+            "LoRA qwen_style is not compatible with model gate_video",
+            json!([{ "id": "qwen_style" }]),
+        ),
+        // A z-image adapter is installed and well-formed, just wrong for THIS lane's model.
+        (
+            "LoRA good_style is not compatible with model gate_video",
+            json!([{ "id": "good_style" }]),
+        ),
+        (
+            "LoRA not found: no_such_lora",
+            json!([{ "id": "no_such_lora" }]),
+        ),
+    ] {
+        let (create_status, create_error) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/video/jobs",
+            json!({
+                "projectId": project_id,
+                "mode": "text_to_video",
+                "prompt": "a drone shot",
+                "model": "gate_video",
+                "loras": loras,
+            }),
+        )
+        .await;
+        assert_eq!(create_status, StatusCode::BAD_REQUEST, "{create_error}");
+        assert_eq!(create_error["detail"], expected);
+
+        for operation in ["retry", "duplicate"] {
+            let (status, error) = request(
+                app.clone(),
+                "POST",
+                &format!("/api/v1/jobs/{job_id}/{operation}"),
+                json!({ "payloadChanges": { "loras": loras } }),
+            )
+            .await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{operation}: {error}");
+            assert_eq!(
+                error["detail"], expected,
+                "{operation} must reproduce the video create path's LoRA refusal verbatim"
+            );
+        }
+    }
+
+    let (_, after) = request(app.clone(), "GET", "/api/v1/jobs", Value::Null).await;
+    assert_eq!(
+        after.as_array().expect("jobs array").len(),
+        before,
+        "a refused retry/duplicate must not persist a job"
+    );
+
+    let (status, replayed) = request(
+        app,
+        "POST",
+        &format!("/api/v1/jobs/{job_id}/duplicate"),
+        json!({ "payloadChanges": { "loras": [{ "id": "motion_style" }] } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{replayed}");
+    assert_eq!(replayed["payload"]["loras"][0]["id"], "motion_style");
 }
 
 /// sc-18420: the same retry/duplicate bypass for the imported-submission gate. The create path

--- a/config/backend-capabilities/matrix.json
+++ b/config/backend-capabilities/matrix.json
@@ -12,8 +12,8 @@
   "sources": {
     "apiContractEntry": "ec989b2adc53a7f17ae092133e687ec83782d111ebeceb3b7a50b37c9b3c117c",
     "apiDto": "3b82a42da63ce67eb67beefdb7047ecdc6cdb908c6864a6366317ea31f8ecce1",
-    "apiGeneration": "2c0d547df3a92ef0ab128551b4610218b6e8491f8b207385f99c6c88fa65ea65",
-    "apiValidation": "0ce3f31d14412538656452fa2ee740be0d64998e10749133191ade93898360ab",
+    "apiGeneration": "91d787711b772a1192e7533544706f654ae459a4f5a2569fb8eeadbb58322a67",
+    "apiValidation": "bcbc2510373132c3c82ada79bcb9bb998901b72f905a11747bb788223ad49972",
     "baseWeightImports": "f61da9f523417d6ad075fabfd6eb57edc7ae7f533aa213606cd6f0f5cad219d2",
     "descriptorAudioFacts": "df411be04e5997a52b7e2107c3ce35a1336ee745af4f268984ee5ede8617dd78",
     "descriptorCandleFacts": "1bb88abe970761f776c4d0e27047ca4a116c1d70d68645b9b95ccb12a0d325b7",

--- a/config/backend-capabilities/matrix.json
+++ b/config/backend-capabilities/matrix.json
@@ -13,7 +13,7 @@
     "apiContractEntry": "ec989b2adc53a7f17ae092133e687ec83782d111ebeceb3b7a50b37c9b3c117c",
     "apiDto": "3b82a42da63ce67eb67beefdb7047ecdc6cdb908c6864a6366317ea31f8ecce1",
     "apiGeneration": "e40bf25a4c7c6f7501b21a9d1a364df14f38fb1840af4485e075151cab4a9105",
-    "apiValidation": "1634a757c682e77ec60bfe1040dce2f679c15d3734e7bbc343abbb63c2969535",
+    "apiValidation": "2cb57b8ee34a135f66da3434be7907beb565770416f23f7fdab9642a941cef17",
     "baseWeightImports": "f61da9f523417d6ad075fabfd6eb57edc7ae7f533aa213606cd6f0f5cad219d2",
     "descriptorAudioFacts": "df411be04e5997a52b7e2107c3ce35a1336ee745af4f268984ee5ede8617dd78",
     "descriptorCandleFacts": "1bb88abe970761f776c4d0e27047ca4a116c1d70d68645b9b95ccb12a0d325b7",

--- a/config/backend-capabilities/matrix.json
+++ b/config/backend-capabilities/matrix.json
@@ -13,7 +13,7 @@
     "apiContractEntry": "ec989b2adc53a7f17ae092133e687ec83782d111ebeceb3b7a50b37c9b3c117c",
     "apiDto": "3b82a42da63ce67eb67beefdb7047ecdc6cdb908c6864a6366317ea31f8ecce1",
     "apiGeneration": "e40bf25a4c7c6f7501b21a9d1a364df14f38fb1840af4485e075151cab4a9105",
-    "apiValidation": "0a8ef25e8598ca2e2b73d89bd7dd72cef31d36f4270f4d63a05916155c48c3d9",
+    "apiValidation": "1634a757c682e77ec60bfe1040dce2f679c15d3734e7bbc343abbb63c2969535",
     "baseWeightImports": "f61da9f523417d6ad075fabfd6eb57edc7ae7f533aa213606cd6f0f5cad219d2",
     "descriptorAudioFacts": "df411be04e5997a52b7e2107c3ce35a1336ee745af4f268984ee5ede8617dd78",
     "descriptorCandleFacts": "1bb88abe970761f776c4d0e27047ca4a116c1d70d68645b9b95ccb12a0d325b7",

--- a/config/backend-capabilities/matrix.json
+++ b/config/backend-capabilities/matrix.json
@@ -12,8 +12,8 @@
   "sources": {
     "apiContractEntry": "ec989b2adc53a7f17ae092133e687ec83782d111ebeceb3b7a50b37c9b3c117c",
     "apiDto": "3b82a42da63ce67eb67beefdb7047ecdc6cdb908c6864a6366317ea31f8ecce1",
-    "apiGeneration": "91d787711b772a1192e7533544706f654ae459a4f5a2569fb8eeadbb58322a67",
-    "apiValidation": "bcbc2510373132c3c82ada79bcb9bb998901b72f905a11747bb788223ad49972",
+    "apiGeneration": "e40bf25a4c7c6f7501b21a9d1a364df14f38fb1840af4485e075151cab4a9105",
+    "apiValidation": "0a8ef25e8598ca2e2b73d89bd7dd72cef31d36f4270f4d63a05916155c48c3d9",
     "baseWeightImports": "f61da9f523417d6ad075fabfd6eb57edc7ae7f533aa213606cd6f0f5cad219d2",
     "descriptorAudioFacts": "df411be04e5997a52b7e2107c3ce35a1336ee745af4f268984ee5ede8617dd78",
     "descriptorCandleFacts": "1bb88abe970761f776c4d0e27047ca4a116c1d70d68645b9b95ccb12a0d325b7",


### PR DESCRIPTION
Closes the enqueue-time capability-gate defects epic 18304's adversarial review found in `apps/rust-api`. Every fix is one of two shapes: a gate that derived the wrong backend, or a creation boundary that skipped a gate entirely.

## The two epic-review majors

**1. The decoder gate validated against the wrong backend.** `validate_selected_decoder_for_manifest` selected its option list with a bare `cfg!(target_os = "macos") -> "mlx"`, while its sibling `validate_imported_submission` in the same file correctly used `!cfg!(macos) || settings.candle_required`. Under `SCENEWORKS_CANDLE_REQUIRED` on macOS — a real, test-exercised mode — the gate validated `advanced.decoder` against MLX's list while the job executed on Candle: an MLX-only decoder was **admitted (201)** and then failed on the worker, and a Candle-valid one would have been 400'd.

The derivation now lives in exactly one place, `generation::enqueue_backend`, which both gates and all three call sites read. The decoder gate takes the resolved backend as a parameter so it cannot re-derive it.

**2. Retry/duplicate skipped the gates its own doc comment claimed it ran.** `validate_and_canonicalize_merged_generation_payload` re-ran the text-encoder gate but neither the decoder gate nor the imported-submission gate. `payload_changes` is a **shallow** merge, so `advanced` arrives replaced wholesale: a retry could enqueue a decoder+`usePid` pair, a non-existent or wrong-backend decoder, a non-string decoder, or an imported request shape with no provider route — every one of which the create path refuses. Both gates now run on the merged object after the manifest rebuild, mirroring `create_image_job`.

## Siblings found while fixing those

**The video half of the same bypass.** `create_video_job` runs the decoder gate too, so the merged boundary now resolves the catalog row for the merged model and gates on it — keyed off an actually-present `advanced.decoder`, so the common decoder-less replay costs no extra catalog resolution.

**The LoRA gate.** `validate_job_lora_compatibility_with` runs at both create boundaries and at neither retry/duplicate one, and `loras` is a **top-level** key the shallow merge replaces wholesale. A retry could swap a validated adapter set for a wrong-family, uninstalled, or entirely unknown one. Mirrored in both branches, in create's order, so the imported gate still sees the server-owned row and the normalized adapter list.

## Character inline-LoRA provenance

Mirroring the LoRA gate with a hard-coded `allow_inline_loras = false` **broke character test jobs**: `characters.rs` creates `image_generate` jobs with inline LoRAs allowed, and a character's adapters are inline links — `character_store::attach_lora` mints `id: "character_lora_<hex>"` with `category: "character"` and a `sourcePath`/`projectPath`, copies the file into the project, and registers it in **no** LoRA catalog. Re-validating that set as catalog-backed refused it with `LoRA not found`, breaking even a retry with empty `payloadChanges`. Confirmed against a real route-created job, not by inspection.

Permission is derived from the original job's provenance, read from the persisted payload **before** the merge.

**Why the link shape and not the `characterId` / `mode` markers.** Both look server-stamped but are caller-settable — `ImageJobRequest` exposes `character_id` and `mode` — so `POST /api/v1/image/jobs { mode: "character_image", characterId: "…", loras: [] }` is an ordinary image job that create happily admits (the LoRA gate no-ops on an empty set) while wearing both. A marker-derived permission would let its retry attach an arbitrary path-bearing adapter as "inline". The link shape cannot be forged that way, because it can only have been *persisted* by a boundary that already allowed inline LoRAs: create validates with `false`, `POST /api/v1/jobs` refuses image/video job types outright (`typed_generation_route`), and retry/duplicate is where the decision is being made.

**Applied hardening (review cycle 3).** The permit is **per-adapter**, not a blanket flag: adapters matching a persisted link are hydrated inline, everything else — including any addition to a genuine character job's set — must be catalog-backed. Identity is the link id **and** agreement on every path field the candidate carries, because `normalize_inline_job_lora` passes a caller's object through almost verbatim, so an id-only match would let a replayed id with a swapped `sourcePath` carry an arbitrary file into the enqueued payload. Splitting the array is verdict-preserving: `validate_lora_specs_for_model` decides each adapter independently.

## Documented, not unified

`models.rs`'s three bare `cfg!(target_os = "macos")` sites are deliberately **not** routed through `enqueue_backend`, and the reasoning is recorded on `enqueue_backend` itself with pointers at each site. They answer a different question — which engines this **build** links — where `enqueue_backend` answers which single backend this **instance** routes to. Unifying them would collapse a lane *pair* that is consulted asymmetrically (a withdrawal crosses lanes, a positive advertisement never does) into a one-hot routing answer, breaking the invariant `apply_imported_lora_advertisement` documents from the recent sc-18480 work; publish positive candle verdicts from a macOS build that links no candle engine; and at the `mlx_catalog_status` site **hide `mlxTiers`** and its per-tier state from the Studio for tier dirs genuinely on disk. The residual skew is real but unshipped — the desktop sets `SCENEWORKS_CANDLE_REQUIRED` only under `cfg(not(target_os = "macos"))` and `Settings::candle_required` is documented "Absent on macOS" — and the note records that closing it properly means making the advertisement lane pair a runtime *deployment* fact, not re-pointing it here.

## Adversarial review history

Three rounds, ending **PASS**.

| Round | Verdict | Outcome |
| --- | --- | --- |
| 1 | CHANGES_REQUIRED | Two majors + video sibling verified fixed; LoRA-gate sibling and two minors raised |
| 2 | CHANGES_REQUIRED | LoRA mirror verified; the regression it introduced for character jobs caught |
| 3 | PASS | Provenance argument survived the forgery hunt; marker rebuttal endorsed; per-adapter hardening applied here |

## Tests

Nine tests at the retry/duplicate boundary plus two unit tests. Every guard was **mutation-verified individually** — reverted one at a time, with the matching test failing on 201-vs-400 and no cross-coverage:

- decoder-gate backend derivation (create path, both directions)
- retry/duplicate decoder gate, image and video
- retry/duplicate imported-submission gate
- retry/duplicate LoRA gate, image and video
- character provenance: hard-coded `false`, provenance read post-merge, and marker-only provenance — the last two both let a forged adapter's `sourcePath` reach the queue
- the hardening: blanket inline flag, and id-only matching without path agreement

Each retry test asserts the **create path's own refusal text** on the identical payload, that no job was persisted, and that the boundary still admits what create admits — so none is a one-directional "everything is refused" test.

## Verification

`npm run rust:check` green (918-test core suite, 599-test rust-api suite). `npm run rust:check:neither` and `npm run rust:check:candle` clean under `-D warnings`, so both Linux configurations a macOS host cannot otherwise see are covered. `config/backend-capabilities/matrix.json` regenerated — `generation.rs`/`jobs.rs` are its `apiGeneration`/`apiValidation` fingerprints; only those two source hashes moved, every cell, summary count and characterization byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
