### PR TITLE
fix(sc-20402): bind bounded campaign watchdog phases

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -10893,7 +10893,16 @@ mod ltx_tests {
             |value: &mut Value| {
                 value["providerPhaseProfile"] = json!(LTX_BOUNDED_CARRIER_PHASE_PROFILE)
             },
+            |value: &mut Value| value["providerPhaseProfile"] = json!("foreign-profile"),
             |value: &mut Value| value["providerPhases"] = json!(LTX_PROVIDER_PHASE_NAMES),
+            |value: &mut Value| {
+                value["providerPhases"] = json!([
+                    "common_load",
+                    "primary_conditioning",
+                    "primary_denoise",
+                    "primary_decode"
+                ])
+            },
             |value: &mut Value| {
                 value["providerPhases"] = json!([
                     "primary_conditioning",

--- a/scripts/memory-calibration-watchdog.py
+++ b/scripts/memory-calibration-watchdog.py
@@ -43,9 +43,17 @@ BOUNDED_CARRIER_PROVIDER_PHASES = (
     "primary_decode",
     "cleanup",
 )
+BOUNDED_CAMPAIGN_ENTRY_PROVIDER_PHASES = (
+    "common_load",
+    "primary_conditioning",
+    "primary_denoise",
+    "primary_decode",
+    "cleanup",
+)
 PROVIDER_PHASE_PROFILES = {
     "campaign-entry": CAMPAIGN_ENTRY_PROVIDER_PHASES,
     "bounded-carrier": BOUNDED_CARRIER_PROVIDER_PHASES,
+    "bounded-campaign-entry": BOUNDED_CAMPAIGN_ENTRY_PROVIDER_PHASES,
 }
 
 

--- a/scripts/memory-calibration-watchdog.test.mjs
+++ b/scripts/memory-calibration-watchdog.test.mjs
@@ -463,6 +463,120 @@ while True:
   );
 });
 
+test("bounded campaign entry profile advertises and acknowledges exactly five phases", async () => {
+  const files = await fixture();
+  const attester = `${files.program}.bounded-campaign-phases.py`;
+  const phases = [
+    "common_load", "primary_conditioning", "primary_denoise", "primary_decode", "cleanup",
+  ];
+  await writeFile(attester, String.raw`import json, os, socket
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect(os.environ["SCENEWORKS_MEMORY_WATCHDOG_SOCKET"])
+def line():
+    data = b""
+    while not data.endswith(b"\n"): data += sock.recv(1)
+    return data.decode().strip()
+payload = json.loads(line()); nonce = payload["nonce"]
+assert payload["providerPhaseProtocol"] == "sceneworks-provider-phase-v1"
+assert payload["providerPhaseProfile"] == "bounded-campaign-entry"
+assert payload["providerPhases"] == ${JSON.stringify(phases)}
+sock.sendall(f"ACK {nonce}\n".encode()); assert line() == f"GO {nonce}"
+for sequence, name in enumerate(payload["providerPhases"], 1):
+    sock.sendall(f"PHASE {nonce} {sequence} {name}\n".encode())
+    while True:
+        acknowledgement = line()
+        if acknowledgement == f"PING {nonce}": continue
+        assert acknowledgement == f"PHASE_ACK {nonce} {sequence} {name}"
+        break
+sock.sendall(f"DONE {nonce}\n".encode())
+while True:
+    message = line()
+    if message == f"BYE {nonce}": break
+    assert message == f"PING {nonce}"
+`);
+  await runWithMockedProductionTelemetry(files, ["python3", attester], {
+    requireProviderPhases: true,
+    providerPhaseProfile: "bounded-campaign-entry",
+  });
+  const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
+  assert.deepEqual(
+    events.filter((event) => event.event === "provider_phase")
+      .map((event) => event.providerPhase.name),
+    phases,
+  );
+  assert.deepEqual(
+    events.find((event) => event.event === "child_completed").providerPhase,
+    { sequence: 5, name: "cleanup" },
+  );
+  assert.equal(events.some((event) => event.event === "hard_stop"), false);
+  validateWatchdogEventChain(events);
+});
+
+test("bounded campaign entry phase omissions and reordering hard-stop before completion", async () => {
+  const phases = [
+    "common_load", "primary_conditioning", "primary_denoise", "primary_decode", "cleanup",
+  ];
+  for (const [mode, expectedReason] of [
+    ["missing", /child_completed_before_provider_phase_sequence:observed_4/],
+    ["reordered", /child_returned_reordered_provider_phase:expected_1:observed_2/],
+  ]) {
+    const files = await fixture();
+    const attester = `${files.program}.bad-bounded-campaign-phase.py`;
+    await writeFile(attester, String.raw`import json, os, socket, sys, time
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+sock.connect(os.environ["SCENEWORKS_MEMORY_WATCHDOG_SOCKET"])
+def line():
+    data = b""
+    while not data.endswith(b"\n"): data += sock.recv(1)
+    return data.decode().strip()
+payload = json.loads(line()); nonce = payload["nonce"]
+sock.sendall(f"ACK {nonce}\n".encode()); assert line() == f"GO {nonce}"
+if sys.argv[1] == "missing":
+    for sequence, name in enumerate(payload["providerPhases"][:-1], 1):
+        sock.sendall(f"PHASE {nonce} {sequence} {name}\n".encode())
+        while True:
+            acknowledgement = line()
+            if acknowledgement == f"PING {nonce}": continue
+            assert acknowledgement == f"PHASE_ACK {nonce} {sequence} {name}"
+            break
+    sock.sendall(f"DONE {nonce}\n".encode())
+else:
+    sock.sendall(f"PHASE {nonce} 2 ${phases[1]}\n".encode())
+time.sleep(60)
+`);
+    let status = 0;
+    try {
+      await runWithMockedProductionTelemetry(files, ["python3", attester, mode], {
+        requireProviderPhases: true,
+        providerPhaseProfile: "bounded-campaign-entry",
+      });
+    } catch (error) {
+      status = error.code;
+    }
+    assert.equal(status, 97);
+    const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
+    assert.match(events.find((event) => event.event === "hard_stop").reason, expectedReason);
+    assert.equal(events.at(-1).event, "terminated");
+  }
+});
+
+test("an unknown provider phase profile is rejected before the guarded command starts", async () => {
+  const files = await fixture();
+  let status = 0;
+  try {
+    await runWithMockedProductionTelemetry(
+      files,
+      ["python3", files.program, "complete", files.pids, files.telemetry, files.events],
+      { requireProviderPhases: true, providerPhaseProfile: "foreign-campaign-profile" },
+    );
+  } catch (error) {
+    status = error.code;
+  }
+  assert.equal(status, 2);
+  assert.equal(await readFile(files.pids, "utf8").catch(() => ""), "");
+  assert.equal(await readFile(files.events, "utf8").catch(() => ""), "");
+});
+
 test("reordered or foreign provider phases hard-stop the owned group", async () => {
   for (const [statement, expectedReason] of [
     ['sock.sendall(f"PHASE {nonce} 2 primary_conditioning\\n".encode())', /reordered_provider_phase/],

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -2106,6 +2106,7 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
   );
   for (const required of [
     "prevalidate_ltx_bounded_campaign_entry(request)?",
+    "consume_ltx_canary_watchdog_attestation(request)?",
     "start_lease_for(&LTX_BOUNDED_CARRIER_PHASE_NAMES)?",
     "LtxRunAdmission::BoundedCampaignEntry",
     "validate_ltx_bounded_campaign_fragment(&fragment)?",
@@ -2116,6 +2117,21 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
   ]) assert.ok(boundedCampaign.includes(required), `bounded campaign must retain ${required}`);
   assert.match(adapter,
     /LTX_BOUNDED_CAMPAIGN_ACTION => run_ltx_bounded_campaign_entry\(&request\)/);
+  const attestationIndex = boundedCampaign.indexOf(
+    "consume_ltx_canary_watchdog_attestation(request)?",
+  );
+  const limitsIndex = boundedCampaign.indexOf("LtxCanaryLimits::install()?");
+  const modelResolutionIndex = boundedCampaign.indexOf("run_ltx_with_admission(");
+  assert.ok(attestationIndex >= 0 && limitsIndex >= 0 && modelResolutionIndex >= 0,
+    "SC-20318 safety ordering anchors must all remain present");
+  assert.ok(
+    attestationIndex < limitsIndex,
+    "SC-20318 must reject a mismatched watchdog phase profile before allocator/model work",
+  );
+  assert.ok(
+    attestationIndex < modelResolutionIndex,
+    "SC-20318 must reject a mismatched watchdog phase profile before model resolution",
+  );
 
   const canary = adapter.slice(
     adapter.indexOf("fn validate_ltx_canary_plan_for("),
@@ -2237,6 +2253,83 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
   assert.match(limitsLifecycle, /set_wired_limit\(self\.previous_wired\);/);
   assert.match(limitsLifecycle, /set_memory_limit\(self\.previous_memory\);/);
   assert.match(limitsLifecycle, /impl Drop for LtxCanaryLimits[\s\S]*self\.restore\(\);/);
+});
+
+test("the SC-20318 provider phase profile is exact across runner, watchdog and adapter", async () => {
+  const [runner, watchdog, adapter] = await Promise.all([
+    source("scripts/run-ltx-safety-canary.mjs"),
+    source("scripts/memory-calibration-watchdog.py"),
+    source("crates/sceneworks-memory-adapter/src/bin/mlx.rs"),
+  ]);
+  const campaignPhases = [
+    "common_load", "primary_conditioning", "primary_denoise", "primary_decode",
+    "lifecycle_warm_repeat", "lifecycle_cancel", "lifecycle_cancel_recovery",
+    "lifecycle_error", "lifecycle_error_recovery", "cleanup",
+  ];
+  const boundedPhases = [
+    "common_load", "primary_conditioning", "primary_denoise", "primary_decode", "cleanup",
+  ];
+  const quotedValues = (sourceText, expression, label) => {
+    const match = sourceText.match(expression);
+    assert.ok(match, `${label} must remain a literal exact contract`);
+    return [...match[1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1]);
+  };
+
+  assert.deepEqual(quotedValues(
+    watchdog,
+    /^CAMPAIGN_ENTRY_PROVIDER_PHASES = \(([\s\S]*?)^\)$/m,
+    "Python campaign-entry phases",
+  ), campaignPhases);
+  assert.deepEqual(quotedValues(
+    watchdog,
+    /^BOUNDED_CARRIER_PROVIDER_PHASES = \(([\s\S]*?)^\)$/m,
+    "Python bounded-carrier phases",
+  ), boundedPhases);
+  assert.deepEqual(quotedValues(
+    watchdog,
+    /^BOUNDED_CAMPAIGN_ENTRY_PROVIDER_PHASES = \(([\s\S]*?)^\)$/m,
+    "Python bounded-campaign-entry phases",
+  ), boundedPhases);
+  const pythonProfiles = watchdog.slice(
+    watchdog.indexOf("PROVIDER_PHASE_PROFILES = {"),
+    watchdog.indexOf("\n}\n", watchdog.indexOf("PROVIDER_PHASE_PROFILES = {")) + 2,
+  );
+  assert.match(pythonProfiles,
+    /"campaign-entry": CAMPAIGN_ENTRY_PROVIDER_PHASES/);
+  assert.match(pythonProfiles,
+    /"bounded-carrier": BOUNDED_CARRIER_PROVIDER_PHASES/);
+  assert.match(pythonProfiles,
+    /"bounded-campaign-entry": BOUNDED_CAMPAIGN_ENTRY_PROVIDER_PHASES/);
+
+  assert.deepEqual(quotedValues(
+    runner,
+    /export const PROVIDER_PHASES = Object\.freeze\(\[([\s\S]*?)\]\);/,
+    "runner campaign-entry phases",
+  ), campaignPhases);
+  assert.deepEqual(quotedValues(
+    runner,
+    /export const BOUNDED_CARRIER_PHASES = Object\.freeze\(\[([\s\S]*?)\]\);/,
+    "runner bounded phases",
+  ), boundedPhases);
+  assert.match(runner,
+    /export const BOUNDED_CAMPAIGN_ENTRY_PROFILE = "bounded-campaign-entry";/);
+  assert.match(runner,
+    /phaseProfile: "bounded-campaign-entry",\n\s*childName: "sc-20318-bounded-campaign-entry"/);
+
+  assert.deepEqual(quotedValues(
+    adapter,
+    /const LTX_PROVIDER_PHASE_NAMES: \[&str; 10\] = \[([\s\S]*?)\];/,
+    "Rust campaign-entry phases",
+  ), campaignPhases);
+  assert.deepEqual(quotedValues(
+    adapter,
+    /const LTX_BOUNDED_CARRIER_PHASE_NAMES: \[&str; 5\] = \[([\s\S]*?)\];/,
+    "Rust bounded phases",
+  ), boundedPhases);
+  assert.match(adapter,
+    /const LTX_BOUNDED_CAMPAIGN_PHASE_PROFILE: &str = "bounded-campaign-entry";/);
+  assert.match(adapter,
+    /Some\(LTX_BOUNDED_CAMPAIGN_ACTION\) => Some\(\(\n\s*LTX_BOUNDED_CAMPAIGN_PHASE_PROFILE,\n\s*&LTX_BOUNDED_CARRIER_PHASE_NAMES,/);
 });
 
 test("the MLX FLUX.2-dev calibration arm is bound to the direct reference-free T2I contract", async () => {


### PR DESCRIPTION
## Summary
- add the missing distinct `bounded-campaign-entry` watchdog profile with the exact five-phase contract already emitted by the runner and required by the adapter
- exercise the real Unix-socket handshake and every phase ACK for the bounded campaign action
- fail closed on unknown, missing, reordered, ten-phase, and profile/action-mismatched attestations before model resolution
- bind the runner, Python watchdog, and Rust adapter contracts with mutation-sensitive source checks

## Validation
- `node --test scripts/memory-calibration-watchdog.test.mjs scripts/platform-review-contracts.test.mjs` (88/88)
- `npm run check` (582/582)
- `cargo test -p sceneworks-memory-adapter --features mlx --all-targets` (112/112)
- focused SC-20318 Rust attestation test (1/1)
- `cargo clippy -p sceneworks-memory-adapter --features mlx --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 -m py_compile scripts/memory-calibration-watchdog.py`
- `git diff --check`

Independent adversarial review: PASS, high confidence.

No model/GPU workload, campaign retry, or evidence publication was performed.