### PR TITLE
feat(sc-20318): ratify bounded q4 campaign entry

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -137,6 +137,7 @@ const LTX_CANARY_WATCHDOG_PROTOCOL: &str = "sceneworks-memory-watchdog-v1";
 const LTX_PROVIDER_PHASE_PROTOCOL: &str = "sceneworks-provider-phase-v1";
 const LTX_CAMPAIGN_ENTRY_PHASE_PROFILE: &str = "campaign-entry";
 const LTX_BOUNDED_CARRIER_PHASE_PROFILE: &str = "bounded-carrier";
+const LTX_BOUNDED_CAMPAIGN_PHASE_PROFILE: &str = "bounded-campaign-entry";
 const LTX_PROVIDER_PHASE_NAMES: [&str; 10] = [
     "common_load",
     "primary_conditioning",
@@ -184,6 +185,12 @@ const LTX_BOUNDED_CARRIER_LOGICAL_CASE_ID: &str =
     "diagnostic-sc20254-q4-768x512-f121-fps30-bounded-192-64";
 const LTX_BOUNDED_CARRIER_FIXTURE: &str =
     "ltx-2-3-mlx-q4-768x512-f121-fps30-seed18946-bounded-decode-192-64-proof";
+const LTX_BOUNDED_CAMPAIGN_ACTION: &str = "bounded_campaign_entry";
+const LTX_BOUNDED_CAMPAIGN_IDENTITY: &str =
+    "sc-20318-q4-768x512-f121-fps30-bounded-192-64-authoritative-v1";
+const LTX_BOUNDED_CAMPAIGN_LOGICAL_CASE_ID: &str = "implan-964db61ed3789af6386b";
+const LTX_BOUNDED_CAMPAIGN_FIXTURE: &str =
+    "ltx-2-3-mlx-q4-768x512-f121-fps30-bounded-decode-192-64-seed18946";
 const LTX_CANARY_ARTIFACT_REVISION: &str = "01df27d308466533aa09d251e3aebdcc627d07eb";
 const LTX_CANARY_Q4_INVENTORY_FILES: u64 = 11;
 const LTX_CANARY_Q4_INVENTORY_SHA256: &str =
@@ -5493,9 +5500,12 @@ fn planned_ltx_capture(
     let remainder = fixture
         .strip_prefix(&prefix)
         .ok_or_else(|| format!("planned.fixture {fixture:?} must start with {prefix:?}"))?;
-    let (fps, seed) = remainder
+    let (fps_and_carrier, seed) = remainder
         .split_once("-seed")
         .ok_or_else(|| format!("planned.fixture {fixture:?} must end with -seed<seed>"))?;
+    let fps = fps_and_carrier
+        .strip_suffix("-bounded-decode-192-64")
+        .unwrap_or(fps_and_carrier);
     let fps = fps
         .parse::<u32>()
         .map_err(|error| format!("parse LTX fixture fps {fps:?}: {error}"))?;
@@ -5593,9 +5603,17 @@ fn validate_ltx_safety_evidence(
         .saturating_mul(u64::from(geometry.height))
         .saturating_mul(u64::from(geometry.frames));
     let predicted_decode_bytes = if bounded {
+        let tile_edge = u64::from(selection.parameters.decode_tile_edge.ok_or_else(|| {
+            "SC-18946 bounded-decode safety row omitted decodeTileEdge".to_owned()
+        })?);
         3_300_000_000_u64
             .saturating_add(40_u64.saturating_mul(voxels))
-            .saturating_add(300 * 384 * 384 * 96)
+            .saturating_add(
+                300_u64
+                    .saturating_mul(tile_edge)
+                    .saturating_mul(tile_edge)
+                    .saturating_mul(96),
+            )
     } else {
         3_300_000_000_u64.saturating_add(340_u64.saturating_mul(voxels))
     };
@@ -5837,6 +5855,134 @@ fn validate_ltx_bounded_carrier_proof(
         || selection.parameters.decode_overlap != Some(LTX_CANARY_OVERLAP)
     {
         return Err("SC-20254 bounded carrier resolved a foreign tuple or strategy".to_owned());
+    }
+    Ok(())
+}
+
+/// The sole promotable bounded campaign entry. The ordinary `run` action continues through the
+/// all-row pre-load refusal; the controller may inject this private action only after the canonical
+/// harness has selected the exact new SC-20318 row and acquired the contained-execution claim.
+fn validate_ltx_bounded_campaign_entry(
+    request: &Value,
+    tier: &str,
+    geometry: LtxGeometry,
+    selection: &MemorySelection,
+) -> Result<(), String> {
+    if protocol::action(request)? != LTX_BOUNDED_CAMPAIGN_ACTION {
+        return Err("SC-20318 bounded campaign action changed".to_owned());
+    }
+    let planned = protocol::planned(request)?;
+    let exact = |pointer: &str, expected: &Value| -> Result<(), String> {
+        let actual = planned.pointer(pointer);
+        if actual == Some(expected) {
+            Ok(())
+        } else {
+            Err(format!(
+                "SC-20318 bounded campaign {pointer} must be {expected}, got {actual:?}"
+            ))
+        }
+    };
+    exact(
+        "/logicalCaseId",
+        &json!(LTX_BOUNDED_CAMPAIGN_LOGICAL_CASE_ID),
+    )?;
+    exact("/evidenceScope", &json!("authoritative"))?;
+    exact("/backend", &json!("mlx"))?;
+    exact("/loadShape", &json!("eager_materialization"))?;
+    exact("/target/provider", &json!(LTX_PROVIDER))?;
+    exact("/target/modelId", &json!(LTX_PROVIDER))?;
+    exact("/target/tier", &json!("q4"))?;
+    exact("/target/mode", &json!("text_to_video"))?;
+    exact("/target/overlay", &json!("none"))?;
+    exact("/target/geometry/width", &json!(LTX_CAMPAIGN_ENTRY_WIDTH))?;
+    exact("/target/geometry/height", &json!(LTX_CAMPAIGN_ENTRY_HEIGHT))?;
+    exact("/target/geometry/batch", &json!(1))?;
+    exact("/target/geometry/frames", &json!(LTX_CAMPAIGN_ENTRY_FRAMES))?;
+    exact("/strategy/rung", &json!("bounded_decode"))?;
+    exact(
+        "/strategy/engagedRungs",
+        &json!(["resident", "staged_residency", "bounded_decode"]),
+    )?;
+    exact(
+        "/strategy/parameters",
+        &json!({
+            "decodeTileEdge": LTX_CANARY_TILE_EDGE,
+            "decodeOverlap": LTX_CANARY_OVERLAP,
+        }),
+    )?;
+    exact(
+        "/calibrationFingerprint",
+        &json!(LTX_CALIBRATION_FINGERPRINT),
+    )?;
+    exact("/fixture", &json!(LTX_BOUNDED_CAMPAIGN_FIXTURE))?;
+    exact("/negative", &json!(false))?;
+    exact("/expectedResult", &json!("passed"))?;
+    exact("/modelLoadPolicy", &json!("fresh_per_case"))?;
+    exact("/modelLoadGroup", &Value::Null)?;
+    exact(
+        "/_watchdog",
+        &json!({ "maxFootprintBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES }),
+    )?;
+    exact(
+        "/_measurementSafety",
+        &json!({
+            "disposition": LTX_SAFETY_REFUSED_OPEN,
+            "tierInventoryBytes": LTX_Q4_INVENTORY_BYTES,
+            "incidentCrashFootprintBytes": LTX_Q4_F305_CRASH_FOOTPRINT_BYTES,
+            "incidentCase": "mlx-ltx-2-3-q4-1280x704-f305-fps30-bounded_decode",
+            "commonLoad": "complete numeric tier plus shared Gemma stack before geometry-specific work",
+            "predictedDecodeBytes": 6_264_848_640_u64,
+            "incidentPredictedDecodeBytes": LTX_INCIDENT_PREDICTED_DECODE_BYTES,
+            "incidentCalibratedProjectionBytes": 84_694_536_320_u64,
+            "projectionAssumptions": [
+                "pinned provider decode cost is the only geometry-varying term used",
+                "immutable tier inventory delta is added byte-for-byte",
+                "incident binding phase is unknown, so the projection is not a physical-footprint bound and cannot admit execution",
+            ],
+            "reason": "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20318 action is admitted",
+        }),
+    )?;
+    exact(
+        "/_boundedCampaignEntry",
+        &json!({
+            "identity": LTX_BOUNDED_CAMPAIGN_IDENTITY,
+            "fps": LTX_CAMPAIGN_ENTRY_FPS,
+            "seed": LTX_SEED,
+            "videoMode": "default_av",
+            "spatialDecodeTiles": 24,
+            "artifact": {
+                "repository": protocol::LTX_REPOSITORY,
+                "revision": LTX_CANARY_ARTIFACT_REVISION,
+                "numericTierInventory": {
+                    "files": LTX_CANARY_Q4_INVENTORY_FILES,
+                    "bytes": LTX_Q4_INVENTORY_BYTES,
+                    "sha256": LTX_CANARY_Q4_INVENTORY_SHA256,
+                },
+                "textEncoderInventory": {
+                    "files": LTX_CANARY_TEXT_ENCODER_INVENTORY_FILES,
+                    "bytes": LTX_CANARY_TEXT_ENCODER_INVENTORY_BYTES,
+                    "sha256": LTX_CANARY_TEXT_ENCODER_INVENTORY_SHA256,
+                },
+            },
+        }),
+    )?;
+    if tier != "q4"
+        || geometry.width != LTX_CAMPAIGN_ENTRY_WIDTH
+        || geometry.height != LTX_CAMPAIGN_ENTRY_HEIGHT
+        || geometry.frames != LTX_CAMPAIGN_ENTRY_FRAMES
+        || selection.strategy != MemoryStrategy::BoundedDecode
+        || selection.parameters.decode_tile_edge != Some(LTX_CANARY_TILE_EDGE)
+        || selection.parameters.decode_overlap != Some(LTX_CANARY_OVERLAP)
+    {
+        return Err("SC-20318 bounded campaign resolved a foreign tuple or strategy".to_owned());
+    }
+    let (fps, seed) = planned_ltx_capture(request, tier, geometry)?;
+    if fps != LTX_CAMPAIGN_ENTRY_FPS || seed != LTX_SEED {
+        return Err("SC-20318 bounded campaign fps or seed changed".to_owned());
+    }
+    let (disposition, _, _) = validate_ltx_safety_evidence(request, tier, geometry, selection)?;
+    if disposition != LTX_SAFETY_REFUSED_OPEN {
+        return Err("SC-20318 ordinary safety disposition changed".to_owned());
     }
     Ok(())
 }
@@ -6733,6 +6879,87 @@ struct LtxLifecycleInput {
     fault_phase: MemoryPhase,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct LtxBoundedWarmMetrics {
+    conditioning: PhaseMemory,
+    denoise: PhaseMemory,
+    decode: PhaseMemory,
+    maximum_error: f64,
+    mean_error: f64,
+    rms_error: f64,
+    audio: DiagnosticAudioIdentity,
+}
+
+/// The SC-20318 quality minimum: one identical-input warm request scope, with its own synchronized
+/// phase memory. Cancellation/error/recovery deliberately do not run on this contained row.
+fn verify_ltx_bounded_warm_repeat(
+    generator: &dyn Generator,
+    context: &MemoryRunContext,
+    selected: &[Image],
+    input: LtxLifecycleInput,
+) -> Result<LtxBoundedWarmMetrics, String> {
+    clear_cache();
+    reset_peak_memory();
+    let conditioning = Cell::new(PhaseMemory {
+        active: 0,
+        cache: 0,
+    });
+    let denoise = Cell::new(PhaseMemory {
+        active: 0,
+        cache: 0,
+    });
+    let (warm, fps, audio) = diagnostic_video_frames(scoped_generate(
+        generator,
+        ltx_request(input.geometry, input.fps, input.seed),
+        context,
+        None,
+        &mut |progress| match progress {
+            Progress::Step { current: 1, .. } => {
+                conditioning.set(PhaseMemory::capture());
+                reset_peak_memory();
+            }
+            Progress::Decoding => {
+                denoise.set(PhaseMemory::capture());
+                reset_peak_memory();
+            }
+            _ => {}
+        },
+    )?)?;
+    let decode = PhaseMemory::capture();
+    let conditioning = conditioning.get();
+    let denoise = denoise.get();
+    if warm.len() != usize::try_from(input.geometry.frames).unwrap_or(usize::MAX)
+        || fps != input.fps
+        || [conditioning.active, denoise.active, decode.active].contains(&0)
+    {
+        return Err("SC-20318 warm repeat changed output or phase shape".to_owned());
+    }
+    let audio = audio
+        .filter(|value| value.samples > 0 && value.sample_rate > 0 && value.channels == 2)
+        .ok_or_else(|| "SC-20318 warm repeat did not return non-empty stereo audio".to_owned())?;
+    let first = warm
+        .first()
+        .ok_or_else(|| "SC-20318 warm repeat returned no frames".to_owned())?;
+    if first.pixels.is_empty() || first.pixels.iter().all(|pixel| *pixel == first.pixels[0]) {
+        return Err("SC-20318 warm repeat returned a degenerate first frame".to_owned());
+    }
+    let (maximum_error, mean_error, rms_error) = video_max_mean_rms_abs(selected, &warm)?;
+    if !ltx_quality_passes(maximum_error, mean_error, rms_error) {
+        return Err(format!(
+            "SC-20318 warm repeat exceeded the LTX determinism envelope: max={maximum_error:.6}, mean={mean_error:.6}, rms={rms_error:.6}"
+        ));
+    }
+    Ok(LtxBoundedWarmMetrics {
+        conditioning,
+        denoise,
+        decode,
+        maximum_error,
+        mean_error,
+        rms_error,
+        audio,
+    })
+}
+
 /// Execute the provider-owned warm/cancel/error request scope on the exact selected rung. One
 /// cancellation and one injected error target the rung's binding phase, and each is followed by a
 /// deterministic recovery render plus allocator bounds against a clean warm control.
@@ -7344,6 +7571,10 @@ fn consume_ltx_canary_watchdog_attestation_stream(
                 LTX_BOUNDED_CARRIER_PHASE_PROFILE,
                 &LTX_BOUNDED_CARRIER_PHASE_NAMES,
             )),
+            Some(LTX_BOUNDED_CAMPAIGN_ACTION) => Some((
+                LTX_BOUNDED_CAMPAIGN_PHASE_PROFILE,
+                &LTX_BOUNDED_CARRIER_PHASE_NAMES,
+            )),
             _ => None,
         };
     let provider_phase_protocol = payload.get("providerPhaseProtocol").and_then(Value::as_str);
@@ -7712,6 +7943,7 @@ fn run_ltx_product_envelope_canary(request: &Value) -> Result<Value, String> {
 enum LtxRunAdmission {
     Ordinary,
     CampaignEntry,
+    BoundedCampaignEntry,
 }
 
 fn run_ltx_with_admission(
@@ -7755,6 +7987,9 @@ fn run_ltx_with_admission(
         }
         LtxRunAdmission::CampaignEntry => {
             validate_ltx_campaign_entry(request, tier, geometry, &selection)?
+        }
+        LtxRunAdmission::BoundedCampaignEntry => {
+            validate_ltx_bounded_campaign_entry(request, tier, geometry, &selection)?
         }
     }
     let (repository, revision, root, text_encoder_root, spec) =
@@ -7806,6 +8041,15 @@ fn run_ltx_with_admission(
     // a deterministic malformed-plan error. This remains before generator load or capture.
     let decode_plan = LtxDecodePlan::resolve_for_selection(&selection, geometry)?;
     decode_plan.validate_selected_strategy(&selection)?;
+    let spatial_decode_tiles = decode_plan.spatial_tile_count(geometry)?;
+    if admission == LtxRunAdmission::BoundedCampaignEntry
+        && (!decode_plan.tiling_engaged()
+            || decode_plan.spatial_tile_px() != u64::from(LTX_CANARY_TILE_EDGE)
+            || decode_plan.spatial_overlap_px() != u64::from(LTX_CANARY_OVERLAP)
+            || spatial_decode_tiles != 24)
+    {
+        return Err("SC-20318 did not resolve the exact 24-tile 192/64 carrier".to_owned());
+    }
     let generator = registry
         .load(LTX_PROVIDER, &spec)
         .map_err(|error| format!("load real LTX-2.3 {tier} provider: {error}"))?;
@@ -7927,6 +8171,9 @@ fn run_ltx_with_admission(
         .ok_or_else(|| {
             "LTX-2.3 full-A/V campaign render returned no non-empty audio track".to_owned()
         })?;
+    if admission == LtxRunAdmission::BoundedCampaignEntry && audio.channels != 2 {
+        return Err("SC-20318 selected render did not return stereo audio".to_owned());
+    }
     let first = measured
         .first()
         .ok_or_else(|| "LTX-2.3 campaign render returned no first frame".to_owned())?;
@@ -7965,18 +8212,44 @@ fn run_ltx_with_admission(
         return Err("LTX-2.3 admission rejected an exact-fit calibrated budget".to_owned());
     }
 
-    let lifecycle = verify_ltx_lifecycle(
-        generator.as_ref(),
-        &context,
-        &measured,
-        LtxLifecycleInput {
-            geometry,
-            fps,
-            seed,
-            fault_phase: decode_plan.lifecycle_fault_phase(),
-        },
-        phase_sink,
-    )?;
+    let lifecycle_input = LtxLifecycleInput {
+        geometry,
+        fps,
+        seed,
+        fault_phase: decode_plan.lifecycle_fault_phase(),
+    };
+    let (lifecycle, bounded_warm) = match admission {
+        LtxRunAdmission::CampaignEntry => (
+            verify_ltx_lifecycle(
+                generator.as_ref(),
+                &context,
+                &measured,
+                lifecycle_input,
+                phase_sink,
+            )?,
+            None,
+        ),
+        LtxRunAdmission::BoundedCampaignEntry => {
+            let warm = verify_ltx_bounded_warm_repeat(
+                generator.as_ref(),
+                &context,
+                &measured,
+                lifecycle_input,
+            )?;
+            (
+                LtxLifecycleMetrics {
+                    maximum_error: warm.maximum_error,
+                    mean_error: warm.mean_error,
+                    rms_error: warm.rms_error,
+                    ..Default::default()
+                },
+                Some(warm),
+            )
+        }
+        LtxRunAdmission::Ordinary => {
+            return Err("ordinary SC-18946 execution escaped its pre-load refusal".to_owned())
+        }
+    };
     let maximum_error = lifecycle.maximum_error;
     let mean_error = lifecycle.mean_error;
     let rms_error = lifecycle.rms_error;
@@ -7992,6 +8265,166 @@ fn run_ltx_with_admission(
         return Err("LTX-2.3 output mutation did not breach the determinism envelope".to_owned());
     }
 
+    let scenarios = if admission == LtxRunAdmission::BoundedCampaignEntry {
+        let blocker = "SC-20318 executes only selected plus warm-repeat parity; cancellation, authorized-error, and recovery renders remain unexecuted";
+        json!([
+            { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": predicted },
+            { "name": "unknown_budget", "result": "passed", "reason": "the loaded provider contract rejected a zero/unknown budget" },
+            { "name": "stale_evidence", "result": "passed", "reason": "the loaded provider contract rejected a mutated calibration fingerprint" },
+            { "name": "warm_repeat", "result": "passed", "reason": "the selected request scope repeated deterministically within the declared clip-wide envelope" },
+            { "name": "cancel", "result": "not_run", "reason": blocker },
+            { "name": "error", "result": "not_run", "reason": blocker },
+            { "name": "loadability", "result": "passed" },
+            { "name": "overlay", "result": "not_applicable", "reason": "settled below from the declared reference-free target" }
+        ])
+    } else {
+        json!([
+            { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": predicted },
+            { "name": "unknown_budget", "result": "passed", "reason": "the loaded provider contract rejected a zero/unknown budget" },
+            { "name": "stale_evidence", "result": "passed", "reason": "the loaded provider contract rejected a mutated calibration fingerprint" },
+            { "name": "warm_repeat", "result": "passed", "reason": "the selected request scope repeated deterministically within the declared clip-wide envelope" },
+            { "name": "cancel", "result": "passed", "reason": "typed cancellation at the selected rung boundary cleaned up and recovered within the clean-warm bounds", "cleanupVerified": true, "warmFollowUpPassed": true },
+            { "name": "error", "result": "passed", "reason": "provider fault injection at the selected rung boundary cleaned up and recovered within the clean-warm bounds", "cleanupVerified": true, "warmFollowUpPassed": true },
+            { "name": "loadability", "result": "passed" },
+            { "name": "overlay", "result": "not_applicable", "reason": "settled below from the declared reference-free target" }
+        ])
+    };
+    let mut diagnostic_measurements = vec![
+        ("preRungActiveAfterClear", "bytes", pre_rung_active),
+        ("preRungCacheAfterClear", "bytes", pre_rung_cache),
+        ("conditioningActivePeak", "bytes", conditioning.active),
+        ("denoiseActivePeak", "bytes", denoise.active),
+        ("decodeActivePeak", "bytes", decode.active),
+        (
+            "overallAllocatorEnvelope",
+            "bytes",
+            overall.allocator_bytes(),
+        ),
+        ("predictedOverallCeiling", "bytes", predicted_peaks.overall),
+        ("denoiseEntryActive", "bytes", denoise_entry.active),
+        ("decodeEntryActive", "bytes", decode_entry.active),
+        ("stagedGemmaBytes", "bytes", gemma_bytes),
+        ("stagedConnectorBytes", "bytes", connector_bytes),
+        ("stagedTextEncoderBytes", "bytes", text_encoder_bytes),
+        ("stagedTransformerBytes", "bytes", transformer_bytes),
+        ("costagedGiantsBytes", "bytes", costaged_bytes),
+        ("tierArtifactBytes", "bytes", tier_bytes),
+        ("renderedFrames", "count", u64::from(geometry.frames)),
+        (
+            "latentTemporalDepth",
+            "count",
+            u64::from(geometry.latent_frames),
+        ),
+        (
+            "latentTokens",
+            "count",
+            u64::from(geometry.latent_frames)
+                * u64::from(geometry.width / 32)
+                * u64::from(geometry.height / 32),
+        ),
+        ("outputFps", "count", u64::from(fps)),
+        ("audioTrackDecoded", "count", 1),
+        (
+            "decodeTilingEngaged",
+            "count",
+            u64::from(decode_plan.tiling_engaged()),
+        ),
+        (
+            "decodeWritableFrameCap",
+            "count",
+            decode_plan.writable_frame_cap.max(0) as u64,
+        ),
+        (
+            "decodeTileSpatialPx",
+            "count",
+            decode_plan.spatial_tile_px(),
+        ),
+        (
+            "decodeTileOverlapPx",
+            "count",
+            decode_plan.spatial_overlap_px(),
+        ),
+        ("spatialDecodeTiles", "count", spatial_decode_tiles),
+        ("mlxMemoryLimitBytes", "bytes", get_memory_limit() as u64),
+        (
+            "negativeMutationMaximumErrorPer255",
+            "count",
+            (mutated_maximum * 255.0).round() as u64,
+        ),
+        (
+            "negativeMutationMeanErrorPer255",
+            "count",
+            (mutated_mean * 255.0).round() as u64,
+        ),
+        (
+            "negativeMutationRootMeanSquareErrorPer255",
+            "count",
+            (mutated_rms * 255.0).round() as u64,
+        ),
+    ];
+    if let Some(warm) = bounded_warm {
+        diagnostic_measurements.extend([
+            (
+                "warmConditioningActivePeak",
+                "bytes",
+                warm.conditioning.active,
+            ),
+            ("warmDenoiseActivePeak", "bytes", warm.denoise.active),
+            ("warmDecodeActivePeak", "bytes", warm.decode.active),
+            ("warmOutputAudioSamples", "count", warm.audio.samples),
+            (
+                "warmOutputAudioSampleRate",
+                "hertz",
+                u64::from(warm.audio.sample_rate),
+            ),
+            (
+                "warmOutputAudioChannels",
+                "count",
+                u64::from(warm.audio.channels),
+            ),
+            ("providerRequestScopeRenders", "count", 2),
+        ]);
+    } else {
+        diagnostic_measurements.extend([
+            ("warmRepeatPeak", "bytes", lifecycle.clean_warm_peak),
+            (
+                "warmRepeatPostCleanupActive",
+                "bytes",
+                lifecycle.clean_post_cleanup.active,
+            ),
+            (
+                "warmRepeatPostCleanupCache",
+                "bytes",
+                lifecycle.clean_post_cleanup.cache,
+            ),
+            (
+                "lifecycleMaxFaultPostCleanupActive",
+                "bytes",
+                lifecycle.max_fault_post_cleanup.active,
+            ),
+            (
+                "lifecycleMaxFaultPostCleanupCache",
+                "bytes",
+                lifecycle.max_fault_post_cleanup.cache,
+            ),
+            (
+                "lifecycleMaxRecoveryPeak",
+                "bytes",
+                lifecycle.max_recovery_peak,
+            ),
+            (
+                "lifecycleMaxRecoveryPostCleanupActive",
+                "bytes",
+                lifecycle.max_recovery_post_cleanup.active,
+            ),
+            (
+                "lifecycleMaxRecoveryPostCleanupCache",
+                "bytes",
+                lifecycle.max_recovery_post_cleanup.cache,
+            ),
+        ]);
+    }
+
     let mut fragment = json!({
         "status": "runtime_complete",
         "strategy": strategy,
@@ -8002,16 +8435,7 @@ fn run_ltx_with_admission(
             "variant": tier,
         },
         "sweep": ltx_complete_sweep(request)?,
-        "scenarios": [
-            { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": predicted },
-            { "name": "unknown_budget", "result": "passed", "reason": "the loaded provider contract rejected a zero/unknown budget" },
-            { "name": "stale_evidence", "result": "passed", "reason": "the loaded provider contract rejected a mutated calibration fingerprint" },
-            { "name": "warm_repeat", "result": "passed", "reason": "the selected request scope repeated deterministically within the declared clip-wide envelope" },
-            { "name": "cancel", "result": "passed", "reason": "typed cancellation at the selected rung boundary cleaned up and recovered within the clean-warm bounds", "cleanupVerified": true, "warmFollowUpPassed": true },
-            { "name": "error", "result": "passed", "reason": "provider fault injection at the selected rung boundary cleaned up and recovered within the clean-warm bounds", "cleanupVerified": true, "warmFollowUpPassed": true },
-            { "name": "loadability", "result": "passed" },
-            { "name": "overlay", "result": "not_applicable", "reason": "settled below from the declared reference-free target" }
-        ],
+        "scenarios": scenarios,
         "predictedPeakBytes": predicted_peaks.json(),
         "observedMemory": {
             "conditioning": conditioning.json(),
@@ -8050,50 +8474,7 @@ fn run_ltx_with_admission(
             "memory-mlx-adapter:ltx-2-3-provider-contract-video",
             "executed",
             [],
-            [
-                ("preRungActiveAfterClear", "bytes", pre_rung_active),
-                ("preRungCacheAfterClear", "bytes", pre_rung_cache),
-                ("conditioningActivePeak", "bytes", conditioning.active),
-                ("denoiseActivePeak", "bytes", denoise.active),
-                ("decodeActivePeak", "bytes", decode.active),
-                ("overallAllocatorEnvelope", "bytes", overall.allocator_bytes()),
-                // Agrees with the emitted predictedPeakBytes.overall by construction:
-                // `predicted_ceiling` is monotonic, so ceiling(max(active)) == max(ceiling(active)).
-                (
-                    "predictedOverallCeiling",
-                    "bytes",
-                    video_predicted_peak_bytes(conditioning, denoise, decode).overall,
-                ),
-                ("denoiseEntryActive", "bytes", denoise_entry.active),
-                ("decodeEntryActive", "bytes", decode_entry.active),
-                ("stagedGemmaBytes", "bytes", gemma_bytes),
-                ("stagedConnectorBytes", "bytes", connector_bytes),
-                ("stagedTextEncoderBytes", "bytes", text_encoder_bytes),
-                ("stagedTransformerBytes", "bytes", transformer_bytes),
-                ("costagedGiantsBytes", "bytes", costaged_bytes),
-                ("tierArtifactBytes", "bytes", tier_bytes),
-                ("warmRepeatPeak", "bytes", lifecycle.clean_warm_peak),
-                ("warmRepeatPostCleanupActive", "bytes", lifecycle.clean_post_cleanup.active),
-                ("warmRepeatPostCleanupCache", "bytes", lifecycle.clean_post_cleanup.cache),
-                ("lifecycleMaxFaultPostCleanupActive", "bytes", lifecycle.max_fault_post_cleanup.active),
-                ("lifecycleMaxFaultPostCleanupCache", "bytes", lifecycle.max_fault_post_cleanup.cache),
-                ("lifecycleMaxRecoveryPeak", "bytes", lifecycle.max_recovery_peak),
-                ("lifecycleMaxRecoveryPostCleanupActive", "bytes", lifecycle.max_recovery_post_cleanup.active),
-                ("lifecycleMaxRecoveryPostCleanupCache", "bytes", lifecycle.max_recovery_post_cleanup.cache),
-                ("renderedFrames", "count", u64::from(geometry.frames)),
-                ("latentTemporalDepth", "count", u64::from(geometry.latent_frames)),
-                ("latentTokens", "count", u64::from(geometry.latent_frames) * u64::from(geometry.width / 32) * u64::from(geometry.height / 32)),
-                ("outputFps", "count", u64::from(fps)),
-                ("audioTrackDecoded", "count", 1),
-                ("decodeTilingEngaged", "count", u64::from(decode_plan.tiling_engaged())),
-                ("decodeWritableFrameCap", "count", decode_plan.writable_frame_cap.max(0) as u64),
-                ("decodeTileSpatialPx", "count", decode_plan.spatial_tile_px()),
-                ("decodeTileOverlapPx", "count", decode_plan.spatial_overlap_px()),
-                ("mlxMemoryLimitBytes", "bytes", get_memory_limit() as u64),
-                ("negativeMutationMaximumErrorPer255", "count", (mutated_maximum * 255.0).round() as u64),
-                ("negativeMutationMeanErrorPer255", "count", (mutated_mean * 255.0).round() as u64),
-                ("negativeMutationRootMeanSquareErrorPer255", "count", (mutated_rms * 255.0).round() as u64),
-            ],
+            diagnostic_measurements,
         ),
         "capturedAt": protocol::captured_at(),
     });
@@ -8112,7 +8493,97 @@ fn campaign_entry_diagnostic(fragment: &Value, name: &str) -> Result<u64, String
         })
         .and_then(|measurement| measurement.get("value"))
         .and_then(Value::as_u64)
-        .ok_or_else(|| format!("SC-20191 campaign entry omitted diagnostic {name}"))
+        .ok_or_else(|| format!("contained LTX campaign omitted diagnostic {name}"))
+}
+
+fn validate_ltx_bounded_campaign_fragment(fragment: &Value) -> Result<(), String> {
+    for (name, expected) in [
+        ("renderedFrames", u64::from(LTX_CAMPAIGN_ENTRY_FRAMES)),
+        ("outputFps", u64::from(LTX_CAMPAIGN_ENTRY_FPS)),
+        ("audioTrackDecoded", 1),
+        ("decodeTilingEngaged", 1),
+        ("decodeTileSpatialPx", u64::from(LTX_CANARY_TILE_EDGE)),
+        ("decodeTileOverlapPx", u64::from(LTX_CANARY_OVERLAP)),
+        ("spatialDecodeTiles", 24),
+        ("latentTemporalDepth", 16),
+        ("latentTokens", 6_144),
+        ("warmOutputAudioChannels", 2),
+        ("providerRequestScopeRenders", 2),
+    ] {
+        let actual = campaign_entry_diagnostic(fragment, name)?;
+        if actual != expected {
+            return Err(format!(
+                "SC-20318 bounded campaign diagnostic {name} must be {expected}, got {actual}"
+            ));
+        }
+    }
+    for name in [
+        "warmConditioningActivePeak",
+        "warmDenoiseActivePeak",
+        "warmDecodeActivePeak",
+        "warmOutputAudioSamples",
+        "warmOutputAudioSampleRate",
+    ] {
+        if campaign_entry_diagnostic(fragment, name)? == 0 {
+            return Err(format!(
+                "SC-20318 bounded campaign diagnostic {name} must be positive"
+            ));
+        }
+    }
+    let scenarios = fragment
+        .get("scenarios")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "SC-20318 bounded campaign omitted scenarios".to_owned())?;
+    let result = |name: &str| {
+        scenarios
+            .iter()
+            .find(|scenario| scenario.get("name").and_then(Value::as_str) == Some(name))
+            .and_then(|scenario| scenario.get("result"))
+            .and_then(Value::as_str)
+    };
+    if fragment.pointer("/strategy/rung").and_then(Value::as_str) != Some("bounded_decode")
+        || fragment.pointer("/strategy/engagedRungs")
+            != Some(&json!(["resident", "staged_residency", "bounded_decode"]))
+        || fragment.pointer("/strategy/parameters")
+            != Some(&json!({
+                "decodeTileEdge": LTX_CANARY_TILE_EDGE,
+                "decodeOverlap": LTX_CANARY_OVERLAP,
+            }))
+        || result("warm_repeat") != Some("passed")
+        || result("cancel") != Some("not_run")
+        || result("error") != Some("not_run")
+        || fragment.pointer("/output/frames").and_then(Value::as_u64)
+            != Some(u64::from(LTX_CAMPAIGN_ENTRY_FRAMES))
+        || fragment.pointer("/output/fps").and_then(Value::as_u64)
+            != Some(u64::from(LTX_CAMPAIGN_ENTRY_FPS))
+        || fragment
+            .pointer("/output/audio/present")
+            .and_then(Value::as_bool)
+            != Some(true)
+        || fragment
+            .pointer("/output/audio/samples")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+            == 0
+        || fragment
+            .pointer("/output/audio/sampleRate")
+            .and_then(Value::as_u64)
+            .unwrap_or(0)
+            == 0
+        || fragment
+            .pointer("/output/audio/channels")
+            .and_then(Value::as_u64)
+            != Some(2)
+        || fragment
+            .pointer("/output/firstFrameNondegenerate")
+            .and_then(Value::as_bool)
+            != Some(true)
+    {
+        return Err(
+            "SC-20318 bounded campaign response changed its exact canonical carrier".to_owned(),
+        );
+    }
+    Ok(())
 }
 
 fn validate_ltx_campaign_entry_fragment(fragment: &Value) -> Result<(), String> {
@@ -8189,6 +8660,24 @@ fn prevalidate_ltx_campaign_entry(request: &Value) -> Result<(), String> {
         return Err("SC-20191 campaign entry calibration fingerprint changed".to_owned());
     }
     validate_ltx_campaign_entry(request, tier, geometry, &selection)
+}
+
+fn prevalidate_ltx_bounded_campaign_entry(request: &Value) -> Result<(), String> {
+    let geometry = validate_ltx_target(request)?;
+    protocol::validate_plain_overlay_target(request, LTX_PLAIN_EXECUTION_PATH)?;
+    if planned_load_shape(request)? != LoadShape::EagerMaterialization {
+        return Err("SC-20318 bounded campaign requires eager materialization".to_owned());
+    }
+    let selection = planned_selection(request)?;
+    let tier = planned_qwen_tier(request)?;
+    let planned_fingerprint = protocol::planned(request)?
+        .get("calibrationFingerprint")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "planned.calibrationFingerprint must be a string".to_owned())?;
+    if planned_fingerprint != LTX_CALIBRATION_FINGERPRINT {
+        return Err("SC-20318 bounded campaign calibration fingerprint changed".to_owned());
+    }
+    validate_ltx_bounded_campaign_entry(request, tier, geometry, &selection)
 }
 
 fn prevalidate_ltx_bounded_carrier_proof(
@@ -8500,6 +8989,64 @@ fn run_ltx_campaign_entry(request: &Value) -> Result<Value, String> {
     Ok(fragment)
 }
 
+fn run_ltx_bounded_campaign_entry(request: &Value) -> Result<Value, String> {
+    prevalidate_ltx_bounded_campaign_entry(request)?;
+    let mut watchdog = consume_ltx_canary_watchdog_attestation(request)?;
+    let mut watchdog_lease = watchdog.start_lease_for(&LTX_BOUNDED_CARRIER_PHASE_NAMES)?;
+    watchdog_lease.mark("common_load")?;
+    let limits = LtxCanaryLimits::install()?;
+    clear_cache();
+    let pre_provider = AllocatorState::capture_current();
+    validate_ltx_canary_pre_provider(pre_provider)?;
+    let expected_persistent_active = ltx_canary_ones_cache_bytes()?;
+    let mut fragment = run_ltx_with_admission(
+        request,
+        LtxRunAdmission::BoundedCampaignEntry,
+        &mut watchdog_lease,
+    )?;
+    validate_ltx_bounded_campaign_fragment(&fragment)?;
+    watchdog_lease.mark("cleanup")?;
+    clear_cache();
+    let post_cleanup = AllocatorState::capture_current();
+    validate_ltx_canary_cleanup(pre_provider, post_cleanup, expected_persistent_active)?;
+    fragment["_boundedCampaignEntry"] = json!({
+        "identity": LTX_BOUNDED_CAMPAIGN_IDENTITY,
+        "inferenceRevision": protocol::INFERENCE_PIN,
+        "watchdog": {
+            "required": true,
+            "protocol": LTX_CANARY_WATCHDOG_PROTOCOL,
+            "providerPhaseProtocol": LTX_PROVIDER_PHASE_PROTOCOL,
+            "providerPhaseProfile": LTX_BOUNDED_CAMPAIGN_PHASE_PROFILE,
+            "providerPhases": LTX_BOUNDED_CARRIER_PHASE_NAMES,
+            "maxFootprintBytes": watchdog.max_footprint_bytes,
+            "maxRuntimeSeconds": watchdog.max_runtime_seconds,
+            "hostMemoryBytes": watchdog.host_memory_bytes,
+            "minInitialMemoryFreeBytes": watchdog.min_initial_memory_free_bytes,
+            "minMemoryFreeBytes": watchdog.min_memory_free_bytes,
+        },
+        "mlxLimits": {
+            "memoryLimitBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES,
+            "wiredLimitBytes": limits.wired,
+        },
+        "cleanup": {
+            "preProviderActiveBytes": pre_provider.active,
+            "preProviderCacheBytes": pre_provider.cache,
+            "expectedPersistentActive": {
+                "identity": LTX_CANARY_ONES_CACHE_IDENTITY,
+                "videoDimension": LTX_CANARY_ONES_CACHE_VIDEO_DIMENSION,
+                "audioDimension": LTX_CANARY_ONES_CACHE_AUDIO_DIMENSION,
+                "dtype": "bfloat16",
+                "bytesPerElement": BFLOAT16_BYTES_PER_ELEMENT,
+                "bytes": expected_persistent_active,
+            },
+            "postCleanupActiveBytes": post_cleanup.active,
+            "postCleanupCacheBytes": post_cleanup.cache,
+        },
+    });
+    watchdog_lease.complete()?;
+    Ok(fragment)
+}
+
 fn run_ltx(request: &Value) -> Result<Value, String> {
     let mut phases = NoLtxCampaignPhases;
     run_ltx_with_admission(request, LtxRunAdmission::Ordinary, &mut phases)
@@ -8542,6 +9089,7 @@ fn main() {
         "product_envelope_canary" => run_ltx_product_envelope_canary(&request),
         LTX_CAMPAIGN_ENTRY_ACTION => run_ltx_campaign_entry(&request),
         LTX_BOUNDED_CARRIER_ACTION => run_ltx_bounded_carrier_proof(&request),
+        LTX_BOUNDED_CAMPAIGN_ACTION => run_ltx_bounded_campaign_entry(&request),
         "assess_batch" => assess_z_image_batch(&request),
         other => Err(format!("unsupported action {other:?}")),
     }
@@ -9819,6 +10367,125 @@ mod ltx_tests {
         request
     }
 
+    fn ltx_bounded_campaign_request_json() -> Value {
+        let mut request = ltx_bounded_carrier_request_json();
+        request["action"] = json!(LTX_BOUNDED_CAMPAIGN_ACTION);
+        request["planned"]
+            .as_object_mut()
+            .unwrap()
+            .remove("_diagnosticOnly");
+        request["planned"]["logicalCaseId"] = json!(LTX_BOUNDED_CAMPAIGN_LOGICAL_CASE_ID);
+        request["planned"]["evidenceScope"] = json!("authoritative");
+        request["planned"]["fixture"] = json!(LTX_BOUNDED_CAMPAIGN_FIXTURE);
+        let carrier = request["planned"]
+            .as_object_mut()
+            .unwrap()
+            .remove("_boundedCarrier")
+            .unwrap();
+        request["planned"]["_boundedCampaignEntry"] = json!({
+            "identity": LTX_BOUNDED_CAMPAIGN_IDENTITY,
+            "fps": LTX_CAMPAIGN_ENTRY_FPS,
+            "seed": LTX_SEED,
+            "videoMode": "default_av",
+            "spatialDecodeTiles": 24,
+            "artifact": carrier["artifact"],
+        });
+        request["planned"]["_measurementSafety"] = json!({
+            "disposition": LTX_SAFETY_REFUSED_OPEN,
+            "tierInventoryBytes": LTX_Q4_INVENTORY_BYTES,
+            "incidentCrashFootprintBytes": LTX_Q4_F305_CRASH_FOOTPRINT_BYTES,
+            "incidentCase": "mlx-ltx-2-3-q4-1280x704-f305-fps30-bounded_decode",
+            "commonLoad": "complete numeric tier plus shared Gemma stack before geometry-specific work",
+            "predictedDecodeBytes": 6_264_848_640_u64,
+            "incidentPredictedDecodeBytes": LTX_INCIDENT_PREDICTED_DECODE_BYTES,
+            "incidentCalibratedProjectionBytes": 84_694_536_320_u64,
+            "projectionAssumptions": [
+                "pinned provider decode cost is the only geometry-varying term used",
+                "immutable tier inventory delta is added byte-for-byte",
+                "incident binding phase is unknown, so the projection is not a physical-footprint bound and cannot admit execution",
+            ],
+            "reason": "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20318 action is admitted",
+        });
+        request
+    }
+
+    #[test]
+    fn sc_20318_admits_only_the_exact_two_render_bounded_campaign_row() {
+        let request = ltx_bounded_campaign_request_json();
+        prevalidate_ltx_bounded_campaign_entry(&request)
+            .expect("the exact new bounded campaign row is admissible");
+        let geometry = LtxGeometry {
+            width: LTX_CAMPAIGN_ENTRY_WIDTH,
+            height: LTX_CAMPAIGN_ENTRY_HEIGHT,
+            frames: LTX_CAMPAIGN_ENTRY_FRAMES,
+            latent_frames: 1 + (LTX_CAMPAIGN_ENTRY_FRAMES - 1) / LTX_TEMPORAL_SCALE,
+        };
+        let generation_request = ltx_request(geometry, LTX_CAMPAIGN_ENTRY_FPS, LTX_SEED);
+        validate_ltx_bounded_carrier_generation_request(&generation_request)
+            .expect("both SC-20318 renders use the exact default-A/V request");
+        for mutate in [
+            |value: &mut GenerationRequest| value.seed = Some(LTX_SEED + 1),
+            |value: &mut GenerationRequest| value.fps = Some(LTX_CAMPAIGN_ENTRY_FPS - 1),
+            |value: &mut GenerationRequest| value.video_mode = Some("no_audio".to_owned()),
+        ] {
+            let mut changed = generation_request.clone();
+            mutate(&mut changed);
+            assert!(validate_ltx_bounded_carrier_generation_request(&changed).is_err());
+        }
+        for (pointer, value) in [
+            ("/action", json!("run")),
+            (
+                "/planned/logicalCaseId",
+                json!(LTX_BOUNDED_CARRIER_LOGICAL_CASE_ID),
+            ),
+            ("/planned/fixture", json!(LTX_BOUNDED_CARRIER_FIXTURE)),
+            ("/planned/target/tier", json!("q8")),
+            ("/planned/strategy/parameters/decodeTileEdge", json!(193)),
+            ("/planned/strategy/parameters/decodeOverlap", json!(63)),
+            ("/planned/_boundedCampaignEntry/identity", json!("mutated")),
+            ("/planned/_boundedCampaignEntry/seed", json!(LTX_SEED + 1)),
+            (
+                "/planned/_boundedCampaignEntry/videoMode",
+                json!("no_audio"),
+            ),
+            (
+                "/planned/_boundedCampaignEntry/spatialDecodeTiles",
+                json!(23),
+            ),
+            (
+                "/planned/_measurementSafety/predictedDecodeBytes",
+                json!(6_264_848_639_u64),
+            ),
+            ("/planned/_measurementSafety/incidentCase", json!("mutated")),
+            ("/planned/_measurementSafety/reason", json!("mutated")),
+        ] {
+            let mut mutated = request.clone();
+            *mutated.pointer_mut(pointer).expect("mutation pointer") = value;
+            let error = prevalidate_ltx_bounded_campaign_entry(&mutated)
+                .expect_err("every SC-20318 identity mutation must fail before weights");
+            assert!(
+                error.contains("SC-20318") || error.contains("SC-18946"),
+                "{pointer}: {error}"
+            );
+        }
+        let direct = run_ltx_bounded_campaign_entry(&request)
+            .expect_err("private JSON alone cannot bypass the live watchdog");
+        assert!(
+            direct.contains("live external watchdog channel"),
+            "{direct}"
+        );
+
+        let mut ordinary = request.clone();
+        ordinary["action"] = json!("run");
+        ordinary["planned"]
+            .as_object_mut()
+            .unwrap()
+            .remove("_boundedCampaignEntry");
+        let refusal = run_ltx(&ordinary)
+            .expect_err("the new row must remain refused by the ordinary campaign action");
+        assert!(refusal.contains("safety_refused_open"), "{refusal}");
+    }
+
     #[test]
     fn sc_20254_admits_only_the_exact_single_render_bounded_carrier() {
         let request = ltx_bounded_carrier_request_json();
@@ -10075,9 +10742,10 @@ mod ltx_tests {
         });
         let (mut watchdog, adapter) = UnixStream::pair().unwrap();
         let peer_nonce = nonce.clone();
+        let peer_payload = payload.clone();
         let peer = std::thread::spawn(move || {
             watchdog
-                .write_all(format!("{payload}\n").as_bytes())
+                .write_all(format!("{peer_payload}\n").as_bytes())
                 .unwrap();
             assert_eq!(
                 read_watchdog_line(&mut watchdog).unwrap(),
@@ -10154,6 +10822,98 @@ mod ltx_tests {
             });
             let error = consume_ltx_canary_watchdog_attestation_stream(&request, bad_adapter)
                 .expect_err("profile, list and order mutations must fail closed");
+            bad_peer.join().unwrap();
+            assert!(
+                error.contains("action-bound authenticated provider phase contract"),
+                "{error}"
+            );
+        }
+    }
+
+    #[test]
+    fn sc_20318_phase_attestation_is_action_bound_to_its_exact_five_phases() {
+        let request = ltx_bounded_campaign_request_json();
+        let host_memory = request["hardware"]["memoryBytes"].as_u64().unwrap();
+        let nonce = "ab".repeat(32);
+        let payload = json!({
+            "protocol": LTX_CANARY_WATCHDOG_PROTOCOL,
+            "nonce": nonce,
+            "maxFootprintBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES,
+            "maxRuntimeSeconds": LTX_CANARY_MAX_RUNTIME_SECONDS,
+            "hostMemoryBytes": host_memory,
+            "minInitialMemoryFreeBytes": 2 * LTX_CANARY_MAX_FOOTPRINT_BYTES + host_memory.div_ceil(100),
+            "minMemoryFreeBytes": LTX_CANARY_MAX_FOOTPRINT_BYTES + host_memory.div_ceil(100),
+            "providerPhaseProtocol": LTX_PROVIDER_PHASE_PROTOCOL,
+            "providerPhaseProfile": LTX_BOUNDED_CAMPAIGN_PHASE_PROFILE,
+            "providerPhases": LTX_BOUNDED_CARRIER_PHASE_NAMES,
+        });
+        let (mut watchdog, adapter) = UnixStream::pair().unwrap();
+        let peer_nonce = nonce.clone();
+        let peer_payload = payload.clone();
+        let peer = std::thread::spawn(move || {
+            watchdog
+                .write_all(format!("{peer_payload}\n").as_bytes())
+                .unwrap();
+            assert_eq!(
+                read_watchdog_line(&mut watchdog).unwrap(),
+                format!("ACK {peer_nonce}")
+            );
+            watchdog
+                .write_all(format!("GO {peer_nonce}\n").as_bytes())
+                .unwrap();
+            for (index, name) in LTX_BOUNDED_CARRIER_PHASE_NAMES.iter().enumerate() {
+                assert_eq!(
+                    read_watchdog_line(&mut watchdog).unwrap(),
+                    format!("PHASE {peer_nonce} {} {name}", index + 1)
+                );
+                watchdog
+                    .write_all(format!("PHASE_ACK {peer_nonce} {} {name}\n", index + 1).as_bytes())
+                    .unwrap();
+            }
+            assert_eq!(
+                read_watchdog_line(&mut watchdog).unwrap(),
+                format!("DONE {peer_nonce}")
+            );
+            watchdog
+                .write_all(format!("BYE {peer_nonce}\n").as_bytes())
+                .unwrap();
+        });
+        let mut attestation =
+            consume_ltx_canary_watchdog_attestation_stream(&request, adapter).unwrap();
+        let mut lease = attestation
+            .start_lease_for(&LTX_BOUNDED_CARRIER_PHASE_NAMES)
+            .unwrap();
+        for name in LTX_BOUNDED_CARRIER_PHASE_NAMES {
+            lease.mark(name).unwrap();
+        }
+        lease.complete().unwrap();
+        peer.join().unwrap();
+
+        for mutate in [
+            |value: &mut Value| {
+                value["providerPhaseProfile"] = json!(LTX_BOUNDED_CARRIER_PHASE_PROFILE)
+            },
+            |value: &mut Value| value["providerPhases"] = json!(LTX_PROVIDER_PHASE_NAMES),
+            |value: &mut Value| {
+                value["providerPhases"] = json!([
+                    "primary_conditioning",
+                    "common_load",
+                    "primary_denoise",
+                    "primary_decode",
+                    "cleanup"
+                ])
+            },
+        ] {
+            let mut changed = payload.clone();
+            mutate(&mut changed);
+            let (mut bad_watchdog, bad_adapter) = UnixStream::pair().unwrap();
+            let bad_peer = std::thread::spawn(move || {
+                bad_watchdog
+                    .write_all(format!("{changed}\n").as_bytes())
+                    .unwrap();
+            });
+            let error = consume_ltx_canary_watchdog_attestation_stream(&request, bad_adapter)
+                .expect_err("SC-20318 phase profile/list/order mutations must fail");
             bad_peer.join().unwrap();
             assert!(
                 error.contains("action-bound authenticated provider phase contract"),

--- a/docs/calibration/sc-18946/ltx-mlx-rung2-sweep.json
+++ b/docs/calibration/sc-18946/ltx-mlx-rung2-sweep.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "SC-18946 rung-2-first matrix. Every q4/q8/bf16 row explicitly selects decodeTileEdge=384 and decodeOverlap=64 at 1280x704 f305/f449. These records are ingested as canonical evidence but never pooled into the single-pass temporal fit.",
+  "_comment": "SC-18946 rung-2-first matrix. The original q4/q8/bf16 rows retain the 384/64 carrier at 1280x704 f305/f449. One separately identified q4 768x512 f121 row uses the SC-20254-proven 192/64, 24-tile carrier and is the only privately admitted campaign entry. These records are never pooled into the single-pass temporal fit.",
   "story": "sc-18946",
   "campaignIdentity": {
     "inferenceRevision": "6f3a84ef4ad4f858c6fe199e14925a01a7943f97",
@@ -366,6 +366,66 @@
       ],
       "_predictedDecodeBytes": 23730848000,
       "_predictedDecodeFormula": "3.3e9 + 40*(width*height*frames) + 300*(384*384*96) bytes"
+    },
+    {
+      "name": "mlx-ltx-2-3-q4-768x512-f121-fps30-bounded_decode-192x64",
+      "_role": "bounded_carrier_entry",
+      "_campaignPhase": "bounded_carrier_ratification",
+      "_coverageExpectation": "captured_or_attempted",
+      "_latentTokens": 6144,
+      "_writableFrameCap": 682,
+      "_outputVoxels": 47579136,
+      "_measurementSafety": {
+        "disposition": "safety_refused_open",
+        "tierInventoryBytes": 20467690460,
+        "incidentCrashFootprintBytes": 96970084480,
+        "incidentCase": "mlx-ltx-2-3-q4-1280x704-f305-fps30-bounded_decode",
+        "commonLoad": "complete numeric tier plus shared Gemma stack before geometry-specific work",
+        "predictedDecodeBytes": 6264848640,
+        "incidentPredictedDecodeBytes": 18540396800,
+        "incidentCalibratedProjectionBytes": 84694536320,
+        "projectionAssumptions": [
+          "pinned provider decode cost is the only geometry-varying term used",
+          "immutable tier inventory delta is added byte-for-byte",
+          "incident binding phase is unknown, so the projection is not a physical-footprint bound and cannot admit execution"
+        ],
+        "reason": "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20318 action is admitted"
+      },
+      "evidenceScope": "authoritative",
+      "backend": "mlx",
+      "loadShape": "eager_materialization",
+      "target": {
+        "provider": "ltx_2_3",
+        "modelId": "ltx_2_3",
+        "tier": "q4",
+        "mode": "text_to_video",
+        "overlay": "none",
+        "geometry": {
+          "width": 768,
+          "height": 512,
+          "batch": 1,
+          "frames": 121
+        }
+      },
+      "rung": "bounded_decode",
+      "engagedRungs": [
+        "resident",
+        "staged_residency",
+        "bounded_decode"
+      ],
+      "calibrationFingerprint": "sc-19109-ltx-2-3-mlx-memory-ladder-v1",
+      "fixture": "ltx-2-3-mlx-q4-768x512-f121-fps30-bounded-decode-192-64-seed18946",
+      "cases": [
+        {
+          "parameters": {
+            "decodeTileEdge": 192,
+            "decodeOverlap": 64
+          },
+          "expectedResult": "passed"
+        }
+      ],
+      "_predictedDecodeBytes": 6264848640,
+      "_predictedDecodeFormula": "3.3e9 + 40*(width*height*frames) + 300*(192*192*96) bytes"
     }
   ]
 }

--- a/packages/schemas/memory-calibration.schema.json
+++ b/packages/schemas/memory-calibration.schema.json
@@ -662,6 +662,13 @@
                       {
                         "allOf": [
                           { "contains": { "properties": { "name": { "const": "warm_repeat" }, "result": { "const": "passed" } }, "required": ["name", "result", "reason"] } },
+                          { "contains": { "properties": { "name": { "const": "cancel" }, "result": { "const": "not_run" } }, "required": ["name", "result", "reason"] } },
+                          { "contains": { "properties": { "name": { "const": "error" }, "result": { "const": "not_run" } }, "required": ["name", "result", "reason"] } }
+                        ]
+                      },
+                      {
+                        "allOf": [
+                          { "contains": { "properties": { "name": { "const": "warm_repeat" }, "result": { "const": "passed" } }, "required": ["name", "result", "reason"] } },
                           { "contains": { "properties": { "name": { "const": "cancel" }, "result": { "const": "passed" }, "cleanupVerified": { "const": true }, "warmFollowUpPassed": { "const": true } }, "required": ["name", "result", "reason", "cleanupVerified", "warmFollowUpPassed"] } },
                           { "contains": { "properties": { "name": { "const": "error" }, "result": { "const": "passed" }, "cleanupVerified": { "const": true }, "warmFollowUpPassed": { "const": true } }, "required": ["name", "result", "reason", "cleanupVerified", "warmFollowUpPassed"] } }
                         ]

--- a/scripts/generate-ltx-sc18946-plan.mjs
+++ b/scripts/generate-ltx-sc18946-plan.mjs
@@ -18,6 +18,11 @@ export const SEED = 18946;
 // at a time, but the checked-in plan must preserve that reviewed operator order too.
 export const TIERS = Object.freeze(["q4", "q8", "bf16"]);
 export const RUNG2_PARAMETERS = Object.freeze({ decodeTileEdge: 384, decodeOverlap: 64 });
+export const RATIFIED_BOUNDED_PARAMETERS = Object.freeze({ decodeTileEdge: 192, decodeOverlap: 64 });
+export const RATIFIED_BOUNDED_PROVIDER =
+  "mlx-ltx-2-3-q4-768x512-f121-fps30-bounded_decode-192x64";
+export const RATIFIED_BOUNDED_FIXTURE =
+  "ltx-2-3-mlx-q4-768x512-f121-fps30-bounded-decode-192-64-seed18946";
 // SC-19642: these are immutable bytes from the exact tier inventories prepared for this campaign.
 // The q4 f305 process later reached the incident footprint below and starved watchdogd. Every row
 // loads its complete tier plus the same Gemma stack before geometry-specific work, so a smaller
@@ -155,6 +160,57 @@ function providerRow(tier, [width, height, frames, fps, role, campaignPhase], ru
   return row;
 }
 
+function ratifiedBoundedRow() {
+  const width = 768;
+  const height = 512;
+  const frames = 121;
+  const outputVoxels = width * height * frames;
+  return {
+    name: RATIFIED_BOUNDED_PROVIDER,
+    _role: "bounded_carrier_entry",
+    _campaignPhase: "bounded_carrier_ratification",
+    _coverageExpectation: "captured_or_attempted",
+    _latentTokens: 6_144,
+    _writableFrameCap: writableFrameCap(width, height),
+    _outputVoxels: outputVoxels,
+    _measurementSafety: {
+      disposition: SAFETY_DISPOSITIONS.SAFETY_REFUSED_OPEN,
+      tierInventoryBytes: TIER_INVENTORY_BYTES.q4,
+      incidentCrashFootprintBytes: Q4_F305_CRASH_FOOTPRINT_BYTES,
+      incidentCase: "mlx-ltx-2-3-q4-1280x704-f305-fps30-bounded_decode",
+      commonLoad: "complete numeric tier plus shared Gemma stack before geometry-specific work",
+      predictedDecodeBytes: 6_264_848_640,
+      incidentPredictedDecodeBytes: INCIDENT_PREDICTED_DECODE_BYTES,
+      incidentCalibratedProjectionBytes: 84_694_536_320,
+      projectionAssumptions: [
+        "pinned provider decode cost is the only geometry-varying term used",
+        "immutable tier inventory delta is added byte-for-byte",
+        "incident binding phase is unknown, so the projection is not a physical-footprint bound and cannot admit execution",
+      ],
+      reason: "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20318 action is admitted",
+    },
+    evidenceScope: "authoritative",
+    backend: "mlx",
+    loadShape: "eager_materialization",
+    target: {
+      provider: PROVIDER,
+      modelId: PROVIDER,
+      tier: "q4",
+      mode: "text_to_video",
+      overlay: "none",
+      geometry: { width, height, batch: 1, frames },
+    },
+    rung: "bounded_decode",
+    engagedRungs: ["resident", "staged_residency", "bounded_decode"],
+    calibrationFingerprint: FINGERPRINT,
+    fixture: RATIFIED_BOUNDED_FIXTURE,
+    cases: [{ parameters: RATIFIED_BOUNDED_PARAMETERS, expectedResult: "passed" }],
+    _predictedDecodeBytes: 6_264_848_640,
+    _predictedDecodeFormula:
+      "3.3e9 + 40*(width*height*frames) + 300*(192*192*96) bytes",
+  };
+}
+
 function plan(comment, rows, rung, { rowMajor = false } = {}) {
   return {
     _comment: comment,
@@ -170,6 +226,16 @@ function plan(comment, rows, rung, { rowMajor = false } = {}) {
   };
 }
 
+function rung2Plan() {
+  const frozen = plan(
+    "SC-18946 rung-2-first matrix. The original q4/q8/bf16 rows retain the 384/64 carrier at 1280x704 f305/f449. One separately identified q4 768x512 f121 row uses the SC-20254-proven 192/64, 24-tile carrier and is the only privately admitted campaign entry. These records are never pooled into the single-pass temporal fit.",
+    rung2Rows,
+    "bounded_decode",
+    { rowMajor: true },
+  );
+  return { ...frozen, providers: [...frozen.providers, ratifiedBoundedRow()] };
+}
+
 export function buildPlans() {
   return {
     "ltx-mlx-single-pass-sweep.json": plan(
@@ -177,12 +243,7 @@ export function buildPlans() {
       singlePassRows,
       "staged_residency",
     ),
-    "ltx-mlx-rung2-sweep.json": plan(
-      "SC-18946 rung-2-first matrix. Every q4/q8/bf16 row explicitly selects decodeTileEdge=384 and decodeOverlap=64 at 1280x704 f305/f449. These records are ingested as canonical evidence but never pooled into the single-pass temporal fit.",
-      rung2Rows,
-      "bounded_decode",
-      { rowMajor: true },
-    ),
+    "ltx-mlx-rung2-sweep.json": rung2Plan(),
     "ltx-mlx-host-risk-probes.json": {
       ...plan(
         "SC-18946 predeclared single-pass host-risk probes. Their coverage state must distinguish captured, attempted/aborted, arithmetic-unmeasurable, and never planned. This unscored bundle is not a curve source.",

--- a/scripts/generate-ltx-sc18946-plan.test.mjs
+++ b/scripts/generate-ltx-sc18946-plan.test.mjs
@@ -10,6 +10,9 @@ import {
   INFERENCE_REVISION,
   INCIDENT_PREDICTED_DECODE_BYTES,
   Q4_F305_CRASH_FOOTPRINT_BYTES,
+  RATIFIED_BOUNDED_FIXTURE,
+  RATIFIED_BOUNDED_PARAMETERS,
+  RATIFIED_BOUNDED_PROVIDER,
   RUNG2_PARAMETERS,
   SAFETY_DISPOSITIONS,
   SEED,
@@ -78,7 +81,7 @@ test("every campaign identity and derived geometry fact is exact and collision-f
       `${row.name} latent tokens`,
     );
     assert.equal(row._writableFrameCap, Math.floor(2_147_483_647 / (8 * width * height)));
-    assert.match(row.fixture, new RegExp(`-${row.target.tier}-${width}x${height}-f${frames}-fps\\d+-seed${SEED}$`));
+    assert.match(row.fixture, new RegExp(`-${row.target.tier}-${width}x${height}-f${frames}-fps\\d+(?:-bounded-decode-192-64)?-seed${SEED}$`));
     assert.equal(row.calibrationFingerprint, FINGERPRINT);
     assert.equal(row.cases.length, 1);
     assert.equal(row.cases[0].expectedResult, "passed");
@@ -99,27 +102,42 @@ test("the flip bands, deep anchors, original six and held-out transfer cells are
   ]) assert.ok(cells.has(cell), cell);
 });
 
-test("rung two is q4 q8 bf16 by f305 f449 with the exact 384 by 64 carrier", () => {
+test("rung two preserves the six 384 by 64 rows and appends one exact ratified carrier", () => {
   const rows = plans["ltx-mlx-rung2-sweep.json"].providers;
-  assert.equal(rows.length, 6);
+  assert.equal(rows.length, 7);
+  const frozen = rows.slice(0, 6);
+  const [ratified] = rows.slice(6);
   assert.deepEqual(TIERS, ["q4", "q8", "bf16"]);
   assert.deepEqual(
-    rows.map((row) => `${row.target.geometry.frames}:${row.target.tier}`),
+    frozen.map((row) => `${row.target.geometry.frames}:${row.target.tier}`),
     ["305:q4", "305:q8", "305:bf16", "449:q4", "449:q8", "449:bf16"],
     "the checked-in matrix preserves the reviewed serialized launch order",
   );
-  assert.deepEqual(new Set(rows.map((row) => row.target.tier)), new Set(TIERS));
-  assert.deepEqual(new Set(rows.map((row) => row.target.geometry.frames)), new Set([305, 449]));
-  for (const row of rows) {
+  assert.deepEqual(new Set(frozen.map((row) => row.target.tier)), new Set(TIERS));
+  assert.deepEqual(new Set(frozen.map((row) => row.target.geometry.frames)), new Set([305, 449]));
+  for (const row of frozen) {
     assert.equal(row.rung, "bounded_decode");
     assert.deepEqual(row.engagedRungs, ["resident", "staged_residency", "bounded_decode"]);
     assert.deepEqual(row.cases, [{ parameters: RUNG2_PARAMETERS, expectedResult: "passed" }]);
     assert.equal(row.calibrationFingerprint, FINGERPRINT);
     assert.match(row.fixture, new RegExp(`seed${SEED}$`));
   }
-  const predicted = Object.fromEntries(rows.filter((row) => row.target.tier === "q8").map((row) => [row.target.geometry.frames, row._predictedDecodeBytes]));
+  const predicted = Object.fromEntries(frozen.filter((row) => row.target.tier === "q8").map((row) => [row.target.geometry.frames, row._predictedDecodeBytes]));
   assert.equal(predicted[305], 18_540_396_800);
   assert.equal(predicted[449], 23_730_848_000);
+  assert.equal(ratified.name, RATIFIED_BOUNDED_PROVIDER);
+  assert.equal(ratified.fixture, RATIFIED_BOUNDED_FIXTURE);
+  assert.equal(ratified._role, "bounded_carrier_entry");
+  assert.equal(ratified._campaignPhase, "bounded_carrier_ratification");
+  assert.deepEqual(ratified.target.geometry, {
+    width: 768, height: 512, batch: 1, frames: 121,
+  });
+  assert.deepEqual(ratified.cases, [{
+    parameters: RATIFIED_BOUNDED_PARAMETERS, expectedResult: "passed",
+  }]);
+  assert.equal(ratified._measurementSafety.disposition, SAFETY_DISPOSITIONS.SAFETY_REFUSED_OPEN);
+  assert.equal(ratified._measurementSafety.predictedDecodeBytes, 6_264_848_640);
+  assert.equal(ratified._measurementSafety.incidentCalibratedProjectionBytes, 84_694_536_320);
 });
 
 test("host-risk coverage is explicitly planned rather than absent", () => {
@@ -141,6 +159,7 @@ test("host-risk coverage is explicitly planned rather than absent", () => {
 
 test("SC-19642 classifies every row for pre-load refusal without inventing a safe host fraction", () => {
   const rows = Object.values(plans).flatMap((plan) => plan.providers);
+  assert.equal(rows.length, 71);
   assert.equal(Q4_F305_CRASH_FOOTPRINT_BYTES, 96_970_084_480);
   assert.deepEqual(TIER_INVENTORY_BYTES, {
     q4: 20_467_690_460,

--- a/scripts/memory-calibration-harness.mjs
+++ b/scripts/memory-calibration-harness.mjs
@@ -651,11 +651,13 @@ function validateRuntimeComplete(record) {
   }
   const lifecycle = ["warm_repeat", "cancel", "error"].map((name) => scenarios.get(name));
   const lifecycleNotRun = lifecycle.every((scenario) => scenario?.result === "not_run");
+  const parityOnlyLifecycle = lifecycle[0]?.result === "passed"
+    && lifecycle.slice(1).every((scenario) => scenario?.result === "not_run");
   const lifecyclePassed = lifecycle.every((scenario) => scenario?.result === "passed")
     && lifecycle.slice(1).every((scenario) =>
       scenario.cleanupVerified === true && scenario.warmFollowUpPassed === true);
-  if (!lifecycleNotRun && !lifecyclePassed) {
-    fail(`${record.id}: runtime lifecycle must be entirely not_run or fully passed with cleanup and recovery`);
+  if (!lifecycleNotRun && !parityOnlyLifecycle && !lifecyclePassed) {
+    fail(`${record.id}: runtime lifecycle must be entirely not_run, parity-only, or fully passed with cleanup and recovery`);
   }
   for (const [index, name] of ["warm_repeat", "cancel", "error"].entries()) {
     text(lifecycle[index].reason, `${record.id}.${name}.reason`);

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -2028,8 +2028,12 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
     "the campaign must still refuse before model-path/provider/weights access",
   );
   const campaignRows = Object.values(buildLtxPlans()).flatMap((plan) => plan.providers);
-  assert.equal(campaignRows.length, 70, "the frozen SC-18946 campaign must retain all 70 rows");
-  for (const row of campaignRows) {
+  assert.equal(campaignRows.length, 71, "SC-20318 must explicitly inventory 71 rows");
+  const ratified = campaignRows.filter((row) => row._role === "bounded_carrier_entry");
+  assert.equal(ratified.length, 1, "only one bounded carrier may be ratified");
+  const originalRows = campaignRows.filter((row) => row._role !== "bounded_carrier_entry");
+  assert.equal(originalRows.length, 70, "all original campaign rows must remain present");
+  for (const row of originalRows) {
     assert.ok(
       ["incident_forbidden", "arithmetic_unmeasurable", "safety_refused_open"]
         .includes(row._measurementSafety.disposition),
@@ -2096,6 +2100,22 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
   assert.equal((boundedCarrier.match(/scoped_generate\(/g) ?? []).length, 1,
     "SC-20254 must contain exactly one full-A/V render call");
   assert.match(adapter, /LTX_BOUNDED_CARRIER_ACTION => run_ltx_bounded_carrier_proof\(&request\)/);
+  const boundedCampaign = adapter.slice(
+    adapter.indexOf("fn run_ltx_bounded_campaign_entry("),
+    adapter.indexOf("fn run_ltx(request:"),
+  );
+  for (const required of [
+    "prevalidate_ltx_bounded_campaign_entry(request)?",
+    "start_lease_for(&LTX_BOUNDED_CARRIER_PHASE_NAMES)?",
+    "LtxRunAdmission::BoundedCampaignEntry",
+    "validate_ltx_bounded_campaign_fragment(&fragment)?",
+    "validate_ltx_canary_cleanup(",
+    '"_boundedCampaignEntry"',
+    'watchdog_lease.mark("common_load")?',
+    'watchdog_lease.mark("cleanup")?',
+  ]) assert.ok(boundedCampaign.includes(required), `bounded campaign must retain ${required}`);
+  assert.match(adapter,
+    /LTX_BOUNDED_CAMPAIGN_ACTION => run_ltx_bounded_campaign_entry\(&request\)/);
 
   const canary = adapter.slice(
     adapter.indexOf("fn validate_ltx_canary_plan_for("),

--- a/scripts/run-ltx-safety-canary.mjs
+++ b/scripts/run-ltx-safety-canary.mjs
@@ -20,6 +20,7 @@ import {
 
 const execFileAsync = promisify(execFile);
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const CONTAINED_CAMPAIGN_ROOT = "/Volumes/Data/sceneworks-safety-canary";
 export const MAX_FOOTPRINT_BYTES = 53_347_146_863;
 export const MAX_RUNTIME_SECONDS = 1_800;
 export const CHILD_ATTESTATION_TIMEOUT_SECONDS = 30;
@@ -38,6 +39,7 @@ export const SAFETY_CANARY_PROFILE = "safety";
 export const PRODUCT_ENVELOPE_CANARY_PROFILE = "product-envelope";
 export const CAMPAIGN_ENTRY_PROFILE = "campaign-entry";
 export const BOUNDED_CARRIER_PROFILE = "bounded-carrier";
+export const BOUNDED_CAMPAIGN_ENTRY_PROFILE = "bounded-campaign-entry";
 export const CAMPAIGN_ENTRY_PROVIDER =
   "mlx-ltx-2-3-q4-768x512-f121-fps30-staged_residency";
 export const CAMPAIGN_ENTRY_FIXTURE =
@@ -56,6 +58,16 @@ export const BOUNDED_CARRIER_SUCCESS_RECEIPT_TYPE =
   "sceneworks_bounded_carrier_success_v1";
 export const BOUNDED_CARRIER_FAILURE_RECEIPT_TYPE =
   "sceneworks_bounded_carrier_failure_v1";
+export const BOUNDED_CAMPAIGN_ENTRY_ACTION = "bounded_campaign_entry";
+export const BOUNDED_CAMPAIGN_ENTRY_PROVIDER =
+  "mlx-ltx-2-3-q4-768x512-f121-fps30-bounded_decode-192x64";
+export const BOUNDED_CAMPAIGN_ENTRY_FIXTURE =
+  "ltx-2-3-mlx-q4-768x512-f121-fps30-bounded-decode-192-64-seed18946";
+export const BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID = "implan-964db61ed3789af6386b";
+export const BOUNDED_CAMPAIGN_ENTRY_IDENTITY =
+  "sc-20318-q4-768x512-f121-fps30-bounded-192-64-authoritative-v1";
+export const BOUNDED_CAMPAIGN_FAILURE_RECEIPT_TYPE =
+  "sceneworks_bounded_campaign_entry_failure_v1";
 export const PROVIDER_PHASE_PROTOCOL = "sceneworks-provider-phase-v1";
 export const WATCHDOG_EVENT_CHAIN_PROTOCOL = "sceneworks-watchdog-event-chain-v1";
 export const PROVIDER_PHASES = Object.freeze([
@@ -79,6 +91,7 @@ export const BOUNDED_CARRIER_PHASES = Object.freeze([
 ]);
 const CAMPAIGN_ENTRY_ACTION = "campaign_entry";
 const CAMPAIGN_ENTRY_PLAN = "docs/calibration/sc-18946/ltx-mlx-single-pass-sweep.json";
+const BOUNDED_CAMPAIGN_ENTRY_PLAN = "docs/calibration/sc-18946/ltx-mlx-rung2-sweep.json";
 const CAMPAIGN_ENTRY_SAFETY = Object.freeze({
   disposition: "safety_refused_open",
   tierInventoryBytes: 20_467_690_460,
@@ -94,6 +107,18 @@ const CAMPAIGN_ENTRY_SAFETY = Object.freeze({
     "incident binding phase is unknown, so the projection is not a physical-footprint bound and cannot admit execution",
   ]),
   reason: "incident-calibrated projection is diagnostic only; no proved bound or hard containment admits this row",
+});
+const BOUNDED_CAMPAIGN_ENTRY_SAFETY = Object.freeze({
+  disposition: "safety_refused_open",
+  tierInventoryBytes: 20_467_690_460,
+  incidentCrashFootprintBytes: 96_970_084_480,
+  incidentCase: "mlx-ltx-2-3-q4-1280x704-f305-fps30-bounded_decode",
+  commonLoad: "complete numeric tier plus shared Gemma stack before geometry-specific work",
+  predictedDecodeBytes: 6_264_848_640,
+  incidentPredictedDecodeBytes: 18_540_396_800,
+  incidentCalibratedProjectionBytes: 84_694_536_320,
+  projectionAssumptions: CAMPAIGN_ENTRY_SAFETY.projectionAssumptions,
+  reason: "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20318 action is admitted",
 });
 const CANARY_PROFILES = Object.freeze({
   [SAFETY_CANARY_PROFILE]: Object.freeze({
@@ -599,6 +624,49 @@ export function campaignEntryPlan(config) {
   return { provider, planned: planned[0] };
 }
 
+export function boundedCampaignEntryPlan(config) {
+  const matches = config?.providers?.filter((provider) =>
+    provider.name === BOUNDED_CAMPAIGN_ENTRY_PROVIDER) ?? [];
+  if (matches.length !== 1) fail("SC-20318 requires exactly one bounded campaign provider");
+  const provider = matches[0];
+  const exactProvider = {
+    name: BOUNDED_CAMPAIGN_ENTRY_PROVIDER,
+    _role: "bounded_carrier_entry",
+    _campaignPhase: "bounded_carrier_ratification",
+    _coverageExpectation: "captured_or_attempted",
+    _latentTokens: 6_144,
+    _writableFrameCap: 682,
+    _outputVoxels: 47_579_136,
+    _measurementSafety: structuredClone(BOUNDED_CAMPAIGN_ENTRY_SAFETY),
+    evidenceScope: "authoritative",
+    backend: "mlx",
+    loadShape: "eager_materialization",
+    target: {
+      provider: PROVIDER, modelId: PROVIDER, tier: "q4", mode: "text_to_video",
+      overlay: "none", geometry: { width: 768, height: 512, batch: 1, frames: 121 },
+    },
+    rung: "bounded_decode",
+    engagedRungs: ["resident", "staged_residency", "bounded_decode"],
+    calibrationFingerprint: FINGERPRINT,
+    fixture: BOUNDED_CAMPAIGN_ENTRY_FIXTURE,
+    cases: [{ parameters: { decodeTileEdge: 192, decodeOverlap: 64 }, expectedResult: "passed" }],
+    _predictedDecodeBytes: 6_264_848_640,
+    _predictedDecodeFormula:
+      "3.3e9 + 40*(width*height*frames) + 300*(192*192*96) bytes",
+  };
+  if (!isDeepStrictEqual(provider, exactProvider)) {
+    fail("SC-20318 bounded campaign provider changed");
+  }
+  const planned = expandPlan({ providers: [provider] });
+  if (planned.length !== 1
+      || planned[0].logicalCaseId !== BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID
+      || planned[0].modelLoadPolicy !== "fresh_per_case"
+      || planned[0].modelLoadGroup !== null) {
+    fail("SC-20318 bounded campaign logical identity changed");
+  }
+  return { provider, planned: planned[0] };
+}
+
 export function validateCampaignEntryHarnessRequest(request, expectedPlanned, {
   sceneWorksRevision, inferenceRevision, sceneWorksRepo, inferenceRepo,
 } = {}) {
@@ -639,6 +707,59 @@ export function campaignEntryAdapterRequest(request, expectedPlanned, expectedSo
   transformed.planned._measurementSafety = structuredClone(CAMPAIGN_ENTRY_SAFETY);
   transformed.planned._campaignEntry = {
     identity: CAMPAIGN_ENTRY_IDENTITY,
+    artifact: {
+      repository: ARTIFACT_REPOSITORY,
+      revision: ARTIFACT_REVISION,
+      numericTierInventory: {
+        files: 11, bytes: Q4_INVENTORY_BYTES, sha256: Q4_INVENTORY_SHA256,
+      },
+      textEncoderInventory: {
+        files: TEXT_ENCODER_INVENTORY_FILES,
+        bytes: TEXT_ENCODER_INVENTORY_BYTES,
+        sha256: TEXT_ENCODER_INVENTORY_SHA256,
+      },
+    },
+  };
+  return transformed;
+}
+
+export function boundedCampaignEntryAdapterRequest(request, expectedPlanned, expectedSource) {
+  if (request?.action !== "run"
+      || !isDeepStrictEqual(request?.planned, expectedPlanned)
+      || request.planned.logicalCaseId !== BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID
+      || request.planned.fixture !== BOUNDED_CAMPAIGN_ENTRY_FIXTURE
+      || request.planned.evidenceScope !== "authoritative"
+      || request.planned.modelLoadPolicy !== "fresh_per_case"
+      || request.planned.modelLoadGroup !== null
+      || request.repositories?.sceneWorks?.dirty !== false
+      || request.repositories?.inference?.dirty !== false
+      || (expectedSource?.sceneWorksRevision !== undefined
+        && request.repositories.sceneWorks.revision !== expectedSource.sceneWorksRevision)
+      || (expectedSource?.inferenceRevision !== undefined
+        && request.repositories.inference.revision !== expectedSource.inferenceRevision)
+      || (expectedSource?.sceneWorksRepo !== undefined
+        && request.repositoryPaths?.sceneWorks !== expectedSource.sceneWorksRepo)
+      || (expectedSource?.inferenceRepo !== undefined
+        && request.repositoryPaths?.inference !== expectedSource.inferenceRepo)
+      || !Number.isSafeInteger(request.hardware?.memoryBytes)
+      || request.hardware.memoryBytes <= 0) {
+    fail("SC-20318 provider wrapper received a non-canonical harness request");
+  }
+  for (const field of ["_watchdog", "_boundedCampaignEntry", "_measurementSafety"]) {
+    if (Object.hasOwn(request.planned, field)) {
+      fail(`canonical SC-20318 request unexpectedly contains ${field}`);
+    }
+  }
+  const transformed = structuredClone(request);
+  transformed.action = BOUNDED_CAMPAIGN_ENTRY_ACTION;
+  transformed.planned._watchdog = { maxFootprintBytes: MAX_FOOTPRINT_BYTES };
+  transformed.planned._measurementSafety = structuredClone(BOUNDED_CAMPAIGN_ENTRY_SAFETY);
+  transformed.planned._boundedCampaignEntry = {
+    identity: BOUNDED_CAMPAIGN_ENTRY_IDENTITY,
+    fps: 30,
+    seed: 18_946,
+    videoMode: "default_av",
+    spatialDecodeTiles: 24,
     artifact: {
       repository: ARTIFACT_REPOSITORY,
       revision: ARTIFACT_REVISION,
@@ -745,6 +866,112 @@ export function validateCampaignEntryAdapterResponse(response, {
   if (cleanup.postCleanupActiveBytes !== expectedPostActive
       || cleanup.postCleanupCacheBytes !== cleanup.preProviderCacheBytes) {
     fail("SC-20191 cleanup did not return to the exact intentional persistent baseline");
+  }
+  return response;
+}
+
+export function validateBoundedCampaignEntryResponse(response, {
+  inferenceRevision, hostMemoryBytes,
+} = {}) {
+  const diagnostics = diagnosticMeasurements(response);
+  for (const [name, expected] of [
+    ["renderedFrames", 121], ["outputFps", 30], ["audioTrackDecoded", 1],
+    ["decodeTilingEngaged", 1], ["decodeTileSpatialPx", 192],
+    ["decodeTileOverlapPx", 64], ["spatialDecodeTiles", 24],
+    ["latentTemporalDepth", 16], ["latentTokens", 6_144],
+    ["warmOutputAudioChannels", 2], ["providerRequestScopeRenders", 2],
+  ]) {
+    if (diagnostics.get(name) !== expected) {
+      fail(`SC-20318 response diagnostic ${name} must be ${expected}`);
+    }
+  }
+  for (const name of [
+    "warmConditioningActivePeak", "warmDenoiseActivePeak", "warmDecodeActivePeak",
+    "warmOutputAudioSamples", "warmOutputAudioSampleRate",
+  ]) {
+    if (!Number.isSafeInteger(diagnostics.get(name)) || diagnostics.get(name) <= 0) {
+      fail(`SC-20318 response diagnostic ${name} must be positive`);
+    }
+  }
+  const scenarios = new Map(response?.scenarios?.map((item) => [item.name, item]) ?? []);
+  const quality = response?.quality;
+  for (const name of [
+    "maximumError", "meanError", "rootMeanSquareError",
+    "maximumErrorThreshold", "meanErrorThreshold", "rootMeanSquareErrorThreshold",
+  ]) {
+    if (!Number.isFinite(quality?.[name]) || quality[name] < 0) {
+      fail(`SC-20318 quality ${name} is invalid`);
+    }
+  }
+  const sidecar = response?._boundedCampaignEntry;
+  if (response?.status !== "runtime_complete"
+      || response?.loadShape !== "eager_materialization"
+      || response?.artifact?.repository !== ARTIFACT_REPOSITORY
+      || response?.artifact?.resolvedRevision !== ARTIFACT_REVISION
+      || response?.artifact?.variant !== "q4"
+      || !isDeepStrictEqual(response?.strategy, {
+        rung: "bounded_decode",
+        engagedRungs: ["resident", "staged_residency", "bounded_decode"],
+        parameters: { decodeTileEdge: 192, decodeOverlap: 64 },
+      })
+      || scenarios.get("warm_repeat")?.result !== "passed"
+      || scenarios.get("cancel")?.result !== "not_run"
+      || scenarios.get("error")?.result !== "not_run"
+      || quality?.result !== "passed" || quality?.identicalInputs !== true
+      || quality.maximumError > quality.maximumErrorThreshold
+      || quality.meanError > quality.meanErrorThreshold
+      || quality.rootMeanSquareError > quality.rootMeanSquareErrorThreshold
+      || response?.output?.frames !== 121 || response?.output?.fps !== 30
+      || response?.output?.audio?.present !== true
+      || !Number.isSafeInteger(response?.output?.audio?.samples)
+      || response.output.audio.samples <= 0
+      || !Number.isSafeInteger(response?.output?.audio?.sampleRate)
+      || response.output.audio.sampleRate <= 0
+      || response?.output?.audio?.channels !== 2
+      || response?.output?.firstFrameNondegenerate !== true
+      || sidecar?.identity !== BOUNDED_CAMPAIGN_ENTRY_IDENTITY
+      || (inferenceRevision !== undefined && sidecar?.inferenceRevision !== inferenceRevision)
+      || sidecar?.watchdog?.required !== true
+      || sidecar?.watchdog?.protocol !== "sceneworks-memory-watchdog-v1"
+      || sidecar?.watchdog?.providerPhaseProtocol !== PROVIDER_PHASE_PROTOCOL
+      || sidecar?.watchdog?.providerPhaseProfile !== "bounded-campaign-entry"
+      || !isDeepStrictEqual(sidecar?.watchdog?.providerPhases, BOUNDED_CARRIER_PHASES)
+      || sidecar?.watchdog?.maxFootprintBytes !== MAX_FOOTPRINT_BYTES
+      || sidecar?.watchdog?.maxRuntimeSeconds !== MAX_RUNTIME_SECONDS
+      || (hostMemoryBytes !== undefined && sidecar?.watchdog?.hostMemoryBytes !== hostMemoryBytes)
+      || sidecar?.watchdog?.minInitialMemoryFreeBytes
+        !== preflightFreeFloor(sidecar?.watchdog?.hostMemoryBytes)
+      || sidecar?.watchdog?.minMemoryFreeBytes
+        !== runtimeFreeFloor(sidecar?.watchdog?.hostMemoryBytes)
+      || Object.hasOwn(sidecar?.watchdog ?? {}, "minSwapFreeBytes")
+      || sidecar?.mlxLimits?.memoryLimitBytes !== MAX_FOOTPRINT_BYTES
+      || !Number.isSafeInteger(sidecar?.mlxLimits?.wiredLimitBytes)
+      || sidecar.mlxLimits.wiredLimitBytes <= 0
+      || sidecar.mlxLimits.wiredLimitBytes > MAX_FOOTPRINT_BYTES) {
+    fail("SC-20318 adapter response changed the exact bounded campaign entry");
+  }
+  const cleanup = sidecar.cleanup;
+  for (const field of [
+    "preProviderActiveBytes", "preProviderCacheBytes",
+    "postCleanupActiveBytes", "postCleanupCacheBytes",
+  ]) {
+    if (!Number.isSafeInteger(cleanup?.[field]) || cleanup[field] < 0) {
+      fail(`SC-20318 cleanup ${field} must be a non-negative safe integer`);
+    }
+  }
+  if (cleanup.preProviderCacheBytes !== 0
+      || !isDeepStrictEqual(cleanup.expectedPersistentActive, {
+        identity: LTX_ONES_CACHE_IDENTITY,
+        videoDimension: LTX_ONES_CACHE_VIDEO_DIMENSION,
+        audioDimension: LTX_ONES_CACHE_AUDIO_DIMENSION,
+        dtype: "bfloat16", bytesPerElement: BFLOAT16_BYTES_PER_ELEMENT,
+        bytes: ltxOnesCacheBytes(),
+      })) fail("SC-20318 cleanup changed the named ONES_CACHE contract");
+  const expectedPost = cleanup.preProviderActiveBytes + cleanup.expectedPersistentActive.bytes;
+  if (!Number.isSafeInteger(expectedPost)
+      || cleanup.postCleanupActiveBytes !== expectedPost
+      || cleanup.postCleanupCacheBytes !== cleanup.preProviderCacheBytes) {
+    fail("SC-20318 cleanup did not return to the exact persistent baseline");
   }
   return response;
 }
@@ -1124,6 +1351,54 @@ export function campaignEntryCanonicalFragment(response, maxObservedFootprintByt
   return canonical;
 }
 
+export function boundedCampaignEntryCanonicalFragment(response, maxObservedFootprintBytes) {
+  if (!Number.isSafeInteger(maxObservedFootprintBytes)
+      || maxObservedFootprintBytes < 0
+      || maxObservedFootprintBytes >= MAX_FOOTPRINT_BYTES) {
+    fail("SC-20318 canonical fragment requires a contained physical-footprint maximum");
+  }
+  const canonical = structuredClone(response);
+  const sidecar = canonical._boundedCampaignEntry;
+  const output = canonical.output;
+  if (!sidecar || !output) fail("SC-20318 canonical fragment omitted private evidence");
+  delete canonical._boundedCampaignEntry;
+  delete canonical.output;
+  const measurements = canonical.diagnostics?.measurements;
+  if (!Array.isArray(measurements)) fail("SC-20318 canonical fragment omitted diagnostics");
+  const existing = new Set(measurements.map((measurement) => measurement.name));
+  const append = (name, unit, value) => {
+    if (existing.has(name) || !Number.isSafeInteger(value) || value < 0) {
+      fail(`SC-20318 canonical diagnostic ${name} is duplicated or invalid`);
+    }
+    existing.add(name);
+    measurements.push({ name, unit, value });
+  };
+  append("boundedCampaignWatchdogMaxFootprintBytes", "bytes", sidecar.watchdog.maxFootprintBytes);
+  append("boundedCampaignWatchdogMaxObservedFootprintBytes", "bytes", maxObservedFootprintBytes);
+  append("boundedCampaignWatchdogMaxRuntimeSeconds", "seconds", sidecar.watchdog.maxRuntimeSeconds);
+  append("boundedCampaignWatchdogHostMemoryBytes", "bytes", sidecar.watchdog.hostMemoryBytes);
+  append("boundedCampaignWatchdogMinInitialMemoryFreeBytes", "bytes",
+    sidecar.watchdog.minInitialMemoryFreeBytes);
+  append("boundedCampaignWatchdogMinMemoryFreeBytes", "bytes",
+    sidecar.watchdog.minMemoryFreeBytes);
+  append("boundedCampaignMlxMemoryLimitBytes", "bytes", sidecar.mlxLimits.memoryLimitBytes);
+  append("boundedCampaignMlxWiredLimitBytes", "bytes", sidecar.mlxLimits.wiredLimitBytes);
+  append("boundedCampaignPreProviderActiveBytes", "bytes", sidecar.cleanup.preProviderActiveBytes);
+  append("boundedCampaignPreProviderCacheBytes", "bytes", sidecar.cleanup.preProviderCacheBytes);
+  append("boundedCampaignExpectedPersistentActiveBytes", "bytes",
+    sidecar.cleanup.expectedPersistentActive.bytes);
+  append("boundedCampaignPostCleanupActiveBytes", "bytes", sidecar.cleanup.postCleanupActiveBytes);
+  append("boundedCampaignPostCleanupCacheBytes", "bytes", sidecar.cleanup.postCleanupCacheBytes);
+  append("boundedCampaignOutputAudioSamples", "count", output.audio.samples);
+  append("boundedCampaignOutputAudioSampleRate", "hertz", output.audio.sampleRate);
+  append("boundedCampaignOutputAudioChannels", "count", output.audio.channels);
+  append("boundedCampaignFirstFrameNondegenerate", "boolean",
+    output.firstFrameNondegenerate ? 1 : 0);
+  append("boundedCampaignOwnedProcessGroupResidue", "count", 0);
+  append("boundedCampaignContainmentComplete", "boolean", 1);
+  return canonical;
+}
+
 export function validateCampaignEntryBundle(bundle) {
   validateBundle(bundle);
   if (bundle.records.length !== 1 || (bundle.sourceSessions?.length ?? 0) !== 0) {
@@ -1188,12 +1463,78 @@ export function validateCampaignEntryBundle(bundle) {
   return bundle;
 }
 
+export function validateBoundedCampaignEntryBundle(bundle) {
+  validateBundle(bundle);
+  if (bundle.records.length !== 1 || (bundle.sourceSessions?.length ?? 0) !== 0) {
+    fail("SC-20318 must publish exactly one canonical record and no source session");
+  }
+  const record = bundle.records[0];
+  const scenarios = new Map(record?.scenarios?.map((item) => [item.name, item]) ?? []);
+  if (record.logicalCaseId !== BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID
+      || record.status !== "runtime_complete"
+      || record.evidenceScope !== "authoritative"
+      || record.fixture !== BOUNDED_CAMPAIGN_ENTRY_FIXTURE
+      || !isDeepStrictEqual(record.strategy, {
+        rung: "bounded_decode",
+        engagedRungs: ["resident", "staged_residency", "bounded_decode"],
+        parameters: { decodeTileEdge: 192, decodeOverlap: 64 },
+      })
+      || scenarios.get("warm_repeat")?.result !== "passed"
+      || scenarios.get("cancel")?.result !== "not_run"
+      || scenarios.get("error")?.result !== "not_run") {
+    fail("SC-20318 canonical bundle changed identity or parity-only lifecycle");
+  }
+  const diagnostics = diagnosticMeasurements(record);
+  for (const [name, expected] of [
+    ["renderedFrames", 121], ["outputFps", 30], ["audioTrackDecoded", 1],
+    ["decodeTilingEngaged", 1], ["decodeTileSpatialPx", 192],
+    ["decodeTileOverlapPx", 64], ["spatialDecodeTiles", 24],
+    ["providerRequestScopeRenders", 2], ["warmOutputAudioChannels", 2],
+    ["boundedCampaignWatchdogMaxFootprintBytes", MAX_FOOTPRINT_BYTES],
+    ["boundedCampaignWatchdogMaxRuntimeSeconds", MAX_RUNTIME_SECONDS],
+    ["boundedCampaignMlxMemoryLimitBytes", MAX_FOOTPRINT_BYTES],
+    ["boundedCampaignPreProviderCacheBytes", 0],
+    ["boundedCampaignExpectedPersistentActiveBytes", ltxOnesCacheBytes()],
+    ["boundedCampaignPostCleanupCacheBytes", 0],
+    ["boundedCampaignOutputAudioChannels", 2],
+    ["boundedCampaignFirstFrameNondegenerate", 1],
+    ["boundedCampaignOwnedProcessGroupResidue", 0],
+    ["boundedCampaignContainmentComplete", 1],
+  ]) {
+    if (diagnostics.get(name) !== expected) {
+      fail(`SC-20318 canonical bundle diagnostic ${name} must be ${expected}`);
+    }
+  }
+  const pre = diagnostics.get("boundedCampaignPreProviderActiveBytes");
+  const post = diagnostics.get("boundedCampaignPostCleanupActiveBytes");
+  const observed = diagnostics.get("boundedCampaignWatchdogMaxObservedFootprintBytes");
+  const host = diagnostics.get("boundedCampaignWatchdogHostMemoryBytes");
+  if (!Number.isSafeInteger(pre) || post !== pre + ltxOnesCacheBytes()
+      || host !== record.hardware.memoryBytes
+      || diagnostics.get("boundedCampaignWatchdogMinInitialMemoryFreeBytes")
+        !== preflightFreeFloor(host)
+      || diagnostics.get("boundedCampaignWatchdogMinMemoryFreeBytes") !== runtimeFreeFloor(host)
+      || diagnostics.get("boundedCampaignMlxWiredLimitBytes") > MAX_FOOTPRINT_BYTES
+      || !Number.isSafeInteger(observed) || observed < 0 || observed >= MAX_FOOTPRINT_BYTES) {
+    fail("SC-20318 canonical bundle cleanup or footprint attestation changed");
+  }
+  return bundle;
+}
+
 export function campaignEntryFailurePath(canonicalOutput) {
   return path.join(path.dirname(canonicalOutput), "sc-20216-campaign-entry-failure.json");
 }
 
 export function campaignEntryOutcomeReservationPath(canonicalOutput) {
   return path.join(path.dirname(canonicalOutput), ".sc-20216-campaign-entry-outcome");
+}
+
+export function boundedCampaignEntryFailurePath(canonicalOutput) {
+  return path.join(path.dirname(canonicalOutput), "sc-20318-bounded-campaign-entry-failure.json");
+}
+
+export function boundedCampaignEntryOutcomeReservationPath(canonicalOutput) {
+  return path.join(path.dirname(canonicalOutput), ".sc-20318-bounded-campaign-entry-outcome");
 }
 
 export function campaignEntryFailureReceipt({
@@ -1268,6 +1609,83 @@ export function campaignEntryFailureReceipt({
     },
   };
   return validateCampaignEntryFailureReceipt(receipt);
+}
+
+export function boundedCampaignEntryFailureReceipt({
+  sceneWorksRevision, sceneWorksTree, inferenceRevision, inferenceTree,
+  identity, preparationKey, preparationRoot, prepared, hostMemoryBytes, events, outcome,
+}) {
+  const failure = validateCampaignEntryFailureEvents(
+    events, hostMemoryBytes, BOUNDED_CARRIER_PHASES,
+  );
+  const receipt = {
+    schemaVersion: 1,
+    recordType: BOUNDED_CAMPAIGN_FAILURE_RECEIPT_TYPE,
+    status: "diagnostic_failure",
+    diagnosticOnly: true,
+    promotable: false,
+    ingestible: false,
+    canonicalBundlePublished: false,
+    outcome: structuredClone(outcome),
+    story: "sc-20318",
+    source: {
+      sceneWorks: { revision: sceneWorksRevision, tree: sceneWorksTree },
+      inference: { revision: inferenceRevision, tree: inferenceTree },
+    },
+    campaignCase: {
+      plan: BOUNDED_CAMPAIGN_ENTRY_PLAN,
+      provider: BOUNDED_CAMPAIGN_ENTRY_PROVIDER,
+      logicalCaseId: BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
+      fixture: BOUNDED_CAMPAIGN_ENTRY_FIXTURE,
+      identity: BOUNDED_CAMPAIGN_ENTRY_IDENTITY,
+      action: BOUNDED_CAMPAIGN_ENTRY_ACTION,
+      target: {
+        provider: PROVIDER, tier: "q4",
+        geometry: { width: 768, height: 512, batch: 1, frames: 121, fps: 30 },
+      },
+      strategy: {
+        rung: "bounded_decode",
+        engagedRungs: ["resident", "staged_residency", "bounded_decode"],
+        parameters: { decodeTileEdge: 192, decodeOverlap: 64 },
+        spatialDecodeTiles: 24,
+      },
+    },
+    artifacts: {
+      repository: ARTIFACT_REPOSITORY,
+      revision: ARTIFACT_REVISION,
+      numericTierInventory: structuredClone(identity.artifact.numericTier),
+      textEncoderInventory: structuredClone(identity.artifact.textEncoder),
+      adapter: structuredClone(prepared.adapter),
+      metallib: structuredClone(prepared.metallib),
+      preparation: {
+        key: preparationKey, root: preparationRoot,
+        identity: structuredClone(identity), manifest: structuredClone(prepared.manifest),
+      },
+    },
+    watchdog: {
+      protocol: "sceneworks-memory-watchdog-v1",
+      providerPhaseProtocol: PROVIDER_PHASE_PROTOCOL,
+      providerPhases: [...BOUNDED_CARRIER_PHASES],
+      maxFootprintBytes: MAX_FOOTPRINT_BYTES,
+      maxRuntimeSeconds: MAX_RUNTIME_SECONDS,
+      hostMemoryBytes,
+      minInitialMemoryFreeBytes: preflightFreeFloor(hostMemoryBytes),
+      minMemoryFreeBytes: runtimeFreeFloor(hostMemoryBytes),
+      failure,
+      eventChain: structuredClone(failure.eventChain),
+      events: structuredClone(events),
+    },
+    cleanup: {
+      ownedProcessGroupResidueVerified: true,
+      runScratchRemoved: true,
+      runRootEmpty: true,
+      sourceIdentityVerified: true,
+      runtimeAssetIdentityVerified: true,
+      preparedCacheVerified: true,
+      preparationTransientResidueVerified: true,
+    },
+  };
+  return validateBoundedCampaignEntryFailureReceipt(receipt);
 }
 
 function validateContainedReceiptArtifactIdentity(receipt, label) {
@@ -1397,6 +1815,70 @@ export function validateCampaignEntryFailureReceipt(receipt) {
   if (!isDeepStrictEqual(receipt.watchdog.failure, validated)
       || !isDeepStrictEqual(receipt.watchdog.eventChain, validated.eventChain)) {
     fail("SC-20216 failure receipt summary does not match its complete event stream");
+  }
+  return receipt;
+}
+
+export function validateBoundedCampaignEntryFailureReceipt(receipt) {
+  let ingestible = true;
+  try { validateBundle(receipt); } catch { ingestible = false; }
+  const expectedCase = {
+    plan: BOUNDED_CAMPAIGN_ENTRY_PLAN,
+    provider: BOUNDED_CAMPAIGN_ENTRY_PROVIDER,
+    logicalCaseId: BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
+    fixture: BOUNDED_CAMPAIGN_ENTRY_FIXTURE,
+    identity: BOUNDED_CAMPAIGN_ENTRY_IDENTITY,
+    action: BOUNDED_CAMPAIGN_ENTRY_ACTION,
+    target: {
+      provider: PROVIDER, tier: "q4",
+      geometry: { width: 768, height: 512, batch: 1, frames: 121, fps: 30 },
+    },
+    strategy: {
+      rung: "bounded_decode",
+      engagedRungs: ["resident", "staged_residency", "bounded_decode"],
+      parameters: { decodeTileEdge: 192, decodeOverlap: 64 },
+      spatialDecodeTiles: 24,
+    },
+  };
+  const expectedCleanup = {
+    ownedProcessGroupResidueVerified: true,
+    runScratchRemoved: true,
+    runRootEmpty: true,
+    sourceIdentityVerified: true,
+    runtimeAssetIdentityVerified: true,
+    preparedCacheVerified: true,
+    preparationTransientResidueVerified: true,
+  };
+  if (ingestible
+      || receipt?.recordType !== BOUNDED_CAMPAIGN_FAILURE_RECEIPT_TYPE
+      || receipt?.status !== "diagnostic_failure"
+      || receipt?.diagnosticOnly !== true || receipt?.promotable !== false
+      || receipt?.ingestible !== false || receipt?.canonicalBundlePublished !== false
+      || receipt?.outcome?.canonicalBundleAbsentAtPublication !== true
+      || receipt?.outcome?.outcomeReservationHeldAtPublication !== true
+      || receipt?.outcome?.outcomeChoice !== "failure"
+      || receipt?.outcome?.failureOutput
+        !== boundedCampaignEntryFailurePath(receipt?.outcome?.canonicalOutput ?? "")
+      || receipt?.outcome?.reservation
+        !== boundedCampaignEntryOutcomeReservationPath(receipt?.outcome?.canonicalOutput ?? "")
+      || receipt?.outcome?.choice !== `${receipt?.outcome?.reservation}.choice`
+      || receipt?.story !== "sc-20318"
+      || !isDeepStrictEqual(receipt?.campaignCase, expectedCase)
+      || receipt?.watchdog?.protocol !== "sceneworks-memory-watchdog-v1"
+      || receipt?.watchdog?.providerPhaseProtocol !== PROVIDER_PHASE_PROTOCOL
+      || !isDeepStrictEqual(receipt?.watchdog?.providerPhases, BOUNDED_CARRIER_PHASES)
+      || receipt?.watchdog?.maxFootprintBytes !== MAX_FOOTPRINT_BYTES
+      || receipt?.watchdog?.maxRuntimeSeconds !== MAX_RUNTIME_SECONDS
+      || !isDeepStrictEqual(receipt?.cleanup, expectedCleanup)) {
+    fail("SC-20318 failure receipt is ingestible, incomplete, or identity-drifted");
+  }
+  validateContainedReceiptArtifactIdentity(receipt, "SC-20318 failure");
+  const validated = validateCampaignEntryFailureEvents(
+    receipt.watchdog.events, receipt.watchdog.hostMemoryBytes, BOUNDED_CARRIER_PHASES,
+  );
+  if (!isDeepStrictEqual(receipt.watchdog.failure, validated)
+      || !isDeepStrictEqual(receipt.watchdog.eventChain, validated.eventChain)) {
+    fail("SC-20318 failure receipt summary changed from its authenticated stream");
   }
   return receipt;
 }
@@ -2625,9 +3107,34 @@ function campaignProviderOptions(argv) {
 }
 
 async function campaignProviderInvocation(options, input, {
-  signal, setActiveWatchdog = () => {}, canonicalClaim,
+  signal, setActiveWatchdog = () => {}, canonicalClaim, executionClaim, bounded = false,
 } = {}) {
   signal?.throwIfAborted();
+  const spec = bounded ? {
+    story: "SC-20318",
+    plan: BOUNDED_CAMPAIGN_ENTRY_PLAN,
+    planEntry: boundedCampaignEntryPlan,
+    failurePath: boundedCampaignEntryFailurePath,
+    outcomePath: boundedCampaignEntryOutcomeReservationPath,
+    adapterRequest: boundedCampaignEntryAdapterRequest,
+    validateResponse: validateBoundedCampaignEntryResponse,
+    canonicalFragment: boundedCampaignEntryCanonicalFragment,
+    phases: BOUNDED_CARRIER_PHASES,
+    phaseProfile: "bounded-campaign-entry",
+    childName: "sc-20318-bounded-campaign-entry",
+  } : {
+    story: "SC-20191",
+    plan: CAMPAIGN_ENTRY_PLAN,
+    planEntry: campaignEntryPlan,
+    failurePath: campaignEntryFailurePath,
+    outcomePath: campaignEntryOutcomeReservationPath,
+    adapterRequest: campaignEntryAdapterRequest,
+    validateResponse: validateCampaignEntryAdapterResponse,
+    canonicalFragment: campaignEntryCanonicalFragment,
+    phases: PROVIDER_PHASES,
+    phaseProfile: "campaign-entry",
+    childName: "sc-20191-campaign-entry",
+  };
   const request = JSON.parse(input);
   const campaignOutcome = {
     canonicalOutput: options["canonical-output"],
@@ -2636,14 +3143,14 @@ async function campaignProviderInvocation(options, input, {
     choice: `${options["outcome-reservation"]}.choice`,
     token: options["outcome-token"],
     canonicalClaim,
+    executionClaim,
   };
-  if (campaignOutcome.failureOutput !== campaignEntryFailurePath(campaignOutcome.canonicalOutput)
-      || campaignOutcome.reservation
-        !== campaignEntryOutcomeReservationPath(campaignOutcome.canonicalOutput)) {
-    fail("SC-20216 campaign provider outcome paths changed");
+  if (campaignOutcome.failureOutput !== spec.failurePath(campaignOutcome.canonicalOutput)
+      || campaignOutcome.reservation !== spec.outcomePath(campaignOutcome.canonicalOutput)) {
+    fail(`${spec.story} campaign provider outcome paths changed`);
   }
-  const config = JSON.parse(await readFile(path.join(ROOT, CAMPAIGN_ENTRY_PLAN), "utf8"));
-  const { planned } = campaignEntryPlan(config);
+  const config = JSON.parse(await readFile(path.join(ROOT, spec.plan), "utf8"));
+  const { planned } = spec.planEntry(config);
   const toolchainChannel = await repositoryToolchain();
   const identity = preparationIdentity(
     options["scene-tree"], options["inference-tree"], toolchainChannel,
@@ -2685,7 +3192,7 @@ async function campaignProviderInvocation(options, input, {
       ) === null) fail("SC-20191 prepared cache disappeared after provider probe");
       output = probeOutput;
     } else {
-      const adapterRequest = campaignEntryAdapterRequest(request, planned, {
+      const adapterRequest = spec.adapterRequest(request, planned, {
         sceneWorksRevision: options["scene-revision"],
         inferenceRevision: options["inference-revision"],
         sceneWorksRepo: ROOT,
@@ -2710,10 +3217,10 @@ async function campaignProviderInvocation(options, input, {
         "--event-file", eventsPath,
         "--require-child-attestation",
         "--require-provider-phases",
-        "--provider-phase-profile", "campaign-entry",
+        "--provider-phase-profile", spec.phaseProfile,
         "--",
         "/bin/sh", "-c", 'set -C; exec "$1" <"$2" >"$3"',
-        "sc-20191-campaign-entry", prepared.adapter.path, requestPath, responsePath,
+        spec.childName, prepared.adapter.path, requestPath, responsePath,
       ];
       await assertCampaignSourceState(options, signal);
       await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal);
@@ -2742,7 +3249,7 @@ async function campaignProviderInvocation(options, input, {
         const watchdogError = new Error(watchdogFailureSummary(status, eventBytes));
         try {
           const events = eventBytes.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
-          validateCampaignEntryFailureEvents(events, hostMemoryBytes);
+          validateCampaignEntryFailureEvents(events, hostMemoryBytes, spec.phases);
           const started = events.find((event) => event.event === "started");
           const processTable = (await execFileAsync(
             "/bin/ps", ["-ww", "-axo", "pid=,pgid=,command="],
@@ -2765,11 +3272,11 @@ async function campaignProviderInvocation(options, input, {
       signal?.throwIfAborted();
       const response = JSON.parse(await readFile(responsePath, "utf8"));
       const events = eventBytes.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
-      validateCampaignEntryAdapterResponse(response, {
+      spec.validateResponse(response, {
         inferenceRevision: options["inference-revision"], hostMemoryBytes,
       });
       const maxObservedFootprintBytes = validateCampaignEntryWatchdogEvents(
-        events, hostMemoryBytes,
+        events, hostMemoryBytes, spec.phases,
       );
       const started = events.find((event) => event.event === "started");
       const processTable = (await execFileAsync(
@@ -2783,7 +3290,7 @@ async function campaignProviderInvocation(options, input, {
       if (await validatePreparedCache(
         options["preparation-root"], options["preparation-key"], identity, signal,
       ) === null) fail("SC-20191 prepared cache disappeared after campaign entry");
-      output = canonicalJson(campaignEntryCanonicalFragment(response, maxObservedFootprintBytes));
+      output = canonicalJson(spec.canonicalFragment(response, maxObservedFootprintBytes));
     }
   } catch (error) {
     operationError = error;
@@ -2800,7 +3307,9 @@ async function campaignProviderInvocation(options, input, {
     let publicationError = null;
     if (failureEvents !== null && cleanupError === null) {
       try {
-        await publishCampaignEntryFailureReceipt(campaignOutcome, {
+        const publishFailure = bounded
+          ? publishBoundedCampaignEntryFailure : publishCampaignEntryFailureReceipt;
+        await publishFailure(campaignOutcome, {
           verify: async () => {
             await assertRunRootEmpty(options["run-root"]);
             await assertCampaignSourceState(options);
@@ -2810,7 +3319,21 @@ async function campaignProviderInvocation(options, input, {
             ) === null) fail("SC-20216 prepared cache disappeared before failure publication");
             await assertPreparationHasNoTransientResidue(options["preparation-root"]);
           },
-          build: (outcome) => campaignEntryFailureReceipt({
+          build: (outcome) => (bounded
+            ? boundedCampaignEntryFailureReceipt({
+              sceneWorksRevision: options["scene-revision"],
+              sceneWorksTree: options["scene-tree"],
+              inferenceRevision: options["inference-revision"],
+              inferenceTree: options["inference-tree"],
+              identity,
+              preparationKey: options["preparation-key"],
+              preparationRoot: options["preparation-root"],
+              prepared,
+              hostMemoryBytes: failureHostMemoryBytes,
+              events: failureEvents,
+              outcome,
+            })
+            : campaignEntryFailureReceipt({
             sceneWorksRevision: options["scene-revision"],
             sceneWorksTree: options["scene-tree"],
             inferenceRevision: options["inference-revision"],
@@ -2822,7 +3345,7 @@ async function campaignProviderInvocation(options, input, {
             hostMemoryBytes: failureHostMemoryBytes,
             events: failureEvents,
             outcome,
-          }),
+          })),
         });
       } catch (error) {
         publicationError = error;
@@ -2940,11 +3463,75 @@ export async function publishCampaignEntryFailureReceipt(outcome, { verify, buil
   });
 }
 
+export async function acquireBoundedCampaignEntryOutcome(canonicalOutput) {
+  const outcome = {
+    canonicalOutput,
+    failureOutput: boundedCampaignEntryFailurePath(canonicalOutput),
+    reservation: boundedCampaignEntryOutcomeReservationPath(canonicalOutput),
+    choice: `${boundedCampaignEntryOutcomeReservationPath(canonicalOutput)}.choice`,
+    token: randomUUID(),
+  };
+  await mkdir(path.dirname(canonicalOutput), { recursive: true });
+  await writeFile(outcome.reservation, `${outcome.token}\n`, { flag: "wx", mode: 0o400 });
+  if (await pathExists(outcome.canonicalOutput) || await pathExists(outcome.failureOutput)) {
+    await unlink(outcome.reservation);
+    fail("SC-20318 already has an immutable canonical or failure outcome");
+  }
+  return outcome;
+}
+
+async function assertBoundedCampaignEntryOutcomeOwner(outcome) {
+  if (await readFile(outcome?.reservation ?? "", "utf8").catch(() => null)
+      !== `${outcome?.token}\n`) fail("SC-20318 outcome reservation ownership changed");
+}
+
+export async function releaseUnpublishedBoundedCampaignEntryOutcome(outcome) {
+  await assertBoundedCampaignEntryOutcomeOwner(outcome);
+  if (await pathExists(outcome.choice)
+      || await pathExists(outcome.canonicalOutput) || await pathExists(outcome.failureOutput)) return;
+  await unlink(outcome.reservation);
+}
+
+async function publishBoundedCampaignEntryOutcome(outcome, kind, build, signal) {
+  await assertBoundedCampaignEntryOutcomeOwner(outcome);
+  await outcome.canonicalClaim.assertOwner();
+  await outcome.executionClaim.assertOwner();
+  const target = kind === "canonical" ? outcome.canonicalOutput : outcome.failureOutput;
+  const other = kind === "canonical" ? outcome.failureOutput : outcome.canonicalOutput;
+  await writeFile(outcome.choice, `${kind}\n`, { flag: "wx", mode: 0o400 });
+  if (await pathExists(target) || await pathExists(other)) fail("SC-20318 outcome is already fixed");
+  const value = await build();
+  await publishExclusiveJson(target, value, signal);
+  return value;
+}
+
+async function publishBoundedCampaignEntryFailure(outcome, { verify, build }) {
+  await verify();
+  return publishBoundedCampaignEntryOutcome(outcome, "failure", async () => {
+    if (await pathExists(outcome.canonicalOutput)) fail("SC-20318 canonical exists; failure suppressed");
+    return validateBoundedCampaignEntryFailureReceipt(await build({
+      canonicalOutput: outcome.canonicalOutput,
+      failureOutput: outcome.failureOutput,
+      reservation: outcome.reservation,
+      choice: outcome.choice,
+      outcomeChoice: "failure",
+      canonicalBundleAbsentAtPublication: true,
+      outcomeReservationHeldAtPublication: true,
+    }));
+  });
+}
+
 export function canonicalPublicationClaimPath(canonicalOutput) {
   return path.join(
     path.dirname(canonicalOutput),
     `.${path.basename(canonicalOutput)}.ltx-canonical-publication-claim`,
   );
+}
+
+export function containedCampaignExecutionClaimTarget(
+  _output, containmentRoot = CONTAINED_CAMPAIGN_ROOT,
+) {
+  return path.join(path.resolve(containmentRoot), ".sc-18946-contained-execution");
 }
 
 const CANONICAL_RECLAMATION_LOCK_HELPER = String.raw`
@@ -3363,18 +3950,48 @@ async function assertPreparationHasNoTransientResidue(preparationRoot) {
 async function runCampaignEntryController({
   output, inferenceRepo, sceneWorksRevision, inferenceRevision,
   sceneWorksTree, inferenceTree, identity, preparationKey, preparationRoot,
-  prepared, signal, setActiveWatchdog,
+  prepared, signal, setActiveWatchdog, bounded = false,
 }) {
-  const config = JSON.parse(await readFile(path.join(ROOT, CAMPAIGN_ENTRY_PLAN), "utf8"));
-  campaignEntryPlan(config);
-  const canonicalClaim = await acquireCanonicalPublicationClaim(output, signal);
+  const spec = bounded ? {
+    plan: BOUNDED_CAMPAIGN_ENTRY_PLAN,
+    planEntry: boundedCampaignEntryPlan,
+    acquireOutcome: acquireBoundedCampaignEntryOutcome,
+    releaseOutcome: releaseUnpublishedBoundedCampaignEntryOutcome,
+    provider: BOUNDED_CAMPAIGN_ENTRY_PROVIDER,
+    logicalCaseId: BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
+    validateBundle: validateBoundedCampaignEntryBundle,
+  } : {
+    plan: CAMPAIGN_ENTRY_PLAN,
+    planEntry: campaignEntryPlan,
+    acquireOutcome: acquireCampaignEntryOutcome,
+    releaseOutcome: releaseUnpublishedCampaignEntryOutcome,
+    provider: CAMPAIGN_ENTRY_PROVIDER,
+    logicalCaseId: CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
+    validateBundle: validateCampaignEntryBundle,
+  };
+  const config = JSON.parse(await readFile(path.join(ROOT, spec.plan), "utf8"));
+  spec.planEntry(config);
+  const executionClaim = await acquireCanonicalPublicationClaim(
+    containedCampaignExecutionClaimTarget(output), signal,
+  );
+  let canonicalClaim;
+  try {
+    canonicalClaim = await acquireCanonicalPublicationClaim(output, signal);
+  } catch (error) {
+    await executionClaim.release();
+    throw error;
+  }
   let campaignOutcome;
   try {
-    campaignOutcome = await acquireCampaignEntryOutcome(output);
+    campaignOutcome = await spec.acquireOutcome(output);
     campaignOutcome.canonicalClaim = canonicalClaim;
+    campaignOutcome.executionClaim = executionClaim;
   } catch (error) {
     let releaseError = null;
     try { await canonicalClaim.release(); } catch (cleanup) { releaseError = cleanup; }
+    try { await executionClaim.release(); } catch (cleanup) {
+      releaseError = preservePrimaryFailure(releaseError, cleanup);
+    }
     throw preservePrimaryFailure(error, releaseError);
   }
   const runRoot = path.join(path.dirname(output), "runs");
@@ -3405,11 +4022,11 @@ async function runCampaignEntryController({
       sceneWorksRepo: ROOT,
       inferenceRepo,
       backend: "mlx",
-      providerName: CAMPAIGN_ENTRY_PROVIDER,
+      providerName: spec.provider,
       onProviderInvocation: ({ action, cases }) => {
         if (action !== "run" || cases.length !== 1
-            || cases[0].logicalCaseId !== CAMPAIGN_ENTRY_LOGICAL_CASE_ID) {
-          fail("SC-20191 attempted a batch or a foreign logical case");
+            || cases[0].logicalCaseId !== spec.logicalCaseId) {
+          fail("contained LTX campaign attempted a batch or a foreign logical case");
         }
       },
       // No checkpoint callback: no partial or pre-validation bundle may reach the output path.
@@ -3419,7 +4036,7 @@ async function runCampaignEntryController({
           fail("SC-20191 harness attempted a foreign provider command");
         }
         return campaignProviderInvocation(providerOptions, input, {
-          signal, setActiveWatchdog, canonicalClaim,
+          signal, setActiveWatchdog, canonicalClaim, executionClaim, bounded,
         });
       },
     });
@@ -3431,8 +4048,14 @@ async function runCampaignEntryController({
       preparationRoot, preparationKey, identity, signal,
     ) === null) fail("SC-20191 prepared cache disappeared before publication");
     await assertPreparationHasNoTransientResidue(preparationRoot);
-    validateCampaignEntryBundle(bundle);
-    await publishCampaignEntryCanonicalOutcome(campaignOutcome, bundle, signal);
+    spec.validateBundle(bundle);
+    if (bounded) {
+      await publishBoundedCampaignEntryOutcome(
+        campaignOutcome, "canonical", async () => bundle, signal,
+      );
+    } else {
+      await publishCampaignEntryCanonicalOutcome(campaignOutcome, bundle, signal);
+    }
   } catch (error) {
     operationError = error;
   } finally {
@@ -3440,8 +4063,9 @@ async function runCampaignEntryController({
       async () => {
         if (await pathExists(runRoot)) await cleanupCanaryScratch(runRoot);
       },
-      async () => releaseUnpublishedCampaignEntryOutcome(campaignOutcome),
+      async () => spec.releaseOutcome(campaignOutcome),
       async () => canonicalClaim.release(),
+      async () => executionClaim.release(),
     ]) {
       try {
         await cleanup();
@@ -3460,7 +4084,16 @@ async function runBoundedCarrierController({
   sceneWorksTree, inferenceTree, identity, preparationKey, preparationRoot,
   prepared, hostMemoryBytes, signal, setActiveWatchdog,
 }) {
-  const canonicalClaim = await acquireCanonicalPublicationClaim(output, signal);
+  const executionClaim = await acquireCanonicalPublicationClaim(
+    containedCampaignExecutionClaimTarget(output), signal,
+  );
+  let canonicalClaim;
+  try {
+    canonicalClaim = await acquireCanonicalPublicationClaim(output, signal);
+  } catch (error) {
+    await executionClaim.release();
+    throw error;
+  }
   let outcome;
   try {
     outcome = await acquireBoundedCarrierOutcome(output);
@@ -3468,6 +4101,9 @@ async function runBoundedCarrierController({
   } catch (error) {
     let releaseError = null;
     try { await canonicalClaim.release(); } catch (cleanup) { releaseError = cleanup; }
+    try { await executionClaim.release(); } catch (cleanup) {
+      releaseError = preservePrimaryFailure(releaseError, cleanup);
+    }
     throw preservePrimaryFailure(error, releaseError);
   }
   const runRoot = path.join(path.dirname(output), "sc-20254-runs");
@@ -3665,6 +4301,7 @@ async function runBoundedCarrierController({
   for (const release of [
     async () => releaseUnpublishedBoundedCarrierOutcome(outcome),
     async () => canonicalClaim.release(),
+    async () => executionClaim.release(),
   ]) {
     try {
       await release();
@@ -3689,9 +4326,11 @@ async function controller(argv) {
   const profileName = options.profile ?? SAFETY_CANARY_PROFILE;
   const campaignEntry = profileName === CAMPAIGN_ENTRY_PROFILE;
   const boundedCarrier = profileName === BOUNDED_CARRIER_PROFILE;
+  const boundedCampaignEntry = profileName === BOUNDED_CAMPAIGN_ENTRY_PROFILE;
   const profile = campaignEntry
     ? { story: "sc-20191" }
-    : boundedCarrier ? { story: "sc-20254" } : canaryProfile(profileName);
+    : boundedCarrier ? { story: "sc-20254" }
+      : boundedCampaignEntry ? { story: "sc-20318" } : canaryProfile(profileName);
   const inferenceRepo = path.resolve(options["inference-repo"]);
   const output = path.resolve(options.output);
   const relativeOutput = path.relative(ROOT, output);
@@ -3841,6 +4480,24 @@ async function controller(argv) {
         hostMemoryBytes: memoryBytes,
         signal,
         setActiveWatchdog: (child) => { activeWatchdog = child; },
+      });
+      return;
+    }
+    if (boundedCampaignEntry) {
+      await runCampaignEntryController({
+        output,
+        inferenceRepo,
+        sceneWorksRevision,
+        inferenceRevision,
+        sceneWorksTree,
+        inferenceTree,
+        identity,
+        preparationKey,
+        preparationRoot,
+        prepared,
+        signal,
+        setActiveWatchdog: (child) => { activeWatchdog = child; },
+        bounded: true,
       });
       return;
     }

--- a/scripts/run-ltx-safety-canary.test.mjs
+++ b/scripts/run-ltx-safety-canary.test.mjs
@@ -19,6 +19,12 @@ import {
   BOUNDED_CARRIER_PHASES,
   BOUNDED_CARRIER_PROFILE,
   BOUNDED_CARRIER_SUCCESS_RECEIPT_TYPE,
+  BOUNDED_CAMPAIGN_ENTRY_ACTION,
+  BOUNDED_CAMPAIGN_ENTRY_FIXTURE,
+  BOUNDED_CAMPAIGN_ENTRY_IDENTITY,
+  BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
+  BOUNDED_CAMPAIGN_ENTRY_PROVIDER,
+  BOUNDED_CAMPAIGN_FAILURE_RECEIPT_TYPE,
   CAMPAIGN_ENTRY_FIXTURE,
   CAMPAIGN_ENTRY_IDENTITY,
   CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
@@ -36,6 +42,15 @@ import {
   acquireCampaignEntryOutcome,
   acquireBoundedCarrierOutcome,
   acquireCanonicalPublicationClaim,
+  boundedCampaignEntryAdapterRequest,
+  boundedCampaignEntryCanonicalFragment,
+  boundedCampaignEntryFailurePath,
+  boundedCampaignEntryFailureReceipt,
+  boundedCampaignEntryOutcomeReservationPath,
+  boundedCampaignEntryPlan,
+  validateBoundedCampaignEntryResponse,
+  validateBoundedCampaignEntryBundle,
+  validateBoundedCampaignEntryFailureReceipt,
   acquirePreparationLock,
   campaignEntryAdapterRequest,
   campaignEntryCanonicalFragment,
@@ -50,6 +65,7 @@ import {
   boundedCarrierSuccessPath,
   boundedCarrierSuccessReceipt,
   canonicalPublicationClaimPath,
+  containedCampaignExecutionClaimTarget,
   canaryWatchdogEnvironment,
   canaryRequest,
   cargoSourceStatusIsClean,
@@ -95,7 +111,9 @@ import {
 } from "./run-ltx-safety-canary.mjs";
 
 import { hashArtifactInventory } from "./hash-artifact-inventory.mjs";
-import { canonicalJson, runProviderPlan, validateBundle } from "./memory-calibration-harness.mjs";
+import {
+  canonicalJson, recordId, runProviderPlan, validateBundle,
+} from "./memory-calibration-harness.mjs";
 
 const TEXT_ENCODER_INVENTORY = {
   root: "/models/gemma",
@@ -110,6 +128,27 @@ async function campaignEntryFixture() {
     import.meta.url,
   ), "utf8"));
   const { provider, planned } = campaignEntryPlan(config);
+  const request = {
+    action: "run",
+    planned,
+    repositories: {
+      sceneWorks: {
+        revision: "1".repeat(40), dirty: false, matrixSourceRevision: "1".repeat(40),
+      },
+      inference: { revision: "2".repeat(40), dirty: false, closureDigest: "3".repeat(64) },
+    },
+    repositoryPaths: { sceneWorks: "/scene", inference: "/inference" },
+    hardware: { probe: "mlx", memoryBytes: 128 * 1024 ** 3 },
+  };
+  return { config, provider, planned, request };
+}
+
+async function boundedCampaignEntryFixture() {
+  const config = JSON.parse(await readFile(new URL(
+    "../docs/calibration/sc-18946/ltx-mlx-rung2-sweep.json",
+    import.meta.url,
+  ), "utf8"));
+  const { provider, planned } = boundedCampaignEntryPlan(config);
   const request = {
     action: "run",
     planned,
@@ -227,6 +266,63 @@ function campaignEntryRuntimeResponse(hostMemoryBytes = 128 * 1024 ** 3) {
     loadability: { result: "passed", resolvedPathFingerprint: "exact@campaign-entry:q4" },
     capturedAt: "2026-08-17T12:00:00Z",
   };
+}
+
+function boundedCampaignEntryRuntimeResponse(hostMemoryBytes = 128 * 1024 ** 3) {
+  const response = campaignEntryRuntimeResponse(hostMemoryBytes);
+  response.strategy = {
+    rung: "bounded_decode",
+    engagedRungs: ["resident", "staged_residency", "bounded_decode"],
+    parameters: { decodeTileEdge: 192, decodeOverlap: 64 },
+  };
+  response.sweep.cases[0].parameters = structuredClone(response.strategy.parameters);
+  for (const name of ["cancel", "error"]) {
+    const scenario = response.scenarios.find((item) => item.name === name);
+    scenario.result = "not_run";
+    scenario.reason = "SC-20318 parity-only lifecycle";
+    delete scenario.cleanupVerified;
+    delete scenario.warmFollowUpPassed;
+  }
+  const values = new Map([
+    ["renderedFrames", 121], ["outputFps", 30], ["audioTrackDecoded", 1],
+    ["decodeTilingEngaged", 1], ["decodeTileSpatialPx", 192],
+    ["decodeTileOverlapPx", 64], ["spatialDecodeTiles", 24],
+    ["latentTemporalDepth", 16], ["latentTokens", 6_144],
+    ["warmConditioningActivePeak", 101], ["warmDenoiseActivePeak", 201],
+    ["warmDecodeActivePeak", 151], ["warmOutputAudioSamples", 48_000],
+    ["warmOutputAudioSampleRate", 48_000], ["warmOutputAudioChannels", 2],
+    ["providerRequestScopeRenders", 2],
+  ]);
+  response.diagnostics.measurements = [...values].map(([name, value]) => ({
+    name, unit: name.includes("Bytes") || name.includes("Peak") ? "bytes" : "count", value,
+  }));
+  delete response._campaignEntry;
+  response._boundedCampaignEntry = {
+    identity: BOUNDED_CAMPAIGN_ENTRY_IDENTITY,
+    inferenceRevision: "2".repeat(40),
+    watchdog: {
+      required: true, protocol: "sceneworks-memory-watchdog-v1",
+      providerPhaseProtocol: "sceneworks-provider-phase-v1",
+      providerPhaseProfile: "bounded-campaign-entry",
+      providerPhases: [...BOUNDED_CARRIER_PHASES],
+      maxFootprintBytes: MAX_FOOTPRINT_BYTES,
+      maxRuntimeSeconds: MAX_RUNTIME_SECONDS,
+      hostMemoryBytes,
+      minInitialMemoryFreeBytes: preflightFreeFloor(hostMemoryBytes),
+      minMemoryFreeBytes: runtimeFreeFloor(hostMemoryBytes),
+    },
+    mlxLimits: { memoryLimitBytes: MAX_FOOTPRINT_BYTES, wiredLimitBytes: MAX_FOOTPRINT_BYTES },
+    cleanup: {
+      preProviderActiveBytes: 0, preProviderCacheBytes: 0,
+      expectedPersistentActive: {
+        identity: "mlx-gen-ltx-transformer-ones-cache-av-bfloat16-v1",
+        videoDimension: 4_096, audioDimension: 2_048,
+        dtype: "bfloat16", bytesPerElement: 2, bytes: 12_288,
+      },
+      postCleanupActiveBytes: 12_288, postCleanupCacheBytes: 0,
+    },
+  };
+  return response;
 }
 
 function boundedCarrierResponse(hostMemoryBytes = 128 * 1024 ** 3) {
@@ -635,6 +731,109 @@ test("SC-20191 rejects carrier, cleanup and watchdog mutations", () => {
   ]) assert.throws(() => validateCampaignEntryWatchdogEvents(events, hostMemoryBytes), /SC-20(?:191|216)/);
 });
 
+test("SC-20318 transforms only the new exact bounded row and rejects every identity mutation", async () => {
+  const { config, planned, request } = await boundedCampaignEntryFixture();
+  const expectedSource = {
+    sceneWorksRevision: "1".repeat(40), inferenceRevision: "2".repeat(40),
+    sceneWorksRepo: "/scene", inferenceRepo: "/inference",
+  };
+  const adapter = boundedCampaignEntryAdapterRequest(request, planned, expectedSource);
+  assert.equal(adapter.action, BOUNDED_CAMPAIGN_ENTRY_ACTION);
+  assert.equal(adapter.planned.logicalCaseId, BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID);
+  assert.equal(adapter.planned.fixture, BOUNDED_CAMPAIGN_ENTRY_FIXTURE);
+  assert.equal(adapter.planned._boundedCampaignEntry.identity, BOUNDED_CAMPAIGN_ENTRY_IDENTITY);
+  assert.equal(adapter.planned._boundedCampaignEntry.seed, 18_946);
+  assert.equal(adapter.planned._boundedCampaignEntry.videoMode, "default_av");
+  assert.equal(adapter.planned._boundedCampaignEntry.spatialDecodeTiles, 24);
+  assert.equal(adapter.planned._measurementSafety.disposition, "safety_refused_open");
+  assert.equal(config.providers.length, 7);
+  for (const mutate of [
+    (value) => { value.action = "run_batch"; },
+    (value) => { value.planned.logicalCaseId = CAMPAIGN_ENTRY_LOGICAL_CASE_ID; },
+    (value) => { value.planned.fixture = CAMPAIGN_ENTRY_FIXTURE; },
+    (value) => { value.planned.target.tier = "q8"; },
+    (value) => { value.planned.strategy.parameters.decodeTileEdge = 193; },
+    (value) => { value.planned.strategy.parameters.decodeOverlap = 63; },
+    (value) => { value.repositories.sceneWorks.dirty = true; },
+    (value) => { value.hardware.memoryBytes = 0; },
+  ]) {
+    const changed = structuredClone(request);
+    mutate(changed);
+    assert.throws(() => boundedCampaignEntryAdapterRequest(changed, planned, expectedSource),
+      /SC-20318|canonical/);
+  }
+});
+
+test("SC-20318 response requires two-render parity, stereo output, exact tiling and cleanup", () => {
+  const hostMemoryBytes = 128 * 1024 ** 3;
+  const response = boundedCampaignEntryRuntimeResponse(hostMemoryBytes);
+  validateBoundedCampaignEntryResponse(response, {
+    inferenceRevision: "2".repeat(40), hostMemoryBytes,
+  });
+  for (const mutate of [
+    (value) => { value.strategy.spatialDecodeTiles = 24; },
+    (value) => { value.output.audio.channels = 1; },
+    (value) => { value.scenarios.find((item) => item.name === "warm_repeat").result = "not_run"; },
+    (value) => { value.scenarios.find((item) => item.name === "cancel").result = "passed"; },
+    (value) => { value.quality.maximumError = value.quality.maximumErrorThreshold + 1; },
+    (value) => { value.diagnostics.measurements.find((item) =>
+      item.name === "providerRequestScopeRenders").value = 1; },
+    (value) => { value.diagnostics.measurements.find((item) =>
+      item.name === "spatialDecodeTiles").value = 23; },
+    (value) => { value.diagnostics.measurements.find((item) =>
+      item.name === "warmDenoiseActivePeak").value = 0; },
+    (value) => { value._boundedCampaignEntry.watchdog.providerPhaseProfile = "bounded-carrier"; },
+    (value) => { value._boundedCampaignEntry.cleanup.postCleanupActiveBytes += 1; },
+  ]) {
+    const changed = structuredClone(response);
+    mutate(changed);
+    assert.throws(() => validateBoundedCampaignEntryResponse(changed, {
+      inferenceRevision: "2".repeat(40), hostMemoryBytes,
+    }), /SC-20318/);
+  }
+});
+
+test("SC-20318 failure receipt stays non-ingestible, phase-bound and mutation-sensitive", () => {
+  const hostMemoryBytes = 128 * 1024 ** 3;
+  const { identity, key, preparationRoot, prepared } = campaignFailurePreparation();
+  const events = campaignFailureEvents(hostMemoryBytes, 3, BOUNDED_CARRIER_PHASES);
+  const canonicalOutput = "/private/results/sc20318-canonical.json";
+  const outcome = {
+    canonicalOutput,
+    failureOutput: boundedCampaignEntryFailurePath(canonicalOutput),
+    reservation: boundedCampaignEntryOutcomeReservationPath(canonicalOutput),
+    choice: `${boundedCampaignEntryOutcomeReservationPath(canonicalOutput)}.choice`,
+    outcomeChoice: "failure",
+    canonicalBundleAbsentAtPublication: true,
+    outcomeReservationHeldAtPublication: true,
+  };
+  const receipt = boundedCampaignEntryFailureReceipt({
+    sceneWorksRevision: "1".repeat(40), sceneWorksTree: "a".repeat(40),
+    inferenceRevision: "3".repeat(40), inferenceTree: "b".repeat(40),
+    identity, preparationKey: key, preparationRoot, prepared,
+    hostMemoryBytes, events, outcome,
+  });
+  assert.equal(receipt.recordType, BOUNDED_CAMPAIGN_FAILURE_RECEIPT_TYPE);
+  assert.equal(receipt.ingestible, false);
+  assert.throws(() => validateBundle(receipt), /schema|object|property|records|required/i);
+  validateBoundedCampaignEntryFailureReceipt(receipt);
+  for (const mutate of [
+    (value) => { value.ingestible = true; },
+    (value) => { value.story = "sc-20216"; },
+    (value) => { value.campaignCase.identity = CAMPAIGN_ENTRY_IDENTITY; },
+    (value) => { value.campaignCase.strategy.spatialDecodeTiles = 23; },
+    (value) => { value.outcome.canonicalBundleAbsentAtPublication = false; },
+    (value) => { value.watchdog.providerPhases = [...PROVIDER_PHASES]; },
+    (value) => { value.watchdog.events[4].providerPhase.name = "primary_decode"; },
+    (value) => { value.watchdog.events.splice(2, 1); },
+    (value) => { value.cleanup.runRootEmpty = false; },
+  ]) {
+    const changed = structuredClone(receipt);
+    mutate(changed);
+    assert.throws(() => validateBoundedCampaignEntryFailureReceipt(changed), /SC-20318|SC-20216/);
+  }
+});
+
 test("SC-20216 failure receipt is phase-authenticated, non-ingestible and mutation-sensitive", () => {
   const hostMemoryBytes = 128 * 1024 ** 3;
   const { identity, key, preparationRoot, prepared } = campaignFailurePreparation();
@@ -831,6 +1030,27 @@ test("SC-20216 jointly reserves canonical and failure outcomes across races and 
   await partialClaim.release();
   await assert.rejects(() => acquireCampaignEntryOutcome(partialOutput), /EEXIST/,
     "a claimed but interrupted outcome must remain fail-closed");
+});
+
+test("distinct contained campaign outputs share one exclusive SC-18946 execution claim", async (t) => {
+  const root = await mkdtemp(path.join(tmpdir(), "sc20318-shared-execution-"));
+  t.after(() => cleanupCanaryScratch(root));
+  const stagedOutput = path.join(root, "sc-20191", "staged.json");
+  const boundedOutput = path.join(root, "sc-20318", "bounded.json");
+  assert.equal(
+    containedCampaignExecutionClaimTarget(stagedOutput),
+    containedCampaignExecutionClaimTarget(boundedOutput),
+    "production containment must not depend on each story's distinct output directory",
+  );
+  const stagedTarget = containedCampaignExecutionClaimTarget(stagedOutput, root);
+  const boundedTarget = containedCampaignExecutionClaimTarget(boundedOutput, root);
+  assert.equal(stagedTarget, boundedTarget);
+  const owner = await acquireCanonicalPublicationClaim(stagedTarget);
+  await assert.rejects(() => acquireCanonicalPublicationClaim(boundedTarget),
+    /live contained LTX run/);
+  await owner.release();
+  const successor = await acquireCanonicalPublicationClaim(boundedTarget);
+  await successor.release();
 });
 
 test("SC-20254 freezes one distinct bounded full-A/V carrier and rejects identity drift", () => {
@@ -1273,6 +1493,75 @@ test("SC-20191 publishes one schema-valid canonical runtime record after strippi
     const changed = structuredClone(result);
     mutate(changed.records[0]);
     assert.throws(() => validateCampaignEntryBundle(changed), /runtime lifecycle|schema|SC-20191/);
+  }
+});
+
+test("SC-20318 synthetic adapter to harness path yields one distinct schema-valid record", async (t) => {
+  const { provider } = await boundedCampaignEntryFixture();
+  const repo = await cleanCampaignHarnessRepo(t);
+  let runRequests = 0;
+  const result = await runProviderPlan({
+    config: { providers: [provider] },
+    providerCommand: ["synthetic-sc20318-provider"],
+    sceneWorksRepo: repo,
+    inferenceRepo: repo,
+    backend: "mlx",
+    providerName: BOUNDED_CAMPAIGN_ENTRY_PROVIDER,
+    closureDigestFor: async () => "c".repeat(64),
+    executeProvider: async (_command, _args, input) => {
+      const request = JSON.parse(input);
+      if (request.action === "probe") {
+        return canonicalJson({ hardware: {
+          probe: "synthetic SC-20318 MLX provider",
+          memoryBytes: 128 * 1024 ** 3,
+          model: "MacFixture", chip: "Apple Fixture", osVersion: "macOS fixture",
+          metalDevice: "Apple Fixture",
+          mlxMemoryLimitBytes: 96 * 1024 ** 3, wiredLimitBytes: 64 * 1024 ** 3,
+        } });
+      }
+      assert.equal(request.action, "run");
+      assert.equal(request.planned.logicalCaseId, BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID);
+      runRequests += 1;
+      const response = boundedCampaignEntryRuntimeResponse(request.hardware.memoryBytes);
+      response._boundedCampaignEntry.inferenceRevision = request.repositories.inference.revision;
+      validateBoundedCampaignEntryResponse(response, {
+        inferenceRevision: request.repositories.inference.revision,
+        hostMemoryBytes: request.hardware.memoryBytes,
+      });
+      return canonicalJson(boundedCampaignEntryCanonicalFragment(response, 43_193_032_536));
+    },
+  });
+  assert.equal(runRequests, 1, "one harness request owns exactly two adapter renders");
+  validateBoundedCampaignEntryBundle(result);
+  const [record] = result.records;
+  assert.equal(record.logicalCaseId, BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID);
+  assert.notEqual(record.logicalCaseId, CAMPAIGN_ENTRY_LOGICAL_CASE_ID);
+  assert.match(record.id, /^imc-[0-9a-f]{20}$/);
+  const stagedIdentity = structuredClone(record);
+  stagedIdentity.fixture = CAMPAIGN_ENTRY_FIXTURE;
+  stagedIdentity.strategy = {
+    rung: "staged_residency", engagedRungs: ["resident", "staged_residency"], parameters: {},
+  };
+  assert.notEqual(record.id, recordId(stagedIdentity),
+    "the bounded canonical record identity must remain distinct from the staged row");
+  assert.equal(Object.hasOwn(record, "output"), false);
+  assert.equal(Object.hasOwn(record, "_boundedCampaignEntry"), false);
+
+  for (const mutate of [
+    (value) => { value.logicalCaseId = CAMPAIGN_ENTRY_LOGICAL_CASE_ID; },
+    (value) => { value.strategy.parameters.decodeTileEdge = 193; },
+    (value) => { value.scenarios.find((item) => item.name === "warm_repeat").result = "not_run"; },
+    (value) => { value.scenarios.find((item) => item.name === "cancel").result = "passed"; },
+    (value) => { value.diagnostics.measurements.find((item) =>
+      item.name === "spatialDecodeTiles").value = 1; },
+    (value) => { value.diagnostics.measurements.find((item) =>
+      item.name === "boundedCampaignWatchdogMaxObservedFootprintBytes").value
+      = MAX_FOOTPRINT_BYTES; },
+  ]) {
+    const changed = structuredClone(result);
+    mutate(changed.records[0]);
+    assert.throws(() => validateBoundedCampaignEntryBundle(changed),
+      /SC-20318|schema|runtime lifecycle|logicalCaseId|logical identity/);
   }
 });
 
@@ -1756,7 +2045,7 @@ test("the production runner can only launch through the identity-checked watchdo
   assert.match(source, /response\?\.inferenceRevision !== expectedInferenceRevision/);
   assert.match(source, /--require-child-attestation/);
   assert.match(source, /--require-provider-phases/);
-  assert.match(source, /"--provider-phase-profile", "campaign-entry"/);
+  assert.match(source, /"--provider-phase-profile", spec\.phaseProfile/);
   assert.equal(CHILD_ATTESTATION_TIMEOUT_SECONDS, 30);
   assert.match(source, /--child-attestation-timeout", String\(CHILD_ATTESTATION_TIMEOUT_SECONDS\)/);
   assert.match(source, /event\.event === "child_attested"/);
@@ -1788,7 +2077,7 @@ test("the production runner can only launch through the identity-checked watchdo
     < failureHandling.indexOf("validateCampaignEntryFailureEvents"),
   "the original watchdog failure must exist before receipt or postcondition validation");
   assert.match(failureHandling, /preserveFailureReceiptSuppression\(watchdogError, error\)/);
-  assert.match(source, /acquireCampaignEntryOutcome\(output\)/);
+  assert.match(source, /campaignOutcome = await spec\.acquireOutcome\(output\)/);
   const canonicalClaim = source.slice(
     source.indexOf("export async function acquireCanonicalPublicationClaim("),
     source.indexOf("export async function acquireBoundedCarrierOutcome("),
@@ -1847,11 +2136,11 @@ test("the production runner can only launch through the identity-checked watchdo
     "await assertCampaignSourceState(providerOptions, signal)",
     "await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal)",
     "await assertPreparationHasNoTransientResidue(preparationRoot)",
-    "validateCampaignEntryBundle(bundle)",
+    "spec.validateBundle(bundle)",
   ]) {
     assert.ok(campaignController.indexOf(operation) >= 0
       && campaignController.indexOf(operation)
-        < campaignController.indexOf("await publishCampaignEntryCanonicalOutcome("),
+        < campaignController.indexOf("if (bounded) {"),
     `${operation} must precede atomic canonical publication`);
   }
   assert.match(source, /cancellation\.abort\(new CanaryInterrupted\(signalName\)\)/);


### PR DESCRIPTION
## Summary
- append one distinct authoritative q4 768x512 f121@30 bounded-decode 192/64 entry, changing the SC-18946 inventory from 70 to 71 while preserving the original 70 provider objects
- keep ordinary campaign execution fail-closed for every row and admit only the exact new row through private containment
- run selected plus one identical-input warm repeat for measured LTX quality parity; cancellation/error/recovery remain truthfully not_run
- publish a schema-valid canonical runtime_complete bundle only after watchdog, allocator, source, artifact, process, scratch, and shared campaign-execution checks
- retain distinct non-ingestible failure evidence and all SC-20191/SC-20216/SC-20254 paths

## Validation
- npm run check: 578/578
- focused Node: 94/94; independent focused review: 156/156
- MLX adapter tests: 94/94; independent LTX review: 42/42
- exact SC-20318 Rust tests: 2/2
- Clippy all targets with warnings denied; cargo fmt; Python compile; diff checks
- independent adversarial review: PASS, high confidence

## Runtime boundary
No real-weight workload ran on this branch. After merge, SC-20318 requires one controlled permanent-head campaign execution containing exactly the selected render plus required parity repeat, followed by independent bundle and residue audit. The prior staged hard stop and diagnostic bounded receipt are not relabeled or ingested.