### PR TITLE
feat(sc-19707): prefer valid local resolved artifacts across every SceneWorks model runtime

### DIFF
--- a/apps/rust-api/src/model_sources.rs
+++ b/apps/rust-api/src/model_sources.rs
@@ -316,9 +316,13 @@ pub(crate) fn local_resolved_artifacts(state: &AppState) -> Vec<ResolvedModelArt
     if !state.settings.resolved_cache.enabled {
         return Vec::new();
     }
+    // Rejections are the worker guard's to report: it is the layer that emits the runtime's
+    // model-source observability, and the catalog would otherwise re-announce the same entry on
+    // every listing.
     sceneworks_core::model_artifacts::resolved_cache::ResolvedCacheStore::valid_local_artifacts(
         &state.settings.data_dir,
     )
+    .artifacts
 }
 
 /// The one availability judgement for a manifest entry on this host: exact selected closure

--- a/apps/rust-api/src/model_sources.rs
+++ b/apps/rust-api/src/model_sources.rs
@@ -307,20 +307,18 @@ pub(crate) async fn resolve_model_manifest_entry_by_repo(
 
 /// App-owned resolved-local artifacts for LocalReady detection. Empty when the resolved cache is
 /// disabled or uninitialized; read-only (never creates a session or refreshes usage).
+///
+/// This is the SAME provider the worker's pre-loader guard uses (sc-19707), so catalog/preflight
+/// and the actual load can never disagree about which entries are valid: an entry that is still
+/// materializing, torn, unverifiable, or in a shape the runtime cannot serve is not a local
+/// candidate on either side of the boundary.
 pub(crate) fn local_resolved_artifacts(state: &AppState) -> Vec<ResolvedModelArtifact> {
     if !state.settings.resolved_cache.enabled {
         return Vec::new();
     }
-    sceneworks_core::model_artifacts::resolved_cache::ResolvedCacheStore::enumerate_existing(
+    sceneworks_core::model_artifacts::resolved_cache::ResolvedCacheStore::valid_local_artifacts(
         &state.settings.data_dir,
     )
-    .map(|entries| {
-        entries
-            .into_iter()
-            .filter_map(|entry| entry.metadata.map(|metadata| metadata.artifact))
-            .collect()
-    })
-    .unwrap_or_default()
 }
 
 /// The one availability judgement for a manifest entry on this host: exact selected closure

--- a/crates/sceneworks-core/src/hf_home.rs
+++ b/crates/sceneworks-core/src/hf_home.rs
@@ -97,7 +97,7 @@ pub fn huggingface_hub_cache_dir(data_dir: &Path) -> PathBuf {
 /// Typed authoritative model source library. Runtime and catalog compatibility helpers delegate
 /// to this value instead of reconstructing a configured Hugging Face root independently.
 pub fn model_source_library(data_dir: &Path) -> ArtifactSourceLibrary {
-    ArtifactSourceLibrary::new(huggingface_hub_cache_dir(data_dir))
+    ArtifactSourceLibrary::new_preferring_local(huggingface_hub_cache_dir(data_dir))
         .expect("the resolved Hugging Face source-library root is nonempty")
 }
 

--- a/crates/sceneworks-core/src/model_artifacts.rs
+++ b/crates/sceneworks-core/src/model_artifacts.rs
@@ -9,6 +9,8 @@
 pub mod artifact_selection;
 #[path = "model_artifacts/external_library.rs"]
 pub mod external_library;
+#[path = "model_artifacts/local_preference.rs"]
+pub mod local_preference;
 #[path = "resolved_cache.rs"]
 pub mod resolved_cache;
 
@@ -622,6 +624,12 @@ pub struct PromotionCandidate {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ArtifactSourceLibrary {
     root: PathBuf,
+    /// Whether snapshot discovery through this handle may be served from an active local-tier
+    /// preference scope (sc-19707). True only for the CONFIGURED runtime library built by
+    /// [`crate::hf_home::model_source_library`]; a library constructed directly for maintenance,
+    /// confinement, or materialization deliberately keeps reading the authoritative source, so
+    /// promoting a bundle can never read from a bundle.
+    prefer_local: bool,
 }
 
 /// Behavior-preserving runtime resolver. Source discovery and runtime validation are separate:
@@ -762,7 +770,22 @@ impl ArtifactSourceLibrary {
                 "source library root is empty".to_owned(),
             ));
         }
-        Ok(Self { root })
+        Ok(Self {
+            root,
+            prefer_local: false,
+        })
+    }
+
+    /// The configured runtime library: snapshot discovery through this handle prefers an active
+    /// local-tier bundle (sc-19707). Reserved for [`crate::hf_home::model_source_library`], the
+    /// one place that resolves the user's configured source library for a runtime load.
+    pub(crate) fn new_preferring_local(
+        root: impl Into<PathBuf>,
+    ) -> Result<Self, ArtifactContractError> {
+        Ok(Self {
+            prefer_local: true,
+            ..Self::new(root)?
+        })
     }
 
     pub fn root(&self) -> &Path {
@@ -819,6 +842,13 @@ impl ArtifactSourceLibrary {
 
     /// Resolve an immutable source snapshot. `None` reads `refs/main` only to obtain its exact
     /// commit; a caller-provided mutable revision is rejected.
+    ///
+    /// On the configured runtime library (see [`Self::new_preferring_local`]) a leased local-tier
+    /// bundle serves the exact `(repository, revision)` pair when one is active — the single point
+    /// at which every model-consuming runtime prefers the local tier (sc-19707). The revision is
+    /// still chosen by the authoritative source whenever it can answer, so a bundle holding a
+    /// superseded revision never wins; only a source library that cannot be read at all (the
+    /// disconnected-drive case) falls back to the bundle's own revision.
     pub fn discover_snapshot(
         &self,
         repository: &str,
@@ -830,14 +860,35 @@ impl ArtifactSourceLibrary {
                 validate_immutable_revision(revision)?;
                 revision.to_owned()
             }
-            None => std::fs::read_to_string(repo_root.join("refs/main"))
-                .map_err(|error| {
-                    ArtifactContractError(format!("cannot resolve {repository} refs/main: {error}"))
-                })?
-                .trim()
-                .to_owned(),
+            None => match std::fs::read_to_string(repo_root.join("refs/main")) {
+                Ok(revision) => revision.trim().to_owned(),
+                Err(error) => {
+                    if self.prefer_local {
+                        if let Some((revision, snapshot)) =
+                            local_preference::unique_local_snapshot(repository)
+                        {
+                            validate_immutable_revision(&revision)?;
+                            return Ok((
+                                ArtifactIdentity::pinned(repository, revision, "default")?,
+                                snapshot,
+                            ));
+                        }
+                    }
+                    return Err(ArtifactContractError(format!(
+                        "cannot resolve {repository} refs/main: {error}"
+                    )));
+                }
+            },
         };
         validate_immutable_revision(&revision)?;
+        if self.prefer_local {
+            if let Some(snapshot) = local_preference::local_snapshot(repository, &revision) {
+                return Ok((
+                    ArtifactIdentity::pinned(repository, revision, "default")?,
+                    snapshot,
+                ));
+            }
+        }
         let snapshot = repo_root.join("snapshots").join(&revision);
         if !snapshot.is_dir() {
             return Err(ArtifactContractError(format!(

--- a/crates/sceneworks-core/src/model_artifacts/local_preference.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference.rs
@@ -152,9 +152,18 @@ pub fn overlay_entries_for_artifact(
     Ok(entries)
 }
 
+#[derive(Debug)]
+struct HeldEntry {
+    entry: LocalArtifactOverlayEntry,
+    /// How many live scopes are serving this exact entry. Ownership is REFCOUNTED rather than
+    /// single-owner: two scopes may legitimately serve one shared component snapshot, and a
+    /// single-owner model would silently un-serve the other one the moment the first scope drops.
+    holders: usize,
+}
+
 #[derive(Debug, Default)]
 struct ActiveOverlay {
-    entries: Vec<LocalArtifactOverlayEntry>,
+    entries: Vec<HeldEntry>,
 }
 
 fn active() -> &'static Mutex<ActiveOverlay> {
@@ -187,74 +196,86 @@ impl Drop for ActiveLocalArtifacts {
     fn drop(&mut self) {
         let mut active = lock_active();
         for entry in self.entries.iter() {
-            if let Some(index) = active.entries.iter().position(|held| held == entry) {
+            let Some(index) = active
+                .entries
+                .iter()
+                .position(|held| &held.entry == entry)
+            else {
+                continue;
+            };
+            if active.entries[index].holders > 1 {
+                active.entries[index].holders -= 1;
+            } else {
                 active.entries.remove(index);
             }
         }
     }
 }
 
-/// Install a local-tier preference scope for `artifacts` (each of which the caller must already
-/// hold a runtime lease on).
+/// Install a local-tier preference scope over EXACTLY the snapshots the caller selected.
 ///
-/// Two bundles legitimately cover one shared snapshot — a text encoder used by two models is
-/// materialized into both. When a `(repository, revision)` pair is already being served, this
-/// installation adopts the serving bundle IF that bundle holds every file this one would have
-/// served for the pair, and otherwise fails closed: silently picking a bundle with a narrower file
-/// set is exactly how a load would be handed an incomplete snapshot. The caller then keeps that
-/// model on the source tier.
-pub fn prefer_local_artifacts(
-    artifacts: &[ResolvedModelArtifact],
+/// The caller — the worker's pre-loader guard — is the only layer that can see every model a job
+/// will load, so it is the layer that decides which `(repository, revision)` pairs may be served
+/// locally at all. This function therefore takes DECIDED entries rather than artifacts: a
+/// directory-level seam cannot ask "does this bundle hold what THIS caller needs" at lookup time,
+/// so a pair is either serveable for every consumer in the process or served to none of them.
+///
+/// A pair already served by a live scope is refcounted, and only when the serving entry is
+/// IDENTICAL. A different bundle claiming the same snapshot is refused outright: silently picking
+/// one is exactly how a load gets handed a snapshot verified for a different selection.
+pub fn prefer_local_snapshots(
+    entries: Vec<LocalArtifactOverlayEntry>,
 ) -> Result<ActiveLocalArtifacts, ArtifactContractError> {
     let mut requested: Vec<LocalArtifactOverlayEntry> = Vec::new();
-    for artifact in artifacts {
-        for entry in overlay_entries_for_artifact(artifact)? {
-            match requested
-                .iter()
-                .find(|held| held.repository == entry.repository && held.revision == entry.revision)
-            {
-                Some(existing) => ensure_covers(existing, &entry)?,
-                None => requested.push(entry),
-            }
-        }
-    }
-    let mut active = lock_active();
-    let mut installed = Vec::new();
-    for entry in requested {
-        match active
-            .entries
+    for entry in entries {
+        match requested
             .iter()
             .find(|held| held.repository == entry.repository && held.revision == entry.revision)
         {
-            // Already served by an active scope that covers everything this one needs: adopt it
-            // rather than installing a second claim on the same snapshot.
-            Some(existing) => ensure_covers(existing, &entry)?,
-            None => installed.push(entry),
+            Some(existing) if existing != &entry => return Err(conflicting_claim(&entry)),
+            Some(_) => continue,
+            None => requested.push(entry),
         }
     }
-    active.entries.extend(installed.iter().cloned());
+    let mut active = lock_active();
+    for entry in &requested {
+        if let Some(held) = active.entries.iter().find(|held| {
+            held.entry.repository == entry.repository && held.entry.revision == entry.revision
+        }) {
+            if &held.entry != entry {
+                return Err(conflicting_claim(entry));
+            }
+        }
+    }
+    for entry in &requested {
+        match active.entries.iter_mut().find(|held| &held.entry == entry) {
+            Some(held) => held.holders += 1,
+            None => active.entries.push(HeldEntry {
+                entry: entry.clone(),
+                holders: 1,
+            }),
+        }
+    }
     drop(active);
     Ok(ActiveLocalArtifacts {
-        entries: Arc::new(installed),
+        entries: Arc::new(requested),
     })
 }
 
-/// The serving bundle must hold every file the requested one would have served for the pair.
-fn ensure_covers(
-    serving: &LocalArtifactOverlayEntry,
-    requested: &LocalArtifactOverlayEntry,
-) -> Result<(), ArtifactContractError> {
-    if requested
-        .files
+fn conflicting_claim(entry: &LocalArtifactOverlayEntry) -> ArtifactContractError {
+    ArtifactContractError(format!(
+        "another resolved-local bundle already claims {}@{}",
+        entry.repository, entry.revision
+    ))
+}
+
+/// Whether this bundle holds every one of `files` (snapshot-relative) for its pair. A snapshot may
+/// only be served to consumers whose ENTIRE file requirement lives inside the bundle — the
+/// directory-level seam cannot re-ask that question once a path has been handed out.
+pub fn entry_covers(entry: &LocalArtifactOverlayEntry, files: &[PathBuf]) -> bool {
+    files
         .iter()
-        .all(|file| serving.files.binary_search(file).is_ok())
-    {
-        return Ok(());
-    }
-    Err(ArtifactContractError(format!(
-        "the bundle already serving {}@{} does not hold every file this artifact needs from it",
-        requested.repository, requested.revision
-    )))
+        .all(|file| entry.files.binary_search(file).is_ok())
 }
 
 /// The leased local snapshot for this exact immutable pair, if one is active AND still on disk.

--- a/crates/sceneworks-core/src/model_artifacts/local_preference.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference.rs
@@ -1,0 +1,282 @@
+//! The one local-tier preference seam (sc-19707).
+//!
+//! A resolved-local bundle is materialized as a **miniature source library**: every member's
+//! destination is exactly `models--<safe repository>/snapshots/<revision>/<source subpath>`, so a
+//! published bundle root is a valid [`crate::model_artifacts::ArtifactSourceLibrary`] holding
+//! precisely the closure's repositories and immutable revisions. That single layout invariant is
+//! what lets every model-consuming runtime prefer the local tier without one line of per-model,
+//! per-route, or per-job-type code: the shared snapshot resolvers already ask the configured
+//! source library for `(repository, revision)`, and this module answers with the leased bundle's
+//! snapshot when one covers that exact pair.
+//!
+//! Scope and safety:
+//!
+//! - Only the worker's pre-loader guard installs a preference scope, and only for artifacts it
+//!   holds a runtime lease on, so an artifact can never be evicted while a load reads it.
+//! - The scope is process-wide because model paths are resolved on engine threads and blocking
+//!   pools far below the async job task; the worker claim loop runs one job at a time, and a
+//!   second overlapping installation for the same repository fails closed (see
+//!   [`prefer_local_artifacts`]).
+//! - Preference is keyed on the exact `(repository, immutable revision)` pair. A superseded
+//!   revision therefore never matches, and a bundle is never consulted for a revision it does not
+//!   contain — the source tier keeps serving those.
+//! - Nothing here downloads, writes, or mutates anything. Redirection only ever answers with a
+//!   path inside an already-published, already-verified bundle.
+
+use super::{
+    ArtifactContractError, ArtifactLocation, ArtifactMemberRole, ResolvedModelArtifact,
+    MODEL_ARTIFACT_CONTRACT_VERSION,
+};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+
+/// One `(repository, revision)` pair served from a leased local bundle.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LocalArtifactOverlayEntry {
+    pub repository: String,
+    pub revision: String,
+    /// `<bundle>/models--<safe>/` — the local mirror of the source library's repository root.
+    pub repository_root: PathBuf,
+    /// `<bundle>/models--<safe>/snapshots/<revision>/` — what a snapshot resolver returns.
+    pub snapshot_root: PathBuf,
+}
+
+/// The canonical bundle-relative destination of one closure member: the source library's own
+/// layout for that member's repository, immutable revision and subpath. Materialization writes
+/// members here, and local preference reads them back through the identical rule, so the two can
+/// never drift into a layout only one of them understands.
+pub fn hub_cache_member_destination(
+    repository: &str,
+    revision: &str,
+    source_subpath: &Path,
+) -> Result<PathBuf, ArtifactContractError> {
+    super::validate_immutable_revision(revision)?;
+    let safe = safe_repository_dir(repository)?;
+    let mut destination = PathBuf::from(format!("models--{safe}"))
+        .join("snapshots")
+        .join(revision);
+    if source_subpath.as_os_str().is_empty() {
+        return Ok(destination);
+    }
+    super::validate_relative_path(source_subpath, "artifact source subpath")?;
+    destination.push(source_subpath);
+    Ok(destination)
+}
+
+/// The `models--<X>` directory name component for `repository`. Byte-identical to
+/// [`crate::model_artifacts::ArtifactSourceLibrary::repository_root`], which is the layout a
+/// bundle mirrors.
+fn safe_repository_dir(repository: &str) -> Result<String, ArtifactContractError> {
+    super::validate_repository(repository)?;
+    Ok(repository.replace('/', "--"))
+}
+
+/// Every `(repository, revision)` a published bundle can serve, or an error naming the exact way
+/// its shape is unsupported.
+///
+/// This is deliberately strict. An artifact whose members do not mirror the source library layout
+/// cannot be handed to the shared snapshot resolvers at all, so it must be reported as an
+/// unsupported shape rather than silently half-used with the rest of the load reading the external
+/// path.
+pub fn overlay_entries_for_artifact(
+    artifact: &ResolvedModelArtifact,
+) -> Result<Vec<LocalArtifactOverlayEntry>, ArtifactContractError> {
+    if artifact.schema_version != MODEL_ARTIFACT_CONTRACT_VERSION {
+        return Err(ArtifactContractError(
+            "unsupported model artifact contract version".to_owned(),
+        ));
+    }
+    let ArtifactLocation::ResolvedLocal { root } = &artifact.location else {
+        return Err(ArtifactContractError(
+            "only an app-owned resolved-local artifact can serve the local tier".to_owned(),
+        ));
+    };
+    if !artifact
+        .closure
+        .members
+        .iter()
+        .any(|member| member.role == ArtifactMemberRole::Primary)
+    {
+        return Err(ArtifactContractError(
+            "resolved-local artifact has no primary member".to_owned(),
+        ));
+    }
+    let mut entries: Vec<LocalArtifactOverlayEntry> = Vec::new();
+    for member in &artifact.closure.members {
+        member.validate()?;
+        let expected = hub_cache_member_destination(
+            &member.source.repository,
+            &member.source.revision,
+            &member.source_subpath,
+        )?;
+        if member.destination != expected {
+            return Err(ArtifactContractError(format!(
+                "resolved-local member {}@{} is not stored in the source-library layout \
+                 (expected {}, found {})",
+                member.source.repository,
+                member.source.revision,
+                expected.display(),
+                member.destination.display()
+            )));
+        }
+        let safe = safe_repository_dir(&member.source.repository)?;
+        let repository_root = root.join(format!("models--{safe}"));
+        let snapshot_root = repository_root.join("snapshots").join(&member.source.revision);
+        let entry = LocalArtifactOverlayEntry {
+            repository: member.source.repository.clone(),
+            revision: member.source.revision.clone(),
+            repository_root,
+            snapshot_root,
+        };
+        if !entries.contains(&entry) {
+            entries.push(entry);
+        }
+    }
+    Ok(entries)
+}
+
+#[derive(Debug, Default)]
+struct ActiveOverlay {
+    entries: Vec<LocalArtifactOverlayEntry>,
+}
+
+fn active() -> &'static Mutex<ActiveOverlay> {
+    static ACTIVE: std::sync::OnceLock<Mutex<ActiveOverlay>> = std::sync::OnceLock::new();
+    ACTIVE.get_or_init(|| Mutex::new(ActiveOverlay::default()))
+}
+
+fn lock_active() -> MutexGuard<'static, ActiveOverlay> {
+    active().lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// RAII preference scope. Dropping it restores source-tier resolution exactly; it holds no locks
+/// and performs no I/O, so a panicking load still leaves the process on the source tier.
+#[derive(Debug)]
+pub struct ActiveLocalArtifacts {
+    entries: Arc<Vec<LocalArtifactOverlayEntry>>,
+}
+
+impl ActiveLocalArtifacts {
+    pub fn entries(&self) -> &[LocalArtifactOverlayEntry] {
+        &self.entries
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl Drop for ActiveLocalArtifacts {
+    fn drop(&mut self) {
+        let mut active = lock_active();
+        for entry in self.entries.iter() {
+            if let Some(index) = active.entries.iter().position(|held| held == entry) {
+                active.entries.remove(index);
+            }
+        }
+    }
+}
+
+/// Install a local-tier preference scope for `artifacts` (each of which the caller must already
+/// hold a runtime lease on).
+///
+/// Fails closed when a `(repository, revision)` pair is already served from a DIFFERENT bundle
+/// root: two bundles disagreeing about one immutable snapshot is exactly the case where silently
+/// picking one could serve a load a file set that was verified for another selection. The caller
+/// then keeps that load on the source tier.
+pub fn prefer_local_artifacts(
+    artifacts: &[ResolvedModelArtifact],
+) -> Result<ActiveLocalArtifacts, ArtifactContractError> {
+    let mut requested: Vec<LocalArtifactOverlayEntry> = Vec::new();
+    for artifact in artifacts {
+        for entry in overlay_entries_for_artifact(artifact)? {
+            if let Some(existing) = requested.iter().find(|held| {
+                held.repository == entry.repository && held.revision == entry.revision
+            }) {
+                if existing != &entry {
+                    return Err(ArtifactContractError(format!(
+                        "two resolved-local bundles claim {}@{}",
+                        entry.repository, entry.revision
+                    )));
+                }
+                continue;
+            }
+            requested.push(entry);
+        }
+    }
+    let mut active = lock_active();
+    for entry in &requested {
+        if active
+            .entries
+            .iter()
+            .any(|held| held.repository == entry.repository && held.revision == entry.revision)
+        {
+            return Err(ArtifactContractError(format!(
+                "a local-tier preference scope already serves {}@{}",
+                entry.repository, entry.revision
+            )));
+        }
+    }
+    active.entries.extend(requested.iter().cloned());
+    drop(active);
+    Ok(ActiveLocalArtifacts {
+        entries: Arc::new(requested),
+    })
+}
+
+/// The leased local snapshot for this exact immutable pair, if one is active.
+pub fn local_snapshot(repository: &str, revision: &str) -> Option<PathBuf> {
+    lock_active()
+        .entries
+        .iter()
+        .find(|entry| entry.repository == repository && entry.revision == revision)
+        .map(|entry| entry.snapshot_root.clone())
+}
+
+/// The leased local snapshot for `repository` when EXACTLY ONE revision of it is active. Used only
+/// where the source library cannot answer which revision a load wants (a disconnected library has
+/// no `refs/main` to read): with two revisions active the question is genuinely ambiguous and the
+/// caller must fail rather than guess.
+pub fn unique_local_snapshot(repository: &str) -> Option<(String, PathBuf)> {
+    let active = lock_active();
+    let mut matches = active
+        .entries
+        .iter()
+        .filter(|entry| entry.repository == repository);
+    let first = matches.next()?;
+    if matches.next().is_some() {
+        return None;
+    }
+    Some((first.revision.clone(), first.snapshot_root.clone()))
+}
+
+/// Rewrite an already-confined path that points into the configured source library so it reads
+/// from the leased local bundle instead.
+///
+/// This serves the runtimes whose model directory was resolved to a concrete source path before
+/// the load (training base models, captioners, analyzers). Only a path that lies under
+/// `<source_library_root>/models--<safe>/snapshots/<revision>/` for a leased pair is rewritten,
+/// and only when the rewritten path actually exists in the bundle — otherwise the caller keeps the
+/// authoritative source path.
+pub fn redirect_source_library_path(source_library_root: &Path, path: &Path) -> Option<PathBuf> {
+    let active = lock_active();
+    for entry in &active.entries {
+        let safe = safe_repository_dir(&entry.repository).ok()?;
+        let source_snapshot = source_library_root
+            .join(format!("models--{safe}"))
+            .join("snapshots")
+            .join(&entry.revision);
+        let Ok(relative) = path.strip_prefix(&source_snapshot) else {
+            continue;
+        };
+        let redirected = entry.snapshot_root.join(relative);
+        if redirected.exists() {
+            return Some(redirected);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+#[path = "local_preference_tests.rs"]
+mod tests;

--- a/crates/sceneworks-core/src/model_artifacts/local_preference.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference.rs
@@ -261,17 +261,30 @@ pub fn unique_local_snapshot(repository: &str) -> Option<(String, PathBuf)> {
 pub fn redirect_source_library_path(source_library_root: &Path, path: &Path) -> Option<PathBuf> {
     let active = lock_active();
     for entry in &active.entries {
-        let safe = safe_repository_dir(&entry.repository).ok()?;
+        let Ok(safe) = safe_repository_dir(&entry.repository) else {
+            continue;
+        };
         let source_snapshot = source_library_root
             .join(format!("models--{safe}"))
             .join("snapshots")
             .join(&entry.revision);
-        let Ok(relative) = path.strip_prefix(&source_snapshot) else {
-            continue;
-        };
-        let redirected = entry.snapshot_root.join(relative);
-        if redirected.exists() {
-            return Some(redirected);
+        // Both the lexical and the canonical form of the source snapshot: callers hand over paths
+        // that have already been confined (canonicalized), while the configured library root is
+        // whatever the environment named — on macOS those differ for any `/var`-style symlink.
+        let mut prefixes = vec![source_snapshot.clone()];
+        if let Ok(canonical) = std::fs::canonicalize(&source_snapshot) {
+            if canonical != source_snapshot {
+                prefixes.push(canonical);
+            }
+        }
+        for prefix in prefixes {
+            let Ok(relative) = path.strip_prefix(&prefix) else {
+                continue;
+            };
+            let redirected = entry.snapshot_root.join(relative);
+            if redirected.exists() {
+                return Some(redirected);
+            }
         }
     }
     None

--- a/crates/sceneworks-core/src/model_artifacts/local_preference.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference.rs
@@ -14,9 +14,9 @@
 //! - Only the worker's pre-loader guard installs a preference scope, and only for artifacts it
 //!   holds a runtime lease on, so an artifact can never be evicted while a load reads it.
 //! - The scope is process-wide because model paths are resolved on engine threads and blocking
-//!   pools far below the async job task; the worker claim loop runs one job at a time, and a
-//!   second overlapping installation for the same repository fails closed (see
-//!   [`prefer_local_artifacts`]).
+//!   pools far below the async job task; the worker claim loop runs one job at a time. A second
+//!   installation covering a snapshot already being served adopts the serving bundle when it holds
+//!   every file needed, and otherwise fails closed (see [`prefer_local_artifacts`]).
 //! - Preference is keyed on the exact `(repository, immutable revision)` pair. A superseded
 //!   revision therefore never matches, and a bundle is never consulted for a revision it does not
 //!   contain — the source tier keeps serving those.
@@ -37,6 +37,10 @@ pub struct LocalArtifactOverlayEntry {
     pub revision: String,
     /// `<bundle>/models--<safe>/snapshots/<revision>/` — what a snapshot resolver returns.
     pub snapshot_root: PathBuf,
+    /// Snapshot-relative files this bundle holds for the pair, sorted. Two bundles may both cover
+    /// one shared snapshot (a text encoder used by two models); this is what decides whether an
+    /// already-serving bundle covers everything a second one would have served.
+    pub files: Vec<PathBuf>,
 }
 
 /// The canonical bundle-relative destination of one closure member: the source library's own
@@ -122,14 +126,28 @@ pub fn overlay_entries_for_artifact(
             .join(format!("models--{safe}"))
             .join("snapshots")
             .join(&member.source.revision);
-        let entry = LocalArtifactOverlayEntry {
-            repository: member.source.repository.clone(),
-            revision: member.source.revision.clone(),
-            snapshot_root,
-        };
-        if !entries.contains(&entry) {
-            entries.push(entry);
+        // Snapshot-relative, so two bundles holding the same repository/revision can be compared
+        // for coverage regardless of which bundle they live in.
+        let files = member
+            .files
+            .iter()
+            .map(|file| member.source_subpath.join(&file.relative_path))
+            .collect::<Vec<_>>();
+        match entries.iter_mut().find(|held| {
+            held.repository == member.source.repository && held.revision == member.source.revision
+        }) {
+            Some(held) => held.files.extend(files),
+            None => entries.push(LocalArtifactOverlayEntry {
+                repository: member.source.repository.clone(),
+                revision: member.source.revision.clone(),
+                snapshot_root,
+                files,
+            }),
         }
+    }
+    for entry in &mut entries {
+        entry.files.sort();
+        entry.files.dedup();
     }
     Ok(entries)
 }
@@ -179,49 +197,64 @@ impl Drop for ActiveLocalArtifacts {
 /// Install a local-tier preference scope for `artifacts` (each of which the caller must already
 /// hold a runtime lease on).
 ///
-/// Fails closed when a `(repository, revision)` pair is already served from a DIFFERENT bundle
-/// root: two bundles disagreeing about one immutable snapshot is exactly the case where silently
-/// picking one could serve a load a file set that was verified for another selection. The caller
-/// then keeps that load on the source tier.
+/// Two bundles legitimately cover one shared snapshot — a text encoder used by two models is
+/// materialized into both. When a `(repository, revision)` pair is already being served, this
+/// installation adopts the serving bundle IF that bundle holds every file this one would have
+/// served for the pair, and otherwise fails closed: silently picking a bundle with a narrower file
+/// set is exactly how a load would be handed an incomplete snapshot. The caller then keeps that
+/// model on the source tier.
 pub fn prefer_local_artifacts(
     artifacts: &[ResolvedModelArtifact],
 ) -> Result<ActiveLocalArtifacts, ArtifactContractError> {
     let mut requested: Vec<LocalArtifactOverlayEntry> = Vec::new();
     for artifact in artifacts {
         for entry in overlay_entries_for_artifact(artifact)? {
-            if let Some(existing) = requested
+            match requested
                 .iter()
                 .find(|held| held.repository == entry.repository && held.revision == entry.revision)
             {
-                if existing != &entry {
-                    return Err(ArtifactContractError(format!(
-                        "two resolved-local bundles claim {}@{}",
-                        entry.repository, entry.revision
-                    )));
-                }
-                continue;
+                Some(existing) => ensure_covers(existing, &entry)?,
+                None => requested.push(entry),
             }
-            requested.push(entry);
         }
     }
     let mut active = lock_active();
-    for entry in &requested {
-        if active
+    let mut installed = Vec::new();
+    for entry in requested {
+        match active
             .entries
             .iter()
-            .any(|held| held.repository == entry.repository && held.revision == entry.revision)
+            .find(|held| held.repository == entry.repository && held.revision == entry.revision)
         {
-            return Err(ArtifactContractError(format!(
-                "a local-tier preference scope already serves {}@{}",
-                entry.repository, entry.revision
-            )));
+            // Already served by an active scope that covers everything this one needs: adopt it
+            // rather than installing a second claim on the same snapshot.
+            Some(existing) => ensure_covers(existing, &entry)?,
+            None => installed.push(entry),
         }
     }
-    active.entries.extend(requested.iter().cloned());
+    active.entries.extend(installed.iter().cloned());
     drop(active);
     Ok(ActiveLocalArtifacts {
-        entries: Arc::new(requested),
+        entries: Arc::new(installed),
     })
+}
+
+/// The serving bundle must hold every file the requested one would have served for the pair.
+fn ensure_covers(
+    serving: &LocalArtifactOverlayEntry,
+    requested: &LocalArtifactOverlayEntry,
+) -> Result<(), ArtifactContractError> {
+    if requested
+        .files
+        .iter()
+        .all(|file| serving.files.binary_search(file).is_ok())
+    {
+        return Ok(());
+    }
+    Err(ArtifactContractError(format!(
+        "the bundle already serving {}@{} does not hold every file this artifact needs from it",
+        requested.repository, requested.revision
+    )))
 }
 
 /// The leased local snapshot for this exact immutable pair, if one is active AND still on disk.

--- a/crates/sceneworks-core/src/model_artifacts/local_preference.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference.rs
@@ -227,12 +227,19 @@ pub fn prefer_local_artifacts(
     })
 }
 
-/// The leased local snapshot for this exact immutable pair, if one is active.
+/// The leased local snapshot for this exact immutable pair, if one is active AND still on disk.
+/// The lease is what keeps a published bundle from being evicted mid-load, so the presence check
+/// is belt-and-braces: an answer this function gives must be loadable, never a path the caller
+/// discovers is gone.
 pub fn local_snapshot(repository: &str, revision: &str) -> Option<PathBuf> {
     lock_active()
         .entries
         .iter()
-        .find(|entry| entry.repository == repository && entry.revision == revision)
+        .find(|entry| {
+            entry.repository == repository
+                && entry.revision == revision
+                && entry.snapshot_root.is_dir()
+        })
         .map(|entry| entry.snapshot_root.clone())
 }
 
@@ -245,7 +252,7 @@ pub fn unique_local_snapshot(repository: &str) -> Option<(String, PathBuf)> {
     let mut matches = active
         .entries
         .iter()
-        .filter(|entry| entry.repository == repository);
+        .filter(|entry| entry.repository == repository && entry.snapshot_root.is_dir());
     let first = matches.next()?;
     if matches.next().is_some() {
         return None;

--- a/crates/sceneworks-core/src/model_artifacts/local_preference.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference.rs
@@ -35,8 +35,6 @@ use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 pub struct LocalArtifactOverlayEntry {
     pub repository: String,
     pub revision: String,
-    /// `<bundle>/models--<safe>/` — the local mirror of the source library's repository root.
-    pub repository_root: PathBuf,
     /// `<bundle>/models--<safe>/snapshots/<revision>/` — what a snapshot resolver returns.
     pub snapshot_root: PathBuf,
 }
@@ -120,14 +118,13 @@ pub fn overlay_entries_for_artifact(
             )));
         }
         let safe = safe_repository_dir(&member.source.repository)?;
-        let repository_root = root.join(format!("models--{safe}"));
-        let snapshot_root = repository_root
+        let snapshot_root = root
+            .join(format!("models--{safe}"))
             .join("snapshots")
             .join(&member.source.revision);
         let entry = LocalArtifactOverlayEntry {
             repository: member.source.repository.clone(),
             revision: member.source.revision.clone(),
-            repository_root,
             snapshot_root,
         };
         if !entries.contains(&entry) {

--- a/crates/sceneworks-core/src/model_artifacts/local_preference.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference.rs
@@ -121,7 +121,9 @@ pub fn overlay_entries_for_artifact(
         }
         let safe = safe_repository_dir(&member.source.repository)?;
         let repository_root = root.join(format!("models--{safe}"));
-        let snapshot_root = repository_root.join("snapshots").join(&member.source.revision);
+        let snapshot_root = repository_root
+            .join("snapshots")
+            .join(&member.source.revision);
         let entry = LocalArtifactOverlayEntry {
             repository: member.source.repository.clone(),
             revision: member.source.revision.clone(),
@@ -190,9 +192,10 @@ pub fn prefer_local_artifacts(
     let mut requested: Vec<LocalArtifactOverlayEntry> = Vec::new();
     for artifact in artifacts {
         for entry in overlay_entries_for_artifact(artifact)? {
-            if let Some(existing) = requested.iter().find(|held| {
-                held.repository == entry.repository && held.revision == entry.revision
-            }) {
+            if let Some(existing) = requested
+                .iter()
+                .find(|held| held.repository == entry.repository && held.revision == entry.revision)
+            {
                 if existing != &entry {
                     return Err(ArtifactContractError(format!(
                         "two resolved-local bundles claim {}@{}",

--- a/crates/sceneworks-core/src/model_artifacts/local_preference.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference.rs
@@ -14,9 +14,11 @@
 //! - Only the worker's pre-loader guard installs a preference scope, and only for artifacts it
 //!   holds a runtime lease on, so an artifact can never be evicted while a load reads it.
 //! - The scope is process-wide because model paths are resolved on engine threads and blocking
-//!   pools far below the async job task; the worker claim loop runs one job at a time. A second
-//!   installation covering a snapshot already being served adopts the serving bundle when it holds
-//!   every file needed, and otherwise fails closed (see [`prefer_local_artifacts`]).
+//!   pools far below the async job task; the worker claim loop runs one job at a time. Which
+//!   `(repository, revision)` pairs may be served at all is decided by the GUARD — the only layer
+//!   that can see every model a job will load — and handed here already decided (see
+//!   [`prefer_local_snapshots`]); a directory-level seam cannot re-ask "does this bundle hold what
+//!   THIS caller needs" once it has answered with a path.
 //! - Preference is keyed on the exact `(repository, immutable revision)` pair. A superseded
 //!   revision therefore never matches, and a bundle is never consulted for a revision it does not
 //!   contain — the source tier keeps serving those.
@@ -196,11 +198,7 @@ impl Drop for ActiveLocalArtifacts {
     fn drop(&mut self) {
         let mut active = lock_active();
         for entry in self.entries.iter() {
-            let Some(index) = active
-                .entries
-                .iter()
-                .position(|held| &held.entry == entry)
-            else {
+            let Some(index) = active.entries.iter().position(|held| &held.entry == entry) else {
                 continue;
             };
             if active.entries[index].holders > 1 {
@@ -286,12 +284,12 @@ pub fn local_snapshot(repository: &str, revision: &str) -> Option<PathBuf> {
     lock_active()
         .entries
         .iter()
-        .find(|entry| {
-            entry.repository == repository
-                && entry.revision == revision
-                && entry.snapshot_root.is_dir()
+        .find(|held| {
+            held.entry.repository == repository
+                && held.entry.revision == revision
+                && held.entry.snapshot_root.is_dir()
         })
-        .map(|entry| entry.snapshot_root.clone())
+        .map(|held| held.entry.snapshot_root.clone())
 }
 
 /// The leased local snapshot for `repository` when EXACTLY ONE revision of it is active. Used only
@@ -303,12 +301,15 @@ pub fn unique_local_snapshot(repository: &str) -> Option<(String, PathBuf)> {
     let mut matches = active
         .entries
         .iter()
-        .filter(|entry| entry.repository == repository && entry.snapshot_root.is_dir());
+        .filter(|held| held.entry.repository == repository && held.entry.snapshot_root.is_dir());
     let first = matches.next()?;
     if matches.next().is_some() {
         return None;
     }
-    Some((first.revision.clone(), first.snapshot_root.clone()))
+    Some((
+        first.entry.revision.clone(),
+        first.entry.snapshot_root.clone(),
+    ))
 }
 
 /// Rewrite an already-confined path that points into the configured source library so it reads
@@ -321,7 +322,8 @@ pub fn unique_local_snapshot(repository: &str) -> Option<(String, PathBuf)> {
 /// authoritative source path.
 pub fn redirect_source_library_path(source_library_root: &Path, path: &Path) -> Option<PathBuf> {
     let active = lock_active();
-    for entry in &active.entries {
+    for held in &active.entries {
+        let entry = &held.entry;
         let Ok(safe) = safe_repository_dir(&entry.repository) else {
             continue;
         };

--- a/crates/sceneworks-core/src/model_artifacts/local_preference.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference.rs
@@ -14,11 +14,23 @@
 //! - Only the worker's pre-loader guard installs a preference scope, and only for artifacts it
 //!   holds a runtime lease on, so an artifact can never be evicted while a load reads it.
 //! - The scope is process-wide because model paths are resolved on engine threads and blocking
-//!   pools far below the async job task; the worker claim loop runs one job at a time. Which
-//!   `(repository, revision)` pairs may be served at all is decided by the GUARD — the only layer
-//!   that can see every model a job will load — and handed here already decided (see
-//!   [`prefer_local_snapshots`]); a directory-level seam cannot re-ask "does this bundle hold what
-//!   THIS caller needs" once it has answered with a path.
+//!   pools far below the async job task. Which `(repository, revision)` pairs may be served at all
+//!   is decided by the GUARD — the only layer that can see every model a job will load — and handed
+//!   here already decided (see [`prefer_local_snapshots`]); a directory-level seam cannot re-ask
+//!   "does this bundle hold what THIS caller needs" once it has answered with a path.
+//! - **The bound on "process-wide", stated honestly.** The worker claim loop runs one job at a
+//!   time, so no two JOBS overlap. That is not the whole story: in the desktop deployment the
+//!   utility worker runs INSIDE the API process (`spawn_inprocess_utility_worker`), so an API read
+//!   path resolving through the same prefer-local
+//!   [`crate::hf_home::model_source_library`] can observe a scope a job installed. For a file
+//!   OUTSIDE that job's union the leased bundle does not hold it, and such a reader sees it as
+//!   ABSENT while the scope is live. The bound is therefore: a concurrent same-process reader may
+//!   get a transient **false absent** that self-heals when the job ends — and never WRONG BYTES,
+//!   because a served path only ever names an already-verified bundle and an out-of-union name
+//!   simply does not exist inside it. Pinned by
+//!   `an_out_of_union_reader_sees_absent_never_the_wrong_bytes`. Narrowing this further means
+//!   giving API read paths a non-preferring library, which is a change across every
+//!   `model_source_library` caller rather than a local one.
 //! - Preference is keyed on the exact `(repository, immutable revision)` pair. A superseded
 //!   revision therefore never matches, and a bundle is never consulted for a revision it does not
 //!   contain — the source tier keeps serving those.

--- a/crates/sceneworks-core/src/model_artifacts/local_preference_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference_tests.rs
@@ -409,6 +409,82 @@ fn a_narrower_serving_bundle_is_never_adopted() {
     assert!(local_snapshot("owner/encoder", COMPONENT_REV).is_none());
 }
 
+/// The honest bound on a PROCESS-WIDE scope, pinned.
+///
+/// In the desktop deployment the utility worker runs inside the API process, so an API read path
+/// resolving through the same prefer-local library can observe a scope a job installed. For a file
+/// OUTSIDE that job's union the leased bundle does not hold it, so such a reader sees it as ABSENT
+/// while the scope is live — a transient false-absent that self-heals when the job ends.
+///
+/// What must NEVER happen is wrong bytes: no reader may be handed a different file's content under
+/// the name it asked for. That is the property this test exists for, and it is what makes the
+/// transient absent tolerable rather than a correctness hole.
+#[test]
+fn an_out_of_union_reader_sees_absent_never_the_wrong_bytes() {
+    let _serialized = overlay_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let library_root = temp.path().join("external-hf");
+    let source = seed_source(
+        &library_root,
+        "owner/model",
+        PRIMARY_REV,
+        "q4/model.safetensors",
+    );
+    // A SECOND file the source library holds and the bundle does not — with distinguishable bytes,
+    // so "wrong bytes" would be detectable rather than merely improbable.
+    std::fs::write(source.join("q4/out-of-union.safetensors"), b"OUT-OF-UNION").unwrap();
+    let artifact = bundle(&temp.path().join("bundle"));
+    let configured = ArtifactSourceLibrary::new_preferring_local(&library_root).unwrap();
+
+    // Before the scope: the out-of-union reader reads its real file.
+    let before = configured
+        .discover_snapshot("owner/model", Some(PRIMARY_REV))
+        .unwrap()
+        .1;
+    assert_eq!(
+        std::fs::read(before.join("q4/out-of-union.safetensors")).unwrap(),
+        b"OUT-OF-UNION"
+    );
+
+    let scope = prefer(&artifact).unwrap();
+    let served = configured
+        .discover_snapshot("owner/model", Some(PRIMARY_REV))
+        .unwrap()
+        .1;
+    assert!(served.starts_with(artifact.location.root()));
+    // In-union: present, and the RIGHT bytes.
+    assert_eq!(
+        std::fs::read(served.join("q4/model.safetensors")).unwrap(),
+        b"weights"
+    );
+    // Out-of-union: ABSENT. This is the transient false-absent the bound admits...
+    assert!(
+        !served.join("q4/out-of-union.safetensors").exists(),
+        "the bundle does not hold this file, so it reads as absent while the scope is live"
+    );
+    // ...and NOT wrong bytes: nothing in the bundle answers to that name at all.
+    assert!(std::fs::read(served.join("q4/out-of-union.safetensors")).is_err());
+    // The already-resolved-path reader likewise keeps its AUTHORITATIVE source path rather than
+    // being rewritten into a bundle that does not hold the file.
+    assert!(redirect_source_library_path(
+        &library_root,
+        &source.join("q4/out-of-union.safetensors")
+    )
+    .is_none());
+
+    // Self-heals the moment the job's scope drops.
+    drop(scope);
+    let after = configured
+        .discover_snapshot("owner/model", Some(PRIMARY_REV))
+        .unwrap()
+        .1;
+    assert_eq!(after, before);
+    assert_eq!(
+        std::fs::read(after.join("q4/out-of-union.safetensors")).unwrap(),
+        b"OUT-OF-UNION"
+    );
+}
+
 /// A model directory that was resolved to a concrete source path before the load (training base
 /// models, captioners, analyzers) is redirected into the leased bundle — and only when the bundle
 /// really holds that file.

--- a/crates/sceneworks-core/src/model_artifacts/local_preference_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference_tests.rs
@@ -18,6 +18,13 @@ fn overlay_guard() -> MutexGuard<'static, ()> {
         .unwrap_or_else(PoisonError::into_inner)
 }
 
+/// Install a scope over one artifact's own snapshots. Production makes this decision at the WORKER
+/// GUARD across the whole job (see `select_local_tier`); at this layer the entries are simply the
+/// artifact's own, which is what every single-artifact case below means.
+fn prefer(artifact: &ResolvedModelArtifact) -> Result<ActiveLocalArtifacts, ArtifactContractError> {
+    prefer_local_snapshots(overlay_entries_for_artifact(artifact)?)
+}
+
 fn member(
     role: ArtifactMemberRole,
     component_id: Option<&str>,
@@ -175,7 +182,7 @@ fn an_active_scope_serves_every_member_and_drop_restores_the_source_tier() {
         primary_source
     );
 
-    let scope = prefer_local_artifacts(std::slice::from_ref(&artifact)).unwrap();
+    let scope = prefer(&artifact).unwrap();
     let (_, primary) = configured
         .discover_snapshot("owner/model", Some(PRIMARY_REV))
         .unwrap();
@@ -231,7 +238,7 @@ fn a_superseded_revision_is_served_from_the_source_tier() {
     let artifact = bundle(&temp.path().join("bundle"));
     let configured = ArtifactSourceLibrary::new_preferring_local(&library_root).unwrap();
 
-    let _scope = prefer_local_artifacts(std::slice::from_ref(&artifact)).unwrap();
+    let _scope = prefer(&artifact).unwrap();
     // Explicit pin at the newer revision: the bundle holds a different commit and must not answer.
     assert_eq!(
         configured
@@ -258,7 +265,7 @@ fn a_disconnected_library_falls_back_to_the_unique_leased_revision() {
     let configured = ArtifactSourceLibrary::new_preferring_local(&library_root).unwrap();
 
     assert!(configured.discover_snapshot("owner/model", None).is_err());
-    let scope = prefer_local_artifacts(std::slice::from_ref(&artifact)).unwrap();
+    let scope = prefer(&artifact).unwrap();
     let (identity, snapshot) = configured.discover_snapshot("owner/model", None).unwrap();
     assert_eq!(identity.revision, PRIMARY_REV);
     assert!(snapshot.join("q4/model.safetensors").is_file());
@@ -281,7 +288,7 @@ fn a_vanished_bundle_directory_is_never_answered_with() {
     );
     let artifact = bundle(&temp.path().join("bundle"));
     let configured = ArtifactSourceLibrary::new_preferring_local(&library_root).unwrap();
-    let _scope = prefer_local_artifacts(std::slice::from_ref(&artifact)).unwrap();
+    let _scope = prefer(&artifact).unwrap();
 
     std::fs::remove_dir_all(artifact.location.root()).unwrap();
     assert!(local_snapshot("owner/model", PRIMARY_REV).is_none());
@@ -295,47 +302,87 @@ fn a_vanished_bundle_directory_is_never_answered_with() {
     );
 }
 
-/// Two models sharing one component snapshot is normal — the shared encoder is materialized into
-/// both bundles. The second installation adopts the bundle already serving that snapshot instead
-/// of failing, so a job carrying both models keeps BOTH on the local tier.
+/// Two scopes may legitimately serve ONE shared component snapshot (a text encoder both models
+/// need). Ownership is REFCOUNTED, not single-owner: the first scope to drop must not un-serve a
+/// snapshot the second is still reading.
 #[test]
-fn a_second_bundle_adopts_the_snapshot_already_being_served() {
+fn a_shared_snapshot_stays_served_until_the_last_scope_drops() {
     let _serialized = overlay_guard();
     let temp = tempfile::tempdir().unwrap();
-    let first = bundle(&temp.path().join("bundle-a"));
-    let second = bundle(&temp.path().join("bundle-b"));
+    let artifact = bundle(&temp.path().join("bundle-a"));
+    let encoder_snapshot = artifact
+        .location
+        .root()
+        .join(format!("models--owner--encoder/snapshots/{COMPONENT_REV}"));
 
-    // One call carrying both, and two separate scopes, both succeed and serve the first bundle.
-    let together = prefer_local_artifacts(&[first.clone(), second.clone()]).unwrap();
+    let first = prefer(&artifact).unwrap();
+    let second = prefer(&artifact).unwrap();
     assert_eq!(
         local_snapshot("owner/encoder", COMPONENT_REV).unwrap(),
-        first
-            .location
-            .root()
-            .join(format!("models--owner--encoder/snapshots/{COMPONENT_REV}"))
+        encoder_snapshot
     );
-    drop(together);
 
-    let scope = prefer_local_artifacts(std::slice::from_ref(&first)).unwrap();
-    let adopted = prefer_local_artifacts(std::slice::from_ref(&second)).unwrap();
-    assert!(adopted.is_empty(), "the second scope installed nothing new");
-    drop(adopted);
-    drop(scope);
+    // The first holder leaves. A single-owner model would stop serving here and hand the second
+    // holder's still-running load a source path mid-flight.
+    drop(first);
+    assert_eq!(
+        local_snapshot("owner/encoder", COMPONENT_REV).unwrap(),
+        encoder_snapshot,
+        "a shared snapshot must stay served while another scope still holds it"
+    );
+
+    drop(second);
+    assert!(local_snapshot("owner/encoder", COMPONENT_REV).is_none());
     assert!(local_snapshot("owner/model", PRIMARY_REV).is_none());
 }
 
-/// A bundle whose file set for the shared snapshot is NARROWER than what the next artifact needs
-/// must not be adopted: that is how a load would be handed an incomplete snapshot. The second
-/// artifact fails to install and its caller keeps it on the source tier.
+/// The subset primitive the guard's coverage rule is built on. A pair may only be served by a
+/// bundle holding a SUPERSET of what is needed from it.
+#[test]
+fn entry_covers_is_a_strict_superset_test() {
+    let temp = tempfile::tempdir().unwrap();
+    let artifact = bundle(&temp.path().join("bundle"));
+    let entries = overlay_entries_for_artifact(&artifact).unwrap();
+    let encoder = entries
+        .iter()
+        .find(|entry| entry.repository == "owner/encoder")
+        .unwrap();
+
+    assert!(entry_covers(encoder, &[]));
+    assert!(entry_covers(
+        encoder,
+        &[PathBuf::from("encoder.safetensors")]
+    ));
+    assert!(!entry_covers(
+        encoder,
+        &[
+            PathBuf::from("encoder.safetensors"),
+            PathBuf::from("encoder.extra.safetensors"),
+        ]
+    ));
+    assert!(!entry_covers(encoder, &[PathBuf::from("absent.bin")]));
+}
+
+/// A SECOND bundle claiming a pair that a live scope is already serving is refused outright, and —
+/// the part that matters — the path layer keeps answering with the bundle that was already
+/// serving. Silently preferring one of two bundles for a pair is exactly how a load gets handed a
+/// snapshot verified for a different selection.
+///
+/// This test previously called `drop(scope)` BEFORE its assertion, which meant it never asked its
+/// own question: with no scope live, `local_snapshot` returns `None` whether or not the refused
+/// bundle was installed. The assertion below is made with the scope STILL HELD, at the path layer,
+/// which is where the defect lived.
 #[test]
 fn a_narrower_serving_bundle_is_never_adopted() {
     let _serialized = overlay_guard();
     let temp = tempfile::tempdir().unwrap();
     let narrow_root = temp.path().join("bundle-narrow");
     let mut narrow = bundle(&narrow_root);
-    let wide = bundle(&temp.path().join("bundle-wide"));
+    let wide_root = temp.path().join("bundle-wide");
+    let wide = bundle(&wide_root);
 
-    // The narrow bundle holds only ONE of the encoder's two files.
+    // The narrow bundle needs a second encoder file that the serving bundle does not hold, so the
+    // serving bundle is NARROWER than what this claim would require of the shared snapshot.
     let mut members = narrow.closure.members.clone();
     let encoder = members
         .iter_mut()
@@ -346,12 +393,18 @@ fn a_narrower_serving_bundle_is_never_adopted() {
         .push(ArtifactFile::new("encoder.extra.safetensors").unwrap());
     narrow.closure = ResolvedBundleClosure::new(members).unwrap();
 
-    let scope = prefer_local_artifacts(std::slice::from_ref(&wide)).unwrap();
-    let error = prefer_local_artifacts(std::slice::from_ref(&narrow)).unwrap_err();
-    assert!(
-        error.to_string().contains("does not hold every file"),
-        "{error}"
-    );
+    let scope = prefer(&wide).unwrap();
+    let error = prefer(&narrow).unwrap_err();
+    assert!(error.to_string().contains("already claims"), "{error}");
+
+    // WITH THE SCOPE STILL HELD: every consumer of the shared pair still reads the bundle that was
+    // serving, and nothing reads the refused one.
+    let served = local_snapshot("owner/encoder", COMPONENT_REV).unwrap();
+    assert!(served.starts_with(&wide_root), "{}", served.display());
+    assert!(!served.starts_with(&narrow_root), "{}", served.display());
+    let primary = local_snapshot("owner/model", PRIMARY_REV).unwrap();
+    assert!(primary.starts_with(&wide_root), "{}", primary.display());
+
     drop(scope);
     assert!(local_snapshot("owner/encoder", COMPONENT_REV).is_none());
 }
@@ -371,7 +424,7 @@ fn a_resolved_source_path_is_redirected_only_when_the_bundle_holds_it() {
         "q4/model.safetensors",
     );
     let artifact = bundle(&temp.path().join("bundle"));
-    let _scope = prefer_local_artifacts(std::slice::from_ref(&artifact)).unwrap();
+    let _scope = prefer(&artifact).unwrap();
 
     let redirected = redirect_source_library_path(&library_root, &source.join("q4")).unwrap();
     assert!(redirected.join("model.safetensors").is_file());

--- a/crates/sceneworks-core/src/model_artifacts/local_preference_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference_tests.rs
@@ -295,28 +295,65 @@ fn a_vanished_bundle_directory_is_never_answered_with() {
     );
 }
 
-/// Two bundles claiming one immutable snapshot is ambiguous, and ambiguity must never be resolved
-/// by picking one: the installation fails and the caller keeps the load on the source tier.
+/// Two models sharing one component snapshot is normal — the shared encoder is materialized into
+/// both bundles. The second installation adopts the bundle already serving that snapshot instead
+/// of failing, so a job carrying both models keeps BOTH on the local tier.
 #[test]
-fn conflicting_bundles_refuse_to_install_a_scope() {
+fn a_second_bundle_adopts_the_snapshot_already_being_served() {
     let _serialized = overlay_guard();
     let temp = tempfile::tempdir().unwrap();
     let first = bundle(&temp.path().join("bundle-a"));
     let second = bundle(&temp.path().join("bundle-b"));
-    let error = prefer_local_artifacts(&[first.clone(), second]).unwrap_err();
-    assert!(
-        error
-            .to_string()
-            .contains("two resolved-local bundles claim"),
-        "{error}"
+
+    // One call carrying both, and two separate scopes, both succeed and serve the first bundle.
+    let together = prefer_local_artifacts(&[first.clone(), second.clone()]).unwrap();
+    assert_eq!(
+        local_snapshot("owner/encoder", COMPONENT_REV).unwrap(),
+        first
+            .location
+            .root()
+            .join(format!("models--owner--encoder/snapshots/{COMPONENT_REV}"))
     );
-    // The failed installation left nothing behind.
-    assert!(local_snapshot("owner/model", PRIMARY_REV).is_none());
+    drop(together);
 
     let scope = prefer_local_artifacts(std::slice::from_ref(&first)).unwrap();
-    assert!(prefer_local_artifacts(std::slice::from_ref(&first)).is_err());
+    let adopted = prefer_local_artifacts(std::slice::from_ref(&second)).unwrap();
+    assert!(adopted.is_empty(), "the second scope installed nothing new");
+    drop(adopted);
     drop(scope);
-    assert!(prefer_local_artifacts(std::slice::from_ref(&first)).is_ok());
+    assert!(local_snapshot("owner/model", PRIMARY_REV).is_none());
+}
+
+/// A bundle whose file set for the shared snapshot is NARROWER than what the next artifact needs
+/// must not be adopted: that is how a load would be handed an incomplete snapshot. The second
+/// artifact fails to install and its caller keeps it on the source tier.
+#[test]
+fn a_narrower_serving_bundle_is_never_adopted() {
+    let _serialized = overlay_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let narrow_root = temp.path().join("bundle-narrow");
+    let mut narrow = bundle(&narrow_root);
+    let wide = bundle(&temp.path().join("bundle-wide"));
+
+    // The narrow bundle holds only ONE of the encoder's two files.
+    let mut members = narrow.closure.members.clone();
+    let encoder = members
+        .iter_mut()
+        .find(|member| member.source.repository == "owner/encoder")
+        .unwrap();
+    encoder
+        .files
+        .push(ArtifactFile::new("encoder.extra.safetensors").unwrap());
+    narrow.closure = ResolvedBundleClosure::new(members).unwrap();
+
+    let scope = prefer_local_artifacts(std::slice::from_ref(&wide)).unwrap();
+    let error = prefer_local_artifacts(std::slice::from_ref(&narrow)).unwrap_err();
+    assert!(
+        error.to_string().contains("does not hold every file"),
+        "{error}"
+    );
+    drop(scope);
+    assert!(local_snapshot("owner/encoder", COMPONENT_REV).is_none());
 }
 
 /// A model directory that was resolved to a concrete source path before the load (training base

--- a/crates/sceneworks-core/src/model_artifacts/local_preference_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference_tests.rs
@@ -116,7 +116,9 @@ fn member_destination_mirrors_the_source_library_layout() {
         PathBuf::from(format!("models--owner--model/snapshots/{PRIMARY_REV}/q4"))
     );
     assert!(hub_cache_member_destination("owner/model", "main", Path::new("")).is_err());
-    assert!(hub_cache_member_destination("owner/model", PRIMARY_REV, Path::new("../escape")).is_err());
+    assert!(
+        hub_cache_member_destination("owner/model", PRIMARY_REV, Path::new("../escape")).is_err()
+    );
 }
 
 /// A bundle stored in any other layout cannot be handed to the shared snapshot resolvers, so it is
@@ -150,7 +152,12 @@ fn an_active_scope_serves_every_member_and_drop_restores_the_source_tier() {
     let _serialized = overlay_guard();
     let temp = tempfile::tempdir().unwrap();
     let library_root = temp.path().join("external-hf");
-    let primary_source = seed_source(&library_root, "owner/model", PRIMARY_REV, "q4/model.safetensors");
+    let primary_source = seed_source(
+        &library_root,
+        "owner/model",
+        PRIMARY_REV,
+        "q4/model.safetensors",
+    );
     let encoder_source = seed_source(
         &library_root,
         "owner/encoder",
@@ -172,9 +179,13 @@ fn an_active_scope_serves_every_member_and_drop_restores_the_source_tier() {
     let (_, primary) = configured
         .discover_snapshot("owner/model", Some(PRIMARY_REV))
         .unwrap();
-    assert_eq!(primary, artifact.location.root().join(format!(
-        "models--owner--model/snapshots/{PRIMARY_REV}"
-    )));
+    assert_eq!(
+        primary,
+        artifact
+            .location
+            .root()
+            .join(format!("models--owner--model/snapshots/{PRIMARY_REV}"))
+    );
     assert!(primary.join("q4/model.safetensors").is_file());
     let (_, encoder) = configured
         .discover_snapshot("owner/encoder", Some(COMPONENT_REV))
@@ -210,7 +221,12 @@ fn a_superseded_revision_is_served_from_the_source_tier() {
     let _serialized = overlay_guard();
     let temp = tempfile::tempdir().unwrap();
     let library_root = temp.path().join("external-hf");
-    let newer = seed_source(&library_root, "owner/model", OTHER_REV, "q4/model.safetensors");
+    let newer = seed_source(
+        &library_root,
+        "owner/model",
+        OTHER_REV,
+        "q4/model.safetensors",
+    );
     write_refs_main(&library_root, "owner/model", OTHER_REV);
     let artifact = bundle(&temp.path().join("bundle"));
     let configured = ArtifactSourceLibrary::new_preferring_local(&library_root).unwrap();
@@ -260,7 +276,9 @@ fn conflicting_bundles_refuse_to_install_a_scope() {
     let second = bundle(&temp.path().join("bundle-b"));
     let error = prefer_local_artifacts(&[first.clone(), second]).unwrap_err();
     assert!(
-        error.to_string().contains("two resolved-local bundles claim"),
+        error
+            .to_string()
+            .contains("two resolved-local bundles claim"),
         "{error}"
     );
     // The failed installation left nothing behind.
@@ -280,7 +298,12 @@ fn a_resolved_source_path_is_redirected_only_when_the_bundle_holds_it() {
     let _serialized = overlay_guard();
     let temp = tempfile::tempdir().unwrap();
     let library_root = temp.path().join("external-hf");
-    let source = seed_source(&library_root, "owner/model", PRIMARY_REV, "q4/model.safetensors");
+    let source = seed_source(
+        &library_root,
+        "owner/model",
+        PRIMARY_REV,
+        "q4/model.safetensors",
+    );
     let artifact = bundle(&temp.path().join("bundle"));
     let _scope = prefer_local_artifacts(std::slice::from_ref(&artifact)).unwrap();
 

--- a/crates/sceneworks-core/src/model_artifacts/local_preference_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference_tests.rs
@@ -1,0 +1,295 @@
+use super::*;
+use crate::model_artifacts::{
+    ArtifactAvailability, ArtifactCompleteness, ArtifactFile, ArtifactIdentity, ArtifactProvenance,
+    ArtifactSourceLibrary, ResolvedBundleClosure, ResolvedBundleMember,
+};
+use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
+
+const PRIMARY_REV: &str = "0123456789abcdef0123456789abcdef01234567";
+const COMPONENT_REV: &str = "89abcdef0123456789abcdef0123456789abcdef";
+const OTHER_REV: &str = "1111111111111111111111111111111111111111";
+
+/// The preference scope is process-wide by design (model paths resolve on engine threads far
+/// below the job task), so these tests serialize against each other.
+fn overlay_guard() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
+fn member(
+    role: ArtifactMemberRole,
+    component_id: Option<&str>,
+    repository: &str,
+    revision: &str,
+    subpath: &str,
+    file: &str,
+) -> ResolvedBundleMember {
+    let source_subpath = PathBuf::from(subpath);
+    ResolvedBundleMember {
+        role,
+        component_id: component_id.map(str::to_owned),
+        source: ArtifactIdentity::pinned(repository, revision, "q4").unwrap(),
+        tier: Some("q4".to_owned()),
+        destination: hub_cache_member_destination(repository, revision, &source_subpath).unwrap(),
+        source_subpath,
+        files: vec![ArtifactFile::new(file).unwrap()],
+    }
+}
+
+/// A published bundle laid out exactly as materialization writes it: one primary plus one
+/// co-requisite from a different repository and revision.
+fn bundle(root: &Path) -> ResolvedModelArtifact {
+    let identity = ArtifactIdentity::pinned("owner/model", PRIMARY_REV, "q4").unwrap();
+    let closure = ResolvedBundleClosure::new(vec![
+        member(
+            ArtifactMemberRole::Primary,
+            None,
+            "owner/model",
+            PRIMARY_REV,
+            "q4",
+            "model.safetensors",
+        ),
+        member(
+            ArtifactMemberRole::CoRequisite,
+            Some("text_encoder"),
+            "owner/encoder",
+            COMPONENT_REV,
+            "",
+            "encoder.safetensors",
+        ),
+    ])
+    .unwrap();
+    for path in closure.rebased_paths(root).unwrap() {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, b"weights").unwrap();
+    }
+    let artifact = ResolvedModelArtifact {
+        schema_version: MODEL_ARTIFACT_CONTRACT_VERSION,
+        provenance: ArtifactProvenance {
+            identity: identity.clone(),
+            fixed_artifact_tier: Some("q4".to_owned()),
+        },
+        identity,
+        location: ArtifactLocation::ResolvedLocal {
+            root: root.to_path_buf(),
+        },
+        closure,
+        completeness: ArtifactCompleteness::Complete,
+        availability: ArtifactAvailability::Available,
+    };
+    artifact.validate().unwrap();
+    artifact
+}
+
+fn seed_source(library: &Path, repository: &str, revision: &str, file: &str) -> PathBuf {
+    let snapshot = ArtifactSourceLibrary::new(library)
+        .unwrap()
+        .repository_root(repository)
+        .unwrap()
+        .join("snapshots")
+        .join(revision);
+    std::fs::create_dir_all(snapshot.join(file).parent().unwrap()).unwrap();
+    std::fs::write(snapshot.join(file), b"weights").unwrap();
+    snapshot
+}
+
+fn write_refs_main(library: &Path, repository: &str, revision: &str) {
+    let repo_root = ArtifactSourceLibrary::new(library)
+        .unwrap()
+        .repository_root(repository)
+        .unwrap();
+    std::fs::create_dir_all(repo_root.join("refs")).unwrap();
+    std::fs::write(repo_root.join("refs").join("main"), revision).unwrap();
+}
+
+/// The bundle layout IS the source-library layout. This is the invariant every runtime relies on.
+#[test]
+fn member_destination_mirrors_the_source_library_layout() {
+    assert_eq!(
+        hub_cache_member_destination("owner/model", PRIMARY_REV, Path::new("")).unwrap(),
+        PathBuf::from(format!("models--owner--model/snapshots/{PRIMARY_REV}"))
+    );
+    assert_eq!(
+        hub_cache_member_destination("owner/model", PRIMARY_REV, Path::new("q4")).unwrap(),
+        PathBuf::from(format!("models--owner--model/snapshots/{PRIMARY_REV}/q4"))
+    );
+    assert!(hub_cache_member_destination("owner/model", "main", Path::new("")).is_err());
+    assert!(hub_cache_member_destination("owner/model", PRIMARY_REV, Path::new("../escape")).is_err());
+}
+
+/// A bundle stored in any other layout cannot be handed to the shared snapshot resolvers, so it is
+/// reported as an unsupported shape instead of being half-used.
+#[test]
+fn a_bundle_outside_the_source_library_layout_is_an_unsupported_shape() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().join("bundle");
+    let mut artifact = bundle(&root);
+    assert_eq!(overlay_entries_for_artifact(&artifact).unwrap().len(), 2);
+
+    let mut members = artifact.closure.members.clone();
+    members[0].destination = PathBuf::from("primary");
+    artifact.closure = ResolvedBundleClosure::new(members).unwrap();
+    let error = overlay_entries_for_artifact(&artifact).unwrap_err();
+    assert!(
+        error.to_string().contains("source-library layout"),
+        "{error}"
+    );
+
+    // A source-tier artifact is never a local-tier candidate.
+    let mut source_tier = bundle(&root);
+    source_tier.location = ArtifactLocation::SourceLibrary { root };
+    assert!(overlay_entries_for_artifact(&source_tier).is_err());
+}
+
+/// The walking skeleton at the contract level: with a scope active, the CONFIGURED library serves
+/// the leased bundle for every member's exact pair, and the scope's drop restores the source tier.
+#[test]
+fn an_active_scope_serves_every_member_and_drop_restores_the_source_tier() {
+    let _serialized = overlay_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let library_root = temp.path().join("external-hf");
+    let primary_source = seed_source(&library_root, "owner/model", PRIMARY_REV, "q4/model.safetensors");
+    let encoder_source = seed_source(
+        &library_root,
+        "owner/encoder",
+        COMPONENT_REV,
+        "encoder.safetensors",
+    );
+    let artifact = bundle(&temp.path().join("bundle"));
+    let configured = ArtifactSourceLibrary::new_preferring_local(&library_root).unwrap();
+
+    assert_eq!(
+        configured
+            .discover_snapshot("owner/model", Some(PRIMARY_REV))
+            .unwrap()
+            .1,
+        primary_source
+    );
+
+    let scope = prefer_local_artifacts(std::slice::from_ref(&artifact)).unwrap();
+    let (_, primary) = configured
+        .discover_snapshot("owner/model", Some(PRIMARY_REV))
+        .unwrap();
+    assert_eq!(primary, artifact.location.root().join(format!(
+        "models--owner--model/snapshots/{PRIMARY_REV}"
+    )));
+    assert!(primary.join("q4/model.safetensors").is_file());
+    let (_, encoder) = configured
+        .discover_snapshot("owner/encoder", Some(COMPONENT_REV))
+        .unwrap();
+    assert!(encoder.join("encoder.safetensors").is_file());
+    assert_ne!(encoder, encoder_source);
+
+    // A library built for maintenance/materialization keeps reading the authoritative source, so
+    // promotion can never copy a bundle out of a bundle.
+    assert_eq!(
+        ArtifactSourceLibrary::new(&library_root)
+            .unwrap()
+            .discover_snapshot("owner/model", Some(PRIMARY_REV))
+            .unwrap()
+            .1,
+        primary_source
+    );
+
+    drop(scope);
+    assert_eq!(
+        configured
+            .discover_snapshot("owner/model", Some(PRIMARY_REV))
+            .unwrap()
+            .1,
+        primary_source
+    );
+}
+
+/// A local bundle never wins for a revision it does not hold: the authoritative library still
+/// chooses the revision whenever it can be read.
+#[test]
+fn a_superseded_revision_is_served_from_the_source_tier() {
+    let _serialized = overlay_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let library_root = temp.path().join("external-hf");
+    let newer = seed_source(&library_root, "owner/model", OTHER_REV, "q4/model.safetensors");
+    write_refs_main(&library_root, "owner/model", OTHER_REV);
+    let artifact = bundle(&temp.path().join("bundle"));
+    let configured = ArtifactSourceLibrary::new_preferring_local(&library_root).unwrap();
+
+    let _scope = prefer_local_artifacts(std::slice::from_ref(&artifact)).unwrap();
+    // Explicit pin at the newer revision: the bundle holds a different commit and must not answer.
+    assert_eq!(
+        configured
+            .discover_snapshot("owner/model", Some(OTHER_REV))
+            .unwrap()
+            .1,
+        newer
+    );
+    // Unpinned resolution reads the library's own `refs/main`, which names the newer commit.
+    assert_eq!(
+        configured.discover_snapshot("owner/model", None).unwrap().1,
+        newer
+    );
+}
+
+/// With the configured library disconnected, an unpinned resolve is served by the leased bundle —
+/// this is what keeps a complete local model usable while the drive is unplugged.
+#[test]
+fn a_disconnected_library_falls_back_to_the_unique_leased_revision() {
+    let _serialized = overlay_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let library_root = temp.path().join("never-mounted");
+    let artifact = bundle(&temp.path().join("bundle"));
+    let configured = ArtifactSourceLibrary::new_preferring_local(&library_root).unwrap();
+
+    assert!(configured.discover_snapshot("owner/model", None).is_err());
+    let scope = prefer_local_artifacts(std::slice::from_ref(&artifact)).unwrap();
+    let (identity, snapshot) = configured.discover_snapshot("owner/model", None).unwrap();
+    assert_eq!(identity.revision, PRIMARY_REV);
+    assert!(snapshot.join("q4/model.safetensors").is_file());
+    drop(scope);
+    assert!(configured.discover_snapshot("owner/model", None).is_err());
+}
+
+/// Two bundles claiming one immutable snapshot is ambiguous, and ambiguity must never be resolved
+/// by picking one: the installation fails and the caller keeps the load on the source tier.
+#[test]
+fn conflicting_bundles_refuse_to_install_a_scope() {
+    let _serialized = overlay_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let first = bundle(&temp.path().join("bundle-a"));
+    let second = bundle(&temp.path().join("bundle-b"));
+    let error = prefer_local_artifacts(&[first.clone(), second]).unwrap_err();
+    assert!(
+        error.to_string().contains("two resolved-local bundles claim"),
+        "{error}"
+    );
+    // The failed installation left nothing behind.
+    assert!(local_snapshot("owner/model", PRIMARY_REV).is_none());
+
+    let scope = prefer_local_artifacts(std::slice::from_ref(&first)).unwrap();
+    assert!(prefer_local_artifacts(std::slice::from_ref(&first)).is_err());
+    drop(scope);
+    assert!(prefer_local_artifacts(std::slice::from_ref(&first)).is_ok());
+}
+
+/// A model directory that was resolved to a concrete source path before the load (training base
+/// models, captioners, analyzers) is redirected into the leased bundle — and only when the bundle
+/// really holds that file.
+#[test]
+fn a_resolved_source_path_is_redirected_only_when_the_bundle_holds_it() {
+    let _serialized = overlay_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let library_root = temp.path().join("external-hf");
+    let source = seed_source(&library_root, "owner/model", PRIMARY_REV, "q4/model.safetensors");
+    let artifact = bundle(&temp.path().join("bundle"));
+    let _scope = prefer_local_artifacts(std::slice::from_ref(&artifact)).unwrap();
+
+    let redirected = redirect_source_library_path(&library_root, &source.join("q4")).unwrap();
+    assert!(redirected.join("model.safetensors").is_file());
+    assert!(redirected.starts_with(artifact.location.root()));
+
+    // A file the bundle does not hold keeps its authoritative source path.
+    assert!(redirect_source_library_path(&library_root, &source.join("q8")).is_none());
+    // A path outside the configured library is never rewritten.
+    assert!(redirect_source_library_path(&library_root, Path::new("/etc/hosts")).is_none());
+}

--- a/crates/sceneworks-core/src/model_artifacts/local_preference_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference_tests.rs
@@ -266,6 +266,35 @@ fn a_disconnected_library_falls_back_to_the_unique_leased_revision() {
     assert!(configured.discover_snapshot("owner/model", None).is_err());
 }
 
+/// A scope can only ever answer with a snapshot that is really there: if the bundle directory is
+/// gone the load falls back to the source tier instead of being handed a path that does not exist.
+#[test]
+fn a_vanished_bundle_directory_is_never_answered_with() {
+    let _serialized = overlay_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let library_root = temp.path().join("external-hf");
+    let source = seed_source(
+        &library_root,
+        "owner/model",
+        PRIMARY_REV,
+        "q4/model.safetensors",
+    );
+    let artifact = bundle(&temp.path().join("bundle"));
+    let configured = ArtifactSourceLibrary::new_preferring_local(&library_root).unwrap();
+    let _scope = prefer_local_artifacts(std::slice::from_ref(&artifact)).unwrap();
+
+    std::fs::remove_dir_all(artifact.location.root()).unwrap();
+    assert!(local_snapshot("owner/model", PRIMARY_REV).is_none());
+    assert!(unique_local_snapshot("owner/model").is_none());
+    assert_eq!(
+        configured
+            .discover_snapshot("owner/model", Some(PRIMARY_REV))
+            .unwrap()
+            .1,
+        source
+    );
+}
+
 /// Two bundles claiming one immutable snapshot is ambiguous, and ambiguity must never be resolved
 /// by picking one: the installation fails and the caller keeps the load on the source tier.
 #[test]

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -1286,6 +1286,7 @@ impl Drop for ResolvedCacheReservation {
     }
 }
 
+#[derive(Debug)]
 pub struct ResolvedCacheLease {
     runtime_lease: Option<ActiveArtifactLease>,
     #[allow(dead_code)]

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -324,9 +324,18 @@ impl ResolvedCacheStore {
     pub fn enumerate_existing(
         data_dir: &Path,
     ) -> Result<Vec<ResolvedCacheEntrySummary>, ResolvedCacheError> {
+        match Self::open_read_only(data_dir)? {
+            Some(store) => store.enumerate(),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// The read-only inspection handle behind [`Self::enumerate_existing`]: no runtime session, no
+    /// session lock, no usage stamping. `None` when no cache has ever been initialized here.
+    fn open_read_only(data_dir: &Path) -> Result<Option<Self>, ResolvedCacheError> {
         let root = data_dir.join("models").join("resolved");
         if !root.exists() {
-            return Ok(Vec::new());
+            return Ok(None);
         }
         ensure_regular_directory(&root)?;
         let marker = std::fs::read(root.join(STORE_MARKER)).map_err(|_| {
@@ -338,14 +347,67 @@ impl ResolvedCacheStore {
             ));
         }
         let root = std::fs::canonicalize(root)?;
-        Self {
+        Ok(Some(Self {
             inner: Arc::new(StoreInner {
                 root,
                 session_id: "read-only-inspection".to_owned(),
                 _session_lock: None,
             }),
+        }))
+    }
+
+    /// Every published artifact this cache can actually serve a runtime load from (sc-19707).
+    ///
+    /// Validity is judged per entry and fails CLOSED to the source tier: an entry that is not
+    /// `Complete`, whose journal or receipt does not verify, whose bundle no longer matches the
+    /// recorded closure (a torn, truncated, or hand-edited bundle), or whose shape the local tier
+    /// cannot serve is silently skipped rather than poisoning the whole answer. Read-only: never
+    /// creates a session, never stamps usage, and never repairs.
+    pub fn valid_local_artifacts(data_dir: &Path) -> Vec<ResolvedModelArtifact> {
+        let Ok(Some(store)) = Self::open_read_only(data_dir) else {
+            return Vec::new();
+        };
+        let Ok(entries) = std::fs::read_dir(store.inner.root.join("entries")) else {
+            return Vec::new();
+        };
+        let mut artifacts = Vec::new();
+        for item in entries.flatten() {
+            let Some(digest) = item
+                .file_name()
+                .to_str()
+                .filter(|value| is_lower_hex_64(value))
+                .map(str::to_owned)
+            else {
+                continue;
+            };
+            if !item.file_type().is_ok_and(|kind| kind.is_dir()) {
+                continue;
+            }
+            let Ok(metadata_lock) = store.lock_metadata(&digest) else {
+                continue;
+            };
+            let read = store.read_metadata_unlocked(&digest);
+            drop(metadata_lock);
+            let Ok(JournalRead::Valid { metadata, .. }) = read else {
+                continue;
+            };
+            if metadata.state != ResolvedCacheEntryState::Complete
+                || validate_complete_metadata(&store, &metadata).is_err()
+            {
+                continue;
+            }
+            // A published bundle that is not stored in the source-library layout cannot be handed
+            // to the shared snapshot resolvers, so it is not a local-tier candidate at all.
+            if crate::model_artifacts::local_preference::overlay_entries_for_artifact(
+                &metadata.artifact,
+            )
+            .is_err()
+            {
+                continue;
+            }
+            artifacts.push(metadata.artifact);
         }
-        .enumerate()
+        artifacts
     }
 
     pub fn root(&self) -> &Path {

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -271,6 +271,29 @@ impl ResolvedCacheMetadata {
     }
 }
 
+/// One published entry the local tier cannot serve because of its SHAPE — the bundle is intact and
+/// verified, but its layout is not one the shared snapshot resolvers can be handed. Kept distinct
+/// from every other rejection class (torn, incomplete, unverifiable) because this is the only one
+/// worth reporting: those are ordinary fail-closed fallbacks, this is a bundle that will never
+/// serve until something changes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LocalArtifactRejection {
+    pub cache_key: String,
+    pub repository: String,
+    pub revision: String,
+    pub reason: String,
+}
+
+/// The result of enumerating the local tier: what can serve, and what was rejected for an
+/// unsupported shape. Rejections are returned rather than dropped so the caller that emits the
+/// runtime's observability can name them — dropping them at the scan made the local-tier-unsupported
+/// class unreachable for exactly the case it is named after.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LocalArtifactScan {
+    pub artifacts: Vec<ResolvedModelArtifact>,
+    pub rejections: Vec<LocalArtifactRejection>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResolvedCacheEntrySummary {
     pub cache_key: String,
@@ -385,16 +408,45 @@ impl ResolvedCacheStore {
     /// Validity is judged per entry and fails CLOSED to the source tier: an entry that is not
     /// `Complete`, whose journal or receipt does not verify, whose bundle no longer matches the
     /// recorded closure (a torn, truncated, or hand-edited bundle), or whose shape the local tier
-    /// cannot serve is silently skipped rather than poisoning the whole answer. Read-only: never
-    /// creates a session, never stamps usage, and never repairs.
-    pub fn valid_local_artifacts(data_dir: &Path) -> Vec<ResolvedModelArtifact> {
-        let Ok(Some(store)) = Self::open_read_only(data_dir) else {
-            return Vec::new();
+    /// cannot serve is skipped rather than poisoning the whole answer. Read-only: never creates a
+    /// session, never stamps usage, and never repairs.
+    ///
+    /// Entries rejected for an UNSUPPORTED SHAPE are reported separately rather than dropped, so
+    /// the guard can name them: they are the only rejection class a user can act on (the bundle is
+    /// intact, but its layout is one the shared snapshot resolvers cannot be handed). Every other
+    /// rejection is a torn/absent/unverifiable entry, which is a fallback rather than a report, and
+    /// is logged at debug with the reason instead of being swallowed silently.
+    pub fn valid_local_artifacts(data_dir: &Path) -> LocalArtifactScan {
+        let store = match Self::open_read_only(data_dir) {
+            Ok(Some(store)) => store,
+            Ok(None) => return LocalArtifactScan::default(),
+            Err(error) => {
+                tracing::debug!(
+                    data_dir = %data_dir.display(),
+                    %error,
+                    "resolved cache could not be opened for local-tier enumeration; every model \
+                     stays on the source tier"
+                );
+                return LocalArtifactScan::default();
+            }
         };
-        let Ok(entries) = std::fs::read_dir(store.inner.root.join("entries")) else {
-            return Vec::new();
+        let entries_root = store.inner.root.join("entries");
+        let entries = match std::fs::read_dir(&entries_root) {
+            Ok(entries) => entries,
+            Err(error) => {
+                // A cache that has never published anything has no `entries/` directory at all;
+                // that is the ordinary empty case, not a fault worth reporting.
+                if error.kind() != std::io::ErrorKind::NotFound {
+                    tracing::debug!(
+                        entries_root = %entries_root.display(),
+                        %error,
+                        "resolved cache entries could not be enumerated for the local tier"
+                    );
+                }
+                return LocalArtifactScan::default();
+            }
         };
-        let mut artifacts = Vec::new();
+        let mut scan = LocalArtifactScan::default();
         for item in entries.flatten() {
             let Some(digest) = item
                 .file_name()
@@ -407,31 +459,68 @@ impl ResolvedCacheStore {
             if !item.file_type().is_ok_and(|kind| kind.is_dir()) {
                 continue;
             }
-            let Ok(metadata_lock) = store.lock_metadata(&digest) else {
-                continue;
+            let metadata_lock = match store.lock_metadata(&digest) {
+                Ok(lock) => lock,
+                Err(error) => {
+                    tracing::debug!(%digest, %error, "resolved cache entry could not be locked for \
+                         local-tier enumeration");
+                    continue;
+                }
             };
             let read = store.read_metadata_unlocked(&digest);
             drop(metadata_lock);
-            let Ok(JournalRead::Valid { metadata, .. }) = read else {
-                continue;
+            let metadata = match read {
+                Ok(JournalRead::Valid { metadata, .. }) => metadata,
+                Ok(other) => {
+                    tracing::debug!(
+                        %digest,
+                        journal = ?std::mem::discriminant(&other),
+                        "resolved cache entry journal is not valid; the model stays on the source \
+                         tier"
+                    );
+                    continue;
+                }
+                Err(error) => {
+                    tracing::debug!(%digest, %error, "resolved cache entry journal could not be read");
+                    continue;
+                }
             };
-            if metadata.state != ResolvedCacheEntryState::Complete
-                || validate_complete_metadata(&store, &metadata).is_err()
-            {
+            if metadata.state != ResolvedCacheEntryState::Complete {
+                tracing::debug!(
+                    %digest,
+                    state = ?metadata.state,
+                    "resolved cache entry is not complete; the model stays on the source tier"
+                );
+                continue;
+            }
+            if let Err(error) = validate_complete_metadata(&store, &metadata) {
+                tracing::debug!(
+                    %digest,
+                    %error,
+                    "resolved cache entry did not re-verify; the model stays on the source tier"
+                );
                 continue;
             }
             // A published bundle that is not stored in the source-library layout cannot be handed
-            // to the shared snapshot resolvers, so it is not a local-tier candidate at all.
-            if crate::model_artifacts::local_preference::overlay_entries_for_artifact(
-                &metadata.artifact,
-            )
-            .is_err()
+            // to the shared snapshot resolvers, so it is not a local-tier candidate at all. This
+            // is REPORTED rather than dropped: the guard emits it as the local-tier-unsupported
+            // class, which is otherwise unreachable for the very case it names.
+            if let Err(error) =
+                crate::model_artifacts::local_preference::overlay_entries_for_artifact(
+                    &metadata.artifact,
+                )
             {
+                scan.rejections.push(LocalArtifactRejection {
+                    cache_key: metadata.cache_key.clone(),
+                    repository: metadata.artifact.identity.repository.clone(),
+                    revision: metadata.artifact.identity.revision.clone(),
+                    reason: error.to_string(),
+                });
                 continue;
             }
-            artifacts.push(metadata.artifact);
+            scan.artifacts.push(metadata.artifact);
         }
-        artifacts
+        scan
     }
 
     pub fn root(&self) -> &Path {

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -165,6 +165,86 @@ fn resolver(root: &Path, registry: ActiveArtifactLeaseRegistry) -> ModelArtifact
     ModelArtifactResolver::with_lease_registry(ArtifactSourceLibrary::new(root).unwrap(), registry)
 }
 
+/// A source candidate laid out the way a promotion writes it: the bundle mirrors the source
+/// library, which is what makes a published entry loadable by every runtime (sc-19707).
+fn hub_layout_candidate(root: &Path, revision: &str) -> PromotionCandidate {
+    let mut candidate = source_candidate(root, revision);
+    let mut members = candidate.artifact.closure.members.clone();
+    members[0].destination = crate::model_artifacts::local_preference::hub_cache_member_destination(
+        &members[0].source.repository,
+        &members[0].source.revision,
+        Path::new(""),
+    )
+    .unwrap();
+    candidate.artifact.closure = ResolvedBundleClosure::new(members).unwrap();
+    candidate.cache_key = candidate.artifact.cache_key().unwrap();
+    candidate
+}
+
+/// The one provider both the API preflight and the worker's pre-loader guard read. It must offer
+/// ONLY entries a runtime can actually load: published, verifiable, and stored in the source
+/// library layout. Everything else stays on the source tier instead of poisoning the answer.
+#[test]
+fn valid_local_artifacts_offers_only_loadable_published_entries() {
+    let scratch = TempDir::new().unwrap();
+    let source = scratch.path().join("source");
+    let data = scratch.path().join("data");
+    std::fs::create_dir(&source).unwrap();
+    assert!(ResolvedCacheStore::valid_local_artifacts(&data).is_empty());
+
+    let store = ResolvedCacheStore::open(&data).unwrap();
+    // An uninitialized-but-open cache offers nothing.
+    assert!(ResolvedCacheStore::valid_local_artifacts(&data).is_empty());
+
+    // An entry still materializing is never a candidate: its bytes are not published yet.
+    let in_flight = hub_layout_candidate(&source, REVISION_B);
+    let reservation = match store.reserve(&in_flight, &source, "fixture:model").unwrap() {
+        ReservationOutcome::Acquired(reservation) => reservation,
+        _ => panic!("fixture reservation must acquire"),
+    };
+    assert!(ResolvedCacheStore::valid_local_artifacts(&data).is_empty());
+    drop(reservation);
+    assert!(ResolvedCacheStore::valid_local_artifacts(&data).is_empty());
+
+    // A published hub-layout bundle IS a candidate.
+    let candidate = hub_layout_candidate(&source, REVISION_A);
+    let materializer = ResolvedCacheMaterializer::new(store.clone());
+    let published = match materializer
+        .materialize(
+            &candidate,
+            &source,
+            "fixture:model",
+            &MaterializationCancellation::default(),
+        )
+        .unwrap()
+    {
+        MaterializationOutcome::Published(metadata) => *metadata,
+        other => panic!("fixture bundle was not published: {other:?}"),
+    };
+    let offered = ResolvedCacheStore::valid_local_artifacts(&data);
+    assert_eq!(offered, vec![published.artifact.clone()]);
+
+    // A published bundle stored in any other layout cannot be handed to the shared snapshot
+    // resolvers, so it is not offered even though the store considers it complete.
+    let legacy = source_candidate(&scratch.path().join("legacy-source"), REVISION_B);
+    match materializer
+        .materialize(
+            &legacy,
+            &scratch.path().join("legacy-source"),
+            "fixture:legacy",
+            &MaterializationCancellation::default(),
+        )
+        .unwrap()
+    {
+        MaterializationOutcome::Published(_) => {}
+        other => panic!("legacy fixture was not published: {other:?}"),
+    }
+    assert_eq!(
+        ResolvedCacheStore::valid_local_artifacts(&data),
+        vec![published.artifact]
+    );
+}
+
 #[cfg(windows)]
 struct WindowsDirectoryJunction {
     path: PathBuf,

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -191,11 +191,15 @@ fn valid_local_artifacts_offers_only_loadable_published_entries() {
     let source = scratch.path().join("source");
     let data = scratch.path().join("data");
     std::fs::create_dir(&source).unwrap();
-    assert!(ResolvedCacheStore::valid_local_artifacts(&data).is_empty());
+    assert!(ResolvedCacheStore::valid_local_artifacts(&data)
+        .artifacts
+        .is_empty());
 
     let store = ResolvedCacheStore::open(&data).unwrap();
     // An uninitialized-but-open cache offers nothing.
-    assert!(ResolvedCacheStore::valid_local_artifacts(&data).is_empty());
+    assert!(ResolvedCacheStore::valid_local_artifacts(&data)
+        .artifacts
+        .is_empty());
 
     // An entry still materializing is never a candidate: its bytes are not published yet.
     let in_flight = hub_layout_candidate(&source, REVISION_B);
@@ -203,9 +207,13 @@ fn valid_local_artifacts_offers_only_loadable_published_entries() {
         ReservationOutcome::Acquired(reservation) => reservation,
         _ => panic!("fixture reservation must acquire"),
     };
-    assert!(ResolvedCacheStore::valid_local_artifacts(&data).is_empty());
+    assert!(ResolvedCacheStore::valid_local_artifacts(&data)
+        .artifacts
+        .is_empty());
     drop(reservation);
-    assert!(ResolvedCacheStore::valid_local_artifacts(&data).is_empty());
+    assert!(ResolvedCacheStore::valid_local_artifacts(&data)
+        .artifacts
+        .is_empty());
 
     // A published hub-layout bundle IS a candidate.
     let candidate = hub_layout_candidate(&source, REVISION_A);
@@ -223,10 +231,13 @@ fn valid_local_artifacts_offers_only_loadable_published_entries() {
         other => panic!("fixture bundle was not published: {other:?}"),
     };
     let offered = ResolvedCacheStore::valid_local_artifacts(&data);
-    assert_eq!(offered, vec![published.artifact.clone()]);
+    assert_eq!(offered.artifacts, vec![published.artifact.clone()]);
+    assert!(offered.rejections.is_empty());
 
     // A published bundle stored in any other layout cannot be handed to the shared snapshot
-    // resolvers, so it is not offered even though the store considers it complete.
+    // resolvers, so it is not offered even though the store considers it complete — and it is
+    // REPORTED as an unsupported shape rather than dropped, so the guard can name it. Dropping it
+    // here is what made the local-tier-unsupported class unreachable for the case it names.
     let legacy = source_candidate(&scratch.path().join("legacy-source"), REVISION_B);
     match materializer
         .materialize(
@@ -240,9 +251,16 @@ fn valid_local_artifacts_offers_only_loadable_published_entries() {
         MaterializationOutcome::Published(_) => {}
         other => panic!("legacy fixture was not published: {other:?}"),
     }
-    assert_eq!(
-        ResolvedCacheStore::valid_local_artifacts(&data),
-        vec![published.artifact]
+    let scanned = ResolvedCacheStore::valid_local_artifacts(&data);
+    assert_eq!(scanned.artifacts, vec![published.artifact]);
+    assert_eq!(scanned.rejections.len(), 1, "{:?}", scanned.rejections);
+    assert_eq!(scanned.rejections[0].revision, REVISION_B);
+    assert!(
+        scanned.rejections[0]
+            .reason
+            .contains("source-library layout"),
+        "{}",
+        scanned.rejections[0].reason
     );
 }
 

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -170,12 +170,13 @@ fn resolver(root: &Path, registry: ActiveArtifactLeaseRegistry) -> ModelArtifact
 fn hub_layout_candidate(root: &Path, revision: &str) -> PromotionCandidate {
     let mut candidate = source_candidate(root, revision);
     let mut members = candidate.artifact.closure.members.clone();
-    members[0].destination = crate::model_artifacts::local_preference::hub_cache_member_destination(
-        &members[0].source.repository,
-        &members[0].source.revision,
-        Path::new(""),
-    )
-    .unwrap();
+    members[0].destination =
+        crate::model_artifacts::local_preference::hub_cache_member_destination(
+            &members[0].source.repository,
+            &members[0].source.revision,
+            Path::new(""),
+        )
+        .unwrap();
     candidate.artifact.closure = ResolvedBundleClosure::new(members).unwrap();
     candidate.cache_key = candidate.artifact.cache_key().unwrap();
     candidate

--- a/crates/sceneworks-worker/src/external_library_runtime.rs
+++ b/crates/sceneworks-worker/src/external_library_runtime.rs
@@ -21,7 +21,7 @@
 //! volume — an engine defect while the source remains available is preserved verbatim, and a raw
 //! loader ENOENT is never what a disconnect surfaces as.
 
-use crate::{JsonObject, Settings, WorkerError, WorkerResult};
+use crate::{emit_event_value, JsonObject, Settings, WorkerError, WorkerResult};
 use sceneworks_core::contracts::JobType;
 use sceneworks_core::model_artifacts::artifact_selection::{
     requested_runtime_variant, selected_requirements_for_model,
@@ -29,11 +29,27 @@ use sceneworks_core::model_artifacts::artifact_selection::{
 use sceneworks_core::model_artifacts::external_library::{
     resolve_model_availability, ExternalSourceSession, ModelAvailability, ModelResolution,
 };
+use sceneworks_core::model_artifacts::local_preference::ActiveLocalArtifacts;
+use sceneworks_core::model_artifacts::resolved_cache::{ResolvedCacheLease, ResolvedCacheStore};
+use sceneworks_core::model_artifacts::{
+    ArtifactSourceLibrary, ModelArtifactResolver, ResolvedModelArtifact,
+};
+use serde_json::json;
+use tracing::Level;
 
 #[derive(Debug)]
 pub(crate) struct RuntimeSourceGuard {
     resolutions: Vec<ModelResolution>,
     sessions: Vec<ExternalSourceSession>,
+    /// The process-wide local-tier preference scopes, one per locally served artifact. Declared
+    /// BEFORE the leases so field drop order stops serving local paths first and only then
+    /// releases the leases protecting those bytes — the reverse of acquisition.
+    local_scopes: Vec<ActiveLocalArtifacts>,
+    /// Cross-process cache leases (one per locally served artifact) held for the whole job. Each
+    /// holds the entry's shared artifact lock, so an evictor taking that lock exclusively — even
+    /// non-blockingly, and even when it re-verifies under the lock — cannot remove bytes a load is
+    /// reading. Released on drop; `finish_success` crosses the promotion boundary first.
+    cache_leases: Vec<ResolvedCacheLease>,
 }
 
 impl RuntimeSourceGuard {
@@ -56,10 +72,7 @@ impl RuntimeSourceGuard {
         let model_free_dry_run = matches!(job_type, JobType::LoraTrain | JobType::ControlTraining)
             && payload.get("dryRun").and_then(serde_json::Value::as_bool) == Some(true);
         if explicit_download || model_free_dry_run {
-            return Ok(Self {
-                resolutions: Vec::new(),
-                sessions: Vec::new(),
-            });
+            return Ok(Self::none());
         }
 
         let model_entries = payload_model_entries(payload);
@@ -77,7 +90,14 @@ impl RuntimeSourceGuard {
         let configured_library = sceneworks_core::hf_home::model_source_library(&settings.data_dir)
             .root()
             .to_path_buf();
+        // Every VALID app-owned bundle, read once for this job. Empty when the resolved cache is
+        // disabled or uninitialized, and — by construction of the provider — never containing an
+        // entry that is torn, unverifiable, or in a shape the runtime cannot serve, so a partial
+        // local copy can only ever move the load back to the source tier.
+        let local_artifacts = local_resolved_artifacts(settings);
         let mut resolutions = Vec::new();
+        let mut cache_leases = Vec::new();
+        let mut local_scopes = Vec::new();
         for entry in &model_entries {
             let has_hf_downloads = entry
                 .get("downloads")
@@ -111,15 +131,36 @@ impl RuntimeSourceGuard {
                 requested_variant.as_deref(),
                 &settings.data_dir,
             );
-            let resolution = resolve_model_availability(
+            let mut resolution = resolve_model_availability(
                 &settings.data_dir,
                 &configured_library,
                 &selected.requirements,
                 selected.receipt_backed,
-                // Local-tier artifacts enter this seam in sc-19707; the resolver already accepts
-                // them, so wiring local preference will not touch this call site's shape.
-                &[],
+                &local_artifacts,
             );
+            // Local preference is only real once the artifact is LEASED and actually reachable
+            // through the shared snapshot resolvers. Anything that prevents either — a vanished or
+            // concurrently evicted entry, a bundle another scope already serves — falls the whole
+            // model back to the authoritative source tier by RE-RESOLVING without local
+            // candidates, so the fallback keeps every typed disconnect/incomplete guarantee
+            // instead of proceeding on a promise the runtime cannot keep.
+            if resolution.availability == ModelAvailability::LocalReady {
+                match admit_local_artifact(settings, resolution.local_artifact.as_ref()) {
+                    Some((lease, scope)) => {
+                        cache_leases.push(lease);
+                        local_scopes.push(scope);
+                    }
+                    None => {
+                        resolution = resolve_model_availability(
+                            &settings.data_dir,
+                            &configured_library,
+                            &selected.requirements,
+                            selected.receipt_backed,
+                            &[],
+                        );
+                    }
+                }
+            }
             if !resolutions.contains(&resolution) {
                 resolutions.push(resolution);
             }
@@ -131,6 +172,8 @@ impl RuntimeSourceGuard {
                 WorkerError::InvalidPayload(format!("invalid model source resolution: {error}"))
             })?;
             match resolution.availability {
+                // Already leased and served from the app-owned tier above; the configured source
+                // library is deliberately not consulted, opened, or probed for it.
                 ModelAvailability::LocalReady => {}
                 ModelAvailability::InstalledExternalUnavailable => {
                     return Err(unavailable(
@@ -174,10 +217,22 @@ impl RuntimeSourceGuard {
                 }
             }
         }
+        emit_source_tiers(&resolutions);
         Ok(Self {
             resolutions,
             sessions,
+            local_scopes,
+            cache_leases,
         })
+    }
+
+    fn none() -> Self {
+        Self {
+            resolutions: Vec::new(),
+            sessions: Vec::new(),
+            local_scopes: Vec::new(),
+            cache_leases: Vec::new(),
+        }
     }
 
     pub(crate) fn finish_success(mut self) -> WorkerResult<()> {
@@ -185,6 +240,13 @@ impl RuntimeSourceGuard {
             session
                 .mark_success()
                 .map_err(|error| WorkerError::Io(std::io::Error::other(error.to_string())))?;
+        }
+        // Stop serving local paths before the leases protecting them are released.
+        self.local_scopes.clear();
+        for lease in self.cache_leases.drain(..) {
+            // The promotion boundary for an artifact that just served a real load. Its own
+            // entry is already published, so this only records the successful use.
+            let _candidate = lease.mark_success();
         }
         Ok(())
     }
@@ -226,6 +288,119 @@ impl RuntimeSourceGuard {
     #[cfg(test)]
     pub(crate) fn resolutions(&self) -> &[ModelResolution] {
         &self.resolutions
+    }
+}
+
+/// Every VALID app-owned resolved artifact on this host, or nothing when the resolved cache is
+/// switched off. Read-only: enumeration never creates a cache session and never stamps usage, so
+/// judging availability cannot look like using a model.
+fn local_resolved_artifacts(settings: &Settings) -> Vec<ResolvedModelArtifact> {
+    if !settings.resolved_cache_policy().enabled {
+        return Vec::new();
+    }
+    ResolvedCacheStore::valid_local_artifacts(&settings.data_dir)
+}
+
+/// Take the runtime lease on one locally resolved artifact and start serving it, or `None` when it
+/// cannot be served after all (concurrently evicted, no longer complete, or a scope for the same
+/// snapshot is already active). Both halves are acquired together so a scope can never outlive the
+/// lease that protects the bytes behind it.
+fn admit_local_artifact(
+    settings: &Settings,
+    artifact: Option<&ResolvedModelArtifact>,
+) -> Option<(ResolvedCacheLease, ActiveLocalArtifacts)> {
+    let artifact = artifact?;
+    let cache_key = artifact.cache_key().ok()?;
+    let store = cache_store(settings)?;
+    let resolver = ModelArtifactResolver::new(
+        ArtifactSourceLibrary::new(sceneworks_core::hf_home::huggingface_hub_cache_dir(
+            &settings.data_dir,
+        ))
+        .ok()?,
+    );
+    // The store takes the entry's SHARED artifact lock before it re-reads and re-validates the
+    // published entry under it, then stamps usage. An evictor that reaches the entry first holds
+    // the exclusive lock, so this waits; an evictor that arrives afterwards finds the lock held
+    // and must leave the entry alone.
+    let lease = store
+        .acquire_complete(&cache_key, &resolver, &artifact.identity.repository)
+        .ok()
+        .flatten()?;
+    match sceneworks_core::model_artifacts::local_preference::prefer_local_artifacts(
+        std::slice::from_ref(lease.artifact()),
+    ) {
+        Ok(scope) => Some((lease, scope)),
+        Err(error) => {
+            emit_event_value(
+                Level::WARN,
+                json!({
+                    "event": "resolved_cache_local_tier_unsupported",
+                    "cacheKey": cache_key,
+                    "repository": artifact.identity.repository,
+                    "revision": artifact.identity.revision,
+                    "reason": error.to_string(),
+                }),
+            );
+            None
+        }
+    }
+}
+
+/// One long-lived cache session per data directory. Opening a session takes a durable session lock
+/// and writes session records, so a fresh session per job would churn the store; the worker claims
+/// one job at a time and keeps this handle for the process lifetime instead.
+fn cache_store(settings: &Settings) -> Option<ResolvedCacheStore> {
+    use std::collections::BTreeMap;
+    use std::sync::{Mutex, OnceLock};
+    static STORES: OnceLock<Mutex<BTreeMap<std::path::PathBuf, ResolvedCacheStore>>> =
+        OnceLock::new();
+    let stores = STORES.get_or_init(|| Mutex::new(BTreeMap::new()));
+    let mut stores = stores
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(store) = stores.get(&settings.data_dir) {
+        return Some(store.clone());
+    }
+    let store = ResolvedCacheStore::open(&settings.data_dir).ok()?;
+    stores.insert(settings.data_dir.clone(), store.clone());
+    Some(store)
+}
+
+/// Report which tier will serve each admitted model. This is the runtime's answer to "where did
+/// this load's weights come from", emitted once per job before any loader runs.
+fn emit_source_tiers(resolutions: &[ModelResolution]) {
+    for resolution in resolutions {
+        let tier = match resolution.availability {
+            ModelAvailability::LocalReady => "resolved_local",
+            ModelAvailability::ExternalReady => "source_library",
+            _ => continue,
+        };
+        let (repository, revision) = match &resolution.local_artifact {
+            Some(artifact) => (
+                artifact.identity.repository.clone(),
+                artifact.identity.revision.clone(),
+            ),
+            None => resolution
+                .requirements
+                .iter()
+                .find(|requirement| requirement.is_primary)
+                .map(|requirement| {
+                    (
+                        requirement.repository.clone(),
+                        requirement.revision.clone().unwrap_or_default(),
+                    )
+                })
+                .unwrap_or_default(),
+        };
+        emit_event_value(
+            Level::INFO,
+            json!({
+                "event": "model_source_tier_selected",
+                "tier": tier,
+                "repository": repository,
+                "revision": revision,
+            }),
+        );
     }
 }
 

--- a/crates/sceneworks-worker/src/external_library_runtime.rs
+++ b/crates/sceneworks-worker/src/external_library_runtime.rs
@@ -31,9 +31,7 @@ use sceneworks_core::model_artifacts::external_library::{
 };
 use sceneworks_core::model_artifacts::local_preference::ActiveLocalArtifacts;
 use sceneworks_core::model_artifacts::resolved_cache::{ResolvedCacheLease, ResolvedCacheStore};
-use sceneworks_core::model_artifacts::{
-    ArtifactSourceLibrary, ModelArtifactResolver, ResolvedModelArtifact,
-};
+use sceneworks_core::model_artifacts::{ModelArtifactResolver, ResolvedModelArtifact};
 use serde_json::json;
 use tracing::Level;
 
@@ -312,12 +310,9 @@ fn admit_local_artifact(
     let artifact = artifact?;
     let cache_key = artifact.cache_key().ok()?;
     let store = cache_store(settings)?;
-    let resolver = ModelArtifactResolver::new(
-        ArtifactSourceLibrary::new(sceneworks_core::hf_home::huggingface_hub_cache_dir(
-            &settings.data_dir,
-        ))
-        .ok()?,
-    );
+    let resolver = ModelArtifactResolver::new(sceneworks_core::hf_home::model_source_library(
+        &settings.data_dir,
+    ));
     // The store takes the entry's SHARED artifact lock before it re-reads and re-validates the
     // published entry under it, then stamps usage. An evictor that reaches the entry first holds
     // the exclusive lock, so this waits; an evictor that arrives afterwards finds the lock held
@@ -523,6 +518,7 @@ fn unavailable(detail: impl Into<String>) -> WorkerError {
 mod tests {
     use super::*;
     use sceneworks_core::model_artifacts::external_library::EXTERNAL_LIBRARY_UNAVAILABLE_CODE;
+    use sceneworks_core::model_artifacts::ArtifactSourceLibrary;
     use serde_json::{json, Value};
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;

--- a/crates/sceneworks-worker/src/external_library_runtime.rs
+++ b/crates/sceneworks-worker/src/external_library_runtime.rs
@@ -27,22 +27,32 @@ use sceneworks_core::model_artifacts::artifact_selection::{
     requested_runtime_variant, selected_requirements_for_model,
 };
 use sceneworks_core::model_artifacts::external_library::{
-    resolve_model_availability, ExternalSourceSession, ModelAvailability, ModelResolution,
+    resolve_model_availability, ExternalArtifactRequirement, ExternalSourceSession,
+    ModelAvailability, ModelResolution,
 };
-use sceneworks_core::model_artifacts::local_preference::ActiveLocalArtifacts;
+use sceneworks_core::model_artifacts::local_preference::{
+    ActiveLocalArtifacts, LocalArtifactOverlayEntry,
+};
 use sceneworks_core::model_artifacts::resolved_cache::{ResolvedCacheLease, ResolvedCacheStore};
-use sceneworks_core::model_artifacts::{ModelArtifactResolver, ResolvedModelArtifact};
+use sceneworks_core::model_artifacts::ModelArtifactResolver;
 use serde_json::json;
+use std::path::PathBuf;
 use tracing::Level;
 
 #[derive(Debug)]
 pub(crate) struct RuntimeSourceGuard {
     resolutions: Vec<ModelResolution>,
     sessions: Vec<ExternalSourceSession>,
-    /// The process-wide local-tier preference scopes, one per locally served artifact. Declared
-    /// BEFORE the leases so field drop order stops serving local paths first and only then
-    /// releases the leases protecting those bytes — the reverse of acquisition.
-    local_scopes: Vec<ActiveLocalArtifacts>,
+    /// The ONE process-wide local-tier preference scope for this job, holding exactly the
+    /// `(repository, revision)` pairs the guard selected. Declared BEFORE the leases so field drop
+    /// order stops serving local paths first and only then releases the leases protecting those
+    /// bytes — the reverse of acquisition.
+    ///
+    /// One scope rather than one per model is load-bearing, not tidiness: the coverage decision is
+    /// made across the WHOLE job, so a per-model scope could install a bundle for one model that a
+    /// sibling model must not be served from, and installing them one at a time leaves a narrower
+    /// bundle serving the process while a later model falls back.
+    local_scope: Option<ActiveLocalArtifacts>,
     /// Cross-process cache leases (one per locally served artifact) held for the whole job. Each
     /// holds the entry's shared artifact lock, so an evictor taking that lock exclusively — even
     /// non-blockingly, and even when it re-verifies under the lock — cannot remove bytes a load is
@@ -92,10 +102,26 @@ impl RuntimeSourceGuard {
         // disabled or uninitialized, and — by construction of the provider — never containing an
         // entry that is torn, unverifiable, or in a shape the runtime cannot serve, so a partial
         // local copy can only ever move the load back to the source tier.
-        let local_artifacts = local_resolved_artifacts(settings);
-        let mut resolutions = Vec::new();
-        let mut cache_leases = Vec::new();
-        let mut local_scopes = Vec::new();
+        let local_scan = local_resolved_artifacts(settings);
+        // A bundle whose SHAPE the local tier cannot serve is the one rejection class a user can
+        // act on, so it is named here rather than dropped at the scan.
+        for rejection in &local_scan.rejections {
+            emit_event_value(
+                Level::WARN,
+                json!({
+                    "event": "resolved_cache_local_tier_unsupported",
+                    "cacheKey": rejection.cache_key,
+                    "repository": rejection.repository,
+                    "revision": rejection.revision,
+                    "reason": rejection.reason,
+                }),
+            );
+        }
+        let local_artifacts = local_scan.artifacts;
+        // PASS 1 — resolve every model entry WITH local candidates, keeping the selected closure
+        // beside each resolution. Nothing is leased and nothing is served yet: which pairs may be
+        // served at all cannot be known until every entry in the job has been resolved.
+        let mut plans: Vec<EntryPlan> = Vec::new();
         for entry in &model_entries {
             let has_hf_downloads = entry
                 .get("downloads")
@@ -129,38 +155,31 @@ impl RuntimeSourceGuard {
                 requested_variant.as_deref(),
                 &settings.data_dir,
             );
-            let mut resolution = resolve_model_availability(
+            let resolution = resolve_model_availability(
                 &settings.data_dir,
                 &configured_library,
                 &selected.requirements,
                 selected.receipt_backed,
                 &local_artifacts,
             );
-            // Local preference is only real once the artifact is LEASED and actually reachable
-            // through the shared snapshot resolvers. Anything that prevents either — a vanished or
-            // concurrently evicted entry, a bundle another scope already serves — falls the whole
-            // model back to the authoritative source tier by RE-RESOLVING without local
-            // candidates, so the fallback keeps every typed disconnect/incomplete guarantee
-            // instead of proceeding on a promise the runtime cannot keep.
-            if resolution.availability == ModelAvailability::LocalReady {
-                match admit_local_artifact(settings, resolution.local_artifact.as_ref()) {
-                    Some((lease, scope)) => {
-                        cache_leases.push(lease);
-                        local_scopes.push(scope);
-                    }
-                    None => {
-                        resolution = resolve_model_availability(
-                            &settings.data_dir,
-                            &configured_library,
-                            &selected.requirements,
-                            selected.receipt_backed,
-                            &[],
-                        );
-                    }
-                }
-            }
-            if !resolutions.contains(&resolution) {
-                resolutions.push(resolution);
+            plans.push(EntryPlan {
+                requirements: selected.requirements,
+                receipt_backed: selected.receipt_backed,
+                resolution,
+            });
+        }
+
+        // PASSES 2 and 3 — decide which `(repository, revision)` pairs the whole job may serve
+        // locally, take the leases behind exactly those, and re-resolve every model that did not
+        // get its ENTIRE closure served. This is the only layer that can see every model a job
+        // loads, and therefore the only layer that can answer the coverage question at all.
+        let (local_scope, cache_leases) =
+            select_local_tier(settings, &configured_library, &mut plans);
+
+        let mut resolutions: Vec<ModelResolution> = Vec::new();
+        for plan in plans {
+            if !resolutions.contains(&plan.resolution) {
+                resolutions.push(plan.resolution);
             }
         }
 
@@ -219,7 +238,7 @@ impl RuntimeSourceGuard {
         Ok(Self {
             resolutions,
             sessions,
-            local_scopes,
+            local_scope,
             cache_leases,
         })
     }
@@ -228,7 +247,7 @@ impl RuntimeSourceGuard {
         Self {
             resolutions: Vec::new(),
             sessions: Vec::new(),
-            local_scopes: Vec::new(),
+            local_scope: None,
             cache_leases: Vec::new(),
         }
     }
@@ -240,7 +259,7 @@ impl RuntimeSourceGuard {
                 .map_err(|error| WorkerError::Io(std::io::Error::other(error.to_string())))?;
         }
         // Stop serving local paths before the leases protecting them are released.
-        self.local_scopes.clear();
+        self.local_scope = None;
         for lease in self.cache_leases.drain(..) {
             // The promotion boundary for an artifact that just served a real load. Its own
             // entry is already published, so this only records the successful use.
@@ -289,26 +308,284 @@ impl RuntimeSourceGuard {
     }
 }
 
-/// Every VALID app-owned resolved artifact on this host, or nothing when the resolved cache is
-/// switched off. Read-only: enumeration never creates a cache session and never stamps usage, so
-/// judging availability cannot look like using a model.
-fn local_resolved_artifacts(settings: &Settings) -> Vec<ResolvedModelArtifact> {
+/// One model entry's pass-1 outcome: the resolution, plus the SELECTED closure that produced it.
+///
+/// The closure is kept here and never re-read off the resolution, because
+/// `ModelResolution::local_ready` deliberately carries `requirements: Vec::new()` — a local-ready
+/// resolution names an artifact, not a source-library closure. Coverage and the pass-3 fallback
+/// both need the real requirement list, so losing it to the resolution would make every
+/// locally-resolved model look like it required nothing at all.
+struct EntryPlan {
+    requirements: Vec<ExternalArtifactRequirement>,
+    receipt_backed: bool,
+    resolution: ModelResolution,
+}
+
+/// Every VALID app-owned resolved artifact on this host, plus the entries rejected for a shape the
+/// local tier cannot serve. Empty when the resolved cache is switched off. Read-only: enumeration
+/// never creates a cache session and never stamps usage, so judging availability cannot look like
+/// using a model.
+fn local_resolved_artifacts(
+    settings: &Settings,
+) -> sceneworks_core::model_artifacts::resolved_cache::LocalArtifactScan {
     if !settings.resolved_cache_policy().enabled {
-        return Vec::new();
+        return Default::default();
     }
     ResolvedCacheStore::valid_local_artifacts(&settings.data_dir)
 }
 
-/// Take the runtime lease on one locally resolved artifact and start serving it, or `None` when it
-/// cannot be served after all (concurrently evicted, no longer complete, or a scope for the same
-/// snapshot is already active). Both halves are acquired together so a scope can never outlive the
-/// lease that protects the bytes behind it.
-fn admit_local_artifact(
+/// Decide the job's local tier, take the leases behind it, and install the one preference scope.
+///
+/// # The rule
+///
+/// > A `(repository, revision)` pair is served locally **iff** one leased bundle holds a SUPERSET
+/// > of the union of file requirements every model entry in this job needs from that pair.
+/// > Otherwise the pair is served to NOBODY and every model needing it re-resolves against the
+/// > authoritative source tier.
+///
+/// # Why it has to be here
+///
+/// The preference seam is directory-level: it answers `(repository, revision)` with a snapshot
+/// path, and once that path is out it cannot re-ask "does this bundle hold what THIS caller
+/// needs". So the question must be settled before any path is handed out, by the only layer that
+/// can see every model the job will load — this one. A per-model decision is precisely the defect:
+/// a job carrying `owner/matrix` q4 (bundled) and q8 (not bundled) would admit q4, install the
+/// overlay for `owner/matrix@REV`, and then resolve the q8 load into the q4 bundle root, which has
+/// no `q8/` subtree at all.
+///
+/// # The deliberate consequence
+///
+/// In that same q4+q8 job the q4 model ALSO falls back to the source tier, because the union for
+/// the shared pair includes q8's files and no bundle covers it. That is the correct conservative
+/// answer, not a gap to engineer around: partial service of a pair is exactly what cannot be made
+/// safe at a directory-level seam.
+///
+/// A requirement carrying `revision: None` (a legacy receipt with no recorded snapshot) makes the
+/// WHOLE repository unserveable — there is no pair to compare coverage against, so no bundle can
+/// be shown to hold what that requirement needs.
+fn select_local_tier(
     settings: &Settings,
-    artifact: Option<&ResolvedModelArtifact>,
-) -> Option<(ResolvedCacheLease, ActiveLocalArtifacts)> {
-    let artifact = artifact?;
-    let cache_key = artifact.cache_key().ok()?;
+    configured_library: &std::path::Path,
+    plans: &mut [EntryPlan],
+) -> (Option<ActiveLocalArtifacts>, Vec<ResolvedCacheLease>) {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    let re_resolve_to_source = |plans: &mut [EntryPlan]| {
+        for plan in plans.iter_mut() {
+            if plan.resolution.availability == ModelAvailability::LocalReady {
+                plan.resolution = resolve_model_availability(
+                    &settings.data_dir,
+                    configured_library,
+                    &plan.requirements,
+                    plan.receipt_backed,
+                    &[],
+                );
+            }
+        }
+    };
+
+    if !plans
+        .iter()
+        .any(|plan| plan.resolution.availability == ModelAvailability::LocalReady)
+    {
+        return (None, Vec::new());
+    }
+
+    // PASS 2a — the union of file requirements per pair, across ALL resolutions, local AND
+    // non-local. The non-local sibling is what poisons a pair: it is a model that will read this
+    // very snapshot from the source tier, so a bundle that does not hold its files cannot be
+    // allowed to answer for the pair at all.
+    let mut required: BTreeMap<(String, String), BTreeSet<PathBuf>> = BTreeMap::new();
+    let mut unserveable_repositories: BTreeSet<String> = BTreeSet::new();
+    for plan in plans.iter() {
+        for requirement in &plan.requirements {
+            let Some(revision) = requirement.revision.as_ref() else {
+                unserveable_repositories.insert(requirement.repository.clone());
+                continue;
+            };
+            required
+                .entry((requirement.repository.clone(), revision.clone()))
+                .or_default()
+                .extend(requirement.files.iter().cloned());
+        }
+    }
+
+    // PASS 2b — candidate entries, read from the SCANNED artifacts. NOTHING is leased yet, and
+    // that is deliberate: `acquire_complete` stamps `last_used_at` and takes the entry's shared
+    // artifact lock through the BLOCKING `FileExt::lock_shared`. Leasing a candidate that coverage
+    // then rejects would both mark an entry this job never reads as recently used — skewing
+    // retention's LRU against the entries that really served — and stall the whole guard behind an
+    // evictor holding a lock on a bundle no load here will ever touch.
+    let mut candidates: Vec<(String, LocalArtifactOverlayEntry)> = Vec::new();
+    // cache key -> repository, the only thing the lease needs from the artifact.
+    let mut candidate_repositories: BTreeMap<String, String> = BTreeMap::new();
+    for plan in plans.iter() {
+        if plan.resolution.availability != ModelAvailability::LocalReady {
+            continue;
+        }
+        let Some(artifact) = plan.resolution.local_artifact.as_ref() else {
+            continue;
+        };
+        let Ok(cache_key) = artifact.cache_key() else {
+            continue;
+        };
+        if candidate_repositories.contains_key(&cache_key) {
+            continue;
+        }
+        match sceneworks_core::model_artifacts::local_preference::overlay_entries_for_artifact(
+            artifact,
+        ) {
+            Ok(entries) => {
+                candidate_repositories
+                    .insert(cache_key.clone(), artifact.identity.repository.clone());
+                candidates.extend(entries.into_iter().map(|entry| (cache_key.clone(), entry)));
+            }
+            Err(error) => {
+                // The scan already reports this class, so reaching it here means the artifact the
+                // resolver chose differs from what the scan offered. Named the same way either way.
+                emit_event_value(
+                    Level::WARN,
+                    json!({
+                        "event": "resolved_cache_local_tier_unsupported",
+                        "cacheKey": cache_key,
+                        "repository": artifact.identity.repository,
+                        "revision": artifact.identity.revision,
+                        "reason": error.to_string(),
+                    }),
+                );
+            }
+        }
+    }
+
+    // PASS 2c — tentatively select at most one serving entry per pair, and only on full coverage.
+    let mut tentative: Vec<(String, LocalArtifactOverlayEntry)> = Vec::new();
+    for ((repository, revision), files) in &required {
+        if unserveable_repositories.contains(repository) {
+            continue;
+        }
+        let files: Vec<PathBuf> = files.iter().cloned().collect();
+        let Some((cache_key, entry)) = candidates.iter().find(|(_, entry)| {
+            entry.repository == *repository
+                && entry.revision == *revision
+                && sceneworks_core::model_artifacts::local_preference::entry_covers(entry, &files)
+        }) else {
+            continue;
+        };
+        tentative.push((cache_key.clone(), entry.clone()));
+    }
+
+    // PASS 2d — lease EXACTLY the winners, and re-prove every selection against the LEASED copy.
+    // The lease re-reads and re-validates the published entry under its shared artifact lock, so a
+    // selection that no longer matches that copy was made against a stale scan; its pair is dropped
+    // (the models needing it fall back in pass 3) rather than served on stale evidence.
+    let mut leases: Vec<ResolvedCacheLease> = Vec::new();
+    let mut selected_entries: Vec<LocalArtifactOverlayEntry> = Vec::new();
+    let mut served_pairs: BTreeSet<(String, String)> = BTreeSet::new();
+    let winners: BTreeSet<String> = tentative.iter().map(|(key, _)| key.clone()).collect();
+    for cache_key in &winners {
+        let Some(repository) = candidate_repositories.get(cache_key) else {
+            continue;
+        };
+        let Some(lease) = lease_local_artifact(settings, cache_key, repository) else {
+            continue;
+        };
+        let Ok(leased) =
+            sceneworks_core::model_artifacts::local_preference::overlay_entries_for_artifact(
+                lease.artifact(),
+            )
+        else {
+            continue;
+        };
+        let mut serves_a_pair = false;
+        for (_, entry) in tentative.iter().filter(|(key, _)| key == cache_key) {
+            // IDENTICAL, not merely present: the coverage decision was made about this exact
+            // snapshot root and file set, and anything else is a different bundle.
+            if !leased.contains(entry) {
+                continue;
+            }
+            served_pairs.insert((entry.repository.clone(), entry.revision.clone()));
+            selected_entries.push(entry.clone());
+            serves_a_pair = true;
+        }
+        if serves_a_pair {
+            leases.push(lease);
+        }
+    }
+
+    // PASS 3 — a model stays LocalReady only if EVERY pair in its closure was selected. Any other
+    // model re-resolves against the source tier, keeping every typed disconnect/incomplete
+    // guarantee instead of proceeding on a promise the runtime cannot keep.
+    for plan in plans.iter_mut() {
+        if plan.resolution.availability != ModelAvailability::LocalReady {
+            continue;
+        }
+        let fully_served = plan.requirements.iter().all(|requirement| {
+            requirement.revision.as_ref().is_some_and(|revision| {
+                served_pairs.contains(&(requirement.repository.clone(), revision.clone()))
+            })
+        });
+        if fully_served {
+            continue;
+        }
+        emit_event_value(
+            Level::INFO,
+            json!({
+                "event": "resolved_cache_local_tier_not_selected",
+                "repository": plan
+                    .requirements
+                    .iter()
+                    .find(|requirement| requirement.is_primary)
+                    .map(|requirement| requirement.repository.clone())
+                    .unwrap_or_default(),
+                "reason": "no leased bundle covers every file this job needs from one of the \
+                           model's (repository, revision) pairs",
+            }),
+        );
+        plan.resolution = resolve_model_availability(
+            &settings.data_dir,
+            configured_library,
+            &plan.requirements,
+            plan.receipt_backed,
+            &[],
+        );
+    }
+
+    if selected_entries.is_empty() {
+        return (None, Vec::new());
+    }
+    // ONE scope holding EXACTLY the selected entries. A pair in it is serveable to every consumer
+    // in the process by construction, including a model that fell back above for a DIFFERENT pair
+    // — the union that admitted this pair already covered that model's needs from it.
+    match sceneworks_core::model_artifacts::local_preference::prefer_local_snapshots(
+        selected_entries,
+    ) {
+        Ok(scope) => (Some(scope), leases),
+        Err(error) => {
+            // FAIL CLOSED, and actually close: nothing is installed, every lease is dropped, and
+            // every locally resolved model goes back to the source tier. Installing a partial
+            // scope here is the exact defect this function exists to prevent.
+            emit_event_value(
+                Level::WARN,
+                json!({
+                    "event": "resolved_cache_local_tier_not_selected",
+                    "reason": error.to_string(),
+                }),
+            );
+            re_resolve_to_source(plans);
+            (None, Vec::new())
+        }
+    }
+}
+
+/// Take the runtime lease on one locally resolved artifact, or `None` when it cannot be leased
+/// after all (concurrently evicted, no longer complete). The lease is what keeps the bytes behind a
+/// served path from being evicted mid-load, so it is always acquired BEFORE the scope that serves
+/// those bytes is installed.
+fn lease_local_artifact(
+    settings: &Settings,
+    cache_key: &str,
+    repository: &str,
+) -> Option<ResolvedCacheLease> {
     let store = cache_store(settings)?;
     let resolver = ModelArtifactResolver::new(sceneworks_core::hf_home::model_source_library(
         &settings.data_dir,
@@ -317,28 +594,10 @@ fn admit_local_artifact(
     // published entry under it, then stamps usage. An evictor that reaches the entry first holds
     // the exclusive lock, so this waits; an evictor that arrives afterwards finds the lock held
     // and must leave the entry alone.
-    let lease = store
-        .acquire_complete(&cache_key, &resolver, &artifact.identity.repository)
+    store
+        .acquire_complete(cache_key, &resolver, repository)
         .ok()
-        .flatten()?;
-    match sceneworks_core::model_artifacts::local_preference::prefer_local_artifacts(
-        std::slice::from_ref(lease.artifact()),
-    ) {
-        Ok(scope) => Some((lease, scope)),
-        Err(error) => {
-            emit_event_value(
-                Level::WARN,
-                json!({
-                    "event": "resolved_cache_local_tier_unsupported",
-                    "cacheKey": cache_key,
-                    "repository": artifact.identity.repository,
-                    "revision": artifact.identity.revision,
-                    "reason": error.to_string(),
-                }),
-            );
-            None
-        }
-    }
+        .flatten()
 }
 
 /// One long-lived cache session per data directory. Opening a session takes a durable session lock
@@ -613,10 +872,26 @@ mod tests {
         (settings(data), library, payload)
     }
 
+    /// Serialize every test that installs a local-tier preference scope. The scope is PROCESS-WIDE
+    /// by design (model paths resolve on engine threads far below the job task), so two of these
+    /// bodies running concurrently would read each other's overlay.
+    ///
+    /// `.cargo/config.toml` currently forces `RUST_TEST_THREADS=1`, which means a green run WITHOUT
+    /// this mutex proves nothing about the shared state these tests actually depend on — it only
+    /// proves the harness happened to serialize them. The mutex makes the dependency real and
+    /// keeps these tests honest if that setting ever changes.
+    fn overlay_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
     /// Pin the configured source library AND switch the resolved cache on for the body. Under
     /// test `Settings::resolved_cache_policy` reads the same environment `Settings::from_env`
     /// would have read, so this is exactly the production "user enabled the cache" state.
     fn with_local_cache<T>(library: &Path, body: impl FnOnce() -> T) -> T {
+        let _serialized = overlay_guard();
         crate::test_env::temp_env_vars(
             &[
                 ("HF_HUB_CACHE", library.to_str().expect("utf-8 temp path")),
@@ -640,7 +915,35 @@ mod tests {
         variant: &str,
         files: &[&str],
     ) -> sceneworks_core::model_artifacts::ResolvedModelArtifact {
-        use sceneworks_core::model_artifacts::local_preference::hub_cache_member_destination;
+        let destination =
+            sceneworks_core::model_artifacts::local_preference::hub_cache_member_destination(
+                repository,
+                revision,
+                Path::new(""),
+            )
+            .unwrap();
+        publish_bundle_at(
+            data_dir,
+            library,
+            repository,
+            revision,
+            variant,
+            files,
+            destination,
+        )
+    }
+
+    /// `publish_bundle`, but with the bundle-relative member destination chosen by the caller — the
+    /// one property that decides whether the published bundle is a shape the local tier can serve.
+    fn publish_bundle_at(
+        data_dir: &Path,
+        library: &Path,
+        repository: &str,
+        revision: &str,
+        variant: &str,
+        files: &[&str],
+        destination: PathBuf,
+    ) -> sceneworks_core::model_artifacts::ResolvedModelArtifact {
         use sceneworks_core::model_artifacts::resolved_cache::{
             MaterializationCancellation, MaterializationOutcome, ResolvedCacheMaterializer,
         };
@@ -656,7 +959,7 @@ mod tests {
             source: identity.clone(),
             tier: Some(variant.to_owned()),
             source_subpath: PathBuf::new(),
-            destination: hub_cache_member_destination(repository, revision, Path::new("")).unwrap(),
+            destination,
             files: files
                 .iter()
                 .map(|file| ArtifactFile::new(*file).unwrap())
@@ -1060,7 +1363,7 @@ mod tests {
         };
         with_local_cache(&library, || {
             // Only the q4 tier is published locally.
-            publish_bundle(
+            let q4_bundle = publish_bundle(
                 &settings.data_dir,
                 &library,
                 "owner/matrix",
@@ -1068,14 +1371,17 @@ mod tests {
                 "q4",
                 &["q4/model.safetensors"],
             );
+            let q4_root = q4_bundle.location.root().to_path_buf();
             let guard =
                 RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload("q4"), &settings)
                     .unwrap();
             assert_eq!(
                 guard.resolutions()[0].availability,
-                ModelAvailability::LocalReady
+                ModelAvailability::LocalReady,
+                "control: the q4 selection IS served by the q4 bundle"
             );
             drop(guard);
+
             // The q8 selection must NOT be served by the q4 bundle even though both share one
             // repository and one immutable revision.
             let guard =
@@ -1085,11 +1391,28 @@ mod tests {
                 guard.resolutions()[0].availability,
                 ModelAvailability::ExternalReady
             );
+            // AND — the assertion this test used to skip by calling `drop(guard)` first — the PATH
+            // layer must agree. Availability said "source tier"; the bug lived one layer down,
+            // where the process-wide overlay would still redirect `owner/matrix@REV_A` into the q4
+            // bundle root, which holds no `q8/` subtree at all. With the guard STILL HELD:
+            let loaded =
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/matrix")
+                    .expect("source snapshot");
+            assert!(
+                loaded.starts_with(&library),
+                "the q8 load must read the source library, not the q4 bundle: {}",
+                loaded.display()
+            );
+            assert!(!loaded.starts_with(&q4_root), "{}", loaded.display());
+            assert!(
+                loaded.join("q8/model.safetensors").is_file(),
+                "and the path it was handed must actually hold the q8 weights"
+            );
             drop(guard);
 
             // A bundle of another revision of the same model is likewise not this model.
             seed_snapshot(&library, "owner/other", REV_B, "model.safetensors");
-            publish_bundle(
+            let other_bundle = publish_bundle(
                 &settings.data_dir,
                 &library,
                 "owner/other",
@@ -1113,6 +1436,344 @@ mod tests {
                 guard.resolutions()[0].availability,
                 ModelAvailability::LocalReady,
                 "a bundle of a different revision must never satisfy a pinned request"
+            );
+            // Path layer, guard still held: the REV_B bundle must not answer for a REV_A request.
+            assert!(crate::model_jobs::huggingface_pinned_snapshot_dir(
+                &settings.data_dir,
+                "owner/other",
+                REV_A
+            )
+            .is_none_or(|path| !path.starts_with(other_bundle.location.root())));
+            drop(guard);
+        });
+    }
+
+    /// The DELIBERATE consequence of deciding coverage across the whole job: when a job carries
+    /// both the q4 and the q8 selection of one model and only q4 is bundled, the q4 model ALSO
+    /// falls back to the source tier.
+    ///
+    /// That is the correct conservative answer, not a gap. The two selections share one
+    /// `(repository, revision)` pair, and the preference seam is directory-level: it answers that
+    /// pair with ONE snapshot path and can never re-ask "which of you is asking" afterwards. Since
+    /// no bundle holds the union of both selections' files, the pair is served to NOBODY. Serving
+    /// q4 alone is exactly the defect — it would put the q8 load inside the q4 bundle root.
+    #[test]
+    fn a_pair_one_sibling_selection_does_not_cover_is_served_to_neither() {
+        let temp = TempDir::new().unwrap();
+        let data = temp.path().join("data");
+        let library = temp.path().join("external-hf");
+        seed_snapshot(&library, "owner/matrix", REV_A, "q4/model.safetensors");
+        seed_snapshot(&library, "owner/matrix", REV_A, "q8/model.safetensors");
+        write_receipts(
+            &data,
+            "owner/matrix",
+            json!([
+                { "repo": "owner/matrix", "modelId": "q4model", "variant": "q4",
+                  "resolvedFiles": ["q4/model.safetensors"], "snapshotRevision": REV_A },
+                { "repo": "owner/matrix", "modelId": "q8model", "variant": "q8",
+                  "resolvedFiles": ["q8/model.safetensors"], "snapshotRevision": REV_A }
+            ]),
+        );
+        let settings = settings(data);
+        let entry = |id: &str, variant: &str, glob: &str| {
+            json!({
+                "id": id,
+                "downloads": [{ "provider": "huggingface", "repo": "owner/matrix",
+                                "variant": variant, "default": true, "files": [glob] }]
+            })
+        };
+        // ONE job carrying BOTH selections of the same repository+revision.
+        let payload = json!({
+            "modelManifestEntry": entry("q4model", "q4", "q4/*"),
+            "modelManifestEntries": [entry("q8model", "q8", "q8/*")]
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        with_local_cache(&library, || {
+            let q4_bundle = publish_bundle(
+                &settings.data_dir,
+                &library,
+                "owner/matrix",
+                REV_A,
+                "q4",
+                &["q4/model.safetensors"],
+            );
+            let q4_root = q4_bundle.location.root().to_path_buf();
+
+            // Control: ALONE, the q4 selection is served from the bundle. This is what makes the
+            // assertion below about the union rather than about the bundle being unusable.
+            let alone = json!({ "modelManifestEntry": entry("q4model", "q4", "q4/*") })
+                .as_object()
+                .unwrap()
+                .clone();
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &alone, &settings).unwrap();
+            assert_eq!(
+                guard.resolutions()[0].availability,
+                ModelAvailability::LocalReady,
+                "control: the q4 selection alone IS served locally"
+            );
+            drop(guard);
+
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap();
+            assert_eq!(guard.resolutions().len(), 2);
+            assert!(
+                guard
+                    .resolutions()
+                    .iter()
+                    .all(|resolution| resolution.availability != ModelAvailability::LocalReady),
+                "neither selection may be served when no bundle covers their shared pair: {:?}",
+                guard
+                    .resolutions()
+                    .iter()
+                    .map(|resolution| &resolution.availability)
+                    .collect::<Vec<_>>()
+            );
+            // The load-bearing half, at the path layer with the guard held: NOTHING resolves into
+            // the q4 bundle, so the q8 load cannot land in a root that has no `q8/` subtree.
+            let loaded =
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/matrix")
+                    .expect("source snapshot");
+            assert!(!loaded.starts_with(&q4_root), "{}", loaded.display());
+            assert!(loaded.starts_with(&library), "{}", loaded.display());
+            assert!(loaded.join("q4/model.safetensors").is_file());
+            assert!(loaded.join("q8/model.safetensors").is_file());
+        });
+    }
+
+    /// Run `body` with `tracing` captured and return everything it emitted.
+    fn captured_events<T>(body: impl FnOnce() -> T) -> (T, String) {
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+
+        // Concurrent subscriber-less tests also drive these callsites; without the floor their
+        // first hit can cache `Interest::never` and silently empty this capture (see test_env).
+        crate::test_env::install_tracing_interest_floor();
+
+        #[derive(Clone, Default)]
+        struct Capture(Arc<Mutex<Vec<u8>>>);
+        impl Write for Capture {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let capture = Capture::default();
+        let writer = capture.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .with_writer(move || writer.clone())
+            .with_ansi(false)
+            .without_time()
+            .finish();
+        let value = tracing::subscriber::with_default(subscriber, body);
+        let logged = String::from_utf8_lossy(
+            &capture
+                .0
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        )
+        .into_owned();
+        (value, logged)
+    }
+
+    /// A published, verified bundle whose LAYOUT the shared snapshot resolvers cannot be handed is
+    /// reported as the local-tier-unsupported class and the model stays on the source tier.
+    ///
+    /// This class was previously unreachable for exactly the case it names: the scan dropped
+    /// layout-unsupported entries with a bare `continue` before the guard ever saw them, so nothing
+    /// could emit it. The event is what tells a user their local copy will never serve.
+    #[test]
+    fn an_unsupported_bundle_shape_is_reported_and_the_model_stays_on_the_source_tier() {
+        let temp = TempDir::new().unwrap();
+        let (settings, library, payload) = installed_model(&temp);
+        with_local_cache(&library, || {
+            // Published and complete, but stored FLAT rather than in the source-library layout.
+            publish_bundle_at(
+                &settings.data_dir,
+                &library,
+                "owner/model",
+                REV_A,
+                "default",
+                &["model.safetensors"],
+                PathBuf::new(),
+            );
+
+            let (guard, logged) = captured_events(|| {
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap()
+            });
+
+            assert!(
+                logged.contains("resolved_cache_local_tier_unsupported"),
+                "the unsupported shape must be reported: {logged}"
+            );
+            assert!(
+                logged.contains("source-library layout"),
+                "and it must name WHY: {logged}"
+            );
+            assert_eq!(
+                guard.resolutions()[0].availability,
+                ModelAvailability::ExternalReady,
+                "an unsupported shape must never serve the load"
+            );
+            let loaded =
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model")
+                    .expect("source snapshot");
+            assert!(loaded.starts_with(&library), "{}", loaded.display());
+        });
+    }
+
+    /// "Where did this load's weights come from" is answered once per job, before any loader runs,
+    /// for BOTH tiers — and the coverage refusal is reported as its OWN class rather than borrowing
+    /// the unsupported-shape label, which describes a different fault entirely.
+    #[test]
+    fn the_serving_tier_is_reported_for_every_admitted_model() {
+        let temp = TempDir::new().unwrap();
+        let data = temp.path().join("data");
+        let library = temp.path().join("external-hf");
+        for repo in ["owner/bundled", "owner/external"] {
+            seed_snapshot(&library, repo, REV_A, "model.safetensors");
+            write_receipts(
+                &data,
+                repo,
+                json!([{ "repo": repo, "modelId": repo,
+                         "resolvedFiles": ["model.safetensors"], "snapshotRevision": REV_A }]),
+            );
+        }
+        let settings = settings(data);
+        let entry = |repo: &str| {
+            json!({
+                "id": repo,
+                "downloads": [{ "provider": "huggingface", "repo": repo, "revision": REV_A,
+                                "files": ["model.safetensors"] }]
+            })
+        };
+        let payload = json!({
+            "modelManifestEntry": entry("owner/bundled"),
+            "modelManifestEntries": [entry("owner/external")]
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        with_local_cache(&library, || {
+            // Only ONE of the two models is bundled locally, so one job reports both tiers. They
+            // are different repositories, so neither poisons the other's pair.
+            publish_bundle(
+                &settings.data_dir,
+                &library,
+                "owner/bundled",
+                REV_A,
+                "default",
+                &["model.safetensors"],
+            );
+
+            let (guard, logged) = captured_events(|| {
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap()
+            });
+
+            assert!(
+                logged.contains("model_source_tier_selected"),
+                "every admitted model must report its tier: {logged}"
+            );
+            assert!(
+                logged.contains("resolved_local"),
+                "the bundled model must report the app-owned tier: {logged}"
+            );
+            assert!(
+                logged.contains("source_library"),
+                "the unbundled model must report the source tier: {logged}"
+            );
+            assert!(
+                logged.contains("owner/bundled") && logged.contains("owner/external"),
+                "each report must name its repository: {logged}"
+            );
+            // The unsupported-shape class describes a bundle that cannot be served at all; nothing
+            // here is unsupported, so borrowing that label would be a lie.
+            assert!(
+                !logged.contains("resolved_cache_local_tier_unsupported"),
+                "an ordinary source-tier model is not an unsupported shape: {logged}"
+            );
+
+            let tiers: Vec<_> = guard
+                .resolutions()
+                .iter()
+                .map(|resolution| resolution.availability.clone())
+                .collect();
+            assert!(tiers.contains(&ModelAvailability::LocalReady), "{tiers:?}");
+            assert!(
+                tiers.contains(&ModelAvailability::ExternalReady),
+                "{tiers:?}"
+            );
+            guard.finish_success().unwrap();
+        });
+    }
+
+    /// A coverage refusal is reported as its own class. It is not an unsupported shape — the bundle
+    /// is perfectly well-formed; it simply does not hold everything THIS job needs from the pair.
+    #[test]
+    fn a_coverage_refusal_is_reported_as_its_own_class_not_as_an_unsupported_shape() {
+        let temp = TempDir::new().unwrap();
+        let data = temp.path().join("data");
+        let library = temp.path().join("external-hf");
+        seed_snapshot(&library, "owner/matrix", REV_A, "q4/model.safetensors");
+        seed_snapshot(&library, "owner/matrix", REV_A, "q8/model.safetensors");
+        write_receipts(
+            &data,
+            "owner/matrix",
+            json!([
+                { "repo": "owner/matrix", "modelId": "q4model", "variant": "q4",
+                  "resolvedFiles": ["q4/model.safetensors"], "snapshotRevision": REV_A },
+                { "repo": "owner/matrix", "modelId": "q8model", "variant": "q8",
+                  "resolvedFiles": ["q8/model.safetensors"], "snapshotRevision": REV_A }
+            ]),
+        );
+        let settings = settings(data);
+        let entry = |id: &str, variant: &str, glob: &str| {
+            json!({
+                "id": id,
+                "downloads": [{ "provider": "huggingface", "repo": "owner/matrix",
+                                "variant": variant, "default": true, "files": [glob] }]
+            })
+        };
+        let payload = json!({
+            "modelManifestEntry": entry("q4model", "q4", "q4/*"),
+            "modelManifestEntries": [entry("q8model", "q8", "q8/*")]
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        with_local_cache(&library, || {
+            publish_bundle(
+                &settings.data_dir,
+                &library,
+                "owner/matrix",
+                REV_A,
+                "q4",
+                &["q4/model.safetensors"],
+            );
+            let (_guard, logged) = captured_events(|| {
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap()
+            });
+            assert!(
+                logged.contains("resolved_cache_local_tier_not_selected"),
+                "the coverage refusal must be reported: {logged}"
+            );
+            assert!(
+                !logged.contains("resolved_cache_local_tier_unsupported"),
+                "a well-formed bundle that merely does not cover the job is NOT an unsupported \
+                 shape: {logged}"
             );
         });
     }

--- a/crates/sceneworks-worker/src/external_library_runtime.rs
+++ b/crates/sceneworks-worker/src/external_library_runtime.rs
@@ -724,9 +724,10 @@ mod tests {
             let loaded =
                 crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model")
                     .expect("leased local snapshot");
-            assert_eq!(loaded, bundle_root.join(format!(
-                "models--owner--model/snapshots/{REV_A}"
-            )));
+            assert_eq!(
+                loaded,
+                bundle_root.join(format!("models--owner--model/snapshots/{REV_A}"))
+            );
             assert!(loaded.join("model.safetensors").is_file());
             // And so does the pinned-component resolver used by the utility/co-requisite lanes.
             assert_eq!(
@@ -742,18 +743,18 @@ mod tests {
             let evictor = ResolvedCacheStore::open(&settings.data_dir).unwrap();
             let candidate = sceneworks_core::model_artifacts::PromotionCandidate {
                 cache_key: cache_key.clone(),
-                artifact: ModelArtifactResolver::new(
-                    ArtifactSourceLibrary::new(&library).unwrap(),
-                )
-                .resolve_source(
-                    artifact.identity.clone(),
-                    artifact.closure.clone(),
-                    sceneworks_core::model_artifacts::ArtifactAvailability::Available,
-                )
-                .unwrap(),
+                artifact: ModelArtifactResolver::new(ArtifactSourceLibrary::new(&library).unwrap())
+                    .resolve_source(
+                        artifact.identity.clone(),
+                        artifact.closure.clone(),
+                        sceneworks_core::model_artifacts::ArtifactAvailability::Available,
+                    )
+                    .unwrap(),
             };
             assert!(matches!(
-                evictor.reserve(&candidate, &library, "owner/model").unwrap(),
+                evictor
+                    .reserve(&candidate, &library, "owner/model")
+                    .unwrap(),
                 sceneworks_core::model_artifacts::resolved_cache::ReservationOutcome::Contended
             ));
 

--- a/crates/sceneworks-worker/src/external_library_runtime.rs
+++ b/crates/sceneworks-worker/src/external_library_runtime.rs
@@ -769,6 +769,79 @@ mod tests {
         });
     }
 
+    /// The runtimes whose model directory is a concrete path resolved BEFORE the load — training
+    /// base models, captioners, analyzers (the `ManagedModelPath` entrypoint) — and the
+    /// receipt-provenance lane both read the leased bundle too, so no model-consuming surface is
+    /// left on the source tier while a lease is active.
+    #[test]
+    fn payload_resolved_and_receipt_paths_are_served_from_the_leased_bundle() {
+        let temp = TempDir::new().unwrap();
+        let (settings, library, payload) = installed_model(&temp);
+        with_local_cache(&library, || {
+            let artifact = publish_bundle(
+                &settings.data_dir,
+                &library,
+                "owner/model",
+                REV_A,
+                "default",
+                &["model.safetensors"],
+            );
+            let bundle_snapshot = artifact
+                .location
+                .root()
+                .join(format!("models--owner--model/snapshots/{REV_A}"));
+            let source_snapshot = ArtifactSourceLibrary::new(&library)
+                .unwrap()
+                .repository_root("owner/model")
+                .unwrap()
+                .join("snapshots")
+                .join(REV_A);
+
+            // Without a lease the authoritative source path survives untouched.
+            let before = crate::paths::normalize_app_managed_model_path(
+                &settings,
+                source_snapshot.to_str().unwrap(),
+                "base model",
+            )
+            .unwrap();
+            assert!(before.ends_with(format!("snapshots/{REV_A}")));
+            assert!(!before.starts_with(artifact.location.root()));
+
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap();
+            let during = crate::paths::normalize_app_managed_model_path(
+                &settings,
+                source_snapshot.to_str().unwrap(),
+                "base model",
+            )
+            .unwrap();
+            assert_eq!(during, bundle_snapshot);
+            // The receipt lane proves its install against the source and then hands the loader the
+            // leased local path.
+            assert_eq!(
+                crate::model_jobs::huggingface_receipt_weights_dir(
+                    &settings.data_dir,
+                    "owner/model",
+                    Some("m"),
+                    None
+                ),
+                Some(bundle_snapshot)
+            );
+            guard.finish_success().unwrap();
+
+            // And the redirect is gone with the lease.
+            assert_eq!(
+                crate::paths::normalize_app_managed_model_path(
+                    &settings,
+                    source_snapshot.to_str().unwrap(),
+                    "base model",
+                )
+                .unwrap(),
+                before
+            );
+        });
+    }
+
     /// The epic's headline outcome: with the configured library disconnected, a complete local
     /// bundle still admits and still resolves — without the runtime ever reaching a downloader or
     /// recreating the configured library root.

--- a/crates/sceneworks-worker/src/external_library_runtime.rs
+++ b/crates/sceneworks-worker/src/external_library_runtime.rs
@@ -1544,6 +1544,132 @@ mod tests {
         });
     }
 
+    /// A requirement whose receipt carries NO `snapshotRevision` makes the WHOLE repository
+    /// unserveable, not merely that one requirement.
+    ///
+    /// A legacy receipt yields `revision: None` (`artifact_selection.rs` maps a missing
+    /// `snapshotRevision` straight through), and there is then no pair to compare coverage against
+    /// — no bundle can be *shown* to hold what that requirement needs. Leaving the pinned sibling
+    /// served anyway is not safe: the unpinned model re-resolves to the source tier, and its
+    /// unpinned load walks `refs/main` into the overlay, which would hand it a bundle whose file
+    /// set was never in the union.
+    #[test]
+    fn a_requirement_with_no_recorded_revision_makes_its_whole_repository_unserveable() {
+        let temp = TempDir::new().unwrap();
+        let data = temp.path().join("data");
+        let library = temp.path().join("external-hf");
+        seed_snapshot(&library, "owner/shared", REV_A, "pinned.safetensors");
+        seed_snapshot(&library, "owner/shared", REV_A, "legacy.safetensors");
+        // `refs/main` is what an unpinned resolve reads — the walk that would reach the overlay.
+        let repo_root = library.join("models--owner--shared");
+        std::fs::create_dir_all(repo_root.join("refs")).unwrap();
+        std::fs::write(repo_root.join("refs").join("main"), REV_A).unwrap();
+
+        let pinned_receipt = json!({ "repo": "owner/shared", "modelId": "pinned",
+                                     "resolvedFiles": ["pinned.safetensors"],
+                                     "snapshotRevision": REV_A });
+        // The legacy receipt: same repository, NO `snapshotRevision`.
+        let legacy_receipt = json!({ "repo": "owner/shared", "modelId": "legacy",
+                                     "resolvedFiles": ["legacy.safetensors"] });
+        let pinned_entry = json!({
+            "id": "pinned",
+            "downloads": [{ "provider": "huggingface", "repo": "owner/shared",
+                            "revision": REV_A, "files": ["pinned.safetensors"] }]
+        });
+        // The legacy carrier declares NO revision, so nothing overrides its receipt's `None` with a
+        // declared-exact pin — this is what makes `revision: None` actually reach the guard.
+        let legacy_entry = json!({
+            "id": "legacy",
+            "downloads": [{ "provider": "huggingface", "repo": "owner/shared",
+                            "files": ["legacy.safetensors"] }]
+        });
+
+        // Control: the pinned selection ALONE is served locally. Without this the assertion below
+        // could pass merely because the bundle was unusable.
+        write_receipts(&data, "owner/shared", json!([pinned_receipt.clone()]));
+        let settings = settings(data.clone());
+        let alone = json!({ "modelManifestEntry": pinned_entry.clone() })
+            .as_object()
+            .unwrap()
+            .clone();
+        with_local_cache(&library, || {
+            publish_bundle(
+                &settings.data_dir,
+                &library,
+                "owner/shared",
+                REV_A,
+                "default",
+                &["pinned.safetensors"],
+            );
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &alone, &settings).unwrap();
+            assert_eq!(
+                guard.resolutions()[0].availability,
+                ModelAvailability::LocalReady,
+                "control: the pinned selection alone IS served locally"
+            );
+            drop(guard);
+        });
+
+        // Now add the legacy carrier on the SAME repository.
+        write_receipts(
+            &data,
+            "owner/shared",
+            json!([pinned_receipt, legacy_receipt]),
+        );
+        let payload = json!({
+            "modelManifestEntry": pinned_entry,
+            "modelManifestEntries": [legacy_entry]
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        with_local_cache(&library, || {
+            let bundle_root = {
+                let scan = sceneworks_core::model_artifacts::resolved_cache::ResolvedCacheStore::valid_local_artifacts(
+                    &settings.data_dir,
+                );
+                scan.artifacts[0].location.root().to_path_buf()
+            };
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap();
+            assert!(
+                guard
+                    .resolutions()
+                    .iter()
+                    .all(|resolution| resolution.availability != ModelAvailability::LocalReady),
+                "an unrevisioned requirement poisons the whole repository: {:?}",
+                guard
+                    .resolutions()
+                    .iter()
+                    .map(|resolution| &resolution.availability)
+                    .collect::<Vec<_>>()
+            );
+            // The load-bearing half, at the PATH layer with the guard held: neither the pinned nor
+            // the unpinned resolve may reach the bundle.
+            let pinned = crate::model_jobs::huggingface_pinned_snapshot_dir(
+                &settings.data_dir,
+                "owner/shared",
+                REV_A,
+            )
+            .expect("source snapshot");
+            assert!(!pinned.starts_with(&bundle_root), "{}", pinned.display());
+            assert!(pinned.starts_with(&library), "{}", pinned.display());
+            // The unpinned walk (`refs/main`) is the one the poison exists to stop.
+            let unpinned =
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/shared")
+                    .expect("source snapshot");
+            assert!(
+                !unpinned.starts_with(&bundle_root),
+                "an unpinned load must never walk refs/main into a bundle whose files were never \
+                 in the union: {}",
+                unpinned.display()
+            );
+            assert!(unpinned.join("legacy.safetensors").is_file());
+        });
+    }
+
     /// Run `body` with `tracing` captured and return everything it emitted.
     fn captured_events<T>(body: impl FnOnce() -> T) -> (T, String) {
         use std::io::Write;

--- a/crates/sceneworks-worker/src/external_library_runtime.rs
+++ b/crates/sceneworks-worker/src/external_library_runtime.rs
@@ -617,6 +617,407 @@ mod tests {
         (settings(data), library, payload)
     }
 
+    /// Pin the configured source library AND switch the resolved cache on for the body. Under
+    /// test `Settings::resolved_cache_policy` reads the same environment `Settings::from_env`
+    /// would have read, so this is exactly the production "user enabled the cache" state.
+    fn with_local_cache<T>(library: &Path, body: impl FnOnce() -> T) -> T {
+        crate::test_env::temp_env_vars(
+            &[
+                ("HF_HUB_CACHE", library.to_str().expect("utf-8 temp path")),
+                (
+                    sceneworks_core::model_artifacts::resolved_cache::RESOLVED_CACHE_ENABLED_ENV,
+                    "1",
+                ),
+            ],
+            body,
+        )
+    }
+
+    /// Publish a real bundle through the PRODUCTION materializer: the source snapshot is copied,
+    /// verified and atomically published exactly as a promotion would do it, so these tests read
+    /// back the same on-disk shape the runtime will meet.
+    fn publish_bundle(
+        data_dir: &Path,
+        library: &Path,
+        repository: &str,
+        revision: &str,
+        variant: &str,
+        files: &[&str],
+    ) -> sceneworks_core::model_artifacts::ResolvedModelArtifact {
+        use sceneworks_core::model_artifacts::local_preference::hub_cache_member_destination;
+        use sceneworks_core::model_artifacts::resolved_cache::{
+            MaterializationCancellation, MaterializationOutcome, ResolvedCacheMaterializer,
+        };
+        use sceneworks_core::model_artifacts::{
+            ArtifactAvailability, ArtifactFile, ArtifactIdentity, ArtifactMemberRole,
+            ResolvedBundleClosure, ResolvedBundleMember,
+        };
+
+        let identity = ArtifactIdentity::pinned(repository, revision, variant).unwrap();
+        let closure = ResolvedBundleClosure::new(vec![ResolvedBundleMember {
+            role: ArtifactMemberRole::Primary,
+            component_id: None,
+            source: identity.clone(),
+            tier: Some(variant.to_owned()),
+            source_subpath: PathBuf::new(),
+            destination: hub_cache_member_destination(repository, revision, Path::new("")).unwrap(),
+            files: files
+                .iter()
+                .map(|file| ArtifactFile::new(*file).unwrap())
+                .collect(),
+        }])
+        .unwrap();
+        let resolver = ModelArtifactResolver::new(ArtifactSourceLibrary::new(library).unwrap());
+        let source = resolver
+            .resolve_source(identity, closure, ArtifactAvailability::Available)
+            .unwrap();
+        let candidate = sceneworks_core::model_artifacts::PromotionCandidate {
+            cache_key: source.cache_key().unwrap(),
+            artifact: source,
+        };
+        let store = ResolvedCacheStore::open(data_dir).unwrap();
+        let outcome = ResolvedCacheMaterializer::new(store)
+            .materialize(
+                &candidate,
+                library,
+                repository,
+                &MaterializationCancellation::default(),
+            )
+            .unwrap();
+        match outcome {
+            MaterializationOutcome::Published(metadata) => metadata.artifact,
+            other => panic!("bundle was not published: {other:?}"),
+        }
+    }
+
+    /// The walking skeleton: an installed model with a published bundle admits from the app-owned
+    /// tier, the SHARED snapshot resolver every image/video/audio/utility loader uses returns the
+    /// bundle path, an evictor cannot take the entry while the job holds it, and finishing the job
+    /// restores the source tier.
+    #[test]
+    fn a_published_bundle_serves_the_load_and_is_lease_protected() {
+        let temp = TempDir::new().unwrap();
+        let (settings, library, payload) = installed_model(&temp);
+        with_local_cache(&library, || {
+            let artifact = publish_bundle(
+                &settings.data_dir,
+                &library,
+                "owner/model",
+                REV_A,
+                "default",
+                &["model.safetensors"],
+            );
+            let cache_key = artifact.cache_key().unwrap();
+            let bundle_root = artifact.location.root().to_path_buf();
+
+            // Before the guard runs, the shared resolver reads the configured source library.
+            let source_snapshot =
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model")
+                    .expect("source snapshot");
+            assert!(source_snapshot.starts_with(&library));
+
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap();
+            assert_eq!(
+                guard.resolutions()[0].availability,
+                ModelAvailability::LocalReady
+            );
+
+            // The one shared snapshot resolver — every model-consuming runtime funnels through it
+            // — now answers with the app-owned bundle.
+            let loaded =
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model")
+                    .expect("leased local snapshot");
+            assert_eq!(loaded, bundle_root.join(format!(
+                "models--owner--model/snapshots/{REV_A}"
+            )));
+            assert!(loaded.join("model.safetensors").is_file());
+            // And so does the pinned-component resolver used by the utility/co-requisite lanes.
+            assert_eq!(
+                crate::model_jobs::huggingface_pinned_snapshot_dir(
+                    &settings.data_dir,
+                    "owner/model",
+                    REV_A
+                ),
+                Some(loaded.clone())
+            );
+
+            // An evictor takes the entry's artifact lock exclusively; the live lease denies it.
+            let evictor = ResolvedCacheStore::open(&settings.data_dir).unwrap();
+            let candidate = sceneworks_core::model_artifacts::PromotionCandidate {
+                cache_key: cache_key.clone(),
+                artifact: ModelArtifactResolver::new(
+                    ArtifactSourceLibrary::new(&library).unwrap(),
+                )
+                .resolve_source(
+                    artifact.identity.clone(),
+                    artifact.closure.clone(),
+                    sceneworks_core::model_artifacts::ArtifactAvailability::Available,
+                )
+                .unwrap(),
+            };
+            assert!(matches!(
+                evictor.reserve(&candidate, &library, "owner/model").unwrap(),
+                sceneworks_core::model_artifacts::resolved_cache::ReservationOutcome::Contended
+            ));
+
+            guard.finish_success().unwrap();
+            // Usage was recorded for a real load, and the entry survives untouched.
+            let metadata = evictor.lookup_complete(&cache_key).unwrap().unwrap();
+            assert!(metadata.last_used_at.is_some());
+            // With the job finished the source tier serves again.
+            assert_eq!(
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model"),
+                Some(source_snapshot)
+            );
+        });
+    }
+
+    /// The epic's headline outcome: with the configured library disconnected, a complete local
+    /// bundle still admits and still resolves — without the runtime ever reaching a downloader or
+    /// recreating the configured library root.
+    #[test]
+    fn a_disconnected_library_still_serves_a_complete_bundle_without_downloading() {
+        let temp = TempDir::new().unwrap();
+        let (settings, library, payload) = installed_model(&temp);
+        with_local_cache(&library, || {
+            publish_bundle(
+                &settings.data_dir,
+                &library,
+                "owner/model",
+                REV_A,
+                "default",
+                &["model.safetensors"],
+            );
+            std::fs::rename(&library, temp.path().join("detached")).unwrap();
+
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap();
+            assert_eq!(
+                guard.resolutions()[0].availability,
+                ModelAvailability::LocalReady
+            );
+            let loaded =
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model")
+                    .expect("leased local snapshot while disconnected");
+            assert!(loaded.join("model.safetensors").is_file());
+            let resolved_root =
+                std::fs::canonicalize(settings.data_dir.join("models").join("resolved")).unwrap();
+            assert!(loaded.starts_with(&resolved_root), "{}", loaded.display());
+            // Nothing recreated the configured library or a parallel download destination: the
+            // preference path never reaches the downloader.
+            assert!(!library.exists());
+            guard.finish_success().unwrap();
+        });
+    }
+
+    /// Each invalid-entry case runs against a bundle that WOULD have served the load, with exactly
+    /// one property broken, and asserts the control first — so a case can only pass because the
+    /// broken property is what moved the load back to the authoritative source tier.
+    fn invalid_local_entry_falls_back(break_it: impl FnOnce(&Path, &Path)) {
+        let temp = TempDir::new().unwrap();
+        let (settings, library, payload) = installed_model(&temp);
+        with_local_cache(&library, || {
+            let artifact = publish_bundle(
+                &settings.data_dir,
+                &library,
+                "owner/model",
+                REV_A,
+                "default",
+                &["model.safetensors"],
+            );
+            let bundle = artifact.location.root().to_path_buf();
+            let source_snapshot =
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model")
+                    .expect("source snapshot");
+
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap();
+            assert_eq!(
+                guard.resolutions()[0].availability,
+                ModelAvailability::LocalReady,
+                "control: the intact bundle must serve this load"
+            );
+            drop(guard);
+
+            break_it(&settings.data_dir, &bundle);
+
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap();
+            assert_eq!(
+                guard.resolutions()[0].availability,
+                ModelAvailability::ExternalReady,
+                "an invalid local entry must fall back to the authoritative source"
+            );
+            assert_eq!(
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model"),
+                Some(source_snapshot),
+                "and the load must read the source library, not the invalid bundle"
+            );
+        });
+    }
+
+    fn published_file(bundle: &Path) -> PathBuf {
+        bundle.join(format!(
+            "models--owner--model/snapshots/{REV_A}/model.safetensors"
+        ))
+    }
+
+    #[test]
+    fn a_torn_local_entry_never_wins() {
+        invalid_local_entry_falls_back(|_, bundle| {
+            std::fs::write(published_file(bundle), b"").unwrap();
+        });
+    }
+
+    #[test]
+    fn a_partial_local_entry_never_wins() {
+        invalid_local_entry_falls_back(|_, bundle| {
+            std::fs::remove_file(published_file(bundle)).unwrap();
+        });
+    }
+
+    #[test]
+    fn an_unverifiable_local_entry_never_wins() {
+        invalid_local_entry_falls_back(|data_dir, _| {
+            let entries = data_dir.join("models/resolved/entries");
+            for entry in std::fs::read_dir(&entries).unwrap().flatten() {
+                for slot in 0..=1 {
+                    let path = entry.path().join(format!("metadata.{slot}.json"));
+                    if path.exists() {
+                        std::fs::write(&path, b"{\"not\":\"a journal\"}").unwrap();
+                    }
+                }
+            }
+        });
+    }
+
+    /// A bundle of a DIFFERENT revision or a DIFFERENT tier than the one this request selected is
+    /// not this request's artifact: the selected closure keeps its source tier and the local entry
+    /// is left alone.
+    #[test]
+    fn a_wrong_revision_or_wrong_tier_bundle_is_not_used() {
+        let temp = TempDir::new().unwrap();
+        let data = temp.path().join("data");
+        let library = temp.path().join("external-hf");
+        seed_snapshot(&library, "owner/matrix", REV_A, "q4/model.safetensors");
+        seed_snapshot(&library, "owner/matrix", REV_A, "q8/model.safetensors");
+        write_receipts(
+            &data,
+            "owner/matrix",
+            json!([
+                { "repo": "owner/matrix", "modelId": "m", "variant": "q4",
+                  "resolvedFiles": ["q4/model.safetensors"], "snapshotRevision": REV_A },
+                { "repo": "owner/matrix", "modelId": "m", "variant": "q8",
+                  "resolvedFiles": ["q8/model.safetensors"], "snapshotRevision": REV_A }
+            ]),
+        );
+        let settings = settings(data);
+        let entry = json!({
+            "id": "m",
+            "downloads": [
+                { "provider": "huggingface", "repo": "owner/matrix", "variant": "q4",
+                  "default": true, "files": ["q4/*"] },
+                { "provider": "huggingface", "repo": "owner/matrix", "variant": "q8",
+                  "files": ["q8/*"] }
+            ]
+        });
+        let payload = |variant: &str| {
+            json!({ "modelManifestEntry": entry, "variant": variant })
+                .as_object()
+                .unwrap()
+                .clone()
+        };
+        with_local_cache(&library, || {
+            // Only the q4 tier is published locally.
+            publish_bundle(
+                &settings.data_dir,
+                &library,
+                "owner/matrix",
+                REV_A,
+                "q4",
+                &["q4/model.safetensors"],
+            );
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload("q4"), &settings)
+                    .unwrap();
+            assert_eq!(
+                guard.resolutions()[0].availability,
+                ModelAvailability::LocalReady
+            );
+            drop(guard);
+            // The q8 selection must NOT be served by the q4 bundle even though both share one
+            // repository and one immutable revision.
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload("q8"), &settings)
+                    .unwrap();
+            assert_eq!(
+                guard.resolutions()[0].availability,
+                ModelAvailability::ExternalReady
+            );
+            drop(guard);
+
+            // A bundle of another revision of the same model is likewise not this model.
+            seed_snapshot(&library, "owner/other", REV_B, "model.safetensors");
+            publish_bundle(
+                &settings.data_dir,
+                &library,
+                "owner/other",
+                REV_B,
+                "default",
+                &["model.safetensors"],
+            );
+            let other = json!({
+                "modelManifestEntry": {
+                    "id": "other",
+                    "downloads": [{ "provider": "huggingface", "repo": "owner/other",
+                                    "revision": REV_A, "files": ["model.safetensors"] }]
+                }
+            })
+            .as_object()
+            .unwrap()
+            .clone();
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &other, &settings).unwrap();
+            assert_ne!(
+                guard.resolutions()[0].availability,
+                ModelAvailability::LocalReady,
+                "a bundle of a different revision must never satisfy a pinned request"
+            );
+        });
+    }
+
+    /// The resolved cache is opt-in: with it switched off no entry is read, no session is opened,
+    /// and every runtime keeps reading the configured source library byte for byte.
+    #[test]
+    fn a_disabled_cache_never_prefers_a_local_bundle() {
+        let temp = TempDir::new().unwrap();
+        let (settings, library, payload) = installed_model(&temp);
+        with_local_cache(&library, || {
+            publish_bundle(
+                &settings.data_dir,
+                &library,
+                "owner/model",
+                REV_A,
+                "default",
+                &["model.safetensors"],
+            );
+        });
+        with_library(&library, || {
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap();
+            assert_eq!(
+                guard.resolutions()[0].availability,
+                ModelAvailability::ExternalReady
+            );
+            assert!(
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model")
+                    .expect("source snapshot")
+                    .starts_with(&library)
+            );
+        });
+    }
+
     #[test]
     fn installed_model_admits_as_external_ready_with_a_source_session() {
         let temp = TempDir::new().unwrap();

--- a/crates/sceneworks-worker/src/external_library_runtime.rs
+++ b/crates/sceneworks-worker/src/external_library_runtime.rs
@@ -770,6 +770,66 @@ mod tests {
         });
     }
 
+    /// A job that carries several models (a primary plus utility/co-requisite carriers) leases and
+    /// serves EVERY one of them from the local tier — admission is per artifact, so one model can
+    /// never silently drag another back onto the source tier.
+    #[test]
+    fn every_model_a_job_carries_is_served_from_its_own_leased_bundle() {
+        let temp = TempDir::new().unwrap();
+        let data = temp.path().join("data");
+        let library = temp.path().join("external-hf");
+        for repo in ["owner/primary", "owner/utility"] {
+            seed_snapshot(&library, repo, REV_A, "model.safetensors");
+            write_receipts(
+                &data,
+                repo,
+                json!([{ "repo": repo, "modelId": repo,
+                         "resolvedFiles": ["model.safetensors"], "snapshotRevision": REV_A }]),
+            );
+        }
+        let settings = settings(data);
+        let entry = |repo: &str| {
+            json!({
+                "id": repo,
+                "downloads": [{ "provider": "huggingface", "repo": repo, "revision": REV_A,
+                                "files": ["model.safetensors"] }]
+            })
+        };
+        let payload = json!({
+            "modelManifestEntry": entry("owner/primary"),
+            "modelManifestEntries": [entry("owner/utility")]
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        with_local_cache(&library, || {
+            for repo in ["owner/primary", "owner/utility"] {
+                publish_bundle(
+                    &settings.data_dir,
+                    &library,
+                    repo,
+                    REV_A,
+                    "default",
+                    &["model.safetensors"],
+                );
+            }
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap();
+            assert_eq!(guard.resolutions().len(), 2);
+            assert!(guard
+                .resolutions()
+                .iter()
+                .all(|resolution| resolution.availability == ModelAvailability::LocalReady));
+            for repo in ["owner/primary", "owner/utility"] {
+                let loaded = crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, repo)
+                    .expect("leased local snapshot");
+                assert!(loaded.join("model.safetensors").is_file());
+                assert!(!loaded.starts_with(&library));
+            }
+            guard.finish_success().unwrap();
+        });
+    }
+
     /// The runtimes whose model directory is a concrete path resolved BEFORE the load — training
     /// base models, captioners, analyzers (the `ManagedModelPath` entrypoint) — and the
     /// receipt-provenance lane both read the leased bundle too, so no model-consuming surface is

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -1772,11 +1772,28 @@ async fn run_utility_job(
     let result = with_shutdown_flag(shutdown.clone(), async {
         // sc-19708: the ONE pre-loader guard. Typed model-source admission happens here for every
         // job type, before any handler runs; handlers never carry availability or cache policy.
-        let source_guard = external_library_runtime::RuntimeSourceGuard::begin(
-            &job.job_type,
-            &job.payload,
-            settings,
-        )
+        //
+        // sc-19707: run it on the BLOCKING pool. The guard walks the resolved-cache journal, stats
+        // whole closures, and — when it leases a local bundle — takes the entry's shared artifact
+        // lock through the blocking `FileExt::lock_shared`. An evictor holding that lock
+        // exclusively would otherwise stall this runtime worker thread, not just this job.
+        let guard_job_type = job.job_type.clone();
+        let guard_payload = job.payload.clone();
+        let guard_settings = settings.clone();
+        let source_guard = tokio::task::spawn_blocking(move || {
+            external_library_runtime::RuntimeSourceGuard::begin(
+                &guard_job_type,
+                &guard_payload,
+                &guard_settings,
+            )
+        })
+        .await
+        .map_err(|error| {
+            (
+                "Model source unavailable.",
+                WorkerError::Io(std::io::Error::other(error.to_string())),
+            )
+        })?
         .map_err(|error| ("Model source unavailable.", error))?;
         let dispatch_result = match job.job_type {
             JobType::Placeholder => run_placeholder_job(api, settings, &job, &shutdown)

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -2915,8 +2915,20 @@ pub(crate) fn huggingface_receipt_weights_dir(
 ) -> Option<PathBuf> {
     // Path-only callers never read provenance, so they must not trigger a receipt write as a side
     // effect of locating weights. Repair belongs to the provenance consumer.
-    huggingface_receipt_weights(data_dir, repo, model_id, variant, ProvenanceRepair::Skip)
-        .map(|resolved| resolved.path)
+    let resolved =
+        huggingface_receipt_weights(data_dir, repo, model_id, variant, ProvenanceRepair::Skip)?;
+    // sc-19707: the receipt resolves and PROVES its install against the authoritative source
+    // (its tree stamp is a source-tree fact and must stay one); only the path handed to the loader
+    // is then served from a leased app-owned bundle covering that exact snapshot. Inert without an
+    // active lease.
+    let library = sceneworks_core::hf_home::model_source_library(data_dir);
+    Some(
+        sceneworks_core::model_artifacts::local_preference::redirect_source_library_path(
+            library.root(),
+            &resolved.path,
+        )
+        .unwrap_or(resolved.path),
+    )
 }
 
 #[cfg(any(target_os = "macos", feature = "backend-candle", test))]

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -3250,8 +3250,10 @@ fn resolve_huggingface_snapshot_dir(data_dir: &Path, repo: &str) -> Option<PathB
     }
     // Fallback: the cached snapshot with the most files, so an empty/partial one never wins over a
     // fully materialized sibling (the old "first dir wins" scan happily returned an empty snapshot).
-    std::fs::read_dir(&snapshots)
-        .ok()?
+    let from_source_library = std::fs::read_dir(&snapshots)
+        .ok()
+        .into_iter()
+        .flatten()
         .flatten()
         .map(|entry| entry.path())
         .filter(|path| path.is_dir())
@@ -3264,7 +3266,19 @@ fn resolve_huggingface_snapshot_dir(data_dir: &Path, repo: &str) -> Option<PathB
                 .discover_source_snapshot(repo, Some(revision))
                 .ok()
                 .map(|(_, path)| path)
-        })
+        });
+    if from_source_library.is_some() {
+        return from_source_library;
+    }
+    // Last resort (sc-19707): the configured library cannot name a revision at all — it is
+    // disconnected, or was never installed here. The typed resolver answers from a leased
+    // app-owned bundle when exactly one revision of this repository is being served, which is what
+    // keeps a complete local model loadable while the drive is unplugged. With no active lease it
+    // still returns nothing, so an uninstalled model keeps its established behavior.
+    resolver
+        .discover_source_snapshot(repo, None)
+        .ok()
+        .map(|(_, path)| path)
 }
 
 /// Short-circuiting presence probe for the hot `refs/main` path. Unlike

--- a/crates/sceneworks-worker/src/paths.rs
+++ b/crates/sceneworks-worker/src/paths.rs
@@ -196,11 +196,34 @@ pub(crate) fn normalize_app_managed_model_path(
             roots.push(canonical);
         }
     }
-    sceneworks_core::model_artifacts::confine_artifact_path(Path::new(raw_path), &roots).map_err(
-        |_| {
-            WorkerError::InvalidPayload(format!("{label} must be inside an app-managed directory."))
-        },
+    let confined = sceneworks_core::model_artifacts::confine_artifact_path(
+        Path::new(raw_path),
+        &roots,
     )
+    .map_err(|_| {
+        WorkerError::InvalidPayload(format!("{label} must be inside an app-managed directory."))
+    })?;
+    // sc-19707: a model directory the API already resolved to a concrete source-library path
+    // (training base models, captioners, analyzers) is served from the leased app-owned bundle
+    // when one covers that exact snapshot. Purely a read redirect inside the app data dir, applied
+    // only while a runtime lease is active and only when the bundle really holds the path — with
+    // no lease this is inert and the authoritative source path is returned unchanged.
+    Ok(prefer_leased_local_path(&source_library, confined))
+}
+
+/// Redirect one already-confined source-library path into the leased app-owned bundle that holds
+/// it (sc-19707). Inert without an active runtime lease, and inert for any path the bundle does not
+/// hold, so the authoritative source path is what survives in every other case. Shared by the model
+/// and adapter confinement seams so neither can drift into serving a different tier than the other.
+fn prefer_leased_local_path(
+    source_library: &sceneworks_core::model_artifacts::ArtifactSourceLibrary,
+    confined: PathBuf,
+) -> PathBuf {
+    sceneworks_core::model_artifacts::local_preference::redirect_source_library_path(
+        source_library.root(),
+        &confined,
+    )
+    .unwrap_or(confined)
 }
 
 /// Confine a LoRA adapter path taken from a job payload to an app-managed root
@@ -252,7 +275,13 @@ pub(crate) fn normalize_app_managed_lora_path(
                 "LoRA path must be inside an app-managed directory.".to_owned(),
             )
         })?;
-    Ok(loadable_confined_lora_path(&normalized, confined))
+    // The loadable (extension-bearing) form first: an HF-cached adapter confines to its
+    // extensionless `blobs/<sha>` target, and only the snapshot-shaped form can be matched against
+    // a leased bundle — which stores real files, so the redirected path keeps its extension.
+    Ok(prefer_leased_local_path(
+        &source_library,
+        loadable_confined_lora_path(&normalized, confined),
+    ))
 }
 
 /// Return a *loadable* form of a confined adapter path (sc-11649). mlx-rs's safetensors

--- a/crates/sceneworks-worker/src/paths.rs
+++ b/crates/sceneworks-worker/src/paths.rs
@@ -196,13 +196,13 @@ pub(crate) fn normalize_app_managed_model_path(
             roots.push(canonical);
         }
     }
-    let confined = sceneworks_core::model_artifacts::confine_artifact_path(
-        Path::new(raw_path),
-        &roots,
-    )
-    .map_err(|_| {
-        WorkerError::InvalidPayload(format!("{label} must be inside an app-managed directory."))
-    })?;
+    let confined =
+        sceneworks_core::model_artifacts::confine_artifact_path(Path::new(raw_path), &roots)
+            .map_err(|_| {
+                WorkerError::InvalidPayload(format!(
+                    "{label} must be inside an app-managed directory."
+                ))
+            })?;
     // sc-19707: a model directory the API already resolved to a concrete source-library path
     // (training base models, captioners, analyzers) is served from the leased app-owned bundle
     // when one covers that exact snapshot. Purely a read redirect inside the app data dir, applied

--- a/crates/sceneworks-worker/src/settings.rs
+++ b/crates/sceneworks-worker/src/settings.rs
@@ -96,6 +96,25 @@ impl fmt::Debug for Settings {
 }
 
 impl Settings {
+    /// The effective resolved-model cache policy (sc-19707). The field itself is
+    /// `cfg(not(test))` — the dozens of test fixtures that build `Settings` literally predate it —
+    /// so under test the SAME environment `from_env` would have read is consulted directly. Both
+    /// forms therefore answer with `ResolvedCachePolicy::from_env_or_safe_default()` for any
+    /// process that took its settings from the environment.
+    #[cfg(not(test))]
+    pub(crate) fn resolved_cache_policy(
+        &self,
+    ) -> sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy {
+        self.resolved_cache.clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn resolved_cache_policy(
+        &self,
+    ) -> sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy {
+        sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy::from_env_or_safe_default()
+    }
+
     pub fn from_env() -> Self {
         let defaults = sceneworks_core::app_paths::AppPaths::platform_default();
         let config_dir = env_path_or("SCENEWORKS_CONFIG_DIR", &defaults.config_dir);

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -127,27 +127,44 @@ include!("tests/temp_fixture_guard.rs");
 /// enabled cannot be stranded by turning the cache off.
 #[test]
 fn resolved_cache_retention_is_opt_in_and_never_creates_the_store() {
-    let temp = tempfile::tempdir().expect("tempdir");
-    let data_dir = temp.path().join("data");
-    std::fs::create_dir_all(&data_dir).expect("data dir creates");
-    let resolved_root = data_dir.join("models").join("resolved");
+    // `resolved_cache_retention` reads the cache policy from the PROCESS environment, so the
+    // "disabled" half of this test only means anything while `SCENEWORKS_RESOLVED_CACHE_ENABLED`
+    // is pinned off. Pinning it through the shared `test_env` lock does both jobs at once: it
+    // states the precondition instead of inheriting whatever the process happens to have, and it
+    // excludes the concurrent env mutators (`with_local_cache` and friends) that would otherwise
+    // flip the policy to enabled mid-assertion. `.cargo/config.toml` does NOT set
+    // `RUST_TEST_THREADS`, so this suite really does run in parallel and the race is live.
+    crate::test_env::temp_env_vars(
+        &[(
+            sceneworks_core::model_artifacts::resolved_cache::RESOLVED_CACHE_ENABLED_ENV,
+            "0",
+        )],
+        || {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let data_dir = temp.path().join("data");
+            std::fs::create_dir_all(&data_dir).expect("data dir creates");
+            let resolved_root = data_dir.join("models").join("resolved");
 
-    assert!(
-        crate::resolved_cache_retention(&data_dir).is_none(),
-        "a disabled cache with no store has nothing to drive"
-    );
-    assert!(
-        !resolved_root.exists(),
-        "probing for retention must not create the managed cache root"
-    );
+            assert!(
+                crate::resolved_cache_retention(&data_dir).is_none(),
+                "a disabled cache with no store has nothing to drive"
+            );
+            assert!(
+                !resolved_root.exists(),
+                "probing for retention must not create the managed cache root"
+            );
 
-    drop(
-        sceneworks_core::model_artifacts::resolved_cache::ResolvedCacheStore::open(&data_dir)
-            .expect("store opens"),
-    );
-    assert!(
-        crate::resolved_cache_retention(&data_dir).is_some(),
-        "an existing store must still be reconciled after the policy is disabled"
+            drop(
+                sceneworks_core::model_artifacts::resolved_cache::ResolvedCacheStore::open(
+                    &data_dir,
+                )
+                .expect("store opens"),
+            );
+            assert!(
+                crate::resolved_cache_retention(&data_dir).is_some(),
+                "an existing store must still be reconciled after the policy is disabled"
+            );
+        },
     );
 }
 


### PR DESCRIPTION
sc-19707 — prefer valid local resolved artifacts across every SceneWorks model runtime.

Base: `feature/sc-19703-resolved-model-hot-cache` (merged in; the PR was CONFLICTING).

## The blocker, and why the fix lives at the guard

The preference overlay is a **directory-level seam**: it answers `(repository, revision)` with a
snapshot path and can never re-ask *"does this bundle hold what THIS caller needs"* once the path is
out. So a per-model decision could not be made safe. A job carrying `owner/matrix` q4 (bundled) and
q8 (not bundled) admitted q4 as LocalReady, installed the overlay for the shared pair, and then
resolved the **q8 load into the q4 bundle root** — which has no `q8/` subtree at all.

`RuntimeSourceGuard::begin` now decides in three passes, in the only layer that can see every model
a job will load:

1. **Pass 1** — resolve every entry with local candidates, keeping the **selected closure** beside
   each resolution. (`ModelResolution::local_ready` deliberately carries `requirements: Vec::new()`,
   so the closure cannot be read back off the resolution — every locally-resolved model would
   otherwise look like it required nothing.)
2. **Pass 2** — build `(repo, revision) -> union of required files` across **all** resolutions,
   local *and* non-local, and select a serving entry only when `entry_covers(entry, union)`. The
   non-local sibling is what poisons a pair. A requirement with `revision: None` makes the whole
   repository unserveable.
3. **Pass 3** — a model stays LocalReady only if **every** pair in its closure was selected; all
   others re-resolve with `&[]`.

Exactly **one** scope is installed, holding exactly the selected entries.

**Deliberate consequence, named in a test** (`a_pair_one_sibling_selection_does_not_cover_is_served_to_neither`):
in a q4+q8 job the **q4 model also falls back to source**. That is the correct conservative answer —
partial service of a pair is exactly what cannot be made safe at a directory-level seam.

## Scope vs each recorded item

| Item | State |
|---|---|
| Base merge (PR was DIRTY) | **done** — one conflict in `resolved_cache.rs` (HEAD's `#[derive(Debug)]` on `ResolvedCacheLease` vs base's `mark_interrupted_on_drop` impl); both sides kept, rebuilt after merging |
| Compile errors (`held.entry.*`, stale `prefer_local_artifacts` callers, deleted `ensure_covers`) | **done** |
| **Blocker 1** — overlay keyed on `(repository, revision)` with no file-coverage check | **done** — three-pass guard selection above |
| **Blocker 2** — fail-closed fallback did not close | **done** — one scope installed only after the whole decision; on refusal nothing is installed, every lease is dropped, and every locally resolved model re-resolves against source |
| **major** `valid_local_artifacts` dropped layout-unsupported entries with a bare `continue` | **done** — returns `LocalArtifactScan { artifacts, rejections }`; the guard emits `resolved_cache_local_tier_unsupported` from the rejections. Coverage/selection failure gets its **own** class, `resolved_cache_local_tier_not_selected` |
| **major** no test asserts `resolved_cache_local_tier_unsupported` / `model_source_tier_selected` | **done** — three new emission tests |
| **minor** blocking `lock_shared` on the job's async block | **done** — `begin` runs on `spawn_blocking`; `acquire_complete`'s lock semantics untouched (shared with sc-19710) |
| **minor** `valid_local_artifacts` swallowed every failure | **done** — every rejection class logs a reason |
| **minor** worker `with_local_cache` tests took no overlay mutex | **done** — `RUST_TEST_THREADS=1` made a green run prove nothing about the process-wide overlay |

## Fixed in passing

`select_local_tier` leases **only the winners**, not every candidate. Leasing a candidate that
coverage then rejects would (a) stamp `last_used_at` on an entry this job never reads, skewing
retention's LRU against the entries that actually served, and (b) block the whole guard on the
blocking `lock_shared` behind an evictor holding a bundle no load here will touch. Selection now runs
against the scanned artifacts, and each winner is re-proved against the **leased** copy before it is
installed.

## Tests

Rewritten (both previously dropped their guard **before** asserting, so neither asked its own
question — with no scope live the assertion passes whether or not the bug is present):

- `a_narrower_serving_bundle_is_never_adopted` — now asserts **with the scope held**, at the **path**
  layer: the serving bundle still answers for the shared pair and the refused one never does.
- `a_wrong_revision_or_wrong_tier_bundle_is_not_used` — now asserts **with the guard held** that the
  q8 load reads the source library, not the q4 bundle root, and that the path it was handed actually
  holds the q8 weights.

Added: `a_pair_one_sibling_selection_does_not_cover_is_served_to_neither` (with an "alone, q4 IS
served" control), `an_unsupported_bundle_shape_is_reported_and_the_model_stays_on_the_source_tier`,
`the_serving_tier_is_reported_for_every_admitted_model`,
`a_coverage_refusal_is_reported_as_its_own_class_not_as_an_unsupported_shape`,
`entry_covers_is_a_strict_superset_test`, `a_shared_snapshot_stays_served_until_the_last_scope_drops`
(refcount asymmetry), plus rejection assertions in
`valid_local_artifacts_offers_only_loadable_published_entries`.

### Mutation evidence (each guard mutated alone, `touch` after restore)

| Mutation | Result |
|---|---|
| union built over LocalReady plans only (drops the non-local sibling) | **kills 2** — coverage + deliberate-consequence tests |
| `entry_covers` → always `true` | **kills 3** — those 2 plus the core superset test |
| pass-3 fallback never fires | **kills 2** |
| scan rejections dropped again (the original defect) | **kills** the unsupported-shape test |
| conflicting claim replaces the serving entry | **kills** the rewritten narrower-bundle test |
| refuses the caller but poisons the overlay anyway (the exact blocker-2 shape) | **kills** the rewritten narrower-bundle test |

**Honest gap:** the pass-2d re-verification (`leased.contains(entry)`) is a defence against the
scan→lease race and **survives mutation** — no test can reach it without a store hook between the
scan and the lease. It is strictly fail-closed: its worst case is behaving as if it were absent.

## Verification (local, macOS)

- `npm run rust:check` — **exit 0** (derived docs, `cargo fmt --all --check`, clippy, workspace
  tests, build). `rust:test`: **3708 passed, 0 failed** across 33 suites.
- `npm run check` — **412 passed, 0 failed**.
- `cargo test -p sceneworks-worker --lib external_library_runtime` — **24 passed**.
- `cargo test -p sceneworks-core --lib` — **1019 passed, 0 failed, 2 ignored**.

No web/TS files changed, so no vitest or contract-snapshot regeneration is implicated. No new file
calls `model_source_library(`, so `model_artifact_inventory.rs` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: base absorb (#2406) + adversarial-review follow-up

`feature/sc-19703-resolved-model-hot-cache` advanced with **#2406 (sc-19709)** after the first base
merge, so it was absorbed here (~518 new lines in `external_library.rs`: `probe_binding`
canonical-path+identity aliasing, `realias_unlocked`, `ModelResolution.library_present`, plus the
API `model_library` module and web files). The merge was clean, but a clean merge proves nothing —
verified the shared seam by hand: `ModelResolution::local_ready` still carries
`requirements: Vec::new()` (the assumption `EntryPlan.requirements` exists for) and
`resolve_model_availability`'s signature and local-candidate matching are unchanged. Then rebuilt
and re-ran everything.

**[major] `revision: None` poison survived mutation.** Replacing the `unserveable_repositories`
insert with a bare `continue` left all 24 guard tests and 10 core tests green, because nothing
constructed a legacy receipt without `snapshotRevision`. Added
`a_requirement_with_no_recorded_revision_makes_its_whole_repository_unserveable` — one bundled pinned
selection plus a legacy carrier on the SAME repository whose receipt records no revision *and whose
manifest declares none either* (a declared pin would otherwise override the receipt's `None` before
the guard ever sees it). Asserts, guard held and at the PATH layer, that neither the pinned nor the
unpinned `refs/main` walk reaches the bundle. **Mutant verified killed**: applied the bare-`continue`
mutation → red on exactly that test with the other 24 green → restored, `touch`ed, re-ran green.

**[minor] Same-process API reader.** Giving API read paths a non-preferring library would touch every
`model_source_library` caller across four API modules, each needing a read-vs-load judgement that
belongs to the availability/catalog stories — so, per the review's own fallback, the safety comment
now states the real bound rather than overclaiming "one job at a time": a concurrent same-process
reader may see a transient **false absent** that self-heals at job end, and **never wrong bytes**.
Pinned by `an_out_of_union_reader_sees_absent_never_the_wrong_bytes`, which seeds a source file the
bundle does not hold with distinguishable content and asserts it reads absent during the scope, is
never answered with other bytes, keeps its authoritative path through `redirect_source_library_path`,
and returns after drop.

**Fixed in passing — a real parallel-test race.**
`resolved_cache_retention_is_opt_in_and_never_creates_the_store` read the cache policy from the
process environment **without** the shared `test_env` lock, so a concurrent `with_local_cache` body
could flip the policy to enabled mid-assertion. It failed once in a full workspace run and passed in
isolation. Note this corrects a premise in the original review item: **`.cargo/config.toml` does NOT
set `RUST_TEST_THREADS`** — this suite really does run in parallel, so the race is live rather than
merely latent. The test now pins the variable off through that lock. (Honest caveat: 6 full-suite
runs of the pre-fix code did not reproduce the failure, so the fix is justified structurally — the
test now cannot observe another test's env — not by a reproduced red.)

### Re-verification on the absorbed base

- `npm run rust:check` — **exit 0** (captured directly). **3731 passed, 0 failed** across 33 suites.
- `cargo test -p sceneworks-worker --lib external_library_runtime` — **25 passed**.
- `cargo test -p sceneworks-core --lib model_artifacts::local_preference` — **11 passed**.
- `cargo test -p sceneworks-worker --lib` — **1530 passed**, run 4x consecutively after the race fix.
