### PR TITLE
fix(api): tolerate cleanup tombstones in variant size refresh

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -2656,6 +2656,32 @@ mod download_receipt_tests {
         }
     }
 
+    /// A platformCleanupOnly tombstone has its `variants` projection stripped by
+    /// `apply_model_catalog_entry`, yet the snapshot pipeline still runs size enrichment on it.
+    /// The refresh must no-op for tombstones while staying a hard error for real entries —
+    /// this exact mismatch 500'd the whole catalog for machines holding legacy Eros weights.
+    /// (Platform-neutral twin of the seeded-cache Eros tests below, which cannot run on Windows:
+    /// their setup writes the literal `gemma/*` manifest pattern as a filename.)
+    #[test]
+    fn size_refresh_tolerates_a_cleanup_tombstone_without_variants() {
+        let mut tombstone = json!({
+            "id": "ltx_2_3_eros",
+            "platformCleanupOnly": true,
+        });
+        refresh_variant_download_sizes(&mut tombstone)
+            .expect("tombstone size refresh must be a no-op");
+        assert!(
+            tombstone.get("variants").is_none(),
+            "tombstone refresh must not invent a variants projection"
+        );
+
+        let mut real_entry = json!({ "id": "ltx_2_3" });
+        assert!(
+            refresh_variant_download_sizes(&mut real_entry).is_err(),
+            "a non-tombstone entry without a variants array is still a contract violation"
+        );
+    }
+
     /// SC-18902: Eros is a real MLX product route, but its exact-head Candle/CUDA capture was
     /// unusable. Pin the complete catalog projection so a future edit cannot restore the 46.8 GB
     /// Windows/Linux offer merely by changing one of the three required download rows.
@@ -2856,6 +2882,18 @@ mod download_receipt_tests {
                 "cleanup projection leaked {field}"
             );
         }
+
+        // The snapshot pipeline runs size enrichment on every retained row AFTER the tombstone
+        // strip. It must tolerate the stripped projection — a hard error here 500s the entire
+        // catalog for any machine still holding legacy Eros weights in its HF cache.
+        let mut enriched = projected.clone();
+        let context = model_download_context(&enriched).unwrap();
+        apply_model_catalog_size_fields(&mut enriched, context.as_ref(), None)
+            .expect("size enrichment tolerates a cleanup tombstone");
+        assert!(
+            enriched.get("variants").is_none(),
+            "size enrichment must not resurrect the variants projection on a tombstone"
+        );
 
         let primary_repo = "TenStrip/LTX2.3-10Eros";
         let adapter_repo = "TenStrip/LTX2.3_Distilled_Lora_1.1_Experiments";
@@ -4479,6 +4517,12 @@ fn apply_variant_fields(object: &mut JsonObject, data_dir: &FsPath) {
 }
 
 fn refresh_variant_download_sizes(model: &mut Value) -> Result<(), ApiError> {
+    // A platformCleanupOnly tombstone strips the whole variants projection in
+    // `apply_model_catalog_entry` — the missing array is its contract, not corruption, and there
+    // is nothing to refresh. Keep the strict array guard below for every real catalog entry.
+    if model.get("platformCleanupOnly").and_then(Value::as_bool) == Some(true) {
+        return Ok(());
+    }
     // `apply_variant_fields` runs in the blocking install-state sweep while live HF estimation runs
     // concurrently. Refresh only the already-built response fields after both complete: rebuilding
     // variants here would repeat filesystem probes serially and undo the intended overlap.


### PR DESCRIPTION
## What does this PR do?

Fixes a whole-catalog 500 — **"Model catalog variants must be an array"** — that appears after the #2400 merge on any Windows/Linux machine whose HF cache still holds legacy LTX-2.3 Eros weights.

The sc-18902 Eros withdrawal keeps a `platformCleanupOnly` tombstone row for machines with legacy Eros artifacts, and `apply_model_catalog_entry` deliberately strips the tombstone's `variants` projection. The snapshot pipeline then runs `apply_model_catalog_size_fields` on every retained row, and `refresh_variant_download_sizes` hard-errored on the missing array, taking down the entire `/models` response.

The fix makes the refresh a no-op for tombstones while keeping the strict array guard for every real catalog entry. Two tests added:

- a platform-neutral unit test (tombstone → no-op; real entry without `variants` → still a hard error), needed because the seeded Eros tombstone tests cannot run on Windows at all — their setup writes the manifest's literal `gemma/*` pattern as a filename;
- a size-enrichment leg on the existing `ltx_eros_legacy_install_is_cleanup_only_and_reclaimable_off_macos` test, which reproduces the crash on the CI lanes.

## Related issue

None — regression introduced by #2400 (sc-18902 rode the sc-18803 train); root-caused and fixed in-session.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## How was this tested?

- [x] Windows (NVIDIA / candle)

On the Windows repro box: new unit test passes; all 78 other `models::` tests and 130 `catalog` tests pass; `cargo fmt` and `cargo clippy -p sceneworks-rust-api --all-targets` clean. The two seeded Eros tombstone tests fail on Windows identically on unmodified main (setup writes a literal `*` filename), verified via stash — CI's non-Windows lanes cover them, including the new size-enrichment leg.

## Checklist

- [ ] I ran `npm run rust:check` (if I touched Rust) and it passed — ran its substance piecewise on Windows (fmt, clippy all-targets, targeted tests); the bundled full `rust:test` cannot go green on Windows due to the pre-existing seeded-Eros test limitation above
- [x] I ran `npm run check` (scaffold checks) — 544/586 pass locally; the 41 failures are the owned-command watchdog family spawning `/bin/sh`, environmental on Windows and byte-identical to main (this diff touches only `apps/rust-api/src/models.rs`)
- [x] I updated documentation where relevant (code comments)
- [x] All my commits are signed off (`git commit -s` — see the DCO section in CONTRIBUTING.md)
- [x] My PR is focused on a single logical change

🤖 Generated with [Claude Code](https://claude.com/claude-code)