### PR TITLE
SC-20430: add bounded cross-tier phase anchors

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -191,10 +191,26 @@ const LTX_BOUNDED_CAMPAIGN_IDENTITY: &str =
 const LTX_BOUNDED_CAMPAIGN_LOGICAL_CASE_ID: &str = "implan-964db61ed3789af6386b";
 const LTX_BOUNDED_CAMPAIGN_FIXTURE: &str =
     "ltx-2-3-mlx-q4-768x512-f121-fps30-bounded-decode-192-64-seed18946";
+const LTX_BOUNDED_CAMPAIGN_Q8_IDENTITY: &str =
+    "sc-20430-q8-768x512-f121-fps30-bounded-192-64-authoritative-v1";
+const LTX_BOUNDED_CAMPAIGN_Q8_LOGICAL_CASE_ID: &str = "implan-d47640caa0c469f2ee13";
+const LTX_BOUNDED_CAMPAIGN_Q8_FIXTURE: &str =
+    "ltx-2-3-mlx-q8-768x512-f121-fps30-bounded-decode-192-64-seed18946";
+const LTX_BOUNDED_CAMPAIGN_BF16_IDENTITY: &str =
+    "sc-20430-bf16-768x512-f121-fps30-bounded-192-64-authoritative-v1";
+const LTX_BOUNDED_CAMPAIGN_BF16_LOGICAL_CASE_ID: &str = "implan-b3926164bf6bfbee98e1";
+const LTX_BOUNDED_CAMPAIGN_BF16_FIXTURE: &str =
+    "ltx-2-3-mlx-bf16-768x512-f121-fps30-bounded-decode-192-64-seed18946";
 const LTX_CANARY_ARTIFACT_REVISION: &str = "01df27d308466533aa09d251e3aebdcc627d07eb";
 const LTX_CANARY_Q4_INVENTORY_FILES: u64 = 11;
 const LTX_CANARY_Q4_INVENTORY_SHA256: &str =
     "4e811932e87bb258f642ada790525e36ef2a55959c520e755f1807caf6fa225a";
+const LTX_CANARY_Q8_INVENTORY_FILES: u64 = 11;
+const LTX_CANARY_Q8_INVENTORY_SHA256: &str =
+    "bb0bb7577157a158ca39494837d64cb36ded0380ca7ee0c930fea7311f22a247";
+const LTX_CANARY_BF16_INVENTORY_FILES: u64 = 10;
+const LTX_CANARY_BF16_INVENTORY_SHA256: &str =
+    "006caeaa9a8638b337cdf5a8622ce8535380b18ebaf90b36c3e2d5d15354f2a8";
 const LTX_CANARY_TEXT_ENCODER_INVENTORY_FILES: u64 = 17;
 const LTX_CANARY_TEXT_ENCODER_INVENTORY_BYTES: u64 = 26_427_894_918;
 const LTX_CANARY_TEXT_ENCODER_INVENTORY_SHA256: &str =
@@ -5859,17 +5875,72 @@ fn validate_ltx_bounded_carrier_proof(
     Ok(())
 }
 
-/// The sole promotable bounded campaign entry. The ordinary `run` action continues through the
-/// all-row pre-load refusal; the controller may inject this private action only after the canonical
-/// harness has selected the exact new SC-20318 row and acquired the contained-execution claim.
+#[derive(Clone, Copy)]
+struct LtxBoundedCampaignSpec {
+    tier: &'static str,
+    identity: &'static str,
+    logical_case_id: &'static str,
+    fixture: &'static str,
+    inventory_files: u64,
+    inventory_bytes: u64,
+    inventory_sha256: &'static str,
+    projection_bytes: u64,
+    story: &'static str,
+}
+
+fn ltx_bounded_campaign_spec(tier: &str) -> Result<LtxBoundedCampaignSpec, String> {
+    match tier {
+        "q4" => Ok(LtxBoundedCampaignSpec {
+            tier: "q4",
+            identity: LTX_BOUNDED_CAMPAIGN_IDENTITY,
+            logical_case_id: LTX_BOUNDED_CAMPAIGN_LOGICAL_CASE_ID,
+            fixture: LTX_BOUNDED_CAMPAIGN_FIXTURE,
+            inventory_files: LTX_CANARY_Q4_INVENTORY_FILES,
+            inventory_bytes: LTX_Q4_INVENTORY_BYTES,
+            inventory_sha256: LTX_CANARY_Q4_INVENTORY_SHA256,
+            projection_bytes: 84_694_536_320,
+            story: "SC-20318",
+        }),
+        "q8" => Ok(LtxBoundedCampaignSpec {
+            tier: "q8",
+            identity: LTX_BOUNDED_CAMPAIGN_Q8_IDENTITY,
+            logical_case_id: LTX_BOUNDED_CAMPAIGN_Q8_LOGICAL_CASE_ID,
+            fixture: LTX_BOUNDED_CAMPAIGN_Q8_FIXTURE,
+            inventory_files: LTX_CANARY_Q8_INVENTORY_FILES,
+            inventory_bytes: LTX_Q8_INVENTORY_BYTES,
+            inventory_sha256: LTX_CANARY_Q8_INVENTORY_SHA256,
+            projection_bytes: 93_955_566_576,
+            story: "SC-20430",
+        }),
+        "bf16" => Ok(LtxBoundedCampaignSpec {
+            tier: "bf16",
+            identity: LTX_BOUNDED_CAMPAIGN_BF16_IDENTITY,
+            logical_case_id: LTX_BOUNDED_CAMPAIGN_BF16_LOGICAL_CASE_ID,
+            fixture: LTX_BOUNDED_CAMPAIGN_BF16_FIXTURE,
+            inventory_files: LTX_CANARY_BF16_INVENTORY_FILES,
+            inventory_bytes: LTX_BF16_INVENTORY_BYTES,
+            inventory_sha256: LTX_CANARY_BF16_INVENTORY_SHA256,
+            projection_bytes: 111_319_657_852,
+            story: "SC-20430",
+        }),
+        other => Err(format!(
+            "SC-20430 bounded campaign tier {other:?} is not exactly allowlisted"
+        )),
+    }
+}
+
+/// The three exact promotable bounded campaign entries. The ordinary `run` action continues
+/// through the all-row pre-load refusal; the controller may inject this private action only after
+/// the canonical harness has selected one allowlisted row and acquired the contained-execution claim.
 fn validate_ltx_bounded_campaign_entry(
     request: &Value,
     tier: &str,
     geometry: LtxGeometry,
     selection: &MemorySelection,
 ) -> Result<(), String> {
+    let spec = ltx_bounded_campaign_spec(tier)?;
     if protocol::action(request)? != LTX_BOUNDED_CAMPAIGN_ACTION {
-        return Err("SC-20318 bounded campaign action changed".to_owned());
+        return Err(format!("{} bounded campaign action changed", spec.story));
     }
     let planned = protocol::planned(request)?;
     let exact = |pointer: &str, expected: &Value| -> Result<(), String> {
@@ -5878,20 +5949,18 @@ fn validate_ltx_bounded_campaign_entry(
             Ok(())
         } else {
             Err(format!(
-                "SC-20318 bounded campaign {pointer} must be {expected}, got {actual:?}"
+                "{} bounded campaign {pointer} must be {expected}, got {actual:?}",
+                spec.story
             ))
         }
     };
-    exact(
-        "/logicalCaseId",
-        &json!(LTX_BOUNDED_CAMPAIGN_LOGICAL_CASE_ID),
-    )?;
+    exact("/logicalCaseId", &json!(spec.logical_case_id))?;
     exact("/evidenceScope", &json!("authoritative"))?;
     exact("/backend", &json!("mlx"))?;
     exact("/loadShape", &json!("eager_materialization"))?;
     exact("/target/provider", &json!(LTX_PROVIDER))?;
     exact("/target/modelId", &json!(LTX_PROVIDER))?;
-    exact("/target/tier", &json!("q4"))?;
+    exact("/target/tier", &json!(spec.tier))?;
     exact("/target/mode", &json!("text_to_video"))?;
     exact("/target/overlay", &json!("none"))?;
     exact("/target/geometry/width", &json!(LTX_CAMPAIGN_ENTRY_WIDTH))?;
@@ -5914,7 +5983,7 @@ fn validate_ltx_bounded_campaign_entry(
         "/calibrationFingerprint",
         &json!(LTX_CALIBRATION_FINGERPRINT),
     )?;
-    exact("/fixture", &json!(LTX_BOUNDED_CAMPAIGN_FIXTURE))?;
+    exact("/fixture", &json!(spec.fixture))?;
     exact("/negative", &json!(false))?;
     exact("/expectedResult", &json!("passed"))?;
     exact("/modelLoadPolicy", &json!("fresh_per_case"))?;
@@ -5927,25 +5996,29 @@ fn validate_ltx_bounded_campaign_entry(
         "/_measurementSafety",
         &json!({
             "disposition": LTX_SAFETY_REFUSED_OPEN,
-            "tierInventoryBytes": LTX_Q4_INVENTORY_BYTES,
+            "tierInventoryBytes": spec.inventory_bytes,
             "incidentCrashFootprintBytes": LTX_Q4_F305_CRASH_FOOTPRINT_BYTES,
             "incidentCase": "mlx-ltx-2-3-q4-1280x704-f305-fps30-bounded_decode",
             "commonLoad": "complete numeric tier plus shared Gemma stack before geometry-specific work",
             "predictedDecodeBytes": 6_264_848_640_u64,
             "incidentPredictedDecodeBytes": LTX_INCIDENT_PREDICTED_DECODE_BYTES,
-            "incidentCalibratedProjectionBytes": 84_694_536_320_u64,
+            "incidentCalibratedProjectionBytes": spec.projection_bytes,
             "projectionAssumptions": [
                 "pinned provider decode cost is the only geometry-varying term used",
                 "immutable tier inventory delta is added byte-for-byte",
                 "incident binding phase is unknown, so the projection is not a physical-footprint bound and cannot admit execution",
             ],
-            "reason": "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20318 action is admitted",
+            "reason": if spec.tier == "q4" {
+                "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20318 action is admitted"
+            } else {
+                "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20430 action is admitted"
+            },
         }),
     )?;
     exact(
         "/_boundedCampaignEntry",
         &json!({
-            "identity": LTX_BOUNDED_CAMPAIGN_IDENTITY,
+            "identity": spec.identity,
             "fps": LTX_CAMPAIGN_ENTRY_FPS,
             "seed": LTX_SEED,
             "videoMode": "default_av",
@@ -5954,9 +6027,9 @@ fn validate_ltx_bounded_campaign_entry(
                 "repository": protocol::LTX_REPOSITORY,
                 "revision": LTX_CANARY_ARTIFACT_REVISION,
                 "numericTierInventory": {
-                    "files": LTX_CANARY_Q4_INVENTORY_FILES,
-                    "bytes": LTX_Q4_INVENTORY_BYTES,
-                    "sha256": LTX_CANARY_Q4_INVENTORY_SHA256,
+                    "files": spec.inventory_files,
+                    "bytes": spec.inventory_bytes,
+                    "sha256": spec.inventory_sha256,
                 },
                 "textEncoderInventory": {
                     "files": LTX_CANARY_TEXT_ENCODER_INVENTORY_FILES,
@@ -5966,15 +6039,17 @@ fn validate_ltx_bounded_campaign_entry(
             },
         }),
     )?;
-    if tier != "q4"
-        || geometry.width != LTX_CAMPAIGN_ENTRY_WIDTH
+    if geometry.width != LTX_CAMPAIGN_ENTRY_WIDTH
         || geometry.height != LTX_CAMPAIGN_ENTRY_HEIGHT
         || geometry.frames != LTX_CAMPAIGN_ENTRY_FRAMES
         || selection.strategy != MemoryStrategy::BoundedDecode
         || selection.parameters.decode_tile_edge != Some(LTX_CANARY_TILE_EDGE)
         || selection.parameters.decode_overlap != Some(LTX_CANARY_OVERLAP)
     {
-        return Err("SC-20318 bounded campaign resolved a foreign tuple or strategy".to_owned());
+        return Err(format!(
+            "{} bounded campaign resolved a foreign tuple or strategy",
+            spec.story
+        ));
     }
     let (fps, seed) = planned_ltx_capture(request, tier, geometry)?;
     if fps != LTX_CAMPAIGN_ENTRY_FPS || seed != LTX_SEED {
@@ -8991,6 +9066,11 @@ fn run_ltx_campaign_entry(request: &Value) -> Result<Value, String> {
 
 fn run_ltx_bounded_campaign_entry(request: &Value) -> Result<Value, String> {
     prevalidate_ltx_bounded_campaign_entry(request)?;
+    let tier = protocol::planned(request)?
+        .pointer("/target/tier")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "bounded campaign target tier must be a string".to_owned())?;
+    let bounded_spec = ltx_bounded_campaign_spec(tier)?;
     let mut watchdog = consume_ltx_canary_watchdog_attestation(request)?;
     let mut watchdog_lease = watchdog.start_lease_for(&LTX_BOUNDED_CARRIER_PHASE_NAMES)?;
     watchdog_lease.mark("common_load")?;
@@ -9010,7 +9090,7 @@ fn run_ltx_bounded_campaign_entry(request: &Value) -> Result<Value, String> {
     let post_cleanup = AllocatorState::capture_current();
     validate_ltx_canary_cleanup(pre_provider, post_cleanup, expected_persistent_active)?;
     fragment["_boundedCampaignEntry"] = json!({
-        "identity": LTX_BOUNDED_CAMPAIGN_IDENTITY,
+        "identity": bounded_spec.identity,
         "inferenceRevision": protocol::INFERENCE_PIN,
         "watchdog": {
             "required": true,
@@ -10409,6 +10489,30 @@ mod ltx_tests {
         request
     }
 
+    fn ltx_bounded_campaign_request_json_for(tier: &str) -> Value {
+        let mut request = ltx_bounded_campaign_request_json();
+        let spec = ltx_bounded_campaign_spec(tier).expect("test tier must be allowlisted");
+        request["planned"]["target"]["tier"] = json!(spec.tier);
+        request["planned"]["logicalCaseId"] = json!(spec.logical_case_id);
+        request["planned"]["fixture"] = json!(spec.fixture);
+        request["planned"]["_boundedCampaignEntry"]["identity"] = json!(spec.identity);
+        request["planned"]["_boundedCampaignEntry"]["artifact"]["numericTierInventory"] = json!({
+            "files": spec.inventory_files,
+            "bytes": spec.inventory_bytes,
+            "sha256": spec.inventory_sha256,
+        });
+        request["planned"]["_measurementSafety"]["tierInventoryBytes"] =
+            json!(spec.inventory_bytes);
+        request["planned"]["_measurementSafety"]["incidentCalibratedProjectionBytes"] =
+            json!(spec.projection_bytes);
+        request["planned"]["_measurementSafety"]["reason"] = json!(if tier == "q4" {
+            "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20318 action is admitted"
+        } else {
+            "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20430 action is admitted"
+        });
+        request
+    }
+
     #[test]
     fn sc_20318_admits_only_the_exact_two_render_bounded_campaign_row() {
         let request = ltx_bounded_campaign_request_json();
@@ -10464,7 +10568,9 @@ mod ltx_tests {
             let error = prevalidate_ltx_bounded_campaign_entry(&mutated)
                 .expect_err("every SC-20318 identity mutation must fail before weights");
             assert!(
-                error.contains("SC-20318") || error.contains("SC-18946"),
+                error.contains("SC-20318")
+                    || error.contains("SC-20430")
+                    || error.contains("SC-18946"),
                 "{pointer}: {error}"
             );
         }
@@ -10484,6 +10590,57 @@ mod ltx_tests {
         let refusal = run_ltx(&ordinary)
             .expect_err("the new row must remain refused by the ordinary campaign action");
         assert!(refusal.contains("safety_refused_open"), "{refusal}");
+    }
+
+    #[test]
+    fn sc_20430_exactly_allowlists_q8_and_bf16_bounded_campaign_rows() {
+        for tier in ["q8", "bf16"] {
+            let request = ltx_bounded_campaign_request_json_for(tier);
+            prevalidate_ltx_bounded_campaign_entry(&request)
+                .unwrap_or_else(|error| panic!("exact {tier} bounded entry rejected: {error}"));
+            for (pointer, mutation) in [
+                ("/action", json!("run")),
+                ("/planned/target/tier", json!("q4")),
+                (
+                    "/planned/logicalCaseId",
+                    json!(LTX_BOUNDED_CAMPAIGN_LOGICAL_CASE_ID),
+                ),
+                ("/planned/fixture", json!(LTX_BOUNDED_CAMPAIGN_FIXTURE)),
+                ("/planned/_boundedCampaignEntry/identity", json!("mutated")),
+                (
+                    "/planned/_boundedCampaignEntry/artifact/numericTierInventory/bytes",
+                    json!(LTX_Q4_INVENTORY_BYTES),
+                ),
+                ("/planned/_boundedCampaignEntry/seed", json!(LTX_SEED + 1)),
+                (
+                    "/planned/strategy/parameters/decodeTileEdge",
+                    json!(LTX_CANARY_TILE_EDGE + 1),
+                ),
+            ] {
+                let mut changed = request.clone();
+                *changed.pointer_mut(pointer).expect("mutation pointer") = mutation;
+                assert!(
+                    prevalidate_ltx_bounded_campaign_entry(&changed).is_err(),
+                    "{tier} mutation {pointer} reached model resolution"
+                );
+            }
+            let direct = run_ltx_bounded_campaign_entry(&request)
+                .expect_err("private JSON alone cannot bypass the watchdog");
+            assert!(
+                direct.contains("live external watchdog channel"),
+                "{direct}"
+            );
+            let mut ordinary = request.clone();
+            ordinary["action"] = json!("run");
+            ordinary["planned"]
+                .as_object_mut()
+                .unwrap()
+                .remove("_boundedCampaignEntry");
+            let refusal = run_ltx(&ordinary)
+                .expect_err("the ordinary 73-row action must refuse every new tier");
+            assert!(refusal.contains("safety_refused_open"), "{refusal}");
+        }
+        assert!(ltx_bounded_campaign_spec("fp16").is_err());
     }
 
     #[test]

--- a/docs/calibration/sc-18946/ltx-mlx-rung2-sweep.json
+++ b/docs/calibration/sc-18946/ltx-mlx-rung2-sweep.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "SC-18946 rung-2-first matrix. The original q4/q8/bf16 rows retain the 384/64 carrier at 1280x704 f305/f449. One separately identified q4 768x512 f121 row uses the SC-20254-proven 192/64, 24-tile carrier and is the only privately admitted campaign entry. These records are never pooled into the single-pass temporal fit.",
+  "_comment": "SC-18946 rung-2-first matrix. The original q4/q8/bf16 rows retain the 384/64 carrier at 1280x704 f305/f449. Three separately identified q4/q8/bf16 768x512 f121 rows use the SC-20254-proven 192/64, 24-tile carrier and are the only privately admitted campaign entries. These records are matched bounded-selector phase anchors only and are never pooled into the single-pass temporal fit or used for coefficient transfer.",
   "story": "sc-18946",
   "campaignIdentity": {
     "inferenceRevision": "6f3a84ef4ad4f858c6fe199e14925a01a7943f97",
@@ -415,6 +415,126 @@
       ],
       "calibrationFingerprint": "sc-19109-ltx-2-3-mlx-memory-ladder-v1",
       "fixture": "ltx-2-3-mlx-q4-768x512-f121-fps30-bounded-decode-192-64-seed18946",
+      "cases": [
+        {
+          "parameters": {
+            "decodeTileEdge": 192,
+            "decodeOverlap": 64
+          },
+          "expectedResult": "passed"
+        }
+      ],
+      "_predictedDecodeBytes": 6264848640,
+      "_predictedDecodeFormula": "3.3e9 + 40*(width*height*frames) + 300*(192*192*96) bytes"
+    },
+    {
+      "name": "mlx-ltx-2-3-q8-768x512-f121-fps30-bounded_decode-192x64",
+      "_role": "bounded_carrier_entry",
+      "_campaignPhase": "bounded_carrier_ratification",
+      "_coverageExpectation": "captured_or_attempted",
+      "_latentTokens": 6144,
+      "_writableFrameCap": 682,
+      "_outputVoxels": 47579136,
+      "_measurementSafety": {
+        "disposition": "safety_refused_open",
+        "tierInventoryBytes": 29728720716,
+        "incidentCrashFootprintBytes": 96970084480,
+        "incidentCase": "mlx-ltx-2-3-q4-1280x704-f305-fps30-bounded_decode",
+        "commonLoad": "complete numeric tier plus shared Gemma stack before geometry-specific work",
+        "predictedDecodeBytes": 6264848640,
+        "incidentPredictedDecodeBytes": 18540396800,
+        "incidentCalibratedProjectionBytes": 93955566576,
+        "projectionAssumptions": [
+          "pinned provider decode cost is the only geometry-varying term used",
+          "immutable tier inventory delta is added byte-for-byte",
+          "incident binding phase is unknown, so the projection is not a physical-footprint bound and cannot admit execution"
+        ],
+        "reason": "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20430 action is admitted"
+      },
+      "evidenceScope": "authoritative",
+      "backend": "mlx",
+      "loadShape": "eager_materialization",
+      "target": {
+        "provider": "ltx_2_3",
+        "modelId": "ltx_2_3",
+        "tier": "q8",
+        "mode": "text_to_video",
+        "overlay": "none",
+        "geometry": {
+          "width": 768,
+          "height": 512,
+          "batch": 1,
+          "frames": 121
+        }
+      },
+      "rung": "bounded_decode",
+      "engagedRungs": [
+        "resident",
+        "staged_residency",
+        "bounded_decode"
+      ],
+      "calibrationFingerprint": "sc-19109-ltx-2-3-mlx-memory-ladder-v1",
+      "fixture": "ltx-2-3-mlx-q8-768x512-f121-fps30-bounded-decode-192-64-seed18946",
+      "cases": [
+        {
+          "parameters": {
+            "decodeTileEdge": 192,
+            "decodeOverlap": 64
+          },
+          "expectedResult": "passed"
+        }
+      ],
+      "_predictedDecodeBytes": 6264848640,
+      "_predictedDecodeFormula": "3.3e9 + 40*(width*height*frames) + 300*(192*192*96) bytes"
+    },
+    {
+      "name": "mlx-ltx-2-3-bf16-768x512-f121-fps30-bounded_decode-192x64",
+      "_role": "bounded_carrier_entry",
+      "_campaignPhase": "bounded_carrier_ratification",
+      "_coverageExpectation": "captured_or_attempted",
+      "_latentTokens": 6144,
+      "_writableFrameCap": 682,
+      "_outputVoxels": 47579136,
+      "_measurementSafety": {
+        "disposition": "safety_refused_open",
+        "tierInventoryBytes": 47092811992,
+        "incidentCrashFootprintBytes": 96970084480,
+        "incidentCase": "mlx-ltx-2-3-q4-1280x704-f305-fps30-bounded_decode",
+        "commonLoad": "complete numeric tier plus shared Gemma stack before geometry-specific work",
+        "predictedDecodeBytes": 6264848640,
+        "incidentPredictedDecodeBytes": 18540396800,
+        "incidentCalibratedProjectionBytes": 111319657852,
+        "projectionAssumptions": [
+          "pinned provider decode cost is the only geometry-varying term used",
+          "immutable tier inventory delta is added byte-for-byte",
+          "incident binding phase is unknown, so the projection is not a physical-footprint bound and cannot admit execution"
+        ],
+        "reason": "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20430 action is admitted"
+      },
+      "evidenceScope": "authoritative",
+      "backend": "mlx",
+      "loadShape": "eager_materialization",
+      "target": {
+        "provider": "ltx_2_3",
+        "modelId": "ltx_2_3",
+        "tier": "bf16",
+        "mode": "text_to_video",
+        "overlay": "none",
+        "geometry": {
+          "width": 768,
+          "height": 512,
+          "batch": 1,
+          "frames": 121
+        }
+      },
+      "rung": "bounded_decode",
+      "engagedRungs": [
+        "resident",
+        "staged_residency",
+        "bounded_decode"
+      ],
+      "calibrationFingerprint": "sc-19109-ltx-2-3-mlx-memory-ladder-v1",
+      "fixture": "ltx-2-3-mlx-bf16-768x512-f121-fps30-bounded-decode-192-64-seed18946",
       "cases": [
         {
           "parameters": {

--- a/scripts/generate-ltx-sc18946-plan.mjs
+++ b/scripts/generate-ltx-sc18946-plan.mjs
@@ -19,6 +19,7 @@ export const SEED = 18946;
 export const TIERS = Object.freeze(["q4", "q8", "bf16"]);
 export const RUNG2_PARAMETERS = Object.freeze({ decodeTileEdge: 384, decodeOverlap: 64 });
 export const RATIFIED_BOUNDED_PARAMETERS = Object.freeze({ decodeTileEdge: 192, decodeOverlap: 64 });
+export const RATIFIED_BOUNDED_TIERS = Object.freeze(["q4", "q8", "bf16"]);
 export const RATIFIED_BOUNDED_PROVIDER =
   "mlx-ltx-2-3-q4-768x512-f121-fps30-bounded_decode-192x64";
 export const RATIFIED_BOUNDED_FIXTURE =
@@ -160,13 +161,13 @@ function providerRow(tier, [width, height, frames, fps, role, campaignPhase], ru
   return row;
 }
 
-function ratifiedBoundedRow() {
+function ratifiedBoundedRow(tier) {
   const width = 768;
   const height = 512;
   const frames = 121;
   const outputVoxels = width * height * frames;
   return {
-    name: RATIFIED_BOUNDED_PROVIDER,
+    name: `mlx-ltx-2-3-${tier}-768x512-f121-fps30-bounded_decode-192x64`,
     _role: "bounded_carrier_entry",
     _campaignPhase: "bounded_carrier_ratification",
     _coverageExpectation: "captured_or_attempted",
@@ -175,19 +176,22 @@ function ratifiedBoundedRow() {
     _outputVoxels: outputVoxels,
     _measurementSafety: {
       disposition: SAFETY_DISPOSITIONS.SAFETY_REFUSED_OPEN,
-      tierInventoryBytes: TIER_INVENTORY_BYTES.q4,
+      tierInventoryBytes: TIER_INVENTORY_BYTES[tier],
       incidentCrashFootprintBytes: Q4_F305_CRASH_FOOTPRINT_BYTES,
       incidentCase: "mlx-ltx-2-3-q4-1280x704-f305-fps30-bounded_decode",
       commonLoad: "complete numeric tier plus shared Gemma stack before geometry-specific work",
       predictedDecodeBytes: 6_264_848_640,
       incidentPredictedDecodeBytes: INCIDENT_PREDICTED_DECODE_BYTES,
-      incidentCalibratedProjectionBytes: 84_694_536_320,
+      incidentCalibratedProjectionBytes:
+        84_694_536_320 + TIER_INVENTORY_BYTES[tier] - TIER_INVENTORY_BYTES.q4,
       projectionAssumptions: [
         "pinned provider decode cost is the only geometry-varying term used",
         "immutable tier inventory delta is added byte-for-byte",
         "incident binding phase is unknown, so the projection is not a physical-footprint bound and cannot admit execution",
       ],
-      reason: "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20318 action is admitted",
+      reason: tier === "q4"
+        ? "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20318 action is admitted"
+        : "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20430 action is admitted",
     },
     evidenceScope: "authoritative",
     backend: "mlx",
@@ -195,7 +199,7 @@ function ratifiedBoundedRow() {
     target: {
       provider: PROVIDER,
       modelId: PROVIDER,
-      tier: "q4",
+      tier,
       mode: "text_to_video",
       overlay: "none",
       geometry: { width, height, batch: 1, frames },
@@ -203,7 +207,7 @@ function ratifiedBoundedRow() {
     rung: "bounded_decode",
     engagedRungs: ["resident", "staged_residency", "bounded_decode"],
     calibrationFingerprint: FINGERPRINT,
-    fixture: RATIFIED_BOUNDED_FIXTURE,
+    fixture: `ltx-2-3-mlx-${tier}-768x512-f121-fps30-bounded-decode-192-64-seed18946`,
     cases: [{ parameters: RATIFIED_BOUNDED_PARAMETERS, expectedResult: "passed" }],
     _predictedDecodeBytes: 6_264_848_640,
     _predictedDecodeFormula:
@@ -228,12 +232,15 @@ function plan(comment, rows, rung, { rowMajor = false } = {}) {
 
 function rung2Plan() {
   const frozen = plan(
-    "SC-18946 rung-2-first matrix. The original q4/q8/bf16 rows retain the 384/64 carrier at 1280x704 f305/f449. One separately identified q4 768x512 f121 row uses the SC-20254-proven 192/64, 24-tile carrier and is the only privately admitted campaign entry. These records are never pooled into the single-pass temporal fit.",
+    "SC-18946 rung-2-first matrix. The original q4/q8/bf16 rows retain the 384/64 carrier at 1280x704 f305/f449. Three separately identified q4/q8/bf16 768x512 f121 rows use the SC-20254-proven 192/64, 24-tile carrier and are the only privately admitted campaign entries. These records are matched bounded-selector phase anchors only and are never pooled into the single-pass temporal fit or used for coefficient transfer.",
     rung2Rows,
     "bounded_decode",
     { rowMajor: true },
   );
-  return { ...frozen, providers: [...frozen.providers, ratifiedBoundedRow()] };
+  return {
+    ...frozen,
+    providers: [...frozen.providers, ...RATIFIED_BOUNDED_TIERS.map(ratifiedBoundedRow)],
+  };
 }
 
 export function buildPlans() {

--- a/scripts/generate-ltx-sc18946-plan.test.mjs
+++ b/scripts/generate-ltx-sc18946-plan.test.mjs
@@ -1,5 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13,6 +14,7 @@ import {
   RATIFIED_BOUNDED_FIXTURE,
   RATIFIED_BOUNDED_PARAMETERS,
   RATIFIED_BOUNDED_PROVIDER,
+  RATIFIED_BOUNDED_TIERS,
   RUNG2_PARAMETERS,
   SAFETY_DISPOSITIONS,
   SEED,
@@ -102,11 +104,24 @@ test("the flip bands, deep anchors, original six and held-out transfer cells are
   ]) assert.ok(cells.has(cell), cell);
 });
 
-test("rung two preserves the six 384 by 64 rows and appends one exact ratified carrier", () => {
+test("rung two preserves the six 384 by 64 rows and appends three matched bounded anchors", () => {
   const rows = plans["ltx-mlx-rung2-sweep.json"].providers;
-  assert.equal(rows.length, 7);
+  assert.equal(rows.length, 9);
+  const originalSeventyOne = Object.entries(plans).flatMap(([name, plan]) =>
+    name === "ltx-mlx-rung2-sweep.json" ? plan.providers.slice(0, 7) : plan.providers);
+  assert.equal(originalSeventyOne.length, 71);
+  assert.equal(
+    createHash("sha256").update(JSON.stringify(originalSeventyOne)).digest("hex"),
+    "473fc389fc12a2ffd4ae2eb1680f24033fc48a5c55503951570124d69b3d97f6",
+    "all 71 pre-SC-20430 rows must remain byte-identical and ordered",
+  );
+  assert.equal(
+    createHash("sha256").update(JSON.stringify(rows.slice(0, 7))).digest("hex"),
+    "1618f6cb8a0589652da550a3cbd27f472c36748995a141cc9199d7847ebdf64a",
+    "the pre-SC-20430 rung-2 rows must remain byte-identical and ordered",
+  );
   const frozen = rows.slice(0, 6);
-  const [ratified] = rows.slice(6);
+  const ratified = rows.slice(6);
   assert.deepEqual(TIERS, ["q4", "q8", "bf16"]);
   assert.deepEqual(
     frozen.map((row) => `${row.target.geometry.frames}:${row.target.tier}`),
@@ -125,19 +140,25 @@ test("rung two preserves the six 384 by 64 rows and appends one exact ratified c
   const predicted = Object.fromEntries(frozen.filter((row) => row.target.tier === "q8").map((row) => [row.target.geometry.frames, row._predictedDecodeBytes]));
   assert.equal(predicted[305], 18_540_396_800);
   assert.equal(predicted[449], 23_730_848_000);
-  assert.equal(ratified.name, RATIFIED_BOUNDED_PROVIDER);
-  assert.equal(ratified.fixture, RATIFIED_BOUNDED_FIXTURE);
-  assert.equal(ratified._role, "bounded_carrier_entry");
-  assert.equal(ratified._campaignPhase, "bounded_carrier_ratification");
-  assert.deepEqual(ratified.target.geometry, {
-    width: 768, height: 512, batch: 1, frames: 121,
-  });
-  assert.deepEqual(ratified.cases, [{
-    parameters: RATIFIED_BOUNDED_PARAMETERS, expectedResult: "passed",
-  }]);
-  assert.equal(ratified._measurementSafety.disposition, SAFETY_DISPOSITIONS.SAFETY_REFUSED_OPEN);
-  assert.equal(ratified._measurementSafety.predictedDecodeBytes, 6_264_848_640);
-  assert.equal(ratified._measurementSafety.incidentCalibratedProjectionBytes, 84_694_536_320);
+  assert.deepEqual(ratified.map((row) => row.target.tier), RATIFIED_BOUNDED_TIERS);
+  assert.equal(ratified[0].name, RATIFIED_BOUNDED_PROVIDER);
+  assert.equal(ratified[0].fixture, RATIFIED_BOUNDED_FIXTURE);
+  for (const row of ratified) {
+    assert.equal(row._role, "bounded_carrier_entry");
+    assert.equal(row._campaignPhase, "bounded_carrier_ratification");
+    assert.deepEqual(row.target.geometry, {
+      width: 768, height: 512, batch: 1, frames: 121,
+    });
+    assert.deepEqual(row.cases, [{
+      parameters: RATIFIED_BOUNDED_PARAMETERS, expectedResult: "passed",
+    }]);
+    assert.equal(row._measurementSafety.disposition, SAFETY_DISPOSITIONS.SAFETY_REFUSED_OPEN);
+    assert.equal(row._measurementSafety.predictedDecodeBytes, 6_264_848_640);
+    assert.equal(
+      row._measurementSafety.incidentCalibratedProjectionBytes,
+      84_694_536_320 + TIER_INVENTORY_BYTES[row.target.tier] - TIER_INVENTORY_BYTES.q4,
+    );
+  }
 });
 
 test("host-risk coverage is explicitly planned rather than absent", () => {
@@ -159,7 +180,7 @@ test("host-risk coverage is explicitly planned rather than absent", () => {
 
 test("SC-19642 classifies every row for pre-load refusal without inventing a safe host fraction", () => {
   const rows = Object.values(plans).flatMap((plan) => plan.providers);
-  assert.equal(rows.length, 71);
+  assert.equal(rows.length, 73);
   assert.equal(Q4_F305_CRASH_FOOTPRINT_BYTES, 96_970_084_480);
   assert.deepEqual(TIER_INVENTORY_BYTES, {
     q4: 20_467_690_460,

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1998,7 +1998,10 @@ test("the MLX LTX arm's manifest constants match the shipped ltx_2_3 limits", as
 });
 
 test("the LTX real-weight safety canary cannot relax or masquerade as campaign evidence", async () => {
-  const adapter = await source("crates/sceneworks-memory-adapter/src/bin/mlx.rs");
+  const [adapter, runner] = await Promise.all([
+    source("crates/sceneworks-memory-adapter/src/bin/mlx.rs"),
+    source("scripts/run-ltx-safety-canary.mjs"),
+  ]);
   const historical = JSON.parse(await source("docs/generated/ltx-mlx-video-sc-18808.json"));
   const costaged = historical.records[0].diagnostics.measurements.find(
     (entry) => entry.name === "costagedGiantsBytes",
@@ -2028,9 +2031,38 @@ test("the LTX real-weight safety canary cannot relax or masquerade as campaign e
     "the campaign must still refuse before model-path/provider/weights access",
   );
   const campaignRows = Object.values(buildLtxPlans()).flatMap((plan) => plan.providers);
-  assert.equal(campaignRows.length, 71, "SC-20318 must explicitly inventory 71 rows");
+  assert.equal(campaignRows.length, 73, "SC-20430 must explicitly inventory 73 rows");
   const ratified = campaignRows.filter((row) => row._role === "bounded_carrier_entry");
-  assert.equal(ratified.length, 1, "only one bounded carrier may be ratified");
+  assert.equal(ratified.length, 3, "exactly one matched bounded carrier per tier may be ratified");
+  assert.deepEqual(ratified.map((row) => row.target.tier), ["q4", "q8", "bf16"]);
+  const crossLayer = {
+    q8: {
+      logicalCaseId: "implan-d47640caa0c469f2ee13",
+      identity: "sc-20430-q8-768x512-f121-fps30-bounded-192-64-authoritative-v1",
+      inventorySha256: "bb0bb7577157a158ca39494837d64cb36ded0380ca7ee0c930fea7311f22a247",
+    },
+    bf16: {
+      logicalCaseId: "implan-b3926164bf6bfbee98e1",
+      identity: "sc-20430-bf16-768x512-f121-fps30-bounded-192-64-authoritative-v1",
+      inventorySha256: "006caeaa9a8638b337cdf5a8622ce8535380b18ebaf90b36c3e2d5d15354f2a8",
+    },
+  };
+  for (const row of ratified.filter(({ target }) => target.tier !== "q4")) {
+    const exact = crossLayer[row.target.tier];
+    for (const [label, value] of [
+      ["provider", row.name], ["fixture", row.fixture],
+      ["logical case", exact.logicalCaseId], ["private identity", exact.identity],
+      ["inventory SHA", exact.inventorySha256],
+    ]) {
+      assert.ok(runner.includes(value), `${row.target.tier} runner ${label} changed`);
+      if (label !== "provider") {
+        assert.ok(adapter.includes(value), `${row.target.tier} adapter ${label} changed`);
+      }
+    }
+  }
+  assert.match(runner,
+    /process\.argv\[2\] === "--bounded-selector-report"[\s\S]*boundedSelectorReportController/,
+    "SC-20430 matched phase anchors must remain executable as a CPU-only report path");
   const originalRows = campaignRows.filter((row) => row._role !== "bounded_carrier_entry");
   assert.equal(originalRows.length, 70, "all original campaign rows must remain present");
   for (const row of originalRows) {
@@ -2314,7 +2346,11 @@ test("the SC-20318 provider phase profile is exact across runner, watchdog and a
   assert.match(runner,
     /export const BOUNDED_CAMPAIGN_ENTRY_PROFILE = "bounded-campaign-entry";/);
   assert.match(runner,
-    /phaseProfile: "bounded-campaign-entry",\n\s*childName: "sc-20318-bounded-campaign-entry"/);
+    /export const BOUNDED_CAMPAIGN_ENTRY_Q8_PROFILE = "bounded-campaign-entry-q8";/);
+  assert.match(runner,
+    /export const BOUNDED_CAMPAIGN_ENTRY_BF16_PROFILE = "bounded-campaign-entry-bf16";/);
+  assert.match(runner,
+    /phaseProfile: "bounded-campaign-entry",\n\s*childName: `\$\{boundedSpec\.story\}-\$\{boundedSpec\.tier\}-bounded-campaign-entry`/);
 
   assert.deepEqual(quotedValues(
     adapter,

--- a/scripts/run-ltx-safety-canary.mjs
+++ b/scripts/run-ltx-safety-canary.mjs
@@ -4,7 +4,7 @@ import { execFile, spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { constants as fsConstants, createReadStream } from "node:fs";
 import {
-  chmod, copyFile, link, lstat, mkdtemp, mkdir, readFile, readdir, realpath, rm,
+  chmod, copyFile, link, lstat, mkdtemp, mkdir, open, readFile, readdir, realpath, rm,
   rename, stat, unlink, writeFile,
 } from "node:fs/promises";
 import { arch } from "node:os";
@@ -40,6 +40,8 @@ export const PRODUCT_ENVELOPE_CANARY_PROFILE = "product-envelope";
 export const CAMPAIGN_ENTRY_PROFILE = "campaign-entry";
 export const BOUNDED_CARRIER_PROFILE = "bounded-carrier";
 export const BOUNDED_CAMPAIGN_ENTRY_PROFILE = "bounded-campaign-entry";
+export const BOUNDED_CAMPAIGN_ENTRY_Q8_PROFILE = "bounded-campaign-entry-q8";
+export const BOUNDED_CAMPAIGN_ENTRY_BF16_PROFILE = "bounded-campaign-entry-bf16";
 export const CAMPAIGN_ENTRY_PROVIDER =
   "mlx-ltx-2-3-q4-768x512-f121-fps30-staged_residency";
 export const CAMPAIGN_ENTRY_FIXTURE =
@@ -120,6 +122,55 @@ const BOUNDED_CAMPAIGN_ENTRY_SAFETY = Object.freeze({
   projectionAssumptions: CAMPAIGN_ENTRY_SAFETY.projectionAssumptions,
   reason: "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20318 action is admitted",
 });
+export const BOUNDED_CAMPAIGN_ENTRY_SPECS = Object.freeze({
+  q4: Object.freeze({
+    profile: BOUNDED_CAMPAIGN_ENTRY_PROFILE,
+    story: "sc-20318",
+    tier: "q4",
+    provider: BOUNDED_CAMPAIGN_ENTRY_PROVIDER,
+    fixture: BOUNDED_CAMPAIGN_ENTRY_FIXTURE,
+    logicalCaseId: BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
+    identity: BOUNDED_CAMPAIGN_ENTRY_IDENTITY,
+  }),
+  q8: Object.freeze({
+    profile: BOUNDED_CAMPAIGN_ENTRY_Q8_PROFILE,
+    story: "sc-20430",
+    tier: "q8",
+    provider: "mlx-ltx-2-3-q8-768x512-f121-fps30-bounded_decode-192x64",
+    fixture: "ltx-2-3-mlx-q8-768x512-f121-fps30-bounded-decode-192-64-seed18946",
+    logicalCaseId: "implan-d47640caa0c469f2ee13",
+    identity: "sc-20430-q8-768x512-f121-fps30-bounded-192-64-authoritative-v1",
+  }),
+  bf16: Object.freeze({
+    profile: BOUNDED_CAMPAIGN_ENTRY_BF16_PROFILE,
+    story: "sc-20430",
+    tier: "bf16",
+    provider: "mlx-ltx-2-3-bf16-768x512-f121-fps30-bounded_decode-192x64",
+    fixture: "ltx-2-3-mlx-bf16-768x512-f121-fps30-bounded-decode-192-64-seed18946",
+    logicalCaseId: "implan-b3926164bf6bfbee98e1",
+    identity: "sc-20430-bf16-768x512-f121-fps30-bounded-192-64-authoritative-v1",
+  }),
+});
+
+function boundedCampaignEntrySpec(value = "q4") {
+  const spec = BOUNDED_CAMPAIGN_ENTRY_SPECS[value]
+    ?? Object.values(BOUNDED_CAMPAIGN_ENTRY_SPECS).find((candidate) => candidate.profile === value);
+  if (spec === undefined) fail(`unsupported bounded campaign entry ${JSON.stringify(value)}`);
+  return spec;
+}
+
+function boundedCampaignSafety(spec) {
+  if (spec.tier === "q4") return structuredClone(BOUNDED_CAMPAIGN_ENTRY_SAFETY);
+  const inventory = NUMERIC_TIER_INVENTORIES[spec.tier];
+  return {
+    ...structuredClone(BOUNDED_CAMPAIGN_ENTRY_SAFETY),
+    tierInventoryBytes: inventory.bytes,
+    incidentCalibratedProjectionBytes:
+      BOUNDED_CAMPAIGN_ENTRY_SAFETY.incidentCalibratedProjectionBytes
+      + inventory.bytes - Q4_INVENTORY_BYTES,
+    reason: "incident-calibrated projection is diagnostic only; ordinary run remains refused and only the exact privately contained SC-20430 action is admitted",
+  };
+}
 const CANARY_PROFILES = Object.freeze({
   [SAFETY_CANARY_PROFILE]: Object.freeze({
     action: "canary",
@@ -156,6 +207,19 @@ const ARTIFACT_REPOSITORY = "SceneWorks/ltx-2.3-mlx";
 const ARTIFACT_REVISION = "01df27d308466533aa09d251e3aebdcc627d07eb";
 const Q4_INVENTORY_BYTES = 20_467_690_460;
 const Q4_INVENTORY_SHA256 = "4e811932e87bb258f642ada790525e36ef2a55959c520e755f1807caf6fa225a";
+const NUMERIC_TIER_INVENTORIES = Object.freeze({
+  q4: Object.freeze({ files: 11, bytes: Q4_INVENTORY_BYTES, sha256: Q4_INVENTORY_SHA256 }),
+  q8: Object.freeze({
+    files: 11,
+    bytes: 29_728_720_716,
+    sha256: "bb0bb7577157a158ca39494837d64cb36ded0380ca7ee0c930fea7311f22a247",
+  }),
+  bf16: Object.freeze({
+    files: 10,
+    bytes: 47_092_811_992,
+    sha256: "006caeaa9a8638b337cdf5a8622ce8535380b18ebaf90b36c3e2d5d15354f2a8",
+  }),
+});
 const TEXT_ENCODER_INVENTORY_FILES = 17;
 const TEXT_ENCODER_INVENTORY_BYTES = 26_427_894_918;
 const TEXT_ENCODER_INVENTORY_SHA256 = "abde2d155aa8991747cc2999d40688d29a50261c080c0d51fac20357653928d7";
@@ -202,7 +266,8 @@ export function runtimeFreeFloor(memoryBytes) {
   return MIN_RUNTIME_FREE_BYTES + telemetryResolutionBytes(memoryBytes);
 }
 
-export function privateArtifactRoots(scratch) {
+export function privateArtifactRoots(scratch, tier = "q4") {
+  if (!Object.hasOwn(NUMERIC_TIER_INVENTORIES, tier)) fail(`unsupported prepared tier ${tier}`);
   const snapshotRoot = path.join(
     scratch,
     "artifacts",
@@ -211,18 +276,20 @@ export function privateArtifactRoots(scratch) {
     ARTIFACT_REVISION,
   );
   return {
-    numericTier: path.join(snapshotRoot, "q4"),
+    numericTier: path.join(snapshotRoot, tier),
     textEncoder: path.join(snapshotRoot, "gemma"),
   };
 }
 
-export function preparationIdentity(sceneWorksTree, inferenceTree, toolchainChannel) {
+export function preparationIdentity(sceneWorksTree, inferenceTree, toolchainChannel, tier = "q4") {
   for (const [label, value] of [
     ["SceneWorks tree", sceneWorksTree], ["inference tree", inferenceTree],
   ]) {
     if (!/^[0-9a-f]{40}$/.test(value)) fail(`${label} must be an exact git tree`);
   }
   if (!/^\d+\.\d+\.\d+$/.test(toolchainChannel)) fail("toolchain channel must be exact");
+  const numericTier = NUMERIC_TIER_INVENTORIES[tier];
+  if (numericTier === undefined) fail(`unsupported preparation tier ${tier}`);
   return {
     schemaVersion: PREPARATION_SCHEMA_VERSION,
     sceneWorksTree,
@@ -233,9 +300,7 @@ export function preparationIdentity(sceneWorksTree, inferenceTree, toolchainChan
     artifact: {
       repository: ARTIFACT_REPOSITORY,
       revision: ARTIFACT_REVISION,
-      numericTier: {
-        files: 11, bytes: Q4_INVENTORY_BYTES, sha256: Q4_INVENTORY_SHA256,
-      },
+      numericTier: structuredClone(numericTier),
       textEncoder: {
         files: TEXT_ENCODER_INVENTORY_FILES,
         bytes: TEXT_ENCODER_INVENTORY_BYTES,
@@ -624,47 +689,48 @@ export function campaignEntryPlan(config) {
   return { provider, planned: planned[0] };
 }
 
-export function boundedCampaignEntryPlan(config) {
+export function boundedCampaignEntryPlan(config, requested = "q4") {
+  const spec = boundedCampaignEntrySpec(requested);
   const matches = config?.providers?.filter((provider) =>
-    provider.name === BOUNDED_CAMPAIGN_ENTRY_PROVIDER) ?? [];
-  if (matches.length !== 1) fail("SC-20318 requires exactly one bounded campaign provider");
+    provider.name === spec.provider) ?? [];
+  if (matches.length !== 1) fail(`${spec.story} requires exactly one bounded campaign provider`);
   const provider = matches[0];
   const exactProvider = {
-    name: BOUNDED_CAMPAIGN_ENTRY_PROVIDER,
+    name: spec.provider,
     _role: "bounded_carrier_entry",
     _campaignPhase: "bounded_carrier_ratification",
     _coverageExpectation: "captured_or_attempted",
     _latentTokens: 6_144,
     _writableFrameCap: 682,
     _outputVoxels: 47_579_136,
-    _measurementSafety: structuredClone(BOUNDED_CAMPAIGN_ENTRY_SAFETY),
+    _measurementSafety: boundedCampaignSafety(spec),
     evidenceScope: "authoritative",
     backend: "mlx",
     loadShape: "eager_materialization",
     target: {
-      provider: PROVIDER, modelId: PROVIDER, tier: "q4", mode: "text_to_video",
+      provider: PROVIDER, modelId: PROVIDER, tier: spec.tier, mode: "text_to_video",
       overlay: "none", geometry: { width: 768, height: 512, batch: 1, frames: 121 },
     },
     rung: "bounded_decode",
     engagedRungs: ["resident", "staged_residency", "bounded_decode"],
     calibrationFingerprint: FINGERPRINT,
-    fixture: BOUNDED_CAMPAIGN_ENTRY_FIXTURE,
+    fixture: spec.fixture,
     cases: [{ parameters: { decodeTileEdge: 192, decodeOverlap: 64 }, expectedResult: "passed" }],
     _predictedDecodeBytes: 6_264_848_640,
     _predictedDecodeFormula:
       "3.3e9 + 40*(width*height*frames) + 300*(192*192*96) bytes",
   };
   if (!isDeepStrictEqual(provider, exactProvider)) {
-    fail("SC-20318 bounded campaign provider changed");
+    fail(`${spec.story} bounded campaign provider changed`);
   }
   const planned = expandPlan({ providers: [provider] });
   if (planned.length !== 1
-      || planned[0].logicalCaseId !== BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID
+      || planned[0].logicalCaseId !== spec.logicalCaseId
       || planned[0].modelLoadPolicy !== "fresh_per_case"
       || planned[0].modelLoadGroup !== null) {
-    fail("SC-20318 bounded campaign logical identity changed");
+    fail(`${spec.story} bounded campaign logical identity changed`);
   }
-  return { provider, planned: planned[0] };
+  return { provider, planned: planned[0], spec };
 }
 
 export function validateCampaignEntryHarnessRequest(request, expectedPlanned, {
@@ -723,11 +789,14 @@ export function campaignEntryAdapterRequest(request, expectedPlanned, expectedSo
   return transformed;
 }
 
-export function boundedCampaignEntryAdapterRequest(request, expectedPlanned, expectedSource) {
+export function boundedCampaignEntryAdapterRequest(
+  request, expectedPlanned, expectedSource, requested = "q4",
+) {
+  const spec = boundedCampaignEntrySpec(requested);
   if (request?.action !== "run"
       || !isDeepStrictEqual(request?.planned, expectedPlanned)
-      || request.planned.logicalCaseId !== BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID
-      || request.planned.fixture !== BOUNDED_CAMPAIGN_ENTRY_FIXTURE
+      || request.planned.logicalCaseId !== spec.logicalCaseId
+      || request.planned.fixture !== spec.fixture
       || request.planned.evidenceScope !== "authoritative"
       || request.planned.modelLoadPolicy !== "fresh_per_case"
       || request.planned.modelLoadGroup !== null
@@ -743,19 +812,19 @@ export function boundedCampaignEntryAdapterRequest(request, expectedPlanned, exp
         && request.repositoryPaths?.inference !== expectedSource.inferenceRepo)
       || !Number.isSafeInteger(request.hardware?.memoryBytes)
       || request.hardware.memoryBytes <= 0) {
-    fail("SC-20318 provider wrapper received a non-canonical harness request");
+    fail(`${spec.story} provider wrapper received a non-canonical harness request`);
   }
   for (const field of ["_watchdog", "_boundedCampaignEntry", "_measurementSafety"]) {
     if (Object.hasOwn(request.planned, field)) {
-      fail(`canonical SC-20318 request unexpectedly contains ${field}`);
+      fail(`canonical ${spec.story} request unexpectedly contains ${field}`);
     }
   }
   const transformed = structuredClone(request);
   transformed.action = BOUNDED_CAMPAIGN_ENTRY_ACTION;
   transformed.planned._watchdog = { maxFootprintBytes: MAX_FOOTPRINT_BYTES };
-  transformed.planned._measurementSafety = structuredClone(BOUNDED_CAMPAIGN_ENTRY_SAFETY);
+  transformed.planned._measurementSafety = boundedCampaignSafety(spec);
   transformed.planned._boundedCampaignEntry = {
-    identity: BOUNDED_CAMPAIGN_ENTRY_IDENTITY,
+    identity: spec.identity,
     fps: 30,
     seed: 18_946,
     videoMode: "default_av",
@@ -764,7 +833,7 @@ export function boundedCampaignEntryAdapterRequest(request, expectedPlanned, exp
       repository: ARTIFACT_REPOSITORY,
       revision: ARTIFACT_REVISION,
       numericTierInventory: {
-        files: 11, bytes: Q4_INVENTORY_BYTES, sha256: Q4_INVENTORY_SHA256,
+        ...NUMERIC_TIER_INVENTORIES[spec.tier],
       },
       textEncoderInventory: {
         files: TEXT_ENCODER_INVENTORY_FILES,
@@ -871,8 +940,9 @@ export function validateCampaignEntryAdapterResponse(response, {
 }
 
 export function validateBoundedCampaignEntryResponse(response, {
-  inferenceRevision, hostMemoryBytes,
+  inferenceRevision, hostMemoryBytes, tier = "q4",
 } = {}) {
+  const spec = boundedCampaignEntrySpec(tier);
   const diagnostics = diagnosticMeasurements(response);
   for (const [name, expected] of [
     ["renderedFrames", 121], ["outputFps", 30], ["audioTrackDecoded", 1],
@@ -908,7 +978,7 @@ export function validateBoundedCampaignEntryResponse(response, {
       || response?.loadShape !== "eager_materialization"
       || response?.artifact?.repository !== ARTIFACT_REPOSITORY
       || response?.artifact?.resolvedRevision !== ARTIFACT_REVISION
-      || response?.artifact?.variant !== "q4"
+      || response?.artifact?.variant !== spec.tier
       || !isDeepStrictEqual(response?.strategy, {
         rung: "bounded_decode",
         engagedRungs: ["resident", "staged_residency", "bounded_decode"],
@@ -929,7 +999,7 @@ export function validateBoundedCampaignEntryResponse(response, {
       || response.output.audio.sampleRate <= 0
       || response?.output?.audio?.channels !== 2
       || response?.output?.firstFrameNondegenerate !== true
-      || sidecar?.identity !== BOUNDED_CAMPAIGN_ENTRY_IDENTITY
+      || sidecar?.identity !== spec.identity
       || (inferenceRevision !== undefined && sidecar?.inferenceRevision !== inferenceRevision)
       || sidecar?.watchdog?.required !== true
       || sidecar?.watchdog?.protocol !== "sceneworks-memory-watchdog-v1"
@@ -948,7 +1018,7 @@ export function validateBoundedCampaignEntryResponse(response, {
       || !Number.isSafeInteger(sidecar?.mlxLimits?.wiredLimitBytes)
       || sidecar.mlxLimits.wiredLimitBytes <= 0
       || sidecar.mlxLimits.wiredLimitBytes > MAX_FOOTPRINT_BYTES) {
-    fail("SC-20318 adapter response changed the exact bounded campaign entry");
+    fail(`${spec.story} adapter response changed the exact bounded campaign entry`);
   }
   const cleanup = sidecar.cleanup;
   for (const field of [
@@ -1463,17 +1533,19 @@ export function validateCampaignEntryBundle(bundle) {
   return bundle;
 }
 
-export function validateBoundedCampaignEntryBundle(bundle) {
+export function validateBoundedCampaignEntryBundle(bundle, requested = "q4") {
+  const spec = boundedCampaignEntrySpec(requested);
   validateBundle(bundle);
   if (bundle.records.length !== 1 || (bundle.sourceSessions?.length ?? 0) !== 0) {
     fail("SC-20318 must publish exactly one canonical record and no source session");
   }
   const record = bundle.records[0];
   const scenarios = new Map(record?.scenarios?.map((item) => [item.name, item]) ?? []);
-  if (record.logicalCaseId !== BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID
+  if (record.logicalCaseId !== spec.logicalCaseId
       || record.status !== "runtime_complete"
       || record.evidenceScope !== "authoritative"
-      || record.fixture !== BOUNDED_CAMPAIGN_ENTRY_FIXTURE
+      || record.fixture !== spec.fixture
+      || record.target?.tier !== spec.tier
       || !isDeepStrictEqual(record.strategy, {
         rung: "bounded_decode",
         engagedRungs: ["resident", "staged_residency", "bounded_decode"],
@@ -1509,7 +1581,16 @@ export function validateBoundedCampaignEntryBundle(bundle) {
   const post = diagnostics.get("boundedCampaignPostCleanupActiveBytes");
   const observed = diagnostics.get("boundedCampaignWatchdogMaxObservedFootprintBytes");
   const host = diagnostics.get("boundedCampaignWatchdogHostMemoryBytes");
-  if (!Number.isSafeInteger(pre) || post !== pre + ltxOnesCacheBytes()
+  const phaseAnchors = [
+    record.observedMemory?.conditioning?.activeBytes,
+    record.observedMemory?.denoise?.activeBytes,
+    record.observedMemory?.decode?.activeBytes,
+    diagnostics.get("warmConditioningActivePeak"),
+    diagnostics.get("warmDenoiseActivePeak"),
+    diagnostics.get("warmDecodeActivePeak"),
+  ];
+  if (phaseAnchors.some((value) => !Number.isSafeInteger(value) || value <= 0)
+      || !Number.isSafeInteger(pre) || post !== pre + ltxOnesCacheBytes()
       || host !== record.hardware.memoryBytes
       || diagnostics.get("boundedCampaignWatchdogMinInitialMemoryFreeBytes")
         !== preflightFreeFloor(host)
@@ -1521,6 +1602,198 @@ export function validateBoundedCampaignEntryBundle(bundle) {
   return bundle;
 }
 
+export function boundedSelectorAnchorReport(bundlesByTier) {
+  const phaseNames = ["conditioning", "denoise", "decode"];
+  let matchBasis = null;
+  const anchors = Object.keys(BOUNDED_CAMPAIGN_ENTRY_SPECS).map((tier) => {
+    const bundle = bundlesByTier?.[tier];
+    validateBoundedCampaignEntryBundle(bundle, tier);
+    const record = bundle.records[0];
+    const diagnostics = diagnosticMeasurements(record);
+    const recordMatchBasis = {
+      hardware: Object.fromEntries([
+        "memoryBytes", "model", "chip", "osVersion", "metalDevice",
+        "mlxMemoryLimitBytes", "wiredLimitBytes",
+      ].map((name) => [name, record.hardware[name]])),
+      inference: {
+        revision: record.repositories.inference.revision,
+        closureDigest: record.repositories.inference.closureDigest,
+      },
+      calibrationFingerprint: record.calibrationFingerprint,
+      artifact: {
+        repository: record.artifact.repository,
+        resolvedRevision: record.artifact.resolvedRevision,
+      },
+      geometry: structuredClone(record.target.geometry),
+      strategy: structuredClone(record.strategy),
+    };
+    if (matchBasis === null) matchBasis = recordMatchBasis;
+    else if (!isDeepStrictEqual(recordMatchBasis, matchBasis)) {
+      fail(`SC-20430 ${tier} capture does not match the bounded-selector comparison basis`);
+    }
+    const selected = Object.fromEntries(phaseNames.map((phase) => {
+      const value = record.observedMemory?.[phase]?.activeBytes;
+      if (!Number.isSafeInteger(value) || value <= 0) {
+        fail(`SC-20430 ${tier} selected ${phase} phase anchor must be positive`);
+      }
+      return [phase, value];
+    }));
+    const warm = Object.fromEntries(phaseNames.map((phase) => {
+      const diagnostic = `warm${phase[0].toUpperCase()}${phase.slice(1)}ActivePeak`;
+      const value = diagnostics.get(diagnostic);
+      if (!Number.isSafeInteger(value) || value <= 0) {
+        fail(`SC-20430 ${tier} warm ${phase} phase anchor must be positive`);
+      }
+      return [phase, value];
+    }));
+    const binding = (values) => {
+      const maximum = Math.max(...Object.values(values));
+      return {
+        phases: phaseNames.filter((phase) => values[phase] === maximum),
+        activePeakBytes: maximum,
+      };
+    };
+    return {
+      tier,
+      logicalCaseId: record.logicalCaseId,
+      recordId: record.id,
+      fixture: record.fixture,
+      source: {
+        sceneWorksRevision: record.repositories.sceneWorks.revision,
+        inferenceRevision: record.repositories.inference.revision,
+        inferenceClosureDigest: record.repositories.inference.closureDigest,
+      },
+      selected: { activePeakBytesByPhase: selected, binding: binding(selected) },
+      warm: { activePeakBytesByPhase: warm, binding: binding(warm) },
+    };
+  });
+  const q8Source = anchors.find(({ tier }) => tier === "q8").source;
+  const bf16Source = anchors.find(({ tier }) => tier === "bf16").source;
+  if (q8Source.sceneWorksRevision !== bf16Source.sceneWorksRevision
+      || q8Source.inferenceRevision !== bf16Source.inferenceRevision
+      || q8Source.inferenceClosureDigest !== bf16Source.inferenceClosureDigest) {
+    fail("SC-20430 q8 and bf16 captures must share the exact ratification source");
+  }
+  const report = {
+    schemaVersion: 1,
+    recordType: "sceneworks_bounded_selector_anchor_v1",
+    status: "diagnostic_anchor_complete",
+    diagnosticOnly: true,
+    promotable: false,
+    ingestible: false,
+    scope: "matched_q4_q8_bf16_bounded_selector",
+    coefficientTransferClaim: false,
+    pooledWithStagedOrSinglePass: false,
+    sourcePolicy: {
+      q4MayPrecedeRatificationSource: true,
+      q8AndBf16SceneWorksRevision: q8Source.sceneWorksRevision,
+    },
+    matchBasis,
+    anchors,
+  };
+  try {
+    validateBundle(report);
+    fail("SC-20430 bounded-selector anchor report became canonically ingestible");
+  } catch (error) {
+    if (String(error?.message ?? error).includes("became canonically ingestible")) throw error;
+  }
+  return report;
+}
+
+function exactFileIdentity(file, stats) {
+  return {
+    path: file,
+    device: stats.dev.toString(),
+    inode: stats.ino.toString(),
+    size: Number(stats.size),
+    mtimeNs: stats.mtimeNs.toString(),
+    ctimeNs: stats.ctimeNs.toString(),
+    mode: Number(stats.mode & 0o777n),
+  };
+}
+
+export async function validateQ8IndependentAudit(auditPath, {
+  sceneWorksRevision, inferenceRevision,
+} = {}) {
+  const absoluteAuditPath = path.resolve(auditPath);
+  const handle = await open(
+    absoluteAuditPath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW,
+  ).catch((error) => fail(`SC-20430 q8 audit must be an exact sealed file: ${error.message}`));
+  let auditBytes;
+  let auditFile;
+  try {
+    const before = await handle.stat({ bigint: true });
+    if (!before.isFile() || Number(before.mode & 0o777n) !== 0o400 || before.size <= 0n
+        || before.size > BigInt(Number.MAX_SAFE_INTEGER)) {
+      fail("SC-20430 q8 audit must be a non-empty read-only regular file");
+    }
+    auditBytes = await handle.readFile();
+    const after = await handle.stat({ bigint: true });
+    if (!isDeepStrictEqual(exactFileIdentity(absoluteAuditPath, before),
+      exactFileIdentity(absoluteAuditPath, after))) {
+      fail("SC-20430 q8 audit changed while it was read");
+    }
+    auditFile = exactFileIdentity(absoluteAuditPath, after);
+  } finally {
+    await handle.close();
+  }
+  const audit = JSON.parse(auditBytes.toString("utf8"));
+  const canonicalOutput = audit?.q8?.canonicalOutput;
+  if (audit?.schemaVersion !== 1
+      || audit?.recordType !== "sceneworks_sc20430_q8_independent_audit_v1"
+      || audit?.result !== "passed"
+      || audit?.independent !== true
+      || audit?.diagnosticOnly !== true
+      || audit?.ingestible !== false
+      || !path.isAbsolute(canonicalOutput ?? "")
+      || !/^[0-9a-f]{64}$/.test(audit?.q8?.canonicalSha256 ?? "")
+      || audit?.q8?.logicalCaseId !== BOUNDED_CAMPAIGN_ENTRY_SPECS.q8.logicalCaseId
+      || !/^imc-[0-9a-f]{20}$/.test(audit?.q8?.recordId ?? "")
+      || !/^[0-9a-f]{40}$/.test(audit?.q8?.sceneWorksRevision ?? "")
+      || !/^[0-9a-f]{40}$/.test(audit?.q8?.inferenceRevision ?? "")) {
+    fail("SC-20430 bf16 release requires an exact passed independent q8 audit");
+  }
+  const bundleBytes = await readFile(canonicalOutput, "utf8");
+  const bundle = JSON.parse(bundleBytes);
+  validateBoundedCampaignEntryBundle(bundle, "q8");
+  const digest = createHash("sha256").update(canonicalJson(bundle)).digest("hex");
+  if (digest !== audit.q8.canonicalSha256
+      || bundle.records[0].id !== audit.q8.recordId
+      || bundle.records[0].repositories?.sceneWorks?.revision !== audit.q8.sceneWorksRevision
+      || bundle.records[0].repositories?.inference?.revision !== audit.q8.inferenceRevision
+      || (sceneWorksRevision !== undefined && audit.q8.sceneWorksRevision !== sceneWorksRevision)
+      || (inferenceRevision !== undefined && audit.q8.inferenceRevision !== inferenceRevision)) {
+    fail("SC-20430 q8 independent audit does not bind the exact canonical bundle");
+  }
+  return {
+    schemaVersion: 1,
+    recordType: "sceneworks_sc20430_q8_release_authorization_v1",
+    auditFile: { ...auditFile, sha256: createHash("sha256").update(auditBytes).digest("hex") },
+    q8: structuredClone(audit.q8),
+  };
+}
+
+async function assertQ8ReleaseAuthorization(expected, auditPath, revisions) {
+  if (expected === null) return null;
+  const current = await validateQ8IndependentAudit(auditPath, revisions);
+  if (!isDeepStrictEqual(current, expected)) {
+    fail("SC-20430 q8 independent-audit authorization changed after release approval");
+  }
+  return current;
+}
+
+export async function publishBoundedSelectorAnchorReport({
+  q4Bundle, q8Bundle, bf16Bundle, output, signal,
+}) {
+  const report = boundedSelectorAnchorReport({
+    q4: JSON.parse(await readFile(path.resolve(q4Bundle), "utf8")),
+    q8: JSON.parse(await readFile(path.resolve(q8Bundle), "utf8")),
+    bf16: JSON.parse(await readFile(path.resolve(bf16Bundle), "utf8")),
+  });
+  await publishExclusiveJson(path.resolve(output), report, signal);
+  return report;
+}
+
 export function campaignEntryFailurePath(canonicalOutput) {
   return path.join(path.dirname(canonicalOutput), "sc-20216-campaign-entry-failure.json");
 }
@@ -1529,12 +1802,20 @@ export function campaignEntryOutcomeReservationPath(canonicalOutput) {
   return path.join(path.dirname(canonicalOutput), ".sc-20216-campaign-entry-outcome");
 }
 
-export function boundedCampaignEntryFailurePath(canonicalOutput) {
-  return path.join(path.dirname(canonicalOutput), "sc-20318-bounded-campaign-entry-failure.json");
+export function boundedCampaignEntryFailurePath(canonicalOutput, requested = "q4") {
+  const spec = boundedCampaignEntrySpec(requested);
+  const filename = spec.tier === "q4"
+    ? "sc-20318-bounded-campaign-entry-failure.json"
+    : `sc-20430-${spec.tier}-bounded-campaign-entry-failure.json`;
+  return path.join(path.dirname(canonicalOutput), filename);
 }
 
-export function boundedCampaignEntryOutcomeReservationPath(canonicalOutput) {
-  return path.join(path.dirname(canonicalOutput), ".sc-20318-bounded-campaign-entry-outcome");
+export function boundedCampaignEntryOutcomeReservationPath(canonicalOutput, requested = "q4") {
+  const spec = boundedCampaignEntrySpec(requested);
+  const filename = spec.tier === "q4"
+    ? ".sc-20318-bounded-campaign-entry-outcome"
+    : `.sc-20430-${spec.tier}-bounded-campaign-entry-outcome`;
+  return path.join(path.dirname(canonicalOutput), filename);
 }
 
 export function campaignEntryFailureReceipt({
@@ -1614,7 +1895,9 @@ export function campaignEntryFailureReceipt({
 export function boundedCampaignEntryFailureReceipt({
   sceneWorksRevision, sceneWorksTree, inferenceRevision, inferenceTree,
   identity, preparationKey, preparationRoot, prepared, hostMemoryBytes, events, outcome,
+  tier = "q4",
 }) {
+  const spec = boundedCampaignEntrySpec(tier);
   const failure = validateCampaignEntryFailureEvents(
     events, hostMemoryBytes, BOUNDED_CARRIER_PHASES,
   );
@@ -1627,20 +1910,20 @@ export function boundedCampaignEntryFailureReceipt({
     ingestible: false,
     canonicalBundlePublished: false,
     outcome: structuredClone(outcome),
-    story: "sc-20318",
+    story: spec.story,
     source: {
       sceneWorks: { revision: sceneWorksRevision, tree: sceneWorksTree },
       inference: { revision: inferenceRevision, tree: inferenceTree },
     },
     campaignCase: {
       plan: BOUNDED_CAMPAIGN_ENTRY_PLAN,
-      provider: BOUNDED_CAMPAIGN_ENTRY_PROVIDER,
-      logicalCaseId: BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
-      fixture: BOUNDED_CAMPAIGN_ENTRY_FIXTURE,
-      identity: BOUNDED_CAMPAIGN_ENTRY_IDENTITY,
+      provider: spec.provider,
+      logicalCaseId: spec.logicalCaseId,
+      fixture: spec.fixture,
+      identity: spec.identity,
       action: BOUNDED_CAMPAIGN_ENTRY_ACTION,
       target: {
-        provider: PROVIDER, tier: "q4",
+        provider: PROVIDER, tier: spec.tier,
         geometry: { width: 768, height: 512, batch: 1, frames: 121, fps: 30 },
       },
       strategy: {
@@ -1685,10 +1968,10 @@ export function boundedCampaignEntryFailureReceipt({
       preparationTransientResidueVerified: true,
     },
   };
-  return validateBoundedCampaignEntryFailureReceipt(receipt);
+  return validateBoundedCampaignEntryFailureReceipt(receipt, spec.tier);
 }
 
-function validateContainedReceiptArtifactIdentity(receipt, label) {
+function validateContainedReceiptArtifactIdentity(receipt, label, expectedTier = null) {
   for (const source of [receipt.source?.sceneWorks, receipt.source?.inference]) {
     if (!/^[0-9a-f]{40}$/.test(source?.revision ?? "")
         || !/^[0-9a-f]{40}$/.test(source?.tree ?? "")) {
@@ -1703,11 +1986,29 @@ function validateContainedReceiptArtifactIdentity(receipt, label) {
     && Number.isSafeInteger(file?.size) && file.size > 0
     && typeof file?.mtimeNs === "string" && typeof file?.ctimeNs === "string"
     && file?.mode === mode;
+  const expectedNumericTier = expectedTier === null
+    ? NUMERIC_TIER_INVENTORIES.q4 : NUMERIC_TIER_INVENTORIES[expectedTier];
+  const expectedIdentity = {
+    schemaVersion: PREPARATION_SCHEMA_VERSION,
+    sceneWorksTree: receipt.source.sceneWorks.tree,
+    inferenceTree: receipt.source.inference.tree,
+    toolchainChannel: identity?.toolchainChannel,
+    platform: "darwin",
+    architecture: "arm64",
+    artifact: {
+      repository: ARTIFACT_REPOSITORY,
+      revision: ARTIFACT_REVISION,
+      numericTier: expectedNumericTier,
+      textEncoder: {
+        files: TEXT_ENCODER_INVENTORY_FILES,
+        bytes: TEXT_ENCODER_INVENTORY_BYTES,
+        sha256: TEXT_ENCODER_INVENTORY_SHA256,
+      },
+    },
+  };
   if (receipt.artifacts?.repository !== ARTIFACT_REPOSITORY
       || receipt.artifacts?.revision !== ARTIFACT_REVISION
-      || !isDeepStrictEqual(receipt.artifacts?.numericTierInventory, {
-        files: 11, bytes: Q4_INVENTORY_BYTES, sha256: Q4_INVENTORY_SHA256,
-      })
+      || !isDeepStrictEqual(receipt.artifacts?.numericTierInventory, expectedNumericTier)
       || !isDeepStrictEqual(receipt.artifacts?.textEncoderInventory, {
         files: TEXT_ENCODER_INVENTORY_FILES,
         bytes: TEXT_ENCODER_INVENTORY_BYTES,
@@ -1717,6 +2018,7 @@ function validateContainedReceiptArtifactIdentity(receipt, label) {
       || !path.isAbsolute(preparation?.root ?? "")
       || path.basename(preparation?.root ?? "") !== preparation.key
       || preparation?.manifest?.key !== preparation.key
+      || preparation?.key !== preparationCacheKey(expectedIdentity)
       || preparation?.manifest?.schemaVersion !== PREPARATION_SCHEMA_VERSION
       || !isDeepStrictEqual(preparation?.manifest?.identity, identity)
       || preparation?.manifest?.preparedFrom?.sceneWorksRevision
@@ -1730,6 +2032,8 @@ function validateContainedReceiptArtifactIdentity(receipt, label) {
       || identity?.sceneWorksTree !== receipt.source.sceneWorks.tree
       || identity?.inferenceTree !== receipt.source.inference.tree
       || identity?.schemaVersion !== PREPARATION_SCHEMA_VERSION
+      || !/^\d+\.\d+\.\d+$/.test(identity?.toolchainChannel ?? "")
+      || !isDeepStrictEqual(identity, expectedIdentity)
       || !isDeepStrictEqual(identity?.artifact, {
         repository: ARTIFACT_REPOSITORY,
         revision: ARTIFACT_REVISION,
@@ -1819,18 +2123,19 @@ export function validateCampaignEntryFailureReceipt(receipt) {
   return receipt;
 }
 
-export function validateBoundedCampaignEntryFailureReceipt(receipt) {
+export function validateBoundedCampaignEntryFailureReceipt(receipt, requested = "q4") {
+  const spec = boundedCampaignEntrySpec(requested);
   let ingestible = true;
   try { validateBundle(receipt); } catch { ingestible = false; }
   const expectedCase = {
     plan: BOUNDED_CAMPAIGN_ENTRY_PLAN,
-    provider: BOUNDED_CAMPAIGN_ENTRY_PROVIDER,
-    logicalCaseId: BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
-    fixture: BOUNDED_CAMPAIGN_ENTRY_FIXTURE,
-    identity: BOUNDED_CAMPAIGN_ENTRY_IDENTITY,
+    provider: spec.provider,
+    logicalCaseId: spec.logicalCaseId,
+    fixture: spec.fixture,
+    identity: spec.identity,
     action: BOUNDED_CAMPAIGN_ENTRY_ACTION,
     target: {
-      provider: PROVIDER, tier: "q4",
+      provider: PROVIDER, tier: spec.tier,
       geometry: { width: 768, height: 512, batch: 1, frames: 121, fps: 30 },
     },
     strategy: {
@@ -1849,6 +2154,25 @@ export function validateBoundedCampaignEntryFailureReceipt(receipt) {
     preparedCacheVerified: true,
     preparationTransientResidueVerified: true,
   };
+  const authorization = receipt?.outcome?.q8ReleaseAuthorization;
+  const exactBf16Authorization = spec.tier === "bf16"
+    && authorization?.schemaVersion === 1
+    && authorization?.recordType === "sceneworks_sc20430_q8_release_authorization_v1"
+    && path.isAbsolute(authorization?.auditFile?.path ?? "")
+    && authorization?.auditFile?.mode === 0o400
+    && Number.isSafeInteger(authorization?.auditFile?.size)
+    && authorization.auditFile.size > 0
+    && typeof authorization?.auditFile?.device === "string"
+    && typeof authorization?.auditFile?.inode === "string"
+    && typeof authorization?.auditFile?.mtimeNs === "string"
+    && typeof authorization?.auditFile?.ctimeNs === "string"
+    && /^[0-9a-f]{64}$/.test(authorization?.auditFile?.sha256 ?? "")
+    && path.isAbsolute(authorization?.q8?.canonicalOutput ?? "")
+    && /^[0-9a-f]{64}$/.test(authorization?.q8?.canonicalSha256 ?? "")
+    && authorization?.q8?.logicalCaseId === BOUNDED_CAMPAIGN_ENTRY_SPECS.q8.logicalCaseId
+    && /^imc-[0-9a-f]{20}$/.test(authorization?.q8?.recordId ?? "")
+    && authorization?.q8?.sceneWorksRevision === receipt?.source?.sceneWorks?.revision
+    && authorization?.q8?.inferenceRevision === receipt?.source?.inference?.revision;
   if (ingestible
       || receipt?.recordType !== BOUNDED_CAMPAIGN_FAILURE_RECEIPT_TYPE
       || receipt?.status !== "diagnostic_failure"
@@ -1858,11 +2182,14 @@ export function validateBoundedCampaignEntryFailureReceipt(receipt) {
       || receipt?.outcome?.outcomeReservationHeldAtPublication !== true
       || receipt?.outcome?.outcomeChoice !== "failure"
       || receipt?.outcome?.failureOutput
-        !== boundedCampaignEntryFailurePath(receipt?.outcome?.canonicalOutput ?? "")
+        !== boundedCampaignEntryFailurePath(receipt?.outcome?.canonicalOutput ?? "", spec.tier)
       || receipt?.outcome?.reservation
-        !== boundedCampaignEntryOutcomeReservationPath(receipt?.outcome?.canonicalOutput ?? "")
+        !== boundedCampaignEntryOutcomeReservationPath(
+          receipt?.outcome?.canonicalOutput ?? "", spec.tier,
+        )
       || receipt?.outcome?.choice !== `${receipt?.outcome?.reservation}.choice`
-      || receipt?.story !== "sc-20318"
+      || receipt?.story !== spec.story
+      || (spec.tier === "bf16" ? !exactBf16Authorization : authorization != null)
       || !isDeepStrictEqual(receipt?.campaignCase, expectedCase)
       || receipt?.watchdog?.protocol !== "sceneworks-memory-watchdog-v1"
       || receipt?.watchdog?.providerPhaseProtocol !== PROVIDER_PHASE_PROTOCOL
@@ -1872,7 +2199,7 @@ export function validateBoundedCampaignEntryFailureReceipt(receipt) {
       || !isDeepStrictEqual(receipt?.cleanup, expectedCleanup)) {
     fail("SC-20318 failure receipt is ingestible, incomplete, or identity-drifted");
   }
-  validateContainedReceiptArtifactIdentity(receipt, "SC-20318 failure");
+  validateContainedReceiptArtifactIdentity(receipt, "SC-20318 failure", spec.tier);
   const validated = validateCampaignEntryFailureEvents(
     receipt.watchdog.events, receipt.watchdog.hostMemoryBytes, BOUNDED_CARRIER_PHASES,
   );
@@ -2535,10 +2862,10 @@ function preparedFileManifestIdentity(file) {
   };
 }
 
-async function validatePreparedStructure(preparationRoot) {
+async function validatePreparedStructure(preparationRoot, tier = "q4") {
   await exactMetadata(preparationRoot, "directory", 0o500);
   await exactEntries(preparationRoot, ["adapter", "artifacts", "prepared.json", "prepared.sha256"]);
-  const roots = privateArtifactRoots(preparationRoot);
+  const roots = privateArtifactRoots(preparationRoot, tier);
   const revisionDirectory = path.dirname(roots.numericTier);
   const snapshotsDirectory = path.dirname(revisionDirectory);
   const modelDirectory = path.dirname(snapshotsDirectory);
@@ -2552,12 +2879,12 @@ async function validatePreparedStructure(preparationRoot) {
   await exactEntries(artifactsDirectory, [path.basename(modelDirectory)]);
   await exactEntries(modelDirectory, ["snapshots"]);
   await exactEntries(snapshotsDirectory, [ARTIFACT_REVISION]);
-  await exactEntries(revisionDirectory, ["gemma", "q4"]);
+  await exactEntries(revisionDirectory, ["gemma", tier]);
   await exactEntries(adapterDirectory, ["memory-mlx-adapter", "mlx.metallib"]);
   return roots;
 }
 
-export async function validatePreparedCache(preparationRoot, key, identity, signal) {
+export async function validatePreparedCache(preparationRoot, key, identity, signal, tier = "q4") {
   const rootMetadata = await lstat(preparationRoot, { bigint: true }).catch((error) => {
     if (error.code === "ENOENT") return null;
     throw error;
@@ -2566,7 +2893,7 @@ export async function validatePreparedCache(preparationRoot, key, identity, sign
   const manifestPath = path.join(preparationRoot, "prepared.json");
   const completionPath = path.join(preparationRoot, "prepared.sha256");
   if (!(await pathExists(manifestPath)) || !(await pathExists(completionPath))) return null;
-  const roots = await validatePreparedStructure(preparationRoot);
+  const roots = await validatePreparedStructure(preparationRoot, tier);
   await exactMetadata(manifestPath, "file", 0o400);
   await exactMetadata(completionPath, "file", 0o400);
   const manifestBytes = await readFile(manifestPath, "utf8");
@@ -2614,12 +2941,14 @@ async function sealPreparationDirectories(directory) {
   if (((await lstat(directory)).mode & 0o777) !== 0o500) await chmod(directory, 0o500);
 }
 
-async function writePreparedManifest(stage, key, identity, preparedFrom, builtArtifacts, signal) {
+async function writePreparedManifest(
+  stage, key, identity, preparedFrom, builtArtifacts, signal, tier = "q4",
+) {
   if (!/^[0-9a-f]{40}$/.test(preparedFrom.sceneWorksRevision)
       || !/^[0-9a-f]{40}$/.test(preparedFrom.inferenceRevision)) {
     fail("prepared canary source revisions must be exact commits");
   }
-  const roots = privateArtifactRoots(stage);
+  const roots = privateArtifactRoots(stage, tier);
   const artifacts = {};
   for (const [name, root] of Object.entries(roots)) {
     const content = assertInventory(
@@ -2805,18 +3134,19 @@ export async function prepareCanaryCache({
   signal,
   hooks = {},
   processIdentityProbe = osProcessIdentity,
+  tier = "q4",
 }) {
   const parent = path.dirname(preparationRoot);
   await mkdir(parent, { recursive: true, mode: 0o700 });
   await exactMetadata(parent, "directory", 0o700);
-  const alreadyPrepared = await validatePreparedCache(preparationRoot, key, identity, signal);
+  const alreadyPrepared = await validatePreparedCache(preparationRoot, key, identity, signal, tier);
   if (alreadyPrepared !== null) return alreadyPrepared;
   const release = await acquirePreparationLock(preparationRoot, signal, processIdentityProbe);
   let stage = null;
   let operationError = null;
   let cleanupError = null;
   try {
-    const wonRace = await validatePreparedCache(preparationRoot, key, identity, signal);
+    const wonRace = await validatePreparedCache(preparationRoot, key, identity, signal, tier);
     if (wonRace !== null) return wonRace;
     if (await pathExists(preparationRoot)) await cleanupCanaryScratch(preparationRoot);
     await cleanupStalePreparationStages(preparationRoot);
@@ -2825,13 +3155,13 @@ export async function prepareCanaryCache({
     const built = await build(stage, signal, hooks);
     signal?.throwIfAborted();
     await hooks.buildComplete?.(stage, signal);
-    await writePreparedManifest(stage, key, identity, preparedFrom, built?.artifacts, signal);
+    await writePreparedManifest(stage, key, identity, preparedFrom, built?.artifacts, signal, tier);
     signal?.throwIfAborted();
     await hooks.beforePublish?.(stage, signal);
     signal?.throwIfAborted();
     await rename(stage, preparationRoot);
     stage = null;
-    const prepared = await validatePreparedCache(preparationRoot, key, identity, signal);
+    const prepared = await validatePreparedCache(preparationRoot, key, identity, signal, tier);
     if (prepared === null) fail("atomic prepared canary publication is incomplete");
     return { ...prepared, reused: false };
   } catch (error) {
@@ -3107,21 +3437,25 @@ function campaignProviderOptions(argv) {
 }
 
 async function campaignProviderInvocation(options, input, {
-  signal, setActiveWatchdog = () => {}, canonicalClaim, executionClaim, bounded = false,
+  signal, setActiveWatchdog = () => {}, canonicalClaim, executionClaim,
+  bounded = false, boundedTier = null, q8ReleaseAuthorization = null,
 } = {}) {
   signal?.throwIfAborted();
-  const spec = bounded ? {
-    story: "SC-20318",
+  const boundedEntry = bounded || boundedTier !== null;
+  const boundedSpec = boundedEntry ? boundedCampaignEntrySpec(boundedTier ?? "q4") : null;
+  const spec = boundedEntry ? {
+    story: boundedSpec.story.toUpperCase(),
     plan: BOUNDED_CAMPAIGN_ENTRY_PLAN,
-    planEntry: boundedCampaignEntryPlan,
-    failurePath: boundedCampaignEntryFailurePath,
-    outcomePath: boundedCampaignEntryOutcomeReservationPath,
-    adapterRequest: boundedCampaignEntryAdapterRequest,
+    planEntry: (config) => boundedCampaignEntryPlan(config, boundedSpec.tier),
+    failurePath: (output) => boundedCampaignEntryFailurePath(output, boundedSpec.tier),
+    outcomePath: (output) => boundedCampaignEntryOutcomeReservationPath(output, boundedSpec.tier),
+    adapterRequest: (request, planned, source) =>
+      boundedCampaignEntryAdapterRequest(request, planned, source, boundedSpec.tier),
     validateResponse: validateBoundedCampaignEntryResponse,
     canonicalFragment: boundedCampaignEntryCanonicalFragment,
     phases: BOUNDED_CARRIER_PHASES,
     phaseProfile: "bounded-campaign-entry",
-    childName: "sc-20318-bounded-campaign-entry",
+    childName: `${boundedSpec.story}-${boundedSpec.tier}-bounded-campaign-entry`,
   } : {
     story: "SC-20191",
     plan: CAMPAIGN_ENTRY_PLAN,
@@ -3144,6 +3478,7 @@ async function campaignProviderInvocation(options, input, {
     token: options["outcome-token"],
     canonicalClaim,
     executionClaim,
+    q8ReleaseAuthorization,
   };
   if (campaignOutcome.failureOutput !== spec.failurePath(campaignOutcome.canonicalOutput)
       || campaignOutcome.reservation !== spec.outcomePath(campaignOutcome.canonicalOutput)) {
@@ -3152,15 +3487,17 @@ async function campaignProviderInvocation(options, input, {
   const config = JSON.parse(await readFile(path.join(ROOT, spec.plan), "utf8"));
   const { planned } = spec.planEntry(config);
   const toolchainChannel = await repositoryToolchain();
+  const preparationTier = boundedSpec?.tier ?? "q4";
   const identity = preparationIdentity(
     options["scene-tree"], options["inference-tree"], toolchainChannel,
+    preparationTier,
   );
   if (preparationCacheKey(identity) !== options["preparation-key"]) {
     fail("SC-20191 campaign provider preparation key changed");
   }
   await assertCampaignSourceState(options, signal);
   const prepared = await validatePreparedCache(
-    options["preparation-root"], options["preparation-key"], identity, signal,
+    options["preparation-root"], options["preparation-key"], identity, signal, preparationTier,
   );
   if (prepared === null) fail("SC-20191 prepared cache disappeared before provider invocation");
   await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal);
@@ -3188,7 +3525,7 @@ async function campaignProviderInvocation(options, input, {
       await assertCampaignSourceState(options, signal);
       await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal);
       if (await validatePreparedCache(
-        options["preparation-root"], options["preparation-key"], identity, signal,
+        options["preparation-root"], options["preparation-key"], identity, signal, preparationTier,
       ) === null) fail("SC-20191 prepared cache disappeared after provider probe");
       output = probeOutput;
     } else {
@@ -3225,8 +3562,16 @@ async function campaignProviderInvocation(options, input, {
       await assertCampaignSourceState(options, signal);
       await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal);
       if (await validatePreparedCache(
-        options["preparation-root"], options["preparation-key"], identity, signal,
+        options["preparation-root"], options["preparation-key"], identity, signal, preparationTier,
       ) === null) fail("SC-20191 prepared cache disappeared before model release");
+      if (boundedSpec?.tier === "bf16") {
+        await assertQ8ReleaseAuthorization(
+          q8ReleaseAuthorization, options["q8-audit"], {
+            sceneWorksRevision: options["scene-revision"],
+            inferenceRevision: options["inference-revision"],
+          },
+        );
+      }
       // This immediate actual-GPU-owner and two-boundary pressure check is deliberately the final
       // operation before the watchdog takes ownership of the model process.
       await assertHostPreflight(hostMemoryBytes, signal);
@@ -3260,7 +3605,8 @@ async function campaignProviderInvocation(options, input, {
           await assertCampaignSourceState(options);
           await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib);
           if (await validatePreparedCache(
-            options["preparation-root"], options["preparation-key"], identity,
+            options["preparation-root"], options["preparation-key"], identity, undefined,
+            preparationTier,
           ) === null) fail("SC-20216 prepared cache disappeared after watchdog failure");
           failureEvents = events;
           failureHostMemoryBytes = hostMemoryBytes;
@@ -3274,6 +3620,7 @@ async function campaignProviderInvocation(options, input, {
       const events = eventBytes.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
       spec.validateResponse(response, {
         inferenceRevision: options["inference-revision"], hostMemoryBytes,
+        tier: boundedSpec?.tier ?? "q4",
       });
       const maxObservedFootprintBytes = validateCampaignEntryWatchdogEvents(
         events, hostMemoryBytes, spec.phases,
@@ -3288,7 +3635,7 @@ async function campaignProviderInvocation(options, input, {
       await assertCampaignSourceState(options, signal);
       await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal);
       if (await validatePreparedCache(
-        options["preparation-root"], options["preparation-key"], identity, signal,
+        options["preparation-root"], options["preparation-key"], identity, signal, preparationTier,
       ) === null) fail("SC-20191 prepared cache disappeared after campaign entry");
       output = canonicalJson(spec.canonicalFragment(response, maxObservedFootprintBytes));
     }
@@ -3307,7 +3654,7 @@ async function campaignProviderInvocation(options, input, {
     let publicationError = null;
     if (failureEvents !== null && cleanupError === null) {
       try {
-        const publishFailure = bounded
+        const publishFailure = boundedEntry
           ? publishBoundedCampaignEntryFailure : publishCampaignEntryFailureReceipt;
         await publishFailure(campaignOutcome, {
           verify: async () => {
@@ -3315,11 +3662,20 @@ async function campaignProviderInvocation(options, input, {
             await assertCampaignSourceState(options);
             await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib);
             if (await validatePreparedCache(
-              options["preparation-root"], options["preparation-key"], identity,
+              options["preparation-root"], options["preparation-key"], identity, undefined,
+              preparationTier,
             ) === null) fail("SC-20216 prepared cache disappeared before failure publication");
             await assertPreparationHasNoTransientResidue(options["preparation-root"]);
+            if (boundedSpec?.tier === "bf16") {
+              await assertQ8ReleaseAuthorization(
+                q8ReleaseAuthorization, options["q8-audit"], {
+                  sceneWorksRevision: options["scene-revision"],
+                  inferenceRevision: options["inference-revision"],
+                },
+              );
+            }
           },
-          build: (outcome) => (bounded
+          build: (outcome) => (boundedEntry
             ? boundedCampaignEntryFailureReceipt({
               sceneWorksRevision: options["scene-revision"],
               sceneWorksTree: options["scene-tree"],
@@ -3332,6 +3688,7 @@ async function campaignProviderInvocation(options, input, {
               hostMemoryBytes: failureHostMemoryBytes,
               events: failureEvents,
               outcome,
+              tier: boundedSpec.tier,
             })
             : campaignEntryFailureReceipt({
             sceneWorksRevision: options["scene-revision"],
@@ -3364,6 +3721,21 @@ async function campaignProvider(argv) {
     campaignProviderOptions(argv), await readStandardInput(),
   );
   process.stdout.write(output);
+}
+
+async function boundedSelectorReportController(argv) {
+  const options = parseArgs(argv);
+  const expected = ["q4-bundle", "q8-bundle", "bf16-bundle", "output"];
+  if (!isDeepStrictEqual(Object.keys(options).sort(), [...expected].sort())) {
+    fail(`bounded-selector report requires exactly ${expected.map((name) => `--${name}`).join(", ")}`);
+  }
+  await publishBoundedSelectorAnchorReport({
+    q4Bundle: options["q4-bundle"],
+    q8Bundle: options["q8-bundle"],
+    bf16Bundle: options["bf16-bundle"],
+    output: options.output,
+  });
+  process.stdout.write(`${path.resolve(options.output)}\n`);
 }
 
 function parseArgs(argv) {
@@ -3463,16 +3835,27 @@ export async function publishCampaignEntryFailureReceipt(outcome, { verify, buil
   });
 }
 
-export async function acquireBoundedCampaignEntryOutcome(canonicalOutput) {
+export async function acquireBoundedCampaignEntryOutcome(
+  canonicalOutput, requested = "q4", q8ReleaseAuthorization = null,
+) {
+  const spec = boundedCampaignEntrySpec(requested);
+  if ((spec.tier === "bf16") !== (q8ReleaseAuthorization !== null)) {
+    fail("SC-20430 bf16 outcome must bind exactly one q8 release authorization");
+  }
   const outcome = {
     canonicalOutput,
-    failureOutput: boundedCampaignEntryFailurePath(canonicalOutput),
-    reservation: boundedCampaignEntryOutcomeReservationPath(canonicalOutput),
-    choice: `${boundedCampaignEntryOutcomeReservationPath(canonicalOutput)}.choice`,
+    failureOutput: boundedCampaignEntryFailurePath(canonicalOutput, spec.tier),
+    reservation: boundedCampaignEntryOutcomeReservationPath(canonicalOutput, spec.tier),
+    choice: `${boundedCampaignEntryOutcomeReservationPath(canonicalOutput, spec.tier)}.choice`,
     token: randomUUID(),
+    tier: spec.tier,
+    q8ReleaseAuthorization: structuredClone(q8ReleaseAuthorization),
   };
+  outcome.ownerBytes = spec.tier === "bf16"
+    ? canonicalJson({ token: outcome.token, tier: spec.tier, q8ReleaseAuthorization })
+    : `${outcome.token}\n`;
   await mkdir(path.dirname(canonicalOutput), { recursive: true });
-  await writeFile(outcome.reservation, `${outcome.token}\n`, { flag: "wx", mode: 0o400 });
+  await writeFile(outcome.reservation, outcome.ownerBytes, { flag: "wx", mode: 0o400 });
   if (await pathExists(outcome.canonicalOutput) || await pathExists(outcome.failureOutput)) {
     await unlink(outcome.reservation);
     fail("SC-20318 already has an immutable canonical or failure outcome");
@@ -3482,7 +3865,7 @@ export async function acquireBoundedCampaignEntryOutcome(canonicalOutput) {
 
 async function assertBoundedCampaignEntryOutcomeOwner(outcome) {
   if (await readFile(outcome?.reservation ?? "", "utf8").catch(() => null)
-      !== `${outcome?.token}\n`) fail("SC-20318 outcome reservation ownership changed");
+      !== outcome?.ownerBytes) fail("SC-20318 outcome reservation ownership changed");
 }
 
 export async function releaseUnpublishedBoundedCampaignEntryOutcome(outcome) {
@@ -3517,7 +3900,8 @@ async function publishBoundedCampaignEntryFailure(outcome, { verify, build }) {
       outcomeChoice: "failure",
       canonicalBundleAbsentAtPublication: true,
       outcomeReservationHeldAtPublication: true,
-    }));
+      q8ReleaseAuthorization: structuredClone(outcome.q8ReleaseAuthorization),
+    }), outcome.tier);
   });
 }
 
@@ -3950,16 +4334,21 @@ async function assertPreparationHasNoTransientResidue(preparationRoot) {
 async function runCampaignEntryController({
   output, inferenceRepo, sceneWorksRevision, inferenceRevision,
   sceneWorksTree, inferenceTree, identity, preparationKey, preparationRoot,
-  prepared, signal, setActiveWatchdog, bounded = false,
+  prepared, signal, setActiveWatchdog, bounded = false, boundedTier = null,
+  q8AuditPath = null, q8ReleaseAuthorization = null,
 }) {
-  const spec = bounded ? {
+  const boundedEntry = bounded || boundedTier !== null;
+  const boundedSpec = boundedEntry ? boundedCampaignEntrySpec(boundedTier ?? "q4") : null;
+  const spec = boundedEntry ? {
     plan: BOUNDED_CAMPAIGN_ENTRY_PLAN,
-    planEntry: boundedCampaignEntryPlan,
-    acquireOutcome: acquireBoundedCampaignEntryOutcome,
+    planEntry: (config) => boundedCampaignEntryPlan(config, boundedSpec.tier),
+    acquireOutcome: (output) => acquireBoundedCampaignEntryOutcome(
+      output, boundedSpec.tier, q8ReleaseAuthorization,
+    ),
     releaseOutcome: releaseUnpublishedBoundedCampaignEntryOutcome,
-    provider: BOUNDED_CAMPAIGN_ENTRY_PROVIDER,
-    logicalCaseId: BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
-    validateBundle: validateBoundedCampaignEntryBundle,
+    provider: boundedSpec.provider,
+    logicalCaseId: boundedSpec.logicalCaseId,
+    validateBundle: (bundle) => validateBoundedCampaignEntryBundle(bundle, boundedSpec.tier),
   } : {
     plan: CAMPAIGN_ENTRY_PLAN,
     planEntry: campaignEntryPlan,
@@ -3971,6 +4360,11 @@ async function runCampaignEntryController({
   };
   const config = JSON.parse(await readFile(path.join(ROOT, spec.plan), "utf8"));
   spec.planEntry(config);
+  if (boundedSpec?.tier === "bf16") {
+    await assertQ8ReleaseAuthorization(q8ReleaseAuthorization, q8AuditPath, {
+      sceneWorksRevision, inferenceRevision,
+    });
+  }
   const executionClaim = await acquireCanonicalPublicationClaim(
     containedCampaignExecutionClaimTarget(output), signal,
   );
@@ -4008,6 +4402,7 @@ async function runCampaignEntryController({
     "failure-output": campaignOutcome.failureOutput,
     "outcome-reservation": campaignOutcome.reservation,
     "outcome-token": campaignOutcome.token,
+    ...(boundedSpec?.tier === "bf16" ? { "q8-audit": q8AuditPath } : {}),
   };
   const providerCommand = [fileURLToPath(import.meta.url), "--campaign-provider"];
   let operationError = null;
@@ -4036,7 +4431,9 @@ async function runCampaignEntryController({
           fail("SC-20191 harness attempted a foreign provider command");
         }
         return campaignProviderInvocation(providerOptions, input, {
-          signal, setActiveWatchdog, canonicalClaim, executionClaim, bounded,
+          signal, setActiveWatchdog, canonicalClaim, executionClaim,
+          bounded: boundedEntry, boundedTier: boundedSpec?.tier ?? null,
+          q8ReleaseAuthorization,
         });
       },
     });
@@ -4045,11 +4442,16 @@ async function runCampaignEntryController({
     await assertCampaignSourceState(providerOptions, signal);
     await assertRuntimeAssetIdentities(prepared.adapter, prepared.metallib, signal);
     if (await validatePreparedCache(
-      preparationRoot, preparationKey, identity, signal,
+      preparationRoot, preparationKey, identity, signal, boundedSpec?.tier ?? "q4",
     ) === null) fail("SC-20191 prepared cache disappeared before publication");
     await assertPreparationHasNoTransientResidue(preparationRoot);
+    if (boundedSpec?.tier === "bf16") {
+      await assertQ8ReleaseAuthorization(q8ReleaseAuthorization, q8AuditPath, {
+        sceneWorksRevision, inferenceRevision,
+      });
+    }
     spec.validateBundle(bundle);
-    if (bounded) {
+    if (boundedEntry) {
       await publishBoundedCampaignEntryOutcome(
         campaignOutcome, "canonical", async () => bundle, signal,
       );
@@ -4320,17 +4722,24 @@ async function controller(argv) {
     if (!options[name]) fail(`--${name} is required`);
   }
   const unexpected = Object.keys(options).filter(
-    (name) => !["inference-repo", "output", "profile"].includes(name),
+    (name) => !["inference-repo", "output", "profile", "q8-audit"].includes(name),
   );
   if (unexpected.length) fail(`unsupported option(s): ${unexpected.join(", ")}`);
   const profileName = options.profile ?? SAFETY_CANARY_PROFILE;
   const campaignEntry = profileName === CAMPAIGN_ENTRY_PROFILE;
   const boundedCarrier = profileName === BOUNDED_CARRIER_PROFILE;
-  const boundedCampaignEntry = profileName === BOUNDED_CAMPAIGN_ENTRY_PROFILE;
+  const boundedCampaignSpec = Object.values(BOUNDED_CAMPAIGN_ENTRY_SPECS)
+    .find((candidate) => candidate.profile === profileName) ?? null;
+  const boundedCampaignEntry = boundedCampaignSpec !== null;
+  if (boundedCampaignSpec?.tier === "bf16") {
+    if (!options["q8-audit"]) fail("--q8-audit is required for the SC-20430 bf16 profile");
+  } else if (options["q8-audit"] !== undefined) {
+    fail("--q8-audit is only valid for the SC-20430 bf16 profile");
+  }
   const profile = campaignEntry
     ? { story: "sc-20191" }
     : boundedCarrier ? { story: "sc-20254" }
-      : boundedCampaignEntry ? { story: "sc-20318" } : canaryProfile(profileName);
+      : boundedCampaignEntry ? { story: boundedCampaignSpec.story } : canaryProfile(profileName);
   const inferenceRepo = path.resolve(options["inference-repo"]);
   const output = path.resolve(options.output);
   const relativeOutput = path.relative(ROOT, output);
@@ -4339,6 +4748,12 @@ async function controller(argv) {
   }
   const sceneWorksRevision = await cleanHead(ROOT, "SceneWorks");
   const inferenceRevision = await cleanHead(inferenceRepo, "inference");
+  let q8ReleaseAuthorization = null;
+  if (boundedCampaignSpec?.tier === "bf16") {
+    q8ReleaseAuthorization = await validateQ8IndependentAudit(options["q8-audit"], {
+      sceneWorksRevision, inferenceRevision,
+    });
+  }
   const [sceneWorksTree, inferenceTree, toolchainChannel] = await Promise.all([
     git(ROOT, ["rev-parse", "HEAD^{tree}"]),
     git(inferenceRepo, ["rev-parse", "HEAD^{tree}"]),
@@ -4357,7 +4772,10 @@ async function controller(argv) {
   if (!Number.isSafeInteger(memoryBytes) || memoryBytes < MIN_PREFLIGHT_FREE_BYTES) {
     fail(`host memory ${memoryBytes} cannot preserve two canary stop boundaries`);
   }
-  const identity = preparationIdentity(sceneWorksTree, inferenceTree, toolchainChannel);
+  const preparationTier = boundedCampaignSpec?.tier ?? "q4";
+  const identity = preparationIdentity(
+    sceneWorksTree, inferenceTree, toolchainChannel, preparationTier,
+  );
   const preparationKey = preparationCacheKey(identity);
   const preparationRoot = preparationCacheRoot(output, preparationKey);
   let activeWatchdog = null;
@@ -4387,6 +4805,7 @@ async function controller(argv) {
       identity,
       preparedFrom: { sceneWorksRevision, inferenceRevision },
       signal,
+      tier: preparationTier,
       build: async (stage, buildSignal, hooks) => {
         const numericTierRoot = await realpath(path.resolve(
           process.env.SCENEWORKS_LTX_ROOT ?? fail("SCENEWORKS_LTX_ROOT is required to prepare q4"),
@@ -4406,7 +4825,7 @@ async function controller(argv) {
           "local text-encoder",
         );
         const preparationDevice = (await stat(stage, { bigint: true })).dev;
-        const roots = privateArtifactRoots(stage);
+        const roots = privateArtifactRoots(stage, preparationTier);
         await mkdir(path.dirname(roots.numericTier), { recursive: true, mode: 0o700 });
         await cloneArtifactTree(numericTierRoot, roots.numericTier, preparationDevice, buildSignal);
         const preparedNumericTier = assertInventory(
@@ -4498,6 +4917,9 @@ async function controller(argv) {
         signal,
         setActiveWatchdog: (child) => { activeWatchdog = child; },
         bounded: true,
+        boundedTier: boundedCampaignSpec.tier,
+        q8AuditPath: options["q8-audit"] ?? null,
+        q8ReleaseAuthorization,
       });
       return;
     }
@@ -4686,6 +5108,8 @@ try {
   if (process.argv[1] === fileURLToPath(import.meta.url)) {
     if (process.argv[2] === "--campaign-provider") {
       await campaignProvider(process.argv.slice(3));
+    } else if (process.argv[2] === "--bounded-selector-report") {
+      await boundedSelectorReportController(process.argv.slice(3));
     } else {
       await controller(process.argv.slice(2));
     }

--- a/scripts/run-ltx-safety-canary.test.mjs
+++ b/scripts/run-ltx-safety-canary.test.mjs
@@ -8,6 +8,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
 
 import {
   CARGO_METADATA_TIMEOUT_MS,
@@ -24,6 +25,7 @@ import {
   BOUNDED_CAMPAIGN_ENTRY_IDENTITY,
   BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID,
   BOUNDED_CAMPAIGN_ENTRY_PROVIDER,
+  BOUNDED_CAMPAIGN_ENTRY_SPECS,
   BOUNDED_CAMPAIGN_FAILURE_RECEIPT_TYPE,
   CAMPAIGN_ENTRY_FIXTURE,
   CAMPAIGN_ENTRY_IDENTITY,
@@ -40,6 +42,7 @@ import {
   PROVIDER_PHASES,
   PRODUCT_ENVELOPE_CANARY_PROFILE,
   acquireCampaignEntryOutcome,
+  acquireBoundedCampaignEntryOutcome,
   acquireBoundedCarrierOutcome,
   acquireCanonicalPublicationClaim,
   boundedCampaignEntryAdapterRequest,
@@ -48,6 +51,8 @@ import {
   boundedCampaignEntryFailureReceipt,
   boundedCampaignEntryOutcomeReservationPath,
   boundedCampaignEntryPlan,
+  boundedSelectorAnchorReport,
+  publishBoundedSelectorAnchorReport,
   validateBoundedCampaignEntryResponse,
   validateBoundedCampaignEntryBundle,
   validateBoundedCampaignEntryFailureReceipt,
@@ -107,6 +112,7 @@ import {
   validateBoundedCarrierWatchdogEvents,
   validateCanaryResponse,
   validatePreparedCache,
+  validateQ8IndependentAudit,
   watchdogFailureSummary,
 } from "./run-ltx-safety-canary.mjs";
 
@@ -143,12 +149,12 @@ async function campaignEntryFixture() {
   return { config, provider, planned, request };
 }
 
-async function boundedCampaignEntryFixture() {
+async function boundedCampaignEntryFixture(tier = "q4") {
   const config = JSON.parse(await readFile(new URL(
     "../docs/calibration/sc-18946/ltx-mlx-rung2-sweep.json",
     import.meta.url,
   ), "utf8"));
-  const { provider, planned } = boundedCampaignEntryPlan(config);
+  const { provider, planned } = boundedCampaignEntryPlan(config, tier);
   const request = {
     action: "run",
     planned,
@@ -268,13 +274,18 @@ function campaignEntryRuntimeResponse(hostMemoryBytes = 128 * 1024 ** 3) {
   };
 }
 
-function boundedCampaignEntryRuntimeResponse(hostMemoryBytes = 128 * 1024 ** 3) {
+function boundedCampaignEntryRuntimeResponse(
+  hostMemoryBytes = 128 * 1024 ** 3, tier = "q4",
+) {
+  const spec = BOUNDED_CAMPAIGN_ENTRY_SPECS[tier];
   const response = campaignEntryRuntimeResponse(hostMemoryBytes);
   response.strategy = {
     rung: "bounded_decode",
     engagedRungs: ["resident", "staged_residency", "bounded_decode"],
     parameters: { decodeTileEdge: 192, decodeOverlap: 64 },
   };
+  response.artifact.variant = tier;
+  response.loadability.resolvedPathFingerprint = `exact@bounded-campaign-entry:${tier}`;
   response.sweep.cases[0].parameters = structuredClone(response.strategy.parameters);
   for (const name of ["cancel", "error"]) {
     const scenario = response.scenarios.find((item) => item.name === name);
@@ -298,7 +309,7 @@ function boundedCampaignEntryRuntimeResponse(hostMemoryBytes = 128 * 1024 ** 3) 
   }));
   delete response._campaignEntry;
   response._boundedCampaignEntry = {
-    identity: BOUNDED_CAMPAIGN_ENTRY_IDENTITY,
+    identity: spec.identity,
     inferenceRevision: "2".repeat(40),
     watchdog: {
       required: true, protocol: "sceneworks-memory-watchdog-v1",
@@ -490,9 +501,13 @@ function campaignSuccessEvents(
 
 function campaignFailurePreparation(
   root = "/private/prepared", sceneWorksRevision = "1".repeat(40),
-  inferenceRevision = "3".repeat(40),
+  inferenceRevision = "3".repeat(40), tier = "q4",
 ) {
-  const identity = preparationIdentity("a".repeat(40), "b".repeat(40), "1.97.1");
+  const identity = preparationIdentity("a".repeat(40), "b".repeat(40), "1.97.1", tier);
+  // Receipts attest the Darwin/arm64 host that can execute the canary, not the platform running
+  // this source-only validator. Keep hosted Linux parity tests on the same immutable evidence shape.
+  identity.platform = "darwin";
+  identity.architecture = "arm64";
   const key = preparationCacheKey(identity);
   const preparationRoot = path.join(root, key);
   const fileIdentity = (name, mode, digest) => ({
@@ -523,6 +538,33 @@ function campaignFailurePreparation(
   };
   return { identity, key, preparationRoot, prepared };
 }
+
+function q8ReleaseAuthorization(sceneWorksRevision = "1".repeat(40),
+  inferenceRevision = "3".repeat(40)) {
+  return {
+    schemaVersion: 1,
+    recordType: "sceneworks_sc20430_q8_release_authorization_v1",
+    auditFile: {
+      path: "/private/audits/sc20430-q8.json", device: "1", inode: "2", size: 4096,
+      mtimeNs: "3", ctimeNs: "4", mode: 0o400, sha256: "5".repeat(64),
+    },
+    q8: {
+      canonicalOutput: "/private/results/sc20430-q8-canonical.json",
+      canonicalSha256: "6".repeat(64),
+      logicalCaseId: BOUNDED_CAMPAIGN_ENTRY_SPECS.q8.logicalCaseId,
+      recordId: `imc-${"7".repeat(20)}`,
+      sceneWorksRevision,
+      inferenceRevision,
+    },
+  };
+}
+
+test("failure receipt validation is independent of the source-test host", () => {
+  const { identity, key } = campaignFailurePreparation();
+  assert.equal(identity.platform, "darwin");
+  assert.equal(identity.architecture, "arm64");
+  assert.equal(key, preparationCacheKey(identity));
+});
 
 async function cleanCampaignHarnessRepo(t) {
   const root = await mkdtemp(path.join(tmpdir(), "sc20191-harness-repo-"));
@@ -746,7 +788,7 @@ test("SC-20318 transforms only the new exact bounded row and rejects every ident
   assert.equal(adapter.planned._boundedCampaignEntry.videoMode, "default_av");
   assert.equal(adapter.planned._boundedCampaignEntry.spatialDecodeTiles, 24);
   assert.equal(adapter.planned._measurementSafety.disposition, "safety_refused_open");
-  assert.equal(config.providers.length, 7);
+  assert.equal(config.providers.length, 9);
   for (const mutate of [
     (value) => { value.action = "run_batch"; },
     (value) => { value.planned.logicalCaseId = CAMPAIGN_ENTRY_LOGICAL_CASE_ID; },
@@ -762,6 +804,44 @@ test("SC-20318 transforms only the new exact bounded row and rejects every ident
     assert.throws(() => boundedCampaignEntryAdapterRequest(changed, planned, expectedSource),
       /SC-20318|canonical/);
   }
+});
+
+test("SC-20430 exactly admits matched q8 and bf16 bounded rows with distinct identities", async () => {
+  const expectedSource = {
+    sceneWorksRevision: "1".repeat(40), inferenceRevision: "2".repeat(40),
+    sceneWorksRepo: "/scene", inferenceRepo: "/inference",
+  };
+  const identities = new Set();
+  for (const tier of ["q8", "bf16"]) {
+    const { planned, request } = await boundedCampaignEntryFixture(tier);
+    const spec = BOUNDED_CAMPAIGN_ENTRY_SPECS[tier];
+    const adapter = boundedCampaignEntryAdapterRequest(request, planned, expectedSource, tier);
+    assert.equal(adapter.action, BOUNDED_CAMPAIGN_ENTRY_ACTION);
+    assert.equal(adapter.planned.target.tier, tier);
+    assert.equal(adapter.planned.logicalCaseId, spec.logicalCaseId);
+    assert.equal(adapter.planned.fixture, spec.fixture);
+    assert.equal(adapter.planned._boundedCampaignEntry.identity, spec.identity);
+    assert.equal(adapter.planned._boundedCampaignEntry.seed, 18_946);
+    assert.equal(adapter.planned._boundedCampaignEntry.videoMode, "default_av");
+    identities.add(`${spec.provider}:${spec.fixture}:${spec.logicalCaseId}:${spec.identity}`);
+    for (const mutate of [
+      (value) => { value.action = "run_batch"; },
+      (value) => { value.planned.target.tier = tier === "q8" ? "bf16" : "q8"; },
+      (value) => { value.planned.logicalCaseId = BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID; },
+      (value) => { value.planned.fixture = BOUNDED_CAMPAIGN_ENTRY_FIXTURE; },
+      (value) => { value.planned.strategy.parameters.decodeTileEdge += 1; },
+    ]) {
+      const changed = structuredClone(request);
+      mutate(changed);
+      assert.throws(
+        () => boundedCampaignEntryAdapterRequest(changed, planned, expectedSource, tier),
+        /sc-20430|canonical/i,
+      );
+    }
+  }
+  assert.equal(identities.size, 2);
+  const { config } = await boundedCampaignEntryFixture();
+  assert.throws(() => boundedCampaignEntryPlan(config, "fp16"));
 });
 
 test("SC-20318 response requires two-render parity, stereo output, exact tiling and cleanup", () => {
@@ -789,7 +869,7 @@ test("SC-20318 response requires two-render parity, stereo output, exact tiling 
     mutate(changed);
     assert.throws(() => validateBoundedCampaignEntryResponse(changed, {
       inferenceRevision: "2".repeat(40), hostMemoryBytes,
-    }), /SC-20318/);
+    }), /sc-20318/i);
   }
 });
 
@@ -832,6 +912,68 @@ test("SC-20318 failure receipt stays non-ingestible, phase-bound and mutation-se
     mutate(changed);
     assert.throws(() => validateBoundedCampaignEntryFailureReceipt(changed), /SC-20318|SC-20216/);
   }
+});
+
+test("SC-20430 q8 and bf16 failures remain distinct and structurally non-ingestible", () => {
+  const hostMemoryBytes = 128 * 1024 ** 3;
+  const paths = new Set();
+  for (const tier of ["q8", "bf16"]) {
+    const { identity, key, preparationRoot, prepared } = campaignFailurePreparation(
+      "/private/prepared", "1".repeat(40), "3".repeat(40), tier,
+    );
+    const canonicalOutput = `/private/results/sc20430-${tier}-canonical.json`;
+    const failureOutput = boundedCampaignEntryFailurePath(canonicalOutput, tier);
+    const reservation = boundedCampaignEntryOutcomeReservationPath(canonicalOutput, tier);
+    paths.add(`${canonicalOutput}:${failureOutput}:${reservation}`);
+    const receipt = boundedCampaignEntryFailureReceipt({
+      sceneWorksRevision: "1".repeat(40), sceneWorksTree: "a".repeat(40),
+      inferenceRevision: "3".repeat(40), inferenceTree: "b".repeat(40),
+      identity, preparationKey: key, preparationRoot, prepared, hostMemoryBytes,
+      events: campaignFailureEvents(hostMemoryBytes, 3, BOUNDED_CARRIER_PHASES),
+      outcome: {
+        canonicalOutput, failureOutput, reservation, choice: `${reservation}.choice`,
+        outcomeChoice: "failure", canonicalBundleAbsentAtPublication: true,
+        outcomeReservationHeldAtPublication: true,
+        q8ReleaseAuthorization: tier === "bf16" ? q8ReleaseAuthorization() : null,
+      },
+      tier,
+    });
+    assert.equal(receipt.story, "sc-20430");
+    assert.equal(receipt.campaignCase.target.tier, tier);
+    assert.throws(() => validateBundle(receipt));
+    validateBoundedCampaignEntryFailureReceipt(receipt, tier);
+    const changed = structuredClone(receipt);
+    changed.campaignCase.identity = BOUNDED_CAMPAIGN_ENTRY_IDENTITY;
+    assert.throws(() => validateBoundedCampaignEntryFailureReceipt(changed, tier));
+    const swappedTier = tier === "q8" ? "bf16" : "q8";
+    const swapped = campaignFailurePreparation(
+      "/private/prepared", "1".repeat(40), "3".repeat(40), swappedTier,
+    );
+    const swappedReceipt = structuredClone(receipt);
+    swappedReceipt.artifacts.numericTierInventory = swapped.identity.artifact.numericTier;
+    swappedReceipt.artifacts.preparation = {
+      key: swapped.key, root: swapped.preparationRoot,
+      identity: swapped.identity, manifest: swapped.prepared.manifest,
+    };
+    assert.throws(() => validateBoundedCampaignEntryFailureReceipt(swappedReceipt, tier),
+      /artifact|preparation|identity/);
+    const foreignPlatform = structuredClone(receipt);
+    const foreignIdentity = foreignPlatform.artifacts.preparation.identity;
+    foreignIdentity.platform = "linux";
+    const foreignKey = preparationCacheKey(foreignIdentity);
+    foreignPlatform.artifacts.preparation.key = foreignKey;
+    foreignPlatform.artifacts.preparation.root = `/private/prepared/${foreignKey}`;
+    foreignPlatform.artifacts.preparation.manifest.key = foreignKey;
+    foreignPlatform.artifacts.preparation.manifest.identity = structuredClone(foreignIdentity);
+    assert.throws(() => validateBoundedCampaignEntryFailureReceipt(foreignPlatform, tier),
+      /artifact|preparation|identity/);
+    if (tier === "bf16") {
+      const missingAuthorization = structuredClone(receipt);
+      missingAuthorization.outcome.q8ReleaseAuthorization = null;
+      assert.throws(() => validateBoundedCampaignEntryFailureReceipt(missingAuthorization, tier));
+    }
+  }
+  assert.equal(paths.size, 2);
 });
 
 test("SC-20216 failure receipt is phase-authenticated, non-ingestible and mutation-sensitive", () => {
@@ -1565,6 +1707,187 @@ test("SC-20318 synthetic adapter to harness path yields one distinct schema-vali
   }
 });
 
+test("SC-20430 q8 and bf16 synthetic adapter paths yield distinct schema-valid bundles", async (t) => {
+  const repo = await cleanCampaignHarnessRepo(t);
+  const records = [];
+  const bundles = {};
+  for (const tier of ["q8", "bf16"]) {
+    const { provider } = await boundedCampaignEntryFixture(tier);
+    const spec = BOUNDED_CAMPAIGN_ENTRY_SPECS[tier];
+    let runRequests = 0;
+    const bundle = await runProviderPlan({
+      config: { providers: [provider] },
+      providerCommand: [`synthetic-sc20430-${tier}-provider`],
+      sceneWorksRepo: repo,
+      inferenceRepo: repo,
+      backend: "mlx",
+      providerName: spec.provider,
+      closureDigestFor: async () => "c".repeat(64),
+      executeProvider: async (_command, _args, input) => {
+        const request = JSON.parse(input);
+        if (request.action === "probe") {
+          return canonicalJson({ hardware: {
+            probe: `synthetic SC-20430 ${tier} MLX provider`,
+            memoryBytes: 128 * 1024 ** 3,
+            model: "MacFixture", chip: "Apple Fixture", osVersion: "macOS fixture",
+            metalDevice: "Apple Fixture",
+            mlxMemoryLimitBytes: 96 * 1024 ** 3, wiredLimitBytes: 64 * 1024 ** 3,
+          } });
+        }
+        assert.equal(request.action, "run");
+        assert.equal(request.planned.logicalCaseId, spec.logicalCaseId);
+        runRequests += 1;
+        const response = boundedCampaignEntryRuntimeResponse(request.hardware.memoryBytes, tier);
+        response._boundedCampaignEntry.inferenceRevision = request.repositories.inference.revision;
+        validateBoundedCampaignEntryResponse(response, {
+          inferenceRevision: request.repositories.inference.revision,
+          hostMemoryBytes: request.hardware.memoryBytes,
+          tier,
+        });
+        return canonicalJson(boundedCampaignEntryCanonicalFragment(response, 43_193_032_536));
+      },
+    });
+    assert.equal(runRequests, 1, `${tier} owns exactly two adapter renders`);
+    validateBoundedCampaignEntryBundle(bundle, tier);
+    validateBundle(bundle);
+    bundles[tier] = bundle;
+    const [record] = bundle.records;
+    assert.equal(record.target.tier, tier);
+    assert.equal(record.logicalCaseId, spec.logicalCaseId);
+    assert.equal(record.fixture, spec.fixture);
+    assert.equal(Object.hasOwn(record, "_boundedCampaignEntry"), false);
+    records.push(record);
+
+    for (const mutate of [
+      (value) => { value.target.tier = tier === "q8" ? "bf16" : "q8"; },
+      (value) => { value.logicalCaseId = BOUNDED_CAMPAIGN_ENTRY_LOGICAL_CASE_ID; },
+      (value) => { value.fixture = BOUNDED_CAMPAIGN_ENTRY_FIXTURE; },
+      (value) => { value.diagnostics.measurements.find((item) =>
+        item.name === "warmDenoiseActivePeak").value = 0; },
+    ]) {
+      const changed = structuredClone(bundle);
+      mutate(changed.records[0]);
+      assert.throws(() => validateBoundedCampaignEntryBundle(changed, tier),
+        /SC-20318|schema|logical identity/);
+    }
+  }
+  assert.notEqual(records[0].logicalCaseId, records[1].logicalCaseId);
+  assert.notEqual(records[0].id, records[1].id);
+
+  const q4Fixture = await boundedCampaignEntryFixture("q4");
+  bundles.q4 = await runProviderPlan({
+    config: { providers: [q4Fixture.provider] },
+    providerCommand: ["synthetic-sc20430-q4-provider"],
+    sceneWorksRepo: repo,
+    inferenceRepo: repo,
+    backend: "mlx",
+    providerName: BOUNDED_CAMPAIGN_ENTRY_PROVIDER,
+    closureDigestFor: async () => "c".repeat(64),
+    executeProvider: async (_command, _args, input) => {
+      const request = JSON.parse(input);
+      if (request.action === "probe") return canonicalJson({ hardware: {
+        probe: "synthetic q4 anchor", memoryBytes: 128 * 1024 ** 3,
+        model: "MacFixture", chip: "Apple Fixture", osVersion: "macOS fixture",
+        metalDevice: "Apple Fixture",
+        mlxMemoryLimitBytes: 96 * 1024 ** 3, wiredLimitBytes: 64 * 1024 ** 3,
+      } });
+      const response = boundedCampaignEntryRuntimeResponse(request.hardware.memoryBytes, "q4");
+      response._boundedCampaignEntry.inferenceRevision = request.repositories.inference.revision;
+      return canonicalJson(boundedCampaignEntryCanonicalFragment(response, 43_193_032_536));
+    },
+  });
+  const report = boundedSelectorAnchorReport(bundles);
+  assert.equal(report.ingestible, false);
+  assert.equal(report.coefficientTransferClaim, false);
+  assert.equal(report.pooledWithStagedOrSinglePass, false);
+  assert.equal(report.matchBasis.hardware.chip, bundles.q4.records[0].hardware.chip);
+  assert.equal(report.matchBasis.hardware.memoryBytes, bundles.q4.records[0].hardware.memoryBytes);
+  assert.equal(report.matchBasis.inference.revision,
+    bundles.q4.records[0].repositories.inference.revision);
+  assert.equal(report.sourcePolicy.q8AndBf16SceneWorksRevision,
+    bundles.q8.records[0].repositories.sceneWorks.revision);
+  assert.deepEqual(report.anchors.map((anchor) => anchor.tier), ["q4", "q8", "bf16"]);
+  assert.throws(() => validateBundle(report));
+  for (const mutate of [
+    (value) => { value.q8.records[0].target.tier = "q4"; },
+    (value) => { value.bf16.records[0].diagnostics.measurements.find((item) =>
+      item.name === "warmDecodeActivePeak").value = 0; },
+    (value) => { delete value.q4; },
+    (value) => { value.q8.records[0].hardware.chip = "foreign chip"; },
+    (value) => { value.bf16.records[0].repositories.inference.revision = "f".repeat(40); },
+    (value) => { value.q8.records[0].repositories.sceneWorks.revision = "e".repeat(40); },
+    (value) => { value.q8.records[0].calibrationFingerprint = "foreign"; },
+    (value) => { value.bf16.records[0].artifact.resolvedRevision = "foreign"; },
+  ]) {
+    const changed = structuredClone(bundles);
+    mutate(changed);
+    assert.throws(() => boundedSelectorAnchorReport(changed));
+  }
+
+  const auditRoot = await mkdtemp(path.join(tmpdir(), "sc20430-q8-audit-"));
+  t.after(() => cleanupCanaryScratch(auditRoot));
+  const reportInputs = {};
+  for (const tier of ["q4", "q8", "bf16"]) {
+    reportInputs[`${tier}Bundle`] = path.join(auditRoot, `${tier}-bundle.json`);
+    await writeFile(reportInputs[`${tier}Bundle`], canonicalJson(bundles[tier]));
+  }
+  const reportOutput = path.join(auditRoot, "bounded-selector-anchors.json");
+  const reportRun = spawnSync(process.execPath, [
+    fileURLToPath(new URL("./run-ltx-safety-canary.mjs", import.meta.url)),
+    "--bounded-selector-report",
+    "--q4-bundle", reportInputs.q4Bundle,
+    "--q8-bundle", reportInputs.q8Bundle,
+    "--bf16-bundle", reportInputs.bf16Bundle,
+    "--output", reportOutput,
+  ], { encoding: "utf8", timeout: 10_000 });
+  assert.equal(reportRun.status, 0, reportRun.stderr);
+  assert.equal(reportRun.stdout.trim(), reportOutput);
+  assert.deepEqual(JSON.parse(await readFile(reportOutput, "utf8")), report);
+  await assert.rejects(
+    () => publishBoundedSelectorAnchorReport({ ...reportInputs, output: reportOutput }),
+    /EEXIST/,
+  );
+  const canonicalOutput = path.join(auditRoot, "q8-canonical.json");
+  await writeFile(canonicalOutput, canonicalJson(bundles.q8));
+  const auditPath = path.join(auditRoot, "q8-independent-audit.json");
+  const audit = {
+    schemaVersion: 1,
+    recordType: "sceneworks_sc20430_q8_independent_audit_v1",
+    result: "passed",
+    independent: true,
+    diagnosticOnly: true,
+    ingestible: false,
+    q8: {
+      canonicalOutput,
+      canonicalSha256: createHash("sha256").update(canonicalJson(bundles.q8)).digest("hex"),
+      logicalCaseId: BOUNDED_CAMPAIGN_ENTRY_SPECS.q8.logicalCaseId,
+      recordId: bundles.q8.records[0].id,
+      sceneWorksRevision: bundles.q8.records[0].repositories.sceneWorks.revision,
+      inferenceRevision: bundles.q8.records[0].repositories.inference.revision,
+    },
+  };
+  await writeFile(auditPath, JSON.stringify(audit));
+  await chmod(auditPath, 0o400);
+  const authorization = await validateQ8IndependentAudit(auditPath);
+  assert.equal(authorization.auditFile.mode, 0o400);
+  assert.equal(authorization.q8.recordId, audit.q8.recordId);
+  const outcomeRoot = path.join(auditRoot, "bf16-outcome");
+  await mkdir(outcomeRoot);
+  const outcome = await acquireBoundedCampaignEntryOutcome(
+    path.join(outcomeRoot, "canonical.json"), "bf16", authorization,
+  );
+  assert.match(await readFile(outcome.reservation, "utf8"), new RegExp(authorization.auditFile.sha256));
+  await assert.rejects(() => validateQ8IndependentAudit(auditPath, {
+    sceneWorksRevision: "f".repeat(40),
+    inferenceRevision: audit.q8.inferenceRevision,
+  }), /does not bind/);
+  await chmod(auditPath, 0o600);
+  audit.q8.canonicalSha256 = "0".repeat(64);
+  await writeFile(auditPath, JSON.stringify(audit));
+  await chmod(auditPath, 0o400);
+  await assert.rejects(() => validateQ8IndependentAudit(auditPath), /does not bind/);
+});
+
 test("the runner freezes the distinct full-A/V product-envelope canary", () => {
   const request = canaryRequest(
     128 * 1024 ** 3, TEXT_ENCODER_INVENTORY, PRODUCT_ENVELOPE_CANARY_PROFILE,
@@ -1603,7 +1926,7 @@ test("private artifact clones preserve the canonical immutable snapshot roots", 
   assert.equal(path.relative(scratch, roots.numericTier).startsWith(".."), false);
   assert.equal(path.relative(scratch, roots.textEncoder).startsWith(".."), false);
   const runnerSource = await readFile(new URL("./run-ltx-safety-canary.mjs", import.meta.url), "utf8");
-  assert.match(runnerSource, /privateArtifactRoots\(stage\)/);
+  assert.match(runnerSource, /privateArtifactRoots\(stage, preparationTier\)/);
   assert.match(runnerSource, /rename\(stage, preparationRoot\)/);
 });
 
@@ -2078,6 +2401,17 @@ test("the production runner can only launch through the identity-checked watchdo
   "the original watchdog failure must exist before receipt or postcondition validation");
   assert.match(failureHandling, /preserveFailureReceiptSuppression\(watchdogError, error\)/);
   assert.match(source, /campaignOutcome = await spec\.acquireOutcome\(output\)/);
+  const modelRelease = source.indexOf("await assertHostPreflight(hostMemoryBytes, signal)",
+    source.indexOf("async function campaignProviderInvocation("));
+  const auditRelease = source.lastIndexOf("await assertQ8ReleaseAuthorization(", modelRelease);
+  assert.ok(auditRelease >= 0 && auditRelease < modelRelease,
+    "bf16 must revalidate its sealed q8 authorization before the final host gate/model release");
+  const boundedPublication = source.indexOf("await publishBoundedCampaignEntryOutcome(",
+    source.indexOf("async function runCampaignEntryController("));
+  const auditPublication = source.lastIndexOf("await assertQ8ReleaseAuthorization(",
+    boundedPublication);
+  assert.ok(auditPublication >= 0 && auditPublication < boundedPublication,
+    "bf16 must revalidate its sealed q8 authorization before canonical publication");
   const canonicalClaim = source.slice(
     source.indexOf("export async function acquireCanonicalPublicationClaim("),
     source.indexOf("export async function acquireBoundedCarrierOutcome("),
@@ -2140,7 +2474,7 @@ test("the production runner can only launch through the identity-checked watchdo
   ]) {
     assert.ok(campaignController.indexOf(operation) >= 0
       && campaignController.indexOf(operation)
-        < campaignController.indexOf("if (bounded) {"),
+        < campaignController.indexOf("if (boundedEntry) {"),
     `${operation} must precede atomic canonical publication`);
   }
   assert.match(source, /cancellation\.abort\(new CanaryInterrupted\(signalName\)\)/);
@@ -2303,6 +2637,16 @@ test("preparation identity and cache keys change for every canonical input", () 
   }
   assert.throws(() => preparationIdentity("short", "2".repeat(40), "1.97.1"));
   assert.throws(() => preparationIdentity("1".repeat(40), "2".repeat(40), "stable"));
+  const q8 = preparationIdentity("1".repeat(40), "2".repeat(40), "1.97.1", "q8");
+  const bf16 = preparationIdentity("1".repeat(40), "2".repeat(40), "1.97.1", "bf16");
+  assert.notEqual(preparationCacheKey(q8), key);
+  assert.notEqual(preparationCacheKey(bf16), key);
+  assert.notEqual(preparationCacheKey(q8), preparationCacheKey(bf16));
+  assert.equal(q8.artifact.numericTier.bytes, 29_728_720_716);
+  assert.equal(bf16.artifact.numericTier.files, 10);
+  assert.throws(() => preparationIdentity(
+    "1".repeat(40), "2".repeat(40), "1.97.1", "fp16",
+  ));
 });
 
 test("a completed cache is atomically reused without rebuilding or rehashing file contents", async (t) => {


### PR DESCRIPTION
## Summary
- extend the frozen SC-18946 inventory from 71 to 73 rows with exact q8 and bf16 matched bounded carriers while preserving the original 71
- generalize the privately contained bounded campaign path across q4/q8/bf16 with exact tier identities, sealed preparation, shared containment, two-render parity, and immutable success/failure outcomes
- gate any voluntary bf16 capture on sealed independent q8 evidence and add a non-ingestible CPU-only matched phase-anchor report
- keep ordinary production/campaign behavior fail-closed; these paths are opt-in calibration tooling, not runtime or CI gates

## Ratified completion policy

Michael corrected the epic acceptance on 2026-08-17: code completion does not require q8/bf16 real-weight captures, positive coefficient-transfer proof, phase-flip closure, or a cross-tier measurement matrix. The existing q4 canonical evidence and earlier multi-frame LTX measurements are sufficient anchors. Unmeasured tiers remain conservative estimates with widened margins and no coefficient promotion.

## Validation
- npm run check (586/586)
- focused Node suites (99/99)
- cargo test -p sceneworks-memory-adapter --features mlx --bin memory-mlx-adapter (95/95)
- cargo clippy -p sceneworks-memory-adapter --features mlx --all-targets -- -D warnings
- cargo fmt --all --check
- node scripts/generate-ltx-sc18946-plan.mjs --check
- git diff --check
- independent adversarial review: PASS

No model, GPU, real-weight, or campaign workload was run, and none is required for this story's acceptance.