### PR TITLE
feat(worker): promotion activation — production populates the resolved-model cache (sc-19706)

### DIFF
--- a/crates/sceneworks-core/src/model_artifacts.rs
+++ b/crates/sceneworks-core/src/model_artifacts.rs
@@ -9,6 +9,8 @@
 pub mod artifact_selection;
 #[path = "model_artifacts/external_library.rs"]
 pub mod external_library;
+#[path = "model_artifacts/promotion.rs"]
+pub mod promotion;
 #[path = "resolved_cache.rs"]
 pub mod resolved_cache;
 

--- a/crates/sceneworks-core/src/model_artifacts/local_preference.rs
+++ b/crates/sceneworks-core/src/model_artifacts/local_preference.rs
@@ -61,6 +61,9 @@ pub struct LocalArtifactOverlayEntry {
 /// layout for that member's repository, immutable revision and subpath. Materialization writes
 /// members here, and local preference reads them back through the identical rule, so the two can
 /// never drift into a layout only one of them understands.
+///
+/// This is the ONE definition: [`crate::model_artifacts::promotion`], the write side, re-exports
+/// this function rather than restating the rule.
 pub fn hub_cache_member_destination(
     repository: &str,
     revision: &str,

--- a/crates/sceneworks-core/src/model_artifacts/promotion.rs
+++ b/crates/sceneworks-core/src/model_artifacts/promotion.rs
@@ -28,9 +28,9 @@
 
 use super::external_library::ExternalArtifactRequirement;
 use super::{
-    ArtifactAvailability, ArtifactContractError, ArtifactFile, ArtifactIdentity, ArtifactMemberRole,
-    ArtifactSourceLibrary, ModelArtifactResolver, PromotionCandidate, ResolvedBundleClosure,
-    ResolvedBundleMember,
+    ArtifactAvailability, ArtifactContractError, ArtifactFile, ArtifactIdentity,
+    ArtifactMemberRole, ArtifactSourceLibrary, ModelArtifactResolver, PromotionCandidate,
+    ResolvedBundleClosure, ResolvedBundleMember,
 };
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -42,26 +42,11 @@ const UNTIERED_VARIANT: &str = "default";
 /// The canonical bundle-relative destination of one closure member: the source library's own
 /// layout for that member's repository, immutable revision and subpath.
 ///
-/// Materialization writes members here and the local tier reads them back through this identical
-/// rule, so the two can never drift into a layout only one of them understands.
-pub fn hub_cache_member_destination(
-    repository: &str,
-    revision: &str,
-    source_subpath: &Path,
-) -> Result<PathBuf, ArtifactContractError> {
-    super::validate_immutable_revision(revision)?;
-    super::validate_repository(repository)?;
-    let safe = repository.replace('/', "--");
-    let mut destination = PathBuf::from(format!("models--{safe}"))
-        .join("snapshots")
-        .join(revision);
-    if source_subpath.as_os_str().is_empty() {
-        return Ok(destination);
-    }
-    super::validate_relative_path(source_subpath, "artifact source subpath")?;
-    destination.push(source_subpath);
-    Ok(destination)
-}
+/// The rule has EXACTLY ONE definition, in the local-preference module, and the write side
+/// re-exports it here. Producing a bundle and reading one back are two halves of the same layout
+/// invariant, so two copies — however byte-identical they start out — are a latent divergence
+/// between the materializer's output and the only module that knows how to serve it.
+pub use super::local_preference::hub_cache_member_destination;
 
 /// Build the promotion candidate for one exact selected requirement closure that a runtime just
 /// loaded successfully from the configured source library.
@@ -171,8 +156,8 @@ fn resolve_requirement_revision(
             requirement.repository
         ))
     })? {
-        let entry =
-            entry.map_err(|error| ArtifactContractError(format!("read source snapshots: {error}")))?;
+        let entry = entry
+            .map_err(|error| ArtifactContractError(format!("read source snapshots: {error}")))?;
         let Some(revision) = entry.file_name().to_str().map(str::to_owned) else {
             continue;
         };

--- a/crates/sceneworks-core/src/model_artifacts/promotion.rs
+++ b/crates/sceneworks-core/src/model_artifacts/promotion.rs
@@ -1,0 +1,206 @@
+//! The one closure producer: how a real manifest entry becomes a [`PromotionCandidate`].
+//!
+//! sc-19704 froze the typed two-tier contract, sc-19705 the store, sc-19706 the materializer and
+//! its scheduler, sc-19708 the *one* selection module that reduces a manifest entry plus this
+//! host's platform plus the request's selected tier to an exact
+//! [`ExternalArtifactRequirement`] closure. Nothing joined them: no production code ever built a
+//! [`ResolvedBundleClosure`] for a real model, so `models/resolved` was only ever populated by
+//! tests. This module is that join.
+//!
+//! It deliberately computes **no** closure of its own. Its input is the requirement closure the
+//! selection module already produced, so a new model stays a manifest-data change: there is no
+//! per-model, per-route or per-job-type branch anywhere below.
+//!
+//! Two invariants make the produced candidate safe to hand to the materializer:
+//!
+//! - **Every member is pinned to an immutable snapshot.** A requirement that records its revision
+//!   is resolved to exactly that snapshot; a legacy receipt without one must be satisfied by
+//!   exactly one installed snapshot, the same uniqueness rule the availability resolver applies.
+//! - **The bundle mirrors the source library.** Each member's destination is
+//!   `models--<safe repository>/snapshots/<revision>/<source subpath>`, so a published bundle root
+//!   is itself a valid [`ArtifactSourceLibrary`] holding precisely the closure's repositories and
+//!   revisions. That is what lets the local tier be preferred without one line of per-model code.
+//!
+//! Nothing here downloads. The candidate is built from files that are **already present** in the
+//! configured source library — [`ModelArtifactResolver::resolve_source`] validates the whole
+//! closure against that library before a candidate exists at all, so a disconnected or incomplete
+//! source produces an error and therefore no promotion, never a fetch.
+
+use super::external_library::ExternalArtifactRequirement;
+use super::{
+    ArtifactAvailability, ArtifactContractError, ArtifactFile, ArtifactIdentity, ArtifactMemberRole,
+    ArtifactSourceLibrary, ModelArtifactResolver, PromotionCandidate, ResolvedBundleClosure,
+    ResolvedBundleMember,
+};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// The variant recorded by a manifest download row that declares no tier. It names no artifact
+/// tier, so it must not become a `fixedArtifactTier` in the promoted provenance.
+const UNTIERED_VARIANT: &str = "default";
+
+/// The canonical bundle-relative destination of one closure member: the source library's own
+/// layout for that member's repository, immutable revision and subpath.
+///
+/// Materialization writes members here and the local tier reads them back through this identical
+/// rule, so the two can never drift into a layout only one of them understands.
+pub fn hub_cache_member_destination(
+    repository: &str,
+    revision: &str,
+    source_subpath: &Path,
+) -> Result<PathBuf, ArtifactContractError> {
+    super::validate_immutable_revision(revision)?;
+    super::validate_repository(repository)?;
+    let safe = repository.replace('/', "--");
+    let mut destination = PathBuf::from(format!("models--{safe}"))
+        .join("snapshots")
+        .join(revision);
+    if source_subpath.as_os_str().is_empty() {
+        return Ok(destination);
+    }
+    super::validate_relative_path(source_subpath, "artifact source subpath")?;
+    destination.push(source_subpath);
+    Ok(destination)
+}
+
+/// Build the promotion candidate for one exact selected requirement closure that a runtime just
+/// loaded successfully from the configured source library.
+///
+/// `requirements` must be the closure produced by
+/// [`crate::model_artifacts::artifact_selection::selected_requirements_for_model`] — the primary
+/// tier this host actually selected plus its hard co-requisites, and nothing else. Every member,
+/// including multi-repository co-requisites and sibling-repo overlays, is carried through; the
+/// bundle is either the whole closure or no bundle at all.
+///
+/// The candidate is minted through the sc-19704 lease boundary: an artifact is resolved against
+/// the source library, leased, and only a lease that is marked successful becomes a candidate.
+pub fn promotion_candidate_for_requirements(
+    resolver: &ModelArtifactResolver,
+    requirements: &[ExternalArtifactRequirement],
+) -> Result<PromotionCandidate, ArtifactContractError> {
+    if requirements.is_empty() {
+        return Err(ArtifactContractError(
+            "promotion requires a nonempty selected requirement closure".to_owned(),
+        ));
+    }
+    if requirements
+        .iter()
+        .filter(|requirement| requirement.is_primary)
+        .count()
+        != 1
+    {
+        return Err(ArtifactContractError(
+            "promotion requires exactly one primary requirement".to_owned(),
+        ));
+    }
+    let library = resolver.source_library();
+    let mut members = Vec::with_capacity(requirements.len());
+    let mut primary_identity = None;
+    for requirement in requirements {
+        let revision = resolve_requirement_revision(library, requirement)?;
+        let source = ArtifactIdentity::pinned(
+            &requirement.repository,
+            &revision,
+            requirement.variant.trim(),
+        )?;
+        if requirement.is_primary {
+            primary_identity = Some(source.clone());
+        }
+        members.push(ResolvedBundleMember {
+            role: if requirement.is_primary {
+                ArtifactMemberRole::Primary
+            } else {
+                ArtifactMemberRole::CoRequisite
+            },
+            // The primary carries no component id by contract; every co-requisite needs a stable
+            // one, and its repository plus selected variant is the only identity the requirement
+            // closure actually has. Two rows of one repository at different tiers stay distinct.
+            component_id: (!requirement.is_primary)
+                .then(|| format!("{}@{}", requirement.repository, requirement.variant.trim())),
+            tier: (requirement.variant.trim() != UNTIERED_VARIANT)
+                .then(|| requirement.variant.trim().to_owned()),
+            // Receipt and manifest file lists are snapshot-relative, so the member root is the
+            // snapshot itself.
+            source_subpath: PathBuf::new(),
+            destination: hub_cache_member_destination(
+                &requirement.repository,
+                &revision,
+                Path::new(""),
+            )?,
+            files: requirement
+                .files
+                .iter()
+                .map(ArtifactFile::new)
+                .collect::<Result<Vec<_>, _>>()?,
+            source,
+        });
+    }
+    let closure = ResolvedBundleClosure::new(members)?;
+    let identity = primary_identity.expect("a closure with exactly one primary has its identity");
+    // Resolves against — and fully validates the closure inside — the configured source library.
+    // A disconnected, incomplete, or tampered source fails here, so no candidate exists to promote.
+    let artifact = resolver.resolve_source(identity, closure, ArtifactAvailability::Available)?;
+    // sc-19704's documented promotion boundary. `mark_success` is the only way to mint a
+    // candidate, so an artifact that never held a successful runtime lease can never be promoted.
+    Ok(resolver
+        .acquire_runtime_lease(&Arc::new(artifact))?
+        .mark_success())
+}
+
+/// The immutable revision that satisfies `requirement` in `library`.
+///
+/// A recorded revision is authoritative and is only checked for installation. A legacy receipt
+/// without one must be satisfied by **exactly one** installed snapshot — the same uniqueness rule
+/// [`crate::model_artifacts::external_library::validate_requirements_at_root`] applies, so an
+/// ambiguous repository declines rather than promoting an arbitrary snapshot.
+fn resolve_requirement_revision(
+    library: &ArtifactSourceLibrary,
+    requirement: &ExternalArtifactRequirement,
+) -> Result<String, ArtifactContractError> {
+    if let Some(revision) = requirement.revision.as_deref() {
+        library.discover_snapshot(&requirement.repository, Some(revision))?;
+        return Ok(revision.to_owned());
+    }
+    let snapshots = library
+        .repository_root(&requirement.repository)?
+        .join("snapshots");
+    let mut matching = Vec::new();
+    for entry in std::fs::read_dir(&snapshots).map_err(|error| {
+        ArtifactContractError(format!(
+            "source repository {} is unavailable: {error}",
+            requirement.repository
+        ))
+    })? {
+        let entry =
+            entry.map_err(|error| ArtifactContractError(format!("read source snapshots: {error}")))?;
+        let Some(revision) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if super::validate_immutable_revision(&revision).is_err()
+            || !entry.file_type().is_ok_and(|kind| kind.is_dir())
+        {
+            continue;
+        }
+        let path = entry.path();
+        if requirement
+            .files
+            .iter()
+            .all(|file| path.join(file).is_file())
+        {
+            matching.push(revision);
+        }
+    }
+    match matching.as_slice() {
+        [revision] => Ok(revision.clone()),
+        _ => Err(ArtifactContractError(format!(
+            "source repository {} has {} snapshots holding the recorded file set; exactly one is \
+             required to promote a revision-less install receipt",
+            requirement.repository,
+            matching.len()
+        ))),
+    }
+}
+
+#[cfg(test)]
+#[path = "promotion_tests.rs"]
+mod tests;

--- a/crates/sceneworks-core/src/model_artifacts/promotion_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/promotion_tests.rs
@@ -16,7 +16,13 @@ const OTHER_REVISION: &str = "2222222222222222222222222222222222222222";
 const TEXT_ENCODER_REVISION: &str = "3333333333333333333333333333333333333333";
 
 /// The exact `models--<safe>/snapshots/<revision>/<file>` layout a real Hugging Face library has.
-fn install_snapshot_file(library: &Path, repository: &str, revision: &str, file: &str, body: &[u8]) {
+fn install_snapshot_file(
+    library: &Path,
+    repository: &str,
+    revision: &str,
+    file: &str,
+    body: &[u8],
+) {
     let path = library
         .join(format!("models--{}", repository.replace('/', "--")))
         .join("snapshots")
@@ -27,9 +33,7 @@ fn install_snapshot_file(library: &Path, repository: &str, revision: &str, file:
 }
 
 fn write_receipts(data_dir: &Path, repository: &str, receipts: Value) {
-    let managed = data_dir
-        .join("models")
-        .join(safe_download_dir(repository));
+    let managed = data_dir.join("models").join(safe_download_dir(repository));
     std::fs::create_dir_all(&managed).unwrap();
     std::fs::write(
         managed.join(".sceneworks-download-complete.json"),
@@ -122,9 +126,7 @@ fn a_multi_repository_closure_becomes_one_source_library_shaped_bundle() {
     assert_eq!(primary.source_subpath, PathBuf::new());
     assert_eq!(
         primary.destination,
-        PathBuf::from(format!(
-            "models--owner--model/snapshots/{PRIMARY_REVISION}"
-        ))
+        PathBuf::from(format!("models--owner--model/snapshots/{PRIMARY_REVISION}"))
     );
 
     let co_requisite = candidate
@@ -312,9 +314,7 @@ fn an_uninstalled_closure_declines_without_creating_anything() {
     .expect_err("an uninstalled co-requisite must decline");
     assert!(!error.to_string().is_empty());
     assert!(
-        !library
-            .join("models--owner--missing")
-            .exists(),
+        !library.join("models--owner--missing").exists(),
         "promotion must never create, fetch, or reserve anything for an absent source"
     );
 }
@@ -440,11 +440,8 @@ fn a_manifest_entry_promotes_and_is_then_recognized_as_the_local_tier() {
         ArtifactLocation::ResolvedLocal { .. }
     ));
     assert_eq!(
-        local_artifact_for_requirements(
-            std::slice::from_ref(&published),
-            &selected.requirements
-        )
-        .map(|artifact| artifact.identity),
+        local_artifact_for_requirements(std::slice::from_ref(&published), &selected.requirements)
+            .map(|artifact| artifact.identity),
         Some(published.identity.clone()),
         "the promoted bundle must cover the exact closure that produced it"
     );

--- a/crates/sceneworks-core/src/model_artifacts/promotion_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/promotion_tests.rs
@@ -1,0 +1,480 @@
+use super::*;
+use crate::model_artifacts::artifact_selection::{
+    safe_download_dir, selected_requirements_for_model,
+};
+use crate::model_artifacts::external_library::local_artifact_for_requirements;
+use crate::model_artifacts::resolved_cache::{
+    MaterializationCancellation, MaterializationOutcome, ResolvedCacheMaterializer,
+    ResolvedCachePolicy, ResolvedCacheStore,
+};
+use crate::model_artifacts::ArtifactLocation;
+use serde_json::{json, Value};
+use std::path::Path;
+
+const PRIMARY_REVISION: &str = "1111111111111111111111111111111111111111";
+const OTHER_REVISION: &str = "2222222222222222222222222222222222222222";
+const TEXT_ENCODER_REVISION: &str = "3333333333333333333333333333333333333333";
+
+/// The exact `models--<safe>/snapshots/<revision>/<file>` layout a real Hugging Face library has.
+fn install_snapshot_file(library: &Path, repository: &str, revision: &str, file: &str, body: &[u8]) {
+    let path = library
+        .join(format!("models--{}", repository.replace('/', "--")))
+        .join("snapshots")
+        .join(revision)
+        .join(file);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, body).unwrap();
+}
+
+fn write_receipts(data_dir: &Path, repository: &str, receipts: Value) {
+    let managed = data_dir
+        .join("models")
+        .join(safe_download_dir(repository));
+    std::fs::create_dir_all(&managed).unwrap();
+    std::fs::write(
+        managed.join(".sceneworks-download-complete.json"),
+        serde_json::to_vec(&json!({ "receipts": receipts })).unwrap(),
+    )
+    .unwrap();
+}
+
+fn resolver_for(library: &Path) -> ModelArtifactResolver {
+    ModelArtifactResolver::new(ArtifactSourceLibrary::new(library).unwrap())
+}
+
+fn requirement(
+    repository: &str,
+    revision: Option<&str>,
+    variant: &str,
+    files: &[&str],
+    is_primary: bool,
+) -> ExternalArtifactRequirement {
+    ExternalArtifactRequirement {
+        repository: repository.to_owned(),
+        revision: revision.map(str::to_owned),
+        variant: variant.to_owned(),
+        files: files.iter().map(PathBuf::from).collect(),
+        is_primary,
+    }
+}
+
+/// The whole selected closure — primary tier plus a multi-repository co-requisite — becomes ONE
+/// bundle laid out as a miniature source library, with every member pinned to its exact immutable
+/// revision. This is the shape the local tier reads back, so it is asserted member by member.
+#[test]
+fn a_multi_repository_closure_becomes_one_source_library_shaped_bundle() {
+    let temp = tempfile::tempdir().unwrap();
+    let library = temp.path().join("library");
+    install_snapshot_file(
+        &library,
+        "owner/model",
+        PRIMARY_REVISION,
+        "q4/model.safetensors",
+        b"primary-weights",
+    );
+    install_snapshot_file(
+        &library,
+        "owner/text-encoder",
+        TEXT_ENCODER_REVISION,
+        "encoder.safetensors",
+        b"encoder-weights",
+    );
+
+    let candidate = promotion_candidate_for_requirements(
+        &resolver_for(&library),
+        &[
+            requirement(
+                "owner/model",
+                Some(PRIMARY_REVISION),
+                "q4",
+                &["q4/model.safetensors"],
+                true,
+            ),
+            requirement(
+                "owner/text-encoder",
+                Some(TEXT_ENCODER_REVISION),
+                "default",
+                &["encoder.safetensors"],
+                false,
+            ),
+        ],
+    )
+    .expect("an installed closure promotes");
+
+    assert_eq!(candidate.artifact.identity.repository, "owner/model");
+    assert_eq!(candidate.artifact.identity.revision, PRIMARY_REVISION);
+    assert_eq!(candidate.artifact.identity.variant, "q4");
+    assert_eq!(
+        candidate.artifact.provenance.fixed_artifact_tier.as_deref(),
+        Some("q4"),
+        "the selected tier is the promoted artifact's fixed tier"
+    );
+    assert_eq!(candidate.artifact.closure.members.len(), 2);
+
+    let primary = candidate
+        .artifact
+        .closure
+        .members
+        .iter()
+        .find(|member| member.role == ArtifactMemberRole::Primary)
+        .expect("the closure has a primary");
+    assert_eq!(primary.component_id, None);
+    assert_eq!(primary.source_subpath, PathBuf::new());
+    assert_eq!(
+        primary.destination,
+        PathBuf::from(format!(
+            "models--owner--model/snapshots/{PRIMARY_REVISION}"
+        ))
+    );
+
+    let co_requisite = candidate
+        .artifact
+        .closure
+        .members
+        .iter()
+        .find(|member| member.role == ArtifactMemberRole::CoRequisite)
+        .expect("the closure keeps its co-requisite");
+    assert_eq!(
+        co_requisite.component_id.as_deref(),
+        Some("owner/text-encoder@default")
+    );
+    assert_eq!(co_requisite.tier, None, "an untiered row declares no tier");
+    assert_eq!(
+        co_requisite.destination,
+        PathBuf::from(format!(
+            "models--owner--text-encoder/snapshots/{TEXT_ENCODER_REVISION}"
+        ))
+    );
+
+    // Every member's destination is exactly the shared layout rule, so a published bundle root is
+    // itself a source library. Asserted through the rule rather than a literal so the two cannot
+    // drift apart silently.
+    for member in &candidate.artifact.closure.members {
+        assert_eq!(
+            member.destination,
+            hub_cache_member_destination(
+                &member.source.repository,
+                &member.source.revision,
+                &member.source_subpath,
+            )
+            .unwrap()
+        );
+    }
+}
+
+/// Two tiers of ONE repository stay two distinct members. Their destinations legitimately coincide
+/// (same repository, same revision — that IS the source layout), so distinctness has to come from
+/// the component id, and their file sets must not collide.
+#[test]
+fn sibling_tiers_of_one_repository_stay_distinct_members() {
+    let temp = tempfile::tempdir().unwrap();
+    let library = temp.path().join("library");
+    install_snapshot_file(
+        &library,
+        "owner/model",
+        PRIMARY_REVISION,
+        "q4/model.safetensors",
+        b"q4",
+    );
+    install_snapshot_file(
+        &library,
+        "owner/model",
+        PRIMARY_REVISION,
+        "shared/vae.safetensors",
+        b"vae",
+    );
+
+    let candidate = promotion_candidate_for_requirements(
+        &resolver_for(&library),
+        &[
+            requirement(
+                "owner/model",
+                Some(PRIMARY_REVISION),
+                "q4",
+                &["q4/model.safetensors"],
+                true,
+            ),
+            requirement(
+                "owner/model",
+                Some(PRIMARY_REVISION),
+                "shared",
+                &["shared/vae.safetensors"],
+                false,
+            ),
+        ],
+    )
+    .expect("a same-repository co-requisite promotes");
+
+    assert_eq!(candidate.artifact.closure.members.len(), 2);
+    assert_eq!(
+        candidate.artifact.closure.members[0].destination,
+        candidate.artifact.closure.members[1].destination,
+        "one repository at one revision is one source-library directory"
+    );
+}
+
+/// A legacy receipt that never recorded its snapshot revision adopts the only installed snapshot
+/// that holds its exact recorded file set.
+#[test]
+fn a_revisionless_receipt_adopts_the_only_matching_snapshot() {
+    let temp = tempfile::tempdir().unwrap();
+    let library = temp.path().join("library");
+    install_snapshot_file(
+        &library,
+        "owner/model",
+        PRIMARY_REVISION,
+        "model.safetensors",
+        b"weights",
+    );
+    // A second snapshot of the same repository that does NOT hold the recorded file.
+    install_snapshot_file(
+        &library,
+        "owner/model",
+        OTHER_REVISION,
+        "other.safetensors",
+        b"other",
+    );
+
+    let candidate = promotion_candidate_for_requirements(
+        &resolver_for(&library),
+        &[requirement(
+            "owner/model",
+            None,
+            "default",
+            &["model.safetensors"],
+            true,
+        )],
+    )
+    .expect("an unambiguous revision-less receipt promotes");
+    assert_eq!(candidate.artifact.identity.revision, PRIMARY_REVISION);
+}
+
+/// Ambiguity declines. Promoting an arbitrary snapshot would give the bundle an identity the
+/// install never had.
+#[test]
+fn an_ambiguous_revisionless_receipt_declines() {
+    let temp = tempfile::tempdir().unwrap();
+    let library = temp.path().join("library");
+    for revision in [PRIMARY_REVISION, OTHER_REVISION] {
+        install_snapshot_file(&library, "owner/model", revision, "model.safetensors", b"w");
+    }
+
+    let error = promotion_candidate_for_requirements(
+        &resolver_for(&library),
+        &[requirement(
+            "owner/model",
+            None,
+            "default",
+            &["model.safetensors"],
+            true,
+        )],
+    )
+    .expect_err("two candidate snapshots must decline");
+    assert!(
+        error.to_string().contains("exactly one is required"),
+        "unexpected error: {error}"
+    );
+}
+
+/// The source library is the ONLY place promotion reads from. A closure whose files are not
+/// installed produces no candidate and writes nothing — promotion can never turn into a download.
+#[test]
+fn an_uninstalled_closure_declines_without_creating_anything() {
+    let temp = tempfile::tempdir().unwrap();
+    let library = temp.path().join("library");
+    install_snapshot_file(
+        &library,
+        "owner/model",
+        PRIMARY_REVISION,
+        "model.safetensors",
+        b"weights",
+    );
+
+    let error = promotion_candidate_for_requirements(
+        &resolver_for(&library),
+        &[
+            requirement(
+                "owner/model",
+                Some(PRIMARY_REVISION),
+                "default",
+                &["model.safetensors"],
+                true,
+            ),
+            requirement(
+                "owner/missing",
+                Some(OTHER_REVISION),
+                "default",
+                &["encoder.safetensors"],
+                false,
+            ),
+        ],
+    )
+    .expect_err("an uninstalled co-requisite must decline");
+    assert!(!error.to_string().is_empty());
+    assert!(
+        !library
+            .join("models--owner--missing")
+            .exists(),
+        "promotion must never create, fetch, or reserve anything for an absent source"
+    );
+}
+
+/// A closure without exactly one primary is not a runtime closure and cannot become a bundle.
+#[test]
+fn a_closure_without_exactly_one_primary_declines() {
+    let temp = tempfile::tempdir().unwrap();
+    let library = temp.path().join("library");
+    install_snapshot_file(
+        &library,
+        "owner/model",
+        PRIMARY_REVISION,
+        "model.safetensors",
+        b"weights",
+    );
+    let resolver = resolver_for(&library);
+    assert!(promotion_candidate_for_requirements(&resolver, &[]).is_err());
+    assert!(promotion_candidate_for_requirements(
+        &resolver,
+        &[
+            requirement(
+                "owner/model",
+                Some(PRIMARY_REVISION),
+                "default",
+                &["model.safetensors"],
+                true
+            ),
+            requirement(
+                "owner/model",
+                Some(PRIMARY_REVISION),
+                "alt",
+                &["model.safetensors"],
+                true
+            ),
+        ]
+    )
+    .is_err());
+}
+
+/// The full data-driven round trip inside core: a real manifest entry and its install receipts go
+/// through the ONE selection module, become a candidate, materialize, and the published bundle is
+/// then recognized by the availability resolver's local-tier matcher for that same closure.
+#[test]
+fn a_manifest_entry_promotes_and_is_then_recognized_as_the_local_tier() {
+    let temp = tempfile::tempdir().unwrap();
+    let data_dir = temp.path().join("data");
+    let library = temp.path().join("library");
+    std::fs::create_dir_all(&data_dir).unwrap();
+    install_snapshot_file(
+        &library,
+        "owner/model",
+        PRIMARY_REVISION,
+        "q4/model.safetensors",
+        b"primary-weights",
+    );
+    install_snapshot_file(
+        &library,
+        "owner/text-encoder",
+        TEXT_ENCODER_REVISION,
+        "encoder.safetensors",
+        b"encoder-weights",
+    );
+    write_receipts(
+        &data_dir,
+        "owner/model",
+        json!([{
+            "repo": "owner/model",
+            "modelId": "demo",
+            "variant": "q4",
+            "resolvedFiles": ["q4/model.safetensors"],
+            "snapshotRevision": PRIMARY_REVISION,
+        }]),
+    );
+    write_receipts(
+        &data_dir,
+        "owner/text-encoder",
+        json!([{
+            "repo": "owner/text-encoder",
+            "resolvedFiles": ["encoder.safetensors"],
+            "snapshotRevision": TEXT_ENCODER_REVISION,
+        }]),
+    );
+    let model = json!({
+        "id": "demo",
+        "downloads": [
+            {"provider": "huggingface", "repo": "owner/model", "variant": "q4", "default": true,
+             "files": ["q4/*"]},
+            {"provider": "huggingface", "repo": "owner/text-encoder", "coRequisite": true,
+             "files": ["encoder.safetensors"]}
+        ]
+    });
+
+    let selected =
+        selected_requirements_for_model(&model, std::env::consts::OS, Some("q4"), &data_dir);
+    assert!(selected.receipt_backed);
+    assert_eq!(selected.requirements.len(), 2);
+
+    let resolver = resolver_for(&library);
+    let candidate =
+        promotion_candidate_for_requirements(&resolver, &selected.requirements).unwrap();
+
+    let store = ResolvedCacheStore::open(&data_dir).unwrap();
+    let outcome = ResolvedCacheMaterializer::new(store.clone())
+        .materialize(
+            &candidate,
+            &library,
+            "demo",
+            &MaterializationCancellation::default(),
+        )
+        .unwrap();
+    let metadata = match outcome {
+        MaterializationOutcome::Published(metadata) => *metadata,
+        other => panic!("expected a published bundle, got {other:?}"),
+    };
+    assert!(metadata.verified_bytes > 0);
+
+    // The published artifact is what the shared availability resolver would prefer for the very
+    // same selected closure — the identity/coverage rule, not a path guess.
+    let published = metadata.artifact;
+    assert!(matches!(
+        published.location,
+        ArtifactLocation::ResolvedLocal { .. }
+    ));
+    assert_eq!(
+        local_artifact_for_requirements(
+            std::slice::from_ref(&published),
+            &selected.requirements
+        )
+        .map(|artifact| artifact.identity),
+        Some(published.identity.clone()),
+        "the promoted bundle must cover the exact closure that produced it"
+    );
+
+    // Every promoted byte landed in the source-library layout, so the bundle root resolves as a
+    // library in its own right.
+    let ArtifactLocation::ResolvedLocal { root } = &published.location else {
+        unreachable!()
+    };
+    let bundle_library = ArtifactSourceLibrary::new(root).unwrap();
+    for (repository, revision) in [
+        ("owner/model", PRIMARY_REVISION),
+        ("owner/text-encoder", TEXT_ENCODER_REVISION),
+    ] {
+        let (identity, snapshot) = bundle_library
+            .discover_snapshot(repository, Some(revision))
+            .expect("the bundle root is a valid source library");
+        assert_eq!(identity.revision, revision);
+        assert!(snapshot.is_dir());
+    }
+    assert_eq!(
+        std::fs::read(
+            root.join(format!("models--owner--model/snapshots/{PRIMARY_REVISION}"))
+                .join("q4/model.safetensors")
+        )
+        .unwrap(),
+        b"primary-weights"
+    );
+
+    // Nothing about the promotion touched the policy defaults: the cache is opt-in and the store
+    // was opened explicitly by this test, never as a side effect of resolving a candidate.
+    assert!(!ResolvedCachePolicy::default().enabled);
+}

--- a/crates/sceneworks-core/src/resolved_cache/materialization.rs
+++ b/crates/sceneworks-core/src/resolved_cache/materialization.rs
@@ -887,21 +887,23 @@ impl ResolvedCachePromotionScheduler {
             state.active = Some((scheduled.candidate.cache_key.clone(), cancellation.clone()));
             (scheduled, cancellation)
         };
-        let result = self.admit(&scheduled).and_then(|admission| match admission {
-            Admission::AlreadyComplete(metadata) => Ok(IdlePromotionOutcome::AlreadyComplete(
-                Box::new(*metadata),
-            )),
-            Admission::Declined(reason) => Ok(IdlePromotionOutcome::Declined(reason)),
-            Admission::Proceed => self
-                .materializer
-                .materialize(
-                    &scheduled.candidate,
-                    &scheduled.source_configured_path,
-                    &scheduled.logical_model_owner,
-                    &cancellation,
-                )
-                .map(IdlePromotionOutcome::Materialized),
-        });
+        let result = self
+            .admit(&scheduled)
+            .and_then(|admission| match admission {
+                Admission::AlreadyComplete(metadata) => {
+                    Ok(IdlePromotionOutcome::AlreadyComplete(Box::new(*metadata)))
+                }
+                Admission::Declined(reason) => Ok(IdlePromotionOutcome::Declined(reason)),
+                Admission::Proceed => self
+                    .materializer
+                    .materialize(
+                        &scheduled.candidate,
+                        &scheduled.source_configured_path,
+                        &scheduled.logical_model_owner,
+                        &cancellation,
+                    )
+                    .map(IdlePromotionOutcome::Materialized),
+            });
         lock_scheduler(&self.state).active = None;
         result
     }
@@ -1001,9 +1003,9 @@ fn source_bundle_bytes(candidate: &PromotionCandidate) -> Result<u64, ResolvedCa
             continue;
         }
         let metadata = std::fs::metadata(&location.source_path)?;
-        total = total.checked_add(metadata.len()).ok_or_else(|| {
-            ResolvedCacheError::new("promotion candidate byte total overflow")
-        })?;
+        total = total
+            .checked_add(metadata.len())
+            .ok_or_else(|| ResolvedCacheError::new("promotion candidate byte total overflow"))?;
     }
     Ok(total)
 }

--- a/crates/sceneworks-core/src/resolved_cache/materialization.rs
+++ b/crates/sceneworks-core/src/resolved_cache/materialization.rs
@@ -738,11 +738,51 @@ pub enum PromotionScheduleOutcome {
     Stopped,
 }
 
+/// Why an admitted-to-the-queue promotion was not materialized after all. Both reasons are
+/// ordinary policy outcomes, never failures: the queue is a hint recorded at load time, and the
+/// world may legitimately have moved on by the time the worker went idle.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PromotionDeclineReason {
+    /// The bundle cannot be held within the size limit without evicting entries that retention is
+    /// not allowed to evict, so promoting it would only be undone by the next sweep.
+    ExceedsSizeLimit {
+        candidate_bytes: u64,
+        protected_bytes: u64,
+        max_bytes: u64,
+    },
+    /// The authoritative source no longer validates. Promotion COPIES what is already installed;
+    /// it never fetches, so an unavailable or incomplete source declines.
+    SourceUnavailable(String),
+}
+
+impl std::fmt::Display for PromotionDeclineReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ExceedsSizeLimit {
+                candidate_bytes,
+                protected_bytes,
+                max_bytes,
+            } => write!(
+                formatter,
+                "promoting {candidate_bytes} bytes alongside {protected_bytes} unevictable bytes \
+                 would exceed the {max_bytes} byte resolved-cache limit"
+            ),
+            Self::SourceUnavailable(detail) => {
+                write!(formatter, "promotion source is unavailable: {detail}")
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum IdlePromotionOutcome {
     NotIdle,
     Empty,
     Stopped,
+    /// The entry is already published and complete, so it was skipped WITHOUT taking its exclusive
+    /// artifact lock — a lock a concurrent load of that same bundle holds shared.
+    AlreadyComplete(Box<ResolvedCacheMetadata>),
+    Declined(PromotionDeclineReason),
     Materialized(MaterializationOutcome),
 }
 
@@ -847,14 +887,61 @@ impl ResolvedCachePromotionScheduler {
             state.active = Some((scheduled.candidate.cache_key.clone(), cancellation.clone()));
             (scheduled, cancellation)
         };
-        let result = self.materializer.materialize(
-            &scheduled.candidate,
-            &scheduled.source_configured_path,
-            &scheduled.logical_model_owner,
-            &cancellation,
-        );
+        let result = self.admit(&scheduled).and_then(|admission| match admission {
+            Admission::AlreadyComplete(metadata) => Ok(IdlePromotionOutcome::AlreadyComplete(
+                Box::new(*metadata),
+            )),
+            Admission::Declined(reason) => Ok(IdlePromotionOutcome::Declined(reason)),
+            Admission::Proceed => self
+                .materializer
+                .materialize(
+                    &scheduled.candidate,
+                    &scheduled.source_configured_path,
+                    &scheduled.logical_model_owner,
+                    &cancellation,
+                )
+                .map(IdlePromotionOutcome::Materialized),
+        });
         lock_scheduler(&self.state).active = None;
-        result.map(IdlePromotionOutcome::Materialized)
+        result
+    }
+
+    /// Policy admission, applied when the worker goes idle rather than when the candidate was
+    /// recorded: the queue is a hint taken at load time, and completeness, cache size and source
+    /// availability are all live facts that must be judged against the world as it is now.
+    fn admit(&self, scheduled: &ScheduledPromotion) -> Result<Admission, ResolvedCacheError> {
+        let store = self.materializer.store();
+        // Never promote what is already published. Checked before anything takes the entry's
+        // EXCLUSIVE artifact lock, which a live local-tier load of that same bundle holds shared.
+        if let Some(metadata) = store.lookup_complete(&scheduled.candidate.cache_key)? {
+            return Ok(Admission::AlreadyComplete(Box::new(metadata)));
+        }
+        // Promotion copies bytes that are already installed. Resolving the closure against the
+        // configured source library is the only way it learns where those bytes are, so a source
+        // that cannot be resolved declines here and no fetch of any kind is reachable.
+        let candidate_bytes = match source_bundle_bytes(&scheduled.candidate) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                return Ok(Admission::Declined(
+                    PromotionDeclineReason::SourceUnavailable(error.to_string()),
+                ));
+            }
+        };
+        // Admit only what retention could still hold. Sizing against the entries retention is
+        // FORBIDDEN to evict — pinned ones — is what stops promote-then-immediately-evict churn:
+        // an unpinned entry can lose its place to a fresher bundle, a pinned one never can, so a
+        // candidate that does not fit beside the pinned set can only ever be evicted straight back.
+        let protected_bytes = protected_bytes(store)?;
+        if protected_bytes.saturating_add(candidate_bytes) > self.policy.max_bytes {
+            return Ok(Admission::Declined(
+                PromotionDeclineReason::ExceedsSizeLimit {
+                    candidate_bytes,
+                    protected_bytes,
+                    max_bytes: self.policy.max_bytes,
+                },
+            ));
+        }
+        Ok(Admission::Proceed)
     }
 
     pub fn cancel_active(&self) -> bool {
@@ -883,6 +970,60 @@ impl ResolvedCachePromotionScheduler {
     pub fn queued_len(&self) -> usize {
         lock_scheduler(&self.state).queue.len()
     }
+}
+
+enum Admission {
+    Proceed,
+    AlreadyComplete(Box<ResolvedCacheMetadata>),
+    Declined(PromotionDeclineReason),
+}
+
+/// The on-disk size of everything the bundle would copy, counting each distinct source file once
+/// because the materializer hard-links repeats within one bundle rather than copying them twice.
+///
+/// Resolving the locations is what proves the source is present: it walks the exact repositories,
+/// immutable revisions and files, refusing links out of the repository. Nothing is fetched.
+fn source_bundle_bytes(candidate: &PromotionCandidate) -> Result<u64, ResolvedCacheError> {
+    let ArtifactLocation::SourceLibrary { root } = &candidate.artifact.location else {
+        return Err(ResolvedCacheError::new(
+            "only a source-library artifact can be materialized",
+        ));
+    };
+    let locations = candidate
+        .artifact
+        .closure
+        .source_file_locations(&candidate.artifact.identity, root)
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+    let mut counted = BTreeSet::new();
+    let mut total = 0_u64;
+    for location in locations {
+        if !counted.insert(location.source_path.clone()) {
+            continue;
+        }
+        let metadata = std::fs::metadata(&location.source_path)?;
+        total = total.checked_add(metadata.len()).ok_or_else(|| {
+            ResolvedCacheError::new("promotion candidate byte total overflow")
+        })?;
+    }
+    Ok(total)
+}
+
+/// Bytes retention is not permitted to reclaim: pinned complete entries. Entries in flight or
+/// merely fresh are deliberately excluded — those CAN lose their place to a newer bundle, so
+/// counting them would refuse promotions the cache is able to hold.
+fn protected_bytes(store: &ResolvedCacheStore) -> Result<u64, ResolvedCacheError> {
+    store
+        .enumerate()?
+        .into_iter()
+        .filter_map(|entry| entry.metadata)
+        .filter(|metadata| {
+            metadata.state == ResolvedCacheEntryState::Complete && metadata.effective_pin
+        })
+        .try_fold(0_u64, |total, metadata| {
+            total.checked_add(metadata.verified_bytes).ok_or_else(|| {
+                ResolvedCacheError::new("resolved-cache protected byte total overflow")
+            })
+        })
 }
 
 fn lock_scheduler<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {

--- a/crates/sceneworks-core/src/resolved_cache/materialization_tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/materialization_tests.rs
@@ -929,6 +929,230 @@ fn scheduler_is_bounded_coalescing_disabled_and_stoppable() {
     );
 }
 
+// ---------------------------------------------------------------------------------------------
+// sc-19706 — POLICY ADMISSION. Everything below covers `ResolvedCachePromotionScheduler::admit`,
+// which is applied when the worker goes IDLE rather than when the candidate was recorded: the
+// queue is a hint taken at load time, and completeness, cache size and source availability are all
+// live facts. Each test names the exact decision it pins, and each of the three admission guards
+// is covered alone so a mutation to one cannot be absorbed by another's test.
+// ---------------------------------------------------------------------------------------------
+
+fn sized_policy(max_bytes: u64) -> ResolvedCachePolicy {
+    ResolvedCachePolicy {
+        enabled: true,
+        max_bytes,
+        ..ResolvedCachePolicy::default()
+    }
+}
+
+/// Publish `candidate` from `source` through the real materializer and return the published
+/// metadata. Used to put a KNOWN number of complete bytes in the store before the test's real
+/// subject runs.
+fn publish(
+    store: &ResolvedCacheStore,
+    candidate: &PromotionCandidate,
+    source: &Path,
+    owner: &str,
+) -> ResolvedCacheMetadata {
+    match ResolvedCacheMaterializer::new(store.clone())
+        .materialize(
+            candidate,
+            source,
+            owner,
+            &MaterializationCancellation::default(),
+        )
+        .unwrap()
+    {
+        MaterializationOutcome::Published(metadata) => *metadata,
+        other => panic!("expected a published bundle, got {other:?}"),
+    }
+}
+
+/// A candidate is admitted only when it fits BESIDE the bytes retention may not reclaim. Promoting
+/// past that point would only be undone by the next sweep, so the promote-then-immediately-evict
+/// churn is refused before a single byte is copied.
+#[test]
+fn a_candidate_that_cannot_fit_beside_the_pinned_set_is_declined_before_any_bytes_move() {
+    let scratch = TempDir::new().unwrap();
+    let (held_source, held) = flat_fixture(&scratch);
+    let second = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture_at_revision(&second, REV_B);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let held_metadata = publish(&store, &held, &held_source, "image:held");
+    // PINNED — the whole point of the rule. An unpinned entry could lose its place to this
+    // candidate, a pinned one never can.
+    store.set_artifact_pin(&held.cache_key, true).unwrap();
+    assert!(held_metadata.verified_bytes > 0);
+
+    // One byte short of holding both.
+    let candidate_bytes = std::fs::metadata(source.join(format!(
+        "models--SceneWorks--model/snapshots/{REV_B}/model.safetensors"
+    )))
+    .unwrap()
+    .len();
+    let max_bytes = held_metadata.verified_bytes + candidate_bytes - 1;
+    let scheduler = ResolvedCachePromotionScheduler::new(
+        sized_policy(max_bytes),
+        ResolvedCacheMaterializer::new(store.clone()),
+        2,
+    )
+    .unwrap();
+    scheduler
+        .schedule(candidate.clone(), source, "image:candidate".to_owned())
+        .unwrap();
+    assert_eq!(
+        scheduler.run_next_if_idle(true).unwrap(),
+        IdlePromotionOutcome::Declined(PromotionDeclineReason::ExceedsSizeLimit {
+            candidate_bytes,
+            protected_bytes: held_metadata.verified_bytes,
+            max_bytes,
+        })
+    );
+    // Declined means NOTHING was reserved, staged or published — not a rollback.
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_none());
+    assert!(std::fs::read_dir(store.root().join("staging"))
+        .unwrap()
+        .next()
+        .is_none());
+}
+
+/// The size rule is deliberately `protected_bytes + candidate_bytes`, NOT total complete bytes.
+/// An unpinned entry can lose its place to a fresher bundle, so counting it would refuse promotions
+/// the cache is perfectly able to hold. This is the same store and the same numbers as the test
+/// above with the pin removed — the pin is the ONLY difference, and it flips the decision.
+#[test]
+fn an_unpinned_complete_entry_never_blocks_a_promotion_the_cache_can_hold() {
+    let scratch = TempDir::new().unwrap();
+    let (held_source, held) = flat_fixture(&scratch);
+    let second = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture_at_revision(&second, REV_B);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let held_metadata = publish(&store, &held, &held_source, "image:held");
+    assert!(!store.effective_pin(&held.cache_key).unwrap());
+
+    let candidate_bytes = std::fs::metadata(source.join(format!(
+        "models--SceneWorks--model/snapshots/{REV_B}/model.safetensors"
+    )))
+    .unwrap()
+    .len();
+    let max_bytes = held_metadata.verified_bytes + candidate_bytes - 1;
+    let scheduler = ResolvedCachePromotionScheduler::new(
+        sized_policy(max_bytes),
+        ResolvedCacheMaterializer::new(store.clone()),
+        2,
+    )
+    .unwrap();
+    scheduler
+        .schedule(candidate.clone(), source, "image:candidate".to_owned())
+        .unwrap();
+    assert!(
+        matches!(
+            scheduler.run_next_if_idle(true).unwrap(),
+            IdlePromotionOutcome::Materialized(MaterializationOutcome::Published(_))
+        ),
+        "an unpinned neighbour must not be counted as protected"
+    );
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_some());
+}
+
+/// Promotion COPIES what is already installed; it never fetches. A source that stopped resolving
+/// between the load that recorded the hint and the idle drain is an ordinary policy decline, and
+/// must not become a download, an error, or a half-written entry.
+#[test]
+fn a_source_that_vanished_between_the_load_and_the_drain_declines_rather_than_fetching() {
+    let scratch = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture(&scratch);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let scheduler = ResolvedCachePromotionScheduler::new(
+        enabled_policy(),
+        ResolvedCacheMaterializer::new(store.clone()),
+        2,
+    )
+    .unwrap();
+    scheduler
+        .schedule(candidate.clone(), source.clone(), "image:model".to_owned())
+        .unwrap();
+    // The library is still configured; the model's own snapshot is gone — the shape a component
+    // removal or an interrupted uninstall leaves behind.
+    std::fs::remove_dir_all(source.join("models--SceneWorks--model")).unwrap();
+
+    let outcome = scheduler.run_next_if_idle(true).unwrap();
+    assert!(
+        matches!(
+            outcome,
+            IdlePromotionOutcome::Declined(PromotionDeclineReason::SourceUnavailable(_))
+        ),
+        "expected a source-unavailable decline, got {outcome:?}"
+    );
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_none());
+    assert!(!store.entry_path(&candidate.cache_key).unwrap().exists());
+}
+
+/// `IdlePromotionOutcome::AlreadyComplete` exists so an already-published entry is skipped WITHOUT
+/// taking its exclusive artifact lock — the lock a live local-tier load of that same bundle holds
+/// SHARED. This test holds exactly that shared lock through a real runtime lease.
+///
+/// Without the `lookup_complete` short-circuit, admission would fall through to `materialize` →
+/// `reserve` → `try_lock_exclusive`, which the held shared lock defeats, and the promotion would be
+/// reported as `Materialized(Contended)`: a live load of a cached model would make its own entry
+/// look contended on every idle turn for as long as the job ran.
+#[test]
+fn an_already_published_entry_is_skipped_without_taking_the_lock_a_live_load_holds() {
+    let scratch = TempDir::new().unwrap();
+    let (source, candidate) = flat_fixture(&scratch);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let published = publish(&store, &candidate, &source, "image:model");
+
+    // A live local-tier load: `acquire_complete` takes the entry's SHARED artifact lock and holds
+    // it for the lifetime of the lease.
+    let resolver = ModelArtifactResolver::new(ArtifactSourceLibrary::new(&source).unwrap());
+    let lease = store
+        .acquire_complete(&candidate.cache_key, &resolver, "image:model")
+        .unwrap()
+        .expect("the published entry leases");
+
+    let scheduler = ResolvedCachePromotionScheduler::new(
+        enabled_policy(),
+        ResolvedCacheMaterializer::new(store.clone()),
+        2,
+    )
+    .unwrap();
+    scheduler
+        .schedule(candidate.clone(), source, "image:model".to_owned())
+        .unwrap();
+    let outcome = scheduler.run_next_if_idle(true).unwrap();
+    // Compared by variant and identity, not by whole metadata: the live lease legitimately stamped
+    // `last_used_at` on the way in, and asserting equality with the pre-lease record would fail for
+    // a reason that has nothing to do with the decision under test.
+    match &outcome {
+        IdlePromotionOutcome::AlreadyComplete(metadata) => {
+            assert_eq!(metadata.cache_key, published.cache_key);
+            assert_eq!(metadata.state, ResolvedCacheEntryState::Complete);
+            assert_eq!(metadata.verified_bytes, published.verified_bytes);
+        }
+        other => panic!(
+            "a published entry under a live shared lock must report AlreadyComplete, never \
+             Contended; got {other:?}"
+        ),
+    }
+    // Proof the lock really was held for the whole decision: taking it exclusively only succeeds
+    // once the lease is dropped, so a `Contended` answer above would have been the lock talking.
+    drop(lease);
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_some());
+}
+
 #[cfg(unix)]
 #[test]
 fn materializer_copies_a_same_repository_hf_blob_symlink() {

--- a/crates/sceneworks-worker/src/external_library_runtime.rs
+++ b/crates/sceneworks-worker/src/external_library_runtime.rs
@@ -58,6 +58,15 @@ pub(crate) struct RuntimeSourceGuard {
     /// non-blockingly, and even when it re-verifies under the lock — cannot remove bytes a load is
     /// reading. Released on drop; `finish_success` crosses the promotion boundary first.
     cache_leases: Vec<ResolvedCacheLease>,
+    /// sc-19706: the closures this job served from the SOURCE tier, recorded here so
+    /// [`Self::finish_success`] can hand them to the promotion intake without doing any work.
+    ///
+    /// This is the whole of the trigger's job-path cost: a `Vec` built from values the guard had
+    /// already computed for admission. Building the promotion candidate needs the source library
+    /// walked, every closure member stat-ed and canonicalized, and a reservation taken — all of it
+    /// belongs on the idle drain (`crate::resolved_cache_promotion`), never in the job's critical
+    /// path, so nothing here touches the filesystem.
+    pending_promotions: Vec<crate::resolved_cache_promotion::PendingPromotion>,
 }
 
 impl RuntimeSourceGuard {
@@ -176,6 +185,20 @@ impl RuntimeSourceGuard {
         let (local_scope, cache_leases) =
             select_local_tier(settings, &configured_library, &mut plans);
 
+        // sc-19706 — the PRODUCER trigger, recorded here and fired only on success. Read AFTER
+        // pass 3 so it reflects the tier that will really serve: a model that fell back from the
+        // local tier is external-ready now, and its own closure is exactly what is missing from
+        // the cache. Only `ExternalReady` qualifies — a local-ready model is already promoted,
+        // and incomplete/missing/unavailable models have nothing installed to copy.
+        let pending_promotions = crate::resolved_cache_promotion::pending_for_plans(
+            settings,
+            &configured_library,
+            plans.iter().filter_map(|plan| {
+                (plan.resolution.availability == ModelAvailability::ExternalReady)
+                    .then_some(plan.requirements.as_slice())
+            }),
+        );
+
         let mut resolutions: Vec<ModelResolution> = Vec::new();
         for plan in plans {
             if !resolutions.contains(&plan.resolution) {
@@ -240,6 +263,7 @@ impl RuntimeSourceGuard {
             sessions,
             local_scope,
             cache_leases,
+            pending_promotions,
         })
     }
 
@@ -249,6 +273,7 @@ impl RuntimeSourceGuard {
             sessions: Vec::new(),
             local_scope: None,
             cache_leases: Vec::new(),
+            pending_promotions: Vec::new(),
         }
     }
 
@@ -265,6 +290,15 @@ impl RuntimeSourceGuard {
             // entry is already published, so this only records the successful use.
             let _candidate = lease.mark_success();
         }
+        // sc-19706 — the only place a real install becomes a promotion candidate. A job that
+        // reached here loaded and ran to completion against the configured source library, which
+        // is the exact evidence promotion needs: the bytes exist, they are valid, and something
+        // actually used them. Pushing is a lock-and-move into a bounded in-memory queue and is
+        // deliberately the last thing the job does — the drain that turns these into bundles runs
+        // on the blocking pool when the worker next claims nothing.
+        crate::resolved_cache_promotion::record_pending(std::mem::take(
+            &mut self.pending_promotions,
+        ));
         Ok(())
     }
 
@@ -782,8 +816,16 @@ mod tests {
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;
 
-    const REV_A: &str = "0123456789abcdef0123456789abcdef01234567";
-    const REV_B: &str = "89abcdef0123456789abcdef0123456789abcdef";
+    // FILE-UNIQUE fixture identities, deliberately. Some of these tests install the PROCESS-WIDE
+    // local-tier preference overlay, and the overlay is keyed on `(repository, revision)` — so a
+    // fixture repository or revision shared with an unrelated test elsewhere in this crate
+    // (`model_jobs.rs`, `image_jobs/tests.rs`, `flux1_control_candle.rs` all used the same
+    // `owner/...` names and the same `0123456789ab…` revision) lets a live overlay here answer for
+    // a snapshot that test expects to read from its own temp library. The suite runs in parallel,
+    // so that is a rare, load-dependent, entirely genuine false red in a file that never mentions
+    // the resolved cache. The `guardfx/` prefix and the `e19706…` revisions appear nowhere else.
+    const REV_A: &str = "e19706aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const REV_B: &str = "e19706bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
     fn settings(data_dir: PathBuf) -> Settings {
         Settings {
@@ -851,18 +893,18 @@ mod tests {
     fn installed_model(temp: &TempDir) -> (Settings, PathBuf, JsonObject) {
         let data = temp.path().join("data");
         let library = temp.path().join("external-hf");
-        seed_snapshot(&library, "owner/model", REV_A, "model.safetensors");
+        seed_snapshot(&library, "guardfx/model", REV_A, "model.safetensors");
         write_receipts(
             &data,
-            "owner/model",
-            json!([{ "repo": "owner/model", "modelId": "m",
+            "guardfx/model",
+            json!([{ "repo": "guardfx/model", "modelId": "m",
                      "resolvedFiles": ["model.safetensors"], "snapshotRevision": REV_A }]),
         );
         let payload = json!({
             "model": "m",
             "modelManifestEntry": {
                 "id": "m",
-                "downloads": [{ "provider": "huggingface", "repo": "owner/model",
+                "downloads": [{ "provider": "huggingface", "repo": "guardfx/model",
                                 "revision": REV_A, "files": ["model.safetensors"] }]
             }
         })
@@ -876,10 +918,10 @@ mod tests {
     /// by design (model paths resolve on engine threads far below the job task), so two of these
     /// bodies running concurrently would read each other's overlay.
     ///
-    /// `.cargo/config.toml` currently forces `RUST_TEST_THREADS=1`, which means a green run WITHOUT
-    /// this mutex proves nothing about the shared state these tests actually depend on — it only
-    /// proves the harness happened to serialize them. The mutex makes the dependency real and
-    /// keeps these tests honest if that setting ever changes.
+    /// This mutex is the ONLY thing serializing them. `.cargo/config.toml` sets no
+    /// `RUST_TEST_THREADS`, so this suite really does run in parallel and the interleaving is live
+    /// rather than hypothetical — an earlier version of this comment claimed the harness already
+    /// serialized the suite, which was false and would have made dropping the mutex look safe.
     fn overlay_guard() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
         LOCK.get_or_init(|| std::sync::Mutex::new(()))
@@ -1001,7 +1043,7 @@ mod tests {
             let artifact = publish_bundle(
                 &settings.data_dir,
                 &library,
-                "owner/model",
+                "guardfx/model",
                 REV_A,
                 "default",
                 &["model.safetensors"],
@@ -1011,7 +1053,7 @@ mod tests {
 
             // Before the guard runs, the shared resolver reads the configured source library.
             let source_snapshot =
-                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model")
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "guardfx/model")
                     .expect("source snapshot");
             assert!(source_snapshot.starts_with(&library));
 
@@ -1025,18 +1067,18 @@ mod tests {
             // The one shared snapshot resolver — every model-consuming runtime funnels through it
             // — now answers with the app-owned bundle.
             let loaded =
-                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model")
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "guardfx/model")
                     .expect("leased local snapshot");
             assert_eq!(
                 loaded,
-                bundle_root.join(format!("models--owner--model/snapshots/{REV_A}"))
+                bundle_root.join(format!("models--guardfx--model/snapshots/{REV_A}"))
             );
             assert!(loaded.join("model.safetensors").is_file());
             // And so does the pinned-component resolver used by the utility/co-requisite lanes.
             assert_eq!(
                 crate::model_jobs::huggingface_pinned_snapshot_dir(
                     &settings.data_dir,
-                    "owner/model",
+                    "guardfx/model",
                     REV_A
                 ),
                 Some(loaded.clone())
@@ -1056,7 +1098,7 @@ mod tests {
             };
             assert!(matches!(
                 evictor
-                    .reserve(&candidate, &library, "owner/model")
+                    .reserve(&candidate, &library, "guardfx/model")
                     .unwrap(),
                 sceneworks_core::model_artifacts::resolved_cache::ReservationOutcome::Contended
             ));
@@ -1067,7 +1109,7 @@ mod tests {
             assert!(metadata.last_used_at.is_some());
             // With the job finished the source tier serves again.
             assert_eq!(
-                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model"),
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "guardfx/model"),
                 Some(source_snapshot)
             );
         });
@@ -1081,7 +1123,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let data = temp.path().join("data");
         let library = temp.path().join("external-hf");
-        for repo in ["owner/primary", "owner/utility"] {
+        for repo in ["guardfx/primary", "guardfx/utility"] {
             seed_snapshot(&library, repo, REV_A, "model.safetensors");
             write_receipts(
                 &data,
@@ -1099,14 +1141,14 @@ mod tests {
             })
         };
         let payload = json!({
-            "modelManifestEntry": entry("owner/primary"),
-            "modelManifestEntries": [entry("owner/utility")]
+            "modelManifestEntry": entry("guardfx/primary"),
+            "modelManifestEntries": [entry("guardfx/utility")]
         })
         .as_object()
         .unwrap()
         .clone();
         with_local_cache(&library, || {
-            for repo in ["owner/primary", "owner/utility"] {
+            for repo in ["guardfx/primary", "guardfx/utility"] {
                 publish_bundle(
                     &settings.data_dir,
                     &library,
@@ -1123,7 +1165,7 @@ mod tests {
                 .resolutions()
                 .iter()
                 .all(|resolution| resolution.availability == ModelAvailability::LocalReady));
-            for repo in ["owner/primary", "owner/utility"] {
+            for repo in ["guardfx/primary", "guardfx/utility"] {
                 let loaded = crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, repo)
                     .expect("leased local snapshot");
                 assert!(loaded.join("model.safetensors").is_file());
@@ -1145,7 +1187,7 @@ mod tests {
             let artifact = publish_bundle(
                 &settings.data_dir,
                 &library,
-                "owner/model",
+                "guardfx/model",
                 REV_A,
                 "default",
                 &["model.safetensors"],
@@ -1153,10 +1195,10 @@ mod tests {
             let bundle_snapshot = artifact
                 .location
                 .root()
-                .join(format!("models--owner--model/snapshots/{REV_A}"));
+                .join(format!("models--guardfx--model/snapshots/{REV_A}"));
             let source_snapshot = ArtifactSourceLibrary::new(&library)
                 .unwrap()
-                .repository_root("owner/model")
+                .repository_root("guardfx/model")
                 .unwrap()
                 .join("snapshots")
                 .join(REV_A);
@@ -1185,7 +1227,7 @@ mod tests {
             assert_eq!(
                 crate::model_jobs::huggingface_receipt_weights_dir(
                     &settings.data_dir,
-                    "owner/model",
+                    "guardfx/model",
                     Some("m"),
                     None
                 ),
@@ -1217,7 +1259,7 @@ mod tests {
             publish_bundle(
                 &settings.data_dir,
                 &library,
-                "owner/model",
+                "guardfx/model",
                 REV_A,
                 "default",
                 &["model.safetensors"],
@@ -1231,7 +1273,7 @@ mod tests {
                 ModelAvailability::LocalReady
             );
             let loaded =
-                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model")
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "guardfx/model")
                     .expect("leased local snapshot while disconnected");
             assert!(loaded.join("model.safetensors").is_file());
             let resolved_root =
@@ -1254,14 +1296,14 @@ mod tests {
             let artifact = publish_bundle(
                 &settings.data_dir,
                 &library,
-                "owner/model",
+                "guardfx/model",
                 REV_A,
                 "default",
                 &["model.safetensors"],
             );
             let bundle = artifact.location.root().to_path_buf();
             let source_snapshot =
-                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model")
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "guardfx/model")
                     .expect("source snapshot");
 
             let guard =
@@ -1283,7 +1325,7 @@ mod tests {
                 "an invalid local entry must fall back to the authoritative source"
             );
             assert_eq!(
-                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model"),
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "guardfx/model"),
                 Some(source_snapshot),
                 "and the load must read the source library, not the invalid bundle"
             );
@@ -1292,7 +1334,7 @@ mod tests {
 
     fn published_file(bundle: &Path) -> PathBuf {
         bundle.join(format!(
-            "models--owner--model/snapshots/{REV_A}/model.safetensors"
+            "models--guardfx--model/snapshots/{REV_A}/model.safetensors"
         ))
     }
 
@@ -1333,15 +1375,15 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let data = temp.path().join("data");
         let library = temp.path().join("external-hf");
-        seed_snapshot(&library, "owner/matrix", REV_A, "q4/model.safetensors");
-        seed_snapshot(&library, "owner/matrix", REV_A, "q8/model.safetensors");
+        seed_snapshot(&library, "guardfx/matrix", REV_A, "q4/model.safetensors");
+        seed_snapshot(&library, "guardfx/matrix", REV_A, "q8/model.safetensors");
         write_receipts(
             &data,
-            "owner/matrix",
+            "guardfx/matrix",
             json!([
-                { "repo": "owner/matrix", "modelId": "m", "variant": "q4",
+                { "repo": "guardfx/matrix", "modelId": "m", "variant": "q4",
                   "resolvedFiles": ["q4/model.safetensors"], "snapshotRevision": REV_A },
-                { "repo": "owner/matrix", "modelId": "m", "variant": "q8",
+                { "repo": "guardfx/matrix", "modelId": "m", "variant": "q8",
                   "resolvedFiles": ["q8/model.safetensors"], "snapshotRevision": REV_A }
             ]),
         );
@@ -1349,9 +1391,9 @@ mod tests {
         let entry = json!({
             "id": "m",
             "downloads": [
-                { "provider": "huggingface", "repo": "owner/matrix", "variant": "q4",
+                { "provider": "huggingface", "repo": "guardfx/matrix", "variant": "q4",
                   "default": true, "files": ["q4/*"] },
-                { "provider": "huggingface", "repo": "owner/matrix", "variant": "q8",
+                { "provider": "huggingface", "repo": "guardfx/matrix", "variant": "q8",
                   "files": ["q8/*"] }
             ]
         });
@@ -1366,7 +1408,7 @@ mod tests {
             let q4_bundle = publish_bundle(
                 &settings.data_dir,
                 &library,
-                "owner/matrix",
+                "guardfx/matrix",
                 REV_A,
                 "q4",
                 &["q4/model.safetensors"],
@@ -1393,10 +1435,10 @@ mod tests {
             );
             // AND — the assertion this test used to skip by calling `drop(guard)` first — the PATH
             // layer must agree. Availability said "source tier"; the bug lived one layer down,
-            // where the process-wide overlay would still redirect `owner/matrix@REV_A` into the q4
+            // where the process-wide overlay would still redirect `guardfx/matrix@REV_A` into the q4
             // bundle root, which holds no `q8/` subtree at all. With the guard STILL HELD:
             let loaded =
-                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/matrix")
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "guardfx/matrix")
                     .expect("source snapshot");
             assert!(
                 loaded.starts_with(&library),
@@ -1411,11 +1453,11 @@ mod tests {
             drop(guard);
 
             // A bundle of another revision of the same model is likewise not this model.
-            seed_snapshot(&library, "owner/other", REV_B, "model.safetensors");
+            seed_snapshot(&library, "guardfx/other", REV_B, "model.safetensors");
             let other_bundle = publish_bundle(
                 &settings.data_dir,
                 &library,
-                "owner/other",
+                "guardfx/other",
                 REV_B,
                 "default",
                 &["model.safetensors"],
@@ -1423,7 +1465,7 @@ mod tests {
             let other = json!({
                 "modelManifestEntry": {
                     "id": "other",
-                    "downloads": [{ "provider": "huggingface", "repo": "owner/other",
+                    "downloads": [{ "provider": "huggingface", "repo": "guardfx/other",
                                     "revision": REV_A, "files": ["model.safetensors"] }]
                 }
             })
@@ -1440,7 +1482,7 @@ mod tests {
             // Path layer, guard still held: the REV_B bundle must not answer for a REV_A request.
             assert!(crate::model_jobs::huggingface_pinned_snapshot_dir(
                 &settings.data_dir,
-                "owner/other",
+                "guardfx/other",
                 REV_A
             )
             .is_none_or(|path| !path.starts_with(other_bundle.location.root())));
@@ -1462,15 +1504,15 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let data = temp.path().join("data");
         let library = temp.path().join("external-hf");
-        seed_snapshot(&library, "owner/matrix", REV_A, "q4/model.safetensors");
-        seed_snapshot(&library, "owner/matrix", REV_A, "q8/model.safetensors");
+        seed_snapshot(&library, "guardfx/matrix", REV_A, "q4/model.safetensors");
+        seed_snapshot(&library, "guardfx/matrix", REV_A, "q8/model.safetensors");
         write_receipts(
             &data,
-            "owner/matrix",
+            "guardfx/matrix",
             json!([
-                { "repo": "owner/matrix", "modelId": "q4model", "variant": "q4",
+                { "repo": "guardfx/matrix", "modelId": "q4model", "variant": "q4",
                   "resolvedFiles": ["q4/model.safetensors"], "snapshotRevision": REV_A },
-                { "repo": "owner/matrix", "modelId": "q8model", "variant": "q8",
+                { "repo": "guardfx/matrix", "modelId": "q8model", "variant": "q8",
                   "resolvedFiles": ["q8/model.safetensors"], "snapshotRevision": REV_A }
             ]),
         );
@@ -1478,7 +1520,7 @@ mod tests {
         let entry = |id: &str, variant: &str, glob: &str| {
             json!({
                 "id": id,
-                "downloads": [{ "provider": "huggingface", "repo": "owner/matrix",
+                "downloads": [{ "provider": "huggingface", "repo": "guardfx/matrix",
                                 "variant": variant, "default": true, "files": [glob] }]
             })
         };
@@ -1495,7 +1537,7 @@ mod tests {
             let q4_bundle = publish_bundle(
                 &settings.data_dir,
                 &library,
-                "owner/matrix",
+                "guardfx/matrix",
                 REV_A,
                 "q4",
                 &["q4/model.safetensors"],
@@ -1535,7 +1577,7 @@ mod tests {
             // The load-bearing half, at the path layer with the guard held: NOTHING resolves into
             // the q4 bundle, so the q8 load cannot land in a root that has no `q8/` subtree.
             let loaded =
-                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/matrix")
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "guardfx/matrix")
                     .expect("source snapshot");
             assert!(!loaded.starts_with(&q4_root), "{}", loaded.display());
             assert!(loaded.starts_with(&library), "{}", loaded.display());
@@ -1558,35 +1600,35 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let data = temp.path().join("data");
         let library = temp.path().join("external-hf");
-        seed_snapshot(&library, "owner/shared", REV_A, "pinned.safetensors");
-        seed_snapshot(&library, "owner/shared", REV_A, "legacy.safetensors");
+        seed_snapshot(&library, "guardfx/shared", REV_A, "pinned.safetensors");
+        seed_snapshot(&library, "guardfx/shared", REV_A, "legacy.safetensors");
         // `refs/main` is what an unpinned resolve reads — the walk that would reach the overlay.
-        let repo_root = library.join("models--owner--shared");
+        let repo_root = library.join("models--guardfx--shared");
         std::fs::create_dir_all(repo_root.join("refs")).unwrap();
         std::fs::write(repo_root.join("refs").join("main"), REV_A).unwrap();
 
-        let pinned_receipt = json!({ "repo": "owner/shared", "modelId": "pinned",
+        let pinned_receipt = json!({ "repo": "guardfx/shared", "modelId": "pinned",
                                      "resolvedFiles": ["pinned.safetensors"],
                                      "snapshotRevision": REV_A });
         // The legacy receipt: same repository, NO `snapshotRevision`.
-        let legacy_receipt = json!({ "repo": "owner/shared", "modelId": "legacy",
+        let legacy_receipt = json!({ "repo": "guardfx/shared", "modelId": "legacy",
                                      "resolvedFiles": ["legacy.safetensors"] });
         let pinned_entry = json!({
             "id": "pinned",
-            "downloads": [{ "provider": "huggingface", "repo": "owner/shared",
+            "downloads": [{ "provider": "huggingface", "repo": "guardfx/shared",
                             "revision": REV_A, "files": ["pinned.safetensors"] }]
         });
         // The legacy carrier declares NO revision, so nothing overrides its receipt's `None` with a
         // declared-exact pin — this is what makes `revision: None` actually reach the guard.
         let legacy_entry = json!({
             "id": "legacy",
-            "downloads": [{ "provider": "huggingface", "repo": "owner/shared",
+            "downloads": [{ "provider": "huggingface", "repo": "guardfx/shared",
                             "files": ["legacy.safetensors"] }]
         });
 
         // Control: the pinned selection ALONE is served locally. Without this the assertion below
         // could pass merely because the bundle was unusable.
-        write_receipts(&data, "owner/shared", json!([pinned_receipt.clone()]));
+        write_receipts(&data, "guardfx/shared", json!([pinned_receipt.clone()]));
         let settings = settings(data.clone());
         let alone = json!({ "modelManifestEntry": pinned_entry.clone() })
             .as_object()
@@ -1596,7 +1638,7 @@ mod tests {
             publish_bundle(
                 &settings.data_dir,
                 &library,
-                "owner/shared",
+                "guardfx/shared",
                 REV_A,
                 "default",
                 &["pinned.safetensors"],
@@ -1614,7 +1656,7 @@ mod tests {
         // Now add the legacy carrier on the SAME repository.
         write_receipts(
             &data,
-            "owner/shared",
+            "guardfx/shared",
             json!([pinned_receipt, legacy_receipt]),
         );
         let payload = json!({
@@ -1650,7 +1692,7 @@ mod tests {
             // the unpinned resolve may reach the bundle.
             let pinned = crate::model_jobs::huggingface_pinned_snapshot_dir(
                 &settings.data_dir,
-                "owner/shared",
+                "guardfx/shared",
                 REV_A,
             )
             .expect("source snapshot");
@@ -1658,7 +1700,7 @@ mod tests {
             assert!(pinned.starts_with(&library), "{}", pinned.display());
             // The unpinned walk (`refs/main`) is the one the poison exists to stop.
             let unpinned =
-                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/shared")
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "guardfx/shared")
                     .expect("source snapshot");
             assert!(
                 !unpinned.starts_with(&bundle_root),
@@ -1728,7 +1770,7 @@ mod tests {
             publish_bundle_at(
                 &settings.data_dir,
                 &library,
-                "owner/model",
+                "guardfx/model",
                 REV_A,
                 "default",
                 &["model.safetensors"],
@@ -1753,7 +1795,7 @@ mod tests {
                 "an unsupported shape must never serve the load"
             );
             let loaded =
-                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model")
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "guardfx/model")
                     .expect("source snapshot");
             assert!(loaded.starts_with(&library), "{}", loaded.display());
         });
@@ -1767,7 +1809,7 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let data = temp.path().join("data");
         let library = temp.path().join("external-hf");
-        for repo in ["owner/bundled", "owner/external"] {
+        for repo in ["guardfx/bundled", "guardfx/external"] {
             seed_snapshot(&library, repo, REV_A, "model.safetensors");
             write_receipts(
                 &data,
@@ -1785,8 +1827,8 @@ mod tests {
             })
         };
         let payload = json!({
-            "modelManifestEntry": entry("owner/bundled"),
-            "modelManifestEntries": [entry("owner/external")]
+            "modelManifestEntry": entry("guardfx/bundled"),
+            "modelManifestEntries": [entry("guardfx/external")]
         })
         .as_object()
         .unwrap()
@@ -1798,7 +1840,7 @@ mod tests {
             publish_bundle(
                 &settings.data_dir,
                 &library,
-                "owner/bundled",
+                "guardfx/bundled",
                 REV_A,
                 "default",
                 &["model.safetensors"],
@@ -1821,7 +1863,7 @@ mod tests {
                 "the unbundled model must report the source tier: {logged}"
             );
             assert!(
-                logged.contains("owner/bundled") && logged.contains("owner/external"),
+                logged.contains("guardfx/bundled") && logged.contains("guardfx/external"),
                 "each report must name its repository: {logged}"
             );
             // The unsupported-shape class describes a bundle that cannot be served at all; nothing
@@ -1852,15 +1894,15 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let data = temp.path().join("data");
         let library = temp.path().join("external-hf");
-        seed_snapshot(&library, "owner/matrix", REV_A, "q4/model.safetensors");
-        seed_snapshot(&library, "owner/matrix", REV_A, "q8/model.safetensors");
+        seed_snapshot(&library, "guardfx/matrix", REV_A, "q4/model.safetensors");
+        seed_snapshot(&library, "guardfx/matrix", REV_A, "q8/model.safetensors");
         write_receipts(
             &data,
-            "owner/matrix",
+            "guardfx/matrix",
             json!([
-                { "repo": "owner/matrix", "modelId": "q4model", "variant": "q4",
+                { "repo": "guardfx/matrix", "modelId": "q4model", "variant": "q4",
                   "resolvedFiles": ["q4/model.safetensors"], "snapshotRevision": REV_A },
-                { "repo": "owner/matrix", "modelId": "q8model", "variant": "q8",
+                { "repo": "guardfx/matrix", "modelId": "q8model", "variant": "q8",
                   "resolvedFiles": ["q8/model.safetensors"], "snapshotRevision": REV_A }
             ]),
         );
@@ -1868,7 +1910,7 @@ mod tests {
         let entry = |id: &str, variant: &str, glob: &str| {
             json!({
                 "id": id,
-                "downloads": [{ "provider": "huggingface", "repo": "owner/matrix",
+                "downloads": [{ "provider": "huggingface", "repo": "guardfx/matrix",
                                 "variant": variant, "default": true, "files": [glob] }]
             })
         };
@@ -1884,7 +1926,7 @@ mod tests {
             publish_bundle(
                 &settings.data_dir,
                 &library,
-                "owner/matrix",
+                "guardfx/matrix",
                 REV_A,
                 "q4",
                 &["q4/model.safetensors"],
@@ -1914,7 +1956,7 @@ mod tests {
             publish_bundle(
                 &settings.data_dir,
                 &library,
-                "owner/model",
+                "guardfx/model",
                 REV_A,
                 "default",
                 &["model.safetensors"],
@@ -1927,10 +1969,124 @@ mod tests {
                 guard.resolutions()[0].availability,
                 ModelAvailability::ExternalReady
             );
+            assert!(crate::model_jobs::huggingface_snapshot_dir(
+                &settings.data_dir,
+                "guardfx/model"
+            )
+            .expect("source snapshot")
+            .starts_with(&library));
+        });
+    }
+
+    /// sc-19706 — THE test the reopened story exists for: production populates the cache.
+    ///
+    /// Nothing here publishes a bundle by hand. A job resolves against the configured source
+    /// library, runs, and finishes; the trigger records the closure; the idle drain builds the
+    /// candidate and materializes it; and a SECOND guard pass over the SAME payload resolves the
+    /// model from the app-owned tier, with the shared snapshot resolver answering from the bundle.
+    /// That whole chain is the epic's user-visible value, and before this story none of it ran
+    /// outside a test that published the bundle itself.
+    ///
+    /// It also pins the two-stage split: the bundle must NOT exist when the job finishes. If
+    /// `finish_success` ever materialized inline, the first assertion below fails — which is the
+    /// only way to catch source-library I/O silently moving onto the job path.
+    #[test]
+    fn a_successful_source_tier_job_promotes_itself_and_the_next_job_loads_from_the_bundle() {
+        let temp = TempDir::new().unwrap();
+        let (settings, library, payload) = installed_model(&temp);
+        with_local_cache(&library, || {
+            // FIRST JOB — nothing is cached, so it is served by the configured source library.
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap();
+            assert_eq!(
+                guard.resolutions()[0].availability,
+                ModelAvailability::ExternalReady
+            );
+            let source_snapshot =
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "guardfx/model")
+                    .expect("source snapshot");
+            assert!(source_snapshot.starts_with(&library));
+
+            guard.finish_success().unwrap();
+
+            // The job path did the queueing and NOTHING else: no bundle, no store, no copy.
             assert!(
-                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "owner/model")
-                    .expect("source snapshot")
-                    .starts_with(&library)
+                crate::resolved_cache_promotion::work_pending(&settings.data_dir),
+                "a successful source-tier load must record a promotion candidate"
+            );
+            assert!(
+                !settings
+                    .data_dir
+                    .join("models")
+                    .join("resolved")
+                    .join("entries")
+                    .is_dir(),
+                "finish_success must not materialize inline — that is source-library I/O on the \
+                 job path"
+            );
+
+            // IDLE DRAIN — what the worker's poll loop runs on the blocking pool when a claim
+            // returns nothing.
+            crate::resolved_cache_promotion::drain_intake(&settings);
+            assert!(
+                !crate::resolved_cache_promotion::work_pending(&settings.data_dir),
+                "the drain consumes the intake"
+            );
+
+            let store = ResolvedCacheStore::open(&settings.data_dir).unwrap();
+            let published = store
+                .enumerate()
+                .unwrap()
+                .into_iter()
+                .filter_map(|entry| entry.metadata)
+                .find(|metadata| {
+                    metadata.state
+                        == sceneworks_core::model_artifacts::resolved_cache::ResolvedCacheEntryState::Complete
+                })
+                .expect("the drain published a complete bundle");
+            assert_eq!(published.artifact.identity.repository, "guardfx/model");
+            assert_eq!(published.artifact.identity.revision, REV_A);
+
+            // SECOND JOB — same payload, same worker, nothing else changed. It must now be served
+            // from the app-owned tier.
+            let second =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap();
+            assert_eq!(
+                second.resolutions()[0].availability,
+                ModelAvailability::LocalReady,
+                "the bundle production just wrote must serve the next load"
+            );
+            let loaded =
+                crate::model_jobs::huggingface_snapshot_dir(&settings.data_dir, "guardfx/model")
+                    .expect("leased local snapshot");
+            // Compared against the published bundle root rather than a `starts_with` on
+            // `data_dir`: the store records the CANONICAL root, and on macOS the temp dir's
+            // `/var` -> `/private/var` symlink makes a lexical prefix check fail on a path that is
+            // in fact inside the bundle.
+            assert_eq!(
+                loaded,
+                published
+                    .artifact
+                    .location
+                    .root()
+                    .join(format!("models--guardfx--model/snapshots/{REV_A}")),
+                "the shared snapshot resolver must answer from the bundle"
+            );
+            assert!(loaded.join("model.safetensors").is_file());
+            second.finish_success().unwrap();
+
+            // And the already-published entry is not promoted a second time: the drain admits it
+            // as already complete and copies nothing.
+            crate::resolved_cache_promotion::drain_intake(&settings);
+            assert_eq!(
+                store
+                    .enumerate()
+                    .unwrap()
+                    .iter()
+                    .filter(|entry| entry.state
+                        == sceneworks_core::model_artifacts::resolved_cache::ResolvedCacheEntryState::Complete)
+                    .count(),
+                1
             );
         });
     }
@@ -1962,7 +2118,7 @@ mod tests {
         with_library(&library, || {
             let receipt_path = settings.data_dir.join("models").join(
                 sceneworks_core::model_artifacts::artifact_selection::safe_download_dir(
-                    "owner/model",
+                    "guardfx/model",
                 ),
             );
             let receipt_before =
@@ -2001,7 +2157,7 @@ mod tests {
                 .unwrap()
                 .finish_success()
                 .unwrap();
-            let safe = sceneworks_core::hf_home::safe_repo_dir_name("owner/model").unwrap();
+            let safe = sceneworks_core::hf_home::safe_repo_dir_name("guardfx/model").unwrap();
             std::fs::remove_file(
                 library
                     .join(format!("models--{safe}"))
@@ -2059,14 +2215,14 @@ mod tests {
         let data = temp.path().join("data");
         let library = temp.path().join("external-hf");
         // q4 fully installed; q8 receipt exists but its library snapshot was pruned.
-        seed_snapshot(&library, "owner/matrix", REV_A, "q4/model.safetensors");
+        seed_snapshot(&library, "guardfx/matrix", REV_A, "q4/model.safetensors");
         write_receipts(
             &data,
-            "owner/matrix",
+            "guardfx/matrix",
             json!([
-                { "repo": "owner/matrix", "modelId": "m", "variant": "q4",
+                { "repo": "guardfx/matrix", "modelId": "m", "variant": "q4",
                   "resolvedFiles": ["q4/model.safetensors"], "snapshotRevision": REV_A },
-                { "repo": "owner/matrix", "modelId": "m", "variant": "q8",
+                { "repo": "guardfx/matrix", "modelId": "m", "variant": "q8",
                   "resolvedFiles": ["q8/model.safetensors"], "snapshotRevision": REV_B }
             ]),
         );
@@ -2074,9 +2230,9 @@ mod tests {
         let entry = json!({
             "id": "m",
             "downloads": [
-                { "provider": "huggingface", "repo": "owner/matrix", "variant": "q4",
+                { "provider": "huggingface", "repo": "guardfx/matrix", "variant": "q4",
                   "default": true, "files": ["q4/*"] },
-                { "provider": "huggingface", "repo": "owner/matrix", "variant": "q8",
+                { "provider": "huggingface", "repo": "guardfx/matrix", "variant": "q8",
                   "files": ["q8/*"] }
             ]
         });
@@ -2122,11 +2278,11 @@ mod tests {
         } else {
             "macos"
         };
-        seed_snapshot(&library, "owner/native", REV_A, "model.safetensors");
+        seed_snapshot(&library, "guardfx/native", REV_A, "model.safetensors");
         write_receipts(
             &data,
-            "owner/native",
-            json!([{ "repo": "owner/native", "modelId": "m",
+            "guardfx/native",
+            json!([{ "repo": "guardfx/native", "modelId": "m",
                      "resolvedFiles": ["model.safetensors"], "snapshotRevision": REV_A }]),
         );
         // The other platform's primary and co-requisite are NOT installed anywhere. If the guard
@@ -2135,11 +2291,11 @@ mod tests {
             "modelManifestEntry": {
                 "id": "m",
                 "downloads": [
-                    { "provider": "huggingface", "repo": "owner/native", "revision": REV_A,
+                    { "provider": "huggingface", "repo": "guardfx/native", "revision": REV_A,
                       "files": ["model.safetensors"], "platforms": [this_os] },
-                    { "provider": "huggingface", "repo": "owner/foreign", "revision": REV_B,
+                    { "provider": "huggingface", "repo": "guardfx/foreign", "revision": REV_B,
                       "files": ["foreign.safetensors"], "platforms": [other_os] },
-                    { "provider": "huggingface", "repo": "owner/foreign-corequisite",
+                    { "provider": "huggingface", "repo": "guardfx/foreign-corequisite",
                       "revision": REV_B, "coRequisite": true,
                       "files": ["encoder.safetensors"], "platforms": [other_os] }
                 ]
@@ -2161,7 +2317,7 @@ mod tests {
                 .iter()
                 .map(|requirement| requirement.repository.as_str())
                 .collect::<Vec<_>>();
-            assert_eq!(repositories, ["owner/native"]);
+            assert_eq!(repositories, ["guardfx/native"]);
         });
     }
 
@@ -2219,7 +2375,7 @@ mod tests {
         let payload = json!({
             "modelManifestEntry": {
                 "id": "m",
-                "downloads": [{ "provider": "huggingface", "repo": "owner/new",
+                "downloads": [{ "provider": "huggingface", "repo": "guardfx/new",
                                 "revision": REV_A, "files": ["q4/*"] }]
             }
         })

--- a/crates/sceneworks-worker/src/external_library_runtime.rs
+++ b/crates/sceneworks-worker/src/external_library_runtime.rs
@@ -2075,6 +2075,18 @@ mod tests {
             assert!(loaded.join("model.safetensors").is_file());
             second.finish_success().unwrap();
 
+            // A LOCALLY served job records NOTHING. This is the qualification rule asserted in the
+            // widening direction, which the `Complete == 1` check below cannot do: relaxing the
+            // filter to record local-ready closures too would still leave exactly one complete
+            // entry, because the redundant candidate is admitted as `AlreadyComplete`. Only the
+            // intake being empty distinguishes "never recorded" from "recorded and then declined",
+            // and the difference is a whole idle turn plus a full source-library closure walk
+            // burned on a bundle that is already published.
+            assert!(
+                !crate::resolved_cache_promotion::work_pending(&settings.data_dir),
+                "a job served from the local tier is already promoted and must record nothing"
+            );
+
             // And the already-published entry is not promoted a second time: the drain admits it
             // as already complete and copies nothing.
             crate::resolved_cache_promotion::drain_intake(&settings);

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -105,6 +105,9 @@ mod cache_thread;
 // shared availability resolver before any handler constructs a loader.
 mod external_library_runtime;
 mod inference_runtime;
+// Promotion activation (sc-19706): the idle-time producer that turns a successful source-tier load
+// into an app-owned resolved bundle. The guard above records an I/O-free hint; this drains it.
+mod resolved_cache_promotion;
 // Backend-neutral generator load/run cache (epic 3720, sc-3724). Typed entirely against
 // `gen_core::*` (no tensor types leak), so it links on ALL targets — the production load seam
 // (`with_cached_generator`) is reached only from the macOS image/video paths, but the all-targets
@@ -1252,6 +1255,18 @@ fn spawn_retention_checkpoint(
     })
 }
 
+/// Starts one resolved-cache promotion drain on the blocking pool and returns its handle **without
+/// awaiting it** (sc-19706).
+///
+/// Same rule as the retention checkpoint, for the same reason: the drain resolves whole closures
+/// against the source library and then copies and hashes a bundle, so awaiting it would make the
+/// next job wait for a promotion it has nothing to do with. Failures are never fatal — the cache is
+/// an optimization, and a closure that could not be promoted is simply recorded again the next time
+/// that model loads.
+fn spawn_promotion_drain(settings: Settings) -> tokio::task::JoinHandle<()> {
+    tokio::task::spawn_blocking(move || resolved_cache_promotion::drain_intake(&settings))
+}
+
 /// Re-run the CUDA probe for a worker that is currently unhealthy, and act on any change
 /// (sc-16260 AC 4).
 ///
@@ -1343,10 +1358,16 @@ pub async fn run_worker_loop(settings: Settings) -> WorkerResult<()> {
     // interval and re-advertises if the host is repaired underneath it. Seeded a full interval
     // out — the startup probe just ran, and re-running it immediately would say nothing new.
     let mut next_gpu_recheck = Instant::now() + GPU_HEALTH_RECHECK;
-    // sc-19710: the startup checkpoint recovers the store (finishing any eviction interrupted by a
-    // crash) and then enforces retention. It is started, never awaited — the first job claim must
-    // not queue behind a recover-plus-retention pass.
-    let mut retention_task = Some(spawn_retention_checkpoint(settings.data_dir.clone(), true));
+    // sc-19710 / sc-19706: ONE resolved-cache maintenance slot, shared by the retention checkpoint
+    // and the promotion drain. A single slot is deliberate rather than one handle each: a sweep
+    // walks and re-hashes eviction candidates while a promotion copies and hashes a whole bundle,
+    // and running both at once would have them competing for the same disk and the same entries —
+    // retention deciding what fits while promotion is still adding to it.
+    //
+    // The startup occupant is the retention checkpoint, which recovers the store (finishing any
+    // eviction interrupted by a crash) and then enforces retention. It is started, never awaited —
+    // the first job claim must not queue behind a recover-plus-retention pass.
+    let mut maintenance_task = Some(spawn_retention_checkpoint(settings.data_dir.clone(), true));
     let mut next_retention_checkpoint = Instant::now() + RESOLVED_CACHE_RETENTION_INTERVAL;
     loop {
         if !health.is_usable() && Instant::now() >= next_gpu_recheck {
@@ -1375,24 +1396,37 @@ pub async fn run_worker_loop(settings: Settings) -> WorkerResult<()> {
         match claim {
             Ok(None) => {
                 lock_failures = 0;
-                // Claiming nothing is the proof of idleness the checkpoint requires: no job is in
-                // flight, so a sweep cannot compete with one. Every artifact lock a sweep takes is
-                // non-blocking, so an in-use model is skipped rather than waited on.
+                // Claiming nothing is the proof of idleness both maintenance activities require:
+                // no job is in flight, so neither a sweep nor a bundle copy can compete with one.
+                // Every artifact lock a sweep takes is non-blocking, so an in-use model is skipped
+                // rather than waited on.
                 //
                 // The handle is polled, never awaited: this arm sits directly on the claim path,
-                // so the loop must come straight back round to claim the next job while a sweep is
-                // still running. A checkpoint is also skipped entirely while its predecessor is in
-                // flight, so slow sweeps cannot stack up.
-                if retention_task
+                // so the loop must come straight back round to claim the next job while
+                // maintenance is still running. Work is also skipped entirely while a predecessor
+                // is in flight, so slow sweeps and slow copies cannot stack up.
+                if maintenance_task
                     .as_ref()
                     .is_some_and(tokio::task::JoinHandle::is_finished)
                 {
-                    retention_task = None;
+                    maintenance_task = None;
                 }
-                if retention_task.is_none() && Instant::now() >= next_retention_checkpoint {
-                    next_retention_checkpoint = Instant::now() + RESOLVED_CACHE_RETENTION_INTERVAL;
-                    retention_task =
-                        Some(spawn_retention_checkpoint(settings.data_dir.clone(), false));
+                if maintenance_task.is_none() {
+                    if Instant::now() >= next_retention_checkpoint {
+                        // Retention wins whenever it is due. It comes due at most once per
+                        // interval, so this cannot starve promotion; the reverse ordering could
+                        // starve retention indefinitely on a worker with a steady promotion
+                        // stream, and retention is what keeps the cache inside its size limit —
+                        // the limit promotion admission itself is judged against.
+                        next_retention_checkpoint =
+                            Instant::now() + RESOLVED_CACHE_RETENTION_INTERVAL;
+                        maintenance_task =
+                            Some(spawn_retention_checkpoint(settings.data_dir.clone(), false));
+                    } else if resolved_cache_promotion::work_pending(&settings.data_dir) {
+                        // sc-19706: in-memory check only — no store open, no stat — because this
+                        // sits on the claim path exactly like the checkpoint gate above.
+                        maintenance_task = Some(spawn_promotion_drain(settings.clone()));
+                    }
                 }
             }
             Ok(Some(job)) => {

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -1413,11 +1413,20 @@ pub async fn run_worker_loop(settings: Settings) -> WorkerResult<()> {
                 }
                 if maintenance_task.is_none() {
                     if Instant::now() >= next_retention_checkpoint {
-                        // Retention wins whenever it is due. It comes due at most once per
-                        // interval, so this cannot starve promotion; the reverse ordering could
-                        // starve retention indefinitely on a worker with a steady promotion
-                        // stream, and retention is what keeps the cache inside its size limit —
-                        // the limit promotion admission itself is judged against.
+                        // Retention wins whenever it is due. The reverse ordering could starve
+                        // retention indefinitely on a worker with a steady promotion stream, and
+                        // retention is what keeps the cache inside its size limit — the limit
+                        // promotion admission itself is judged against.
+                        //
+                        // This does NOT make starving promotion impossible, only bounded by an
+                        // assumption: the next checkpoint is armed when this one is STARTED, so a
+                        // sweep that runs longer than the interval is already due again when it
+                        // finishes and sweeps run back to back, with no idle turn left over for a
+                        // drain. That holds only while sweep duration stays under the interval.
+                        // It is self-stabilizing rather than a defect — a sweep that slow means
+                        // the cache is over its limit, which is the condition promotion must not
+                        // be adding to — so the ordering stands, but the guarantee is
+                        // "promotion yields to retention", not "promotion always runs".
                         next_retention_checkpoint =
                             Instant::now() + RESOLVED_CACHE_RETENTION_INTERVAL;
                         maintenance_task =

--- a/crates/sceneworks-worker/src/model_artifact_inventory.rs
+++ b/crates/sceneworks-worker/src/model_artifact_inventory.rs
@@ -263,6 +263,31 @@ pub const PRODUCTION_MODEL_CONSUMERS: &[ModelConsumerInventoryEntry] = &[
             entrypoint: TypedResolverEntrypoint::SourceLibrary,
         },
     },
+    // sc-19706: the idle-time promotion producer. It never resolves a path for a LOAD — it turns a
+    // closure a successful load already used into an app-owned bundle — and it constructs no model
+    // root of its own: the source root is handed to it by the guard above, which obtained it from
+    // the typed `model_source_library` entrypoint. It rebuilds a NON-preferring
+    // `ArtifactSourceLibrary` over that same root on purpose, so a bundle can never be promoted
+    // from a bundle. Classified rather than exempted because it does resolve closures against the
+    // authoritative source.
+    ModelConsumerInventoryEntry {
+        source_files: &["crates/sceneworks-worker/src/resolved_cache_promotion.rs"],
+        categories: &[
+            Category::Image,
+            Category::Video,
+            Category::Audio,
+            Category::CaptioningUtility,
+            Category::Training,
+            Category::LoraControl,
+            Category::Primary,
+            Category::OptionalComponent,
+            Category::CoRequisite,
+            Category::ImportedConverted,
+        ],
+        resolution: Resolution::SharedContract {
+            entrypoint: TypedResolverEntrypoint::SourceLibrary,
+        },
+    },
     // sc-19708: the API's single model-source seam (carrier attachment + submission preflight);
     // same shared source-library contract, mirrored on the API side of the boundary.
     ModelConsumerInventoryEntry {

--- a/crates/sceneworks-worker/src/resolved_cache_promotion.rs
+++ b/crates/sceneworks-worker/src/resolved_cache_promotion.rs
@@ -1,0 +1,425 @@
+//! sc-19706 — promotion activation: the idle half of the two-stage producer.
+//!
+//! sc-19704 froze the artifact contract, sc-19705 the store, sc-19706 the materializer and its
+//! scheduler, sc-19708 the one selection module that reduces a manifest entry to an exact
+//! requirement closure, and `model_artifacts::promotion` joined them into a candidate producer.
+//! None of that ran in production: `<data_dir>/models/resolved/` was populated only by tests. This
+//! module is what makes a real install promote itself.
+//!
+//! # Two stages, and why the split is load-bearing
+//!
+//! [`RuntimeSourceGuard::finish_success`](crate::external_library_runtime) records a
+//! [`PendingPromotion`] — a `Vec` of values the guard already had — into a bounded in-memory
+//! intake. That is the ENTIRE cost on the job path: one mutex, one move, no filesystem.
+//!
+//! [`drain_intake`] does the expensive half, on the blocking pool, only when the worker's claim
+//! poll returned nothing. Building one candidate resolves the whole closure against the source
+//! library (dozens of stats and canonicalizes, plus a runtime lease), and materializing one copies
+//! and hashes gigabytes. Doing either where the guard runs would put source-library I/O directly in
+//! front of the load the user is waiting on — the thing the local tier exists to make faster.
+//!
+//! # What this module deliberately does not decide
+//!
+//! Every policy question — is the cache enabled, is the entry already published, does the bundle
+//! fit beside the pinned set, is the source still there — belongs to
+//! [`ResolvedCachePromotionScheduler`], and is answered at DRAIN time against the world as it is
+//! then, not at record time. The intake is a hint, never a decision. There is likewise no
+//! per-model, per-route or per-job-type code here: a candidate is built from the generic closure
+//! the selection module produced, so a new model is a manifest-data change and nothing else.
+//!
+//! Nothing here downloads. Promotion copies bytes that are already installed; a source that no
+//! longer resolves declines, and no fetch of any kind is reachable from this module.
+
+use crate::{emit_event_value, Settings};
+use sceneworks_core::model_artifacts::external_library::ExternalArtifactRequirement;
+use sceneworks_core::model_artifacts::promotion::promotion_candidate_for_requirements;
+use sceneworks_core::model_artifacts::resolved_cache::{
+    IdlePromotionOutcome, PromotionScheduleOutcome, ResolvedCacheMaterializer,
+    ResolvedCachePromotionScheduler, ResolvedCacheStore,
+};
+use sceneworks_core::model_artifacts::{ArtifactSourceLibrary, ModelArtifactResolver};
+use serde_json::json;
+use std::collections::{BTreeMap, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
+use tracing::Level;
+
+/// How many closures may wait for a drain per data directory.
+///
+/// The intake is a hint that a load happened, so dropping the oldest under sustained pressure loses
+/// nothing durable: the next job that loads the same model records it again. Bounded rather than
+/// unbounded because a worker that never goes idle would otherwise accumulate one entry per job
+/// forever.
+const INTAKE_CAPACITY: usize = 16;
+
+/// How many admitted candidates the scheduler may hold. Kept small on purpose: each is a whole
+/// bundle copy, and the worker runs at most one at a time.
+const SCHEDULER_CAPACITY: usize = 4;
+
+/// One source-tier load worth promoting, captured with NO filesystem work.
+///
+/// It carries the requirement closure rather than a built candidate precisely because building the
+/// candidate is the expensive part. `requirements` is the closure
+/// `artifact_selection::selected_requirements_for_model` produced for this host and this request's
+/// tier — the same value that admitted the model — so the promoted bundle holds exactly what the
+/// job loaded, never a variant union.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PendingPromotion {
+    pub(crate) data_dir: PathBuf,
+    /// The configured source-library root the closure was admitted against. Recorded rather than
+    /// re-derived at drain time so a library reconfigured between the load and the drain cannot
+    /// silently promote from a different root than the one that served the job.
+    pub(crate) source_configured_path: PathBuf,
+    pub(crate) requirements: Vec<ExternalArtifactRequirement>,
+    pub(crate) logical_model_owner: String,
+}
+
+/// Build the intake records for the closures a job served from the source tier.
+///
+/// Returns an empty vector when the cache is switched off, so an opt-out install never accumulates
+/// promotion state. A closure with no primary requirement is skipped: the promotion producer
+/// requires exactly one, and a malformed carrier is not something to discover at drain time.
+pub(crate) fn pending_for_plans<'a>(
+    settings: &Settings,
+    source_configured_path: &Path,
+    closures: impl Iterator<Item = &'a [ExternalArtifactRequirement]>,
+) -> Vec<PendingPromotion> {
+    if !settings.resolved_cache_policy().enabled {
+        return Vec::new();
+    }
+    closures
+        .filter_map(|requirements| {
+            let owner = requirements
+                .iter()
+                .find(|requirement| requirement.is_primary)?;
+            Some(PendingPromotion {
+                data_dir: settings.data_dir.clone(),
+                source_configured_path: source_configured_path.to_path_buf(),
+                // The primary repository is the stable logical id the store already uses for
+                // ownership everywhere else (`acquire_complete` is handed the same value), so a
+                // promotion and a later lease of the same bundle agree on who owns it.
+                logical_model_owner: owner.repository.clone(),
+                requirements: requirements.to_vec(),
+            })
+        })
+        .collect()
+}
+
+/// Record closures for a later drain. Lock-and-move only; never touches the filesystem.
+///
+/// Identical closures coalesce here, before any I/O could reveal that they share a cache key: a job
+/// carrying the same model twice, or two jobs draining together, must not both walk the source.
+pub(crate) fn record_pending(pending: Vec<PendingPromotion>) {
+    if pending.is_empty() {
+        return;
+    }
+    let mut intake = lock_intake();
+    for item in pending {
+        let queue = intake.entry(item.data_dir.clone()).or_default();
+        if queue.contains(&item) {
+            continue;
+        }
+        if queue.len() >= INTAKE_CAPACITY {
+            queue.pop_front();
+        }
+        queue.push_back(item);
+    }
+}
+
+/// Whether an idle turn has promotion work to do. Reads only in-memory state — it sits directly on
+/// the claim path, so it must never open the store or stat anything.
+///
+/// The scheduler queue is included because one drain materializes at most ONE bundle: a job that
+/// admitted three closures needs three idle turns, and reporting "nothing pending" after the first
+/// would strand the rest until the next load re-recorded them.
+pub(crate) fn work_pending(data_dir: &Path) -> bool {
+    if lock_intake()
+        .get(data_dir)
+        .is_some_and(|queue| !queue.is_empty())
+    {
+        return true;
+    }
+    lock_schedulers()
+        .get(data_dir)
+        .is_some_and(|scheduler| scheduler.queued_len() > 0)
+}
+
+/// Drain the intake and run at most one promotion. Blocking; call from `spawn_blocking`.
+///
+/// Order matters: every recorded closure is turned into a candidate and offered to the scheduler
+/// FIRST, and only then does one materialization run. Building candidates is cheap relative to a
+/// bundle copy, and admitting them all up front is what lets the scheduler coalesce duplicates and
+/// apply its bound before any bytes move.
+pub(crate) fn drain_intake(settings: &Settings) {
+    let policy = settings.resolved_cache_policy();
+    if !policy.enabled {
+        // An operator turning the cache off between a load and this drain must not have the
+        // recorded hints promoted afterwards.
+        lock_intake().remove(&settings.data_dir);
+        return;
+    }
+    let pending: Vec<PendingPromotion> = lock_intake()
+        .get_mut(&settings.data_dir)
+        .map(|queue| queue.drain(..).collect())
+        .unwrap_or_default();
+    let Some(scheduler) = scheduler_for(settings) else {
+        return;
+    };
+    for item in pending {
+        // The AUTHORITATIVE source library, never the preferring one: promoting a bundle by
+        // reading from a bundle would launder an unverified copy into a published entry. No
+        // preference scope is installed on an idle worker anyway, so this states the requirement
+        // rather than relying on the timing.
+        let resolver = ModelArtifactResolver::new(
+            match ArtifactSourceLibrary::new(&item.source_configured_path) {
+                Ok(library) => library,
+                Err(error) => {
+                    decline(&item, &error.to_string());
+                    continue;
+                }
+            },
+        );
+        // Resolves and fully validates the closure against that library. A disconnected or
+        // incomplete source produces an error and therefore no candidate — never a fetch.
+        let candidate = match promotion_candidate_for_requirements(&resolver, &item.requirements) {
+            Ok(candidate) => candidate,
+            Err(error) => {
+                decline(&item, &error.to_string());
+                continue;
+            }
+        };
+        let cache_key = candidate.cache_key.clone();
+        match scheduler.schedule(
+            candidate,
+            item.source_configured_path.clone(),
+            item.logical_model_owner.clone(),
+        ) {
+            Ok(PromotionScheduleOutcome::Enqueued) => emit_event_value(
+                Level::INFO,
+                json!({
+                    "event": "resolved_cache_promotion_scheduled",
+                    "cacheKey": cache_key,
+                    "repository": item.logical_model_owner,
+                }),
+            ),
+            // Coalesced/Full/Disabled/Stopped are ordinary outcomes, not failures.
+            Ok(_) => {}
+            Err(error) => decline(&item, &error.to_string()),
+        }
+    }
+    match scheduler.run_next_if_idle(true) {
+        Ok(IdlePromotionOutcome::Materialized(outcome)) => emit_event_value(
+            Level::INFO,
+            json!({
+                "event": "resolved_cache_promotion_materialized",
+                "outcome": format!("{outcome:?}"),
+            }),
+        ),
+        Ok(IdlePromotionOutcome::Declined(reason)) => emit_event_value(
+            Level::INFO,
+            json!({
+                "event": "resolved_cache_promotion_declined",
+                "reason": reason.to_string(),
+            }),
+        ),
+        Ok(_) => {}
+        Err(error) => {
+            tracing::warn!(error = %error, "resolved-cache promotion drain failed")
+        }
+    }
+}
+
+fn decline(item: &PendingPromotion, reason: &str) {
+    emit_event_value(
+        Level::INFO,
+        json!({
+            "event": "resolved_cache_promotion_declined",
+            "repository": item.logical_model_owner,
+            "reason": reason,
+        }),
+    );
+}
+
+/// One long-lived scheduler per data directory.
+///
+/// It must outlive a single drain: the queue, the coalescing key set and the single active slot all
+/// live in it, so a fresh scheduler per idle turn would lose the queue every time and re-materialize
+/// whatever a previous turn had already admitted. Opening the store is real I/O, which is why this
+/// is only ever reached from the blocking drain and never from [`work_pending`].
+fn scheduler_for(settings: &Settings) -> Option<ResolvedCachePromotionScheduler> {
+    let mut schedulers = lock_schedulers();
+    if let Some(scheduler) = schedulers.get(&settings.data_dir) {
+        return Some(scheduler.clone());
+    }
+    let store = match ResolvedCacheStore::open(&settings.data_dir) {
+        Ok(store) => store,
+        Err(error) => {
+            tracing::warn!(error = %error, "resolved-cache store unavailable; promotion is skipped");
+            return None;
+        }
+    };
+    let scheduler = match ResolvedCachePromotionScheduler::new(
+        settings.resolved_cache_policy(),
+        ResolvedCacheMaterializer::new(store),
+        SCHEDULER_CAPACITY,
+    ) {
+        Ok(scheduler) => scheduler,
+        Err(error) => {
+            tracing::warn!(error = %error, "resolved-cache promotion policy is invalid; promotion is skipped");
+            return None;
+        }
+    };
+    schedulers.insert(settings.data_dir.clone(), scheduler.clone());
+    Some(scheduler)
+}
+
+type Intake = BTreeMap<PathBuf, VecDeque<PendingPromotion>>;
+
+fn lock_intake() -> MutexGuard<'static, Intake> {
+    static INTAKE: OnceLock<Mutex<Intake>> = OnceLock::new();
+    INTAKE
+        .get_or_init(|| Mutex::new(Intake::new()))
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
+type Schedulers = BTreeMap<PathBuf, ResolvedCachePromotionScheduler>;
+
+fn lock_schedulers() -> MutexGuard<'static, Schedulers> {
+    static SCHEDULERS: OnceLock<Mutex<Schedulers>> = OnceLock::new();
+    SCHEDULERS
+        .get_or_init(|| Mutex::new(Schedulers::new()))
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn requirement(repository: &str, is_primary: bool) -> ExternalArtifactRequirement {
+        ExternalArtifactRequirement {
+            repository: repository.to_owned(),
+            revision: Some("c19706cccccccccccccccccccccccccccccccccc".to_owned()),
+            variant: "default".to_owned(),
+            files: vec![PathBuf::from("model.safetensors")],
+            is_primary,
+        }
+    }
+
+    fn pending(data_dir: &Path, repository: &str) -> PendingPromotion {
+        PendingPromotion {
+            data_dir: data_dir.to_path_buf(),
+            source_configured_path: data_dir.join("library"),
+            requirements: vec![requirement(repository, true)],
+            logical_model_owner: repository.to_owned(),
+        }
+    }
+
+    /// The intake is a HINT, so its bound must drop the oldest rather than refuse the newest: the
+    /// most recent load is the one most likely to be loaded again. An unbounded queue on a worker
+    /// that never idles would grow one entry per job forever.
+    #[test]
+    fn the_intake_is_bounded_and_drops_the_oldest_hint() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let data_dir = temp.path().join("bounded");
+        for index in 0..(INTAKE_CAPACITY + 3) {
+            record_pending(vec![pending(&data_dir, &format!("guardfx/model-{index}"))]);
+        }
+        let intake = lock_intake();
+        let queue = intake
+            .get(&data_dir)
+            .expect("the intake holds this data dir");
+        assert_eq!(queue.len(), INTAKE_CAPACITY);
+        assert_eq!(
+            queue.front().unwrap().logical_model_owner,
+            "guardfx/model-3"
+        );
+        assert_eq!(
+            queue.back().unwrap().logical_model_owner,
+            format!("guardfx/model-{}", INTAKE_CAPACITY + 2)
+        );
+    }
+
+    /// Two loads of the same closure must not both walk the source library at drain time. The
+    /// scheduler coalesces on cache key, but learning the cache key costs the very I/O the intake
+    /// exists to defer, so the identical-closure case has to collapse here.
+    #[test]
+    fn an_identical_closure_is_recorded_once() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let data_dir = temp.path().join("coalesce");
+        let item = pending(&data_dir, "guardfx/repeated");
+        record_pending(vec![item.clone(), item.clone()]);
+        record_pending(vec![item]);
+        assert_eq!(lock_intake().get(&data_dir).map(VecDeque::len), Some(1));
+    }
+
+    /// A closure with no primary requirement cannot produce a candidate, so it must never reach the
+    /// intake — discovering it at drain time would burn a whole idle turn on a guaranteed failure.
+    #[test]
+    fn a_closure_without_a_primary_is_never_recorded() {
+        crate::test_env::temp_env_vars(
+            &[(
+                sceneworks_core::model_artifacts::resolved_cache::RESOLVED_CACHE_ENABLED_ENV,
+                "1",
+            )],
+            || {
+                let temp = tempfile::tempdir().expect("tempdir");
+                let settings = Settings::for_test(temp.path().join("data"));
+                let closure = vec![requirement("guardfx/corequisite-only", false)];
+                assert!(pending_for_plans(
+                    &settings,
+                    &temp.path().join("library"),
+                    std::iter::once(closure.as_slice()),
+                )
+                .is_empty());
+            },
+        );
+    }
+
+    /// An opt-out install must accumulate no promotion state at all: not a bundle, and not the
+    /// in-memory record that would promote one the moment the cache was switched on.
+    #[test]
+    fn a_disabled_cache_records_nothing() {
+        crate::test_env::temp_env_vars(
+            &[(
+                sceneworks_core::model_artifacts::resolved_cache::RESOLVED_CACHE_ENABLED_ENV,
+                "0",
+            )],
+            || {
+                let temp = tempfile::tempdir().expect("tempdir");
+                let settings = Settings::for_test(temp.path().join("data"));
+                let closure = vec![requirement("guardfx/disabled", true)];
+                assert!(pending_for_plans(
+                    &settings,
+                    &temp.path().join("library"),
+                    std::iter::once(closure.as_slice()),
+                )
+                .is_empty());
+            },
+        );
+    }
+
+    /// Turning the cache off BETWEEN a load and the drain must discard what the load recorded, and
+    /// must not create the managed cache root while doing it.
+    #[test]
+    fn a_disabled_drain_discards_the_intake_without_creating_the_store() {
+        crate::test_env::temp_env_vars(
+            &[(
+                sceneworks_core::model_artifacts::resolved_cache::RESOLVED_CACHE_ENABLED_ENV,
+                "0",
+            )],
+            || {
+                let temp = tempfile::tempdir().expect("tempdir");
+                let data_dir = temp.path().join("switched-off");
+                std::fs::create_dir_all(&data_dir).expect("data dir creates");
+                record_pending(vec![pending(&data_dir, "guardfx/switched-off")]);
+                assert!(work_pending(&data_dir));
+                let settings = Settings::for_test(data_dir.clone());
+                drain_intake(&settings);
+                assert!(!work_pending(&data_dir));
+                assert!(!data_dir.join("models").join("resolved").exists());
+            },
+        );
+    }
+}

--- a/crates/sceneworks-worker/src/resolved_cache_promotion.rs
+++ b/crates/sceneworks-worker/src/resolved_cache_promotion.rs
@@ -244,13 +244,26 @@ fn decline(item: &PendingPromotion, reason: &str) {
 ///
 /// It must outlive a single drain: the queue, the coalescing key set and the single active slot all
 /// live in it, so a fresh scheduler per idle turn would lose the queue every time and re-materialize
-/// whatever a previous turn had already admitted. Opening the store is real I/O, which is why this
-/// is only ever reached from the blocking drain and never from [`work_pending`].
+/// whatever a previous turn had already admitted.
+///
+/// # The memo lock is never held across I/O
+///
+/// `ResolvedCacheStore::open` takes a durable session lock and writes session records. That lock is
+/// therefore taken, dropped, and only re-taken to publish the result — because [`work_pending`]
+/// locks the same mutex and runs **on the claim path**, where blocking behind a store open would
+/// delay the next job. Today the single maintenance slot means no two callers can reach the I/O at
+/// once, so the contention is unreachable; that is a positional accident of the poll loop's shape,
+/// not a property of this function, and this ordering makes it structural instead.
+///
+/// The race that ordering admits — two callers both building a scheduler — resolves **first-wins**:
+/// a loser drops its own scheduler and adopts the installed one. Last-wins would replace a
+/// scheduler that may already hold queued work AND leave two live "single active slot" owners for
+/// one store, which is exactly the concurrent-materialization case the slot exists to prevent.
 fn scheduler_for(settings: &Settings) -> Option<ResolvedCachePromotionScheduler> {
-    let mut schedulers = lock_schedulers();
-    if let Some(scheduler) = schedulers.get(&settings.data_dir) {
+    if let Some(scheduler) = lock_schedulers().get(&settings.data_dir) {
         return Some(scheduler.clone());
     }
+    // Unlocked: real filesystem work.
     let store = match ResolvedCacheStore::open(&settings.data_dir) {
         Ok(store) => store,
         Err(error) => {
@@ -269,8 +282,12 @@ fn scheduler_for(settings: &Settings) -> Option<ResolvedCachePromotionScheduler>
             return None;
         }
     };
-    schedulers.insert(settings.data_dir.clone(), scheduler.clone());
-    Some(scheduler)
+    Some(
+        lock_schedulers()
+            .entry(settings.data_dir.clone())
+            .or_insert(scheduler)
+            .clone(),
+    )
 }
 
 type Intake = BTreeMap<PathBuf, VecDeque<PendingPromotion>>;

--- a/crates/sceneworks-worker/src/settings.rs
+++ b/crates/sceneworks-worker/src/settings.rs
@@ -115,6 +115,36 @@ impl Settings {
         sceneworks_core::model_artifacts::resolved_cache::ResolvedCachePolicy::from_env_or_safe_default()
     }
 
+    /// A minimal offline `Settings` for tests that only care about `data_dir`. Every field that
+    /// could reach the network is pinned to the offline stub URL, so a test using this cannot
+    /// accidentally acquire a live dependency.
+    #[cfg(test)]
+    pub(crate) fn for_test(data_dir: PathBuf) -> Self {
+        Self {
+            api_url: crate::test_env::OFFLINE_URL.to_owned(),
+            access_token: None,
+            data_dir,
+            config_dir: PathBuf::new(),
+            worker_id: "worker".to_owned(),
+            gpu_id: "cpu".to_owned(),
+            is_child_worker: false,
+            poll_seconds: 1,
+            heartbeat_seconds: 1,
+            shutdown_timeout_seconds: 1,
+            huggingface_base_url: crate::test_env::OFFLINE_URL.to_owned(),
+            huggingface_token: None,
+            credentials: Vec::new(),
+            max_lora_url_bytes: 1,
+            max_model_url_bytes: 1,
+            allow_private_lora_urls: false,
+            utility_workers: 1,
+            backend_mlx_enabled: false,
+            backend_candle_enabled: false,
+            external_model_roots: Vec::new(),
+            gpu_memory_limit_bytes: 0,
+        }
+    }
+
     pub fn from_env() -> Self {
         let defaults = sceneworks_core::app_paths::AppPaths::platform_default();
         let config_dir = env_path_or("SCENEWORKS_CONFIG_DIR", &defaults.config_dir);

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -232,4 +232,12 @@ async fn a_retention_checkpoint_never_blocks_the_caller_that_starts_it() {
         loop_body.contains("resolved_cache_promotion::work_pending(&settings.data_dir)"),
         "the poll loop must gate the promotion drain on the in-memory pending check"
     );
+    // ...and the gate must actually START something. The never-await rules above are all
+    // ABSENCE assertions, so an empty `else if work_pending(..) {}` body satisfies every one of
+    // them while promotion silently never runs — which is precisely the shape of the defect that
+    // reopened this story.
+    assert!(
+        loop_body.contains("spawn_promotion_drain(settings.clone())"),
+        "the poll loop must spawn the promotion drain, not merely test for pending work"
+    );
 }

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -198,25 +198,38 @@ async fn a_retention_checkpoint_never_blocks_the_caller_that_starts_it() {
     // that the poll loop never *awaits* a checkpoint — is pinned at the source level, the same way
     // this crate pins its temp-fixture rule. Re-introducing an await on the claim path reddens
     // this immediately, where a behavioural test would silently keep passing on a small cache.
+    //
+    // sc-19706 folded the promotion drain into the SAME maintenance slot, so the anchor is the
+    // slot rather than the retention handle, and the rule now covers both occupants: a promotion
+    // copies and hashes a whole bundle, which is if anything worse to sit behind than a sweep.
     let source = include_str!("lib.rs");
     let loop_body = source
-        .split_once("let mut retention_task =")
-        .expect("the poll loop keeps the checkpoint handle in a local")
+        .split_once("let mut maintenance_task =")
+        .expect("the poll loop keeps the maintenance handle in a local")
         .1;
     assert!(
-        !loop_body.contains("retention_task.expect")
-            && !loop_body.contains("retention_task.unwrap"),
-        "the poll loop must not unwrap the checkpoint handle"
+        !loop_body.contains("maintenance_task.expect")
+            && !loop_body.contains("maintenance_task.unwrap"),
+        "the poll loop must not unwrap the maintenance handle"
     );
     for forbidden in [
         "spawn_retention_checkpoint(settings.data_dir.clone(), false).await",
         "spawn_retention_checkpoint(settings.data_dir.clone(), true).await",
         "run_retention_checkpoint",
+        "spawn_promotion_drain(settings.clone()).await",
+        "resolved_cache_promotion::drain_intake",
     ] {
         assert!(
             !loop_body.contains(forbidden),
-            "the poll loop must never await a retention checkpoint (found `{forbidden}`): a sweep \
-             re-hashes every eviction candidate's source, so awaiting one delays the next claim"
+            "the poll loop must never await resolved-cache maintenance (found `{forbidden}`): a \
+             sweep re-hashes every eviction candidate's source and a promotion copies a whole \
+             bundle, so awaiting either delays the next claim"
         );
     }
+    // The drain's gate is on the claim path itself, so it must be the in-memory check and never
+    // the blocking one. `drain_intake` opens the store; `work_pending` reads two mutexes.
+    assert!(
+        loop_body.contains("resolved_cache_promotion::work_pending(&settings.data_dir)"),
+        "the poll loop must gate the promotion drain on the in-memory pending check"
+    );
 }


### PR DESCRIPTION
## Why this exists (the reopen reason)

sc-19706 shipped the materialization **mechanism** in #2396, and it was never
called. `schedule` / `run_next_if_idle` had no production caller and nothing built
a `ResolvedBundleClosure` for a real manifest entry, so `<data_dir>/models/resolved/`
was populated **only by tests**. Every piece of the epic existed except the one that
makes a real install faster.

The gap fell between two stories that each passed adversarial review inside their own
scope: sc-19706 said "generic seam; production activation is 19707's scope", and
sc-19707's ACs cover *preferring* artifacts that exist, not *producing* them.

This PR is the producer. The test that proves it is
`a_successful_source_tier_job_promotes_itself_and_the_next_job_loads_from_the_bundle` —
no hand-published bundle anywhere in it.

## Design: a two-stage producer

**Stage 1 — trigger (`external_library_runtime.rs`).**
`RuntimeSourceGuard::finish_success` records a `PendingPromotion` into a bounded,
per-data-dir intake. It is **I/O-free by construction**: the closure it carries is the
one the guard already computed for admission, so the whole job-path cost is one mutex
and one move. Only `ExternalReady` resolutions qualify — a local-ready model is already
promoted, and incomplete/missing/unavailable models have nothing installed to copy.
The list is read **after** the three-pass local-tier selection, so a model that fell
back from the local tier records the closure that is genuinely missing from the cache.

**Stage 2 — idle drain (`resolved_cache_promotion.rs`, new).**
Runs on `spawn_blocking` when the claim poll returns nothing. It builds each candidate
(resolving the whole closure against the source library — dozens of stats and
canonicalizes, plus a runtime lease), offers them all to the scheduler, then runs
**one** materialization. Building inline would put source-library I/O directly in front
of the load the user is waiting on, which is the thing the local tier exists to make faster.

The drain rebuilds a **non-preferring** `ArtifactSourceLibrary` over the recorded root:
promoting a bundle by reading from a bundle would launder an unverified copy into a
published entry. No preference scope is installed on an idle worker anyway, so this
states the requirement rather than relying on the timing.

**Poll loop.** Retention and promotion now share **ONE maintenance slot**. A sweep walks
and re-hashes eviction candidates while a promotion copies and hashes a whole bundle;
running both at once has them competing for the same disk and the same entries — retention
deciding what fits while promotion is still adding to it. Retention wins whenever it is
**due**, which cannot starve promotion (due at most once per interval); the reverse
ordering could starve retention indefinitely on a worker with a steady promotion stream,
and retention is what keeps the cache inside the very limit promotion is judged against.

The gate on the claim path is `work_pending`, which reads two mutexes and **never** opens
the store. It includes the scheduler queue because one drain materializes at most one
bundle: a job that admitted three closures needs three idle turns.

## Admission tests — the code had ZERO

`ExceedsSizeLimit`, `SourceUnavailable` and `AlreadyComplete` were all untested. Four new
tests, each naming the exact decision it pins:

- `a_candidate_that_cannot_fit_beside_the_pinned_set_is_declined_before_any_bytes_move`
- `an_unpinned_complete_entry_never_blocks_a_promotion_the_cache_can_hold` — the same
  store and the same numbers as the test above **with the pin removed**. The pin is the
  only difference and it flips the decision, which is what makes the rule
  `protected_bytes + candidate_bytes > max_bytes` (protected = Complete **and**
  `effective_pin`) a real assertion rather than a restatement. Sizing against *total*
  bytes would refuse promotions the cache can hold.
- `a_source_that_vanished_between_the_load_and_the_drain_declines_rather_than_fetching`
- `an_already_published_entry_is_skipped_without_taking_the_lock_a_live_load_holds` —
  holds the **shared** artifact lock through a real `acquire_complete` lease. Without the
  `lookup_complete` short-circuit, admission falls through to `reserve` →
  `try_lock_exclusive`, which the shared lock defeats, and a live load of a cached model
  would report its own entry as `Contended` on every idle turn. That is exactly why
  `IdlePromotionOutcome::AlreadyComplete` is distinct from `Materialized(AlreadyComplete)`.

### Per-guard mutation evidence

Each guard mutated **alone**, file `touch`ed, suite re-run, then restored (restore verified
byte-identical before formatting):

| Mutation | Test that reddened | Others |
|---|---|---|
| `lookup_complete` short-circuit disabled | `an_already_published_entry_is_skipped_without_taking_the_lock_a_live_load_holds` | 18 pass |
| `SourceUnavailable` decline replaced with `0` bytes | `a_source_that_vanished_between_the_load_and_the_drain_declines_rather_than_fetching` | 18 pass |
| size-limit `if` forced false | `a_candidate_that_cannot_fit_beside_the_pinned_set_is_declined_before_any_bytes_move` | 18 pass |
| protected set widened to every Complete entry (pin ignored) | `an_unpinned_complete_entry_never_blocks_a_promotion_the_cache_can_hold` | 18 pass |

Exactly one test per mutation, and it is that guard's own test — no guard is covered only
incidentally by another's.

## Merge-hazard resolution (called out as required)

`hub_cache_member_destination` was duplicated **byte-identically** in
`promotion.rs` (this branch) and `#2407`'s `local_preference.rs`. The copy in
`promotion.rs` is **deleted**; it now re-exports the local-preference definition.
Producing a bundle and reading one back are two halves of the same layout invariant, so
two copies — however identical they start — are a latent divergence between the
materializer's output and the only module that knows how to serve it.

## Folded in from #2407's review (batched here to save a CI cycle)

1. **`external_library_runtime.rs` overlay-guard doc comment was false.** It claimed
   `.cargo/config.toml` forces `RUST_TEST_THREADS=1`; there is no such setting and the
   suite genuinely runs in parallel. As written it made dropping the mutex look safe.
   Corrected to state the real justification: the mutex is the only thing serializing
   the process-wide overlay state.
2. **Overlay-installing tests shared fixture identities with unrelated worker tests.**
   `owner/model`, `owner/shared`, and the `0123456789ab…567` revision are also used by
   `model_jobs.rs`, `image_jobs/tests.rs` and `flux1_control_candle.rs`. The overlay is
   keyed on `(repository, revision)` and is process-wide, so a live scope here could
   answer for a snapshot one of those tests expects from its own temp library — a rare,
   load-dependent, entirely genuine false red in a file that never mentions the resolved
   cache. All fixtures in the guard's test module are now `guardfx/…` at `e19706…`
   revisions, which appear nowhere else in the repo.

## Poll-loop source assertion

`worker/src/tests.rs` anchored on `split_once("let mut retention_task =")`. The single
maintenance slot renames that local, so the test was **updated to a better anchor**
(`let mut maintenance_task =`) rather than worked around, and its rule extended to cover
the drain: the loop must never `await` either occupant, and must gate the drain on the
in-memory `work_pending` rather than the blocking `drain_intake`.

## Verification (macos-hosted lane; no GPU, no MLX device tests, no real weights)

- `npm run rust:check` — **exit 0** (exit code captured directly), **3748 tests passing**,
  0 failures; fmt, clippy `-D warnings`, memory-matrix and tier-integrity `--check` all
  clean with no working-tree drift.
- `npm run check` — **exit 0**, 412 tests.
- `cargo check -p sceneworks-desktop --all-targets` — exit 0 (desktop depends on
  `sceneworks-core`, which this touches).
- New file `resolved_cache_promotion.rs` classified in `model_artifact_inventory.rs`.
- Merged `origin/feature/sc-19703-resolved-model-hot-cache` @ `3154bd238` (now containing
  #2407) after verifying; the merge brought in only the #2407 merge commit whose content
  was already present, and the resulting tree is byte-identical to the verified one.

No measurement work run: no capability dumps, no calibration, no memory-matrix
regeneration, no canaries.

Story: sc-19706 (reopened) · Epic: sc-19703
