### PR TITLE
sc-19709: connect-drive, relocate-library, and retry UX for an unavailable model library

### DIFF
--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -11,6 +11,8 @@ fn main() {
             "choose_folder",
             "set_data_dir",
             "choose_data_dir",
+            // Relocating an unavailable model library (sc-19709).
+            "set_model_library",
             "reveal_in_os",
             "resolve_asset_path",
             "save_asset_as",

--- a/apps/desktop/build.rs
+++ b/apps/desktop/build.rs
@@ -13,6 +13,7 @@ fn main() {
             "choose_data_dir",
             // Relocating an unavailable model library (sc-19709).
             "set_model_library",
+            "restart_app",
             "reveal_in_os",
             "resolve_asset_path",
             "save_asset_as",

--- a/apps/desktop/capabilities/default.json
+++ b/apps/desktop/capabilities/default.json
@@ -18,6 +18,8 @@
     "allow-choose-folder",
     "allow-set-data-dir",
     "allow-choose-data-dir",
+    "allow-set-model-library",
+    "allow-restart-app",
     "allow-reveal-in-os",
     "allow-resolve-asset-path",
     "allow-save-asset-as",

--- a/apps/desktop/permissions/autogenerated/restart_app.toml
+++ b/apps/desktop/permissions/autogenerated/restart_app.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-restart-app"
+description = "Enables the restart_app command without any pre-configured scope."
+commands.allow = ["restart_app"]
+
+[[permission]]
+identifier = "deny-restart-app"
+description = "Denies the restart_app command without any pre-configured scope."
+commands.deny = ["restart_app"]

--- a/apps/desktop/permissions/autogenerated/set_model_library.toml
+++ b/apps/desktop/permissions/autogenerated/set_model_library.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-set-model-library"
+description = "Enables the set_model_library command without any pre-configured scope."
+commands.allow = ["set_model_library"]
+
+[[permission]]
+identifier = "deny-set-model-library"
+description = "Denies the set_model_library command without any pre-configured scope."
+commands.deny = ["set_model_library"]

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -85,6 +85,7 @@ fn main() {
             settings::choose_data_dir,
             // Relocating an unavailable model library (sc-19709).
             settings::set_model_library,
+            settings::restart_app,
             settings::reveal_in_os,
             // Save an asset to a user-chosen destination + resolve an asset's
             // project-relative path to its absolute on-disk path (sc-8726).

--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -83,6 +83,8 @@ fn main() {
             settings::choose_folder,
             settings::set_data_dir,
             settings::choose_data_dir,
+            // Relocating an unavailable model library (sc-19709).
+            settings::set_model_library,
             settings::reveal_in_os,
             // Save an asset to a user-chosen destination + resolve an asset's
             // project-relative path to its absolute on-disk path (sc-8726).

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -945,6 +945,25 @@ pub async fn choose_data_dir(app: AppHandle) -> Option<String> {
     pick_folder(&app)
 }
 
+/// Persist a relocated model library (sc-19709).
+///
+/// The API has already validated the chosen root and re-bound its durable identity; it returns the
+/// exact `HF_HOME` that resolves to that library, and this is the ONE place it becomes durable.
+/// Deliberately the same field, normalization and file as the first-run storage step — relocation
+/// is a change to the existing library-path configuration, not a parallel setting. Like the data
+/// directory, the sidecars receive it as spawn environment, so it applies on the next launch.
+#[tauri::command]
+pub fn set_model_library(path: String) -> Result<AppSettings, String> {
+    let mut settings = load_settings();
+    let hf_home = storage_override_input("Model library folder", &path)?;
+    if hf_home.is_none() {
+        return Err("A model library folder is required.".to_owned());
+    }
+    settings.hf_home = hf_home;
+    save_settings(&settings)?;
+    Ok(settings)
+}
+
 #[tauri::command]
 pub fn reveal_in_os(path: String) -> Result<(), String> {
     let target = validate_reveal_target(&path)?;

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -1312,6 +1312,18 @@ pub fn restart_worker(app: AppHandle) {
     crate::setup::restart_gpu_worker(&app);
 }
 
+/// Relaunch the whole app so a spawn-environment setting takes effect (sc-19709).
+///
+/// The relocated model library reaches the API and GPU worker as `HF_HOME` at spawn, so it cannot
+/// apply to the running sidecars. This is the "Restart now" the disclosure offers: the SAME
+/// graceful teardown as quitting — SIGTERM then grace, never an immediate force-kill of a worker
+/// that may be mid-render — followed by a relaunch. Idempotent: a second call while a teardown is
+/// already running is a no-op, so a double click cannot start two.
+#[tauri::command]
+pub fn restart_app(app: AppHandle) {
+    crate::setup::begin_restart(&app);
+}
+
 #[tauri::command]
 pub fn get_gpu_info() -> GpuInfo {
     #[cfg(target_os = "macos")]

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -955,13 +955,22 @@ pub async fn choose_data_dir(app: AppHandle) -> Option<String> {
 #[tauri::command]
 pub fn set_model_library(path: String) -> Result<AppSettings, String> {
     let mut settings = load_settings();
-    let hf_home = storage_override_input("Model library folder", &path)?;
-    if hf_home.is_none() {
-        return Err("A model library folder is required.".to_owned());
-    }
-    settings.hf_home = hf_home;
+    settings.hf_home = Some(model_library_override_for(
+        &path,
+        cfg!(all(unix, not(target_os = "macos"))),
+    )?);
     save_settings(&settings)?;
     Ok(settings)
+}
+
+/// The pure decision behind [`set_model_library`], with the Linux absolute-path rule as an explicit
+/// argument so it is testable on every platform. Relocation always names a concrete folder, so —
+/// unlike the first-run storage step — an empty value is a rejection rather than "use the default":
+/// silently reverting to the platform default would leave the user pointed at a library that is not
+/// the one they just chose.
+fn model_library_override_for(path: &str, linux_absolute: bool) -> Result<String, String> {
+    storage_override_input_for("Model library folder", path, linux_absolute)?
+        .ok_or_else(|| "A model library folder is required.".to_owned())
 }
 
 #[tauri::command]
@@ -1424,6 +1433,23 @@ mod tests {
         let hf_error = storage_override_input_for("HF cache", "./huggingface", true)
             .expect_err("relative Linux HF cache must be rejected");
         assert!(hf_error.contains("absolute path on Linux"));
+    }
+
+    /// sc-19709: relocating the model library writes the SAME `hf_home` override the first-run
+    /// storage step writes, with the same normalization — but an empty choice is a rejection, not a
+    /// silent revert to the platform default (the user just picked a specific library).
+    #[test]
+    fn relocating_the_model_library_normalizes_and_refuses_an_empty_choice() {
+        assert_eq!(
+            model_library_override_for(" /Volumes/Models/hf ", true).expect("absolute path"),
+            "/Volumes/Models/hf".to_owned()
+        );
+        let empty = model_library_override_for("   ", false)
+            .expect_err("an empty folder must not clear the override");
+        assert!(empty.contains("required"), "{empty}");
+        let relative = model_library_override_for("./models", true)
+            .expect_err("relative Linux library root must be rejected");
+        assert!(relative.contains("absolute path on Linux"), "{relative}");
     }
 
     #[test]

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -3014,6 +3014,20 @@ fn unix_shutdown_pids(
         .collect()
 }
 
+/// What the graceful teardown does once every sidecar is down (sc-19709).
+///
+/// Relaunching after a settings change that only the sidecars' spawn environment can carry — a
+/// relocated model library — is the SAME teardown as quitting, not a faster one. It deliberately
+/// reuses [`begin_teardown`] rather than the auto-update path's `stop_sidecars_for_update`, which
+/// force-kills immediately because an NSIS installer is waiting on a file lock: a hard kill of an
+/// MLX worker mid-render can wedge the host GPU client until reboot, so a user-initiated restart
+/// must go through SIGTERM-and-grace like an ordinary quit.
+#[derive(Clone, Copy)]
+enum Teardown {
+    Exit,
+    Relaunch,
+}
+
 /// Begin graceful shutdown: stop the GPU worker (MLX on macOS, candle on
 /// Windows/Linux) then the API sidecar.
 /// On Unix this sends SIGTERM and waits up to the grace period before
@@ -3021,6 +3035,16 @@ fn unix_shutdown_pids(
 /// Windows-session refinement). Returns true if shutdown was initiated (caller
 /// should prevent the immediate exit), false if it was already in progress.
 pub fn begin_shutdown(app: &AppHandle) -> bool {
+    begin_teardown(app, Teardown::Exit)
+}
+
+/// The identical graceful teardown, followed by a relaunch instead of an exit (sc-19709). Returns
+/// false when a teardown is already running, so a second "Restart now" cannot start a second one.
+pub fn begin_restart(app: &AppHandle) -> bool {
+    begin_teardown(app, Teardown::Relaunch)
+}
+
+fn begin_teardown(app: &AppHandle, then: Teardown) -> bool {
     let managed = app.state::<Managed>();
     if managed.shutting_down.swap(true, Ordering::SeqCst) {
         return false;
@@ -3099,7 +3123,11 @@ pub fn begin_shutdown(app: &AppHandle) -> bool {
         if let Some(cred_ipc) = cred_ipc {
             let _ = std::fs::remove_file(&cred_ipc.socket);
         }
-        handle.exit(0);
+        match then {
+            Teardown::Exit => handle.exit(0),
+            // Diverges: the process is replaced, so nothing after this runs.
+            Teardown::Relaunch => handle.restart(),
+        }
     });
     true
 }

--- a/apps/rust-api/src/catalogs.rs
+++ b/apps/rust-api/src/catalogs.rs
@@ -1613,6 +1613,7 @@ pub(crate) async fn update_catalog_analyzer_config(
             ApiError {
                 status: StatusCode::CONFLICT,
                 detail: "Catalog analyzer configuration changed; refresh and retry".to_owned(),
+                context: None,
                 code: Some("catalog_analyzer_config_conflict"),
             }
         } else {

--- a/apps/rust-api/src/error.rs
+++ b/apps/rust-api/src/error.rs
@@ -13,6 +13,7 @@ use serde_json::json;
 
 use sceneworks_core::catalog_store::CatalogError;
 use sceneworks_core::jobs_store::JobsStoreError;
+use sceneworks_core::model_artifacts::external_library::ExternalLibraryUnavailableContext;
 use sceneworks_core::project_store::ProjectStoreError;
 
 #[derive(Debug)]
@@ -20,6 +21,10 @@ pub(crate) struct ApiError {
     pub(crate) status: StatusCode,
     pub(crate) detail: String,
     pub(crate) code: Option<&'static str>,
+    /// Typed machine-readable context for the codes whose client must ACT on the rejection rather
+    /// than print it (sc-19709). Rendered as a `context` object beside `detail`/`code`, so a client
+    /// drives its recovery UI from named fields instead of parsing the detail sentence.
+    pub(crate) context: Option<serde_json::Value>,
 }
 
 impl ApiError {
@@ -27,6 +32,7 @@ impl ApiError {
         Self {
             status: StatusCode::BAD_REQUEST,
             detail: detail.into(),
+            context: None,
             code: None,
         }
     }
@@ -35,6 +41,7 @@ impl ApiError {
         Self {
             status: StatusCode::UNAUTHORIZED,
             detail: detail.into(),
+            context: None,
             code: None,
         }
     }
@@ -43,6 +50,7 @@ impl ApiError {
         Self {
             status: StatusCode::FORBIDDEN,
             detail: detail.into(),
+            context: None,
             code: None,
         }
     }
@@ -51,6 +59,7 @@ impl ApiError {
         Self {
             status: StatusCode::PAYLOAD_TOO_LARGE,
             detail: detail.into(),
+            context: None,
             code: None,
         }
     }
@@ -59,6 +68,7 @@ impl ApiError {
         Self {
             status: StatusCode::CONFLICT,
             detail: detail.into(),
+            context: None,
             code: None,
         }
     }
@@ -67,6 +77,7 @@ impl ApiError {
         Self {
             status: StatusCode::SERVICE_UNAVAILABLE,
             detail: detail.into(),
+            context: None,
             code: Some("catalog_preflight_unavailable"),
         }
     }
@@ -74,13 +85,38 @@ impl ApiError {
     /// The typed "Installed — external library unavailable" submission-preflight rejection
     /// (sc-19708). 503 because the installation is intact and the request is well-formed: the
     /// operator reconnects the library and retries.
-    pub(crate) fn external_model_library_unavailable(detail: impl Into<String>) -> Self {
+    ///
+    /// The `context` payload (sc-19709) is what makes the rejection actionable: the desktop prompt
+    /// names the model and the expected library location from those fields, so no client ever
+    /// parses `detail` and no raw filesystem error reaches a user.
+    pub(crate) fn external_model_library_unavailable(
+        detail: impl Into<String>,
+        context: &ExternalLibraryUnavailableContext,
+    ) -> Self {
         Self {
             status: StatusCode::SERVICE_UNAVAILABLE,
             detail: detail.into(),
+            context: serde_json::to_value(context).ok(),
             code: Some(
                 sceneworks_core::model_artifacts::external_library::EXTERNAL_LIBRARY_UNAVAILABLE_CODE,
             ),
+        }
+    }
+
+    /// A typed rejection whose client must act on named fields (the model-library relocation
+    /// rejections, sc-19709). Status is the caller's: relocation rejections are 409 because the
+    /// request is well-formed but the named library cannot be adopted.
+    pub(crate) fn typed(
+        status: StatusCode,
+        detail: impl Into<String>,
+        code: &'static str,
+        context: serde_json::Value,
+    ) -> Self {
+        Self {
+            status,
+            detail: detail.into(),
+            context: Some(context),
+            code: Some(code),
         }
     }
 
@@ -88,6 +124,7 @@ impl ApiError {
         Self {
             status: StatusCode::CONFLICT,
             detail: detail.into(),
+            context: None,
             code: Some(code),
         }
     }
@@ -96,6 +133,7 @@ impl ApiError {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             detail: detail.into(),
+            context: None,
             code: None,
         }
     }
@@ -104,6 +142,7 @@ impl ApiError {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
             detail: detail.into(),
+            context: None,
             code: Some("database_locked"),
         }
     }
@@ -118,11 +157,13 @@ impl From<JobsStoreError> for ApiError {
             JobsStoreError::NotFound(_) => Self {
                 status: StatusCode::NOT_FOUND,
                 detail: "Record not found".to_owned(),
+                context: None,
                 code: None,
             },
             JobsStoreError::InvalidStatus(status) => Self {
                 status: StatusCode::BAD_REQUEST,
                 detail: format!("Unsupported job status: {status}"),
+                context: None,
                 code: None,
             },
             JobsStoreError::InvalidNumber(field) => {
@@ -132,6 +173,7 @@ impl From<JobsStoreError> for ApiError {
             JobsStoreError::RetryLimit { max_attempts } => Self {
                 status: StatusCode::BAD_REQUEST,
                 detail: format!("Job retry limit reached after {max_attempts} attempts."),
+                context: None,
                 code: None,
             },
             // 409 tells the worker its report lost a race with cancel/sweep/
@@ -141,6 +183,7 @@ impl From<JobsStoreError> for ApiError {
                 detail: format!(
                     "Job {job_id} is already {status}; terminal jobs cannot be updated."
                 ),
+                context: None,
                 code: None,
             },
             JobsStoreError::NotJobOwner { job_id } => Self {
@@ -148,6 +191,7 @@ impl From<JobsStoreError> for ApiError {
                 detail: format!(
                     "Progress rejected: the reporting worker no longer owns job {job_id}."
                 ),
+                context: None,
                 code: None,
             },
             other => Self::internal(other.to_string()),
@@ -162,6 +206,7 @@ impl From<ProjectStoreError> for ApiError {
             ProjectStoreError::NotFound(detail) => Self {
                 status: StatusCode::NOT_FOUND,
                 detail,
+                context: None,
                 code: None,
             },
             // A non-writable workspace folder is an environment problem, not a bad
@@ -171,6 +216,7 @@ impl From<ProjectStoreError> for ApiError {
             ProjectStoreError::StorageNotWritable(detail) => Self {
                 status: StatusCode::INSUFFICIENT_STORAGE,
                 detail,
+                context: None,
                 code: None,
             },
             other => Self::internal(other.to_string()),
@@ -184,36 +230,43 @@ impl From<CatalogError> for ApiError {
             CatalogError::InvalidCatalog(_) => Self {
                 status: StatusCode::BAD_REQUEST,
                 detail: "Invalid catalog request".to_owned(),
+                context: None,
                 code: Some("catalog_invalid"),
             },
             CatalogError::NotFound(_) => Self {
                 status: StatusCode::NOT_FOUND,
                 detail: "Attached catalog not found".to_owned(),
+                context: None,
                 code: Some("catalog_not_found"),
             },
             CatalogError::AlreadyExists(_) => Self {
                 status: StatusCode::CONFLICT,
                 detail: "Catalog location is not empty or is already in use".to_owned(),
+                context: None,
                 code: Some("catalog_already_exists"),
             },
             CatalogError::Conflict(_) => Self {
                 status: StatusCode::CONFLICT,
                 detail: "Catalog processing state changed or is active".to_owned(),
+                context: None,
                 code: Some("catalog_processing_conflict"),
             },
             CatalogError::Incompatible { .. } => Self {
                 status: StatusCode::CONFLICT,
                 detail: "Catalog format is newer than this SceneWorks version supports".to_owned(),
+                context: None,
                 code: Some("catalog_incompatible"),
             },
             CatalogError::Corrupt { .. } => Self {
                 status: StatusCode::UNPROCESSABLE_ENTITY,
                 detail: "Catalog files are invalid or corrupt".to_owned(),
+                context: None,
                 code: Some("catalog_corrupt"),
             },
             CatalogError::Io(_) | CatalogError::Sqlite(_) | CatalogError::Json(_) => Self {
                 status: StatusCode::INTERNAL_SERVER_ERROR,
                 detail: "Catalog operation failed".to_owned(),
+                context: None,
                 code: Some("catalog_operation_failed"),
             },
         }
@@ -239,10 +292,13 @@ impl IntoResponse for ApiError {
                 detail = %self.detail,
             );
         }
-        let body = match self.code {
+        let mut body = match self.code {
             Some(code) => json!({ "detail": self.detail, "code": code }),
             None => json!({ "detail": self.detail }),
         };
+        if let (Some(object), Some(context)) = (body.as_object_mut(), self.context) {
+            object.insert("context".to_owned(), context);
+        }
         (self.status, Json(body)).into_response()
     }
 }

--- a/apps/rust-api/src/events.rs
+++ b/apps/rust-api/src/events.rs
@@ -67,6 +67,7 @@ pub(crate) async fn create_event_ticket(
             .map_err(|error| ApiError {
                 status: StatusCode::UNPROCESSABLE_ENTITY,
                 detail: format!("JSON decode error: {error}"),
+                context: None,
                 code: None,
             })?
             .unwrap_or_default()
@@ -106,6 +107,7 @@ pub(crate) async fn create_event_ticket(
                 "Too many outstanding event tickets; retry after at most \
                  {EVENT_TICKET_TTL_SECONDS} seconds"
             ),
+            context: None,
             code: None,
         })
 }

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -191,6 +191,7 @@ use dto::{
 mod manifest;
 // The single model-source seam every job-creation path calls (sc-19708): generic carrier
 // attachment + typed external-library availability preflight, all data-driven.
+mod model_library;
 mod model_sources;
 use manifest::{
     acquire_manifest_file_lock, load_manifest_entries, manifest_write_lock, merge_entries_by_id,
@@ -1733,6 +1734,16 @@ fn create_app_with_state_mode(
         .route(
             UI_PREFERENCES_PATH,
             get(get_ui_preferences).put(set_ui_preferences),
+        )
+        // The model source library's live status + relocation seam (sc-19709). Its own path
+        // prefix, not `/models/...`, so a library operation can never collide with a model id.
+        .route(
+            "/api/v1/model-library",
+            get(model_library::get_model_library),
+        )
+        .route(
+            "/api/v1/model-library/relocate",
+            post(model_library::relocate_model_library),
         )
         .route("/api/v1/models", get(list_models))
         .route("/api/v1/models/:model_id", delete(delete_model))
@@ -4734,6 +4745,7 @@ fn find_timeline_item<'a>(timeline: &'a Value, item_id: &str) -> Result<&'a Valu
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "Timeline item not found".to_owned(),
+            context: None,
             code: None,
         })
 }

--- a/apps/rust-api/src/loras.rs
+++ b/apps/rust-api/src/loras.rs
@@ -37,6 +37,7 @@ pub(crate) async fn create_lora_download_job(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "LoRA not found".to_owned(),
+            context: None,
             code: None,
         })?;
     if lora.get("installState").and_then(Value::as_str) == Some("installed")
@@ -52,6 +53,7 @@ pub(crate) async fn create_lora_download_job(
         return Err(ApiError {
             status: StatusCode::BAD_REQUEST,
             detail: "LoRA is already installed".to_owned(),
+            context: None,
             code: Some("lora_already_installed"),
         });
     }
@@ -164,6 +166,7 @@ pub(crate) async fn delete_lora(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "LoRA not found".to_owned(),
+            context: None,
             code: None,
         })?;
     let scope = query
@@ -320,6 +323,7 @@ pub(crate) async fn update_lora(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "LoRA not found".to_owned(),
+            context: None,
             code: None,
         })?;
     let scope = query
@@ -387,6 +391,7 @@ pub(crate) async fn update_lora(
     updated.map(Json).ok_or_else(|| ApiError {
         status: StatusCode::NOT_FOUND,
         detail: "LoRA has no editable manifest entry in this scope".to_owned(),
+        context: None,
         code: None,
     })
 }
@@ -412,6 +417,7 @@ pub(crate) async fn lora_embedded_tags(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "LoRA not found".to_owned(),
+            context: None,
             code: None,
         })?;
     let Some(installed_path) = lora

--- a/apps/rust-api/src/model_library.rs
+++ b/apps/rust-api/src/model_library.rs
@@ -193,12 +193,12 @@ mod tests {
         seed_snapshot(&hub, "owner/model");
         let target = resolve_relocation_target(&home).unwrap();
         assert_eq!(target.library_root, hub);
-        assert_eq!(target.huggingface_home, home);
+        assert_eq!(target.hf_home, home);
 
         // Picking the hub directory itself resolves to the same pair.
         let target = resolve_relocation_target(&hub).unwrap();
         assert_eq!(target.library_root, hub);
-        assert_eq!(target.huggingface_home, home);
+        assert_eq!(target.hf_home, home);
     }
 
     /// Relocation must never orphan installed weights: a library that lacks a recorded closure is

--- a/apps/rust-api/src/model_library.rs
+++ b/apps/rust-api/src/model_library.rs
@@ -13,22 +13,30 @@
 //!
 //! Relocation re-binds the durable identity ledger; it never rewrites download receipts, never
 //! clears the validated-closure ledger, and never downloads. The persisted `HF_HOME` that survives
-//! a relaunch is desktop state, so the response returns the exact `huggingFaceHome` the shell must
-//! store — the API resolves the pair, the shell owns persistence, and neither guesses.
+//! a relaunch is desktop state, so the response returns the exact `hfHome` the shell must store —
+//! the API resolves the pair, the shell owns persistence, and neither guesses.
+//!
+//! Relocation is a LOCAL operation (loopback peers only). It names an absolute host path, rewrites
+//! durable local state, and its typed refusals would otherwise answer "does this path exist?" for
+//! any token-holding LAN client — who could also re-point a shared server's library.
 
 use crate::error::ApiError;
 use crate::AppState;
-use axum::extract::State;
+use axum::extract::{ConnectInfo, State};
 use axum::http::StatusCode;
 use axum::Json;
 use sceneworks_core::model_artifacts::external_library::{
     probe_model_source_library, resolve_relocation_target, ExternalLibraryBindingStore,
-    LibraryRelocationError, LibraryRelocationRejection, ModelSourceLibraryStatus, RelocationTarget,
+    ExternalLibraryError, LibraryRelocationError, LibraryRelocationRejection,
+    ModelSourceLibraryStatus, RelocationTarget,
 };
 use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 
 pub(crate) const RELOCATION_REJECTED_CODE: &str = "model_library_relocation_rejected";
+pub(crate) const RELOCATION_NOT_PERMITTED_CODE: &str = "model_library_relocation_not_permitted";
 
 fn configured_library(state: &AppState) -> PathBuf {
     sceneworks_core::hf_home::model_source_library(&state.settings.data_dir)
@@ -55,6 +63,14 @@ pub(crate) struct RelocateModelLibraryRequest {
     /// The folder the operator picked. Either a Hugging Face cache home (the folder containing
     /// `hub`) or the `hub` directory itself; the seam resolves which.
     pub path: String,
+    /// Validate the candidate and resolve the target WITHOUT writing anything.
+    ///
+    /// This exists so the client can order its two durable writes safely: the shell must persist
+    /// the new `HF_HOME` and the server must re-bind the identity ledger, and whichever runs second
+    /// can fail. A dry run moves every ordinary refusal (wrong folder, missing models) ahead of
+    /// BOTH writes, leaving only an exceptional race in the window where the two could disagree.
+    #[serde(default)]
+    pub dry_run: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -62,38 +78,100 @@ pub(crate) struct RelocateModelLibraryRequest {
 pub(crate) struct RelocateModelLibraryResponse {
     #[serde(flatten)]
     pub target: RelocationTarget,
-    pub status: ModelSourceLibraryStatus,
+    /// Whether the durable binding was actually re-pointed at `libraryRoot`. False for a dry run.
+    ///
+    /// Deliberately NOT a probe of the adopted root: that would report `available: true` while
+    /// `GET /api/v1/model-library` — which probes the CONFIGURED library, the one this process is
+    /// still using — reports false, because the new root only takes effect on the next launch.
+    pub adopted: bool,
 }
 
 /// `POST /api/v1/model-library/relocate` — adopt a new library root without redownloading.
+///
+/// Local-only (see [`require_local_peer`]): it takes an absolute host path, and its typed refusals
+/// would otherwise be a filesystem-existence oracle for any token-holding LAN client — which could
+/// also re-point a shared server's library out from under everyone else.
 pub(crate) async fn relocate_model_library(
     State(state): State<AppState>,
+    connect_info: Option<ConnectInfo<SocketAddr>>,
     Json(request): Json<RelocateModelLibraryRequest>,
 ) -> Result<Json<RelocateModelLibraryResponse>, ApiError> {
+    require_local_peer(connect_info.map(|ConnectInfo(addr)| addr))?;
     let picked = request.path.trim().to_owned();
     if picked.is_empty() {
         return Err(ApiError::bad_request("A library folder is required."));
     }
+    let dry_run = request.dry_run;
     let data_dir = state.settings.data_dir.clone();
     tokio::task::spawn_blocking(move || {
         let target = resolve_relocation_target(std::path::Path::new(&picked))
             .map_err(rejection_to_api_error)?;
         let store = ExternalLibraryBindingStore::new(&data_dir).map_err(|error| {
-            ApiError::internal(format!("model library ledger unavailable: {error}"))
+            relocation_failed("model library binding ledger is unavailable", &error)
         })?;
+        if dry_run {
+            store
+                .validate_relocation(&target.library_root)
+                .map_err(relocation_error_to_api_error)?;
+            return Ok(Json(RelocateModelLibraryResponse {
+                target,
+                adopted: false,
+            }));
+        }
         store
             .relocate_binding(&target.library_root)
-            .map_err(|error| match error {
-                LibraryRelocationError::Rejected(rejection) => rejection_to_api_error(rejection),
-                LibraryRelocationError::Failed(failure) => {
-                    ApiError::internal(format!("model library relocation failed: {failure}"))
-                }
-            })?;
-        let status = probe_model_source_library(&data_dir, &target.library_root);
-        Ok(Json(RelocateModelLibraryResponse { target, status }))
+            .map_err(relocation_error_to_api_error)?;
+        Ok(Json(RelocateModelLibraryResponse {
+            target,
+            adopted: true,
+        }))
     })
     .await
-    .map_err(|error| ApiError::internal(format!("model library relocation failed: {error}")))?
+    .map_err(|error| {
+        relocation_failed(
+            "model library relocation could not be completed",
+            &ExternalLibraryError(error.to_string()),
+        )
+    })?
+}
+
+/// Relocation names a host path and rewrites durable local state, so it is a local operation only.
+/// A missing peer fails closed: "we could not tell who is calling" is not permission.
+fn require_local_peer(peer: Option<SocketAddr>) -> Result<(), ApiError> {
+    if peer.is_some_and(|addr| addr.ip().is_loopback()) {
+        return Ok(());
+    }
+    Err(ApiError::typed(
+        StatusCode::FORBIDDEN,
+        "The model library can only be relocated from SceneWorks running on this machine. \
+         Reconnect the library on the host, or change its location there.",
+        RELOCATION_NOT_PERMITTED_CODE,
+        json!({ "reason": "not_a_local_client" }),
+    ))
+}
+
+fn relocation_error_to_api_error(error: LibraryRelocationError) -> ApiError {
+    match error {
+        LibraryRelocationError::Rejected(rejection) => rejection_to_api_error(rejection),
+        LibraryRelocationError::Failed(failure) => {
+            relocation_failed("model library relocation could not be completed", &failure)
+        }
+    }
+}
+
+/// An internal failure the operator cannot act on. The underlying error is LOGGED, never returned:
+/// a raw `io::Error` ("Permission denied (os error 13)") rendered into a dialog is exactly the raw
+/// filesystem text this whole seam exists to keep away from users.
+fn relocation_failed(summary: &'static str, error: &ExternalLibraryError) -> ApiError {
+    tracing::error!(
+        event = "model_library_relocation_failed",
+        detail = %error,
+        "{summary}"
+    );
+    ApiError::internal(
+        "SceneWorks could not update the model library location. The previous library is \
+         unchanged; check that the folder is readable and try again.",
+    )
 }
 
 /// Typed rejection → typed 409. The `detail` sentence is a human summary; the `reason` inside
@@ -115,6 +193,11 @@ fn rejection_to_api_error(rejection: LibraryRelocationRejection) -> ApiError {
              that contains them, or reconnect the original drive.",
             repositories.join(", ")
         ),
+        LibraryRelocationRejection::NoInstalledModels => {
+            "SceneWorks has no record of any installed models, so there is nothing to relocate. \
+             Reconnect the original library, or download the models you need."
+                .to_owned()
+        }
         LibraryRelocationRejection::HubDirectoryExpected => {
             "SceneWorks reads models from a `hub` folder inside the Hugging Face cache. Choose the \
              folder that contains `hub` (or the `hub` folder itself)."
@@ -161,6 +244,34 @@ mod tests {
             .join(REVISION);
         std::fs::create_dir_all(&snapshot).unwrap();
         std::fs::write(snapshot.join("model.safetensors"), b"weights").unwrap();
+    }
+
+    /// The one place a raw `io::Error` could still have reached a user: an internal failure whose
+    /// underlying cause is a filesystem error. It is logged, never returned — the dialog renders
+    /// `detail` verbatim, so "Permission denied (os error 13)" crossing this boundary would defeat
+    /// the entire typed seam.
+    #[test]
+    fn an_internal_failure_never_returns_raw_filesystem_text() {
+        let raw = ExternalLibraryError(
+            std::io::Error::from(std::io::ErrorKind::PermissionDenied).to_string(),
+        );
+        assert!(
+            raw.0.contains("denied"),
+            "the fixture must actually carry raw io text: {raw}"
+        );
+        let error = relocation_failed("model library relocation could not be completed", &raw);
+        assert_eq!(error.status, StatusCode::INTERNAL_SERVER_ERROR);
+        let detail = error.detail.to_lowercase();
+        for leak in ["os error", "permission denied", "no such file", "errno"] {
+            assert!(
+                !detail.contains(leak),
+                "raw filesystem text leaked: {detail}"
+            );
+        }
+        assert!(
+            detail.contains("previous library is unchanged"),
+            "a failure must still say what state the operator is in: {detail}"
+        );
     }
 
     /// An unrelated folder is rejected with the typed `not_a_model_library` reason and a 409 —

--- a/apps/rust-api/src/model_library.rs
+++ b/apps/rust-api/src/model_library.rs
@@ -1,0 +1,264 @@
+//! The model source library's live status and relocation seam (sc-19709).
+//!
+//! When a model is installed on an external library that is currently unavailable, the desktop
+//! prompt has exactly two recovery paths, and both need a server seam:
+//!
+//! * **Connect drive and retry** — `GET /api/v1/model-library` re-probes the configured library's
+//!   durable physical identity once. Write-free and cheap: a retry gates on the single `available`
+//!   boolean rather than rebuilding the model catalog or re-deriving availability in the client.
+//! * **Choose a different library location** — `POST /api/v1/model-library/relocate` adopts a new
+//!   root, but only after it physically carries every closure this install recorded. Rejections are
+//!   typed (`reason` discriminants), never raw filesystem errors, so the prompt can render
+//!   actionable guidance instead of an `ENOENT`.
+//!
+//! Relocation re-binds the durable identity ledger; it never rewrites download receipts, never
+//! clears the validated-closure ledger, and never downloads. The persisted `HF_HOME` that survives
+//! a relaunch is desktop state, so the response returns the exact `huggingFaceHome` the shell must
+//! store — the API resolves the pair, the shell owns persistence, and neither guesses.
+
+use crate::error::ApiError;
+use crate::AppState;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use sceneworks_core::model_artifacts::external_library::{
+    probe_model_source_library, resolve_relocation_target, ExternalLibraryBindingStore,
+    LibraryRelocationError, LibraryRelocationRejection, ModelSourceLibraryStatus, RelocationTarget,
+};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+pub(crate) const RELOCATION_REJECTED_CODE: &str = "model_library_relocation_rejected";
+
+fn configured_library(state: &AppState) -> PathBuf {
+    sceneworks_core::hf_home::model_source_library(&state.settings.data_dir)
+        .root()
+        .to_path_buf()
+}
+
+/// `GET /api/v1/model-library` — one write-free identity probe of the configured library.
+pub(crate) async fn get_model_library(
+    State(state): State<AppState>,
+) -> Result<Json<ModelSourceLibraryStatus>, ApiError> {
+    let data_dir = state.settings.data_dir.clone();
+    let configured = configured_library(&state);
+    let status =
+        tokio::task::spawn_blocking(move || probe_model_source_library(&data_dir, &configured))
+            .await
+            .map_err(|error| ApiError::internal(format!("model library probe failed: {error}")))?;
+    Ok(Json(status))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RelocateModelLibraryRequest {
+    /// The folder the operator picked. Either a Hugging Face cache home (the folder containing
+    /// `hub`) or the `hub` directory itself; the seam resolves which.
+    pub path: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RelocateModelLibraryResponse {
+    #[serde(flatten)]
+    pub target: RelocationTarget,
+    pub status: ModelSourceLibraryStatus,
+}
+
+/// `POST /api/v1/model-library/relocate` — adopt a new library root without redownloading.
+pub(crate) async fn relocate_model_library(
+    State(state): State<AppState>,
+    Json(request): Json<RelocateModelLibraryRequest>,
+) -> Result<Json<RelocateModelLibraryResponse>, ApiError> {
+    let picked = request.path.trim().to_owned();
+    if picked.is_empty() {
+        return Err(ApiError::bad_request("A library folder is required."));
+    }
+    let data_dir = state.settings.data_dir.clone();
+    tokio::task::spawn_blocking(move || {
+        let target = resolve_relocation_target(std::path::Path::new(&picked))
+            .map_err(rejection_to_api_error)?;
+        let store = ExternalLibraryBindingStore::new(&data_dir).map_err(|error| {
+            ApiError::internal(format!("model library ledger unavailable: {error}"))
+        })?;
+        store
+            .relocate_binding(&target.library_root)
+            .map_err(|error| match error {
+                LibraryRelocationError::Rejected(rejection) => rejection_to_api_error(rejection),
+                LibraryRelocationError::Failed(failure) => {
+                    ApiError::internal(format!("model library relocation failed: {failure}"))
+                }
+            })?;
+        let status = probe_model_source_library(&data_dir, &target.library_root);
+        Ok(Json(RelocateModelLibraryResponse { target, status }))
+    })
+    .await
+    .map_err(|error| ApiError::internal(format!("model library relocation failed: {error}")))?
+}
+
+/// Typed rejection → typed 409. The `detail` sentence is a human summary; the `reason` inside
+/// `context` is what the client branches on, so guidance never depends on message text.
+fn rejection_to_api_error(rejection: LibraryRelocationRejection) -> ApiError {
+    let detail = match &rejection {
+        LibraryRelocationRejection::NotADirectory => {
+            "That location could not be opened as a folder. Reconnect the drive, then choose the \
+             model library folder again."
+                .to_owned()
+        }
+        LibraryRelocationRejection::NotAModelLibrary => {
+            "That folder does not contain a SceneWorks model library. Choose the Hugging Face \
+             cache folder that holds your downloaded models."
+                .to_owned()
+        }
+        LibraryRelocationRejection::MissingInstalledModels { repositories } => format!(
+            "That library is missing models this installation already has: {}. Choose the library \
+             that contains them, or reconnect the original drive.",
+            repositories.join(", ")
+        ),
+        LibraryRelocationRejection::HubDirectoryExpected => {
+            "SceneWorks reads models from a `hub` folder inside the Hugging Face cache. Choose the \
+             folder that contains `hub` (or the `hub` folder itself)."
+                .to_owned()
+        }
+        LibraryRelocationRejection::IdentityUnavailable { .. } => {
+            "That volume's identity could not be read, so SceneWorks cannot bind it. Choose a \
+             library on a mounted local or external disk."
+                .to_owned()
+        }
+    };
+    let context = serde_json::to_value(&rejection).unwrap_or(serde_json::Value::Null);
+    ApiError::typed(
+        StatusCode::CONFLICT,
+        detail,
+        RELOCATION_REJECTED_CODE,
+        context,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sceneworks_core::model_artifacts::external_library::ExternalArtifactRequirement;
+    use std::path::Path;
+
+    const REVISION: &str = "0123456789abcdef0123456789abcdef01234567";
+
+    fn requirement(repository: &str) -> ExternalArtifactRequirement {
+        ExternalArtifactRequirement {
+            repository: repository.to_owned(),
+            revision: Some(REVISION.to_owned()),
+            variant: "default".to_owned(),
+            files: vec![PathBuf::from("model.safetensors")],
+            is_primary: true,
+        }
+    }
+
+    fn seed_snapshot(hub: &Path, repository: &str) {
+        let safe = sceneworks_core::hf_home::safe_repo_dir_name(repository).unwrap();
+        let snapshot = hub
+            .join(format!("models--{safe}"))
+            .join("snapshots")
+            .join(REVISION);
+        std::fs::create_dir_all(&snapshot).unwrap();
+        std::fs::write(snapshot.join("model.safetensors"), b"weights").unwrap();
+    }
+
+    /// An unrelated folder is rejected with the typed `not_a_model_library` reason and a 409 —
+    /// never a raw filesystem error, and never a silent adoption that would orphan the install.
+    #[test]
+    fn an_unrelated_folder_is_rejected_with_typed_guidance() {
+        let temp = tempfile::tempdir().unwrap();
+        let unrelated = temp.path().join("holiday-photos");
+        std::fs::create_dir_all(&unrelated).unwrap();
+        let error = rejection_to_api_error(resolve_relocation_target(&unrelated).unwrap_err());
+        assert_eq!(error.status, StatusCode::CONFLICT);
+        assert_eq!(error.code, Some(RELOCATION_REJECTED_CODE));
+        assert_eq!(
+            error
+                .context
+                .as_ref()
+                .and_then(|value| value["reason"].as_str()),
+            Some("not_a_model_library")
+        );
+    }
+
+    /// The happy path: the operator picks the Hugging Face cache home of a relocated library and
+    /// the seam resolves the hub root plus the `HF_HOME` the shell must persist.
+    #[test]
+    fn picking_a_cache_home_resolves_the_hub_root_and_the_home_to_persist() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("relocated");
+        let hub = home.join("hub");
+        std::fs::create_dir_all(&hub).unwrap();
+        seed_snapshot(&hub, "owner/model");
+        let target = resolve_relocation_target(&home).unwrap();
+        assert_eq!(target.library_root, hub);
+        assert_eq!(target.huggingface_home, home);
+
+        // Picking the hub directory itself resolves to the same pair.
+        let target = resolve_relocation_target(&hub).unwrap();
+        assert_eq!(target.library_root, hub);
+        assert_eq!(target.huggingface_home, home);
+    }
+
+    /// Relocation must never orphan installed weights: a library that lacks a recorded closure is
+    /// rejected, naming the repositories it is missing.
+    #[test]
+    fn relocation_rejects_a_library_missing_recorded_models_and_preserves_the_binding() {
+        let temp = tempfile::tempdir().unwrap();
+        let data = temp.path().join("data");
+        let original = temp.path().join("original").join("hub");
+        std::fs::create_dir_all(&original).unwrap();
+        seed_snapshot(&original, "owner/model");
+        let store = ExternalLibraryBindingStore::new(&data).unwrap();
+        let bound = store
+            .bind_or_probe_validated(&original, &[requirement("owner/model")])
+            .unwrap()
+            .0;
+
+        let empty = temp.path().join("elsewhere").join("hub");
+        std::fs::create_dir_all(&empty).unwrap();
+        seed_snapshot(&empty, "someone/else");
+        let error = store.relocate_binding(&empty).unwrap_err();
+        assert_eq!(
+            error,
+            LibraryRelocationError::Rejected(LibraryRelocationRejection::MissingInstalledModels {
+                repositories: vec!["owner/model".to_owned()],
+            })
+        );
+        assert_eq!(store.load().unwrap(), Some(bound));
+    }
+
+    /// The accepted path re-points the durable binding at the new root and leaves the
+    /// validated-closure ledger (the install evidence) byte-identical — no redownload, no lost
+    /// installed state.
+    #[test]
+    fn relocation_rebinds_without_touching_install_evidence() {
+        let temp = tempfile::tempdir().unwrap();
+        let data = temp.path().join("data");
+        let original = temp.path().join("original").join("hub");
+        std::fs::create_dir_all(&original).unwrap();
+        seed_snapshot(&original, "owner/model");
+        let store = ExternalLibraryBindingStore::new(&data).unwrap();
+        store
+            .bind_or_probe_validated(&original, &[requirement("owner/model")])
+            .unwrap();
+        let closures_path = data
+            .join("models")
+            .join(".sceneworks-external-library-closures.json");
+        let evidence_before = std::fs::read(&closures_path).unwrap();
+
+        let moved = temp.path().join("moved").join("hub");
+        std::fs::create_dir_all(moved.parent().unwrap()).unwrap();
+        std::fs::rename(&original, &moved).unwrap();
+        let binding = store.relocate_binding(&moved).unwrap();
+        assert_eq!(
+            binding.canonical_path,
+            std::fs::canonicalize(&moved).unwrap()
+        );
+        assert_eq!(std::fs::read(&closures_path).unwrap(), evidence_before);
+
+        let status = probe_model_source_library(&data, &moved);
+        assert!(status.available, "relocated library must probe available");
+    }
+}

--- a/apps/rust-api/src/model_sources.rs
+++ b/apps/rust-api/src/model_sources.rs
@@ -23,7 +23,8 @@ use sceneworks_core::model_artifacts::artifact_selection::{
     requested_runtime_variant, selected_requirements_for_model,
 };
 use sceneworks_core::model_artifacts::external_library::{
-    resolve_model_availability, ModelAvailability, ModelResolution,
+    resolve_model_availability, ExternalLibraryUnavailableContext, ModelAvailability,
+    ModelResolution,
 };
 use sceneworks_core::model_artifacts::ResolvedModelArtifact;
 use serde_json::{json, Value};
@@ -489,11 +490,20 @@ async fn preflight_payload_model_sources(
                     .get("id")
                     .and_then(Value::as_str)
                     .unwrap_or("<unknown>");
-                return Err(ApiError::external_model_library_unavailable(format!(
-                    "Model '{model_id}' is installed on an external model library that is \
-                     currently unavailable. Reconnect the configured library and retry; the \
-                     installation itself is preserved."
-                )));
+                let model_name = entry.get("name").and_then(Value::as_str).map(str::to_owned);
+                let context = ExternalLibraryUnavailableContext::from_resolution(
+                    model_id,
+                    model_name,
+                    &resolution,
+                );
+                return Err(ApiError::external_model_library_unavailable(
+                    format!(
+                        "Model '{model_id}' is installed on an external model library that is \
+                         currently unavailable. Reconnect the configured library and retry; the \
+                         installation itself is preserved."
+                    ),
+                    &context,
+                ));
             }
         }
         Ok(())

--- a/apps/rust-api/src/model_sources.rs
+++ b/apps/rust-api/src/model_sources.rs
@@ -436,6 +436,9 @@ fn refresh_live_external_availability_blocking(
                 Some(binding.clone()),
                 resolution.requirements.clone(),
             )
+            // Present-but-mismatched vs disconnected drives a different prompt (sc-19709), and the
+            // catalog READ path has to make the same distinction the resolver does.
+            .with_library_present(resolution.configured_library_path.is_dir())
         };
         if let Some(object) = model.as_object_mut() {
             object.insert(

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -481,6 +481,7 @@ pub(crate) async fn create_model_download_job(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "Model not found".to_owned(),
+            context: None,
             code: None,
         })?;
     // Tier selection (sc-8508): an explicit `variant` installs that quant tier's download entry; an
@@ -953,6 +954,7 @@ pub(crate) async fn create_model_convert_job(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "Model not found".to_owned(),
+            context: None,
             code: None,
         })?;
     let mlx = model
@@ -1075,6 +1077,7 @@ pub(crate) async fn delete_model(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "Model not found".to_owned(),
+            context: None,
             code: None,
         })?;
     let manifest_path = state
@@ -1183,6 +1186,7 @@ pub(crate) async fn delete_model_variant(
         .ok_or_else(|| ApiError {
             status: StatusCode::NOT_FOUND,
             detail: "Model not found".to_owned(),
+            context: None,
             code: None,
         })?;
     let data_dir = &state.settings.data_dir;

--- a/apps/rust-api/src/prompt_batches.rs
+++ b/apps/rust-api/src/prompt_batches.rs
@@ -325,6 +325,7 @@ fn prompt_batch_not_found() -> ApiError {
     ApiError {
         status: StatusCode::NOT_FOUND,
         detail: "Prompt batch not found".to_owned(),
+        context: None,
         code: None,
     }
 }

--- a/apps/rust-api/src/recipe_presets.rs
+++ b/apps/rust-api/src/recipe_presets.rs
@@ -574,6 +574,7 @@ pub(crate) fn recipe_preset_not_found() -> ApiError {
     ApiError {
         status: StatusCode::NOT_FOUND,
         detail: "Recipe preset not found".to_owned(),
+        context: None,
         code: None,
     }
 }

--- a/apps/rust-api/src/tests/mod.rs
+++ b/apps/rust-api/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod embedded_web;
 mod jobs;
 mod mcp;
 mod media;
+mod model_library;
 mod projects;
 mod prompt_batches;
 mod recipe_presets;

--- a/apps/rust-api/src/tests/model_library.rs
+++ b/apps/rust-api/src/tests/model_library.rs
@@ -11,6 +11,8 @@ use sceneworks_core::model_artifacts::external_library::{
 use std::path::{Path, PathBuf};
 
 const REVISION: &str = "0123456789abcdef0123456789abcdef01234567";
+/// Relocation is a local-only operation, so every accepted call presents a loopback peer.
+const LOCAL_PEER: &str = "127.0.0.1:54321";
 
 /// The hub root the API resolves when no HF-cache env var is set — the cross-platform way to give
 /// a test an isolated "external library" it can rename away to simulate an unplugged drive.
@@ -178,11 +180,12 @@ async fn relocating_to_an_unrelated_folder_is_refused_with_a_typed_reason() {
 
     let unrelated = temp_dir.path().join("holiday-photos");
     std::fs::create_dir_all(&unrelated).expect("unrelated dir creates");
-    let (status, body) = request(
+    let (status, body) = request_with_peer(
         app.clone(),
         "POST",
         "/api/v1/model-library/relocate",
         json!({ "path": unrelated.to_string_lossy() }),
+        LOCAL_PEER,
     )
     .await;
     assert_eq!(status, StatusCode::CONFLICT, "{body}");
@@ -196,8 +199,133 @@ async fn relocating_to_an_unrelated_folder_is_refused_with_a_typed_reason() {
     );
 }
 
+/// The fail-open this seam must not have: an installation whose evidence is RECEIPTS ONLY (no
+/// validated-closure ledger record — an install that predates the ledger, or was never validated on
+/// a bound library) must still be checked against the candidate. A decoy Hugging Face cache that
+/// merely has SOME `models--*` directory is refused, naming the model it does not contain, and the
+/// durable binding is untouched.
+#[tokio::test]
+async fn a_decoy_library_cannot_capture_a_receipt_backed_install() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let _env = isolate_hf_cache();
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    std::fs::create_dir_all(&data_dir).expect("data dir creates");
+    // Receipt evidence WITHOUT any binding or validated-closure record.
+    let hub = isolated_hub(&data_dir);
+    seed_snapshot(&hub, "owner/model");
+    write_receipt(&data_dir, "owner/model");
+    let app = create_app(settings).expect("app creates");
+
+    let decoy = temp_dir.path().join("decoy").join("hub");
+    std::fs::create_dir_all(&decoy).expect("decoy dir creates");
+    seed_snapshot(&decoy, "someone/unrelated");
+    let (status, body) = request_with_peer(
+        app.clone(),
+        "POST",
+        "/api/v1/model-library/relocate",
+        json!({ "path": decoy.to_string_lossy() }),
+        LOCAL_PEER,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert_eq!(body["context"]["reason"], "missing_installed_models");
+    assert_eq!(body["context"]["repositories"][0], "owner/model");
+    assert!(
+        ExternalLibraryBindingStore::new(&data_dir)
+            .expect("binding store")
+            .load()
+            .expect("binding reads")
+            .is_none(),
+        "a refused relocation must not have written a binding"
+    );
+}
+
+/// Relocation names a host path and rewrites durable local state, so it is refused for any caller
+/// that is not on this machine — including one holding a valid token.
+#[tokio::test]
+async fn relocation_is_refused_for_a_remote_caller() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let _env = isolate_hf_cache();
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    std::fs::create_dir_all(&data_dir).expect("data dir creates");
+    install_then_disconnect(&data_dir, "owner/model");
+    let app = create_app(settings).expect("app creates");
+
+    for peer in [Some("10.0.0.7:5555"), None] {
+        let path = temp_dir
+            .path()
+            .join("anything")
+            .to_string_lossy()
+            .into_owned();
+        let body = json!({ "path": path });
+        let (status, body) = match peer {
+            Some(peer) => {
+                request_with_peer(
+                    app.clone(),
+                    "POST",
+                    "/api/v1/model-library/relocate",
+                    body,
+                    peer,
+                )
+                .await
+            }
+            // No connect info at all: "we cannot tell who is calling" is not permission.
+            None => request(app.clone(), "POST", "/api/v1/model-library/relocate", body).await,
+        };
+        assert_eq!(status, StatusCode::FORBIDDEN, "peer {peer:?}: {body}");
+        assert_eq!(body["code"], "model_library_relocation_not_permitted");
+        assert_eq!(body["context"]["reason"], "not_a_local_client");
+    }
+}
+
+/// The dry run answers the same refusals with nothing written, which is what lets the client order
+/// its two durable writes (the shell's `HF_HOME`, the server's binding) safely.
+#[tokio::test]
+async fn a_dry_run_validates_without_adopting() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let _env = isolate_hf_cache();
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    std::fs::create_dir_all(&data_dir).expect("data dir creates");
+    let detached = install_then_disconnect(&data_dir, "owner/model");
+    let store = ExternalLibraryBindingStore::new(&data_dir).expect("binding store");
+    let before = store.load().expect("binding reads");
+    let relocated_home = temp_dir.path().join("relocated");
+    std::fs::create_dir_all(&relocated_home).expect("relocated home creates");
+    std::fs::rename(&detached, relocated_home.join("hub")).expect("library moves");
+    let app = create_app(settings).expect("app creates");
+
+    let (status, body) = request_with_peer(
+        app.clone(),
+        "POST",
+        "/api/v1/model-library/relocate",
+        json!({ "path": relocated_home.to_string_lossy(), "dryRun": true }),
+        LOCAL_PEER,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["adopted"], false);
+    assert_eq!(store.load().expect("binding reads"), before);
+
+    // A dry run refuses exactly what the real call would, still without writing.
+    let unrelated = temp_dir.path().join("holiday-photos");
+    std::fs::create_dir_all(&unrelated).expect("unrelated dir creates");
+    let (status, body) = request_with_peer(
+        app.clone(),
+        "POST",
+        "/api/v1/model-library/relocate",
+        json!({ "path": unrelated.to_string_lossy(), "dryRun": true }),
+        LOCAL_PEER,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert_eq!(store.load().expect("binding reads"), before);
+}
+
 /// The accepted relocation: the library moved, so the operator names its new home. The seam adopts
-/// it, reports the `HF_HOME` the shell must persist, and probes available — without redownloading.
+/// it and reports the `HF_HOME` the shell must persist — without redownloading.
 #[tokio::test]
 async fn relocating_to_the_moved_library_adopts_it_and_names_the_home_to_persist() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
@@ -211,15 +339,16 @@ async fn relocating_to_the_moved_library_adopts_it_and_names_the_home_to_persist
     std::fs::rename(&detached, relocated_home.join("hub")).expect("library moves");
     let app = create_app(settings).expect("app creates");
 
-    let (status, body) = request(
+    let (status, body) = request_with_peer(
         app.clone(),
         "POST",
         "/api/v1/model-library/relocate",
         json!({ "path": relocated_home.to_string_lossy() }),
+        LOCAL_PEER,
     )
     .await;
     assert_eq!(status, StatusCode::OK, "{body}");
-    assert_eq!(body["status"]["available"], true);
+    assert_eq!(body["adopted"], true);
     assert!(
         body["hfHome"]
             .as_str()

--- a/apps/rust-api/src/tests/model_library.rs
+++ b/apps/rust-api/src/tests/model_library.rs
@@ -1,0 +1,232 @@
+//! HTTP-level contract for the unavailable-external-library recovery flow (sc-19709).
+//!
+//! The desktop prompt is driven entirely by what crosses this boundary: a typed `code` plus a
+//! typed `context` object, a write-free re-probe endpoint, and typed relocation rejections. These
+//! tests pin that contract at the wire, because a client that has to read `detail` prose — or
+//! re-derive availability itself — is exactly the failure mode the seam exists to prevent.
+use super::support::*;
+use sceneworks_core::model_artifacts::external_library::{
+    ExternalArtifactRequirement, ExternalLibraryBindingStore, EXTERNAL_LIBRARY_UNAVAILABLE_CODE,
+};
+use std::path::{Path, PathBuf};
+
+const REVISION: &str = "0123456789abcdef0123456789abcdef01234567";
+
+/// The hub root the API resolves when no HF-cache env var is set — the cross-platform way to give
+/// a test an isolated "external library" it can rename away to simulate an unplugged drive.
+fn isolated_hub(data_dir: &Path) -> PathBuf {
+    data_dir.join("cache").join("huggingface").join("hub")
+}
+
+fn seed_snapshot(hub: &Path, repository: &str) {
+    let safe = sceneworks_core::hf_home::safe_repo_dir_name(repository).expect("safe repo name");
+    let snapshot = hub
+        .join(format!("models--{safe}"))
+        .join("snapshots")
+        .join(REVISION);
+    std::fs::create_dir_all(&snapshot).expect("snapshot dir creates");
+    std::fs::write(snapshot.join("model.safetensors"), b"weights").expect("weights write");
+}
+
+/// A durable download receipt: the install evidence that lets a disconnected library read
+/// `installed_external_unavailable` instead of `missing`.
+fn write_receipt(data_dir: &Path, repository: &str) {
+    let managed = data_dir
+        .join("models")
+        .join(sceneworks_core::model_artifacts::artifact_selection::safe_download_dir(repository));
+    std::fs::create_dir_all(&managed).expect("managed dir creates");
+    std::fs::write(
+        managed.join(".sceneworks-download-complete.json"),
+        serde_json::to_vec(&json!({
+            "receipts": [{
+                "repo": repository,
+                "modelId": "relocatable",
+                "variant": "default",
+                "resolvedFiles": ["model.safetensors"],
+                "snapshotRevision": REVISION,
+            }]
+        }))
+        .expect("receipt serializes"),
+    )
+    .expect("receipt writes");
+}
+
+fn requirement(repository: &str) -> ExternalArtifactRequirement {
+    ExternalArtifactRequirement {
+        repository: repository.to_owned(),
+        revision: Some(REVISION.to_owned()),
+        variant: "default".to_owned(),
+        files: vec![PathBuf::from("model.safetensors")],
+        is_primary: true,
+    }
+}
+
+/// Bind the library, then rename it away so the configured path no longer resolves — the CI-safe
+/// stand-in for unplugging the drive.
+fn install_then_disconnect(data_dir: &Path, repository: &str) -> PathBuf {
+    let hub = isolated_hub(data_dir);
+    seed_snapshot(&hub, repository);
+    write_receipt(data_dir, repository);
+    ExternalLibraryBindingStore::new(data_dir)
+        .expect("binding store")
+        .bind_or_probe_validated(&hub, &[requirement(repository)])
+        .expect("library binds while connected");
+    let detached = data_dir.join("detached-library");
+    std::fs::rename(&hub, &detached).expect("library detaches");
+    detached
+}
+
+/// The walking skeleton, end to end at the wire: a submission whose model lives on a disconnected
+/// library is rejected with the typed 503 AND a typed context object naming the model and the
+/// expected library — everything the prompt needs, none of it parsed out of prose. Reconnecting
+/// the library makes the identical submission succeed, with no download and no reinstall.
+#[tokio::test]
+async fn a_disconnected_library_rejects_with_typed_context_and_a_reconnect_resumes_the_same_job() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let _env = isolate_hf_cache();
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    single_model_manifest(
+        &settings.config_dir.join("manifests"),
+        "relocatable",
+        "owner/model",
+    );
+    std::fs::create_dir_all(&data_dir).expect("data dir creates");
+    let detached = install_then_disconnect(&data_dir, "owner/model");
+    let app = create_app(settings).expect("app creates");
+
+    let (_, project) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Library Project" }),
+    )
+    .await;
+    let project_id = project["id"].as_str().expect("project id").to_owned();
+    let submission = json!({
+        "projectId": project_id,
+        "prompt": "a lighthouse",
+        "model": "relocatable",
+        "count": 1,
+        "width": 512,
+        "height": 512,
+    });
+
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/image/jobs",
+        submission.clone(),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "a disconnected library must be a typed refusal, not a job: {body}"
+    );
+    assert_eq!(body["code"], EXTERNAL_LIBRARY_UNAVAILABLE_CODE);
+    let context = &body["context"];
+    assert_eq!(context["availability"], "installed_external_unavailable");
+    assert_eq!(context["modelId"], "relocatable");
+    assert_eq!(context["modelName"], "relocatable");
+    assert!(
+        context["configuredLibraryPath"]
+            .as_str()
+            .is_some_and(|path| !path.is_empty()),
+        "the prompt names the expected library location: {body}"
+    );
+    assert!(
+        context["expectedLibraryPath"].as_str().is_some(),
+        "a bound library must report where it is expected: {body}"
+    );
+
+    // The re-probe endpoint agrees, and is the single boolean a retry gates on.
+    let (status, probe) = request(app.clone(), "GET", "/api/v1/model-library", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(probe["available"], false);
+    assert_eq!(probe["probeStatus"], "unavailable");
+
+    // Reconnect the same physical library: the binding is restored by identity alone.
+    std::fs::rename(&detached, isolated_hub(&data_dir)).expect("library reconnects");
+    let (status, probe) = request(app.clone(), "GET", "/api/v1/model-library", Value::Null).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        probe["available"], true,
+        "reconnect must re-probe available"
+    );
+
+    let (status, body) = request(app.clone(), "POST", "/api/v1/image/jobs", submission).await;
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "the resumed submission must enqueue after reconnect: {body}"
+    );
+    assert_eq!(body["payload"]["model"], "relocatable");
+}
+
+/// Relocation at the wire: an unrelated folder is refused with a typed `reason` the prompt can
+/// branch on, and the durable binding is left untouched so nothing is lost by trying.
+#[tokio::test]
+async fn relocating_to_an_unrelated_folder_is_refused_with_a_typed_reason() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let _env = isolate_hf_cache();
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    std::fs::create_dir_all(&data_dir).expect("data dir creates");
+    install_then_disconnect(&data_dir, "owner/model");
+    let app = create_app(settings).expect("app creates");
+
+    let unrelated = temp_dir.path().join("holiday-photos");
+    std::fs::create_dir_all(&unrelated).expect("unrelated dir creates");
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/model-library/relocate",
+        json!({ "path": unrelated.to_string_lossy() }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert_eq!(body["code"], "model_library_relocation_rejected");
+    assert_eq!(body["context"]["reason"], "not_a_model_library");
+    assert!(
+        body["detail"]
+            .as_str()
+            .is_some_and(|detail| !detail.is_empty()),
+        "a refusal still carries human guidance: {body}"
+    );
+}
+
+/// The accepted relocation: the library moved, so the operator names its new home. The seam adopts
+/// it, reports the `HF_HOME` the shell must persist, and probes available — without redownloading.
+#[tokio::test]
+async fn relocating_to_the_moved_library_adopts_it_and_names_the_home_to_persist() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let _env = isolate_hf_cache();
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    std::fs::create_dir_all(&data_dir).expect("data dir creates");
+    let detached = install_then_disconnect(&data_dir, "owner/model");
+    let relocated_home = temp_dir.path().join("relocated");
+    std::fs::create_dir_all(&relocated_home).expect("relocated home creates");
+    std::fs::rename(&detached, relocated_home.join("hub")).expect("library moves");
+    let app = create_app(settings).expect("app creates");
+
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/model-library/relocate",
+        json!({ "path": relocated_home.to_string_lossy() }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["status"]["available"], true);
+    assert!(
+        body["hfHome"]
+            .as_str()
+            .is_some_and(|home| Path::new(home) == relocated_home),
+        "the shell is told exactly which HF_HOME to persist: {body}"
+    );
+    assert!(body["libraryRoot"]
+        .as_str()
+        .is_some_and(|root| Path::new(root) == relocated_home.join("hub")));
+}

--- a/apps/rust-api/src/workflows.rs
+++ b/apps/rust-api/src/workflows.rs
@@ -112,6 +112,7 @@ fn multipart_error(error: &axum::extract::multipart::MultipartError) -> ApiError
         ApiError {
             status: error.status(),
             detail: error.body_text(),
+            context: None,
             code: None,
         },
         INSPECT_CODE_BAD_MULTIPART,
@@ -148,6 +149,7 @@ pub(crate) async fn inspect_workflow(
     let mut multipart = multipart.map_err(|rejection| ApiError {
         status: rejection.status(),
         detail: rejection.body_text(),
+        context: None,
         code: Some(INSPECT_CODE_BAD_MULTIPART),
     })?;
     let mut file: Option<PathBuf> = None;
@@ -166,6 +168,7 @@ pub(crate) async fn inspect_workflow(
                         return Err(ApiError {
                             status: StatusCode::BAD_REQUEST,
                             detail: "Only one file field is allowed".to_owned(),
+                            context: None,
                             code: Some(INSPECT_CODE_BAD_MULTIPART),
                         });
                     }
@@ -197,6 +200,7 @@ pub(crate) async fn inspect_workflow(
     let temp_path = file.ok_or_else(|| ApiError {
         status: StatusCode::BAD_REQUEST,
         detail: "Upload file field is required".to_owned(),
+        context: None,
         code: Some(INSPECT_CODE_BAD_MULTIPART),
     })?;
     // The chunk read is bounded but synchronous (`workflow_png` walks chunk headers off the
@@ -208,6 +212,7 @@ pub(crate) async fn inspect_workflow(
     let read = read.map_err(|error| ApiError {
         status: StatusCode::INTERNAL_SERVER_ERROR,
         detail: format!("Workflow chunk read failed: {error}"),
+        context: None,
         code: Some(INSPECT_CODE_READ_FAILED),
     })?;
 
@@ -317,6 +322,7 @@ pub(crate) async fn get_asset_workflow(
             detail: "SceneWorks recorded a workflow on this image but can no longer read it back. \
                      The image itself is unaffected."
                 .to_owned(),
+            context: None,
             code: Some(ASSET_WORKFLOW_CODE_UNREADABLE),
         }
     })?;
@@ -350,6 +356,7 @@ pub(crate) async fn get_asset_workflow(
             detail: "SceneWorks recorded a workflow on this image but can no longer read it back. \
                      The image itself is unaffected."
                 .to_owned(),
+            context: None,
             code: Some(ASSET_WORKFLOW_CODE_UNREADABLE),
         });
     }
@@ -458,6 +465,7 @@ fn inspect_error(error: &WorkflowChunkError) -> ApiError {
         WorkflowChunkError::NotPng => ApiError {
             status: StatusCode::BAD_REQUEST,
             detail: error.to_string(),
+            context: None,
             code: Some(INSPECT_CODE_NOT_PNG),
         },
         // OUR staged temp could not be opened or read. The caller's bytes were written
@@ -468,6 +476,7 @@ fn inspect_error(error: &WorkflowChunkError) -> ApiError {
             detail: "SceneWorks could not read the uploaded image back off disk, so its workflow \
                      could not be checked. Nothing is known to be wrong with the file — try again."
                 .to_owned(),
+            context: None,
             code: Some(INSPECT_CODE_READ_FAILED),
         },
         // A PNG whose framing never got as far as our keyword. The upstream `detail` is `png`'s
@@ -477,6 +486,7 @@ fn inspect_error(error: &WorkflowChunkError) -> ApiError {
             detail: "This PNG could not be read far enough to look for a workflow, so it may be \
                      truncated or damaged."
                 .to_owned(),
+            context: None,
             code: Some(INSPECT_CODE_UNREADABLE),
         },
         // Same treatment, same reason: a corrupt zlib stream's message is not a sentence.
@@ -486,6 +496,7 @@ fn inspect_error(error: &WorkflowChunkError) -> ApiError {
                 "This PNG's workflow text could not be read as text within {limit} bytes, so the \
                  recipe it claims cannot be shown."
             ),
+            context: None,
             code: Some(INSPECT_CODE_UNREADABLE),
         },
         // `Encode` is unreachable on a read; given a sentence rather than left to a catch-all so a
@@ -493,6 +504,7 @@ fn inspect_error(error: &WorkflowChunkError) -> ApiError {
         WorkflowChunkError::Encode { .. } => ApiError {
             status: StatusCode::UNPROCESSABLE_ENTITY,
             detail: "This image's workflow could not be processed.".to_owned(),
+            context: None,
             code: Some(INSPECT_CODE_UNREADABLE),
         },
         // The remaining variants' own sentences are already written FOR a person and name a
@@ -504,6 +516,7 @@ fn inspect_error(error: &WorkflowChunkError) -> ApiError {
         | WorkflowChunkError::Envelope(_) => ApiError {
             status: StatusCode::UNPROCESSABLE_ENTITY,
             detail: error.to_string(),
+            context: None,
             code: Some(INSPECT_CODE_UNREADABLE),
         },
     }

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -69,11 +69,13 @@ import { buildWorkersById } from "./workers.js";
 import { createEditorScratchRegistry } from "./editorScratch.js";
 import { appConfirm, ConfirmHost } from "./appConfirm.jsx";
 import { ModelLibraryDialog } from "./components/ModelLibraryDialog.jsx";
+import { ModelLibraryRestartDialog } from "./components/ModelLibraryRestartDialog.jsx";
 import {
   createModelLibraryGate,
   fetchModelLibraryStatus,
   relocateModelLibrary,
   setModelLibraryHandler,
+  validateModelLibrary,
 } from "./modelLibrary.js";
 import { isDesktop as isDesktopShell, tauriInvoke } from "./runtime.js";
 // Simple UI (design handoff "Simple UI for creative studios") — an ALTERNATIVE shell that
@@ -718,13 +720,20 @@ export function App() {
     () =>
       createModelLibraryGate({
         probe: () => fetchModelLibraryStatus(token),
-        relocate: (path) => relocateModelLibrary(token, path),
-        // Durable persistence of a relocated library is desktop state: the API validated and
-        // re-bound the identity, and hands back the exact HF_HOME the shell must store. Same
-        // field, file and normalization as the first-run storage step.
-        persist: async (adopted) => {
-          if (!isDesktopShell || !adopted?.hfHome) return;
-          await tauriInvoke("set_model_library", { path: adopted.hfHome });
+        validate: (path) => validateModelLibrary(token, path),
+        adopt: (path) => relocateModelLibrary(token, path),
+        // Durable persistence of a relocated library is desktop state: the API hands back the exact
+        // HF_HOME the shell must store, in the same field, file and normalization as the first-run
+        // storage step. Returns an undo so the gate can restore the previous location if the
+        // server's re-bind then fails — the two copies must never disagree.
+        persist: async (target) => {
+          if (!isDesktopShell || !target?.hfHome) return null;
+          const before = await tauriInvoke("get_storage_setup").catch(() => null);
+          const previous = before?.hfHome ?? before?.hfHomeDefault ?? null;
+          await tauriInvoke("set_model_library", { path: target.hfHome });
+          return previous
+            ? () => tauriInvoke("set_model_library", { path: previous })
+            : null;
         },
       }),
     [token],
@@ -734,15 +743,30 @@ export function App() {
     modelLibraryGate.getState,
   );
   useEffect(() => setModelLibraryHandler(modelLibraryGate.block), [modelLibraryGate]);
+  // The relocated library, held until the user answers the restart disclosure. The relocation is
+  // already durable at this point — this only decides WHEN the app picks it up.
+  const [modelLibraryRelocation, setModelLibraryRelocation] = useState(null);
+  // True while the NATIVE folder picker is up. The prompt's auto re-probe pauses on it: a drive
+  // that comes back while the user is choosing a folder must not resume the submission behind a
+  // modal OS dialog the user cannot see past.
+  const [modelLibraryPickerOpen, setModelLibraryPickerOpen] = useState(false);
   const chooseModelLibraryLocation = useCallback(async () => {
     if (!isDesktopShell) return;
-    const picked = await tauriInvoke("choose_folder").catch(() => null);
+    setModelLibraryPickerOpen(true);
+    let picked = null;
+    try {
+      picked = await tauriInvoke("choose_folder").catch(() => null);
+    } finally {
+      setModelLibraryPickerOpen(false);
+    }
     if (!picked) return;
     const adopted = await modelLibraryGate.relocate(picked);
     if (adopted?.hfHome) {
+      setModelLibraryRelocation(adopted);
+      // The notice outlives the dialog, so "Later" still leaves the reason visible.
       pushNotice(
         "general",
-        `Model library set to ${adopted.hfHome} — restart SceneWorks to apply it.`,
+        `Model library set to ${adopted.hfHome} — restart SceneWorks to apply it. The generation you started was not queued; submit it again after the restart.`,
       );
     }
   }, [modelLibraryGate, pushNotice]);
@@ -1407,6 +1431,16 @@ export function App() {
       { active: 0 },
     );
   }, [jobs, queueSummary]);
+  // Jobs actually executing on a worker. The restart disclosure (sc-19709) withholds "Restart now"
+  // while any of these are in flight: the teardown is graceful, but interrupting a render still
+  // throws away the work, so the user defers rather than discovers. Prefers the server's own count
+  // when the queue summary is loaded, since `jobs` is a recent window rather than the whole queue.
+  const runningJobCount = useMemo(
+    () =>
+      queueSummary?.counts?.running ??
+      jobs.filter((job) => job.status === "running").length,
+    [jobs, queueSummary],
+  );
   const filteredJobs = useMemo(() => {
     if (projectFilter === "all") {
       return jobs;
@@ -3139,6 +3173,36 @@ export function App() {
     />
   );
 
+  // The unavailable-model-library prompt and its post-relocation restart disclosure (sc-19709).
+  // Built once and rendered in BOTH shells for the same reason `workflowDropPanel` is: the handler
+  // that opens them is registered at App level and therefore fires in both, so a Simple-UI user
+  // whose library is disconnected would otherwise have their submission swallowed by a dialog that
+  // was never mounted — a silently dead Generate button. Both portal to <body>, so neither
+  // disturbs the shell it renders in.
+  const modelLibraryOverlays = (
+    <>
+      <ModelLibraryDialog
+        autoProbePaused={modelLibraryPickerOpen}
+        canRelocate={isDesktopShell}
+        onCancel={modelLibraryGate.cancel}
+        onRelocate={chooseModelLibraryLocation}
+        onRetry={modelLibraryGate.retry}
+        state={modelLibraryState}
+      />
+      <ModelLibraryRestartDialog
+        canRestart={isDesktopShell}
+        onLater={() => setModelLibraryRelocation(null)}
+        onRestart={() => {
+          void tauriInvoke("restart_app").catch((error) =>
+            pushNotice("general", `SceneWorks could not restart: ${String(error)}`),
+          );
+        }}
+        relocation={modelLibraryRelocation}
+        runningJobCount={runningJobCount}
+      />
+    </>
+  );
+
   const jobAction = useCallback(
     async (job, action, options = {}) => {
       try {
@@ -3607,6 +3671,7 @@ export function App() {
               too — otherwise a Simple-UI user's drop would be inspected and then answered by
               nothing. It portals to <body>, so it does not disturb this shell's layout. */}
           {workflowDropPanel}
+          {modelLibraryOverlays}
         </AppLiveContext.Provider>
       </AppStaticContext.Provider>
     );
@@ -3919,16 +3984,10 @@ export function App() {
           silently no-ops in the Tauri WebView). Renders nothing until a confirm is asked. */}
       <ConfirmHost />
 
-      {/* The unavailable-model-library prompt (sc-19709). Mounted once at the app root so a
-          blocked submission from any studio — and a selection that is already blocked — raise the
-          same single dialog. Renders nothing while the gate is idle, which is every normal run. */}
-      <ModelLibraryDialog
-        canRelocate={isDesktopShell}
-        onCancel={modelLibraryGate.cancel}
-        onRelocate={chooseModelLibraryLocation}
-        onRetry={modelLibraryGate.retry}
-        state={modelLibraryState}
-      />
+      {/* The unavailable-model-library prompt and its post-relocation restart disclosure
+          (sc-19709), built above and rendered in BOTH shells. Renders nothing while the gate is
+          idle, which is every normal run. */}
+      {modelLibraryOverlays}
 
       {/* "Workflow found" (sc-15951) — opened by a drop no in-app dropzone claimed, and only
           after the file turned out to carry a recipe. Renders nothing otherwise, which is the

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -726,14 +726,32 @@ export function App() {
         // HF_HOME the shell must store, in the same field, file and normalization as the first-run
         // storage step. Returns an undo so the gate can restore the previous location if the
         // server's re-bind then fails — the two copies must never disagree.
+        //
+        // Fails CLOSED when the previous location cannot be read, BEFORE the first durable write:
+        // without a previous location there is no undo, so a re-bind failure afterwards would leave
+        // the shell pointed at the new library while the gate reported the previous location still
+        // in use — the disagreement this undo path exists to prevent, with the wrong message on top.
         persist: async (target) => {
-          if (!isDesktopShell || !target?.hfHome) return null;
-          const before = await tauriInvoke("get_storage_setup").catch(() => null);
+          // Nothing to persist — the browser shell keeps no copy of the location. A NO-OP undo, not
+          // `null`: the gate treats a missing undo as "changed and unrestorable", and here nothing
+          // changed, so the previous location genuinely is still in use.
+          if (!isDesktopShell || !target?.hfHome) return () => {};
+          let before = null;
+          try {
+            before = await tauriInvoke("get_storage_setup");
+          } catch (error) {
+            throw new Error(
+              `The current model library location could not be read, so nothing was changed. ${String(error)}`.trim(),
+            );
+          }
           const previous = before?.hfHome ?? before?.hfHomeDefault ?? null;
+          if (!previous) {
+            throw new Error(
+              "The current model library location could not be read, so nothing was changed.",
+            );
+          }
           await tauriInvoke("set_model_library", { path: target.hfHome });
-          return previous
-            ? () => tauriInvoke("set_model_library", { path: previous })
-            : null;
+          return () => tauriInvoke("set_model_library", { path: previous });
         },
       }),
     [token],
@@ -3192,11 +3210,15 @@ export function App() {
       <ModelLibraryRestartDialog
         canRestart={isDesktopShell}
         onLater={() => setModelLibraryRelocation(null)}
-        onRestart={() => {
-          void tauriInvoke("restart_app").catch((error) =>
-            pushNotice("general", `SceneWorks could not restart: ${String(error)}`),
-          );
-        }}
+        // The rejection is RE-THROWN after the notice: the dialog needs it to leave its restarting
+        // state, or a restart that never launched would leave the disclosure permanently stuck on
+        // "Restarting SceneWorks…" with both buttons disabled, for this and every later relocation.
+        onRestart={() =>
+          tauriInvoke("restart_app").catch((error) => {
+            pushNotice("general", `SceneWorks could not restart: ${String(error)}`);
+            throw error;
+          })
+        }
         relocation={modelLibraryRelocation}
         runningJobCount={runningJobCount}
       />

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,4 +1,12 @@
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { apiFetch, isAbortError } from "./api.js";
 import {
   beginAssetRequest,
@@ -60,6 +68,13 @@ import {
 import { buildWorkersById } from "./workers.js";
 import { createEditorScratchRegistry } from "./editorScratch.js";
 import { appConfirm, ConfirmHost } from "./appConfirm.jsx";
+import { ModelLibraryDialog } from "./components/ModelLibraryDialog.jsx";
+import {
+  createModelLibraryGate,
+  fetchModelLibraryStatus,
+  relocateModelLibrary,
+  setModelLibraryHandler,
+} from "./modelLibrary.js";
 import { isDesktop as isDesktopShell, tauriInvoke } from "./runtime.js";
 // Simple UI (design handoff "Simple UI for creative studios") — an ALTERNATIVE shell that
 // renders instead of this workspace when the sidebar switch is on Simple. The workspace
@@ -695,6 +710,42 @@ export function App() {
     saveToken,
     lockRemote,
   } = useAccessGate({ setError, pushNotice, dismissNoticeKind });
+  // The unavailable-model-library prompt (sc-19709). One gate for the whole app: it holds at most
+  // one blocked action and resumes it at most once, so a reconnect (or an impatient second click)
+  // can never turn one blocked generation into two jobs. Registered as the module-level handler so
+  // every submission path — and the studios' selection check — reaches it without prop threading.
+  const modelLibraryGate = useMemo(
+    () =>
+      createModelLibraryGate({
+        probe: () => fetchModelLibraryStatus(token),
+        relocate: (path) => relocateModelLibrary(token, path),
+        // Durable persistence of a relocated library is desktop state: the API validated and
+        // re-bound the identity, and hands back the exact HF_HOME the shell must store. Same
+        // field, file and normalization as the first-run storage step.
+        persist: async (adopted) => {
+          if (!isDesktopShell || !adopted?.hfHome) return;
+          await tauriInvoke("set_model_library", { path: adopted.hfHome });
+        },
+      }),
+    [token],
+  );
+  const modelLibraryState = useSyncExternalStore(
+    modelLibraryGate.subscribe,
+    modelLibraryGate.getState,
+  );
+  useEffect(() => setModelLibraryHandler(modelLibraryGate.block), [modelLibraryGate]);
+  const chooseModelLibraryLocation = useCallback(async () => {
+    if (!isDesktopShell) return;
+    const picked = await tauriInvoke("choose_folder").catch(() => null);
+    if (!picked) return;
+    const adopted = await modelLibraryGate.relocate(picked);
+    if (adopted?.hfHome) {
+      pushNotice(
+        "general",
+        `Model library set to ${adopted.hfHome} — restart SceneWorks to apply it.`,
+      );
+    }
+  }, [modelLibraryGate, pushNotice]);
   // The drop guard that stops a stray file from navigating the webview (issue #1308) is
   // installed further down, next to `useWorkflowDrop` — it now hands the unclaimed file to
   // the workflow inspector (sc-15951), which needs the active project and `importAsset`.
@@ -3867,6 +3918,17 @@ export function App() {
           navTo — resolve through a real React dialog instead of window.confirm (which
           silently no-ops in the Tauri WebView). Renders nothing until a confirm is asked. */}
       <ConfirmHost />
+
+      {/* The unavailable-model-library prompt (sc-19709). Mounted once at the app root so a
+          blocked submission from any studio — and a selection that is already blocked — raise the
+          same single dialog. Renders nothing while the gate is idle, which is every normal run. */}
+      <ModelLibraryDialog
+        canRelocate={isDesktopShell}
+        onCancel={modelLibraryGate.cancel}
+        onRelocate={chooseModelLibraryLocation}
+        onRetry={modelLibraryGate.retry}
+        state={modelLibraryState}
+      />
 
       {/* "Workflow found" (sc-15951) — opened by a drop no in-app dropzone claimed, and only
           after the file turned out to carry a recipe. Renders nothing otherwise, which is the

--- a/apps/web/src/App.modelLibrary.test.jsx
+++ b/apps/web/src/App.modelLibrary.test.jsx
@@ -1,0 +1,207 @@
+// sc-19709: the unavailable-model-library recovery, driven through the REAL app shell.
+//
+// The stale-UI case the story names: the catalog said the library was there, the drive went away
+// before the user pressed Generate, and the submission comes back with the typed 503. The app must
+// answer with an actionable prompt naming the model and the expected location — not a raw error —
+// and a reconnect must resume that submission EXACTLY ONCE, no matter how many retry events land.
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "./main.jsx";
+import {
+  changeField,
+  field,
+  FakeEventSource,
+  response,
+  settle,
+} from "./main.testSupport.jsx";
+
+const MODEL = {
+  id: "z_image_turbo",
+  name: "Z-Image Turbo",
+  type: "image",
+  family: "z-image",
+  installState: "installed",
+  downloadable: true,
+  // The catalog was read while the drive was still attached.
+  modelAvailability: "external_ready",
+};
+
+const UNAVAILABLE_BODY = {
+  detail:
+    "Model 'z_image_turbo' is installed on an external model library that is currently unavailable.",
+  code: "external_model_library_unavailable",
+  context: {
+    schemaVersion: 1,
+    availability: "installed_external_unavailable",
+    modelId: "z_image_turbo",
+    modelName: "Z-Image Turbo",
+    configuredLibraryPath: "/Volumes/SceneWorks Models/hf/hub",
+    expectedLibraryPath: "/Volumes/SceneWorks Models/hf/hub",
+    expectedVolumeId: "macos-volume:abc",
+  },
+};
+
+function errorResponse(status, body) {
+  return {
+    ok: false,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+describe("App unavailable model library prompt (sc-19709)", () => {
+  let container;
+  let root;
+  let imageJobPosts;
+  let libraryAvailable;
+  let probeCalls;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+    imageJobPosts = [];
+    probeCalls = 0;
+    libraryAvailable = false;
+    global.fetch = vi.fn((url, options = {}) => {
+      const path = new URL(url).pathname;
+      const method = options.method ?? "GET";
+      if (path.endsWith("/health")) {
+        return Promise.resolve(response({ status: "ok", authRequired: false }));
+      }
+      if (path.endsWith("/access")) return Promise.resolve(response({ authRequired: false }));
+      if (path.endsWith("/jobs/events/ticket")) {
+        return Promise.resolve(response({ ticket: "stream-ticket" }));
+      }
+      if (path.endsWith("/projects")) {
+        return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+      }
+      if (path.endsWith("/ui-preferences")) {
+        // The workflow-embed disclosure gates the very first generation; mark it answered so the
+        // submission actually reaches the API and this test stays about the model library.
+        return Promise.resolve(
+          response({ embedWorkflowInImages: true, workflowEmbedNoticeSeen: true }),
+        );
+      }
+      if (path.endsWith("/models")) return Promise.resolve(response([MODEL]));
+      if (path.endsWith("/model-library")) {
+        probeCalls += 1;
+        return Promise.resolve(
+          response({
+            schemaVersion: 1,
+            configuredLibraryPath: "/Volumes/SceneWorks Models/hf/hub",
+            expectedLibrary: null,
+            probeStatus: libraryAvailable ? "available" : "unavailable",
+            available: libraryAvailable,
+          }),
+        );
+      }
+      if (path.endsWith("/image/jobs") && method === "POST") {
+        imageJobPosts.push(JSON.parse(options.body));
+        if (!libraryAvailable) {
+          return Promise.resolve(errorResponse(503, UNAVAILABLE_BODY));
+        }
+        return Promise.resolve(
+          response({
+            id: `image-job-${imageJobPosts.length}`,
+            status: "queued",
+            createdAt: "2026-08-17T12:00:00Z",
+          }),
+        );
+      }
+      return Promise.resolve(response([]));
+    });
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  function dialog() {
+    return document.body.querySelector(".model-library-modal");
+  }
+
+  function button(label) {
+    return [...(dialog()?.querySelectorAll("button") ?? [])].find(
+      (item) => item.textContent === label,
+    );
+  }
+
+  async function generate() {
+    root = createRoot(container);
+    await act(async () => root.render(<App />));
+    await settle();
+
+    const imageNav = [...document.body.querySelectorAll(".nav-label")].find(
+      (item) => item.textContent === "Image",
+    );
+    expect(imageNav).toBeTruthy();
+    await act(async () => imageNav.closest("button").click());
+    await settle();
+
+    const form = document.body.querySelector(".image-studio form");
+    expect(form).toBeTruthy();
+    const prompt = field(form, "Prompt") ?? form.querySelector("textarea");
+    expect(prompt).toBeTruthy();
+    await changeField(prompt, "a lighthouse at dusk");
+    await act(async () => form.requestSubmit());
+    await settle();
+  }
+
+  it("prompts with the typed context, then resumes the blocked submission exactly once", async () => {
+    await generate();
+
+    expect(imageJobPosts).toHaveLength(1);
+    expect(dialog()).toBeTruthy();
+    expect(dialog().textContent).toContain("Z-Image Turbo");
+    expect(dialog().textContent).toContain("/Volumes/SceneWorks Models/hf/hub");
+    // The raw refusal sentence must not have leaked into the notice band.
+    expect(document.body.textContent).not.toContain(UNAVAILABLE_BODY.detail);
+
+    // Retrying while the drive is still missing must not submit anything.
+    await act(async () => button("Connect drive and retry").click());
+    await settle();
+    expect(imageJobPosts).toHaveLength(1);
+    expect(dialog()).toBeTruthy();
+    expect(probeCalls).toBeGreaterThan(0);
+
+    // The drive comes back. Two retry clicks land before the first probe settles.
+    libraryAvailable = true;
+    await act(async () => {
+      button("Connect drive and retry").click();
+      button("Connect drive and retry").click();
+    });
+    await settle();
+
+    expect(imageJobPosts).toHaveLength(2);
+    expect(imageJobPosts[1]).toEqual(imageJobPosts[0]);
+    expect(dialog()).toBeNull();
+  });
+
+  it("cancel closes the prompt and leaves nothing queued", async () => {
+    await generate();
+    expect(dialog()).toBeTruthy();
+
+    await act(async () => button("Cancel").click());
+    await settle();
+    expect(dialog()).toBeNull();
+
+    // Even once the library is back, the abandoned submission must never appear.
+    libraryAvailable = true;
+    await settle();
+    expect(imageJobPosts).toHaveLength(1);
+  });
+
+  it("offers server guidance instead of a folder picker outside the desktop shell", async () => {
+    await generate();
+    expect(button("Choose a different library location")).toBeUndefined();
+    expect(dialog().textContent).toContain("desktop setting");
+  });
+});

--- a/apps/web/src/App.modelLibrary.test.jsx
+++ b/apps/web/src/App.modelLibrary.test.jsx
@@ -57,6 +57,7 @@ describe("App unavailable model library prompt (sc-19709)", () => {
   let imageJobPosts;
   let libraryAvailable;
   let probeCalls;
+  let simpleUi;
 
   beforeEach(() => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
@@ -68,6 +69,7 @@ describe("App unavailable model library prompt (sc-19709)", () => {
     imageJobPosts = [];
     probeCalls = 0;
     libraryAvailable = false;
+    simpleUi = false;
     global.fetch = vi.fn((url, options = {}) => {
       const path = new URL(url).pathname;
       const method = options.method ?? "GET";
@@ -85,7 +87,11 @@ describe("App unavailable model library prompt (sc-19709)", () => {
         // The workflow-embed disclosure gates the very first generation; mark it answered so the
         // submission actually reaches the API and this test stays about the model library.
         return Promise.resolve(
-          response({ embedWorkflowInImages: true, workflowEmbedNoticeSeen: true }),
+          response({
+            embedWorkflowInImages: true,
+            workflowEmbedNoticeSeen: true,
+            simpleUi,
+          }),
         );
       }
       if (path.endsWith("/models")) return Promise.resolve(response([MODEL]));
@@ -197,6 +203,37 @@ describe("App unavailable model library prompt (sc-19709)", () => {
     libraryAvailable = true;
     await settle();
     expect(imageJobPosts).toHaveLength(1);
+  });
+
+  // The Simple shell is an ALTERNATIVE root that returns before the Advanced shell's overlays.
+  // The handler that opens this prompt is registered at App level and therefore fires in BOTH, so
+  // a prompt mounted only in the Advanced branch would leave a Simple-UI user with a Generate
+  // button that swallows its own failure and then never works again — strictly worse than the
+  // error banner it replaced.
+  it("raises the same prompt in the Simple shell", async () => {
+    simpleUi = true;
+    root = createRoot(container);
+    await act(async () => root.render(<App />));
+    await settle();
+    expect(document.body.querySelector(".su-root")).toBeTruthy();
+
+    const prompt = document.body.querySelector(".su-textarea");
+    expect(prompt).toBeTruthy();
+    await changeField(prompt, "a lighthouse at dusk");
+    const generate = [...document.body.querySelectorAll("button.su-generate")][0];
+    expect(generate).toBeTruthy();
+    await act(async () => generate.click());
+    await settle();
+
+    expect(imageJobPosts).toHaveLength(1);
+    expect(dialog()).toBeTruthy();
+    expect(dialog().textContent).toContain("Z-Image Turbo");
+
+    libraryAvailable = true;
+    await act(async () => button("Connect drive and retry").click());
+    await settle();
+    expect(imageJobPosts).toHaveLength(2);
+    expect(dialog()).toBeNull();
   });
 
   it("offers server guidance instead of a folder picker outside the desktop shell", async () => {

--- a/apps/web/src/App.modelLibraryRelocate.test.jsx
+++ b/apps/web/src/App.modelLibraryRelocate.test.jsx
@@ -1,0 +1,229 @@
+// sc-19709: the relocate branch, driven through the REAL desktop app shell.
+//
+// Relocating goes through the app's existing library-path configuration (`set_model_library`
+// writes the same `hf_home` the first-run storage step writes), which the sidecars receive as
+// spawn environment — so it applies on the next launch. That is disclosed, not hidden, and the
+// restart is offered: "Restart now" relaunches through the app's graceful teardown, "Later" leaves
+// the relocation durable with nothing queued.
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
+vi.mock("./runtime.js", () => ({ isDesktop: true, tauriInvoke: invoke }));
+
+import { App } from "./main.jsx";
+import {
+  changeField,
+  field,
+  FakeEventSource,
+  response,
+  settle,
+} from "./main.testSupport.jsx";
+
+const MODEL = {
+  id: "z_image_turbo",
+  name: "Z-Image Turbo",
+  type: "image",
+  family: "z-image",
+  installState: "installed",
+  modelAvailability: "external_ready",
+};
+
+const UNAVAILABLE_BODY = {
+  detail: "Model 'z_image_turbo' is installed on an external model library…",
+  code: "external_model_library_unavailable",
+  context: {
+    schemaVersion: 1,
+    availability: "installed_external_unavailable",
+    modelId: "z_image_turbo",
+    modelName: "Z-Image Turbo",
+    configuredLibraryPath: "/Volumes/Models/hf/hub",
+    expectedLibraryPath: "/Volumes/Models/hf/hub",
+    expectedVolumeId: "macos-volume:abc",
+  },
+};
+
+const RELOCATED = {
+  libraryRoot: "/Volumes/Models 1/hf/hub",
+  hfHome: "/Volumes/Models 1/hf",
+  status: { schemaVersion: 1, probeStatus: "available", available: true },
+};
+
+function errorResponse(status, body) {
+  return { ok: false, status, json: async () => body, text: async () => JSON.stringify(body) };
+}
+
+describe("App model library relocation + restart disclosure (sc-19709)", () => {
+  let container;
+  let root;
+  let imageJobPosts;
+  let relocateRequests;
+  let runningJobs;
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    FakeEventSource.instances = [];
+    window.EventSource = FakeEventSource;
+    window.localStorage.clear();
+    imageJobPosts = [];
+    relocateRequests = [];
+    runningJobs = [];
+    invoke.mockReset();
+    invoke.mockImplementation((command) => {
+      if (command === "get_storage_setup") return Promise.resolve({ setupCompleted: true });
+      if (command === "choose_folder") return Promise.resolve("/Volumes/Models 1/hf");
+      return Promise.resolve(null);
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url, options = {}) => {
+        const path = new URL(url).pathname;
+        const method = options.method ?? "GET";
+        if (path.endsWith("/health")) {
+          return Promise.resolve(response({ status: "ok", authRequired: false }));
+        }
+        if (path.endsWith("/access")) return Promise.resolve(response({ authRequired: false }));
+        if (path.endsWith("/jobs/events/ticket")) {
+          return Promise.resolve(response({ ticket: "stream-ticket" }));
+        }
+        if (path.endsWith("/projects")) {
+          return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
+        }
+        if (path.endsWith("/ui-preferences")) {
+          return Promise.resolve(
+            response({ embedWorkflowInImages: true, workflowEmbedNoticeSeen: true }),
+          );
+        }
+        if (path.endsWith("/models")) return Promise.resolve(response([MODEL]));
+        if (path.endsWith("/jobs") && method === "GET") {
+          return Promise.resolve(response(runningJobs));
+        }
+        if (path.endsWith("/model-library")) {
+          return Promise.resolve(
+            response({
+              schemaVersion: 1,
+              configuredLibraryPath: "/Volumes/Models/hf/hub",
+              expectedLibrary: null,
+              probeStatus: "unavailable",
+              available: false,
+            }),
+          );
+        }
+        if (path.endsWith("/model-library/relocate")) {
+          relocateRequests.push(JSON.parse(options.body));
+          return Promise.resolve(response(RELOCATED));
+        }
+        if (path.endsWith("/image/jobs") && method === "POST") {
+          imageJobPosts.push(JSON.parse(options.body));
+          return Promise.resolve(errorResponse(503, UNAVAILABLE_BODY));
+        }
+        return Promise.resolve(response([]));
+      }),
+    );
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  function dialogs() {
+    return [...document.body.querySelectorAll(".model-library-modal")];
+  }
+
+  function button(label) {
+    return dialogs()
+      .flatMap((dialog) => [...dialog.querySelectorAll("button")])
+      .find((item) => item.textContent === label);
+  }
+
+  async function relocate() {
+    root = createRoot(container);
+    await act(async () => root.render(<App />));
+    await settle();
+
+    const imageNav = [...document.body.querySelectorAll(".nav-label")].find(
+      (item) => item.textContent === "Image",
+    );
+    await act(async () => imageNav.closest("button").click());
+    await settle();
+
+    const form = document.body.querySelector(".image-studio form");
+    const prompt = field(form, "Prompt") ?? form.querySelector("textarea");
+    await changeField(prompt, "a lighthouse at dusk");
+    await act(async () => form.requestSubmit());
+    await settle();
+
+    expect(button("Choose a different library location")).toBeTruthy();
+    await act(async () => button("Choose a different library location").click());
+    await settle();
+  }
+
+  it("persists through the shell, then discloses the restart and performs it exactly once", async () => {
+    await relocate();
+
+    // Validated with nothing written FIRST, then adopted — so an ordinary refusal could never
+    // leave the shell's persisted location and the server's binding disagreeing.
+    expect(relocateRequests).toEqual([
+      { path: "/Volumes/Models 1/hf", dryRun: true },
+      { path: "/Volumes/Models 1/hf" },
+    ]);
+    // Persistence goes through the app's existing library-path configuration command.
+    expect(invoke).toHaveBeenCalledWith("set_model_library", {
+      path: "/Volumes/Models 1/hf",
+    });
+
+    // The blocked prompt is gone; the disclosure has taken its place.
+    expect(button("Connect drive and retry")).toBeUndefined();
+    const disclosure = dialogs()[0];
+    expect(disclosure.textContent).toContain("after it restarts");
+    expect(disclosure.textContent).toContain("/Volumes/Models 1/hf");
+
+    const restart = button("Restart now");
+    await act(async () => {
+      restart.click();
+      restart.click();
+    });
+    await settle();
+    const restarts = invoke.mock.calls.filter(([command]) => command === "restart_app");
+    expect(restarts).toHaveLength(1);
+  });
+
+  it("Later dismisses the disclosure and leaves no queued generation", async () => {
+    await relocate();
+    const posts = imageJobPosts.length;
+
+    await act(async () => button("Later").click());
+    await settle();
+
+    expect(dialogs()).toHaveLength(0);
+    expect(invoke.mock.calls.filter(([command]) => command === "restart_app")).toHaveLength(0);
+    // The relocation stays durable, and the abandoned submission never fires.
+    expect(imageJobPosts).toHaveLength(posts);
+    expect(document.body.textContent).toContain("restart SceneWorks to apply it");
+    // The notice outlives the dialog, so the abandoned generation is still accounted for.
+    expect(document.body.textContent).toContain("was not queued");
+  });
+
+  it("withholds Restart now while a job is running", async () => {
+    runningJobs = [
+      {
+        id: "job-running",
+        projectId: "project-default",
+        type: "image_generate",
+        status: "running",
+        createdAt: "2026-08-17T12:00:00Z",
+      },
+    ];
+    await relocate();
+
+    expect(button("Restart now").disabled).toBe(true);
+    await act(async () => button("Restart now").click());
+    expect(invoke.mock.calls.filter(([command]) => command === "restart_app")).toHaveLength(0);
+    expect(dialogs()[0].textContent).toContain("still running");
+  });
+});

--- a/apps/web/src/App.modelLibraryRelocate.test.jsx
+++ b/apps/web/src/App.modelLibraryRelocate.test.jsx
@@ -72,8 +72,16 @@ describe("App model library relocation + restart disclosure (sc-19709)", () => {
     relocateRequests = [];
     runningJobs = [];
     invoke.mockReset();
+    // The real command always answers with `hfHomeDefault` even before a library is configured,
+    // so the fixture has to as well: the persist step refuses outright without a previous location.
     invoke.mockImplementation((command) => {
-      if (command === "get_storage_setup") return Promise.resolve({ setupCompleted: true });
+      if (command === "get_storage_setup") {
+        return Promise.resolve({
+          setupCompleted: true,
+          hfHome: "/Volumes/Models/hf",
+          hfHomeDefault: "/Users/me/.cache/huggingface",
+        });
+      }
       if (command === "choose_folder") return Promise.resolve("/Volumes/Models 1/hf");
       return Promise.resolve(null);
     });
@@ -141,6 +149,25 @@ describe("App model library relocation + restart disclosure (sc-19709)", () => {
       .find((item) => item.textContent === label);
   }
 
+  function status() {
+    return dialogs()
+      .map((dialog) => dialog.querySelector('[role="status"]')?.textContent ?? "")
+      .join(" ");
+  }
+
+  // Submit a generation (refused by the seam), then answer the prompt by picking a new library.
+  async function submitAndChooseLocation(prompt = "a lighthouse at dusk") {
+    const form = document.body.querySelector(".image-studio form");
+    const promptField = field(form, "Prompt") ?? form.querySelector("textarea");
+    await changeField(promptField, prompt);
+    await act(async () => form.requestSubmit());
+    await settle();
+
+    expect(button("Choose a different library location")).toBeTruthy();
+    await act(async () => button("Choose a different library location").click());
+    await settle();
+  }
+
   async function relocate() {
     root = createRoot(container);
     await act(async () => root.render(<App />));
@@ -152,15 +179,7 @@ describe("App model library relocation + restart disclosure (sc-19709)", () => {
     await act(async () => imageNav.closest("button").click());
     await settle();
 
-    const form = document.body.querySelector(".image-studio form");
-    const prompt = field(form, "Prompt") ?? form.querySelector("textarea");
-    await changeField(prompt, "a lighthouse at dusk");
-    await act(async () => form.requestSubmit());
-    await settle();
-
-    expect(button("Choose a different library location")).toBeTruthy();
-    await act(async () => button("Choose a different library location").click());
-    await settle();
+    await submitAndChooseLocation();
   }
 
   it("persists through the shell, then discloses the restart and performs it exactly once", async () => {
@@ -207,6 +226,87 @@ describe("App model library relocation + restart disclosure (sc-19709)", () => {
     expect(document.body.textContent).toContain("restart SceneWorks to apply it");
     // The notice outlives the dialog, so the abandoned generation is still accounted for.
     expect(document.body.textContent).toContain("was not queued");
+  });
+
+  // Reading the previous location is what makes the relocation UNDOABLE. If that read fails there
+  // is no undo, so the shell must not be written at all — otherwise a later re-bind failure would
+  // leave the shell's copy changed while the prompt claimed the previous location was still in use.
+  it("refuses the relocation before any durable write when the previous location cannot be read", async () => {
+    invoke.mockImplementation((command) => {
+      if (command === "get_storage_setup") {
+        return Promise.reject(new Error("settings file is unreadable"));
+      }
+      if (command === "choose_folder") return Promise.resolve("/Volumes/Models 1/hf");
+      return Promise.resolve(null);
+    });
+    await relocate();
+
+    // The shell was never written, and the server was never re-bound: only the dry-run probe ran.
+    expect(invoke.mock.calls.filter(([command]) => command === "set_model_library")).toEqual([]);
+    expect(relocateRequests).toEqual([{ path: "/Volumes/Models 1/hf", dryRun: true }]);
+
+    // No restart disclosure — nothing was relocated.
+    expect(button("Restart now")).toBeUndefined();
+    // …and the message matches the state the user is actually in.
+    const prompt = dialogs()[0];
+    expect(prompt.textContent).toContain("previous location is still in use");
+    expect(prompt.textContent).not.toContain("could not restore the previous location");
+    expect(prompt.textContent).toContain("could not be read");
+    // The blocked generation is still there to resume, and was never queued behind the failure.
+    expect(button("Connect drive and retry")).toBeTruthy();
+    expect(imageJobPosts).toHaveLength(1);
+  });
+
+  // A restart that never launches must leave the disclosure usable. Before this, the once-only
+  // latch and the restarting state were never released, so the dialog stayed on "Restarting
+  // SceneWorks…" with both buttons dead — for this relocation AND every later one.
+  it("recovers when the restart fails, and a later relocation can restart again", async () => {
+    let restartAttempts = 0;
+    invoke.mockImplementation((command) => {
+      if (command === "get_storage_setup") {
+        return Promise.resolve({ setupCompleted: true, hfHomeDefault: "/Volumes/Models/hf" });
+      }
+      if (command === "choose_folder") return Promise.resolve("/Volumes/Models 1/hf");
+      if (command === "restart_app") {
+        restartAttempts += 1;
+        return restartAttempts <= 2
+          ? Promise.reject(new Error("relaunch refused"))
+          : Promise.resolve(null);
+      }
+      return Promise.resolve(null);
+    });
+    await relocate();
+
+    await act(async () => button("Restart now").click());
+    await settle();
+    expect(restartAttempts).toBe(1);
+    // The failure is surfaced, and the dialog is actionable again rather than stuck.
+    expect(document.body.textContent).toContain("SceneWorks could not restart");
+    expect(status()).not.toContain("Restarting SceneWorks");
+    expect(button("Restart now").disabled).toBe(false);
+    expect(button("Later").disabled).toBe(false);
+
+    // Retrying from the very same disclosure works.
+    await act(async () => button("Restart now").click());
+    await settle();
+    expect(restartAttempts).toBe(2);
+
+    // Deferring is still available after the failures, so the disclosure can be dismissed at all.
+    expect(button("Later").disabled).toBe(false);
+    await act(async () => button("Later").click());
+    await settle();
+    expect(dialogs()).toHaveLength(0);
+
+    // And a whole new relocation opens a LIVE dialog, not the dead restarting one.
+    await submitAndChooseLocation("a second lighthouse");
+    expect(button("Restart now")).toBeTruthy();
+    expect(button("Restart now").disabled).toBe(false);
+    expect(status()).not.toContain("Restarting SceneWorks");
+    await act(async () => button("Restart now").click());
+    await settle();
+    expect(restartAttempts).toBe(3);
+    // This one launched, so the dialog correctly stays in its restarting state.
+    expect(status()).toContain("Restarting SceneWorks");
   });
 
   it("withholds Restart now while a job is running", async () => {

--- a/apps/web/src/api.js
+++ b/apps/web/src/api.js
@@ -28,12 +28,16 @@ export function isAbortError(err) {
 // existing `setError(err.message)` call sites are untouched; the status just rides
 // along for the few places that want it.
 export class ApiError extends Error {
-  constructor(message, { status, detail, authRequired, code } = {}) {
+  constructor(message, { status, detail, authRequired, code, context } = {}) {
     super(message);
     this.name = "ApiError";
     this.status = status;
     this.detail = detail;
     this.code = code;
+    // Typed machine-readable payload for the codes whose client must ACT on the rejection
+    // rather than print it (`apps/rust-api/src/error.rs`, sc-19709). The unavailable-model-library
+    // prompt is driven entirely from these named fields — never by matching on `message`.
+    this.context = context ?? null;
     // The API tags its auth rejection (`apps/rust-api/src/auth.rs`); other 4xx bodies
     // don't carry the key, so this is a plain boolean rather than a tri-state.
     this.authRequired = authRequired === true;
@@ -112,6 +116,7 @@ export async function apiFetch(path, token, options = {}) {
       detail,
       authRequired: payload?.authRequired,
       code: payload?.code,
+      context: payload?.context,
     });
     // `token` matters: a 401 on a request that deliberately presented NO credential says
     // nothing about the session token, so it must not drag the gate up. The case that

--- a/apps/web/src/components/ModelLibraryDialog.jsx
+++ b/apps/web/src/components/ModelLibraryDialog.jsx
@@ -19,6 +19,7 @@ export function ModelLibraryDialog({
   onCancel,
   canRelocate,
   autoProbeMs = 5000,
+  autoProbePaused = false,
 }) {
   const blocked = state?.status === "blocked";
   const busy = state?.status === "retrying" || state?.status === "relocating";
@@ -27,11 +28,15 @@ export function ModelLibraryDialog({
   // While the prompt is open, keep re-probing: plugging the drive back in should resolve the
   // prompt without demanding a click. Every tick funnels through the same guarded retry the button
   // uses, so a tick that lands during an in-flight attempt is a no-op rather than a second submit.
+  //
+  // Paused while the NATIVE folder picker is up: that dialog is modal and opaque to this window, so
+  // a drive returning mid-selection would otherwise resume the submission behind something the user
+  // cannot see past — a job appearing out of an interaction they had not finished.
   useEffect(() => {
-    if (!blocked || !autoProbeMs || !onRetry) return undefined;
+    if (!blocked || autoProbePaused || !autoProbeMs || !onRetry) return undefined;
     const id = setInterval(() => onRetry({ auto: true }), autoProbeMs);
     return () => clearInterval(id);
-  }, [blocked, autoProbeMs, onRetry]);
+  }, [blocked, autoProbePaused, autoProbeMs, onRetry]);
 
   if (!open) return null;
 

--- a/apps/web/src/components/ModelLibraryDialog.jsx
+++ b/apps/web/src/components/ModelLibraryDialog.jsx
@@ -43,6 +43,11 @@ export function ModelLibraryDialog({
   const context = state.context ?? {};
   const modelLabel = context.modelName || context.modelId || "This model";
   const libraryPath = context.expectedLibraryPath || context.configuredLibraryPath;
+  // The configured library is right there and readable, but it is not the one SceneWorks recorded
+  // — a different disk mounted where the old one was, or a location that moved. "Reconnect the
+  // drive" is the wrong instruction for that: there is nothing to reconnect, and without saying so
+  // the state is a dead end the user has no reason to associate with the relocate control.
+  const mismatched = context.libraryPresent === true;
 
   return (
     <Modal
@@ -52,11 +57,14 @@ export function ModelLibraryDialog({
       onClose={onCancel}
     >
       <h2 className="discard-confirm-title" id="model-library-title">
-        {modelLabel} needs its model library
+        {mismatched
+          ? `${modelLabel} is on a different model library`
+          : `${modelLabel} needs its model library`}
       </h2>
       <p className="discard-confirm-body" id="model-library-body">
-        {modelLabel} is installed, but the library holding its files is not available right now.
-        Nothing was lost — reconnect the drive and SceneWorks will pick it up again.
+        {mismatched
+          ? `${modelLabel} is installed, but the folder SceneWorks is configured to read is not the library it was installed on. Nothing was lost — point SceneWorks at the library holding your models.`
+          : `${modelLabel} is installed, but the library holding its files is not available right now. Nothing was lost — reconnect the drive and SceneWorks will pick it up again.`}
       </p>
       {libraryPath ? (
         <p className="model-library-path">
@@ -73,17 +81,25 @@ export function ModelLibraryDialog({
             ? "Checking that library…"
             : state.error || state.hint || ""}
       </p>
+      {/* Same three exits either way — only which one leads changes. A mismatched library is not
+          fixed by retrying, so relocation takes the primary action; a disconnected one is, so
+          retry keeps it. */}
       <div className="discard-confirm-actions">
         <button disabled={busy} onClick={onCancel} type="button">
           Cancel
         </button>
         {canRelocate ? (
-          <button disabled={busy} onClick={onRelocate} type="button">
+          <button
+            className={mismatched ? "primary-action" : undefined}
+            disabled={busy}
+            onClick={onRelocate}
+            type="button"
+          >
             Choose a different library location
           </button>
         ) : null}
         <button
-          className="primary-action"
+          className={mismatched ? undefined : "primary-action"}
           disabled={busy}
           onClick={() => onRetry?.()}
           type="button"
@@ -93,8 +109,9 @@ export function ModelLibraryDialog({
       </div>
       {canRelocate ? null : (
         <p className="model-library-hint">
-          Relocating the model library is a desktop setting. On a shared server, reconnect the
-          library on the machine running SceneWorks, then retry.
+          {mismatched
+            ? "Changing the model library location is a desktop setting. On a shared server, set the library location on the machine running SceneWorks."
+            : "Relocating the model library is a desktop setting. On a shared server, reconnect the library on the machine running SceneWorks, then retry."}
         </p>
       )}
     </Modal>

--- a/apps/web/src/components/ModelLibraryDialog.jsx
+++ b/apps/web/src/components/ModelLibraryDialog.jsx
@@ -1,0 +1,97 @@
+import React, { useEffect } from "react";
+import { Modal } from "./Modal.jsx";
+
+// The blocking prompt for a model that is installed on a library the app cannot reach right now
+// (sc-19709). Everything it renders comes from the seam's typed context — the model's name and the
+// expected library location — so the user never sees a raw filesystem error, and the app never
+// guesses at availability.
+//
+// Three exits, and only three: reconnect and retry, name a different library, or abandon the
+// action. The gate owns which of them may fire; this component only renders its state, which is
+// why a double click or a reconnect landing mid-retry cannot produce a second submission.
+//
+// Reuses `Modal`, so focus is trapped and restored, Escape closes, and the dialog is portaled —
+// no bespoke overlay, no `window.confirm` (inert in the Tauri WebView).
+export function ModelLibraryDialog({
+  state,
+  onRetry,
+  onRelocate,
+  onCancel,
+  canRelocate,
+  autoProbeMs = 5000,
+}) {
+  const blocked = state?.status === "blocked";
+  const busy = state?.status === "retrying" || state?.status === "relocating";
+  const open = blocked || busy;
+
+  // While the prompt is open, keep re-probing: plugging the drive back in should resolve the
+  // prompt without demanding a click. Every tick funnels through the same guarded retry the button
+  // uses, so a tick that lands during an in-flight attempt is a no-op rather than a second submit.
+  useEffect(() => {
+    if (!blocked || !autoProbeMs || !onRetry) return undefined;
+    const id = setInterval(() => onRetry({ auto: true }), autoProbeMs);
+    return () => clearInterval(id);
+  }, [blocked, autoProbeMs, onRetry]);
+
+  if (!open) return null;
+
+  const context = state.context ?? {};
+  const modelLabel = context.modelName || context.modelId || "This model";
+  const libraryPath = context.expectedLibraryPath || context.configuredLibraryPath;
+
+  return (
+    <Modal
+      className="discard-confirm-modal model-library-modal"
+      describedBy="model-library-body"
+      labelledBy="model-library-title"
+      onClose={onCancel}
+    >
+      <h2 className="discard-confirm-title" id="model-library-title">
+        {modelLabel} needs its model library
+      </h2>
+      <p className="discard-confirm-body" id="model-library-body">
+        {modelLabel} is installed, but the library holding its files is not available right now.
+        Nothing was lost — reconnect the drive and SceneWorks will pick it up again.
+      </p>
+      {libraryPath ? (
+        <p className="model-library-path">
+          <span className="model-library-path-label">Expected location</span>
+          <code>{libraryPath}</code>
+        </p>
+      ) : null}
+      {/* One live region for every transient answer: "still not connected", a rejected folder, or
+          the in-flight state. Screen readers hear the outcome of a retry without a focus jump. */}
+      <p aria-live="polite" className="model-library-status" role="status">
+        {state.status === "retrying"
+          ? "Checking for the library…"
+          : state.status === "relocating"
+            ? "Checking that library…"
+            : state.error || state.hint || ""}
+      </p>
+      <div className="discard-confirm-actions">
+        <button disabled={busy} onClick={onCancel} type="button">
+          Cancel
+        </button>
+        {canRelocate ? (
+          <button disabled={busy} onClick={onRelocate} type="button">
+            Choose a different library location
+          </button>
+        ) : null}
+        <button
+          className="primary-action"
+          disabled={busy}
+          onClick={() => onRetry?.()}
+          type="button"
+        >
+          Connect drive and retry
+        </button>
+      </div>
+      {canRelocate ? null : (
+        <p className="model-library-hint">
+          Relocating the model library is a desktop setting. On a shared server, reconnect the
+          library on the machine running SceneWorks, then retry.
+        </p>
+      )}
+    </Modal>
+  );
+}

--- a/apps/web/src/components/ModelLibraryDialog.test.jsx
+++ b/apps/web/src/components/ModelLibraryDialog.test.jsx
@@ -1,0 +1,192 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ModelLibraryDialog } from "./ModelLibraryDialog.jsx";
+
+const CONTEXT = {
+  schemaVersion: 1,
+  availability: "installed_external_unavailable",
+  modelId: "z_image",
+  modelName: "Z-Image Turbo",
+  configuredLibraryPath: "/Volumes/Models/hf/hub",
+  expectedLibraryPath: "/Volumes/Models/hf/hub",
+  expectedVolumeId: "macos-volume:abc",
+};
+
+function blocked(overrides = {}) {
+  return { status: "blocked", context: CONTEXT, hint: "", error: "", ...overrides };
+}
+
+describe("ModelLibraryDialog", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  async function render(props) {
+    await act(async () => {
+      root.render(
+        <ModelLibraryDialog
+          autoProbeMs={0}
+          canRelocate
+          onCancel={() => {}}
+          onRelocate={() => {}}
+          onRetry={() => {}}
+          {...props}
+        />,
+      );
+    });
+    return document.body.querySelector(".model-library-modal");
+  }
+
+  function buttons(dialog) {
+    return [...dialog.querySelectorAll("button")].reduce((map, button) => {
+      map[button.textContent] = button;
+      return map;
+    }, {});
+  }
+
+  it("renders nothing while the gate is idle", async () => {
+    const dialog = await render({ state: { status: "idle", context: null } });
+    expect(dialog).toBeNull();
+  });
+
+  it("names the model and the expected library, and never shows raw error text", async () => {
+    const dialog = await render({ state: blocked() });
+    expect(dialog.textContent).toContain("Z-Image Turbo");
+    expect(dialog.textContent).toContain("/Volumes/Models/hf/hub");
+    expect(dialog.textContent).not.toMatch(/ENOENT|No such file|os error/i);
+    // Accessible dialog wiring comes from the shared Modal primitive.
+    expect(dialog.getAttribute("role")).toBe("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-labelledby")).toBe("model-library-title");
+    expect(document.getElementById("model-library-title")).not.toBeNull();
+    expect(dialog.querySelector('[role="status"]').getAttribute("aria-live")).toBe(
+      "polite",
+    );
+    expect(document.activeElement).toBe(dialog);
+  });
+
+  it("offers exactly the three recovery exits, and wires each to the gate", async () => {
+    const onRetry = vi.fn();
+    const onRelocate = vi.fn();
+    const onCancel = vi.fn();
+    const dialog = await render({ state: blocked(), onRetry, onRelocate, onCancel });
+    const named = buttons(dialog);
+    expect(Object.keys(named)).toEqual([
+      "Cancel",
+      "Choose a different library location",
+      "Connect drive and retry",
+    ]);
+
+    await act(async () => named["Connect drive and retry"].click());
+    await act(async () => named["Choose a different library location"].click());
+    await act(async () => named.Cancel.click());
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRelocate).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape, which the gate treats as cancel", async () => {
+    const onCancel = vi.fn();
+    const dialog = await render({ state: blocked(), onCancel });
+    await act(async () => {
+      dialog.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables every exit while an attempt is in flight, so a click cannot double-fire", async () => {
+    const onRetry = vi.fn();
+    const dialog = await render({
+      state: { ...blocked(), status: "retrying" },
+      onRetry,
+    });
+    const named = buttons(dialog);
+    expect(named["Connect drive and retry"].disabled).toBe(true);
+    expect(named.Cancel.disabled).toBe(true);
+    expect(dialog.querySelector('[role="status"]').textContent).toContain("Checking");
+    await act(async () => named["Connect drive and retry"].click());
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("announces the seam's guidance for a still-missing library or a rejected folder", async () => {
+    let dialog = await render({
+      state: blocked({ hint: "That library is still not connected." }),
+    });
+    expect(dialog.querySelector('[role="status"]').textContent).toBe(
+      "That library is still not connected.",
+    );
+    dialog = await render({
+      state: blocked({ error: "That folder does not contain a SceneWorks model library." }),
+    });
+    expect(dialog.querySelector('[role="status"]').textContent).toContain(
+      "does not contain a SceneWorks model library",
+    );
+  });
+
+  it("replaces the relocate action with server guidance when relocation is not this app's to do", async () => {
+    const dialog = await render({ state: blocked(), canRelocate: false });
+    expect(Object.keys(buttons(dialog))).toEqual([
+      "Cancel",
+      "Connect drive and retry",
+    ]);
+    expect(dialog.textContent).toContain("desktop setting");
+  });
+
+  it("re-probes on a timer while blocked, and stops the moment an attempt is in flight", async () => {
+    vi.useFakeTimers();
+    const onRetry = vi.fn();
+    await act(async () => {
+      root.render(
+        <ModelLibraryDialog
+          autoProbeMs={1000}
+          canRelocate
+          onCancel={() => {}}
+          onRelocate={() => {}}
+          onRetry={onRetry}
+          state={blocked()}
+        />,
+      );
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+    });
+    expect(onRetry).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledWith({ auto: true });
+
+    // Once an attempt is running the poller is torn down: the gate's own guard would reject a
+    // concurrent tick anyway, but not scheduling it keeps the two from racing at all.
+    onRetry.mockClear();
+    await act(async () => {
+      root.render(
+        <ModelLibraryDialog
+          autoProbeMs={1000}
+          canRelocate
+          onCancel={() => {}}
+          onRelocate={() => {}}
+          onRetry={onRetry}
+          state={{ ...blocked(), status: "retrying" }}
+        />,
+      );
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/ModelLibraryDialog.test.jsx
+++ b/apps/web/src/components/ModelLibraryDialog.test.jsx
@@ -139,6 +139,34 @@ describe("ModelLibraryDialog", () => {
     );
   });
 
+  // A library that is present but whose identity disagrees is not fixed by reconnecting anything,
+  // so the prompt must not tell the user to. Same three exits; relocation leads.
+  it("leads with relocation when the library is present but is not the recorded one", async () => {
+    const dialog = await render({
+      state: blocked({ context: { ...CONTEXT, libraryPresent: true } }),
+    });
+    expect(dialog.textContent).toContain("is on a different model library");
+    expect(dialog.textContent).toContain("point SceneWorks at the library holding your models");
+    expect(dialog.textContent).not.toContain("reconnect the drive");
+    const named = buttons(dialog);
+    expect(named["Choose a different library location"].className).toContain(
+      "primary-action",
+    );
+    expect(named["Connect drive and retry"].className).not.toContain("primary-action");
+    // Retrying is still offered — it is simply no longer the recommended answer.
+    expect(named["Connect drive and retry"]).toBeTruthy();
+  });
+
+  it("keeps reconnect as the lead when the library is genuinely disconnected", async () => {
+    const dialog = await render({ state: blocked() });
+    expect(dialog.textContent).toContain("needs its model library");
+    const named = buttons(dialog);
+    expect(named["Connect drive and retry"].className).toContain("primary-action");
+    expect(named["Choose a different library location"].className).not.toContain(
+      "primary-action",
+    );
+  });
+
   it("replaces the relocate action with server guidance when relocation is not this app's to do", async () => {
     const dialog = await render({ state: blocked(), canRelocate: false });
     expect(Object.keys(buttons(dialog))).toEqual([

--- a/apps/web/src/components/ModelLibraryRestartDialog.jsx
+++ b/apps/web/src/components/ModelLibraryRestartDialog.jsx
@@ -1,0 +1,85 @@
+import React, { useRef, useState } from "react";
+import { Modal } from "./Modal.jsx";
+
+// The disclosure shown after a model library has been successfully relocated (sc-19709).
+//
+// The relocated path reaches the API and GPU worker as spawn environment (`HF_HOME`), so it cannot
+// apply to the sidecars already running. That is a real, product-approved property of the app —
+// not an error — so it is stated plainly, with a restart offered rather than demanded.
+//
+// "Restart now" is gated on there being no running job. The teardown behind it is the same
+// SIGTERM-then-grace path as quitting, but interrupting a render still costs the user the work in
+// flight, so while a job is running the affordance says so and only "Later" is available.
+export function ModelLibraryRestartDialog({
+  relocation,
+  canRestart,
+  runningJobCount = 0,
+  onRestart,
+  onLater,
+}) {
+  // A ref, not just the disabled attribute: two clicks dispatched in the same tick would both see
+  // the pre-render `disabled` value, and restarting twice is exactly the kind of double-fire this
+  // epic's gate exists to prevent.
+  const requested = useRef(false);
+  const [restarting, setRestarting] = useState(false);
+  if (!relocation) return null;
+
+  const jobRunning = runningJobCount > 0;
+  const restartNow = () => {
+    if (requested.current) return;
+    requested.current = true;
+    setRestarting(true);
+    onRestart?.();
+  };
+
+  return (
+    <Modal
+      className="discard-confirm-modal model-library-modal"
+      describedBy="model-library-restart-body"
+      labelledBy="model-library-restart-title"
+      onClose={onLater}
+    >
+      <h2 className="discard-confirm-title" id="model-library-restart-title">
+        Model library updated
+      </h2>
+      <p className="discard-confirm-body" id="model-library-restart-body">
+        SceneWorks will read models from this library after it restarts. Until then, models stored
+        there stay unavailable — nothing was moved, copied, or downloaded.
+      </p>
+      {/* Say what happened to the work they were doing. From the user's seat they pressed Generate,
+          answered a dialog, and got a settings message: without this line, the missing job reads as
+          a bug rather than the deliberate consequence of relocating. */}
+      <p className="discard-confirm-body">
+        The generation you started was not queued. Submit it again after SceneWorks restarts.
+      </p>
+      <p className="model-library-path">
+        <span className="model-library-path-label">New location</span>
+        <code>{relocation.hfHome ?? relocation.libraryRoot}</code>
+      </p>
+      <p aria-live="polite" className="model-library-status" role="status">
+        {restarting
+          ? "Restarting SceneWorks…"
+          : !canRestart
+            ? "Restart the SceneWorks server to apply it."
+            : jobRunning
+              ? `${runningJobCount === 1 ? "A job is" : `${runningJobCount} jobs are`} still running. Restarting would interrupt ${runningJobCount === 1 ? "it" : "them"} — restart once ${runningJobCount === 1 ? "it is" : "they are"} finished.`
+              : ""}
+      </p>
+      <div className="discard-confirm-actions">
+        <button disabled={restarting} onClick={onLater} type="button">
+          Later
+        </button>
+        {canRestart ? (
+          <button
+            className="primary-action"
+            disabled={restarting || jobRunning}
+            onClick={restartNow}
+            type="button"
+          >
+            Restart now
+          </button>
+        ) : null}
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/components/ModelLibraryRestartDialog.jsx
+++ b/apps/web/src/components/ModelLibraryRestartDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Modal } from "./Modal.jsx";
 
 // The disclosure shown after a model library has been successfully relocated (sc-19709).
@@ -22,14 +22,33 @@ export function ModelLibraryRestartDialog({
   // epic's gate exists to prevent.
   const requested = useRef(false);
   const [restarting, setRestarting] = useState(false);
+  // This component stays mounted across relocations, so the once-only latch and the restarting
+  // state are per-RELOCATION, not per-mount. Without this reset a restart that failed to launch
+  // would leave every later relocation opening straight into a dead "Restarting SceneWorks…" with
+  // both buttons disabled, and restart could never fire again without reloading the app.
+  useEffect(() => {
+    requested.current = false;
+    setRestarting(false);
+  }, [relocation]);
   if (!relocation) return null;
 
   const jobRunning = runningJobCount > 0;
+  // A restart that never launches must not wedge the dialog: `onRestart` reports that by rejecting
+  // (or returning false), and the dialog returns to an actionable state so the user can try again
+  // or dismiss. On success the app is going away, so nothing settles here.
   const restartNow = () => {
     if (requested.current) return;
     requested.current = true;
     setRestarting(true);
-    onRestart?.();
+    Promise.resolve()
+      .then(() => onRestart?.())
+      .then((result) => {
+        if (result === false) throw new Error("restart did not start");
+      })
+      .catch(() => {
+        requested.current = false;
+        setRestarting(false);
+      });
   };
 
   return (

--- a/apps/web/src/components/ModelLibraryRestartDialog.test.jsx
+++ b/apps/web/src/components/ModelLibraryRestartDialog.test.jsx
@@ -1,0 +1,131 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ModelLibraryRestartDialog } from "./ModelLibraryRestartDialog.jsx";
+
+const RELOCATION = {
+  libraryRoot: "/Volumes/Models 1/hf/hub",
+  hfHome: "/Volumes/Models 1/hf",
+  status: { available: true },
+};
+
+describe("ModelLibraryRestartDialog (sc-19709)", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  async function render(props) {
+    await act(async () => {
+      root.render(
+        <ModelLibraryRestartDialog
+          canRestart
+          onLater={() => {}}
+          onRestart={() => {}}
+          relocation={RELOCATION}
+          {...props}
+        />,
+      );
+    });
+    return document.body.querySelector(".model-library-modal");
+  }
+
+  function button(dialog, label) {
+    return [...dialog.querySelectorAll("button")].find(
+      (item) => item.textContent === label,
+    );
+  }
+
+  it("renders nothing until a relocation actually succeeded", async () => {
+    expect(await render({ relocation: null })).toBeNull();
+  });
+
+  it("discloses the next-launch behavior and names the new location", async () => {
+    const dialog = await render({});
+    expect(dialog.textContent).toContain("after it restarts");
+    expect(dialog.textContent).toContain("/Volumes/Models 1/hf");
+    // The user must not think anything was copied or re-downloaded.
+    expect(dialog.textContent).toContain("nothing was moved, copied, or downloaded");
+    // …and must be told what became of the generation they actually started. Without this, the
+    // missing job reads as a bug rather than the consequence of relocating.
+    expect(dialog.textContent).toContain("was not queued");
+    expect(dialog.textContent).toContain("Submit it again after SceneWorks restarts");
+    expect(dialog.getAttribute("role")).toBe("dialog");
+    expect(dialog.getAttribute("aria-labelledby")).toBe("model-library-restart-title");
+    expect(dialog.querySelector('[role="status"]').getAttribute("aria-live")).toBe(
+      "polite",
+    );
+  });
+
+  it("invokes the relaunch exactly once, however many times the button is clicked", async () => {
+    const onRestart = vi.fn();
+    const dialog = await render({ onRestart });
+    const restart = button(dialog, "Restart now");
+    await act(async () => {
+      restart.click();
+      restart.click();
+    });
+    await act(async () => restart.click());
+    expect(onRestart).toHaveBeenCalledTimes(1);
+    expect(button(dialog, "Restart now").disabled).toBe(true);
+    expect(dialog.querySelector('[role="status"]').textContent).toContain("Restarting");
+  });
+
+  it("withholds the restart while a job is running, and says why", async () => {
+    const onRestart = vi.fn();
+    const dialog = await render({ onRestart, runningJobCount: 1 });
+    const restart = button(dialog, "Restart now");
+    expect(restart.disabled).toBe(true);
+    await act(async () => restart.click());
+    expect(onRestart).not.toHaveBeenCalled();
+    expect(dialog.querySelector('[role="status"]').textContent).toContain(
+      "A job is still running",
+    );
+    // Deferring is always available.
+    expect(button(dialog, "Later").disabled).toBe(false);
+  });
+
+  it("pluralizes the running-job warning", async () => {
+    const dialog = await render({ runningJobCount: 3 });
+    expect(dialog.querySelector('[role="status"]').textContent).toContain(
+      "3 jobs are still running",
+    );
+  });
+
+  it("dismisses on Later and on Escape without restarting", async () => {
+    const onLater = vi.fn();
+    const onRestart = vi.fn();
+    let dialog = await render({ onLater, onRestart });
+    await act(async () => button(dialog, "Later").click());
+    expect(onLater).toHaveBeenCalledTimes(1);
+
+    dialog = await render({ onLater, onRestart });
+    await act(async () => {
+      dialog.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+    expect(onLater).toHaveBeenCalledTimes(2);
+    expect(onRestart).not.toHaveBeenCalled();
+  });
+
+  it("degrades to guidance with no restart control outside the desktop shell", async () => {
+    const dialog = await render({ canRestart: false });
+    expect(button(dialog, "Restart now")).toBeUndefined();
+    expect(button(dialog, "Later")).toBeTruthy();
+    expect(dialog.querySelector('[role="status"]').textContent).toContain(
+      "Restart the SceneWorks server",
+    );
+  });
+});

--- a/apps/web/src/components/ModelLibraryRestartDialog.test.jsx
+++ b/apps/web/src/components/ModelLibraryRestartDialog.test.jsx
@@ -82,6 +82,54 @@ describe("ModelLibraryRestartDialog (sc-19709)", () => {
     expect(dialog.querySelector('[role="status"]').textContent).toContain("Restarting");
   });
 
+  // The dialog stays mounted across relocations, so a restart that never launched must not latch it
+  // permanently into "Restarting…" with both buttons disabled.
+  it("leaves the restarting state when the relaunch rejects, and can be retried", async () => {
+    const onRestart = vi.fn().mockRejectedValueOnce(new Error("relaunch refused"));
+    const dialog = await render({ onRestart });
+    await act(async () => button(dialog, "Restart now").click());
+    await act(async () => {});
+
+    expect(dialog.querySelector('[role="status"]').textContent).not.toContain("Restarting");
+    expect(button(dialog, "Restart now").disabled).toBe(false);
+    expect(button(dialog, "Later").disabled).toBe(false);
+    await act(async () => button(dialog, "Restart now").click());
+    expect(onRestart).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats a false result from the relaunch as a failure too", async () => {
+    const onRestart = vi.fn(async () => false);
+    const dialog = await render({ onRestart });
+    await act(async () => button(dialog, "Restart now").click());
+    await act(async () => {});
+    expect(button(dialog, "Restart now").disabled).toBe(false);
+  });
+
+  // Both the once-only latch and the restarting state are per-RELOCATION, not per-mount: this
+  // component stays mounted, so without a reset the dead restarting state carries straight into the
+  // NEXT relocation and restart can never fire again without reloading the app. Driven here with a
+  // relaunch that never settles, so the reset is proven independently of the rejection path.
+  it("resets for a new relocation after a restart that never completed", async () => {
+    const onRestart = vi.fn(() => new Promise(() => {}));
+    let dialog = await render({ onRestart });
+    await act(async () => button(dialog, "Restart now").click());
+    expect(dialog.querySelector('[role="status"]').textContent).toContain("Restarting");
+
+    // The disclosure is dismissed, then a fresh relocation opens it again.
+    await render({ onRestart, relocation: null });
+    dialog = await render({
+      onRestart,
+      relocation: { ...RELOCATION, hfHome: "/Volumes/Models 2/hf" },
+    });
+
+    expect(dialog.textContent).toContain("/Volumes/Models 2/hf");
+    expect(dialog.querySelector('[role="status"]').textContent).not.toContain("Restarting");
+    expect(button(dialog, "Restart now").disabled).toBe(false);
+    await act(async () => button(dialog, "Restart now").click());
+    expect(onRestart).toHaveBeenCalledTimes(2);
+    expect(dialog.querySelector('[role="status"]').textContent).toContain("Restarting");
+  });
+
   it("withholds the restart while a job is running, and says why", async () => {
     const onRestart = vi.fn();
     const dialog = await render({ onRestart, runningJobCount: 1 });

--- a/apps/web/src/components/generationStudio.jsx
+++ b/apps/web/src/components/generationStudio.jsx
@@ -4,6 +4,10 @@ import { Icon } from "./Icons.jsx";
 import { StudioUpdateBadge, StudioUpdateNotice } from "./StudioUpdateNotice.jsx";
 import { terminalStatuses } from "../jobTypes.js";
 import {
+  modelLibraryContextForModel,
+  raiseModelLibraryPrompt,
+} from "../modelLibrary.js";
+import {
   LORA_WEIGHT_MAX,
   LORA_WEIGHT_MIN,
   LORA_WEIGHT_STEP,
@@ -323,6 +327,25 @@ export function useGenerationStudio({
       setModel(models[0]?.id ?? fallbackModelId);
     }
   }, [models, model, setModel, fallbackModelId]);
+
+  // Raise the model-library prompt at SELECTION time, not only at submit (sc-19709): picking a
+  // model whose library is disconnected should say so immediately rather than after the user has
+  // written a prompt and pressed Generate. The catalog re-probes live, so this is the seam's own
+  // typed judgement — never a client-side re-derivation.
+  //
+  // Keyed on the model id + its typed availability, NOT on the `selectedModel` object: a catalog
+  // refresh mints new objects every poll, and an object-identity dependency would re-open the
+  // prompt seconds after the user dismissed it.
+  const selectedLibraryContext = modelLibraryContextForModel(selectedModel);
+  const blockedModelKey = selectedLibraryContext
+    ? `${selectedLibraryContext.modelId}:${selectedLibraryContext.expectedLibraryPath ?? ""}`
+    : null;
+  const selectedLibraryContextRef = useRef(selectedLibraryContext);
+  selectedLibraryContextRef.current = selectedLibraryContext;
+  useEffect(() => {
+    if (!blockedModelKey) return;
+    raiseModelLibraryPrompt(selectedLibraryContextRef.current);
+  }, [blockedModelKey]);
 
   // Drop a character selection that's no longer in the catalog. Guard on a loaded catalog
   // (sc-11964): on the first mount after a restart the character catalog is still resolving

--- a/apps/web/src/createJob.js
+++ b/apps/web/src/createJob.js
@@ -1,4 +1,5 @@
 import { apiFetch } from "./api.js";
+import { handleModelLibraryRejection } from "./modelLibrary.js";
 import { upsertJobNewest } from "./sorters.js";
 
 function generationBody([payload], project, requestedGpu) {
@@ -63,7 +64,7 @@ export function makeCreateJob({
   beforeCreate,
   afterCreate,
 }) {
-  return async (...args) => {
+  return async function createJob(...args) {
     if (!project) {
       setError("Create or open a project first.");
       return null;
@@ -81,6 +82,12 @@ export function makeCreateJob({
       setError("");
       return job;
     } catch (err) {
+      // A model installed on a currently-unavailable library is recoverable, not a failure to
+      // report: hand the prompt this exact submission as the action to resume. The prompt owns
+      // single-fire, so a reconnect can never turn one blocked click into two jobs.
+      if (handleModelLibraryRejection(err, () => createJob(...args))) {
+        return null;
+      }
       setError(err.message);
       return null;
     }

--- a/apps/web/src/createJob.test.js
+++ b/apps/web/src/createJob.test.js
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { apiFetch } from "./api.js";
 import { CREATE_JOB_DEFINITIONS, makeCreateJob } from "./createJob.js";
+import {
+  createModelLibraryGate,
+  setModelLibraryHandler,
+  MODEL_LIBRARY_UNAVAILABLE_CODE,
+} from "./modelLibrary.js";
 
 vi.mock("./api.js", () => ({
   apiFetch: vi.fn(),
@@ -183,5 +188,111 @@ describe("makeCreateJob", () => {
     });
     await expect(failingCreator({ prompt: "x" })).resolves.toBeNull();
     expect(setError).toHaveBeenLastCalledWith("network down");
+  });
+
+  // sc-19709. The end-to-end shape of the recovery, at the one choke point every generation
+  // submission passes through: a typed unavailable-library rejection becomes a prompt (not an
+  // error banner), and resuming it re-POSTs the SAME submission exactly once.
+  describe("unavailable model library", () => {
+    function unavailableRejection() {
+      return {
+        code: MODEL_LIBRARY_UNAVAILABLE_CODE,
+        message: "Model 'z_image' is installed on an external model library…",
+        context: {
+          schemaVersion: 1,
+          availability: "installed_external_unavailable",
+          modelId: "z_image",
+          modelName: "Z-Image",
+          configuredLibraryPath: "/Volumes/Models/hf/hub",
+          expectedLibraryPath: "/Volumes/Models/hf/hub",
+          expectedVolumeId: "macos-volume:abc",
+        },
+      };
+    }
+
+    it("hands the blocked submission to the prompt and resumes it exactly once", async () => {
+      const job = { id: "job-image", status: "queued", createdAt: "2026-07-25T12:00:00Z" };
+      apiFetch.mockRejectedValueOnce(unavailableRejection()).mockResolvedValue(job);
+      const probe = vi.fn(async () => ({ available: true }));
+      const gate = createModelLibraryGate({ probe });
+      const unregister = setModelLibraryHandler(gate.block);
+      const setError = vi.fn();
+      let jobs = [];
+      const creator = makeCreateJob({
+        definition: CREATE_JOB_DEFINITIONS.image,
+        token: "token-1",
+        project,
+        requestedGpu: "gpu-2",
+        setJobs: (update) => {
+          jobs = update(jobs);
+        },
+        setError,
+      });
+
+      await expect(creator({ prompt: "a lighthouse" })).resolves.toBeNull();
+      // No raw error surface: the prompt owns it, and it names the model from the typed context.
+      expect(setError).not.toHaveBeenCalledWith(
+        expect.stringContaining("external model library"),
+      );
+      expect(gate.getState()).toMatchObject({ status: "blocked" });
+      expect(gate.getState().context.modelName).toBe("Z-Image");
+      expect(apiFetch).toHaveBeenCalledTimes(1);
+
+      // Reconnect: the queued submission resumes, and the double-click plus a concurrent
+      // reconnect event produce ONE additional POST, not three.
+      const resumed = await Promise.all([gate.retry(), gate.retry(), gate.retry({ auto: true })]);
+      expect(resumed.filter(Boolean)).toEqual([job]);
+      expect(apiFetch).toHaveBeenCalledTimes(2);
+      expect(apiFetch).toHaveBeenLastCalledWith("/api/v1/image/jobs", "token-1", {
+        method: "POST",
+        body: JSON.stringify({
+          prompt: "a lighthouse",
+          projectId: "project-7",
+          projectName: "Project Seven",
+          requestedGpu: "gpu-2",
+        }),
+      });
+      expect(jobs).toEqual([job]);
+      unregister();
+    });
+
+    it("leaves no queued submission behind when the prompt is cancelled", async () => {
+      apiFetch.mockRejectedValue(unavailableRejection());
+      const gate = createModelLibraryGate({ probe: async () => ({ available: true }) });
+      const unregister = setModelLibraryHandler(gate.block);
+      const creator = makeCreateJob({
+        definition: CREATE_JOB_DEFINITIONS.image,
+        token: "",
+        project,
+        requestedGpu: "auto",
+        setJobs: vi.fn(),
+        setError: vi.fn(),
+      });
+
+      await creator({ prompt: "x" });
+      gate.cancel();
+      expect(gate.getState()).toMatchObject({ status: "idle", context: null });
+      apiFetch.mockClear();
+      await gate.retry();
+      expect(apiFetch).not.toHaveBeenCalled();
+      unregister();
+    });
+
+    it("still reports ordinary failures when no prompt is registered", async () => {
+      apiFetch.mockRejectedValue(unavailableRejection());
+      const setError = vi.fn();
+      const creator = makeCreateJob({
+        definition: CREATE_JOB_DEFINITIONS.image,
+        token: "",
+        project,
+        requestedGpu: "auto",
+        setJobs: vi.fn(),
+        setError,
+      });
+      await expect(creator({ prompt: "x" })).resolves.toBeNull();
+      expect(setError).toHaveBeenCalledWith(
+        "Model 'z_image' is installed on an external model library…",
+      );
+    });
   });
 });

--- a/apps/web/src/hooks/useTraining.js
+++ b/apps/web/src/hooks/useTraining.js
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import { apiFetch, isAbortError } from "../api.js";
 import { isCurrentProjectRequest } from "../appStateHelpers.js";
+import { rethrowUnlessPrompted } from "../modelLibrary.js";
 import { refreshFailure, refreshSuccess } from "../refreshResult.js";
 import { upsertJobNewest } from "../sorters.js";
 
@@ -381,14 +382,22 @@ export function useTraining({ token, activeProject, activeProjectRef, setError, 
   );
 
   const createTrainingJob = useCallback(
-    async (request, projectId = activeProject?.id) => {
+    async function submitTrainingJob(request, projectId = activeProject?.id) {
       if (!projectId) {
         throw new Error("Select a workspace before creating a training job.");
       }
-      const job = await apiFetch(`/api/v1/projects/${projectId}/training/jobs`, token, {
-        method: "POST",
-        body: JSON.stringify(request),
-      });
+      let job;
+      try {
+        job = await apiFetch(`/api/v1/projects/${projectId}/training/jobs`, token, {
+          method: "POST",
+          body: JSON.stringify(request),
+        });
+      } catch (error) {
+        // A base model on a disconnected library is recoverable, not a failure to print: hand the
+        // prompt this exact submission to resume (sc-19709). It owns single-fire, so a reconnect
+        // cannot queue two training runs.
+        rethrowUnlessPrompted(error, () => submitTrainingJob(request, projectId));
+      }
       setJobs((items) => upsertJobNewest(items, job));
       setError("");
       return job;

--- a/apps/web/src/modelLibrary.js
+++ b/apps/web/src/modelLibrary.js
@@ -56,8 +56,17 @@ export function fetchModelLibraryStatus(token, options) {
   return apiFetch("/api/v1/model-library", token, options);
 }
 
-// Adopt a different library root. The API validates it and re-binds the durable identity; it never
-// downloads and never rewrites install receipts.
+// Check a candidate library root without writing anything, anywhere. Every ordinary refusal — the
+// wrong folder, a library missing installed models — lands here, BEFORE either durable write.
+export function validateModelLibrary(token, path) {
+  return apiFetch("/api/v1/model-library/relocate", token, {
+    method: "POST",
+    body: JSON.stringify({ path, dryRun: true }),
+  });
+}
+
+// Adopt a different library root: the API re-binds the durable identity. It never downloads and
+// never rewrites install receipts.
 export function relocateModelLibrary(token, path) {
   return apiFetch("/api/v1/model-library/relocate", token, {
     method: "POST",
@@ -123,10 +132,17 @@ const IDLE = Object.freeze({
 
 /// A blocked-action gate: at most one pending action, resumed at most once.
 //
-// `probe` returns the seam's library status; `relocate` adopts a new root and returns the
-// `{ libraryRoot, hfHome }` the shell must persist. Both are injected so the state machine is
-// testable without a transport.
-export function createModelLibraryGate({ probe, relocate, persist } = {}) {
+// Injected so the state machine is testable without a transport:
+//   `probe`    — the seam's library status; a retry gates on its `available`.
+//   `validate` — check a candidate root, writing nothing anywhere.
+//   `adopt`    — re-bind the server's durable identity to that root.
+//   `persist`  — store the client's own copy of the location; may return an undo function.
+//
+// Relocation has TWO durable writes in different places (the shell's `HF_HOME` and the server's
+// binding ledger) and they must not be allowed to disagree: `validate` first so every ordinary
+// refusal happens before either, then `persist`, then `adopt`, and if `adopt` fails the persist is
+// undone. What the user is told always matches what actually happened.
+export function createModelLibraryGate({ probe, validate, adopt, persist } = {}) {
   let state = IDLE;
   // The single pending action. It is REMOVED from this slot before it runs, so no second caller —
   // a double click, a poll, a reconnect event — can ever find it again to run it twice.
@@ -191,6 +207,9 @@ export function createModelLibraryGate({ probe, relocate, persist } = {}) {
         pending = action;
         emit({
           status: "blocked",
+          // Clearing `error` matters: a stale failure from an earlier attempt must not sit in the
+          // live region next to this attempt's hint, reading as two simultaneous answers.
+          error: "",
           hint: auto ? "" : "That library is still not connected.",
         });
         return null;
@@ -207,22 +226,50 @@ export function createModelLibraryGate({ probe, relocate, persist } = {}) {
       const action = takePending();
       const attempt = ++epoch;
       emit({ status: "relocating", hint: "", error: "" });
-      let adopted = null;
+
+      // 1. Validate. Nothing is written, so a refusal here leaves the blocked action intact and
+      //    the user simply picks again.
+      let target = null;
       try {
-        adopted = await relocate?.(path);
-        await persist?.(adopted);
+        target = (await validate?.(path)) ?? { hfHome: path, libraryRoot: path };
       } catch (error) {
         if (attempt !== epoch) return null;
         pending = action;
         emit({
           status: "blocked",
+          hint: "",
           error: error?.message || "That library could not be used.",
         });
         return null;
       }
+
+      // 2. Persist the client's copy, then 3. re-bind the server's. If the re-bind fails, undo the
+      //    persist so the two cannot disagree — and say what actually happened either way.
+      let undoPersist = null;
+      try {
+        undoPersist = (await persist?.(target)) ?? null;
+        await adopt?.(path);
+      } catch (error) {
+        let restored = true;
+        try {
+          await undoPersist?.();
+        } catch {
+          restored = false;
+        }
+        if (attempt !== epoch) return null;
+        pending = action;
+        emit({
+          status: "blocked",
+          hint: "",
+          error: restored
+            ? `SceneWorks could not finish moving the model library, so the previous location is still in use. ${error?.message ?? ""}`.trim()
+            : "SceneWorks could not finish moving the model library, and could not restore the previous location. Set the model library folder in Settings.",
+        });
+        return null;
+      }
       if (attempt !== epoch) return null;
-      emit({ ...IDLE, relocated: adopted ?? null });
-      return adopted;
+      emit({ ...IDLE, relocated: target });
+      return target;
     },
 
     // Abandon the blocked action outright. Nothing is queued, nothing partial is left behind, and

--- a/apps/web/src/modelLibrary.js
+++ b/apps/web/src/modelLibrary.js
@@ -48,6 +48,7 @@ export function modelLibraryContextForModel(model) {
     configuredLibraryPath: resolution.configuredLibraryPath ?? null,
     expectedLibraryPath: binding?.canonicalPath ?? null,
     expectedVolumeId: binding?.physicalIdentity?.volumeId ?? null,
+    libraryPresent: resolution.libraryPresent === true,
   };
 }
 

--- a/apps/web/src/modelLibrary.js
+++ b/apps/web/src/modelLibrary.js
@@ -87,6 +87,25 @@ export function handleModelLibraryRejection(error, action) {
   return blockedHandler?.(context, action) === true;
 }
 
+// The failure a call site rethrows once the prompt has taken ownership. Its message is empty on
+// purpose: the ~85 `setError(err.message)` / `setConfigError(err.message)` handlers in this app then
+// CLEAR their banner instead of printing a second, redundant surface beside the dialog.
+export class ModelLibraryPrompted extends Error {
+  constructor() {
+    super("");
+    this.name = "ModelLibraryPrompted";
+  }
+}
+
+// The throw-shaped counterpart of `handleModelLibraryRejection`, for the submission paths that
+// propagate their failure to a caller rather than swallowing it (training). Always throws.
+export function rethrowUnlessPrompted(error, action) {
+  if (handleModelLibraryRejection(error, action)) {
+    throw new ModelLibraryPrompted();
+  }
+  throw error;
+}
+
 // Raise the prompt for a model the catalog already reports as unavailable (selection time), with
 // no queued action: the recovery is the point, and there is nothing to resume.
 export function raiseModelLibraryPrompt(context) {

--- a/apps/web/src/modelLibrary.js
+++ b/apps/web/src/modelLibrary.js
@@ -1,0 +1,188 @@
+import { apiFetch } from "./api.js";
+
+// The unavailable-external-library recovery flow (sc-19709).
+//
+// A model can be fully installed and still unloadable: its weights live on an external library
+// (an unplugged drive, an unmounted network volume) that is not attached right now. The API
+// answers that with a TYPED refusal — `code` plus a `context` object naming the model and the
+// expected library — precisely so the app can offer a recovery instead of printing a filesystem
+// error. Nothing here parses a message, and nothing re-derives availability client-side: the
+// state comes from the seam, or it does not exist.
+//
+// The gate below owns one correctness property that is not a UI nicety: a blocked action resumes
+// EXACTLY ONCE. Repeated clicks, a poll that notices the drive at the same moment the user hits
+// retry, and a reconnect arriving while a retry is already in flight must all converge on a single
+// submission — a duplicated generation job costs the user real GPU minutes.
+
+export const MODEL_LIBRARY_UNAVAILABLE_CODE = "external_model_library_unavailable";
+export const MODEL_LIBRARY_RELOCATION_REJECTED_CODE = "model_library_relocation_rejected";
+const UNAVAILABLE_AVAILABILITY = "installed_external_unavailable";
+
+/// The typed context of an unavailable-library rejection, or `null` for every other failure.
+// Both the code and the typed availability must agree: a `code` alone could survive a contract
+// change that dropped the payload, and a prompt with no library to name is worse than a notice.
+export function modelLibraryContext(error) {
+  if (!error || error.code !== MODEL_LIBRARY_UNAVAILABLE_CODE) return null;
+  const context = error.context;
+  if (!context || context.availability !== UNAVAILABLE_AVAILABILITY) return null;
+  return context;
+}
+
+// A catalog row is blocked when the seam says so. The listing re-probes live, so this is the same
+// judgement the submission preflight would make — read, never recomputed.
+export function modelLibraryUnavailable(model) {
+  return model?.modelAvailability === UNAVAILABLE_AVAILABILITY;
+}
+
+// The context shape the catalog row carries, so selecting an unavailable model opens the same
+// prompt as a rejected submission without inventing a second payload shape.
+export function modelLibraryContextForModel(model) {
+  if (!modelLibraryUnavailable(model)) return null;
+  const resolution = model?.modelResolution ?? {};
+  const binding = resolution.expectedLibrary ?? null;
+  return {
+    schemaVersion: resolution.schemaVersion ?? 1,
+    availability: UNAVAILABLE_AVAILABILITY,
+    modelId: model.id,
+    modelName: model.name ?? null,
+    configuredLibraryPath: resolution.configuredLibraryPath ?? null,
+    expectedLibraryPath: binding?.canonicalPath ?? null,
+    expectedVolumeId: binding?.physicalIdentity?.volumeId ?? null,
+  };
+}
+
+// One write-free identity probe of the configured library. This is what a retry gates on.
+export function fetchModelLibraryStatus(token, options) {
+  return apiFetch("/api/v1/model-library", token, options);
+}
+
+// Adopt a different library root. The API validates it and re-binds the durable identity; it never
+// downloads and never rewrites install receipts.
+export function relocateModelLibrary(token, path) {
+  return apiFetch("/api/v1/model-library/relocate", token, {
+    method: "POST",
+    body: JSON.stringify({ path }),
+  });
+}
+
+const IDLE = Object.freeze({
+  status: "idle",
+  context: null,
+  hint: "",
+  error: "",
+  relocated: null,
+});
+
+/// A blocked-action gate: at most one pending action, resumed at most once.
+//
+// `probe` returns the seam's library status; `relocate` adopts a new root and returns the
+// `{ libraryRoot, hfHome }` the shell must persist. Both are injected so the state machine is
+// testable without a transport.
+export function createModelLibraryGate({ probe, relocate, persist } = {}) {
+  let state = IDLE;
+  // The single pending action. It is REMOVED from this slot before it runs, so no second caller —
+  // a double click, a poll, a reconnect event — can ever find it again to run it twice.
+  let pending = null;
+  // Bumped by every attempt and by cancel. An attempt whose epoch is stale when its probe finally
+  // answers has been superseded (the user cancelled, or a newer attempt owns the gate) and must
+  // neither run the action nor write state — otherwise "Cancel" could still submit the job.
+  let epoch = 0;
+  const listeners = new Set();
+
+  function emit(next) {
+    state = Object.freeze({ ...state, ...next });
+    for (const listener of listeners) listener();
+  }
+
+  function takePending() {
+    const action = pending;
+    pending = null;
+    return action;
+  }
+
+  return {
+    getState: () => state,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+
+    // Capture a rejection. Returns true when the gate owns it, so the caller suppresses its own
+    // error surface. A second rejection while blocked is DROPPED rather than queued: one dialog,
+    // one pending action, and no hidden backlog to fire later.
+    block(context, action) {
+      if (!context) return false;
+      if (state.status !== "idle") return true;
+      pending = typeof action === "function" ? action : null;
+      emit({ status: "blocked", context, hint: "", error: "", relocated: null });
+      return true;
+    },
+
+    // Re-probe and resume. A no-op unless the gate is settled in `blocked`, which is what makes a
+    // reconnect that lands mid-retry harmless. `auto` marks a poll-driven attempt, whose failure is
+    // silence rather than an error the user did not ask for.
+    async retry({ auto = false } = {}) {
+      if (state.status !== "blocked") return null;
+      const action = takePending();
+      const attempt = ++epoch;
+      emit({ status: "retrying", hint: "", error: "" });
+      let available = false;
+      try {
+        available = (await probe?.())?.available === true;
+      } catch (error) {
+        if (attempt !== epoch) return null;
+        pending = action;
+        emit({
+          status: "blocked",
+          error: auto ? "" : error?.message || "The model library could not be checked.",
+        });
+        return null;
+      }
+      if (attempt !== epoch) return null;
+      if (!available) {
+        pending = action;
+        emit({
+          status: "blocked",
+          hint: auto ? "" : "That library is still not connected.",
+        });
+        return null;
+      }
+      emit({ ...IDLE });
+      return action ? action() : null;
+    },
+
+    // Adopt a different library root. The pending action is dropped, not resumed: the relocated
+    // path becomes effective for the sidecars on the next launch, so resuming now would only be
+    // refused again. Dropping it is the same guarantee cancel gives — nothing left queued.
+    async relocate(path) {
+      if (state.status !== "blocked") return null;
+      const action = takePending();
+      const attempt = ++epoch;
+      emit({ status: "relocating", hint: "", error: "" });
+      let adopted = null;
+      try {
+        adopted = await relocate?.(path);
+        await persist?.(adopted);
+      } catch (error) {
+        if (attempt !== epoch) return null;
+        pending = action;
+        emit({
+          status: "blocked",
+          error: error?.message || "That library could not be used.",
+        });
+        return null;
+      }
+      if (attempt !== epoch) return null;
+      emit({ ...IDLE, relocated: adopted ?? null });
+      return adopted;
+    },
+
+    // Abandon the blocked action outright. Nothing is queued, nothing partial is left behind, and
+    // an attempt already in flight is superseded so it cannot resume behind the user's back.
+    cancel() {
+      takePending();
+      epoch += 1;
+      emit({ ...IDLE });
+    },
+  };
+}

--- a/apps/web/src/modelLibrary.js
+++ b/apps/web/src/modelLibrary.js
@@ -65,6 +65,35 @@ export function relocateModelLibrary(token, path) {
   });
 }
 
+// The one place that reacts to an unavailable model library, registered by the app shell. Module
+// level — the same pattern as `setUnauthorizedHandler` — so EVERY submission path participates
+// without threading a callback through six job creators and two studios, and so a path added later
+// is covered by construction rather than by remembering.
+let blockedHandler = null;
+
+export function setModelLibraryHandler(handler) {
+  const next = typeof handler === "function" ? handler : null;
+  blockedHandler = next;
+  return () => {
+    if (blockedHandler === next) blockedHandler = null;
+  };
+}
+
+// Hand a rejection to the prompt. Returns true when the prompt owns it, so the caller suppresses
+// its own error surface — a raw filesystem/loader message must never reach the user for this case.
+export function handleModelLibraryRejection(error, action) {
+  const context = modelLibraryContext(error);
+  if (!context) return false;
+  return blockedHandler?.(context, action) === true;
+}
+
+// Raise the prompt for a model the catalog already reports as unavailable (selection time), with
+// no queued action: the recovery is the point, and there is nothing to resume.
+export function raiseModelLibraryPrompt(context) {
+  if (!context) return false;
+  return blockedHandler?.(context, null) === true;
+}
+
 const IDLE = Object.freeze({
   status: "idle",
   context: null,

--- a/apps/web/src/modelLibrary.js
+++ b/apps/web/src/modelLibrary.js
@@ -137,7 +137,9 @@ const IDLE = Object.freeze({
 //   `probe`    — the seam's library status; a retry gates on its `available`.
 //   `validate` — check a candidate root, writing nothing anywhere.
 //   `adopt`    — re-bind the server's durable identity to that root.
-//   `persist`  — store the client's own copy of the location; may return an undo function.
+//   `persist`  — store the client's own copy of the location. It must either return an undo that
+//                restores the previous location, or throw BEFORE writing anything. Returning
+//                without an undo is treated as "changed and unrestorable", never as "unchanged".
 //
 // Relocation has TWO durable writes in different places (the shell's `HF_HOME` and the server's
 // binding ledger) and they must not be allowed to disagree: `validate` first so every ordinary
@@ -247,15 +249,31 @@ export function createModelLibraryGate({ probe, validate, adopt, persist } = {})
       // 2. Persist the client's copy, then 3. re-bind the server's. If the re-bind fails, undo the
       //    persist so the two cannot disagree — and say what actually happened either way.
       let undoPersist = null;
+      // Whether `persist` got far enough to have written anything. A `persist` that THREW wrote
+      // nothing (it is required to fail before its own durable write), so the previous location
+      // really is still in use; one that returned is the only case where restoring is in question.
+      let persisted = false;
       try {
-        undoPersist = (await persist?.(target)) ?? null;
+        if (persist) {
+          undoPersist = (await persist(target)) ?? null;
+          persisted = true;
+        }
         await adopt?.(path);
       } catch (error) {
         let restored = true;
-        try {
-          await undoPersist?.();
-        } catch {
-          restored = false;
+        if (persisted) {
+          if (typeof undoPersist === "function") {
+            try {
+              await undoPersist();
+            } catch {
+              restored = false;
+            }
+          } else {
+            // Persisted, but handed back no undo: the client's copy has changed and cannot be put
+            // back. Claiming "the previous location is still in use" here would be a lie, and the
+            // two copies would be left disagreeing with the user told otherwise.
+            restored = false;
+          }
         }
         if (attempt !== epoch) return null;
         pending = action;

--- a/apps/web/src/modelLibrary.test.js
+++ b/apps/web/src/modelLibrary.test.js
@@ -4,6 +4,9 @@ import {
   modelLibraryContext,
   modelLibraryContextForModel,
   modelLibraryUnavailable,
+  rethrowUnlessPrompted,
+  setModelLibraryHandler,
+  ModelLibraryPrompted,
   MODEL_LIBRARY_UNAVAILABLE_CODE,
 } from "./modelLibrary.js";
 
@@ -239,6 +242,31 @@ describe("model library gate", () => {
     // The original action survived the rejected attempt.
     await gate.retry();
     expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  // The throwing submission paths (training) must not print a second surface beside the dialog,
+  // and must still propagate every other failure untouched.
+  it("converts a typed rejection into a silent throw for propagating call sites", async () => {
+    const action = vi.fn(async () => "training-job-1");
+    const gate = createModelLibraryGate({ probe: async () => ({ available: true }) });
+    const unregister = setModelLibraryHandler(gate.block);
+
+    expect(() => rethrowUnlessPrompted(unavailableError(), action)).toThrow(
+      ModelLibraryPrompted,
+    );
+    // An empty message is what makes `setError(err.message)` CLEAR rather than print.
+    try {
+      rethrowUnlessPrompted(unavailableError(), action);
+    } catch (error) {
+      expect(error.message).toBe("");
+    }
+    expect(gate.getState()).toMatchObject({ status: "blocked" });
+    await gate.retry();
+    expect(action).toHaveBeenCalledTimes(1);
+
+    const ordinary = new Error("network down");
+    expect(() => rethrowUnlessPrompted(ordinary, action)).toThrow(ordinary);
+    unregister();
   });
 
   it("notifies subscribers on every settled transition", async () => {

--- a/apps/web/src/modelLibrary.test.js
+++ b/apps/web/src/modelLibrary.test.js
@@ -194,26 +194,40 @@ describe("model library gate", () => {
     expect(action).not.toHaveBeenCalled();
   });
 
-  it("relocates through the seam, persists the returned home, and queues nothing afterwards", async () => {
+  it("validates, then persists, then adopts — and queues nothing afterwards", async () => {
     const action = vi.fn(async () => "job-1");
-    const adopted = {
+    const target = {
       libraryRoot: "/Volumes/Models 1/hf/hub",
       hfHome: "/Volumes/Models 1/hf",
-      status: { available: true },
+      adopted: false,
     };
-    const relocate = vi.fn(async () => adopted);
-    const persist = vi.fn(async () => ({}));
+    const order = [];
+    const validate = vi.fn(async () => {
+      order.push("validate");
+      return target;
+    });
+    const persist = vi.fn(async () => {
+      order.push("persist");
+      return null;
+    });
+    const adopt = vi.fn(async () => {
+      order.push("adopt");
+    });
     const gate = createModelLibraryGate({
       probe: async () => ({ available: false }),
-      relocate,
+      validate,
       persist,
+      adopt,
     });
     gate.block(unavailableError().context, action);
 
-    await expect(gate.relocate("/Volumes/Models 1/hf")).resolves.toBe(adopted);
-    expect(relocate).toHaveBeenCalledWith("/Volumes/Models 1/hf");
-    expect(persist).toHaveBeenCalledWith(adopted);
-    expect(gate.getState()).toMatchObject({ status: "idle", relocated: adopted });
+    await expect(gate.relocate("/Volumes/Models 1/hf")).resolves.toBe(target);
+    // Validation runs BEFORE either durable write, so an ordinary refusal never leaves the two
+    // copies of the location disagreeing.
+    expect(order).toEqual(["validate", "persist", "adopt"]);
+    expect(validate).toHaveBeenCalledWith("/Volumes/Models 1/hf");
+    expect(persist).toHaveBeenCalledWith(target);
+    expect(gate.getState()).toMatchObject({ status: "idle", relocated: target });
     // Relocation takes effect on the next launch, so resuming now would only be refused again:
     // the action is dropped, exactly like cancel, rather than left queued.
     expect(action).not.toHaveBeenCalled();
@@ -226,22 +240,85 @@ describe("model library gate", () => {
     const rejection = new Error(
       "That folder does not contain a SceneWorks model library.",
     );
-    const relocate = vi.fn().mockRejectedValueOnce(rejection);
+    const validate = vi.fn().mockRejectedValueOnce(rejection);
     const persist = vi.fn();
+    const adopt = vi.fn();
     const gate = createModelLibraryGate({
       probe: async () => ({ available: true }),
-      relocate,
+      validate,
       persist,
+      adopt,
     });
     gate.block(unavailableError().context, action);
 
     await expect(gate.relocate("/Users/me/Pictures")).resolves.toBeNull();
+    // Nothing was written anywhere, which is the entire point of validating first.
     expect(persist).not.toHaveBeenCalled();
+    expect(adopt).not.toHaveBeenCalled();
     expect(gate.getState()).toMatchObject({ status: "blocked" });
     expect(gate.getState().error).toBe(rejection.message);
     // The original action survived the rejected attempt.
     await gate.retry();
     expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  // The two durable writes live in different places (the shell's settings file, the server's
+  // binding ledger). If the second fails, the first must be undone — and whatever the user is told
+  // has to match the state they are actually in.
+  it("undoes the persisted location when the server's re-bind fails, and says so", async () => {
+    const action = vi.fn(async () => "job-1");
+    const target = { libraryRoot: "/new/hub", hfHome: "/new" };
+    const undo = vi.fn(async () => {});
+    const persist = vi.fn(async () => undo);
+    const adopt = vi.fn().mockRejectedValueOnce(new Error("the library went away"));
+    const gate = createModelLibraryGate({
+      probe: async () => ({ available: true }),
+      validate: async () => target,
+      persist,
+      adopt,
+    });
+    gate.block(unavailableError().context, action);
+
+    await expect(gate.relocate("/new")).resolves.toBeNull();
+    expect(undo).toHaveBeenCalledTimes(1);
+    expect(gate.getState().error).toContain("previous location is still in use");
+    expect(gate.getState()).toMatchObject({ status: "blocked" });
+    // The blocked submission is still resumable — nothing was lost by the failed attempt.
+    await gate.retry();
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("says the previous location could NOT be restored when the undo also fails", async () => {
+    const undo = vi.fn().mockRejectedValueOnce(new Error("settings file is read-only"));
+    const gate = createModelLibraryGate({
+      probe: async () => ({ available: true }),
+      validate: async () => ({ libraryRoot: "/new/hub", hfHome: "/new" }),
+      persist: async () => undo,
+      adopt: async () => {
+        throw new Error("re-bind failed");
+      },
+    });
+    gate.block(unavailableError().context, vi.fn());
+
+    await expect(gate.relocate("/new")).resolves.toBeNull();
+    expect(gate.getState().error).toContain("could not restore the previous location");
+    expect(gate.getState().error).toContain("Settings");
+  });
+
+  it("clears a stale error when a later retry answers with a hint", async () => {
+    const gate = createModelLibraryGate({
+      probe: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Request failed with 500"))
+        .mockResolvedValueOnce({ available: false }),
+    });
+    gate.block(unavailableError().context, vi.fn());
+
+    await gate.retry();
+    expect(gate.getState().error).toBeTruthy();
+    await gate.retry();
+    expect(gate.getState().error).toBe("");
+    expect(gate.getState().hint).toBeTruthy();
   });
 
   // The throwing submission paths (training) must not print a second surface beside the dialog,

--- a/apps/web/src/modelLibrary.test.js
+++ b/apps/web/src/modelLibrary.test.js
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createModelLibraryGate,
+  modelLibraryContext,
+  modelLibraryContextForModel,
+  modelLibraryUnavailable,
+  MODEL_LIBRARY_UNAVAILABLE_CODE,
+} from "./modelLibrary.js";
+
+function unavailableError(overrides = {}) {
+  return {
+    code: MODEL_LIBRARY_UNAVAILABLE_CODE,
+    message: "Model 'z-image' is installed on an external model library…",
+    context: {
+      schemaVersion: 1,
+      availability: "installed_external_unavailable",
+      modelId: "z-image",
+      modelName: "Z-Image",
+      configuredLibraryPath: "/Volumes/Models/hf/hub",
+      expectedLibraryPath: "/Volumes/Models/hf/hub",
+      expectedVolumeId: "macos-volume:abc",
+      ...overrides,
+    },
+  };
+}
+
+// A probe whose answer the test releases by hand, so a second event can be injected while the
+// first attempt is genuinely still in flight.
+function deferredProbe() {
+  let release;
+  const gate = new Promise((resolve) => {
+    release = resolve;
+  });
+  const probe = vi.fn(() => gate);
+  return { probe, release: (value) => release(value) };
+}
+
+describe("modelLibraryContext", () => {
+  it("recognizes only the typed rejection, never a message that reads like one", () => {
+    expect(modelLibraryContext(unavailableError())?.modelId).toBe("z-image");
+    expect(
+      modelLibraryContext({
+        message: "external model library is currently unavailable",
+        status: 503,
+      }),
+    ).toBeNull();
+    // Code without the typed payload is not enough to open a prompt that must name a library.
+    expect(
+      modelLibraryContext({ code: MODEL_LIBRARY_UNAVAILABLE_CODE }),
+    ).toBeNull();
+    // A different typed availability is a different story (missing/incomplete keep their
+    // established download path).
+    expect(
+      modelLibraryContext(unavailableError({ availability: "missing" })),
+    ).toBeNull();
+  });
+
+  it("reads a catalog row's availability from the seam rather than re-deriving it", () => {
+    const row = {
+      id: "z-image",
+      name: "Z-Image",
+      installState: "installed",
+      modelAvailability: "installed_external_unavailable",
+      modelResolution: {
+        schemaVersion: 1,
+        configuredLibraryPath: "/Volumes/Models/hf/hub",
+        expectedLibrary: {
+          canonicalPath: "/Volumes/Models/hf/hub",
+          physicalIdentity: { volumeId: "macos-volume:abc" },
+        },
+      },
+    };
+    expect(modelLibraryUnavailable(row)).toBe(true);
+    expect(modelLibraryContextForModel(row)).toMatchObject({
+      modelId: "z-image",
+      modelName: "Z-Image",
+      expectedLibraryPath: "/Volumes/Models/hf/hub",
+      expectedVolumeId: "macos-volume:abc",
+    });
+    // A complete local model is never prompted about.
+    expect(
+      modelLibraryUnavailable({ id: "local", modelAvailability: "local_ready" }),
+    ).toBe(false);
+    expect(
+      modelLibraryContextForModel({ id: "local", modelAvailability: "local_ready" }),
+    ).toBeNull();
+  });
+});
+
+describe("model library gate", () => {
+  it("resumes the blocked action exactly once when the library comes back", async () => {
+    const action = vi.fn(async () => "job-1");
+    const probe = vi.fn(async () => ({ available: true }));
+    const gate = createModelLibraryGate({ probe });
+
+    expect(gate.block(unavailableError().context, action)).toBe(true);
+    expect(gate.getState().status).toBe("blocked");
+    expect(action).not.toHaveBeenCalled();
+
+    await expect(gate.retry()).resolves.toBe("job-1");
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(gate.getState()).toMatchObject({ status: "idle", context: null });
+
+    // The pending slot is empty: a retry after the resume can never re-fire it.
+    await gate.retry();
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not double-submit when a reconnect event lands while a retry is in flight", async () => {
+    const action = vi.fn(async () => "job-1");
+    const { probe, release } = deferredProbe();
+    const gate = createModelLibraryGate({ probe });
+    gate.block(unavailableError().context, action);
+
+    const first = gate.retry();
+    // The drive-watcher fires again, and the user clicks the button, both mid-probe.
+    const second = gate.retry({ auto: true });
+    const third = gate.retry();
+    release({ available: true });
+    await Promise.all([first, second, third]);
+
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps exactly one pending action when a second rejection arrives while blocked", async () => {
+    const first = vi.fn(async () => "job-1");
+    const second = vi.fn(async () => "job-2");
+    const gate = createModelLibraryGate({ probe: async () => ({ available: true }) });
+
+    gate.block(unavailableError().context, first);
+    // The second click is owned by the gate (no second dialog, no second error banner) but its
+    // action is dropped rather than queued behind the first.
+    expect(gate.block(unavailableError().context, second)).toBe(true);
+    await gate.retry();
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it("stays blocked, and keeps the action runnable, when the library is still missing", async () => {
+    const action = vi.fn(async () => "job-1");
+    const probe = vi
+      .fn()
+      .mockResolvedValueOnce({ available: false })
+      .mockResolvedValueOnce({ available: true });
+    const gate = createModelLibraryGate({ probe });
+    gate.block(unavailableError().context, action);
+
+    await gate.retry();
+    expect(action).not.toHaveBeenCalled();
+    expect(gate.getState()).toMatchObject({ status: "blocked" });
+    expect(gate.getState().hint).toBeTruthy();
+
+    await gate.retry();
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a probe failure without losing the pending action, and never as a raw throw", async () => {
+    const action = vi.fn(async () => "job-1");
+    const probe = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Request failed with 500"))
+      .mockResolvedValueOnce({ available: true });
+    const gate = createModelLibraryGate({ probe });
+    gate.block(unavailableError().context, action);
+
+    await expect(gate.retry()).resolves.toBeNull();
+    expect(gate.getState()).toMatchObject({ status: "blocked" });
+    expect(gate.getState().error).toBeTruthy();
+
+    await gate.retry();
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves nothing queued on cancel — including a retry already in flight", async () => {
+    const action = vi.fn(async () => "job-1");
+    const { probe, release } = deferredProbe();
+    const gate = createModelLibraryGate({ probe });
+    gate.block(unavailableError().context, action);
+
+    const inFlight = gate.retry();
+    gate.cancel();
+    expect(gate.getState()).toMatchObject({ status: "idle", context: null });
+    // The drive really did come back — but the user already cancelled, so nothing may submit.
+    release({ available: true });
+    await inFlight;
+    expect(action).not.toHaveBeenCalled();
+
+    await gate.retry();
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("relocates through the seam, persists the returned home, and queues nothing afterwards", async () => {
+    const action = vi.fn(async () => "job-1");
+    const adopted = {
+      libraryRoot: "/Volumes/Models 1/hf/hub",
+      hfHome: "/Volumes/Models 1/hf",
+      status: { available: true },
+    };
+    const relocate = vi.fn(async () => adopted);
+    const persist = vi.fn(async () => ({}));
+    const gate = createModelLibraryGate({
+      probe: async () => ({ available: false }),
+      relocate,
+      persist,
+    });
+    gate.block(unavailableError().context, action);
+
+    await expect(gate.relocate("/Volumes/Models 1/hf")).resolves.toBe(adopted);
+    expect(relocate).toHaveBeenCalledWith("/Volumes/Models 1/hf");
+    expect(persist).toHaveBeenCalledWith(adopted);
+    expect(gate.getState()).toMatchObject({ status: "idle", relocated: adopted });
+    // Relocation takes effect on the next launch, so resuming now would only be refused again:
+    // the action is dropped, exactly like cancel, rather than left queued.
+    expect(action).not.toHaveBeenCalled();
+    await gate.retry();
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("keeps the prompt open with actionable guidance when a relocation is rejected", async () => {
+    const action = vi.fn(async () => "job-1");
+    const rejection = new Error(
+      "That folder does not contain a SceneWorks model library.",
+    );
+    const relocate = vi.fn().mockRejectedValueOnce(rejection);
+    const persist = vi.fn();
+    const gate = createModelLibraryGate({
+      probe: async () => ({ available: true }),
+      relocate,
+      persist,
+    });
+    gate.block(unavailableError().context, action);
+
+    await expect(gate.relocate("/Users/me/Pictures")).resolves.toBeNull();
+    expect(persist).not.toHaveBeenCalled();
+    expect(gate.getState()).toMatchObject({ status: "blocked" });
+    expect(gate.getState().error).toBe(rejection.message);
+    // The original action survived the rejected attempt.
+    await gate.retry();
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies subscribers on every settled transition", async () => {
+    const listener = vi.fn();
+    const gate = createModelLibraryGate({ probe: async () => ({ available: true }) });
+    const unsubscribe = gate.subscribe(listener);
+    gate.block(unavailableError().context, async () => "job-1");
+    await gate.retry();
+    expect(listener).toHaveBeenCalled();
+    unsubscribe();
+    const seen = listener.mock.calls.length;
+    gate.block(unavailableError().context, async () => "job-2");
+    expect(listener.mock.calls.length).toBe(seen);
+  });
+});

--- a/apps/web/src/modelLibrary.test.js
+++ b/apps/web/src/modelLibrary.test.js
@@ -314,6 +314,71 @@ describe("model library gate", () => {
     expect(gate.getState().error).toContain("Settings");
   });
 
+  // A `persist` that returns WITHOUT an undo has still changed the client's copy. Treating that as
+  // "restored" would emit "the previous location is still in use" while the shell was in fact
+  // pointed at the new library — the two-copies-disagree state with the wrong message on top.
+  it("never claims the previous location survived when persist handed back no undo", async () => {
+    const persist = vi.fn(async () => null);
+    const gate = createModelLibraryGate({
+      probe: async () => ({ available: true }),
+      validate: async () => ({ libraryRoot: "/new/hub", hfHome: "/new" }),
+      persist,
+      adopt: async () => {
+        throw new Error("re-bind failed");
+      },
+    });
+    gate.block(unavailableError().context, vi.fn());
+
+    await expect(gate.relocate("/new")).resolves.toBeNull();
+    expect(persist).toHaveBeenCalledTimes(1);
+    expect(gate.getState().error).toContain("could not restore the previous location");
+    expect(gate.getState().error).not.toContain("previous location is still in use");
+  });
+
+  // A shell that keeps no copy of its own says so with a NO-OP undo, and must not be mistaken for
+  // one that wrote and cannot undo: nothing changed, so the previous location really is in use.
+  it("reports the previous location still in use when persist wrote nothing", async () => {
+    const gate = createModelLibraryGate({
+      probe: async () => ({ available: true }),
+      validate: async () => ({ libraryRoot: "/new/hub", hfHome: "/new" }),
+      persist: async () => () => {},
+      adopt: async () => {
+        throw new Error("re-bind failed");
+      },
+    });
+    gate.block(unavailableError().context, vi.fn());
+
+    await expect(gate.relocate("/new")).resolves.toBeNull();
+    expect(gate.getState().error).toContain("previous location is still in use");
+    expect(gate.getState().error).not.toContain("could not restore");
+  });
+
+  // The other half of the contract: a `persist` that THREW is required to have written nothing, so
+  // the previous location genuinely is still in use and the message must say exactly that.
+  it("reports the previous location still in use when persist refused before writing", async () => {
+    const action = vi.fn(async () => "job-1");
+    const adopt = vi.fn();
+    const gate = createModelLibraryGate({
+      probe: async () => ({ available: true }),
+      validate: async () => ({ libraryRoot: "/new/hub", hfHome: "/new" }),
+      persist: async () => {
+        throw new Error("The current model library location could not be read.");
+      },
+      adopt,
+    });
+    gate.block(unavailableError().context, action);
+
+    await expect(gate.relocate("/new")).resolves.toBeNull();
+    // A refusal in persist happens before the server is ever re-bound.
+    expect(adopt).not.toHaveBeenCalled();
+    expect(gate.getState().error).toContain("previous location is still in use");
+    expect(gate.getState().error).toContain("could not be read");
+    expect(gate.getState()).toMatchObject({ status: "blocked" });
+    // The blocked submission survives, so the user can reconnect the original drive instead.
+    await gate.retry();
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
   it("clears a stale error when a later retry answers with a hint", async () => {
     const gate = createModelLibraryGate({
       probe: vi

--- a/apps/web/src/modelLibrary.test.js
+++ b/apps/web/src/modelLibrary.test.js
@@ -79,7 +79,16 @@ describe("modelLibraryContext", () => {
       modelName: "Z-Image",
       expectedLibraryPath: "/Volumes/Models/hf/hub",
       expectedVolumeId: "macos-volume:abc",
+      // Absent means "not present" — a stamped resolution from before this field existed must not
+      // read as a mismatched library.
+      libraryPresent: false,
     });
+    expect(
+      modelLibraryContextForModel({
+        ...row,
+        modelResolution: { ...row.modelResolution, libraryPresent: true },
+      }).libraryPresent,
+    ).toBe(true);
     // A complete local model is never prompted about.
     expect(
       modelLibraryUnavailable({ id: "local", modelAvailability: "local_ready" }),

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -16349,6 +16349,40 @@ details[open] > summary.lora-scope-group-heading::before,
   gap: 8px;
 }
 
+/* Unavailable model library prompt (sc-19709). Wider than a plain confirm because it names a
+   filesystem location the user has to recognize, and carries three exits rather than two. */
+.model-library-modal {
+  width: 460px;
+}
+.model-library-path {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  font-size: 12px;
+}
+.model-library-path-label {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 11px;
+}
+.model-library-path code {
+  overflow-wrap: anywhere;
+  font-size: 12px;
+}
+.model-library-status {
+  margin: 0;
+  min-height: 16px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.model-library-hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
 /* Generation Stats screen (epic 10402, sc-10408/sc-10409) */
 .stats-filters {
   display: flex;

--- a/crates/sceneworks-core/src/model_artifacts/external_library.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library.rs
@@ -824,13 +824,13 @@ impl std::fmt::Display for LibraryRelocationError {
 }
 
 /// A validated relocation choice: the Hugging Face hub root SceneWorks binds, plus the `HF_HOME`
-/// value that resolves to it. The two are always related as `library_root == huggingface_home/hub`
+/// value that resolves to it. The two are always related as `library_root == hf_home/hub`
 /// because that is exactly what [`crate::hf_home::huggingface_hub_cache_dir`] computes.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct RelocationTarget {
     pub library_root: PathBuf,
-    pub huggingface_home: PathBuf,
+    pub hf_home: PathBuf,
 }
 
 /// Map a folder the operator picked to the pair of paths relocation needs.
@@ -856,7 +856,7 @@ pub fn resolve_relocation_target(
     {
         return Ok(RelocationTarget {
             library_root: hub,
-            huggingface_home: picked,
+            hf_home: picked,
         });
     }
     if !has_repository_layout(&canonical) {
@@ -869,7 +869,7 @@ pub fn resolve_relocation_target(
     match (is_hub, parent) {
         (true, Some(home)) => Ok(RelocationTarget {
             library_root: picked,
-            huggingface_home: home,
+            hf_home: home,
         }),
         _ => Err(LibraryRelocationRejection::HubDirectoryExpected),
     }

--- a/crates/sceneworks-core/src/model_artifacts/external_library.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library.rs
@@ -118,6 +118,14 @@ pub struct ModelResolution {
     pub expected_library: Option<ExternalLibraryBinding>,
     pub requirements: Vec<ExternalArtifactRequirement>,
     pub local_artifact: Option<ResolvedModelArtifact>,
+    /// The configured library root is a readable directory RIGHT NOW, while the model still reads
+    /// unavailable (sc-19709). That is the "present but the recorded identity disagrees" case — a
+    /// different volume mounted where the library used to be, or a binding that predates a move —
+    /// and it is not fixed by reconnecting anything, so the prompt leads with relocation instead.
+    ///
+    /// `serde(default)` keeps resolutions stamped into jobs before this field readable.
+    #[serde(default)]
+    pub library_present: bool,
 }
 
 impl ModelResolution {
@@ -134,6 +142,7 @@ impl ModelResolution {
             expected_library: Some(expected_library),
             requirements,
             local_artifact: None,
+            library_present: false,
         })
     }
 
@@ -149,6 +158,7 @@ impl ModelResolution {
             expected_library,
             requirements,
             local_artifact: None,
+            library_present: false,
         }
     }
 
@@ -172,7 +182,16 @@ impl ModelResolution {
             expected_library: None,
             requirements,
             local_artifact: None,
+            library_present: false,
         })
+    }
+
+    /// Mark an unavailable resolution as one whose configured library root IS readable right now —
+    /// the "present but the recorded identity disagrees" case, which reconnecting cannot fix.
+    #[must_use]
+    pub fn with_library_present(mut self, present: bool) -> Self {
+        self.library_present = present;
+        self
     }
 
     pub fn local_ready(artifact: ResolvedModelArtifact) -> Result<Self, ExternalLibraryError> {
@@ -191,6 +210,7 @@ impl ModelResolution {
             expected_library: None,
             requirements: Vec::new(),
             local_artifact: Some(artifact),
+            library_present: false,
         })
     }
 
@@ -332,8 +352,17 @@ impl ExternalLibraryBindingStore {
         if let Some(binding) = self.read_unlocked()? {
             let probe = probe_binding(configured_path, &binding);
             if probe.status == ExternalLibraryProbeStatus::Available {
+                // The library is reachable under a name the ledger does not record — the operator
+                // configured the drive directly where the binding remembers the symlink, or vice
+                // versa. Canonical path and volume identity already proved it is the SAME library,
+                // so record the name in use. Nothing else about the binding changes (not the
+                // canonical path, not the identity, not `bound_at`): this is the ledger catching up
+                // with an alias, not a re-bind, and it keeps the `configured_path` invariant that
+                // stamped resolutions and the worker's pre-loader guard check.
+                let binding = self.realias_unlocked(binding, configured_path)?;
                 validate_requirements_at_root(&binding.canonical_path, requirements)?;
                 self.remember_validated_closure_unlocked(requirements)?;
+                return Ok((binding, probe));
             }
             return Ok((binding, probe));
         }
@@ -546,6 +575,26 @@ impl ExternalLibraryBindingStore {
             }
         }
         Ok(probe_before)
+    }
+
+    /// Record the name the library is currently configured as, when it differs from the one the
+    /// ledger holds and the probe has ALREADY proven both name the same directory on the same
+    /// volume. A no-op when the names match, which is the overwhelmingly common case.
+    fn realias_unlocked(
+        &self,
+        binding: ExternalLibraryBinding,
+        configured_path: &Path,
+    ) -> Result<ExternalLibraryBinding, ExternalLibraryError> {
+        let configured_path = absolute_lexical(configured_path)?;
+        if configured_path == binding.configured_path {
+            return Ok(binding);
+        }
+        let realiased = ExternalLibraryBinding {
+            configured_path,
+            ..binding
+        };
+        self.write_unlocked(&realiased)?;
+        Ok(realiased)
     }
 
     fn ledger_path(&self) -> PathBuf {
@@ -1118,6 +1167,10 @@ pub struct ExternalLibraryUnavailableContext {
     pub configured_library_path: PathBuf,
     pub expected_library_path: Option<PathBuf>,
     pub expected_volume_id: Option<String>,
+    /// The configured library is present and browsable, but its identity disagrees with the
+    /// recording. The prompt leads with "choose the library" rather than "reconnect the drive",
+    /// because there is nothing to reconnect.
+    pub library_present: bool,
 }
 
 impl ExternalLibraryUnavailableContext {
@@ -1140,10 +1193,24 @@ impl ExternalLibraryUnavailableContext {
                 .expected_library
                 .as_ref()
                 .map(|binding| binding.physical_identity.volume_id.clone()),
+            library_present: resolution.library_present,
         }
     }
 }
 
+/// Live identity probe of the configured library against its durable binding.
+///
+/// The authority is the CANONICAL path plus the volume's physical identity — never the lexical
+/// string the library happens to be configured as. Those two prove "the same directory on the same
+/// volume", and nothing else does: `~/.cache/huggingface/hub` symlinked to
+/// `/Volumes/Models/huggingface/hub` is one library reached by two names, and rejecting the second
+/// name on the lexical difference alone was a pure false negative that pinned every receipt-backed
+/// model to `installed_external_unavailable` — and every other one back onto the download path —
+/// the moment an operator configured the drive directly instead of through the symlink (sc-19709).
+///
+/// It still fails closed where it must: a different canonical path is a different library, and the
+/// SAME canonical path on a different volume (a decoy remounted where the real drive was) is an
+/// identity mismatch, because the physical identity half of the comparison catches it.
 pub fn probe_binding(
     configured_path: &Path,
     binding: &ExternalLibraryBinding,
@@ -1152,13 +1219,6 @@ pub fn probe_binding(
         Ok(path) => path,
         Err(_) => return unknown_probe(),
     };
-    if configured_path != binding.configured_path {
-        return ExternalLibraryProbe {
-            status: ExternalLibraryProbeStatus::IdentityMismatch,
-            observed_path: None,
-            observed_identity: None,
-        };
-    }
     let canonical = match std::fs::canonicalize(&configured_path) {
         Ok(path) => path,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -1648,6 +1708,7 @@ pub fn resolve_model_availability(
             expected_library: None,
             requirements: Vec::new(),
             local_artifact: None,
+            library_present: false,
         };
     }
     let not_installed = || {
@@ -1695,7 +1756,11 @@ pub fn resolve_model_availability(
             configured_library.to_path_buf(),
             Some(binding),
             requirements.to_vec(),
-        ),
+        )
+        // The probe was not Available, yet the root reads as a directory: the library is present
+        // and browsable but its recorded identity disagrees. Reconnecting cannot fix that, so the
+        // prompt has to offer the re-bind instead of asking for a drive that is already there.
+        .with_library_present(configured_library.is_dir()),
         // The bound volume is disconnected, but nothing proves THIS model was ever installed on
         // it (no receipt, no validated-closure record): it is a missing model, and its
         // established install path must stay reachable.
@@ -1735,6 +1800,7 @@ pub fn resolve_model_availability(
                     existing_binding,
                     requirements.to_vec(),
                 )
+                .with_library_present(configured_library.is_dir())
             }
         }
     }

--- a/crates/sceneworks-core/src/model_artifacts/external_library.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library.rs
@@ -371,6 +371,81 @@ impl ExternalLibraryBindingStore {
         ))
     }
 
+    /// Deliberate, user-driven relocation of the model source library (sc-19709).
+    ///
+    /// [`Self::bind_or_probe_validated`] never replaces a binding — that is what makes a different
+    /// physical volume at the same path fail closed. Relocation is the one explicit escape hatch:
+    /// the operator names a new library root, and the binding is replaced ONLY after that root
+    /// physically carries every closure this install previously validated. Download receipts and
+    /// the validated-closure ledger are never touched, so relocation never redownloads anything and
+    /// never loses installed state — it only re-points the durable identity at where the library
+    /// now lives.
+    pub fn relocate_binding(
+        &self,
+        library_root: &Path,
+    ) -> Result<ExternalLibraryBinding, LibraryRelocationError> {
+        let _lock = self
+            .lock_exclusive()
+            .map_err(LibraryRelocationError::Failed)?;
+        let canonical_before = canonical_library_directory(library_root)?;
+        if !has_repository_layout(&canonical_before) {
+            return Err(LibraryRelocationError::Rejected(
+                LibraryRelocationRejection::NotAModelLibrary,
+            ));
+        }
+        let closures = self
+            .read_validated_closures_unlocked()
+            .map_err(LibraryRelocationError::Failed)?;
+        let mut missing = Vec::new();
+        for closure in &closures {
+            if validate_requirements_at_root(&canonical_before, closure).is_err() {
+                missing.extend(
+                    closure
+                        .iter()
+                        .map(|requirement| requirement.repository.clone()),
+                );
+            }
+        }
+        if !missing.is_empty() {
+            missing.sort();
+            missing.dedup();
+            return Err(LibraryRelocationError::Rejected(
+                LibraryRelocationRejection::MissingInstalledModels {
+                    repositories: missing,
+                },
+            ));
+        }
+        let identity_before = physical_identity(&canonical_before).map_err(|error| {
+            LibraryRelocationError::Rejected(LibraryRelocationRejection::IdentityUnavailable {
+                detail: error.0,
+            })
+        })?;
+        // Same TOCTOU discipline as the initial bind: the closure walk touches many files and can
+        // race an unmount, so the exact identity must still hold after validation.
+        let canonical_after = canonical_library_directory(library_root)?;
+        let identity_after = physical_identity(&canonical_after).map_err(|error| {
+            LibraryRelocationError::Rejected(LibraryRelocationRejection::IdentityUnavailable {
+                detail: error.0,
+            })
+        })?;
+        if canonical_before != canonical_after || identity_before != identity_after {
+            return Err(LibraryRelocationError::Failed(ExternalLibraryError(
+                "external model library changed while it was being validated".to_owned(),
+            )));
+        }
+        let binding = ExternalLibraryBinding {
+            schema_version: EXTERNAL_LIBRARY_CONTRACT_VERSION,
+            configured_path: absolute_lexical(library_root)
+                .map_err(LibraryRelocationError::Failed)?,
+            canonical_path: canonical_before,
+            physical_identity: identity_before,
+            bound_at: now_seconds().map_err(LibraryRelocationError::Failed)?,
+        };
+        self.write_unlocked(&binding)
+            .map_err(LibraryRelocationError::Failed)?;
+        Ok(binding)
+    }
+
     pub fn probe_resolution(
         &self,
         resolution: &ModelResolution,
@@ -704,6 +779,213 @@ impl Drop for ExternalSourceSession {
     fn drop(&mut self) {
         if !self.complete {
             let _ = self.cleanup();
+        }
+    }
+}
+
+/// Typed, machine-readable reason a candidate model-library root was rejected for relocation
+/// (sc-19709). The desktop prompt renders its guidance from this discriminant — a client must never
+/// have to parse an error string, and a raw filesystem error must never reach the user.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "reason", rename_all = "snake_case")]
+pub enum LibraryRelocationRejection {
+    /// The chosen path does not exist, is not a directory, or could not be opened.
+    NotADirectory,
+    /// The chosen directory carries no Hugging Face `models--<repo>` layout at all — the classic
+    /// "picked an unrelated folder" case.
+    NotAModelLibrary,
+    /// The layout is right, but models this install recorded as present are not in that library.
+    /// Accepting it would silently orphan installed weights, so it fails closed.
+    MissingInstalledModels { repositories: Vec<String> },
+    /// The library validates, but the app cannot express it as a Hugging Face cache home: the
+    /// configured root is always `<HF_HOME>/hub`, so the operator must choose the folder that
+    /// CONTAINS `hub` (or the `hub` folder itself).
+    HubDirectoryExpected,
+    /// The volume's durable physical identity could not be read, so no binding can be written.
+    IdentityUnavailable { detail: String },
+}
+
+/// Relocation failures split into "the operator can fix this by choosing differently"
+/// ([`LibraryRelocationError::Rejected`]) and "the app failed" ([`LibraryRelocationError::Failed`]).
+/// Only the former is ever rendered to a user.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LibraryRelocationError {
+    Rejected(LibraryRelocationRejection),
+    Failed(ExternalLibraryError),
+}
+
+impl std::fmt::Display for LibraryRelocationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rejected(rejection) => write!(formatter, "{rejection:?}"),
+            Self::Failed(error) => formatter.write_str(&error.0),
+        }
+    }
+}
+
+/// A validated relocation choice: the Hugging Face hub root SceneWorks binds, plus the `HF_HOME`
+/// value that resolves to it. The two are always related as `library_root == huggingface_home/hub`
+/// because that is exactly what [`crate::hf_home::huggingface_hub_cache_dir`] computes.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct RelocationTarget {
+    pub library_root: PathBuf,
+    pub huggingface_home: PathBuf,
+}
+
+/// Map a folder the operator picked to the pair of paths relocation needs.
+///
+/// Two shapes are accepted, in this order: the picked folder is a Hugging Face cache home (it has a
+/// `hub` child carrying the repository layout), or the picked folder IS the hub root (named `hub`).
+/// A directory that carries the layout but cannot be addressed as `<HF_HOME>/hub` is rejected with
+/// [`LibraryRelocationRejection::HubDirectoryExpected`] rather than silently binding a root the app
+/// could never resolve again after a restart.
+pub fn resolve_relocation_target(
+    picked: &Path,
+) -> Result<RelocationTarget, LibraryRelocationRejection> {
+    let picked = absolute_lexical(picked).map_err(|_| LibraryRelocationRejection::NotADirectory)?;
+    let canonical =
+        std::fs::canonicalize(&picked).map_err(|_| LibraryRelocationRejection::NotADirectory)?;
+    if !canonical.is_dir() {
+        return Err(LibraryRelocationRejection::NotADirectory);
+    }
+    let hub = picked.join("hub");
+    if std::fs::canonicalize(&hub)
+        .map(|path| has_repository_layout(&path))
+        .unwrap_or(false)
+    {
+        return Ok(RelocationTarget {
+            library_root: hub,
+            huggingface_home: picked,
+        });
+    }
+    if !has_repository_layout(&canonical) {
+        return Err(LibraryRelocationRejection::NotAModelLibrary);
+    }
+    let is_hub = picked
+        .file_name()
+        .is_some_and(|name| name.eq_ignore_ascii_case("hub"));
+    let parent = picked.parent().map(Path::to_path_buf);
+    match (is_hub, parent) {
+        (true, Some(home)) => Ok(RelocationTarget {
+            library_root: picked,
+            huggingface_home: home,
+        }),
+        _ => Err(LibraryRelocationRejection::HubDirectoryExpected),
+    }
+}
+
+/// Does `root` look like a Hugging Face hub cache at all? One `models--<repo>` directory is enough:
+/// this only separates "an unrelated folder" from "a model library", never "the RIGHT library" —
+/// that judgement belongs to the recorded closures.
+fn has_repository_layout(root: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return false;
+    };
+    entries.filter_map(Result::ok).any(|entry| {
+        entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| name.starts_with("models--"))
+            && entry.file_type().is_ok_and(|kind| kind.is_dir())
+    })
+}
+
+fn canonical_library_directory(root: &Path) -> Result<PathBuf, LibraryRelocationError> {
+    let canonical = std::fs::canonicalize(root)
+        .map_err(|_| LibraryRelocationError::Rejected(LibraryRelocationRejection::NotADirectory))?;
+    ensure_regular_directory(&canonical)
+        .map_err(|_| LibraryRelocationError::Rejected(LibraryRelocationRejection::NotADirectory))?;
+    Ok(canonical)
+}
+
+/// Live status of the configured model source library (sc-19709). The desktop prompt's
+/// "Connect drive and retry" re-probe reads exactly this — one cheap, write-free identity probe
+/// rather than a catalog rebuild.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ModelSourceLibraryStatus {
+    pub schema_version: u32,
+    pub configured_library_path: PathBuf,
+    pub expected_library: Option<ExternalLibraryBinding>,
+    pub probe_status: ExternalLibraryProbeStatus,
+    /// The single boolean a retry gates on: the expected library is verified present.
+    pub available: bool,
+}
+
+/// Probe the configured library once, write-free. With a durable binding this is an identity
+/// probe; without one, availability is simply whether the configured root is a readable directory
+/// (nothing is installed there yet, so there is no identity to prove).
+pub fn probe_model_source_library(
+    data_dir: &Path,
+    configured_library: &Path,
+) -> ModelSourceLibraryStatus {
+    let binding = ExternalLibraryBindingStore::new(data_dir)
+        .ok()
+        .and_then(|store| store.load().ok())
+        .flatten();
+    let (probe_status, available) = match &binding {
+        Some(binding) => {
+            let status = probe_binding(configured_library, binding).status;
+            let available = status == ExternalLibraryProbeStatus::Available;
+            (status, available)
+        }
+        None => {
+            let present = configured_library.is_dir();
+            (
+                if present {
+                    ExternalLibraryProbeStatus::Available
+                } else {
+                    ExternalLibraryProbeStatus::Unavailable
+                },
+                present,
+            )
+        }
+    };
+    ModelSourceLibraryStatus {
+        schema_version: EXTERNAL_LIBRARY_CONTRACT_VERSION,
+        configured_library_path: configured_library.to_path_buf(),
+        expected_library: binding,
+        probe_status,
+        available,
+    }
+}
+
+/// The typed payload the API attaches to an `external_model_library_unavailable` rejection
+/// (sc-19709). The desktop prompt names the model and the expected library location from THESE
+/// fields — never by parsing `detail`, and never by re-deriving availability client-side.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ExternalLibraryUnavailableContext {
+    pub schema_version: u32,
+    pub availability: ModelAvailability,
+    pub model_id: String,
+    pub model_name: Option<String>,
+    pub configured_library_path: PathBuf,
+    pub expected_library_path: Option<PathBuf>,
+    pub expected_volume_id: Option<String>,
+}
+
+impl ExternalLibraryUnavailableContext {
+    pub fn from_resolution(
+        model_id: impl Into<String>,
+        model_name: Option<String>,
+        resolution: &ModelResolution,
+    ) -> Self {
+        Self {
+            schema_version: EXTERNAL_LIBRARY_CONTRACT_VERSION,
+            availability: resolution.availability.clone(),
+            model_id: model_id.into(),
+            model_name,
+            configured_library_path: resolution.configured_library_path.clone(),
+            expected_library_path: resolution
+                .expected_library
+                .as_ref()
+                .map(|binding| binding.canonical_path.clone()),
+            expected_volume_id: resolution
+                .expected_library
+                .as_ref()
+                .map(|binding| binding.physical_identity.volume_id.clone()),
         }
     }
 }

--- a/crates/sceneworks-core/src/model_artifacts/external_library.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library.rs
@@ -18,6 +18,9 @@ pub const EXTERNAL_LIBRARY_CONTRACT_VERSION: u32 = 1;
 pub const EXTERNAL_LIBRARY_UNAVAILABLE_CODE: &str = "external_model_library_unavailable";
 const LEDGER_FILE: &str = ".sceneworks-external-library-state.json";
 const LEDGER_LOCK: &str = ".sceneworks-external-library-state.lock";
+/// The durable download receipt written per managed model directory. Read here (never written) so
+/// relocation judges the same install evidence `resolve_model_availability` does.
+const DOWNLOAD_RECEIPT_FILE: &str = ".sceneworks-download-complete.json";
 const VALIDATED_CLOSURES_FILE: &str = ".sceneworks-external-library-closures.json";
 const SESSION_DIR: &str = ".sceneworks-external-source-sessions";
 
@@ -371,15 +374,40 @@ impl ExternalLibraryBindingStore {
         ))
     }
 
+    /// Every closure this installation has DURABLE INSTALL EVIDENCE for — the exact union
+    /// `resolve_model_availability` consults when it decides whether a disconnected library is
+    /// "installed but unavailable": the validated-closure ledger AND the download receipts.
+    ///
+    /// Reading only the ledger is a fail-open: a receipt-backed install that predates the ledger
+    /// (or was never validated on a bound library) contributes nothing, so an unrelated folder with
+    /// a single `models--*` directory would validate vacuously and the binding would be overwritten
+    /// onto the wrong volume. Both sources, always.
+    fn installed_evidence_closures(
+        &self,
+    ) -> Result<Vec<Vec<ExternalArtifactRequirement>>, ExternalLibraryError> {
+        let mut closures = self.read_validated_closures_unlocked()?;
+        for requirement in receipt_installed_requirements(&self.models_dir) {
+            let closure = vec![requirement];
+            if !closures.contains(&closure) {
+                closures.push(closure);
+            }
+        }
+        Ok(closures)
+    }
+
     /// Deliberate, user-driven relocation of the model source library (sc-19709).
     ///
     /// [`Self::bind_or_probe_validated`] never replaces a binding — that is what makes a different
     /// physical volume at the same path fail closed. Relocation is the one explicit escape hatch:
     /// the operator names a new library root, and the binding is replaced ONLY after that root
-    /// physically carries every closure this install previously validated. Download receipts and
-    /// the validated-closure ledger are never touched, so relocation never redownloads anything and
+    /// physically carries every closure this install has evidence for. Download receipts and the
+    /// validated-closure ledger are never touched, so relocation never redownloads anything and
     /// never loses installed state — it only re-points the durable identity at where the library
     /// now lives.
+    ///
+    /// It fails CLOSED in both directions: a library missing any recorded install is refused, and
+    /// an installation with no evidence at all is refused outright rather than binding whatever
+    /// Hugging-Face-shaped directory it was handed.
     pub fn relocate_binding(
         &self,
         library_root: &Path,
@@ -387,15 +415,50 @@ impl ExternalLibraryBindingStore {
         let _lock = self
             .lock_exclusive()
             .map_err(LibraryRelocationError::Failed)?;
+        let (canonical, identity) = self.check_relocation_unlocked(library_root)?;
+        let binding = ExternalLibraryBinding {
+            schema_version: EXTERNAL_LIBRARY_CONTRACT_VERSION,
+            configured_path: absolute_lexical(library_root)
+                .map_err(LibraryRelocationError::Failed)?,
+            canonical_path: canonical,
+            physical_identity: identity,
+            bound_at: now_seconds().map_err(LibraryRelocationError::Failed)?,
+        };
+        self.write_unlocked(&binding)
+            .map_err(LibraryRelocationError::Failed)?;
+        Ok(binding)
+    }
+
+    /// Every check [`Self::relocate_binding`] makes, with nothing written.
+    ///
+    /// The client persists its own copy of the library location (the desktop shell's `HF_HOME`) and
+    /// the server re-binds the identity ledger. Whichever of those two durable writes runs second
+    /// can fail, and there is no compensating action for the FIRST one when the library it pointed
+    /// at is the disconnected drive. Validating first moves every ordinary refusal ahead of both
+    /// writes, so the only surviving failure window is an exceptional race — not a wrong folder.
+    pub fn validate_relocation(&self, library_root: &Path) -> Result<(), LibraryRelocationError> {
+        let _lock = self.lock_shared().map_err(LibraryRelocationError::Failed)?;
+        self.check_relocation_unlocked(library_root).map(|_| ())
+    }
+
+    fn check_relocation_unlocked(
+        &self,
+        library_root: &Path,
+    ) -> Result<(PathBuf, ExternalLibraryPhysicalIdentity), LibraryRelocationError> {
         let canonical_before = canonical_library_directory(library_root)?;
+        let closures = self
+            .installed_evidence_closures()
+            .map_err(LibraryRelocationError::Failed)?;
+        if closures.is_empty() {
+            return Err(LibraryRelocationError::Rejected(
+                LibraryRelocationRejection::NoInstalledModels,
+            ));
+        }
         if !has_repository_layout(&canonical_before) {
             return Err(LibraryRelocationError::Rejected(
                 LibraryRelocationRejection::NotAModelLibrary,
             ));
         }
-        let closures = self
-            .read_validated_closures_unlocked()
-            .map_err(LibraryRelocationError::Failed)?;
         let mut missing = Vec::new();
         for closure in &closures {
             if validate_requirements_at_root(&canonical_before, closure).is_err() {
@@ -428,22 +491,17 @@ impl ExternalLibraryBindingStore {
                 detail: error.0,
             })
         })?;
-        if canonical_before != canonical_after || identity_before != identity_after {
+        if !relocation_identity_held(
+            &canonical_before,
+            &canonical_after,
+            &identity_before,
+            &identity_after,
+        ) {
             return Err(LibraryRelocationError::Failed(ExternalLibraryError(
                 "external model library changed while it was being validated".to_owned(),
             )));
         }
-        let binding = ExternalLibraryBinding {
-            schema_version: EXTERNAL_LIBRARY_CONTRACT_VERSION,
-            configured_path: absolute_lexical(library_root)
-                .map_err(LibraryRelocationError::Failed)?,
-            canonical_path: canonical_before,
-            physical_identity: identity_before,
-            bound_at: now_seconds().map_err(LibraryRelocationError::Failed)?,
-        };
-        self.write_unlocked(&binding)
-            .map_err(LibraryRelocationError::Failed)?;
-        Ok(binding)
+        Ok((canonical_before, identity_before))
     }
 
     pub fn probe_resolution(
@@ -797,6 +855,10 @@ pub enum LibraryRelocationRejection {
     /// The layout is right, but models this install recorded as present are not in that library.
     /// Accepting it would silently orphan installed weights, so it fails closed.
     MissingInstalledModels { repositories: Vec<String> },
+    /// This installation has no durable install evidence at all — no receipts, no validated
+    /// closures — so there is nothing to relocate and nothing to check a candidate against.
+    /// Binding an arbitrary Hugging-Face-shaped directory here would be a guess, not a relocation.
+    NoInstalledModels,
     /// The library validates, but the app cannot express it as a Hugging Face cache home: the
     /// configured root is always `<HF_HOME>/hub`, so the operator must choose the folder that
     /// CONTAINS `hub` (or the `hub` folder itself).
@@ -873,6 +935,98 @@ pub fn resolve_relocation_target(
         }),
         _ => Err(LibraryRelocationRejection::HubDirectoryExpected),
     }
+}
+
+/// The relocation TOCTOU rule, pure so it can be asserted directly: the exact canonical path AND
+/// the exact physical identity must both survive the closure walk. A remount that swaps the volume
+/// under the same path is precisely what the identity half catches.
+fn relocation_identity_held(
+    canonical_before: &Path,
+    canonical_after: &Path,
+    identity_before: &ExternalLibraryPhysicalIdentity,
+    identity_after: &ExternalLibraryPhysicalIdentity,
+) -> bool {
+    canonical_before == canonical_after && identity_before == identity_after
+}
+
+/// Every install recorded by a durable download receipt, one self-contained requirement per receipt
+/// entry.
+///
+/// Deliberately manifest-free: relocation must judge what this machine actually INSTALLED, not what
+/// the current catalog happens to declare, and a receipt is self-describing (repo, immutable
+/// revision, variant, exact resolved files). Receipts are read, never written. A receipt whose
+/// shape cannot be understood is skipped rather than trusted — it contributes no evidence, and the
+/// caller still refuses when nothing at all is understood.
+fn receipt_installed_requirements(models_dir: &Path) -> Vec<ExternalArtifactRequirement> {
+    let Ok(entries) = std::fs::read_dir(models_dir) else {
+        return Vec::new();
+    };
+    let mut requirements: Vec<ExternalArtifactRequirement> = Vec::new();
+    for entry in entries.filter_map(Result::ok) {
+        if !entry.file_type().is_ok_and(|kind| kind.is_dir()) {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(entry.path().join(DOWNLOAD_RECEIPT_FILE)) else {
+            continue;
+        };
+        let Ok(document) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+            continue;
+        };
+        let receipts = document
+            .get("receipts")
+            .and_then(serde_json::Value::as_array)
+            .cloned()
+            .unwrap_or_else(|| vec![document]);
+        for receipt in receipts {
+            let Some(repository) = receipt.get("repo").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            let files = receipt
+                .get("resolvedFiles")
+                .and_then(serde_json::Value::as_array)
+                .map(|files| {
+                    files
+                        .iter()
+                        .filter_map(serde_json::Value::as_str)
+                        .map(PathBuf::from)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            if files.is_empty() {
+                continue;
+            }
+            let requirement = ExternalArtifactRequirement {
+                repository: repository.to_owned(),
+                revision: receipt
+                    .get("snapshotRevision")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned),
+                // Matches `receipt_requirements_for_model`: a variant-less legacy receipt is the
+                // `default` variant.
+                variant: receipt
+                    .get("variant")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or("default")
+                    .to_owned(),
+                files,
+                is_primary: true,
+            };
+            if !requirements.contains(&requirement) {
+                requirements.push(requirement);
+            }
+        }
+    }
+    requirements.sort_by(|left, right| {
+        (&left.repository, &left.revision, &left.variant, &left.files).cmp(&(
+            &right.repository,
+            &right.revision,
+            &right.variant,
+            &right.files,
+        ))
+    });
+    requirements
 }
 
 /// Does `root` look like a Hugging Face hub cache at all? One `models--<repo>` directory is enough:

--- a/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
@@ -836,3 +836,168 @@ fn a_resolution_stamped_before_relocation_no_longer_matches_the_binding() {
         vec![canonical_requirement_closure(&requirements)]
     );
 }
+
+/// The full identity matrix behind `probe_binding` (sc-19709). CANONICAL PATH + VOLUME IDENTITY are
+/// the authority; the lexical name the library is configured as is not.
+///
+/// The case that forced this: `~/.cache/huggingface/hub` is a symlink to a real external drive, so
+/// an operator who configures the drive directly — the intended way to use an external library —
+/// was handing the app a second NAME for the library it had already bound. Comparing names first
+/// made that an identity mismatch, which pinned every receipt-backed model to
+/// `installed_external_unavailable` and pushed every other one back onto the download path, for a
+/// library that was sitting right there.
+#[cfg(unix)]
+#[test]
+fn an_alias_of_the_bound_library_probes_available_while_real_changes_still_fail_closed() {
+    use std::os::unix::fs::symlink;
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    let real = temp.path().join("Volumes").join("Models").join("hub");
+    std::fs::create_dir_all(&real).unwrap();
+    seed_snapshot(&real, "owner/model", "model.safetensors");
+    let requirements = vec![requirement("owner/model", "model.safetensors")];
+    let store = ExternalLibraryBindingStore::new(&data).unwrap();
+    let (binding, _) = store.bind_or_probe_validated(&real, &requirements).unwrap();
+
+    // 1. Same lexical name → available (unchanged behavior).
+    assert_eq!(
+        probe_binding(&real, &binding).status,
+        ExternalLibraryProbeStatus::Available
+    );
+
+    // 2. DIFFERENT lexical name, same canonical path, same volume: the symlink an HF cache home
+    //    normally is. Provably the same directory, so it must be available.
+    let alias_home = temp.path().join("home-cache");
+    std::fs::create_dir_all(&alias_home).unwrap();
+    let alias = alias_home.join("hub");
+    symlink(&real, &alias).unwrap();
+    assert_eq!(
+        probe_binding(&alias, &binding).status,
+        ExternalLibraryProbeStatus::Available,
+        "a symlink to the bound library is the SAME library"
+    );
+
+    // 3. Different lexical name AND different canonical path → still a mismatch.
+    let other = temp.path().join("other").join("hub");
+    std::fs::create_dir_all(&other).unwrap();
+    assert_eq!(
+        probe_binding(&other, &binding).status,
+        ExternalLibraryProbeStatus::IdentityMismatch
+    );
+
+    // 4. Same canonical path, DIFFERENT recorded volume identity — the decoy remounted where the
+    //    real drive was. The identity half of the comparison is what catches this.
+    let decoy_binding = ExternalLibraryBinding {
+        physical_identity: ExternalLibraryPhysicalIdentity {
+            volume_id: "some-other-volume".to_owned(),
+            directory_id: binding.physical_identity.directory_id,
+        },
+        ..binding.clone()
+    };
+    assert_eq!(
+        probe_binding(&real, &decoy_binding).status,
+        ExternalLibraryProbeStatus::IdentityMismatch,
+        "the same path on a different volume must never read available"
+    );
+
+    // 5. A missing configured root is unavailable (disconnected), not a mismatch.
+    assert_eq!(
+        probe_binding(&temp.path().join("never-mounted"), &binding).status,
+        ExternalLibraryProbeStatus::Unavailable
+    );
+}
+
+/// End to end on the resolver: switching the configured library from the symlink to the drive it
+/// points at keeps every installed model ready, with no user action, no re-download, and no typed
+/// disconnect. The ledger quietly records the name now in use so the rest of the seam — stamped
+/// resolutions, the worker's pre-loader guard — keeps its `configured_path` invariant.
+#[cfg(unix)]
+#[test]
+fn configuring_the_drive_directly_instead_of_its_symlink_stays_ready() {
+    use std::os::unix::fs::symlink;
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    let real = temp.path().join("Volumes").join("Models").join("hub");
+    std::fs::create_dir_all(&real).unwrap();
+    seed_snapshot(&real, "owner/model", "model.safetensors");
+    let alias_home = temp.path().join("home-cache");
+    std::fs::create_dir_all(&alias_home).unwrap();
+    let alias = alias_home.join("hub");
+    symlink(&real, &alias).unwrap();
+    let requirements = vec![requirement("owner/model", "model.safetensors")];
+
+    // Bound while configured through the symlink, as an existing install would be.
+    let through_symlink = resolve_model_availability(&data, &alias, &requirements, true, &[]);
+    assert_eq!(
+        through_symlink.availability,
+        ModelAvailability::ExternalReady
+    );
+
+    // The operator now configures the drive directly. Same library, so it stays ready.
+    let direct = resolve_model_availability(&data, &real, &requirements, true, &[]);
+    assert_eq!(
+        direct.availability,
+        ModelAvailability::ExternalReady,
+        "the same library under its real path must not read as a different one"
+    );
+    direct.validate().unwrap();
+    let binding = direct.expected_library.as_ref().unwrap();
+    assert_eq!(
+        binding.configured_path, real,
+        "the ledger records the name now in use, so stamped resolutions stay valid"
+    );
+    assert_eq!(
+        binding.canonical_path,
+        std::fs::canonicalize(&real).unwrap()
+    );
+
+    // And back again: neither name is privileged.
+    let back = resolve_model_availability(&data, &alias, &requirements, true, &[]);
+    assert_eq!(back.availability, ModelAvailability::ExternalReady);
+}
+
+/// A library that is PRESENT but whose identity disagrees is a different problem from a
+/// disconnected one, and it is not fixed by reconnecting anything. The resolution says so, which is
+/// what lets the prompt lead with "choose the library" instead of "reconnect the drive" — the state
+/// was otherwise a dead end with no path out the user could find.
+#[test]
+fn a_present_but_mismatched_library_is_flagged_separately_from_a_disconnected_one() {
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    let library = temp.path().join("external-hf");
+    std::fs::create_dir_all(&library).unwrap();
+    seed_snapshot(&library, "owner/model", "model.safetensors");
+    let requirements = vec![requirement("owner/model", "model.safetensors")];
+    let ready = resolve_model_availability(&data, &library, &requirements, true, &[]);
+    assert_eq!(ready.availability, ModelAvailability::ExternalReady);
+
+    // Disconnected: the configured root is gone.
+    let detached = temp.path().join("detached");
+    std::fs::rename(&library, &detached).unwrap();
+    let disconnected = resolve_model_availability(&data, &library, &requirements, true, &[]);
+    assert_eq!(
+        disconnected.availability,
+        ModelAvailability::InstalledExternalUnavailable
+    );
+    assert!(
+        !disconnected.library_present,
+        "a disconnected drive is not present"
+    );
+
+    // Present but different: an unrelated directory now occupies the configured path.
+    std::fs::create_dir_all(&library).unwrap();
+    seed_snapshot(&library, "owner/model", "model.safetensors");
+    let mismatched = resolve_model_availability(&data, &library, &requirements, true, &[]);
+    assert_eq!(
+        mismatched.availability,
+        ModelAvailability::InstalledExternalUnavailable
+    );
+    assert!(
+        mismatched.library_present,
+        "a browsable library with the wrong identity must be distinguishable from a missing one"
+    );
+    assert!(
+        ExternalLibraryUnavailableContext::from_resolution("m", None, &mismatched).library_present,
+        "the typed context the prompt reads must carry the same distinction"
+    );
+}

--- a/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
@@ -590,3 +590,249 @@ fn source_file_symlink_must_remain_inside_the_same_repository() {
     )
     .is_err());
 }
+
+// ---------------------------------------------------------------------------------------------
+// Relocation (sc-19709). `bind_or_probe_validated` never replaces a binding, which is what makes a
+// different volume at the same path fail closed; `relocate_binding` is the one deliberate escape
+// hatch, and every test below exists to keep it from becoming a way to bind the WRONG volume.
+// ---------------------------------------------------------------------------------------------
+
+/// A durable download receipt for `repo` — install evidence that exists WITHOUT any binding or
+/// validated-closure record, which is the state every relocation check has to survive.
+fn write_download_receipt(data_dir: &Path, repo: &str, file: &str) {
+    let managed = data_dir
+        .join("models")
+        .join(crate::model_artifacts::artifact_selection::safe_download_dir(repo));
+    std::fs::create_dir_all(&managed).unwrap();
+    std::fs::write(
+        managed.join(".sceneworks-download-complete.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "receipts": [{
+                "repo": repo,
+                "variant": "default",
+                "resolvedFiles": [file],
+                "snapshotRevision": REVISION,
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+}
+
+/// Nothing installed means nothing to relocate. Binding whatever Hugging-Face-shaped directory the
+/// operator happened to pick would be a guess, and it would silently become the identity every
+/// later install is judged against.
+#[test]
+fn relocation_refuses_outright_when_there_is_no_install_evidence() {
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    let candidate = temp.path().join("someones-cache").join("hub");
+    std::fs::create_dir_all(&candidate).unwrap();
+    seed_snapshot(&candidate, "someone/unrelated", "model.safetensors");
+
+    let store = ExternalLibraryBindingStore::new(&data).unwrap();
+    assert_eq!(
+        store.relocate_binding(&candidate).unwrap_err(),
+        LibraryRelocationError::Rejected(LibraryRelocationRejection::NoInstalledModels)
+    );
+    assert!(store.load().unwrap().is_none());
+}
+
+/// THE fail-open this exists to prevent. Evidence can be RECEIPTS ONLY — an install that predates
+/// the validated-closure ledger, or one never validated on a bound library. Judging the candidate
+/// against the ledger alone would find nothing to check, so any directory with a single `models--*`
+/// child would validate vacuously and capture the binding.
+#[test]
+fn relocation_checks_receipt_evidence_even_with_an_empty_ledger() {
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    write_download_receipt(&data, "owner/model", "model.safetensors");
+    let store = ExternalLibraryBindingStore::new(&data).unwrap();
+    assert!(
+        store.validated_closures().unwrap().is_empty(),
+        "this test is only meaningful while the ledger is empty"
+    );
+
+    let decoy = temp.path().join("decoy").join("hub");
+    std::fs::create_dir_all(&decoy).unwrap();
+    seed_snapshot(&decoy, "someone/unrelated", "model.safetensors");
+    assert_eq!(
+        store.relocate_binding(&decoy).unwrap_err(),
+        LibraryRelocationError::Rejected(LibraryRelocationRejection::MissingInstalledModels {
+            repositories: vec!["owner/model".to_owned()],
+        })
+    );
+    assert!(store.load().unwrap().is_none(), "a refusal writes nothing");
+
+    // The library that actually holds the receipted install is adopted.
+    let moved = temp.path().join("moved").join("hub");
+    std::fs::create_dir_all(&moved).unwrap();
+    seed_snapshot(&moved, "owner/model", "model.safetensors");
+    let binding = store.relocate_binding(&moved).unwrap();
+    assert_eq!(
+        binding.canonical_path,
+        std::fs::canonicalize(&moved).unwrap()
+    );
+}
+
+/// A legacy receipt with no recorded variant is the `default` variant, exactly as
+/// `receipt_requirements_for_model` reads it — otherwise a pre-variant install would contribute no
+/// evidence and reopen the same fail-open.
+#[test]
+fn a_variant_less_legacy_receipt_still_counts_as_evidence() {
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    let managed = data
+        .join("models")
+        .join(crate::model_artifacts::artifact_selection::safe_download_dir("owner/legacy"));
+    std::fs::create_dir_all(&managed).unwrap();
+    std::fs::write(
+        managed.join(".sceneworks-download-complete.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "receipts": [{
+                "repo": "owner/legacy",
+                "resolvedFiles": ["legacy.safetensors"],
+                "snapshotRevision": REVISION,
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let decoy = temp.path().join("decoy").join("hub");
+    std::fs::create_dir_all(&decoy).unwrap();
+    seed_snapshot(&decoy, "someone/unrelated", "model.safetensors");
+    let store = ExternalLibraryBindingStore::new(&data).unwrap();
+    assert_eq!(
+        store.relocate_binding(&decoy).unwrap_err(),
+        LibraryRelocationError::Rejected(LibraryRelocationRejection::MissingInstalledModels {
+            repositories: vec!["owner/legacy".to_owned()],
+        })
+    );
+}
+
+/// A library that holds SOME of what is installed is still the wrong library: accepting it would
+/// silently orphan the rest. Every missing repository is named, so the guidance is actionable.
+#[test]
+fn relocation_refuses_a_partial_library_and_names_what_is_missing() {
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    let original = temp.path().join("original").join("hub");
+    std::fs::create_dir_all(&original).unwrap();
+    seed_snapshot(&original, "owner/one", "model.safetensors");
+    seed_snapshot(&original, "owner/two", "model.safetensors");
+    let store = ExternalLibraryBindingStore::new(&data).unwrap();
+    // Both closures validated on the bound library, so both are in the ledger.
+    store
+        .bind_or_probe_validated(&original, &[requirement("owner/one", "model.safetensors")])
+        .unwrap();
+    store
+        .bind_or_probe_validated(&original, &[requirement("owner/two", "model.safetensors")])
+        .unwrap();
+    // A receipt for a third install with no ledger record at all.
+    write_download_receipt(&data, "owner/three", "model.safetensors");
+
+    let partial = temp.path().join("partial").join("hub");
+    std::fs::create_dir_all(&partial).unwrap();
+    seed_snapshot(&partial, "owner/one", "model.safetensors");
+    match store.relocate_binding(&partial).unwrap_err() {
+        LibraryRelocationError::Rejected(LibraryRelocationRejection::MissingInstalledModels {
+            repositories,
+        }) => assert_eq!(repositories, ["owner/three", "owner/two"]),
+        other => panic!("expected a missing-models refusal, got {other:?}"),
+    }
+}
+
+/// The dry run answers identically and writes nothing — neither a binding nor a ledger byte — which
+/// is what lets the client validate before it persists its own copy of the location.
+#[test]
+fn validate_relocation_answers_like_the_real_call_and_writes_nothing() {
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    let original = temp.path().join("original").join("hub");
+    std::fs::create_dir_all(&original).unwrap();
+    seed_snapshot(&original, "owner/model", "model.safetensors");
+    let store = ExternalLibraryBindingStore::new(&data).unwrap();
+    store
+        .bind_or_probe_validated(
+            &original,
+            &[requirement("owner/model", "model.safetensors")],
+        )
+        .unwrap();
+    let binding_before = store.load().unwrap();
+    let closures_before = store.validated_closures().unwrap();
+
+    let moved = temp.path().join("moved").join("hub");
+    std::fs::create_dir_all(moved.parent().unwrap()).unwrap();
+    std::fs::rename(&original, &moved).unwrap();
+    store.validate_relocation(&moved).unwrap();
+    assert_eq!(store.load().unwrap(), binding_before);
+    assert_eq!(store.validated_closures().unwrap(), closures_before);
+
+    let unrelated = temp.path().join("holiday-photos");
+    std::fs::create_dir_all(&unrelated).unwrap();
+    assert_eq!(
+        store.validate_relocation(&unrelated).unwrap_err(),
+        LibraryRelocationError::Rejected(LibraryRelocationRejection::NotAModelLibrary)
+    );
+    assert_eq!(store.load().unwrap(), binding_before);
+}
+
+/// The TOCTOU re-check: the closure walk touches many files and can race an unmount/remount, so the
+/// exact canonical path AND physical identity must still hold after validation. Asserted on the
+/// pure comparison, because the race itself cannot be scheduled deterministically in a test.
+#[test]
+fn relocation_requires_the_identity_to_hold_across_the_closure_walk() {
+    let path = PathBuf::from("/Volumes/Models/hf/hub");
+    let other = PathBuf::from("/Volumes/Models 1/hf/hub");
+    let identity = ExternalLibraryPhysicalIdentity {
+        volume_id: "volume-a".to_owned(),
+        directory_id: 7,
+    };
+    let remounted = ExternalLibraryPhysicalIdentity {
+        volume_id: "volume-b".to_owned(),
+        directory_id: 7,
+    };
+    assert!(relocation_identity_held(&path, &path, &identity, &identity));
+    assert!(!relocation_identity_held(
+        &path, &other, &identity, &identity
+    ));
+    assert!(!relocation_identity_held(
+        &path, &path, &identity, &remounted
+    ));
+}
+
+/// Relocation replaces the ONE durable binding, so a resolution stamped against the old library —
+/// the copy a worker is still carrying with an in-flight job — must stop validating rather than be
+/// silently accepted against the new volume. It fails closed as an identity mismatch.
+#[test]
+fn a_resolution_stamped_before_relocation_no_longer_matches_the_binding() {
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    let original = temp.path().join("original").join("hub");
+    std::fs::create_dir_all(&original).unwrap();
+    seed_snapshot(&original, "owner/model", "model.safetensors");
+    let requirements = vec![requirement("owner/model", "model.safetensors")];
+    let store = ExternalLibraryBindingStore::new(&data).unwrap();
+    let (old_binding, _) = store
+        .bind_or_probe_validated(&original, &requirements)
+        .unwrap();
+    let stamped =
+        ModelResolution::external_ready(original.clone(), old_binding, requirements.clone())
+            .unwrap();
+
+    let moved = temp.path().join("moved").join("hub");
+    std::fs::create_dir_all(moved.parent().unwrap()).unwrap();
+    std::fs::rename(&original, &moved).unwrap();
+    store.relocate_binding(&moved).unwrap();
+
+    assert_eq!(
+        store.probe_resolution(&stamped).unwrap().status,
+        ExternalLibraryProbeStatus::IdentityMismatch,
+    );
+    // Install evidence is untouched by relocation: nothing is redownloaded and nothing is lost.
+    assert_eq!(
+        store.validated_closures().unwrap(),
+        vec![canonical_requirement_closure(&requirements)]
+    );
+}

--- a/crates/sceneworks-worker/src/model_artifact_inventory.rs
+++ b/crates/sceneworks-worker/src/model_artifact_inventory.rs
@@ -283,6 +283,27 @@ pub const PRODUCTION_MODEL_CONSUMERS: &[ModelConsumerInventoryEntry] = &[
             entrypoint: TypedResolverEntrypoint::SourceLibrary,
         },
     },
+    // sc-19709: the model source library's status + relocation seam. It never resolves a MODEL
+    // path — it probes and re-binds the library ROOT itself — but it reaches that root through the
+    // same typed `model_source_library` entrypoint, so it is classified here rather than exempted.
+    ModelConsumerInventoryEntry {
+        source_files: &["apps/rust-api/src/model_library.rs"],
+        categories: &[
+            Category::Image,
+            Category::Video,
+            Category::Audio,
+            Category::CaptioningUtility,
+            Category::Training,
+            Category::LoraControl,
+            Category::Primary,
+            Category::OptionalComponent,
+            Category::CoRequisite,
+            Category::ImportedConverted,
+        ],
+        resolution: Resolution::SharedContract {
+            entrypoint: TypedResolverEntrypoint::SourceLibrary,
+        },
+    },
 ];
 
 pub const EXPLICITLY_UNSUPPORTED_ARTIFACTS: &[ModelConsumerInventoryEntry] = &[

--- a/tests/fixtures/rust_api_contract_snapshots/snapshots.json
+++ b/tests/fixtures/rust_api_contract_snapshots/snapshots.json
@@ -2611,6 +2611,7 @@
         "availability": "missing",
         "configuredLibraryPath": "<runtime-root>/data/cache/huggingface/hub",
         "expectedLibrary": null,
+        "libraryPresent": false,
         "localArtifact": null,
         "requirements": [],
         "schemaVersion": 1
@@ -2682,6 +2683,7 @@
         "availability": "missing",
         "configuredLibraryPath": "<runtime-root>/data/cache/huggingface/hub",
         "expectedLibrary": null,
+        "libraryPresent": false,
         "localArtifact": null,
         "requirements": [],
         "schemaVersion": 1


### PR DESCRIPTION
## sc-19709 — connect-drive, relocate-library, and retry UX for unavailable models

sc-19708 landed the typed availability seam (`local_ready` / `external_ready` /
`installed_external_unavailable` / `incomplete` / `missing`) with volume-identity binding and a
typed 503 at submission preflight. This is the user-facing half: when a model is installed but its
external library is not attached, the app now offers a real recovery instead of a failure.

Everything the prompt renders comes from the seam. Nothing string-matches an error message, and
nothing re-derives availability in the UI — where a field was missing, it was added at the seam.

### What changed

**Core (`crates/sceneworks-core/.../external_library.rs`)** — additive:
- `ExternalLibraryUnavailableContext` — the typed payload the API attaches to the 503 (model id and
  name, configured library path, expected library path, expected volume id).
- `ModelSourceLibraryStatus` + `probe_model_source_library` — one write-free identity probe; the
  single `available` boolean a retry gates on.
- `ExternalLibraryBindingStore::relocate_binding` — the one explicit escape hatch from
  "a binding is never replaced". It replaces the durable binding ONLY after the candidate root
  physically carries every closure this installation has durable evidence for — **the validated
  closure ledger AND the download receipts**, the same union `resolve_model_availability` consults.
  An installation with no evidence at all is refused outright rather than binding whatever
  HF-shaped directory it was handed. Receipts and the ledger are never written, so relocation never
  redownloads and never loses installed state.
- `validate_relocation` — every relocation check with nothing written (see "two durable writes").
- `resolve_relocation_target` + typed `LibraryRelocationRejection` (`not_a_directory` /
  `not_a_model_library` / `missing_installed_models` / `no_installed_models` /
  `hub_directory_expected` / `identity_unavailable`) — guidance by discriminant, never message text.

**API (`apps/rust-api`)**
- `ApiError` gained an optional `context` object, rendered beside `detail`/`code`. The typed 503 now
  carries the unavailable-library context; every existing body is unchanged.
- `GET /api/v1/model-library` — live, write-free re-probe.
- `POST /api/v1/model-library/relocate` — validate (`dryRun`) or validate + re-bind; typed 409 with
  a `reason` on refusal; returns the exact `hfHome` the desktop shell must persist and an `adopted`
  boolean (deliberately not a probe of the adopted root, which would contradict the GET until the
  next launch). **Loopback peers only**: it takes an absolute host path, rewrites durable local
  state, and its typed refusals would otherwise be a filesystem-existence oracle for any
  token-holding LAN client — who could also re-point a shared server's library. A missing peer fails
  closed. Internal failures return a fixed sentence and log the underlying error, so no raw
  `io::Error` ever reaches a dialog.

**Desktop (`apps/desktop`)**
- `set_model_library`: persists the relocated library through the EXISTING library-path
  configuration (`settings.hf_home`, same normalization and file as the first-run storage step).
- `restart_app` / `setup::begin_restart`: the same graceful teardown as quitting (SIGTERM, grace,
  then force) followed by a relaunch — deliberately NOT the auto-update path's immediate
  force-kill, because hard-killing an MLX worker mid-render can wedge the host GPU client.

**Web (`apps/web`)**
- `modelLibrary.js` — the gate. At most one pending action, resumed at most once; an epoch guard
  makes a probe that settles after Cancel a no-op.
- `ModelLibraryDialog.jsx` — shared `Modal` (focus trap, Escape, portal), `role="status"` live
  region, three exits, auto re-probe through the same guarded retry (paused while the native folder
  picker is open, so a drive returning mid-selection cannot resume behind an OS dialog).
- `ModelLibraryRestartDialog.jsx` — the post-relocation disclosure (below).
- Wired at the submission choke points (`createJob.js` for every generation route, `useTraining.js`
  for training jobs) and at model SELECTION in the shared studio hook. Both overlays render in the
  Simple shell as well as the Advanced one — the handler is registered at App level and fires in
  both, so mounting them in one branch only would leave a Simple-UI user's Generate button
  swallowing its own failure.

### Relocation applies on the next launch — disclosed, with a restart offered

The configured library root reaches the API and GPU worker as spawn environment (`HF_HOME`), so a
relocated path cannot apply to the sidecars already running. **Product decision (Michael): keep
next-launch semantics — do not move the library root off the environment, and do not change where
downloads land — and disclose it with a restart affordance.** So after a successful relocation the
app now says plainly that the new location takes effect after a restart, that the generation the
user had started was NOT queued and needs resubmitting, and offers **Restart now** / **Later**.
"Restart now" relaunches through the graceful teardown and fires exactly once however many times it
is clicked; it is withheld while a job is running, naming the running jobs, so a render is never
interrupted by surprise. Outside the desktop shell it degrades to guidance with no restart button.

### Two durable writes, ordered so they cannot disagree

Relocation writes in two places: the shell's `HF_HOME` and the server's binding ledger. The gate now
validates with `dryRun` FIRST — so every ordinary refusal (wrong folder, missing models) happens
before either write — then persists, then re-binds, and undoes the persist if the re-bind fails.
What the user is told always matches the state they are actually in, including the case where the
undo itself fails.

### Acceptance criteria

| Criterion | Where |
|---|---|
| External-only selection never exposes raw filesystem or loader errors | typed `context` end to end; `App.modelLibrary.test.jsx`; `an_internal_failure_never_returns_raw_filesystem_text` pins the one path where an `io::Error` could have leaked |
| Reconnect + retry resumes exactly one blocked action, no reinstall/transfer | `modelLibrary.test.js` (concurrent retries, reconnect mid-flight), `createJob.test.js`, `App.modelLibrary.test.jsx` (real shell, Advanced + Simple), `tests/model_library.rs` (503 → reconnect → 201) |
| Correct relocated library succeeds; unrelated folder rejected with guidance | `relocation_checks_receipt_evidence_even_with_an_empty_ledger`, `relocation_refuses_a_partial_library_and_names_what_is_missing`, `relocation_refuses_outright_when_there_is_no_install_evidence`, `a_decoy_library_cannot_capture_a_receipt_backed_install` |
| Cancel leaves no queued generation or partial state | `leaves nothing queued on cancel — including a retry already in flight`; `cancel closes the prompt and leaves nothing queued` |
| Local-ready models operate without the drive or prompt | `modelLibraryUnavailable`/`modelLibraryContextForModel` false/null for `local_ready` |
| UI, Tauri command, API-contract, accessibility, and race tests pass | web suite green; `settings::tests::relocating_the_model_library_normalizes_and_refuses_an_empty_choice`; `apps/rust-api/src/tests/model_library.rs`; dialog a11y tests |

### Symlinked vs direct external-drive configuration (merged-code defect, fixed here)

`probe_binding` compared the LEXICAL configured path first and returned `IdentityMismatch` before
canonical path or volume identity were consulted, and `bind_or_probe_validated` never replaces a
binding. So `~/.cache/huggingface/hub` (a symlink) and `/Volumes/Models/huggingface/hub` (its
target) were permanently *different libraries* despite identical canonical path, identical volume
UUID and identical bytes — which pinned every receipt-backed model to
`installed_external_unavailable` forever and pushed every non-receipt one back onto the download
path. That is exactly what an operator hits when they configure the external drive directly, which
is the intended way to use one.

- **`probe_binding` now judges on canonical path + volume identity**, which is what actually proves
  "the same directory on the same volume". A different canonical path, or the same canonical path on
  a different volume (a decoy remounted where the drive was), still fails closed. All four
  combinations are tested, including the real symlink→target case.
- **The ledger records the alias in use** when the probe has already proven the two names are the
  same library — nothing else about the binding changes (not the canonical path, not the identity,
  not `bound_at`), which keeps the `configured_path` invariant that stamped resolutions and the
  worker's pre-loader guard check.
- **What this makes work with no user action:** switching the configured library between a symlink
  and its target — in either direction — keeps every installed model `external_ready`. No prompt, no
  relocation, no re-download. It reduces how often relocation is needed; it does not replace it.
- **Where it does not apply, the wedge is now recoverable:** a library that is present and browsable
  but whose recorded identity disagrees is flagged (`libraryPresent`) all the way to the prompt,
  which then leads with "Choose a different library location" and drops the "reconnect the drive"
  instruction that cannot help. Previously that state was terminal with no path out the user could
  find.

### Review fixes in this branch

1. **Simple shell (blocker)** — both overlays now render in the Simple branch too, following the
   `workflowDropPanel` precedent. Covered by a Simple-shell case that fails without the fix.
2. **Relocation fail-open (blocker)** — `relocate_binding` judged only the validated-closure ledger,
   so a receipt-backed-but-unlogged install could be captured by a decoy directory. It now judges
   the same evidence union availability does, and refuses outright when there is none.
3. **Core coverage** — 8 relocation cases added to `external_library_tests.rs` (empty ledger,
   receipt-only, variant-less legacy receipt, partial library, decoy, dry run, TOCTOU re-check,
   relocation under a stamped worker resolution).
4. **Write ordering** — validate → persist → adopt, with undo (above), plus tests for both the
   undo-succeeds and undo-fails messages.
5. **Misleading `status`** — replaced with `adopted`.
6. **Raw `io::Error` in a 500** — fixed sentence + `tracing::error!`, pinned by test.
7. **Stale error beside a new hint** — the not-available branch clears `error`.
8. **Auto-probe during the folder picker** — paused.
9. **Relocation endpoint exposure** — loopback-only, fail-closed on an unknown peer.

### Notes

- **Found while verifying the restart work:** neither new Tauri command was listed in
  `apps/desktop/capabilities/default.json`, so both would have been rejected by the ACL at the
  shell's remote `http://127.0.0.1:<port>` origin at runtime — invisible to the web tests, which
  mock `tauriInvoke`. `allow-set-model-library` and `allow-restart-app` are now granted.
- **Pre-existing defect fixed in place:** `bind_or_probe_validated` never replaces a binding, so
  before this change a genuinely relocated library resolved `IdentityMismatch` →
  `InstalledExternalUnavailable` forever, with no way to re-bind.
- Disconnection is simulated through the seam's own surfaces (a real rename of the bound library
  under a tempdir) — the same idiom sc-19708 uses. Real external-volume acceptance is sc-19712.
- No snapshot in this branch contains a host path, home directory, username or hostname; the API
  tests resolve the library under the test's own `data_dir` with `isolate_hf_cache()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
