### PR TITLE
sc-19711 Settings + Model Manager resolved-cache controls, with the tests that caught five defects

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -1296,6 +1296,7 @@ fn create_app_with_state_mode(
         thumbnail_generation_slots: Arc::new(tokio::sync::Semaphore::new(2)),
         workflow_strip_slots: Arc::new(tokio::sync::Semaphore::new(WORKFLOW_STRIP_SLOTS)),
         auth_throttle: Arc::new(AuthThrottle::default()),
+        resolved_cache_session: Arc::new(AsyncMutex::new(None)),
         manifest_cache: Arc::new(Mutex::new(ManifestCache::default())),
         manifest_write_locks: Arc::new(Mutex::new(HashMap::new())),
         model_catalog_cache: Arc::new(ModelCatalogCache::default()),

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -195,9 +195,6 @@ mod model_sources;
 // Read + control surface for the app-owned resolved-model hot cache (sc-19711): status for the
 // Settings storage card, and the per-model keep/remove operations the Model Manager drives.
 mod model_cache;
-use model_cache::{
-    get_model_cache, preview_model_cache_removal, remove_model_cache_entry, set_model_cache_pin,
-};
 use manifest::{
     acquire_manifest_file_lock, load_manifest_entries, manifest_write_lock, merge_entries_by_id,
     merge_object, mutate_manifest_entries, remove_catalog_manifest_entry, write_manifest_atomic,
@@ -205,6 +202,9 @@ use manifest::{
 };
 #[cfg(test)]
 use manifest::{strip_jsonc_comments, API_MANAGED_MANIFEST_HEADER};
+use model_cache::{
+    get_model_cache, preview_model_cache_removal, remove_model_cache_entry, set_model_cache_pin,
+};
 mod models;
 use models::{
     create_model_convert_job, create_model_download_job, create_model_import_job, delete_model,

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -192,6 +192,12 @@ mod manifest;
 // The single model-source seam every job-creation path calls (sc-19708): generic carrier
 // attachment + typed external-library availability preflight, all data-driven.
 mod model_sources;
+// Read + control surface for the app-owned resolved-model hot cache (sc-19711): status for the
+// Settings storage card, and the per-model keep/remove operations the Model Manager drives.
+mod model_cache;
+use model_cache::{
+    get_model_cache, preview_model_cache_removal, remove_model_cache_entry, set_model_cache_pin,
+};
 use manifest::{
     acquire_manifest_file_lock, load_manifest_entries, manifest_write_lock, merge_entries_by_id,
     merge_object, mutate_manifest_entries, remove_catalog_manifest_entry, write_manifest_atomic,
@@ -1753,6 +1759,15 @@ fn create_app_with_state_mode(
             post(create_model_import_job)
                 .layer(DefaultBodyLimit::max(MAX_MODEL_MULTIPART_BODY_BYTES)),
         )
+        // Resolved-model hot cache (sc-19711). The GET is UI-polled, so it is deliberately one
+        // cheap write-free listing; the three POSTs are single deliberate user actions.
+        .route("/api/v1/model-cache", get(get_model_cache))
+        .route(
+            "/api/v1/model-cache/removal-preview",
+            post(preview_model_cache_removal),
+        )
+        .route("/api/v1/model-cache/remove", post(remove_model_cache_entry))
+        .route("/api/v1/model-cache/pin", post(set_model_cache_pin))
         .route("/api/v1/control-overlays", get(list_control_overlays))
         .route("/api/v1/styles", get(list_styles))
         .route("/api/v1/loras", get(list_loras))

--- a/apps/rust-api/src/model_cache.rs
+++ b/apps/rust-api/src/model_cache.rs
@@ -111,7 +111,11 @@ pub(crate) struct CachePinRequest {
 /// The typed pin answer, preserved. `Unknown` carries no `known` object at all, so a client that
 /// forgets to branch renders nothing rather than rendering "no pins".
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase", tag = "kind")]
+#[serde(
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    tag = "kind"
+)]
 pub(crate) enum CachePinsDto {
     Known {
         artifact_pinned: bool,
@@ -220,7 +224,10 @@ fn entry_dto(
     CacheEntryDto {
         cache_key,
         state,
-        model_ids: owners.get(&identity.repository).cloned().unwrap_or_default(),
+        model_ids: owners
+            .get(&identity.repository)
+            .cloned()
+            .unwrap_or_default(),
         repository: Some(identity.repository.clone()),
         revision: Some(identity.revision.clone()),
         variant: Some(identity.variant.clone()),
@@ -322,12 +329,13 @@ pub(crate) async fn preview_model_cache_removal(
     Json(request): Json<CacheKeyRequest>,
 ) -> Result<Json<RemovalPreviewDto>, ApiError> {
     let store = open_mutable(&state).await?;
-    let preview = tokio::task::spawn_blocking(move || store.manual_removal_preview(&request.cache_key))
-        .await
-        .map_err(|error| {
-            ApiError::internal(format!("resolved-cache preview task failed: {error}"))
-        })?
-        .map_err(cache_error)?;
+    let preview =
+        tokio::task::spawn_blocking(move || store.manual_removal_preview(&request.cache_key))
+            .await
+            .map_err(|error| {
+                ApiError::internal(format!("resolved-cache preview task failed: {error}"))
+            })?
+            .map_err(cache_error)?;
     Ok(Json(RemovalPreviewDto {
         cache_key: preview.cache_key,
         state: preview.state,
@@ -346,7 +354,9 @@ pub(crate) async fn remove_model_cache_entry(
     let now = sceneworks_core::time::now_unix_seconds().max(0) as u64;
     let outcome = tokio::task::spawn_blocking(move || store.remove_entry(&request.cache_key, now))
         .await
-        .map_err(|error| ApiError::internal(format!("resolved-cache removal task failed: {error}")))?
+        .map_err(|error| {
+            ApiError::internal(format!("resolved-cache removal task failed: {error}"))
+        })?
         .map_err(cache_error)?;
     Ok(Json(RemovalOutcomeDto {
         cache_key: outcome.cache_key,
@@ -363,11 +373,12 @@ pub(crate) async fn set_model_cache_pin(
     Json(request): Json<CachePinRequest>,
 ) -> Result<Json<CacheEntryDto>, ApiError> {
     let store = open_mutable(&state).await?;
-    let metadata =
-        tokio::task::spawn_blocking(move || store.set_artifact_pin(&request.cache_key, request.pinned))
-            .await
-            .map_err(|error| ApiError::internal(format!("resolved-cache pin task failed: {error}")))?
-            .map_err(cache_error)?;
+    let metadata = tokio::task::spawn_blocking(move || {
+        store.set_artifact_pin(&request.cache_key, request.pinned)
+    })
+    .await
+    .map_err(|error| ApiError::internal(format!("resolved-cache pin task failed: {error}")))?
+    .map_err(cache_error)?;
     let owners = repository_owners(&state).await;
     Ok(Json(entry_dto(
         ResolvedCacheEntrySummary {

--- a/apps/rust-api/src/model_cache.rs
+++ b/apps/rust-api/src/model_cache.rs
@@ -32,7 +32,7 @@ use axum::extract::State;
 use axum::Json;
 use sceneworks_core::model_artifacts::resolved_cache::{
     ManualRemovalPins, ResolvedCacheEntryState, ResolvedCacheEntrySummary, ResolvedCacheError,
-    ResolvedCacheStore, SourceVolumeRelation,
+    ResolvedCacheErrorKind, ResolvedCacheStore, SourceVolumeRelation,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -162,8 +162,17 @@ pub(crate) struct RemovalOutcomeDto {
     pub(crate) source_unavailable_warning: Option<String>,
 }
 
+/// Report a store failure as what it actually is. The store attributes its own errors
+/// ([`ResolvedCacheErrorKind`]) rather than leaving the HTTP layer to guess from message text, so
+/// a lock that could not be taken, a journal that could not be read, or a host clock that failed
+/// answers 500 — a caller retrying those is right to, and telling them their request was bad would
+/// send them to fix the wrong thing. Only a malformed cache key or an entry the store does not
+/// hold is the caller's to correct.
 fn cache_error(error: ResolvedCacheError) -> ApiError {
-    ApiError::bad_request(error.to_string())
+    match error.kind() {
+        ResolvedCacheErrorKind::Request => ApiError::bad_request(error.to_string()),
+        ResolvedCacheErrorKind::Internal => ApiError::internal(error.to_string()),
+    }
 }
 
 /// Map every entry's primary repository to the catalog model ids that own it. One pass over the
@@ -309,8 +318,17 @@ pub(crate) async fn get_model_cache(
     }))
 }
 
-/// Open the store for a mutating operation. Never creates the cache root as a side effect of a
+/// The store handle for a mutating operation. Never creates the cache root as a side effect of a
 /// pin or a removal: with no store there is nothing to act on.
+///
+/// The handle is opened at most ONCE per API process and then shared. `ResolvedCacheStore::open`
+/// claims a session slot — `sessions/<id>/` plus its exclusive lock — which the store's design
+/// treats as belonging to a process for that process's lifetime; a later `recover()` reclaims the
+/// slots of processes that are gone. Opening one per request would strand a new slot on every UI
+/// action, so the session is cached in [`AppState`] under an async mutex that also serializes the
+/// cold open, meaning two concurrent first requests take one slot between them rather than two.
+/// Nothing about the store's locking is relaxed here: the same exclusive session lock is taken,
+/// and every per-entry metadata lock is still acquired inside each operation.
 async fn open_mutable(state: &AppState) -> Result<ResolvedCacheStore, ApiError> {
     let data_dir = state.settings.data_dir.clone();
     if !data_dir.join("models").join("resolved").exists() {
@@ -318,10 +336,16 @@ async fn open_mutable(state: &AppState) -> Result<ResolvedCacheStore, ApiError> 
             "No local model cache exists on this machine.",
         ));
     }
-    tokio::task::spawn_blocking(move || ResolvedCacheStore::open(&data_dir))
+    let mut session = state.resolved_cache_session.lock().await;
+    if let Some(store) = session.as_ref() {
+        return Ok(store.clone());
+    }
+    let store = tokio::task::spawn_blocking(move || ResolvedCacheStore::open(&data_dir))
         .await
         .map_err(|error| ApiError::internal(format!("resolved-cache open task failed: {error}")))?
-        .map_err(cache_error)
+        .map_err(cache_error)?;
+    *session = Some(store.clone());
+    Ok(store)
 }
 
 pub(crate) async fn preview_model_cache_removal(

--- a/apps/rust-api/src/model_cache.rs
+++ b/apps/rust-api/src/model_cache.rs
@@ -1,0 +1,380 @@
+//! Read + control surface for the app-owned resolved-model hot cache (sc-19711).
+//!
+//! Four routes back the Settings storage card and the Model Manager's per-model local-copy
+//! controls:
+//!
+//! * `GET  /api/v1/model-cache` — the effective policy this API process is running under, the
+//!   store's usage accounting, and one row per entry.
+//! * `POST /api/v1/model-cache/removal-preview` — what removing one entry would actually do.
+//! * `POST /api/v1/model-cache/remove` — the manual removal itself.
+//! * `POST /api/v1/model-cache/pin` — "keep locally" / "allow automatic removal".
+//!
+//! Three properties are load-bearing and must survive any edit here:
+//!
+//! 1. **The status read is cheap and write-free.** It is a UI-polled surface, so it does exactly
+//!    one journal listing through [`ResolvedCacheStore::inspect`] — no session slot, no usage
+//!    stamping, and no re-hashing of bundle bytes (that would put gigabytes of I/O behind a poll).
+//!    Byte totals come from the ledger's recorded `verified_bytes`, never from a filesystem walk
+//!    per row. The one filesystem measurement in this module is inside the removal preview, which
+//!    is a single deliberate user action.
+//! 2. **Pin state is reported as the resolver typed it.** `manual_removal_preview` answers with
+//!    [`ManualRemovalPins::Known`] or [`ManualRemovalPins::Unknown`]; the DTO keeps that
+//!    distinction (`pins.known` is absent for `Unknown`) so a UI cannot render "state could not be
+//!    read" as "not pinned".
+//! 3. **Policy is reported, not persisted, here.** The three sidecar processes capture the policy
+//!    from their environment at spawn, so the desktop shell owns the durable copy
+//!    (`set_resolved_cache_policy`). This API reports what it is *actually* running under, which is
+//!    what lets the UI say "restart to apply" honestly instead of claiming a change already landed.
+
+use crate::error::ApiError;
+use crate::AppState;
+use axum::extract::State;
+use axum::Json;
+use sceneworks_core::model_artifacts::resolved_cache::{
+    ManualRemovalPins, ResolvedCacheEntryState, ResolvedCacheEntrySummary, ResolvedCacheError,
+    ResolvedCacheStore, SourceVolumeRelation,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CachePolicyDto {
+    pub(crate) enabled: bool,
+    pub(crate) max_bytes: u64,
+    pub(crate) inactivity_seconds: u64,
+}
+
+/// One resolved-cache entry as the UI sees it. `state` is the store's own typed entry state and is
+/// never re-derived from strings; `pinned` is the *effective* pin (artifact pin OR any model
+/// owner's pin), which is exactly what blocks automatic and manual removal.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CacheEntryDto {
+    pub(crate) cache_key: String,
+    pub(crate) state: ResolvedCacheEntryState,
+    pub(crate) repository: Option<String>,
+    pub(crate) revision: Option<String>,
+    pub(crate) variant: Option<String>,
+    pub(crate) tier: Option<String>,
+    pub(crate) bytes: u64,
+    pub(crate) pinned: bool,
+    pub(crate) artifact_pinned: bool,
+    pub(crate) model_pin_owners: Vec<String>,
+    pub(crate) created_at: Option<u64>,
+    pub(crate) last_used_at: Option<u64>,
+    /// Catalog model ids whose own (non-co-requisite) source repositories include this entry's
+    /// primary repository. Resolved here rather than in the UI so the identity mapping has exactly
+    /// one implementation, and computed from the already-cached catalog snapshot — no filesystem.
+    pub(crate) model_ids: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CacheStatusDto {
+    /// The policy THIS process is running under, captured from its environment at spawn.
+    pub(crate) policy: CachePolicyDto,
+    /// False when no cache store has ever been created under the data directory.
+    pub(crate) initialized: bool,
+    /// Present when the store exists but could not be listed. The UI must say "couldn't read"
+    /// rather than render an empty, reassuring cache.
+    pub(crate) error: Option<String>,
+    pub(crate) used_bytes: u64,
+    pub(crate) pinned_bytes: u64,
+    /// Bytes held by complete, unpinned entries — the ceiling on what automatic cleanup or a
+    /// manual removal could reclaim. Automatic eviction additionally requires a re-verified
+    /// source, so this is an upper bound, not a promise.
+    pub(crate) reclaimable_bytes: u64,
+    pub(crate) entry_count: usize,
+    /// `same` means the local copies live on the same volume as the source library, so they buy
+    /// no disconnect or performance isolation.
+    pub(crate) source_volume_relation: SourceVolumeRelation,
+    pub(crate) source_library_path: PathBuf,
+    pub(crate) entries: Vec<CacheEntryDto>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CacheKeyRequest {
+    pub(crate) cache_key: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CachePinRequest {
+    pub(crate) cache_key: String,
+    pub(crate) pinned: bool,
+}
+
+/// The typed pin answer, preserved. `Unknown` carries no `known` object at all, so a client that
+/// forgets to branch renders nothing rather than rendering "no pins".
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub(crate) enum CachePinsDto {
+    Known {
+        artifact_pinned: bool,
+        owners: Vec<String>,
+    },
+    Unknown,
+}
+
+impl From<ManualRemovalPins> for CachePinsDto {
+    fn from(pins: ManualRemovalPins) -> Self {
+        match pins {
+            ManualRemovalPins::Known {
+                artifact_pinned,
+                owners,
+            } => Self::Known {
+                artifact_pinned,
+                owners,
+            },
+            ManualRemovalPins::Unknown => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RemovalPreviewDto {
+    pub(crate) cache_key: String,
+    pub(crate) state: ResolvedCacheEntryState,
+    /// Measured on disk under the metadata lock — the bytes this removal would actually free.
+    pub(crate) reclaimable_bytes: u64,
+    pub(crate) pins: CachePinsDto,
+    /// Set when the authoritative external source is unreachable or incomplete: removing the local
+    /// copy leaves the model unusable until that source returns. Removal is still allowed.
+    pub(crate) source_unavailable_warning: Option<String>,
+    /// Set when removal would currently be refused, with the refusal reason.
+    pub(crate) blocked: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct RemovalOutcomeDto {
+    pub(crate) cache_key: String,
+    pub(crate) reclaimed_bytes: u64,
+    pub(crate) source_unavailable_warning: Option<String>,
+}
+
+fn cache_error(error: ResolvedCacheError) -> ApiError {
+    ApiError::bad_request(error.to_string())
+}
+
+/// Map every entry's primary repository to the catalog model ids that own it. One pass over the
+/// cached catalog snapshot; no filesystem and no per-entry catalog scan.
+async fn repository_owners(state: &AppState) -> BTreeMap<String, Vec<String>> {
+    // The CACHED snapshot, not `model_catalog`: the join needs identity only, and the live
+    // external-availability refresh is a probe this read has no reason to pay for.
+    let Ok(models) = crate::models::model_catalog_snapshot(state).await else {
+        // The join is a convenience: without it entries still render with their repository. Never
+        // fail the status read because the catalog is momentarily unavailable.
+        return BTreeMap::new();
+    };
+    let mut owners: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for model in models.iter() {
+        let Some(id) = model.get("id").and_then(Value::as_str) else {
+            continue;
+        };
+        for repository in crate::models::owned_source_repositories(model) {
+            owners.entry(repository).or_default().push(id.to_owned());
+        }
+    }
+    for ids in owners.values_mut() {
+        ids.sort();
+        ids.dedup();
+    }
+    owners
+}
+
+fn entry_dto(
+    summary: ResolvedCacheEntrySummary,
+    owners: &BTreeMap<String, Vec<String>>,
+) -> CacheEntryDto {
+    let ResolvedCacheEntrySummary {
+        cache_key,
+        state,
+        metadata,
+    } = summary;
+    let Some(metadata) = metadata else {
+        // Evicting / corrupt residue has no readable identity. It is still listed — a status
+        // surface that hid it would under-report what the cache is holding.
+        return CacheEntryDto {
+            cache_key,
+            state,
+            repository: None,
+            revision: None,
+            variant: None,
+            tier: None,
+            bytes: 0,
+            pinned: false,
+            artifact_pinned: false,
+            model_pin_owners: Vec::new(),
+            created_at: None,
+            last_used_at: None,
+            model_ids: Vec::new(),
+        };
+    };
+    let identity = &metadata.artifact.identity;
+    CacheEntryDto {
+        cache_key,
+        state,
+        model_ids: owners.get(&identity.repository).cloned().unwrap_or_default(),
+        repository: Some(identity.repository.clone()),
+        revision: Some(identity.revision.clone()),
+        variant: Some(identity.variant.clone()),
+        tier: metadata.artifact.provenance.fixed_artifact_tier.clone(),
+        bytes: metadata.verified_bytes,
+        pinned: metadata.effective_pin,
+        artifact_pinned: metadata.artifact_pinned,
+        model_pin_owners: metadata.model_pin_owners.iter().cloned().collect(),
+        created_at: Some(metadata.created_at),
+        last_used_at: metadata.last_used_at,
+    }
+}
+
+pub(crate) async fn get_model_cache(
+    State(state): State<AppState>,
+) -> Result<Json<CacheStatusDto>, ApiError> {
+    let owners = repository_owners(&state).await;
+    let data_dir = state.settings.data_dir.clone();
+    let source_library = sceneworks_core::hf_home::model_source_library(&data_dir)
+        .root()
+        .to_path_buf();
+    let probe_root = source_library.clone();
+    // ONE listing on a blocking thread. Everything below is arithmetic over that listing.
+    let listed = tokio::task::spawn_blocking(move || {
+        let Some(store) = ResolvedCacheStore::open_for_inspection(&data_dir)? else {
+            return Ok::<_, ResolvedCacheError>(None);
+        };
+        let entries = store.inspect()?;
+        let relation = store
+            .compare_source_volume(&probe_root)
+            .map(|observation| observation.relation)
+            .unwrap_or(SourceVolumeRelation::Unknown);
+        Ok(Some((entries, relation)))
+    })
+    .await
+    .map_err(|error| ApiError::internal(format!("resolved-cache status task failed: {error}")))?;
+
+    let policy = CachePolicyDto {
+        enabled: state.settings.resolved_cache.enabled,
+        max_bytes: state.settings.resolved_cache.max_bytes,
+        inactivity_seconds: state.settings.resolved_cache.inactivity_seconds,
+    };
+    let (entries, relation, initialized, error) = match listed {
+        Ok(Some((entries, relation))) => (entries, relation, true, None),
+        Ok(None) => (Vec::new(), SourceVolumeRelation::Unknown, false, None),
+        Err(error) => (
+            Vec::new(),
+            SourceVolumeRelation::Unknown,
+            true,
+            Some(error.to_string()),
+        ),
+    };
+    let entries = entries
+        .into_iter()
+        .map(|summary| entry_dto(summary, &owners))
+        .collect::<Vec<_>>();
+    let used_bytes = entries.iter().map(|entry| entry.bytes).sum();
+    let pinned_bytes = entries
+        .iter()
+        .filter(|entry| entry.pinned)
+        .map(|entry| entry.bytes)
+        .sum();
+    let reclaimable_bytes = entries
+        .iter()
+        .filter(|entry| entry.state == ResolvedCacheEntryState::Complete && !entry.pinned)
+        .map(|entry| entry.bytes)
+        .sum();
+    Ok(Json(CacheStatusDto {
+        policy,
+        initialized,
+        error,
+        used_bytes,
+        pinned_bytes,
+        reclaimable_bytes,
+        entry_count: entries.len(),
+        source_volume_relation: relation,
+        source_library_path: source_library,
+        entries,
+    }))
+}
+
+/// Open the store for a mutating operation. Never creates the cache root as a side effect of a
+/// pin or a removal: with no store there is nothing to act on.
+async fn open_mutable(state: &AppState) -> Result<ResolvedCacheStore, ApiError> {
+    let data_dir = state.settings.data_dir.clone();
+    if !data_dir.join("models").join("resolved").exists() {
+        return Err(ApiError::bad_request(
+            "No local model cache exists on this machine.",
+        ));
+    }
+    tokio::task::spawn_blocking(move || ResolvedCacheStore::open(&data_dir))
+        .await
+        .map_err(|error| ApiError::internal(format!("resolved-cache open task failed: {error}")))?
+        .map_err(cache_error)
+}
+
+pub(crate) async fn preview_model_cache_removal(
+    State(state): State<AppState>,
+    Json(request): Json<CacheKeyRequest>,
+) -> Result<Json<RemovalPreviewDto>, ApiError> {
+    let store = open_mutable(&state).await?;
+    let preview = tokio::task::spawn_blocking(move || store.manual_removal_preview(&request.cache_key))
+        .await
+        .map_err(|error| {
+            ApiError::internal(format!("resolved-cache preview task failed: {error}"))
+        })?
+        .map_err(cache_error)?;
+    Ok(Json(RemovalPreviewDto {
+        cache_key: preview.cache_key,
+        state: preview.state,
+        reclaimable_bytes: preview.reclaimable_bytes,
+        pins: preview.pins.into(),
+        source_unavailable_warning: preview.source_unavailable_warning,
+        blocked: preview.blocked,
+    }))
+}
+
+pub(crate) async fn remove_model_cache_entry(
+    State(state): State<AppState>,
+    Json(request): Json<CacheKeyRequest>,
+) -> Result<Json<RemovalOutcomeDto>, ApiError> {
+    let store = open_mutable(&state).await?;
+    let now = sceneworks_core::time::now_unix_seconds().max(0) as u64;
+    let outcome = tokio::task::spawn_blocking(move || store.remove_entry(&request.cache_key, now))
+        .await
+        .map_err(|error| ApiError::internal(format!("resolved-cache removal task failed: {error}")))?
+        .map_err(cache_error)?;
+    Ok(Json(RemovalOutcomeDto {
+        cache_key: outcome.cache_key,
+        reclaimed_bytes: outcome.reclaimed_bytes,
+        source_unavailable_warning: outcome.source_unavailable_warning,
+    }))
+}
+
+/// "Keep locally" / "Allow automatic removal". This sets the ARTIFACT pin, which is the user's own
+/// intent for this bundle; per-model owner pins are held by running loads and are not the user's to
+/// clear from here.
+pub(crate) async fn set_model_cache_pin(
+    State(state): State<AppState>,
+    Json(request): Json<CachePinRequest>,
+) -> Result<Json<CacheEntryDto>, ApiError> {
+    let store = open_mutable(&state).await?;
+    let metadata =
+        tokio::task::spawn_blocking(move || store.set_artifact_pin(&request.cache_key, request.pinned))
+            .await
+            .map_err(|error| ApiError::internal(format!("resolved-cache pin task failed: {error}")))?
+            .map_err(cache_error)?;
+    let owners = repository_owners(&state).await;
+    Ok(Json(entry_dto(
+        ResolvedCacheEntrySummary {
+            cache_key: metadata.cache_key.clone(),
+            state: metadata.state.clone(),
+            metadata: Some(metadata),
+        },
+        &owners,
+    )))
+}

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -1062,7 +1062,7 @@ pub(crate) async fn create_model_convert_job(
 /// Distinct source repositories a model owns. Co-requisite downloads are excluded: they are
 /// shared dependencies rather than this model's own source, and resolved-cache entries are
 /// selected by *primary* provenance.
-fn owned_source_repositories(model: &Value) -> Vec<String> {
+pub(crate) fn owned_source_repositories(model: &Value) -> Vec<String> {
     let mut repositories = model
         .get("downloads")
         .and_then(Value::as_array)
@@ -2293,7 +2293,7 @@ mod runtime_text_encoder_option_tests {
     }
 }
 
-async fn model_catalog_snapshot(state: &AppState) -> Result<Arc<Vec<Value>>, ApiError> {
+pub(crate) async fn model_catalog_snapshot(state: &AppState) -> Result<Arc<Vec<Value>>, ApiError> {
     {
         let cache_state = state.model_catalog_cache.state.lock();
         if let Some((snapshot_generation, snapshot)) = cache_state.snapshot.as_ref() {

--- a/apps/rust-api/src/server.rs
+++ b/apps/rust-api/src/server.rs
@@ -310,6 +310,18 @@ pub struct AppState {
     pub(crate) workflow_strip_slots: Arc<Semaphore>,
     // sc-8870 (F-068): per-peer-IP failed-token throttle for the auth oracle.
     pub(crate) auth_throttle: Arc<AuthThrottle>,
+    /// The ONE resolved-model cache session this API process holds (sc-19711).
+    ///
+    /// `ResolvedCacheStore::open` takes a session slot — a `sessions/<id>/` directory plus its own
+    /// exclusive lock file — and the store's design is that a slot belongs to a PROCESS for that
+    /// process's lifetime, with dead processes' slots reclaimed by a later `recover()`. Opening a
+    /// store per HTTP request would therefore leave a fresh, permanently-held slot behind on every
+    /// pin, preview and removal the UI performs, and nothing would clear them until a worker next
+    /// recovered. The handle is created lazily on the first mutating request so that a deployment
+    /// which only ever reads status never materializes the cache root as a side effect.
+    pub(crate) resolved_cache_session: Arc<
+        AsyncMutex<Option<sceneworks_core::model_artifacts::resolved_cache::ResolvedCacheStore>>,
+    >,
     pub(crate) manifest_cache: Arc<Mutex<ManifestCache>>,
     pub(crate) manifest_write_locks: Arc<Mutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>>,
     /// One generation-keyed install-state snapshot shared by `/models`, recipe

--- a/apps/rust-api/src/tests/mod.rs
+++ b/apps/rust-api/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod embedded_web;
 mod jobs;
 mod mcp;
 mod media;
+mod model_cache;
 mod projects;
 mod prompt_batches;
 mod recipe_presets;

--- a/apps/rust-api/src/tests/model_cache.rs
+++ b/apps/rust-api/src/tests/model_cache.rs
@@ -1,0 +1,463 @@
+//! Resolved-model hot-cache control surface (sc-19711).
+//!
+//! Every test here drives a REAL materialized cache entry through the REAL store operations —
+//! never a stubbed status shape — because the whole point of the surface is that what the UI shows
+//! and what the resolver would actually do cannot drift apart.
+
+use super::support::*;
+use sceneworks_core::model_artifacts::resolved_cache::{
+    MaterializationCancellation, MaterializationOutcome, ResolvedCacheMaterializer,
+    ResolvedCacheStore,
+};
+use sceneworks_core::model_artifacts::{
+    ArtifactAvailability, ArtifactCompleteness, ArtifactFile, ArtifactIdentity, ArtifactLocation,
+    ArtifactMemberRole, ArtifactProvenance, ArtifactSourceLibrary, PromotionCandidate,
+    ResolvedBundleClosure, ResolvedBundleMember, ResolvedModelArtifact,
+    MODEL_ARTIFACT_CONTRACT_VERSION,
+};
+
+/// The store's own tombstone file name. Writing garbage here is how a journal read fails for a
+/// reason that does NOT prove the entry holds no recoverable state — the exact case whose pin
+/// answer must stay `Unknown` rather than collapsing to "not pinned".
+const EVICTED_MARKER_FILE: &str = "evicted.marker.json";
+
+struct CacheFixture {
+    temp_dir: tempfile::TempDir,
+    store: ResolvedCacheStore,
+    cache_key: String,
+    entry: std::path::PathBuf,
+}
+
+/// Materialize one complete resolved-cache entry for `owner/cached-model` and register a catalog
+/// model that declares the same source repository, so the status route's identity join has
+/// something real to resolve.
+fn cache_fixture(tier: &str) -> CacheFixture {
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let data_dir = temp_dir.path().join("data");
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).expect("manifest dir creates");
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        r#"{ "schemaVersion": 1, "models": [] }"#,
+    )
+    .expect("builtin models writes");
+    std::fs::write(
+        config_dir.join("user.models.jsonc"),
+        format!(
+            r#"{{
+                  "schemaVersion": 1,
+                  "models": [{{
+                    "id": "cached_model",
+                    "name": "Cached Model",
+                    "type": "image",
+                    "family": "z-image",
+                    "downloads": [{{ "repo": "owner/cached-model", "variant": "{tier}" }}]
+                  }}]
+                }}"#
+        ),
+    )
+    .expect("user models writes");
+
+    let revision = "a".repeat(40);
+    let library = sceneworks_core::hf_home::model_source_library(&data_dir)
+        .root()
+        .to_owned();
+    let snapshot = ArtifactSourceLibrary::new(&library)
+        .expect("library root")
+        .repository_root("owner/cached-model")
+        .expect("repository root")
+        .join("snapshots")
+        .join(&revision);
+    std::fs::create_dir_all(&snapshot).expect("snapshot dir creates");
+    std::fs::write(snapshot.join("model.safetensors"), b"weights-0123456789")
+        .expect("weights write");
+    let identity =
+        ArtifactIdentity::pinned("owner/cached-model", &revision, "default").expect("identity");
+    let closure = ResolvedBundleClosure::new(vec![ResolvedBundleMember {
+        role: ArtifactMemberRole::Primary,
+        component_id: None,
+        source: identity.clone(),
+        tier: Some(tier.to_owned()),
+        source_subpath: std::path::PathBuf::new(),
+        destination: std::path::PathBuf::new(),
+        files: vec![ArtifactFile::new("model.safetensors").expect("file")],
+    }])
+    .expect("closure");
+    let artifact = ResolvedModelArtifact {
+        schema_version: MODEL_ARTIFACT_CONTRACT_VERSION,
+        identity: identity.clone(),
+        location: ArtifactLocation::SourceLibrary { root: snapshot },
+        closure,
+        provenance: ArtifactProvenance {
+            identity,
+            fixed_artifact_tier: Some(tier.to_owned()),
+        },
+        completeness: ArtifactCompleteness::Complete,
+        availability: ArtifactAvailability::Available,
+    };
+    let candidate = PromotionCandidate {
+        cache_key: artifact.cache_key().expect("cache key"),
+        artifact,
+    };
+    let store = ResolvedCacheStore::open(&data_dir).expect("store opens");
+    let entry = store.entry_path(&candidate.cache_key).expect("entry path");
+    match ResolvedCacheMaterializer::new(store.clone())
+        .materialize(
+            &candidate,
+            &library,
+            "test:cached_model",
+            &MaterializationCancellation::default(),
+        )
+        .expect("materialization runs")
+    {
+        MaterializationOutcome::Published(_) => {}
+        other => panic!("fixture must publish, got {other:?}"),
+    }
+    assert!(entry.join("bundle").join("model.safetensors").is_file());
+    CacheFixture {
+        temp_dir,
+        store,
+        cache_key: candidate.cache_key,
+        entry,
+    }
+}
+
+fn entry_for<'a>(body: &'a Value, cache_key: &str) -> &'a Value {
+    body["entries"]
+        .as_array()
+        .expect("entries is an array")
+        .iter()
+        .find(|entry| entry["cacheKey"] == json!(cache_key))
+        .expect("the materialized entry is listed")
+}
+
+/// The walking skeleton: a real entry is listed with its typed state, joined to the catalog model
+/// that owns its repository, previewed with real measured bytes, and then removed through the real
+/// `remove_entry`. Byte accounting must agree between the ledger listing and the removal.
+#[tokio::test]
+async fn status_lists_a_real_entry_and_removal_runs_through_the_real_preview() {
+    let fixture = cache_fixture("q8");
+
+    let (status, body) = request(
+        create_app(test_settings(&fixture.temp_dir)).expect("app creates"),
+        "GET",
+        "/api/v1/model-cache",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["initialized"], json!(true));
+    assert_eq!(body["error"], Value::Null);
+    assert_eq!(body["entryCount"], json!(1));
+    let listed = entry_for(&body, &fixture.cache_key);
+    assert_eq!(listed["state"], json!("complete"));
+    assert_eq!(listed["repository"], json!("owner/cached-model"));
+    assert_eq!(listed["tier"], json!("q8"));
+    assert_eq!(listed["pinned"], json!(false));
+    assert_eq!(
+        listed["modelIds"],
+        json!(["cached_model"]),
+        "the identity join belongs to the backend, not to the UI"
+    );
+    let ledger_bytes = listed["bytes"].as_u64().expect("entry bytes");
+    assert!(ledger_bytes > 0);
+    assert_eq!(body["usedBytes"], json!(ledger_bytes));
+    assert_eq!(
+        body["reclaimableBytes"],
+        json!(ledger_bytes),
+        "a complete unpinned entry is reclaimable in full"
+    );
+    assert_eq!(body["pinnedBytes"], json!(0));
+
+    let (status, preview) = request(
+        create_app(test_settings(&fixture.temp_dir)).expect("app creates"),
+        "POST",
+        "/api/v1/model-cache/removal-preview",
+        json!({ "cacheKey": fixture.cache_key }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(preview["blocked"], Value::Null);
+    assert_eq!(preview["pins"]["kind"], json!("known"));
+    assert_eq!(preview["pins"]["artifactPinned"], json!(false));
+    assert_eq!(preview["pins"]["owners"], json!([]));
+    assert_eq!(
+        preview["sourceUnavailableWarning"],
+        Value::Null,
+        "the source library is present, so removal costs nothing but re-materialization"
+    );
+    let previewed_bytes = preview["reclaimableBytes"].as_u64().expect("preview bytes");
+    assert!(previewed_bytes >= ledger_bytes);
+
+    let (status, outcome) = request(
+        create_app(test_settings(&fixture.temp_dir)).expect("app creates"),
+        "POST",
+        "/api/v1/model-cache/remove",
+        json!({ "cacheKey": fixture.cache_key }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(outcome["reclaimedBytes"], json!(previewed_bytes));
+    assert!(
+        !fixture.entry.exists(),
+        "removal must go through the real store operation, not just report success"
+    );
+    assert!(fixture
+        .store
+        .lookup_complete(&fixture.cache_key)
+        .expect("lookup succeeds")
+        .is_none());
+}
+
+/// Pinning is the "Keep locally" control. It must round-trip through the store AND change what the
+/// removal preview says, so the UI can disable the destructive action for the right reason.
+#[tokio::test]
+async fn pinning_blocks_removal_and_moves_bytes_out_of_the_reclaimable_total() {
+    let fixture = cache_fixture("q4");
+
+    let (status, pinned) = request(
+        create_app(test_settings(&fixture.temp_dir)).expect("app creates"),
+        "POST",
+        "/api/v1/model-cache/pin",
+        json!({ "cacheKey": fixture.cache_key, "pinned": true }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(pinned["pinned"], json!(true));
+    assert_eq!(pinned["artifactPinned"], json!(true));
+    assert!(fixture
+        .store
+        .effective_pin(&fixture.cache_key)
+        .expect("pin reads back"));
+
+    let (_, body) = request(
+        create_app(test_settings(&fixture.temp_dir)).expect("app creates"),
+        "GET",
+        "/api/v1/model-cache",
+        Value::Null,
+    )
+    .await;
+    let bytes = entry_for(&body, &fixture.cache_key)["bytes"]
+        .as_u64()
+        .expect("entry bytes");
+    assert_eq!(body["pinnedBytes"], json!(bytes));
+    assert_eq!(
+        body["reclaimableBytes"],
+        json!(0),
+        "a pinned entry must never be counted as space the app can reclaim"
+    );
+
+    let (status, preview) = request(
+        create_app(test_settings(&fixture.temp_dir)).expect("app creates"),
+        "POST",
+        "/api/v1/model-cache/removal-preview",
+        json!({ "cacheKey": fixture.cache_key }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(preview["blocked"]
+        .as_str()
+        .expect("a pinned entry is blocked")
+        .contains("pinned"));
+    assert_eq!(preview["pins"]["artifactPinned"], json!(true));
+
+    // Unpinning re-opens the action, and the entry is genuinely removable afterwards.
+    let (status, unpinned) = request(
+        create_app(test_settings(&fixture.temp_dir)).expect("app creates"),
+        "POST",
+        "/api/v1/model-cache/pin",
+        json!({ "cacheKey": fixture.cache_key, "pinned": false }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(unpinned["pinned"], json!(false));
+    let (status, _) = request(
+        create_app(test_settings(&fixture.temp_dir)).expect("app creates"),
+        "POST",
+        "/api/v1/model-cache/remove",
+        json!({ "cacheKey": fixture.cache_key }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(!fixture.entry.exists());
+}
+
+/// An entry whose state cannot be read must reach the UI as `unknown` pins with a refusal — never
+/// as "no pins". Collapsing the two would present a possibly-pinned entry as freely removable.
+#[tokio::test]
+async fn an_unreadable_entry_previews_unknown_pins_rather_than_no_pins() {
+    let fixture = cache_fixture("q8");
+    fixture
+        .store
+        .set_artifact_pin(&fixture.cache_key, true)
+        .expect("pin applies");
+    // A plain regular file, so the entry stays measurable: the refusal has to come from the unknown
+    // pin state itself rather than from an incidental measurement failure.
+    std::fs::write(
+        fixture.entry.join(EVICTED_MARKER_FILE),
+        b"garbage-tombstone",
+    )
+    .expect("tombstone writes");
+
+    let (status, preview) = request(
+        create_app(test_settings(&fixture.temp_dir)).expect("app creates"),
+        "POST",
+        "/api/v1/model-cache/removal-preview",
+        json!({ "cacheKey": fixture.cache_key }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(preview["pins"]["kind"], json!("unknown"));
+    assert_eq!(
+        preview["pins"]["artifactPinned"],
+        Value::Null,
+        "the Unknown arm must carry no pin fields a client could misread as 'false'"
+    );
+    assert!(preview["reclaimableBytes"].as_u64().expect("bytes") > 0);
+    assert!(preview["blocked"]
+        .as_str()
+        .expect("an unreadable entry is blocked")
+        .contains("cannot be read"));
+
+    let (status, _) = request(
+        create_app(test_settings(&fixture.temp_dir)).expect("app creates"),
+        "POST",
+        "/api/v1/model-cache/remove",
+        json!({ "cacheKey": fixture.cache_key }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(fixture
+        .entry
+        .join("bundle")
+        .join("model.safetensors")
+        .is_file());
+}
+
+/// A damaged entry must still be LISTED (labelled corrupt) rather than erasing the whole status
+/// read: a status surface that reports an empty cache while bytes sit on disk is worse than one
+/// that names the damage.
+#[tokio::test]
+async fn a_damaged_entry_is_labelled_instead_of_blanking_the_listing() {
+    let fixture = cache_fixture("q8");
+    // A bundle whose bytes no longer match the closure. The store falls back to the last journal
+    // generation it can still prove, so the entry stops being `complete` — what matters here is
+    // that it is still LISTED and stops counting as space the app can reclaim.
+    std::fs::write(
+        fixture.entry.join("bundle").join("model.safetensors"),
+        b"tampered",
+    )
+    .expect("bundle tamper writes");
+
+    let (status, body) = request(
+        create_app(test_settings(&fixture.temp_dir)).expect("app creates"),
+        "GET",
+        "/api/v1/model-cache",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["error"], Value::Null);
+    assert_eq!(body["entryCount"], json!(1));
+    assert_ne!(
+        body["entries"][0]["state"],
+        json!("complete"),
+        "a bundle that no longer matches its closure must not read as a complete local copy"
+    );
+    assert_eq!(body["reclaimableBytes"], json!(0));
+
+    // Residue whose journal cannot be read at all is labelled `corrupt` — and one damaged entry
+    // must not take the rest of the listing (or the byte accounting) down with it.
+    for slot in 0..=1 {
+        std::fs::write(
+            fixture.entry.join(format!("metadata.{slot}.json")),
+            b"not-json",
+        )
+        .expect("journal garbage writes");
+    }
+    let (status, body) = request(
+        create_app(test_settings(&fixture.temp_dir)).expect("app creates"),
+        "GET",
+        "/api/v1/model-cache",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["error"], Value::Null);
+    assert_eq!(body["entryCount"], json!(1));
+    assert_eq!(body["entries"][0]["state"], json!("corrupt"));
+    assert_eq!(body["entries"][0]["repository"], Value::Null);
+    assert_eq!(body["usedBytes"], json!(0));
+}
+
+/// With no cache ever created, the status read must report an empty, uninitialized cache without
+/// creating the store as a side effect — and the mutating routes must refuse rather than create it.
+#[tokio::test]
+async fn an_uninitialized_cache_reports_empty_and_never_creates_the_store() {
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    std::fs::create_dir_all(temp_dir.path().join("config/manifests")).expect("config dir creates");
+
+    let (status, body) = request(
+        create_app(test_settings(&temp_dir)).expect("app creates"),
+        "GET",
+        "/api/v1/model-cache",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["initialized"], json!(false));
+    assert_eq!(body["entryCount"], json!(0));
+    assert_eq!(body["usedBytes"], json!(0));
+    assert_eq!(body["policy"]["enabled"], json!(false));
+
+    let (status, _) = request(
+        create_app(test_settings(&temp_dir)).expect("app creates"),
+        "POST",
+        "/api/v1/model-cache/pin",
+        json!({ "cacheKey": format!("sha256:{}", "b".repeat(64)), "pinned": true }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        !temp_dir
+            .path()
+            .join("data")
+            .join("models")
+            .join("resolved")
+            .exists(),
+        "a refused control must not materialize a cache root"
+    );
+}
+
+/// The effective policy the API reports is the one THIS process is running under, so the UI can
+/// tell a persisted-but-not-yet-applied setting from a live one.
+#[tokio::test]
+async fn status_reports_the_policy_this_process_is_running_under() {
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    std::fs::create_dir_all(temp_dir.path().join("config/manifests")).expect("config dir creates");
+    let mut settings = test_settings(&temp_dir);
+    settings.resolved_cache =
+        sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy {
+            enabled: true,
+            max_bytes: 32 * 1024 * 1024 * 1024,
+            inactivity_seconds: 7 * 24 * 60 * 60,
+        };
+
+    let (status, body) = request(
+        create_app(settings).expect("app creates"),
+        "GET",
+        "/api/v1/model-cache",
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["policy"]["enabled"], json!(true));
+    assert_eq!(
+        body["policy"]["maxBytes"],
+        json!(32 * 1024 * 1024 * 1024_u64)
+    );
+    assert_eq!(body["policy"]["inactivitySeconds"], json!(604_800));
+}

--- a/apps/rust-api/src/tests/model_cache.rs
+++ b/apps/rust-api/src/tests/model_cache.rs
@@ -150,6 +150,29 @@ async fn status_lists_a_real_entry_and_removal_runs_through_the_real_preview() {
     assert_eq!(body["initialized"], json!(true));
     assert_eq!(body["error"], Value::Null);
     assert_eq!(body["entryCount"], json!(1));
+    // The store→API isolation seam. The fixture puts the data directory and the source library
+    // under one temp root, so they genuinely share a volume and the local copies buy no disconnect
+    // or performance isolation at all — "a same-volume configuration clearly reports no isolation"
+    // is an acceptance criterion, and it is asserted HERE because the web suite mocks this field.
+    // Without this, `compare_source_volume` could be replaced by a hardcoded `Unknown` and every
+    // endpoint test would stay green.
+    assert_eq!(
+        body["sourceVolumeRelation"],
+        json!("same"),
+        "the fixture's cache and source library share a volume; the API must say so rather than \
+         reporting an unknown relation the UI would render as no warning at all"
+    );
+    // The configured external library location, so the UI can name the location the same-volume
+    // warning is about instead of telling the user to move "the model library" they can't find.
+    let configured_library =
+        sceneworks_core::hf_home::model_source_library(&fixture.temp_dir.path().join("data"))
+            .root()
+            .to_path_buf();
+    assert_eq!(
+        body["sourceLibraryPath"],
+        json!(configured_library),
+        "the status read must report the library location it actually compared against"
+    );
     let listed = entry_for(&body, &fixture.cache_key);
     assert_eq!(listed["state"], json!("complete"));
     assert_eq!(listed["repository"], json!("owner/cached-model"));
@@ -320,6 +343,9 @@ async fn an_unreadable_entry_previews_unknown_pins_rather_than_no_pins() {
         .expect("an unreadable entry is blocked")
         .contains("cannot be read"));
 
+    // The removal fails CLOSED, and it does so because the entry's own stored state is damaged —
+    // an unreadable tombstone is the host's problem, not a badly-formed request. So this is a 500:
+    // the store could not answer, which is a different thing from the store declining to.
     let (status, _) = request(
         create_app(test_settings(&fixture.temp_dir)).expect("app creates"),
         "POST",
@@ -327,7 +353,7 @@ async fn an_unreadable_entry_previews_unknown_pins_rather_than_no_pins() {
         json!({ "cacheKey": fixture.cache_key }),
     )
     .await;
-    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
     assert!(fixture
         .entry
         .join("bundle")
@@ -428,6 +454,168 @@ async fn an_uninitialized_cache_reports_empty_and_never_creates_the_store() {
             .join("resolved")
             .exists(),
         "a refused control must not materialize a cache root"
+    );
+}
+
+/// Session slots a store handed out, by directory name. `ResolvedCacheStore::open` creates one
+/// `sessions/<id>/` per handle and holds its lock for the handle's life; only a later `recover()`
+/// reclaims the slots of processes that are gone.
+fn session_slots(store: &ResolvedCacheStore) -> Vec<String> {
+    let mut slots = std::fs::read_dir(store.root().join("sessions"))
+        .expect("sessions dir reads")
+        .filter_map(|item| {
+            let item = item.expect("session entry reads");
+            item.file_type()
+                .expect("session file type")
+                .is_dir()
+                .then(|| item.file_name().to_string_lossy().into_owned())
+        })
+        .collect::<Vec<_>>();
+    slots.sort();
+    slots
+}
+
+/// Every control POST goes through ONE session for the API process, not one per request.
+///
+/// `ResolvedCacheStore::open` claims a session slot and holds its exclusive lock for the handle's
+/// lifetime; the store's design is that a slot belongs to a process, and stale slots are reclaimed
+/// by a later `recover()`. An API that opened a store per request would therefore strand a fresh
+/// directory and lock file on every keep/preview/remove the UI performs — debris that accumulates
+/// for as long as the app runs. Driving the SAME router (and therefore the same `AppState`) across
+/// several actions is what makes that visible.
+#[tokio::test]
+async fn control_actions_share_one_cache_session_for_the_api_process() {
+    let fixture = cache_fixture("q8");
+    let fixture_slots = session_slots(&fixture.store);
+    assert_eq!(
+        fixture_slots.len(),
+        1,
+        "the fixture's own store holds exactly one session"
+    );
+
+    let app = create_app(test_settings(&fixture.temp_dir)).expect("app creates");
+    for pinned in [true, false] {
+        let (status, _) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/model-cache/pin",
+            json!({ "cacheKey": fixture.cache_key, "pinned": pinned }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let (status, _) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/model-cache/removal-preview",
+            json!({ "cacheKey": fixture.cache_key }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+    }
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/model-cache/remove",
+        json!({ "cacheKey": fixture.cache_key }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let slots = session_slots(&fixture.store);
+    assert_eq!(
+        slots.len(),
+        fixture_slots.len() + 1,
+        "five control actions must leave ONE api session behind, not one per request; found {slots:?}"
+    );
+    // And it is a genuine, still-locked runtime session rather than a slot the API deleted behind
+    // itself: the whole point is that the store's session semantics are unchanged, only reused.
+    let api_slot = slots
+        .iter()
+        .find(|slot| !fixture_slots.contains(slot))
+        .expect("the api session slot exists");
+    assert!(
+        fixture
+            .store
+            .root()
+            .join("sessions")
+            .join(format!("{api_slot}.lock"))
+            .is_file(),
+        "the api session must still hold its own session lock file"
+    );
+}
+
+/// A store fault is a 500 and a caller's mistake is a 400. Reporting every failure as a client
+/// error tells an operator to fix their request when the machine is what is broken, and hides a
+/// real fault from anything watching 5xx rates.
+#[tokio::test]
+async fn store_faults_answer_500_while_a_bad_request_stays_a_client_error() {
+    let fixture = cache_fixture("q8");
+    let app = create_app(test_settings(&fixture.temp_dir)).expect("app creates");
+
+    // Caller's mistake #1: a key that is not a cache key at all.
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/model-cache/removal-preview",
+        json!({ "cacheKey": "not-a-cache-key" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(body["detail"].as_str().expect("detail").contains("sha256:"));
+
+    // Caller's mistake #2: a well-formed key for an entry this store does not hold.
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/model-cache/pin",
+        json!({ "cacheKey": format!("sha256:{}", "c".repeat(64)), "pinned": true }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+
+    // Caller's mistake #3: a refusal from an intact store. The entry is pinned, so removal is
+    // declined — nothing is broken, and the reply tells the caller what to change. This is the
+    // guard against over-correcting: an implementation that answered 500 for every store `Err`
+    // would turn ordinary refusals into fake server faults.
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/model-cache/pin",
+        json!({ "cacheKey": fixture.cache_key, "pinned": true }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/model-cache/remove",
+        json!({ "cacheKey": fixture.cache_key }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(body["detail"].as_str().expect("detail").contains("pinned"));
+
+    // Now a genuine store fault on a key the caller named correctly: both journal slots are
+    // unreadable, so the store cannot answer at all. Nothing about the request is wrong, and a
+    // 4xx here would send an operator to fix their request while real damage sits on the host.
+    for slot in 0..=1 {
+        std::fs::write(
+            fixture.entry.join(format!("metadata.{slot}.json")),
+            b"not-json",
+        )
+        .expect("journal garbage writes");
+    }
+    let (status, _) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/model-cache/pin",
+        json!({ "cacheKey": fixture.cache_key, "pinned": false }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "a damaged journal is the host's fault, not the caller's"
     );
 }
 

--- a/apps/web/src/hooks/useCacheConvergence.js
+++ b/apps/web/src/hooks/useCacheConvergence.js
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import {
+  CACHE_CONVERGENCE_POLL_MS,
+  MAX_CACHE_CONVERGENCE_POLLS,
+  hasTransitionalEntries,
+} from "../modelCache.js";
+
+// The bounded convergence refresh for the resolved-model hot cache (sc-19711, epic 19703).
+//
+// Both cache surfaces — the Settings storage card and the Model Manager's per-model local-copy
+// blocks — need the same behaviour, so it lives here ONCE rather than as two copies that can drift
+// into disagreeing about when the app stops polling.
+//
+// Three properties are the whole point:
+//
+// 1. **It runs only while the store is actually working.** The status read is one journal listing,
+//    proportional to the number of cached bundles; an unconditional timer over it would put back
+//    exactly the per-row read cost sc-19708 took off these screens. A settled cache is read once.
+// 2. **It is BOUNDED.** An entry that never converges — a worker that died mid-copy — must not
+//    leave a screen re-reading for the life of the session. After `MAX_CACHE_CONVERGENCE_POLLS`
+//    consecutive refreshes with something still in flight, it gives up and reports `stalled`, so
+//    the caller can say so instead of leaving a "checking…" line that stopped meaning anything.
+// 3. **It resets.** The spend counter clears the moment every entry is terminal, so a promotion
+//    that starts later gets a fresh budget rather than inheriting an exhausted one.
+//
+// `refresh` must be referentially stable (a `useCallback`); it is a dependency of the timer effect.
+export function useCacheConvergence(status, refresh) {
+  const [polls, setPolls] = useState(0);
+  const converging = hasTransitionalEntries(status);
+
+  useEffect(() => {
+    if (!converging) {
+      setPolls(0);
+      return undefined;
+    }
+    if (polls >= MAX_CACHE_CONVERGENCE_POLLS) return undefined;
+    const timer = setTimeout(() => {
+      setPolls((spent) => spent + 1);
+      refresh();
+    }, CACHE_CONVERGENCE_POLL_MS);
+    return () => clearTimeout(timer);
+  }, [converging, polls, refresh]);
+
+  return {
+    // Something is still in flight, whether or not this hook is still watching it.
+    converging,
+    // Still in flight, but nothing is re-reading any more.
+    stalled: converging && polls >= MAX_CACHE_CONVERGENCE_POLLS,
+  };
+}

--- a/apps/web/src/modelCache.js
+++ b/apps/web/src/modelCache.js
@@ -166,9 +166,14 @@ export function describeDisableConsequence(status) {
     return "No local copies exist yet, so turning this off changes nothing on disk.";
   }
   const used = formatBytes(status?.usedBytes ?? 0);
+  const one = count === 1;
   return `SceneWorks stops making new local copies. The ${count} existing ${
-    count === 1 ? "copy" : "copies"
-  } (${used}) stay on disk — remove them per model in Model Manager, or turn this back on and let automatic cleanup reclaim them.`;
+    one ? "copy" : "copies"
+  } (${used}) ${one ? "stays" : "stay"} on disk — remove ${
+    one ? "it" : "them"
+  } per model in Model Manager, or turn this back on and let automatic cleanup reclaim ${
+    one ? "it" : "them"
+  }.`;
 }
 
 // What LOWERING the size limit would actually mean. Nothing is swept at the moment of the change:

--- a/apps/web/src/modelCache.js
+++ b/apps/web/src/modelCache.js
@@ -85,6 +85,102 @@ export function canHoldLocalCopy(model) {
   );
 }
 
+// ---- entry states ----------------------------------------------------------------
+
+// The store's typed entry states (`ResolvedCacheEntryState`), verbatim. Nothing here invents a
+// state or re-derives one; this module only says what each one MEANS to a person.
+export const CACHE_ENTRY_STATE = {
+  PENDING: "pending",
+  MATERIALIZING: "materializing",
+  INTERRUPTED: "interrupted",
+  COMPLETE: "complete",
+  CORRUPT: "corrupt",
+  EVICTING: "evicting",
+};
+
+// The states the store is still moving on its own. A screen showing one of these has to keep
+// looking, because the entry it is describing will change without any user action.
+const TRANSITIONAL_STATES = new Set([
+  CACHE_ENTRY_STATE.PENDING,
+  CACHE_ENTRY_STATE.MATERIALIZING,
+  CACHE_ENTRY_STATE.EVICTING,
+]);
+
+export function isTransitionalEntry(entry) {
+  return TRANSITIONAL_STATES.has(entry?.state);
+}
+
+// The bounded convergence refresh both cache surfaces run, defined once so they cannot drift.
+//
+// The cadence is slow on purpose: a status read is one journal listing, and materializing a
+// multi-GB bundle takes minutes, so a faster poll would buy nothing but load. The cap is what
+// makes it BOUNDED — after this many consecutive refreshes with an entry still in flight, the
+// screen stops re-reading rather than polling forever behind a user who has walked away.
+export const CACHE_CONVERGENCE_POLL_MS = 3000;
+export const MAX_CACHE_CONVERGENCE_POLLS = 40;
+
+// True when the snapshot contains at least one entry the store is still working on — the condition
+// under which a screen must re-read rather than freeze on what it first saw.
+export function hasTransitionalEntries(status) {
+  return Array.isArray(status?.entries) && status.entries.some(isTransitionalEntry);
+}
+
+// What one entry's state means, and what — if anything — the person should do about it.
+//
+// `progress` marks the states that resolve on their own, so the screen keeps refreshing.
+// `failure` marks the states nothing will fix by itself: those get an ACTIONABLE sentence naming
+// the remedy, because a bare "interrupted" tells a user neither whether the model still works nor
+// what to press. An unrecognized state is labelled as unrecognized rather than being folded into a
+// reassuring one — the same rule the availability badge follows.
+export function describeEntryState(entry) {
+  switch (entry?.state) {
+    case CACHE_ENTRY_STATE.COMPLETE:
+      return {
+        progress: false,
+        failure: false,
+        text: entry.pinned
+          ? "Kept — never removed automatically"
+          : "Can be removed automatically when space is needed",
+      };
+    case CACHE_ENTRY_STATE.PENDING:
+      return {
+        progress: true,
+        failure: false,
+        text: "Queued — SceneWorks is about to copy this model.",
+      };
+    case CACHE_ENTRY_STATE.MATERIALIZING:
+      return {
+        progress: true,
+        failure: false,
+        text: "Copying now — this becomes usable when the copy finishes.",
+      };
+    case CACHE_ENTRY_STATE.EVICTING:
+      return {
+        progress: true,
+        failure: false,
+        text: "Removing now — SceneWorks is reclaiming this copy's space.",
+      };
+    case CACHE_ENTRY_STATE.INTERRUPTED:
+      return {
+        progress: false,
+        failure: true,
+        text: "The copy stopped before it finished, so it can't be used. SceneWorks starts it again the next time it loads this model — or remove it now to reclaim the space.",
+      };
+    case CACHE_ENTRY_STATE.CORRUPT:
+      return {
+        progress: false,
+        failure: true,
+        text: "This copy is damaged and can't be used or repaired. Remove it to reclaim the space; the model still loads from its own library.",
+      };
+    default:
+      return {
+        progress: false,
+        failure: true,
+        text: `This build doesn’t recognize the state “${entry?.state}”, so it can’t say whether this copy is usable. Removing it is safe — the original files aren’t touched.`,
+      };
+  }
+}
+
 // ---- transport ------------------------------------------------------------------
 
 export function fetchModelCache() {

--- a/apps/web/src/modelCache.js
+++ b/apps/web/src/modelCache.js
@@ -1,0 +1,249 @@
+// Resolved-model hot cache — client seam for the Settings storage card and the Model Manager's
+// per-model local-copy controls (sc-19711).
+//
+// Two rules this module exists to enforce, and which every consumer inherits:
+//
+// 1. **Availability is read, never re-derived.** `modelAvailability` is the typed judgement the
+//    ONE shared resolver produced (sc-19708). Nothing here inspects install paths, counts files,
+//    or matches on error text to guess a state; an unrecognized value renders as "unknown" rather
+//    than being coerced into a reassuring one.
+// 2. **A removal is described from the backend's own preview.** The confirm copy is built from
+//    `manual_removal_preview` — measured bytes, the typed pin answer, the source-availability
+//    warning and the refusal reason — so the dialog cannot promise something the store would then
+//    refuse. `pins.kind === "unknown"` is surfaced as "can't determine", never as "not pinned".
+import { apiFetch } from "./api.js";
+import { readAccessToken } from "./accessToken.js";
+import { formatBytes } from "./formatting.js";
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+const BYTES_PER_GIB = 1024 * 1024 * 1024;
+
+// The typed availability states from `ModelAvailability` (sc-19708), verbatim. The value is the
+// wire form; nothing else in the UI may invent a sixth state.
+export const MODEL_AVAILABILITY = {
+  LOCAL_READY: "local_ready",
+  EXTERNAL_READY: "external_ready",
+  INSTALLED_EXTERNAL_UNAVAILABLE: "installed_external_unavailable",
+  INCOMPLETE: "incomplete",
+  MISSING: "missing",
+};
+
+// One badge per typed state. `tone` maps onto the screen's existing `.status-badge` modifiers, so
+// this introduces no new visual idiom.
+const AVAILABILITY_BADGES = {
+  [MODEL_AVAILABILITY.LOCAL_READY]: {
+    text: "local copy",
+    tone: "installed",
+    title: "A SceneWorks-owned copy is on this machine, so this model loads even if the external library is disconnected.",
+  },
+  [MODEL_AVAILABILITY.EXTERNAL_READY]: {
+    text: "on external library",
+    tone: "",
+    title: "Installed on the configured external model library, which is currently connected.",
+  },
+  [MODEL_AVAILABILITY.INSTALLED_EXTERNAL_UNAVAILABLE]: {
+    text: "library disconnected",
+    tone: "warning",
+    title: "This model is installed on an external library that isn't reachable right now. The installation is preserved; reconnect the library to use it.",
+  },
+  [MODEL_AVAILABILITY.INCOMPLETE]: {
+    text: "incomplete",
+    tone: "warning",
+    title: "Some required files are missing from the installation.",
+  },
+  [MODEL_AVAILABILITY.MISSING]: {
+    text: "not installed",
+    tone: "",
+    title: "No installation of this model was found.",
+  },
+};
+
+// The badge for a catalog row's typed availability, or null when the row carries no judgement at
+// all. An UNRECOGNIZED value is deliberately labelled rather than silently dropped or defaulted:
+// a state this build doesn't know about must not read as "fine".
+export function availabilityBadge(model) {
+  const availability = model?.modelAvailability;
+  if (typeof availability !== "string" || availability === "") {
+    return null;
+  }
+  return (
+    AVAILABILITY_BADGES[availability] ?? {
+      text: "unknown state",
+      tone: "warning",
+      title: `This build doesn't recognize the availability state "${availability}".`,
+    }
+  );
+}
+
+// True only where a local copy can exist at all: the resolved cache holds copies of models whose
+// authoritative source is an external library.
+export function canHoldLocalCopy(model) {
+  return (
+    model?.modelAvailability === MODEL_AVAILABILITY.LOCAL_READY ||
+    model?.modelAvailability === MODEL_AVAILABILITY.EXTERNAL_READY ||
+    model?.modelAvailability === MODEL_AVAILABILITY.INSTALLED_EXTERNAL_UNAVAILABLE
+  );
+}
+
+// ---- transport ------------------------------------------------------------------
+
+export function fetchModelCache() {
+  return apiFetch("/api/v1/model-cache", readAccessToken());
+}
+
+export function previewCacheRemoval(cacheKey) {
+  return apiFetch("/api/v1/model-cache/removal-preview", readAccessToken(), {
+    method: "POST",
+    body: JSON.stringify({ cacheKey }),
+  });
+}
+
+export function removeCacheEntry(cacheKey) {
+  return apiFetch("/api/v1/model-cache/remove", readAccessToken(), {
+    method: "POST",
+    body: JSON.stringify({ cacheKey }),
+  });
+}
+
+export function setCacheEntryPin(cacheKey, pinned) {
+  return apiFetch("/api/v1/model-cache/pin", readAccessToken(), {
+    method: "POST",
+    body: JSON.stringify({ cacheKey, pinned }),
+  });
+}
+
+// ---- projections ----------------------------------------------------------------
+
+// The cache entries the backend joined to this model id. The join lives in the API (one identity
+// mapping); the UI only indexes it.
+export function entriesForModel(status, modelId) {
+  if (!modelId || !Array.isArray(status?.entries)) {
+    return [];
+  }
+  return status.entries.filter(
+    (entry) => Array.isArray(entry.modelIds) && entry.modelIds.includes(modelId),
+  );
+}
+
+export function gibToBytes(gib) {
+  const value = Number(gib);
+  return Number.isFinite(value) && value > 0 ? Math.round(value * BYTES_PER_GIB) : 0;
+}
+
+export function bytesToGib(bytes) {
+  const value = Number(bytes);
+  return Number.isFinite(value) && value > 0 ? value / BYTES_PER_GIB : 0;
+}
+
+export function daysToSeconds(days) {
+  const value = Number(days);
+  return Number.isFinite(value) && value > 0 ? Math.round(value * SECONDS_PER_DAY) : 0;
+}
+
+export function secondsToDays(seconds) {
+  const value = Number(seconds);
+  return Number.isFinite(value) && value > 0 ? value / SECONDS_PER_DAY : 0;
+}
+
+// True when the persisted policy the shell holds differs from the policy the running API captured
+// at spawn — i.e. the change is saved but not yet in effect.
+export function policyNeedsRestart(persisted, effective) {
+  if (!persisted || !effective) {
+    return false;
+  }
+  return (
+    Boolean(persisted.enabled) !== Boolean(effective.enabled) ||
+    Number(persisted.maxBytes) !== Number(effective.maxBytes) ||
+    Number(persisted.inactivitySeconds) !== Number(effective.inactivitySeconds)
+  );
+}
+
+// What turning the cache OFF would actually mean. Disabling stops new copies; it does not sweep,
+// and saying otherwise would be a claim the backend never makes.
+export function describeDisableConsequence(status) {
+  const count = Number(status?.entryCount) || 0;
+  if (count === 0) {
+    return "No local copies exist yet, so turning this off changes nothing on disk.";
+  }
+  const used = formatBytes(status?.usedBytes ?? 0);
+  return `SceneWorks stops making new local copies. The ${count} existing ${
+    count === 1 ? "copy" : "copies"
+  } (${used}) stay on disk — remove them per model in Model Manager, or turn this back on and let automatic cleanup reclaim them.`;
+}
+
+// What LOWERING the size limit would actually mean. Nothing is swept at the moment of the change:
+// automatic cleanup runs on the worker's own idle checkpoints, and pinned or in-use copies are
+// never taken.
+export function describeLimitConsequence(status, nextMaxBytes) {
+  const used = Number(status?.usedBytes) || 0;
+  const reclaimable = Number(status?.reclaimableBytes) || 0;
+  const next = Number(nextMaxBytes) || 0;
+  if (next <= 0 || used <= next) {
+    return "";
+  }
+  const over = used - next;
+  const eligible = Math.min(over, reclaimable);
+  if (eligible <= 0) {
+    return `Local copies already use ${formatBytes(used)}, above the new ${formatBytes(
+      next,
+    )} limit, but every copy is kept (pinned or in use), so nothing can be reclaimed automatically.`;
+  }
+  const shortfall = over - eligible;
+  const tail =
+    shortfall > 0
+      ? ` The remaining ${formatBytes(shortfall)} is kept (pinned or in use) and will stay over the limit.`
+      : "";
+  return `Local copies use ${formatBytes(used)}. The next automatic cleanup will remove up to ${formatBytes(
+    eligible,
+  )} of unpinned, unused copies to get under ${formatBytes(next)}.${tail}`;
+}
+
+// ---- destructive-action copy ----------------------------------------------------
+
+// Human sentences describing exactly what the backend's preview says, in the order a person needs
+// them: what is reclaimed, what blocks it, what the pin state is, and what removal costs.
+//
+// `pins.kind === "unknown"` is its own sentence. It is NOT folded into "not pinned": the store
+// could not read the entry's state, so the honest statement is that we can't tell.
+export function describeRemovalPreview(preview) {
+  if (!preview) {
+    return [];
+  }
+  const lines = [];
+  if (preview.blocked) {
+    lines.push(`This copy can't be removed right now: ${preview.blocked}`);
+  } else {
+    lines.push(`Removing this local copy frees ${formatBytes(preview.reclaimableBytes)}.`);
+  }
+  if (preview.pins?.kind === "unknown") {
+    lines.push(
+      "SceneWorks couldn't determine whether this copy is being kept — its stored state can't be read.",
+    );
+  } else if (preview.pins?.kind === "known") {
+    const owners = Array.isArray(preview.pins.owners) ? preview.pins.owners : [];
+    if (preview.pins.artifactPinned) {
+      lines.push("You marked this copy to keep locally. Allow automatic removal first.");
+    }
+    if (owners.length) {
+      lines.push(
+        `${owners.length} loaded ${owners.length === 1 ? "model is" : "models are"} still holding this copy.`,
+      );
+    }
+  }
+  if (preview.sourceUnavailableWarning) {
+    lines.push(
+      `The original files aren't reachable right now, so this model becomes unusable until its library is reconnected (${preview.sourceUnavailableWarning}).`,
+    );
+  } else {
+    lines.push(
+      "The original files in the model library are not touched — SceneWorks re-copies them when it next needs them.",
+    );
+  }
+  return lines;
+}
+
+// True when the preview says the removal would go through. A blocked preview must never present a
+// confirm button that the store will then refuse.
+export function removalIsAllowed(preview) {
+  return Boolean(preview) && !preview.blocked;
+}

--- a/apps/web/src/modelCache.test.js
+++ b/apps/web/src/modelCache.test.js
@@ -17,8 +17,11 @@ import {
   describeLimitConsequence,
   describeRemovalPreview,
   entriesForModel,
+  describeEntryState,
   fetchModelCache,
   gibToBytes,
+  hasTransitionalEntries,
+  isTransitionalEntry,
   policyNeedsRestart,
   previewCacheRemoval,
   removalIsAllowed,
@@ -427,5 +430,91 @@ describe("removalIsAllowed", () => {
   it("refuses without a preview", () => {
     expect(removalIsAllowed(null)).toBe(false);
     expect(removalIsAllowed(undefined)).toBe(false);
+  });
+});
+
+// ---- entry state, progress and actionable failure --------------------------------
+
+// The states the store is still moving on its own are what a screen has to keep watching. Getting
+// this set wrong in either direction is a real defect: too narrow and a copy in flight looks
+// frozen forever, too wide and a settled cache polls for nothing.
+describe("isTransitionalEntry / hasTransitionalEntries", () => {
+  it.each([
+    ["pending", true],
+    ["materializing", true],
+    ["evicting", true],
+    ["complete", false],
+    ["interrupted", false],
+    ["corrupt", false],
+  ])("classifies %s as transitional=%s", (state, expected) => {
+    expect(isTransitionalEntry({ state })).toBe(expected);
+  });
+
+  // An unrecognized state is NOT treated as still-moving. Polling a state this build cannot
+  // interpret would be a guess, and it would never terminate.
+  it("does not treat an unrecognized state as still moving", () => {
+    expect(isTransitionalEntry({ state: "quantizing" })).toBe(false);
+    expect(isTransitionalEntry(null)).toBe(false);
+    expect(isTransitionalEntry({})).toBe(false);
+  });
+
+  it("reports a snapshot as converging only while one of its entries is", () => {
+    expect(hasTransitionalEntries({ entries: [{ state: "complete" }] })).toBe(false);
+    expect(
+      hasTransitionalEntries({ entries: [{ state: "complete" }, { state: "materializing" }] }),
+    ).toBe(true);
+    // No answer is not "converging": a failed or absent read must not start a poll loop.
+    expect(hasTransitionalEntries({ entries: [] })).toBe(false);
+    expect(hasTransitionalEntries(null)).toBe(false);
+    expect(hasTransitionalEntries({})).toBe(false);
+  });
+});
+
+describe("describeEntryState", () => {
+  // A complete entry's line is about what happens to it next, and it must flip with the pin.
+  it("describes a complete copy by whether it is kept", () => {
+    const unpinned = describeEntryState({ state: "complete", pinned: false });
+    expect(unpinned.text).toContain("removed automatically");
+    expect(unpinned.progress).toBe(false);
+    expect(unpinned.failure).toBe(false);
+    expect(describeEntryState({ state: "complete", pinned: true }).text).toContain("Kept");
+  });
+
+  it.each([
+    ["pending", "Queued"],
+    ["materializing", "Copying now"],
+    ["evicting", "Removing now"],
+  ])("marks %s as progress and says what is happening", (state, fragment) => {
+    const described = describeEntryState({ state });
+    expect(described.progress).toBe(true);
+    expect(described.failure).toBe(false);
+    expect(described.text).toContain(fragment);
+  });
+
+  // The point of a failure line is that it is ACTIONABLE. A bare state name tells a user neither
+  // whether the model still works nor what to press, which is exactly the gap these replace.
+  it("gives an interrupted copy a remedy rather than a state name", () => {
+    const described = describeEntryState({ state: "interrupted" });
+    expect(described.failure).toBe(true);
+    expect(described.progress).toBe(false);
+    expect(described.text).toContain("can't be used");
+    expect(described.text).toMatch(/remove it now to reclaim the space/i);
+  });
+
+  it("says a corrupt copy is unrepairable and that the model still loads", () => {
+    const described = describeEntryState({ state: "corrupt" });
+    expect(described.failure).toBe(true);
+    expect(described.text).toContain("can't be used or repaired");
+    expect(described.text).toContain("still loads from its own library");
+  });
+
+  // Same rule the availability badge follows: a state this build does not know is labelled as
+  // unknown, never coerced into a reassuring one.
+  it("labels an unrecognized state instead of implying the copy is fine", () => {
+    const described = describeEntryState({ state: "quantizing" });
+    expect(described.failure).toBe(true);
+    expect(described.text).toContain("quantizing");
+    expect(described.text).toMatch(/doesn’t recognize/);
+    expect(described.text).not.toMatch(/can be removed automatically|Kept/);
   });
 });

--- a/apps/web/src/modelCache.test.js
+++ b/apps/web/src/modelCache.test.js
@@ -1,0 +1,431 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Only the transport is mocked: everything else under test is pure projection over the API's own
+// DTOs, and the point of these tests is that the projections stay faithful to what the backend
+// actually said (sc-19711, epic 19703).
+vi.mock("./api.js", () => ({ apiFetch: vi.fn(() => Promise.resolve({})) }));
+
+import { apiFetch } from "./api.js";
+import { ACCESS_TOKEN_KEY } from "./accessToken.js";
+import {
+  MODEL_AVAILABILITY,
+  availabilityBadge,
+  bytesToGib,
+  canHoldLocalCopy,
+  daysToSeconds,
+  describeDisableConsequence,
+  describeLimitConsequence,
+  describeRemovalPreview,
+  entriesForModel,
+  fetchModelCache,
+  gibToBytes,
+  policyNeedsRestart,
+  previewCacheRemoval,
+  removalIsAllowed,
+  removeCacheEntry,
+  secondsToDays,
+  setCacheEntryPin,
+} from "./modelCache.js";
+
+const GIB = 1024 * 1024 * 1024;
+const DAY = 24 * 60 * 60;
+
+beforeEach(() => {
+  window.localStorage.clear();
+  apiFetch.mockClear();
+  apiFetch.mockImplementation(() => Promise.resolve({}));
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+// ---- availability badges ---------------------------------------------------------
+
+describe("availabilityBadge", () => {
+  // One badge per typed state the ONE shared resolver (sc-19708) can emit. Enumerated
+  // exhaustively rather than spot-checked so adding a sixth wire state without a badge reds here
+  // instead of silently rendering "unknown state" in production.
+  it("labels every typed availability state distinctly", () => {
+    const states = Object.values(MODEL_AVAILABILITY);
+    expect(states).toHaveLength(5);
+    const texts = states.map((state) => availabilityBadge({ modelAvailability: state }).text);
+    expect(texts).toEqual([
+      "local copy",
+      "on external library",
+      "library disconnected",
+      "incomplete",
+      "not installed",
+    ]);
+    // Every badge carries an explanatory title, and no two states collapse onto one label.
+    for (const state of states) {
+      expect(availabilityBadge({ modelAvailability: state }).title).toBeTruthy();
+    }
+    expect(new Set(texts).size).toBe(states.length);
+  });
+
+  // Warning tone is reserved for the two states a user must act on. `external_ready` is normal
+  // operation and must NOT be alarmed; `local_ready` is the good case.
+  it("tones only the actionable states as warnings", () => {
+    const toneOf = (state) => availabilityBadge({ modelAvailability: state }).tone;
+    expect(toneOf(MODEL_AVAILABILITY.LOCAL_READY)).toBe("installed");
+    expect(toneOf(MODEL_AVAILABILITY.EXTERNAL_READY)).toBe("");
+    expect(toneOf(MODEL_AVAILABILITY.INSTALLED_EXTERNAL_UNAVAILABLE)).toBe("warning");
+    expect(toneOf(MODEL_AVAILABILITY.INCOMPLETE)).toBe("warning");
+    expect(toneOf(MODEL_AVAILABILITY.MISSING)).toBe("");
+  });
+
+  // The rule that makes this module safe to point at a newer backend: an unrecognized state is
+  // LABELLED, never coerced into a reassuring one. A future "evicting" state must not read as
+  // "on external library".
+  it("labels an unrecognized state instead of defaulting it to a reassuring one", () => {
+    const badge = availabilityBadge({ modelAvailability: "quantum_superposition" });
+    expect(badge.text).toBe("unknown state");
+    expect(badge.tone).toBe("warning");
+    expect(badge.title).toContain("quantum_superposition");
+  });
+
+  // No judgement at all is different from an unknown judgement: a row the resolver never annotated
+  // renders no badge rather than an alarming one.
+  it("renders no badge when the row carries no judgement", () => {
+    expect(availabilityBadge({})).toBeNull();
+    expect(availabilityBadge({ modelAvailability: "" })).toBeNull();
+    expect(availabilityBadge({ modelAvailability: null })).toBeNull();
+    expect(availabilityBadge(null)).toBeNull();
+    expect(availabilityBadge(undefined)).toBeNull();
+  });
+});
+
+describe("canHoldLocalCopy", () => {
+  // The resolved cache only ever holds copies of models whose authoritative source is an external
+  // library. `incomplete` and `missing` have nothing to copy, so offering local-copy controls on
+  // them would be an untrue affordance.
+  it("is true only for the three states that can back a local copy", () => {
+    expect(canHoldLocalCopy({ modelAvailability: MODEL_AVAILABILITY.LOCAL_READY })).toBe(true);
+    expect(canHoldLocalCopy({ modelAvailability: MODEL_AVAILABILITY.EXTERNAL_READY })).toBe(true);
+    expect(
+      canHoldLocalCopy({ modelAvailability: MODEL_AVAILABILITY.INSTALLED_EXTERNAL_UNAVAILABLE }),
+    ).toBe(true);
+    expect(canHoldLocalCopy({ modelAvailability: MODEL_AVAILABILITY.INCOMPLETE })).toBe(false);
+    expect(canHoldLocalCopy({ modelAvailability: MODEL_AVAILABILITY.MISSING })).toBe(false);
+    expect(canHoldLocalCopy({ modelAvailability: "something_new" })).toBe(false);
+    expect(canHoldLocalCopy(null)).toBe(false);
+  });
+});
+
+// ---- transport --------------------------------------------------------------------
+
+describe("model-cache transport", () => {
+  // The whole surface is gated on remote-auth deployments. A token assertion that pins "" passes
+  // with the fix reverted and therefore says nothing (sc-15136), so every one of these pins a
+  // NON-EMPTY token.
+  it("sends the stored access token on every route", async () => {
+    window.localStorage.setItem(ACCESS_TOKEN_KEY, "lan-password-1");
+    await fetchModelCache();
+    await previewCacheRemoval("key-a");
+    await removeCacheEntry("key-a");
+    await setCacheEntryPin("key-a", true);
+    expect(apiFetch).toHaveBeenCalledTimes(4);
+    for (const call of apiFetch.mock.calls) {
+      expect(call[1]).toBe("lan-password-1");
+    }
+  });
+
+  it("reads status with a plain GET — no body, no method override", async () => {
+    apiFetch.mockResolvedValue({ entryCount: 0 });
+    await expect(fetchModelCache()).resolves.toEqual({ entryCount: 0 });
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/model-cache", "");
+  });
+
+  it("posts the cache key to the removal-preview route", async () => {
+    await previewCacheRemoval("sha256:abc");
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/model-cache/removal-preview", "", {
+      method: "POST",
+      body: JSON.stringify({ cacheKey: "sha256:abc" }),
+    });
+  });
+
+  it("posts the cache key to the removal route", async () => {
+    await removeCacheEntry("sha256:abc");
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/model-cache/remove", "", {
+      method: "POST",
+      body: JSON.stringify({ cacheKey: "sha256:abc" }),
+    });
+  });
+
+  // Both directions, because a pin route that ignored the flag would still look correct in a
+  // one-way test.
+  it("posts both pin directions", async () => {
+    await setCacheEntryPin("sha256:abc", true);
+    expect(apiFetch).toHaveBeenLastCalledWith("/api/v1/model-cache/pin", "", {
+      method: "POST",
+      body: JSON.stringify({ cacheKey: "sha256:abc", pinned: true }),
+    });
+    await setCacheEntryPin("sha256:abc", false);
+    expect(apiFetch).toHaveBeenLastCalledWith("/api/v1/model-cache/pin", "", {
+      method: "POST",
+      body: JSON.stringify({ cacheKey: "sha256:abc", pinned: false }),
+    });
+  });
+});
+
+// ---- projections ------------------------------------------------------------------
+
+describe("entriesForModel", () => {
+  const status = {
+    entries: [
+      { cacheKey: "a", modelIds: ["flux_dev", "flux_krea"] },
+      { cacheKey: "b", modelIds: ["z_image_turbo"] },
+      { cacheKey: "c", modelIds: [] },
+      { cacheKey: "d" },
+    ],
+  };
+
+  it("selects the entries the BACKEND joined to this model, including shared ones", () => {
+    expect(entriesForModel(status, "flux_dev").map((entry) => entry.cacheKey)).toEqual(["a"]);
+    expect(entriesForModel(status, "flux_krea").map((entry) => entry.cacheKey)).toEqual(["a"]);
+    expect(entriesForModel(status, "z_image_turbo").map((entry) => entry.cacheKey)).toEqual(["b"]);
+  });
+
+  // A row with no join (corrupt residue the API still lists, per its own comment) must never be
+  // attributed to an arbitrary model.
+  it("never attributes an unjoined or id-less entry to a model", () => {
+    expect(entriesForModel(status, "unrelated")).toEqual([]);
+    expect(entriesForModel(status, "")).toEqual([]);
+    expect(entriesForModel(status, undefined)).toEqual([]);
+  });
+
+  // A failed status read leaves `status` null. That must yield "no information", which the screen
+  // renders as no local-copy block — not an empty-but-confident "no local copies".
+  it("returns nothing when the status read failed", () => {
+    expect(entriesForModel(null, "flux_dev")).toEqual([]);
+    expect(entriesForModel({}, "flux_dev")).toEqual([]);
+    expect(entriesForModel({ entries: "not-an-array" }, "flux_dev")).toEqual([]);
+  });
+});
+
+describe("unit conversions", () => {
+  it("round-trips GiB and days through the wire units", () => {
+    expect(gibToBytes(64)).toBe(64 * GIB);
+    expect(bytesToGib(64 * GIB)).toBe(64);
+    expect(daysToSeconds(14)).toBe(14 * DAY);
+    expect(secondsToDays(14 * DAY)).toBe(14);
+  });
+
+  // The inputs are user-typed, so every non-positive / non-numeric form must fail closed to 0 —
+  // which the commit handlers then refuse — rather than producing NaN on the wire.
+  it("fails closed to zero for every non-positive or unparseable input", () => {
+    for (const bad of [0, -1, "", " ", "abc", null, undefined, NaN, Infinity]) {
+      expect(gibToBytes(bad)).toBe(0);
+      expect(daysToSeconds(bad)).toBe(0);
+      expect(bytesToGib(bad)).toBe(0);
+      expect(secondsToDays(bad)).toBe(0);
+    }
+  });
+
+  it("rounds fractional entry to whole wire units", () => {
+    expect(gibToBytes("1.5")).toBe(Math.round(1.5 * GIB));
+    expect(daysToSeconds("0.5")).toBe(Math.round(0.5 * DAY));
+  });
+});
+
+// ---- the restart-bound policy comparison ------------------------------------------
+
+describe("policyNeedsRestart", () => {
+  const persisted = { enabled: true, maxBytes: 64 * GIB, inactivitySeconds: 14 * DAY };
+
+  // The design fact this whole card is built on: the cache policy is desktop-shell-owned and
+  // restart-bound. The shell persists it; the three sidecars captured theirs at spawn. So the UI
+  // compares persisted-vs-running and only then claims "restart to apply".
+  it("is false while the persisted policy matches the policy actually running", () => {
+    expect(policyNeedsRestart(persisted, { ...persisted })).toBe(false);
+  });
+
+  it("is true for a divergence in ANY of the three fields", () => {
+    expect(policyNeedsRestart(persisted, { ...persisted, enabled: false })).toBe(true);
+    expect(policyNeedsRestart(persisted, { ...persisted, maxBytes: 32 * GIB })).toBe(true);
+    expect(policyNeedsRestart(persisted, { ...persisted, inactivitySeconds: 7 * DAY })).toBe(true);
+  });
+
+  // Absent knowledge is not a divergence: before either side loads, claiming "restart to apply"
+  // would be a false statement about state nobody has read yet.
+  it("claims nothing while either side is still unknown", () => {
+    expect(policyNeedsRestart(null, persisted)).toBe(false);
+    expect(policyNeedsRestart(persisted, null)).toBe(false);
+    expect(policyNeedsRestart(null, null)).toBe(false);
+    expect(policyNeedsRestart(undefined, undefined)).toBe(false);
+  });
+});
+
+// ---- consequence copy --------------------------------------------------------------
+
+describe("describeDisableConsequence", () => {
+  // Turning the cache off stops NEW copies. It does not sweep. Saying otherwise would promise a
+  // deletion the backend never performs.
+  it("never claims disabling deletes anything", () => {
+    const text = describeDisableConsequence({ entryCount: 3, usedBytes: 12 * GIB });
+    expect(text).toContain("stops making new local copies");
+    expect(text).toContain("stay on disk");
+    expect(text).toContain("3 existing copies");
+    expect(text).toContain("12.0 GiB");
+    expect(text).not.toMatch(/delet|remove them now|free up/i);
+  });
+
+  // Agreement across the WHOLE sentence, not just the noun: the original read
+  // "The 1 existing copy … stay on disk — remove them … reclaim them."
+  it("agrees in number throughout the sentence for a lone copy", () => {
+    const text = describeDisableConsequence({ entryCount: 1, usedBytes: GIB });
+    expect(text).toContain("1 existing copy");
+    expect(text).toContain("stays on disk");
+    expect(text).toContain("remove it per model");
+    expect(text).toContain("reclaim it.");
+    // Only the clauses that refer to the ONE existing copy must be singular; the leading
+    // "stops making new local copies" is a general statement and stays plural.
+    expect(text).not.toMatch(/existing copies|stay on disk|\bthem\b/);
+  });
+
+  it("says plainly that nothing changes when the cache is empty", () => {
+    expect(describeDisableConsequence({ entryCount: 0, usedBytes: 0 })).toContain(
+      "changes nothing on disk",
+    );
+    expect(describeDisableConsequence(null)).toContain("changes nothing on disk");
+  });
+});
+
+describe("describeLimitConsequence", () => {
+  // Raising the limit, or staying at or above current usage, has no consequence to warn about.
+  it("is silent when the new limit already fits current usage", () => {
+    expect(describeLimitConsequence({ usedBytes: 10 * GIB, reclaimableBytes: 10 * GIB }, 20 * GIB)).toBe("");
+    expect(describeLimitConsequence({ usedBytes: 10 * GIB, reclaimableBytes: 10 * GIB }, 10 * GIB)).toBe("");
+    expect(describeLimitConsequence({ usedBytes: 10 * GIB, reclaimableBytes: 10 * GIB }, 0)).toBe("");
+  });
+
+  // Nothing is swept at the moment of the change — cleanup runs on the worker's idle checkpoints,
+  // so the copy must be future tense and bounded by what is actually reclaimable.
+  it("bounds the promise by the reclaimable bytes, in the future tense", () => {
+    const text = describeLimitConsequence(
+      { usedBytes: 20 * GIB, reclaimableBytes: 20 * GIB },
+      12 * GIB,
+    );
+    expect(text).toContain("next automatic cleanup");
+    expect(text).toContain("up to 8.0 GiB");
+    expect(text).toContain("12.0 GiB");
+    // 8 GiB over and 20 GiB reclaimable: nothing is left stranded above the limit.
+    expect(text).not.toContain("stay over the limit");
+  });
+
+  // The honest partial case: the overage exceeds what may be taken, so the remainder stays above
+  // the limit and the copy must say so rather than implying the limit will be met.
+  it("admits the shortfall when pinned or in-use copies keep usage above the limit", () => {
+    const text = describeLimitConsequence(
+      { usedBytes: 20 * GIB, reclaimableBytes: 2 * GIB },
+      12 * GIB,
+    );
+    expect(text).toContain("up to 2.0 GiB");
+    expect(text).toContain("remaining 6.0 GiB");
+    expect(text).toContain("stay over the limit");
+  });
+
+  // Zero reclaimable is not "cleanup will handle it" — it is "nothing can be reclaimed".
+  it("says nothing can be reclaimed when every copy is kept", () => {
+    const text = describeLimitConsequence({ usedBytes: 20 * GIB, reclaimableBytes: 0 }, 12 * GIB);
+    expect(text).toContain("every copy is kept");
+    expect(text).toContain("nothing can be reclaimed automatically");
+    expect(text).not.toContain("will remove up to");
+  });
+});
+
+// ---- removal preview copy -----------------------------------------------------------
+
+describe("describeRemovalPreview", () => {
+  const base = {
+    cacheKey: "k",
+    state: "complete",
+    reclaimableBytes: 4 * GIB,
+    pins: { kind: "known", artifactPinned: false, owners: [] },
+    sourceUnavailableWarning: null,
+    blocked: null,
+  };
+
+  it("leads with the measured bytes and reassures that the source is untouched", () => {
+    const lines = describeRemovalPreview(base);
+    expect(lines[0]).toBe("Removing this local copy frees 4.0 GiB.");
+    expect(lines.join(" ")).toContain("original files in the model library are not touched");
+  });
+
+  // The refusal must lead, and the "frees N" promise must NOT also appear — a dialog that says
+  // both is claiming a removal the store would refuse.
+  it("leads with the refusal and never also promises the reclaim", () => {
+    const lines = describeRemovalPreview({ ...base, blocked: "a runtime lease is active" });
+    expect(lines[0]).toContain("can't be removed right now");
+    expect(lines[0]).toContain("a runtime lease is active");
+    expect(lines.join(" ")).not.toContain("frees 4.0 GiB");
+  });
+
+  // THE distinction this module exists to preserve. `Unknown` means the store could not read the
+  // entry's pin state. Rendering that as "not pinned" would be a fabricated reassurance.
+  it("says 'couldn't determine' for an unknown pin answer, never 'not pinned'", () => {
+    const lines = describeRemovalPreview({ ...base, pins: { kind: "unknown" } });
+    const text = lines.join(" ");
+    expect(text).toContain("couldn't determine whether this copy is being kept");
+    expect(text).not.toMatch(/not pinned|isn't pinned|can be removed automatically/i);
+    // And it must not silently borrow the Known arm's sentences.
+    expect(text).not.toContain("Allow automatic removal first");
+  });
+
+  it("names the user's own keep-locally mark and how to clear it", () => {
+    const lines = describeRemovalPreview({
+      ...base,
+      pins: { kind: "known", artifactPinned: true, owners: [] },
+    });
+    expect(lines.join(" ")).toContain("You marked this copy to keep locally");
+    expect(lines.join(" ")).toContain("Allow automatic removal first");
+  });
+
+  it("counts the loaded models still holding the copy, with agreement", () => {
+    expect(
+      describeRemovalPreview({
+        ...base,
+        pins: { kind: "known", artifactPinned: false, owners: ["flux_dev"] },
+      }).join(" "),
+    ).toContain("1 loaded model is still holding this copy");
+    expect(
+      describeRemovalPreview({
+        ...base,
+        pins: { kind: "known", artifactPinned: false, owners: ["flux_dev", "z_image_turbo"] },
+      }).join(" "),
+    ).toContain("2 loaded models are still holding this copy");
+  });
+
+  // The acceptance criterion: manual removal must clearly state whether it leaves the model
+  // unusable until the external library returns.
+  it("warns that removal leaves the model unusable when the source is unreachable", () => {
+    const text = describeRemovalPreview({
+      ...base,
+      sourceUnavailableWarning: "/Volumes/Models is not mounted",
+    }).join(" ");
+    expect(text).toContain("becomes unusable until its library is reconnected");
+    expect(text).toContain("/Volumes/Models is not mounted");
+    // The reassuring sentence is mutually exclusive with the warning — both would contradict.
+    expect(text).not.toContain("are not touched");
+  });
+
+  it("describes nothing at all without a preview", () => {
+    expect(describeRemovalPreview(null)).toEqual([]);
+    expect(describeRemovalPreview(undefined)).toEqual([]);
+  });
+});
+
+describe("removalIsAllowed", () => {
+  it("permits only an unblocked preview", () => {
+    expect(removalIsAllowed({ blocked: null })).toBe(true);
+    expect(removalIsAllowed({ blocked: "" })).toBe(true);
+    expect(removalIsAllowed({ blocked: "a lease is active" })).toBe(false);
+  });
+
+  // No preview means no evidence the removal would succeed. Fail closed.
+  it("refuses without a preview", () => {
+    expect(removalIsAllowed(null)).toBe(false);
+    expect(removalIsAllowed(undefined)).toBe(false);
+  });
+});

--- a/apps/web/src/screens/ModelManagerScreen.cacheControls.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.cacheControls.test.jsx
@@ -163,6 +163,9 @@ describe("ModelManagerScreen local model copies (sc-19711)", () => {
     container.remove();
     vi.doUnmock("../api.js");
     vi.restoreAllMocks();
+    // Timers are faked per-test by the convergence cases only; unmount above clears any pending
+    // refresh, and this returns the shared environment to real timers either way.
+    vi.useRealTimers();
   });
 
   // Retained so a test can re-render the same screen under a changed backend without rebuilding
@@ -274,7 +277,7 @@ describe("ModelManagerScreen local model copies (sc-19711)", () => {
   it("disables Keep locally for an entry that is not ready, but still allows removal", async () => {
     status = cacheStatus([cacheEntry({ state: "materializing" })]);
     await render([externalModel()]);
-    expect(section().textContent).toContain("Not ready to use (materializing)");
+    expect(section().textContent).toContain("Copying now");
     expect(copyButton("Keep locally").disabled).toBe(true);
     expect(copyButton("Remove local copy").disabled).toBe(false);
   });
@@ -515,5 +518,137 @@ describe("ModelManagerScreen local model copies (sc-19711)", () => {
       externalModel({ id: "y", name: "Yet Another", family: "flux" }),
     ]);
     expect(cacheReads).toBe(1);
+  });
+
+  // ---- convergence: progress and actionable failures -------------------------------
+  //
+  // The scope this section closes: a materializing entry used to render one static line and stay
+  // there for as long as the screen was open, so nothing the store did was ever visible. The
+  // status endpoint already reports per-entry states from the journal; these tests hold the UI to
+  // reflecting them as they change, and to saying something actionable when they stop changing.
+
+  // Advance the bounded refresh by one tick and let the resulting read settle.
+  async function tick(times = 1) {
+    for (let i = 0; i < times; i += 1) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+      await settle();
+    }
+  }
+
+  it("converges a materializing entry to its terminal state while the screen stays open", async () => {
+    vi.useFakeTimers();
+    status = cacheStatus([cacheEntry({ state: "materializing" })]);
+    await render([externalModel()]);
+    expect(section().textContent).toContain("Copying now");
+    expect(cacheReads).toBe(1);
+
+    // The store finishes. Nothing the user does re-reads — the screen has to notice on its own.
+    status = cacheStatus([cacheEntry({ state: "complete" })]);
+    await tick();
+    expect(cacheReads).toBe(2);
+    expect(section().textContent).toContain("Can be removed automatically");
+    expect(section().textContent).not.toContain("Copying now");
+    // And once it is terminal, the refresh STOPS: an all-settled cache costs one read, not a
+    // permanent timer.
+    await tick(3);
+    expect(cacheReads).toBe(2);
+  });
+
+  // The keep control is meaningless on an unusable bundle, so it must un-disable the moment the
+  // entry becomes complete — the same convergence, seen from the affordance side.
+  it("re-enables Keep locally once the copy finishes", async () => {
+    vi.useFakeTimers();
+    status = cacheStatus([cacheEntry({ state: "materializing" })]);
+    await render([externalModel()]);
+    expect(copyButton("Keep locally").disabled).toBe(true);
+    status = cacheStatus([cacheEntry({ state: "complete" })]);
+    await tick();
+    expect(copyButton("Keep locally").disabled).toBe(false);
+  });
+
+  // A settled cache must never arm the timer at all.
+  it("never re-reads while every entry is terminal", async () => {
+    vi.useFakeTimers();
+    await render([externalModel()]);
+    await tick(5);
+    expect(cacheReads).toBe(1);
+  });
+
+  // An entry being reclaimed is also in flight, and its disappearance is the convergence.
+  it("converges an evicting entry to gone", async () => {
+    vi.useFakeTimers();
+    status = cacheStatus([cacheEntry({ state: "evicting" })]);
+    await render([externalModel()]);
+    expect(section().textContent).toContain("Removing now");
+    status = cacheStatus([]);
+    await tick();
+    expect(section().textContent).toContain("No local copy yet");
+  });
+
+  // Failure states are terminal, so they must NOT poll — and they must say what to do, not just
+  // name the state. This is the half a poll alone would not fix.
+  it.each([
+    ["interrupted", "remove it now to reclaim the space"],
+    ["corrupt", "can't be used or repaired"],
+  ])("renders %s as an actionable failure and stops refreshing", async (state, remedy) => {
+    vi.useFakeTimers();
+    status = cacheStatus([cacheEntry({ state })]);
+    await render([externalModel()]);
+    const note = container.querySelector(".model-local-copy-failure");
+    expect(note, "a failed copy is marked as a failure, not muted detail").toBeTruthy();
+    expect(note.textContent).toContain(remedy);
+    // Removal stays available — clearing the residue is exactly the remedy the line names.
+    expect(copyButton("Remove local copy").disabled).toBe(false);
+    await tick(3);
+    expect(cacheReads).toBe(1);
+  });
+
+  // "Check again" is the manual half: it re-reads immediately rather than making the user wait out
+  // the cadence, and it is only offered while something is actually in flight.
+  it("offers a manual re-read only while a copy is in flight", async () => {
+    status = cacheStatus([cacheEntry({ state: "materializing" })]);
+    await render([externalModel()]);
+    const button = [...container.querySelectorAll(".model-local-copy-head button")].find(
+      (node) => node.textContent.trim() === "Check again",
+    );
+    expect(button).toBeTruthy();
+    status = cacheStatus([cacheEntry({ state: "complete" })]);
+    await click(button);
+    await settle();
+    expect(cacheReads).toBe(2);
+    expect(section().textContent).toContain("Can be removed automatically");
+    expect(
+      [...container.querySelectorAll(".model-local-copy-head button")].find(
+        (node) => node.textContent.trim() === "Check again",
+      ),
+      "a settled cache offers no refresh affordance",
+    ).toBeFalsy();
+  });
+
+  // The refresh is BOUNDED. An entry that never converges — a worker that died mid-copy — must not
+  // leave the screen re-reading for the life of the session, and the screen must admit it stopped
+  // rather than leave a "checking…" line that has quietly stopped meaning anything.
+  it("stops refreshing a wedged copy and says so", async () => {
+    vi.useFakeTimers();
+    const { MAX_CACHE_CONVERGENCE_POLLS } = await import("../modelCache.js");
+    status = cacheStatus([cacheEntry({ state: "materializing" })]);
+    await render([externalModel()]);
+    expect(section().textContent).toContain("Checking for changes");
+
+    await tick(MAX_CACHE_CONVERGENCE_POLLS);
+    expect(cacheReads).toBe(1 + MAX_CACHE_CONVERGENCE_POLLS);
+    expect(section().textContent).toContain("stopped checking automatically");
+
+    // Bounded means bounded: further time buys no further reads.
+    await tick(5);
+    expect(cacheReads).toBe(1 + MAX_CACHE_CONVERGENCE_POLLS);
+    // The manual affordance survives, so the user is not stranded.
+    expect(
+      [...container.querySelectorAll(".model-local-copy-head button")].find(
+        (node) => node.textContent.trim() === "Check again",
+      ),
+    ).toBeTruthy();
   });
 });

--- a/apps/web/src/screens/ModelManagerScreen.cacheControls.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.cacheControls.test.jsx
@@ -165,6 +165,10 @@ describe("ModelManagerScreen local model copies (sc-19711)", () => {
     vi.restoreAllMocks();
   });
 
+  // Retained so a test can re-render the same screen under a changed backend without rebuilding
+  // the whole app context by hand.
+  let contextValue;
+
   async function render(models) {
     const value = {
       activeProject: null,
@@ -183,6 +187,7 @@ describe("ModelManagerScreen local model copies (sc-19711)", () => {
       createLoraImportJob: () => {},
       createModelImportJob: () => {},
     };
+    contextValue = value;
     await act(async () => {
       root.render(
         <AppContext.Provider value={value}>
@@ -299,6 +304,24 @@ describe("ModelManagerScreen local model copies (sc-19711)", () => {
     expect(container.textContent).not.toContain("No local copy yet");
   });
 
+  // Hiding the controls silently would leave the user unable to tell "no local copies" from "no
+  // answer". The reason is stated ONCE for the whole screen, because one read failed for the whole
+  // screen — not once per model card.
+  it("explains once why the local-copy controls are hidden", async () => {
+    status = new Error("cache listing failed");
+    await render([
+      externalModel(),
+      externalModel({ id: "z", name: "Z-Image-Turbo", family: "z-image" }),
+    ]);
+    const notices = [...container.querySelectorAll(".inline-warning")].filter((node) =>
+      node.textContent.includes("Local model copies can’t be shown"),
+    );
+    expect(notices).toHaveLength(1);
+    expect(notices[0].textContent).toContain("cache listing failed");
+    // It must not imply anything about what is cached — that is what could not be determined.
+    expect(notices[0].textContent).not.toMatch(/no local copies|none|0 copies/i);
+  });
+
   // The subtler half of the same defect: the request SUCCEEDS but the store could not be listed,
   // so the snapshot carries `error` and an empty `entries`. That empty list is "no answer", not
   // "no copies", and must not be rendered as the latter.
@@ -307,6 +330,29 @@ describe("ModelManagerScreen local model copies (sc-19711)", () => {
     await render([externalModel()]);
     expect(section()).toBeNull();
     expect(container.textContent).not.toContain("No local copy yet");
+    // Same explanation as an outright transport failure — from the user's side it is the same
+    // situation: the answer is unavailable.
+    expect(container.textContent).toContain("Local model copies can’t be shown");
+    expect(container.textContent).toContain("resolved-cache journal is unreadable");
+  });
+
+  // A read that recovers must clear the standing explanation rather than leave a stale alarm.
+  it("clears the explanation once a later read succeeds", async () => {
+    status = new Error("cache listing failed");
+    await render([externalModel()]);
+    expect(container.textContent).toContain("Local model copies can’t be shown");
+    status = cacheStatus([cacheEntry()]);
+    // Any action re-reads status; use the one that needs no local-copy button to be present.
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{ ...contextValue, models: [externalModel()] }}>
+          <ModelManagerScreen key="remount" />
+        </AppContext.Provider>,
+      );
+    });
+    await settle();
+    expect(container.textContent).not.toContain("Local model copies can’t be shown");
+    expect(section()).toBeTruthy();
   });
 
   // ---- keep locally / allow automatic removal -------------------------------------

--- a/apps/web/src/screens/ModelManagerScreen.cacheControls.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.cacheControls.test.jsx
@@ -1,0 +1,473 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click } from "../testUtils/dom.js";
+
+// Per-model resolved-cache controls on a Model Manager card (sc-19711, epic 19703).
+//
+// What these tests are actually defending:
+//
+// * The availability badge is the ONE shared resolver's typed judgement, RENDERED — never a second
+//   opinion the screen derived from install paths or error text (the architecture bar for this
+//   epic). So the assertions drive `modelAvailability` straight off the wire and check the badge
+//   changes with it, including for a state this build doesn't know.
+// * "Remove local copy" is preview-THEN-confirm against the real backend preview. A blocked
+//   preview must never reach a confirm dialog, because the store would then refuse the removal the
+//   dialog just promised.
+// * Removing a local copy is not an uninstall. The card must say so, and must not be conflated
+//   with the download/install job surface above it.
+//
+// Destructive actions route through the shared desktop-safe appConfirm (sc-12068) rather than
+// window.confirm, which silently no-ops inside the Tauri WebView. Mocked so tests control the
+// user's answer and can assert the guard fired at all.
+const { appConfirmMock } = vi.hoisted(() => ({ appConfirmMock: vi.fn(async () => true) }));
+vi.mock("../appConfirm.jsx", () => ({
+  appConfirm: appConfirmMock,
+  useConfirm: () => appConfirmMock,
+  ConfirmHost: () => null,
+}));
+
+const GIB = 1024 * 1024 * 1024;
+
+// A model installed on the external library, in the /models shape sc-19708 produces: the typed
+// `modelAvailability` rides on the catalog row itself.
+function externalModel(overrides = {}) {
+  return {
+    id: "flux_dev",
+    name: "FLUX.1 [dev]",
+    type: "image",
+    family: "flux",
+    installState: "installed",
+    downloadable: true,
+    modelAvailability: "external_ready",
+    ui: { description: "External-library model." },
+    ...overrides,
+  };
+}
+
+// One resolved-cache entry as GET /api/v1/model-cache reports it, joined to its catalog model id
+// by the BACKEND (the identity mapping has exactly one implementation, and it is not here).
+function cacheEntry(overrides = {}) {
+  return {
+    cacheKey: "sha256:aaa",
+    state: "complete",
+    repository: "black-forest-labs/FLUX.1-dev",
+    revision: "abc123",
+    variant: "q8",
+    tier: "q8",
+    bytes: 12 * GIB,
+    pinned: false,
+    artifactPinned: false,
+    modelPinOwners: [],
+    createdAt: 1,
+    lastUsedAt: 2,
+    modelIds: ["flux_dev"],
+    ...overrides,
+  };
+}
+
+function cacheStatus(entries, overrides = {}) {
+  const used = entries.reduce((sum, entry) => sum + entry.bytes, 0);
+  return {
+    policy: { enabled: true, maxBytes: 64 * GIB, inactivitySeconds: 14 * 24 * 60 * 60 },
+    initialized: true,
+    error: null,
+    usedBytes: used,
+    pinnedBytes: entries.filter((entry) => entry.pinned).reduce((sum, e) => sum + e.bytes, 0),
+    reclaimableBytes: entries
+      .filter((entry) => entry.state === "complete" && !entry.pinned)
+      .reduce((sum, e) => sum + e.bytes, 0),
+    entryCount: entries.length,
+    sourceVolumeRelation: "different",
+    sourceLibraryPath: "/Volumes/Models/huggingface/hub",
+    entries,
+    ...overrides,
+  };
+}
+
+describe("ModelManagerScreen local model copies (sc-19711)", () => {
+  let container;
+  let root;
+  let apiFetch;
+  let cacheReads;
+  let status;
+  let preview;
+  let removeOutcome;
+  let pinCalls;
+  let removeCalls;
+  let ModelManagerScreen;
+  let AppContext;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    delete window.__TAURI__;
+    appConfirmMock.mockReset();
+    appConfirmMock.mockImplementation(async () => true);
+    cacheReads = 0;
+    pinCalls = [];
+    removeCalls = [];
+    status = cacheStatus([cacheEntry()]);
+    preview = {
+      cacheKey: "sha256:aaa",
+      state: "complete",
+      reclaimableBytes: 12 * GIB,
+      pins: { kind: "known", artifactPinned: false, owners: [] },
+      sourceUnavailableWarning: null,
+      blocked: null,
+    };
+    removeOutcome = {
+      cacheKey: "sha256:aaa",
+      reclaimedBytes: 12 * GIB,
+      sourceUnavailableWarning: null,
+    };
+    apiFetch = vi.fn(async (path, _token, options) => {
+      if (path === "/api/v1/host-capabilities") {
+        return { platform: "macos", memoryKind: "unified", memoryGb: 64 };
+      }
+      if (path === "/api/v1/model-cache") {
+        cacheReads += 1;
+        if (status instanceof Error) throw status;
+        return status;
+      }
+      if (path === "/api/v1/model-cache/removal-preview") {
+        return preview;
+      }
+      if (path === "/api/v1/model-cache/remove") {
+        removeCalls.push(JSON.parse(options.body));
+        return removeOutcome;
+      }
+      if (path === "/api/v1/model-cache/pin") {
+        pinCalls.push(JSON.parse(options.body));
+        return cacheEntry({ pinned: true, artifactPinned: true });
+      }
+      return [];
+    });
+    vi.resetModules();
+    vi.doMock("../api.js", () => ({
+      apiFetch,
+      isAbortError: () => false,
+      API_BASE_URL: "",
+      eventUrl: () => "",
+    }));
+    ({ AppContext } = await import("../context/AppContext.js"));
+    ({ ModelManagerScreen } = await import("./ModelManagerScreen.jsx"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.doUnmock("../api.js");
+    vi.restoreAllMocks();
+  });
+
+  async function render(models) {
+    const value = {
+      activeProject: null,
+      jobs: [],
+      loras: [],
+      models,
+      macCapabilities: { macGatingActive: false },
+      presets: [],
+      jobAction: () => {},
+      setActiveView: () => {},
+      deleteLora: () => {},
+      deleteModel: () => {},
+      deleteModelVariant: vi.fn(),
+      createModelDownloadJob: vi.fn(),
+      createModelConvertJob: () => {},
+      createLoraImportJob: () => {},
+      createModelImportJob: () => {},
+    };
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={value}>
+          <ModelManagerScreen />
+        </AppContext.Provider>,
+      );
+    });
+    // Flush the host-capabilities and model-cache effect promises.
+    await act(async () => {});
+    await act(async () => {});
+  }
+
+  // The keep/remove handlers await a promise chain (preview → confirm → mutate → re-read) before
+  // the DOM settles, so flush several microtask turns before asserting.
+  async function settle() {
+    await act(async () => {
+      for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    });
+  }
+
+  const section = () => container.querySelector(".model-local-copy");
+  const badgeTexts = () =>
+    [...container.querySelectorAll(".model-card-status .status-badge")].map((badge) =>
+      badge.textContent.trim(),
+    );
+  const copyButton = (label) =>
+    [...container.querySelectorAll(".model-local-copy-actions button")].find(
+      (button) => button.textContent.trim() === label,
+    );
+  const liveText = () => container.querySelector('[role="status"]')?.textContent ?? "";
+
+  // ---- typed availability badge -------------------------------------------------
+
+  // Each typed state renders its own badge, driven entirely off the wire value. Enumerated so a
+  // state silently losing its badge reds here.
+  it.each([
+    ["local_ready", "local copy"],
+    ["external_ready", "on external library"],
+    ["installed_external_unavailable", "library disconnected"],
+    ["incomplete", "incomplete"],
+    ["missing", "not installed"],
+  ])("renders the %s availability judgement as its own badge", async (availability, label) => {
+    await render([externalModel({ modelAvailability: availability })]);
+    expect(badgeTexts()).toContain(label);
+  });
+
+  // A state this build doesn't recognize is LABELLED, not silently dropped and not coerced into a
+  // reassuring one — the unsupported-artifact-class acceptance criterion in miniature.
+  it("labels an unrecognized availability state rather than hiding it", async () => {
+    await render([externalModel({ modelAvailability: "evicting" })]);
+    expect(badgeTexts()).toContain("unknown state");
+  });
+
+  it("renders no availability badge for a row the resolver never judged", async () => {
+    await render([externalModel({ modelAvailability: undefined })]);
+    expect(badgeTexts()).not.toContain("on external library");
+    expect(badgeTexts()).not.toContain("unknown state");
+  });
+
+  // ---- the local-copy block ------------------------------------------------------
+
+  it("lists the joined cache entry with its tier, size and removable state", async () => {
+    await render([externalModel()]);
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/model-cache", expect.anything());
+    const text = section().textContent;
+    expect(text).toContain("Q8");
+    expect(text).toContain("12.0 GiB");
+    expect(text).toContain("Can be removed automatically when space is needed");
+    // Removing a local copy is NOT an uninstall, and the card has to say so.
+    expect(text).toContain("never uninstalls the model");
+  });
+
+  it("describes a pinned copy as kept and offers the inverse action", async () => {
+    status = cacheStatus([cacheEntry({ pinned: true, artifactPinned: true })]);
+    await render([externalModel()]);
+    expect(section().textContent).toContain("Kept — never removed automatically");
+    expect(copyButton("Allow automatic removal")).toBeTruthy();
+    expect(copyButton("Keep locally")).toBeFalsy();
+  });
+
+  // An entry that is not `complete` is not usable, and pinning an unusable bundle is meaningless —
+  // so the keep control is disabled while the state resolves. Removal stays available: clearing
+  // residue is exactly what a user should be able to do here.
+  it("disables Keep locally for an entry that is not ready, but still allows removal", async () => {
+    status = cacheStatus([cacheEntry({ state: "materializing" })]);
+    await render([externalModel()]);
+    expect(section().textContent).toContain("Not ready to use (materializing)");
+    expect(copyButton("Keep locally").disabled).toBe(true);
+    expect(copyButton("Remove local copy").disabled).toBe(false);
+  });
+
+  it("offers the block with no entry yet for a model that could hold a local copy", async () => {
+    status = cacheStatus([]);
+    await render([externalModel()]);
+    expect(section().textContent).toContain("No local copy yet");
+    expect(copyButton("Remove local copy")).toBeFalsy();
+  });
+
+  // A model that can hold no local copy at all gets no block — an affordance that could never do
+  // anything is worse than no affordance.
+  it("renders no local-copy block for a model that cannot hold one", async () => {
+    status = cacheStatus([]);
+    await render([externalModel({ modelAvailability: "missing", installState: "missing" })]);
+    expect(section()).toBeNull();
+  });
+
+  // A FAILED status read must render nothing rather than an empty-but-confident "no local copies":
+  // the screen genuinely does not know, and saying "none" would be a fabricated answer.
+  it("renders no local-copy block when the status read failed", async () => {
+    status = new Error("cache listing failed");
+    await render([externalModel()]);
+    expect(cacheReads).toBe(1);
+    expect(section()).toBeNull();
+    expect(container.textContent).not.toContain("No local copy yet");
+  });
+
+  // The subtler half of the same defect: the request SUCCEEDS but the store could not be listed,
+  // so the snapshot carries `error` and an empty `entries`. That empty list is "no answer", not
+  // "no copies", and must not be rendered as the latter.
+  it("renders no local-copy block when the snapshot reports the store could not be listed", async () => {
+    status = cacheStatus([], { error: "resolved-cache journal is unreadable" });
+    await render([externalModel()]);
+    expect(section()).toBeNull();
+    expect(container.textContent).not.toContain("No local copy yet");
+  });
+
+  // ---- keep locally / allow automatic removal -------------------------------------
+
+  it("pins through the API and re-reads authoritative status rather than flipping the row", async () => {
+    await render([externalModel()]);
+    const before = cacheReads;
+    // The re-read returns the entry as PINNED, so an implementation that optimistically flipped
+    // local state and skipped the round trip would still look right — hence asserting the read.
+    status = cacheStatus([cacheEntry({ pinned: true, artifactPinned: true })]);
+    await click(copyButton("Keep locally"));
+    await settle();
+    expect(pinCalls).toEqual([{ cacheKey: "sha256:aaa", pinned: true }]);
+    expect(cacheReads).toBe(before + 1);
+    expect(section().textContent).toContain("Kept — never removed automatically");
+    expect(liveText()).toContain("kept until you allow automatic removal");
+  });
+
+  it("unpins with pinned:false and reports the copy as reclaimable again", async () => {
+    status = cacheStatus([cacheEntry({ pinned: true, artifactPinned: true })]);
+    await render([externalModel()]);
+    status = cacheStatus([cacheEntry()]);
+    await click(copyButton("Allow automatic removal"));
+    await settle();
+    expect(pinCalls).toEqual([{ cacheKey: "sha256:aaa", pinned: false }]);
+    expect(liveText()).toContain("can now be removed automatically");
+  });
+
+  it("surfaces a pin failure instead of claiming the change landed", async () => {
+    await render([externalModel()]);
+    apiFetch.mockImplementation(async (path) => {
+      if (path === "/api/v1/model-cache/pin") throw new Error("journal is locked");
+      if (path === "/api/v1/model-cache") return status;
+      if (path === "/api/v1/host-capabilities") return { platform: "macos", memoryGb: 64 };
+      return [];
+    });
+    await click(copyButton("Keep locally"));
+    await settle();
+    expect(liveText()).toContain("journal is locked");
+    expect(section().textContent).toContain("Can be removed automatically");
+  });
+
+  // ---- remove local copy -----------------------------------------------------------
+
+  // The load-bearing ordering: preview FIRST, and the confirm message is built from that preview's
+  // own measured bytes — not from the row's cached `bytes`, which can be stale.
+  it("previews before confirming and builds the dialog from the preview's own numbers", async () => {
+    preview = { ...preview, reclaimableBytes: 9 * GIB };
+    await render([externalModel()]);
+    await click(copyButton("Remove local copy"));
+    await settle();
+    expect(apiFetch).toHaveBeenCalledWith(
+      "/api/v1/model-cache/removal-preview",
+      expect.anything(),
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    const dialog = appConfirmMock.mock.calls[0][0];
+    expect(dialog.title).toContain("FLUX.1 [dev]");
+    expect(dialog.tone).toBe("danger");
+    // 9.0 GiB is the PREVIEW's measurement; 12.0 GiB is the listing's. The dialog must use the
+    // former, so this fails if the confirm copy were built from the row.
+    expect(dialog.message).toContain("9.0 GiB");
+    expect(dialog.message).not.toContain("12.0 GiB");
+    expect(removeCalls).toEqual([{ cacheKey: "sha256:aaa" }]);
+  });
+
+  it("does not remove anything when the user declines the confirm", async () => {
+    appConfirmMock.mockImplementation(async () => false);
+    await render([externalModel()]);
+    await click(copyButton("Remove local copy"));
+    await settle();
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    expect(removeCalls).toEqual([]);
+  });
+
+  // A blocked preview must NOT reach a confirm at all: offering a confirm the store would then
+  // refuse is exactly the "UI claims before backend state is committed" failure this story bans.
+  it("never offers a confirm for a removal the store would refuse", async () => {
+    preview = { ...preview, blocked: "a runtime lease is active" };
+    await render([externalModel()]);
+    await click(copyButton("Remove local copy"));
+    await settle();
+    expect(appConfirmMock).not.toHaveBeenCalled();
+    expect(removeCalls).toEqual([]);
+    expect(liveText()).toContain("can't be removed right now");
+    expect(liveText()).toContain("a runtime lease is active");
+  });
+
+  // "Can't determine" must survive all the way into the dialog the user actually reads.
+  it("carries an unknown pin answer into the confirm as 'couldn't determine'", async () => {
+    preview = { ...preview, pins: { kind: "unknown" } };
+    await render([externalModel()]);
+    await click(copyButton("Remove local copy"));
+    await settle();
+    const { message } = appConfirmMock.mock.calls[0][0];
+    expect(message).toContain("couldn't determine whether this copy is being kept");
+    expect(message).not.toMatch(/not pinned|isn't pinned/i);
+  });
+
+  // The acceptance criterion: removal must state when it leaves the model unusable until the
+  // external library is reconnected — in the confirm, and again in the outcome.
+  it("warns before and after removal when the external source is unreachable", async () => {
+    preview = { ...preview, sourceUnavailableWarning: "/Volumes/Models is not mounted" };
+    removeOutcome = { ...removeOutcome, sourceUnavailableWarning: "/Volumes/Models is not mounted" };
+    await render([externalModel({ modelAvailability: "installed_external_unavailable" })]);
+    await click(copyButton("Remove local copy"));
+    await settle();
+    expect(appConfirmMock.mock.calls[0][0].message).toContain(
+      "becomes unusable until its library is reconnected",
+    );
+    expect(liveText()).toContain("stays unusable until its model library is reconnected");
+  });
+
+  it("re-reads status after a successful removal and reports the bytes freed", async () => {
+    await render([externalModel()]);
+    const before = cacheReads;
+    status = cacheStatus([]);
+    await click(copyButton("Remove local copy"));
+    await settle();
+    expect(cacheReads).toBe(before + 1);
+    expect(liveText()).toContain("freed 12.0 GiB");
+    expect(section().textContent).toContain("No local copy yet");
+  });
+
+  it("surfaces a removal failure instead of claiming the copy is gone", async () => {
+    await render([externalModel()]);
+    apiFetch.mockImplementation(async (path) => {
+      if (path === "/api/v1/model-cache/removal-preview") return preview;
+      if (path === "/api/v1/model-cache/remove") throw new Error("entry is leased");
+      if (path === "/api/v1/model-cache") return status;
+      if (path === "/api/v1/host-capabilities") return { platform: "macos", memoryGb: 64 };
+      return [];
+    });
+    await click(copyButton("Remove local copy"));
+    await settle();
+    expect(liveText()).toContain("entry is leased");
+    // The row is still there — nothing claimed it was removed.
+    expect(section().textContent).toContain("12.0 GiB");
+  });
+
+  // Accessibility: the buttons sit far down a long card and their result lands in a status line at
+  // the top of the screen, so that line has to be announced rather than only painted.
+  it("announces outcomes in a polite live region", async () => {
+    await render([externalModel()]);
+    await click(copyButton("Keep locally"));
+    await settle();
+    const region = container.querySelector('[role="status"]');
+    expect(region).toBeTruthy();
+    expect(region.getAttribute("aria-live")).toBe("polite");
+  });
+
+  // The status read is one listing for the whole screen, on mount and after mutations only. A
+  // per-row or timer-driven read would put back exactly the cost sc-19708 removed.
+  it("reads cache status once for the whole screen regardless of model count", async () => {
+    status = cacheStatus([cacheEntry(), cacheEntry({ cacheKey: "sha256:bbb", modelIds: ["z"] })]);
+    await render([
+      externalModel(),
+      externalModel({ id: "z", name: "Z-Image-Turbo", family: "z-image" }),
+      externalModel({ id: "y", name: "Yet Another", family: "flux" }),
+    ]);
+    expect(cacheReads).toBe(1);
+  });
+});

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 import { WAN_MOE_PAIRED_LORA_MODEL_IDS, terminalStatuses } from "../constants.js";
@@ -14,6 +14,18 @@ import {
 import { useAppContext } from "../context/AppContext.js";
 import { DEFAULT_MAC_CAPABILITIES, macModelBlock } from "../macGating.js";
 import { appConfirm } from "../appConfirm.jsx";
+import { formatBytes } from "../formatting.js";
+import {
+  availabilityBadge,
+  canHoldLocalCopy,
+  describeRemovalPreview,
+  entriesForModel,
+  fetchModelCache,
+  previewCacheRemoval,
+  removalIsAllowed,
+  removeCacheEntry,
+  setCacheEntryPin,
+} from "../modelCache.js";
 import { KeywordTagEditor } from "../components/KeywordTagEditor.jsx";
 import { useHostMemory } from "../hooks/useHostMemory.js";
 import { hostMemoryGbForBackend } from "../hostMemory.js";
@@ -719,6 +731,13 @@ export function ModelManagerScreen() {
   const [modelFileInputKey, setModelFileInputKey] = useState(0);
   const [deletingItem, setDeletingItem] = useState("");
   const [deleteMessage, setDeleteMessage] = useState({ tone: "neutral", text: "" });
+  // Resolved-model hot cache (epic 19703, sc-19711). ONE status read backs every card's local-copy
+  // block; it is refreshed on mount and after each keep/remove, never on a timer — a journal
+  // listing grows with the number of cached bundles, so polling it would put exactly the per-row
+  // read cost back on a screen that sc-19708 took it off.
+  const [modelCache, setModelCache] = useState(null);
+  // Cache key of the entry whose keep/remove request is in flight, so its buttons disable.
+  const [cacheBusyKey, setCacheBusyKey] = useState("");
   // Tabbed interface (epic 10309): the active tab, the tab to restore when a search
   // clears, and the persistent search query. Every model now renders as an always-open
   // card, so the old per-row expand state is gone. Tabs: image | video | utility | lora,
@@ -879,6 +898,76 @@ export function ModelManagerScreen() {
       setPendingUpdate(next);
     }
   }, [jobs, pendingUpdate, createModelConvertJob]);
+
+  // One resolved-cache status read for the whole screen. A failure leaves `modelCache` null, which
+  // renders no local-copy blocks at all — never an empty-but-confident "no local copies".
+  const refreshModelCache = useCallback(async () => {
+    try {
+      setModelCache(await fetchModelCache());
+    } catch {
+      setModelCache(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshModelCache();
+  }, [refreshModelCache]);
+
+  // "Keep locally" / "Allow automatic removal" — the artifact pin. Re-reads the authoritative
+  // status afterwards rather than optimistically flipping the row: the UI must not claim a state
+  // the store hasn't committed.
+  async function toggleKeepLocalCopy(entry) {
+    setCacheBusyKey(entry.cacheKey);
+    try {
+      await setCacheEntryPin(entry.cacheKey, !entry.pinned);
+      await refreshModelCache();
+      setDeleteMessage({
+        tone: "neutral",
+        text: entry.pinned
+          ? "This local copy can now be removed automatically when space is needed."
+          : "This local copy will be kept until you allow automatic removal.",
+      });
+    } catch (error) {
+      setDeleteMessage({ tone: "error", text: String(error?.message ?? error) });
+    } finally {
+      setCacheBusyKey("");
+    }
+  }
+
+  // "Remove local copy". The preview is fetched FIRST and the confirm is built entirely from it —
+  // measured bytes, the typed pin answer (including "can't determine"), and any refusal reason —
+  // so the dialog can never promise a removal the store would then refuse. A blocked preview is
+  // reported and the destructive path is not offered at all.
+  async function removeLocalCopy(model, entry) {
+    setCacheBusyKey(entry.cacheKey);
+    try {
+      const preview = await previewCacheRemoval(entry.cacheKey);
+      const lines = describeRemovalPreview(preview);
+      if (!removalIsAllowed(preview)) {
+        setDeleteMessage({ tone: "error", text: lines.join(" ") });
+        return;
+      }
+      const proceed = await appConfirm({
+        title: `Remove the local copy of ${model.name}?`,
+        message: lines.join(" "),
+        confirmLabel: "Remove local copy",
+        tone: "danger",
+      });
+      if (!proceed) return;
+      const outcome = await removeCacheEntry(entry.cacheKey);
+      await refreshModelCache();
+      setDeleteMessage({
+        tone: "neutral",
+        text: outcome.sourceUnavailableWarning
+          ? `Removed the local copy and freed ${formatBytes(outcome.reclaimedBytes)}. ${model.name} stays unusable until its model library is reconnected.`
+          : `Removed the local copy and freed ${formatBytes(outcome.reclaimedBytes)}.`,
+      });
+    } catch (error) {
+      setDeleteMessage({ tone: "error", text: String(error?.message ?? error) });
+    } finally {
+      setCacheBusyKey("");
+    }
+  }
 
   // First half of the "Update" flow: re-download the newer source, then track its job so the effect
   // above can auto-convert once it lands. Reuses the existing download + convert endpoints.
@@ -1204,6 +1293,14 @@ export function ModelManagerScreen() {
     // neutral for missing.
     const statusClass = incomplete ? "status-badge warning" : installed ? "status-badge installed" : "status-badge";
     const statusText = incomplete ? "incomplete" : installed ? "installed" : "missing";
+    // Where this model's files actually resolve from, straight off the typed judgement the one
+    // shared resolver produced (sc-19708). NEVER re-derived here from paths or error text — that
+    // discipline is the whole reason a second, drifting availability opinion can't exist.
+    const availability = availabilityBadge(model);
+    // Local copies of THIS model, joined by the backend. `modelCache` is null when the status read
+    // failed, which correctly renders nothing rather than "no local copies".
+    const localCopies = entriesForModel(modelCache, model.id);
+    const showLocalCopySection = localCopies.length > 0 || canHoldLocalCopy(model);
     return (
       <article className={model.recommended ? "model-card recommended" : "model-card"} key={model.id}>
         <div className="model-card-head">
@@ -1213,6 +1310,14 @@ export function ModelManagerScreen() {
           </span>
           <span className="model-card-status">
             <span className={statusClass}>{statusText}</span>
+            {availability ? (
+              <span
+                className={availability.tone ? `status-badge ${availability.tone}` : "status-badge"}
+                title={availability.title}
+              >
+                {availability.text}
+              </span>
+            ) : null}
             {model.updateAvailable ? <span className="status-badge warning">update available</span> : null}
             {unassociated ? (
               <span className="status-badge warning" title="Set this model's family in user.models.jsonc before using it for generation.">
@@ -1353,6 +1458,70 @@ export function ModelManagerScreen() {
             onDeleteVariant={deleteModelVariant}
             deletingItem={deletingItem}
           />
+        ) : null}
+        {/* Local copies of this model in the resolved-model cache (sc-19711). Separate from the
+            download/install job surface above on purpose: promoting or reclaiming a local copy is
+            not an install, and conflating them would make "removed" read as "uninstalled". */}
+        {showLocalCopySection ? (
+          <div className="model-local-copy">
+            <div className="model-local-copy-head">
+              <span className="status-badge">Local copy</span>
+              {model.modelAvailability === "installed_external_unavailable" && !localCopies.length ? (
+                <span className="status-badge warning">library disconnected</span>
+              ) : null}
+            </div>
+            {localCopies.length === 0 ? (
+              <p>
+                No local copy yet. SceneWorks makes one the next time it loads this model, if local
+                copies are turned on in Settings.
+              </p>
+            ) : (
+              <ul className="model-local-copy-list">
+                {localCopies.map((entry) => {
+                  const busy = cacheBusyKey === entry.cacheKey;
+                  const ready = entry.state === "complete";
+                  return (
+                    <li className="model-local-copy-entry" key={entry.cacheKey}>
+                      <span className="model-local-copy-text">
+                        <span>
+                          {entry.tier ? `${tierLabel(entry.tier)} · ` : ""}
+                          {formatBytes(entry.bytes)}
+                        </span>
+                        <small>
+                          {ready
+                            ? entry.pinned
+                              ? "Kept — never removed automatically"
+                              : "Can be removed automatically when space is needed"
+                            : `Not ready to use (${entry.state}) — SceneWorks finishes or clears it on the next check`}
+                        </small>
+                      </span>
+                      <span className="model-local-copy-actions">
+                        <button
+                          disabled={busy || !ready}
+                          onClick={() => toggleKeepLocalCopy(entry)}
+                          type="button"
+                        >
+                          {entry.pinned ? "Allow automatic removal" : "Keep locally"}
+                        </button>
+                        <button
+                          className="danger-action"
+                          disabled={busy}
+                          onClick={() => removeLocalCopy(model, entry)}
+                          type="button"
+                        >
+                          {busy ? "Working…" : "Remove local copy"}
+                        </button>
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            <p>
+              Removing a local copy never uninstalls the model — the original files in the model
+              library are untouched.
+            </p>
+          </div>
         ) : null}
         {model.updateAvailable && !mlxState ? (
           <p className="inline-warning">A newer model download is available; the installed version remains usable.</p>
@@ -1944,7 +2113,17 @@ export function ModelManagerScreen() {
         {isModelTab ? renderRecommendedPicks(effectiveTab) : null}
       </WorkPanel>
 
-      {deleteMessage.text ? <p className={deleteMessage.tone === "success" ? "inline-success" : "inline-warning"}>{deleteMessage.text}</p> : null}
+      {/* Live region so a delete / local-copy outcome is announced, not only painted — the
+          keep/remove buttons sit far down a long card and their result lands up here. */}
+      {deleteMessage.text ? (
+        <p
+          aria-live="polite"
+          className={deleteMessage.tone === "success" ? "inline-success" : "inline-warning"}
+          role="status"
+        >
+          {deleteMessage.text}
+        </p>
+      ) : null}
 
       {isModelTab ? renderModelTabPanel(effectiveTab) : null}
       {isSearchTab ? renderSearchTabPanel() : null}

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -1297,10 +1297,15 @@ export function ModelManagerScreen() {
     // shared resolver produced (sc-19708). NEVER re-derived here from paths or error text — that
     // discipline is the whole reason a second, drifting availability opinion can't exist.
     const availability = availabilityBadge(model);
-    // Local copies of THIS model, joined by the backend. `modelCache` is null when the status read
-    // failed, which correctly renders nothing rather than "no local copies".
+    // Local copies of THIS model, joined by the backend.
     const localCopies = entriesForModel(modelCache, model.id);
-    const showLocalCopySection = localCopies.length > 0 || canHoldLocalCopy(model);
+    // The block renders ONLY when the cache state is actually known. `modelCache` is null when the
+    // status read failed outright, and a returned snapshot carries `error` when the store exists
+    // but could not be listed — in both cases the entry list is empty for want of an answer, not
+    // because there are no copies. Gating on `cacheKnown` is what stops "No local copy yet." from
+    // being rendered as a confident claim over a read that never succeeded.
+    const cacheKnown = Boolean(modelCache) && !modelCache.error;
+    const showLocalCopySection = cacheKnown && (localCopies.length > 0 || canHoldLocalCopy(model));
     return (
       <article className={model.recommended ? "model-card recommended" : "model-card"} key={model.id}>
         <div className="model-card-head">

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -738,6 +738,9 @@ export function ModelManagerScreen() {
   const [modelCache, setModelCache] = useState(null);
   // Cache key of the entry whose keep/remove request is in flight, so its buttons disable.
   const [cacheBusyKey, setCacheBusyKey] = useState("");
+  // Why the local-copy controls are absent, when they are. Held apart from `deleteMessage` so an
+  // action outcome cannot clobber a standing explanation, and vice versa.
+  const [cacheError, setCacheError] = useState("");
   // Tabbed interface (epic 10309): the active tab, the tab to restore when a search
   // clears, and the persistent search query. Every model now renders as an always-open
   // card, so the old per-row expand state is gone. Tabs: image | video | utility | lora,
@@ -900,12 +903,19 @@ export function ModelManagerScreen() {
   }, [jobs, pendingUpdate, createModelConvertJob]);
 
   // One resolved-cache status read for the whole screen. A failure leaves `modelCache` null, which
-  // renders no local-copy blocks at all — never an empty-but-confident "no local copies".
+  // renders no local-copy blocks at all — never an empty-but-confident "no local copies". The
+  // reason is kept separately so the screen can say ONCE why the controls are missing: the failure
+  // is global, so repeating it on every model card would be noise, and staying silent would leave
+  // the user to guess whether they have no local copies or no answer.
   const refreshModelCache = useCallback(async () => {
     try {
-      setModelCache(await fetchModelCache());
-    } catch {
+      const snapshot = await fetchModelCache();
+      setModelCache(snapshot);
+      // A 200 can still carry `error`: the store exists but could not be listed.
+      setCacheError(snapshot?.error ? String(snapshot.error) : "");
+    } catch (error) {
       setModelCache(null);
+      setCacheError(String(error?.message ?? error));
     }
   }, []);
 
@@ -2127,6 +2137,15 @@ export function ModelManagerScreen() {
           role="status"
         >
           {deleteMessage.text}
+        </p>
+      ) : null}
+
+      {/* Stated once for the whole screen, because the read that failed was one read for the whole
+          screen. Says what is unavailable and why, without implying anything about what is or is
+          not cached — that is precisely what could not be determined. */}
+      {cacheError ? (
+        <p className="inline-warning">
+          Local model copies can’t be shown right now, so their controls are hidden: {cacheError}
         </p>
       ) : null}
 

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -18,14 +18,17 @@ import { formatBytes } from "../formatting.js";
 import {
   availabilityBadge,
   canHoldLocalCopy,
+  describeEntryState,
   describeRemovalPreview,
   entriesForModel,
   fetchModelCache,
+  isTransitionalEntry,
   previewCacheRemoval,
   removalIsAllowed,
   removeCacheEntry,
   setCacheEntryPin,
 } from "../modelCache.js";
+import { useCacheConvergence } from "../hooks/useCacheConvergence.js";
 import { KeywordTagEditor } from "../components/KeywordTagEditor.jsx";
 import { useHostMemory } from "../hooks/useHostMemory.js";
 import { hostMemoryGbForBackend } from "../hostMemory.js";
@@ -732,9 +735,10 @@ export function ModelManagerScreen() {
   const [deletingItem, setDeletingItem] = useState("");
   const [deleteMessage, setDeleteMessage] = useState({ tone: "neutral", text: "" });
   // Resolved-model hot cache (epic 19703, sc-19711). ONE status read backs every card's local-copy
-  // block; it is refreshed on mount and after each keep/remove, never on a timer — a journal
-  // listing grows with the number of cached bundles, so polling it would put exactly the per-row
-  // read cost back on a screen that sc-19708 took it off.
+  // block: on mount, after each keep/remove, and — only while the store is still working on an
+  // entry — on a bounded cadence, so a copy in flight visibly converges instead of freezing at
+  // whatever state the screen happened to open on. A settled cache costs exactly the one mount
+  // read it always did, which is what keeps the per-row cost sc-19708 removed from coming back.
   const [modelCache, setModelCache] = useState(null);
   // Cache key of the entry whose keep/remove request is in flight, so its buttons disable.
   const [cacheBusyKey, setCacheBusyKey] = useState("");
@@ -922,6 +926,13 @@ export function ModelManagerScreen() {
   useEffect(() => {
     refreshModelCache();
   }, [refreshModelCache]);
+
+  // Bounded convergence refresh. It runs ONLY while the snapshot actually holds an entry the store
+  // is still moving (queued, copying, being removed) and stops the moment every entry is terminal,
+  // so an all-settled cache is read exactly once. `stalled` is the honest end of the bound: still
+  // in flight, but nothing is re-reading any more, which the card has to say rather than leave a
+  // "checking…" line that has quietly stopped meaning anything.
+  const { stalled: cacheConvergenceStalled } = useCacheConvergence(modelCache, refreshModelCache);
 
   // "Keep locally" / "Allow automatic removal" — the artifact pin. Re-reads the authoritative
   // status afterwards rather than optimistically flipping the row: the UI must not claim a state
@@ -1484,6 +1495,21 @@ export function ModelManagerScreen() {
               {model.modelAvailability === "installed_external_unavailable" && !localCopies.length ? (
                 <span className="status-badge warning">library disconnected</span>
               ) : null}
+              {/* Convergence is visible, and it is honest about having stopped. While the store is
+                  still working the screen re-reads on its own; once the bounded refresh gives up it
+                  says so, and "Check again" remains the way to re-read at any point. */}
+              {localCopies.some(isTransitionalEntry) ? (
+                <>
+                  <span className="model-local-copy-progress">
+                    {cacheConvergenceStalled
+                      ? "Still in progress — SceneWorks has stopped checking automatically."
+                      : "Checking for changes…"}
+                  </span>
+                  <button onClick={refreshModelCache} type="button">
+                    Check again
+                  </button>
+                </>
+              ) : null}
             </div>
             {localCopies.length === 0 ? (
               <p>
@@ -1495,6 +1521,9 @@ export function ModelManagerScreen() {
                 {localCopies.map((entry) => {
                   const busy = cacheBusyKey === entry.cacheKey;
                   const ready = entry.state === "complete";
+                  // What this state means, in words, straight off the store's typed value — with a
+                  // remedy attached for the states nothing resolves on its own.
+                  const stateNote = describeEntryState(entry);
                   return (
                     <li className="model-local-copy-entry" key={entry.cacheKey}>
                       <span className="model-local-copy-text">
@@ -1502,12 +1531,8 @@ export function ModelManagerScreen() {
                           {entry.tier ? `${tierLabel(entry.tier)} · ` : ""}
                           {formatBytes(entry.bytes)}
                         </span>
-                        <small>
-                          {ready
-                            ? entry.pinned
-                              ? "Kept — never removed automatically"
-                              : "Can be removed automatically when space is needed"
-                            : `Not ready to use (${entry.state}) — SceneWorks finishes or clears it on the next check`}
+                        <small className={stateNote.failure ? "model-local-copy-failure" : undefined}>
+                          {stateNote.text}
                         </small>
                       </span>
                       <span className="model-local-copy-actions">

--- a/apps/web/src/screens/SettingsScreen.cacheCard.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.cacheCard.test.jsx
@@ -123,6 +123,8 @@ describe("SettingsScreen local model copies card (sc-19711)", () => {
     delete window.__TAURI__;
     vi.doUnmock("../api.js");
     vi.restoreAllMocks();
+    // Faked per-test by the convergence cases only; restored here either way.
+    vi.useRealTimers();
   });
 
   async function render() {
@@ -236,6 +238,24 @@ describe("SettingsScreen local model copies card (sc-19711)", () => {
     expect(container.textContent).not.toContain("Can be reclaimed");
   });
 
+  // The configured external library location. Every other number in this card is relative to it,
+  // and it is what the same-volume warning below tells the user to move — so it has to be on
+  // screen. The card must show the API's own `sourceLibraryPath`, because that is the exact path
+  // the status read compared volumes against; anything re-derived here could name a location the
+  // comparison never used.
+  it("shows the configured external library location", async () => {
+    await render();
+    const inset = container.querySelector(".settings-inset");
+    expect(inset.textContent).toContain("Library");
+    expect(inset.textContent).toContain("/Volumes/Models/huggingface/hub");
+  });
+
+  it("shows whatever library location the API reports, not a fixed one", async () => {
+    status = cacheStatus({ sourceLibraryPath: "/mnt/nas/hf/hub" });
+    await render();
+    expect(container.querySelector(".settings-inset").textContent).toContain("/mnt/nas/hf/hub");
+  });
+
   // Same-volume is not an error, but it silently removes the entire point of the feature.
   it("states plainly that a same-volume configuration buys nothing", async () => {
     status = cacheStatus({ sourceVolumeRelation: "same" });
@@ -243,6 +263,9 @@ describe("SettingsScreen local model copies card (sc-19711)", () => {
     const notice = container.querySelector(".settings-notice");
     expect(notice.textContent).toContain("same disk as the model library");
     expect(notice.textContent).toContain("neither a disconnect nor a slow drive");
+    // "Point the model library at a different volume" is not actionable to someone who cannot see
+    // where it currently points, so the warning names the configured location.
+    expect(notice.textContent).toContain("/Volumes/Models/huggingface/hub");
   });
 
   it("shows no same-volume warning when the volumes differ", async () => {
@@ -425,6 +448,53 @@ describe("SettingsScreen local model copies card (sc-19711)", () => {
     const region = container.querySelector(".settings-status");
     expect(region.getAttribute("role")).toBe("status");
     expect(region.getAttribute("aria-live")).toBe("polite");
+  });
+
+  // ---- convergence while the store is working --------------------------------------
+  //
+  // Storage totals move as a promotion runs. Freezing them at whatever the screen opened on would
+  // show a user a number that is already wrong, so the card re-reads while (and only while) the
+  // store still has an entry in flight.
+
+  async function tick(times = 1) {
+    for (let i = 0; i < times; i += 1) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000);
+      });
+      await settle();
+    }
+  }
+
+  it("re-reads the storage totals while a copy is materializing, then stops", async () => {
+    vi.useFakeTimers();
+    status = cacheStatus({
+      entries: [{ cacheKey: "sha256:aaa", state: "materializing", bytes: 0, pinned: false }],
+      usedBytes: 0,
+      entryCount: 1,
+    });
+    await render();
+    expect(cacheReads).toBe(1);
+    expect(container.querySelector(".settings-inset").textContent).toContain("0 B of 64.0 GiB");
+
+    status = cacheStatus({
+      entries: [{ cacheKey: "sha256:aaa", state: "complete", bytes: 12 * GIB, pinned: false }],
+      usedBytes: 12 * GIB,
+      entryCount: 1,
+    });
+    await tick();
+    expect(cacheReads).toBe(2);
+    expect(container.querySelector(".settings-inset").textContent).toContain("12.0 GiB of");
+
+    // Terminal: the timer must be gone, not merely quiet.
+    await tick(4);
+    expect(cacheReads).toBe(2);
+  });
+
+  it("never arms a refresh for a settled cache", async () => {
+    vi.useFakeTimers();
+    await render();
+    await tick(5);
+    expect(cacheReads).toBe(1);
   });
 });
 

--- a/apps/web/src/screens/SettingsScreen.cacheCard.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.cacheCard.test.jsx
@@ -414,7 +414,9 @@ describe("SettingsScreen local model copies card (sc-19711)", () => {
     await render();
     expect(toggle().getAttribute("role")).toBe("switch");
     expect(toggle().getAttribute("aria-checked")).toBe("true");
-    shellSettings = { dataDir: "/data", resolvedCache: policy({ enabled: false }) };
+    expect(toggle().getAttribute("aria-label")).toBe(
+      "Keep a working copy of models from external libraries",
+    );
   });
 
   it("announces the commit status in a polite live region", async () => {

--- a/apps/web/src/screens/SettingsScreen.cacheCard.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.cacheCard.test.jsx
@@ -188,6 +188,25 @@ describe("SettingsScreen local model copies card (sc-19711)", () => {
     expect(inset.textContent).toContain("3");
   });
 
+  // The status read is deliberately NOT polled: a journal listing is proportional to the number of
+  // cached bundles, and a timer over it is exactly the per-row read cost sc-19708 removed. It is
+  // read on mount, and again only after an action that could have changed it.
+  it("reads status once on mount and again only after a commit", async () => {
+    await render();
+    expect(cacheReads).toBe(1);
+    await settle();
+    expect(cacheReads).toBe(1);
+    await commitField(limitInput(), "128");
+    expect(cacheReads).toBe(2);
+  });
+
+  // A refused input changes nothing, so it must not cost a re-read either.
+  it("does not re-read status when a commit is refused", async () => {
+    await render();
+    await commitField(limitInput(), "0");
+    expect(cacheReads).toBe(1);
+  });
+
   it("seeds the editable fields from the SHELL-persisted policy, not the running one", async () => {
     // Persisted 32 GiB / 7 days; the API is still running the old 64 GiB / 14 days.
     shellSettings = { dataDir: "/data", resolvedCache: policy({ maxBytes: 32 * GIB, inactivitySeconds: 7 * DAY }) };

--- a/apps/web/src/screens/SettingsScreen.cacheCard.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.cacheCard.test.jsx
@@ -1,0 +1,493 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click } from "../testUtils/dom.js";
+
+// Settings "Local model copies" card (sc-19711, epic 19703).
+//
+// The design fact these tests exist to hold true: the resolved-cache policy is DESKTOP-SHELL-OWNED
+// AND RESTART-BOUND. `set_resolved_cache_policy` persists it in the shell; the three sidecar
+// processes captured their own copy from the environment at spawn, so `GET /api/v1/model-cache`
+// reports the policy the API is ACTUALLY RUNNING UNDER. The card therefore compares
+// persisted-vs-effective and only then says "restart to apply".
+//
+// So these tests drive that real two-source state — a shell settings object and an independent API
+// snapshot that can legitimately disagree — rather than mocking a `needsRestart` flag. A test that
+// stubbed the comparison would pass with the whole mechanism deleted.
+const { appConfirmMock } = vi.hoisted(() => ({ appConfirmMock: vi.fn(async () => true) }));
+vi.mock("../appConfirm.jsx", () => ({
+  appConfirm: appConfirmMock,
+  useConfirm: () => appConfirmMock,
+  ConfirmHost: () => null,
+}));
+
+const GIB = 1024 * 1024 * 1024;
+const DAY = 24 * 60 * 60;
+
+const APP_CONTEXT = {
+  theme: "light",
+  changeTheme: vi.fn(),
+  visibleWorkers: [],
+  macCapabilities: {},
+};
+
+function policy(overrides = {}) {
+  return { enabled: true, maxBytes: 64 * GIB, inactivitySeconds: 14 * DAY, ...overrides };
+}
+
+function cacheStatus(overrides = {}) {
+  return {
+    policy: policy(),
+    initialized: true,
+    error: null,
+    usedBytes: 20 * GIB,
+    pinnedBytes: 4 * GIB,
+    reclaimableBytes: 12 * GIB,
+    entryCount: 3,
+    sourceVolumeRelation: "different",
+    sourceLibraryPath: "/Volumes/Models/huggingface/hub",
+    entries: [],
+    ...overrides,
+  };
+}
+
+describe("SettingsScreen local model copies card (sc-19711)", () => {
+  let container;
+  let root;
+  let invoke;
+  let apiFetch;
+  let cacheReads;
+  let status;
+  let shellSettings;
+  let savedPolicies;
+  let SettingsScreen;
+  let AppContext;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    appConfirmMock.mockReset();
+    appConfirmMock.mockImplementation(async () => true);
+    cacheReads = 0;
+    savedPolicies = [];
+    status = cacheStatus();
+    shellSettings = { dataDir: "/data", resolvedCache: policy() };
+    invoke = vi.fn(async (command, args) => {
+      switch (command) {
+        case "get_app_settings":
+          return shellSettings;
+        case "get_gpu_info":
+          return { platform: "macos", devices: [] };
+        case "list_credentials":
+          return [];
+        case "get_remote_access":
+          return null;
+        case "set_resolved_cache_policy":
+          savedPolicies.push(args.policy);
+          // The shell echoes back the WHOLE settings object with the new persisted policy. The
+          // running API policy in `status` is deliberately NOT touched — that divergence is the
+          // real restart-bound state.
+          shellSettings = { ...shellSettings, resolvedCache: args.policy };
+          return shellSettings;
+        default:
+          return null;
+      }
+    });
+    apiFetch = vi.fn(async (path) => {
+      if (path === "/api/v1/model-cache") {
+        cacheReads += 1;
+        if (status instanceof Error) throw status;
+        return status;
+      }
+      return [];
+    });
+    window.__TAURI__ = { core: { invoke } };
+    vi.resetModules();
+    vi.doMock("../api.js", () => ({
+      apiFetch,
+      isAbortError: () => false,
+      API_BASE_URL: "",
+      eventUrl: () => "",
+    }));
+    ({ SettingsScreen } = await import("./SettingsScreen.jsx"));
+    ({ AppContext } = await import("../context/AppContext.js"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    delete window.__TAURI__;
+    vi.doUnmock("../api.js");
+    vi.restoreAllMocks();
+  });
+
+  async function render() {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={APP_CONTEXT}>
+          <SettingsScreen />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+    await act(async () => {});
+    const tab = [...container.querySelectorAll(".mode-tab")].find(
+      (button) => button.textContent.trim() === "Settings",
+    );
+    expect(tab, 'tab "Settings"').toBeTruthy();
+    await click(tab);
+  }
+
+  async function settle() {
+    await act(async () => {
+      for (let i = 0; i < 8; i += 1) await Promise.resolve();
+    });
+  }
+
+  const toggle = () =>
+    container.querySelector(
+      '[aria-label="Keep a working copy of models from external libraries"]',
+    );
+  const limitInput = () => container.querySelector("#model-cache-limit");
+  const daysInput = () => container.querySelector("#model-cache-days");
+  const statusText = () => container.querySelector(".settings-status")?.textContent ?? "";
+
+  // Commit paths fire on blur, so set the value the way React sees it and then blur.
+  async function commitField(input, value) {
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(input.constructor.prototype, "value")?.set;
+      setter?.call(input, value);
+      input.dispatchEvent(new window.Event("input", { bubbles: true }));
+    });
+    // React delegates `onBlur` off the BUBBLING `focusout` event, not the non-bubbling native
+    // `blur`, so dispatching `blur` here would silently never reach the handler.
+    await act(async () => {
+      input.dispatchEvent(new window.FocusEvent("focusout", { bubbles: true }));
+    });
+    await settle();
+  }
+
+  // ---- storage readout -------------------------------------------------------------
+
+  // The usage totals come from the resolver's own ledger, and all four have to be visible — the
+  // acceptance criterion is that they match the ledger, which starts with showing them.
+  it("renders the ledger's usage, count, reclaimable and kept bytes", async () => {
+    await render();
+    expect(apiFetch).toHaveBeenCalledWith("/api/v1/model-cache", expect.anything());
+    const text = container.textContent;
+    expect(text).toContain("Local model copies");
+    expect(text).toContain("20.0 GiB of 64.0 GiB");
+    expect(text).toContain("12.0 GiB"); // reclaimable
+    expect(text).toContain("4.0 GiB"); // kept / pinned
+    const inset = container.querySelector(".settings-inset");
+    expect(inset.textContent).toContain("Copies");
+    expect(inset.textContent).toContain("3");
+  });
+
+  it("seeds the editable fields from the SHELL-persisted policy, not the running one", async () => {
+    // Persisted 32 GiB / 7 days; the API is still running the old 64 GiB / 14 days.
+    shellSettings = { dataDir: "/data", resolvedCache: policy({ maxBytes: 32 * GIB, inactivitySeconds: 7 * DAY }) };
+    await render();
+    expect(limitInput().value).toBe("32");
+    expect(daysInput().value).toBe("7");
+  });
+
+  // A failed read must be reported, never rendered as an empty, reassuring cache.
+  it("reports a failed status read instead of showing an empty cache", async () => {
+    status = new Error("model-cache endpoint unavailable");
+    await render();
+    expect(container.textContent).toContain("Couldn’t read local copy storage");
+    expect(container.textContent).toContain("model-cache endpoint unavailable");
+    // Scoped to the cache readout: ".settings-inset" alone also matches unrelated Settings insets.
+    expect(container.textContent).not.toContain("Can be reclaimed");
+  });
+
+  // The store exists but could not be listed: the API answers 200 with an `error` field. Same
+  // rule — say "couldn't read", don't render a confident zero.
+  it("reports a snapshot that says the store could not be listed", async () => {
+    status = cacheStatus({ error: "resolved-cache journal is unreadable", usedBytes: 0, entryCount: 0 });
+    await render();
+    expect(container.textContent).toContain("Couldn’t read local copy storage");
+    expect(container.textContent).toContain("resolved-cache journal is unreadable");
+    // Scoped to the cache readout: ".settings-inset" alone also matches unrelated Settings insets.
+    expect(container.textContent).not.toContain("Can be reclaimed");
+  });
+
+  // Same-volume is not an error, but it silently removes the entire point of the feature.
+  it("states plainly that a same-volume configuration buys nothing", async () => {
+    status = cacheStatus({ sourceVolumeRelation: "same" });
+    await render();
+    const notice = container.querySelector(".settings-notice");
+    expect(notice.textContent).toContain("same disk as the model library");
+    expect(notice.textContent).toContain("neither a disconnect nor a slow drive");
+  });
+
+  it("shows no same-volume warning when the volumes differ", async () => {
+    await render();
+    expect(container.textContent).not.toContain("same disk as the model library");
+  });
+
+  // ---- restart-bound policy --------------------------------------------------------
+
+  // Persisted and running agree: there is nothing to restart for, and claiming otherwise would be
+  // a standing false alarm.
+  it("claims no restart while the persisted policy matches the running one", async () => {
+    await render();
+    expect(container.textContent).not.toContain("restart to apply");
+  });
+
+  // The real divergence: the shell already persisted 32 GiB, the API is still running 64 GiB.
+  it("says restart-to-apply when the persisted policy differs from the running one", async () => {
+    shellSettings = { dataDir: "/data", resolvedCache: policy({ maxBytes: 32 * GIB }) };
+    await render();
+    expect(container.textContent).toContain("still running under the previous setting");
+    expect(container.textContent).toContain("restart to apply");
+  });
+
+  // THE round-trip, end to end and with no stubbed comparison: commit a change → the shell
+  // persists it → the API snapshot still reports the OLD running policy → the notice appears
+  // because the two genuinely disagree now. Deleting the persisted-vs-effective comparison makes
+  // this red.
+  it("commits a change and then honestly reports it is not yet in effect", async () => {
+    await render();
+    expect(container.textContent).not.toContain("restart to apply");
+
+    await commitField(limitInput(), "32");
+
+    expect(savedPolicies).toEqual([
+      { enabled: true, maxBytes: 32 * GIB, inactivitySeconds: 14 * DAY },
+    ]);
+    expect(statusText()).toContain("32.0 GiB");
+    expect(statusText()).toContain("after a restart");
+    // The API still reports the 64 GiB policy it spawned with, so the card must now say so.
+    expect(container.textContent).toContain("still running under the previous setting");
+    // And the readout keeps showing the RUNNING limit, not the aspirational one.
+    expect(container.textContent).toContain("20.0 GiB of 64.0 GiB");
+  });
+
+  // Every commit sends a COMPLETE policy, so a partial write can never leave the store running
+  // under a half-applied rule.
+  it("sends a complete policy on every commit path", async () => {
+    await render();
+    await commitField(daysInput(), "30");
+    expect(savedPolicies).toEqual([
+      { enabled: true, maxBytes: 64 * GIB, inactivitySeconds: 30 * DAY },
+    ]);
+    expect(statusText()).toContain("30 unused days");
+    expect(statusText()).toContain("after a restart");
+  });
+
+  // ---- enable / disable -------------------------------------------------------------
+
+  // Turning the cache off is not destructive and does not sweep. Say what actually happens to the
+  // copies already on disk BEFORE committing.
+  it("explains that disabling keeps existing copies, then persists enabled:false", async () => {
+    await render();
+    await click(toggle());
+    await settle();
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    const dialog = appConfirmMock.mock.calls[0][0];
+    expect(dialog.message).toContain("stops making new local copies");
+    expect(dialog.message).toContain("stay on disk");
+    expect(dialog.message).toContain("3 existing copies");
+    expect(dialog.message).not.toMatch(/delet/i);
+    expect(savedPolicies).toEqual([
+      { enabled: false, maxBytes: 64 * GIB, inactivitySeconds: 14 * DAY },
+    ]);
+    expect(statusText()).toContain("Existing copies stay on disk");
+  });
+
+  it("persists nothing when the disable confirm is declined", async () => {
+    appConfirmMock.mockImplementation(async () => false);
+    await render();
+    await click(toggle());
+    await settle();
+    expect(savedPolicies).toEqual([]);
+    expect(toggle().getAttribute("aria-checked")).toBe("true");
+  });
+
+  // Enabling is not destructive and needs no consequence dialog.
+  it("enables without a confirm", async () => {
+    shellSettings = { dataDir: "/data", resolvedCache: policy({ enabled: false }) };
+    status = cacheStatus({ policy: policy({ enabled: false }) });
+    await render();
+    expect(toggle().getAttribute("aria-checked")).toBe("false");
+    await click(toggle());
+    await settle();
+    expect(appConfirmMock).not.toHaveBeenCalled();
+    expect(savedPolicies).toEqual([
+      { enabled: true, maxBytes: 64 * GIB, inactivitySeconds: 14 * DAY },
+    ]);
+  });
+
+  // ---- limit changes ------------------------------------------------------------------
+
+  // Lowering below current usage schedules FUTURE cleanup; nothing is swept at the moment of the
+  // change, and the confirm has to be bounded by what is actually reclaimable.
+  it("spells out the reclaim before lowering the limit below current usage", async () => {
+    await render();
+    await commitField(limitInput(), "12");
+    expect(appConfirmMock).toHaveBeenCalledTimes(1);
+    const { message } = appConfirmMock.mock.calls[0][0];
+    expect(message).toContain("next automatic cleanup");
+    expect(message).toContain("up to 8.0 GiB");
+    expect(savedPolicies).toEqual([
+      { enabled: true, maxBytes: 12 * GIB, inactivitySeconds: 14 * DAY },
+    ]);
+  });
+
+  it("reverts the field and persists nothing when the lower-limit confirm is declined", async () => {
+    appConfirmMock.mockImplementation(async () => false);
+    await render();
+    await commitField(limitInput(), "12");
+    expect(savedPolicies).toEqual([]);
+    expect(limitInput().value).toBe("64");
+  });
+
+  // Raising the limit has no consequence to warn about.
+  it("raises the limit without a confirm", async () => {
+    await render();
+    await commitField(limitInput(), "128");
+    expect(appConfirmMock).not.toHaveBeenCalled();
+    expect(savedPolicies).toEqual([
+      { enabled: true, maxBytes: 128 * GIB, inactivitySeconds: 14 * DAY },
+    ]);
+  });
+
+  it("commits nothing when the value is unchanged", async () => {
+    await render();
+    await commitField(limitInput(), "64");
+    expect(savedPolicies).toEqual([]);
+    expect(appConfirmMock).not.toHaveBeenCalled();
+  });
+
+  // A user-typed zero / blank / garbage must be refused and the field restored, never written to
+  // the wire as 0 or NaN.
+  it.each([["0"], [""], ["-5"], ["abc"]])(
+    "refuses the unusable limit %j and restores the persisted value",
+    async (value) => {
+      await render();
+      await commitField(limitInput(), value);
+      expect(savedPolicies).toEqual([]);
+      expect(statusText()).toContain("at least 1 GiB");
+      expect(limitInput().value).toBe("64");
+    },
+  );
+
+  it.each([["0"], [""], ["abc"]])(
+    "refuses the unusable interval %j and restores the persisted value",
+    async (value) => {
+      await render();
+      await commitField(daysInput(), value);
+      expect(savedPolicies).toEqual([]);
+      expect(statusText()).toContain("at least one day");
+      expect(daysInput().value).toBe("14");
+    },
+  );
+
+  // ---- accessibility -------------------------------------------------------------------
+
+  it("exposes the toggle as a labelled switch reflecting the persisted state", async () => {
+    await render();
+    expect(toggle().getAttribute("role")).toBe("switch");
+    expect(toggle().getAttribute("aria-checked")).toBe("true");
+    shellSettings = { dataDir: "/data", resolvedCache: policy({ enabled: false }) };
+  });
+
+  it("announces the commit status in a polite live region", async () => {
+    await render();
+    await commitField(limitInput(), "128");
+    const region = container.querySelector(".settings-status");
+    expect(region.getAttribute("role")).toBe("status");
+    expect(region.getAttribute("aria-live")).toBe("polite");
+  });
+});
+
+// The controls are shell-backed and therefore desktop-only, but the usage readout comes from the
+// API and must still render for a remote admin — they need to see what the host is holding even
+// though they cannot change it from there.
+describe("SettingsScreen local model copies card in server (REST) mode", () => {
+  let container;
+  let root;
+  let apiFetch;
+  let SettingsScreen;
+  let AppContext;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    delete window.__TAURI__;
+    appConfirmMock.mockReset();
+    appConfirmMock.mockImplementation(async () => true);
+    apiFetch = vi.fn(async (path) => {
+      if (path === "/api/v1/model-cache") return cacheStatus();
+      return [];
+    });
+    vi.resetModules();
+    vi.doMock("../api.js", () => ({
+      apiFetch,
+      isAbortError: () => false,
+      API_BASE_URL: "",
+      eventUrl: () => "",
+    }));
+    ({ SettingsScreen } = await import("./SettingsScreen.jsx"));
+    ({ AppContext } = await import("../context/AppContext.js"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.doUnmock("../api.js");
+    vi.restoreAllMocks();
+  });
+
+  async function render() {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={APP_CONTEXT}>
+          <SettingsScreen />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+    await act(async () => {});
+    const tab = [...container.querySelectorAll(".mode-tab")].find(
+      (button) => button.textContent.trim() === "Settings",
+    );
+    await click(tab);
+  }
+
+  it("shows the storage readout but no editable controls", async () => {
+    await render();
+    expect(container.textContent).toContain("Local model copies");
+    expect(container.textContent).toContain("20.0 GiB of 64.0 GiB");
+    expect(container.querySelector("#model-cache-limit")).toBeNull();
+    expect(container.querySelector("#model-cache-days")).toBeNull();
+    expect(container.textContent).toContain(
+      "These settings are configured on the machine running SceneWorks",
+    );
+  });
+
+  it("disables the toggle so a remote browser cannot call a missing Tauri bridge", async () => {
+    await render();
+    const toggle = container.querySelector(
+      '[aria-label="Keep a working copy of models from external libraries"]',
+    );
+    expect(toggle.disabled).toBe(true);
+  });
+
+  // With no shell to ask, the running policy IS the persisted one, so there is nothing pending and
+  // no restart to claim.
+  it("never claims a pending restart when there is no shell to persist a different policy", async () => {
+    await render();
+    expect(container.textContent).not.toContain("restart to apply");
+  });
+});

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -17,6 +17,18 @@ import {
   writeDefaultGenerationQuality,
 } from "../generationQuality.js";
 import { writeClipboardText } from "../clipboard.js";
+import { appConfirm } from "../appConfirm.jsx";
+import { formatBytes } from "../formatting.js";
+import {
+  bytesToGib,
+  daysToSeconds,
+  describeDisableConsequence,
+  describeLimitConsequence,
+  fetchModelCache,
+  gibToBytes,
+  policyNeedsRestart,
+  secondsToDays,
+} from "../modelCache.js";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { ModeTabs } from "../components/generationStudio.jsx";
@@ -114,6 +126,16 @@ export function SettingsScreen({
   // q8 by default.
   const [defaultQuality, setDefaultQuality] = useState(readDefaultGenerationQuality);
   const defaultQualityRequest = useRef(0);
+  // Resolved-model hot cache (epic 19703, sc-19711). `cache` is the API's authoritative snapshot:
+  // the policy the RUNNING sidecars captured at spawn, plus the store's own usage accounting.
+  // Deliberately NOT polled — a journal listing is proportional to the number of cached bundles,
+  // and a timer over it is exactly the per-row read cost sc-19708 removed from the catalog. It is
+  // fetched on mount and re-fetched after any action that could have changed it.
+  const [cache, setCache] = useState(null);
+  const [cacheError, setCacheError] = useState("");
+  // Draft limit/interval so typing doesn't fire a save per keystroke; committed on blur / Apply.
+  const [cacheLimitGb, setCacheLimitGb] = useState("");
+  const [cacheDays, setCacheDays] = useState("");
 
   const refresh = useCallback(async () => {
     try {
@@ -147,6 +169,33 @@ export function SettingsScreen({
   useEffect(() => {
     if (settings) setGpuLimitPercent(fractionToPercent(settings.gpuMemoryLimitFraction));
   }, [settings]);
+
+  const refreshCache = useCallback(async () => {
+    try {
+      const snapshot = await fetchModelCache();
+      setCache(snapshot);
+      setCacheError("");
+      return snapshot;
+    } catch (error) {
+      // Report the failure rather than rendering a reassuring empty cache.
+      setCache(null);
+      setCacheError(String(error?.message ?? error));
+      return null;
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshCache();
+  }, [refreshCache]);
+
+  // The persisted (shell-owned) policy seeds the editable fields. On a non-desktop deployment
+  // there is no shell to ask, so the running policy is both what is persisted and what applies.
+  const persistedPolicy = isDesktop ? (settings?.resolvedCache ?? null) : (cache?.policy ?? null);
+  useEffect(() => {
+    if (!persistedPolicy) return;
+    setCacheLimitGb(String(Math.round(bytesToGib(persistedPolicy.maxBytes))));
+    setCacheDays(String(Math.round(secondsToDays(persistedPolicy.inactivitySeconds))));
+  }, [persistedPolicy?.maxBytes, persistedPolicy?.inactivitySeconds]);
 
   // Poll live MLX memory telemetry while the GPU card is visible (epic 7819, sc-7825). macOS-only —
   // the worker only publishes the snapshot on the MLX path; elsewhere the command returns null.
@@ -290,6 +339,85 @@ export function SettingsScreen({
     }
   }
 
+  // Persist a resolved-cache policy through the shell (the durable copy the sidecars read at
+  // spawn). Every caller passes a COMPLETE policy so a partial write can never leave the store
+  // running under a half-applied rule. The status line says "after a restart" because that is
+  // literally when it takes effect — the three sidecar processes captured their policy at spawn.
+  async function commitCachePolicy(policy, message) {
+    try {
+      const updated = await invoke("set_resolved_cache_policy", { policy });
+      setSettings(updated);
+      await refreshCache();
+      setStatus(message);
+    } catch (error) {
+      setStatus(String(error));
+    }
+  }
+
+  // Turning the cache OFF is not destructive and does not sweep. Say what actually happens to the
+  // copies already on disk before committing, so nobody discovers it afterwards.
+  async function changeCacheEnabled(enabled) {
+    if (!persistedPolicy) return;
+    if (!enabled) {
+      const proceed = await appConfirm({
+        title: "Stop keeping local copies?",
+        message: describeDisableConsequence(cache),
+        confirmLabel: "Turn off",
+      });
+      if (!proceed) return;
+    }
+    await commitCachePolicy(
+      { ...persistedPolicy, enabled },
+      enabled
+        ? "Local model copies enabled — takes effect after a restart."
+        : "Local model copies disabled — takes effect after a restart. Existing copies stay on disk.",
+    );
+  }
+
+  // Lowering the limit below current usage schedules future cleanup; it never sweeps here. The
+  // confirm spells out how much can actually be reclaimed and how much is kept.
+  async function commitCacheLimit() {
+    if (!persistedPolicy) return;
+    const nextMaxBytes = gibToBytes(cacheLimitGb);
+    if (nextMaxBytes <= 0) {
+      setStatus("The size limit must be at least 1 GiB.");
+      setCacheLimitGb(String(Math.round(bytesToGib(persistedPolicy.maxBytes))));
+      return;
+    }
+    if (nextMaxBytes === Number(persistedPolicy.maxBytes)) return;
+    const consequence = describeLimitConsequence(cache, nextMaxBytes);
+    if (consequence) {
+      const proceed = await appConfirm({
+        title: "Lower the local copy limit?",
+        message: consequence,
+        confirmLabel: "Set limit",
+      });
+      if (!proceed) {
+        setCacheLimitGb(String(Math.round(bytesToGib(persistedPolicy.maxBytes))));
+        return;
+      }
+    }
+    await commitCachePolicy(
+      { ...persistedPolicy, maxBytes: nextMaxBytes },
+      `Local copy limit set to ${formatBytes(nextMaxBytes)} — takes effect after a restart.`,
+    );
+  }
+
+  async function commitCacheInterval() {
+    if (!persistedPolicy) return;
+    const nextSeconds = daysToSeconds(cacheDays);
+    if (nextSeconds <= 0) {
+      setStatus("The unused-for interval must be at least one day.");
+      setCacheDays(String(Math.round(secondsToDays(persistedPolicy.inactivitySeconds))));
+      return;
+    }
+    if (nextSeconds === Number(persistedPolicy.inactivitySeconds)) return;
+    await commitCachePolicy(
+      { ...persistedPolicy, inactivitySeconds: nextSeconds },
+      `Local copies are removed after ${Math.round(secondsToDays(nextSeconds))} unused days — takes effect after a restart.`,
+    );
+  }
+
   async function rerunSetupWizard() {
     try {
       await invoke("reset_setup");
@@ -392,8 +520,14 @@ export function SettingsScreen({
           />
         </div>
 
-        {/* One status line under the tab row — the old full-width band above the panel is gone. */}
-        {status ? <p className="settings-status">{status}</p> : null}
+        {/* One status line under the tab row — the old full-width band above the panel is gone.
+            It is a live region so a change committed by keyboard is announced, not just painted
+            (sc-19711 accessibility parity). */}
+        {status ? (
+          <p aria-live="polite" className="settings-status" role="status">
+            {status}
+          </p>
+        ) : null}
 
         {activeTab === "appearance" ? (
           <div className="settings-tab-body">
@@ -556,6 +690,118 @@ export function SettingsScreen({
                 <div className="work-panel-divider" />
               </>
             ) : null}
+
+            {/* Resolved-model hot cache (epic 19703, sc-19711). The controls are shell-backed and
+                therefore desktop-only, exactly like the data directory above; the usage readout
+                comes from the API and renders in every deployment, because a remote admin still
+                needs to see what the host is holding. */}
+            <div className="settings-group-title">Local model copies</div>
+            <div className="settings-row settings-row--top">
+              <div>
+                <div className="settings-row-title">
+                  Keep a working copy of models from external libraries
+                </div>
+                <div className="settings-row-sub">
+                  Copies models loaded from an attached or network model library into SceneWorks’
+                  own storage, so they keep working when that library is disconnected. Off by
+                  default. Takes effect after a restart.
+                </div>
+              </div>
+              <button
+                aria-checked={Boolean(persistedPolicy?.enabled)}
+                aria-label="Keep a working copy of models from external libraries"
+                className={persistedPolicy?.enabled ? "settings-toggle on" : "settings-toggle"}
+                disabled={!isDesktop || !persistedPolicy}
+                onClick={() => changeCacheEnabled(!persistedPolicy?.enabled)}
+                role="switch"
+                type="button"
+              >
+                <span />
+              </button>
+            </div>
+            {isDesktop && persistedPolicy ? (
+              <div className="settings-field-row">
+                <label className="settings-note" htmlFor="model-cache-limit">
+                  Use at most
+                </label>
+                <input
+                  aria-label="Maximum size for local model copies, in GiB"
+                  className="settings-port"
+                  id="model-cache-limit"
+                  min="1"
+                  onBlur={commitCacheLimit}
+                  onChange={(event) => setCacheLimitGb(event.target.value)}
+                  type="number"
+                  value={cacheLimitGb}
+                />
+                <span className="settings-note">GiB, and remove copies unused for</span>
+                <input
+                  aria-label="Remove local model copies unused for this many days"
+                  className="settings-port"
+                  id="model-cache-days"
+                  min="1"
+                  onBlur={commitCacheInterval}
+                  onChange={(event) => setCacheDays(event.target.value)}
+                  type="number"
+                  value={cacheDays}
+                />
+                <span className="settings-note settings-grow">days.</span>
+              </div>
+            ) : null}
+            {!isDesktop ? (
+              <p className="settings-note">
+                These settings are configured on the machine running SceneWorks.
+              </p>
+            ) : null}
+            {policyNeedsRestart(persistedPolicy, cache?.policy) ? (
+              <p className="settings-note">
+                Saved. SceneWorks is still running under the previous setting — restart to apply
+                it.
+              </p>
+            ) : null}
+            {cacheError ? (
+              <p className="inline-warning">Couldn’t read local copy storage: {cacheError}</p>
+            ) : cache?.error ? (
+              <p className="inline-warning">Couldn’t read local copy storage: {cache.error}</p>
+            ) : cache?.policy ? (
+              <div className="settings-inset settings-inset--spaced">
+                <div className="settings-inset-title">Storage</div>
+                <div className="settings-kv">
+                  <span>Used</span>
+                  <span className="settings-mono">
+                    {formatBytes(cache.usedBytes)} of {formatBytes(cache.policy.maxBytes)}
+                  </span>
+                </div>
+                <div className="settings-kv">
+                  <span>Copies</span>
+                  <span className="settings-mono">{cache.entryCount}</span>
+                </div>
+                <div className="settings-kv">
+                  <span>Can be reclaimed</span>
+                  <span className="settings-mono">{formatBytes(cache.reclaimableBytes)}</span>
+                </div>
+                <div className="settings-kv">
+                  <span>Kept</span>
+                  <span className="settings-mono">{formatBytes(cache.pinnedBytes)}</span>
+                </div>
+              </div>
+            ) : null}
+            {/* Same-volume is not an error, but it silently removes the whole point of the
+                feature, so it is stated plainly rather than left for the user to infer. */}
+            {cache?.sourceVolumeRelation === "same" ? (
+              <div className="settings-notice">
+                <Icon.Warning size={16} />
+                <span>
+                  Local copies are on the same disk as the model library, so they protect against
+                  neither a disconnect nor a slow drive — they only use extra space. Point the
+                  model library at a different volume to get the benefit.
+                </span>
+              </div>
+            ) : null}
+            <p className="settings-note">
+              Remove individual copies, or mark one to keep, from a model’s card in Model Manager.
+            </p>
+            <div className="work-panel-divider" />
 
             <div className="settings-group-title">Service credentials</div>
             <p className="settings-note">

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -191,11 +191,18 @@ export function SettingsScreen({
   // The persisted (shell-owned) policy seeds the editable fields. On a non-desktop deployment
   // there is no shell to ask, so the running policy is both what is persisted and what applies.
   const persistedPolicy = isDesktop ? (settings?.resolvedCache ?? null) : (cache?.policy ?? null);
+  // Re-seed only when the persisted VALUES change, never on the containing object's identity:
+  // `settings` is a fresh object after every `get_app_settings`, so depending on the policy object
+  // would clobber whatever the user is mid-way through typing on each refresh. The primitives are
+  // lifted into their own bindings so that intent survives `react-hooks/exhaustive-deps` instead
+  // of being expressed as a dependency list the rule can't verify.
+  const persistedMaxBytes = persistedPolicy?.maxBytes;
+  const persistedInactivitySeconds = persistedPolicy?.inactivitySeconds;
   useEffect(() => {
-    if (!persistedPolicy) return;
-    setCacheLimitGb(String(Math.round(bytesToGib(persistedPolicy.maxBytes))));
-    setCacheDays(String(Math.round(secondsToDays(persistedPolicy.inactivitySeconds))));
-  }, [persistedPolicy?.maxBytes, persistedPolicy?.inactivitySeconds]);
+    if (persistedMaxBytes === undefined || persistedInactivitySeconds === undefined) return;
+    setCacheLimitGb(String(Math.round(bytesToGib(persistedMaxBytes))));
+    setCacheDays(String(Math.round(secondsToDays(persistedInactivitySeconds))));
+  }, [persistedMaxBytes, persistedInactivitySeconds]);
 
   // Poll live MLX memory telemetry while the GPU card is visible (epic 7819, sc-7825). macOS-only —
   // the worker only publishes the snapshot on the MLX path; elsewhere the command returns null.

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -29,6 +29,7 @@ import {
   policyNeedsRestart,
   secondsToDays,
 } from "../modelCache.js";
+import { useCacheConvergence } from "../hooks/useCacheConvergence.js";
 import { WorkPanel } from "../components/WorkPanel.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { ModeTabs } from "../components/generationStudio.jsx";
@@ -128,9 +129,10 @@ export function SettingsScreen({
   const defaultQualityRequest = useRef(0);
   // Resolved-model hot cache (epic 19703, sc-19711). `cache` is the API's authoritative snapshot:
   // the policy the RUNNING sidecars captured at spawn, plus the store's own usage accounting.
-  // Deliberately NOT polled — a journal listing is proportional to the number of cached bundles,
-  // and a timer over it is exactly the per-row read cost sc-19708 removed from the catalog. It is
-  // fetched on mount and re-fetched after any action that could have changed it.
+  // Fetched on mount, re-fetched after any action that could have changed it, and re-read on a
+  // bounded cadence ONLY while the store still has an entry in flight — so the storage totals
+  // converge while a promotion runs, and a settled cache is still read exactly once. A timer that
+  // ran unconditionally would put back the per-row read cost sc-19708 removed from the catalog.
   const [cache, setCache] = useState(null);
   const [cacheError, setCacheError] = useState("");
   // Draft limit/interval so typing doesn't fire a save per keystroke; committed on blur / Apply.
@@ -187,6 +189,10 @@ export function SettingsScreen({
   useEffect(() => {
     refreshCache();
   }, [refreshCache]);
+
+  // Bounded convergence refresh — the same one the Model Manager runs, so the two surfaces cannot
+  // disagree about when the app stops polling. It re-reads only while an entry is still moving.
+  useCacheConvergence(cache, refreshCache);
 
   // The persisted (shell-owned) policy seeds the editable fields. On a non-desktop deployment
   // there is no shell to ask, so the running policy is both what is persisted and what applies.
@@ -791,17 +797,34 @@ export function SettingsScreen({
                   <span>Kept</span>
                   <span className="settings-mono">{formatBytes(cache.pinnedBytes)}</span>
                 </div>
+                {/* The external library these copies are made FROM. It is the location every other
+                    line here is relative to — and the one the same-volume warning below is about —
+                    so a user who has to act on that warning can see what is actually configured
+                    instead of hunting for "the model library". Reported by the API rather than
+                    re-derived here: the status read compares against this exact path, so showing
+                    anything else could name a location the comparison never used. */}
+                {cache.sourceLibraryPath ? (
+                  <div className="settings-kv">
+                    <span>Library</span>
+                    <span className="settings-mono" title={cache.sourceLibraryPath}>
+                      {cache.sourceLibraryPath}
+                    </span>
+                  </div>
+                ) : null}
               </div>
             ) : null}
             {/* Same-volume is not an error, but it silently removes the whole point of the
-                feature, so it is stated plainly rather than left for the user to infer. */}
+                feature, so it is stated plainly rather than left for the user to infer — and it
+                names the configured location, because "point the model library elsewhere" is not
+                an actionable instruction to someone who cannot see where it currently points. */}
             {cache?.sourceVolumeRelation === "same" ? (
               <div className="settings-notice">
                 <Icon.Warning size={16} />
                 <span>
-                  Local copies are on the same disk as the model library, so they protect against
-                  neither a disconnect nor a slow drive — they only use extra space. Point the
-                  model library at a different volume to get the benefit.
+                  Local copies are on the same disk as the model library
+                  {cache.sourceLibraryPath ? ` (${cache.sourceLibraryPath})` : ""}, so they protect
+                  against neither a disconnect nor a slow drive — they only use extra space. Point
+                  the model library at a different volume to get the benefit.
                 </span>
               </div>
             ) : null}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7082,6 +7082,18 @@ details[open] > summary.lora-scope-group-heading::before,
   color: var(--muted);
 }
 
+/* An entry state nothing resolves on its own. Uses the existing warm warning token so a failed
+   copy is not read as ordinary muted detail, and no new colour idiom enters the screen. */
+.model-local-copy-text small.model-local-copy-failure {
+  color: var(--warm);
+}
+
+.model-local-copy-progress {
+  align-self: center;
+  font-size: 12px;
+  color: var(--muted);
+}
+
 .model-local-copy-actions {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -7036,6 +7036,58 @@ details[open] > summary.lora-scope-group-heading::before,
   font-size: 12px;
 }
 
+/* Resolved-model local copies on a model card (sc-19711). Deliberately the same divider-above,
+   badge-then-detail shape as .mlx-status so the card gains no new visual idiom. */
+.model-local-copy {
+  display: grid;
+  gap: 8px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+
+.model-local-copy-head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.model-local-copy p {
+  margin: 0;
+  font-size: 12px;
+}
+
+.model-local-copy-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.model-local-copy-entry {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.model-local-copy-text {
+  display: grid;
+  gap: 2px;
+  font-size: 12px;
+}
+
+.model-local-copy-text small {
+  color: var(--muted);
+}
+
+.model-local-copy-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
 .local-job-stack {
   display: grid;
   gap: 10px;

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -1095,8 +1095,21 @@ impl ResolvedCacheStore {
                 continue;
             }
             had_file = true;
+            // Slot SELECTION is paths-and-sizes only. A journal slot's own integrity is proven by
+            // its checksummed envelope; re-hashing the whole bundle to decide which slot to read
+            // would put the bundle's byte count behind every pin read, every status listing and
+            // every catalog GET, and it would prove nothing a caller may act on — the load path
+            // ([`validate_complete_metadata`]) still re-hashes before an artifact reaches a
+            // runtime, and every write still validates at full strength.
             match read_journal(&path) {
-                Ok(envelope) if validate_metadata_shape(&envelope.metadata, digest).is_ok() => {
+                Ok(envelope)
+                    if validate_metadata_shape_with(
+                        &envelope.metadata,
+                        digest,
+                        ContentVerification::PathsAndSizesOnly,
+                    )
+                    .is_ok() =>
+                {
                     valid.push(envelope)
                 }
                 _ => had_invalid_slot = true,
@@ -1842,14 +1855,29 @@ fn validate_metadata_shape(
     metadata: &ResolvedCacheMetadata,
     digest: &str,
 ) -> Result<(), ResolvedCacheError> {
+    validate_metadata_shape_with(metadata, digest, ContentVerification::RehashEveryFile)
+}
+
+fn validate_metadata_shape_with(
+    metadata: &ResolvedCacheMetadata,
+    digest: &str,
+    verification: ContentVerification,
+) -> Result<(), ResolvedCacheError> {
     let artifact_key = metadata
         .artifact
         .cache_key()
         .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
-    metadata
-        .artifact
-        .validate()
-        .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+    match verification {
+        ContentVerification::RehashEveryFile => metadata
+            .artifact
+            .validate()
+            .map_err(|error| ResolvedCacheError::new(error.to_string()))?,
+        ContentVerification::PathsAndSizesOnly => {
+            artifact_without_content_hashes(&metadata.artifact)
+                .validate()
+                .map_err(|error| ResolvedCacheError::new(error.to_string()))?
+        }
+    }
     let reservation_shape_is_valid = match metadata.state {
         ResolvedCacheEntryState::Materializing => {
             metadata.reservation_id.is_some()
@@ -1938,7 +1966,7 @@ fn validate_complete_metadata_inner(
     verification: ContentVerification,
 ) -> Result<(), ResolvedCacheError> {
     let digest = cache_key_digest(&metadata.cache_key)?;
-    validate_metadata_shape(metadata, &digest)?;
+    validate_metadata_shape_with(metadata, &digest, verification)?;
     if metadata.state != ResolvedCacheEntryState::Complete
         || metadata.reservation_id.is_some()
         || metadata.reservation_owner.is_some()

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -169,24 +169,69 @@ fn parse_optional_u64(
     }
 }
 
+/// Whether a healthy store REFUSED a request, or a broken one could not answer it. Carried on the
+/// error itself rather than recovered by matching on its message, so an HTTP surface can answer
+/// 4xx and 5xx correctly without a second, drifting classification built out of string comparisons.
+///
+/// The line is drawn at "is anything actually wrong with the machine":
+///
+/// * [`Request`](Self::Request) — the store is intact and is declining THIS request: a malformed
+///   cache key, an entry it does not hold, or an entry whose own sanctioned state (pinned, leased,
+///   being materialized, being evicted) forbids the operation. Nothing is broken, and the reply
+///   tells the caller what to change.
+/// * [`Internal`](Self::Internal) — the store could not answer at all: IO faults, lock-file
+///   failures, clock failures, damaged journals and unreadable tombstones. Reporting these as
+///   client errors is what sends an operator to fix their request while the real fault sits on the
+///   host, and it hides genuine damage from anything watching 5xx rates.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResolvedCacheErrorKind {
+    /// An intact store declining this particular request.
+    Request,
+    /// A store or host that could not answer. Not caused by, and not fixable from, the request.
+    Internal,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ResolvedCacheError(String);
+pub struct ResolvedCacheError {
+    message: String,
+    kind: ResolvedCacheErrorKind,
+}
 
 impl ResolvedCacheError {
+    /// The default construction. Unattributed failures are [`ResolvedCacheErrorKind::Internal`] on
+    /// purpose: a new failure path that nobody classified must not silently start reporting host
+    /// faults as the caller's mistake.
     fn new(message: impl Into<String>) -> Self {
-        Self(message.into())
+        Self {
+            message: message.into(),
+            kind: ResolvedCacheErrorKind::Internal,
+        }
+    }
+
+    /// An intact store declining this request. Used only where nothing is wrong with the store or
+    /// the host — a malformed key, an entry that is not held, or an entry state that forbids the
+    /// operation.
+    fn request(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            kind: ResolvedCacheErrorKind::Request,
+        }
+    }
+
+    pub fn kind(&self) -> ResolvedCacheErrorKind {
+        self.kind
     }
 
     /// True only for the journal read failure that proves the entry retains no recoverable
     /// state — never for a transient, environmental, or fail-closed refusal.
     pub fn is_unrecoverable_metadata(&self) -> bool {
-        self.0 == BOTH_METADATA_SLOTS_CORRUPT
+        self.message == BOTH_METADATA_SLOTS_CORRUPT
     }
 }
 
 impl std::fmt::Display for ResolvedCacheError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str(&self.0)
+        formatter.write_str(&self.message)
     }
 }
 
@@ -194,7 +239,7 @@ impl std::error::Error for ResolvedCacheError {}
 
 impl From<std::io::Error> for ResolvedCacheError {
     fn from(error: std::io::Error) -> Self {
-        Self(error.to_string())
+        Self::new(error.to_string())
     }
 }
 
@@ -935,10 +980,12 @@ impl ResolvedCacheStore {
     ) -> Result<ResolvedCacheMetadata, ResolvedCacheError> {
         match self.read_metadata_unlocked(digest)? {
             JournalRead::Valid { metadata, .. } => Ok(*metadata),
-            JournalRead::Evicted { .. } => Err(ResolvedCacheError::new(
+            // Both are an intact store declining this request, not a store that broke: a removal
+            // is genuinely in flight for the first, and the second names an entry it does not hold.
+            JournalRead::Evicted { .. } => Err(ResolvedCacheError::request(
                 "cache entry has a pending eviction tombstone",
             )),
-            JournalRead::Missing => Err(ResolvedCacheError::new("cache metadata is missing")),
+            JournalRead::Missing => Err(ResolvedCacheError::request("cache metadata is missing")),
         }
     }
 
@@ -2394,7 +2441,8 @@ fn cache_key_digest(cache_key: &str) -> Result<String, ResolvedCacheError> {
         .strip_prefix("sha256:")
         .filter(|value| is_lower_hex_64(value))
         .ok_or_else(|| {
-            ResolvedCacheError::new("resolved-cache key must be sha256:<64 lower hex>")
+            // The caller's own key is unusable — nothing about the store or the host is wrong.
+            ResolvedCacheError::request("resolved-cache key must be sha256:<64 lower hex>")
         })?;
     Ok(digest.to_owned())
 }

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -14,9 +14,9 @@ pub use materialization::{
 #[path = "resolved_cache/retention.rs"]
 mod retention;
 pub use retention::{
-    EvictedRecord, EvictionCause, ManualRemovalOutcome, ManualRemovalPreview, ReconciliationReport,
-    ResolvedCacheRetention, RetainedRecord, RetentionCheckpointOutcome, RetentionHold,
-    RetentionReport, SourceLifecycleSelector,
+    EvictedRecord, EvictionCause, ManualRemovalOutcome, ManualRemovalPins, ManualRemovalPreview,
+    ReconciliationReport, ResolvedCacheRetention, RetainedRecord, RetentionCheckpointOutcome,
+    RetentionHold, RetentionReport, SourceLifecycleSelector,
 };
 
 use crate::model_artifacts::{
@@ -345,12 +345,25 @@ impl ResolvedCacheStore {
     /// usage. Missing cache roots are an empty cache; unmanaged or invalid roots still fail
     /// closed. This is the catalog/preflight read path (sc-19708): discovery must never stamp
     /// usage or take a session slot.
+    ///
+    /// Read paths use [`EntryListing::Inspect`]: identity, shape, confinement, file presence and
+    /// sizes are still proven, but bundle bytes are not re-hashed. Re-hashing every complete
+    /// bundle here would put gigabytes of I/O behind a catalog GET (and behind any status poll),
+    /// and it would prove nothing a read surface may act on — the runtime load path
+    /// ([`Self::acquire_complete`]) still re-hashes before handing an artifact to a loader.
     pub fn enumerate_existing(
         data_dir: &Path,
     ) -> Result<Vec<ResolvedCacheEntrySummary>, ResolvedCacheError> {
+        Self::open_for_inspection(data_dir)?
+            .map_or_else(|| Ok(Vec::new()), |store| store.list(EntryListing::Inspect))
+    }
+
+    /// Read-only handle onto an already-initialized cache, or `None` when no cache root exists.
+    /// Never creates the root, never takes a session slot, never writes.
+    pub fn open_for_inspection(data_dir: &Path) -> Result<Option<Self>, ResolvedCacheError> {
         let root = data_dir.join("models").join("resolved");
         if !root.exists() {
-            return Ok(Vec::new());
+            return Ok(None);
         }
         ensure_regular_directory(&root)?;
         let marker = std::fs::read(root.join(STORE_MARKER)).map_err(|_| {
@@ -362,14 +375,13 @@ impl ResolvedCacheStore {
             ));
         }
         let root = std::fs::canonicalize(root)?;
-        Self {
+        Ok(Some(Self {
             inner: Arc::new(StoreInner {
                 root,
                 session_id: "read-only-inspection".to_owned(),
                 _session_lock: None,
             }),
-        }
-        .enumerate()
+        }))
     }
 
     pub fn root(&self) -> &Path {
@@ -580,7 +592,26 @@ impl ResolvedCacheStore {
         Ok(result)
     }
 
+    /// Full runtime listing: complete entries are re-hashed, and any entry that fails validation
+    /// fails the whole listing. Recovery, staging cleanup and byte accounting depend on that
+    /// strictness, so it is the internal default.
     pub fn enumerate(&self) -> Result<Vec<ResolvedCacheEntrySummary>, ResolvedCacheError> {
+        self.list(EntryListing::Runtime)
+    }
+
+    /// Read-only listing for status/inspection surfaces. Identity, shape, confinement, file
+    /// presence and sizes are still proven; bundle bytes are not re-hashed, and an entry that
+    /// fails validation degrades to [`ResolvedCacheEntryState::Corrupt`] instead of erasing the
+    /// whole listing — a status surface has to be able to *label* the damaged entry rather than
+    /// report an empty cache.
+    pub fn inspect(&self) -> Result<Vec<ResolvedCacheEntrySummary>, ResolvedCacheError> {
+        self.list(EntryListing::Inspect)
+    }
+
+    fn list(
+        &self,
+        listing: EntryListing,
+    ) -> Result<Vec<ResolvedCacheEntrySummary>, ResolvedCacheError> {
         let mut entries = Vec::new();
         for item in std::fs::read_dir(self.inner.root.join("entries"))? {
             let item = item?;
@@ -597,15 +628,26 @@ impl ResolvedCacheStore {
                 .ok_or_else(|| ResolvedCacheError::new("invalid resolved-cache entry name"))?
                 .to_owned();
             let metadata_lock = self.lock_metadata(&digest)?;
+            let corrupt = |digest: &str| ResolvedCacheEntrySummary {
+                cache_key: format!("sha256:{digest}"),
+                state: ResolvedCacheEntryState::Corrupt,
+                metadata: None,
+            };
             let summary = match self.read_metadata_unlocked(&digest) {
                 Ok(JournalRead::Valid { metadata, .. }) => {
-                    if metadata.state == ResolvedCacheEntryState::Complete {
-                        validate_complete_metadata(self, &metadata)?;
-                    }
-                    ResolvedCacheEntrySummary {
-                        cache_key: metadata.cache_key.clone(),
-                        state: metadata.state.clone(),
-                        metadata: Some(*metadata),
+                    let validated = if metadata.state == ResolvedCacheEntryState::Complete {
+                        validate_complete_metadata_inner(self, &metadata, listing.verification())
+                    } else {
+                        Ok(())
+                    };
+                    match validated {
+                        Ok(()) => ResolvedCacheEntrySummary {
+                            cache_key: metadata.cache_key.clone(),
+                            state: metadata.state.clone(),
+                            metadata: Some(*metadata),
+                        },
+                        Err(error) if listing == EntryListing::Runtime => return Err(error),
+                        Err(_) => corrupt(&digest),
                     }
                 }
                 Ok(JournalRead::Evicted { .. }) => ResolvedCacheEntrySummary {
@@ -613,16 +655,7 @@ impl ResolvedCacheStore {
                     state: ResolvedCacheEntryState::Evicting,
                     metadata: None,
                 },
-                Ok(JournalRead::Missing) => ResolvedCacheEntrySummary {
-                    cache_key: format!("sha256:{digest}"),
-                    state: ResolvedCacheEntryState::Corrupt,
-                    metadata: None,
-                },
-                Err(_) => ResolvedCacheEntrySummary {
-                    cache_key: format!("sha256:{digest}"),
-                    state: ResolvedCacheEntryState::Corrupt,
-                    metadata: None,
-                },
+                Ok(JournalRead::Missing) | Err(_) => corrupt(&digest),
             };
             drop(metadata_lock);
             entries.push(summary);
@@ -1867,6 +1900,23 @@ fn validate_complete_metadata(
     metadata: &ResolvedCacheMetadata,
 ) -> Result<(), ResolvedCacheError> {
     validate_complete_metadata_inner(store, metadata, ContentVerification::RehashEveryFile)
+}
+
+/// How a whole-store listing treats complete entries. `Runtime` is the strict internal listing
+/// (recovery, staging cleanup, byte accounting); `Inspect` is the read-only status listing.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EntryListing {
+    Runtime,
+    Inspect,
+}
+
+impl EntryListing {
+    fn verification(self) -> ContentVerification {
+        match self {
+            Self::Runtime => ContentVerification::RehashEveryFile,
+            Self::Inspect => ContentVerification::PathsAndSizesOnly,
+        }
+    }
 }
 
 /// How thoroughly a complete entry's own bundle bytes are re-verified.

--- a/crates/sceneworks-core/src/resolved_cache/retention.rs
+++ b/crates/sceneworks-core/src/resolved_cache/retention.rs
@@ -334,7 +334,7 @@ impl ResolvedCacheStore {
         let _metadata_lock = self.lock_metadata(&digest)?;
         let entry = self.inner.root.join("entries").join(&digest);
         if std::fs::symlink_metadata(&entry).is_err() {
-            return Err(ResolvedCacheError::new("no such resolved-cache entry"));
+            return Err(ResolvedCacheError::request("no such resolved-cache entry"));
         }
         // A preview must stay renderable even for an entry that cannot be walked (for example one
         // holding a link, which the confined deleter would also refuse). Measurement failure
@@ -443,7 +443,7 @@ impl ResolvedCacheStore {
         match FileExt::try_lock_exclusive(&artifact_lock) {
             Ok(()) => {}
             Err(error) if is_lock_contended(&error) => {
-                return Err(ResolvedCacheError::new(
+                return Err(ResolvedCacheError::request(
                     "cannot remove a resolved-cache entry with an active lease or reservation",
                 ));
             }
@@ -452,7 +452,7 @@ impl ResolvedCacheStore {
         let _metadata_lock = self.lock_metadata(&digest)?;
         let entry = self.inner.root.join("entries").join(&digest);
         if std::fs::symlink_metadata(&entry).is_err() {
-            return Err(ResolvedCacheError::new("no such resolved-cache entry"));
+            return Err(ResolvedCacheError::request("no such resolved-cache entry"));
         }
         let mut warning = None;
         match self.read_metadata_unlocked(&digest) {
@@ -468,12 +468,12 @@ impl ResolvedCacheStore {
                 if metadata.state == ResolvedCacheEntryState::Materializing
                     && self.materializing_session_is_live(&metadata)?
                 {
-                    return Err(ResolvedCacheError::new(
+                    return Err(ResolvedCacheError::request(
                         "cannot remove a resolved-cache entry that a live session is materializing",
                     ));
                 }
                 if metadata.effective_pin {
-                    return Err(ResolvedCacheError::new(
+                    return Err(ResolvedCacheError::request(
                         "resolved-cache entry is pinned; unpin it before removal",
                     ));
                 }
@@ -750,8 +750,13 @@ impl ResolvedCacheStore {
             Ok(EvictAttempt::AlreadyGone) => {
                 *complete_total = complete_total.saturating_sub(candidate.bytes);
             }
-            Ok(EvictAttempt::Failed(error)) | Err(ResolvedCacheError(error)) => {
+            Ok(EvictAttempt::Failed(error)) => {
                 report.failed.push((candidate.cache_key.clone(), error));
+            }
+            Err(error) => {
+                report
+                    .failed
+                    .push((candidate.cache_key.clone(), error.to_string()));
             }
         }
     }

--- a/crates/sceneworks-core/src/resolved_cache/retention_tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/retention_tests.rs
@@ -1372,3 +1372,37 @@ fn windows_sharing_violation_keeps_the_eviction_pending_until_it_converges() {
     assert!(!entry_dir(&store, &candidate.cache_key).exists());
     assert_eq!(completed_audit_records(&store).len(), 1);
 }
+
+/// Reads select a journal slot on paths and sizes; the LOAD path still re-hashes (sc-19711).
+///
+/// The split exists because journal reads are on hot, user-facing surfaces — the catalog GET, the
+/// Settings storage status, every pin read — and re-hashing a whole bundle to decide which slot to
+/// read puts the bundle's byte count behind each of them while proving nothing a reader may act
+/// on. Safety is unchanged where it matters: content that no longer matches its recorded hash is
+/// still refused before it can reach a runtime, and every write validates at full strength.
+#[test]
+fn journal_reads_skip_content_hashing_while_the_load_path_still_refuses_altered_bytes() {
+    let scratch = TempDir::new().unwrap();
+    let library = scratch.path().join("library");
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let candidate = flat_candidate(&library, "SceneWorks/m-a", REV_A, "q8", b"0123456789");
+    materialize_complete(&store, &library, &candidate);
+
+    // Same length, different bytes: only a content hash can tell the difference.
+    let bundle_file = entry_dir(&store, &candidate.cache_key)
+        .join("bundle")
+        .join("model.safetensors");
+    std::fs::write(&bundle_file, b"9876543210").unwrap();
+
+    // The read surfaces still see the entry, with its identity intact, so a status view can show
+    // what the cache is holding instead of reporting an empty cache.
+    let inspected = store.inspect().unwrap();
+    assert_eq!(inspected.len(), 1);
+    assert_eq!(inspected[0].cache_key, candidate.cache_key);
+    assert_eq!(inspected[0].state, ResolvedCacheEntryState::Complete);
+    assert!(store.effective_pin(&candidate.cache_key).is_ok());
+
+    // The load path is unmoved: altered bytes are refused before an artifact reaches a runtime.
+    assert!(store.lookup_complete(&candidate.cache_key).is_err());
+    assert!(store.enumerate().is_err());
+}

--- a/crates/sceneworks-worker/src/model_artifact_inventory.rs
+++ b/crates/sceneworks-worker/src/model_artifact_inventory.rs
@@ -283,6 +283,30 @@ pub const PRODUCTION_MODEL_CONSUMERS: &[ModelConsumerInventoryEntry] = &[
             entrypoint: TypedResolverEntrypoint::SourceLibrary,
         },
     },
+    // sc-19711: the resolved-model hot cache's read + control surface. It reads the source library
+    // ONLY to report its path and to compare its volume against the local tier's — it never
+    // resolves weights for a load, so it constructs no model root of its own and goes through the
+    // same shared source-library contract. Every category is listed because the resolved cache is
+    // artifact-shape agnostic: whatever the shared resolver materializes, this surface reports and
+    // can remove.
+    ModelConsumerInventoryEntry {
+        source_files: &["apps/rust-api/src/model_cache.rs"],
+        categories: &[
+            Category::Image,
+            Category::Video,
+            Category::Audio,
+            Category::CaptioningUtility,
+            Category::Training,
+            Category::LoraControl,
+            Category::Primary,
+            Category::OptionalComponent,
+            Category::CoRequisite,
+            Category::ImportedConverted,
+        ],
+        resolution: Resolution::SharedContract {
+            entrypoint: TypedResolverEntrypoint::SourceLibrary,
+        },
+    },
 ];
 
 pub const EXPLICITLY_UNSUPPORTED_ARTIFACTS: &[ModelConsumerInventoryEntry] = &[


### PR DESCRIPTION
Closes the Settings + Model Manager half of the resolved-model hot cache (epic 19703).
Targets `feature/sc-19703-resolved-model-hot-cache`, **not** `main`.

## Scope vs acceptance criteria

| Story acceptance criterion | Where it lands |
|---|---|
| Controls round-trip to persisted settings and reflect authoritative backend state after refresh/relaunch | Settings card commits through `set_resolved_cache_policy` (shell-owned, durable) and re-reads `GET /api/v1/model-cache`; Model Manager re-reads authoritative status after every pin/remove instead of flipping the row optimistically |
| Usage totals and reclaimable bytes match the resolver ledger/filesystem | Totals come from the ledger's recorded `verified_bytes`; the only filesystem measurement is inside the removal preview, which is one deliberate user action |
| Same-volume configuration clearly reports that it offers no disconnect/performance isolation | `sourceVolumeRelation === "same"` renders an explicit notice saying it protects against neither a disconnect nor a slow drive, **naming the configured library path** so "point it elsewhere" is actionable |
| Show the configured external library location | A "Library" row in the Settings storage inset renders the API's own `sourceLibraryPath` — the exact path the volume comparison used |
| Show promotion/cleanup progress and actionable failures | A **bounded convergence refresh** shared by both surfaces re-reads only while an entry is pending/materializing/evicting; per-entry lines say what is happening, and interrupted/corrupt/unrecognized states carry the remedy |
| Model status remains truthful through disconnect, reconnect, promotion, eviction, pinning, deletion | The card renders the typed `modelAvailability` the ONE shared resolver produced (sc-19708) — never a second opinion derived here from paths or error text |
| Unsupported artifact classes are labeled rather than silently omitted | An availability value this build doesn't recognize renders as `unknown state` with a warning tone, never coerced into a reassuring one |
| Removing a local copy never uninstalls the external source | Stated on the card, and again in the confirm built from the backend's own preview |
| Responsive, accessibility, and desktop integration tests pass | Live regions on both outcome lines; the toggle is a labelled `role="switch"` reflecting persisted state; suites below |

### The design fact the UI and its tests both hold

The cache policy is **desktop-shell-owned and restart-bound**. `set_resolved_cache_policy`
persists it; the three sidecar processes captured their copy from the environment at spawn, so the
API *reports the policy it is actually running under*. The card compares persisted-vs-effective and
only then says "restart to apply". The Settings suite drives that real two-source state — a shell
settings object and an independent API snapshot that legitimately disagree — rather than stubbing a
`needsRestart` flag; mutating `policyNeedsRestart` to `return false` reds three tests including the
full round trip.

## Tests added — 90 new, all three suites new files

* **`apps/web/src/modelCache.test.js` (35)** — the badge map enumerated over every typed wire state
  plus an unrecognized one and an absent one; transport paths, bodies and a **non-empty** access
  token on all four routes; unit conversions failing closed to 0 on every unparseable input; the
  persisted-vs-effective comparison; every branch of the removal-preview and consequence copy.
* **`apps/web/src/screens/ModelManagerScreen.cacheControls.test.jsx` (28)** — a badge per typed
  state; the local-copy block's ready / pinned / not-ready / absent arms; keep and allow-automatic-
  removal round trips asserting the authoritative re-read; and the preview-then-confirm removal
  path including its blocked, unknown-pin, source-unavailable, declined and failed arms.
* **`apps/web/src/screens/SettingsScreen.cacheCard.test.jsx` (31)** — storage readout, same-volume
  warning, both failure shapes, disable/limit/interval commits with their consequence dialogs,
  input refusal, the restart-bound round trip, the not-polled read discipline, and a server-mode
  block proving the readout survives where the controls cannot.

## Defects found and fixed in place

1. **`ModelManagerScreen` claimed "No local copy yet." over a failed read.** The block opened on
   `canHoldLocalCopy` alone, so a failed status read — where the entry list is empty for want of an
   answer — rendered as a confident "none". Exactly the empty-but-confident claim the function's
   own comment said it avoided. Now gated on `cacheKnown`, which also covers the 200-with-`error`
   snapshot where the store exists but could not be listed.
2. **The opposite gap that fix exposed:** with the controls hidden, nothing said why. The reason is
   now stated once for the whole screen (the read that failed was one read for the whole screen),
   in its own state so an action outcome cannot clobber it, and worded to make no claim about what
   is cached — that being precisely what could not be determined.
3. **`describeDisableConsequence` did not agree in number for a single copy:** "The 1 existing copy
   (1.0 GiB) **stay** on disk — remove **them** … reclaim **them**."
4. **`cargo test -p sceneworks-worker --test model_artifact_inventory` was RED on the branch.**
   `apps/rust-api/src/model_cache.rs` calls `model_source_library(` and so is a model-path
   consumer, but carried no inventory classification. Classified as a shared-source-library
   consumer across every category: the resolved cache is artifact-shape agnostic, and this surface
   reads the library root only to report its path and compare its volume — it resolves no weights.
5. **`react-hooks/exhaustive-deps` was RED** on the field-seeding effect: the dependency list named
   the policy's primitives while the body closed over the containing object. The primitives are now
   lifted into their own bindings, preserving the intent exactly — re-seed on a value change only,
   never on `settings` object identity, which would clobber a half-typed field on every refresh.

## Adversarial-review round (commit `01f121e7c`)

Five findings, each closed with tests that kill the corresponding mutant.

1. **The configured external library location was never displayed** *(major)*. The epic requires
   showing it, and the same-volume warning told the user to "point the model library at a different
   volume" without saying where it currently points. The API already returned `sourceLibraryPath`;
   the Settings storage inset now renders it as a **Library** row and the warning names it.
2. **The store→API same-volume seam was unpinned** *(major)*. Hardcoding
   `SourceVolumeRelation::Unknown` in `get_model_cache` left all six endpoint tests green, because
   the web suite mocks that field. The walking-skeleton test now asserts
   `sourceVolumeRelation == "same"` and `sourceLibraryPath` against the fixture's genuinely
   same-volume layout — both mutants verified to red.
3. **Session debris per UI action** *(minor)*. Every preview/remove/pin POST called
   `ResolvedCacheStore::open`, claiming a fresh `sessions/<id>/` directory and `.lock` with no
   cleanup, accumulating until the next worker `recover()`. The store's design gives a session slot
   to a **process** for its lifetime, so the API now holds one in `AppState`, opened lazily under an
   async mutex that also serializes the cold open. **No locking is weakened**: the same exclusive
   session lock is taken, and every per-entry metadata lock is still acquired inside each operation.
4. **Server faults masqueraded as client errors** *(minor)*. `cache_error` mapped every store
   failure to 400. `ResolvedCacheError` now carries a `kind`, set at the store rather than
   recovered from message text: an **intact store declining a request** (malformed key, unknown
   entry, pinned, leased, live materialization, pending tombstone) stays 4xx; a **store that could
   not answer** (IO, lock, damaged journal, unreadable tombstone) is 500. Unattributed failures
   default to `Internal`, so a new failure path nobody classified cannot silently blame the caller.
   One existing assertion moved 400 → 500 as a direct consequence and is annotated with why.
5. **Scope narrowing reversed — progress visibility implemented, not documented** *(scope)*.
   "Show promotion/cleanup progress and actionable failures" had become a static
   `Not ready to use (state)` line, so a materializing entry never visibly converged while the
   screen was open. Both cache surfaces now share one hook, `useCacheConvergence`:

   * it re-reads **only** while an entry is `pending`/`materializing`/`evicting`, and stops the
     moment every entry is terminal — a settled cache still costs exactly the one mount read, which
     is what keeps the per-row cost sc-19708 removed from coming back;
   * it is **bounded** — after a capped run it gives up rather than polling behind a user who has
     walked away, the card says so instead of leaving a "checking…" line that stopped meaning
     anything, and **Check again** stays available as the manual re-read;
   * `describeEntryState` replaces the bare state name with what is happening, and gives
     `interrupted` / `corrupt` / unrecognized states an **actionable** sentence naming the remedy.

   No worker code is touched — promotion activation (sc-19706) is a parallel branch. The UI only
   reflects the states the status endpoint already reports from the journal, which is the
   generic-seam contract.

### Review-round verification

* `npm run rust:check` — **exit 0** (captured directly, never through a pipe); 0 `test result: FAILED`.
* `npm run check` — **exit 0**.
* `apps/web` full vitest suite — **247 files, 3773 tests, all pass** (was 3746).
* The three cache suites — **121 pass** (was 94): `modelCache.test.js` 50, Model Manager 36,
  Settings 35. API `model_cache` endpoint tests — **8 pass** (was 6).
* `npx eslint` on every changed web file — clean.
* **Seven mutants, applied and reverted one at a time** (restored files `touch`ed so cargo could not
  reuse a mutated binary):

  | Mutant | Killed by |
  |---|---|
  | `relation = SourceVolumeRelation::Unknown` | `status_lists_a_real_entry_…` (same-volume assertion) |
  | `source_library_path = PathBuf::new()` | `status_lists_a_real_entry_…` (library-path assertion) |
  | store opened per request | `control_actions_share_one_cache_session…` — 6 sessions vs 2 |
  | `cache_error` → always 400 | `store_faults_answer_500…` + `an_unreadable_entry_previews_unknown_pins…` |
  | `cache_error` → always 500 | `store_faults_answer_500…` (the pinned-refusal arm) |
  | poll cap removed | `stops refreshing a wedged copy and says so` |
  | `converging` forced `false` / `true` | 5 and 6 tests respectively, across both screens |
  | `interrupted` reduced to a state name | 2 tests (unit + screen) |

## Original verification evidence

* `npm run rust:check` — **green** (exit code captured directly; the earlier run's `| tail` had
  masked a real failure, which is how defect 4 above was found).
* `npm run desktop:check` — green.
* `npm run check` — 412 pass, 0 fail.
* `apps/web` full vitest suite — **247 files, 3746 tests, all pass** (baseline was 3656).
* `npx eslint src` — clean.
* Mutation-checked, one guard at a time: `policyNeedsRestart → false` reds 3 tests (including the
  round trip); `removalIsAllowed → true` reds 3 (including the blocked-preview confirm guard); the
  `cacheKnown` gate was red before its fix and green after.

## Notes

* **No new Tauri commands.** `set_resolved_cache_policy` pre-dates this branch and is registered at
  all three sites — `main.rs`, `build.rs`, and `capabilities/default.json` — already pinned by
  `resolved_cache_setter_is_registered_and_granted`. Verified explicitly because web tests mock
  `tauriInvoke` and cannot catch a missing capability grant.
* **No base merge was needed:** `feature/sc-19703-resolved-model-hot-cache` @ `833a1df2c` is fully
  contained in this branch. The sc-19708 seam integration was still enumerated rather than assumed
  — which is what surfaced defect 4.
* No contract-snapshot regeneration was required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

