### PR TITLE
sc-19706 Materialize complete resolved model bundles

### DIFF
--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -165,8 +165,8 @@ jobs:
         run: node apps/desktop/scripts/stage-test-sidecars.mjs
       - name: Run Windows project-registry fingerprint regression
         run: cargo test -p sceneworks-core windows_registry_cache_detects_between_window_rewrite_with_restored_mtime
-      - name: Run Windows resolved-cache safety regressions
-        run: "cargo test -p sceneworks-core model_artifacts::resolved_cache::tests:: -- --test-threads=1"
+      - name: Run Windows resolved-cache and materialization safety regressions
+        run: "cargo test -p sceneworks-core model_artifacts::resolved_cache:: -- --test-threads=1"
       - name: Run desktop Rust tests
         run: cargo test -p sceneworks-desktop
       - name: Check desktop Rust lint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +115,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1709,6 +1727,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cvt"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ae9bf77fbf2d39ef573205d554d87e86c12f1994e9ea335b0651b9b278bcf1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2382,6 +2409,20 @@ checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "fs_at"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14af6c9694ea25db25baa2a1788703b9e7c6648dcaeeebeb98f7561b5384c036"
+dependencies = [
+ "aligned",
+ "cfg-if",
+ "cvt",
+ "libc",
+ "nix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4717,6 +4758,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8911957c4b1549ac0dc74e30db9c8b0e66ddcd6d7acc33098f4c63a64a6d7ed"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5965,6 +6015,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a694f9e0eb3104451127f6cc1e5de55f59d3b1fc8c5ddfaeb6f1e716479ceb4a"
+dependencies = [
+ "cfg-if",
+ "cvt",
+ "fs_at",
+ "libc",
+ "normpath",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6390,6 +6454,7 @@ version = "0.8.7"
 dependencies = [
  "directories",
  "fs2",
+ "fs_at",
  "getrandom 0.3.4",
  "image",
  "imagesize",
@@ -6397,7 +6462,9 @@ dependencies = [
  "mime_guess",
  "parking_lot",
  "png 0.18.1",
+ "remove_dir_all",
  "rusqlite",
+ "rustix",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/sceneworks-core/Cargo.toml
+++ b/crates/sceneworks-core/Cargo.toml
@@ -40,12 +40,19 @@ tracing-subscriber = { workspace = true }
 trash = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
+# Safe NtCreateFile-backed relative operations prevent Windows junction/reparse TOCTOU escapes.
+fs_at = "0.2.1"
+# Deletes children through already-open Windows handles rather than a racy recursive path walk.
+remove_dir_all = "=0.8.4"
 # Safe wrapper around GetFileInformationByHandle. The recent-project registry
 # cache uses volume + file index to distinguish atomic replacement.
 winapi-util = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+# Descriptor-relative filesystem operations keep resolved-cache staging publication and cleanup
+# confined even when a managed path is concurrently replaced.
+rustix = { version = "1", features = ["fs"] }
 
 [dev-dependencies]
 tempfile = "3.13"

--- a/crates/sceneworks-core/src/model_artifacts.rs
+++ b/crates/sceneworks-core/src/model_artifacts.rs
@@ -173,6 +173,16 @@ pub struct ResolvedBundleClosure {
     pub members: Vec<ResolvedBundleMember>,
 }
 
+/// One exact source file and its final logical output path. Indices refer back to the canonical
+/// closure so callers do not duplicate identity, role, component, tier, size, or hash fields.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedBundleFileLocation {
+    pub member_index: usize,
+    pub file_index: usize,
+    pub source_path: PathBuf,
+    pub output_path: PathBuf,
+}
+
 impl ResolvedBundleClosure {
     pub fn new(mut members: Vec<ResolvedBundleMember>) -> Result<Self, ArtifactContractError> {
         for member in &mut members {
@@ -219,67 +229,66 @@ impl ResolvedBundleClosure {
     }
 
     pub fn validate_at_root(&self, root: &Path) -> Result<(), ArtifactContractError> {
-        if Self::new(self.members.clone())? != *self {
-            return Err(ArtifactContractError(
-                "artifact closure is not in canonical sorted form".to_owned(),
-            ));
-        }
+        self.validate_canonical()?;
         let root = canonical_or_absolute(root)?;
         for member in &self.members {
             member.validate()?;
             let member_root = rebase_under(&root, &member.destination)?;
             for file in &member.files {
                 let path = rebase_under(&member_root, &file.relative_path)?;
-                let metadata = std::fs::metadata(&path).map_err(|error| {
-                    ArtifactContractError(format!(
-                        "artifact closure file {} is unavailable: {error}",
-                        path.display()
-                    ))
-                })?;
-                if !metadata.is_file() {
-                    return Err(ArtifactContractError(format!(
-                        "artifact closure entry {} is not a file",
-                        path.display()
-                    )));
-                }
-                if file
-                    .size_bytes
-                    .is_some_and(|expected| expected != metadata.len())
-                {
-                    return Err(ArtifactContractError(format!(
-                        "artifact closure size changed for {}",
-                        path.display()
-                    )));
-                }
-                if let Some(expected) = &file.sha256 {
-                    use std::io::Read;
-                    let mut input = std::fs::File::open(&path).map_err(|error| {
-                        ArtifactContractError(format!("cannot hash {}: {error}", path.display()))
-                    })?;
-                    let mut digest = Sha256::new();
-                    let mut buffer = [0_u8; 64 * 1024];
-                    loop {
-                        let read = input.read(&mut buffer).map_err(|error| {
-                            ArtifactContractError(format!(
-                                "cannot hash {}: {error}",
-                                path.display()
-                            ))
-                        })?;
-                        if read == 0 {
-                            break;
-                        }
-                        digest.update(&buffer[..read]);
-                    }
-                    if format!("sha256:{:x}", digest.finalize()) != *expected {
-                        return Err(ArtifactContractError(format!(
-                            "artifact closure hash changed for {}",
-                            path.display()
-                        )));
-                    }
-                }
+                validate_artifact_file(&path, file)?;
             }
         }
         Ok(())
+    }
+
+    /// Resolve every member from its exact repository, immutable revision and source subpath.
+    /// Hugging Face's normal final-file symlink into the same repository's `blobs` directory is
+    /// accepted; intermediate links and links into another repository or arbitrary host path fail
+    /// closed. Returned source paths are canonical targets selected during validation, so a later
+    /// swap of a snapshot-visible link cannot redirect the materializer outside the repository.
+    pub fn source_file_locations(
+        &self,
+        primary_identity: &ArtifactIdentity,
+        primary_snapshot_root: &Path,
+    ) -> Result<Vec<ResolvedBundleFileLocation>, ArtifactContractError> {
+        self.validate_canonical()?;
+        primary_identity.validate()?;
+        let library = source_library_for_primary_snapshot(primary_identity, primary_snapshot_root)?;
+        let primary = self
+            .members
+            .iter()
+            .find(|member| member.role == ArtifactMemberRole::Primary)
+            .expect("canonical closure has exactly one primary");
+        if &primary.source != primary_identity {
+            return Err(ArtifactContractError(
+                "primary bundle member identity differs from artifact identity".to_owned(),
+            ));
+        }
+
+        let mut locations = Vec::new();
+        for (member_index, member) in self.members.iter().enumerate() {
+            member.validate()?;
+            let (_, snapshot) = library
+                .discover_snapshot(&member.source.repository, Some(&member.source.revision))?;
+            validate_source_snapshot(&library, &member.source, &snapshot)?;
+            let member_root = snapshot.join(&member.source_subpath);
+            validate_source_ancestors(&snapshot, &member_root)?;
+            for (file_index, file) in member.files.iter().enumerate() {
+                let source_path = member_root.join(&file.relative_path);
+                let source_path =
+                    validate_source_file(&library, &member.source, &snapshot, &source_path, file)?;
+                let output_path = member.destination.join(&file.relative_path);
+                validate_relative_path(&output_path, "artifact output file")?;
+                locations.push(ResolvedBundleFileLocation {
+                    member_index,
+                    file_index,
+                    source_path,
+                    output_path,
+                });
+            }
+        }
+        Ok(locations)
     }
 
     pub fn rebased_paths(&self, root: &Path) -> Result<Vec<PathBuf>, ArtifactContractError> {
@@ -293,6 +302,15 @@ impl ResolvedBundleClosure {
                 })
             })
             .collect()
+    }
+
+    fn validate_canonical(&self) -> Result<(), ArtifactContractError> {
+        if Self::new(self.members.clone())? != *self {
+            return Err(ArtifactContractError(
+                "artifact closure is not in canonical sorted form".to_owned(),
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -374,7 +392,13 @@ impl ResolvedModelArtifact {
                 "artifact is not complete and runtime-loadable".to_owned(),
             ));
         }
-        self.closure.validate_at_root(self.location.root())
+        match &self.location {
+            ArtifactLocation::SourceLibrary { root } => {
+                self.closure.source_file_locations(&self.identity, root)?;
+                Ok(())
+            }
+            ArtifactLocation::ResolvedLocal { root } => self.closure.validate_at_root(root),
+        }
     }
 
     /// Stable key over the versioned immutable identity, full sorted closure and provenance.
@@ -922,6 +946,265 @@ fn primary_tier(closure: &ResolvedBundleClosure) -> Option<String> {
         .and_then(|member| member.tier.clone())
 }
 
+fn validate_artifact_file(path: &Path, file: &ArtifactFile) -> Result<(), ArtifactContractError> {
+    let metadata = std::fs::metadata(path).map_err(|error| {
+        ArtifactContractError(format!(
+            "artifact closure file {} is unavailable: {error}",
+            path.display()
+        ))
+    })?;
+    if !metadata.is_file() {
+        return Err(ArtifactContractError(format!(
+            "artifact closure entry {} is not a file",
+            path.display()
+        )));
+    }
+    if file
+        .size_bytes
+        .is_some_and(|expected| expected != metadata.len())
+    {
+        return Err(ArtifactContractError(format!(
+            "artifact closure size changed for {}",
+            path.display()
+        )));
+    }
+    if let Some(expected) = &file.sha256 {
+        use std::io::Read;
+        let mut input = std::fs::File::open(path).map_err(|error| {
+            ArtifactContractError(format!("cannot hash {}: {error}", path.display()))
+        })?;
+        let mut digest = Sha256::new();
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read = input.read(&mut buffer).map_err(|error| {
+                ArtifactContractError(format!("cannot hash {}: {error}", path.display()))
+            })?;
+            if read == 0 {
+                break;
+            }
+            digest.update(&buffer[..read]);
+        }
+        if format!("sha256:{:x}", digest.finalize()) != *expected {
+            return Err(ArtifactContractError(format!(
+                "artifact closure hash changed for {}",
+                path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn source_library_for_primary_snapshot(
+    identity: &ArtifactIdentity,
+    snapshot: &Path,
+) -> Result<ArtifactSourceLibrary, ArtifactContractError> {
+    let revision = snapshot.file_name().and_then(|value| value.to_str());
+    let snapshots = snapshot.parent();
+    let repository = snapshots.and_then(Path::parent);
+    let library = repository.and_then(Path::parent);
+    if revision != Some(identity.revision.as_str())
+        || snapshots
+            .and_then(Path::file_name)
+            .and_then(|value| value.to_str())
+            != Some("snapshots")
+    {
+        return Err(ArtifactContractError(format!(
+            "source snapshot {} does not encode the artifact revision",
+            snapshot.display()
+        )));
+    }
+    let library = library.ok_or_else(|| {
+        ArtifactContractError(format!(
+            "source snapshot {} is outside a Hugging Face repository",
+            snapshot.display()
+        ))
+    })?;
+    let library = ArtifactSourceLibrary::new(library)?;
+    let expected = library
+        .repository_root(&identity.repository)?
+        .join("snapshots")
+        .join(&identity.revision);
+    if canonical_or_absolute(&expected)? != canonical_or_absolute(snapshot)? {
+        return Err(ArtifactContractError(format!(
+            "source snapshot {} does not match {}@{}",
+            snapshot.display(),
+            identity.repository,
+            identity.revision
+        )));
+    }
+    validate_source_snapshot(&library, identity, snapshot)?;
+    Ok(library)
+}
+
+fn validate_source_snapshot(
+    library: &ArtifactSourceLibrary,
+    identity: &ArtifactIdentity,
+    snapshot: &Path,
+) -> Result<(), ArtifactContractError> {
+    let repository = library.repository_root(&identity.repository)?;
+    let snapshots = repository.join("snapshots");
+    let expected = snapshots.join(&identity.revision);
+    if canonical_or_absolute(&expected)? != canonical_or_absolute(snapshot)? {
+        return Err(ArtifactContractError(format!(
+            "source snapshot {} differs from the exact immutable repository location",
+            snapshot.display()
+        )));
+    }
+    for (path, label) in [
+        (&repository, "source repository"),
+        (&snapshots, "source snapshots directory"),
+        (&expected, "source snapshot"),
+    ] {
+        let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+            ArtifactContractError(format!(
+                "{label} {} is unavailable: {error}",
+                path.display()
+            ))
+        })?;
+        if metadata.file_type().is_symlink()
+            || metadata_is_reparse_point(&metadata)
+            || !metadata.is_dir()
+        {
+            return Err(ArtifactContractError(format!(
+                "{label} {} is a link, reparse point, or not a directory",
+                path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_source_ancestors(
+    snapshot: &Path,
+    descendant: &Path,
+) -> Result<(), ArtifactContractError> {
+    let relative = descendant.strip_prefix(snapshot).map_err(|_| {
+        ArtifactContractError(format!(
+            "artifact source path escaped snapshot: {}",
+            descendant.display()
+        ))
+    })?;
+    let mut cursor = snapshot.to_path_buf();
+    for component in relative.components() {
+        cursor.push(component.as_os_str());
+        match std::fs::symlink_metadata(&cursor) {
+            Ok(metadata)
+                if metadata.file_type().is_symlink() || metadata_is_reparse_point(&metadata) =>
+            {
+                return Err(ArtifactContractError(format!(
+                    "artifact source ancestor {} is a link or reparse point",
+                    cursor.display()
+                )));
+            }
+            Ok(metadata) if !metadata.is_dir() => {
+                return Err(ArtifactContractError(format!(
+                    "artifact source ancestor {} is not a directory",
+                    cursor.display()
+                )));
+            }
+            Ok(_) => {}
+            Err(error) => {
+                return Err(ArtifactContractError(format!(
+                    "artifact source ancestor {} is unavailable: {error}",
+                    cursor.display()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_source_file(
+    library: &ArtifactSourceLibrary,
+    identity: &ArtifactIdentity,
+    snapshot: &Path,
+    path: &Path,
+    file: &ArtifactFile,
+) -> Result<PathBuf, ArtifactContractError> {
+    let parent = path.parent().ok_or_else(|| {
+        ArtifactContractError(format!(
+            "artifact source file {} has no parent",
+            path.display()
+        ))
+    })?;
+    validate_source_ancestors(snapshot, parent)?;
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        ArtifactContractError(format!(
+            "artifact closure file {} is unavailable: {error}",
+            path.display()
+        ))
+    })?;
+    if metadata_is_reparse_point(&metadata) && !metadata.file_type().is_symlink() {
+        return Err(ArtifactContractError(format!(
+            "artifact source file {} is a reparse point",
+            path.display()
+        )));
+    }
+    let canonical = std::fs::canonicalize(path).map_err(|error| {
+        ArtifactContractError(format!(
+            "cannot resolve artifact source file {}: {error}",
+            path.display()
+        ))
+    })?;
+    if metadata.file_type().is_symlink() {
+        let repository = library.repository_root(&identity.repository)?;
+        let blobs = repository.join("blobs");
+        let blobs_metadata = std::fs::symlink_metadata(&blobs).map_err(|error| {
+            ArtifactContractError(format!(
+                "source blobs directory {} is unavailable: {error}",
+                blobs.display()
+            ))
+        })?;
+        if blobs_metadata.file_type().is_symlink()
+            || metadata_is_reparse_point(&blobs_metadata)
+            || !blobs_metadata.is_dir()
+        {
+            return Err(ArtifactContractError(format!(
+                "source blobs directory {} is linked, reparsed, or not a directory",
+                blobs.display()
+            )));
+        }
+        let canonical_repository = std::fs::canonicalize(&repository).map_err(|error| {
+            ArtifactContractError(format!(
+                "source repository {} is unavailable: {error}",
+                repository.display()
+            ))
+        })?;
+        let blobs = std::fs::canonicalize(&blobs).map_err(|error| {
+            ArtifactContractError(format!(
+                "source blobs directory {} is unavailable: {error}",
+                blobs.display()
+            ))
+        })?;
+        if blobs.parent() != Some(canonical_repository.as_path()) || !canonical.starts_with(&blobs)
+        {
+            return Err(ArtifactContractError(format!(
+                "artifact source link {} escapes its repository blobs",
+                path.display()
+            )));
+        }
+    } else if !canonical.starts_with(canonical_or_absolute(snapshot)?) {
+        return Err(ArtifactContractError(format!(
+            "artifact source file {} escapes its immutable snapshot",
+            path.display()
+        )));
+    }
+    validate_artifact_file(&canonical, file)?;
+    Ok(canonical)
+}
+
+#[cfg(windows)]
+fn metadata_is_reparse_point(metadata: &std::fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}
+
+#[cfg(not(windows))]
+fn metadata_is_reparse_point(_metadata: &std::fs::Metadata) -> bool {
+    false
+}
+
 fn validate_relative_path_allow_empty(
     path: &Path,
     label: &str,
@@ -1064,6 +1347,18 @@ mod tests {
     use super::*;
 
     const REV: &str = "0123456789abcdef0123456789abcdef01234567";
+    const OTHER_REV: &str = "1111111111111111111111111111111111111111";
+
+    fn snapshot(root: &Path, repository: &str, revision: &str) -> PathBuf {
+        let library = ArtifactSourceLibrary::new(root).unwrap();
+        let snapshot = library
+            .repository_root(repository)
+            .unwrap()
+            .join("snapshots")
+            .join(revision);
+        std::fs::create_dir_all(&snapshot).unwrap();
+        snapshot
+    }
 
     fn primary(destination: &str, file: &str) -> ResolvedBundleMember {
         ResolvedBundleMember {
@@ -1114,16 +1409,14 @@ mod tests {
         assert_eq!(a, b);
 
         let root = tempfile::tempdir().unwrap();
-        std::fs::write(root.path().join("model.safetensors"), b"model").unwrap();
-        std::fs::create_dir(root.path().join("optional")).unwrap();
-        std::fs::write(root.path().join("optional/adapter.safetensors"), b"adapter").unwrap();
+        let snapshot = snapshot(root.path(), "SceneWorks/model", REV);
+        std::fs::write(snapshot.join("model.safetensors"), b"model").unwrap();
+        std::fs::write(snapshot.join("adapter.safetensors"), b"adapter").unwrap();
         let identity = ArtifactIdentity::pinned("SceneWorks/model", REV, "q8").unwrap();
         let artifact = ResolvedModelArtifact {
             schema_version: MODEL_ARTIFACT_CONTRACT_VERSION,
             identity: identity.clone(),
-            location: ArtifactLocation::SourceLibrary {
-                root: root.path().to_owned(),
-            },
+            location: ArtifactLocation::SourceLibrary { root: snapshot },
             closure: a,
             provenance: ArtifactProvenance {
                 identity,
@@ -1409,6 +1702,137 @@ mod tests {
         assert!(
             from_source.validate().is_err(),
             "usable-stale still requires its exact closure"
+        );
+    }
+
+    #[test]
+    fn source_enumeration_resolves_multi_repo_tier_and_derived_members_exactly() {
+        let source = tempfile::tempdir().unwrap();
+        let primary_snapshot = snapshot(source.path(), "SceneWorks/model", REV);
+        let tokenizer_snapshot = snapshot(source.path(), "SceneWorks/tokenizer", OTHER_REV);
+        std::fs::create_dir_all(primary_snapshot.join("q8")).unwrap();
+        std::fs::create_dir_all(primary_snapshot.join("derived")).unwrap();
+        std::fs::create_dir_all(tokenizer_snapshot.join("tokenizer")).unwrap();
+        std::fs::write(primary_snapshot.join("q8/model.safetensors"), b"model").unwrap();
+        std::fs::write(
+            primary_snapshot.join("derived/tokenizer_config.json"),
+            b"derived",
+        )
+        .unwrap();
+        std::fs::write(
+            tokenizer_snapshot.join("tokenizer/tokenizer.json"),
+            b"tokenizer",
+        )
+        .unwrap();
+
+        let identity = ArtifactIdentity::pinned("SceneWorks/model", REV, "q8").unwrap();
+        let mut primary = primary("", "model.safetensors");
+        primary.source_subpath = PathBuf::from("q8");
+        let mut tokenizer = component(
+            ArtifactMemberRole::CoRequisite,
+            "tokenizer",
+            "tokenizer",
+            "tokenizer.json",
+        );
+        tokenizer.source =
+            ArtifactIdentity::pinned("SceneWorks/tokenizer", OTHER_REV, "default").unwrap();
+        tokenizer.source_subpath = PathBuf::from("tokenizer");
+        let mut derived = component(
+            ArtifactMemberRole::DerivedOverlay,
+            "tokenizer-config",
+            "tokenizer",
+            "tokenizer_config.json",
+        );
+        derived.source_subpath = PathBuf::from("derived");
+        let closure = ResolvedBundleClosure::new(vec![tokenizer, primary, derived]).unwrap();
+        let artifact = ResolvedModelArtifact {
+            schema_version: MODEL_ARTIFACT_CONTRACT_VERSION,
+            identity: identity.clone(),
+            location: ArtifactLocation::SourceLibrary {
+                root: primary_snapshot.clone(),
+            },
+            closure,
+            provenance: ArtifactProvenance {
+                identity,
+                fixed_artifact_tier: Some("q8".to_owned()),
+            },
+            completeness: ArtifactCompleteness::Complete,
+            availability: ArtifactAvailability::Available,
+        };
+        artifact.validate().unwrap();
+        let locations = artifact
+            .closure
+            .source_file_locations(&artifact.identity, &primary_snapshot)
+            .unwrap();
+        assert_eq!(locations.len(), 3);
+        assert!(locations.iter().any(|location| {
+            location.source_path
+                == std::fs::canonicalize(tokenizer_snapshot.join("tokenizer/tokenizer.json"))
+                    .unwrap()
+                && location.output_path == Path::new("tokenizer/tokenizer.json")
+        }));
+        assert!(locations.iter().any(|location| {
+            location.source_path
+                == std::fs::canonicalize(primary_snapshot.join("derived/tokenizer_config.json"))
+                    .unwrap()
+                && location.output_path == Path::new("tokenizer/tokenizer_config.json")
+        }));
+
+        std::fs::remove_file(tokenizer_snapshot.join("tokenizer/tokenizer.json")).unwrap();
+        assert!(artifact.validate().is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_accepts_only_same_repository_blob_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let source = tempfile::tempdir().unwrap();
+        let snapshot = snapshot(source.path(), "SceneWorks/model", REV);
+        let repository = ArtifactSourceLibrary::new(source.path())
+            .unwrap()
+            .repository_root("SceneWorks/model")
+            .unwrap();
+        let blobs = repository.join("blobs");
+        std::fs::create_dir_all(&blobs).unwrap();
+        std::fs::write(blobs.join("model-blob"), b"model").unwrap();
+        symlink("../../blobs/model-blob", snapshot.join("model.safetensors")).unwrap();
+        let closure = ResolvedBundleClosure::new(vec![primary("", "model.safetensors")]).unwrap();
+        let identity = ArtifactIdentity::pinned("SceneWorks/model", REV, "q8").unwrap();
+        let artifact = ResolvedModelArtifact {
+            schema_version: MODEL_ARTIFACT_CONTRACT_VERSION,
+            identity: identity.clone(),
+            location: ArtifactLocation::SourceLibrary {
+                root: snapshot.clone(),
+            },
+            closure,
+            provenance: ArtifactProvenance {
+                identity,
+                fixed_artifact_tier: Some("q8".to_owned()),
+            },
+            completeness: ArtifactCompleteness::Complete,
+            availability: ArtifactAvailability::Available,
+        };
+        artifact.validate().unwrap();
+
+        std::fs::remove_file(snapshot.join("model.safetensors")).unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("model-blob"), b"model").unwrap();
+        symlink(
+            outside.path().join("model-blob"),
+            snapshot.join("model.safetensors"),
+        )
+        .unwrap();
+        assert!(artifact.validate().is_err());
+
+        std::fs::remove_file(snapshot.join("model.safetensors")).unwrap();
+        std::fs::remove_dir_all(&blobs).unwrap();
+        symlink(outside.path(), &blobs).unwrap();
+        symlink("../../blobs/model-blob", snapshot.join("model.safetensors")).unwrap();
+        assert!(artifact.validate().is_err());
+        assert_eq!(
+            std::fs::read(outside.path().join("model-blob")).unwrap(),
+            b"model"
         );
     }
 

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -2021,13 +2021,43 @@ fn sync_tree(path: &Path) -> Result<(), ResolvedCacheError> {
         }
         sync_dir(path)?;
     } else if metadata.is_file() {
-        File::open(path)?.sync_all()?;
+        sync_regular_file(path)?;
     } else {
         return Err(ResolvedCacheError::new(format!(
             "cannot sync unmanaged filesystem entry {}",
             path.display()
         )));
     }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn sync_regular_file(path: &Path) -> Result<(), ResolvedCacheError> {
+    use std::os::windows::fs::OpenOptionsExt;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    const FILE_SHARE_READ_WRITE_DELETE: u32 = 0x0000_0001 | 0x0000_0002 | 0x0000_0004;
+
+    // FlushFileBuffers requires a write-capable handle on Windows. Open the file itself rather
+    // than following a late replacement, then recheck the opened handle before flushing it.
+    let file = OpenOptions::new()
+        .write(true)
+        .share_mode(FILE_SHARE_READ_WRITE_DELETE)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata_is_reparse_point(&metadata) {
+        return Err(ResolvedCacheError::new(format!(
+            "cannot sync linked managed path {}",
+            path.display()
+        )));
+    }
+    file.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn sync_regular_file(path: &Path) -> Result<(), ResolvedCacheError> {
+    File::open(path)?.sync_all()?;
     Ok(())
 }
 

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -4,6 +4,13 @@
 //! `<data_dir>/models/resolved`, refuses to adopt an unmarked directory, and names entries from
 //! the portable immutable cache key defined by [`crate::model_artifacts`].
 
+#[path = "resolved_cache/materialization.rs"]
+mod materialization;
+pub use materialization::{
+    IdlePromotionOutcome, MaterializationCancellation, MaterializationOutcome,
+    PromotionScheduleOutcome, ResolvedCacheMaterializer, ResolvedCachePromotionScheduler,
+};
+
 use crate::model_artifacts::{
     ActiveArtifactLease, ArtifactLocation, ModelArtifactResolver, PromotionCandidate,
     ResolvedModelArtifact,
@@ -711,8 +718,53 @@ impl ResolvedCacheStore {
                 }
             }
         }
+        self.cleanup_stale_staging()?;
         self.clean_stale_sessions()?;
         self.enumerate()
+    }
+
+    /// Remove only exact, lock-authorized stale materialization staging directories. Malformed
+    /// names, reparse points and live reservations are retained fail-closed. Complete bundles live
+    /// under `entries/` and are never traversed by this cleanup.
+    pub fn cleanup_stale_staging(&self) -> Result<usize, ResolvedCacheError> {
+        let staging_root = self.inner.root.join("staging");
+        let mut removed = 0;
+        for item in std::fs::read_dir(&staging_root)? {
+            let item = item?;
+            let name = item.file_name();
+            let Some((digest, reservation_id)) = name.to_str().and_then(parse_staging_name) else {
+                continue;
+            };
+            let metadata = item.file_type()?;
+            if !metadata.is_dir() || metadata.is_symlink() {
+                continue;
+            }
+            let artifact_lock = open_lock_file(&self.artifact_lock_path(digest))?;
+            match FileExt::try_lock_exclusive(&artifact_lock) {
+                Ok(()) => {}
+                Err(error) if is_lock_contended(&error) => continue,
+                Err(error) => return Err(error.into()),
+            }
+            let _metadata_lock = self.lock_metadata(digest)?;
+            let live = match self.read_metadata_unlocked(digest) {
+                Ok(JournalRead::Valid { metadata, .. })
+                    if metadata.state == ResolvedCacheEntryState::Materializing
+                        && metadata.reservation_id.as_deref() == Some(reservation_id) =>
+                {
+                    match metadata.session_id.as_deref() {
+                        Some(session) => !self.session_lock_is_acquirable(session)?,
+                        None => true,
+                    }
+                }
+                _ => false,
+            };
+            if live {
+                continue;
+            }
+            remove_managed_tree(&item.path(), &staging_root)?;
+            removed += 1;
+        }
+        Ok(removed)
     }
 
     fn update_metadata(
@@ -968,6 +1020,66 @@ impl ResolvedCacheReservation {
 
     pub fn bundle_path(&self) -> Result<PathBuf, ResolvedCacheError> {
         self.store.bundle_path(&self.cache_key)
+    }
+
+    pub(crate) fn prepare_for_materialization(&self) -> Result<(), ResolvedCacheError> {
+        let _metadata_lock = self.store.lock_metadata(&self.digest)?;
+        let metadata = self.store.read_metadata_locked(&self.digest)?;
+        self.verify_ownership(&metadata)?;
+        reject_link_or_reparse(&self.staging_path, "resolved cache staging directory")?;
+        if std::fs::read_dir(&self.staging_path)?.next().is_some() {
+            return Err(ResolvedCacheError::new(
+                "materialization staging directory is not empty",
+            ));
+        }
+        let bundle = self.bundle_path()?;
+        if std::fs::symlink_metadata(&bundle).is_ok() {
+            let entry = self.store.entry_path(&self.cache_key)?;
+            remove_managed_tree(&bundle, &entry)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn publish_staged(
+        self,
+        mut artifact: ResolvedModelArtifact,
+    ) -> Result<ResolvedCacheMetadata, ResolvedCacheError> {
+        if !matches!(&artifact.location, ArtifactLocation::ResolvedLocal { root } if root == &self.staging_path)
+        {
+            return Err(ResolvedCacheError::new(
+                "staged artifact is not rooted at its reservation staging directory",
+            ));
+        }
+        validate_staging_confinement(&self)?;
+        artifact
+            .validate()
+            .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+        if artifact
+            .cache_key()
+            .map_err(|error| ResolvedCacheError::new(error.to_string()))?
+            != self.cache_key
+        {
+            return Err(ResolvedCacheError::new(
+                "staged artifact cache key differs from its reservation",
+            ));
+        }
+        sync_tree(&self.staging_path)?;
+        let entry = self.store.entry_path(&self.cache_key)?;
+        let bundle = self.bundle_path()?;
+        if std::fs::symlink_metadata(&bundle).is_ok() {
+            return Err(ResolvedCacheError::new(
+                "resolved cache bundle appeared before atomic publication",
+            ));
+        }
+        {
+            let _metadata_lock = self.store.lock_metadata(&self.digest)?;
+            let metadata = self.store.read_metadata_locked(&self.digest)?;
+            self.verify_ownership(&metadata)?;
+        }
+        std::fs::rename(&self.staging_path, &bundle)?;
+        sync_dir(&entry)?;
+        artifact.location = ArtifactLocation::ResolvedLocal { root: bundle };
+        self.record_complete(artifact)
     }
 
     /// Marks only this still-owned reservation interrupted. The private reservation/session
@@ -1515,6 +1627,244 @@ fn validate_completion_confinement(
     Ok(())
 }
 
+fn validate_staging_confinement(
+    reservation: &ResolvedCacheReservation,
+) -> Result<(), ResolvedCacheError> {
+    let staging_root = reservation.store.root().join("staging");
+    reject_link_or_reparse(&staging_root, "resolved cache staging root")?;
+    reject_link_or_reparse(
+        &reservation.staging_path,
+        "resolved cache reservation staging directory",
+    )?;
+    let canonical_root = std::fs::canonicalize(&staging_root)?;
+    let canonical_staging = std::fs::canonicalize(&reservation.staging_path)?;
+    if canonical_staging.parent() != Some(canonical_root.as_path()) {
+        return Err(ResolvedCacheError::new(
+            "materialization staging directory escaped its managed root",
+        ));
+    }
+    validate_regular_tree(&reservation.staging_path)
+}
+
+fn validate_regular_tree(path: &Path) -> Result<(), ResolvedCacheError> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || metadata_is_reparse_point(&metadata) {
+        return Err(ResolvedCacheError::new(format!(
+            "managed cache path {} is a link or reparse point",
+            path.display()
+        )));
+    }
+    if metadata.is_dir() {
+        for item in std::fs::read_dir(path)? {
+            validate_regular_tree(&item?.path())?;
+        }
+    } else if !metadata.is_file() {
+        return Err(ResolvedCacheError::new(format!(
+            "managed cache path {} is not a regular file or directory",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn remove_managed_tree(path: &Path, managed_parent: &Path) -> Result<(), ResolvedCacheError> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    ensure_regular_directory(managed_parent)?;
+    if path.parent() != Some(managed_parent) {
+        return Err(ResolvedCacheError::new(format!(
+            "refusing to remove non-child managed path {}",
+            path.display()
+        )));
+    }
+    let name = path
+        .file_name()
+        .ok_or_else(|| ResolvedCacheError::new("managed path has no final name"))?;
+    if name.as_bytes().contains(&b'/') {
+        return Err(ResolvedCacheError::new(
+            "managed path name contains a separator",
+        ));
+    }
+    let parent = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW)
+        .open(managed_parent)?;
+    remove_entry_at(&parent, name)
+}
+
+#[cfg(windows)]
+fn remove_managed_tree(path: &Path, managed_parent: &Path) -> Result<(), ResolvedCacheError> {
+    use remove_dir_all::RemoveDir;
+
+    let (parent, directory, name) = windows_confined_directory(path, managed_parent)?;
+    let mut handle = directory;
+    handle
+        .remove_dir_contents(Some(path))
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+    drop(handle);
+    fs_at::OpenOptions::default().rmdir_at(&parent, name)?;
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn remove_managed_tree(_path: &Path, _managed_parent: &Path) -> Result<(), ResolvedCacheError> {
+    Err(ResolvedCacheError::new(
+        "managed cache cleanup is unsupported on this platform",
+    ))
+}
+
+#[cfg(windows)]
+fn windows_confined_directory(
+    path: &Path,
+    managed_parent: &Path,
+) -> Result<(File, File, std::ffi::OsString), ResolvedCacheError> {
+    use std::os::windows::fs::OpenOptionsExt;
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+
+    ensure_regular_directory(managed_parent)?;
+    if path.parent() != Some(managed_parent) {
+        return Err(ResolvedCacheError::new(format!(
+            "managed directory {} is not a direct child of {}",
+            path.display(),
+            managed_parent.display()
+        )));
+    }
+    let name = path
+        .file_name()
+        .ok_or_else(|| ResolvedCacheError::new("managed directory has no final name"))?
+        .to_owned();
+    reject_link_or_reparse(path, "managed cache directory")?;
+    #[cfg(test)]
+    run_windows_directory_after_validation_hook();
+    let parent = OpenOptions::new()
+        .read(true)
+        .share_mode(0x0000_0001 | 0x0000_0002)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(managed_parent)?;
+    let mut options = fs_at::OpenOptions::default();
+    options.follow(false);
+    let directory = options.open_dir_at(&parent, &name)?;
+    reject_link_or_reparse(path, "managed cache directory")?;
+    let current = options.open_dir_at(&parent, &name)?;
+    let directory_information = winapi_util::file::information(&directory)?;
+    let current_information = winapi_util::file::information(&current)?;
+    if directory_information.volume_serial_number() != current_information.volume_serial_number()
+        || directory_information.file_index() != current_information.file_index()
+    {
+        return Err(ResolvedCacheError::new(format!(
+            "managed cache directory {} changed while it was opened",
+            path.display()
+        )));
+    }
+    Ok((parent, directory, name))
+}
+
+#[cfg(all(test, windows))]
+thread_local! {
+    static WINDOWS_DIRECTORY_AFTER_VALIDATION_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(all(test, windows))]
+fn set_windows_directory_after_validation_hook(hook: impl FnOnce() + 'static) {
+    WINDOWS_DIRECTORY_AFTER_VALIDATION_HOOK.with(|slot| {
+        *slot.borrow_mut() = Some(Box::new(hook));
+    });
+}
+
+#[cfg(all(test, windows))]
+fn run_windows_directory_after_validation_hook() {
+    WINDOWS_DIRECTORY_AFTER_VALIDATION_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+#[cfg(unix)]
+fn remove_entry_at(parent: &File, name: &std::ffi::OsStr) -> Result<(), ResolvedCacheError> {
+    use rustix::fs::{openat, statat, unlinkat, AtFlags, Dir, FileType, Mode, OFlags};
+    use std::os::unix::ffi::OsStrExt;
+
+    let stat = statat(parent, name, AtFlags::SYMLINK_NOFOLLOW)
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+    #[cfg(test)]
+    run_remove_entry_after_stat_hook();
+    let kind = FileType::from_raw_mode(stat.st_mode);
+    if kind == FileType::Symlink {
+        return Err(ResolvedCacheError::new(
+            "refusing to remove linked managed path",
+        ));
+    }
+    if kind == FileType::Directory {
+        let descriptor = openat(
+            parent,
+            name,
+            OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY | OFlags::NOFOLLOW,
+            Mode::empty(),
+        )
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+        let directory = File::from(descriptor);
+        let names = Dir::read_from(&directory)
+            .map_err(|error| ResolvedCacheError::new(error.to_string()))?
+            .map(|item| {
+                item.map(|item| std::ffi::OsStr::from_bytes(item.file_name().to_bytes()).to_owned())
+                    .map_err(|error| ResolvedCacheError::new(error.to_string()))
+            })
+            .filter(|item| {
+                !matches!(item, Ok(name) if name == std::ffi::OsStr::new(".") || name == std::ffi::OsStr::new(".."))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        for child in names {
+            remove_entry_at(&directory, &child)?;
+        }
+        unlinkat(parent, name, AtFlags::REMOVEDIR)
+            .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+    } else if kind == FileType::RegularFile {
+        unlinkat(parent, name, AtFlags::empty())
+            .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+    } else {
+        return Err(ResolvedCacheError::new(
+            "refusing to remove unmanaged filesystem entry",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+thread_local! {
+    static REMOVE_ENTRY_AFTER_STAT_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(all(test, unix))]
+fn set_remove_entry_after_stat_hook(hook: impl FnOnce() + 'static) {
+    REMOVE_ENTRY_AFTER_STAT_HOOK.with(|slot| {
+        *slot.borrow_mut() = Some(Box::new(hook));
+    });
+}
+
+#[cfg(all(test, unix))]
+fn run_remove_entry_after_stat_hook() {
+    REMOVE_ENTRY_AFTER_STAT_HOOK.with(|slot| {
+        if let Some(hook) = slot.borrow_mut().take() {
+            hook();
+        }
+    });
+}
+
+fn parse_staging_name(name: &str) -> Option<(&str, &str)> {
+    let (digest, reservation_id) = name.split_once('-')?;
+    if is_lower_hex_64(digest) && is_valid_session_id(reservation_id) {
+        Some((digest, reservation_id))
+    } else {
+        None
+    }
+}
+
 fn reject_link_or_reparse(path: &Path, label: &str) -> Result<(), ResolvedCacheError> {
     let metadata = std::fs::symlink_metadata(path)?;
     if metadata.file_type().is_symlink() || metadata_is_reparse_point(&metadata) {
@@ -1654,6 +2004,30 @@ fn write_synced_file(path: &Path, body: &[u8]) -> Result<(), ResolvedCacheError>
     let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
     file.write_all(body)?;
     file.sync_all()?;
+    Ok(())
+}
+
+fn sync_tree(path: &Path) -> Result<(), ResolvedCacheError> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || metadata_is_reparse_point(&metadata) {
+        return Err(ResolvedCacheError::new(format!(
+            "cannot sync linked managed path {}",
+            path.display()
+        )));
+    }
+    if metadata.is_dir() {
+        for item in std::fs::read_dir(path)? {
+            sync_tree(&item?.path())?;
+        }
+        sync_dir(path)?;
+    } else if metadata.is_file() {
+        File::open(path)?.sync_all()?;
+    } else {
+        return Err(ResolvedCacheError::new(format!(
+            "cannot sync unmanaged filesystem entry {}",
+            path.display()
+        )));
+    }
     Ok(())
 }
 

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -1745,7 +1745,7 @@ fn windows_confined_directory(
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
         .open(managed_parent)?;
     let mut options = fs_at::OpenOptions::default();
-    options.follow(false);
+    options.read(true).follow(false);
     let directory = options.open_dir_at(&parent, &name)?;
     reject_link_or_reparse(path, "managed cache directory")?;
     let current = options.open_dir_at(&parent, &name)?;

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -1076,8 +1076,13 @@ impl ResolvedCacheReservation {
             let metadata = self.store.read_metadata_locked(&self.digest)?;
             self.verify_ownership(&metadata)?;
         }
-        std::fs::rename(&self.staging_path, &bundle)?;
-        sync_dir(&entry)?;
+        publish_rename(&self.staging_path, &bundle)?;
+        sync_dir(&entry).map_err(|error| {
+            ResolvedCacheError::new(format!(
+                "sync published entry directory {}: {error}",
+                entry.display()
+            ))
+        })?;
         artifact.location = ArtifactLocation::ResolvedLocal { root: bundle };
         self.record_complete(artifact)
     }
@@ -1739,9 +1744,11 @@ fn windows_confined_directory(
     reject_link_or_reparse(path, "managed cache directory")?;
     #[cfg(test)]
     run_windows_directory_after_validation_hook();
+    // FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE: this handle must never make a
+    // concurrent owner's rename or delete of the managed parent fail while we hold it open.
     let parent = OpenOptions::new()
         .read(true)
-        .share_mode(0x0000_0001 | 0x0000_0002)
+        .share_mode(0x0000_0001 | 0x0000_0002 | 0x0000_0004)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
         .open(managed_parent)?;
     let mut options = fs_at::OpenOptions::default();
@@ -1901,7 +1908,14 @@ fn checked_artifact_bytes(artifact: &ResolvedModelArtifact) -> Result<u64, Resol
         .map_err(|error| ResolvedCacheError::new(error.to_string()))?
         .into_iter()
         .try_fold(0_u64, |total, path| {
-            let size = std::fs::metadata(&path)?.len();
+            let size = std::fs::metadata(&path)
+                .map_err(|error| {
+                    ResolvedCacheError::new(format!(
+                        "measure resolved artifact file {}: {error}",
+                        path.display()
+                    ))
+                })?
+                .len();
             total.checked_add(size).ok_or_else(|| {
                 ResolvedCacheError::new("resolved artifact verified byte total overflow")
             })
@@ -1997,7 +2011,9 @@ fn atomic_write_json(path: &Path, value: &impl Serialize) -> Result<(), Resolved
     if result.is_err() {
         let _ = std::fs::remove_file(&temporary);
     }
-    result
+    result.map_err(|error| {
+        ResolvedCacheError::new(format!("write cache record {}: {error}", path.display()))
+    })
 }
 
 fn write_synced_file(path: &Path, body: &[u8]) -> Result<(), ResolvedCacheError> {
@@ -2007,8 +2023,28 @@ fn write_synced_file(path: &Path, body: &[u8]) -> Result<(), ResolvedCacheError>
     Ok(())
 }
 
+/// Directory-entry durability walk over a fully staged tree, run immediately before
+/// publication.
+///
+/// File *content* durability is deliberately NOT re-established here. `copy_and_verify`
+/// already calls `File::sync_all` on the very write handle that produced the verified
+/// bytes, which binds the flush to the verified identity by construction — no path
+/// reopen, no TOCTOU window. Reopening each staged file by path here (as earlier
+/// revisions did) reintroduced exactly that window on Windows: a parent-directory
+/// junction swap or delete-and-recreate between validation and the reopen would flush
+/// the wrong file while publication proceeded. It also required a write-capable reopen
+/// for `FlushFileBuffers`, which failed closed (`ERROR_ACCESS_DENIED`) or handed
+/// interference filters (AV/indexers) a fresh dirty-close to scan right before the
+/// publish rename. So this walk only:
+/// - re-validates that every staged entry is still a regular file or directory, and
+/// - on Unix, syncs each directory so the entries naming the already-durable inodes are
+///   durable before the rename. Windows has no POSIX directory fsync (`sync_dir` is a
+///   no-op there); journaled NTFS metadata plus the write-through publish rename cover
+///   that side.
 fn sync_tree(path: &Path) -> Result<(), ResolvedCacheError> {
-    let metadata = std::fs::symlink_metadata(path)?;
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        ResolvedCacheError::new(format!("inspect staged path {}: {error}", path.display()))
+    })?;
     if metadata.file_type().is_symlink() || metadata_is_reparse_point(&metadata) {
         return Err(ResolvedCacheError::new(format!(
             "cannot sync linked managed path {}",
@@ -2016,48 +2052,30 @@ fn sync_tree(path: &Path) -> Result<(), ResolvedCacheError> {
         )));
     }
     if metadata.is_dir() {
-        for item in std::fs::read_dir(path)? {
-            sync_tree(&item?.path())?;
+        let items = std::fs::read_dir(path).map_err(|error| {
+            ResolvedCacheError::new(format!(
+                "enumerate staged directory {}: {error}",
+                path.display()
+            ))
+        })?;
+        for item in items {
+            let item = item.map_err(|error| {
+                ResolvedCacheError::new(format!(
+                    "enumerate staged directory {}: {error}",
+                    path.display()
+                ))
+            })?;
+            sync_tree(&item.path())?;
         }
-        sync_dir(path)?;
-    } else if metadata.is_file() {
-        sync_regular_file(path)?;
-    } else {
+        sync_dir(path).map_err(|error| {
+            ResolvedCacheError::new(format!("sync staged directory {}: {error}", path.display()))
+        })?;
+    } else if !metadata.is_file() {
         return Err(ResolvedCacheError::new(format!(
             "cannot sync unmanaged filesystem entry {}",
             path.display()
         )));
     }
-    Ok(())
-}
-
-#[cfg(windows)]
-fn sync_regular_file(path: &Path) -> Result<(), ResolvedCacheError> {
-    use std::os::windows::fs::OpenOptionsExt;
-    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-    const FILE_SHARE_READ_WRITE_DELETE: u32 = 0x0000_0001 | 0x0000_0002 | 0x0000_0004;
-
-    // FlushFileBuffers requires a write-capable handle on Windows. Open the file itself rather
-    // than following a late replacement, then recheck the opened handle before flushing it.
-    let file = OpenOptions::new()
-        .write(true)
-        .share_mode(FILE_SHARE_READ_WRITE_DELETE)
-        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
-        .open(path)?;
-    let metadata = file.metadata()?;
-    if !metadata.is_file() || metadata_is_reparse_point(&metadata) {
-        return Err(ResolvedCacheError::new(format!(
-            "cannot sync linked managed path {}",
-            path.display()
-        )));
-    }
-    file.sync_all()?;
-    Ok(())
-}
-
-#[cfg(not(windows))]
-fn sync_regular_file(path: &Path) -> Result<(), ResolvedCacheError> {
-    File::open(path)?.sync_all()?;
     Ok(())
 }
 
@@ -2070,6 +2088,61 @@ fn sync_dir(path: &Path) -> Result<(), ResolvedCacheError> {
 #[cfg(not(unix))]
 fn sync_dir(_path: &Path) -> Result<(), ResolvedCacheError> {
     Ok(())
+}
+
+/// Atomically renames the validated staging tree onto its bundle path.
+#[cfg(not(windows))]
+fn publish_rename(staging: &Path, bundle: &Path) -> Result<(), ResolvedCacheError> {
+    std::fs::rename(staging, bundle).map_err(|error| publish_rename_error(staging, bundle, &error))
+}
+
+/// Atomically renames the validated staging tree onto its bundle path.
+///
+/// Windows refuses to rename a directory while ANY handle is open on it or a descendant —
+/// including handles the process never opened: antivirus and search-indexer filters briefly open
+/// freshly written files after their write handles close. Those transient
+/// `ERROR_ACCESS_DENIED`/`ERROR_SHARING_VIOLATION` holds are retried with a bounded backoff
+/// before failing closed with the operation and both paths named. Durability of the rename
+/// record itself relies on journaled NTFS metadata: Windows has no POSIX directory fsync, std
+/// `fs::rename` does not expose `MOVEFILE_WRITE_THROUGH`, and this workspace forbids the direct
+/// `unsafe` FFI that reaching it would need.
+#[cfg(windows)]
+fn publish_rename(staging: &Path, bundle: &Path) -> Result<(), ResolvedCacheError> {
+    const ERROR_ACCESS_DENIED: i32 = 5;
+    const ERROR_SHARING_VIOLATION: i32 = 32;
+    const ATTEMPTS: u32 = 8;
+
+    let mut delay = std::time::Duration::from_millis(30);
+    let mut attempt = 0;
+    loop {
+        attempt += 1;
+        match std::fs::rename(staging, bundle) {
+            Ok(()) => return Ok(()),
+            Err(error)
+                if attempt < ATTEMPTS
+                    && matches!(
+                        error.raw_os_error(),
+                        Some(ERROR_ACCESS_DENIED | ERROR_SHARING_VIOLATION)
+                    ) =>
+            {
+                std::thread::sleep(delay);
+                delay = delay.saturating_mul(2);
+            }
+            Err(error) => return Err(publish_rename_error(staging, bundle, &error)),
+        }
+    }
+}
+
+fn publish_rename_error(
+    staging: &Path,
+    bundle: &Path,
+    error: &std::io::Error,
+) -> ResolvedCacheError {
+    ResolvedCacheError::new(format!(
+        "publish staged bundle {} -> {}: {error}",
+        staging.display(),
+        bundle.display()
+    ))
 }
 
 fn random_id() -> Result<String, ResolvedCacheError> {

--- a/crates/sceneworks-core/src/resolved_cache/materialization.rs
+++ b/crates/sceneworks-core/src/resolved_cache/materialization.rs
@@ -591,7 +591,13 @@ fn create_confined_output(root: &Path, relative: &Path) -> Result<File, Resolved
 
     let (parent, file_name) = windows_confined_parent(root, relative, true)?;
     let mut options = fs_at::OpenOptions::default();
+    // read(true) is required for the post-copy destination verification: fs_at requests the
+    // exact rights implied by its options (no generic mapping), and a write-only handle
+    // (FILE_GENERIC_WRITE | SYNCHRONIZE) lacks FILE_READ_ATTRIBUTES, so `File::metadata` on it
+    // fails with ERROR_ACCESS_DENIED. This was the single native publication failure: every
+    // staged copy died at `inspect staged file`, before any flush or rename ran.
     options
+        .read(true)
         .follow(false)
         .write(OpenOptionsWriteMode::Write)
         .create_new(true);

--- a/crates/sceneworks-core/src/resolved_cache/materialization.rs
+++ b/crates/sceneworks-core/src/resolved_cache/materialization.rs
@@ -1,0 +1,862 @@
+use super::*;
+use crate::model_artifacts::{ArtifactFile, ResolvedBundleClosure, ResolvedBundleFileLocation};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::io::{Read, Write};
+use std::path::Component;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+const COPY_BUFFER_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone, Debug, Default)]
+pub struct MaterializationCancellation {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl MaterializationCancellation {
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MaterializationOutcome {
+    Published(Box<ResolvedCacheMetadata>),
+    AlreadyComplete(Box<ResolvedCacheMetadata>),
+    Contended,
+    Cancelled,
+}
+
+#[derive(Clone)]
+pub struct ResolvedCacheMaterializer {
+    store: ResolvedCacheStore,
+    #[cfg(test)]
+    test_hook: Option<Arc<TestCopyHook>>,
+}
+
+#[cfg(test)]
+type TestCopyHook = dyn Fn(usize, &Path) -> std::io::Result<()> + Send + Sync;
+
+impl std::fmt::Debug for ResolvedCacheMaterializer {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ResolvedCacheMaterializer")
+            .field("store", &self.store)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ResolvedCacheMaterializer {
+    pub fn new(store: ResolvedCacheStore) -> Self {
+        Self {
+            store,
+            #[cfg(test)]
+            test_hook: None,
+        }
+    }
+
+    pub fn store(&self) -> &ResolvedCacheStore {
+        &self.store
+    }
+
+    pub fn materialize(
+        &self,
+        candidate: &PromotionCandidate,
+        source_configured_path: &Path,
+        logical_model_owner: &str,
+        cancellation: &MaterializationCancellation,
+    ) -> Result<MaterializationOutcome, ResolvedCacheError> {
+        validate_configured_source(candidate, source_configured_path)?;
+        let reservation =
+            match self
+                .store
+                .reserve(candidate, source_configured_path, logical_model_owner)?
+            {
+                ReservationOutcome::AlreadyComplete(metadata) => {
+                    return Ok(MaterializationOutcome::AlreadyComplete(metadata));
+                }
+                ReservationOutcome::Contended => return Ok(MaterializationOutcome::Contended),
+                ReservationOutcome::Acquired(reservation) => reservation,
+            };
+        reservation.prepare_for_materialization()?;
+        if cancellation.is_cancelled() {
+            return cancel_reservation(*reservation);
+        }
+
+        let primary_root = match &candidate.artifact.location {
+            ArtifactLocation::SourceLibrary { root } => root,
+            ArtifactLocation::ResolvedLocal { .. } => {
+                return Err(ResolvedCacheError::new(
+                    "only a source-library artifact can be materialized",
+                ));
+            }
+        };
+        let locations = match candidate
+            .artifact
+            .closure
+            .source_file_locations(&candidate.artifact.identity, primary_root)
+        {
+            Ok(locations) => locations,
+            Err(error) => {
+                cleanup_failed_reservation(*reservation)?;
+                return Err(ResolvedCacheError::new(error.to_string()));
+            }
+        };
+        let sources = match locations
+            .into_iter()
+            .map(PlannedSourceFile::open)
+            .collect::<Result<Vec<_>, _>>()
+        {
+            Ok(sources) => sources,
+            Err(error) => {
+                cleanup_failed_reservation(*reservation)?;
+                return Err(error);
+            }
+        };
+        let result = self.copy_bundle(candidate, &reservation, sources, cancellation);
+        let artifact = match result {
+            Ok(artifact) => artifact,
+            Err(_error) if cancellation.is_cancelled() => {
+                cleanup_failed_reservation(*reservation)?;
+                return Ok(MaterializationOutcome::Cancelled);
+            }
+            Err(error) => {
+                if let Err(cleanup) = cleanup_failed_reservation(*reservation) {
+                    return Err(ResolvedCacheError::new(format!(
+                        "{error}; failed to clean interrupted staging: {cleanup}"
+                    )));
+                }
+                return Err(error);
+            }
+        };
+        if cancellation.is_cancelled() {
+            cleanup_failed_reservation(*reservation)?;
+            return Ok(MaterializationOutcome::Cancelled);
+        }
+        reservation
+            .publish_staged(artifact)
+            .map(|metadata| MaterializationOutcome::Published(Box::new(metadata)))
+    }
+
+    fn copy_bundle(
+        &self,
+        candidate: &PromotionCandidate,
+        reservation: &ResolvedCacheReservation,
+        sources: Vec<PlannedSourceFile>,
+        cancellation: &MaterializationCancellation,
+    ) -> Result<ResolvedModelArtifact, ResolvedCacheError> {
+        let mut artifact = candidate.artifact.clone();
+        artifact.location = ArtifactLocation::ResolvedLocal {
+            root: reservation.staging_path().to_owned(),
+        };
+        let mut copied = BTreeMap::<(String, PathBuf), (PathBuf, VerifiedFile)>::new();
+        #[cfg(test)]
+        let mut copy_index = 0_usize;
+        for mut source in sources {
+            let location = source.location.clone();
+            if cancellation.is_cancelled() {
+                return Err(ResolvedCacheError::new("materialization cancelled"));
+            }
+            #[cfg(test)]
+            if let Some(hook) = &self.test_hook {
+                hook(copy_index, &location.source_path)?;
+                copy_index += 1;
+            }
+            let member = candidate
+                .artifact
+                .closure
+                .members
+                .get(location.member_index)
+                .ok_or_else(|| ResolvedCacheError::new("source plan member index changed"))?;
+            let destination = reservation.staging_path().join(&location.output_path);
+            let source_key = (
+                member.source.fingerprint.clone(),
+                location.source_path.clone(),
+            );
+            let expected = expected_file(candidate, &location)?;
+            let verified = if let Some((existing, verified)) = copied.get(&source_key) {
+                source.validate_unchanged()?;
+                verify_expected(&location.source_path, expected, verified)?;
+                match hard_link_confined(
+                    reservation.staging_path(),
+                    existing,
+                    &location.output_path,
+                ) {
+                    Ok(()) => verified.clone(),
+                    Err(_) => {
+                        let output = create_confined_output(
+                            reservation.staging_path(),
+                            &location.output_path,
+                        )?;
+                        copy_and_verify(&mut source, output, &destination, expected, cancellation)?
+                    }
+                }
+            } else {
+                let output =
+                    create_confined_output(reservation.staging_path(), &location.output_path)?;
+                let verified =
+                    copy_and_verify(&mut source, output, &destination, expected, cancellation)?;
+                copied.insert(source_key, (location.output_path.clone(), verified.clone()));
+                verified
+            };
+            let file = artifact
+                .closure
+                .members
+                .get_mut(location.member_index)
+                .and_then(|member| member.files.get_mut(location.file_index))
+                .ok_or_else(|| ResolvedCacheError::new("source plan file index changed"))?;
+            file.size_bytes = Some(verified.size_bytes);
+            file.sha256 = Some(verified.sha256);
+        }
+        artifact.closure = ResolvedBundleClosure::new(artifact.closure.members)
+            .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+        artifact
+            .validate()
+            .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+        if artifact
+            .cache_key()
+            .map_err(|error| ResolvedCacheError::new(error.to_string()))?
+            != candidate.cache_key
+        {
+            return Err(ResolvedCacheError::new(
+                "verification enrichment changed the immutable cache key",
+            ));
+        }
+        Ok(artifact)
+    }
+
+    #[cfg(test)]
+    fn with_test_hook(
+        mut self,
+        hook: impl Fn(usize, &Path) -> std::io::Result<()> + Send + Sync + 'static,
+    ) -> Self {
+        self.test_hook = Some(Arc::new(hook));
+        self
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct VerifiedFile {
+    size_bytes: u64,
+    sha256: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SourceFileIdentity {
+    len: u64,
+    modified: Option<std::time::SystemTime>,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    changed_seconds: i64,
+    #[cfg(unix)]
+    changed_nanoseconds: i64,
+    #[cfg(windows)]
+    volume_serial_number: u64,
+    #[cfg(windows)]
+    file_index: u64,
+}
+
+impl SourceFileIdentity {
+    fn from_file(file: &File) -> Result<Self, ResolvedCacheError> {
+        let metadata = file.metadata()?;
+        if !metadata.is_file() {
+            return Err(ResolvedCacheError::new(
+                "materialization source handle is not a regular file",
+            ));
+        }
+        #[cfg(windows)]
+        let information = winapi_util::file::information(file)
+            .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+        Ok(Self {
+            len: metadata.len(),
+            modified: metadata.modified().ok(),
+            #[cfg(unix)]
+            device: {
+                use std::os::unix::fs::MetadataExt;
+                metadata.dev()
+            },
+            #[cfg(unix)]
+            inode: {
+                use std::os::unix::fs::MetadataExt;
+                metadata.ino()
+            },
+            #[cfg(unix)]
+            changed_seconds: {
+                use std::os::unix::fs::MetadataExt;
+                metadata.ctime()
+            },
+            #[cfg(unix)]
+            changed_nanoseconds: {
+                use std::os::unix::fs::MetadataExt;
+                metadata.ctime_nsec()
+            },
+            #[cfg(windows)]
+            volume_serial_number: information.volume_serial_number(),
+            #[cfg(windows)]
+            file_index: information.file_index(),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct PlannedSourceFile {
+    location: ResolvedBundleFileLocation,
+    input: File,
+    identity: SourceFileIdentity,
+}
+
+impl PlannedSourceFile {
+    fn open(location: ResolvedBundleFileLocation) -> Result<Self, ResolvedCacheError> {
+        validate_source_path_is_regular_canonical(&location.source_path)?;
+        let input = open_source_no_follow(&location.source_path)?;
+        let identity = SourceFileIdentity::from_file(&input)?;
+        validate_source_path_identity(&location.source_path, &identity)?;
+        Ok(Self {
+            location,
+            input,
+            identity,
+        })
+    }
+
+    fn validate_unchanged(&self) -> Result<(), ResolvedCacheError> {
+        if SourceFileIdentity::from_file(&self.input)? != self.identity {
+            return Err(ResolvedCacheError::new(format!(
+                "materialization source mutated while copying {}",
+                self.location.source_path.display()
+            )));
+        }
+        validate_source_path_identity(&self.location.source_path, &self.identity)
+    }
+}
+
+fn expected_file<'a>(
+    candidate: &'a PromotionCandidate,
+    location: &ResolvedBundleFileLocation,
+) -> Result<&'a ArtifactFile, ResolvedCacheError> {
+    candidate
+        .artifact
+        .closure
+        .members
+        .get(location.member_index)
+        .and_then(|member| member.files.get(location.file_index))
+        .ok_or_else(|| ResolvedCacheError::new("source plan no longer matches artifact closure"))
+}
+
+fn copy_and_verify(
+    source: &mut PlannedSourceFile,
+    mut output: File,
+    destination: &Path,
+    expected: &ArtifactFile,
+    cancellation: &MaterializationCancellation,
+) -> Result<VerifiedFile, ResolvedCacheError> {
+    if expected
+        .size_bytes
+        .is_some_and(|size| size != source.identity.len)
+    {
+        return Err(ResolvedCacheError::new(format!(
+            "materialization source size changed for {}",
+            source.location.source_path.display()
+        )));
+    }
+    let mut digest = Sha256::new();
+    let mut size_bytes = 0_u64;
+    let mut buffer = vec![0_u8; COPY_BUFFER_BYTES];
+    loop {
+        if cancellation.is_cancelled() {
+            return Err(ResolvedCacheError::new("materialization cancelled"));
+        }
+        let read = source.input.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        output.write_all(&buffer[..read])?;
+        digest.update(&buffer[..read]);
+        size_bytes = size_bytes
+            .checked_add(read as u64)
+            .ok_or_else(|| ResolvedCacheError::new("materialized byte count overflow"))?;
+    }
+    output.sync_all()?;
+    let sha256 = format!("sha256:{:x}", digest.finalize());
+    let verified = VerifiedFile { size_bytes, sha256 };
+    verify_expected(&source.location.source_path, expected, &verified)?;
+    source.validate_unchanged()?;
+    let destination_metadata = output.metadata()?;
+    if !destination_metadata.is_file() || destination_metadata.len() != size_bytes {
+        return Err(ResolvedCacheError::new(format!(
+            "materialized destination verification failed for {}",
+            destination.display()
+        )));
+    }
+    Ok(verified)
+}
+
+fn verify_expected(
+    source: &Path,
+    expected: &ArtifactFile,
+    verified: &VerifiedFile,
+) -> Result<(), ResolvedCacheError> {
+    if expected
+        .size_bytes
+        .is_some_and(|expected| expected != verified.size_bytes)
+        || expected
+            .sha256
+            .as_ref()
+            .is_some_and(|expected| expected != &verified.sha256)
+    {
+        return Err(ResolvedCacheError::new(format!(
+            "materialization source verification changed for {}",
+            source.display()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_source_path_identity(
+    source: &Path,
+    expected: &SourceFileIdentity,
+) -> Result<(), ResolvedCacheError> {
+    validate_source_path_is_regular_canonical(source)?;
+    let current = open_source_no_follow(source)?;
+    if SourceFileIdentity::from_file(&current)? != *expected {
+        return Err(ResolvedCacheError::new(format!(
+            "materialization source identity changed for {}",
+            source.display()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_source_path_is_regular_canonical(source: &Path) -> Result<(), ResolvedCacheError> {
+    let metadata = std::fs::symlink_metadata(source)?;
+    if metadata.file_type().is_symlink()
+        || metadata_is_reparse_point(&metadata)
+        || !metadata.is_file()
+    {
+        return Err(ResolvedCacheError::new(format!(
+            "materialization source {} is linked, reparsed, or not a file",
+            source.display()
+        )));
+    }
+    if std::fs::canonicalize(source)? != source {
+        return Err(ResolvedCacheError::new(format!(
+            "materialization source {} is no longer its planned canonical path",
+            source.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn open_source_no_follow(source: &Path) -> Result<File, ResolvedCacheError> {
+    use std::os::unix::fs::OpenOptionsExt;
+    Ok(OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(source)?)
+}
+
+#[cfg(windows)]
+fn open_source_no_follow(source: &Path) -> Result<File, ResolvedCacheError> {
+    use std::os::windows::fs::OpenOptionsExt;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    Ok(OpenOptions::new()
+        .read(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(source)?)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn open_source_no_follow(source: &Path) -> Result<File, ResolvedCacheError> {
+    Ok(File::open(source)?)
+}
+
+#[cfg(unix)]
+fn confined_parent(
+    root: &Path,
+    relative: &Path,
+    create: bool,
+) -> Result<(File, std::ffi::OsString), ResolvedCacheError> {
+    use rustix::fs::{mkdirat, openat, Mode, OFlags};
+    use std::os::unix::fs::OpenOptionsExt;
+
+    if relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(ResolvedCacheError::new(
+            "materialized output path is not a confined relative path",
+        ));
+    }
+    let mut components = relative.components().collect::<Vec<_>>();
+    let file_name = components
+        .pop()
+        .ok_or_else(|| ResolvedCacheError::new("materialized output path has no file name"))?
+        .as_os_str()
+        .to_owned();
+    let mut directory = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW)
+        .open(root)?;
+    for component in components {
+        let name = component.as_os_str();
+        let flags = OFlags::RDONLY | OFlags::CLOEXEC | OFlags::DIRECTORY | OFlags::NOFOLLOW;
+        let descriptor = match openat(&directory, name, flags, Mode::empty()) {
+            Ok(descriptor) => descriptor,
+            Err(error) if create && error == rustix::io::Errno::NOENT => {
+                if let Err(error) = mkdirat(&directory, name, Mode::RUSR | Mode::WUSR | Mode::XUSR)
+                {
+                    if error != rustix::io::Errno::EXIST {
+                        return Err(ResolvedCacheError::new(error.to_string()));
+                    }
+                }
+                openat(&directory, name, flags, Mode::empty())
+                    .map_err(|error| ResolvedCacheError::new(error.to_string()))?
+            }
+            Err(error) => return Err(ResolvedCacheError::new(error.to_string())),
+        };
+        directory = File::from(descriptor);
+    }
+    Ok((directory, file_name))
+}
+
+#[cfg(unix)]
+fn create_confined_output(root: &Path, relative: &Path) -> Result<File, ResolvedCacheError> {
+    use rustix::fs::{openat, Mode, OFlags};
+
+    let (parent, file_name) = confined_parent(root, relative, true)?;
+    let descriptor = openat(
+        &parent,
+        &file_name,
+        OFlags::WRONLY | OFlags::CREATE | OFlags::EXCL | OFlags::CLOEXEC | OFlags::NOFOLLOW,
+        Mode::RUSR | Mode::WUSR,
+    )
+    .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+    Ok(File::from(descriptor))
+}
+
+#[cfg(unix)]
+fn hard_link_confined(
+    root: &Path,
+    existing: &Path,
+    destination: &Path,
+) -> Result<(), ResolvedCacheError> {
+    use rustix::fs::{linkat, AtFlags};
+
+    let (source_parent, source_name) = confined_parent(root, existing, false)?;
+    let (destination_parent, destination_name) = confined_parent(root, destination, true)?;
+    linkat(
+        &source_parent,
+        &source_name,
+        &destination_parent,
+        &destination_name,
+        AtFlags::empty(),
+    )
+    .map_err(|error| ResolvedCacheError::new(error.to_string()))
+}
+
+#[cfg(windows)]
+fn create_confined_output(root: &Path, relative: &Path) -> Result<File, ResolvedCacheError> {
+    use fs_at::OpenOptionsWriteMode;
+
+    let (parent, file_name) = windows_confined_parent(root, relative, true)?;
+    let mut options = fs_at::OpenOptions::default();
+    options
+        .follow(false)
+        .write(OpenOptionsWriteMode::Write)
+        .create_new(true);
+    Ok(options.open_at(&parent, file_name)?)
+}
+
+#[cfg(windows)]
+fn hard_link_confined(
+    _root: &Path,
+    _existing: &Path,
+    _destination: &Path,
+) -> Result<(), ResolvedCacheError> {
+    // Windows has no std handle-relative hard-link API. Returning an error deliberately selects
+    // the streamed-copy fallback rather than reopening a validated path and reintroducing a
+    // junction race.
+    Err(ResolvedCacheError::new(
+        "safe staging hard links are unavailable on Windows",
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn create_confined_output(_root: &Path, _relative: &Path) -> Result<File, ResolvedCacheError> {
+    Err(ResolvedCacheError::new(
+        "resolved-cache materialization is unsupported on this platform",
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn hard_link_confined(
+    _root: &Path,
+    _existing: &Path,
+    _destination: &Path,
+) -> Result<(), ResolvedCacheError> {
+    Err(ResolvedCacheError::new(
+        "resolved-cache materialization is unsupported on this platform",
+    ))
+}
+
+#[cfg(windows)]
+fn validate_confined_relative_path(relative: &Path) -> Result<(), ResolvedCacheError> {
+    if relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(ResolvedCacheError::new(
+            "materialized output path is not a confined relative path",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn windows_confined_parent(
+    root: &Path,
+    relative: &Path,
+    create: bool,
+) -> Result<(File, std::ffi::OsString), ResolvedCacheError> {
+    validate_confined_relative_path(relative)?;
+    let mut components = relative.components().collect::<Vec<_>>();
+    let file_name = components
+        .pop()
+        .ok_or_else(|| ResolvedCacheError::new("materialized output path has no file name"))?
+        .as_os_str()
+        .to_owned();
+    let managed_parent = root
+        .parent()
+        .ok_or_else(|| ResolvedCacheError::new("staging directory has no managed parent"))?;
+    let (_, mut directory, _) = windows_confined_directory(root, managed_parent)?;
+    for component in components {
+        let mut options = fs_at::OpenOptions::default();
+        options.follow(false);
+        directory = match options.open_dir_at(&directory, component.as_os_str()) {
+            Ok(directory) => directory,
+            Err(error) if create && error.kind() == std::io::ErrorKind::NotFound => options
+                .mkdir_at(&directory, component.as_os_str())
+                .map_err(ResolvedCacheError::from)?,
+            Err(error) => return Err(error.into()),
+        };
+    }
+    Ok((directory, file_name))
+}
+
+fn validate_configured_source(
+    candidate: &PromotionCandidate,
+    source_configured_path: &Path,
+) -> Result<(), ResolvedCacheError> {
+    let snapshot = match &candidate.artifact.location {
+        ArtifactLocation::SourceLibrary { root } => root,
+        ArtifactLocation::ResolvedLocal { .. } => {
+            return Err(ResolvedCacheError::new(
+                "promotion candidate is not source-library backed",
+            ));
+        }
+    };
+    let library = snapshot
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .ok_or_else(|| ResolvedCacheError::new("source snapshot has no library root"))?;
+    if std::fs::canonicalize(library)? != std::fs::canonicalize(source_configured_path)? {
+        return Err(ResolvedCacheError::new(
+            "configured source library differs from promotion candidate provenance",
+        ));
+    }
+    Ok(())
+}
+
+fn cleanup_failed_reservation(
+    mut reservation: ResolvedCacheReservation,
+) -> Result<(), ResolvedCacheError> {
+    if reservation.staging_path().exists() {
+        let staging_root = reservation.store.root().join("staging");
+        remove_managed_tree(reservation.staging_path(), &staging_root)?;
+    }
+    reservation.mark_interrupted()?;
+    Ok(())
+}
+
+fn cancel_reservation(
+    reservation: ResolvedCacheReservation,
+) -> Result<MaterializationOutcome, ResolvedCacheError> {
+    cleanup_failed_reservation(reservation)?;
+    Ok(MaterializationOutcome::Cancelled)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PromotionScheduleOutcome {
+    Enqueued,
+    Coalesced,
+    Disabled,
+    Full,
+    Stopped,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IdlePromotionOutcome {
+    NotIdle,
+    Empty,
+    Stopped,
+    Materialized(MaterializationOutcome),
+}
+
+#[derive(Clone, Debug)]
+struct ScheduledPromotion {
+    candidate: PromotionCandidate,
+    source_configured_path: PathBuf,
+    logical_model_owner: String,
+}
+
+#[derive(Debug, Default)]
+struct PromotionQueueState {
+    queue: VecDeque<ScheduledPromotion>,
+    keys: BTreeSet<String>,
+    active: Option<(String, MaterializationCancellation)>,
+    stopped: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct ResolvedCachePromotionScheduler {
+    policy: ResolvedCachePolicy,
+    materializer: ResolvedCacheMaterializer,
+    capacity: usize,
+    state: Arc<Mutex<PromotionQueueState>>,
+}
+
+impl ResolvedCachePromotionScheduler {
+    pub fn new(
+        policy: ResolvedCachePolicy,
+        materializer: ResolvedCacheMaterializer,
+        capacity: usize,
+    ) -> Result<Self, ResolvedCacheError> {
+        policy.validate()?;
+        if capacity == 0 {
+            return Err(ResolvedCacheError::new(
+                "resolved-cache promotion queue capacity must be nonzero",
+            ));
+        }
+        Ok(Self {
+            policy,
+            materializer,
+            capacity,
+            state: Arc::new(Mutex::new(PromotionQueueState::default())),
+        })
+    }
+
+    pub fn schedule(
+        &self,
+        candidate: PromotionCandidate,
+        source_configured_path: PathBuf,
+        logical_model_owner: String,
+    ) -> Result<PromotionScheduleOutcome, ResolvedCacheError> {
+        if !self.policy.enabled {
+            return Ok(PromotionScheduleOutcome::Disabled);
+        }
+        validate_model_owner(&logical_model_owner)?;
+        cache_key_digest(&candidate.cache_key)?;
+        let mut state = lock_scheduler(&self.state);
+        if state.stopped {
+            return Ok(PromotionScheduleOutcome::Stopped);
+        }
+        if state.keys.contains(&candidate.cache_key)
+            || state
+                .active
+                .as_ref()
+                .is_some_and(|(key, _)| key == &candidate.cache_key)
+        {
+            return Ok(PromotionScheduleOutcome::Coalesced);
+        }
+        if state.queue.len() + usize::from(state.active.is_some()) >= self.capacity {
+            return Ok(PromotionScheduleOutcome::Full);
+        }
+        state.keys.insert(candidate.cache_key.clone());
+        state.queue.push_back(ScheduledPromotion {
+            candidate,
+            source_configured_path,
+            logical_model_owner,
+        });
+        Ok(PromotionScheduleOutcome::Enqueued)
+    }
+
+    /// Run one queued promotion only when the caller proves its worker is idle. The caller owns the
+    /// thread or blocking-task lifetime; this type never detaches work, and `schedule` itself never
+    /// performs source I/O or delays the successful first request.
+    pub fn run_next_if_idle(&self, idle: bool) -> Result<IdlePromotionOutcome, ResolvedCacheError> {
+        if !idle {
+            return Ok(IdlePromotionOutcome::NotIdle);
+        }
+        let (scheduled, cancellation) = {
+            let mut state = lock_scheduler(&self.state);
+            if state.stopped {
+                return Ok(IdlePromotionOutcome::Stopped);
+            }
+            if state.active.is_some() {
+                return Ok(IdlePromotionOutcome::NotIdle);
+            }
+            let Some(scheduled) = state.queue.pop_front() else {
+                return Ok(IdlePromotionOutcome::Empty);
+            };
+            state.keys.remove(&scheduled.candidate.cache_key);
+            let cancellation = MaterializationCancellation::default();
+            state.active = Some((scheduled.candidate.cache_key.clone(), cancellation.clone()));
+            (scheduled, cancellation)
+        };
+        let result = self.materializer.materialize(
+            &scheduled.candidate,
+            &scheduled.source_configured_path,
+            &scheduled.logical_model_owner,
+            &cancellation,
+        );
+        lock_scheduler(&self.state).active = None;
+        result.map(IdlePromotionOutcome::Materialized)
+    }
+
+    pub fn cancel_active(&self) -> bool {
+        let cancellation = lock_scheduler(&self.state)
+            .active
+            .as_ref()
+            .map(|(_, cancellation)| cancellation.clone());
+        if let Some(cancellation) = cancellation {
+            cancellation.cancel();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn shutdown(&self) {
+        let mut state = lock_scheduler(&self.state);
+        state.stopped = true;
+        state.queue.clear();
+        state.keys.clear();
+        if let Some((_, cancellation)) = &state.active {
+            cancellation.cancel();
+        }
+    }
+
+    pub fn queued_len(&self) -> usize {
+        lock_scheduler(&self.state).queue.len()
+    }
+}
+
+fn lock_scheduler<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+#[path = "materialization_tests.rs"]
+mod tests;

--- a/crates/sceneworks-core/src/resolved_cache/materialization.rs
+++ b/crates/sceneworks-core/src/resolved_cache/materialization.rs
@@ -640,7 +640,7 @@ fn windows_confined_parent(
     let (_, mut directory, _) = windows_confined_directory(root, managed_parent)?;
     for component in components {
         let mut options = fs_at::OpenOptions::default();
-        options.follow(false);
+        options.read(true).follow(false);
         directory = match options.open_dir_at(&directory, component.as_os_str()) {
             Ok(directory) => directory,
             Err(error) if create && error.kind() == std::io::ErrorKind::NotFound => options

--- a/crates/sceneworks-core/src/resolved_cache/materialization.rs
+++ b/crates/sceneworks-core/src/resolved_cache/materialization.rs
@@ -372,22 +372,45 @@ fn copy_and_verify(
         if cancellation.is_cancelled() {
             return Err(ResolvedCacheError::new("materialization cancelled"));
         }
-        let read = source.input.read(&mut buffer)?;
+        let read = source.input.read(&mut buffer).map_err(|error| {
+            ResolvedCacheError::new(format!(
+                "read materialization source {}: {error}",
+                source.location.source_path.display()
+            ))
+        })?;
         if read == 0 {
             break;
         }
-        output.write_all(&buffer[..read])?;
+        output.write_all(&buffer[..read]).map_err(|error| {
+            ResolvedCacheError::new(format!(
+                "write staged file {}: {error}",
+                destination.display()
+            ))
+        })?;
         digest.update(&buffer[..read]);
         size_bytes = size_bytes
             .checked_add(read as u64)
             .ok_or_else(|| ResolvedCacheError::new("materialized byte count overflow"))?;
     }
-    output.sync_all()?;
+    // The only content-durability point for this file: flush through the very write handle that
+    // produced the verified bytes. Publication never reopens staged files by path to flush them
+    // again — that reopen is what a parent-junction swap could redirect (see `sync_tree`).
+    output.sync_all().map_err(|error| {
+        ResolvedCacheError::new(format!(
+            "sync staged file {}: {error}",
+            destination.display()
+        ))
+    })?;
     let sha256 = format!("sha256:{:x}", digest.finalize());
     let verified = VerifiedFile { size_bytes, sha256 };
     verify_expected(&source.location.source_path, expected, &verified)?;
     source.validate_unchanged()?;
-    let destination_metadata = output.metadata()?;
+    let destination_metadata = output.metadata().map_err(|error| {
+        ResolvedCacheError::new(format!(
+            "inspect staged file {}: {error}",
+            destination.display()
+        ))
+    })?;
     if !destination_metadata.is_file() || destination_metadata.len() != size_bytes {
         return Err(ResolvedCacheError::new(format!(
             "materialized destination verification failed for {}",
@@ -572,7 +595,12 @@ fn create_confined_output(root: &Path, relative: &Path) -> Result<File, Resolved
         .follow(false)
         .write(OpenOptionsWriteMode::Write)
         .create_new(true);
-    Ok(options.open_at(&parent, file_name)?)
+    options.open_at(&parent, file_name).map_err(|error| {
+        ResolvedCacheError::new(format!(
+            "create staged file {}: {error}",
+            root.join(relative).display()
+        ))
+    })
 }
 
 #[cfg(windows)]

--- a/crates/sceneworks-core/src/resolved_cache/materialization_tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/materialization_tests.rs
@@ -1,0 +1,1026 @@
+use super::*;
+use crate::model_artifacts::{
+    ArtifactAvailability, ArtifactCompleteness, ArtifactIdentity, ArtifactMemberRole,
+    ArtifactProvenance, ArtifactSourceLibrary, ModelArtifactResolver, ResolvedBundleMember,
+    MODEL_ARTIFACT_CONTRACT_VERSION,
+};
+use std::sync::mpsc;
+use std::thread;
+use tempfile::TempDir;
+
+const REV_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const REV_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+fn identity(repository: &str, revision: &str, variant: &str) -> ArtifactIdentity {
+    ArtifactIdentity::pinned(repository, revision, variant).unwrap()
+}
+
+fn snapshot(library: &Path, repository: &str, revision: &str) -> PathBuf {
+    let snapshot = ArtifactSourceLibrary::new(library)
+        .unwrap()
+        .repository_root(repository)
+        .unwrap()
+        .join("snapshots")
+        .join(revision);
+    std::fs::create_dir_all(&snapshot).unwrap();
+    snapshot
+}
+
+fn member(
+    role: ArtifactMemberRole,
+    component_id: Option<&str>,
+    source: ArtifactIdentity,
+    tier: Option<&str>,
+    source_subpath: &str,
+    destination: &str,
+    files: &[&str],
+) -> ResolvedBundleMember {
+    ResolvedBundleMember {
+        role,
+        component_id: component_id.map(str::to_owned),
+        source,
+        tier: tier.map(str::to_owned),
+        source_subpath: PathBuf::from(source_subpath),
+        destination: PathBuf::from(destination),
+        files: files
+            .iter()
+            .map(|file| ArtifactFile::new(file).unwrap())
+            .collect(),
+    }
+}
+
+fn candidate(
+    primary_snapshot: PathBuf,
+    primary_identity: ArtifactIdentity,
+    members: Vec<ResolvedBundleMember>,
+) -> PromotionCandidate {
+    let closure = ResolvedBundleClosure::new(members).unwrap();
+    let artifact = ResolvedModelArtifact {
+        schema_version: MODEL_ARTIFACT_CONTRACT_VERSION,
+        identity: primary_identity.clone(),
+        location: ArtifactLocation::SourceLibrary {
+            root: primary_snapshot,
+        },
+        closure,
+        provenance: ArtifactProvenance {
+            identity: primary_identity,
+            fixed_artifact_tier: Some("q8".to_owned()),
+        },
+        completeness: ArtifactCompleteness::Complete,
+        availability: ArtifactAvailability::Available,
+    };
+    artifact.validate().unwrap();
+    PromotionCandidate {
+        cache_key: artifact.cache_key().unwrap(),
+        artifact,
+    }
+}
+
+fn flat_fixture(scratch: &TempDir) -> (PathBuf, PromotionCandidate) {
+    flat_fixture_at_revision(scratch, REV_A)
+}
+
+fn flat_fixture_at_revision(scratch: &TempDir, revision: &str) -> (PathBuf, PromotionCandidate) {
+    let library = scratch.path().join("source");
+    let primary_identity = identity("SceneWorks/model", revision, "q8");
+    let primary_snapshot = snapshot(&library, "SceneWorks/model", revision);
+    std::fs::write(primary_snapshot.join("model.safetensors"), b"model-weights").unwrap();
+    let candidate = candidate(
+        primary_snapshot,
+        primary_identity.clone(),
+        vec![member(
+            ArtifactMemberRole::Primary,
+            None,
+            primary_identity,
+            Some("q8"),
+            "",
+            "",
+            &["model.safetensors"],
+        )],
+    );
+    (library, candidate)
+}
+
+fn enabled_policy() -> ResolvedCachePolicy {
+    ResolvedCachePolicy {
+        enabled: true,
+        ..ResolvedCachePolicy::default()
+    }
+}
+
+#[cfg(windows)]
+struct WindowsDirectoryJunction(PathBuf);
+
+#[cfg(windows)]
+impl WindowsDirectoryJunction {
+    fn create(path: &Path, target: &Path) -> Self {
+        let output = std::process::Command::new("cmd")
+            .args(["/D", "/C", "mklink", "/J"])
+            .arg(path)
+            .arg(target)
+            .output()
+            .expect("launch cmd.exe to create source directory junction");
+        assert!(
+            output.status.success(),
+            "mklink /J failed with {}\nstdout: {}\nstderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let metadata = std::fs::symlink_metadata(path).unwrap();
+        assert!(metadata_is_reparse_point(&metadata));
+        Self(path.to_owned())
+    }
+
+    fn remove(self) {
+        std::fs::remove_dir(&self.0).unwrap();
+        std::mem::forget(self);
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsDirectoryJunction {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir(&self.0);
+    }
+}
+
+#[test]
+fn flat_bundle_streams_verifies_enriches_and_publishes_atomically() {
+    let scratch = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture(&scratch);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let key_before = candidate.cache_key.clone();
+    let outcome = ResolvedCacheMaterializer::new(store.clone())
+        .materialize(
+            &candidate,
+            &source,
+            "image:model",
+            &MaterializationCancellation::default(),
+        )
+        .unwrap();
+    let metadata = match outcome {
+        MaterializationOutcome::Published(metadata) => metadata,
+        other => panic!("unexpected materialization outcome: {other:?}"),
+    };
+    assert_eq!(metadata.cache_key, key_before);
+    assert_eq!(metadata.state, ResolvedCacheEntryState::Complete);
+    assert_eq!(metadata.verified_bytes, b"model-weights".len() as u64);
+    let file = &metadata.artifact.closure.members[0].files[0];
+    assert_eq!(file.size_bytes, Some(b"model-weights".len() as u64));
+    assert!(file
+        .sha256
+        .as_deref()
+        .is_some_and(|hash| hash.starts_with("sha256:")));
+    assert_eq!(metadata.artifact.cache_key().unwrap(), key_before);
+    assert_eq!(
+        std::fs::read(
+            store
+                .bundle_path(&key_before)
+                .unwrap()
+                .join("model.safetensors")
+        )
+        .unwrap(),
+        b"model-weights"
+    );
+    assert!(std::fs::read_dir(store.root().join("staging"))
+        .unwrap()
+        .next()
+        .is_none());
+    assert!(store.lookup_complete(&key_before).unwrap().is_some());
+    assert!(matches!(
+        ResolvedCacheMaterializer::new(store)
+            .materialize(
+                &candidate,
+                &source,
+                "image:model",
+                &MaterializationCancellation::default(),
+            )
+            .unwrap(),
+        MaterializationOutcome::AlreadyComplete(_)
+    ));
+}
+
+#[test]
+fn tiered_multi_repo_optional_derived_and_shared_members_are_self_contained() {
+    let scratch = TempDir::new().unwrap();
+    let library = scratch.path().join("source");
+    let primary_identity = identity("SceneWorks/model", REV_A, "q8");
+    let tokenizer_identity = identity("SceneWorks/tokenizer", REV_B, "default");
+    let primary_snapshot = snapshot(&library, "SceneWorks/model", REV_A);
+    let tokenizer_snapshot = snapshot(&library, "SceneWorks/tokenizer", REV_B);
+    for directory in ["q8", "optional", "derived", "shared"] {
+        std::fs::create_dir_all(primary_snapshot.join(directory)).unwrap();
+    }
+    std::fs::create_dir_all(tokenizer_snapshot.join("tokenizer")).unwrap();
+    std::fs::write(primary_snapshot.join("q8/model.safetensors"), b"primary").unwrap();
+    std::fs::write(
+        primary_snapshot.join("optional/style.safetensors"),
+        b"style",
+    )
+    .unwrap();
+    std::fs::write(
+        primary_snapshot.join("derived/tokenizer_config.json"),
+        b"derived",
+    )
+    .unwrap();
+    std::fs::write(primary_snapshot.join("shared/config.json"), b"shared").unwrap();
+    std::fs::write(
+        tokenizer_snapshot.join("tokenizer/tokenizer.json"),
+        b"tokenizer",
+    )
+    .unwrap();
+    let candidate = candidate(
+        primary_snapshot,
+        primary_identity.clone(),
+        vec![
+            member(
+                ArtifactMemberRole::Primary,
+                None,
+                primary_identity.clone(),
+                Some("q8"),
+                "q8",
+                "",
+                &["model.safetensors"],
+            ),
+            member(
+                ArtifactMemberRole::OptionalComponent,
+                Some("style"),
+                primary_identity.clone(),
+                Some("q8"),
+                "optional",
+                "adapters",
+                &["style.safetensors"],
+            ),
+            member(
+                ArtifactMemberRole::CoRequisite,
+                Some("tokenizer"),
+                tokenizer_identity,
+                None,
+                "tokenizer",
+                "tokenizer",
+                &["tokenizer.json"],
+            ),
+            member(
+                ArtifactMemberRole::DerivedOverlay,
+                Some("tokenizer-config"),
+                primary_identity.clone(),
+                Some("q8"),
+                "derived",
+                "tokenizer",
+                &["tokenizer_config.json"],
+            ),
+            member(
+                ArtifactMemberRole::RequiredComponent,
+                Some("shared-a"),
+                primary_identity.clone(),
+                Some("q8"),
+                "shared",
+                "component-a",
+                &["config.json"],
+            ),
+            member(
+                ArtifactMemberRole::RequiredComponent,
+                Some("shared-b"),
+                primary_identity,
+                Some("q8"),
+                "shared",
+                "component-b",
+                &["config.json"],
+            ),
+        ],
+    );
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let outcome = ResolvedCacheMaterializer::new(store.clone())
+        .materialize(
+            &candidate,
+            &library,
+            "video:model",
+            &MaterializationCancellation::default(),
+        )
+        .unwrap();
+    assert!(matches!(outcome, MaterializationOutcome::Published(_)));
+    let bundle = store.bundle_path(&candidate.cache_key).unwrap();
+    for file in [
+        "model.safetensors",
+        "adapters/style.safetensors",
+        "tokenizer/tokenizer.json",
+        "tokenizer/tokenizer_config.json",
+        "component-a/config.json",
+        "component-b/config.json",
+    ] {
+        assert!(bundle.join(file).is_file(), "missing materialized {file}");
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        assert_eq!(
+            std::fs::metadata(bundle.join("component-a/config.json"))
+                .unwrap()
+                .ino(),
+            std::fs::metadata(bundle.join("component-b/config.json"))
+                .unwrap()
+                .ino(),
+            "identical immutable source members should deduplicate inside staging"
+        );
+    }
+}
+
+#[test]
+fn cancellation_and_io_failures_leave_only_interrupted_metadata() {
+    #[cfg(unix)]
+    let failures = vec![
+        std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+        std::io::Error::from_raw_os_error(libc::ENOSPC),
+    ];
+    #[cfg(not(unix))]
+    let failures = vec![std::io::Error::from(std::io::ErrorKind::PermissionDenied)];
+    for failure in failures {
+        let scratch = TempDir::new().unwrap();
+        let (source, candidate) = flat_fixture(&scratch);
+        let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+        let kind = failure.kind();
+        let raw = failure.raw_os_error();
+        let materializer =
+            ResolvedCacheMaterializer::new(store.clone()).with_test_hook(move |_, _| {
+                Err(raw
+                    .map(std::io::Error::from_raw_os_error)
+                    .unwrap_or_else(|| std::io::Error::from(kind)))
+            });
+        assert!(materializer
+            .materialize(
+                &candidate,
+                &source,
+                "image:model",
+                &MaterializationCancellation::default(),
+            )
+            .is_err());
+        assert!(store
+            .lookup_complete(&candidate.cache_key)
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            store.enumerate().unwrap()[0].state,
+            ResolvedCacheEntryState::Interrupted
+        );
+        assert!(std::fs::read_dir(store.root().join("staging"))
+            .unwrap()
+            .next()
+            .is_none());
+        assert_eq!(
+            std::fs::read(
+                match &candidate.artifact.location {
+                    ArtifactLocation::SourceLibrary { root } => root,
+                    _ => unreachable!(),
+                }
+                .join("model.safetensors")
+            )
+            .unwrap(),
+            b"model-weights"
+        );
+    }
+
+    let scratch = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture(&scratch);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let cancellation = MaterializationCancellation::default();
+    cancellation.cancel();
+    assert_eq!(
+        ResolvedCacheMaterializer::new(store.clone())
+            .materialize(&candidate, &source, "image:model", &cancellation)
+            .unwrap(),
+        MaterializationOutcome::Cancelled
+    );
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn source_disconnect_or_provenance_mutation_rejects_publication() {
+    for mutate in [false, true] {
+        let scratch = TempDir::new().unwrap();
+        let (source, mut candidate) = flat_fixture(&scratch);
+        let source_file = match &candidate.artifact.location {
+            ArtifactLocation::SourceLibrary { root } => root.join("model.safetensors"),
+            _ => unreachable!(),
+        };
+        if mutate {
+            candidate.artifact.closure.members[0].files[0].size_bytes =
+                Some(b"model-weights".len() as u64);
+            candidate.artifact.closure.members[0].files[0].sha256 =
+                Some(format!("sha256:{:x}", Sha256::digest(b"model-weights")));
+            candidate.cache_key = candidate.artifact.cache_key().unwrap();
+        }
+        let hook_path = source_file.clone();
+        let materializer = ResolvedCacheMaterializer::new(
+            ResolvedCacheStore::open(&scratch.path().join("data")).unwrap(),
+        )
+        .with_test_hook(move |_, _| {
+            if mutate {
+                std::fs::write(&hook_path, b"changed-bytes").unwrap();
+            } else {
+                std::fs::remove_file(&hook_path).unwrap();
+            }
+            Ok(())
+        });
+        assert!(materializer
+            .materialize(
+                &candidate,
+                &source,
+                "image:model",
+                &MaterializationCancellation::default(),
+            )
+            .is_err());
+        assert!(!matches!(
+            materializer.store().lookup_complete(&candidate.cache_key),
+            Ok(Some(_))
+        ));
+    }
+}
+
+#[test]
+fn same_size_no_hash_source_replacement_cannot_change_the_planned_file() {
+    let scratch = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture(&scratch);
+    let source_file = match &candidate.artifact.location {
+        ArtifactLocation::SourceLibrary { root } => root.join("model.safetensors"),
+        _ => unreachable!(),
+    };
+    let replacement = scratch.path().join("replacement");
+    std::fs::write(&replacement, b"other-weights").unwrap();
+    assert_eq!(
+        std::fs::metadata(&source_file).unwrap().len(),
+        std::fs::metadata(&replacement).unwrap().len()
+    );
+    let hook_source = source_file.clone();
+    let materializer = ResolvedCacheMaterializer::new(
+        ResolvedCacheStore::open(&scratch.path().join("data")).unwrap(),
+    )
+    .with_test_hook(move |_, _| {
+        std::fs::remove_file(&hook_source).unwrap();
+        std::fs::rename(&replacement, &hook_source).unwrap();
+        Ok(())
+    });
+    assert!(materializer
+        .materialize(
+            &candidate,
+            &source,
+            "image:model",
+            &MaterializationCancellation::default(),
+        )
+        .is_err());
+    assert!(!matches!(
+        materializer.store().lookup_complete(&candidate.cache_key),
+        Ok(Some(_))
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn post_plan_source_symlink_swap_cannot_publish_external_bytes() {
+    use std::os::unix::fs::symlink;
+
+    let scratch = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture(&scratch);
+    let source_file = match &candidate.artifact.location {
+        ArtifactLocation::SourceLibrary { root } => root.join("model.safetensors"),
+        _ => unreachable!(),
+    };
+    let external = scratch.path().join("external");
+    std::fs::write(&external, b"other-weights").unwrap();
+    let hook_source = source_file.clone();
+    let hook_external = external.clone();
+    let materializer = ResolvedCacheMaterializer::new(
+        ResolvedCacheStore::open(&scratch.path().join("data")).unwrap(),
+    )
+    .with_test_hook(move |_, _| {
+        std::fs::remove_file(&hook_source).unwrap();
+        symlink(&hook_external, &hook_source).unwrap();
+        Ok(())
+    });
+    assert!(materializer
+        .materialize(
+            &candidate,
+            &source,
+            "image:model",
+            &MaterializationCancellation::default(),
+        )
+        .is_err());
+    assert!(!matches!(
+        materializer.store().lookup_complete(&candidate.cache_key),
+        Ok(Some(_))
+    ));
+    assert_eq!(std::fs::read(external).unwrap(), b"other-weights");
+}
+
+#[cfg(unix)]
+#[test]
+fn staging_root_swap_cannot_write_into_an_external_directory() {
+    use std::os::unix::fs::symlink;
+
+    let scratch = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture(&scratch);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let external = scratch.path().join("external-staging-target");
+    std::fs::create_dir(&external).unwrap();
+    let sentinel = external.join("sentinel");
+    std::fs::write(&sentinel, b"untouched").unwrap();
+    let parked = scratch.path().join("parked-staging");
+    let staging_root = store.root().join("staging");
+    let materializer = ResolvedCacheMaterializer::new(store.clone()).with_test_hook({
+        let external = external.clone();
+        let parked = parked.clone();
+        move |_, _| {
+            let staging = std::fs::read_dir(&staging_root)
+                .unwrap()
+                .next()
+                .unwrap()
+                .unwrap()
+                .path();
+            std::fs::rename(&staging, &parked).unwrap();
+            symlink(&external, &staging).unwrap();
+            Ok(())
+        }
+    });
+
+    assert!(materializer
+        .materialize(
+            &candidate,
+            &source,
+            "image:model",
+            &MaterializationCancellation::default(),
+        )
+        .is_err());
+    assert_eq!(std::fs::read(&sentinel).unwrap(), b"untouched");
+    assert!(!external.join("model.safetensors").exists());
+    let linked_staging = std::fs::read_dir(store.root().join("staging"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    std::fs::remove_file(linked_staging).unwrap();
+    std::fs::remove_dir_all(parked).unwrap();
+}
+
+#[cfg(windows)]
+#[test]
+fn staging_root_junction_swap_cannot_write_into_an_external_directory() {
+    let scratch = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture(&scratch);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let external = scratch.path().join("external-staging-target");
+    std::fs::create_dir(&external).unwrap();
+    let sentinel = external.join("sentinel");
+    std::fs::write(&sentinel, b"untouched").unwrap();
+    let staging_root = store.root().join("staging");
+    let external_target = external.clone();
+    set_windows_directory_after_validation_hook(move || {
+        let staging = std::fs::read_dir(&staging_root)
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap()
+            .path();
+        std::fs::remove_dir_all(&staging).unwrap();
+        let junction = WindowsDirectoryJunction::create(&staging, &external_target);
+        std::mem::forget(junction);
+    });
+
+    assert!(ResolvedCacheMaterializer::new(store.clone())
+        .materialize(
+            &candidate,
+            &source,
+            "image:model",
+            &MaterializationCancellation::default(),
+        )
+        .is_err());
+    assert_eq!(std::fs::read(&sentinel).unwrap(), b"untouched");
+    assert!(!external.join("model.safetensors").exists());
+    let linked_staging = std::fs::read_dir(store.root().join("staging"))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    std::fs::remove_dir(linked_staging).unwrap();
+}
+
+#[test]
+fn same_key_concurrency_exposes_no_partial_and_publishes_one_bundle() {
+    let scratch = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture(&scratch);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let release_rx = Arc::new(Mutex::new(release_rx));
+    let first_materializer = ResolvedCacheMaterializer::new(store.clone()).with_test_hook({
+        let release_rx = Arc::clone(&release_rx);
+        move |_, _| {
+            entered_tx.send(()).unwrap();
+            release_rx.lock().unwrap().recv().unwrap();
+            Ok(())
+        }
+    });
+    let first_candidate = candidate.clone();
+    let first_source = source.clone();
+    let first = thread::spawn(move || {
+        first_materializer.materialize(
+            &first_candidate,
+            &first_source,
+            "image:model",
+            &MaterializationCancellation::default(),
+        )
+    });
+    entered_rx.recv().unwrap();
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_none());
+    assert!(!store.bundle_path(&candidate.cache_key).unwrap().exists());
+    assert_eq!(
+        ResolvedCacheMaterializer::new(store.clone())
+            .materialize(
+                &candidate,
+                &source,
+                "image:model",
+                &MaterializationCancellation::default(),
+            )
+            .unwrap(),
+        MaterializationOutcome::Contended
+    );
+    release_tx.send(()).unwrap();
+    assert!(matches!(
+        first.join().unwrap().unwrap(),
+        MaterializationOutcome::Published(_)
+    ));
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_some());
+}
+
+#[test]
+fn stale_staging_cleanup_requires_artifact_and_session_authority() {
+    let scratch = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture(&scratch);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let reservation = match store.reserve(&candidate, &source, "image:model").unwrap() {
+        ReservationOutcome::Acquired(reservation) => reservation,
+        _ => panic!("fixture reservation must acquire"),
+    };
+    let staging = reservation.staging_path().to_owned();
+    std::fs::write(staging.join("partial"), b"partial").unwrap();
+    assert_eq!(store.cleanup_stale_staging().unwrap(), 0);
+    assert!(staging.exists());
+    drop(reservation);
+    assert_eq!(store.cleanup_stale_staging().unwrap(), 1);
+    assert!(!staging.exists());
+
+    let malformed = store.root().join("staging/not-a-cache-key");
+    std::fs::create_dir(&malformed).unwrap();
+    let external = scratch.path().join("external-sentinel");
+    std::fs::write(&external, b"untouched").unwrap();
+    assert_eq!(store.cleanup_stale_staging().unwrap(), 0);
+    assert!(malformed.exists());
+    assert_eq!(std::fs::read(external).unwrap(), b"untouched");
+}
+
+#[test]
+fn crash_after_atomic_rename_stays_unavailable_and_next_reservation_republishes() {
+    let scratch = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture(&scratch);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let reservation = match store.reserve(&candidate, &source, "image:model").unwrap() {
+        ReservationOutcome::Acquired(reservation) => reservation,
+        _ => panic!("fixture reservation must acquire"),
+    };
+    reservation.prepare_for_materialization().unwrap();
+    std::fs::write(
+        reservation.staging_path().join("model.safetensors"),
+        b"model-weights",
+    )
+    .unwrap();
+    let orphan_bundle = reservation.bundle_path().unwrap();
+    std::fs::rename(reservation.staging_path(), &orphan_bundle).unwrap();
+    drop(reservation);
+
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_none());
+    assert!(orphan_bundle.join("model.safetensors").is_file());
+    let recovered = store.recover().unwrap();
+    assert_eq!(recovered[0].state, ResolvedCacheEntryState::Interrupted);
+    assert!(orphan_bundle.join("model.safetensors").is_file());
+
+    assert!(matches!(
+        ResolvedCacheMaterializer::new(store.clone())
+            .materialize(
+                &candidate,
+                &source,
+                "image:model",
+                &MaterializationCancellation::default(),
+            )
+            .unwrap(),
+        MaterializationOutcome::Published(_)
+    ));
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_some());
+}
+
+#[test]
+fn success_candidate_schedules_nonblocking_and_materializes_only_when_idle() {
+    let scratch = TempDir::new().unwrap();
+    let (source, direct_candidate) = flat_fixture(&scratch);
+    let library = ArtifactSourceLibrary::new(&source).unwrap();
+    let resolver = ModelArtifactResolver::new(library);
+    let lease = resolver
+        .acquire_runtime_lease(&Arc::new(direct_candidate.artifact.clone()))
+        .unwrap();
+    let candidate = lease.mark_success();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let scheduler = ResolvedCachePromotionScheduler::new(
+        enabled_policy(),
+        ResolvedCacheMaterializer::new(store.clone()),
+        2,
+    )
+    .unwrap();
+    assert_eq!(
+        scheduler
+            .schedule(candidate.clone(), source.clone(), "image:model".to_owned())
+            .unwrap(),
+        PromotionScheduleOutcome::Enqueued
+    );
+    assert_eq!(scheduler.queued_len(), 1);
+    assert!(!store.bundle_path(&candidate.cache_key).unwrap().exists());
+    assert_eq!(
+        scheduler.run_next_if_idle(false).unwrap(),
+        IdlePromotionOutcome::NotIdle
+    );
+    assert!(!store.bundle_path(&candidate.cache_key).unwrap().exists());
+    assert!(matches!(
+        scheduler.run_next_if_idle(true).unwrap(),
+        IdlePromotionOutcome::Materialized(MaterializationOutcome::Published(_))
+    ));
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_some());
+}
+
+#[test]
+fn active_scheduler_cancellation_interrupts_and_cleans_the_reservation() {
+    let scratch = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture(&scratch);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let release_rx = Arc::new(Mutex::new(release_rx));
+    let materializer = ResolvedCacheMaterializer::new(store.clone()).with_test_hook({
+        let release_rx = Arc::clone(&release_rx);
+        move |_, _| {
+            entered_tx.send(()).unwrap();
+            release_rx.lock().unwrap().recv().unwrap();
+            Ok(())
+        }
+    });
+    let scheduler =
+        ResolvedCachePromotionScheduler::new(enabled_policy(), materializer, 1).unwrap();
+    assert_eq!(
+        scheduler
+            .schedule(candidate.clone(), source, "image:model".to_owned())
+            .unwrap(),
+        PromotionScheduleOutcome::Enqueued
+    );
+    let worker = {
+        let scheduler = scheduler.clone();
+        thread::spawn(move || scheduler.run_next_if_idle(true))
+    };
+    entered_rx.recv().unwrap();
+    assert!(scheduler.cancel_active());
+    release_tx.send(()).unwrap();
+    assert_eq!(
+        worker.join().unwrap().unwrap(),
+        IdlePromotionOutcome::Materialized(MaterializationOutcome::Cancelled)
+    );
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_none());
+    assert!(std::fs::read_dir(store.root().join("staging"))
+        .unwrap()
+        .next()
+        .is_none());
+}
+
+#[test]
+fn concurrent_idle_runners_never_overwrite_the_active_promotion() {
+    let scratch = TempDir::new().unwrap();
+    let (source_a, candidate_a) = flat_fixture(&scratch);
+    let second = TempDir::new().unwrap();
+    let (source_b, candidate_b) = flat_fixture_at_revision(&second, REV_B);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let release_rx = Arc::new(Mutex::new(release_rx));
+    let materializer = ResolvedCacheMaterializer::new(store).with_test_hook({
+        let release_rx = Arc::clone(&release_rx);
+        move |_, _| {
+            entered_tx.send(()).unwrap();
+            release_rx.lock().unwrap().recv().unwrap();
+            Ok(())
+        }
+    });
+    let scheduler =
+        ResolvedCachePromotionScheduler::new(enabled_policy(), materializer, 2).unwrap();
+    assert_eq!(
+        scheduler
+            .schedule(candidate_a, source_a, "image:model-a".to_owned())
+            .unwrap(),
+        PromotionScheduleOutcome::Enqueued
+    );
+    assert_eq!(
+        scheduler
+            .schedule(candidate_b, source_b, "video:model-b".to_owned())
+            .unwrap(),
+        PromotionScheduleOutcome::Enqueued
+    );
+    let first = {
+        let scheduler = scheduler.clone();
+        thread::spawn(move || scheduler.run_next_if_idle(true))
+    };
+    entered_rx.recv().unwrap();
+    assert_eq!(
+        scheduler.run_next_if_idle(true).unwrap(),
+        IdlePromotionOutcome::NotIdle
+    );
+    assert_eq!(scheduler.queued_len(), 1);
+    assert!(scheduler.cancel_active());
+    release_tx.send(()).unwrap();
+    assert_eq!(
+        first.join().unwrap().unwrap(),
+        IdlePromotionOutcome::Materialized(MaterializationOutcome::Cancelled)
+    );
+    assert_eq!(scheduler.queued_len(), 1);
+    scheduler.shutdown();
+}
+
+#[test]
+fn scheduler_is_bounded_coalescing_disabled_and_stoppable() {
+    let scratch = TempDir::new().unwrap();
+    let (source, candidate_a) = flat_fixture(&scratch);
+    let second = TempDir::new().unwrap();
+    let (source_b, candidate_b) = flat_fixture_at_revision(&second, REV_B);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let disabled = ResolvedCachePromotionScheduler::new(
+        ResolvedCachePolicy::default(),
+        ResolvedCacheMaterializer::new(store.clone()),
+        1,
+    )
+    .unwrap();
+    assert_eq!(
+        disabled
+            .schedule(
+                candidate_a.clone(),
+                source.clone(),
+                "image:model".to_owned()
+            )
+            .unwrap(),
+        PromotionScheduleOutcome::Disabled
+    );
+    let scheduler = ResolvedCachePromotionScheduler::new(
+        enabled_policy(),
+        ResolvedCacheMaterializer::new(store),
+        1,
+    )
+    .unwrap();
+    assert_eq!(
+        scheduler
+            .schedule(
+                candidate_a.clone(),
+                source.clone(),
+                "image:model".to_owned()
+            )
+            .unwrap(),
+        PromotionScheduleOutcome::Enqueued
+    );
+    assert_eq!(
+        scheduler
+            .schedule(candidate_a, source, "image:model".to_owned())
+            .unwrap(),
+        PromotionScheduleOutcome::Coalesced
+    );
+    assert_eq!(
+        scheduler
+            .schedule(candidate_b, source_b, "video:model".to_owned())
+            .unwrap(),
+        PromotionScheduleOutcome::Full
+    );
+    scheduler.shutdown();
+    assert_eq!(scheduler.queued_len(), 0);
+    assert_eq!(
+        scheduler.run_next_if_idle(true).unwrap(),
+        IdlePromotionOutcome::Stopped
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn materializer_copies_a_same_repository_hf_blob_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let scratch = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture(&scratch);
+    let source_file = match &candidate.artifact.location {
+        ArtifactLocation::SourceLibrary { root } => root.join("model.safetensors"),
+        _ => unreachable!(),
+    };
+    let repository = ArtifactSourceLibrary::new(&source)
+        .unwrap()
+        .repository_root("SceneWorks/model")
+        .unwrap();
+    std::fs::remove_file(&source_file).unwrap();
+    std::fs::create_dir(repository.join("blobs")).unwrap();
+    std::fs::write(repository.join("blobs/model-blob"), b"model-weights").unwrap();
+    symlink("../../blobs/model-blob", &source_file).unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    assert!(matches!(
+        ResolvedCacheMaterializer::new(store.clone())
+            .materialize(
+                &candidate,
+                &source,
+                "image:model",
+                &MaterializationCancellation::default(),
+            )
+            .unwrap(),
+        MaterializationOutcome::Published(_)
+    ));
+    assert_eq!(
+        std::fs::read(
+            store
+                .bundle_path(&candidate.cache_key)
+                .unwrap()
+                .join("model.safetensors")
+        )
+        .unwrap(),
+        b"model-weights"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn materializer_rejects_a_source_subpath_junction_without_touching_external_bytes() {
+    let scratch = TempDir::new().unwrap();
+    let library = scratch.path().join("source");
+    let primary_identity = identity("SceneWorks/model", REV_A, "q8");
+    let primary_snapshot = snapshot(&library, "SceneWorks/model", REV_A);
+    let selected = primary_snapshot.join("selected");
+    std::fs::create_dir(&selected).unwrap();
+    std::fs::write(selected.join("model.safetensors"), b"model-weights").unwrap();
+    let candidate = candidate(
+        primary_snapshot,
+        primary_identity.clone(),
+        vec![member(
+            ArtifactMemberRole::Primary,
+            None,
+            primary_identity,
+            Some("q8"),
+            "selected",
+            "",
+            &["model.safetensors"],
+        )],
+    );
+    std::fs::remove_dir_all(&selected).unwrap();
+    let external = scratch.path().join("external");
+    std::fs::create_dir(&external).unwrap();
+    std::fs::write(external.join("model.safetensors"), b"model-weights").unwrap();
+    std::fs::write(external.join("sentinel"), b"must-survive").unwrap();
+    let junction = WindowsDirectoryJunction::create(&selected, &external);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    assert!(ResolvedCacheMaterializer::new(store.clone())
+        .materialize(
+            &candidate,
+            &library,
+            "image:model",
+            &MaterializationCancellation::default(),
+        )
+        .is_err());
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        std::fs::read(external.join("model.safetensors")).unwrap(),
+        b"model-weights"
+    );
+    assert_eq!(
+        std::fs::read(external.join("sentinel")).unwrap(),
+        b"must-survive"
+    );
+    junction.remove();
+}

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -19,8 +19,14 @@ fn policy_from(values: &[(&str, &str)]) -> Result<ResolvedCachePolicy, ResolvedC
 }
 
 fn source_candidate(root: &Path, revision: &str) -> PromotionCandidate {
-    std::fs::create_dir_all(root).unwrap();
-    std::fs::write(root.join("weights.bin"), b"model-weights").unwrap();
+    let library = ArtifactSourceLibrary::new(root).unwrap();
+    let snapshot = library
+        .repository_root("owner/model")
+        .unwrap()
+        .join("snapshots")
+        .join(revision);
+    std::fs::create_dir_all(&snapshot).unwrap();
+    std::fs::write(snapshot.join("weights.bin"), b"model-weights").unwrap();
     let identity = ArtifactIdentity::pinned("owner/model", revision, "default").unwrap();
     let closure = ResolvedBundleClosure::new(vec![ResolvedBundleMember {
         role: ArtifactMemberRole::Primary,
@@ -35,9 +41,7 @@ fn source_candidate(root: &Path, revision: &str) -> PromotionCandidate {
     let artifact = ResolvedModelArtifact {
         schema_version: MODEL_ARTIFACT_CONTRACT_VERSION,
         identity: identity.clone(),
-        location: ArtifactLocation::SourceLibrary {
-            root: root.to_path_buf(),
-        },
+        location: ArtifactLocation::SourceLibrary { root: snapshot },
         closure,
         provenance: ArtifactProvenance {
             identity,
@@ -53,6 +57,82 @@ fn source_candidate(root: &Path, revision: &str) -> PromotionCandidate {
     }
 }
 
+fn source_snapshot(candidate: &PromotionCandidate) -> &Path {
+    match &candidate.artifact.location {
+        ArtifactLocation::SourceLibrary { root } => root,
+        ArtifactLocation::ResolvedLocal { .. } => panic!("fixture candidate is source-backed"),
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn stale_cleanup_directory_swap_never_follows_an_external_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let scratch = TempDir::new().unwrap();
+    let source = scratch.path().join("source");
+    std::fs::create_dir(&source).unwrap();
+    let candidate = source_candidate(&source, REVISION_A);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let reservation = match store.reserve(&candidate, &source, "fixture:model").unwrap() {
+        ReservationOutcome::Acquired(reservation) => reservation,
+        _ => panic!("fixture reservation must acquire"),
+    };
+    let staging = reservation.staging_path().to_owned();
+    std::fs::write(staging.join("partial"), b"partial").unwrap();
+    drop(reservation);
+
+    let external = scratch.path().join("external");
+    std::fs::create_dir(&external).unwrap();
+    let sentinel = external.join("sentinel");
+    std::fs::write(&sentinel, b"untouched").unwrap();
+    let swapped_staging = staging.clone();
+    let external_target = external.clone();
+    set_remove_entry_after_stat_hook(move || {
+        std::fs::remove_dir_all(&swapped_staging).unwrap();
+        symlink(&external_target, &swapped_staging).unwrap();
+    });
+
+    assert!(store.cleanup_stale_staging().is_err());
+    assert_eq!(std::fs::read(&sentinel).unwrap(), b"untouched");
+    assert!(external.is_dir());
+    std::fs::remove_file(staging).unwrap();
+}
+
+#[cfg(windows)]
+#[test]
+fn stale_cleanup_directory_swap_never_follows_an_external_junction() {
+    let scratch = TempDir::new().unwrap();
+    let source = scratch.path().join("source");
+    std::fs::create_dir(&source).unwrap();
+    let candidate = source_candidate(&source, REVISION_A);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let reservation = match store.reserve(&candidate, &source, "fixture:model").unwrap() {
+        ReservationOutcome::Acquired(reservation) => reservation,
+        _ => panic!("fixture reservation must acquire"),
+    };
+    let staging = reservation.staging_path().to_owned();
+    std::fs::write(staging.join("partial"), b"partial").unwrap();
+    drop(reservation);
+
+    let external = scratch.path().join("external");
+    std::fs::create_dir(&external).unwrap();
+    let sentinel = external.join("sentinel");
+    std::fs::write(&sentinel, b"untouched").unwrap();
+    let swapped_staging = staging.clone();
+    let external_target = external.clone();
+    set_windows_directory_after_validation_hook(move || {
+        std::fs::remove_dir_all(&swapped_staging).unwrap();
+        let junction = WindowsDirectoryJunction::create(&swapped_staging, &external_target);
+        std::mem::forget(junction);
+    });
+
+    assert!(store.cleanup_stale_staging().is_err());
+    assert_eq!(std::fs::read(&sentinel).unwrap(), b"untouched");
+    assert!(external.is_dir());
+    std::fs::remove_dir(staging).unwrap();
+}
+
 fn make_complete(
     store: &ResolvedCacheStore,
     candidate: &PromotionCandidate,
@@ -65,7 +145,11 @@ fn make_complete(
     };
     let bundle = reservation.bundle_path().unwrap();
     std::fs::create_dir_all(&bundle).unwrap();
-    std::fs::copy(source.join("weights.bin"), bundle.join("weights.bin")).unwrap();
+    std::fs::copy(
+        source_snapshot(candidate).join("weights.bin"),
+        bundle.join("weights.bin"),
+    )
+    .unwrap();
     let mut local = candidate.artifact.clone();
     local.location = ArtifactLocation::ResolvedLocal { root: bundle };
     let metadata = reservation.record_complete(local).unwrap();
@@ -404,7 +488,11 @@ fn one_reservation_cannot_interrupt_or_complete_another_owner() {
     };
     let bundle = reservation_b.bundle_path().unwrap();
     std::fs::create_dir(&bundle).unwrap();
-    std::fs::copy(source_b.join("weights.bin"), bundle.join("weights.bin")).unwrap();
+    std::fs::copy(
+        source_snapshot(&candidate_b).join("weights.bin"),
+        bundle.join("weights.bin"),
+    )
+    .unwrap();
     store
         .update_metadata(&candidate_b.cache_key, |metadata| {
             metadata.reservation_owner = Some("other:model".to_owned());
@@ -927,6 +1015,10 @@ fn cross_process_same_key_reservation_shared_lease_and_kill_recovery() {
             .state,
         ResolvedCacheEntryState::Interrupted
     );
+    assert!(std::fs::read_dir(store.root().join("staging"))
+        .unwrap()
+        .next()
+        .is_none());
 
     make_complete(&store, &candidate_a, &source_a);
     let mut child = spawn_child(&data, &source_a, scratch.path(), "lease");
@@ -989,7 +1081,10 @@ fn cross_process_store_child() {
     let candidate = source_candidate(&source, REVISION_A);
     let _held: Box<dyn std::any::Any> = if mode == "reserve" {
         match store.reserve(&candidate, &source, "child:model").unwrap() {
-            ReservationOutcome::Acquired(reservation) => reservation,
+            ReservationOutcome::Acquired(reservation) => {
+                std::fs::write(reservation.staging_path().join("partial"), b"partial").unwrap();
+                reservation
+            }
             ReservationOutcome::AlreadyComplete(_) => panic!("child entry is already complete"),
             ReservationOutcome::Contended => panic!("child reservation contended"),
         }

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -828,6 +828,36 @@ fn incomplete_complete_entry_is_never_available_or_reconstructed() {
     assert_eq!(std::fs::read(bundle_file).unwrap(), b"short");
 }
 
+/// Publication's pre-rename walk must never reopen staged files by path: the reopen is the
+/// TOCTOU window (a parent junction swap between validation and reopen flushes the wrong file)
+/// and a write-capable reopen cannot even be assumed possible (read-only staged content,
+/// `FlushFileBuffers` denials on Windows). Content durability is bound to the copy-time write
+/// handle in `copy_and_verify`; the walk only validates entries and syncs directories. A
+/// read-only staged file therefore must not fail the walk — under both earlier reopen-flush
+/// revisions this failed on Windows with `ERROR_ACCESS_DENIED`.
+#[test]
+fn publish_walk_accepts_read_only_staged_files_without_reopening_them() {
+    let scratch = TempDir::new().unwrap();
+    let staged = scratch.path().join("staged");
+    std::fs::create_dir_all(staged.join("nested")).unwrap();
+    std::fs::write(staged.join("model.safetensors"), b"weights").unwrap();
+    std::fs::write(staged.join("nested/config.json"), b"{}").unwrap();
+    for file in ["model.safetensors", "nested/config.json"] {
+        let path = staged.join(file);
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_readonly(true);
+        std::fs::set_permissions(&path, permissions).unwrap();
+    }
+    sync_tree(&staged).unwrap();
+    for file in ["model.safetensors", "nested/config.json"] {
+        let path = staged.join(file);
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        #[allow(clippy::permissions_set_readonly_false)]
+        permissions.set_readonly(false);
+        std::fs::set_permissions(&path, permissions).unwrap();
+    }
+}
+
 #[test]
 fn checked_enumeration_rejects_overflow() {
     let scratch = TempDir::new().unwrap();

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1435,6 +1435,26 @@ function assertFeaturePullRequestCoverage(workflow, context) {
   );
 }
 
+function assertWindowsResolvedCacheRuntimeCoverage(workflow, context) {
+  const lines = workflow.split("\n");
+  const buildStart = lines.findIndex((line) => line === "  build-windows:");
+  assert.ok(buildStart >= 0, `${context}: build-windows job must be present`);
+  const nextJob = lines
+    .slice(buildStart + 1)
+    .findIndex((line) => /^  [A-Za-z0-9_-]+:\s*$/.test(line));
+  assert.ok(nextJob >= 0, `${context}: build-windows job must have a following job boundary`);
+  const requiredBuild = lines
+    .slice(buildStart, buildStart + 1 + nextJob)
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+  assert.match(
+    requiredBuild,
+    /^ {8}run: "cargo test -p sceneworks-core model_artifacts::resolved_cache:: -- --test-threads=1"$/m,
+    `${context}: required build-windows must execute both the durable-store and native ` +
+      "materialization safety suites, not only compile or select one half",
+  );
+}
+
 test("every required workflow reports on feature-target pull requests", async () => {
   for (const path of REQUIRED_WORKFLOWS) {
     assertFeaturePullRequestCoverage(await source(path), path);
@@ -1618,14 +1638,36 @@ test("dropping the PR path filter did not expose the self-hosted pools", async (
     "build-windows is the required check; it must actually run on the speculative merge rather " +
       "than skip into a free Success.",
   );
-  const buildStart = desktop.indexOf("\n  build-windows:");
-  const packageStart = desktop.indexOf("\n  package-windows:");
-  assert.ok(buildStart >= 0 && packageStart > buildStart, "desktop Windows jobs must be parseable");
-  const requiredBuild = desktop.slice(buildStart, packageStart);
-  assert.match(
-    requiredBuild,
-    /run: "cargo test -p sceneworks-core model_artifacts::resolved_cache::tests:: -- --test-threads=1"/,
-    "required build-windows must execute the native resolved-cache safety suite, not only compile it",
+  assertWindowsResolvedCacheRuntimeCoverage(desktop, ".github/workflows/desktop-windows.yml");
+});
+
+test("Windows resolved-cache coverage rejects either narrowed test module", async () => {
+  const workflow = await source(".github/workflows/desktop-windows.yml");
+  for (const narrowed of [
+    "model_artifacts::resolved_cache::tests::",
+    "model_artifacts::resolved_cache::materialization::tests::",
+  ]) {
+    const mutated = workflow.replace("model_artifacts::resolved_cache:: --", `${narrowed} --`);
+    assert.notEqual(mutated, workflow, "the workflow mutation must replace the widened filter");
+    assert.throws(
+      () => assertWindowsResolvedCacheRuntimeCoverage(mutated, `${narrowed} mutation`),
+      /execute both the durable-store and native materialization safety suites/,
+    );
+  }
+
+  const decoy = workflow
+    .replace(
+      '        run: "cargo test -p sceneworks-core model_artifacts::resolved_cache:: -- --test-threads=1"',
+      '        run: "cargo test -p sceneworks-core model_artifacts::resolved_cache::tests:: -- --test-threads=1"\n' +
+        '        # run: "cargo test -p sceneworks-core model_artifacts::resolved_cache:: -- --test-threads=1"',
+    )
+    .replace(
+      "\n  package-windows:",
+      '\n  decoy-resolved-cache:\n    steps:\n      - run: "cargo test -p sceneworks-core model_artifacts::resolved_cache:: -- --test-threads=1"\n\n  package-windows:',
+    );
+  assert.throws(
+    () => assertWindowsResolvedCacheRuntimeCoverage(decoy, "comment and sibling decoy mutation"),
+    /execute both the durable-store and native materialization safety suites/,
   );
 });
 


### PR DESCRIPTION
## Outcome

Adds the generic SC-19706 materialization layer for the app-owned resolved model cache:

- Enumerates every closure member from its exact repository, immutable revision, source subpath, role, component, tier, and destination.
- Accepts normal Hugging Face final-file blob symlinks only when confined to the same repository; intermediate links, linked blob roots, cross-repository targets, junctions, and reparse escapes fail closed.
- Holds no-follow source handles across deterministic streamed copy/hash/size verification, enriches the validated closure, safely deduplicates within staging, fsyncs, atomically publishes, and records Complete only after full bundle validation.
- Recovers only exact managed staging trees after artifact-lock and session authority are proven; cancellation, mutation, I/O failure, crash, and concurrent same-key work never expose a partial bundle.
- Adds a bounded, key-coalescing idle scheduler and a real runtime-success -> PromotionCandidate -> non-blocking enqueue -> idle materialization seam.

## Story boundary

SC-19706 intentionally does not activate this scheduler from concrete image/video/audio/training consumers. SC-19707 owns source fallback, local preference, and runtime lease wiring across those production consumers. The generic success callback, queue, scheduler lifecycle, materializer, and end-to-end integration proof are complete here so SC-19707 can activate them without reimplementing storage or scheduling.

## Safety and platform details

Unix staging creation, dedupe, and cleanup use descriptor-relative no-follow operations. Windows uses NtCreateFile-relative `fs_at` operations and handle-based `remove_dir_all`; native cfg(windows) tests exercise junction/reparse races and the required CI can execute them. Other unsupported platforms fail closed. The new dependency graph is target-scoped and additive; `remove_dir_all` is pinned to 0.8.4 to retain the workspace Rust 1.80 MSRV.

## Validation

- `cargo test -p sceneworks-core -- --test-threads=1`: 959 passed, 2 intentional ignored; every core integration/doc suite passed.
- Final focused core contract runs: materialization 15/15, resolved cache 21/21, source artifact 11/11.
- `cargo test -p sceneworks-worker -- --test-threads=1`: 1502 passed, 210 intentional real-weight/device ignores; all integrations passed, including model artifact inventory 4/4.
- `cargo test -p sceneworks-rust-api -- --test-threads=1`: 572 passed, 4 intentional integration/real-weight ignores.
- `node apps/desktop/scripts/stage-test-sidecars.mjs && cargo test -p sceneworks-desktop -- --test-threads=1`: 96/96 passed.
- `cargo test -p sceneworks-core checked_in_matrix_matches_all_authoritative_sources -- --test-threads=1`: 1/1 passed.
- `cargo clippy -p sceneworks-core -p sceneworks-worker -p sceneworks-rust-api -p sceneworks-desktop --all-targets -- -D warnings`: passed.
- Windows cross-target core all-target clippy with warnings denied: passed.
- `cargo fmt --all -- --check`: passed.
- `npm run --silent check:rust-derived-docs`: passed (21 mutation self-tests; 111 declared measured exceptions; integrity OK).
- `cargo metadata --locked --no-deps --format-version 1`, `git diff --check`, dependency/diff/pin/generated-artifact audits: passed.

## Scope audit

No inference pin, measured/generated capability artifact, disabled gate script, runtime consumer wiring, GPU/Metal/nax path, or real-weight campaign changed or ran.

## Review cycle 1 correction

- Replacement head `ba7599c46` widens the existing required Windows command to `cargo test -p sceneworks-core model_artifacts::resolved_cache:: -- --test-threads=1`, selecting both durable-store and materialization modules.
- Local listing proves 21 durable-store plus 15 host-applicable materialization tests are selected; the exact command passed 36/36. Windows `cargo check --tests` cross-compiles the cfg(windows) test target, including the native staging-junction swap and source-subpath-junction rejection tests.
- The platform workflow contract is 48/48 green and mutation-tests narrowing to either module, commented broad-command decoys, and sibling-job decoys while parsing only the required `build-windows` job.
- Independent re-review: PASS, high confidence. Native current-head execution remains assigned to the required hosted Windows job.

## Native Windows execution correction

The widened required job executed 36 tests on Windows and exposed a shared `fs_at` option defect: both handle-relative directory opens specified `follow(false)` without read or write access, which `fs_at` correctly rejected as Windows error 87. Head `ba7599c46` adds explicit read access at both call sites while retaining no-follow reparse confinement. macOS focused 36/36, Windows `cargo check --tests`, macOS and Windows-target all-target clippy, workflow contracts 48/48, fmt, derived-doc, and diff audits pass; independent re-review PASS, high confidence. A new required native Windows run will provide final current-head execution evidence.

## Native Windows publication flush correction

The required native Windows run 32044287664 executed the widened command and selected all 36 tests: 31 passed, including every junction/reparse, lock, crash-authority, cancellation, and cleanup regression; five success-publication cases failed with Windows error 5. That result localized the defect to `sync_tree`: `FlushFileBuffers` rejects the read-only handle returned by `File::open` on Windows. Replacement head `9e59a7178` opens a write-capable, share-delete handle with `FILE_FLAG_OPEN_REPARSE_POINT`, verifies the opened handle is a regular non-reparse file, and then flushes it; non-Windows behavior is unchanged. Local focused 36/36, Windows-target and macOS all-target clippy, workflow contracts 48/48, fmt, derived-doc, and diff audits pass; independent re-review PASS, high confidence. Final required native Windows current-head execution is pending.

## Publish-flush TOCTOU removal + native publication root cause (heads `a9e510188`, `85d32de73`)

**TOCTOU (declared review blocker) — resolved by removal, which is stronger than the demanded identity-binding.** The publish-time per-file flush in `sync_tree` reopened each staged file by path; `FILE_FLAG_OPEN_REPARSE_POINT` guarded only the final component, so a parent-directory junction swap or delete-and-recreate between validation and the reopen could flush the wrong file. Head `a9e510188` removes the per-file reopen-flush entirely: it was redundant, because `copy_and_verify` already calls `File::sync_all` on the very write handle that produced the verified bytes — identity-exact by construction. With no reopen, there is no window; the reviewer's demanded "junction swap cannot satisfy the flush" mutation test is moot because the operation it would mutate no longer exists. The pre-rename walk now only re-validates staged entries and syncs directories on Unix (Windows has no POSIX directory fsync; `sync_dir` remains a no-op there and journaled NTFS covers the rename record — `MOVEFILE_WRITE_THROUGH` was considered and rejected since std `fs::rename` does not expose it and the workspace forbids `unsafe` FFI). New regression test `publish_walk_accepts_read_only_staged_files_without_reopening_them` pins the contract observably: the publish walk must accept read-only staged files, which both reopen-flush revisions failed on Windows with `ERROR_ACCESS_DENIED`.

**Native publication err-5 — root cause found, one line, and it was never the flush.** Head `a9e510188` also added per-operation, per-path error context throughout the copy and publish paths (CI has no backtraces). The next native run localized the failure exactly: every failing publication test died at `inspect staged file <staging>\model.safetensors: Access is denied (os error 5)` — the post-copy destination verification `File::metadata` call on the staged-output handle inside `copy_and_verify`, *before any flush or rename ever executed*. `fs_at` requests exactly the rights its options imply (no Win32 generic mapping), so the write-only staged output carried `FILE_GENERIC_WRITE | SYNCHRONIZE` and lacked `FILE_READ_ATTRIBUTES`, which `File::metadata` needs. Both earlier flush-oriented corrections targeted code this failure prevented from ever running, which is why the failure count never moved. Head `85d32de73` opens staged outputs read+write (`read(true)` on the `fs_at` options), keeping `create_new` no-follow confinement unchanged; Unix is unaffected (`fstat` works on write-only descriptors).

**Hardening landed alongside (all would-have-been latent failures or diagnosability gaps):**
- The publish rename retries transient `ERROR_ACCESS_DENIED`/`ERROR_SHARING_VIOLATION` holds (AV/indexer descendant handles) with a bounded backoff and fails closed naming the operation and both paths. An audit found no in-process handle spanning the rename: confined-directory and validation handles are scoped and dropped before publication, and artifact/session/metadata locks live under `locks/`/`sessions/`, outside the renamed tree.
- `windows_confined_directory` parent handles now also share DELETE so they can never block a concurrent owner's rename or delete.
- Copy, staging, and publish operations carry per-op, per-path error context so any future native failure localizes itself — this is what turned three blind guesses into a one-line root cause.

**Native verification:** required `build-windows` run [32064188361](https://github.com/SceneWorks/SceneWorks/actions/runs/32064188361) is green at head `85d32de73`: resolved-cache + materialization suite **37/37** (36 prior tests plus the new read-only-staged-file regression test), with all five previously failing publication tests passing natively for the first time.
