### PR TITLE
sc-20305: exercise resolved-cache safety on required Windows CI

### DIFF
--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -165,6 +165,8 @@ jobs:
         run: node apps/desktop/scripts/stage-test-sidecars.mjs
       - name: Run Windows project-registry fingerprint regression
         run: cargo test -p sceneworks-core windows_registry_cache_detects_between_window_rewrite_with_restored_mtime
+      - name: Run Windows resolved-cache safety regressions
+        run: "cargo test -p sceneworks-core model_artifacts::resolved_cache::tests:: -- --test-threads=1"
       - name: Run desktop Rust tests
         run: cargo test -p sceneworks-desktop
       - name: Check desktop Rust lint

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -249,7 +249,7 @@ pub struct ResolvedCacheEntrySummary {
 
 #[derive(Debug)]
 pub enum ReservationOutcome {
-    Acquired(ResolvedCacheReservation),
+    Acquired(Box<ResolvedCacheReservation>),
     AlreadyComplete(Box<ResolvedCacheMetadata>),
     Contended,
 }
@@ -474,18 +474,20 @@ impl ResolvedCacheStore {
             acquired_at: now,
         };
         let record_path = self.write_session_record(&record)?;
-        Ok(ReservationOutcome::Acquired(ResolvedCacheReservation {
-            store: self.clone(),
-            cache_key: candidate.cache_key.clone(),
-            digest,
-            reservation_id,
-            reservation_owner: logical_model_owner,
-            session_id: self.inner.session_id.clone(),
-            staging_path: staging,
-            record_path,
-            artifact_lock: Some(artifact_lock),
-            finished: false,
-        }))
+        Ok(ReservationOutcome::Acquired(Box::new(
+            ResolvedCacheReservation {
+                store: self.clone(),
+                cache_key: candidate.cache_key.clone(),
+                digest,
+                reservation_id,
+                reservation_owner: logical_model_owner,
+                session_id: self.inner.session_id.clone(),
+                staging_path: staging,
+                record_path,
+                artifact_lock: Some(artifact_lock),
+                finished: false,
+            },
+        )))
     }
 
     pub fn lookup_complete(
@@ -1710,11 +1712,9 @@ fn volume_identity(path: &Path) -> Result<u64, ResolvedCacheError> {
         .read(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
         .open(path)?;
-    Ok(u64::from(
-        winapi_util::file::information(&file)
-            .map_err(|error| ResolvedCacheError::new(error.to_string()))?
-            .volume_serial_number(),
-    ))
+    Ok(winapi_util::file::information(&file)
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?
+        .volume_serial_number())
 }
 
 #[cfg(not(any(unix, windows)))]

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -132,6 +132,14 @@ impl Drop for WindowsDirectoryJunction {
 }
 
 #[test]
+fn reservation_outcome_keeps_the_lock_holding_reservation_behind_indirection() {
+    assert!(
+        std::mem::size_of::<ReservationOutcome>() <= 4 * std::mem::size_of::<usize>(),
+        "ReservationOutcome must not inline the lock-holding reservation"
+    );
+}
+
+#[test]
 fn policy_defaults_are_finite_disabled_and_serde_defaults_upgrade() {
     let policy = ResolvedCachePolicy::default();
     assert!(!policy.enabled);
@@ -981,7 +989,7 @@ fn cross_process_store_child() {
     let candidate = source_candidate(&source, REVISION_A);
     let _held: Box<dyn std::any::Any> = if mode == "reserve" {
         match store.reserve(&candidate, &source, "child:model").unwrap() {
-            ReservationOutcome::Acquired(reservation) => Box::new(reservation),
+            ReservationOutcome::Acquired(reservation) => reservation,
             ReservationOutcome::AlreadyComplete(_) => panic!("child entry is already complete"),
             ReservationOutcome::Contended => panic!("child reservation contended"),
         }

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -81,6 +81,56 @@ fn resolver(root: &Path, registry: ActiveArtifactLeaseRegistry) -> ModelArtifact
     ModelArtifactResolver::with_lease_registry(ArtifactSourceLibrary::new(root).unwrap(), registry)
 }
 
+#[cfg(windows)]
+struct WindowsDirectoryJunction {
+    path: PathBuf,
+    removed: bool,
+}
+
+#[cfg(windows)]
+impl WindowsDirectoryJunction {
+    fn create(path: &Path, target: &Path) -> Self {
+        let output = Command::new("cmd")
+            .args(["/D", "/C", "mklink", "/J"])
+            .arg(path)
+            .arg(target)
+            .output()
+            .expect("launch cmd.exe to create directory junction");
+        assert!(
+            output.status.success(),
+            "mklink /J failed with {}\nstdout: {}\nstderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let metadata = std::fs::symlink_metadata(path)
+            .expect("read the created directory junction without following it");
+        assert!(
+            metadata_is_reparse_point(&metadata),
+            "mklink /J fixture must carry FILE_ATTRIBUTE_REPARSE_POINT"
+        );
+        Self {
+            path: path.to_path_buf(),
+            removed: false,
+        }
+    }
+
+    fn remove(mut self) {
+        std::fs::remove_dir(&self.path)
+            .expect("remove the junction itself without traversing its target");
+        self.removed = true;
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsDirectoryJunction {
+    fn drop(&mut self) {
+        if !self.removed {
+            let _ = std::fs::remove_dir(&self.path);
+        }
+    }
+}
+
 #[test]
 fn policy_defaults_are_finite_disabled_and_serde_defaults_upgrade() {
     let policy = ResolvedCachePolicy::default();
@@ -448,8 +498,7 @@ fn complete_validation_rejects_a_post_publication_bundle_swap_everywhere() {
 
 #[cfg(windows)]
 #[test]
-fn completion_rejects_a_directory_reparse_point_when_windows_allows_fixture_creation() {
-    use std::os::windows::fs::symlink_dir;
+fn completion_rejects_a_directory_junction_without_touching_external_bytes() {
     let scratch = TempDir::new().unwrap();
     let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
     let source = scratch.path().join("source");
@@ -461,13 +510,9 @@ fn completion_rejects_a_directory_reparse_point_when_windows_allows_fixture_crea
     let external = scratch.path().join("external");
     std::fs::create_dir(&external).unwrap();
     std::fs::write(external.join("weights.bin"), b"external-model-bytes").unwrap();
+    std::fs::write(external.join("sentinel"), b"external-must-survive").unwrap();
     let bundle = reservation.bundle_path().unwrap();
-    if let Err(error) = symlink_dir(&external, &bundle) {
-        if error.kind() == std::io::ErrorKind::PermissionDenied {
-            return;
-        }
-        panic!("create directory reparse fixture: {error}");
-    }
+    let junction = WindowsDirectoryJunction::create(&bundle, &external);
     let mut local = candidate.artifact.clone();
     local.location = ArtifactLocation::ResolvedLocal { root: bundle };
     assert!(reservation.record_complete(local).is_err());
@@ -475,12 +520,17 @@ fn completion_rejects_a_directory_reparse_point_when_windows_allows_fixture_crea
         std::fs::read(external.join("weights.bin")).unwrap(),
         b"external-model-bytes"
     );
+    assert_eq!(
+        std::fs::read(external.join("sentinel")).unwrap(),
+        b"external-must-survive"
+    );
+    junction.remove();
+    assert!(external.is_dir());
 }
 
 #[cfg(windows)]
 #[test]
-fn complete_validation_rejects_a_post_publication_directory_reparse_point() {
-    use std::os::windows::fs::symlink_dir;
+fn complete_validation_rejects_a_post_publication_directory_junction_everywhere() {
     let scratch = TempDir::new().unwrap();
     let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
     let source = scratch.path().join("source");
@@ -492,21 +542,38 @@ fn complete_validation_rejects_a_post_publication_directory_reparse_point() {
     std::fs::create_dir(&external).unwrap();
     std::fs::write(external.join("weights.bin"), b"model-weights").unwrap();
     std::fs::write(external.join("sentinel"), b"external-must-survive").unwrap();
-    if let Err(error) = symlink_dir(&external, &bundle) {
-        if error.kind() == std::io::ErrorKind::PermissionDenied {
-            return;
-        }
-        panic!("create directory reparse fixture: {error}");
-    }
+    let junction = WindowsDirectoryJunction::create(&bundle, &external);
     assert!(store.lookup_complete(&candidate.cache_key).is_err());
     let resolver = resolver(&source, ActiveArtifactLeaseRegistry::default());
     assert!(store
         .acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
         .is_err());
+    assert!(store.enumerate().is_err());
+    let digest = cache_key_digest(&candidate.cache_key).unwrap();
+    let metadata_lock = store.lock_metadata(&digest).unwrap();
+    assert_eq!(
+        store.read_metadata_locked(&digest).unwrap().last_used_at,
+        None
+    );
+    drop(metadata_lock);
+
+    let entry = store.entry_path(&candidate.cache_key).unwrap();
+    for slot in 0..=1 {
+        std::fs::write(entry.join(format!("metadata.{slot}.json")), b"corrupt").unwrap();
+    }
+    let recovered = store.recover().unwrap();
+    assert_eq!(recovered[0].state, ResolvedCacheEntryState::Corrupt);
+    assert!(recovered[0].metadata.is_none());
+    assert_eq!(
+        std::fs::read(external.join("weights.bin")).unwrap(),
+        b"model-weights"
+    );
     assert_eq!(
         std::fs::read(external.join("sentinel")).unwrap(),
         b"external-must-survive"
     );
+    junction.remove();
+    assert!(external.is_dir());
 }
 
 #[test]

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1618,6 +1618,15 @@ test("dropping the PR path filter did not expose the self-hosted pools", async (
     "build-windows is the required check; it must actually run on the speculative merge rather " +
       "than skip into a free Success.",
   );
+  const buildStart = desktop.indexOf("\n  build-windows:");
+  const packageStart = desktop.indexOf("\n  package-windows:");
+  assert.ok(buildStart >= 0 && packageStart > buildStart, "desktop Windows jobs must be parseable");
+  const requiredBuild = desktop.slice(buildStart, packageStart);
+  assert.match(
+    requiredBuild,
+    /run: "cargo test -p sceneworks-core model_artifacts::resolved_cache::tests:: -- --test-threads=1"/,
+    "required build-windows must execute the native resolved-cache safety suite, not only compile it",
+  );
 });
 
 test("windows-candle stays out of the queue and out of the required set", async () => {


### PR DESCRIPTION
## Summary

- run the focused `sceneworks-core` resolved-cache suite in the existing required hosted Windows `build-windows` job
- replace privilege-dependent Windows directory symlinks and PermissionDenied skips with a checked `mklink /J` junction fixture
- expand the native post-publication junction mutation across lookup, runtime acquisition, enumeration, corrupt-journal recovery, usage stamping, and external-byte preservation
- pin the required-job command with a repository workflow contract while leaving all dismantled capability/pin/measurement gates untouched

Shortcut: [SC-20305](https://app.shortcut.com/trefry/story/20305)
Stacked base: `codex/sc-19705-resolved-cache-store` at `9a66ef2b20bfb71e0f15ac6fe594581f18d5da84`

## Acceptance coverage

1. **Required native execution:** `build-windows` now executes `cargo test -p sceneworks-core model_artifacts::resolved_cache::tests:: -- --test-threads=1`; a workflow contract scopes the exact command to the required job rather than allowing a compile-only or packaging-only substitute.
2. **Privilege-independent fixture:** both Windows reparse mutations use `cmd /D /C mklink /J` with checked launch, exit status, stdout, stderr, and post-create reparse metadata. There is no PermissionDenied return/skip.
3. **Safe cleanup:** a junction guard removes the junction itself with `remove_dir`; it never recursively removes or follows the external target.
4. **Native safety surface:** the focused suite includes Windows fs2 contention classification, directory volume serial identity through `FILE_FLAG_BACKUP_SEMANTICS`, initial completion rejection, and post-publication rejection through lookup/acquire/enumerate/recovery with no usage stamp and preserved external weights/sentinel.
5. **Detector audit:** production checks `FILE_ATTRIBUTE_REPARSE_POINT` (`0x400`), so junction and mount-point reparse tags are rejected, not only symbolic-link tags. The native fixture asserts the junction carries that attribute.
6. **Scope integrity:** the Windows lint follow-up changes only reservation enum indirection and removes a type-identical volume-serial conversion; ownership, held-lock, and volume API semantics are unchanged. No inference pin, Cargo manifest/lockfile, measured/generated capability artifact, disabled gate, or model/device campaign changed.

## Windows CI follow-up

- the initial required Windows run executed the native resolved-cache suite successfully: 20 passed, including junction confinement, fs2 contention, and BACKUP_SEMANTICS volume identity
- the later desktop lint step found Windows-only large-enum and redundant-conversion warnings; replacement head boxes the lock-holding reservation and removes the type-identical conversion
- a cross-platform enum-size regression test prevents re-inlining the reservation

## Validation

- `cargo test -p sceneworks-core model_artifacts::resolved_cache::tests:: -- --test-threads=1` — 20 passed on macOS (Unix fixture surface)
- `cargo test -p sceneworks-core` — 940 passed, 2 expected ignores; all integration suites passed
- `cargo test -p sceneworks-core jobs_store::routing::matrix::tests::checked_in_matrix_matches_all_authoritative_sources -- --exact` — 1 passed
- `node --test scripts/platform-review-contracts.test.mjs` — 47 passed
- `cargo clippy -p sceneworks-core --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `npm run --silent check:rust-derived-docs` — passed (21 mutation self-tests; 111 declared/measured exceptions)
- `actionlint` — workflow syntax passed after ignoring only the file's pre-existing intentional unused cross-workflow anchor and custom self-hosted `cuda` label diagnostics
- required Windows build on the initial head — native resolved-cache suite 20/20; replacement-head rerun pending after lint-only fixes
- independent adversarial review of the replacement fix — PASS
- macOS-to-MSVC `cargo check` cannot reach SceneWorks Rust because bundled `libsqlite3-sys` needs unavailable MSVC C headers (`stdlib.h`); this PR deliberately makes the required hosted Windows job execute the native suite and report the platform evidence

