### PR TITLE
Stabilize watchdog provider-phase timing test

### DIFF
--- a/scripts/memory-calibration-watchdog.test.mjs
+++ b/scripts/memory-calibration-watchdog.test.mjs
@@ -352,6 +352,9 @@ test("authenticated provider phases are exact, monotonic and bound to terminal e
     "lifecycle_warm_repeat", "lifecycle_cancel", "lifecycle_cancel_recovery",
     "lifecycle_error", "lifecycle_error_recovery", "cleanup",
   ];
+  const telemetryTimeoutSeconds = 0.5;
+  // Bound startup, each serialized phase/ACK barrier, and completion independently.
+  const maxRuntimeSeconds = (phases.length + 2) * telemetryTimeoutSeconds;
   await writeFile(attester, String.raw`import json, os, socket
 sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 sock.connect(os.environ["SCENEWORKS_MEMORY_WATCHDOG_SOCKET"])
@@ -377,9 +380,20 @@ while True:
     if message == f"BYE {nonce}": break
     assert message == f"PING {nonce}"
 `);
-  await runWithMockedProductionTelemetry(files, ["python3", attester], {
-    requireProviderPhases: true,
-  });
+  try {
+    await runWithMockedProductionTelemetry(files, ["python3", attester], {
+      requireProviderPhases: true,
+      maxRuntimeSeconds,
+    });
+  } catch (error) {
+    const events = (await readFile(files.events, "utf8").catch(() => "")).trim()
+      .split("\n").filter(Boolean).map(JSON.parse);
+    const hardStops = events.filter((event) => event.event === "hard_stop")
+      .map((event) => event.reason);
+    assert.fail(
+      `provider-phase watchdog unexpectedly exited ${error.code}; hard_stop=${JSON.stringify(hardStops)}; events=${JSON.stringify(events)}`,
+    );
+  }
   const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
   const markers = events.filter((event) => event.event === "provider_phase");
   assert.deepEqual(markers.map((event) => event.providerPhase.name), phases);
@@ -398,6 +412,7 @@ while True:
     assert.equal(events[index].previousEventHash, events[index - 1].eventHash);
   }
   assert.ok(events.every((event) => /^[0-9a-f]{64}$/.test(event.eventHash)));
+  assert.equal(events.some((event) => event.event === "hard_stop"), false);
   validateWatchdogEventChain(events);
 });
 


### PR DESCRIPTION
## Summary
- give the ten-phase authenticated watchdog test a phase-count-derived six-second synthetic runtime ceiling
- preserve the production watchdog and all fail-closed runtime and telemetry semantics
- include parsed watchdog events and exact hard-stop reasons on unexpected exit

## Diagnosis
PR #2390 head a0dbc011 failed this test after 2570.530 ms while the helper imposed a two-second total runtime across ten serialized phase/ACK barriers. The source-consistent fail-closed reason is runtime_at_or_above_2.0s; the duplicate workflow passed the same source. Production uses its existing 1800-second campaign ceiling and is unchanged.

## Validation
- provider-phase concurrent stress: 12/12
- complete watchdog suite: 31/31
- npm run check: 573/573
- independent review: PASS, high confidence
- git diff --check: passed

Related blocker: https://github.com/SceneWorks/SceneWorks/pull/2390