### PR TITLE
feat(sc-20254): add bounded-decode carrier proof

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -135,6 +135,8 @@ const LTX_CANARY_MAX_FOOTPRINT_BYTES: u64 = 53_347_146_863;
 const LTX_CANARY_MAX_RUNTIME_SECONDS: f64 = 1_800.0;
 const LTX_CANARY_WATCHDOG_PROTOCOL: &str = "sceneworks-memory-watchdog-v1";
 const LTX_PROVIDER_PHASE_PROTOCOL: &str = "sceneworks-provider-phase-v1";
+const LTX_CAMPAIGN_ENTRY_PHASE_PROFILE: &str = "campaign-entry";
+const LTX_BOUNDED_CARRIER_PHASE_PROFILE: &str = "bounded-carrier";
 const LTX_PROVIDER_PHASE_NAMES: [&str; 10] = [
     "common_load",
     "primary_conditioning",
@@ -145,6 +147,13 @@ const LTX_PROVIDER_PHASE_NAMES: [&str; 10] = [
     "lifecycle_cancel_recovery",
     "lifecycle_error",
     "lifecycle_error_recovery",
+    "cleanup",
+];
+const LTX_BOUNDED_CARRIER_PHASE_NAMES: [&str; 5] = [
+    "common_load",
+    "primary_conditioning",
+    "primary_denoise",
+    "primary_decode",
     "cleanup",
 ];
 const LTX_CANARY_WIDTH: u32 = 256;
@@ -169,6 +178,12 @@ const LTX_CAMPAIGN_ENTRY_WIDTH: u32 = 768;
 const LTX_CAMPAIGN_ENTRY_HEIGHT: u32 = 512;
 const LTX_CAMPAIGN_ENTRY_FRAMES: u32 = 121;
 const LTX_CAMPAIGN_ENTRY_FPS: u32 = 30;
+const LTX_BOUNDED_CARRIER_ACTION: &str = "bounded_carrier_proof";
+const LTX_BOUNDED_CARRIER_IDENTITY: &str = "sc-20254-q4-768x512-f121-fps30-bounded-192-64-v1";
+const LTX_BOUNDED_CARRIER_LOGICAL_CASE_ID: &str =
+    "diagnostic-sc20254-q4-768x512-f121-fps30-bounded-192-64";
+const LTX_BOUNDED_CARRIER_FIXTURE: &str =
+    "ltx-2-3-mlx-q4-768x512-f121-fps30-seed18946-bounded-decode-192-64-proof";
 const LTX_CANARY_ARTIFACT_REVISION: &str = "01df27d308466533aa09d251e3aebdcc627d07eb";
 const LTX_CANARY_Q4_INVENTORY_FILES: u64 = 11;
 const LTX_CANARY_Q4_INVENTORY_SHA256: &str =
@@ -5725,6 +5740,107 @@ fn validate_ltx_campaign_entry(
     Ok(())
 }
 
+/// A private diagnostic carrier, deliberately outside the frozen SC-18946 plan. It reuses the
+/// campaign containment machinery but cannot inherit the failed staged row's action, fixture,
+/// logical case, or strategy identity.
+fn validate_ltx_bounded_carrier_proof(
+    request: &Value,
+    tier: &str,
+    geometry: LtxGeometry,
+    selection: &MemorySelection,
+) -> Result<(), String> {
+    if protocol::action(request)? != LTX_BOUNDED_CARRIER_ACTION {
+        return Err("SC-20254 bounded-carrier action changed".to_owned());
+    }
+    let planned = protocol::planned(request)?;
+    let exact = |pointer: &str, expected: &Value| -> Result<(), String> {
+        let actual = planned.pointer(pointer);
+        if actual == Some(expected) {
+            Ok(())
+        } else {
+            Err(format!(
+                "SC-20254 bounded carrier {pointer} must be {expected}, got {actual:?}"
+            ))
+        }
+    };
+    exact("/_diagnosticOnly", &json!(true))?;
+    exact(
+        "/logicalCaseId",
+        &json!(LTX_BOUNDED_CARRIER_LOGICAL_CASE_ID),
+    )?;
+    exact("/evidenceScope", &json!("fixture"))?;
+    exact("/backend", &json!("mlx"))?;
+    exact("/loadShape", &json!("eager_materialization"))?;
+    exact("/target/provider", &json!(LTX_PROVIDER))?;
+    exact("/target/modelId", &json!(LTX_PROVIDER))?;
+    exact("/target/tier", &json!("q4"))?;
+    exact("/target/mode", &json!("text_to_video"))?;
+    exact("/target/overlay", &json!("none"))?;
+    exact("/target/geometry/width", &json!(LTX_CAMPAIGN_ENTRY_WIDTH))?;
+    exact("/target/geometry/height", &json!(LTX_CAMPAIGN_ENTRY_HEIGHT))?;
+    exact("/target/geometry/batch", &json!(1))?;
+    exact("/target/geometry/frames", &json!(LTX_CAMPAIGN_ENTRY_FRAMES))?;
+    exact("/strategy/rung", &json!("bounded_decode"))?;
+    exact(
+        "/strategy/engagedRungs",
+        &json!(["resident", "staged_residency", "bounded_decode"]),
+    )?;
+    exact(
+        "/strategy/parameters",
+        &json!({
+            "decodeTileEdge": LTX_CANARY_TILE_EDGE,
+            "decodeOverlap": LTX_CANARY_OVERLAP,
+        }),
+    )?;
+    exact(
+        "/calibrationFingerprint",
+        &json!(LTX_CALIBRATION_FINGERPRINT),
+    )?;
+    exact("/fixture", &json!(LTX_BOUNDED_CARRIER_FIXTURE))?;
+    exact("/negative", &json!(false))?;
+    exact("/expectedResult", &json!("passed"))?;
+    exact("/modelLoadPolicy", &json!("fresh_per_case"))?;
+    exact("/modelLoadGroup", &Value::Null)?;
+    exact(
+        "/_watchdog",
+        &json!({ "maxFootprintBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES }),
+    )?;
+    exact(
+        "/_boundedCarrier",
+        &json!({
+            "identity": LTX_BOUNDED_CARRIER_IDENTITY,
+            "fps": LTX_CAMPAIGN_ENTRY_FPS,
+            "seed": LTX_SEED,
+            "videoMode": "default_av",
+            "artifact": {
+                "repository": protocol::LTX_REPOSITORY,
+                "revision": LTX_CANARY_ARTIFACT_REVISION,
+                "numericTierInventory": {
+                    "files": LTX_CANARY_Q4_INVENTORY_FILES,
+                    "bytes": LTX_Q4_INVENTORY_BYTES,
+                    "sha256": LTX_CANARY_Q4_INVENTORY_SHA256,
+                },
+                "textEncoderInventory": {
+                    "files": LTX_CANARY_TEXT_ENCODER_INVENTORY_FILES,
+                    "bytes": LTX_CANARY_TEXT_ENCODER_INVENTORY_BYTES,
+                    "sha256": LTX_CANARY_TEXT_ENCODER_INVENTORY_SHA256,
+                },
+            },
+        }),
+    )?;
+    if tier != "q4"
+        || geometry.width != LTX_CAMPAIGN_ENTRY_WIDTH
+        || geometry.height != LTX_CAMPAIGN_ENTRY_HEIGHT
+        || geometry.frames != LTX_CAMPAIGN_ENTRY_FRAMES
+        || selection.strategy != MemoryStrategy::BoundedDecode
+        || selection.parameters.decode_tile_edge != Some(LTX_CANARY_TILE_EDGE)
+        || selection.parameters.decode_overlap != Some(LTX_CANARY_OVERLAP)
+    {
+        return Err("SC-20254 bounded carrier resolved a foreign tuple or strategy".to_owned());
+    }
+    Ok(())
+}
+
 /// The production A/V request. `video_mode` is deliberately left unset so the arm measures the same
 /// path a real job takes (`crates/sceneworks-worker/src/video_jobs/ltx.rs` only sets `"no_audio"`
 /// when the caller asks for it): the audio latents are denoised jointly with the video regardless,
@@ -5742,6 +5858,23 @@ fn ltx_request(geometry: LtxGeometry, fps: u32, seed: u64) -> GenerationRequest 
         fps: Some(fps),
         ..Default::default()
     }
+}
+
+fn validate_ltx_bounded_carrier_generation_request(
+    request: &GenerationRequest,
+) -> Result<(), String> {
+    if request.width != LTX_CAMPAIGN_ENTRY_WIDTH
+        || request.height != LTX_CAMPAIGN_ENTRY_HEIGHT
+        || request.count != 1
+        || request.frames != Some(LTX_CAMPAIGN_ENTRY_FRAMES)
+        || request.fps != Some(LTX_CAMPAIGN_ENTRY_FPS)
+        || request.seed != Some(LTX_SEED)
+        || request.video_mode.is_some()
+        || request.memory.is_some()
+    {
+        return Err("SC-20254 constructed a foreign provider generation request".to_owned());
+    }
+    Ok(())
 }
 
 /// One non-promotable diagnostic request. The safety profile is intentionally outside the product
@@ -6998,6 +7131,7 @@ struct LtxCanaryWatchdogLease {
     phase_acknowledgements: std::sync::mpsc::Receiver<Result<(usize, String), String>>,
     nonce: String,
     phase_sequence: usize,
+    expected_phases: &'static [&'static str],
 }
 
 trait LtxCampaignPhaseSink {
@@ -7014,6 +7148,13 @@ impl LtxCampaignPhaseSink for NoLtxCampaignPhases {
 
 impl LtxCanaryWatchdogAttestation {
     fn start_lease(&mut self) -> Result<LtxCanaryWatchdogLease, String> {
+        self.start_lease_for(&LTX_PROVIDER_PHASE_NAMES)
+    }
+
+    fn start_lease_for(
+        &mut self,
+        expected_phases: &'static [&'static str],
+    ) -> Result<LtxCanaryWatchdogLease, String> {
         let stream = self
             .stream
             .take()
@@ -7076,17 +7217,18 @@ impl LtxCanaryWatchdogAttestation {
             phase_acknowledgements,
             nonce: self.nonce.clone(),
             phase_sequence: 0,
+            expected_phases,
         })
     }
 }
 
 impl LtxCanaryWatchdogLease {
     fn complete(mut self) -> Result<(), String> {
-        if self.phase_sequence != 0 && self.phase_sequence != LTX_PROVIDER_PHASE_NAMES.len() {
+        if self.phase_sequence != 0 && self.phase_sequence != self.expected_phases.len() {
             return Err(format!(
                 "SC-20216 provider phase sequence completed at {} of {}",
                 self.phase_sequence,
-                LTX_PROVIDER_PHASE_NAMES.len()
+                self.expected_phases.len()
             ));
         }
         self.writer
@@ -7121,7 +7263,8 @@ fn wait_for_ltx_phase_acknowledgement(
 
 impl LtxCampaignPhaseSink for LtxCanaryWatchdogLease {
     fn mark(&mut self, name: &'static str) -> Result<(), String> {
-        let expected = LTX_PROVIDER_PHASE_NAMES
+        let expected = self
+            .expected_phases
             .get(self.phase_sequence)
             .ok_or_else(|| {
                 "SC-20216 provider phase sequence exceeded its exact bound".to_owned()
@@ -7192,22 +7335,36 @@ fn consume_ltx_canary_watchdog_attestation_stream(
     if payload.get("protocol").and_then(Value::as_str) != Some(LTX_CANARY_WATCHDOG_PROTOCOL) {
         return Err("LTX safety canary watchdog protocol changed".to_owned());
     }
-    let requires_provider_phases =
-        request.get("action").and_then(Value::as_str) == Some(LTX_CAMPAIGN_ENTRY_ACTION);
+    let expected_phase_contract: Option<(&str, &[&str])> =
+        match request.get("action").and_then(Value::as_str) {
+            Some(LTX_CAMPAIGN_ENTRY_ACTION) => {
+                Some((LTX_CAMPAIGN_ENTRY_PHASE_PROFILE, &LTX_PROVIDER_PHASE_NAMES))
+            }
+            Some(LTX_BOUNDED_CARRIER_ACTION) => Some((
+                LTX_BOUNDED_CARRIER_PHASE_PROFILE,
+                &LTX_BOUNDED_CARRIER_PHASE_NAMES,
+            )),
+            _ => None,
+        };
     let provider_phase_protocol = payload.get("providerPhaseProtocol").and_then(Value::as_str);
+    let provider_phase_profile = payload.get("providerPhaseProfile").and_then(Value::as_str);
     let provider_phase_names = payload.get("providerPhases");
-    if requires_provider_phases {
+    if let Some((expected_profile, expected_names)) = expected_phase_contract {
         if provider_phase_protocol != Some(LTX_PROVIDER_PHASE_PROTOCOL)
-            || provider_phase_names != Some(&json!(LTX_PROVIDER_PHASE_NAMES))
+            || provider_phase_profile != Some(expected_profile)
+            || provider_phase_names != Some(&json!(expected_names))
         {
             return Err(
-                "SC-20216 watchdog omitted the exact authenticated provider phase protocol"
+                "watchdog omitted the exact action-bound authenticated provider phase contract"
                     .to_owned(),
             );
         }
-    } else if provider_phase_protocol.is_some() || provider_phase_names.is_some() {
+    } else if provider_phase_protocol.is_some()
+        || provider_phase_profile.is_some()
+        || provider_phase_names.is_some()
+    {
         return Err(
-            "provider phase telemetry is restricted to the exact campaign-entry action".to_owned(),
+            "provider phase telemetry is restricted to exact contained LTX actions".to_owned(),
         );
     }
     let nonce = payload
@@ -8034,6 +8191,261 @@ fn prevalidate_ltx_campaign_entry(request: &Value) -> Result<(), String> {
     validate_ltx_campaign_entry(request, tier, geometry, &selection)
 }
 
+fn prevalidate_ltx_bounded_carrier_proof(
+    request: &Value,
+) -> Result<(LtxGeometry, MemorySelection), String> {
+    let geometry = validate_ltx_target(request)?;
+    protocol::validate_plain_overlay_target(request, LTX_PLAIN_EXECUTION_PATH)?;
+    if planned_load_shape(request)? != LoadShape::EagerMaterialization {
+        return Err("SC-20254 bounded carrier requires eager materialization".to_owned());
+    }
+    let selection = planned_selection(request)?;
+    let tier = planned_qwen_tier(request)?;
+    let planned_fingerprint = protocol::planned(request)?
+        .get("calibrationFingerprint")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "planned.calibrationFingerprint must be a string".to_owned())?;
+    if planned_fingerprint != LTX_CALIBRATION_FINGERPRINT {
+        return Err("SC-20254 bounded-carrier calibration fingerprint changed".to_owned());
+    }
+    validate_ltx_bounded_carrier_proof(request, tier, geometry, &selection)?;
+    let host_memory = request
+        .pointer("/hardware/memoryBytes")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| "SC-20254 hardware.memoryBytes must be an integer".to_owned())?;
+    if host_memory < LTX_CANARY_MAX_FOOTPRINT_BYTES * 2 {
+        return Err("SC-20254 host cannot preserve two exact stop boundaries".to_owned());
+    }
+    Ok((geometry, selection))
+}
+
+fn run_ltx_bounded_carrier_proof(request: &Value) -> Result<Value, String> {
+    // The exact private identity is fully checked before the live watchdog handshake, limits,
+    // artifact paths, registry construction, or model allocation.
+    let (geometry, selection) = prevalidate_ltx_bounded_carrier_proof(request)?;
+    let mut watchdog = consume_ltx_canary_watchdog_attestation(request)?;
+    let mut watchdog_lease = watchdog.start_lease_for(&LTX_BOUNDED_CARRIER_PHASE_NAMES)?;
+    watchdog_lease.mark("common_load")?;
+    let limits = LtxCanaryLimits::install()?;
+    clear_cache();
+    let pre_provider = AllocatorState::capture_current();
+    validate_ltx_canary_pre_provider(pre_provider)?;
+    let expected_persistent_active = ltx_canary_ones_cache_bytes()?;
+    let (repository, revision, root, text_encoder_root, spec) =
+        ltx_load_spec(request, "q4", &selection)?;
+    if revision != LTX_CANARY_ARTIFACT_REVISION {
+        return Err(format!(
+            "SC-20254 artifact revision must be {LTX_CANARY_ARTIFACT_REVISION}, got {revision}"
+        ));
+    }
+    let registry =
+        mlx_gen_ltx::provider_registry().map_err(|error| format!("build LTX registry: {error}"))?;
+    let contract = registry
+        .memory_strategy_contract(LTX_PROVIDER, &spec)
+        .map_err(|error| format!("read {LTX_PROVIDER} memory-strategy contract: {error}"))?
+        .ok_or_else(|| "pinned MLX LTX-2.3 provider has no memory-strategy contract".to_owned())?;
+    contract
+        .validate_selection(&selection)
+        .map_err(|error| format!("pinned LTX-2.3 contract rejected bounded carrier: {error}"))?;
+    let calibration = contract
+        .calibration
+        .as_ref()
+        .ok_or_else(|| "pinned LTX-2.3 contract has no calibration identity".to_owned())?;
+    if calibration.fingerprint != LTX_CALIBRATION_FINGERPRINT {
+        return Err("SC-20254 pinned provider calibration identity changed".to_owned());
+    }
+    let decode_plan = LtxDecodePlan::resolve_for_selection(&selection, geometry)?;
+    decode_plan.validate_selected_strategy(&selection)?;
+    let spatial_decode_tile_count = decode_plan.spatial_tile_count(geometry)?;
+    if !decode_plan.tiling_engaged()
+        || decode_plan.spatial_tile_px() != u64::from(LTX_CANARY_TILE_EDGE)
+        || decode_plan.spatial_overlap_px() != u64::from(LTX_CANARY_OVERLAP)
+        || spatial_decode_tile_count != 24
+    {
+        return Err("SC-20254 did not resolve the exact 24-tile 192/64 carrier".to_owned());
+    }
+    let generator = registry
+        .load(LTX_PROVIDER, &spec)
+        .map_err(|error| format!("load real LTX-2.3 q4 bounded carrier: {error}"))?;
+    if generator.memory_strategy_contract() != Some(&contract) {
+        return Err("SC-20254 loaded generator contract differs from registry".to_owned());
+    }
+    let context = ltx_context(
+        selection,
+        calibration,
+        &calibration.fingerprint,
+        geometry,
+        LTX_CANARY_MAX_FOOTPRINT_BYTES,
+        LTX_CANARY_MAX_FOOTPRINT_BYTES,
+    );
+    if !matches!(
+        generator.memory_strategy_safety_check(&context),
+        MemorySafetyDecision::Accept
+    ) {
+        return Err("LTX-2.3 provider rejected the exact SC-20254 budget".to_owned());
+    }
+    clear_cache();
+    reset_peak_memory();
+    let mut conditioning = PhaseMemory {
+        active: 0,
+        cache: 0,
+    };
+    let mut denoise = PhaseMemory {
+        active: 0,
+        cache: 0,
+    };
+    watchdog_lease.mark("primary_conditioning")?;
+    let generation_request = ltx_request(geometry, LTX_CAMPAIGN_ENTRY_FPS, LTX_SEED);
+    validate_ltx_bounded_carrier_generation_request(&generation_request)?;
+    let generated = scoped_generate(
+        generator.as_ref(),
+        generation_request,
+        &context,
+        None,
+        &mut |progress| match progress {
+            Progress::Step { current: 1, .. } => {
+                if let Err(error) = watchdog_lease.mark("primary_denoise") {
+                    eprintln!("{error}");
+                    std::process::abort();
+                }
+                conditioning = PhaseMemory::capture();
+                reset_peak_memory();
+            }
+            Progress::Decoding => {
+                if let Err(error) = watchdog_lease.mark("primary_decode") {
+                    eprintln!("{error}");
+                    std::process::abort();
+                }
+                denoise = PhaseMemory::capture();
+                reset_peak_memory();
+            }
+            _ => {}
+        },
+    )?;
+    let (frames, fps, audio) = diagnostic_video_frames(generated)?;
+    let decode = PhaseMemory::capture();
+    if frames.len() != LTX_CAMPAIGN_ENTRY_FRAMES as usize || fps != LTX_CAMPAIGN_ENTRY_FPS {
+        return Err(format!(
+            "SC-20254 returned frames={}, fps={fps}",
+            frames.len()
+        ));
+    }
+    let audio = audio
+        .filter(|value| value.samples > 0 && value.sample_rate > 0 && value.channels > 0)
+        .ok_or_else(|| "SC-20254 full-A/V render returned no non-empty audio track".to_owned())?;
+    let first = frames
+        .first()
+        .ok_or_else(|| "SC-20254 bounded carrier returned no frames".to_owned())?;
+    if first.pixels.is_empty() || first.pixels.iter().all(|pixel| *pixel == first.pixels[0]) {
+        return Err("SC-20254 bounded carrier returned a degenerate first frame".to_owned());
+    }
+    if [conditioning.active, denoise.active, decode.active].contains(&0) {
+        return Err("SC-20254 synchronized phase reported a zero active peak".to_owned());
+    }
+    let peak_active = [conditioning.active, denoise.active, decode.active]
+        .into_iter()
+        .max()
+        .unwrap_or(0);
+    drop(frames);
+    drop(generator);
+    watchdog_lease.mark("cleanup")?;
+    clear_cache();
+    let post_cleanup = AllocatorState::capture_current();
+    validate_ltx_canary_cleanup(pre_provider, post_cleanup, expected_persistent_active)?;
+    let planned_artifact = protocol::planned(request)?
+        .pointer("/_boundedCarrier/artifact")
+        .cloned()
+        .ok_or_else(|| "SC-20254 lost its exact artifact identity".to_owned())?;
+    let mut strategy = ltx_attested_strategy(request, &context.selection, &contract)?;
+    strategy["spatialDecodeTiles"] = json!(spatial_decode_tile_count);
+    watchdog_lease.complete()?;
+    Ok(json!({
+        "schemaVersion": 1,
+        "recordType": "sceneworks_bounded_carrier_proof_response_v1",
+        "status": "diagnostic_bounded_carrier_complete",
+        "story": "sc-20254",
+        "logicalCaseId": LTX_BOUNDED_CARRIER_LOGICAL_CASE_ID,
+        "fixture": LTX_BOUNDED_CARRIER_FIXTURE,
+        "identity": LTX_BOUNDED_CARRIER_IDENTITY,
+        "diagnosticOnly": true,
+        "promotable": false,
+        "ingestible": false,
+        "inferenceRevision": protocol::INFERENCE_PIN,
+        "calibrationFingerprint": calibration.fingerprint,
+        "artifact": {
+            "repository": repository,
+            "resolvedRevision": revision,
+            "variant": "q4",
+            "tierRoot": root,
+            "textEncoderRoot": text_encoder_root,
+            "numericTierInventory": planned_artifact["numericTierInventory"],
+            "textEncoderInventory": planned_artifact["textEncoderInventory"],
+        },
+        "target": {
+            "provider": LTX_PROVIDER,
+            "tier": "q4",
+            "geometry": {
+                "width": LTX_CAMPAIGN_ENTRY_WIDTH,
+                "height": LTX_CAMPAIGN_ENTRY_HEIGHT,
+                "frames": LTX_CAMPAIGN_ENTRY_FRAMES,
+                "fps": LTX_CAMPAIGN_ENTRY_FPS,
+            },
+            "seed": LTX_SEED,
+            "videoMode": "default_av",
+            "audio": true,
+        },
+        "strategy": strategy,
+        "watchdog": {
+            "required": true,
+            "protocol": LTX_CANARY_WATCHDOG_PROTOCOL,
+            "providerPhaseProtocol": LTX_PROVIDER_PHASE_PROTOCOL,
+            "providerPhaseProfile": LTX_BOUNDED_CARRIER_PHASE_PROFILE,
+            "providerPhases": LTX_BOUNDED_CARRIER_PHASE_NAMES,
+            "maxFootprintBytes": watchdog.max_footprint_bytes,
+            "maxRuntimeSeconds": watchdog.max_runtime_seconds,
+            "hostMemoryBytes": watchdog.host_memory_bytes,
+            "minInitialMemoryFreeBytes": watchdog.min_initial_memory_free_bytes,
+            "minMemoryFreeBytes": watchdog.min_memory_free_bytes,
+        },
+        "mlxLimits": {
+            "memoryLimitBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES,
+            "wiredLimitBytes": limits.wired,
+        },
+        "observedMemory": {
+            "preProviderActiveBytes": pre_provider.active,
+            "preProviderCacheBytes": pre_provider.cache,
+            "expectedPersistentActive": {
+                "identity": LTX_CANARY_ONES_CACHE_IDENTITY,
+                "videoDimension": LTX_CANARY_ONES_CACHE_VIDEO_DIMENSION,
+                "audioDimension": LTX_CANARY_ONES_CACHE_AUDIO_DIMENSION,
+                "dtype": "bfloat16",
+                "bytesPerElement": BFLOAT16_BYTES_PER_ELEMENT,
+                "bytes": expected_persistent_active,
+            },
+            "conditioning": conditioning.json(),
+            "denoise": denoise.json(),
+            "decode": decode.json(),
+            "peakActiveBytes": peak_active,
+            "postCleanupActiveBytes": post_cleanup.active,
+            "postCleanupCacheBytes": post_cleanup.cache,
+        },
+        "output": {
+            "frames": LTX_CAMPAIGN_ENTRY_FRAMES,
+            "fps": LTX_CAMPAIGN_ENTRY_FPS,
+            "audio": {
+                "present": true,
+                "samples": audio.samples,
+                "sampleRate": audio.sample_rate,
+                "channels": audio.channels,
+            },
+            "frameTimelineSeconds": f64::from(LTX_CAMPAIGN_ENTRY_FRAMES - 1)
+                / f64::from(LTX_CAMPAIGN_ENTRY_FPS),
+            "firstFrameNondegenerate": true,
+        },
+        "capturedAt": protocol::captured_at(),
+    }))
+}
+
 fn run_ltx_campaign_entry(request: &Value) -> Result<Value, String> {
     // Every request identity check precedes the live watchdog handshake, process-global limits,
     // model-path resolution and provider registry construction.
@@ -8129,6 +8541,7 @@ fn main() {
         "canary" => run_ltx_canary(&request),
         "product_envelope_canary" => run_ltx_product_envelope_canary(&request),
         LTX_CAMPAIGN_ENTRY_ACTION => run_ltx_campaign_entry(&request),
+        LTX_BOUNDED_CARRIER_ACTION => run_ltx_bounded_carrier_proof(&request),
         "assess_batch" => assess_z_image_batch(&request),
         other => Err(format!("unsupported action {other:?}")),
     }
@@ -9372,6 +9785,103 @@ mod ltx_tests {
         request
     }
 
+    fn ltx_bounded_carrier_request_json() -> Value {
+        let mut request = ltx_canary_request_json();
+        request["action"] = json!(LTX_BOUNDED_CARRIER_ACTION);
+        request["planned"]["logicalCaseId"] = json!(LTX_BOUNDED_CARRIER_LOGICAL_CASE_ID);
+        request["planned"]["target"]["geometry"] = json!({
+            "width": LTX_CAMPAIGN_ENTRY_WIDTH,
+            "height": LTX_CAMPAIGN_ENTRY_HEIGHT,
+            "batch": 1,
+            "frames": LTX_CAMPAIGN_ENTRY_FRAMES,
+        });
+        request["planned"]["fixture"] = json!(LTX_BOUNDED_CARRIER_FIXTURE);
+        request["planned"]["negative"] = json!(false);
+        request["planned"]["expectedResult"] = json!("passed");
+        request["planned"]["modelLoadPolicy"] = json!("fresh_per_case");
+        request["planned"]["modelLoadGroup"] = Value::Null;
+        request["planned"]
+            .as_object_mut()
+            .unwrap()
+            .remove("_canary");
+        let artifact = request["planned"]
+            .as_object_mut()
+            .unwrap()
+            .remove("_artifact")
+            .unwrap();
+        request["planned"]["_boundedCarrier"] = json!({
+            "identity": LTX_BOUNDED_CARRIER_IDENTITY,
+            "fps": LTX_CAMPAIGN_ENTRY_FPS,
+            "seed": LTX_SEED,
+            "videoMode": "default_av",
+            "artifact": artifact,
+        });
+        request
+    }
+
+    #[test]
+    fn sc_20254_admits_only_the_exact_single_render_bounded_carrier() {
+        let request = ltx_bounded_carrier_request_json();
+        let (geometry, selection) = prevalidate_ltx_bounded_carrier_proof(&request)
+            .expect("the exact diagnostic bounded carrier is admissible");
+        let decode = LtxDecodePlan::resolve_for_selection(&selection, geometry).unwrap();
+        assert!(decode.tiling_engaged());
+        assert_eq!(decode.spatial_tile_px(), u64::from(LTX_CANARY_TILE_EDGE));
+        assert_eq!(decode.spatial_overlap_px(), u64::from(LTX_CANARY_OVERLAP));
+        assert_eq!(decode.spatial_tile_count(geometry).unwrap(), 24);
+
+        for (pointer, value) in [
+            ("/action", json!(LTX_CAMPAIGN_ENTRY_ACTION)),
+            (
+                "/planned/logicalCaseId",
+                json!(LTX_CAMPAIGN_ENTRY_LOGICAL_CASE_ID),
+            ),
+            ("/planned/fixture", json!(LTX_CAMPAIGN_ENTRY_FIXTURE)),
+            ("/planned/strategy/rung", json!("staged_residency")),
+            (
+                "/planned/strategy/parameters/decodeTileEdge",
+                json!(LTX_CANARY_TILE_EDGE + 1),
+            ),
+            (
+                "/planned/strategy/parameters/decodeOverlap",
+                json!(LTX_CANARY_OVERLAP + 1),
+            ),
+            ("/planned/_boundedCarrier/identity", json!("mutated")),
+            ("/planned/_boundedCarrier/seed", json!(LTX_SEED + 1)),
+            (
+                "/planned/_watchdog/maxFootprintBytes",
+                json!(LTX_CANARY_MAX_FOOTPRINT_BYTES + 1),
+            ),
+        ] {
+            let mut mutated = request.clone();
+            *mutated.pointer_mut(pointer).expect("mutation pointer") = value;
+            let error = prevalidate_ltx_bounded_carrier_proof(&mutated)
+                .expect_err("every bounded-carrier identity mutation must fail closed");
+            assert!(error.contains("SC-20254"), "{pointer}: {error}");
+        }
+
+        let generation_request = ltx_request(geometry, LTX_CAMPAIGN_ENTRY_FPS, LTX_SEED);
+        validate_ltx_bounded_carrier_generation_request(&generation_request)
+            .expect("the exact provider request is bound independently");
+        for mutate in [
+            |value: &mut GenerationRequest| value.seed = Some(LTX_SEED + 1),
+            |value: &mut GenerationRequest| value.fps = Some(LTX_CAMPAIGN_ENTRY_FPS + 1),
+            |value: &mut GenerationRequest| value.frames = Some(LTX_CAMPAIGN_ENTRY_FRAMES - 1),
+            |value: &mut GenerationRequest| value.video_mode = Some("no_audio".to_owned()),
+        ] {
+            let mut mutated = generation_request.clone();
+            mutate(&mut mutated);
+            assert!(validate_ltx_bounded_carrier_generation_request(&mutated).is_err());
+        }
+
+        let direct = run_ltx_bounded_carrier_proof(&request)
+            .expect_err("private JSON alone cannot bypass the live watchdog");
+        assert!(
+            direct.contains("live external watchdog channel"),
+            "{direct}"
+        );
+    }
+
     #[test]
     fn sc_20191_admits_only_the_exact_private_campaign_row_before_weight_work() {
         let request = ltx_campaign_entry_request_json();
@@ -9424,7 +9934,7 @@ mod ltx_tests {
     }
 
     #[test]
-    fn sc_20216_phase_channel_is_exact_monotonic_and_campaign_only() {
+    fn sc_20216_phase_channel_is_exact_monotonic_and_action_bound() {
         let request = ltx_campaign_entry_request_json();
         let host_memory = request["hardware"]["memoryBytes"].as_u64().unwrap();
         let nonce = "cd".repeat(32);
@@ -9446,7 +9956,7 @@ mod ltx_tests {
         let error = consume_ltx_canary_watchdog_attestation_stream(&request, missing_adapter)
             .expect_err("campaign entry must require authenticated phases");
         missing_thread.join().unwrap();
-        assert!(error.contains("authenticated provider phase protocol"));
+        assert!(error.contains("action-bound authenticated provider phase contract"));
 
         let (adapter, mut watchdog) = UnixStream::pair().unwrap();
         let mut attestation = LtxCanaryWatchdogAttestation {
@@ -9538,11 +10048,118 @@ mod ltx_tests {
             phase_acknowledgements,
             nonce,
             phase_sequence: 0,
+            expected_phases: &LTX_PROVIDER_PHASE_NAMES,
         };
         assert!(reordered
             .mark("primary_decode")
             .unwrap_err()
             .contains("reordered"));
+    }
+
+    #[test]
+    fn sc_20254_phase_attestation_accepts_only_its_exact_five_phase_socket_contract() {
+        let request = ltx_bounded_carrier_request_json();
+        let host_memory = request["hardware"]["memoryBytes"].as_u64().unwrap();
+        let nonce = "ef".repeat(32);
+        let payload = json!({
+            "protocol": LTX_CANARY_WATCHDOG_PROTOCOL,
+            "nonce": nonce,
+            "maxFootprintBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES,
+            "maxRuntimeSeconds": LTX_CANARY_MAX_RUNTIME_SECONDS,
+            "hostMemoryBytes": host_memory,
+            "minInitialMemoryFreeBytes": 2 * LTX_CANARY_MAX_FOOTPRINT_BYTES + host_memory.div_ceil(100),
+            "minMemoryFreeBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES + host_memory.div_ceil(100),
+            "providerPhaseProtocol": LTX_PROVIDER_PHASE_PROTOCOL,
+            "providerPhaseProfile": LTX_BOUNDED_CARRIER_PHASE_PROFILE,
+            "providerPhases": LTX_BOUNDED_CARRIER_PHASE_NAMES,
+        });
+        let (mut watchdog, adapter) = UnixStream::pair().unwrap();
+        let peer_nonce = nonce.clone();
+        let peer = std::thread::spawn(move || {
+            watchdog
+                .write_all(format!("{payload}\n").as_bytes())
+                .unwrap();
+            assert_eq!(
+                read_watchdog_line(&mut watchdog).unwrap(),
+                format!("ACK {peer_nonce}")
+            );
+            watchdog
+                .write_all(format!("GO {peer_nonce}\n").as_bytes())
+                .unwrap();
+            for (index, name) in LTX_BOUNDED_CARRIER_PHASE_NAMES.iter().enumerate() {
+                assert_eq!(
+                    read_watchdog_line(&mut watchdog).unwrap(),
+                    format!("PHASE {peer_nonce} {} {name}", index + 1)
+                );
+                watchdog
+                    .write_all(format!("PHASE_ACK {peer_nonce} {} {name}\n", index + 1).as_bytes())
+                    .unwrap();
+            }
+            assert_eq!(
+                read_watchdog_line(&mut watchdog).unwrap(),
+                format!("DONE {peer_nonce}")
+            );
+            watchdog
+                .write_all(format!("BYE {peer_nonce}\n").as_bytes())
+                .unwrap();
+        });
+        let mut attestation =
+            consume_ltx_canary_watchdog_attestation_stream(&request, adapter).unwrap();
+        let mut lease = attestation
+            .start_lease_for(&LTX_BOUNDED_CARRIER_PHASE_NAMES)
+            .unwrap();
+        for name in LTX_BOUNDED_CARRIER_PHASE_NAMES {
+            lease
+                .mark(name)
+                .expect("watchdog must ACK each exact phase");
+        }
+        lease.complete().unwrap();
+        peer.join().unwrap();
+
+        for mutate in [
+            |value: &mut Value| {
+                value["providerPhaseProfile"] = json!(LTX_CAMPAIGN_ENTRY_PHASE_PROFILE);
+            },
+            |value: &mut Value| {
+                value["providerPhases"] = json!(LTX_PROVIDER_PHASE_NAMES);
+            },
+            |value: &mut Value| {
+                value["providerPhases"] = json!([
+                    "primary_conditioning",
+                    "common_load",
+                    "primary_denoise",
+                    "primary_decode",
+                    "cleanup",
+                ]);
+            },
+        ] {
+            let mut mutated = json!({
+                "protocol": LTX_CANARY_WATCHDOG_PROTOCOL,
+                "nonce": nonce,
+                "maxFootprintBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES,
+                "maxRuntimeSeconds": LTX_CANARY_MAX_RUNTIME_SECONDS,
+                "hostMemoryBytes": host_memory,
+                "minInitialMemoryFreeBytes": 2 * LTX_CANARY_MAX_FOOTPRINT_BYTES + host_memory.div_ceil(100),
+                "minMemoryFreeBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES + host_memory.div_ceil(100),
+                "providerPhaseProtocol": LTX_PROVIDER_PHASE_PROTOCOL,
+                "providerPhaseProfile": LTX_BOUNDED_CARRIER_PHASE_PROFILE,
+                "providerPhases": LTX_BOUNDED_CARRIER_PHASE_NAMES,
+            });
+            mutate(&mut mutated);
+            let (mut bad_watchdog, bad_adapter) = UnixStream::pair().unwrap();
+            let bad_peer = std::thread::spawn(move || {
+                bad_watchdog
+                    .write_all(format!("{mutated}\n").as_bytes())
+                    .unwrap();
+            });
+            let error = consume_ltx_canary_watchdog_attestation_stream(&request, bad_adapter)
+                .expect_err("profile, list and order mutations must fail closed");
+            bad_peer.join().unwrap();
+            assert!(
+                error.contains("action-bound authenticated provider phase contract"),
+                "{error}"
+            );
+        }
     }
 
     #[test]

--- a/scripts/memory-calibration-watchdog.py
+++ b/scripts/memory-calibration-watchdog.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 HARD_STOP_EXIT = 97
 PROVIDER_PHASE_PROTOCOL = "sceneworks-provider-phase-v1"
-PROVIDER_PHASES = (
+CAMPAIGN_ENTRY_PROVIDER_PHASES = (
     "common_load",
     "primary_conditioning",
     "primary_denoise",
@@ -36,6 +36,17 @@ PROVIDER_PHASES = (
     "lifecycle_error_recovery",
     "cleanup",
 )
+BOUNDED_CARRIER_PROVIDER_PHASES = (
+    "common_load",
+    "primary_conditioning",
+    "primary_denoise",
+    "primary_decode",
+    "cleanup",
+)
+PROVIDER_PHASE_PROFILES = {
+    "campaign-entry": CAMPAIGN_ENTRY_PROVIDER_PHASES,
+    "bounded-carrier": BOUNDED_CARRIER_PROVIDER_PHASES,
+}
 
 
 @dataclass(frozen=True)
@@ -599,6 +610,11 @@ def guard(args: argparse.Namespace) -> int:
         for signum, handler in previous_handlers.items():
             signal.signal(signum, handler)
         raise
+    provider_phases = (
+        PROVIDER_PHASE_PROFILES[args.provider_phase_profile]
+        if args.provider_phase_profile is not None
+        else ()
+    )
     runtime_deadline = None
     attestation_nonce = None
     attestation_buffer = bytearray()
@@ -630,12 +646,12 @@ def guard(args: argparse.Namespace) -> int:
                 except ValueError:
                     return "child_returned_non_integer_provider_phase_sequence"
                 expected_sequence = provider_phase_sequence + 1
-                if sequence != expected_sequence or sequence > len(PROVIDER_PHASES):
+                if sequence != expected_sequence or sequence > len(provider_phases):
                     return (
                         "child_returned_reordered_provider_phase:"
                         f"expected_{expected_sequence}:observed_{sequence}"
                     )
-                expected_name = PROVIDER_PHASES[sequence - 1]
+                expected_name = provider_phases[sequence - 1]
                 if fields[3] != expected_name:
                     return (
                         "child_returned_invalid_provider_phase_name:"
@@ -663,7 +679,7 @@ def guard(args: argparse.Namespace) -> int:
             if fields == ["DONE", str(attestation_nonce)]:
                 if child_reported_done:
                     return "child_returned_duplicate_completion_attestation"
-                if args.require_provider_phases and provider_phase_sequence != len(PROVIDER_PHASES):
+                if args.require_provider_phases and provider_phase_sequence != len(provider_phases):
                     return (
                         "child_completed_before_provider_phase_sequence:"
                         f"observed_{provider_phase_sequence}"
@@ -773,7 +789,8 @@ def guard(args: argparse.Namespace) -> int:
             if args.require_provider_phases:
                 attestation.update({
                     "providerPhaseProtocol": PROVIDER_PHASE_PROTOCOL,
-                    "providerPhases": list(PROVIDER_PHASES),
+                    "providerPhaseProfile": args.provider_phase_profile,
+                    "providerPhases": list(provider_phases),
                 })
             if args.min_swap_free_bytes is not None:
                 attestation["minSwapFreeBytes"] = args.min_swap_free_bytes
@@ -1107,6 +1124,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--allow-synthetic-telemetry", action="store_true")
     parser.add_argument("--require-child-attestation", action="store_true")
     parser.add_argument("--require-provider-phases", action="store_true")
+    parser.add_argument("--provider-phase-profile", choices=tuple(PROVIDER_PHASE_PROFILES))
     parser.add_argument("--synthetic-spawn-delay", type=float, default=0.0, help=argparse.SUPPRESS)
     parser.add_argument("--synthetic-launch-ready-file", type=Path, help=argparse.SUPPRESS)
     parser.add_argument("command", nargs=argparse.REMAINDER)
@@ -1148,6 +1166,8 @@ def parse_args() -> argparse.Namespace:
         parser.error("child attestation requires production Darwin telemetry and launch controls")
     if args.require_provider_phases and not args.require_child_attestation:
         parser.error("provider phases require child attestation")
+    if args.require_provider_phases != (args.provider_phase_profile is not None):
+        parser.error("provider phases require exactly one named phase profile")
     return args
 
 

--- a/scripts/memory-calibration-watchdog.test.mjs
+++ b/scripts/memory-calibration-watchdog.test.mjs
@@ -143,6 +143,7 @@ async function runWithMockedProductionTelemetry(files, childCommand, options = {
     telemetryTimeout = 0.5, actualHostMemory = 1000, requestedHostMemory = 1000,
     childAttestationTimeout = 1,
     requireProviderPhases = false,
+    providerPhaseProfile = "campaign-entry",
     memoryFreePercent = 90, memoryFreeBytes = 900, swapFreeBytes = 900,
     pressureSamples = [[memoryFreePercent, memoryFreeBytes, swapFreeBytes]],
     pressureFailureAt = null,
@@ -176,7 +177,9 @@ sys.argv = [${JSON.stringify(WATCHDOG)},
     "--telemetry-timeout", ${JSON.stringify(String(telemetryTimeout))},
     "--child-attestation-timeout", ${JSON.stringify(String(childAttestationTimeout))},
     "--term-grace", "0.1", "--event-file", ${JSON.stringify(files.events)},
-    "--require-child-attestation", ${requireProviderPhases ? '"--require-provider-phases",' : ""}
+    "--require-child-attestation", ${requireProviderPhases
+      ? `"--require-provider-phases", "--provider-phase-profile", ${JSON.stringify(providerPhaseProfile)},`
+      : ""}
     "--", *${JSON.stringify(childCommand)}]
 raise SystemExit(module.guard(module.parse_args()))
 `);
@@ -357,6 +360,7 @@ def line():
     return data.decode().strip()
 payload = json.loads(line()); nonce = payload["nonce"]
 assert payload["providerPhaseProtocol"] == "sceneworks-provider-phase-v1"
+assert payload["providerPhaseProfile"] == "campaign-entry"
 assert payload["providerPhases"] == ${JSON.stringify(phases)}
 sock.sendall(f"ACK {nonce}\n".encode()); assert line() == f"GO {nonce}"
 for sequence, name in enumerate(payload["providerPhases"], 1):
@@ -394,6 +398,53 @@ while True:
   }
   assert.ok(events.every((event) => /^[0-9a-f]{64}$/.test(event.eventHash)));
   validateWatchdogEventChain(events);
+});
+
+test("bounded carrier profile advertises and acknowledges exactly five phases", async () => {
+  const files = await fixture();
+  const attester = `${files.program}.bounded-phases.py`;
+  const phases = [
+    "common_load", "primary_conditioning", "primary_denoise", "primary_decode", "cleanup",
+  ];
+  await writeFile(attester, String.raw`import json, os, socket
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect(os.environ["SCENEWORKS_MEMORY_WATCHDOG_SOCKET"])
+def line():
+    data = b""
+    while not data.endswith(b"\n"): data += sock.recv(1)
+    return data.decode().strip()
+payload = json.loads(line()); nonce = payload["nonce"]
+assert payload["providerPhaseProtocol"] == "sceneworks-provider-phase-v1"
+assert payload["providerPhaseProfile"] == "bounded-carrier"
+assert payload["providerPhases"] == ${JSON.stringify(phases)}
+sock.sendall(f"ACK {nonce}\n".encode()); assert line() == f"GO {nonce}"
+for sequence, name in enumerate(payload["providerPhases"], 1):
+    sock.sendall(f"PHASE {nonce} {sequence} {name}\n".encode())
+    while True:
+        acknowledgement = line()
+        if acknowledgement == f"PING {nonce}": continue
+        assert acknowledgement == f"PHASE_ACK {nonce} {sequence} {name}"
+        break
+sock.sendall(f"DONE {nonce}\n".encode())
+while True:
+    message = line()
+    if message == f"BYE {nonce}": break
+    assert message == f"PING {nonce}"
+`);
+  await runWithMockedProductionTelemetry(files, ["python3", attester], {
+    requireProviderPhases: true,
+    providerPhaseProfile: "bounded-carrier",
+  });
+  const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
+  assert.deepEqual(
+    events.filter((event) => event.event === "provider_phase")
+      .map((event) => event.providerPhase.name),
+    phases,
+  );
+  assert.deepEqual(
+    events.find((event) => event.event === "child_completed").providerPhase,
+    { sequence: 5, name: "cleanup" },
+  );
 });
 
 test("reordered or foreign provider phases hard-stop the owned group", async () => {

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -2041,7 +2041,7 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
     /LTX_(?:CANARY|PRODUCT_CANARY)_FIXTURE|diagnostic_(?:product_envelope_)?canary_complete/,
   );
   const campaignEntry = adapter.slice(
-    adapter.indexOf("fn prevalidate_ltx_campaign_entry("),
+    adapter.indexOf("fn run_ltx_campaign_entry("),
     adapter.indexOf("fn run_ltx(request:"),
   );
   for (const required of [
@@ -2070,6 +2070,32 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
       < campaignEntry.indexOf("consume_ltx_canary_watchdog_attestation(request)?"),
     "the exact campaign row must be validated before the watchdog releases model allocation",
   );
+  const boundedCarrier = adapter.slice(
+    adapter.indexOf("fn run_ltx_bounded_carrier_proof("),
+    adapter.indexOf("fn run_ltx_campaign_entry("),
+  );
+  for (const required of [
+    "prevalidate_ltx_bounded_carrier_proof(request)?",
+    "start_lease_for(&LTX_BOUNDED_CARRIER_PHASE_NAMES)?",
+    'watchdog_lease.mark("common_load")?',
+    'watchdog_lease.mark("primary_conditioning")?',
+    'watchdog_lease.mark("primary_denoise")',
+    'watchdog_lease.mark("primary_decode")',
+    'watchdog_lease.mark("cleanup")?',
+    "validate_ltx_bounded_carrier_generation_request(&generation_request)?",
+    "scoped_generate(",
+    "spatial_decode_tile_count != 24",
+    "validate_ltx_canary_cleanup(",
+    '"diagnosticOnly": true',
+    '"promotable": false',
+    '"ingestible": false',
+    '"seed": LTX_SEED',
+  ]) assert.ok(boundedCarrier.includes(required), `bounded carrier must retain ${required}`);
+  assert.doesNotMatch(boundedCarrier, /verify_ltx_lifecycle|LtxRunAdmission::CampaignEntry/,
+    "SC-20254 must execute one provider request scope, not the multi-render campaign lifecycle");
+  assert.equal((boundedCarrier.match(/scoped_generate\(/g) ?? []).length, 1,
+    "SC-20254 must contain exactly one full-A/V render call");
+  assert.match(adapter, /LTX_BOUNDED_CARRIER_ACTION => run_ltx_bounded_carrier_proof\(&request\)/);
 
   const canary = adapter.slice(
     adapter.indexOf("fn validate_ltx_canary_plan_for("),

--- a/scripts/run-ltx-safety-canary.mjs
+++ b/scripts/run-ltx-safety-canary.mjs
@@ -9,6 +9,7 @@ import {
 } from "node:fs/promises";
 import { arch } from "node:os";
 import path from "node:path";
+import { createInterface } from "node:readline";
 import { isDeepStrictEqual, promisify } from "node:util";
 import { fileURLToPath } from "node:url";
 
@@ -36,6 +37,7 @@ const FINGERPRINT = "sc-19109-ltx-2-3-mlx-memory-ladder-v1";
 export const SAFETY_CANARY_PROFILE = "safety";
 export const PRODUCT_ENVELOPE_CANARY_PROFILE = "product-envelope";
 export const CAMPAIGN_ENTRY_PROFILE = "campaign-entry";
+export const BOUNDED_CARRIER_PROFILE = "bounded-carrier";
 export const CAMPAIGN_ENTRY_PROVIDER =
   "mlx-ltx-2-3-q4-768x512-f121-fps30-staged_residency";
 export const CAMPAIGN_ENTRY_FIXTURE =
@@ -43,6 +45,17 @@ export const CAMPAIGN_ENTRY_FIXTURE =
 export const CAMPAIGN_ENTRY_LOGICAL_CASE_ID = "implan-9b107d4d1ca0d61d4faa";
 export const CAMPAIGN_ENTRY_IDENTITY = "sc-20191-q4-768x512-f121-fps30-staged-v1";
 export const CAMPAIGN_FAILURE_RECEIPT_TYPE = "sceneworks_campaign_entry_failure_v1";
+export const BOUNDED_CARRIER_ACTION = "bounded_carrier_proof";
+export const BOUNDED_CARRIER_IDENTITY =
+  "sc-20254-q4-768x512-f121-fps30-bounded-192-64-v1";
+export const BOUNDED_CARRIER_LOGICAL_CASE_ID =
+  "diagnostic-sc20254-q4-768x512-f121-fps30-bounded-192-64";
+export const BOUNDED_CARRIER_FIXTURE =
+  "ltx-2-3-mlx-q4-768x512-f121-fps30-seed18946-bounded-decode-192-64-proof";
+export const BOUNDED_CARRIER_SUCCESS_RECEIPT_TYPE =
+  "sceneworks_bounded_carrier_success_v1";
+export const BOUNDED_CARRIER_FAILURE_RECEIPT_TYPE =
+  "sceneworks_bounded_carrier_failure_v1";
 export const PROVIDER_PHASE_PROTOCOL = "sceneworks-provider-phase-v1";
 export const WATCHDOG_EVENT_CHAIN_PROTOCOL = "sceneworks-watchdog-event-chain-v1";
 export const PROVIDER_PHASES = Object.freeze([
@@ -55,6 +68,13 @@ export const PROVIDER_PHASES = Object.freeze([
   "lifecycle_cancel_recovery",
   "lifecycle_error",
   "lifecycle_error_recovery",
+  "cleanup",
+]);
+export const BOUNDED_CARRIER_PHASES = Object.freeze([
+  "common_load",
+  "primary_conditioning",
+  "primary_denoise",
+  "primary_decode",
   "cleanup",
 ]);
 const CAMPAIGN_ENTRY_ACTION = "campaign_entry";
@@ -478,6 +498,63 @@ export function canaryRequest(
   };
 }
 
+export function boundedCarrierRequest(memoryBytes, textEncoderInventory) {
+  assertInventory(textEncoderInventory, {
+    files: TEXT_ENCODER_INVENTORY_FILES,
+    bytes: TEXT_ENCODER_INVENTORY_BYTES,
+    sha256: TEXT_ENCODER_INVENTORY_SHA256,
+  }, "immutable text-encoder");
+  return {
+    action: BOUNDED_CARRIER_ACTION,
+    hardware: { memoryBytes },
+    planned: {
+      _diagnosticOnly: true,
+      logicalCaseId: BOUNDED_CARRIER_LOGICAL_CASE_ID,
+      evidenceScope: "fixture",
+      backend: "mlx",
+      loadShape: "eager_materialization",
+      target: {
+        provider: PROVIDER,
+        modelId: PROVIDER,
+        tier: "q4",
+        mode: "text_to_video",
+        overlay: "none",
+        geometry: { width: 768, height: 512, batch: 1, frames: 121 },
+      },
+      strategy: {
+        rung: "bounded_decode",
+        engagedRungs: ["resident", "staged_residency", "bounded_decode"],
+        parameters: { decodeTileEdge: 192, decodeOverlap: 64 },
+      },
+      calibrationFingerprint: FINGERPRINT,
+      fixture: BOUNDED_CARRIER_FIXTURE,
+      negative: false,
+      expectedResult: "passed",
+      modelLoadPolicy: "fresh_per_case",
+      modelLoadGroup: null,
+      _watchdog: { maxFootprintBytes: MAX_FOOTPRINT_BYTES },
+      _boundedCarrier: {
+        identity: BOUNDED_CARRIER_IDENTITY,
+        fps: 30,
+        seed: 18_946,
+        videoMode: "default_av",
+        artifact: {
+          repository: ARTIFACT_REPOSITORY,
+          revision: ARTIFACT_REVISION,
+          numericTierInventory: {
+            files: 11, bytes: Q4_INVENTORY_BYTES, sha256: Q4_INVENTORY_SHA256,
+          },
+          textEncoderInventory: {
+            files: textEncoderInventory.files,
+            bytes: textEncoderInventory.bytes,
+            sha256: textEncoderInventory.sha256,
+          },
+        },
+      },
+    },
+  };
+}
+
 export function campaignEntryPlan(config) {
   const matches = config?.providers?.filter((provider) =>
     provider.name === CAMPAIGN_ENTRY_PROVIDER) ?? [];
@@ -672,7 +749,143 @@ export function validateCampaignEntryAdapterResponse(response, {
   return response;
 }
 
-export function validateCampaignEntryWatchdogEvents(events, hostMemoryBytes) {
+export function validateBoundedCarrierResponse(response, {
+  inferenceRevision, hostMemoryBytes,
+} = {}) {
+  let canonicallyIngestible = true;
+  try {
+    validateBundle(response);
+  } catch {
+    canonicallyIngestible = false;
+  }
+  if (canonicallyIngestible
+      || response?.schemaVersion !== 1
+      || response?.recordType !== "sceneworks_bounded_carrier_proof_response_v1"
+      || response?.status !== "diagnostic_bounded_carrier_complete"
+      || response?.story !== "sc-20254"
+      || response?.logicalCaseId !== BOUNDED_CARRIER_LOGICAL_CASE_ID
+      || response?.fixture !== BOUNDED_CARRIER_FIXTURE
+      || response?.identity !== BOUNDED_CARRIER_IDENTITY
+      || response?.diagnosticOnly !== true
+      || response?.promotable !== false
+      || response?.ingestible !== false
+      || (inferenceRevision !== undefined && response?.inferenceRevision !== inferenceRevision)
+      || response?.calibrationFingerprint !== FINGERPRINT
+      || response?.artifact?.repository !== ARTIFACT_REPOSITORY
+      || response?.artifact?.resolvedRevision !== ARTIFACT_REVISION
+      || response?.artifact?.variant !== "q4"
+      || !isDeepStrictEqual(response?.artifact?.numericTierInventory, {
+        files: 11, bytes: Q4_INVENTORY_BYTES, sha256: Q4_INVENTORY_SHA256,
+      })
+      || !isDeepStrictEqual(response?.artifact?.textEncoderInventory, {
+        files: TEXT_ENCODER_INVENTORY_FILES,
+        bytes: TEXT_ENCODER_INVENTORY_BYTES,
+        sha256: TEXT_ENCODER_INVENTORY_SHA256,
+      })
+      || !isDeepStrictEqual(response?.target, {
+        provider: PROVIDER,
+        tier: "q4",
+        geometry: { width: 768, height: 512, frames: 121, fps: 30 },
+        seed: 18_946,
+        videoMode: "default_av",
+        audio: true,
+      })
+      || !isDeepStrictEqual(response?.strategy, {
+        rung: "bounded_decode",
+        engagedRungs: ["resident", "staged_residency", "bounded_decode"],
+        parameters: { decodeTileEdge: 192, decodeOverlap: 64 },
+        spatialDecodeTiles: 24,
+      })
+      || response?.watchdog?.required !== true
+      || response?.watchdog?.protocol !== "sceneworks-memory-watchdog-v1"
+      || response?.watchdog?.providerPhaseProtocol !== PROVIDER_PHASE_PROTOCOL
+      || response?.watchdog?.providerPhaseProfile !== "bounded-carrier"
+      || !isDeepStrictEqual(response?.watchdog?.providerPhases, BOUNDED_CARRIER_PHASES)
+      || response?.watchdog?.maxFootprintBytes !== MAX_FOOTPRINT_BYTES
+      || response?.watchdog?.maxRuntimeSeconds !== MAX_RUNTIME_SECONDS
+      || (hostMemoryBytes !== undefined && response?.watchdog?.hostMemoryBytes !== hostMemoryBytes)
+      || response?.watchdog?.minInitialMemoryFreeBytes
+        !== preflightFreeFloor(response?.watchdog?.hostMemoryBytes)
+      || response?.watchdog?.minMemoryFreeBytes
+        !== runtimeFreeFloor(response?.watchdog?.hostMemoryBytes)
+      || Object.hasOwn(response?.watchdog ?? {}, "minSwapFreeBytes")
+      || Object.hasOwn(response?.watchdog ?? {}, "minInitialMemoryFreePercent")
+      || response?.mlxLimits?.memoryLimitBytes !== MAX_FOOTPRINT_BYTES
+      || !Number.isSafeInteger(response?.mlxLimits?.wiredLimitBytes)
+      || response.mlxLimits.wiredLimitBytes <= 0
+      || response.mlxLimits.wiredLimitBytes > MAX_FOOTPRINT_BYTES
+      || !isDeepStrictEqual(response?.output, {
+        frames: 121,
+        fps: 30,
+        audio: response?.output?.audio,
+        frameTimelineSeconds: 4,
+        firstFrameNondegenerate: true,
+      })
+      || response?.output?.audio?.present !== true
+      || !Number.isSafeInteger(response?.output?.audio?.samples)
+      || response.output.audio.samples <= 0
+      || !Number.isSafeInteger(response?.output?.audio?.sampleRate)
+      || response.output.audio.sampleRate <= 0
+      || !Number.isSafeInteger(response?.output?.audio?.channels)
+      || response.output.audio.channels <= 0) {
+    fail("SC-20254 response changed the exact non-ingestible bounded carrier");
+  }
+  const observed = response.observedMemory;
+  const phaseActive = [];
+  for (const phaseName of ["conditioning", "denoise", "decode"]) {
+    const phase = observed?.[phaseName];
+    for (const field of ["activeBytes", "allocatorBytes", "reclaimableBytes"]) {
+      if (!Number.isSafeInteger(phase?.[field]) || phase[field] < 0) {
+        fail(`SC-20254 observedMemory.${phaseName}.${field} is invalid`);
+      }
+    }
+    if (phase.activeBytes <= 0
+        || phase.allocatorBytes !== phase.activeBytes + phase.reclaimableBytes) {
+      fail(`SC-20254 observedMemory.${phaseName} is not exact`);
+    }
+    phaseActive.push(phase.activeBytes);
+  }
+  for (const field of [
+    "preProviderActiveBytes", "preProviderCacheBytes",
+    "postCleanupActiveBytes", "postCleanupCacheBytes",
+  ]) {
+    if (!Number.isSafeInteger(observed?.[field]) || observed[field] < 0) {
+      fail(`SC-20254 observedMemory.${field} must be a non-negative safe integer`);
+    }
+  }
+  if (observed.peakActiveBytes !== Math.max(...phaseActive)
+      || observed.preProviderCacheBytes !== 0
+      || !isDeepStrictEqual(observed.expectedPersistentActive, {
+        identity: LTX_ONES_CACHE_IDENTITY,
+        videoDimension: LTX_ONES_CACHE_VIDEO_DIMENSION,
+        audioDimension: LTX_ONES_CACHE_AUDIO_DIMENSION,
+        dtype: "bfloat16",
+        bytesPerElement: BFLOAT16_BYTES_PER_ELEMENT,
+        bytes: ltxOnesCacheBytes(),
+      })) {
+    fail("SC-20254 allocator phase or named persistent identity changed");
+  }
+  const expectedPostActive = observed.preProviderActiveBytes
+    + observed.expectedPersistentActive.bytes;
+  if (!Number.isSafeInteger(expectedPostActive)) {
+    fail("SC-20254 cleanup active-byte arithmetic overflowed");
+  }
+  if (observed.postCleanupActiveBytes !== expectedPostActive
+      || observed.postCleanupCacheBytes !== observed.preProviderCacheBytes) {
+    fail("SC-20254 cleanup did not return to its exact intentional persistent baseline");
+  }
+  return response;
+}
+
+export function validateBoundedCarrierWatchdogEvents(events, hostMemoryBytes) {
+  return validateCampaignEntryWatchdogEvents(
+    events, hostMemoryBytes, BOUNDED_CARRIER_PHASES,
+  );
+}
+
+export function validateCampaignEntryWatchdogEvents(
+  events, hostMemoryBytes, expectedPhases = PROVIDER_PHASES,
+) {
   if (!Array.isArray(events) || events.length === 0) fail("SC-20191 watchdog stream is empty");
   const startedIndex = events.findIndex((event) => event.event === "started");
   const attestedIndex = events.findIndex((event) => event.event === "child_attested");
@@ -705,7 +918,7 @@ export function validateCampaignEntryWatchdogEvents(events, hostMemoryBytes) {
       || events.some((event) => event.event === "hard_stop" || event.event === "terminated")) {
     fail("SC-20191 watchdog stream is incomplete or crossed a safety boundary");
   }
-  validateProviderPhaseTimeline(events, { complete: true });
+  validateProviderPhaseTimeline(events, { complete: true, expectedPhases });
   return Math.max(...samples.map((event) => event.physicalFootprintBytes));
 }
 
@@ -748,7 +961,9 @@ export function validateWatchdogEventChain(events) {
   };
 }
 
-export function validateProviderPhaseTimeline(events, { complete = false } = {}) {
+export function validateProviderPhaseTimeline(events, {
+  complete = false, expectedPhases = PROVIDER_PHASES,
+} = {}) {
   validateWatchdogEventChain(events);
   let current = null;
   let sequence = 0;
@@ -760,7 +975,7 @@ export function validateProviderPhaseTimeline(events, { complete = false } = {})
     previousAt = event.at;
     if (event.event === "provider_phase") {
       const expectedSequence = sequence + 1;
-      const expectedName = PROVIDER_PHASES[sequence];
+      const expectedName = expectedPhases[sequence];
       if (event.authenticated !== true
           || event.providerPhase?.sequence !== expectedSequence
           || event.providerPhase?.name !== expectedName) {
@@ -775,15 +990,17 @@ export function validateProviderPhaseTimeline(events, { complete = false } = {})
       fail("SC-20216 watchdog event is not bound to the latest authenticated provider phase");
     }
   }
-  if (sequence === 0 || (complete && sequence !== PROVIDER_PHASES.length)) {
+  if (sequence === 0 || (complete && sequence !== expectedPhases.length)) {
     fail("SC-20216 watchdog stream omitted required authenticated provider phases");
   }
   return current;
 }
 
-export function validateCampaignEntryFailureEvents(events, hostMemoryBytes) {
+export function validateCampaignEntryFailureEvents(
+  events, hostMemoryBytes, expectedPhases = PROVIDER_PHASES,
+) {
   if (!Array.isArray(events) || events.length === 0) fail("SC-20216 failure stream is empty");
-  validateProviderPhaseTimeline(events);
+  validateProviderPhaseTimeline(events, { expectedPhases });
   const eventChain = validateWatchdogEventChain(events);
   const hardStops = events.filter((event) => event.event === "hard_stop");
   const terminated = events.filter((event) => event.event === "terminated");
@@ -1053,6 +1270,64 @@ export function campaignEntryFailureReceipt({
   return validateCampaignEntryFailureReceipt(receipt);
 }
 
+function validateContainedReceiptArtifactIdentity(receipt, label) {
+  for (const source of [receipt.source?.sceneWorks, receipt.source?.inference]) {
+    if (!/^[0-9a-f]{40}$/.test(source?.revision ?? "")
+        || !/^[0-9a-f]{40}$/.test(source?.tree ?? "")) {
+      fail(`${label} receipt source identity is malformed`);
+    }
+  }
+  const preparation = receipt.artifacts?.preparation;
+  const identity = preparation?.identity;
+  const validFileIdentity = (file, mode) => path.isAbsolute(file?.path ?? "")
+    && /^[0-9a-f]{64}$/.test(file?.sha256 ?? "")
+    && typeof file?.device === "string" && typeof file?.inode === "string"
+    && Number.isSafeInteger(file?.size) && file.size > 0
+    && typeof file?.mtimeNs === "string" && typeof file?.ctimeNs === "string"
+    && file?.mode === mode;
+  if (receipt.artifacts?.repository !== ARTIFACT_REPOSITORY
+      || receipt.artifacts?.revision !== ARTIFACT_REVISION
+      || !isDeepStrictEqual(receipt.artifacts?.numericTierInventory, {
+        files: 11, bytes: Q4_INVENTORY_BYTES, sha256: Q4_INVENTORY_SHA256,
+      })
+      || !isDeepStrictEqual(receipt.artifacts?.textEncoderInventory, {
+        files: TEXT_ENCODER_INVENTORY_FILES,
+        bytes: TEXT_ENCODER_INVENTORY_BYTES,
+        sha256: TEXT_ENCODER_INVENTORY_SHA256,
+      })
+      || !/^[0-9a-f]{64}$/.test(preparation?.key ?? "")
+      || !path.isAbsolute(preparation?.root ?? "")
+      || path.basename(preparation?.root ?? "") !== preparation.key
+      || preparation?.manifest?.key !== preparation.key
+      || preparation?.manifest?.schemaVersion !== PREPARATION_SCHEMA_VERSION
+      || !isDeepStrictEqual(preparation?.manifest?.identity, identity)
+      || preparation?.manifest?.preparedFrom?.sceneWorksRevision
+        !== receipt.source.sceneWorks.revision
+      || preparation?.manifest?.preparedFrom?.inferenceRevision
+        !== receipt.source.inference.revision
+      || !isDeepStrictEqual(preparation?.manifest?.artifacts?.numericTier?.content,
+        receipt.artifacts.numericTierInventory)
+      || !isDeepStrictEqual(preparation?.manifest?.artifacts?.textEncoder?.content,
+        receipt.artifacts.textEncoderInventory)
+      || identity?.sceneWorksTree !== receipt.source.sceneWorks.tree
+      || identity?.inferenceTree !== receipt.source.inference.tree
+      || identity?.schemaVersion !== PREPARATION_SCHEMA_VERSION
+      || !isDeepStrictEqual(identity?.artifact, {
+        repository: ARTIFACT_REPOSITORY,
+        revision: ARTIFACT_REVISION,
+        numericTier: receipt.artifacts.numericTierInventory,
+        textEncoder: receipt.artifacts.textEncoderInventory,
+      })
+      || !validFileIdentity(receipt.artifacts?.adapter, 0o500)
+      || !validFileIdentity(receipt.artifacts?.metallib, 0o400)
+      || !isDeepStrictEqual(preparation?.manifest?.adapter,
+        preparedFileManifestIdentity(receipt.artifacts.adapter))
+      || !isDeepStrictEqual(preparation?.manifest?.metallib,
+        preparedFileManifestIdentity(receipt.artifacts.metallib))) {
+    fail(`${label} receipt artifact or sealed-preparation identity changed`);
+  }
+}
+
 export function validateCampaignEntryFailureReceipt(receipt) {
   let canonicallyIngestible = true;
   try {
@@ -1115,67 +1390,216 @@ export function validateCampaignEntryFailureReceipt(receipt) {
       || !isDeepStrictEqual(receipt?.cleanup, expectedCleanup)) {
     fail("SC-20216 failure receipt is ingestible, incomplete, or identity-drifted");
   }
-  for (const source of [receipt.source?.sceneWorks, receipt.source?.inference]) {
-    if (!/^[0-9a-f]{40}$/.test(source?.revision ?? "")
-        || !/^[0-9a-f]{40}$/.test(source?.tree ?? "")) {
-      fail("SC-20216 failure receipt source identity is malformed");
-    }
-  }
-  const preparation = receipt.artifacts?.preparation;
-  const identity = preparation?.identity;
-  const validFileIdentity = (file, mode) => path.isAbsolute(file?.path ?? "")
-    && /^[0-9a-f]{64}$/.test(file?.sha256 ?? "")
-    && typeof file?.device === "string" && typeof file?.inode === "string"
-    && Number.isSafeInteger(file?.size) && file.size > 0
-    && typeof file?.mtimeNs === "string" && typeof file?.ctimeNs === "string"
-    && file?.mode === mode;
-  if (receipt.artifacts?.repository !== ARTIFACT_REPOSITORY
-      || receipt.artifacts?.revision !== ARTIFACT_REVISION
-      || !isDeepStrictEqual(receipt.artifacts?.numericTierInventory, {
-        files: 11, bytes: Q4_INVENTORY_BYTES, sha256: Q4_INVENTORY_SHA256,
-      })
-      || !isDeepStrictEqual(receipt.artifacts?.textEncoderInventory, {
-        files: TEXT_ENCODER_INVENTORY_FILES,
-        bytes: TEXT_ENCODER_INVENTORY_BYTES,
-        sha256: TEXT_ENCODER_INVENTORY_SHA256,
-      })
-      || !/^[0-9a-f]{64}$/.test(preparation?.key ?? "")
-      || !path.isAbsolute(preparation?.root ?? "")
-      || path.basename(preparation?.root ?? "") !== preparation.key
-      || preparation?.manifest?.key !== preparation.key
-      || preparation?.manifest?.schemaVersion !== PREPARATION_SCHEMA_VERSION
-      || !isDeepStrictEqual(preparation?.manifest?.identity, identity)
-      || preparation?.manifest?.preparedFrom?.sceneWorksRevision
-        !== receipt.source.sceneWorks.revision
-      || preparation?.manifest?.preparedFrom?.inferenceRevision
-        !== receipt.source.inference.revision
-      || !isDeepStrictEqual(preparation?.manifest?.artifacts?.numericTier?.content,
-        receipt.artifacts.numericTierInventory)
-      || !isDeepStrictEqual(preparation?.manifest?.artifacts?.textEncoder?.content,
-        receipt.artifacts.textEncoderInventory)
-      || identity?.sceneWorksTree !== receipt.source.sceneWorks.tree
-      || identity?.inferenceTree !== receipt.source.inference.tree
-      || identity?.schemaVersion !== PREPARATION_SCHEMA_VERSION
-      || !isDeepStrictEqual(identity?.artifact, {
-        repository: ARTIFACT_REPOSITORY,
-        revision: ARTIFACT_REVISION,
-        numericTier: receipt.artifacts.numericTierInventory,
-        textEncoder: receipt.artifacts.textEncoderInventory,
-      })
-      || !validFileIdentity(receipt.artifacts?.adapter, 0o500)
-      || !validFileIdentity(receipt.artifacts?.metallib, 0o400)
-      || !isDeepStrictEqual(preparation?.manifest?.adapter,
-        preparedFileManifestIdentity(receipt.artifacts.adapter))
-      || !isDeepStrictEqual(preparation?.manifest?.metallib,
-        preparedFileManifestIdentity(receipt.artifacts.metallib))) {
-    fail("SC-20216 failure receipt artifact or sealed-preparation identity changed");
-  }
+  validateContainedReceiptArtifactIdentity(receipt, "SC-20216 failure");
   const validated = validateCampaignEntryFailureEvents(
     receipt.watchdog.events, receipt.watchdog.hostMemoryBytes,
   );
   if (!isDeepStrictEqual(receipt.watchdog.failure, validated)
       || !isDeepStrictEqual(receipt.watchdog.eventChain, validated.eventChain)) {
     fail("SC-20216 failure receipt summary does not match its complete event stream");
+  }
+  return receipt;
+}
+
+export function boundedCarrierSuccessPath(canonicalOutput) {
+  return path.join(path.dirname(canonicalOutput), "sc-20254-bounded-carrier-success.json");
+}
+
+export function boundedCarrierFailurePath(canonicalOutput) {
+  return path.join(path.dirname(canonicalOutput), "sc-20254-bounded-carrier-failure.json");
+}
+
+export function boundedCarrierOutcomeReservationPath(canonicalOutput) {
+  return path.join(path.dirname(canonicalOutput), ".sc-20254-bounded-carrier-outcome");
+}
+
+function boundedCarrierCaseIdentity() {
+  return {
+    action: BOUNDED_CARRIER_ACTION,
+    logicalCaseId: BOUNDED_CARRIER_LOGICAL_CASE_ID,
+    fixture: BOUNDED_CARRIER_FIXTURE,
+    identity: BOUNDED_CARRIER_IDENTITY,
+    target: {
+      provider: PROVIDER, tier: "q4",
+      geometry: { width: 768, height: 512, batch: 1, frames: 121, fps: 30 },
+      seed: 18_946, videoMode: "default_av", audio: true,
+    },
+    strategy: {
+      rung: "bounded_decode",
+      engagedRungs: ["resident", "staged_residency", "bounded_decode"],
+      parameters: { decodeTileEdge: 192, decodeOverlap: 64 },
+      spatialDecodeTiles: 24,
+    },
+  };
+}
+
+function boundedCarrierReceiptBase({
+  recordType, status, sceneWorksRevision, sceneWorksTree, inferenceRevision, inferenceTree,
+  identity, preparationKey, preparationRoot, prepared, hostMemoryBytes, events, outcome,
+}) {
+  return {
+    schemaVersion: 1,
+    recordType,
+    status,
+    diagnosticOnly: true,
+    promotable: false,
+    ingestible: false,
+    canonicalBundlePublished: false,
+    outcome: structuredClone(outcome),
+    story: "sc-20254",
+    source: {
+      sceneWorks: { revision: sceneWorksRevision, tree: sceneWorksTree },
+      inference: { revision: inferenceRevision, tree: inferenceTree },
+    },
+    boundedCarrier: boundedCarrierCaseIdentity(),
+    artifacts: {
+      repository: ARTIFACT_REPOSITORY,
+      revision: ARTIFACT_REVISION,
+      numericTierInventory: structuredClone(identity.artifact.numericTier),
+      textEncoderInventory: structuredClone(identity.artifact.textEncoder),
+      adapter: structuredClone(prepared.adapter),
+      metallib: structuredClone(prepared.metallib),
+      preparation: {
+        key: preparationKey,
+        root: preparationRoot,
+        identity: structuredClone(identity),
+        manifest: structuredClone(prepared.manifest),
+      },
+    },
+    watchdog: {
+      protocol: "sceneworks-memory-watchdog-v1",
+      providerPhaseProtocol: PROVIDER_PHASE_PROTOCOL,
+      providerPhaseProfile: "bounded-carrier",
+      providerPhases: [...BOUNDED_CARRIER_PHASES],
+      maxFootprintBytes: MAX_FOOTPRINT_BYTES,
+      maxRuntimeSeconds: MAX_RUNTIME_SECONDS,
+      hostMemoryBytes,
+      minInitialMemoryFreeBytes: preflightFreeFloor(hostMemoryBytes),
+      minMemoryFreeBytes: runtimeFreeFloor(hostMemoryBytes),
+      eventChain: validateWatchdogEventChain(events),
+      events: structuredClone(events),
+    },
+    cleanup: {
+      ownedProcessGroupResidueVerified: true,
+      runScratchRemoved: true,
+      runRootEmpty: true,
+      sourceIdentityVerified: true,
+      runtimeAssetIdentityVerified: true,
+      preparedCacheVerified: true,
+      preparationTransientResidueVerified: true,
+    },
+  };
+}
+
+export function boundedCarrierSuccessReceipt(options) {
+  const maxObservedFootprintBytes = validateBoundedCarrierWatchdogEvents(
+    options.events, options.hostMemoryBytes,
+  );
+  const receipt = boundedCarrierReceiptBase({
+    ...options,
+    recordType: BOUNDED_CARRIER_SUCCESS_RECEIPT_TYPE,
+    status: "diagnostic_success",
+  });
+  receipt.response = structuredClone(validateBoundedCarrierResponse(options.response, {
+    inferenceRevision: options.inferenceRevision,
+    hostMemoryBytes: options.hostMemoryBytes,
+  }));
+  receipt.watchdog.maxObservedFootprintBytes = maxObservedFootprintBytes;
+  return validateBoundedCarrierReceipt(receipt);
+}
+
+export function boundedCarrierFailureReceipt(options) {
+  const failure = validateCampaignEntryFailureEvents(
+    options.events, options.hostMemoryBytes, BOUNDED_CARRIER_PHASES,
+  );
+  const receipt = boundedCarrierReceiptBase({
+    ...options,
+    recordType: BOUNDED_CARRIER_FAILURE_RECEIPT_TYPE,
+    status: "diagnostic_failure",
+  });
+  receipt.watchdog.failure = failure;
+  return validateBoundedCarrierReceipt(receipt);
+}
+
+export function validateBoundedCarrierReceipt(receipt) {
+  let canonicallyIngestible = true;
+  try {
+    validateBundle(receipt);
+  } catch {
+    canonicallyIngestible = false;
+  }
+  const success = receipt?.recordType === BOUNDED_CARRIER_SUCCESS_RECEIPT_TYPE
+    && receipt?.status === "diagnostic_success";
+  const failure = receipt?.recordType === BOUNDED_CARRIER_FAILURE_RECEIPT_TYPE
+    && receipt?.status === "diagnostic_failure";
+  const expectedCleanup = {
+    ownedProcessGroupResidueVerified: true,
+    runScratchRemoved: true,
+    runRootEmpty: true,
+    sourceIdentityVerified: true,
+    runtimeAssetIdentityVerified: true,
+    preparedCacheVerified: true,
+    preparationTransientResidueVerified: true,
+  };
+  const canonicalOutput = receipt?.outcome?.canonicalOutput ?? "";
+  if (canonicallyIngestible
+      || (!success && !failure)
+      || receipt?.diagnosticOnly !== true
+      || receipt?.promotable !== false
+      || receipt?.ingestible !== false
+      || receipt?.canonicalBundlePublished !== false
+      || receipt?.story !== "sc-20254"
+      || !isDeepStrictEqual(receipt?.boundedCarrier, boundedCarrierCaseIdentity())
+      || !path.isAbsolute(canonicalOutput)
+      || receipt?.outcome?.successOutput !== boundedCarrierSuccessPath(canonicalOutput)
+      || receipt?.outcome?.failureOutput !== boundedCarrierFailurePath(canonicalOutput)
+      || receipt?.outcome?.reservation !== boundedCarrierOutcomeReservationPath(canonicalOutput)
+      || receipt?.outcome?.choice !== `${receipt?.outcome?.reservation}.choice`
+      || receipt?.outcome?.canonicalPublicationClaim
+        !== canonicalPublicationClaimPath(canonicalOutput)
+      || receipt?.outcome?.canonicalPublicationClaimHeldAtPublication !== true
+      || receipt?.outcome?.canonicalBundleAbsentAtPublication !== true
+      || receipt?.outcome?.outcomeReservationHeldAtPublication !== true
+      || receipt?.outcome?.outcomeChoice !== (success ? "success" : "failure")
+      || receipt?.watchdog?.protocol !== "sceneworks-memory-watchdog-v1"
+      || receipt?.watchdog?.providerPhaseProtocol !== PROVIDER_PHASE_PROTOCOL
+      || receipt?.watchdog?.providerPhaseProfile !== "bounded-carrier"
+      || !isDeepStrictEqual(receipt?.watchdog?.providerPhases, BOUNDED_CARRIER_PHASES)
+      || receipt?.watchdog?.eventChain?.protocol !== WATCHDOG_EVENT_CHAIN_PROTOCOL
+      || receipt?.watchdog?.maxFootprintBytes !== MAX_FOOTPRINT_BYTES
+      || receipt?.watchdog?.maxRuntimeSeconds !== MAX_RUNTIME_SECONDS
+      || receipt?.watchdog?.minInitialMemoryFreeBytes
+        !== preflightFreeFloor(receipt?.watchdog?.hostMemoryBytes)
+      || receipt?.watchdog?.minMemoryFreeBytes
+        !== runtimeFreeFloor(receipt?.watchdog?.hostMemoryBytes)
+      || !isDeepStrictEqual(receipt?.cleanup, expectedCleanup)) {
+    fail("SC-20254 receipt is ingestible, incomplete, or identity-drifted");
+  }
+  validateContainedReceiptArtifactIdentity(receipt, "SC-20254");
+  const expectedEventChain = validateWatchdogEventChain(receipt.watchdog.events);
+  if (!isDeepStrictEqual(receipt.watchdog.eventChain, expectedEventChain)) {
+    fail("SC-20254 receipt event chain does not match its complete stream");
+  }
+  if (success) {
+    const maximum = validateBoundedCarrierWatchdogEvents(
+      receipt.watchdog.events, receipt.watchdog.hostMemoryBytes,
+    );
+    validateBoundedCarrierResponse(receipt.response, {
+      inferenceRevision: receipt.source.inference.revision,
+      hostMemoryBytes: receipt.watchdog.hostMemoryBytes,
+    });
+    if (receipt.watchdog.maxObservedFootprintBytes !== maximum
+        || Object.hasOwn(receipt.watchdog, "failure")) {
+      fail("SC-20254 success receipt watchdog summary changed");
+    }
+  } else {
+    const validated = validateCampaignEntryFailureEvents(
+      receipt.watchdog.events, receipt.watchdog.hostMemoryBytes, BOUNDED_CARRIER_PHASES,
+    );
+    if (!isDeepStrictEqual(receipt.watchdog.failure, validated)
+        || Object.hasOwn(receipt, "response")) {
+      fail("SC-20254 failure receipt summary changed");
+    }
   }
   return receipt;
 }
@@ -2163,7 +2587,7 @@ async function assertRunRootEmpty(runRoot) {
   if (entries.length !== 0) fail(`SC-20191 run scratch retained residue: ${entries.join(", ")}`);
 }
 
-async function assertCampaignSourceState(options, signal) {
+async function assertCampaignSourceState(options, signal, operation = "SC-20191 campaign entry") {
   const pairs = [
     [ROOT, "SceneWorks", options["scene-revision"], options["scene-tree"]],
     [options["inference-repo"], "inference", options["inference-revision"], options["inference-tree"]],
@@ -2171,7 +2595,7 @@ async function assertCampaignSourceState(options, signal) {
   for (const [repo, label, revision, tree] of pairs) {
     if (await cleanHead(repo, label, signal) !== revision
         || await git(repo, ["rev-parse", "HEAD^{tree}"], signal) !== tree) {
-      fail(`${label} source changed during SC-20191 campaign entry`);
+      fail(`${label} source changed during ${operation}`);
     }
   }
 }
@@ -2201,7 +2625,7 @@ function campaignProviderOptions(argv) {
 }
 
 async function campaignProviderInvocation(options, input, {
-  signal, setActiveWatchdog = () => {},
+  signal, setActiveWatchdog = () => {}, canonicalClaim,
 } = {}) {
   signal?.throwIfAborted();
   const request = JSON.parse(input);
@@ -2211,6 +2635,7 @@ async function campaignProviderInvocation(options, input, {
     reservation: options["outcome-reservation"],
     choice: `${options["outcome-reservation"]}.choice`,
     token: options["outcome-token"],
+    canonicalClaim,
   };
   if (campaignOutcome.failureOutput !== campaignEntryFailurePath(campaignOutcome.canonicalOutput)
       || campaignOutcome.reservation
@@ -2285,6 +2710,7 @@ async function campaignProviderInvocation(options, input, {
         "--event-file", eventsPath,
         "--require-child-attestation",
         "--require-provider-phases",
+        "--provider-phase-profile", "campaign-entry",
         "--",
         "/bin/sh", "-c", 'set -C; exec "$1" <"$2" >"$3"',
         "sc-20191-campaign-entry", prepared.adapter.path, requestPath, responsePath,
@@ -2474,6 +2900,10 @@ export async function releaseUnpublishedCampaignEntryOutcome(outcome) {
 
 async function publishCampaignEntryOutcome(outcome, kind, build, signal) {
   await assertCampaignEntryOutcomeOwner(outcome);
+  if (typeof outcome?.canonicalClaim?.assertOwner !== "function") {
+    fail("SC-20216 publication requires the shared canonical claim");
+  }
+  await outcome.canonicalClaim.assertOwner();
   const target = kind === "canonical" ? outcome.canonicalOutput : outcome.failureOutput;
   const other = kind === "canonical" ? outcome.failureOutput : outcome.canonicalOutput;
   await writeFile(outcome.choice, `${kind}\n`, { flag: "wx", mode: 0o400 });
@@ -2510,6 +2940,411 @@ export async function publishCampaignEntryFailureReceipt(outcome, { verify, buil
   });
 }
 
+export function canonicalPublicationClaimPath(canonicalOutput) {
+  return path.join(
+    path.dirname(canonicalOutput),
+    `.${path.basename(canonicalOutput)}.ltx-canonical-publication-claim`,
+  );
+}
+
+const CANONICAL_RECLAMATION_LOCK_HELPER = String.raw`
+import base64
+import fcntl
+import os
+import stat
+import sys
+
+lock_path = sys.argv[1]
+lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
+initial_stat = os.fstat(lock_fd)
+if (
+    not stat.S_ISREG(initial_stat.st_mode)
+    or initial_stat.st_nlink != 1
+    or stat.S_IMODE(initial_stat.st_mode) != 0o600
+):
+    raise RuntimeError("reclamation lock is not an exact private regular file")
+fcntl.flock(lock_fd, fcntl.LOCK_EX)
+lock_stat = os.fstat(lock_fd)
+if lock_stat.st_size > 16384:
+    raise RuntimeError("reclamation lock owner is oversized")
+os.lseek(lock_fd, 0, os.SEEK_SET)
+previous_owner = b""
+while len(previous_owner) < lock_stat.st_size:
+    previous_owner += os.read(lock_fd, lock_stat.st_size - len(previous_owner))
+encoded_previous_owner = base64.b64encode(previous_owner).decode("ascii") or "-"
+print(
+    f"LOCKED {lock_stat.st_dev} {lock_stat.st_ino} {encoded_previous_owner}",
+    flush=True,
+)
+owner_command = sys.stdin.readline().strip().split(" ")
+if owner_command == ["RELEASE"]:
+    sys.exit(0)
+if owner_command[0] != "OWNER" or len(owner_command) != 2:
+    raise RuntimeError("missing reclamation lock owner")
+owner_bytes = base64.b64decode(owner_command[1])
+os.fchmod(lock_fd, 0o600)
+os.ftruncate(lock_fd, 0)
+os.lseek(lock_fd, 0, os.SEEK_SET)
+remaining = memoryview(owner_bytes)
+while remaining:
+    remaining = remaining[os.write(lock_fd, remaining):]
+os.fsync(lock_fd)
+owned_stat = os.fstat(lock_fd)
+print(
+    f"OWNED {owned_stat.st_dev} {owned_stat.st_ino} "
+    f"{stat.S_IMODE(owned_stat.st_mode)} {owned_stat.st_size} {owned_stat.st_nlink}",
+    flush=True,
+)
+command = sys.stdin.readline().strip().split(" ")
+if command[0] == "RENAME" and len(command) == 3:
+    source = base64.b64decode(command[1]).decode("utf-8")
+    target = base64.b64decode(command[2]).decode("utf-8")
+    os.rename(source, target)
+    print("RENAMED", flush=True)
+elif command != ["RELEASE"]:
+    raise RuntimeError("invalid reclamation lock command")
+`;
+
+function encodedLockPath(value) {
+  return Buffer.from(value, "utf8").toString("base64");
+}
+
+function encodedLockOwner(value) {
+  return Buffer.from(`${JSON.stringify(value)}\n`, "utf8").toString("base64");
+}
+
+async function acquireCanonicalClaimReclamationMutex(
+  claimPath, signal, processIdentityProbe,
+) {
+  // Keep one stable inode: unlinking it could split an existing waiter from a new opener. The
+  // kernel lock, not the retained diagnostic owner bytes, is authoritative and is released when
+  // this helper exits after an explicit command or loss of its parent pipe.
+  const mutexPath = `${claimPath}.reclaiming`;
+  const deadline = Date.now() + 2_000;
+  signal?.throwIfAborted();
+  const child = spawn("/usr/bin/python3", ["-c", CANONICAL_RECLAMATION_LOCK_HELPER, mutexPath], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  child.stderr.setEncoding("utf8");
+  let stderr = "";
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  const lines = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  const iterator = lines[Symbol.asyncIterator]();
+  const childClosed = new Promise((resolve) => {
+    child.once("close", (code, childSignal) => resolve([code, childSignal]));
+  });
+  let termination = null;
+  const terminate = (error) => {
+    if (termination !== null) return;
+    termination = error;
+    child.kill("SIGKILL");
+  };
+  const timeout = setTimeout(() => terminate(
+    new Error("canonical claim reclamation serialization remained unavailable"),
+  ), Math.max(0, deadline - Date.now()));
+  const onAbort = () => terminate(signal.reason ?? new Error("canonical claim reclamation aborted"));
+  signal?.addEventListener("abort", onAbort, { once: true });
+  let locked;
+  try {
+    locked = await iterator.next();
+  } finally {
+    clearTimeout(timeout);
+    signal?.removeEventListener("abort", onAbort);
+  }
+  if (termination !== null) {
+    await childClosed;
+    throw termination;
+  }
+  if (locked.done) fail(`canonical reclamation lock helper exited before ownership: ${stderr}`);
+  const match = /^LOCKED ([0-9]+) ([0-9]+) ([A-Za-z0-9+/=]+|-)$/.exec(locked.value);
+  if (match === null) fail("canonical reclamation lock helper returned invalid ownership");
+  const filesystemIdentity = { device: match[1], inode: match[2] };
+  const previousOwnerBytes = match[3] === "-"
+    ? "" : Buffer.from(match[3], "base64").toString("utf8");
+  if (previousOwnerBytes !== "") {
+    let previousOwner;
+    try {
+      previousOwner = JSON.parse(previousOwnerBytes);
+    } catch {
+      previousOwner = null;
+    }
+    if (previousOwner?.schemaVersion !== 1
+        || previousOwner?.kind !== "canonical-claim-reclamation-mutex"
+        || !Number.isSafeInteger(previousOwner?.pid) || previousOwner.pid <= 0
+        || !validProcessIdentity(previousOwner?.processIdentity)
+        || typeof previousOwner?.token !== "string" || previousOwner.token === ""
+        || !sameJson(previousOwner?.filesystemIdentity, filesystemIdentity)) {
+      child.stdin.end("RELEASE\n");
+      await childClosed;
+      fail("preexisting canonical reclamation lock owner is invalid");
+    }
+  }
+  const token = randomUUID();
+  let processIdentity;
+  try {
+    processIdentity = await processIdentityProbe(process.pid, signal);
+    if (!validProcessIdentity(processIdentity)) {
+      fail("cannot bind canonical reclamation lock to this process start identity");
+    }
+  } catch (error) {
+    child.stdin.end("RELEASE\n");
+    await childClosed;
+    throw error;
+  }
+  const owner = {
+    schemaVersion: 1,
+    kind: "canonical-claim-reclamation-mutex",
+    pid: process.pid,
+    processIdentity,
+    token,
+    filesystemIdentity,
+  };
+  try {
+    const ownerBytes = Buffer.byteLength(`${JSON.stringify(owner)}\n`);
+    child.stdin.write(`OWNER ${encodedLockOwner(owner)}\n`);
+    const owned = await iterator.next();
+    const ownedMatch = owned.done ? null
+      : /^OWNED ([0-9]+) ([0-9]+) ([0-9]+) ([0-9]+) ([0-9]+)$/
+      .exec(owned.value);
+    if (ownedMatch === null
+        || ownedMatch[1] !== filesystemIdentity.device
+        || ownedMatch[2] !== filesystemIdentity.inode
+        || Number(ownedMatch[3]) !== 0o600
+        || Number(ownedMatch[4]) !== ownerBytes
+        || Number(ownedMatch[5]) !== 1) {
+      fail("canonical reclamation lock helper changed its locked inode during owner publication");
+    }
+  } catch (error) {
+    child.stdin.end("RELEASE\n");
+    await childClosed;
+    throw error;
+  }
+  const assertOwner = async () => {
+    if (child.exitCode !== null) fail("canonical reclamation lock helper exited unexpectedly");
+    const [actualOwner, metadata, actualIdentity] = await Promise.all([
+      readFile(mutexPath, "utf8").then(JSON.parse),
+      lstat(mutexPath, { bigint: true }),
+      processIdentityProbe(process.pid),
+    ]);
+    const actualFilesystemIdentity = {
+      device: String(metadata.dev), inode: String(metadata.ino),
+    };
+    if (!metadata.isFile() || metadata.isSymbolicLink()
+        || Number(metadata.mode & 0o777n) !== 0o600
+        || !sameJson(actualOwner, owner)
+        || !sameJson(actualFilesystemIdentity, filesystemIdentity)
+        || !sameJson(actualIdentity, processIdentity)) {
+      fail("canonical reclamation lock ownership changed");
+    }
+  };
+  let closed = false;
+  const finish = async (command, expectedLine) => {
+    if (closed) fail("canonical reclamation lock was already released");
+    try {
+      await assertOwner();
+      child.stdin.end(`${command}\n`);
+      const response = await iterator.next();
+      if (expectedLine === null ? !response.done : response.done || response.value !== expectedLine) {
+        fail(`canonical reclamation lock helper rejected its command: ${stderr}`);
+      }
+      const [code, childSignal] = await childClosed;
+      if (code !== 0 || childSignal !== null) {
+        fail(`canonical reclamation lock helper failed: code=${code} signal=${childSignal} ${stderr}`);
+      }
+      closed = true;
+    } catch (error) {
+      child.kill("SIGKILL");
+      await childClosed;
+      closed = true;
+      throw error;
+    }
+  };
+  return {
+    rename: async (source, target) => finish(
+      `RENAME ${encodedLockPath(source)} ${encodedLockPath(target)}`, "RENAMED",
+    ),
+    release: async () => { if (!closed) await finish("RELEASE", null); },
+  };
+}
+
+export async function acquireCanonicalPublicationClaim(
+  canonicalOutput, signal, processIdentityProbe = osProcessIdentity, reclamationHooks = {},
+) {
+  const claimPath = canonicalPublicationClaimPath(canonicalOutput);
+  const token = randomUUID();
+  for (;;) {
+    signal?.throwIfAborted();
+    let acquired = false;
+    try {
+      await mkdir(claimPath, { mode: 0o700 });
+      acquired = true;
+      const processIdentity = await processIdentityProbe(process.pid, signal);
+      if (!validProcessIdentity(processIdentity)) {
+        fail("cannot bind canonical publication claim to this process start identity");
+      }
+      await writeFile(path.join(claimPath, "owner.json"), `${JSON.stringify({
+        schemaVersion: 1,
+        pid: process.pid,
+        processIdentity,
+        token,
+      })}\n`, { flag: "wx", mode: 0o400 });
+      const assertOwner = async () => {
+        const owner = JSON.parse(await readFile(path.join(claimPath, "owner.json"), "utf8"));
+        const actualIdentity = await processIdentityProbe(process.pid);
+        if (owner.token !== token || owner.pid !== process.pid
+            || !sameJson(owner.processIdentity, actualIdentity)) {
+          fail("canonical publication claim ownership changed");
+        }
+      };
+      return {
+        path: claimPath,
+        assertOwner,
+        release: async () => {
+          await assertOwner();
+          await cleanupCanaryScratch(claimPath);
+        },
+      };
+    } catch (error) {
+      if (error.code !== "EEXIST") {
+        if (acquired) await cleanupCanaryScratch(claimPath);
+        throw error;
+      }
+    }
+    await reclamationHooks.beforeSerialization?.(claimPath);
+    const reclamation = await acquireCanonicalClaimReclamationMutex(
+      claimPath, signal, processIdentityProbe,
+    );
+    try {
+      signal?.throwIfAborted();
+      // A contender may have replaced the stale claim while this process waited for the
+      // reclamation mutex. Re-read every byte and re-probe the current owner while serialized;
+      // only this exact observation may authorize the subsequent rename.
+      const ownerPath = path.join(claimPath, "owner.json");
+      const owner = await readFile(ownerPath, "utf8").then(JSON.parse).catch(() => null);
+      const metadata = await lstat(claimPath, { bigint: true }).catch((error) => {
+        if (error.code === "ENOENT") return null;
+        throw error;
+      });
+      if (metadata === null) continue;
+      const oldEnough = Date.now() - Number(metadata.mtimeMs)
+        >= PREPARATION_LOCK_ORPHAN_GRACE_MS;
+      const verifiableOwner = owner?.schemaVersion === 1
+        && Number.isSafeInteger(owner.pid) && owner.pid > 0
+        && validProcessIdentity(owner.processIdentity);
+      const observedIdentity = verifiableOwner
+        ? await processIdentityProbe(owner.pid, signal) : null;
+      const staleOwner = verifiableOwner
+        ? !sameJson(observedIdentity, owner.processIdentity) : oldEnough;
+      if (!staleOwner) {
+        fail("another live contained LTX run owns the canonical publication claim");
+      }
+      await reclamationHooks.afterStaleRevalidation?.(claimPath);
+      signal?.throwIfAborted();
+      const stale = `${claimPath}.stale-${randomUUID()}`;
+      try {
+        await reclamation.rename(claimPath, stale);
+        await cleanupCanaryScratch(stale);
+      } catch (error) {
+        if (error.code !== "ENOENT") throw error;
+      }
+      continue;
+    } finally {
+      if (reclamation.release !== null) await reclamation.release();
+    }
+  }
+}
+
+export async function acquireBoundedCarrierOutcome(canonicalOutput) {
+  const outcome = {
+    canonicalOutput,
+    successOutput: boundedCarrierSuccessPath(canonicalOutput),
+    failureOutput: boundedCarrierFailurePath(canonicalOutput),
+    reservation: boundedCarrierOutcomeReservationPath(canonicalOutput),
+    choice: `${boundedCarrierOutcomeReservationPath(canonicalOutput)}.choice`,
+    token: randomUUID(),
+  };
+  await mkdir(path.dirname(canonicalOutput), { recursive: true });
+  await writeFile(outcome.reservation, `${outcome.token}\n`, { flag: "wx", mode: 0o400 });
+  if (await pathExists(outcome.canonicalOutput)
+      || await pathExists(outcome.successOutput)
+      || await pathExists(outcome.failureOutput)) {
+    await unlink(outcome.reservation);
+    fail("SC-20254 already has an immutable canonical, success, or failure outcome");
+  }
+  return outcome;
+}
+
+async function assertBoundedCarrierOutcomeOwner(outcome) {
+  if (await readFile(outcome?.reservation ?? "", "utf8").catch(() => null)
+      !== `${outcome?.token}\n`) {
+    fail("SC-20254 outcome reservation ownership changed");
+  }
+}
+
+export async function releaseUnpublishedBoundedCarrierOutcome(outcome) {
+  await assertBoundedCarrierOutcomeOwner(outcome);
+  if (await pathExists(outcome.choice)
+      || await pathExists(outcome.canonicalOutput)
+      || await pathExists(outcome.successOutput)
+      || await pathExists(outcome.failureOutput)) return;
+  await unlink(outcome.reservation);
+}
+
+async function publishBoundedCarrierOutcome(outcome, kind, build, signal) {
+  await assertBoundedCarrierOutcomeOwner(outcome);
+  if (typeof outcome?.canonicalClaim?.assertOwner !== "function") {
+    fail("SC-20254 publication requires the shared canonical claim");
+  }
+  await outcome.canonicalClaim.assertOwner();
+  const target = kind === "success" ? outcome.successOutput : outcome.failureOutput;
+  const other = kind === "success" ? outcome.failureOutput : outcome.successOutput;
+  await writeFile(outcome.choice, `${kind}\n`, { flag: "wx", mode: 0o400 });
+  if (await pathExists(outcome.canonicalOutput)
+      || await pathExists(target) || await pathExists(other)) {
+    fail("SC-20254 bounded-carrier outcome is already fixed");
+  }
+  const value = await build({
+    canonicalOutput: outcome.canonicalOutput,
+    successOutput: outcome.successOutput,
+    failureOutput: outcome.failureOutput,
+    reservation: outcome.reservation,
+    choice: outcome.choice,
+    canonicalPublicationClaim: outcome.canonicalClaim.path,
+    canonicalPublicationClaimHeldAtPublication: true,
+    outcomeChoice: kind,
+    canonicalBundleAbsentAtPublication: true,
+    outcomeReservationHeldAtPublication: true,
+  });
+  await publishExclusiveJson(target, value, signal);
+  return value;
+}
+
+export async function publishBoundedCarrierSuccessReceipt(outcome, { verify, build, signal }) {
+  if (typeof verify !== "function" || typeof build !== "function") {
+    fail("SC-20254 success publication requires validation and receipt builders");
+  }
+  await verify();
+  return publishBoundedCarrierOutcome(outcome, "success", async (publication) => {
+    if (await pathExists(outcome.canonicalOutput)) {
+      fail("SC-20254 canonical bundle exists; success receipt suppressed");
+    }
+    return validateBoundedCarrierReceipt(await build(publication));
+  }, signal);
+}
+
+export async function publishBoundedCarrierFailureReceipt(outcome, { verify, build, signal }) {
+  if (typeof verify !== "function" || typeof build !== "function") {
+    fail("SC-20254 failure publication requires validation and receipt builders");
+  }
+  await verify();
+  return publishBoundedCarrierOutcome(outcome, "failure", async (publication) => {
+    if (await pathExists(outcome.canonicalOutput)) {
+      fail("SC-20254 canonical bundle exists; failure receipt suppressed");
+    }
+    return validateBoundedCarrierReceipt(await build(publication));
+  }, signal);
+}
+
 async function assertPreparationHasNoTransientResidue(preparationRoot) {
   const parent = path.dirname(preparationRoot);
   const key = path.basename(preparationRoot);
@@ -2532,7 +3367,16 @@ async function runCampaignEntryController({
 }) {
   const config = JSON.parse(await readFile(path.join(ROOT, CAMPAIGN_ENTRY_PLAN), "utf8"));
   campaignEntryPlan(config);
-  const campaignOutcome = await acquireCampaignEntryOutcome(output);
+  const canonicalClaim = await acquireCanonicalPublicationClaim(output, signal);
+  let campaignOutcome;
+  try {
+    campaignOutcome = await acquireCampaignEntryOutcome(output);
+    campaignOutcome.canonicalClaim = canonicalClaim;
+  } catch (error) {
+    let releaseError = null;
+    try { await canonicalClaim.release(); } catch (cleanup) { releaseError = cleanup; }
+    throw preservePrimaryFailure(error, releaseError);
+  }
   const runRoot = path.join(path.dirname(output), "runs");
   const providerOptions = {
     "inference-repo": inferenceRepo,
@@ -2575,7 +3419,7 @@ async function runCampaignEntryController({
           fail("SC-20191 harness attempted a foreign provider command");
         }
         return campaignProviderInvocation(providerOptions, input, {
-          signal, setActiveWatchdog,
+          signal, setActiveWatchdog, canonicalClaim,
         });
       },
     });
@@ -2592,16 +3436,244 @@ async function runCampaignEntryController({
   } catch (error) {
     operationError = error;
   } finally {
-    try {
-      if (await pathExists(runRoot)) await cleanupCanaryScratch(runRoot);
-      await releaseUnpublishedCampaignEntryOutcome(campaignOutcome);
-    } catch (error) {
-      cleanupError = error;
+    for (const cleanup of [
+      async () => {
+        if (await pathExists(runRoot)) await cleanupCanaryScratch(runRoot);
+      },
+      async () => releaseUnpublishedCampaignEntryOutcome(campaignOutcome),
+      async () => canonicalClaim.release(),
+    ]) {
+      try {
+        await cleanup();
+      } catch (error) {
+        cleanupError = preservePrimaryFailure(cleanupError, error);
+      }
     }
   }
   const finalError = preservePrimaryFailure(operationError, cleanupError);
   if (finalError !== null) throw finalError;
   process.stdout.write(`${output}\n`);
+}
+
+async function runBoundedCarrierController({
+  output, inferenceRepo, sceneWorksRevision, inferenceRevision,
+  sceneWorksTree, inferenceTree, identity, preparationKey, preparationRoot,
+  prepared, hostMemoryBytes, signal, setActiveWatchdog,
+}) {
+  const canonicalClaim = await acquireCanonicalPublicationClaim(output, signal);
+  let outcome;
+  try {
+    outcome = await acquireBoundedCarrierOutcome(output);
+    outcome.canonicalClaim = canonicalClaim;
+  } catch (error) {
+    let releaseError = null;
+    try { await canonicalClaim.release(); } catch (cleanup) { releaseError = cleanup; }
+    throw preservePrimaryFailure(error, releaseError);
+  }
+  const runRoot = path.join(path.dirname(output), "sc-20254-runs");
+  const sourceOptions = {
+    "inference-repo": inferenceRepo,
+    "scene-revision": sceneWorksRevision,
+    "scene-tree": sceneWorksTree,
+    "inference-revision": inferenceRevision,
+    "inference-tree": inferenceTree,
+  };
+  let runScratch = null;
+  let operationError = null;
+  let cleanupError = null;
+  let failureEvents = null;
+  let response = null;
+  let successEvents = null;
+  try {
+    await mkdir(runRoot, { recursive: true, mode: 0o700 });
+    await assertRunRootEmpty(runRoot);
+    runScratch = await mkdtemp(path.join(runRoot, "sc-20254-run-"));
+    const runtimeHome = path.join(runScratch, "home");
+    await mkdir(runtimeHome, { mode: 0o700 });
+    await exactMetadata(runtimeHome, "directory", 0o700);
+    await exactEntries(runtimeHome, []);
+    const requestPath = path.join(runScratch, "request.json");
+    const responsePath = path.join(runScratch, "response.json");
+    const eventsPath = path.join(runScratch, "watchdog.jsonl");
+    const request = boundedCarrierRequest(
+      hostMemoryBytes,
+      inventoryAtRoot(identity.artifact.textEncoder, prepared.roots.textEncoder),
+    );
+    await writeFile(requestPath, canonicalJson(request), { flag: "wx" });
+    const launchPrepared = await validatePreparedCache(
+      preparationRoot, preparationKey, identity, signal,
+    );
+    if (launchPrepared === null) fail("SC-20254 prepared cache disappeared before launch");
+    await assertRuntimeAssetIdentities(
+      launchPrepared.adapter, launchPrepared.metallib, signal,
+    );
+    const runtimeMemoryFreeFloor = runtimeFreeFloor(hostMemoryBytes);
+    const watchdogArgs = [
+      path.join(ROOT, "scripts/memory-calibration-watchdog.py"),
+      "--max-footprint-bytes", String(MAX_FOOTPRINT_BYTES),
+      "--max-runtime-seconds", String(MAX_RUNTIME_SECONDS),
+      "--host-memory-bytes", String(hostMemoryBytes),
+      "--min-memory-free-bytes", String(runtimeMemoryFreeFloor),
+      "--sample-interval", "0.25",
+      "--telemetry-timeout", "1",
+      "--child-attestation-timeout", String(CHILD_ATTESTATION_TIMEOUT_SECONDS),
+      "--term-grace", "1",
+      "--event-file", eventsPath,
+      "--require-child-attestation",
+      "--require-provider-phases",
+      "--provider-phase-profile", "bounded-carrier",
+      "--",
+      "/bin/sh", "-c", 'set -C; exec "$1" <"$2" >"$3"',
+      "sc-20254-bounded-carrier", prepared.adapter.path, requestPath, responsePath,
+    ];
+    const environment = canaryWatchdogEnvironment(
+      process.env, prepared.roots, prepared.metallib.path, runtimeHome,
+    );
+    await assertCampaignSourceState(
+      sourceOptions, signal, "SC-20254 bounded carrier",
+    );
+    // The sole fresh actual-GPU-owner and two-boundary host check remains the final operation before
+    // the watchdog owns and releases the one provider render.
+    await assertHostPreflight(hostMemoryBytes, signal);
+    const status = await new Promise((resolve, reject) => {
+      const child = spawn("/usr/bin/python3", watchdogArgs, {
+        stdio: "inherit", env: environment,
+      });
+      setActiveWatchdog(child);
+      const onAbort = () => child.kill(signal.reason?.signalName ?? "SIGTERM");
+      signal.addEventListener("abort", onAbort, { once: true });
+      child.on("error", reject);
+      child.on("close", (code, childSignal) => {
+        signal.removeEventListener("abort", onAbort);
+        setActiveWatchdog(null);
+        resolve({ code, signal: childSignal });
+      });
+    });
+    const eventBytes = await readFile(eventsPath, "utf8").catch(() => "");
+    if (status.code !== 0 || status.signal) {
+      const watchdogError = new Error(watchdogFailureSummary(status, eventBytes));
+      try {
+        const events = eventBytes.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+        validateCampaignEntryFailureEvents(
+          events, hostMemoryBytes, BOUNDED_CARRIER_PHASES,
+        );
+        const started = events.find((event) => event.event === "started");
+        const processTable = (await execFileAsync(
+          "/bin/ps", ["-ww", "-axo", "pid=,pgid=,command="],
+          { encoding: "utf8", timeout: 2_000 },
+        )).stdout;
+        const residue = ownedProcessGroupResidue(processTable, started?.pgid);
+        if (residue.length) fail(`SC-20254 watchdog process group retained residue:\n${residue.join("\n")}`);
+        await assertCampaignSourceState(
+          sourceOptions, undefined, "SC-20254 bounded carrier",
+        );
+        await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib);
+        if (await validatePreparedCache(
+          preparationRoot, preparationKey, identity,
+        ) === null) fail("SC-20254 prepared cache disappeared after watchdog failure");
+        failureEvents = events;
+      } catch (error) {
+        throw preserveFailureReceiptSuppression(watchdogError, error);
+      }
+      throw watchdogError;
+    }
+    signal.throwIfAborted();
+    response = validateBoundedCarrierResponse(
+      JSON.parse(await readFile(responsePath, "utf8")),
+      { inferenceRevision, hostMemoryBytes },
+    );
+    successEvents = eventBytes.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+    validateBoundedCarrierWatchdogEvents(successEvents, hostMemoryBytes);
+    const started = successEvents.find((event) => event.event === "started");
+    const processTable = (await execFileAsync(
+      "/bin/ps", ["-ww", "-axo", "pid=,pgid=,command="],
+      { encoding: "utf8", timeout: 2_000 },
+    )).stdout;
+    const residue = ownedProcessGroupResidue(processTable, started?.pgid);
+    if (residue.length) fail(`SC-20254 watchdog process group retained residue:\n${residue.join("\n")}`);
+    await assertCampaignSourceState(sourceOptions, signal, "SC-20254 bounded carrier");
+    await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal);
+    if (await validatePreparedCache(
+      preparationRoot, preparationKey, identity, signal,
+    ) === null) fail("SC-20254 prepared cache disappeared after bounded carrier");
+  } catch (error) {
+    operationError = error;
+  } finally {
+    try {
+      if (runScratch !== null) await cleanupCanaryScratch(runScratch);
+      await assertRunRootEmpty(runRoot);
+    } catch (error) {
+      cleanupError = error;
+    }
+  }
+  const finalError = preservePrimaryFailure(operationError, cleanupError);
+  let terminalError = null;
+  try {
+    if (finalError !== null) {
+      let publicationError = null;
+      if (failureEvents !== null && cleanupError === null) {
+        try {
+          await publishBoundedCarrierFailureReceipt(outcome, {
+            verify: async () => {
+              await assertRunRootEmpty(runRoot);
+              await assertCampaignSourceState(
+                sourceOptions, undefined, "SC-20254 bounded carrier",
+              );
+              await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib);
+              if (await validatePreparedCache(
+                preparationRoot, preparationKey, identity,
+              ) === null) fail("SC-20254 prepared cache disappeared before failure publication");
+              await assertPreparationHasNoTransientResidue(preparationRoot);
+            },
+            build: (publication) => boundedCarrierFailureReceipt({
+              sceneWorksRevision, sceneWorksTree, inferenceRevision, inferenceTree,
+              identity, preparationKey, preparationRoot, prepared,
+              hostMemoryBytes, events: failureEvents, outcome: publication,
+            }),
+          });
+        } catch (error) {
+          publicationError = error;
+        }
+      }
+      if (publicationError !== null) {
+        throw preserveFailureReceiptSuppression(finalError, publicationError);
+      }
+      throw finalError;
+    }
+    await publishBoundedCarrierSuccessReceipt(outcome, {
+      signal,
+      verify: async () => {
+        await assertRunRootEmpty(runRoot);
+        await assertCampaignSourceState(sourceOptions, signal, "SC-20254 bounded carrier");
+        await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal);
+        if (await validatePreparedCache(
+          preparationRoot, preparationKey, identity, signal,
+        ) === null) fail("SC-20254 prepared cache disappeared before success publication");
+        await assertPreparationHasNoTransientResidue(preparationRoot);
+      },
+      build: (publication) => boundedCarrierSuccessReceipt({
+        sceneWorksRevision, sceneWorksTree, inferenceRevision, inferenceTree,
+        identity, preparationKey, preparationRoot, prepared,
+        hostMemoryBytes, events: successEvents, response, outcome: publication,
+      }),
+    });
+    process.stdout.write(`${outcome.successOutput}\n`);
+  } catch (error) {
+    terminalError = error;
+  }
+  let releaseError = null;
+  for (const release of [
+    async () => releaseUnpublishedBoundedCarrierOutcome(outcome),
+    async () => canonicalClaim.release(),
+  ]) {
+    try {
+      await release();
+    } catch (error) {
+      releaseError = preservePrimaryFailure(releaseError, error);
+    }
+  }
+  const completedError = preservePrimaryFailure(terminalError, releaseError);
+  if (completedError !== null) throw completedError;
 }
 
 async function controller(argv) {
@@ -2616,7 +3688,10 @@ async function controller(argv) {
   if (unexpected.length) fail(`unsupported option(s): ${unexpected.join(", ")}`);
   const profileName = options.profile ?? SAFETY_CANARY_PROFILE;
   const campaignEntry = profileName === CAMPAIGN_ENTRY_PROFILE;
-  const profile = campaignEntry ? { story: "sc-20191" } : canaryProfile(profileName);
+  const boundedCarrier = profileName === BOUNDED_CARRIER_PROFILE;
+  const profile = campaignEntry
+    ? { story: "sc-20191" }
+    : boundedCarrier ? { story: "sc-20254" } : canaryProfile(profileName);
   const inferenceRepo = path.resolve(options["inference-repo"]);
   const output = path.resolve(options.output);
   const relativeOutput = path.relative(ROOT, output);
@@ -2751,6 +3826,24 @@ async function controller(argv) {
     const textEncoderInventory = inventoryAtRoot(
       identity.artifact.textEncoder, privateTextEncoderRoot,
     );
+    if (boundedCarrier) {
+      await runBoundedCarrierController({
+        output,
+        inferenceRepo,
+        sceneWorksRevision,
+        inferenceRevision,
+        sceneWorksTree,
+        inferenceTree,
+        identity,
+        preparationKey,
+        preparationRoot,
+        prepared,
+        hostMemoryBytes: memoryBytes,
+        signal,
+        setActiveWatchdog: (child) => { activeWatchdog = child; },
+      });
+      return;
+    }
     if (campaignEntry) {
       await runCampaignEntryController({
         output,

--- a/scripts/run-ltx-safety-canary.test.mjs
+++ b/scripts/run-ltx-safety-canary.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
-  chmod, mkdir, mkdtemp, readFile, readdir, stat, symlink, writeFile,
+  chmod, link, lstat, mkdir, mkdtemp, readFile, readdir, stat, symlink, writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -11,6 +11,14 @@ import { setTimeout as delay } from "node:timers/promises";
 
 import {
   CARGO_METADATA_TIMEOUT_MS,
+  BOUNDED_CARRIER_ACTION,
+  BOUNDED_CARRIER_FAILURE_RECEIPT_TYPE,
+  BOUNDED_CARRIER_FIXTURE,
+  BOUNDED_CARRIER_IDENTITY,
+  BOUNDED_CARRIER_LOGICAL_CASE_ID,
+  BOUNDED_CARRIER_PHASES,
+  BOUNDED_CARRIER_PROFILE,
+  BOUNDED_CARRIER_SUCCESS_RECEIPT_TYPE,
   CAMPAIGN_ENTRY_FIXTURE,
   CAMPAIGN_ENTRY_IDENTITY,
   CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
@@ -26,6 +34,8 @@ import {
   PROVIDER_PHASES,
   PRODUCT_ENVELOPE_CANARY_PROFILE,
   acquireCampaignEntryOutcome,
+  acquireBoundedCarrierOutcome,
+  acquireCanonicalPublicationClaim,
   acquirePreparationLock,
   campaignEntryAdapterRequest,
   campaignEntryCanonicalFragment,
@@ -33,6 +43,13 @@ import {
   campaignEntryFailureReceipt,
   campaignEntryOutcomeReservationPath,
   campaignEntryPlan,
+  boundedCarrierFailurePath,
+  boundedCarrierFailureReceipt,
+  boundedCarrierOutcomeReservationPath,
+  boundedCarrierRequest,
+  boundedCarrierSuccessPath,
+  boundedCarrierSuccessReceipt,
+  canonicalPublicationClaimPath,
   canaryWatchdogEnvironment,
   canaryRequest,
   cargoSourceStatusIsClean,
@@ -53,7 +70,10 @@ import {
   preserveFailureReceiptSuppression,
   publishCampaignEntryCanonicalOutcome,
   publishCampaignEntryFailureReceipt,
+  publishBoundedCarrierFailureReceipt,
+  publishBoundedCarrierSuccessReceipt,
   releaseUnpublishedCampaignEntryOutcome,
+  releaseUnpublishedBoundedCarrierOutcome,
   preflightFreeFloor,
   repositoryToolchain,
   runtimeFreeFloor,
@@ -66,6 +86,9 @@ import {
   validateCampaignEntryFailureReceipt,
   validateCampaignEntryHarnessRequest,
   validateCampaignEntryWatchdogEvents,
+  validateBoundedCarrierReceipt,
+  validateBoundedCarrierResponse,
+  validateBoundedCarrierWatchdogEvents,
   validateCanaryResponse,
   validatePreparedCache,
   watchdogFailureSummary,
@@ -206,6 +229,85 @@ function campaignEntryRuntimeResponse(hostMemoryBytes = 128 * 1024 ** 3) {
   };
 }
 
+function boundedCarrierResponse(hostMemoryBytes = 128 * 1024 ** 3) {
+  const phase = (activeBytes) => ({
+    activeBytes, allocatorBytes: activeBytes + 10, reclaimableBytes: 10,
+  });
+  return {
+    schemaVersion: 1,
+    recordType: "sceneworks_bounded_carrier_proof_response_v1",
+    status: "diagnostic_bounded_carrier_complete",
+    story: "sc-20254",
+    logicalCaseId: BOUNDED_CARRIER_LOGICAL_CASE_ID,
+    fixture: BOUNDED_CARRIER_FIXTURE,
+    identity: BOUNDED_CARRIER_IDENTITY,
+    diagnosticOnly: true,
+    promotable: false,
+    ingestible: false,
+    inferenceRevision: "3".repeat(40),
+    calibrationFingerprint: "sc-19109-ltx-2-3-mlx-memory-ladder-v1",
+    artifact: {
+      repository: "SceneWorks/ltx-2.3-mlx",
+      resolvedRevision: "01df27d308466533aa09d251e3aebdcc627d07eb",
+      variant: "q4",
+      tierRoot: "/prepared/q4",
+      textEncoderRoot: "/prepared/gemma",
+      numericTierInventory: {
+        files: 11, bytes: 20_467_690_460,
+        sha256: "4e811932e87bb258f642ada790525e36ef2a55959c520e755f1807caf6fa225a",
+      },
+      textEncoderInventory: {
+        files: 17, bytes: 26_427_894_918,
+        sha256: "abde2d155aa8991747cc2999d40688d29a50261c080c0d51fac20357653928d7",
+      },
+    },
+    target: {
+      provider: "ltx_2_3", tier: "q4",
+      geometry: { width: 768, height: 512, frames: 121, fps: 30 },
+      seed: 18_946, videoMode: "default_av", audio: true,
+    },
+    strategy: {
+      rung: "bounded_decode",
+      engagedRungs: ["resident", "staged_residency", "bounded_decode"],
+      parameters: { decodeTileEdge: 192, decodeOverlap: 64 },
+      spatialDecodeTiles: 24,
+    },
+    watchdog: {
+      required: true,
+      protocol: "sceneworks-memory-watchdog-v1",
+      providerPhaseProtocol: "sceneworks-provider-phase-v1",
+      providerPhaseProfile: "bounded-carrier",
+      providerPhases: [...BOUNDED_CARRIER_PHASES],
+      maxFootprintBytes: MAX_FOOTPRINT_BYTES,
+      maxRuntimeSeconds: MAX_RUNTIME_SECONDS,
+      hostMemoryBytes,
+      minInitialMemoryFreeBytes: preflightFreeFloor(hostMemoryBytes),
+      minMemoryFreeBytes: runtimeFreeFloor(hostMemoryBytes),
+    },
+    mlxLimits: { memoryLimitBytes: MAX_FOOTPRINT_BYTES, wiredLimitBytes: MAX_FOOTPRINT_BYTES },
+    observedMemory: {
+      preProviderActiveBytes: 0,
+      preProviderCacheBytes: 0,
+      expectedPersistentActive: {
+        identity: "mlx-gen-ltx-transformer-ones-cache-av-bfloat16-v1",
+        videoDimension: 4_096, audioDimension: 2_048,
+        dtype: "bfloat16", bytesPerElement: 2, bytes: 12_288,
+      },
+      conditioning: phase(100), denoise: phase(200), decode: phase(150),
+      peakActiveBytes: 200,
+      postCleanupActiveBytes: 12_288,
+      postCleanupCacheBytes: 0,
+    },
+    output: {
+      frames: 121, fps: 30,
+      audio: { present: true, samples: 48_000, sampleRate: 48_000, channels: 2 },
+      frameTimelineSeconds: 4,
+      firstFrameNondegenerate: true,
+    },
+    capturedAt: "2026-08-17T12:00:00Z",
+  };
+}
+
 const PROCESS_IDENTITIES = [
   { pid: 1234, pgid: 1234, started: "Sun Aug 17 12:00:00 2026" },
   { pid: 1235, pgid: 1234, started: "Sun Aug 17 12:00:01 2026" },
@@ -233,7 +335,9 @@ function chainWatchdogEvents(events) {
   return events;
 }
 
-function campaignFailureEvents(hostMemoryBytes = 128 * 1024 ** 3, phaseCount = 1) {
+function campaignFailureEvents(
+  hostMemoryBytes = 128 * 1024 ** 3, phaseCount = 1, phases = PROVIDER_PHASES,
+) {
   const runtimeFloor = runtimeFreeFloor(hostMemoryBytes);
   let at = 1;
   const events = [
@@ -253,7 +357,7 @@ function campaignFailureEvents(hostMemoryBytes = 128 * 1024 ** 3, phaseCount = 1
   ];
   let providerPhase = null;
   for (let index = 0; index < phaseCount; index += 1) {
-    providerPhase = { sequence: index + 1, name: PROVIDER_PHASES[index] };
+    providerPhase = { sequence: index + 1, name: phases[index] };
     events.push({
       at: at++, event: "provider_phase", providerPhase, authenticated: true,
     });
@@ -275,13 +379,15 @@ function campaignFailureEvents(hostMemoryBytes = 128 * 1024 ** 3, phaseCount = 1
   return chainWatchdogEvents(events);
 }
 
-function campaignSuccessEvents(hostMemoryBytes = 128 * 1024 ** 3) {
-  const events = campaignFailureEvents(hostMemoryBytes, PROVIDER_PHASES.length);
+function campaignSuccessEvents(
+  hostMemoryBytes = 128 * 1024 ** 3, phases = PROVIDER_PHASES,
+) {
+  const events = campaignFailureEvents(hostMemoryBytes, phases.length, phases);
   const sample = events.at(-3);
   sample.physicalFootprintBytes = 3;
   events.splice(-2, 2, {
     at: events.at(-2).at, event: "child_completed",
-    providerPhase: { sequence: PROVIDER_PHASES.length, name: PROVIDER_PHASES.at(-1) },
+    providerPhase: { sequence: phases.length, name: phases.at(-1) },
   });
   return chainWatchdogEvents(events);
 }
@@ -631,7 +737,9 @@ test("SC-20216 publishes only after validation and never overwrites a failure re
   const root = await mkdtemp(path.join(tmpdir(), "sc20216-failure-publish-"));
   t.after(() => cleanupCanaryScratch(root));
   const canonical = path.join(root, "canonical.json");
+  const canonicalClaim = await acquireCanonicalPublicationClaim(canonical);
   const outcome = await acquireCampaignEntryOutcome(canonical);
+  outcome.canonicalClaim = canonicalClaim;
   const output = outcome.failureOutput;
   const hostMemoryBytes = 128 * 1024 ** 3;
   const { identity, key, preparationRoot, prepared } = campaignFailurePreparation(root);
@@ -662,18 +770,21 @@ test("SC-20216 publishes only after validation and never overwrites a failure re
     verify: async () => {}, build,
   }), /EEXIST/);
   await assert.rejects(() => acquireCampaignEntryOutcome(canonical), /EEXIST/);
+  await canonicalClaim.release();
 });
 
 test("SC-20216 jointly reserves canonical and failure outcomes across races and stale state", async (t) => {
   const root = await mkdtemp(path.join(tmpdir(), "sc20216-outcome-race-"));
   t.after(() => cleanupCanaryScratch(root));
   const canonical = path.join(root, "canonical.json");
+  const canonicalClaim = await acquireCanonicalPublicationClaim(canonical);
   const raced = await Promise.allSettled([
     acquireCampaignEntryOutcome(canonical), acquireCampaignEntryOutcome(canonical),
   ]);
   assert.equal(raced.filter((result) => result.status === "fulfilled").length, 1);
   assert.equal(raced.filter((result) => result.status === "rejected").length, 1);
   const outcome = raced.find((result) => result.status === "fulfilled").value;
+  outcome.canonicalClaim = canonicalClaim;
   const hostMemoryBytes = 128 * 1024 ** 3;
   const { identity, key, preparationRoot, prepared } = campaignFailurePreparation(root);
   const publications = await Promise.allSettled([
@@ -696,6 +807,7 @@ test("SC-20216 jointly reserves canonical and failure outcomes across races and 
   ]);
   assert.notEqual(canonicalBytes === null, failureBytes === null,
     "exactly one jointly reserved outcome must publish");
+  await canonicalClaim.release();
 
   const retryDirectory = path.join(root, "retry");
   await mkdir(retryDirectory);
@@ -710,12 +822,397 @@ test("SC-20216 jointly reserves canonical and failure outcomes across races and 
   const partialDirectory = path.join(root, "partial");
   await mkdir(partialDirectory);
   const partialOutput = path.join(partialDirectory, "canonical.json");
+  const partialClaim = await acquireCanonicalPublicationClaim(partialOutput);
   const partial = await acquireCampaignEntryOutcome(partialOutput);
+  partial.canonicalClaim = partialClaim;
   await assert.rejects(() => publishCampaignEntryCanonicalOutcome(partial, { invalid: 1n }),
     /BigInt/);
   await releaseUnpublishedCampaignEntryOutcome(partial);
+  await partialClaim.release();
   await assert.rejects(() => acquireCampaignEntryOutcome(partialOutput), /EEXIST/,
     "a claimed but interrupted outcome must remain fail-closed");
+});
+
+test("SC-20254 freezes one distinct bounded full-A/V carrier and rejects identity drift", () => {
+  const hostMemoryBytes = 128 * 1024 ** 3;
+  const request = boundedCarrierRequest(hostMemoryBytes, TEXT_ENCODER_INVENTORY);
+  assert.equal(request.action, BOUNDED_CARRIER_ACTION);
+  assert.equal(request.planned.logicalCaseId, BOUNDED_CARRIER_LOGICAL_CASE_ID);
+  assert.equal(request.planned.fixture, BOUNDED_CARRIER_FIXTURE);
+  assert.equal(request.planned._boundedCarrier.identity, BOUNDED_CARRIER_IDENTITY);
+  assert.equal(request.planned._boundedCarrier.seed, 18_946);
+  assert.notEqual(request.planned.logicalCaseId, CAMPAIGN_ENTRY_LOGICAL_CASE_ID);
+  assert.notEqual(request.planned.fixture, CAMPAIGN_ENTRY_FIXTURE);
+  assert.deepEqual(request.planned.target.geometry, {
+    width: 768, height: 512, batch: 1, frames: 121,
+  });
+  assert.deepEqual(request.planned.strategy, {
+    rung: "bounded_decode",
+    engagedRungs: ["resident", "staged_residency", "bounded_decode"],
+    parameters: { decodeTileEdge: 192, decodeOverlap: 64 },
+  });
+
+  const response = boundedCarrierResponse(hostMemoryBytes);
+  validateBoundedCarrierResponse(response, {
+    inferenceRevision: "3".repeat(40), hostMemoryBytes,
+  });
+  assert.throws(() => validateBundle(response), /bundle|schema|records/);
+  for (const mutate of [
+    (value) => { value.logicalCaseId = CAMPAIGN_ENTRY_LOGICAL_CASE_ID; },
+    (value) => { value.fixture = CAMPAIGN_ENTRY_FIXTURE; },
+    (value) => { value.strategy.parameters.decodeTileEdge = 193; },
+    (value) => { value.target.seed += 1; },
+    (value) => { value.strategy.spatialDecodeTiles = 1; },
+    (value) => { value.output.audio.samples = 0; },
+    (value) => { value.output.firstFrameNondegenerate = false; },
+    (value) => { value.observedMemory.decode.activeBytes = 0; },
+    (value) => { value.observedMemory.postCleanupActiveBytes += 1; },
+    (value) => { value.watchdog.providerPhases.splice(1, 1); },
+    (value) => { value.watchdog.maxFootprintBytes += 1; },
+  ]) {
+    const changed = structuredClone(response);
+    mutate(changed);
+    assert.throws(
+      () => validateBoundedCarrierResponse(changed, {
+        inferenceRevision: "3".repeat(40), hostMemoryBytes,
+      }),
+      /SC-20254/,
+    );
+  }
+});
+
+test("SC-20254 success/failure receipts are chained, exclusive and canonically rejected", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "sc20254-outcome-"));
+  t.after(() => cleanupCanaryScratch(root));
+  const canonicalOutput = path.join(root, "canonical-campaign-bundle.json");
+  const hostMemoryBytes = 128 * 1024 ** 3;
+  const { identity, key, preparationRoot, prepared } = campaignFailurePreparation(
+    root, "1".repeat(40), "3".repeat(40),
+  );
+  const receiptOptions = {
+    sceneWorksRevision: "1".repeat(40), sceneWorksTree: "a".repeat(40),
+    inferenceRevision: "3".repeat(40), inferenceTree: "b".repeat(40),
+    identity, preparationKey: key, preparationRoot, prepared, hostMemoryBytes,
+  };
+  const successEvents = campaignSuccessEvents(hostMemoryBytes, BOUNDED_CARRIER_PHASES);
+  assert.equal(validateBoundedCarrierWatchdogEvents(successEvents, hostMemoryBytes), 3);
+  const failureEvents = campaignFailureEvents(hostMemoryBytes, 4, BOUNDED_CARRIER_PHASES);
+  const publication = (kind) => ({
+    canonicalOutput,
+    successOutput: boundedCarrierSuccessPath(canonicalOutput),
+    failureOutput: boundedCarrierFailurePath(canonicalOutput),
+    reservation: boundedCarrierOutcomeReservationPath(canonicalOutput),
+    choice: `${boundedCarrierOutcomeReservationPath(canonicalOutput)}.choice`,
+    canonicalPublicationClaim: canonicalPublicationClaimPath(canonicalOutput),
+    canonicalPublicationClaimHeldAtPublication: true,
+    outcomeChoice: kind,
+    canonicalBundleAbsentAtPublication: true,
+    outcomeReservationHeldAtPublication: true,
+  });
+  const success = boundedCarrierSuccessReceipt({
+    ...receiptOptions, events: successEvents, response: boundedCarrierResponse(hostMemoryBytes),
+    outcome: publication("success"),
+  });
+  const failure = boundedCarrierFailureReceipt({
+    ...receiptOptions, events: failureEvents, outcome: publication("failure"),
+  });
+  assert.equal(success.recordType, BOUNDED_CARRIER_SUCCESS_RECEIPT_TYPE);
+  assert.equal(failure.recordType, BOUNDED_CARRIER_FAILURE_RECEIPT_TYPE);
+  assert.notEqual(boundedCarrierFailurePath(canonicalOutput), campaignEntryFailurePath(canonicalOutput));
+  assert.throws(() => validateBundle(success), /bundle|schema|records/);
+  assert.throws(() => validateBundle(failure), /bundle|schema|records/);
+  validateBoundedCarrierReceipt(success);
+  validateBoundedCarrierReceipt(failure);
+
+  for (const mutate of [
+    (value) => { value.canonicalBundlePublished = true; },
+    (value) => { value.outcome.canonicalBundleAbsentAtPublication = false; },
+    (value) => { value.boundedCarrier.strategy.spatialDecodeTiles = 1; },
+    (value) => { value.watchdog.events[2].physicalFootprintBytes += 1; },
+    (value) => { value.artifacts.adapter.mode = 0o700; },
+  ]) {
+    const changed = structuredClone(success);
+    mutate(changed);
+    assert.throws(() => validateBoundedCarrierReceipt(changed), /SC-20254|SC-20216/);
+  }
+  const missingPhase = structuredClone(failure);
+  missingPhase.watchdog.events = missingPhase.watchdog.events.filter((event) =>
+    event.providerPhase?.name !== "primary_denoise");
+  chainWatchdogEvents(missingPhase.watchdog.events);
+  missingPhase.watchdog.eventChain = {
+    protocol: "sceneworks-watchdog-event-chain-v1",
+    count: missingPhase.watchdog.events.length,
+    head: missingPhase.watchdog.events.at(-1).eventHash,
+  };
+  assert.throws(() => validateBoundedCarrierReceipt(missingPhase), /SC-20216|SC-20254/);
+
+  const acquisitionPath = path.join(root, "acquisition-race.json");
+  const acquisitions = await Promise.allSettled([
+    acquireBoundedCarrierOutcome(acquisitionPath), acquireBoundedCarrierOutcome(acquisitionPath),
+  ]);
+  assert.equal(acquisitions.filter((result) => result.status === "fulfilled").length, 1);
+  assert.equal(acquisitions.filter((result) => result.status === "rejected").length, 1);
+  await releaseUnpublishedBoundedCarrierOutcome(
+    acquisitions.find((result) => result.status === "fulfilled").value,
+  );
+
+  const racedClaim = await acquireCanonicalPublicationClaim(canonicalOutput);
+  const racedOutcome = await acquireBoundedCarrierOutcome(canonicalOutput);
+  racedOutcome.canonicalClaim = racedClaim;
+  const publications = await Promise.allSettled([
+    publishBoundedCarrierSuccessReceipt(racedOutcome, {
+      verify: async () => {},
+      build: (outcome) => boundedCarrierSuccessReceipt({
+        ...receiptOptions, events: successEvents,
+        response: boundedCarrierResponse(hostMemoryBytes), outcome,
+      }),
+    }),
+    publishBoundedCarrierFailureReceipt(racedOutcome, {
+      verify: async () => {},
+      build: (outcome) => boundedCarrierFailureReceipt({
+        ...receiptOptions, events: failureEvents, outcome,
+      }),
+    }),
+  ]);
+  assert.equal(publications.filter((result) => result.status === "fulfilled").length, 1);
+  assert.equal(publications.filter((result) => result.status === "rejected").length, 1);
+  assert.equal(await readFile(canonicalOutput, "utf8").catch(() => null), null);
+  const [successBytes, failureBytes] = await Promise.all([
+    readFile(boundedCarrierSuccessPath(canonicalOutput), "utf8").catch(() => null),
+    readFile(boundedCarrierFailurePath(canonicalOutput), "utf8").catch(() => null),
+  ]);
+  assert.notEqual(successBytes === null, failureBytes === null);
+  await releaseUnpublishedBoundedCarrierOutcome(racedOutcome);
+  await racedClaim.release();
+
+  const legacyDirectory = path.join(root, "legacy-failure");
+  await mkdir(legacyDirectory);
+  const legacyOutput = path.join(legacyDirectory, "canonical.json");
+  await writeFile(campaignEntryFailurePath(legacyOutput), "legacy immutable SC-20216 failure\n");
+  await writeFile(campaignEntryOutcomeReservationPath(legacyOutput), "legacy owner\n");
+  await writeFile(`${campaignEntryOutcomeReservationPath(legacyOutput)}.choice`, "failure\n");
+  const legacyClaim = await acquireCanonicalPublicationClaim(legacyOutput);
+  const legacyBounded = await acquireBoundedCarrierOutcome(legacyOutput);
+  await releaseUnpublishedBoundedCarrierOutcome(legacyBounded);
+  await legacyClaim.release();
+
+  const staleOutput = path.join(root, "stale-canonical.json");
+  const staleClaimPath = canonicalPublicationClaimPath(staleOutput);
+  await mkdir(staleClaimPath, { mode: 0o700 });
+  await writeFile(path.join(staleClaimPath, "owner.json"), JSON.stringify({
+    schemaVersion: 1,
+    pid: process.pid,
+    processIdentity: { startIdentity: "reused pid", executable: "old-node" },
+    token: "stale",
+  }));
+  const reclamationPath = `${staleClaimPath}.reclaiming`;
+  await writeFile(reclamationPath, "", { mode: 0o600 });
+  const orphanedReclamationMetadata = await lstat(reclamationPath, { bigint: true });
+  await writeFile(reclamationPath, `${JSON.stringify({
+    schemaVersion: 1,
+    kind: "canonical-claim-reclamation-mutex",
+    pid: 999_999,
+    processIdentity: { startIdentity: "dead process", executable: "old-node" },
+    token: "orphaned-reclamation-owner",
+    filesystemIdentity: {
+      device: String(orphanedReclamationMetadata.dev),
+      inode: String(orphanedReclamationMetadata.ino),
+    },
+  })}\n`, { mode: 0o600 });
+  const currentIdentity = { startIdentity: "current process", executable: "node" };
+
+  const symlinkOutput = path.join(root, "symlink-canonical.json");
+  const symlinkClaimPath = canonicalPublicationClaimPath(symlinkOutput);
+  await mkdir(symlinkClaimPath, { mode: 0o700 });
+  await writeFile(path.join(symlinkClaimPath, "owner.json"), JSON.stringify({
+    schemaVersion: 1,
+    pid: process.pid,
+    processIdentity: { startIdentity: "reused pid", executable: "old-node" },
+    token: "stale",
+  }));
+  const foreignTarget = path.join(root, "foreign-reclamation-target");
+  await writeFile(foreignTarget, "must remain byte-identical\n", { mode: 0o640 });
+  const foreignBefore = await lstat(foreignTarget, { bigint: true });
+  await symlink(foreignTarget, `${symlinkClaimPath}.reclaiming`);
+  await assert.rejects(
+    acquireCanonicalPublicationClaim(
+      symlinkOutput, undefined, async () => currentIdentity,
+    ),
+    /reclamation lock helper exited before ownership/,
+  );
+  const foreignAfter = await lstat(foreignTarget, { bigint: true });
+  assert.equal(await readFile(foreignTarget, "utf8"), "must remain byte-identical\n");
+  assert.deepEqual({
+    device: foreignAfter.dev,
+    inode: foreignAfter.ino,
+    mode: foreignAfter.mode,
+    size: foreignAfter.size,
+    mtimeNs: foreignAfter.mtimeNs,
+    ctimeNs: foreignAfter.ctimeNs,
+  }, {
+    device: foreignBefore.dev,
+    inode: foreignBefore.ino,
+    mode: foreignBefore.mode,
+    size: foreignBefore.size,
+    mtimeNs: foreignBefore.mtimeNs,
+    ctimeNs: foreignBefore.ctimeNs,
+  });
+
+  const foreignInodeOutput = path.join(root, "foreign-inode-canonical.json");
+  const foreignInodeClaimPath = canonicalPublicationClaimPath(foreignInodeOutput);
+  await mkdir(foreignInodeClaimPath, { mode: 0o700 });
+  await writeFile(path.join(foreignInodeClaimPath, "owner.json"), JSON.stringify({
+    schemaVersion: 1,
+    pid: process.pid,
+    processIdentity: { startIdentity: "reused pid", executable: "old-node" },
+    token: "stale",
+  }));
+  const foreignInodePath = `${foreignInodeClaimPath}.reclaiming`;
+  await writeFile(foreignInodePath, "foreign inode must remain unchanged\n", { mode: 0o600 });
+  const foreignInodeBefore = await lstat(foreignInodePath, { bigint: true });
+  await assert.rejects(
+    acquireCanonicalPublicationClaim(
+      foreignInodeOutput, undefined, async () => currentIdentity,
+    ),
+    /preexisting canonical reclamation lock owner is invalid/,
+  );
+  const foreignInodeAfter = await lstat(foreignInodePath, { bigint: true });
+  assert.equal(await readFile(foreignInodePath, "utf8"), "foreign inode must remain unchanged\n");
+  assert.deepEqual({
+    mode: foreignInodeAfter.mode, size: foreignInodeAfter.size,
+    mtimeNs: foreignInodeAfter.mtimeNs, ctimeNs: foreignInodeAfter.ctimeNs,
+  }, {
+    mode: foreignInodeBefore.mode, size: foreignInodeBefore.size,
+    mtimeNs: foreignInodeBefore.mtimeNs, ctimeNs: foreignInodeBefore.ctimeNs,
+  });
+
+  const hardlinkOutput = path.join(root, "hardlink-canonical.json");
+  const hardlinkClaimPath = canonicalPublicationClaimPath(hardlinkOutput);
+  await mkdir(hardlinkClaimPath, { mode: 0o700 });
+  await writeFile(path.join(hardlinkClaimPath, "owner.json"), JSON.stringify({
+    schemaVersion: 1,
+    pid: process.pid,
+    processIdentity: { startIdentity: "reused pid", executable: "old-node" },
+    token: "stale",
+  }));
+  const linkedTarget = path.join(root, "hard-linked-reclamation-target");
+  await writeFile(linkedTarget, "hard link must remain unchanged\n", { mode: 0o640 });
+  await link(linkedTarget, `${hardlinkClaimPath}.reclaiming`);
+  const linkedBefore = await lstat(linkedTarget, { bigint: true });
+  await assert.rejects(
+    acquireCanonicalPublicationClaim(
+      hardlinkOutput, undefined, async () => currentIdentity,
+    ),
+    /reclamation lock helper exited before ownership/,
+  );
+  const linkedAfter = await lstat(linkedTarget, { bigint: true });
+  assert.equal(await readFile(linkedTarget, "utf8"), "hard link must remain unchanged\n");
+  assert.deepEqual({ mode: linkedAfter.mode, size: linkedAfter.size, ctimeNs: linkedAfter.ctimeNs }, {
+    mode: linkedBefore.mode, size: linkedBefore.size, ctimeNs: linkedBefore.ctimeNs,
+  });
+
+  let serializationArrivals = 0;
+  let releaseSerialization;
+  let reportBothArrived;
+  let reportStaleRevalidated;
+  let releaseStaleRevalidation;
+  const serializationGate = new Promise((resolve) => { releaseSerialization = resolve; });
+  const bothArrived = new Promise((resolve) => { reportBothArrived = resolve; });
+  const staleRevalidated = new Promise((resolve) => { reportStaleRevalidated = resolve; });
+  const staleGate = new Promise((resolve) => { releaseStaleRevalidation = resolve; });
+  const hooks = {
+    beforeSerialization: async () => {
+      serializationArrivals += 1;
+      if (serializationArrivals === 2) reportBothArrived();
+      await serializationGate;
+    },
+    afterStaleRevalidation: async () => {
+      const owner = JSON.parse(await readFile(reclamationPath, "utf8"));
+      const metadata = await lstat(reclamationPath, { bigint: true });
+      assert.equal(owner.pid, process.pid);
+      assert.deepEqual(owner.processIdentity, currentIdentity);
+      assert.notEqual(owner.token, "orphaned-reclamation-owner");
+      assert.deepEqual(owner.filesystemIdentity, {
+        device: String(metadata.dev), inode: String(metadata.ino),
+      });
+      reportStaleRevalidated();
+      await staleGate;
+    },
+  };
+  const reclaimers = [1, 2].map(() => acquireCanonicalPublicationClaim(
+    staleOutput, undefined, async () => currentIdentity, hooks,
+  ));
+  await bothArrived;
+  releaseSerialization();
+  await staleRevalidated;
+  releaseStaleRevalidation();
+  const reclaimed = await Promise.allSettled(reclaimers);
+  assert.equal(reclaimed.filter((result) => result.status === "fulfilled").length, 1);
+  assert.equal(reclaimed.filter((result) => result.status === "rejected").length, 1);
+  assert.match(reclaimed.find((result) => result.status === "rejected").reason.message,
+    /live contained LTX run/);
+  const recoveredClaim = reclaimed.find((result) => result.status === "fulfilled").value;
+  await recoveredClaim.assertOwner();
+  assert.deepEqual((await readdir(root)).filter((name) =>
+    name.includes("stale-canonical.json.ltx-canonical-publication-claim.stale-")), []);
+  const recoveredReclamationOwner = JSON.parse(await readFile(reclamationPath, "utf8"));
+  assert.equal(recoveredReclamationOwner.pid, process.pid);
+  assert.deepEqual(recoveredReclamationOwner.processIdentity, currentIdentity);
+  assert.notEqual(recoveredReclamationOwner.token, "orphaned-reclamation-owner");
+  await recoveredClaim.release();
+
+  const campaignRaceDirectory = path.join(root, "campaign-race");
+  await mkdir(campaignRaceDirectory);
+  const campaignRaceOutput = path.join(campaignRaceDirectory, "canonical.json");
+  const campaignClaim = await acquireCanonicalPublicationClaim(campaignRaceOutput);
+  const campaignOutcome = await acquireCampaignEntryOutcome(campaignRaceOutput);
+  campaignOutcome.canonicalClaim = campaignClaim;
+  const campaignRace = await Promise.allSettled([
+    publishCampaignEntryCanonicalOutcome(campaignOutcome, { exact: "canonical" }),
+    acquireCanonicalPublicationClaim(campaignRaceOutput),
+  ]);
+  assert.equal(campaignRace[0].status, "fulfilled");
+  assert.equal(campaignRace[1].status, "rejected");
+  assert.match(campaignRace[1].reason.message, /live contained LTX run/);
+  assert.equal(await readFile(boundedCarrierSuccessPath(campaignRaceOutput), "utf8")
+    .catch(() => null), null);
+  assert.equal(await readFile(boundedCarrierFailurePath(campaignRaceOutput), "utf8")
+    .catch(() => null), null);
+  await releaseUnpublishedCampaignEntryOutcome(campaignOutcome);
+  await campaignClaim.release();
+
+  for (const kind of ["success", "failure"]) {
+    const raceDirectory = path.join(root, `bounded-${kind}-race`);
+    await mkdir(raceDirectory);
+    const raceOutput = path.join(raceDirectory, "canonical.json");
+    const boundedClaim = await acquireCanonicalPublicationClaim(raceOutput);
+    const boundedOutcome = await acquireBoundedCarrierOutcome(raceOutput);
+    boundedOutcome.canonicalClaim = boundedClaim;
+    const publish = kind === "success"
+      ? publishBoundedCarrierSuccessReceipt(boundedOutcome, {
+        verify: async () => {},
+        build: (outcome) => boundedCarrierSuccessReceipt({
+          ...receiptOptions, events: successEvents,
+          response: boundedCarrierResponse(hostMemoryBytes), outcome,
+        }),
+      })
+      : publishBoundedCarrierFailureReceipt(boundedOutcome, {
+        verify: async () => {},
+        build: (outcome) => boundedCarrierFailureReceipt({
+          ...receiptOptions, events: failureEvents, outcome,
+        }),
+      });
+    const boundedRace = await Promise.allSettled([
+      publish,
+      acquireCanonicalPublicationClaim(raceOutput),
+    ]);
+    assert.equal(boundedRace[0].status, "fulfilled");
+    assert.equal(boundedRace[1].status, "rejected");
+    assert.match(boundedRace[1].reason.message, /live contained LTX run/);
+    assert.equal(await readFile(raceOutput, "utf8").catch(() => null), null);
+    await releaseUnpublishedBoundedCarrierOutcome(boundedOutcome);
+    await boundedClaim.release();
+  }
 });
 
 test("SC-20191 publishes one schema-valid canonical runtime record after stripping private evidence", async (t) => {
@@ -1259,6 +1756,7 @@ test("the production runner can only launch through the identity-checked watchdo
   assert.match(source, /response\?\.inferenceRevision !== expectedInferenceRevision/);
   assert.match(source, /--require-child-attestation/);
   assert.match(source, /--require-provider-phases/);
+  assert.match(source, /"--provider-phase-profile", "campaign-entry"/);
   assert.equal(CHILD_ATTESTATION_TIMEOUT_SECONDS, 30);
   assert.match(source, /--child-attestation-timeout", String\(CHILD_ATTESTATION_TIMEOUT_SECONDS\)/);
   assert.match(source, /event\.event === "child_attested"/);
@@ -1291,8 +1789,24 @@ test("the production runner can only launch through the identity-checked watchdo
   "the original watchdog failure must exist before receipt or postcondition validation");
   assert.match(failureHandling, /preserveFailureReceiptSuppression\(watchdogError, error\)/);
   assert.match(source, /acquireCampaignEntryOutcome\(output\)/);
+  const canonicalClaim = source.slice(
+    source.indexOf("export async function acquireCanonicalPublicationClaim("),
+    source.indexOf("export async function acquireBoundedCarrierOutcome("),
+  );
+  const reclamationMutex = canonicalClaim.indexOf(
+    "acquireCanonicalClaimReclamationMutex(\n      claimPath, signal, processIdentityProbe,",
+  );
+  const serializedOwnerRead = canonicalClaim.indexOf(
+    'path.join(claimPath, "owner.json")', reclamationMutex,
+  );
+  assert.ok(
+    reclamationMutex >= 0
+      && reclamationMutex < serializedOwnerRead
+      && serializedOwnerRead < canonicalClaim.indexOf("await reclamation.rename(claimPath, stale)"),
+    "stale claim identity must be re-read under serialized reclamation before its exact rename",
+  );
   assert.match(source, /canonicalBundleAbsentAtPublication: true/);
-  assert.equal(source.match(/await assertHostPreflight\(/g)?.length, 2,
+  assert.equal(source.match(/await assertHostPreflight\(/g)?.length, 3,
     "each contained execution profile has one immediate model-release check");
   assert.doesNotMatch(source, /300_000|5 \* 60 \* 1_000/);
   assert.match(
@@ -1305,11 +1819,27 @@ test("the production runner can only launch through the identity-checked watchdo
     /await assertHostPreflight\(hostMemoryBytes, signal\);\n\s*const status = await new Promise\(\(resolve, reject\) => \{\n\s*const child = spawn/,
     "the campaign entry host gate must also be the final operation before watchdog launch",
   );
+  const boundedController = source.slice(
+    source.indexOf("async function runBoundedCarrierController("),
+    source.indexOf("async function controller("),
+  );
+  assert.match(
+    boundedController,
+    /await assertHostPreflight\(hostMemoryBytes, signal\);\n\s*const status = await new Promise\(\(resolve, reject\) => \{\n\s*const child = spawn/,
+    "the bounded carrier host gate must be the final operation before its one watchdog launch",
+  );
+  assert.equal(BOUNDED_CARRIER_PROFILE, "bounded-carrier");
+  assert.match(boundedController, /--require-provider-phases/);
+  assert.match(boundedController, /"--provider-phase-profile", "bounded-carrier"/);
+  assert.match(boundedController, /acquireCanonicalPublicationClaim\(output, signal\)/);
+  assert.match(boundedController, /boundedCarrierSuccessReceipt/);
+  assert.match(boundedController, /boundedCarrierFailureReceipt/);
   assert.match(source, /sourceAfterRun: \{ sceneWorks: sceneWorksAfterRun, inference: inferenceAfterRun \}/);
   const campaignController = source.slice(
     source.indexOf("async function runCampaignEntryController("),
     source.indexOf("async function controller("),
   );
+  assert.match(campaignController, /acquireCanonicalPublicationClaim\(output, signal\)/);
   assert.doesNotMatch(campaignController, /onProviderCheckpoint/,
     "the one-row campaign entry must never publish a partial harness checkpoint");
   for (const operation of [


### PR DESCRIPTION
## Summary
- add a private, non-ingestible q4 LTX bounded-decode proof at 768x512, f121, 30 fps, seed 18946, full A/V
- execute exactly one ordinary provider request-scope render with bounded decode 192/64 and attest 24 spatial tiles
- reuse the phase-authenticated watchdog, exact memory cap, sealed assets, allocator cleanup, and exclusive outcome machinery without changing the frozen 70-row campaign
- make cross-profile canonical publication claims crash-recoverable, ABA-safe, and symlink/inode hardened

## Validation
- focused Node suites: 113/113
- full npm run check: 573/573
- LTX Rust tests: 40/40
- SC-20254 Rust tests: 2/2
- Clippy all targets with warnings denied
- cargo fmt, Node syntax, Python compile, and diff checks
- independent adversarial review: PASS, high confidence

## Runtime boundary
No real-weight workload was run in this PR. After merge, SC-20254 requires exactly one permanent-head bounded carrier execution. Its success or failure receipt is diagnostic-only, non-promotable, and non-ingestible; canonical SC-18946 output remains absent.