### PR TITLE
feat(sc-20216): preserve phase-tagged failure evidence

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -134,6 +134,19 @@ const LTX_Q4_F305_CRASH_FOOTPRINT_BYTES: u64 = 96_970_084_480;
 const LTX_CANARY_MAX_FOOTPRINT_BYTES: u64 = 53_347_146_863;
 const LTX_CANARY_MAX_RUNTIME_SECONDS: f64 = 1_800.0;
 const LTX_CANARY_WATCHDOG_PROTOCOL: &str = "sceneworks-memory-watchdog-v1";
+const LTX_PROVIDER_PHASE_PROTOCOL: &str = "sceneworks-provider-phase-v1";
+const LTX_PROVIDER_PHASE_NAMES: [&str; 10] = [
+    "common_load",
+    "primary_conditioning",
+    "primary_denoise",
+    "primary_decode",
+    "lifecycle_warm_repeat",
+    "lifecycle_cancel",
+    "lifecycle_cancel_recovery",
+    "lifecycle_error",
+    "lifecycle_error_recovery",
+    "cleanup",
+];
 const LTX_CANARY_WIDTH: u32 = 256;
 const LTX_CANARY_HEIGHT: u32 = 256;
 const LTX_CANARY_FRAMES: u32 = 9;
@@ -6579,6 +6592,14 @@ struct LtxLifecycleMetrics {
     max_recovery_post_cleanup: AllocatorState,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct LtxLifecycleInput {
+    geometry: LtxGeometry,
+    fps: u32,
+    seed: u64,
+    fault_phase: MemoryPhase,
+}
+
 /// Execute the provider-owned warm/cancel/error request scope on the exact selected rung. One
 /// cancellation and one injected error target the rung's binding phase, and each is followed by a
 /// deterministic recovery render plus allocator bounds against a clean warm control.
@@ -6586,13 +6607,18 @@ fn verify_ltx_lifecycle(
     generator: &dyn Generator,
     context: &MemoryRunContext,
     selected: &[Image],
-    geometry: LtxGeometry,
-    fps: u32,
-    seed: u64,
-    fault_phase: MemoryPhase,
+    input: LtxLifecycleInput,
+    phase_sink: &mut dyn LtxCampaignPhaseSink,
 ) -> Result<LtxLifecycleMetrics, String> {
+    let LtxLifecycleInput {
+        geometry,
+        fps,
+        seed,
+        fault_phase,
+    } = input;
     clear_cache();
     reset_peak_memory();
+    phase_sink.mark("lifecycle_warm_repeat")?;
     let (clean_warm, _, _) = video_frames(scoped_generate(
         generator,
         ltx_request(geometry, fps, seed),
@@ -6618,6 +6644,7 @@ fn verify_ltx_lifecycle(
         rms_error,
         ..Default::default()
     };
+    phase_sink.mark("lifecycle_cancel")?;
     let cancelled = ltx_request(geometry, fps, seed);
     let cancel_signal = cancelled.cancel.clone();
     let mut cancel_triggered = false;
@@ -6663,6 +6690,7 @@ fn verify_ltx_lifecycle(
         ));
     }
     reset_peak_memory();
+    phase_sink.mark("lifecycle_cancel_recovery")?;
     let (cancel_recovery, _, _) = video_frames(scoped_generate(
         generator,
         ltx_request(geometry, fps, seed),
@@ -6691,6 +6719,7 @@ fn verify_ltx_lifecycle(
         return Err("LTX-2.3 cancellation cleanup changed the warm recovery clip".to_owned());
     }
 
+    phase_sink.mark("lifecycle_error")?;
     let mut injected_failure = None;
     let injected_result = scoped_generate_observed(
         generator,
@@ -6732,6 +6761,7 @@ fn verify_ltx_lifecycle(
         ));
     }
     reset_peak_memory();
+    phase_sink.mark("lifecycle_error_recovery")?;
     let (error_recovery, _, _) = video_frames(scoped_generate(
         generator,
         ltx_request(geometry, fps, seed),
@@ -6965,7 +6995,21 @@ struct LtxCanaryWatchdogAttestation {
 struct LtxCanaryWatchdogLease {
     writer: UnixStream,
     completion: std::sync::mpsc::Receiver<Result<(), String>>,
+    phase_acknowledgements: std::sync::mpsc::Receiver<Result<(usize, String), String>>,
     nonce: String,
+    phase_sequence: usize,
+}
+
+trait LtxCampaignPhaseSink {
+    fn mark(&mut self, name: &'static str) -> Result<(), String>;
+}
+
+struct NoLtxCampaignPhases;
+
+impl LtxCampaignPhaseSink for NoLtxCampaignPhases {
+    fn mark(&mut self, _name: &'static str) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 impl LtxCanaryWatchdogAttestation {
@@ -6982,10 +7026,33 @@ impl LtxCanaryWatchdogAttestation {
             .map_err(|error| format!("configure LTX watchdog lease reader: {error}"))?;
         let expected = self.nonce.clone();
         let (sender, completion) = std::sync::mpsc::sync_channel(1);
+        let (phase_sender, phase_acknowledgements) = std::sync::mpsc::sync_channel(1);
         std::thread::spawn(move || {
             let result = loop {
                 match read_watchdog_line(&mut reader) {
                     Ok(line) if line == format!("PING {expected}") => continue,
+                    Ok(line) if line.starts_with(&format!("PHASE_ACK {expected} ")) => {
+                        let fields = line.split_whitespace().collect::<Vec<_>>();
+                        let acknowledgement = if fields.len() == 4 {
+                            fields[2]
+                                .parse::<usize>()
+                                .map(|sequence| (sequence, fields[3].to_owned()))
+                                .map_err(|_| {
+                                    "SC-20216 watchdog returned a malformed phase acknowledgement"
+                                        .to_owned()
+                                })
+                        } else {
+                            Err(
+                                "SC-20216 watchdog returned a malformed phase acknowledgement"
+                                    .to_owned(),
+                            )
+                        };
+                        if phase_sender.send(acknowledgement).is_err() {
+                            break Err(
+                                "SC-20216 phase acknowledgement receiver disappeared".to_owned()
+                            );
+                        }
+                    }
                     Ok(line) if line == format!("BYE {expected}") => break Ok(()),
                     Ok(_) => {
                         break Err(
@@ -7006,13 +7073,22 @@ impl LtxCanaryWatchdogAttestation {
         Ok(LtxCanaryWatchdogLease {
             writer: stream,
             completion,
+            phase_acknowledgements,
             nonce: self.nonce.clone(),
+            phase_sequence: 0,
         })
     }
 }
 
 impl LtxCanaryWatchdogLease {
     fn complete(mut self) -> Result<(), String> {
+        if self.phase_sequence != 0 && self.phase_sequence != LTX_PROVIDER_PHASE_NAMES.len() {
+            return Err(format!(
+                "SC-20216 provider phase sequence completed at {} of {}",
+                self.phase_sequence,
+                LTX_PROVIDER_PHASE_NAMES.len()
+            ));
+        }
         self.writer
             .write_all(format!("DONE {}\n", self.nonce).as_bytes())
             .map_err(|error| format!("complete LTX canary watchdog lease: {error}"))?;
@@ -7021,6 +7097,51 @@ impl LtxCanaryWatchdogLease {
             .map_err(|error| {
                 format!("wait for LTX canary watchdog completion release: {error}")
             })??;
+        Ok(())
+    }
+}
+
+fn wait_for_ltx_phase_acknowledgement(
+    acknowledgements: &std::sync::mpsc::Receiver<Result<(usize, String), String>>,
+    sequence: usize,
+    name: &str,
+    timeout: Duration,
+) -> Result<(), String> {
+    let acknowledged = acknowledgements.recv_timeout(timeout).map_err(|error| {
+        format!("wait for SC-20216 provider phase {name} acknowledgement: {error}")
+    })??;
+    if acknowledged != (sequence, name.to_owned()) {
+        return Err(format!(
+            "SC-20216 watchdog acknowledged a foreign provider phase: expected {sequence} {name}, got {} {}",
+            acknowledged.0, acknowledged.1
+        ));
+    }
+    Ok(())
+}
+
+impl LtxCampaignPhaseSink for LtxCanaryWatchdogLease {
+    fn mark(&mut self, name: &'static str) -> Result<(), String> {
+        let expected = LTX_PROVIDER_PHASE_NAMES
+            .get(self.phase_sequence)
+            .ok_or_else(|| {
+                "SC-20216 provider phase sequence exceeded its exact bound".to_owned()
+            })?;
+        if name != *expected {
+            return Err(format!(
+                "SC-20216 provider phase reordered: expected {expected}, got {name}"
+            ));
+        }
+        let sequence = self.phase_sequence + 1;
+        self.writer
+            .write_all(format!("PHASE {} {sequence} {name}\n", self.nonce).as_bytes())
+            .map_err(|error| format!("report SC-20216 provider phase {name}: {error}"))?;
+        wait_for_ltx_phase_acknowledgement(
+            &self.phase_acknowledgements,
+            sequence,
+            name,
+            Duration::from_secs(2),
+        )?;
+        self.phase_sequence = sequence;
         Ok(())
     }
 }
@@ -7070,6 +7191,24 @@ fn consume_ltx_canary_watchdog_attestation_stream(
         .map_err(|error| format!("parse LTX canary watchdog attestation: {error}"))?;
     if payload.get("protocol").and_then(Value::as_str) != Some(LTX_CANARY_WATCHDOG_PROTOCOL) {
         return Err("LTX safety canary watchdog protocol changed".to_owned());
+    }
+    let requires_provider_phases =
+        request.get("action").and_then(Value::as_str) == Some(LTX_CAMPAIGN_ENTRY_ACTION);
+    let provider_phase_protocol = payload.get("providerPhaseProtocol").and_then(Value::as_str);
+    let provider_phase_names = payload.get("providerPhases");
+    if requires_provider_phases {
+        if provider_phase_protocol != Some(LTX_PROVIDER_PHASE_PROTOCOL)
+            || provider_phase_names != Some(&json!(LTX_PROVIDER_PHASE_NAMES))
+        {
+            return Err(
+                "SC-20216 watchdog omitted the exact authenticated provider phase protocol"
+                    .to_owned(),
+            );
+        }
+    } else if provider_phase_protocol.is_some() || provider_phase_names.is_some() {
+        return Err(
+            "provider phase telemetry is restricted to the exact campaign-entry action".to_owned(),
+        );
     }
     let nonce = payload
         .get("nonce")
@@ -7418,7 +7557,11 @@ enum LtxRunAdmission {
     CampaignEntry,
 }
 
-fn run_ltx_with_admission(request: &Value, admission: LtxRunAdmission) -> Result<Value, String> {
+fn run_ltx_with_admission(
+    request: &Value,
+    admission: LtxRunAdmission,
+    phase_sink: &mut dyn LtxCampaignPhaseSink,
+) -> Result<Value, String> {
     let geometry = validate_ltx_target(request)?;
     protocol::validate_plain_overlay_target(request, LTX_PLAIN_EXECUTION_PATH)?;
     let load_shape = planned_load_shape(request)?;
@@ -7567,6 +7710,7 @@ fn run_ltx_with_admission(request: &Value, admission: LtxRunAdmission) -> Result
     reset_peak_memory();
     let pre_rung_active = get_active_memory() as u64;
     let pre_rung_cache = get_cache_memory() as u64;
+    phase_sink.mark("primary_conditioning")?;
     let (measured, output_fps, audio) = diagnostic_video_frames(scoped_generate(
         generator.as_ref(),
         ltx_request(geometry, fps, seed),
@@ -7578,11 +7722,19 @@ fn run_ltx_with_admission(request: &Value, admission: LtxRunAdmission) -> Result
                 // phase legitimately spans BOTH giants' materializations; the staging bound below
                 // is what proves they did not co-reside.
                 Progress::Step { current: 1, .. } => {
+                    if let Err(error) = phase_sink.mark("primary_denoise") {
+                        eprintln!("{error}");
+                        std::process::abort();
+                    }
                     conditioning.set(PhaseMemory::capture());
                     denoise_entry.set(AllocatorState::capture_current());
                     reset_peak_memory();
                 }
                 Progress::Decoding => {
+                    if let Err(error) = phase_sink.mark("primary_decode") {
+                        eprintln!("{error}");
+                        std::process::abort();
+                    }
                     denoise.set(PhaseMemory::capture());
                     decode_entry.set(AllocatorState::capture_current());
                     reset_peak_memory();
@@ -7660,10 +7812,13 @@ fn run_ltx_with_admission(request: &Value, admission: LtxRunAdmission) -> Result
         generator.as_ref(),
         &context,
         &measured,
-        geometry,
-        fps,
-        seed,
-        decode_plan.lifecycle_fault_phase(),
+        LtxLifecycleInput {
+            geometry,
+            fps,
+            seed,
+            fault_phase: decode_plan.lifecycle_fault_phase(),
+        },
+        phase_sink,
     )?;
     let maximum_error = lifecycle.maximum_error;
     let mean_error = lifecycle.mean_error;
@@ -7884,14 +8039,17 @@ fn run_ltx_campaign_entry(request: &Value) -> Result<Value, String> {
     // model-path resolution and provider registry construction.
     prevalidate_ltx_campaign_entry(request)?;
     let mut watchdog = consume_ltx_canary_watchdog_attestation(request)?;
-    let watchdog_lease = watchdog.start_lease()?;
+    let mut watchdog_lease = watchdog.start_lease()?;
+    watchdog_lease.mark("common_load")?;
     let limits = LtxCanaryLimits::install()?;
     clear_cache();
     let pre_provider = AllocatorState::capture_current();
     validate_ltx_canary_pre_provider(pre_provider)?;
     let expected_persistent_active = ltx_canary_ones_cache_bytes()?;
-    let mut fragment = run_ltx_with_admission(request, LtxRunAdmission::CampaignEntry)?;
+    let mut fragment =
+        run_ltx_with_admission(request, LtxRunAdmission::CampaignEntry, &mut watchdog_lease)?;
     validate_ltx_campaign_entry_fragment(&fragment)?;
+    watchdog_lease.mark("cleanup")?;
     clear_cache();
     let post_cleanup = AllocatorState::capture_current();
     validate_ltx_canary_cleanup(pre_provider, post_cleanup, expected_persistent_active)?;
@@ -7931,7 +8089,8 @@ fn run_ltx_campaign_entry(request: &Value) -> Result<Value, String> {
 }
 
 fn run_ltx(request: &Value) -> Result<Value, String> {
-    run_ltx_with_admission(request, LtxRunAdmission::Ordinary)
+    let mut phases = NoLtxCampaignPhases;
+    run_ltx_with_admission(request, LtxRunAdmission::Ordinary, &mut phases)
 }
 
 fn run(request: &Value) -> Result<Value, String> {
@@ -9262,6 +9421,128 @@ mod ltx_tests {
             direct.contains("live external watchdog channel"),
             "{direct}"
         );
+    }
+
+    #[test]
+    fn sc_20216_phase_channel_is_exact_monotonic_and_campaign_only() {
+        let request = ltx_campaign_entry_request_json();
+        let host_memory = request["hardware"]["memoryBytes"].as_u64().unwrap();
+        let nonce = "cd".repeat(32);
+        let base = json!({
+            "protocol": LTX_CANARY_WATCHDOG_PROTOCOL,
+            "nonce": nonce,
+            "maxFootprintBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES,
+            "maxRuntimeSeconds": LTX_CANARY_MAX_RUNTIME_SECONDS,
+            "hostMemoryBytes": host_memory,
+            "minInitialMemoryFreeBytes": 2 * LTX_CANARY_MAX_FOOTPRINT_BYTES + host_memory.div_ceil(100),
+            "minMemoryFreeBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES + host_memory.div_ceil(100),
+        });
+        let (mut missing_watchdog, missing_adapter) = UnixStream::pair().unwrap();
+        let missing_thread = std::thread::spawn(move || {
+            missing_watchdog
+                .write_all(format!("{base}\n").as_bytes())
+                .unwrap();
+        });
+        let error = consume_ltx_canary_watchdog_attestation_stream(&request, missing_adapter)
+            .expect_err("campaign entry must require authenticated phases");
+        missing_thread.join().unwrap();
+        assert!(error.contains("authenticated provider phase protocol"));
+
+        let (adapter, mut watchdog) = UnixStream::pair().unwrap();
+        let mut attestation = LtxCanaryWatchdogAttestation {
+            max_footprint_bytes: LTX_CANARY_MAX_FOOTPRINT_BYTES,
+            max_runtime_seconds: LTX_CANARY_MAX_RUNTIME_SECONDS,
+            host_memory_bytes: host_memory,
+            min_initial_memory_free_bytes: 0,
+            min_memory_free_bytes: 0,
+            nonce: nonce.clone(),
+            stream: Some(adapter),
+        };
+        let lease = attestation.start_lease().unwrap();
+        let (marked_sender, marked_receiver) = std::sync::mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let mut lease = lease;
+            let result = lease.mark("common_load");
+            marked_sender.send((lease, result)).unwrap();
+        });
+        assert_eq!(
+            read_watchdog_line(&mut watchdog).unwrap(),
+            format!("PHASE {nonce} 1 common_load")
+        );
+        assert!(matches!(
+            marked_receiver.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ));
+        watchdog
+            .write_all(format!("PHASE_ACK {nonce} 1 common_load\n").as_bytes())
+            .unwrap();
+        let (mut lease, result) = marked_receiver.recv().unwrap();
+        result.expect("phase entry remains blocked until the watchdog acknowledges it");
+
+        let remaining_nonce = nonce.clone();
+        let peer = std::thread::spawn(move || {
+            for (index, name) in LTX_PROVIDER_PHASE_NAMES.iter().enumerate().skip(1) {
+                assert_eq!(
+                    read_watchdog_line(&mut watchdog).unwrap(),
+                    format!("PHASE {remaining_nonce} {} {name}", index + 1)
+                );
+                watchdog
+                    .write_all(
+                        format!("PHASE_ACK {remaining_nonce} {} {name}\n", index + 1).as_bytes(),
+                    )
+                    .unwrap();
+            }
+            assert_eq!(
+                read_watchdog_line(&mut watchdog).unwrap(),
+                format!("DONE {remaining_nonce}")
+            );
+            watchdog
+                .write_all(format!("BYE {remaining_nonce}\n").as_bytes())
+                .unwrap();
+        });
+        for name in LTX_PROVIDER_PHASE_NAMES.iter().skip(1) {
+            lease.mark(name).expect("exact next phase");
+        }
+        assert!(lease.mark("cleanup").unwrap_err().contains("exceeded"));
+        lease.complete().unwrap();
+        peer.join().unwrap();
+
+        let (_timeout_sender, timeout_receiver) = std::sync::mpsc::sync_channel(1);
+        assert!(wait_for_ltx_phase_acknowledgement(
+            &timeout_receiver,
+            1,
+            "common_load",
+            Duration::ZERO,
+        )
+        .unwrap_err()
+        .contains("acknowledgement"));
+        let (foreign_sender, foreign_receiver) = std::sync::mpsc::sync_channel(1);
+        foreign_sender
+            .send(Ok((2, "primary_conditioning".to_owned())))
+            .unwrap();
+        assert!(wait_for_ltx_phase_acknowledgement(
+            &foreign_receiver,
+            1,
+            "common_load",
+            Duration::ZERO,
+        )
+        .unwrap_err()
+        .contains("foreign provider phase"));
+
+        let (writer, _reader) = UnixStream::pair().unwrap();
+        let (_sender, completion) = std::sync::mpsc::sync_channel(1);
+        let (_phase_sender, phase_acknowledgements) = std::sync::mpsc::sync_channel(1);
+        let mut reordered = LtxCanaryWatchdogLease {
+            writer,
+            completion,
+            phase_acknowledgements,
+            nonce,
+            phase_sequence: 0,
+        };
+        assert!(reordered
+            .mark("primary_decode")
+            .unwrap_err()
+            .contains("reordered"));
     }
 
     #[test]

--- a/scripts/memory-calibration-watchdog.py
+++ b/scripts/memory-calibration-watchdog.py
@@ -9,6 +9,7 @@ available only behind an explicit test-only flag.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import secrets
@@ -22,6 +23,19 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 HARD_STOP_EXIT = 97
+PROVIDER_PHASE_PROTOCOL = "sceneworks-provider-phase-v1"
+PROVIDER_PHASES = (
+    "common_load",
+    "primary_conditioning",
+    "primary_denoise",
+    "primary_decode",
+    "lifecycle_warm_repeat",
+    "lifecycle_cancel",
+    "lifecycle_cancel_recovery",
+    "lifecycle_error",
+    "lifecycle_error_recovery",
+    "cleanup",
+)
 
 
 @dataclass(frozen=True)
@@ -415,15 +429,42 @@ class OwnedGroup:
             raise RuntimeError(f"owned process group retained live identities: {survivors}")
 
 
-def emit(event_file: Path | None, event: dict[str, object]) -> None:
-    line = json.dumps({"at": time.time(), **event}, separators=(",", ":"))
-    if event_file:
-        with event_file.open("a") as output:
-            output.write(f"{line}\n")
-            output.flush()
-            os.fsync(output.fileno())
-    else:
-        print(line, file=sys.stderr, flush=True)
+class EventChain:
+    """Append-only event evidence with deletion/reorder/mutation detection."""
+
+    def __init__(self, event_file: Path | None):
+        self.event_file = event_file
+        self.sequence = 0
+        self.previous_hash = "0" * 64
+
+    def emit(self, event: dict[str, object]) -> None:
+        self.sequence += 1
+        payload = {
+            "eventSequence": self.sequence,
+            "previousEventHash": self.previous_hash,
+            "at": time.time(),
+            **event,
+        }
+        event_hash = hashlib.sha256(json.dumps(
+            payload, ensure_ascii=False, separators=(",", ":"), sort_keys=True,
+        ).encode()).hexdigest()
+        line = json.dumps({**payload, "eventHash": event_hash}, separators=(",", ":"))
+        self.previous_hash = event_hash
+        if self.event_file:
+            with self.event_file.open("a") as output:
+                output.write(f"{line}\n")
+                output.flush()
+                os.fsync(output.fileno())
+        else:
+            print(line, file=sys.stderr, flush=True)
+
+
+def identity_json(identity: Identity) -> dict[str, object]:
+    return {
+        "pid": identity.pid,
+        "pgid": identity.pgid,
+        "started": identity.started,
+    }
 
 
 class MonitorSignal(Exception):
@@ -467,6 +508,7 @@ def observe_group(
 
 
 def guard(args: argparse.Namespace) -> int:
+    events = EventChain(args.event_file)
     attested_initial_memory_free_bytes = None
     if args.require_child_attestation:
         actual_host_memory = DarwinHostPressureSampler.actual_host_memory_bytes(
@@ -561,6 +603,77 @@ def guard(args: argparse.Namespace) -> int:
     attestation_nonce = None
     attestation_buffer = bytearray()
     child_reported_done = False
+    completion_released = False
+    provider_phase: dict[str, object] | None = None
+    provider_phase_sequence = 0
+
+    def process_attestation_lines() -> str | None:
+        nonlocal attestation_buffer, child_reported_done
+        nonlocal provider_phase, provider_phase_sequence
+        while b"\n" in attestation_buffer:
+            line, remainder = bytes(attestation_buffer).split(b"\n", 1)
+            attestation_buffer = bytearray(remainder)
+            try:
+                decoded = line.decode()
+            except UnicodeDecodeError:
+                return "child_returned_non_utf8_attestation"
+            fields = decoded.split()
+            if fields[:1] == ["PHASE"]:
+                if child_reported_done:
+                    return "child_returned_provider_phase_after_completion"
+                if not args.require_provider_phases or len(fields) != 4:
+                    return "child_returned_invalid_provider_phase"
+                if fields[1] != attestation_nonce:
+                    return "child_returned_foreign_provider_phase_nonce"
+                try:
+                    sequence = int(fields[2])
+                except ValueError:
+                    return "child_returned_non_integer_provider_phase_sequence"
+                expected_sequence = provider_phase_sequence + 1
+                if sequence != expected_sequence or sequence > len(PROVIDER_PHASES):
+                    return (
+                        "child_returned_reordered_provider_phase:"
+                        f"expected_{expected_sequence}:observed_{sequence}"
+                    )
+                expected_name = PROVIDER_PHASES[sequence - 1]
+                if fields[3] != expected_name:
+                    return (
+                        "child_returned_invalid_provider_phase_name:"
+                        f"expected_{expected_name}:observed_{fields[3]}"
+                    )
+                provider_phase_sequence = sequence
+                provider_phase = {"sequence": sequence, "name": expected_name}
+                events.emit({
+                    "event": "provider_phase",
+                    "providerPhase": provider_phase,
+                    "authenticated": True,
+                })
+                try:
+                    assert attestation_stream is not None
+                    attestation_stream.setblocking(True)
+                    attestation_stream.settimeout(args.telemetry_timeout)
+                    attestation_stream.sendall(
+                        f"PHASE_ACK {attestation_nonce} {sequence} {expected_name}\n".encode())
+                except (OSError, TimeoutError) as error:
+                    return f"provider_phase_ack_failed:{type(error).__name__}:{error}"
+                finally:
+                    if attestation_stream is not None:
+                        attestation_stream.setblocking(False)
+                continue
+            if fields == ["DONE", str(attestation_nonce)]:
+                if child_reported_done:
+                    return "child_returned_duplicate_completion_attestation"
+                if args.require_provider_phases and provider_phase_sequence != len(PROVIDER_PHASES):
+                    return (
+                        "child_completed_before_provider_phase_sequence:"
+                        f"observed_{provider_phase_sequence}"
+                    )
+                child_reported_done = True
+                continue
+            return "child_returned_invalid_completion_attestation"
+        if len(attestation_buffer) > 4096:
+            return "child_attestation_message_exceeded_size_bound"
+        return None
 
     def check_observation(footprint: int, pressure: HostPressure | None) -> str | None:
         if footprint >= args.max_footprint_bytes:
@@ -599,6 +712,7 @@ def guard(args: argparse.Namespace) -> int:
     def emit_sample(footprint: int, pressure: HostPressure | None, phase: str) -> None:
         event: dict[str, object] = {
             "event": "sample", "phase": phase, "physicalFootprintBytes": footprint,
+            "providerPhase": provider_phase,
         }
         if pressure is not None:
             event.update({
@@ -606,7 +720,7 @@ def guard(args: argparse.Namespace) -> int:
                 "memoryFreeBytes": pressure.memory_free_bytes,
                 "swapFreeBytes": pressure.swap_free_bytes,
             })
-        emit(args.event_file, event)
+        events.emit(event)
 
     def bounded_telemetry_timeout() -> float:
         if runtime_deadline is None:
@@ -620,7 +734,12 @@ def guard(args: argparse.Namespace) -> int:
         # A signal pending from the blocked launch window is delivered here, inside the cleanup
         # try, never in the gap between establishing the group and arming cleanup.
         signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
-        emit(args.event_file, {"event": "started", "pid": group.child.pid, "pgid": group.pgid})
+        events.emit({
+            "event": "started", "pid": group.child.pid, "pgid": group.pgid,
+            "providerPhase": provider_phase,
+            "processIdentities": [identity_json(item) for item in sorted(
+                group.retained, key=lambda item: item.pid)],
+        })
         try:
             _, footprint, pressure, _ = observe_group(
                 group, sampler, host_sampler, args.telemetry_timeout,
@@ -651,6 +770,11 @@ def guard(args: argparse.Namespace) -> int:
                 "minInitialMemoryFreeBytes": attested_initial_memory_free_bytes,
                 "minMemoryFreeBytes": args.min_memory_free_bytes,
             }
+            if args.require_provider_phases:
+                attestation.update({
+                    "providerPhaseProtocol": PROVIDER_PHASE_PROTOCOL,
+                    "providerPhases": list(PROVIDER_PHASES),
+                })
             if args.min_swap_free_bytes is not None:
                 attestation["minSwapFreeBytes"] = args.min_swap_free_bytes
             try:
@@ -782,7 +906,9 @@ def guard(args: argparse.Namespace) -> int:
                     hard_stop, footprint, pressure = observe_startup()
                     if hard_stop is None:
                         emit_sample(footprint, pressure, "child_attested_before_allocation")
-                        emit(args.event_file, {"event": "child_attested"})
+                        events.emit({
+                            "event": "child_attested", "providerPhase": provider_phase,
+                        })
                         remaining = startup_deadline - time.monotonic()
                         if remaining <= 0:
                             hard_stop = startup_deadline_reason()
@@ -825,6 +951,36 @@ def guard(args: argparse.Namespace) -> int:
                     return status
                 hard_stop = f"launch_sentinel_failed_with_live_group:status_{status}"
                 break
+            if attestation_stream is not None and not child_reported_done:
+                try:
+                    while True:
+                        chunk = attestation_stream.recv(4096)
+                        if not chunk:
+                            hard_stop = "child_attestation_channel_lost_before_done"
+                            break
+                        attestation_buffer.extend(chunk)
+                        if len(chunk) < 4096:
+                            break
+                except BlockingIOError:
+                    pass
+                except ConnectionResetError:
+                    hard_stop = "child_attestation_channel_lost_before_done"
+                if hard_stop is None:
+                    hard_stop = process_attestation_lines()
+                if hard_stop is not None:
+                    break
+                if args.require_provider_phases and provider_phase is None:
+                    time.sleep(min(args.sample_interval, bounded_telemetry_timeout()))
+                    continue
+            if attestation_stream is not None and child_reported_done and not completion_released:
+                attestation_stream.setblocking(True)
+                attestation_stream.settimeout(args.telemetry_timeout)
+                attestation_stream.sendall(f"BYE {attestation_nonce}\n".encode())
+                completion_released = True
+                events.emit({
+                    "event": "child_completed", "providerPhase": provider_phase,
+                })
+                attestation_stream.setblocking(False)
             try:
                 _, footprint, pressure, _ = observe_group(
                     group, sampler, host_sampler, bounded_telemetry_timeout(),
@@ -859,29 +1015,32 @@ def guard(args: argparse.Namespace) -> int:
                     hard_stop = "child_attestation_channel_lost_before_done"
                     break
                 try:
-                    chunk = attestation_stream.recv(4096)
-                    if not chunk:
-                        hard_stop = "child_attestation_channel_lost_before_done"
-                        break
-                    attestation_buffer.extend(chunk)
+                    while True:
+                        chunk = attestation_stream.recv(4096)
+                        if not chunk:
+                            hard_stop = "child_attestation_channel_lost_before_done"
+                            break
+                        attestation_buffer.extend(chunk)
+                        if len(chunk) < 4096:
+                            break
                 except BlockingIOError:
                     pass
                 except ConnectionResetError:
                     hard_stop = "child_attestation_channel_lost_before_done"
                     break
-                if len(attestation_buffer) > 4096:
-                    hard_stop = "child_completion_attestation_exceeded_size_bound"
+                if hard_stop is None:
+                    hard_stop = process_attestation_lines()
+                if hard_stop is not None:
                     break
-                if b"\n" in attestation_buffer:
-                    line, remainder = bytes(attestation_buffer).split(b"\n", 1)
-                    if remainder or line.decode() != f"DONE {attestation_nonce}":
-                        hard_stop = "child_returned_invalid_completion_attestation"
-                        break
+                if child_reported_done and not completion_released:
                     attestation_stream.setblocking(True)
                     attestation_stream.settimeout(args.telemetry_timeout)
                     attestation_stream.sendall(f"BYE {attestation_nonce}\n".encode())
-                    child_reported_done = True
-                    emit(args.event_file, {"event": "child_completed"})
+                    completion_released = True
+                    events.emit({
+                        "event": "child_completed", "providerPhase": provider_phase,
+                    })
+                    attestation_stream.setblocking(False)
             sleep_seconds = args.sample_interval
             if runtime_deadline is not None:
                 sleep_seconds = min(sleep_seconds, max(0.0, runtime_deadline - time.monotonic()))
@@ -900,12 +1059,22 @@ def guard(args: argparse.Namespace) -> int:
     finally:
         if hard_stop is not None:
             try:
-                emit(args.event_file, {"event": "hard_stop", "reason": hard_stop})
+                events.emit({
+                    "event": "hard_stop", "reason": hard_stop,
+                    "providerPhase": provider_phase,
+                    "processIdentities": [identity_json(item) for item in sorted(
+                        group.retained, key=lambda item: item.pid)],
+                })
             except Exception:
                 pass
             group.terminate(args.term_grace)
             try:
-                emit(args.event_file, {"event": "terminated", "reason": hard_stop})
+                events.emit({
+                    "event": "terminated", "reason": hard_stop,
+                    "providerPhase": provider_phase,
+                    "processIdentities": [identity_json(item) for item in sorted(
+                        group.retained, key=lambda item: item.pid)],
+                })
             except Exception:
                 pass
         if attestation_stream is not None:
@@ -937,6 +1106,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--host-pressure-file", type=Path, help=argparse.SUPPRESS)
     parser.add_argument("--allow-synthetic-telemetry", action="store_true")
     parser.add_argument("--require-child-attestation", action="store_true")
+    parser.add_argument("--require-provider-phases", action="store_true")
     parser.add_argument("--synthetic-spawn-delay", type=float, default=0.0, help=argparse.SUPPRESS)
     parser.add_argument("--synthetic-launch-ready-file", type=Path, help=argparse.SUPPRESS)
     parser.add_argument("command", nargs=argparse.REMAINDER)
@@ -976,6 +1146,8 @@ def parse_args() -> argparse.Namespace:
             or args.synthetic_spawn_delay != 0
             or args.synthetic_launch_ready_file is not None):
         parser.error("child attestation requires production Darwin telemetry and launch controls")
+    if args.require_provider_phases and not args.require_child_attestation:
+        parser.error("provider phases require child attestation")
     return args
 
 

--- a/scripts/memory-calibration-watchdog.test.mjs
+++ b/scripts/memory-calibration-watchdog.test.mjs
@@ -7,6 +7,8 @@ import test from "node:test";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 
+import { validateWatchdogEventChain } from "./run-ltx-safety-canary.mjs";
+
 const execFileAsync = promisify(execFile);
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const WATCHDOG = path.join(ROOT, "scripts/memory-calibration-watchdog.py");
@@ -140,6 +142,7 @@ async function runWithMockedProductionTelemetry(files, childCommand, options = {
   const {
     telemetryTimeout = 0.5, actualHostMemory = 1000, requestedHostMemory = 1000,
     childAttestationTimeout = 1,
+    requireProviderPhases = false,
     memoryFreePercent = 90, memoryFreeBytes = 900, swapFreeBytes = 900,
     pressureSamples = [[memoryFreePercent, memoryFreeBytes, swapFreeBytes]],
     pressureFailureAt = null,
@@ -173,7 +176,8 @@ sys.argv = [${JSON.stringify(WATCHDOG)},
     "--telemetry-timeout", ${JSON.stringify(String(telemetryTimeout))},
     "--child-attestation-timeout", ${JSON.stringify(String(childAttestationTimeout))},
     "--term-grace", "0.1", "--event-file", ${JSON.stringify(files.events)},
-    "--require-child-attestation", "--", *${JSON.stringify(childCommand)}]
+    "--require-child-attestation", ${requireProviderPhases ? '"--require-provider-phases",' : ""}
+    "--", *${JSON.stringify(childCommand)}]
 raise SystemExit(module.guard(module.parse_args()))
 `);
   return execFileAsync("python3", [launcher], { timeout: 10_000, env: environment });
@@ -334,6 +338,96 @@ while True:
   assert.ok(events.some((event) => event.event === "child_completed"));
   assert.ok(events.some((event) => event.event === "sample" && event.swapFreeBytes === 0),
     "swap telemetry remains present without imposing an arbitrary free-capacity floor");
+});
+
+test("authenticated provider phases are exact, monotonic and bound to terminal evidence", async () => {
+  const files = await fixture();
+  const attester = `${files.program}.phases.py`;
+  const phases = [
+    "common_load", "primary_conditioning", "primary_denoise", "primary_decode",
+    "lifecycle_warm_repeat", "lifecycle_cancel", "lifecycle_cancel_recovery",
+    "lifecycle_error", "lifecycle_error_recovery", "cleanup",
+  ];
+  await writeFile(attester, String.raw`import json, os, socket
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect(os.environ["SCENEWORKS_MEMORY_WATCHDOG_SOCKET"])
+def line():
+    data = b""
+    while not data.endswith(b"\n"): data += sock.recv(1)
+    return data.decode().strip()
+payload = json.loads(line()); nonce = payload["nonce"]
+assert payload["providerPhaseProtocol"] == "sceneworks-provider-phase-v1"
+assert payload["providerPhases"] == ${JSON.stringify(phases)}
+sock.sendall(f"ACK {nonce}\n".encode()); assert line() == f"GO {nonce}"
+for sequence, name in enumerate(payload["providerPhases"], 1):
+    sock.sendall(f"PHASE {nonce} {sequence} {name}\n".encode())
+    while True:
+        acknowledgement = line()
+        if acknowledgement == f"PING {nonce}": continue
+        assert acknowledgement == f"PHASE_ACK {nonce} {sequence} {name}"
+        break
+sock.sendall(f"DONE {nonce}\n".encode())
+while True:
+    message = line()
+    if message == f"BYE {nonce}": break
+    assert message == f"PING {nonce}"
+`);
+  await runWithMockedProductionTelemetry(files, ["python3", attester], {
+    requireProviderPhases: true,
+  });
+  const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
+  const markers = events.filter((event) => event.event === "provider_phase");
+  assert.deepEqual(markers.map((event) => event.providerPhase.name), phases);
+  assert.ok(markers.every((event) => event.authenticated === true));
+  const completed = events.find((event) => event.event === "child_completed");
+  assert.deepEqual(completed.providerPhase, { sequence: 10, name: "cleanup" });
+  for (const event of events.filter((event) => event.event === "sample"
+      && event.providerPhase !== null)) {
+    const preceding = markers.filter((marker) => marker.at <= event.at).at(-1);
+    assert.deepEqual(event.providerPhase, preceding.providerPhase);
+  }
+  assert.deepEqual(events.map((event) => event.eventSequence),
+    events.map((_, index) => index + 1));
+  assert.equal(events[0].previousEventHash, "0".repeat(64));
+  for (let index = 1; index < events.length; index += 1) {
+    assert.equal(events[index].previousEventHash, events[index - 1].eventHash);
+  }
+  assert.ok(events.every((event) => /^[0-9a-f]{64}$/.test(event.eventHash)));
+  validateWatchdogEventChain(events);
+});
+
+test("reordered or foreign provider phases hard-stop the owned group", async () => {
+  for (const [statement, expectedReason] of [
+    ['sock.sendall(f"PHASE {nonce} 2 primary_conditioning\\n".encode())', /reordered_provider_phase/],
+    ['sock.sendall(b"PHASE foreign 1 common_load\\n")', /foreign_provider_phase_nonce/],
+  ]) {
+    const files = await fixture();
+    const attester = `${files.program}.bad-phase.py`;
+    await writeFile(attester, String.raw`import json, os, socket, time
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect(os.environ["SCENEWORKS_MEMORY_WATCHDOG_SOCKET"])
+def line():
+    data = b""
+    while not data.endswith(b"\n"): data += sock.recv(1)
+    return data.decode().strip()
+payload = json.loads(line()); nonce = payload["nonce"]
+sock.sendall(f"ACK {nonce}\n".encode()); assert line() == f"GO {nonce}"
+${statement}
+time.sleep(60)
+`);
+    let status = 0;
+    try {
+      await runWithMockedProductionTelemetry(files, ["python3", attester], {
+        requireProviderPhases: true,
+      });
+    } catch (error) {
+      status = error.code;
+    }
+    assert.equal(status, 97);
+    const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
+    assert.match(events.find((event) => event.event === "hard_stop").reason, expectedReason);
+    assert.equal(events.at(-1).event, "terminated");
+  }
 });
 
 test("child attestation uses a short socket path when TMPDIR is a long external path", async (t) => {

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -2018,7 +2018,10 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
     adapter.indexOf("fn run_ltx(request:"),
     adapter.indexOf("fn run(request:"),
   );
-  assert.match(ordinary, /run_ltx_with_admission\(request, LtxRunAdmission::Ordinary\)/);
+  assert.match(
+    ordinary,
+    /run_ltx_with_admission\(request, LtxRunAdmission::Ordinary, &mut phases\)/,
+  );
   assert.ok(campaign.indexOf("refuse_unsafe_ltx_capture(") >= 0);
   assert.ok(
     campaign.indexOf("refuse_unsafe_ltx_capture(") < campaign.indexOf("ltx_load_spec("),
@@ -2050,7 +2053,18 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
     "validate_ltx_canary_cleanup(",
     '"_campaignEntry"',
     "watchdog_lease.complete()?",
+    'watchdog_lease.mark("common_load")?',
+    'watchdog_lease.mark("cleanup")?',
   ]) assert.ok(campaignEntry.includes(required), `campaign entry must retain ${required}`);
+  for (const phase of [
+    "primary_conditioning", "primary_denoise", "primary_decode",
+  ]) assert.ok(campaign.includes(`phase_sink.mark("${phase}")`),
+    `campaign execution must report ${phase}`);
+  for (const phase of [
+    "lifecycle_warm_repeat", "lifecycle_cancel", "lifecycle_cancel_recovery",
+    "lifecycle_error", "lifecycle_error_recovery",
+  ]) assert.ok(adapter.includes(`phase_sink.mark("${phase}")`),
+    `campaign lifecycle must report ${phase}`);
   assert.ok(
     campaignEntry.indexOf("prevalidate_ltx_campaign_entry(request)?")
       < campaignEntry.indexOf("consume_ltx_canary_watchdog_attestation(request)?"),

--- a/scripts/run-ltx-safety-canary.mjs
+++ b/scripts/run-ltx-safety-canary.mjs
@@ -42,6 +42,21 @@ export const CAMPAIGN_ENTRY_FIXTURE =
   "ltx-2-3-mlx-q4-768x512-f121-fps30-seed18946";
 export const CAMPAIGN_ENTRY_LOGICAL_CASE_ID = "implan-9b107d4d1ca0d61d4faa";
 export const CAMPAIGN_ENTRY_IDENTITY = "sc-20191-q4-768x512-f121-fps30-staged-v1";
+export const CAMPAIGN_FAILURE_RECEIPT_TYPE = "sceneworks_campaign_entry_failure_v1";
+export const PROVIDER_PHASE_PROTOCOL = "sceneworks-provider-phase-v1";
+export const WATCHDOG_EVENT_CHAIN_PROTOCOL = "sceneworks-watchdog-event-chain-v1";
+export const PROVIDER_PHASES = Object.freeze([
+  "common_load",
+  "primary_conditioning",
+  "primary_denoise",
+  "primary_decode",
+  "lifecycle_warm_repeat",
+  "lifecycle_cancel",
+  "lifecycle_cancel_recovery",
+  "lifecycle_error",
+  "lifecycle_error_recovery",
+  "cleanup",
+]);
 const CAMPAIGN_ENTRY_ACTION = "campaign_entry";
 const CAMPAIGN_ENTRY_PLAN = "docs/calibration/sc-18946/ltx-mlx-single-pass-sweep.json";
 const CAMPAIGN_ENTRY_SAFETY = Object.freeze({
@@ -269,6 +284,15 @@ export function preservePrimaryFailure(primary, cleanup) {
   error.message += `; scratch cleanup failed: ${cleanupMessage
     .replaceAll(/[\u0000-\u001f\u007f]/g, " ").slice(0, 512)}`;
   if (error.cause === undefined) error.cause = cleanup;
+  return error;
+}
+
+export function preserveFailureReceiptSuppression(primary, receiptError) {
+  const error = primary instanceof Error ? primary : new Error(String(primary));
+  const detail = receiptError instanceof Error ? receiptError.message : String(receiptError);
+  error.message += `; SC-20216 failure receipt suppressed: ${detail
+    .replaceAll(/[\u0000-\u001f\u007f]/g, " ").slice(0, 512)}`;
+  if (error.cause === undefined) error.cause = receiptError;
   return error;
 }
 
@@ -681,7 +705,160 @@ export function validateCampaignEntryWatchdogEvents(events, hostMemoryBytes) {
       || events.some((event) => event.event === "hard_stop" || event.event === "terminated")) {
     fail("SC-20191 watchdog stream is incomplete or crossed a safety boundary");
   }
+  validateProviderPhaseTimeline(events, { complete: true });
   return Math.max(...samples.map((event) => event.physicalFootprintBytes));
+}
+
+function validProcessIdentities(value) {
+  return Array.isArray(value) && value.length > 0
+    && new Set(value.map((identity) => identity?.pid)).size === value.length
+    && value.every((identity) => Number.isSafeInteger(identity?.pid) && identity.pid > 0
+      && Number.isSafeInteger(identity?.pgid) && identity.pgid > 0
+      && typeof identity?.started === "string" && identity.started.length > 0);
+}
+
+function stableCompactJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableCompactJson).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) =>
+      `${JSON.stringify(key)}:${stableCompactJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function validateWatchdogEventChain(events) {
+  if (!Array.isArray(events) || events.length === 0) {
+    fail("SC-20216 watchdog event chain is empty");
+  }
+  let previous = "0".repeat(64);
+  for (const [index, event] of events.entries()) {
+    const { eventHash, ...payload } = event ?? {};
+    const expectedHash = createHash("sha256").update(stableCompactJson(payload)).digest("hex");
+    if (event?.eventSequence !== index + 1
+        || event?.previousEventHash !== previous
+        || eventHash !== expectedHash) {
+      fail("SC-20216 watchdog event chain is missing, mutated, duplicated, or reordered");
+    }
+    previous = eventHash;
+  }
+  return {
+    protocol: WATCHDOG_EVENT_CHAIN_PROTOCOL,
+    count: events.length,
+    head: previous,
+  };
+}
+
+export function validateProviderPhaseTimeline(events, { complete = false } = {}) {
+  validateWatchdogEventChain(events);
+  let current = null;
+  let sequence = 0;
+  let previousAt = -Infinity;
+  for (const event of events) {
+    if (typeof event?.at !== "number" || !Number.isFinite(event.at) || event.at < previousAt) {
+      fail("SC-20216 watchdog event timestamps are missing or reordered");
+    }
+    previousAt = event.at;
+    if (event.event === "provider_phase") {
+      const expectedSequence = sequence + 1;
+      const expectedName = PROVIDER_PHASES[sequence];
+      if (event.authenticated !== true
+          || event.providerPhase?.sequence !== expectedSequence
+          || event.providerPhase?.name !== expectedName) {
+        fail("SC-20216 provider phase telemetry is missing, stale, malformed, or reordered");
+      }
+      sequence = expectedSequence;
+      current = { sequence, name: expectedName };
+    } else if ([
+      "started", "sample", "child_attested", "child_completed", "hard_stop", "terminated",
+    ].includes(event.event) && (!Object.hasOwn(event, "providerPhase")
+      || !isDeepStrictEqual(event.providerPhase, current))) {
+      fail("SC-20216 watchdog event is not bound to the latest authenticated provider phase");
+    }
+  }
+  if (sequence === 0 || (complete && sequence !== PROVIDER_PHASES.length)) {
+    fail("SC-20216 watchdog stream omitted required authenticated provider phases");
+  }
+  return current;
+}
+
+export function validateCampaignEntryFailureEvents(events, hostMemoryBytes) {
+  if (!Array.isArray(events) || events.length === 0) fail("SC-20216 failure stream is empty");
+  validateProviderPhaseTimeline(events);
+  const eventChain = validateWatchdogEventChain(events);
+  const hardStops = events.filter((event) => event.event === "hard_stop");
+  const terminated = events.filter((event) => event.event === "terminated");
+  const started = events.filter((event) => event.event === "started");
+  const hardStopIndex = events.findIndex((event) => event.event === "hard_stop");
+  const terminatedIndex = events.findIndex((event) => event.event === "terminated");
+  const attestedIndex = events.findIndex((event) => event.event === "child_attested");
+  const allowedEvents = new Set([
+    "started", "sample", "child_attested", "provider_phase", "hard_stop", "terminated",
+  ]);
+  const samples = events.filter((event) => event.event === "sample");
+  if (started.length !== 1 || hardStops.length !== 1 || terminated.length !== 1
+      || events[0]?.event !== "started"
+      || hardStopIndex < 0 || terminatedIndex !== events.length - 1
+      || terminatedIndex !== hardStopIndex + 1
+      || events.filter((event) => event.event === "child_attested").length !== 1
+      || attestedIndex <= 0 || attestedIndex >= hardStopIndex
+      || events.some((event) => event.event === "child_completed")
+      || events.some((event) => !allowedEvents.has(event.event))
+      || !events.slice(0, attestedIndex).some((event) =>
+        event.event === "sample" && event.phase === "before_child_release")
+      || !events.slice(0, attestedIndex).some((event) =>
+        event.event === "sample" && event.phase === "child_attested_before_allocation")
+      || !events.slice(attestedIndex + 1, hardStopIndex).some((event) =>
+        event.event === "provider_phase")
+      || typeof hardStops[0].reason !== "string" || hardStops[0].reason.length === 0
+      || terminated[0].reason !== hardStops[0].reason
+      || !validProcessIdentities(started[0].processIdentities)
+      || !validProcessIdentities(hardStops[0].processIdentities)
+      || !validProcessIdentities(terminated[0].processIdentities)
+      || !isDeepStrictEqual(hardStops[0].processIdentities, terminated[0].processIdentities)
+      || started[0].processIdentities.every((identity) => identity.pid !== started[0].pid)
+      || [hardStops[0], terminated[0]].some((event) =>
+        started[0].processIdentities.some((startedIdentity) =>
+          !event.processIdentities.some((identity) => isDeepStrictEqual(identity, startedIdentity))))
+      || [started[0], hardStops[0], terminated[0]].some((event) =>
+        event.processIdentities.some((identity) => identity.pgid !== started[0].pgid))) {
+    fail("SC-20216 failure stream is incomplete or lacks exact process termination identity");
+  }
+  const runtimeFloor = runtimeFreeFloor(hostMemoryBytes);
+  if (samples.some((event) => !Number.isSafeInteger(event.physicalFootprintBytes)
+      || event.physicalFootprintBytes < 0
+      || !Number.isSafeInteger(event.memoryFreeBytes)
+      || event.memoryFreeBytes < 0
+      || !Number.isSafeInteger(event.swapFreeBytes)
+      || event.swapFreeBytes < 0)) {
+    fail("SC-20216 failure stream contains malformed watchdog telemetry");
+  }
+  const violating = events.findIndex((event) => event.event === "sample"
+    && (event.physicalFootprintBytes >= MAX_FOOTPRINT_BYTES
+      || event.memoryFreeBytes < runtimeFloor));
+  const thresholdReason = hardStops[0].reason.startsWith("physical_footprint_at_or_above_")
+    || hardStops[0].reason.startsWith("host_memory_free_below_");
+  if (violating >= 0) {
+    const sample = events[violating];
+    const expectedReason = sample.physicalFootprintBytes >= MAX_FOOTPRINT_BYTES
+      ? `physical_footprint_at_or_above_${MAX_FOOTPRINT_BYTES}:observed_${sample.physicalFootprintBytes}`
+      : `host_memory_free_below_${runtimeFloor}:observed_${sample.memoryFreeBytes}`;
+    if (violating !== hardStopIndex - 1 || hardStops[0].reason !== expectedReason
+        || events.slice(0, violating).some((event) => event.event === "sample"
+          && (event.physicalFootprintBytes >= MAX_FOOTPRINT_BYTES
+            || event.memoryFreeBytes < runtimeFloor))) {
+      fail("SC-20216 failure stream does not bind the first exact violating sample and reason");
+    }
+  } else if (thresholdReason) {
+    fail("SC-20216 threshold hard stop omitted its exact first violating sample");
+  }
+  return {
+    reason: hardStops[0].reason,
+    firstViolatingEventIndex: violating >= 0 ? violating : null,
+    firstViolatingSample: violating >= 0 ? structuredClone(events[violating]) : null,
+    terminalProviderPhase: structuredClone(hardStops[0].providerPhase),
+    started: structuredClone(started[0]),
+    eventChain,
+  };
 }
 
 export function campaignEntryCanonicalFragment(response, maxObservedFootprintBytes) {
@@ -792,6 +969,215 @@ export function validateCampaignEntryBundle(bundle) {
     fail("SC-20191 canonical bundle cleanup or footprint attestation changed");
   }
   return bundle;
+}
+
+export function campaignEntryFailurePath(canonicalOutput) {
+  return path.join(path.dirname(canonicalOutput), "sc-20216-campaign-entry-failure.json");
+}
+
+export function campaignEntryOutcomeReservationPath(canonicalOutput) {
+  return path.join(path.dirname(canonicalOutput), ".sc-20216-campaign-entry-outcome");
+}
+
+export function campaignEntryFailureReceipt({
+  sceneWorksRevision, sceneWorksTree, inferenceRevision, inferenceTree,
+  identity, preparationKey, preparationRoot, prepared, hostMemoryBytes, events, outcome,
+}) {
+  const failure = validateCampaignEntryFailureEvents(events, hostMemoryBytes);
+  const receipt = {
+    schemaVersion: 1,
+    recordType: CAMPAIGN_FAILURE_RECEIPT_TYPE,
+    status: "diagnostic_failure",
+    diagnosticOnly: true,
+    promotable: false,
+    ingestible: false,
+    canonicalBundlePublished: false,
+    outcome: structuredClone(outcome),
+    story: "sc-20216",
+    source: {
+      sceneWorks: { revision: sceneWorksRevision, tree: sceneWorksTree },
+      inference: { revision: inferenceRevision, tree: inferenceTree },
+    },
+    campaignCase: {
+      plan: CAMPAIGN_ENTRY_PLAN,
+      provider: CAMPAIGN_ENTRY_PROVIDER,
+      logicalCaseId: CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
+      fixture: CAMPAIGN_ENTRY_FIXTURE,
+      identity: CAMPAIGN_ENTRY_IDENTITY,
+      action: CAMPAIGN_ENTRY_ACTION,
+      target: {
+        provider: PROVIDER, tier: "q4",
+        geometry: { width: 768, height: 512, batch: 1, frames: 121, fps: 30 },
+      },
+      strategy: {
+        rung: "staged_residency", engagedRungs: ["resident", "staged_residency"], parameters: {},
+      },
+    },
+    artifacts: {
+      repository: ARTIFACT_REPOSITORY,
+      revision: ARTIFACT_REVISION,
+      numericTierInventory: structuredClone(identity.artifact.numericTier),
+      textEncoderInventory: structuredClone(identity.artifact.textEncoder),
+      adapter: structuredClone(prepared.adapter),
+      metallib: structuredClone(prepared.metallib),
+      preparation: {
+        key: preparationKey,
+        root: preparationRoot,
+        identity: structuredClone(identity),
+        manifest: structuredClone(prepared.manifest),
+      },
+    },
+    watchdog: {
+      protocol: "sceneworks-memory-watchdog-v1",
+      providerPhaseProtocol: PROVIDER_PHASE_PROTOCOL,
+      providerPhases: [...PROVIDER_PHASES],
+      maxFootprintBytes: MAX_FOOTPRINT_BYTES,
+      maxRuntimeSeconds: MAX_RUNTIME_SECONDS,
+      hostMemoryBytes,
+      minInitialMemoryFreeBytes: preflightFreeFloor(hostMemoryBytes),
+      minMemoryFreeBytes: runtimeFreeFloor(hostMemoryBytes),
+      failure,
+      eventChain: structuredClone(failure.eventChain),
+      events: structuredClone(events),
+    },
+    cleanup: {
+      ownedProcessGroupResidueVerified: true,
+      runScratchRemoved: true,
+      runRootEmpty: true,
+      sourceIdentityVerified: true,
+      runtimeAssetIdentityVerified: true,
+      preparedCacheVerified: true,
+      preparationTransientResidueVerified: true,
+    },
+  };
+  return validateCampaignEntryFailureReceipt(receipt);
+}
+
+export function validateCampaignEntryFailureReceipt(receipt) {
+  let canonicallyIngestible = true;
+  try {
+    validateBundle(receipt);
+  } catch {
+    canonicallyIngestible = false;
+  }
+  const expectedCampaignCase = {
+    plan: CAMPAIGN_ENTRY_PLAN,
+    provider: CAMPAIGN_ENTRY_PROVIDER,
+    logicalCaseId: CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
+    fixture: CAMPAIGN_ENTRY_FIXTURE,
+    identity: CAMPAIGN_ENTRY_IDENTITY,
+    action: CAMPAIGN_ENTRY_ACTION,
+    target: {
+      provider: PROVIDER, tier: "q4",
+      geometry: { width: 768, height: 512, batch: 1, frames: 121, fps: 30 },
+    },
+    strategy: {
+      rung: "staged_residency", engagedRungs: ["resident", "staged_residency"], parameters: {},
+    },
+  };
+  const expectedCleanup = {
+    ownedProcessGroupResidueVerified: true,
+    runScratchRemoved: true,
+    runRootEmpty: true,
+    sourceIdentityVerified: true,
+    runtimeAssetIdentityVerified: true,
+    preparedCacheVerified: true,
+    preparationTransientResidueVerified: true,
+  };
+  if (canonicallyIngestible
+      || receipt?.recordType !== CAMPAIGN_FAILURE_RECEIPT_TYPE
+      || receipt?.status !== "diagnostic_failure"
+      || receipt?.diagnosticOnly !== true
+      || receipt?.promotable !== false
+      || receipt?.ingestible !== false
+      || receipt?.canonicalBundlePublished !== false
+      || receipt?.outcome?.canonicalBundleAbsentAtPublication !== true
+      || receipt?.outcome?.outcomeReservationHeldAtPublication !== true
+      || receipt?.outcome?.outcomeChoice !== "failure"
+      || !path.isAbsolute(receipt?.outcome?.canonicalOutput ?? "")
+      || receipt?.outcome?.failureOutput
+        !== campaignEntryFailurePath(receipt?.outcome?.canonicalOutput ?? "")
+      || receipt?.outcome?.reservation
+        !== campaignEntryOutcomeReservationPath(receipt?.outcome?.canonicalOutput ?? "")
+      || receipt?.outcome?.choice !== `${receipt?.outcome?.reservation}.choice`
+      || receipt?.story !== "sc-20216"
+      || !isDeepStrictEqual(receipt?.campaignCase, expectedCampaignCase)
+      || receipt?.watchdog?.protocol !== "sceneworks-memory-watchdog-v1"
+      || receipt?.watchdog?.providerPhaseProtocol !== PROVIDER_PHASE_PROTOCOL
+      || !isDeepStrictEqual(receipt?.watchdog?.providerPhases, PROVIDER_PHASES)
+      || receipt?.watchdog?.eventChain?.protocol !== WATCHDOG_EVENT_CHAIN_PROTOCOL
+      || receipt?.watchdog?.maxFootprintBytes !== MAX_FOOTPRINT_BYTES
+      || receipt?.watchdog?.maxRuntimeSeconds !== MAX_RUNTIME_SECONDS
+      || receipt?.watchdog?.minInitialMemoryFreeBytes
+        !== preflightFreeFloor(receipt?.watchdog?.hostMemoryBytes)
+      || receipt?.watchdog?.minMemoryFreeBytes
+        !== runtimeFreeFloor(receipt?.watchdog?.hostMemoryBytes)
+      || !isDeepStrictEqual(receipt?.cleanup, expectedCleanup)) {
+    fail("SC-20216 failure receipt is ingestible, incomplete, or identity-drifted");
+  }
+  for (const source of [receipt.source?.sceneWorks, receipt.source?.inference]) {
+    if (!/^[0-9a-f]{40}$/.test(source?.revision ?? "")
+        || !/^[0-9a-f]{40}$/.test(source?.tree ?? "")) {
+      fail("SC-20216 failure receipt source identity is malformed");
+    }
+  }
+  const preparation = receipt.artifacts?.preparation;
+  const identity = preparation?.identity;
+  const validFileIdentity = (file, mode) => path.isAbsolute(file?.path ?? "")
+    && /^[0-9a-f]{64}$/.test(file?.sha256 ?? "")
+    && typeof file?.device === "string" && typeof file?.inode === "string"
+    && Number.isSafeInteger(file?.size) && file.size > 0
+    && typeof file?.mtimeNs === "string" && typeof file?.ctimeNs === "string"
+    && file?.mode === mode;
+  if (receipt.artifacts?.repository !== ARTIFACT_REPOSITORY
+      || receipt.artifacts?.revision !== ARTIFACT_REVISION
+      || !isDeepStrictEqual(receipt.artifacts?.numericTierInventory, {
+        files: 11, bytes: Q4_INVENTORY_BYTES, sha256: Q4_INVENTORY_SHA256,
+      })
+      || !isDeepStrictEqual(receipt.artifacts?.textEncoderInventory, {
+        files: TEXT_ENCODER_INVENTORY_FILES,
+        bytes: TEXT_ENCODER_INVENTORY_BYTES,
+        sha256: TEXT_ENCODER_INVENTORY_SHA256,
+      })
+      || !/^[0-9a-f]{64}$/.test(preparation?.key ?? "")
+      || !path.isAbsolute(preparation?.root ?? "")
+      || path.basename(preparation?.root ?? "") !== preparation.key
+      || preparation?.manifest?.key !== preparation.key
+      || preparation?.manifest?.schemaVersion !== PREPARATION_SCHEMA_VERSION
+      || !isDeepStrictEqual(preparation?.manifest?.identity, identity)
+      || preparation?.manifest?.preparedFrom?.sceneWorksRevision
+        !== receipt.source.sceneWorks.revision
+      || preparation?.manifest?.preparedFrom?.inferenceRevision
+        !== receipt.source.inference.revision
+      || !isDeepStrictEqual(preparation?.manifest?.artifacts?.numericTier?.content,
+        receipt.artifacts.numericTierInventory)
+      || !isDeepStrictEqual(preparation?.manifest?.artifacts?.textEncoder?.content,
+        receipt.artifacts.textEncoderInventory)
+      || identity?.sceneWorksTree !== receipt.source.sceneWorks.tree
+      || identity?.inferenceTree !== receipt.source.inference.tree
+      || identity?.schemaVersion !== PREPARATION_SCHEMA_VERSION
+      || !isDeepStrictEqual(identity?.artifact, {
+        repository: ARTIFACT_REPOSITORY,
+        revision: ARTIFACT_REVISION,
+        numericTier: receipt.artifacts.numericTierInventory,
+        textEncoder: receipt.artifacts.textEncoderInventory,
+      })
+      || !validFileIdentity(receipt.artifacts?.adapter, 0o500)
+      || !validFileIdentity(receipt.artifacts?.metallib, 0o400)
+      || !isDeepStrictEqual(preparation?.manifest?.adapter,
+        preparedFileManifestIdentity(receipt.artifacts.adapter))
+      || !isDeepStrictEqual(preparation?.manifest?.metallib,
+        preparedFileManifestIdentity(receipt.artifacts.metallib))) {
+    fail("SC-20216 failure receipt artifact or sealed-preparation identity changed");
+  }
+  const validated = validateCampaignEntryFailureEvents(
+    receipt.watchdog.events, receipt.watchdog.hostMemoryBytes,
+  );
+  if (!isDeepStrictEqual(receipt.watchdog.failure, validated)
+      || !isDeepStrictEqual(receipt.watchdog.eventChain, validated.eventChain)) {
+    fail("SC-20216 failure receipt summary does not match its complete event stream");
+  }
+  return receipt;
 }
 
 function sameInventory(left, right) {
@@ -1795,15 +2181,20 @@ function campaignProviderOptions(argv) {
   for (const name of [
     "inference-repo", "preparation-root", "preparation-key", "run-root",
     "scene-revision", "scene-tree", "inference-revision", "inference-tree",
+    "canonical-output", "failure-output", "outcome-reservation", "outcome-token",
   ]) {
     if (!options[name]) fail(`campaign provider requires --${name}`);
   }
   const unexpected = Object.keys(options).filter((name) => ![
     "inference-repo", "preparation-root", "preparation-key", "run-root",
     "scene-revision", "scene-tree", "inference-revision", "inference-tree",
+    "canonical-output", "failure-output", "outcome-reservation", "outcome-token",
   ].includes(name));
   if (unexpected.length) fail(`unsupported campaign provider option(s): ${unexpected.join(", ")}`);
-  for (const name of ["inference-repo", "preparation-root", "run-root"]) {
+  for (const name of [
+    "inference-repo", "preparation-root", "run-root", "canonical-output", "failure-output",
+    "outcome-reservation",
+  ]) {
     options[name] = path.resolve(options[name]);
   }
   return options;
@@ -1814,6 +2205,18 @@ async function campaignProviderInvocation(options, input, {
 } = {}) {
   signal?.throwIfAborted();
   const request = JSON.parse(input);
+  const campaignOutcome = {
+    canonicalOutput: options["canonical-output"],
+    failureOutput: options["failure-output"],
+    reservation: options["outcome-reservation"],
+    choice: `${options["outcome-reservation"]}.choice`,
+    token: options["outcome-token"],
+  };
+  if (campaignOutcome.failureOutput !== campaignEntryFailurePath(campaignOutcome.canonicalOutput)
+      || campaignOutcome.reservation
+        !== campaignEntryOutcomeReservationPath(campaignOutcome.canonicalOutput)) {
+    fail("SC-20216 campaign provider outcome paths changed");
+  }
   const config = JSON.parse(await readFile(path.join(ROOT, CAMPAIGN_ENTRY_PLAN), "utf8"));
   const { planned } = campaignEntryPlan(config);
   const toolchainChannel = await repositoryToolchain();
@@ -1834,6 +2237,8 @@ async function campaignProviderInvocation(options, input, {
   const runScratch = await mkdtemp(path.join(options["run-root"], "sc-20191-run-"));
   let operationError = null;
   let cleanupError = null;
+  let failureEvents = null;
+  let failureHostMemoryBytes = null;
   let output = null;
   try {
     const runtimeHome = path.join(runScratch, "home");
@@ -1879,6 +2284,7 @@ async function campaignProviderInvocation(options, input, {
         "--term-grace", "1",
         "--event-file", eventsPath,
         "--require-child-attestation",
+        "--require-provider-phases",
         "--",
         "/bin/sh", "-c", 'set -C; exec "$1" <"$2" >"$3"',
         "sc-20191-campaign-entry", prepared.adapter.path, requestPath, responsePath,
@@ -1905,9 +2311,32 @@ async function campaignProviderInvocation(options, input, {
           resolve({ code, signal: childSignal });
         });
       });
-      signal?.throwIfAborted();
       const eventBytes = await readFile(eventsPath, "utf8").catch(() => "");
-      if (status.code !== 0 || status.signal) fail(watchdogFailureSummary(status, eventBytes));
+      if (status.code !== 0 || status.signal) {
+        const watchdogError = new Error(watchdogFailureSummary(status, eventBytes));
+        try {
+          const events = eventBytes.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+          validateCampaignEntryFailureEvents(events, hostMemoryBytes);
+          const started = events.find((event) => event.event === "started");
+          const processTable = (await execFileAsync(
+            "/bin/ps", ["-ww", "-axo", "pid=,pgid=,command="],
+            { encoding: "utf8", timeout: 2_000 },
+          )).stdout;
+          const residue = ownedProcessGroupResidue(processTable, started?.pgid);
+          if (residue.length) fail(`SC-20216 watchdog process group retained residue:\n${residue.join("\n")}`);
+          await assertCampaignSourceState(options);
+          await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib);
+          if (await validatePreparedCache(
+            options["preparation-root"], options["preparation-key"], identity,
+          ) === null) fail("SC-20216 prepared cache disappeared after watchdog failure");
+          failureEvents = events;
+          failureHostMemoryBytes = hostMemoryBytes;
+        } catch (error) {
+          throw preserveFailureReceiptSuppression(watchdogError, error);
+        }
+        throw watchdogError;
+      }
+      signal?.throwIfAborted();
       const response = JSON.parse(await readFile(responsePath, "utf8"));
       const events = eventBytes.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
       validateCampaignEntryAdapterResponse(response, {
@@ -1941,7 +2370,43 @@ async function campaignProviderInvocation(options, input, {
     }
   }
   const finalError = preservePrimaryFailure(operationError, cleanupError);
-  if (finalError !== null) throw finalError;
+  if (finalError !== null) {
+    let publicationError = null;
+    if (failureEvents !== null && cleanupError === null) {
+      try {
+        await publishCampaignEntryFailureReceipt(campaignOutcome, {
+          verify: async () => {
+            await assertRunRootEmpty(options["run-root"]);
+            await assertCampaignSourceState(options);
+            await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib);
+            if (await validatePreparedCache(
+              options["preparation-root"], options["preparation-key"], identity,
+            ) === null) fail("SC-20216 prepared cache disappeared before failure publication");
+            await assertPreparationHasNoTransientResidue(options["preparation-root"]);
+          },
+          build: (outcome) => campaignEntryFailureReceipt({
+            sceneWorksRevision: options["scene-revision"],
+            sceneWorksTree: options["scene-tree"],
+            inferenceRevision: options["inference-revision"],
+            inferenceTree: options["inference-tree"],
+            identity,
+            preparationKey: options["preparation-key"],
+            preparationRoot: options["preparation-root"],
+            prepared,
+            hostMemoryBytes: failureHostMemoryBytes,
+            events: failureEvents,
+            outcome,
+          }),
+        });
+      } catch (error) {
+        publicationError = error;
+      }
+    }
+    if (publicationError !== null) {
+      throw preserveFailureReceiptSuppression(finalError, publicationError);
+    }
+    throw finalError;
+  }
   return output;
 }
 
@@ -1976,6 +2441,75 @@ async function publishExclusiveJson(output, value, signal) {
   }
 }
 
+export async function acquireCampaignEntryOutcome(canonicalOutput) {
+  const outcome = {
+    canonicalOutput,
+    failureOutput: campaignEntryFailurePath(canonicalOutput),
+    reservation: campaignEntryOutcomeReservationPath(canonicalOutput),
+    choice: `${campaignEntryOutcomeReservationPath(canonicalOutput)}.choice`,
+    token: randomUUID(),
+  };
+  await mkdir(path.dirname(canonicalOutput), { recursive: true });
+  await writeFile(outcome.reservation, `${outcome.token}\n`, { flag: "wx", mode: 0o400 });
+  if (await pathExists(outcome.canonicalOutput) || await pathExists(outcome.failureOutput)) {
+    await unlink(outcome.reservation);
+    fail("SC-20216 campaign entry already has an immutable canonical or failure outcome");
+  }
+  return outcome;
+}
+
+async function assertCampaignEntryOutcomeOwner(outcome) {
+  if (await readFile(outcome?.reservation ?? "", "utf8").catch(() => null)
+      !== `${outcome?.token}\n`) {
+    fail("SC-20216 campaign entry outcome reservation ownership changed");
+  }
+}
+
+export async function releaseUnpublishedCampaignEntryOutcome(outcome) {
+  await assertCampaignEntryOutcomeOwner(outcome);
+  if (await pathExists(outcome.choice)
+      || await pathExists(outcome.canonicalOutput) || await pathExists(outcome.failureOutput)) return;
+  await unlink(outcome.reservation);
+}
+
+async function publishCampaignEntryOutcome(outcome, kind, build, signal) {
+  await assertCampaignEntryOutcomeOwner(outcome);
+  const target = kind === "canonical" ? outcome.canonicalOutput : outcome.failureOutput;
+  const other = kind === "canonical" ? outcome.failureOutput : outcome.canonicalOutput;
+  await writeFile(outcome.choice, `${kind}\n`, { flag: "wx", mode: 0o400 });
+  if (await pathExists(target) || await pathExists(other)) {
+    fail("SC-20216 campaign entry outcome is already fixed");
+  }
+  const value = await build();
+  await publishExclusiveJson(target, value, signal);
+  return value;
+}
+
+export async function publishCampaignEntryCanonicalOutcome(outcome, bundle, signal) {
+  await publishCampaignEntryOutcome(outcome, "canonical", async () => bundle, signal);
+}
+
+export async function publishCampaignEntryFailureReceipt(outcome, { verify, build }) {
+  if (typeof verify !== "function" || typeof build !== "function") {
+    fail("SC-20216 failure publication requires validation and receipt builders");
+  }
+  await verify();
+  return publishCampaignEntryOutcome(outcome, "failure", async () => {
+    if (await pathExists(outcome.canonicalOutput)) {
+      fail("SC-20216 canonical outcome already exists; failure receipt suppressed");
+    }
+    return validateCampaignEntryFailureReceipt(await build({
+      canonicalOutput: outcome.canonicalOutput,
+      failureOutput: outcome.failureOutput,
+      reservation: outcome.reservation,
+      choice: outcome.choice,
+      outcomeChoice: "failure",
+      canonicalBundleAbsentAtPublication: true,
+      outcomeReservationHeldAtPublication: true,
+    }));
+  });
+}
+
 async function assertPreparationHasNoTransientResidue(preparationRoot) {
   const parent = path.dirname(preparationRoot);
   const key = path.basename(preparationRoot);
@@ -1998,9 +2532,8 @@ async function runCampaignEntryController({
 }) {
   const config = JSON.parse(await readFile(path.join(ROOT, CAMPAIGN_ENTRY_PLAN), "utf8"));
   campaignEntryPlan(config);
+  const campaignOutcome = await acquireCampaignEntryOutcome(output);
   const runRoot = path.join(path.dirname(output), "runs");
-  await mkdir(runRoot, { recursive: true, mode: 0o700 });
-  await assertRunRootEmpty(runRoot);
   const providerOptions = {
     "inference-repo": inferenceRepo,
     "preparation-root": preparationRoot,
@@ -2010,12 +2543,18 @@ async function runCampaignEntryController({
     "scene-tree": sceneWorksTree,
     "inference-revision": inferenceRevision,
     "inference-tree": inferenceTree,
+    "canonical-output": campaignOutcome.canonicalOutput,
+    "failure-output": campaignOutcome.failureOutput,
+    "outcome-reservation": campaignOutcome.reservation,
+    "outcome-token": campaignOutcome.token,
   };
   const providerCommand = [fileURLToPath(import.meta.url), "--campaign-provider"];
   let operationError = null;
   let cleanupError = null;
   let bundle = null;
   try {
+    await mkdir(runRoot, { recursive: true, mode: 0o700 });
+    await assertRunRootEmpty(runRoot);
     bundle = await runProviderPlan({
       config,
       providerCommand,
@@ -2049,12 +2588,13 @@ async function runCampaignEntryController({
     ) === null) fail("SC-20191 prepared cache disappeared before publication");
     await assertPreparationHasNoTransientResidue(preparationRoot);
     validateCampaignEntryBundle(bundle);
-    await publishExclusiveJson(output, bundle, signal);
+    await publishCampaignEntryCanonicalOutcome(campaignOutcome, bundle, signal);
   } catch (error) {
     operationError = error;
   } finally {
     try {
       if (await pathExists(runRoot)) await cleanupCanaryScratch(runRoot);
+      await releaseUnpublishedCampaignEntryOutcome(campaignOutcome);
     } catch (error) {
       cleanupError = error;
     }

--- a/scripts/run-ltx-safety-canary.test.mjs
+++ b/scripts/run-ltx-safety-canary.test.mjs
@@ -15,6 +15,7 @@ import {
   CAMPAIGN_ENTRY_IDENTITY,
   CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
   CAMPAIGN_ENTRY_PROVIDER,
+  CAMPAIGN_FAILURE_RECEIPT_TYPE,
   CHILD_ATTESTATION_TIMEOUT_SECONDS,
   CanaryInterrupted,
   MAX_FOOTPRINT_BYTES,
@@ -22,10 +23,15 @@ import {
   MIN_PREFLIGHT_FREE_BYTES,
   MIN_RUNTIME_FREE_BYTES,
   PREPARATION_SCHEMA_VERSION,
+  PROVIDER_PHASES,
   PRODUCT_ENVELOPE_CANARY_PROFILE,
+  acquireCampaignEntryOutcome,
   acquirePreparationLock,
   campaignEntryAdapterRequest,
   campaignEntryCanonicalFragment,
+  campaignEntryFailurePath,
+  campaignEntryFailureReceipt,
+  campaignEntryOutcomeReservationPath,
   campaignEntryPlan,
   canaryWatchdogEnvironment,
   canaryRequest,
@@ -44,6 +50,10 @@ import {
   prepareCanaryCache,
   privateArtifactRoots,
   preservePrimaryFailure,
+  preserveFailureReceiptSuppression,
+  publishCampaignEntryCanonicalOutcome,
+  publishCampaignEntryFailureReceipt,
+  releaseUnpublishedCampaignEntryOutcome,
   preflightFreeFloor,
   repositoryToolchain,
   runtimeFreeFloor,
@@ -52,6 +62,8 @@ import {
   telemetryResolutionBytes,
   validateCampaignEntryAdapterResponse,
   validateCampaignEntryBundle,
+  validateCampaignEntryFailureEvents,
+  validateCampaignEntryFailureReceipt,
   validateCampaignEntryHarnessRequest,
   validateCampaignEntryWatchdogEvents,
   validateCanaryResponse,
@@ -60,7 +72,7 @@ import {
 } from "./run-ltx-safety-canary.mjs";
 
 import { hashArtifactInventory } from "./hash-artifact-inventory.mjs";
-import { canonicalJson, runProviderPlan } from "./memory-calibration-harness.mjs";
+import { canonicalJson, runProviderPlan, validateBundle } from "./memory-calibration-harness.mjs";
 
 const TEXT_ENCODER_INVENTORY = {
   root: "/models/gemma",
@@ -192,6 +204,122 @@ function campaignEntryRuntimeResponse(hostMemoryBytes = 128 * 1024 ** 3) {
     loadability: { result: "passed", resolvedPathFingerprint: "exact@campaign-entry:q4" },
     capturedAt: "2026-08-17T12:00:00Z",
   };
+}
+
+const PROCESS_IDENTITIES = [
+  { pid: 1234, pgid: 1234, started: "Sun Aug 17 12:00:00 2026" },
+  { pid: 1235, pgid: 1234, started: "Sun Aug 17 12:00:01 2026" },
+];
+
+function stableCompactJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableCompactJson).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) =>
+      `${JSON.stringify(key)}:${stableCompactJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function chainWatchdogEvents(events) {
+  let previousEventHash = "0".repeat(64);
+  for (const [index, event] of events.entries()) {
+    delete event.eventSequence;
+    delete event.previousEventHash;
+    delete event.eventHash;
+    Object.assign(event, { eventSequence: index + 1, previousEventHash });
+    event.eventHash = createHash("sha256").update(stableCompactJson(event)).digest("hex");
+    previousEventHash = event.eventHash;
+  }
+  return events;
+}
+
+function campaignFailureEvents(hostMemoryBytes = 128 * 1024 ** 3, phaseCount = 1) {
+  const runtimeFloor = runtimeFreeFloor(hostMemoryBytes);
+  let at = 1;
+  const events = [
+    {
+      at: at++, event: "started", pid: 1234, pgid: 1234,
+      providerPhase: null, processIdentities: PROCESS_IDENTITIES,
+    },
+    {
+      at: at++, event: "sample", phase: "before_child_release", providerPhase: null,
+      physicalFootprintBytes: 1, memoryFreeBytes: runtimeFloor, swapFreeBytes: 0,
+    },
+    {
+      at: at++, event: "sample", phase: "child_attested_before_allocation", providerPhase: null,
+      physicalFootprintBytes: 2, memoryFreeBytes: runtimeFloor, swapFreeBytes: 0,
+    },
+    { at: at++, event: "child_attested", providerPhase: null },
+  ];
+  let providerPhase = null;
+  for (let index = 0; index < phaseCount; index += 1) {
+    providerPhase = { sequence: index + 1, name: PROVIDER_PHASES[index] };
+    events.push({
+      at: at++, event: "provider_phase", providerPhase, authenticated: true,
+    });
+  }
+  const physicalFootprintBytes = MAX_FOOTPRINT_BYTES + 1;
+  const reason = `physical_footprint_at_or_above_${MAX_FOOTPRINT_BYTES}:observed_${physicalFootprintBytes}`;
+  events.push({
+    at: at++, event: "sample", phase: "runtime", providerPhase,
+    physicalFootprintBytes, memoryFreeBytes: runtimeFloor, swapFreeBytes: 0,
+  });
+  events.push({
+    at: at++, event: "hard_stop", reason, providerPhase,
+    processIdentities: PROCESS_IDENTITIES,
+  });
+  events.push({
+    at: at++, event: "terminated", reason, providerPhase,
+    processIdentities: PROCESS_IDENTITIES,
+  });
+  return chainWatchdogEvents(events);
+}
+
+function campaignSuccessEvents(hostMemoryBytes = 128 * 1024 ** 3) {
+  const events = campaignFailureEvents(hostMemoryBytes, PROVIDER_PHASES.length);
+  const sample = events.at(-3);
+  sample.physicalFootprintBytes = 3;
+  events.splice(-2, 2, {
+    at: events.at(-2).at, event: "child_completed",
+    providerPhase: { sequence: PROVIDER_PHASES.length, name: PROVIDER_PHASES.at(-1) },
+  });
+  return chainWatchdogEvents(events);
+}
+
+function campaignFailurePreparation(
+  root = "/private/prepared", sceneWorksRevision = "1".repeat(40),
+  inferenceRevision = "3".repeat(40),
+) {
+  const identity = preparationIdentity("a".repeat(40), "b".repeat(40), "1.97.1");
+  const key = preparationCacheKey(identity);
+  const preparationRoot = path.join(root, key);
+  const fileIdentity = (name, mode, digest) => ({
+    path: path.join(preparationRoot, "adapter", name), sha256: digest.repeat(64),
+    device: "1", inode: name === "mlx.metallib" ? "2" : "3", size: 100,
+    mtimeNs: "4", ctimeNs: "5", mode,
+  });
+  const prepared = {
+    adapter: fileIdentity("memory-mlx-adapter", 0o500, "d"),
+    metallib: fileIdentity("mlx.metallib", 0o400, "c"),
+  };
+  const manifestIdentity = (file) => ({
+    sha256: file.sha256, size: file.size,
+    seal: {
+      device: file.device, inode: file.inode, mtimeNs: file.mtimeNs,
+      ctimeNs: file.ctimeNs, mode: file.mode,
+    },
+  });
+  prepared.manifest = {
+    schemaVersion: PREPARATION_SCHEMA_VERSION, key, identity,
+    preparedFrom: { sceneWorksRevision, inferenceRevision },
+    artifacts: {
+      numericTier: { content: identity.artifact.numericTier, seal: {} },
+      textEncoder: { content: identity.artifact.textEncoder, seal: {} },
+    },
+    adapter: manifestIdentity(prepared.adapter),
+    metallib: manifestIdentity(prepared.metallib),
+  };
+  return { identity, key, preparationRoot, prepared };
 }
 
 async function cleanCampaignHarnessRepo(t) {
@@ -384,34 +512,210 @@ test("SC-20191 rejects carrier, cleanup and watchdog mutations", () => {
   }
 
   const runtimeFloor = runtimeFreeFloor(hostMemoryBytes);
-  const validEvents = [
-    { event: "started" },
-    {
-      event: "sample", phase: "before_child_release", physicalFootprintBytes: 1,
-      memoryFreeBytes: runtimeFloor, swapFreeBytes: 0,
-    },
-    {
-      event: "sample", phase: "child_attested_before_allocation", physicalFootprintBytes: 2,
-      memoryFreeBytes: runtimeFloor, swapFreeBytes: 0,
-    },
-    { event: "child_attested" },
-    {
-      event: "sample", phase: "running", physicalFootprintBytes: 3,
-      memoryFreeBytes: runtimeFloor, swapFreeBytes: 0,
-    },
-    { event: "child_completed" },
-  ];
+  const validEvents = campaignSuccessEvents(hostMemoryBytes);
   assert.equal(validateCampaignEntryWatchdogEvents(validEvents, hostMemoryBytes), 3);
   for (const events of [
     validEvents.filter((event) => event.event !== "child_completed"),
-    validEvents.filter((event) => event.phase !== "running"),
+    validEvents.filter((event) => event.phase !== "runtime"),
+    validEvents.filter((event) => event.providerPhase?.name !== "lifecycle_cancel"),
+    [...validEvents.slice(0, -1), structuredClone(validEvents.find((event) =>
+      event.providerPhase?.name === "cleanup" && event.event === "provider_phase")), validEvents.at(-1)],
     [validEvents[0], ...validEvents.slice(1).reverse()],
     [...validEvents, { event: "hard_stop" }],
     validEvents.map((event) => event.phase === "before_child_release"
       ? { ...event, physicalFootprintBytes: MAX_FOOTPRINT_BYTES } : event),
     validEvents.map((event) => event.phase === "before_child_release"
       ? { ...event, memoryFreeBytes: runtimeFloor - 1 } : event),
-  ]) assert.throws(() => validateCampaignEntryWatchdogEvents(events, hostMemoryBytes), /SC-20191/);
+  ]) assert.throws(() => validateCampaignEntryWatchdogEvents(events, hostMemoryBytes), /SC-20(?:191|216)/);
+});
+
+test("SC-20216 failure receipt is phase-authenticated, non-ingestible and mutation-sensitive", () => {
+  const hostMemoryBytes = 128 * 1024 ** 3;
+  const { identity, key, preparationRoot, prepared } = campaignFailurePreparation();
+  const events = campaignFailureEvents(hostMemoryBytes);
+  const canonicalOutput = "/private/results/canonical.json";
+  const outcome = {
+    canonicalOutput,
+    failureOutput: campaignEntryFailurePath(canonicalOutput),
+    reservation: campaignEntryOutcomeReservationPath(canonicalOutput),
+    choice: `${campaignEntryOutcomeReservationPath(canonicalOutput)}.choice`,
+    outcomeChoice: "failure",
+    canonicalBundleAbsentAtPublication: true,
+    outcomeReservationHeldAtPublication: true,
+  };
+  const receipt = campaignEntryFailureReceipt({
+    sceneWorksRevision: "1".repeat(40), sceneWorksTree: "a".repeat(40),
+    inferenceRevision: "3".repeat(40), inferenceTree: "b".repeat(40),
+    identity, preparationKey: key, preparationRoot,
+    prepared, hostMemoryBytes, events, outcome,
+  });
+  assert.equal(receipt.recordType, CAMPAIGN_FAILURE_RECEIPT_TYPE);
+  assert.equal(receipt.ingestible, false);
+  assert.equal(receipt.canonicalBundlePublished, false);
+  assert.equal(receipt.watchdog.failure.terminalProviderPhase.name, "common_load");
+  assert.equal(receipt.watchdog.failure.firstViolatingSample.physicalFootprintBytes,
+    MAX_FOOTPRINT_BYTES + 1);
+  assert.throws(() => validateBundle(receipt), /schema|object|property|records|required/i);
+  validateCampaignEntryFailureReceipt(receipt);
+
+  const mutations = [
+    (value) => { value.ingestible = true; },
+    (value) => { value.outcome.canonicalBundleAbsentAtPublication = false; },
+    (value) => { value.outcome.outcomeChoice = "canonical"; },
+    (value) => { value.outcome.choice += ".mutated"; },
+    (value) => { value.cleanup.runRootEmpty = false; },
+    (value) => { value.cleanup = {}; },
+    (value) => { value.campaignCase.target.geometry.frames = 120; },
+    (value) => { value.artifacts.metallib.sha256 = "0".repeat(64); },
+    (value) => { value.artifacts.preparation.manifest.preparedFrom.sceneWorksRevision
+      = "9".repeat(40); },
+    (value) => { value.artifacts.preparation.manifest.artifacts.numericTier.content.bytes += 1; },
+    (value) => { value.artifacts.preparation.root = value.artifacts.preparation.key; },
+    (value) => { delete value.watchdog.events[0].providerPhase; },
+    (value) => { value.watchdog.events.at(-1).processIdentities
+      = [value.watchdog.events.at(-1).processIdentities[0]]; },
+    (value) => { value.watchdog.events.find((event) => event.event === "provider_phase")
+      .providerPhase.sequence = 2; },
+    (value) => { value.watchdog.events.find((event) => event.event === "provider_phase")
+      .providerPhase.name = "primary_decode"; },
+    (value) => { value.watchdog.events.find((event) => event.event === "provider_phase")
+      .authenticated = false; },
+    (value) => { value.watchdog.events.find((event) => event.event === "hard_stop")
+      .providerPhase = null; },
+    (value) => { value.watchdog.events.find((event) => event.event === "hard_stop")
+      .reason = "physical_footprint_at_or_above_mutated"; },
+    (value) => { value.watchdog.events.at(-1).at = 0; },
+    (value) => { value.watchdog.eventChain.head = "0".repeat(64); },
+    (value) => { value.watchdog.events.splice(1, 1); },
+    (value) => { [value.watchdog.events[1], value.watchdog.events[2]]
+      = [value.watchdog.events[2], value.watchdog.events[1]]; },
+    (value) => { value.watchdog.events.splice(2, 0, structuredClone(value.watchdog.events[1])); },
+    (value) => { value.watchdog.failure.firstViolatingEventIndex += 1; },
+  ];
+  for (const mutate of mutations) {
+    const changed = structuredClone(receipt);
+    mutate(changed);
+    assert.throws(() => validateCampaignEntryFailureReceipt(changed), /SC-20216/);
+  }
+
+  const interrupted = campaignFailureEvents(hostMemoryBytes);
+  interrupted.at(-3).physicalFootprintBytes = 3;
+  interrupted.at(-2).reason = "monitor_signal_SIGTERM";
+  interrupted.at(-1).reason = "monitor_signal_SIGTERM";
+  chainWatchdogEvents(interrupted);
+  const interruption = validateCampaignEntryFailureEvents(interrupted, hostMemoryBytes);
+  assert.equal(interruption.firstViolatingSample, null);
+  assert.equal(interruption.reason, "monitor_signal_SIGTERM");
+
+  const thresholdWithoutSample = campaignFailureEvents(hostMemoryBytes);
+  thresholdWithoutSample.at(-3).physicalFootprintBytes = 3;
+  chainWatchdogEvents(thresholdWithoutSample);
+  assert.throws(
+    () => validateCampaignEntryFailureEvents(thresholdWithoutSample, hostMemoryBytes),
+    /threshold hard stop omitted its exact first violating sample/,
+  );
+
+  const unequalTerminalIdentities = campaignFailureEvents(hostMemoryBytes);
+  unequalTerminalIdentities.at(-2).processIdentities = [
+    ...unequalTerminalIdentities.at(-2).processIdentities,
+    { pid: 1236, pgid: 1234, started: "Sun Aug 17 12:00:02 2026" },
+  ];
+  chainWatchdogEvents(unequalTerminalIdentities);
+  assert.throws(
+    () => validateCampaignEntryFailureEvents(unequalTerminalIdentities, hostMemoryBytes),
+    /exact process termination identity/,
+  );
+});
+
+test("SC-20216 publishes only after validation and never overwrites a failure receipt", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "sc20216-failure-publish-"));
+  t.after(() => cleanupCanaryScratch(root));
+  const canonical = path.join(root, "canonical.json");
+  const outcome = await acquireCampaignEntryOutcome(canonical);
+  const output = outcome.failureOutput;
+  const hostMemoryBytes = 128 * 1024 ** 3;
+  const { identity, key, preparationRoot, prepared } = campaignFailurePreparation(root);
+  const order = [];
+  const build = (publication) => {
+    order.push("build");
+    return campaignEntryFailureReceipt({
+      sceneWorksRevision: "1".repeat(40), sceneWorksTree: "a".repeat(40),
+      inferenceRevision: "3".repeat(40), inferenceTree: "b".repeat(40),
+      identity, preparationKey: key, preparationRoot,
+      prepared, hostMemoryBytes, events: campaignFailureEvents(hostMemoryBytes),
+      outcome: publication,
+    });
+  };
+  await assert.rejects(() => publishCampaignEntryFailureReceipt(outcome, {
+    verify: async () => { throw new Error("residue remained"); }, build,
+  }), /residue remained/);
+  assert.equal(await readFile(output, "utf8").catch(() => null), null);
+  assert.deepEqual(order, []);
+  await publishCampaignEntryFailureReceipt(outcome, {
+    verify: async () => { order.push("cleanup-and-identity-verified"); }, build,
+  });
+  order.push("published");
+  assert.deepEqual(order, ["cleanup-and-identity-verified", "build", "published"]);
+  assert.equal(await readFile(canonical, "utf8").catch(() => null), null);
+  validateCampaignEntryFailureReceipt(JSON.parse(await readFile(output, "utf8")));
+  await assert.rejects(() => publishCampaignEntryFailureReceipt(outcome, {
+    verify: async () => {}, build,
+  }), /EEXIST/);
+  await assert.rejects(() => acquireCampaignEntryOutcome(canonical), /EEXIST/);
+});
+
+test("SC-20216 jointly reserves canonical and failure outcomes across races and stale state", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "sc20216-outcome-race-"));
+  t.after(() => cleanupCanaryScratch(root));
+  const canonical = path.join(root, "canonical.json");
+  const raced = await Promise.allSettled([
+    acquireCampaignEntryOutcome(canonical), acquireCampaignEntryOutcome(canonical),
+  ]);
+  assert.equal(raced.filter((result) => result.status === "fulfilled").length, 1);
+  assert.equal(raced.filter((result) => result.status === "rejected").length, 1);
+  const outcome = raced.find((result) => result.status === "fulfilled").value;
+  const hostMemoryBytes = 128 * 1024 ** 3;
+  const { identity, key, preparationRoot, prepared } = campaignFailurePreparation(root);
+  const publications = await Promise.allSettled([
+    publishCampaignEntryCanonicalOutcome(outcome, { canonical: true }),
+    publishCampaignEntryFailureReceipt(outcome, {
+      verify: async () => {},
+      build: (publication) => campaignEntryFailureReceipt({
+        sceneWorksRevision: "1".repeat(40), sceneWorksTree: "a".repeat(40),
+        inferenceRevision: "3".repeat(40), inferenceTree: "b".repeat(40),
+        identity, preparationKey: key, preparationRoot, prepared, hostMemoryBytes,
+        events: campaignFailureEvents(hostMemoryBytes), outcome: publication,
+      }),
+    }),
+  ]);
+  assert.equal(publications.filter((result) => result.status === "fulfilled").length, 1);
+  assert.equal(publications.filter((result) => result.status === "rejected").length, 1);
+  const [canonicalBytes, failureBytes] = await Promise.all([
+    readFile(canonical, "utf8").catch(() => null),
+    readFile(outcome.failureOutput, "utf8").catch(() => null),
+  ]);
+  assert.notEqual(canonicalBytes === null, failureBytes === null,
+    "exactly one jointly reserved outcome must publish");
+
+  const retryDirectory = path.join(root, "retry");
+  await mkdir(retryDirectory);
+  const retry = path.join(retryDirectory, "retry.json");
+  const unpublished = await acquireCampaignEntryOutcome(retry);
+  await releaseUnpublishedCampaignEntryOutcome(unpublished);
+  const reacquired = await acquireCampaignEntryOutcome(retry);
+  await releaseUnpublishedCampaignEntryOutcome(reacquired);
+  await writeFile(campaignEntryOutcomeReservationPath(retry), "stale-owner\n", { flag: "wx" });
+  await assert.rejects(() => acquireCampaignEntryOutcome(retry), /EEXIST/);
+
+  const partialDirectory = path.join(root, "partial");
+  await mkdir(partialDirectory);
+  const partialOutput = path.join(partialDirectory, "canonical.json");
+  const partial = await acquireCampaignEntryOutcome(partialOutput);
+  await assert.rejects(() => publishCampaignEntryCanonicalOutcome(partial, { invalid: 1n }),
+    /BigInt/);
+  await releaseUnpublishedCampaignEntryOutcome(partial);
+  await assert.rejects(() => acquireCampaignEntryOutcome(partialOutput), /EEXIST/,
+    "a claimed but interrupted outcome must remain fail-closed");
 });
 
 test("SC-20191 publishes one schema-valid canonical runtime record after stripping private evidence", async (t) => {
@@ -893,6 +1197,16 @@ test("scratch cleanup cannot mask the primary watchdog or signal failure", () =>
   assert.strictEqual(preservePrimaryFailure(null, cleanup), cleanup);
 });
 
+test("a stale failure receipt cannot mask the primary watchdog failure", () => {
+  const primary = new Error("watchdog hard stop");
+  const collision = Object.assign(new Error("destination exists"), { code: "EEXIST" });
+  const combined = preserveFailureReceiptSuppression(primary, collision);
+  assert.equal(combined, primary);
+  assert.match(combined.message, /watchdog hard stop/);
+  assert.match(combined.message, /failure receipt suppressed: destination exists/);
+  assert.equal(combined.cause, collision);
+});
+
 test("the production runner can only launch through the identity-checked watchdog", async () => {
   const source = await readFile(new URL("./run-ltx-safety-canary.mjs", import.meta.url), "utf8");
   assert.match(source, /scripts\/memory-calibration-watchdog\.py/);
@@ -944,6 +1258,7 @@ test("the production runner can only launch through the identity-checked watchdo
   assert.match(source, /Cargo inference source tree differs from the verified checkout/);
   assert.match(source, /response\?\.inferenceRevision !== expectedInferenceRevision/);
   assert.match(source, /--require-child-attestation/);
+  assert.match(source, /--require-provider-phases/);
   assert.equal(CHILD_ATTESTATION_TIMEOUT_SECONDS, 30);
   assert.match(source, /--child-attestation-timeout", String\(CHILD_ATTESTATION_TIMEOUT_SECONDS\)/);
   assert.match(source, /event\.event === "child_attested"/);
@@ -960,6 +1275,23 @@ test("the production runner can only launch through the identity-checked watchdo
   const cleanup = source.indexOf("await cleanupCanaryScratch(runScratch)");
   assert.ok(failureRead >= 0 && cleanup > failureRead,
     "watchdog failure reason must be read before scratch cleanup");
+  const failurePublisher = source.slice(
+    source.indexOf("export async function publishCampaignEntryFailureReceipt("),
+    source.indexOf("async function assertPreparationHasNoTransientResidue("),
+  );
+  assert.ok(failurePublisher.indexOf("await verify()")
+    < failurePublisher.indexOf('return publishCampaignEntryOutcome(outcome, "failure"'),
+  "failure validation and cleanup must precede atomic publication");
+  const failureHandling = source.slice(
+    source.indexOf("if (status.code !== 0 || status.signal)"),
+    source.indexOf("signal?.throwIfAborted()", source.indexOf("if (status.code !== 0 || status.signal)")),
+  );
+  assert.ok(failureHandling.indexOf("const watchdogError = new Error(watchdogFailureSummary")
+    < failureHandling.indexOf("validateCampaignEntryFailureEvents"),
+  "the original watchdog failure must exist before receipt or postcondition validation");
+  assert.match(failureHandling, /preserveFailureReceiptSuppression\(watchdogError, error\)/);
+  assert.match(source, /acquireCampaignEntryOutcome\(output\)/);
+  assert.match(source, /canonicalBundleAbsentAtPublication: true/);
   assert.equal(source.match(/await assertHostPreflight\(/g)?.length, 2,
     "each contained execution profile has one immediate model-release check");
   assert.doesNotMatch(source, /300_000|5 \* 60 \* 1_000/);
@@ -988,7 +1320,8 @@ test("the production runner can only launch through the identity-checked watchdo
     "validateCampaignEntryBundle(bundle)",
   ]) {
     assert.ok(campaignController.indexOf(operation) >= 0
-      && campaignController.indexOf(operation) < campaignController.indexOf("await publishExclusiveJson("),
+      && campaignController.indexOf(operation)
+        < campaignController.indexOf("await publishCampaignEntryCanonicalOutcome("),
     `${operation} must precede atomic canonical publication`);
   }
   assert.match(source, /cancellation\.abort\(new CanaryInterrupted\(signalName\)\)/);


### PR DESCRIPTION
## Summary
- add a nonce-authenticated, watchdog-acknowledged provider phase protocol for the private SC-20191 campaign entry
- preserve a contiguous SHA-256-chained watchdog stream and a structurally non-ingestible failure receipt only after verified termination and cleanup
- atomically arbitrate canonical versus diagnostic outcomes while preserving the original watchdog failure through receipt suppression

## Safety boundaries
- keeps the exact 53,347,146,863-byte physical-footprint stop
- keeps ordinary SC-18946 `run` refusal for all 70 rows
- keeps the exact q4 768x512 f121@30 private carrier; no calibration disposition changes
- no model, GPU, MLX device, or real-weight workload was run

## Validation
- focused Node/watchdog/runner/platform: 110/110
- full `npm run check`: 570/570
- MLX adapter tests: 38/38
- exact MLX all-target Clippy with `-D warnings`
- Python compile, JavaScript syntax, Rust formatting, and diff checks
- independent adversarial review PASS on exact head `e988d280ebee1af2e728c1f6d21ae33f07a7580b` after four P1/P2 failure-path defects were fixed

Shortcut: SC-20216