### PR TITLE
sc-19705: add durable resolved model cache store

### DIFF
--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -165,6 +165,8 @@ jobs:
         run: node apps/desktop/scripts/stage-test-sidecars.mjs
       - name: Run Windows project-registry fingerprint regression
         run: cargo test -p sceneworks-core windows_registry_cache_detects_between_window_rewrite_with_restored_mtime
+      - name: Run Windows resolved-cache safety regressions
+        run: "cargo test -p sceneworks-core model_artifacts::resolved_cache::tests:: -- --test-threads=1"
       - name: Run desktop Rust tests
         run: cargo test -p sceneworks-desktop
       - name: Check desktop Rust lint

--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -22,6 +22,7 @@ fn main() {
             "get_gpu_info",
             // GPU memory cap + live telemetry (epic 7819, sc-7825).
             "set_gpu_memory_limit",
+            "set_resolved_cache_policy",
             "get_gpu_telemetry",
             // LAN remote access (epic 4484, stories 4/5).
             "get_remote_access",

--- a/apps/desktop/capabilities/default.json
+++ b/apps/desktop/capabilities/default.json
@@ -28,6 +28,7 @@
     "allow-restart-worker",
     "allow-get-gpu-info",
     "allow-set-gpu-memory-limit",
+    "allow-set-resolved-cache-policy",
     "allow-get-gpu-telemetry",
     "allow-get-remote-access",
     "allow-set-remote-access",

--- a/apps/desktop/permissions/autogenerated/set_resolved_cache_policy.toml
+++ b/apps/desktop/permissions/autogenerated/set_resolved_cache_policy.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-set-resolved-cache-policy"
+description = "Enables the set_resolved_cache_policy command without any pre-configured scope."
+commands.allow = ["set_resolved_cache_policy"]
+
+[[permission]]
+identifier = "deny-set-resolved-cache-policy"
+description = "Denies the set_resolved_cache_policy command without any pre-configured scope."
+commands.deny = ["set_resolved_cache_policy"]

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -96,6 +96,7 @@ fn main() {
             settings::get_gpu_info,
             // GPU memory cap (epic 7819).
             settings::set_gpu_memory_limit,
+            settings::set_resolved_cache_policy,
             // Live MLX memory telemetry for the Settings readout (epic 7819, sc-7825).
             settings::get_gpu_telemetry,
             // LAN remote access (epic 4484, stories 4/5).

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -253,6 +253,10 @@ pub struct AppSettings {
     /// only today — the candle/Windows path is tracked separately (sc-7826).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gpu_memory_limit_fraction: Option<f32>,
+    /// App-owned resolved-model hot-cache policy. Nested serde defaults preserve upgrades from
+    /// settings files written before the cache existed. Disabled by default.
+    #[serde(default)]
+    pub resolved_cache: sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy,
 }
 
 fn settings_path() -> PathBuf {
@@ -305,10 +309,11 @@ fn sanitize_storage_overrides(settings: &mut AppSettings, linux_absolute: bool) 
 }
 
 pub fn load_settings() -> AppSettings {
-    let settings = std::fs::read_to_string(settings_path())
+    let mut settings: AppSettings = std::fs::read_to_string(settings_path())
         .ok()
         .and_then(|body| serde_json::from_str(&body).ok())
         .unwrap_or_default();
+    sanitize_resolved_cache_policy(&mut settings);
     #[cfg(all(unix, not(target_os = "macos")))]
     {
         let mut settings = settings;
@@ -318,6 +323,13 @@ pub fn load_settings() -> AppSettings {
     #[cfg(not(all(unix, not(target_os = "macos"))))]
     {
         settings
+    }
+}
+
+fn sanitize_resolved_cache_policy(settings: &mut AppSettings) {
+    if let Err(error) = settings.resolved_cache.validate() {
+        eprintln!("invalid persisted resolved-cache policy; disabling cache: {error}");
+        settings.resolved_cache = Default::default();
     }
 }
 
@@ -791,6 +803,19 @@ pub fn set_gpu_memory_limit(fraction: Option<f32>) -> Result<AppSettings, String
     save_settings(&settings)?;
     #[cfg(target_os = "macos")]
     write_gpu_memory_limit_file();
+    Ok(settings)
+}
+
+/// Persist a validated resolved-model cache policy. The three process environments are captured
+/// when the API/MLX/Candle sidecars start, so callers should present this as requiring restart.
+#[tauri::command]
+pub fn set_resolved_cache_policy(
+    policy: sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy,
+) -> Result<AppSettings, String> {
+    policy.validate().map_err(|error| error.to_string())?;
+    let mut settings = load_settings();
+    settings.resolved_cache = policy;
+    save_settings(&settings)?;
     Ok(settings)
 }
 
@@ -2105,5 +2130,55 @@ mod tests {
             !remote_access_change_needs_confirmation(false),
             "disabling is fail-safe and must not be gated"
         );
+    }
+
+    #[test]
+    fn resolved_cache_settings_upgrade_round_trip_and_invalid_values_fail_closed() {
+        let legacy: AppSettings = serde_json::from_str("{}").unwrap();
+        assert_eq!(
+            legacy.resolved_cache,
+            sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy::default()
+        );
+        assert!(!legacy.resolved_cache.enabled);
+
+        let policy = sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy {
+            enabled: true,
+            max_bytes: 8_589_934_592,
+            inactivity_seconds: 86_400,
+        };
+        let settings = AppSettings {
+            resolved_cache: policy.clone(),
+            ..AppSettings::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains("resolvedCache"));
+        assert_eq!(
+            serde_json::from_str::<AppSettings>(&json)
+                .unwrap()
+                .resolved_cache,
+            policy
+        );
+
+        let mut invalid = AppSettings {
+            resolved_cache: sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy {
+                enabled: true,
+                max_bytes: 0,
+                inactivity_seconds: 0,
+            },
+            ..AppSettings::default()
+        };
+        sanitize_resolved_cache_policy(&mut invalid);
+        assert_eq!(invalid.resolved_cache, Default::default());
+        assert!(!invalid.resolved_cache.enabled);
+    }
+
+    #[test]
+    fn resolved_cache_setter_is_registered_and_granted() {
+        let capability = include_str!("../capabilities/default.json");
+        assert!(capability.contains("allow-set-resolved-cache-policy"));
+        let build = include_str!("../build.rs");
+        assert!(build.contains("\"set_resolved_cache_policy\""));
+        let main = include_str!("main.rs");
+        assert!(main.contains("settings::set_resolved_cache_policy"));
     }
 }

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -593,6 +593,24 @@ fn inject_huggingface_cache_env(command: Command, hf_home: &str) -> Command {
         .fold(command, |command, (name, value)| command.env(name, value))
 }
 
+fn resolved_cache_env(
+    policy: &sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy,
+) -> Result<[(&'static str, String); 3], String> {
+    policy.env_pairs().map_err(|error| error.to_string())
+}
+
+/// One centralized spawn seam for the API and both native GPU worker processes. All three receive
+/// exactly the same validated policy; an invalid policy aborts the spawn rather than enabling or
+/// unbounding a sidecar.
+fn inject_resolved_cache_env(
+    command: Command,
+    policy: &sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy,
+) -> Result<Command, String> {
+    Ok(resolved_cache_env(policy)?
+        .into_iter()
+        .fold(command, |command, (name, value)| command.env(name, value)))
+}
+
 fn huggingface_home() -> PathBuf {
     let ambient = std::env::var("HF_HOME").ok();
     let persisted = crate::settings::load_settings().hf_home;
@@ -1361,6 +1379,7 @@ fn spawn_api(app: &AppHandle) -> Result<(), String> {
     // The catalog's install-state detection resolves the HF cache from these;
     // they must match the worker's download root or every model reads "missing".
     command = inject_huggingface_cache_env(command, &hf_home);
+    command = inject_resolved_cache_env(command, &settings.resolved_cache)?;
     // Epic 3482 (Python Eradication) final cutover (sc-3492) — macOS runs MLX-only.
     // `Settings.mlx_required` ← `SCENEWORKS_MLX_REQUIRED` (sc-3483): the MPS/torch worker
     // never claims an MLX-eligible job, and an MLX-eligible job that no live `mlx` worker
@@ -2408,6 +2427,10 @@ fn supervise_mlx_worker(app: AppHandle) {
                     config_dir().to_string_lossy().to_string(),
                 );
             command = inject_huggingface_cache_env(command, ctx.hf_home);
+            command = inject_resolved_cache_env(
+                command,
+                &crate::settings::load_settings().resolved_cache,
+            )?;
             // sc-7821 (epic 7819): the user's GPU memory ceiling, as fraction × total unified
             // memory. run_worker_loop applies it to the MLX runtime process-globally (covers
             // generations, upscales, AND LoRA training). Absent ⇒ no env ⇒ MLX default budget.
@@ -2531,6 +2554,10 @@ fn supervise_candle_worker(app: AppHandle) {
                     config_dir().to_string_lossy().to_string(),
                 );
             command = inject_huggingface_cache_env(command, ctx.hf_home);
+            command = inject_resolved_cache_env(
+                command,
+                &crate::settings::load_settings().resolved_cache,
+            )?;
             // cudarc dynamic-linking `LoadLibrary`s the CUDA runtime DLLs by name;
             // prepend the bundled redist dir to this worker's PATH so they resolve
             // without a CUDA Toolkit on the machine (sc-5560).
@@ -3742,8 +3769,8 @@ pub async fn start_setup(app: AppHandle) {
 #[cfg(test)]
 mod path_tests {
     use super::{
-        huggingface_cache_env, packaged_macos_bundle_paths, select_huggingface_home,
-        LinuxDesktopPaths, MacosBundlePaths,
+        huggingface_cache_env, packaged_macos_bundle_paths, resolved_cache_env,
+        select_huggingface_home, LinuxDesktopPaths, MacosBundlePaths,
     };
     use std::collections::HashMap;
     use std::ffi::OsString;
@@ -3768,6 +3795,46 @@ mod path_tests {
         std::fs::create_dir_all(path.parent().expect("fixture parent"))
             .expect("create fixture parent");
         std::fs::write(path, b"fixture").expect("write fixture file");
+    }
+
+    #[test]
+    fn resolved_cache_spawn_environment_is_exact_for_every_sidecar() {
+        let policy = sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy {
+            enabled: true,
+            max_bytes: 4_294_967_296,
+            inactivity_seconds: 604_800,
+        };
+        let expected = [
+            ("SCENEWORKS_RESOLVED_CACHE_ENABLED", "true".to_owned()),
+            (
+                "SCENEWORKS_RESOLVED_CACHE_MAX_BYTES",
+                "4294967296".to_owned(),
+            ),
+            (
+                "SCENEWORKS_RESOLVED_CACHE_INACTIVITY_SECONDS",
+                "604800".to_owned(),
+            ),
+        ];
+        assert_eq!(resolved_cache_env(&policy).unwrap(), expected);
+        let source = include_str!("setup.rs");
+        let injection_call = ["command = inject_", "resolved_cache_env("].concat();
+        assert_eq!(
+            source.matches(&injection_call).count(),
+            3,
+            "API, MLX, and Candle must all enter the centralized policy seam"
+        );
+        let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+        for path in [
+            manifest.join("../rust-api/src/server.rs"),
+            manifest.join("../../crates/sceneworks-worker/src/settings.rs"),
+        ] {
+            let consumer = std::fs::read_to_string(&path).unwrap();
+            assert!(
+                consumer.contains("ResolvedCachePolicy::from_env_or_safe_default()"),
+                "{} must use the shared fail-closed parser",
+                path.display()
+            );
+        }
     }
 
     #[test]

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -60,6 +60,8 @@ pub struct Settings {
     pub host: String,
     pub port: u16,
     pub data_dir: PathBuf,
+    /// Finite, disabled-by-default app-owned resolved-model cache policy shared with workers.
+    pub resolved_cache: sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy,
     pub config_dir: PathBuf,
     /// Directory holding the `credentials.json` store (sc-16540). Resolved by
     /// [`sceneworks_core::credentials::credentials_dir`] and deliberately independent
@@ -173,6 +175,8 @@ impl Settings {
             host: host.clone(),
             port,
             data_dir,
+            resolved_cache:
+                sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy::from_env_or_safe_default(),
             config_dir,
             credentials_dir,
             access_token: std::env::var("SCENEWORKS_ACCESS_TOKEN")

--- a/apps/rust-api/src/tests/support.rs
+++ b/apps/rust-api/src/tests/support.rs
@@ -150,6 +150,7 @@ pub(crate) fn test_settings(temp_dir: &tempfile::TempDir) -> Settings {
         host: "127.0.0.1".to_owned(),
         port: 0,
         data_dir: temp_dir.path().join("data"),
+        resolved_cache: Default::default(),
         config_dir: temp_dir.path().join("config"),
         // Pinned to the tempdir on purpose. Resolving this the way production does
         // (`credentials::credentials_dir`) would hand tests the developer's REAL OS

--- a/crates/sceneworks-core/src/model_artifacts.rs
+++ b/crates/sceneworks-core/src/model_artifacts.rs
@@ -5,6 +5,9 @@
 //! distinct prevents a cache path from silently becoming artifact identity, and gives the hot
 //! cache a behavior-preserving migration seam.
 
+#[path = "resolved_cache.rs"]
+pub mod resolved_cache;
+
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -525,11 +525,16 @@ impl ResolvedCacheStore {
                 .to_owned();
             let metadata_lock = self.lock_metadata(&digest)?;
             let summary = match self.read_metadata_unlocked(&digest) {
-                Ok(JournalRead::Valid { metadata, .. }) => ResolvedCacheEntrySummary {
-                    cache_key: metadata.cache_key.clone(),
-                    state: metadata.state.clone(),
-                    metadata: Some(*metadata),
-                },
+                Ok(JournalRead::Valid { metadata, .. }) => {
+                    if metadata.state == ResolvedCacheEntryState::Complete {
+                        validate_complete_metadata(self, &metadata)?;
+                    }
+                    ResolvedCacheEntrySummary {
+                        cache_key: metadata.cache_key.clone(),
+                        state: metadata.state.clone(),
+                        metadata: Some(*metadata),
+                    }
+                }
                 Ok(JournalRead::Missing) => ResolvedCacheEntrySummary {
                     cache_key: format!("sha256:{digest}"),
                     state: ResolvedCacheEntryState::Corrupt,
@@ -1421,6 +1426,7 @@ fn validate_complete_metadata(
             "complete cache artifact has the wrong local root",
         ));
     }
+    validate_completion_confinement(store, &metadata.cache_key, &metadata.artifact)?;
     metadata
         .artifact
         .validate()

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -1,0 +1,1545 @@
+//! Durable app-owned resolved-model cache policy and store.
+//!
+//! The store is deliberately separate from the authoritative source library. It owns only
+//! `<data_dir>/models/resolved`, refuses to adopt an unmarked directory, and names entries from
+//! the portable immutable cache key defined by [`crate::model_artifacts`].
+
+use crate::model_artifacts::{
+    ActiveArtifactLease, ArtifactLocation, ModelArtifactResolver, PromotionCandidate,
+    ResolvedModelArtifact,
+};
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const RESOLVED_CACHE_POLICY_VERSION: u32 = 1;
+pub const RESOLVED_CACHE_DEFAULT_MAX_BYTES: u64 = 68_719_476_736;
+pub const RESOLVED_CACHE_DEFAULT_INACTIVITY_SECONDS: u64 = 1_209_600;
+pub const RESOLVED_CACHE_ENABLED_ENV: &str = "SCENEWORKS_RESOLVED_CACHE_ENABLED";
+pub const RESOLVED_CACHE_MAX_BYTES_ENV: &str = "SCENEWORKS_RESOLVED_CACHE_MAX_BYTES";
+pub const RESOLVED_CACHE_INACTIVITY_SECONDS_ENV: &str =
+    "SCENEWORKS_RESOLVED_CACHE_INACTIVITY_SECONDS";
+pub const RESOLVED_CACHE_STORE_VERSION: u32 = 1;
+
+const STORE_MARKER: &str = ".sceneworks-resolved-cache-v1";
+const STORE_MARKER_BODY: &[u8] = b"sceneworks-resolved-cache\nschema=1\n";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ResolvedCachePolicy {
+    pub enabled: bool,
+    pub max_bytes: u64,
+    pub inactivity_seconds: u64,
+}
+
+impl Default for ResolvedCachePolicy {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_bytes: RESOLVED_CACHE_DEFAULT_MAX_BYTES,
+            inactivity_seconds: RESOLVED_CACHE_DEFAULT_INACTIVITY_SECONDS,
+        }
+    }
+}
+
+impl ResolvedCachePolicy {
+    pub fn validate(&self) -> Result<(), ResolvedCacheError> {
+        if self.max_bytes == 0 {
+            return Err(ResolvedCacheError::new(
+                "resolved cache maxBytes must be finite and greater than zero",
+            ));
+        }
+        if self.inactivity_seconds == 0 {
+            return Err(ResolvedCacheError::new(
+                "resolved cache inactivitySeconds must be greater than zero",
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn env_pairs(&self) -> Result<[(&'static str, String); 3], ResolvedCacheError> {
+        self.validate()?;
+        Ok([
+            (
+                RESOLVED_CACHE_ENABLED_ENV,
+                if self.enabled { "true" } else { "false" }.to_owned(),
+            ),
+            (RESOLVED_CACHE_MAX_BYTES_ENV, self.max_bytes.to_string()),
+            (
+                RESOLVED_CACHE_INACTIVITY_SECONDS_ENV,
+                self.inactivity_seconds.to_string(),
+            ),
+        ])
+    }
+
+    pub fn from_env() -> Result<Self, ResolvedCacheError> {
+        Self::from_env_values(|name| std::env::var(name).ok())
+    }
+
+    pub fn from_env_or_safe_default() -> Self {
+        match Self::from_env() {
+            Ok(policy) => policy,
+            Err(error) => {
+                tracing::warn!(error = %error, "invalid resolved-cache environment; disabling cache");
+                Self::default()
+            }
+        }
+    }
+
+    pub fn from_env_values(
+        mut value: impl FnMut(&str) -> Option<String>,
+    ) -> Result<Self, ResolvedCacheError> {
+        let defaults = Self::default();
+        let enabled = match value(RESOLVED_CACHE_ENABLED_ENV) {
+            None => defaults.enabled,
+            Some(raw) => parse_bool(&raw).ok_or_else(|| {
+                ResolvedCacheError::new(format!(
+                    "{RESOLVED_CACHE_ENABLED_ENV} must be true/false or 1/0"
+                ))
+            })?,
+        };
+        let max_bytes = parse_optional_u64(
+            value(RESOLVED_CACHE_MAX_BYTES_ENV),
+            RESOLVED_CACHE_MAX_BYTES_ENV,
+            defaults.max_bytes,
+        )?;
+        let inactivity_seconds = parse_optional_u64(
+            value(RESOLVED_CACHE_INACTIVITY_SECONDS_ENV),
+            RESOLVED_CACHE_INACTIVITY_SECONDS_ENV,
+            defaults.inactivity_seconds,
+        )?;
+        let policy = Self {
+            enabled,
+            max_bytes,
+            inactivity_seconds,
+        };
+        policy.validate()?;
+        Ok(policy)
+    }
+}
+
+fn parse_bool(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" => Some(true),
+        "0" | "false" => Some(false),
+        _ => None,
+    }
+}
+
+fn parse_optional_u64(
+    value: Option<String>,
+    name: &str,
+    default: u64,
+) -> Result<u64, ResolvedCacheError> {
+    match value {
+        None => Ok(default),
+        Some(value) => value
+            .trim()
+            .parse::<u64>()
+            .ok()
+            .filter(|value| *value > 0)
+            .ok_or_else(|| ResolvedCacheError::new(format!("{name} must be a positive integer"))),
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedCacheError(String);
+
+impl ResolvedCacheError {
+    fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl std::fmt::Display for ResolvedCacheError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for ResolvedCacheError {}
+
+impl From<std::io::Error> for ResolvedCacheError {
+    fn from(error: std::io::Error) -> Self {
+        Self(error.to_string())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolvedCacheEntryState {
+    Pending,
+    Materializing,
+    Interrupted,
+    Complete,
+    Corrupt,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecoveryStatus {
+    Clean,
+    RecoveredFromOlderSlot,
+    ReconstructedFromCompleteReceipt,
+    InterruptedReservation,
+    CorruptUnrecoverable,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceVolumeRelation {
+    Same,
+    Different,
+    Unavailable,
+    Unknown,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SourceVolumeObservation {
+    pub relation: SourceVolumeRelation,
+    pub source_identity: Option<u64>,
+    pub resolved_identity: Option<u64>,
+    pub observed_at: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ResolvedCacheMetadata {
+    pub schema_version: u32,
+    pub cache_key: String,
+    pub artifact: ResolvedModelArtifact,
+    pub source_configured_path: PathBuf,
+    pub source_canonical_path: PathBuf,
+    pub entry_relative_path: PathBuf,
+    pub bundle_relative_path: PathBuf,
+    pub state: ResolvedCacheEntryState,
+    pub verified_bytes: u64,
+    pub created_at: u64,
+    pub updated_at: u64,
+    pub last_used_at: Option<u64>,
+    pub artifact_pinned: bool,
+    pub model_pin_owners: BTreeSet<String>,
+    pub effective_pin: bool,
+    pub reservation_id: Option<String>,
+    pub reservation_owner: Option<String>,
+    pub session_id: Option<String>,
+    pub recovery_status: RecoveryStatus,
+    pub source_volume: SourceVolumeObservation,
+}
+
+impl ResolvedCacheMetadata {
+    fn refresh_effective_pin(&mut self) {
+        self.effective_pin = self.artifact_pinned || !self.model_pin_owners.is_empty();
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedCacheEntrySummary {
+    pub cache_key: String,
+    pub state: ResolvedCacheEntryState,
+    pub metadata: Option<ResolvedCacheMetadata>,
+}
+
+#[derive(Debug)]
+pub enum ReservationOutcome {
+    Acquired(MaterializationReservation),
+    Contended,
+}
+
+#[derive(Clone)]
+pub struct ResolvedCacheStore {
+    inner: Arc<StoreInner>,
+}
+
+struct StoreInner {
+    root: PathBuf,
+    session_id: String,
+    _session_lock: File,
+}
+
+impl std::fmt::Debug for ResolvedCacheStore {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ResolvedCacheStore")
+            .field("root", &self.inner.root)
+            .field("session_id", &self.inner.session_id)
+            .finish()
+    }
+}
+
+impl ResolvedCacheStore {
+    pub fn open(data_dir: &Path) -> Result<Self, ResolvedCacheError> {
+        let models = data_dir.join("models");
+        std::fs::create_dir_all(&models).map_err(|error| {
+            ResolvedCacheError::new(format!(
+                "create model directory {}: {error}",
+                models.display()
+            ))
+        })?;
+        ensure_regular_directory(&models)?;
+        let root = models.join("resolved");
+        initialize_or_validate_root(&root)?;
+        let root = std::fs::canonicalize(&root).map_err(|error| {
+            ResolvedCacheError::new(format!("canonicalize resolved root: {error}"))
+        })?;
+        let session_id = random_id()?;
+        let session_lock_path = root.join("sessions").join(format!("{session_id}.lock"));
+        let session_lock = open_lock_file(&session_lock_path)?;
+        FileExt::try_lock_exclusive(&session_lock).map_err(|error| {
+            ResolvedCacheError::new(format!("lock cache session {session_id}: {error}"))
+        })?;
+        std::fs::create_dir(root.join("sessions").join(&session_id)).map_err(|error| {
+            ResolvedCacheError::new(format!("create cache session records: {error}"))
+        })?;
+        Ok(Self {
+            inner: Arc::new(StoreInner {
+                root,
+                session_id,
+                _session_lock: session_lock,
+            }),
+        })
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.inner.root
+    }
+
+    pub fn session_id(&self) -> &str {
+        &self.inner.session_id
+    }
+
+    pub fn entry_path(&self, cache_key: &str) -> Result<PathBuf, ResolvedCacheError> {
+        let digest = cache_key_digest(cache_key)?;
+        Ok(self.inner.root.join("entries").join(digest))
+    }
+
+    pub fn bundle_path(&self, cache_key: &str) -> Result<PathBuf, ResolvedCacheError> {
+        Ok(self.entry_path(cache_key)?.join("bundle"))
+    }
+
+    pub fn compare_source_volume(
+        &self,
+        source_root: &Path,
+    ) -> Result<SourceVolumeObservation, ResolvedCacheError> {
+        let observed_at = now_seconds()?;
+        if !source_root.exists() {
+            return Ok(SourceVolumeObservation {
+                relation: SourceVolumeRelation::Unavailable,
+                source_identity: None,
+                resolved_identity: volume_identity(&self.inner.root).ok(),
+                observed_at,
+            });
+        }
+        let source = match volume_identity(source_root) {
+            Ok(identity) => identity,
+            Err(_) => {
+                return Ok(SourceVolumeObservation {
+                    relation: SourceVolumeRelation::Unknown,
+                    source_identity: None,
+                    resolved_identity: volume_identity(&self.inner.root).ok(),
+                    observed_at,
+                });
+            }
+        };
+        let resolved = match volume_identity(&self.inner.root) {
+            Ok(identity) => identity,
+            Err(_) => {
+                return Ok(SourceVolumeObservation {
+                    relation: SourceVolumeRelation::Unknown,
+                    source_identity: Some(source),
+                    resolved_identity: None,
+                    observed_at,
+                });
+            }
+        };
+        Ok(SourceVolumeObservation {
+            relation: relation_for_volume_identities(Some(source), Some(resolved), true),
+            source_identity: Some(source),
+            resolved_identity: Some(resolved),
+            observed_at,
+        })
+    }
+
+    pub fn reserve(
+        &self,
+        candidate: &PromotionCandidate,
+        source_configured_path: &Path,
+        logical_model_owner: &str,
+    ) -> Result<ReservationOutcome, ResolvedCacheError> {
+        validate_candidate(candidate)?;
+        let logical_model_owner = validate_model_owner(logical_model_owner)?.to_owned();
+        let source_canonical_path =
+            std::fs::canonicalize(source_configured_path).map_err(|error| {
+                ResolvedCacheError::new(format!(
+                    "source root {} is unavailable: {error}",
+                    source_configured_path.display()
+                ))
+            })?;
+        if !source_canonical_path.is_dir() {
+            return Err(ResolvedCacheError::new("source root is not a directory"));
+        }
+        let digest = cache_key_digest(&candidate.cache_key)?;
+        let artifact_lock = open_lock_file(&self.artifact_lock_path(&digest))?;
+        match FileExt::try_lock_exclusive(&artifact_lock) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                return Ok(ReservationOutcome::Contended);
+            }
+            Err(error) => return Err(error.into()),
+        }
+        let entry = self.entry_path(&candidate.cache_key)?;
+        ensure_managed_entry_dir(&entry)?;
+        let reservation_id = random_id()?;
+        let staging = self
+            .inner
+            .root
+            .join("staging")
+            .join(format!("{digest}-{reservation_id}"));
+        std::fs::create_dir(&staging).map_err(|error| {
+            ResolvedCacheError::new(format!("create materialization staging: {error}"))
+        })?;
+        let now = now_seconds()?;
+        let mut metadata = ResolvedCacheMetadata {
+            schema_version: RESOLVED_CACHE_STORE_VERSION,
+            cache_key: candidate.cache_key.clone(),
+            artifact: candidate.artifact.clone(),
+            source_configured_path: source_configured_path.to_path_buf(),
+            source_canonical_path,
+            entry_relative_path: PathBuf::from("entries").join(&digest),
+            bundle_relative_path: PathBuf::from("entries").join(&digest).join("bundle"),
+            state: ResolvedCacheEntryState::Materializing,
+            verified_bytes: 0,
+            created_at: now,
+            updated_at: now,
+            last_used_at: None,
+            artifact_pinned: false,
+            model_pin_owners: BTreeSet::new(),
+            effective_pin: false,
+            reservation_id: Some(reservation_id.clone()),
+            reservation_owner: Some(logical_model_owner.clone()),
+            session_id: Some(self.inner.session_id.clone()),
+            recovery_status: RecoveryStatus::Clean,
+            source_volume: self.compare_source_volume(source_configured_path)?,
+        };
+        let _metadata_lock = self.lock_metadata(&digest)?;
+        if let Ok(existing) = self.read_metadata_locked(&digest) {
+            metadata.created_at = existing.created_at;
+            metadata.artifact_pinned = existing.artifact_pinned;
+            metadata.model_pin_owners = existing.model_pin_owners;
+            metadata.refresh_effective_pin();
+        }
+        self.write_metadata_unlocked(&digest, &metadata)?;
+        let record = SessionRecord {
+            schema_version: RESOLVED_CACHE_STORE_VERSION,
+            cache_key: candidate.cache_key.clone(),
+            operation_id: reservation_id.clone(),
+            model_owner: logical_model_owner,
+            kind: SessionRecordKind::Reservation,
+            acquired_at: now,
+        };
+        let record_path = self.write_session_record(&record)?;
+        Ok(ReservationOutcome::Acquired(MaterializationReservation {
+            store: self.clone(),
+            cache_key: candidate.cache_key.clone(),
+            digest,
+            reservation_id,
+            staging_path: staging,
+            record_path,
+            artifact_lock: Some(artifact_lock),
+            finished: false,
+        }))
+    }
+
+    pub fn lookup_complete(
+        &self,
+        cache_key: &str,
+    ) -> Result<Option<ResolvedCacheMetadata>, ResolvedCacheError> {
+        let digest = cache_key_digest(cache_key)?;
+        let metadata_lock = self.lock_metadata(&digest)?;
+        let result = match self.read_metadata_unlocked(&digest)? {
+            JournalRead::Valid { metadata, .. }
+                if metadata.state == ResolvedCacheEntryState::Complete =>
+            {
+                validate_complete_metadata(self, &metadata)?;
+                Some(*metadata)
+            }
+            _ => None,
+        };
+        drop(metadata_lock);
+        Ok(result)
+    }
+
+    pub fn enumerate(&self) -> Result<Vec<ResolvedCacheEntrySummary>, ResolvedCacheError> {
+        let mut entries = Vec::new();
+        for item in std::fs::read_dir(self.inner.root.join("entries"))? {
+            let item = item?;
+            if !item.file_type()?.is_dir() {
+                return Err(ResolvedCacheError::new(format!(
+                    "unmanaged resolved-cache entry {}",
+                    item.path().display()
+                )));
+            }
+            let digest = item
+                .file_name()
+                .to_str()
+                .filter(|value| is_lower_hex_64(value))
+                .ok_or_else(|| ResolvedCacheError::new("invalid resolved-cache entry name"))?
+                .to_owned();
+            let metadata_lock = self.lock_metadata(&digest)?;
+            let summary = match self.read_metadata_unlocked(&digest) {
+                Ok(JournalRead::Valid { metadata, .. }) => ResolvedCacheEntrySummary {
+                    cache_key: metadata.cache_key.clone(),
+                    state: metadata.state.clone(),
+                    metadata: Some(*metadata),
+                },
+                Ok(JournalRead::Missing) => ResolvedCacheEntrySummary {
+                    cache_key: format!("sha256:{digest}"),
+                    state: ResolvedCacheEntryState::Corrupt,
+                    metadata: None,
+                },
+                Err(_) => ResolvedCacheEntrySummary {
+                    cache_key: format!("sha256:{digest}"),
+                    state: ResolvedCacheEntryState::Corrupt,
+                    metadata: None,
+                },
+            };
+            drop(metadata_lock);
+            entries.push(summary);
+        }
+        entries.sort_by(|left, right| left.cache_key.cmp(&right.cache_key));
+        Ok(entries)
+    }
+
+    pub fn checked_verified_bytes(&self) -> Result<u64, ResolvedCacheError> {
+        self.enumerate()?
+            .into_iter()
+            .filter_map(|entry| entry.metadata)
+            .try_fold(0_u64, |total, metadata| {
+                total.checked_add(metadata.verified_bytes).ok_or_else(|| {
+                    ResolvedCacheError::new("resolved-cache verified byte total overflow")
+                })
+            })
+    }
+
+    pub fn set_artifact_pin(
+        &self,
+        cache_key: &str,
+        pinned: bool,
+    ) -> Result<ResolvedCacheMetadata, ResolvedCacheError> {
+        self.update_metadata(cache_key, |metadata| {
+            metadata.artifact_pinned = pinned;
+            metadata.refresh_effective_pin();
+            Ok(())
+        })
+    }
+
+    pub fn set_model_pin(
+        &self,
+        cache_key: &str,
+        owner: &str,
+        pinned: bool,
+    ) -> Result<ResolvedCacheMetadata, ResolvedCacheError> {
+        let owner = validate_model_owner(owner)?.to_owned();
+        self.update_metadata(cache_key, move |metadata| {
+            if pinned {
+                metadata.model_pin_owners.insert(owner);
+            } else {
+                metadata.model_pin_owners.remove(&owner);
+            }
+            metadata.refresh_effective_pin();
+            Ok(())
+        })
+    }
+
+    pub fn effective_pin(&self, cache_key: &str) -> Result<bool, ResolvedCacheError> {
+        let digest = cache_key_digest(cache_key)?;
+        let _lock = self.lock_metadata(&digest)?;
+        Ok(self.read_metadata_locked(&digest)?.effective_pin)
+    }
+
+    pub fn mark_interrupted(
+        &self,
+        cache_key: &str,
+    ) -> Result<ResolvedCacheMetadata, ResolvedCacheError> {
+        self.update_metadata(cache_key, |metadata| {
+            if metadata.state == ResolvedCacheEntryState::Complete {
+                return Err(ResolvedCacheError::new(
+                    "a complete resolved-cache entry cannot be marked interrupted",
+                ));
+            }
+            metadata.state = ResolvedCacheEntryState::Interrupted;
+            metadata.recovery_status = RecoveryStatus::InterruptedReservation;
+            metadata.reservation_id = None;
+            metadata.reservation_owner = None;
+            metadata.session_id = None;
+            Ok(())
+        })
+    }
+
+    pub fn acquire_complete(
+        &self,
+        cache_key: &str,
+        resolver: &ModelArtifactResolver,
+        logical_model_owner: &str,
+    ) -> Result<Option<ResolvedCacheLease>, ResolvedCacheError> {
+        let logical_model_owner = validate_model_owner(logical_model_owner)?.to_owned();
+        let digest = cache_key_digest(cache_key)?;
+        let artifact_lock = open_lock_file(&self.artifact_lock_path(&digest))?;
+        FileExt::lock_shared(&artifact_lock)?;
+        let metadata_lock = self.lock_metadata(&digest)?;
+        let mut metadata = match self.read_metadata_unlocked(&digest)? {
+            JournalRead::Valid { metadata, .. }
+                if metadata.state == ResolvedCacheEntryState::Complete =>
+            {
+                *metadata
+            }
+            _ => return Ok(None),
+        };
+        validate_complete_metadata(self, &metadata)?;
+        let artifact = Arc::new(metadata.artifact.clone());
+        let runtime_lease = resolver
+            .acquire_runtime_lease(&artifact)
+            .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+        let lease_id = random_id()?;
+        let now = now_seconds()?;
+        let record = SessionRecord {
+            schema_version: RESOLVED_CACHE_STORE_VERSION,
+            cache_key: cache_key.to_owned(),
+            operation_id: lease_id,
+            model_owner: logical_model_owner,
+            kind: SessionRecordKind::RuntimeLease,
+            acquired_at: now,
+        };
+        let record_path = self.write_session_record(&record)?;
+        metadata.last_used_at = Some(now);
+        metadata.updated_at = now;
+        self.write_metadata_unlocked(&digest, &metadata)?;
+        drop(metadata_lock);
+        Ok(Some(ResolvedCacheLease {
+            runtime_lease: Some(runtime_lease),
+            artifact_lock,
+            record_path,
+        }))
+    }
+
+    pub fn recover(&self) -> Result<Vec<ResolvedCacheEntrySummary>, ResolvedCacheError> {
+        let summaries = self.enumerate()?;
+        for summary in &summaries {
+            let digest = cache_key_digest(&summary.cache_key)?;
+            let artifact_lock = open_lock_file(&self.artifact_lock_path(&digest))?;
+            match FileExt::try_lock_exclusive(&artifact_lock) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => continue,
+                Err(error) => return Err(error.into()),
+            }
+            let _metadata_lock = self.lock_metadata(&digest)?;
+            match self.read_metadata_unlocked(&digest) {
+                Ok(JournalRead::Valid {
+                    mut metadata,
+                    had_invalid_slot,
+                }) => {
+                    let mut changed = false;
+                    if had_invalid_slot {
+                        metadata.recovery_status = RecoveryStatus::RecoveredFromOlderSlot;
+                        metadata.artifact_pinned = true;
+                        metadata.refresh_effective_pin();
+                        changed = true;
+                    }
+                    if metadata.state == ResolvedCacheEntryState::Materializing
+                        && metadata
+                            .session_id
+                            .as_deref()
+                            .map_or(true, |session| self.session_is_stale(session))
+                    {
+                        metadata.state = ResolvedCacheEntryState::Interrupted;
+                        metadata.recovery_status = RecoveryStatus::InterruptedReservation;
+                        metadata.reservation_id = None;
+                        metadata.reservation_owner = None;
+                        metadata.session_id = None;
+                        changed = true;
+                    }
+                    if changed {
+                        metadata.updated_at = now_seconds()?;
+                        self.write_metadata_unlocked(&digest, &metadata)?;
+                    }
+                }
+                Ok(JournalRead::Missing) => self.write_corrupt_marker(&digest)?,
+                Err(_) => {
+                    let receipt = self.read_complete_receipt(&digest).and_then(|metadata| {
+                        validate_complete_metadata(self, &metadata)?;
+                        Ok(metadata)
+                    });
+                    if let Ok(mut metadata) = receipt {
+                        metadata.recovery_status = RecoveryStatus::ReconstructedFromCompleteReceipt;
+                        metadata.artifact_pinned = true;
+                        metadata.refresh_effective_pin();
+                        metadata.updated_at = now_seconds()?;
+                        self.write_metadata_unlocked(&digest, &metadata)?;
+                    } else {
+                        self.write_corrupt_marker(&digest)?;
+                    }
+                }
+            }
+        }
+        self.clean_stale_sessions()?;
+        self.enumerate()
+    }
+
+    fn update_metadata(
+        &self,
+        cache_key: &str,
+        update: impl FnOnce(&mut ResolvedCacheMetadata) -> Result<(), ResolvedCacheError>,
+    ) -> Result<ResolvedCacheMetadata, ResolvedCacheError> {
+        let digest = cache_key_digest(cache_key)?;
+        let _lock = self.lock_metadata(&digest)?;
+        let mut metadata = self.read_metadata_locked(&digest)?;
+        update(&mut metadata)?;
+        metadata.updated_at = now_seconds()?;
+        self.write_metadata_unlocked(&digest, &metadata)?;
+        Ok(metadata)
+    }
+
+    fn artifact_lock_path(&self, digest: &str) -> PathBuf {
+        self.inner
+            .root
+            .join("locks")
+            .join(format!("{digest}.artifact.lock"))
+    }
+
+    fn metadata_lock_path(&self, digest: &str) -> PathBuf {
+        self.inner
+            .root
+            .join("locks")
+            .join(format!("{digest}.metadata.lock"))
+    }
+
+    fn lock_metadata(&self, digest: &str) -> Result<File, ResolvedCacheError> {
+        let file = open_lock_file(&self.metadata_lock_path(digest))?;
+        FileExt::lock_exclusive(&file)?;
+        Ok(file)
+    }
+
+    fn read_metadata_locked(
+        &self,
+        digest: &str,
+    ) -> Result<ResolvedCacheMetadata, ResolvedCacheError> {
+        match self.read_metadata_unlocked(digest)? {
+            JournalRead::Valid { metadata, .. } => Ok(*metadata),
+            JournalRead::Missing => Err(ResolvedCacheError::new("cache metadata is missing")),
+        }
+    }
+
+    fn read_metadata_unlocked(&self, digest: &str) -> Result<JournalRead, ResolvedCacheError> {
+        let entry = self.inner.root.join("entries").join(digest);
+        let mut valid = Vec::new();
+        let mut had_file = false;
+        let mut had_invalid_slot = false;
+        for slot in 0..=1 {
+            let path = entry.join(format!("metadata.{slot}.json"));
+            if !path.exists() {
+                continue;
+            }
+            had_file = true;
+            match read_journal(&path) {
+                Ok(envelope) if validate_metadata_shape(&envelope.metadata, digest).is_ok() => {
+                    valid.push(envelope)
+                }
+                _ => had_invalid_slot = true,
+            }
+        }
+        valid.sort_by_key(|envelope| envelope.generation);
+        if let Some(envelope) = valid.pop() {
+            return Ok(JournalRead::Valid {
+                metadata: Box::new(envelope.metadata),
+                had_invalid_slot,
+            });
+        }
+        if had_file {
+            Err(ResolvedCacheError::new(
+                "both cache metadata slots are corrupt",
+            ))
+        } else {
+            Ok(JournalRead::Missing)
+        }
+    }
+
+    fn write_metadata_unlocked(
+        &self,
+        digest: &str,
+        metadata: &ResolvedCacheMetadata,
+    ) -> Result<(), ResolvedCacheError> {
+        validate_metadata_shape(metadata, digest)?;
+        let generation = match self.read_metadata_unlocked(digest) {
+            Ok(JournalRead::Valid { .. }) => {
+                highest_generation(&self.inner.root.join("entries").join(digest))?
+                    .checked_add(1)
+                    .ok_or_else(|| ResolvedCacheError::new("cache metadata generation overflow"))?
+            }
+            _ => 1,
+        };
+        let envelope = JournalEnvelope::new(generation, metadata.clone())?;
+        let slot = generation % 2;
+        let path = self
+            .inner
+            .root
+            .join("entries")
+            .join(digest)
+            .join(format!("metadata.{slot}.json"));
+        atomic_write_json(&path, &envelope)
+    }
+
+    fn write_complete_receipt(
+        &self,
+        digest: &str,
+        metadata: &ResolvedCacheMetadata,
+    ) -> Result<(), ResolvedCacheError> {
+        let envelope = ReceiptEnvelope::new(metadata.clone())?;
+        atomic_write_json(
+            &self
+                .inner
+                .root
+                .join("entries")
+                .join(digest)
+                .join("complete.receipt.json"),
+            &envelope,
+        )
+    }
+
+    fn read_complete_receipt(
+        &self,
+        digest: &str,
+    ) -> Result<ResolvedCacheMetadata, ResolvedCacheError> {
+        let path = self
+            .inner
+            .root
+            .join("entries")
+            .join(digest)
+            .join("complete.receipt.json");
+        let body = std::fs::read(&path)?;
+        let envelope: ReceiptEnvelope = serde_json::from_slice(&body).map_err(|error| {
+            ResolvedCacheError::new(format!("decode complete receipt: {error}"))
+        })?;
+        envelope.validate()?;
+        Ok(envelope.metadata)
+    }
+
+    fn write_corrupt_marker(&self, digest: &str) -> Result<(), ResolvedCacheError> {
+        let marker = CorruptMarker {
+            schema_version: RESOLVED_CACHE_STORE_VERSION,
+            cache_key: format!("sha256:{digest}"),
+            state: ResolvedCacheEntryState::Corrupt,
+            recovery_status: RecoveryStatus::CorruptUnrecoverable,
+            observed_at: now_seconds()?,
+        };
+        atomic_write_json(
+            &self
+                .inner
+                .root
+                .join("entries")
+                .join(digest)
+                .join("corrupt.marker.json"),
+            &marker,
+        )
+    }
+
+    fn write_session_record(&self, record: &SessionRecord) -> Result<PathBuf, ResolvedCacheError> {
+        let path = self
+            .inner
+            .root
+            .join("sessions")
+            .join(&self.inner.session_id)
+            .join(format!("{}.json", record.operation_id));
+        atomic_write_json(&path, record)?;
+        Ok(path)
+    }
+
+    fn session_is_stale(&self, session: &str) -> bool {
+        if session == self.inner.session_id {
+            return false;
+        }
+        let path = self
+            .inner
+            .root
+            .join("sessions")
+            .join(format!("{session}.lock"));
+        let Ok(file) = open_lock_file(&path) else {
+            return false;
+        };
+        FileExt::try_lock_exclusive(&file).is_ok()
+    }
+
+    fn clean_stale_sessions(&self) -> Result<(), ResolvedCacheError> {
+        let sessions = self.inner.root.join("sessions");
+        for item in std::fs::read_dir(&sessions)? {
+            let item = item?;
+            let name = item.file_name().to_string_lossy().into_owned();
+            let Some(session) = name.strip_suffix(".lock") else {
+                continue;
+            };
+            if session == self.inner.session_id {
+                continue;
+            }
+            let file = open_lock_file(&item.path())?;
+            if FileExt::try_lock_exclusive(&file).is_ok() {
+                let records = sessions.join(session);
+                if records.is_dir() {
+                    std::fs::remove_dir_all(records)?;
+                }
+                drop(file);
+                let _ = std::fs::remove_file(item.path());
+            }
+        }
+        Ok(())
+    }
+}
+
+pub struct MaterializationReservation {
+    store: ResolvedCacheStore,
+    cache_key: String,
+    digest: String,
+    reservation_id: String,
+    staging_path: PathBuf,
+    record_path: PathBuf,
+    artifact_lock: Option<File>,
+    finished: bool,
+}
+
+impl std::fmt::Debug for MaterializationReservation {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MaterializationReservation")
+            .field("cache_key", &self.cache_key)
+            .field("reservation_id", &self.reservation_id)
+            .field("staging_path", &self.staging_path)
+            .finish()
+    }
+}
+
+impl MaterializationReservation {
+    pub fn cache_key(&self) -> &str {
+        &self.cache_key
+    }
+
+    pub fn reservation_id(&self) -> &str {
+        &self.reservation_id
+    }
+
+    pub fn staging_path(&self) -> &Path {
+        &self.staging_path
+    }
+
+    pub fn bundle_path(&self) -> Result<PathBuf, ResolvedCacheError> {
+        self.store.bundle_path(&self.cache_key)
+    }
+
+    /// Records publication after a later materializer has atomically installed and validated the
+    /// bundle. This method does not copy, move, or delete any model bytes.
+    pub fn record_complete(
+        mut self,
+        artifact: ResolvedModelArtifact,
+    ) -> Result<ResolvedCacheMetadata, ResolvedCacheError> {
+        let expected_root = self.bundle_path()?;
+        if !matches!(&artifact.location, ArtifactLocation::ResolvedLocal { root } if root == &expected_root)
+        {
+            return Err(ResolvedCacheError::new(
+                "complete artifact is not rooted at its resolved-cache bundle",
+            ));
+        }
+        artifact
+            .validate()
+            .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+        if artifact
+            .cache_key()
+            .map_err(|error| ResolvedCacheError::new(error.to_string()))?
+            != self.cache_key
+        {
+            return Err(ResolvedCacheError::new(
+                "complete artifact cache key differs from its reservation",
+            ));
+        }
+        let verified_bytes = checked_artifact_bytes(&artifact)?;
+        let _metadata_lock = self.store.lock_metadata(&self.digest)?;
+        let mut metadata = self.store.read_metadata_locked(&self.digest)?;
+        if metadata.reservation_id.as_deref() != Some(&self.reservation_id) {
+            return Err(ResolvedCacheError::new(
+                "materialization reservation changed",
+            ));
+        }
+        metadata.artifact = artifact;
+        metadata.state = ResolvedCacheEntryState::Complete;
+        metadata.verified_bytes = verified_bytes;
+        metadata.updated_at = now_seconds()?;
+        metadata.reservation_id = None;
+        metadata.reservation_owner = None;
+        metadata.session_id = None;
+        metadata.recovery_status = RecoveryStatus::Clean;
+        self.store.write_complete_receipt(&self.digest, &metadata)?;
+        self.store
+            .write_metadata_unlocked(&self.digest, &metadata)?;
+        self.finished = true;
+        let _ = std::fs::remove_file(&self.record_path);
+        self.artifact_lock.take();
+        Ok(metadata)
+    }
+}
+
+impl Drop for MaterializationReservation {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        if let Ok(_metadata_lock) = self.store.lock_metadata(&self.digest) {
+            if let Ok(mut metadata) = self.store.read_metadata_locked(&self.digest) {
+                if metadata.reservation_id.as_deref() == Some(&self.reservation_id) {
+                    metadata.state = ResolvedCacheEntryState::Interrupted;
+                    metadata.reservation_id = None;
+                    metadata.reservation_owner = None;
+                    metadata.session_id = None;
+                    metadata.recovery_status = RecoveryStatus::InterruptedReservation;
+                    metadata.updated_at = now_seconds().unwrap_or(metadata.updated_at);
+                    let _ = self.store.write_metadata_unlocked(&self.digest, &metadata);
+                }
+            }
+        }
+        let _ = std::fs::remove_file(&self.record_path);
+        self.artifact_lock.take();
+    }
+}
+
+pub struct ResolvedCacheLease {
+    runtime_lease: Option<ActiveArtifactLease>,
+    #[allow(dead_code)]
+    artifact_lock: File,
+    record_path: PathBuf,
+}
+
+impl ResolvedCacheLease {
+    pub fn artifact(&self) -> &ResolvedModelArtifact {
+        self.runtime_lease
+            .as_ref()
+            .expect("resolved cache lease is active")
+            .artifact()
+    }
+
+    pub fn mark_success(mut self) -> PromotionCandidate {
+        let candidate = self
+            .runtime_lease
+            .take()
+            .expect("resolved cache lease is active")
+            .mark_success();
+        let _ = std::fs::remove_file(&self.record_path);
+        candidate
+    }
+}
+
+impl Drop for ResolvedCacheLease {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.record_path);
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct JournalEnvelope {
+    schema_version: u32,
+    generation: u64,
+    checksum: String,
+    metadata: ResolvedCacheMetadata,
+}
+
+impl JournalEnvelope {
+    fn new(generation: u64, metadata: ResolvedCacheMetadata) -> Result<Self, ResolvedCacheError> {
+        let checksum = journal_checksum(generation, &metadata)?;
+        Ok(Self {
+            schema_version: RESOLVED_CACHE_STORE_VERSION,
+            generation,
+            checksum,
+            metadata,
+        })
+    }
+
+    fn validate(&self) -> Result<(), ResolvedCacheError> {
+        if self.schema_version != RESOLVED_CACHE_STORE_VERSION
+            || self.checksum != journal_checksum(self.generation, &self.metadata)?
+        {
+            return Err(ResolvedCacheError::new(
+                "cache metadata checksum is invalid",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ReceiptEnvelope {
+    schema_version: u32,
+    checksum: String,
+    metadata: ResolvedCacheMetadata,
+}
+
+impl ReceiptEnvelope {
+    fn new(metadata: ResolvedCacheMetadata) -> Result<Self, ResolvedCacheError> {
+        let checksum = metadata_checksum(&metadata)?;
+        Ok(Self {
+            schema_version: RESOLVED_CACHE_STORE_VERSION,
+            checksum,
+            metadata,
+        })
+    }
+
+    fn validate(&self) -> Result<(), ResolvedCacheError> {
+        if self.schema_version != RESOLVED_CACHE_STORE_VERSION
+            || self.metadata.state != ResolvedCacheEntryState::Complete
+            || self.checksum != metadata_checksum(&self.metadata)?
+        {
+            return Err(ResolvedCacheError::new(
+                "complete receipt checksum is invalid",
+            ));
+        }
+        Ok(())
+    }
+}
+
+enum JournalRead {
+    Missing,
+    Valid {
+        metadata: Box<ResolvedCacheMetadata>,
+        had_invalid_slot: bool,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SessionRecordKind {
+    Reservation,
+    RuntimeLease,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SessionRecord {
+    schema_version: u32,
+    cache_key: String,
+    operation_id: String,
+    model_owner: String,
+    kind: SessionRecordKind,
+    acquired_at: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CorruptMarker {
+    schema_version: u32,
+    cache_key: String,
+    state: ResolvedCacheEntryState,
+    recovery_status: RecoveryStatus,
+    observed_at: u64,
+}
+
+fn initialize_or_validate_root(root: &Path) -> Result<(), ResolvedCacheError> {
+    match std::fs::symlink_metadata(root) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                return Err(ResolvedCacheError::new(format!(
+                    "resolved cache root {} is a symlink or not a directory",
+                    root.display()
+                )));
+            }
+            let marker = std::fs::read(root.join(STORE_MARKER)).map_err(|_| {
+                ResolvedCacheError::new(format!(
+                    "refusing to adopt unmanaged resolved cache root {}",
+                    root.display()
+                ))
+            })?;
+            if marker != STORE_MARKER_BODY {
+                return Err(ResolvedCacheError::new(
+                    "resolved cache root marker is invalid or unsupported",
+                ));
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let parent = root
+                .parent()
+                .ok_or_else(|| ResolvedCacheError::new("resolved cache root has no parent"))?;
+            let staging = parent.join(format!(".resolved-init-{}", random_id()?));
+            std::fs::create_dir(&staging)?;
+            for name in ["entries", "locks", "sessions", "staging"] {
+                std::fs::create_dir(staging.join(name))?;
+            }
+            write_synced_file(&staging.join(STORE_MARKER), STORE_MARKER_BODY)?;
+            sync_dir(&staging)?;
+            match std::fs::rename(&staging, root) {
+                Ok(()) => sync_dir(parent)?,
+                Err(_rename_error) if root.exists() => {
+                    std::fs::remove_dir_all(&staging)?;
+                    initialize_or_validate_root(root)?;
+                }
+                Err(rename_error) => {
+                    let _ = std::fs::remove_dir_all(&staging);
+                    return Err(rename_error.into());
+                }
+            }
+        }
+        Err(error) => return Err(error.into()),
+    }
+    for name in ["entries", "locks", "sessions", "staging"] {
+        ensure_regular_directory(&root.join(name))?;
+    }
+    Ok(())
+}
+
+fn ensure_regular_directory(path: &Path) -> Result<(), ResolvedCacheError> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        ResolvedCacheError::new(format!(
+            "required cache directory {}: {error}",
+            path.display()
+        ))
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(ResolvedCacheError::new(format!(
+            "cache path {} is a symlink or not a directory",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_managed_entry_dir(path: &Path) -> Result<(), ResolvedCacheError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => Err(
+            ResolvedCacheError::new(format!("cache entry {} is unmanaged", path.display())),
+        ),
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir(path)?;
+            Ok(())
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn open_lock_file(path: &Path) -> Result<File, ResolvedCacheError> {
+    if let Ok(metadata) = std::fs::symlink_metadata(path) {
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            return Err(ResolvedCacheError::new(format!(
+                "cache lock {} is not a regular file",
+                path.display()
+            )));
+        }
+    }
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+        .map_err(Into::into)
+}
+
+fn validate_candidate(candidate: &PromotionCandidate) -> Result<(), ResolvedCacheError> {
+    candidate
+        .artifact
+        .validate()
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+    if !matches!(
+        candidate.artifact.location,
+        ArtifactLocation::SourceLibrary { .. }
+    ) {
+        return Err(ResolvedCacheError::new(
+            "only a source-library artifact can be reserved for materialization",
+        ));
+    }
+    let key = candidate
+        .artifact
+        .cache_key()
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+    if key != candidate.cache_key {
+        return Err(ResolvedCacheError::new(
+            "promotion candidate cache key does not match its artifact",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_metadata_shape(
+    metadata: &ResolvedCacheMetadata,
+    digest: &str,
+) -> Result<(), ResolvedCacheError> {
+    let artifact_key = metadata
+        .artifact
+        .cache_key()
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+    metadata
+        .artifact
+        .validate()
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+    let reservation_shape_is_valid = match metadata.state {
+        ResolvedCacheEntryState::Materializing => {
+            metadata.reservation_id.is_some()
+                && metadata.reservation_owner.is_some()
+                && metadata.session_id.is_some()
+        }
+        _ => {
+            metadata.reservation_id.is_none()
+                && metadata.reservation_owner.is_none()
+                && metadata.session_id.is_none()
+        }
+    };
+    if metadata.schema_version != RESOLVED_CACHE_STORE_VERSION
+        || cache_key_digest(&metadata.cache_key)? != digest
+        || artifact_key != metadata.cache_key
+        || metadata.entry_relative_path != PathBuf::from("entries").join(digest)
+        || metadata.bundle_relative_path != PathBuf::from("entries").join(digest).join("bundle")
+        || metadata.effective_pin
+            != (metadata.artifact_pinned || !metadata.model_pin_owners.is_empty())
+        || !reservation_shape_is_valid
+        || metadata
+            .reservation_id
+            .as_deref()
+            .is_some_and(|value| !is_lower_hex_32(value))
+        || metadata
+            .session_id
+            .as_deref()
+            .is_some_and(|value| !is_lower_hex_32(value))
+        || metadata
+            .reservation_owner
+            .as_deref()
+            .is_some_and(|owner| validate_model_owner(owner) != Ok(owner))
+        || metadata
+            .model_pin_owners
+            .iter()
+            .any(|owner| validate_model_owner(owner) != Ok(owner.as_str()))
+    {
+        return Err(ResolvedCacheError::new(
+            "cache metadata invariant is invalid",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_complete_metadata(
+    store: &ResolvedCacheStore,
+    metadata: &ResolvedCacheMetadata,
+) -> Result<(), ResolvedCacheError> {
+    let digest = cache_key_digest(&metadata.cache_key)?;
+    validate_metadata_shape(metadata, &digest)?;
+    if metadata.state != ResolvedCacheEntryState::Complete
+        || metadata.reservation_id.is_some()
+        || metadata.reservation_owner.is_some()
+        || metadata.session_id.is_some()
+    {
+        return Err(ResolvedCacheError::new("cache entry is not complete"));
+    }
+    let bundle = store.bundle_path(&metadata.cache_key)?;
+    if !matches!(&metadata.artifact.location, ArtifactLocation::ResolvedLocal { root } if root == &bundle)
+    {
+        return Err(ResolvedCacheError::new(
+            "complete cache artifact has the wrong local root",
+        ));
+    }
+    metadata
+        .artifact
+        .validate()
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+    if metadata
+        .artifact
+        .cache_key()
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?
+        != metadata.cache_key
+        || checked_artifact_bytes(&metadata.artifact)? != metadata.verified_bytes
+    {
+        return Err(ResolvedCacheError::new(
+            "complete cache artifact identity or verified bytes changed",
+        ));
+    }
+    Ok(())
+}
+
+fn checked_artifact_bytes(artifact: &ResolvedModelArtifact) -> Result<u64, ResolvedCacheError> {
+    artifact
+        .closure
+        .rebased_paths(artifact.location.root())
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?
+        .into_iter()
+        .try_fold(0_u64, |total, path| {
+            let size = std::fs::metadata(&path)?.len();
+            total.checked_add(size).ok_or_else(|| {
+                ResolvedCacheError::new("resolved artifact verified byte total overflow")
+            })
+        })
+}
+
+fn validate_model_owner(owner: &str) -> Result<&str, ResolvedCacheError> {
+    let owner = owner.trim();
+    if owner.is_empty() || owner.len() > 256 || owner.chars().any(char::is_control) {
+        Err(ResolvedCacheError::new(
+            "model pin owner must be a nonempty stable logical id",
+        ))
+    } else {
+        Ok(owner)
+    }
+}
+
+fn cache_key_digest(cache_key: &str) -> Result<String, ResolvedCacheError> {
+    let digest = cache_key
+        .strip_prefix("sha256:")
+        .filter(|value| is_lower_hex_64(value))
+        .ok_or_else(|| {
+            ResolvedCacheError::new("resolved-cache key must be sha256:<64 lower hex>")
+        })?;
+    Ok(digest.to_owned())
+}
+
+fn is_lower_hex_64(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn is_lower_hex_32(value: &str) -> bool {
+    value.len() == 32
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn journal_checksum(
+    generation: u64,
+    metadata: &ResolvedCacheMetadata,
+) -> Result<String, ResolvedCacheError> {
+    let mut digest = Sha256::new();
+    digest.update(generation.to_le_bytes());
+    digest.update(serde_json::to_vec(metadata).map_err(|error| {
+        ResolvedCacheError::new(format!("encode cache metadata checksum: {error}"))
+    })?);
+    Ok(format!("sha256:{:x}", digest.finalize()))
+}
+
+fn metadata_checksum(metadata: &ResolvedCacheMetadata) -> Result<String, ResolvedCacheError> {
+    let bytes = serde_json::to_vec(metadata).map_err(|error| {
+        ResolvedCacheError::new(format!("encode complete receipt checksum: {error}"))
+    })?;
+    Ok(format!("sha256:{:x}", Sha256::digest(bytes)))
+}
+
+fn read_journal(path: &Path) -> Result<JournalEnvelope, ResolvedCacheError> {
+    let body = std::fs::read(path)?;
+    let envelope: JournalEnvelope = serde_json::from_slice(&body)
+        .map_err(|error| ResolvedCacheError::new(format!("decode cache metadata: {error}")))?;
+    envelope.validate()?;
+    Ok(envelope)
+}
+
+fn highest_generation(entry: &Path) -> Result<u64, ResolvedCacheError> {
+    let mut highest = 0;
+    for slot in 0..=1 {
+        let path = entry.join(format!("metadata.{slot}.json"));
+        if let Ok(envelope) = read_journal(&path) {
+            highest = highest.max(envelope.generation);
+        }
+    }
+    Ok(highest)
+}
+
+fn atomic_write_json(path: &Path, value: &impl Serialize) -> Result<(), ResolvedCacheError> {
+    let body = serde_json::to_vec_pretty(value)
+        .map_err(|error| ResolvedCacheError::new(format!("encode cache record: {error}")))?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| ResolvedCacheError::new("cache record has no parent"))?;
+    ensure_regular_directory(parent)?;
+    let temporary = parent.join(format!(".tmp-{}", random_id()?));
+    let result = (|| {
+        write_synced_file(&temporary, &body)?;
+        std::fs::rename(&temporary, path)?;
+        sync_dir(parent)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn write_synced_file(path: &Path, body: &[u8]) -> Result<(), ResolvedCacheError> {
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    file.write_all(body)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn sync_dir(path: &Path) -> Result<(), ResolvedCacheError> {
+    File::open(path)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_dir(_path: &Path) -> Result<(), ResolvedCacheError> {
+    Ok(())
+}
+
+fn random_id() -> Result<String, ResolvedCacheError> {
+    let mut bytes = [0_u8; 16];
+    getrandom::fill(&mut bytes)
+        .map_err(|error| ResolvedCacheError::new(format!("generate cache id: {error}")))?;
+    Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+fn now_seconds() -> Result<u64, ResolvedCacheError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|error| ResolvedCacheError::new(format!("system time before epoch: {error}")))
+}
+
+fn relation_for_volume_identities(
+    source: Option<u64>,
+    resolved: Option<u64>,
+    source_exists: bool,
+) -> SourceVolumeRelation {
+    if !source_exists {
+        SourceVolumeRelation::Unavailable
+    } else {
+        match (source, resolved) {
+            (Some(source), Some(resolved)) if source == resolved => SourceVolumeRelation::Same,
+            (Some(_), Some(_)) => SourceVolumeRelation::Different,
+            _ => SourceVolumeRelation::Unknown,
+        }
+    }
+}
+
+#[cfg(unix)]
+fn volume_identity(path: &Path) -> Result<u64, ResolvedCacheError> {
+    use std::os::unix::fs::MetadataExt;
+    Ok(std::fs::metadata(path)?.dev())
+}
+
+#[cfg(windows)]
+fn volume_identity(path: &Path) -> Result<u64, ResolvedCacheError> {
+    let file = File::open(path)?;
+    Ok(u64::from(
+        winapi_util::file::information(&file)
+            .map_err(|error| ResolvedCacheError::new(error.to_string()))?
+            .volume_serial_number(),
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn volume_identity(_path: &Path) -> Result<u64, ResolvedCacheError> {
+    Err(ResolvedCacheError::new(
+        "volume identity is unavailable on this platform",
+    ))
+}
+
+#[cfg(test)]
+#[path = "resolved_cache/tests.rs"]
+mod tests;

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -249,7 +249,8 @@ pub struct ResolvedCacheEntrySummary {
 
 #[derive(Debug)]
 pub enum ReservationOutcome {
-    Acquired(MaterializationReservation),
+    Acquired(ResolvedCacheReservation),
+    AlreadyComplete(Box<ResolvedCacheMetadata>),
     Contended,
 }
 
@@ -389,13 +390,42 @@ impl ResolvedCacheStore {
         let artifact_lock = open_lock_file(&self.artifact_lock_path(&digest))?;
         match FileExt::try_lock_exclusive(&artifact_lock) {
             Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+            Err(error) if is_lock_contended(&error) => {
                 return Ok(ReservationOutcome::Contended);
             }
             Err(error) => return Err(error.into()),
         }
         let entry = self.entry_path(&candidate.cache_key)?;
         ensure_managed_entry_dir(&entry)?;
+        let _metadata_lock = self.lock_metadata(&digest)?;
+        let existing = match self.read_metadata_unlocked(&digest)? {
+            JournalRead::Missing => None,
+            JournalRead::Valid { metadata, .. } => Some(*metadata),
+        };
+        if let Some(mut metadata) = existing {
+            match metadata.state {
+                ResolvedCacheEntryState::Complete => {
+                    validate_complete_metadata(self, &metadata)?;
+                    return Ok(ReservationOutcome::AlreadyComplete(Box::new(metadata)));
+                }
+                ResolvedCacheEntryState::Materializing => {
+                    let session = metadata.session_id.as_deref().ok_or_else(|| {
+                        ResolvedCacheError::new("materializing cache entry has no owning session")
+                    })?;
+                    if !self.session_lock_is_acquirable(session)? {
+                        return Ok(ReservationOutcome::Contended);
+                    }
+                    metadata.state = ResolvedCacheEntryState::Interrupted;
+                    metadata.recovery_status = RecoveryStatus::InterruptedReservation;
+                    metadata.reservation_id = None;
+                    metadata.reservation_owner = None;
+                    metadata.session_id = None;
+                    metadata.updated_at = now_seconds()?;
+                    self.write_metadata_unlocked(&digest, &metadata)?;
+                }
+                _ => {}
+            }
+        }
         let reservation_id = random_id()?;
         let staging = self
             .inner
@@ -428,7 +458,6 @@ impl ResolvedCacheStore {
             recovery_status: RecoveryStatus::Clean,
             source_volume: self.compare_source_volume(source_configured_path)?,
         };
-        let _metadata_lock = self.lock_metadata(&digest)?;
         if let Ok(existing) = self.read_metadata_locked(&digest) {
             metadata.created_at = existing.created_at;
             metadata.artifact_pinned = existing.artifact_pinned;
@@ -440,16 +469,18 @@ impl ResolvedCacheStore {
             schema_version: RESOLVED_CACHE_STORE_VERSION,
             cache_key: candidate.cache_key.clone(),
             operation_id: reservation_id.clone(),
-            model_owner: logical_model_owner,
+            model_owner: logical_model_owner.clone(),
             kind: SessionRecordKind::Reservation,
             acquired_at: now,
         };
         let record_path = self.write_session_record(&record)?;
-        Ok(ReservationOutcome::Acquired(MaterializationReservation {
+        Ok(ReservationOutcome::Acquired(ResolvedCacheReservation {
             store: self.clone(),
             cache_key: candidate.cache_key.clone(),
             digest,
             reservation_id,
+            reservation_owner: logical_model_owner,
+            session_id: self.inner.session_id.clone(),
             staging_path: staging,
             record_path,
             artifact_lock: Some(artifact_lock),
@@ -564,25 +595,6 @@ impl ResolvedCacheStore {
         Ok(self.read_metadata_locked(&digest)?.effective_pin)
     }
 
-    pub fn mark_interrupted(
-        &self,
-        cache_key: &str,
-    ) -> Result<ResolvedCacheMetadata, ResolvedCacheError> {
-        self.update_metadata(cache_key, |metadata| {
-            if metadata.state == ResolvedCacheEntryState::Complete {
-                return Err(ResolvedCacheError::new(
-                    "a complete resolved-cache entry cannot be marked interrupted",
-                ));
-            }
-            metadata.state = ResolvedCacheEntryState::Interrupted;
-            metadata.recovery_status = RecoveryStatus::InterruptedReservation;
-            metadata.reservation_id = None;
-            metadata.reservation_owner = None;
-            metadata.session_id = None;
-            Ok(())
-        })
-    }
-
     pub fn acquire_complete(
         &self,
         cache_key: &str,
@@ -636,7 +648,7 @@ impl ResolvedCacheStore {
             let artifact_lock = open_lock_file(&self.artifact_lock_path(&digest))?;
             match FileExt::try_lock_exclusive(&artifact_lock) {
                 Ok(()) => {}
-                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => continue,
+                Err(error) if is_lock_contended(&error) => continue,
                 Err(error) => return Err(error.into()),
             }
             let _metadata_lock = self.lock_metadata(&digest)?;
@@ -652,12 +664,16 @@ impl ResolvedCacheStore {
                         metadata.refresh_effective_pin();
                         changed = true;
                     }
-                    if metadata.state == ResolvedCacheEntryState::Materializing
-                        && metadata
-                            .session_id
-                            .as_deref()
-                            .map_or(true, |session| self.session_is_stale(session))
-                    {
+                    let materializing_session_is_stale =
+                        if metadata.state == ResolvedCacheEntryState::Materializing {
+                            match metadata.session_id.as_deref() {
+                                Some(session) => self.session_lock_is_acquirable(session)?,
+                                None => false,
+                            }
+                        } else {
+                            false
+                        };
+                    if materializing_session_is_stale {
                         metadata.state = ResolvedCacheEntryState::Interrupted;
                         metadata.recovery_status = RecoveryStatus::InterruptedReservation;
                         metadata.reservation_id = None;
@@ -860,19 +876,21 @@ impl ResolvedCacheStore {
         Ok(path)
     }
 
-    fn session_is_stale(&self, session: &str) -> bool {
-        if session == self.inner.session_id {
-            return false;
+    fn session_lock_is_acquirable(&self, session: &str) -> Result<bool, ResolvedCacheError> {
+        if !is_valid_session_id(session) || session == self.inner.session_id {
+            return Ok(false);
         }
         let path = self
             .inner
             .root
             .join("sessions")
             .join(format!("{session}.lock"));
-        let Ok(file) = open_lock_file(&path) else {
-            return false;
-        };
-        FileExt::try_lock_exclusive(&file).is_ok()
+        let file = open_lock_file(&path)?;
+        match FileExt::try_lock_exclusive(&file) {
+            Ok(()) => Ok(true),
+            Err(error) if is_lock_contended(&error) => Ok(false),
+            Err(error) => Err(error.into()),
+        }
     }
 
     fn clean_stale_sessions(&self) -> Result<(), ResolvedCacheError> {
@@ -883,38 +901,44 @@ impl ResolvedCacheStore {
             let Some(session) = name.strip_suffix(".lock") else {
                 continue;
             };
-            if session == self.inner.session_id {
+            if !is_valid_session_id(session) || session == self.inner.session_id {
                 continue;
             }
             let file = open_lock_file(&item.path())?;
-            if FileExt::try_lock_exclusive(&file).is_ok() {
-                let records = sessions.join(session);
-                if records.is_dir() {
-                    std::fs::remove_dir_all(records)?;
+            match FileExt::try_lock_exclusive(&file) {
+                Ok(()) => {
+                    let records = sessions.join(session);
+                    if records.is_dir() {
+                        std::fs::remove_dir_all(records)?;
+                    }
+                    drop(file);
+                    let _ = std::fs::remove_file(item.path());
                 }
-                drop(file);
-                let _ = std::fs::remove_file(item.path());
+                Err(error) if is_lock_contended(&error) => {}
+                Err(error) => return Err(error.into()),
             }
         }
         Ok(())
     }
 }
 
-pub struct MaterializationReservation {
+pub struct ResolvedCacheReservation {
     store: ResolvedCacheStore,
     cache_key: String,
     digest: String,
     reservation_id: String,
+    reservation_owner: String,
+    session_id: String,
     staging_path: PathBuf,
     record_path: PathBuf,
     artifact_lock: Option<File>,
     finished: bool,
 }
 
-impl std::fmt::Debug for MaterializationReservation {
+impl std::fmt::Debug for ResolvedCacheReservation {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
-            .debug_struct("MaterializationReservation")
+            .debug_struct("ResolvedCacheReservation")
             .field("cache_key", &self.cache_key)
             .field("reservation_id", &self.reservation_id)
             .field("staging_path", &self.staging_path)
@@ -922,7 +946,7 @@ impl std::fmt::Debug for MaterializationReservation {
     }
 }
 
-impl MaterializationReservation {
+impl ResolvedCacheReservation {
     pub fn cache_key(&self) -> &str {
         &self.cache_key
     }
@@ -939,6 +963,26 @@ impl MaterializationReservation {
         self.store.bundle_path(&self.cache_key)
     }
 
+    /// Marks only this still-owned reservation interrupted. The private reservation/session
+    /// identities and held artifact lock prevent key-only or cross-owner invalidation.
+    pub fn mark_interrupted(&mut self) -> Result<ResolvedCacheMetadata, ResolvedCacheError> {
+        let _metadata_lock = self.store.lock_metadata(&self.digest)?;
+        let mut metadata = self.store.read_metadata_locked(&self.digest)?;
+        self.verify_ownership(&metadata)?;
+        metadata.state = ResolvedCacheEntryState::Interrupted;
+        metadata.reservation_id = None;
+        metadata.reservation_owner = None;
+        metadata.session_id = None;
+        metadata.recovery_status = RecoveryStatus::InterruptedReservation;
+        metadata.updated_at = now_seconds()?;
+        self.store
+            .write_metadata_unlocked(&self.digest, &metadata)?;
+        self.finished = true;
+        let _ = std::fs::remove_file(&self.record_path);
+        self.artifact_lock.take();
+        Ok(metadata)
+    }
+
     /// Records publication after a later materializer has atomically installed and validated the
     /// bundle. This method does not copy, move, or delete any model bytes.
     pub fn record_complete(
@@ -952,6 +996,7 @@ impl MaterializationReservation {
                 "complete artifact is not rooted at its resolved-cache bundle",
             ));
         }
+        validate_completion_confinement(&self.store, &self.cache_key, &artifact)?;
         artifact
             .validate()
             .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
@@ -967,11 +1012,7 @@ impl MaterializationReservation {
         let verified_bytes = checked_artifact_bytes(&artifact)?;
         let _metadata_lock = self.store.lock_metadata(&self.digest)?;
         let mut metadata = self.store.read_metadata_locked(&self.digest)?;
-        if metadata.reservation_id.as_deref() != Some(&self.reservation_id) {
-            return Err(ResolvedCacheError::new(
-                "materialization reservation changed",
-            ));
-        }
+        self.verify_ownership(&metadata)?;
         metadata.artifact = artifact;
         metadata.state = ResolvedCacheEntryState::Complete;
         metadata.verified_bytes = verified_bytes;
@@ -988,16 +1029,29 @@ impl MaterializationReservation {
         self.artifact_lock.take();
         Ok(metadata)
     }
+
+    fn verify_ownership(&self, metadata: &ResolvedCacheMetadata) -> Result<(), ResolvedCacheError> {
+        if metadata.state != ResolvedCacheEntryState::Materializing
+            || metadata.reservation_id.as_deref() != Some(&self.reservation_id)
+            || metadata.reservation_owner.as_deref() != Some(&self.reservation_owner)
+            || metadata.session_id.as_deref() != Some(&self.session_id)
+        {
+            return Err(ResolvedCacheError::new(
+                "materialization reservation ownership changed",
+            ));
+        }
+        Ok(())
+    }
 }
 
-impl Drop for MaterializationReservation {
+impl Drop for ResolvedCacheReservation {
     fn drop(&mut self) {
         if self.finished {
             return;
         }
         if let Ok(_metadata_lock) = self.store.lock_metadata(&self.digest) {
             if let Ok(mut metadata) = self.store.read_metadata_locked(&self.digest) {
-                if metadata.reservation_id.as_deref() == Some(&self.reservation_id) {
+                if self.verify_ownership(&metadata).is_ok() {
                     metadata.state = ResolvedCacheEntryState::Interrupted;
                     metadata.reservation_id = None;
                     metadata.reservation_owner = None;
@@ -1147,7 +1201,10 @@ struct CorruptMarker {
 fn initialize_or_validate_root(root: &Path) -> Result<(), ResolvedCacheError> {
     match std::fs::symlink_metadata(root) {
         Ok(metadata) => {
-            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            if metadata.file_type().is_symlink()
+                || metadata_is_reparse_point(&metadata)
+                || !metadata.is_dir()
+            {
                 return Err(ResolvedCacheError::new(format!(
                     "resolved cache root {} is a symlink or not a directory",
                     root.display()
@@ -1203,7 +1260,10 @@ fn ensure_regular_directory(path: &Path) -> Result<(), ResolvedCacheError> {
             path.display()
         ))
     })?;
-    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+    if metadata.file_type().is_symlink()
+        || metadata_is_reparse_point(&metadata)
+        || !metadata.is_dir()
+    {
         return Err(ResolvedCacheError::new(format!(
             "cache path {} is a symlink or not a directory",
             path.display()
@@ -1214,9 +1274,16 @@ fn ensure_regular_directory(path: &Path) -> Result<(), ResolvedCacheError> {
 
 fn ensure_managed_entry_dir(path: &Path) -> Result<(), ResolvedCacheError> {
     match std::fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => Err(
-            ResolvedCacheError::new(format!("cache entry {} is unmanaged", path.display())),
-        ),
+        Ok(metadata)
+            if metadata.file_type().is_symlink()
+                || metadata_is_reparse_point(&metadata)
+                || !metadata.is_dir() =>
+        {
+            Err(ResolvedCacheError::new(format!(
+                "cache entry {} is unmanaged",
+                path.display()
+            )))
+        }
         Ok(_) => Ok(()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             std::fs::create_dir(path)?;
@@ -1228,7 +1295,10 @@ fn ensure_managed_entry_dir(path: &Path) -> Result<(), ResolvedCacheError> {
 
 fn open_lock_file(path: &Path) -> Result<File, ResolvedCacheError> {
     if let Ok(metadata) = std::fs::symlink_metadata(path) {
-        if metadata.file_type().is_symlink() || !metadata.is_file() {
+        if metadata.file_type().is_symlink()
+            || metadata_is_reparse_point(&metadata)
+            || !metadata.is_file()
+        {
             return Err(ResolvedCacheError::new(format!(
                 "cache lock {} is not a regular file",
                 path.display()
@@ -1242,6 +1312,12 @@ fn open_lock_file(path: &Path) -> Result<File, ResolvedCacheError> {
         .truncate(false)
         .open(path)
         .map_err(Into::into)
+}
+
+fn is_lock_contended(error: &std::io::Error) -> bool {
+    let fs2_contended = fs2::lock_contended_error().raw_os_error();
+    error.kind() == std::io::ErrorKind::WouldBlock
+        || fs2_contended.is_some() && error.raw_os_error() == fs2_contended
 }
 
 fn validate_candidate(candidate: &PromotionCandidate) -> Result<(), ResolvedCacheError> {
@@ -1304,11 +1380,11 @@ fn validate_metadata_shape(
         || metadata
             .reservation_id
             .as_deref()
-            .is_some_and(|value| !is_lower_hex_32(value))
+            .is_some_and(|value| !is_valid_session_id(value))
         || metadata
             .session_id
             .as_deref()
-            .is_some_and(|value| !is_lower_hex_32(value))
+            .is_some_and(|value| !is_valid_session_id(value))
         || metadata
             .reservation_owner
             .as_deref()
@@ -1363,6 +1439,103 @@ fn validate_complete_metadata(
     Ok(())
 }
 
+fn validate_completion_confinement(
+    store: &ResolvedCacheStore,
+    cache_key: &str,
+    artifact: &ResolvedModelArtifact,
+) -> Result<(), ResolvedCacheError> {
+    let canonical_root = std::fs::canonicalize(store.root())?;
+    if canonical_root != store.root() {
+        return Err(ResolvedCacheError::new(
+            "resolved cache root changed after store open",
+        ));
+    }
+    let entries = store.root().join("entries");
+    reject_link_or_reparse(&entries, "resolved cache entries directory")?;
+    let canonical_entries = std::fs::canonicalize(&entries)?;
+    if canonical_entries.parent() != Some(canonical_root.as_path()) {
+        return Err(ResolvedCacheError::new(
+            "resolved cache entries directory escaped its managed root",
+        ));
+    }
+    let entry = store.entry_path(cache_key)?;
+    reject_link_or_reparse(&entry, "resolved cache entry")?;
+    let canonical_entry = std::fs::canonicalize(&entry)?;
+    if canonical_entry.parent() != Some(canonical_entries.as_path()) {
+        return Err(ResolvedCacheError::new(
+            "resolved cache entry escaped its managed entries directory",
+        ));
+    }
+    let bundle = entry.join("bundle");
+    reject_link_or_reparse(&bundle, "resolved cache bundle")?;
+    let canonical_bundle = std::fs::canonicalize(&bundle)?;
+    if canonical_bundle.parent() != Some(canonical_entry.as_path())
+        || canonical_bundle != canonical_entry.join("bundle")
+    {
+        return Err(ResolvedCacheError::new(
+            "resolved cache bundle escaped its managed entry",
+        ));
+    }
+    for path in artifact
+        .closure
+        .rebased_paths(artifact.location.root())
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?
+    {
+        if !path.starts_with(&bundle) {
+            return Err(ResolvedCacheError::new(
+                "resolved artifact file escaped its lexical bundle",
+            ));
+        }
+        let mut cursor = Some(path.as_path());
+        while let Some(current) = cursor {
+            if !current.starts_with(&entry) {
+                return Err(ResolvedCacheError::new(
+                    "resolved artifact ancestor escaped its managed entry",
+                ));
+            }
+            if !std::fs::canonicalize(current)?.starts_with(&canonical_entry) {
+                return Err(ResolvedCacheError::new(
+                    "resolved artifact ancestor resolves outside its managed entry",
+                ));
+            }
+            if current == entry {
+                break;
+            }
+            cursor = current.parent();
+        }
+    }
+    Ok(())
+}
+
+fn reject_link_or_reparse(path: &Path, label: &str) -> Result<(), ResolvedCacheError> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || metadata_is_reparse_point(&metadata) {
+        return Err(ResolvedCacheError::new(format!(
+            "{label} {} is a symlink or reparse point",
+            path.display()
+        )));
+    }
+    if !metadata.is_dir() {
+        return Err(ResolvedCacheError::new(format!(
+            "{label} {} is not a directory",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn metadata_is_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(not(windows))]
+fn metadata_is_reparse_point(_metadata: &std::fs::Metadata) -> bool {
+    false
+}
+
 fn checked_artifact_bytes(artifact: &ResolvedModelArtifact) -> Result<u64, ResolvedCacheError> {
     artifact
         .closure
@@ -1405,7 +1578,7 @@ fn is_lower_hex_64(value: &str) -> bool {
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
-fn is_lower_hex_32(value: &str) -> bool {
+fn is_valid_session_id(value: &str) -> bool {
     value.len() == 32
         && value
             .bytes()
@@ -1525,7 +1698,12 @@ fn volume_identity(path: &Path) -> Result<u64, ResolvedCacheError> {
 
 #[cfg(windows)]
 fn volume_identity(path: &Path) -> Result<u64, ResolvedCacheError> {
-    let file = File::open(path)?;
+    use std::os::windows::fs::OpenOptionsExt;
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(path)?;
     Ok(u64::from(
         winapi_util::file::information(&file)
             .map_err(|error| ResolvedCacheError::new(error.to_string()))?

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -249,7 +249,7 @@ pub struct ResolvedCacheEntrySummary {
 
 #[derive(Debug)]
 pub enum ReservationOutcome {
-    Acquired(ResolvedCacheReservation),
+    Acquired(Box<ResolvedCacheReservation>),
     AlreadyComplete(Box<ResolvedCacheMetadata>),
     Contended,
 }
@@ -474,18 +474,20 @@ impl ResolvedCacheStore {
             acquired_at: now,
         };
         let record_path = self.write_session_record(&record)?;
-        Ok(ReservationOutcome::Acquired(ResolvedCacheReservation {
-            store: self.clone(),
-            cache_key: candidate.cache_key.clone(),
-            digest,
-            reservation_id,
-            reservation_owner: logical_model_owner,
-            session_id: self.inner.session_id.clone(),
-            staging_path: staging,
-            record_path,
-            artifact_lock: Some(artifact_lock),
-            finished: false,
-        }))
+        Ok(ReservationOutcome::Acquired(Box::new(
+            ResolvedCacheReservation {
+                store: self.clone(),
+                cache_key: candidate.cache_key.clone(),
+                digest,
+                reservation_id,
+                reservation_owner: logical_model_owner,
+                session_id: self.inner.session_id.clone(),
+                staging_path: staging,
+                record_path,
+                artifact_lock: Some(artifact_lock),
+                finished: false,
+            },
+        )))
     }
 
     pub fn lookup_complete(
@@ -1710,11 +1712,9 @@ fn volume_identity(path: &Path) -> Result<u64, ResolvedCacheError> {
         .read(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
         .open(path)?;
-    Ok(u64::from(
-        winapi_util::file::information(&file)
-            .map_err(|error| ResolvedCacheError::new(error.to_string()))?
-            .volume_serial_number(),
-    ))
+    Ok(winapi_util::file::information(&file)
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?
+        .volume_serial_number())
 }
 
 #[cfg(not(any(unix, windows)))]

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -132,6 +132,14 @@ impl Drop for WindowsDirectoryJunction {
 }
 
 #[test]
+fn reservation_outcome_keeps_the_lock_holding_reservation_behind_indirection() {
+    assert!(
+        std::mem::size_of::<ReservationOutcome>() <= 4 * std::mem::size_of::<usize>(),
+        "ReservationOutcome must not inline the lock-holding reservation"
+    );
+}
+
+#[test]
 fn policy_defaults_are_finite_disabled_and_serde_defaults_upgrade() {
     let policy = ResolvedCachePolicy::default();
     assert!(!policy.enabled);
@@ -981,7 +989,7 @@ fn cross_process_store_child() {
     let candidate = source_candidate(&source, REVISION_A);
     let _held: Box<dyn std::any::Any> = if mode == "reserve" {
         match store.reserve(&candidate, &source, "child:model").unwrap() {
-            ReservationOutcome::Acquired(reservation) => Box::new(reservation),
+            ReservationOutcome::Acquired(reservation) => reservation,
             ReservationOutcome::AlreadyComplete(_) => panic!("child entry is already complete"),
             ReservationOutcome::Contended => panic!("child reservation contended"),
         }

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -81,6 +81,56 @@ fn resolver(root: &Path, registry: ActiveArtifactLeaseRegistry) -> ModelArtifact
     ModelArtifactResolver::with_lease_registry(ArtifactSourceLibrary::new(root).unwrap(), registry)
 }
 
+#[cfg(windows)]
+struct WindowsDirectoryJunction {
+    path: PathBuf,
+    removed: bool,
+}
+
+#[cfg(windows)]
+impl WindowsDirectoryJunction {
+    fn create(path: &Path, target: &Path) -> Self {
+        let output = Command::new("cmd")
+            .args(["/D", "/C", "mklink", "/J"])
+            .arg(path)
+            .arg(target)
+            .output()
+            .expect("launch cmd.exe to create directory junction");
+        assert!(
+            output.status.success(),
+            "mklink /J failed with {}\nstdout: {}\nstderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let metadata = std::fs::symlink_metadata(path)
+            .expect("read the created directory junction without following it");
+        assert!(
+            metadata_is_reparse_point(&metadata),
+            "mklink /J fixture must carry FILE_ATTRIBUTE_REPARSE_POINT"
+        );
+        Self {
+            path: path.to_path_buf(),
+            removed: false,
+        }
+    }
+
+    fn remove(mut self) {
+        std::fs::remove_dir(&self.path)
+            .expect("remove the junction itself without traversing its target");
+        self.removed = true;
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsDirectoryJunction {
+    fn drop(&mut self) {
+        if !self.removed {
+            let _ = std::fs::remove_dir(&self.path);
+        }
+    }
+}
+
 #[test]
 fn policy_defaults_are_finite_disabled_and_serde_defaults_upgrade() {
     let policy = ResolvedCachePolicy::default();
@@ -448,8 +498,7 @@ fn complete_validation_rejects_a_post_publication_bundle_swap_everywhere() {
 
 #[cfg(windows)]
 #[test]
-fn completion_rejects_a_directory_reparse_point_when_windows_allows_fixture_creation() {
-    use std::os::windows::fs::symlink_dir;
+fn completion_rejects_a_directory_junction_without_touching_external_bytes() {
     let scratch = TempDir::new().unwrap();
     let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
     let source = scratch.path().join("source");
@@ -461,13 +510,9 @@ fn completion_rejects_a_directory_reparse_point_when_windows_allows_fixture_crea
     let external = scratch.path().join("external");
     std::fs::create_dir(&external).unwrap();
     std::fs::write(external.join("weights.bin"), b"external-model-bytes").unwrap();
+    std::fs::write(external.join("sentinel"), b"external-must-survive").unwrap();
     let bundle = reservation.bundle_path().unwrap();
-    if let Err(error) = symlink_dir(&external, &bundle) {
-        if error.kind() == std::io::ErrorKind::PermissionDenied {
-            return;
-        }
-        panic!("create directory reparse fixture: {error}");
-    }
+    let junction = WindowsDirectoryJunction::create(&bundle, &external);
     let mut local = candidate.artifact.clone();
     local.location = ArtifactLocation::ResolvedLocal { root: bundle };
     assert!(reservation.record_complete(local).is_err());
@@ -475,12 +520,17 @@ fn completion_rejects_a_directory_reparse_point_when_windows_allows_fixture_crea
         std::fs::read(external.join("weights.bin")).unwrap(),
         b"external-model-bytes"
     );
+    assert_eq!(
+        std::fs::read(external.join("sentinel")).unwrap(),
+        b"external-must-survive"
+    );
+    junction.remove();
+    assert!(external.is_dir());
 }
 
 #[cfg(windows)]
 #[test]
-fn complete_validation_rejects_a_post_publication_directory_reparse_point() {
-    use std::os::windows::fs::symlink_dir;
+fn complete_validation_rejects_a_post_publication_directory_junction_everywhere() {
     let scratch = TempDir::new().unwrap();
     let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
     let source = scratch.path().join("source");
@@ -492,21 +542,38 @@ fn complete_validation_rejects_a_post_publication_directory_reparse_point() {
     std::fs::create_dir(&external).unwrap();
     std::fs::write(external.join("weights.bin"), b"model-weights").unwrap();
     std::fs::write(external.join("sentinel"), b"external-must-survive").unwrap();
-    if let Err(error) = symlink_dir(&external, &bundle) {
-        if error.kind() == std::io::ErrorKind::PermissionDenied {
-            return;
-        }
-        panic!("create directory reparse fixture: {error}");
-    }
+    let junction = WindowsDirectoryJunction::create(&bundle, &external);
     assert!(store.lookup_complete(&candidate.cache_key).is_err());
     let resolver = resolver(&source, ActiveArtifactLeaseRegistry::default());
     assert!(store
         .acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
         .is_err());
+    assert!(store.enumerate().is_err());
+    let digest = cache_key_digest(&candidate.cache_key).unwrap();
+    let metadata_lock = store.lock_metadata(&digest).unwrap();
+    assert_eq!(
+        store.read_metadata_locked(&digest).unwrap().last_used_at,
+        None
+    );
+    drop(metadata_lock);
+
+    let entry = store.entry_path(&candidate.cache_key).unwrap();
+    for slot in 0..=1 {
+        std::fs::write(entry.join(format!("metadata.{slot}.json")), b"corrupt").unwrap();
+    }
+    let recovered = store.recover().unwrap();
+    assert_eq!(recovered[0].state, ResolvedCacheEntryState::Corrupt);
+    assert!(recovered[0].metadata.is_none());
+    assert_eq!(
+        std::fs::read(external.join("weights.bin")).unwrap(),
+        b"model-weights"
+    );
     assert_eq!(
         std::fs::read(external.join("sentinel")).unwrap(),
         b"external-must-survive"
     );
+    junction.remove();
+    assert!(external.is_dir());
 }
 
 #[test]

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -398,6 +398,54 @@ fn completion_rejects_a_bundle_symlink_without_touching_external_bytes() {
         .is_none());
 }
 
+#[cfg(unix)]
+#[test]
+fn complete_validation_rejects_a_post_publication_bundle_swap_everywhere() {
+    use std::os::unix::fs::symlink;
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let source = scratch.path().join("source");
+    let candidate = source_candidate(&source, REVISION_A);
+    make_complete(&store, &candidate, &source);
+    let bundle = store.bundle_path(&candidate.cache_key).unwrap();
+    std::fs::remove_dir_all(&bundle).unwrap();
+    let external = scratch.path().join("external");
+    std::fs::create_dir(&external).unwrap();
+    std::fs::write(external.join("weights.bin"), b"model-weights").unwrap();
+    std::fs::write(external.join("sentinel"), b"external-must-survive").unwrap();
+    symlink(&external, &bundle).unwrap();
+
+    assert!(store.lookup_complete(&candidate.cache_key).is_err());
+    let resolver = resolver(&source, ActiveArtifactLeaseRegistry::default());
+    assert!(store
+        .acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
+        .is_err());
+    assert!(store.enumerate().is_err());
+    let digest = cache_key_digest(&candidate.cache_key).unwrap();
+    let _lock = store.lock_metadata(&digest).unwrap();
+    assert_eq!(
+        store.read_metadata_locked(&digest).unwrap().last_used_at,
+        None
+    );
+    drop(_lock);
+
+    let entry = store.entry_path(&candidate.cache_key).unwrap();
+    for slot in 0..=1 {
+        std::fs::write(entry.join(format!("metadata.{slot}.json")), b"corrupt").unwrap();
+    }
+    let recovered = store.recover().unwrap();
+    assert_eq!(recovered[0].state, ResolvedCacheEntryState::Corrupt);
+    assert!(recovered[0].metadata.is_none());
+    assert_eq!(
+        std::fs::read(external.join("weights.bin")).unwrap(),
+        b"model-weights"
+    );
+    assert_eq!(
+        std::fs::read(external.join("sentinel")).unwrap(),
+        b"external-must-survive"
+    );
+}
+
 #[cfg(windows)]
 #[test]
 fn completion_rejects_a_directory_reparse_point_when_windows_allows_fixture_creation() {
@@ -426,6 +474,38 @@ fn completion_rejects_a_directory_reparse_point_when_windows_allows_fixture_crea
     assert_eq!(
         std::fs::read(external.join("weights.bin")).unwrap(),
         b"external-model-bytes"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn complete_validation_rejects_a_post_publication_directory_reparse_point() {
+    use std::os::windows::fs::symlink_dir;
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let source = scratch.path().join("source");
+    let candidate = source_candidate(&source, REVISION_A);
+    make_complete(&store, &candidate, &source);
+    let bundle = store.bundle_path(&candidate.cache_key).unwrap();
+    std::fs::remove_dir_all(&bundle).unwrap();
+    let external = scratch.path().join("external");
+    std::fs::create_dir(&external).unwrap();
+    std::fs::write(external.join("weights.bin"), b"model-weights").unwrap();
+    std::fs::write(external.join("sentinel"), b"external-must-survive").unwrap();
+    if let Err(error) = symlink_dir(&external, &bundle) {
+        if error.kind() == std::io::ErrorKind::PermissionDenied {
+            return;
+        }
+        panic!("create directory reparse fixture: {error}");
+    }
+    assert!(store.lookup_complete(&candidate.cache_key).is_err());
+    let resolver = resolver(&source, ActiveArtifactLeaseRegistry::default());
+    assert!(store
+        .acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
+        .is_err());
+    assert_eq!(
+        std::fs::read(external.join("sentinel")).unwrap(),
+        b"external-must-survive"
     );
 }
 

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -60,6 +60,7 @@ fn make_complete(
 ) -> ResolvedCacheMetadata {
     let reservation = match store.reserve(candidate, source, "fixture:model").unwrap() {
         ReservationOutcome::Acquired(reservation) => reservation,
+        ReservationOutcome::AlreadyComplete(_) => panic!("unexpected complete entry"),
         ReservationOutcome::Contended => panic!("unexpected reservation contention"),
     };
     let bundle = reservation.bundle_path().unwrap();
@@ -191,11 +192,12 @@ fn reservation_is_exclusive_unrelated_keys_progress_and_drop_interrupts() {
     let source_b = scratch.path().join("source-b");
     let candidate_a = source_candidate(&source_a, REVISION_A);
     let candidate_b = source_candidate(&source_b, REVISION_B);
-    let first = match store
+    let mut first = match store
         .reserve(&candidate_a, &source_a, "image:model-a")
         .unwrap()
     {
         ReservationOutcome::Acquired(value) => value,
+        ReservationOutcome::AlreadyComplete(_) => panic!("first cannot already be complete"),
         ReservationOutcome::Contended => panic!("first must win"),
     };
     let active = store
@@ -214,6 +216,13 @@ fn reservation_is_exclusive_unrelated_keys_progress_and_drop_interrupts() {
         &cache_key_digest(&candidate_a.cache_key).unwrap()
     )
     .is_err());
+    assert!(matches!(
+        store
+            .reserve(&candidate_a, &source_a, "image:model-a")
+            .unwrap(),
+        ReservationOutcome::Contended
+    ));
+    first.artifact_lock.take();
     assert!(matches!(
         store
             .reserve(&candidate_a, &source_a, "image:model-a")
@@ -240,6 +249,184 @@ fn reservation_is_exclusive_unrelated_keys_progress_and_drop_interrupts() {
         .unwrap()
         .is_none());
     assert!(store.reserve(&candidate_a, &source_a, "\n").is_err());
+}
+
+#[test]
+fn complete_entries_are_preserved_and_reservations_require_exact_ownership() {
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let source = scratch.path().join("source");
+    let candidate = source_candidate(&source, REVISION_A);
+    let complete = make_complete(&store, &candidate, &source);
+    let bundle_file = store
+        .bundle_path(&candidate.cache_key)
+        .unwrap()
+        .join("weights.bin");
+    let bytes = std::fs::read(&bundle_file).unwrap();
+    match store.reserve(&candidate, &source, "image:model-a").unwrap() {
+        ReservationOutcome::AlreadyComplete(metadata) => assert_eq!(*metadata, complete),
+        ReservationOutcome::Acquired(_) => panic!("complete entry was overwritten"),
+        ReservationOutcome::Contended => panic!("complete entry was treated as materializing"),
+    }
+    assert_eq!(std::fs::read(&bundle_file).unwrap(), bytes);
+
+    let source_b = scratch.path().join("source-b");
+    let candidate_b = source_candidate(&source_b, REVISION_B);
+    let mut reservation = match store
+        .reserve(&candidate_b, &source_b, "video:model-b")
+        .unwrap()
+    {
+        ReservationOutcome::Acquired(reservation) => reservation,
+        _ => panic!("new entry must reserve"),
+    };
+    let genuine_id = reservation.reservation_id.clone();
+    reservation.reservation_id = "cccccccccccccccccccccccccccccccc".to_owned();
+    assert!(reservation.mark_interrupted().is_err());
+    assert_eq!(
+        store
+            .enumerate()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.cache_key == candidate_b.cache_key)
+            .unwrap()
+            .state,
+        ResolvedCacheEntryState::Materializing
+    );
+    reservation.reservation_id = genuine_id;
+    assert_eq!(
+        reservation.mark_interrupted().unwrap().state,
+        ResolvedCacheEntryState::Interrupted
+    );
+}
+
+#[test]
+fn one_reservation_cannot_interrupt_or_complete_another_owner() {
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let source = scratch.path().join("source");
+    let candidate = source_candidate(&source, REVISION_A);
+    let mut reservation = match store.reserve(&candidate, &source, "image:model-a").unwrap() {
+        ReservationOutcome::Acquired(reservation) => reservation,
+        _ => panic!("new entry must reserve"),
+    };
+    let original_id = reservation.reservation_id.clone();
+    let original_owner = reservation.reservation_owner.clone();
+    store
+        .update_metadata(&candidate.cache_key, |metadata| {
+            metadata.reservation_id = Some("dddddddddddddddddddddddddddddddd".to_owned());
+            metadata.reservation_owner = Some("other:model".to_owned());
+            Ok(())
+        })
+        .unwrap();
+    assert!(reservation.mark_interrupted().is_err());
+    let current = store.enumerate().unwrap()[0].metadata.clone().unwrap();
+    assert_eq!(
+        current.reservation_id.as_deref(),
+        Some("dddddddddddddddddddddddddddddddd")
+    );
+    assert_eq!(current.reservation_owner.as_deref(), Some("other:model"));
+
+    store
+        .update_metadata(&candidate.cache_key, |metadata| {
+            metadata.reservation_id = Some(original_id.clone());
+            metadata.reservation_owner = Some(original_owner.clone());
+            Ok(())
+        })
+        .unwrap();
+    reservation.mark_interrupted().unwrap();
+
+    let source_b = scratch.path().join("source-b");
+    let candidate_b = source_candidate(&source_b, REVISION_B);
+    let reservation_b = match store
+        .reserve(&candidate_b, &source_b, "video:model-b")
+        .unwrap()
+    {
+        ReservationOutcome::Acquired(reservation) => reservation,
+        _ => panic!("second entry must reserve"),
+    };
+    let bundle = reservation_b.bundle_path().unwrap();
+    std::fs::create_dir(&bundle).unwrap();
+    std::fs::copy(source_b.join("weights.bin"), bundle.join("weights.bin")).unwrap();
+    store
+        .update_metadata(&candidate_b.cache_key, |metadata| {
+            metadata.reservation_owner = Some("other:model".to_owned());
+            Ok(())
+        })
+        .unwrap();
+    let mut local = candidate_b.artifact.clone();
+    local.location = ArtifactLocation::ResolvedLocal { root: bundle };
+    assert!(reservation_b.record_complete(local).is_err());
+    let current_b = store
+        .enumerate()
+        .unwrap()
+        .into_iter()
+        .find(|entry| entry.cache_key == candidate_b.cache_key)
+        .unwrap()
+        .metadata
+        .unwrap();
+    assert_eq!(current_b.state, ResolvedCacheEntryState::Materializing);
+    assert_eq!(current_b.reservation_owner.as_deref(), Some("other:model"));
+}
+
+#[cfg(unix)]
+#[test]
+fn completion_rejects_a_bundle_symlink_without_touching_external_bytes() {
+    use std::os::unix::fs::symlink;
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let source = scratch.path().join("source");
+    let candidate = source_candidate(&source, REVISION_A);
+    let reservation = match store.reserve(&candidate, &source, "image:model-a").unwrap() {
+        ReservationOutcome::Acquired(reservation) => reservation,
+        _ => panic!("new entry must reserve"),
+    };
+    let external = scratch.path().join("external");
+    std::fs::create_dir(&external).unwrap();
+    std::fs::write(external.join("weights.bin"), b"external-model-bytes").unwrap();
+    let bundle = reservation.bundle_path().unwrap();
+    symlink(&external, &bundle).unwrap();
+    let mut local = candidate.artifact.clone();
+    local.location = ArtifactLocation::ResolvedLocal { root: bundle };
+    assert!(reservation.record_complete(local).is_err());
+    assert_eq!(
+        std::fs::read(external.join("weights.bin")).unwrap(),
+        b"external-model-bytes"
+    );
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_none());
+}
+
+#[cfg(windows)]
+#[test]
+fn completion_rejects_a_directory_reparse_point_when_windows_allows_fixture_creation() {
+    use std::os::windows::fs::symlink_dir;
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let source = scratch.path().join("source");
+    let candidate = source_candidate(&source, REVISION_A);
+    let reservation = match store.reserve(&candidate, &source, "image:model-a").unwrap() {
+        ReservationOutcome::Acquired(reservation) => reservation,
+        _ => panic!("new entry must reserve"),
+    };
+    let external = scratch.path().join("external");
+    std::fs::create_dir(&external).unwrap();
+    std::fs::write(external.join("weights.bin"), b"external-model-bytes").unwrap();
+    let bundle = reservation.bundle_path().unwrap();
+    if let Err(error) = symlink_dir(&external, &bundle) {
+        if error.kind() == std::io::ErrorKind::PermissionDenied {
+            return;
+        }
+        panic!("create directory reparse fixture: {error}");
+    }
+    let mut local = candidate.artifact.clone();
+    local.location = ArtifactLocation::ResolvedLocal { root: bundle };
+    assert!(reservation.record_complete(local).is_err());
+    assert_eq!(
+        std::fs::read(external.join("weights.bin")).unwrap(),
+        b"external-model-bytes"
+    );
 }
 
 #[test]
@@ -456,6 +643,24 @@ fn volume_probe_is_deterministic_and_missing_source_is_unavailable() {
 fn stale_sessions_are_removed_only_after_their_lock_is_acquirable() {
     let scratch = TempDir::new().unwrap();
     let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let own_records = store.root().join("sessions").join(store.session_id());
+    std::fs::write(own_records.join("keep.json"), b"live").unwrap();
+    let unrelated_entry = store.root().join("keep-unrelated");
+    std::fs::write(&unrelated_entry, b"unrelated").unwrap();
+    for malformed in [
+        ".lock",
+        "..lock",
+        "...lock",
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA.lock",
+        "short.lock",
+        "deadbeefdeadbeefdeadbeefdeadbeef.lock.extra",
+    ] {
+        std::fs::write(store.root().join("sessions").join(malformed), b"").unwrap();
+    }
+    assert!(!is_valid_session_id(""));
+    assert!(!is_valid_session_id(".."));
+    assert!(!is_valid_session_id("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+    assert!(is_valid_session_id("deadbeefdeadbeefdeadbeefdeadbeef"));
     let stale = "deadbeefdeadbeefdeadbeefdeadbeef";
     let lock = store.root().join("sessions").join(format!("{stale}.lock"));
     std::fs::write(&lock, b"").unwrap();
@@ -475,6 +680,60 @@ fn stale_sessions_are_removed_only_after_their_lock_is_acquirable() {
     std::fs::write(live_records.join("keep.json"), b"garbage").unwrap();
     store.recover().unwrap();
     assert!(live_records.exists());
+    assert!(live_lock_path.exists());
+    assert_eq!(
+        std::fs::read(own_records.join("keep.json")).unwrap(),
+        b"live"
+    );
+    assert_eq!(std::fs::read(unrelated_entry).unwrap(), b"unrelated");
+    for malformed in [
+        ".lock",
+        "..lock",
+        "...lock",
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA.lock",
+        "short.lock",
+        "deadbeefdeadbeefdeadbeefdeadbeef.lock.extra",
+    ] {
+        assert!(store.root().join("sessions").join(malformed).exists());
+    }
+}
+
+#[test]
+fn lock_contention_classifier_covers_fs2_and_would_block_without_masking_other_errors() {
+    let fs2_error = fs2::lock_contended_error();
+    assert!(is_lock_contended(&fs2_error));
+    assert!(is_lock_contended(&std::io::Error::from(
+        std::io::ErrorKind::WouldBlock
+    )));
+    assert!(!is_lock_contended(&std::io::Error::from(
+        std::io::ErrorKind::PermissionDenied
+    )));
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_runtime_file_lock_contention_uses_the_portable_classifier() {
+    let scratch = TempDir::new().unwrap();
+    let path = scratch.path().join("contention.lock");
+    let first = open_lock_file(&path).unwrap();
+    let second = open_lock_file(&path).unwrap();
+    FileExt::lock_exclusive(&first).unwrap();
+    let error = FileExt::try_lock_exclusive(&second).unwrap_err();
+    assert!(is_lock_contended(&error));
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_directory_volume_probe_returns_a_native_same_volume_identity() {
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let observation = store.compare_source_volume(scratch.path()).unwrap();
+    assert_eq!(observation.relation, SourceVolumeRelation::Same);
+    assert!(observation.source_identity.is_some());
+    assert_eq!(
+        observation.source_identity, observation.resolved_identity,
+        "source and resolved directory handles must report the same volume serial"
+    );
 }
 
 #[test]
@@ -576,6 +835,7 @@ fn cross_process_store_child() {
     let _held: Box<dyn std::any::Any> = if mode == "reserve" {
         match store.reserve(&candidate, &source, "child:model").unwrap() {
             ReservationOutcome::Acquired(reservation) => Box::new(reservation),
+            ReservationOutcome::AlreadyComplete(_) => panic!("child entry is already complete"),
             ReservationOutcome::Contended => panic!("child reservation contended"),
         }
     } else {

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -1,0 +1,594 @@
+use super::*;
+use crate::model_artifacts::{
+    ActiveArtifactLeaseRegistry, ArtifactAvailability, ArtifactCompleteness, ArtifactFile,
+    ArtifactIdentity, ArtifactMemberRole, ArtifactProvenance, ArtifactSourceLibrary,
+    ResolvedBundleClosure, ResolvedBundleMember, MODEL_ARTIFACT_CONTRACT_VERSION,
+};
+use std::collections::BTreeMap;
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+use tempfile::TempDir;
+
+const REVISION_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const REVISION_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+fn policy_from(values: &[(&str, &str)]) -> Result<ResolvedCachePolicy, ResolvedCacheError> {
+    let values = values.iter().copied().collect::<BTreeMap<_, _>>();
+    ResolvedCachePolicy::from_env_values(|name| values.get(name).map(|value| (*value).to_owned()))
+}
+
+fn source_candidate(root: &Path, revision: &str) -> PromotionCandidate {
+    std::fs::create_dir_all(root).unwrap();
+    std::fs::write(root.join("weights.bin"), b"model-weights").unwrap();
+    let identity = ArtifactIdentity::pinned("owner/model", revision, "default").unwrap();
+    let closure = ResolvedBundleClosure::new(vec![ResolvedBundleMember {
+        role: ArtifactMemberRole::Primary,
+        component_id: None,
+        source: identity.clone(),
+        tier: Some("fp16".to_owned()),
+        source_subpath: PathBuf::new(),
+        destination: PathBuf::new(),
+        files: vec![ArtifactFile::new("weights.bin").unwrap()],
+    }])
+    .unwrap();
+    let artifact = ResolvedModelArtifact {
+        schema_version: MODEL_ARTIFACT_CONTRACT_VERSION,
+        identity: identity.clone(),
+        location: ArtifactLocation::SourceLibrary {
+            root: root.to_path_buf(),
+        },
+        closure,
+        provenance: ArtifactProvenance {
+            identity,
+            fixed_artifact_tier: Some("fp16".to_owned()),
+        },
+        completeness: ArtifactCompleteness::Complete,
+        availability: ArtifactAvailability::Available,
+    };
+    artifact.validate().unwrap();
+    PromotionCandidate {
+        cache_key: artifact.cache_key().unwrap(),
+        artifact,
+    }
+}
+
+fn make_complete(
+    store: &ResolvedCacheStore,
+    candidate: &PromotionCandidate,
+    source: &Path,
+) -> ResolvedCacheMetadata {
+    let reservation = match store.reserve(candidate, source, "fixture:model").unwrap() {
+        ReservationOutcome::Acquired(reservation) => reservation,
+        ReservationOutcome::Contended => panic!("unexpected reservation contention"),
+    };
+    let bundle = reservation.bundle_path().unwrap();
+    std::fs::create_dir_all(&bundle).unwrap();
+    std::fs::copy(source.join("weights.bin"), bundle.join("weights.bin")).unwrap();
+    let mut local = candidate.artifact.clone();
+    local.location = ArtifactLocation::ResolvedLocal { root: bundle };
+    let metadata = reservation.record_complete(local).unwrap();
+    assert!(!store
+        .entry_path(&candidate.cache_key)
+        .unwrap()
+        .join(".sceneworks-download-complete.json")
+        .exists());
+    metadata
+}
+
+fn resolver(root: &Path, registry: ActiveArtifactLeaseRegistry) -> ModelArtifactResolver {
+    ModelArtifactResolver::with_lease_registry(ArtifactSourceLibrary::new(root).unwrap(), registry)
+}
+
+#[test]
+fn policy_defaults_are_finite_disabled_and_serde_defaults_upgrade() {
+    let policy = ResolvedCachePolicy::default();
+    assert!(!policy.enabled);
+    assert_eq!(policy.max_bytes, 68_719_476_736);
+    assert_eq!(policy.inactivity_seconds, 1_209_600);
+    policy.validate().unwrap();
+
+    #[derive(Default, Deserialize)]
+    #[serde(default)]
+    struct LegacySettings {
+        resolved_cache: ResolvedCachePolicy,
+    }
+    let upgraded: LegacySettings = serde_json::from_str("{}").unwrap();
+    assert_eq!(upgraded.resolved_cache, policy);
+    let future: ResolvedCachePolicy = serde_json::from_str(
+        r#"{"enabled":false,"maxBytes":123,"inactivitySeconds":456,"future":true}"#,
+    )
+    .unwrap();
+    assert_eq!(future.max_bytes, 123);
+}
+
+#[test]
+fn env_policy_is_exact_and_invalid_values_fail_closed() {
+    assert_eq!(policy_from(&[]).unwrap(), ResolvedCachePolicy::default());
+    let enabled = policy_from(&[
+        (RESOLVED_CACHE_ENABLED_ENV, "true"),
+        (RESOLVED_CACHE_MAX_BYTES_ENV, "4096"),
+        (RESOLVED_CACHE_INACTIVITY_SECONDS_ENV, "60"),
+    ])
+    .unwrap();
+    assert!(enabled.enabled);
+    assert_eq!(
+        enabled.env_pairs().unwrap(),
+        [
+            (RESOLVED_CACHE_ENABLED_ENV, "true".to_owned()),
+            (RESOLVED_CACHE_MAX_BYTES_ENV, "4096".to_owned()),
+            (RESOLVED_CACHE_INACTIVITY_SECONDS_ENV, "60".to_owned()),
+        ]
+    );
+    for (name, value) in [
+        (RESOLVED_CACHE_ENABLED_ENV, "sometimes"),
+        (RESOLVED_CACHE_MAX_BYTES_ENV, "0"),
+        (RESOLVED_CACHE_MAX_BYTES_ENV, "unlimited"),
+        (RESOLVED_CACHE_INACTIVITY_SECONDS_ENV, "0"),
+    ] {
+        assert!(policy_from(&[(name, value)]).is_err(), "{name}={value}");
+    }
+}
+
+#[test]
+fn store_refuses_unmanaged_roots_and_hashes_all_entry_paths() {
+    let scratch = TempDir::new().unwrap();
+    let data = scratch.path().join("data with spaces 雪");
+    let unmanaged = data.join("models/resolved");
+    std::fs::create_dir_all(&unmanaged).unwrap();
+    std::fs::write(unmanaged.join("keep.bin"), b"keep").unwrap();
+    let error = ResolvedCacheStore::open(&data).unwrap_err();
+    assert!(error.to_string().contains("refusing to adopt unmanaged"));
+    assert_eq!(std::fs::read(unmanaged.join("keep.bin")).unwrap(), b"keep");
+
+    let managed_data = scratch.path().join("managed 雪");
+    let store = ResolvedCacheStore::open(&managed_data).unwrap();
+    let key = format!("sha256:{}", "a".repeat(64));
+    let entry = store.entry_path(&key).unwrap();
+    assert!(entry.starts_with(store.root()));
+    assert_eq!(entry.file_name().unwrap(), "a".repeat(64).as_str());
+    for hostile in ["../escape", "sha256:../escape", "sha256:ABC", "C:\\weights"] {
+        assert!(store.entry_path(hostile).is_err());
+    }
+    for neighbor in [
+        "receipts",
+        "mlx",
+        "converted",
+        "imported",
+        "trained",
+        "user",
+    ] {
+        assert!(!managed_data.join("models").join(neighbor).exists());
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn store_refuses_symlink_root_without_mutating_target() {
+    use std::os::unix::fs::symlink;
+    let scratch = TempDir::new().unwrap();
+    let target = scratch.path().join("outside");
+    std::fs::create_dir(&target).unwrap();
+    std::fs::write(target.join("keep.bin"), b"keep").unwrap();
+    let data = scratch.path().join("data");
+    std::fs::create_dir_all(data.join("models")).unwrap();
+    symlink(&target, data.join("models/resolved")).unwrap();
+    assert!(ResolvedCacheStore::open(&data).is_err());
+    assert_eq!(std::fs::read(target.join("keep.bin")).unwrap(), b"keep");
+
+    let data_with_linked_models = scratch.path().join("data-linked-models");
+    std::fs::create_dir(&data_with_linked_models).unwrap();
+    symlink(&target, data_with_linked_models.join("models")).unwrap();
+    assert!(ResolvedCacheStore::open(&data_with_linked_models).is_err());
+    assert!(!target.join("resolved").exists());
+}
+
+#[test]
+fn reservation_is_exclusive_unrelated_keys_progress_and_drop_interrupts() {
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let source_a = scratch.path().join("source-a");
+    let source_b = scratch.path().join("source-b");
+    let candidate_a = source_candidate(&source_a, REVISION_A);
+    let candidate_b = source_candidate(&source_b, REVISION_B);
+    let first = match store
+        .reserve(&candidate_a, &source_a, "image:model-a")
+        .unwrap()
+    {
+        ReservationOutcome::Acquired(value) => value,
+        ReservationOutcome::Contended => panic!("first must win"),
+    };
+    let active = store
+        .enumerate()
+        .unwrap()
+        .into_iter()
+        .find(|entry| entry.cache_key == candidate_a.cache_key)
+        .unwrap()
+        .metadata
+        .unwrap();
+    assert_eq!(active.reservation_owner.as_deref(), Some("image:model-a"));
+    let mut traversing = active.clone();
+    traversing.session_id = Some("../../outside".to_owned());
+    assert!(validate_metadata_shape(
+        &traversing,
+        &cache_key_digest(&candidate_a.cache_key).unwrap()
+    )
+    .is_err());
+    assert!(matches!(
+        store
+            .reserve(&candidate_a, &source_a, "image:model-a")
+            .unwrap(),
+        ReservationOutcome::Contended
+    ));
+    let unrelated = store
+        .reserve(&candidate_b, &source_b, "video:model-b")
+        .unwrap();
+    assert!(matches!(unrelated, ReservationOutcome::Acquired(_)));
+    drop(unrelated);
+    drop(first);
+    let metadata = store
+        .enumerate()
+        .unwrap()
+        .into_iter()
+        .find(|entry| entry.cache_key == candidate_a.cache_key)
+        .unwrap()
+        .metadata
+        .unwrap();
+    assert_eq!(metadata.state, ResolvedCacheEntryState::Interrupted);
+    assert!(store
+        .lookup_complete(&candidate_a.cache_key)
+        .unwrap()
+        .is_none());
+    assert!(store.reserve(&candidate_a, &source_a, "\n").is_err());
+}
+
+#[test]
+fn catalog_reads_do_not_stamp_usage_but_runtime_acquisition_does() {
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let source = scratch.path().join("source");
+    let candidate = source_candidate(&source, REVISION_A);
+    make_complete(&store, &candidate, &source);
+    assert_eq!(
+        store
+            .lookup_complete(&candidate.cache_key)
+            .unwrap()
+            .unwrap()
+            .last_used_at,
+        None
+    );
+    assert_eq!(
+        store.enumerate().unwrap()[0]
+            .metadata
+            .as_ref()
+            .unwrap()
+            .last_used_at,
+        None
+    );
+    let registry = ActiveArtifactLeaseRegistry::default();
+    let resolver = resolver(&source, registry.clone());
+    let lease = store
+        .acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
+        .unwrap()
+        .unwrap();
+    assert_eq!(registry.active_lease_count(&candidate.cache_key), 1);
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .unwrap()
+        .last_used_at
+        .is_some());
+    assert_eq!(lease.mark_success().cache_key, candidate.cache_key);
+    assert_eq!(registry.active_lease_count(&candidate.cache_key), 0);
+}
+
+#[test]
+fn pin_owners_aggregate_exactly() {
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let source = scratch.path().join("source");
+    let candidate = source_candidate(&source, REVISION_A);
+    make_complete(&store, &candidate, &source);
+    assert!(!store.effective_pin(&candidate.cache_key).unwrap());
+    store
+        .set_model_pin(&candidate.cache_key, "image:model-a", true)
+        .unwrap();
+    store
+        .set_model_pin(&candidate.cache_key, "video:model-b", true)
+        .unwrap();
+    let metadata = store
+        .set_model_pin(&candidate.cache_key, "image:model-a", false)
+        .unwrap();
+    assert_eq!(metadata.model_pin_owners.len(), 1);
+    store
+        .set_model_pin(&candidate.cache_key, "video:model-b", false)
+        .unwrap();
+    assert!(!store.effective_pin(&candidate.cache_key).unwrap());
+    store.set_artifact_pin(&candidate.cache_key, true).unwrap();
+    assert!(store.effective_pin(&candidate.cache_key).unwrap());
+    assert!(store
+        .set_model_pin(&candidate.cache_key, "\n", true)
+        .is_err());
+}
+
+#[test]
+fn newest_corruption_recovers_older_and_both_slots_require_valid_receipt() {
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let source = scratch.path().join("source");
+    let candidate = source_candidate(&source, REVISION_A);
+    make_complete(&store, &candidate, &source);
+    store.set_artifact_pin(&candidate.cache_key, false).unwrap();
+    let entry = store.entry_path(&candidate.cache_key).unwrap();
+    let newest = [entry.join("metadata.0.json"), entry.join("metadata.1.json")]
+        .into_iter()
+        .max_by_key(|path| {
+            read_journal(path)
+                .map(|value| value.generation)
+                .unwrap_or(0)
+        })
+        .unwrap();
+    std::fs::write(newest, b"corrupt").unwrap();
+    let recovered = store.recover().unwrap();
+    let metadata = recovered[0].metadata.as_ref().unwrap();
+    assert_eq!(
+        metadata.recovery_status,
+        RecoveryStatus::RecoveredFromOlderSlot
+    );
+    assert!(metadata.effective_pin);
+
+    for slot in 0..=1 {
+        std::fs::write(entry.join(format!("metadata.{slot}.json")), b"corrupt").unwrap();
+    }
+    let recovered = store.recover().unwrap();
+    assert_eq!(
+        recovered[0].metadata.as_ref().unwrap().recovery_status,
+        RecoveryStatus::ReconstructedFromCompleteReceipt
+    );
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_some());
+    assert!(store
+        .bundle_path(&candidate.cache_key)
+        .unwrap()
+        .join("weights.bin")
+        .is_file());
+
+    for slot in 0..=1 {
+        std::fs::write(
+            entry.join(format!("metadata.{slot}.json")),
+            b"corrupt-again",
+        )
+        .unwrap();
+    }
+    std::fs::write(entry.join("complete.receipt.json"), b"bad-receipt").unwrap();
+    let recovered = store.recover().unwrap();
+    assert_eq!(recovered[0].state, ResolvedCacheEntryState::Corrupt);
+    assert!(recovered[0].metadata.is_none());
+    assert!(entry.join("corrupt.marker.json").is_file());
+    assert!(store
+        .bundle_path(&candidate.cache_key)
+        .unwrap()
+        .join("weights.bin")
+        .is_file());
+}
+
+#[test]
+fn incomplete_complete_entry_is_never_available_or_reconstructed() {
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let source = scratch.path().join("source");
+    let candidate = source_candidate(&source, REVISION_A);
+    make_complete(&store, &candidate, &source);
+    let bundle_file = store
+        .bundle_path(&candidate.cache_key)
+        .unwrap()
+        .join("weights.bin");
+    std::fs::write(&bundle_file, b"short").unwrap();
+    assert!(store.lookup_complete(&candidate.cache_key).is_err());
+
+    let entry = store.entry_path(&candidate.cache_key).unwrap();
+    for slot in 0..=1 {
+        std::fs::write(entry.join(format!("metadata.{slot}.json")), b"corrupt").unwrap();
+    }
+    let recovered = store.recover().unwrap();
+    assert_eq!(recovered[0].state, ResolvedCacheEntryState::Corrupt);
+    assert!(recovered[0].metadata.is_none());
+    assert_eq!(std::fs::read(bundle_file).unwrap(), b"short");
+}
+
+#[test]
+fn checked_enumeration_rejects_overflow() {
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let source_a = scratch.path().join("source-a");
+    let source_b = scratch.path().join("source-b");
+    let candidate_a = source_candidate(&source_a, REVISION_A);
+    let candidate_b = source_candidate(&source_b, REVISION_B);
+    make_complete(&store, &candidate_a, &source_a);
+    make_complete(&store, &candidate_b, &source_b);
+    for (candidate, bytes) in [(&candidate_a, u64::MAX), (&candidate_b, 1)] {
+        let digest = cache_key_digest(&candidate.cache_key).unwrap();
+        let _lock = store.lock_metadata(&digest).unwrap();
+        let mut metadata = store.read_metadata_locked(&digest).unwrap();
+        metadata.verified_bytes = bytes;
+        store.write_metadata_unlocked(&digest, &metadata).unwrap();
+    }
+    assert!(store.checked_verified_bytes().is_err());
+}
+
+#[test]
+fn volume_probe_is_deterministic_and_missing_source_is_unavailable() {
+    assert_eq!(
+        relation_for_volume_identities(Some(7), Some(7), true),
+        SourceVolumeRelation::Same
+    );
+    assert_eq!(
+        relation_for_volume_identities(Some(7), Some(8), true),
+        SourceVolumeRelation::Different
+    );
+    assert_eq!(
+        relation_for_volume_identities(None, Some(8), true),
+        SourceVolumeRelation::Unknown
+    );
+    assert_eq!(
+        relation_for_volume_identities(Some(7), Some(7), false),
+        SourceVolumeRelation::Unavailable
+    );
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    assert_eq!(
+        store
+            .compare_source_volume(scratch.path())
+            .unwrap()
+            .relation,
+        SourceVolumeRelation::Same
+    );
+    let missing = store
+        .compare_source_volume(&scratch.path().join("missing/source"))
+        .unwrap();
+    assert_eq!(missing.relation, SourceVolumeRelation::Unavailable);
+    assert!(missing.source_identity.is_none());
+}
+
+#[test]
+fn stale_sessions_are_removed_only_after_their_lock_is_acquirable() {
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let stale = "deadbeefdeadbeefdeadbeefdeadbeef";
+    let lock = store.root().join("sessions").join(format!("{stale}.lock"));
+    std::fs::write(&lock, b"").unwrap();
+    let records = store.root().join("sessions").join(stale);
+    std::fs::create_dir(&records).unwrap();
+    std::fs::write(records.join("malformed.json"), b"garbage").unwrap();
+    store.recover().unwrap();
+    assert!(!records.exists());
+    assert!(!lock.exists());
+
+    let live = "feedfacefeedfacefeedfacefeedface";
+    let live_lock_path = store.root().join("sessions").join(format!("{live}.lock"));
+    let live_lock = open_lock_file(&live_lock_path).unwrap();
+    FileExt::lock_exclusive(&live_lock).unwrap();
+    let live_records = store.root().join("sessions").join(live);
+    std::fs::create_dir(&live_records).unwrap();
+    std::fs::write(live_records.join("keep.json"), b"garbage").unwrap();
+    store.recover().unwrap();
+    assert!(live_records.exists());
+}
+
+#[test]
+fn cross_process_same_key_reservation_shared_lease_and_kill_recovery() {
+    let scratch = TempDir::new().unwrap();
+    let data = scratch.path().join("data");
+    let source_a = scratch.path().join("source-a");
+    let source_b = scratch.path().join("source-b");
+    let store = ResolvedCacheStore::open(&data).unwrap();
+    let candidate_a = source_candidate(&source_a, REVISION_A);
+    let candidate_b = source_candidate(&source_b, REVISION_B);
+    let mut child = spawn_child(&data, &source_a, scratch.path(), "reserve");
+    wait_for(&scratch.path().join("reserve-ready"));
+    assert!(matches!(
+        store
+            .reserve(&candidate_a, &source_a, "image:model-a")
+            .unwrap(),
+        ReservationOutcome::Contended
+    ));
+    assert!(matches!(
+        store
+            .reserve(&candidate_b, &source_b, "video:model-b")
+            .unwrap(),
+        ReservationOutcome::Acquired(_)
+    ));
+    child.kill().unwrap();
+    child.wait().unwrap();
+    store.recover().unwrap();
+    assert_eq!(
+        store
+            .enumerate()
+            .unwrap()
+            .into_iter()
+            .find(|entry| entry.cache_key == candidate_a.cache_key)
+            .unwrap()
+            .state,
+        ResolvedCacheEntryState::Interrupted
+    );
+
+    make_complete(&store, &candidate_a, &source_a);
+    let mut child = spawn_child(&data, &source_a, scratch.path(), "lease");
+    wait_for(&scratch.path().join("lease-ready"));
+    assert!(matches!(
+        store
+            .reserve(&candidate_a, &source_a, "image:model-a")
+            .unwrap(),
+        ReservationOutcome::Contended
+    ));
+    child.kill().unwrap();
+    child.wait().unwrap();
+    store.recover().unwrap();
+    assert!(store
+        .lookup_complete(&candidate_a.cache_key)
+        .unwrap()
+        .is_some());
+}
+
+fn spawn_child(data: &Path, source: &Path, scratch: &Path, mode: &str) -> std::process::Child {
+    Command::new(std::env::current_exe().unwrap())
+        .arg("--exact")
+        .arg("model_artifacts::resolved_cache::tests::cross_process_store_child")
+        .arg("--nocapture")
+        .env("SCENEWORKS_CACHE_CHILD_MODE", mode)
+        .env("SCENEWORKS_CACHE_CHILD_DATA", data)
+        .env("SCENEWORKS_CACHE_CHILD_SOURCE", source)
+        .env(
+            "SCENEWORKS_CACHE_CHILD_READY",
+            scratch.join(format!("{mode}-ready")),
+        )
+        .env(
+            "SCENEWORKS_CACHE_CHILD_RELEASE",
+            scratch.join(format!("{mode}-release")),
+        )
+        .spawn()
+        .unwrap()
+}
+
+fn wait_for(path: &Path) {
+    for _ in 0..200 {
+        if path.exists() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    panic!("child did not create {}", path.display());
+}
+
+#[test]
+fn cross_process_store_child() {
+    let Ok(mode) = std::env::var("SCENEWORKS_CACHE_CHILD_MODE") else {
+        return;
+    };
+    let data = PathBuf::from(std::env::var_os("SCENEWORKS_CACHE_CHILD_DATA").unwrap());
+    let source = PathBuf::from(std::env::var_os("SCENEWORKS_CACHE_CHILD_SOURCE").unwrap());
+    let ready = PathBuf::from(std::env::var_os("SCENEWORKS_CACHE_CHILD_READY").unwrap());
+    let release = PathBuf::from(std::env::var_os("SCENEWORKS_CACHE_CHILD_RELEASE").unwrap());
+    let store = ResolvedCacheStore::open(&data).unwrap();
+    let candidate = source_candidate(&source, REVISION_A);
+    let _held: Box<dyn std::any::Any> = if mode == "reserve" {
+        match store.reserve(&candidate, &source, "child:model").unwrap() {
+            ReservationOutcome::Acquired(reservation) => Box::new(reservation),
+            ReservationOutcome::Contended => panic!("child reservation contended"),
+        }
+    } else {
+        let resolver = resolver(&source, ActiveArtifactLeaseRegistry::default());
+        Box::new(
+            store
+                .acquire_complete(&candidate.cache_key, &resolver, "child:model")
+                .unwrap()
+                .expect("complete child artifact"),
+        )
+    };
+    std::fs::write(ready, b"ready").unwrap();
+    while !release.exists() {
+        thread::sleep(Duration::from_millis(20));
+    }
+}

--- a/crates/sceneworks-worker/src/settings.rs
+++ b/crates/sceneworks-worker/src/settings.rs
@@ -6,6 +6,10 @@ pub struct Settings {
     pub api_url: String,
     pub access_token: Option<String>,
     pub data_dir: PathBuf,
+    /// App-owned resolved-model cache policy. Invalid environment is fail-closed to the finite,
+    /// disabled shared default rather than enabling or unbounding the cache.
+    #[cfg(not(test))]
+    pub resolved_cache: sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy,
     pub config_dir: PathBuf,
     pub worker_id: String,
     pub gpu_id: String,
@@ -58,11 +62,14 @@ pub struct Settings {
 
 impl fmt::Debug for Settings {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("Settings")
+        let mut debug = formatter.debug_struct("Settings");
+        debug
             .field("api_url", &self.api_url)
             .field("access_token", &self.access_token.as_ref().map(|_| "***"))
-            .field("data_dir", &self.data_dir)
+            .field("data_dir", &self.data_dir);
+        #[cfg(not(test))]
+        debug.field("resolved_cache", &self.resolved_cache);
+        debug
             .field("config_dir", &self.config_dir)
             .field("worker_id", &self.worker_id)
             .field("gpu_id", &self.gpu_id)
@@ -100,6 +107,9 @@ impl Settings {
                 .map(|value| value.trim().to_owned())
                 .filter(|value| !value.is_empty()),
             data_dir: env_path_or("SCENEWORKS_DATA_DIR", &defaults.data_dir),
+            #[cfg(not(test))]
+            resolved_cache:
+                sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy::from_env_or_safe_default(),
             config_dir: config_dir.clone(),
             worker_id: env_string("SCENEWORKS_WORKER_ID", "rust-utility-worker"),
             gpu_id: env_string("SCENEWORKS_GPU_ID", "cpu"),

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1618,6 +1618,15 @@ test("dropping the PR path filter did not expose the self-hosted pools", async (
     "build-windows is the required check; it must actually run on the speculative merge rather " +
       "than skip into a free Success.",
   );
+  const buildStart = desktop.indexOf("\n  build-windows:");
+  const packageStart = desktop.indexOf("\n  package-windows:");
+  assert.ok(buildStart >= 0 && packageStart > buildStart, "desktop Windows jobs must be parseable");
+  const requiredBuild = desktop.slice(buildStart, packageStart);
+  assert.match(
+    requiredBuild,
+    /run: "cargo test -p sceneworks-core model_artifacts::resolved_cache::tests:: -- --test-threads=1"/,
+    "required build-windows must execute the native resolved-cache safety suite, not only compile it",
+  );
 });
 
 test("windows-candle stays out of the queue and out of the required set", async () => {


### PR DESCRIPTION
## Summary

- add the shared, disabled-by-default resolved-cache policy with the exact 64 GiB / 14-day defaults, strict fail-closed validation, nested desktop settings persistence, a validated Tauri setter, and one centralized API/MLX/Candle spawn environment seam
- add the reserved `<data>/models/resolved` store with hash-only entry paths, unmanaged/symlink/reparse rejection, two-slot checksummed metadata journals, immutable complete receipts, conservative crash/corruption recovery, and no legacy download receipt emission
- add reservation, complete lookup/enumeration, checked accounting, artifact/model pin aggregation, exact-source volume probes, and composed in-process/cross-process runtime leases whose catalog reads never stamp usage
- preserve the merged SC-19704 immutable artifact/cache-key/promotion contract and leave materialization copying/publication to SC-19706

## Acceptance coverage

1. **Policy/settings/env:** `ResolvedCachePolicy` defaults to disabled, 68,719,476,736 bytes, and 1,209,600 seconds. Invalid persisted or environment values fail closed. Desktop settings upgrade/round-trip, setter ACL/build registration, and exact three-variable API/MLX/Candle propagation are tested. API and worker use the same core parser.
2. **Reserved store:** the store owns only `<data>/models/resolved`, requires its versioned marker, rejects symlinked/reparse or unmanaged `models`/`resolved` paths, uses SHA-256 entry names, confines all internal locks/metadata/staging/sessions, and never mutates neighboring model directories or writes `.sceneworks-download-complete.json`.
3. **Durable API:** versioned metadata carries the full SC-19704 artifact contract, configured/canonical source roots, relative entry/bundle paths, all lifecycle states, verified bytes, timestamps/usage, artifact and model-owner pins/effective pin, reservation/session identity, recovery state, and persisted volume observation. Store APIs cover open/paths/reserve/lookup/enumerate/accounting/acquire/pins/owned interruption/recovery/volume comparison.
4. **Usage/leases:** only acquisition of a fully revalidated complete artifact stamps `lastUsedAt`; reads do not. Runtime acquisition composes the SC-19704 lease registry, a shared artifact OS lock, an exclusive metadata lock, and session records guarded by a live process lock. Stale records are removed only after validating an exact lowercase-hex session identity and proving its session lock acquirable.
5. **Journal/recovery:** same-directory temp+fsync+rename writes feed a two-slot generation/checksum journal. Recovery prefers the highest valid generation, pins older-slot recovery, reconstructs only from a fully validated complete receipt, marks other cases corrupt, and never deletes bundle bytes.
6. **Reservation only:** same-key reservation has one exclusive winner, unrelated keys proceed independently, staging is unique and internal, and dropped/killed reservations become interrupted and unusable. Complete entries return `AlreadyComplete` without replacement; interruption and completion require the live reservation's private owner/session/reservation identities while its artifact lock is held. The completion seam rejects escaping bundle symlinks/reparse points and canonical ancestor escapes, validates/records a caller-installed bundle, and performs no copy or publication.
7. **Volume identity:** probes require the exact source root to exist, use Unix device IDs or Windows directory handles with `FILE_FLAG_BACKUP_SEMANTICS` for volume serials, return Same/Different/Unavailable/Unknown, and persist observations without using them as live truth.
8. **Tests:** focused tests cover legacy/future policy serde, invalid env, exact spawn parity, Unicode/spaces/Windows-safe paths, traversal and symlink rejection, malformed session filenames, portable lock classification, reservation ownership, complete preservation, bundle confinement, neighbor preservation, accounting overflow, pin aggregation, usage boundaries, real child-process reservation/shared lease/kill/stale-session behavior, journal/receipt corruption with retained bytes, and incomplete/corrupt availability refusal. Native `cfg(windows)` tests cover runtime lock contention, directory volume identity, and reparse-point completion rejection.

## Adversarial review fixes

- validate every filename-derived session identity as exactly 32 lowercase hexadecimal characters before any join or removal; malformed, traversal-shaped, uppercase, and suffixed entries are ignored without touching live records or unrelated entries
- classify fs2 contention through one portable helper used by reservation, recovery, and session cleanup/probing
- make complete state authoritative and ownership transitions token-bound: valid complete entries are preserved, live materialization is contended, stale transition requires session-lock authority, and only the genuine live reservation may interrupt or complete
- reject symlink/junction/reparse and canonical-ancestor escapes at the completion boundary while leaving external bytes untouched
- open Windows directory volume probes with backup-semantics handles so native directory volume serials are observable
- revalidate lexical and canonical managed-entry confinement every time Complete metadata is exposed, leased, enumerated, reserved, or reconstructed; post-publication bundle swaps fail closed without usage stamping or external-byte mutation

## Validation

- `cargo test -p sceneworks-core model_artifacts::resolved_cache::tests:: -- --test-threads=1` — 19 passed, 0 failed
- `cargo test -p sceneworks-core` — 940 unit tests passed, 2 expected ignores; every integration suite passed (character 9, contract 7, jobs 171, training 41 + 2 expected ignores, workflow MP4 28, parameters 22, PNG 17, resolution 41, share 85, derived-doc 27)
- `cargo test -p sceneworks-worker --lib` — 1,502 passed, 0 failed, 210 expected device/real-weight ignores
- `cargo test -p sceneworks-rust-api` — 572 passed, 0 failed, 4 expected real-weight ignores
- `cargo test -p sceneworks-desktop` — 96 passed, 0 failed
- `cargo test -p sceneworks-core jobs_store::routing::matrix::tests::checked_in_matrix_matches_all_authoritative_sources -- --exact` — 1 passed, 0 failed
- `cargo clippy -p sceneworks-core -p sceneworks-worker -p sceneworks-rust-api -p sceneworks-desktop --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `npm run --silent check:rust-derived-docs` — passed (21 mutation self-tests; 111 declared/measured exceptions)
- `git diff --cached --check` before commit — passed
- `cargo check -p sceneworks-core --target x86_64-pc-windows-msvc --tests` — could not reach Rust compilation on this macOS host because bundled `libsqlite3-sys` requires unavailable MSVC C headers (`stdlib.h`); native Windows tests are checked in for the platform lane

No inference pin, Cargo lockfile, measured/generated capability artifact, runtime `lib.rs` wiring, or disabled gate script changed. The authoritative capability matrix remains unchanged and green.

