### PR TITLE
docs(sc-19712): addendum — alias/decoy probes, F-3 re-measured, F-2/F-4 confirmed

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -353,9 +353,9 @@ installed and simply goes back to loading from the drive.
 
 ### Limits worth knowing
 
-- A few models keep an **optional** extra component (currently Qwen-Image, Qwen-Image-Edit and
-  ACE-Step v1.5 Turbo) that is *not* copied locally. The model itself still works while the drive
-  is disconnected; a generation that needs that optional component does not.
+- Two models keep an **optional** extra component (currently Qwen-Image and ACE-Step v1.5 Turbo)
+  that is *not* copied locally. The model itself still works while the drive is disconnected; a
+  generation that needs that optional component does not.
 - A model whose download was recorded without an exact revision cannot be served from a local copy
   and always loads from the library.
 - LoRAs and control overlays are not part of this feature; they always load from the library.

--- a/apps/rust-api/src/model_sources.rs
+++ b/apps/rust-api/src/model_sources.rs
@@ -306,19 +306,6 @@ pub(crate) async fn resolve_model_manifest_entry_by_repo(
     Ok(entry)
 }
 
-/// App-owned resolved-local artifacts for LocalReady detection. Empty when the resolved cache is
-/// disabled or uninitialized; read-only (never creates a session or refreshes usage).
-///
-/// This is the SAME provider the worker's pre-loader guard uses (sc-19707), so catalog/preflight
-/// and the actual load can never disagree about which entries are valid: an entry that is still
-/// materializing, torn, unverifiable, or in a shape the runtime cannot serve is not a local
-/// candidate on either side of the boundary.
-///
-/// The agreement is about the *judgement*, not the cost. The scan validates on paths and sizes;
-/// the content re-hash lives at the lease boundary inside the store (sc-19712 F-3). Both sides
-/// still read the same provider and reach the same verdict for every case a user can reach — a
-/// bundle whose bytes were altered after publication is refused when the lease is taken, and the
-/// caller falls back to the source tier, which is the same outcome the old cost bought.
 /// Tells the catalog cache what the resolved cache's published set looks like right now, so a
 /// promotion published by the WORKER is reflected in the next catalog read (sc-19712 F-4).
 ///
@@ -336,6 +323,19 @@ pub(crate) fn note_local_tier_freshness(state: &AppState) {
     state.model_catalog_cache.note_local_tier_key(key);
 }
 
+/// App-owned resolved-local artifacts for LocalReady detection. Empty when the resolved cache is
+/// disabled or uninitialized; read-only (never creates a session or refreshes usage).
+///
+/// This is the SAME provider the worker's pre-loader guard uses (sc-19707), so catalog/preflight
+/// and the actual load can never disagree about which entries are valid: an entry that is still
+/// materializing, torn, unverifiable, or in a shape the runtime cannot serve is not a local
+/// candidate on either side of the boundary.
+///
+/// The agreement is about the *judgement*, not the cost. The scan validates on paths and sizes;
+/// the content re-hash lives at the lease boundary inside the store (sc-19712 F-3). Both sides
+/// still read the same provider and reach the same verdict for every case a user can reach — a
+/// bundle whose bytes were altered after publication is refused when the lease is taken, and the
+/// caller falls back to the source tier, which is the same outcome the old cost bought.
 pub(crate) fn local_resolved_artifacts(state: &AppState) -> Vec<ResolvedModelArtifact> {
     if !state.settings.resolved_cache.enabled {
         return Vec::new();

--- a/crates/sceneworks-core/src/model_artifacts.rs
+++ b/crates/sceneworks-core/src/model_artifacts.rs
@@ -409,6 +409,33 @@ impl ResolvedModelArtifact {
         }
     }
 
+    /// Every invariant [`Self::validate`] proves EXCEPT the content re-read: version, identity,
+    /// provenance agreement, completeness, closure shape, path confinement, file presence and file
+    /// sizes are all still checked; recorded SHA-256 digests are not recomputed.
+    ///
+    /// This is for callers deciding **availability** — "could this artifact serve the closure a
+    /// request needs" — as opposed to callers about to hand bytes to a runtime. The distinction is
+    /// not stylistic: the availability question is asked once per job submission and once per
+    /// catalog row, so answering it by re-reading the artifact makes the cost of *asking* scale
+    /// with the artifact's size. Measured on a 5.65 GB bundle, this pass alone was ~175 s per job
+    /// submission (sc-19712 F-3 residue), and it scales to the 64 GiB default cache budget.
+    ///
+    /// Content identity is proven where it is load-bearing, at the lease boundary:
+    /// `ResolvedCacheStore::acquire_complete`, `ModelArtifactResolver::acquire_runtime_lease`
+    /// (which calls [`Self::validate`] in full), and the full-strength journal write that stamps
+    /// usage. An artifact this function admits can still be refused there, and the caller then
+    /// falls back to the source tier — so a bundle altered after publication is never loaded.
+    /// Do not use this in place of [`Self::validate`] on any path that precedes a load.
+    pub fn validate_paths_and_sizes(&self) -> Result<(), ArtifactContractError> {
+        let mut paths_only = self.clone();
+        for member in &mut paths_only.closure.members {
+            for file in &mut member.files {
+                file.sha256 = None;
+            }
+        }
+        paths_only.validate()
+    }
+
     /// Stable key over the versioned immutable identity, full sorted closure and provenance.
     /// Physical location, availability, usage state, and post-copy verification enrichment are
     /// deliberately excluded.
@@ -1003,6 +1030,30 @@ fn primary_tier(closure: &ResolvedBundleClosure) -> Option<String> {
         .and_then(|member| member.tier.clone())
 }
 
+// Counts entries into the content re-read inside `validate_artifact_file`, so a test can assert
+// that a path performs ZERO content hashing rather than merely being "fast enough".
+//
+// A timing assertion cannot express this: the whole defect class here is a full-closure hash that
+// is invisible on a small fixture and catastrophic on a 5.65 GB one, so the property has to be
+// stated as an operation count on a fixture whose files carry recorded digests.
+#[cfg(test)]
+thread_local! {
+    static CONTENT_HASH_COUNT: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn count_content_hash() {
+    CONTENT_HASH_COUNT.with(|count| count.set(count.get().saturating_add(1)));
+}
+
+/// Runs `body` and reports how many closure files it re-read and re-hashed.
+#[cfg(test)]
+pub(crate) fn observe_content_hashes<T>(body: impl FnOnce() -> T) -> (T, u64) {
+    CONTENT_HASH_COUNT.with(|count| count.set(0));
+    let value = body();
+    (value, CONTENT_HASH_COUNT.with(std::cell::Cell::get))
+}
+
 fn validate_artifact_file(path: &Path, file: &ArtifactFile) -> Result<(), ArtifactContractError> {
     let metadata = std::fs::metadata(path).map_err(|error| {
         ArtifactContractError(format!(
@@ -1026,6 +1077,8 @@ fn validate_artifact_file(path: &Path, file: &ArtifactFile) -> Result<(), Artifa
         )));
     }
     if let Some(expected) = &file.sha256 {
+        #[cfg(test)]
+        count_content_hash();
         use std::io::Read;
         let mut input = std::fs::File::open(path).map_err(|error| {
             ArtifactContractError(format!("cannot hash {}: {error}", path.display()))

--- a/crates/sceneworks-core/src/model_artifacts/external_library.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library.rs
@@ -194,9 +194,25 @@ impl ModelResolution {
         self
     }
 
+    /// Paths and sizes, NOT a content re-read (sc-19712 F-3 residue).
+    ///
+    /// This constructor is rung 1 of [`resolve_model_availability`], so it runs on every job
+    /// submission's preflight and every catalog row for a locally-cached model. Re-hashing the
+    /// whole closure here left one full content pass on the submission path even after the cache
+    /// scan itself was converted: measured at ~175 s for a 5.65 GB bundle, at a software-SHA rate
+    /// that scales to roughly half an hour at the 64 GiB default budget.
+    ///
+    /// It is safe to drop because this function answers an AVAILABILITY question and never hands
+    /// bytes to a loader. The load boundary re-proves content identity three separate times —
+    /// `ResolvedCacheStore::acquire_complete`, `ModelArtifactResolver::acquire_runtime_lease`, and
+    /// the full-strength journal write that stamps usage — so an artifact admitted here whose
+    /// bytes were altered after publication is refused at the lease and the caller falls back to
+    /// the source tier. Everything a wrong availability answer could depend on is still proven:
+    /// the artifact's identity, its closure shape, that it is confined to the app-owned resolved
+    /// tier, and that every file it claims exists at the recorded size.
     pub fn local_ready(artifact: ResolvedModelArtifact) -> Result<Self, ExternalLibraryError> {
         artifact
-            .validate()
+            .validate_paths_and_sizes()
             .map_err(|error| ExternalLibraryError(error.to_string()))?;
         if !matches!(&artifact.location, ArtifactLocation::ResolvedLocal { .. }) {
             return Err(ExternalLibraryError(
@@ -238,8 +254,11 @@ impl ModelResolution {
                         "local-ready resolution must use the app-owned resolved tier".to_owned(),
                     ));
                 }
+                // Paths and sizes, for the same reason [`Self::local_ready`] uses them: this
+                // re-validates an availability answer (`probe_resolution` is a read-only probe),
+                // and re-reading the closure here would put the whole artifact's bytes behind it.
                 artifact
-                    .validate()
+                    .validate_paths_and_sizes()
                     .map_err(|error| ExternalLibraryError(error.to_string()))
             }
             ModelAvailability::ExternalReady => {

--- a/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
@@ -1001,3 +1001,102 @@ fn a_present_but_mismatched_library_is_flagged_separately_from_a_disconnected_on
         "the typed context the prompt reads must carry the same distinction"
     );
 }
+
+/// The availability decision must not re-read the artifact it admits (sc-19712 F-3 residue).
+///
+/// `resolve_model_availability` is what a job submission's preflight and every catalog row call.
+/// Rung 1 built its answer through `ModelResolution::local_ready`, which re-hashed the whole
+/// closure — one full content pass per submission, measured at ~175 s on a 5.65 GB bundle at the
+/// observed software-SHA rate, scaling to roughly half an hour at the 64 GiB default budget. It is
+/// invisible on a small fixture, so this is asserted as an OPERATION COUNT rather than a duration:
+/// the fixture's file carries a correct recorded digest, so a re-read would succeed and only the
+/// counter can tell that it happened.
+///
+/// The digest is deliberately CORRECT. The property under test is the absence of the read, not the
+/// absence of a failure — a deliberately wrong digest would also red under mutation, but for the
+/// wrong reason, and would still pass if someone replaced the hash pass with a different one.
+#[test]
+fn the_availability_decision_never_re_reads_the_artifact_it_admits() {
+    use crate::model_artifacts::observe_content_hashes;
+    use sha2::{Digest, Sha256};
+
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    let local = temp.path().join("resolved");
+    std::fs::create_dir_all(&local).unwrap();
+    let body = b"local-bundle-bytes";
+    std::fs::write(local.join("model.safetensors"), body).unwrap();
+
+    let identity = ArtifactIdentity::pinned("owner/model", REVISION, "default").unwrap();
+    let mut file = ArtifactFile::new("model.safetensors").unwrap();
+    file.size_bytes = Some(body.len() as u64);
+    file.sha256 = Some(format!("sha256:{:x}", Sha256::digest(body)));
+    let artifact = ResolvedModelArtifact {
+        schema_version: MODEL_ARTIFACT_CONTRACT_VERSION,
+        identity: identity.clone(),
+        location: ArtifactLocation::ResolvedLocal { root: local },
+        closure: ResolvedBundleClosure::new(vec![ResolvedBundleMember {
+            role: ArtifactMemberRole::Primary,
+            component_id: None,
+            source: identity.clone(),
+            tier: None,
+            source_subpath: PathBuf::new(),
+            destination: PathBuf::new(),
+            files: vec![file],
+        }])
+        .unwrap(),
+        provenance: ArtifactProvenance {
+            identity,
+            fixed_artifact_tier: None,
+        },
+        completeness: ArtifactCompleteness::Complete,
+        availability: ArtifactAvailability::Available,
+    };
+    // The recorded digest really does match the bytes on disk, so full-strength validation would
+    // PASS here — the only thing that distinguishes the two modes is whether it ran at all.
+    assert!(artifact.validate().is_ok());
+
+    let requirements = vec![requirement("owner/model", "model.safetensors")];
+    let local_artifacts = vec![artifact.clone()];
+    let (resolution, hashes) = observe_content_hashes(|| {
+        resolve_model_availability(
+            &data,
+            &temp.path().join("library"),
+            &requirements,
+            true,
+            &local_artifacts,
+        )
+    });
+    assert_eq!(
+        resolution.availability,
+        ModelAvailability::LocalReady,
+        "the local copy still answers the availability question"
+    );
+    assert_eq!(
+        resolution.local_artifact.as_ref().unwrap().identity,
+        artifact.identity,
+        "and still names the artifact it resolved"
+    );
+    assert_eq!(
+        hashes, 0,
+        "the submission/preflight path must not re-read a single closure file to decide \
+         availability; content identity is proven at the lease boundary"
+    );
+
+    // The read-only probe over an already-built resolution is the same kind of question.
+    let store = ExternalLibraryBindingStore::new(&data).unwrap();
+    let (probe, probe_hashes) = observe_content_hashes(|| store.probe_resolution(&resolution));
+    assert_eq!(probe.unwrap().status, ExternalLibraryProbeStatus::Available);
+    assert_eq!(
+        probe_hashes, 0,
+        "re-probing a resolution must not re-read it either"
+    );
+
+    // The counter is not vacuous: full-strength validation of the same artifact DOES read it.
+    let (result, full_hashes) = observe_content_hashes(|| artifact.validate());
+    assert!(result.is_ok());
+    assert_eq!(
+        full_hashes, 1,
+        "the probe must be able to see a content read when one happens"
+    );
+}

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -912,13 +912,27 @@ impl ResolvedCacheStore {
                 .filter(|value| is_lower_hex_64(value))
                 .ok_or_else(|| ResolvedCacheError::new("invalid resolved-cache entry name"))?
                 .to_owned();
-            let metadata_lock = self.lock_metadata(&digest)?;
+            // The exclusive metadata lock is scoped to the journal READ; the entry is then judged
+            // unlocked (sc-19712). `EntryListing::Runtime` validates at full strength, so holding
+            // the lock across that judgement put a whole-bundle re-hash underneath it — and
+            // `valid_local_artifacts`, the availability read behind every job submission, takes
+            // the same per-entry lock. Measured: with the worker mid-checkpoint, one submission
+            // took 33.2 s and the next had not returned after ~11 minutes, with the API at 0 % CPU
+            // parked on `flock` and the worker at 99 % CPU hashing. Nothing is read twice here —
+            // the judgement is made against the value the read returned, and every caller that
+            // ACTS on a summary (`recover`, retention) re-proves it under fresh locks first.
+            let journal = {
+                let _metadata_lock = self.lock_metadata(&digest)?;
+                self.read_metadata_unlocked(&digest)
+            };
+            #[cfg(test)]
+            run_listing_validation_observer();
             let corrupt = |digest: &str| ResolvedCacheEntrySummary {
                 cache_key: format!("sha256:{digest}"),
                 state: ResolvedCacheEntryState::Corrupt,
                 metadata: None,
             };
-            let summary = match self.read_metadata_unlocked(&digest) {
+            let summary = match journal {
                 Ok(JournalRead::Valid { metadata, .. }) => {
                     let validated = if metadata.state == ResolvedCacheEntryState::Complete {
                         validate_complete_metadata_inner(self, &metadata, listing.verification())
@@ -942,7 +956,6 @@ impl ResolvedCacheStore {
                 },
                 Ok(JournalRead::Missing) | Err(_) => corrupt(&digest),
             };
-            drop(metadata_lock);
             entries.push(summary);
         }
         entries.sort_by(|left, right| left.cache_key.cmp(&right.cache_key));
@@ -2315,6 +2328,32 @@ fn validate_complete_metadata_inner(
         ));
     }
     Ok(())
+}
+
+// Runs once at the point a whole-store listing judges an entry — after its journal has been read
+// and the metadata lock released, with the (possibly full-strength) validation still to come. A
+// test observes from here which locks are held, because this is the window in which the
+// availability read behind every job submission used to be parked (sc-19712).
+#[cfg(test)]
+thread_local! {
+    static LISTING_VALIDATION_OBSERVER: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn set_listing_validation_observer(observer: impl FnOnce() + 'static) {
+    LISTING_VALIDATION_OBSERVER.with(|slot| {
+        *slot.borrow_mut() = Some(Box::new(observer));
+    });
+}
+
+#[cfg(test)]
+fn run_listing_validation_observer() {
+    LISTING_VALIDATION_OBSERVER.with(|slot| {
+        if let Some(observer) = slot.borrow_mut().take() {
+            observer();
+        }
+    });
 }
 
 fn artifact_without_content_hashes(artifact: &ResolvedModelArtifact) -> ResolvedModelArtifact {

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -6,6 +6,8 @@ use crate::model_artifacts::{
 };
 use std::collections::BTreeMap;
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use tempfile::TempDir;
@@ -184,6 +186,94 @@ fn the_local_tier_scan_skips_content_hashing_while_the_lease_boundary_still_refu
     assert_eq!(
         session_records, 0,
         "the lease boundary must refuse altered bytes before it writes a session record"
+    );
+}
+
+/// A submission's availability read must not park behind the sweep's expensive verification
+/// (sc-19712, the coupled residue).
+///
+/// `recover()` — the startup half of every maintenance checkpoint — begins with `enumerate()`,
+/// which validates at FULL strength. While that judgement ran under each entry's exclusive
+/// metadata lock, `valid_local_artifacts` (the provider behind `preflight_payload_model_sources`,
+/// and so behind every job submission) blocked on the same lock: one submission measured 33.2 s
+/// and the next had not returned after ~11 minutes, API at 0 % CPU on `flock`, worker at 99 % CPU
+/// hashing. F-2 gave the status endpoint this treatment; the submission path did not get it.
+///
+/// Observed from inside the listing's own validation window, so it pins the ordering rather than a
+/// duration. The probe is non-blocking on purpose: a `try_lock` reports a held lock, where the
+/// blocking acquire the real reader uses would simply hang the suite.
+#[test]
+fn a_full_strength_listing_never_parks_the_availability_read_behind_its_verification() {
+    let scratch = TempDir::new().unwrap();
+    let source = scratch.path().join("source");
+    let data = scratch.path().join("data");
+    std::fs::create_dir(&source).unwrap();
+    let store = ResolvedCacheStore::open(&data).unwrap();
+    let materializer = ResolvedCacheMaterializer::new(store.clone());
+    for revision in [REVISION_A, REVISION_B] {
+        let candidate = hub_layout_candidate(&source, revision);
+        match materializer
+            .materialize(
+                &candidate,
+                &source,
+                "fixture:model",
+                &MaterializationCancellation::default(),
+            )
+            .unwrap()
+        {
+            MaterializationOutcome::Published(_) => {}
+            other => panic!("fixture bundle was not published: {other:?}"),
+        }
+    }
+    let lock_paths = std::fs::read_dir(store.root().join("entries"))
+        .unwrap()
+        .flatten()
+        .map(|entry| {
+            let digest = entry.file_name().to_str().unwrap().to_owned();
+            store
+                .root()
+                .join("locks")
+                .join(format!("{digest}.metadata.lock"))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(lock_paths.len(), 2, "the fixture cache holds two entries");
+
+    let observed = Arc::new(AtomicBool::new(false));
+    let seen = Arc::new(AtomicBool::new(false));
+    let probe = {
+        let observed = Arc::clone(&observed);
+        let seen = Arc::clone(&seen);
+        let lock_paths = lock_paths.clone();
+        move || {
+            seen.store(true, Ordering::SeqCst);
+            observed.store(
+                lock_paths.iter().all(|path| {
+                    let handle = open_lock_file(path).unwrap();
+                    FileExt::try_lock_exclusive(&handle).is_ok()
+                }),
+                Ordering::SeqCst,
+            );
+        }
+    };
+    set_listing_validation_observer(probe);
+
+    // The startup checkpoint's own entry point, at full strength.
+    let recovered = store.recover().unwrap();
+    assert_eq!(recovered.len(), 2, "recovery still judges every entry");
+    assert!(seen.load(Ordering::SeqCst), "the observer must have run");
+    assert!(
+        observed.load(Ordering::SeqCst),
+        "no entry's metadata lock may be held while a listing verifies bundle contents, or the \
+         availability read behind every job submission blocks for the whole checkpoint"
+    );
+
+    // And the read the submission path actually performs still answers, with both entries intact.
+    assert_eq!(
+        ResolvedCacheStore::valid_local_artifacts(&data)
+            .artifacts
+            .len(),
+        2,
+        "the availability read still offers both published entries"
     );
 }
 

--- a/docs/resolved-cache-validation-sc19712.md
+++ b/docs/resolved-cache-validation-sc19712.md
@@ -606,7 +606,28 @@ back to `validate()` alone and reds the count assertion (`left: 1, right: 0`).
   record of the state that was fixed)
 - expected post-fix cost: the O(entries) `stat` walk — presence and size per closure file, with no
   bytes read
-- post-fix measured: `<pending live re-measure>`
+- post-fix measured: **0.0104 s / 0.0094 s / 0.0093 s** — three consecutive `POST /api/v1/image/jobs`
+  against the identical 5.65 GB, 2-entry cache (`SceneWorks/Sana_1600M_1024px_mlx` 5,574,343,418 B
+  + `SceneWorks/yolo11m-person-detect-mlx` 80,388,864 B) on `75fdf5732`. Catalog read
+  `GET /api/v1/models`: **3.96 s** on a cold snapshot build (92 rows, fresh API), **0.110 s /
+  0.111 s** warm. `GET /api/v1/model-cache` stayed at **0.0041 s**. Availability is unchanged and
+  still correct — `sana_1600m` and `person_detector` both read `local_ready`.
+
+  Against the same cache, that is **929.6 s → ~175 s → 0.0093 s**: about four orders of magnitude
+  below the original finding and roughly 18,700× below the intermediate state. The O(entries)
+  `stat` walk is, as predicted, not measurable next to the rest of the request.
+
+  **One caveat, measured rather than assumed.** The numbers above were taken with no retention
+  sweep in flight. While the worker *is* sweeping, a submission still blocks: the first attempt
+  took **33.2 s** and the next did not return at all for the ~11 minutes it was given. Sampled
+  mid-block, the API was at **0.0 % CPU with zero `sha2` frames** — the content pass really is gone
+  — sitting on `preflight_payload_model_sources → local_resolved_artifacts` with a `flock` leaf,
+  while the worker held 99 % CPU in `scan_entry`'s bundle re-hash. So what remains on the
+  submission path is **not work, it is lock-wait behind F-2's retention scan**. F-2's fix made the
+  *status* read lock-free; the submission path was not given the same treatment, so the two
+  findings are now coupled: the residual submission latency is entirely a function of how long a
+  retention sweep holds the per-entry metadata lock (`retention.rs:646` + `:650`, still
+  `RehashEveryFile`). Worth folding into whatever eventually addresses the retention cost.
 
 ## F-4 and F-2 spot checks · **both confirmed fixed**
 

--- a/docs/resolved-cache-validation-sc19712.md
+++ b/docs/resolved-cache-validation-sc19712.md
@@ -535,7 +535,7 @@ impostor differing only in bytes and physical identity.
 choose-a-different-location lead is the one a user gets here, and the recovery is user-reachable
 rather than a dead end. The decoy was never adopted and the real binding was never overwritten.
 
-## F-3 re-measured · **improved 5.3×, NOT resolved**
+## F-3 re-measured · **improved 5.3×; the residue is fixed in this PR**
 
 Same endpoint, same model, same machine, same unoptimized build; the only variable is the cache
 the request has to reason about.
@@ -573,8 +573,40 @@ request burned roughly 5,600 CPU-seconds (929.6 s at ~600 % CPU); it now burns r
 
 Recommendation, unchanged in kind from the original finding: the submission path is deciding
 *availability*, not handing bytes to a loader, so it should not need a content pass at all — the
-lease boundary already re-verifies before the load. Until the last pass is gone, the feature still
-gets slower the more it is used.
+lease boundary already re-verifies before the load.
+
+### The residue is removed in this same PR
+
+The recommendation above was acted on rather than filed. The last pass was **not** in the cache
+scan #2411 converted — it was one rung further in, in the availability answer itself:
+
+| Site | Role |
+|---|---|
+| `ModelResolution::local_ready` (`external_library.rs:197`) | rung 1 of `resolve_model_availability` — reached by **every** submission preflight and every catalog row for a locally-cached model |
+| `ModelResolution::validate`, `LocalReady` arm (`external_library.rs:~241`) | re-validation of an already-built resolution, used by the read-only `probe_resolution` |
+
+Both called `ResolvedModelArtifact::validate()`, which re-reads and re-hashes every closure file.
+That is the single 32 MB/s pass the throughput identified. Both now call a new
+`ResolvedModelArtifact::validate_paths_and_sizes()`, which proves every other invariant `validate`
+does — version, identity, provenance agreement, completeness, closure shape, path confinement,
+file presence and file **sizes** — and skips only the content re-read.
+
+The availability answer stays correct because it never depended on the digests: an artifact
+admitted here can still be refused at the lease, where content identity is proven three times over
+(`acquire_complete`, `acquire_runtime_lease`, and the full-strength journal write that stamps
+usage), after which the caller falls back to the source tier. **None of those three was touched.**
+
+Pinned by `the_availability_decision_never_re_reads_the_artifact_it_admits`
+(`external_library_tests.rs`), which asserts an **operation count of zero** at the
+`validate_artifact_file` seam rather than a duration — the fixture's recorded digest is correct, so
+a re-read would succeed and only a counter can see it happen. Each of the two sites was mutated
+back to `validate()` alone and reds the count assertion (`left: 1, right: 0`).
+
+- pre-fix measured: **174–185 s** on a 5.65 GB / 2-entry cache (the table above; this stands as the
+  record of the state that was fixed)
+- expected post-fix cost: the O(entries) `stat` walk — presence and size per closure file, with no
+  bytes read
+- post-fix measured: `<pending live re-measure>`
 
 ## F-4 and F-2 spot checks · **both confirmed fixed**
 
@@ -590,7 +622,9 @@ gets slower the more it is used.
   0.0042 / 0.0042 s**. Previously this endpoint did not answer within 40 s during a sweep.
 
 Note the asymmetry the numbers expose: the **status** read was made cheap, but the **submission**
-path was not given the same treatment, which is why F-3 has a residue and F-2 does not.
+path was not given the same treatment, which is why F-3 had a residue and F-2 did not. That
+asymmetry is what the fix above closes — both paths now answer their question without reading the
+bytes they are answering about.
 
 ## Addendum verification
 

--- a/docs/resolved-cache-validation-sc19712.md
+++ b/docs/resolved-cache-validation-sc19712.md
@@ -293,7 +293,7 @@ a `resolved_cache_local_tier_not_selected` event.
 
 Scale, measured against the **real** install rather than this campaign's synthetic one — 85
 receipts under `~/SceneWorks/data/models`, of which exactly **one** is revision-less:
-`SceneWorks/qwen-image-mlx`. That single model is also one of the three soft-co-requisite models
+`SceneWorks/qwen-image-mlx`. That single model is also one of the two soft-co-requisite models
 below, so `qwen_image` is excluded from the local tier on both counts. The backfill path is rare in
 practice; it is not theoretical.
 
@@ -365,13 +365,13 @@ and exactly one provider (`huggingface`, 298/298 rows).
 | Hard co-requisite, multi-repo, `componentId`/`subdir` | `mage_flow_edit_base` → `SceneWorks/Mage-Flow-Components-mlx` | **yes**, as `ArtifactMemberRole::CoRequisite` | `a_multi_repository_closure_becomes_one_source_library_shaped_bundle` (`promotion_tests.rs:69`) |
 | Platform-restricted rows | `lens` (macOS-only) | **yes** — filtered to the worker's own OS by `retain_downloads_for_os` (`artifact_selection.rs:71-87`) | by construction |
 | Sibling quant tiers | `q4`/`q8`/`bf16` | **yes**, as distinct members; never unioned | `sibling_tiers_of_one_repository_stay_distinct_members` (`promotion_tests.rs:171`) |
-| **Soft co-requisite** (`required: "soft"`) | `qwen_image`, `qwen_image_edit`, `acestep_v15_turbo` | **NO — silently excluded** by `.filter(\|d\| d.get("required") != Some("soft"))` at `artifact_selection.rs:251,342,412`. No event, no badge. The primary promotes and shows "local copy" while that component still reads from the source library. | code-cited; **see limitation note below** |
+| **Soft co-requisite** (`required: "soft"`) | `qwen_image`, `acestep_v15_turbo` (exactly two — see the addendum's correction) | **NO — silently excluded** by `.filter(\|d\| d.get("required") != Some("soft"))` at `artifact_selection.rs:251,342,412`. No event, no badge. The primary promotes and shows "local copy" while that component still reads from the source library. | code-cited; **see limitation note below** |
 | **Revision-less requirement** | `svd`, `flux2_klein_9b_true_v2`, `wan_2_2_vace_fun_14b`, `prompt_refine_anubis_8b`, `joycaption_beta_one`, `controlnet_tile_sdxl` (no pinned row at all), plus the unpinned LoRA co-requisites of `ltx_2_3_eros` / `wan_2_2_t2v_14b` / `wan_2_2_i2v_14b` | **NO — poisons the whole repository** at serve time (`external_library_runtime.rs:436-439`). Promotion may still build the bundle, so those entries can occupy cache bytes and never be served. | `a_requirement_with_no_recorded_revision_makes_its_whole_repository_unserveable` (`external_library_runtime.rs:1599`); reported as `resolved_cache_local_tier_not_selected` |
 | **LoRAs and control overlays** | `config/manifests/builtin.loras.jsonc` (8), `builtin.control_overlays.jsonc` (1) | **NO — no path into the cache at all.** They are not model manifest entries; `payload_model_entries` reads only `modelManifestEntry` / `baseModelManifestEntry` / `modelManifestEntries` (`external_library_runtime.rs:742-755`), and the producer only ever emits `Primary` and `CoRequisite`, leaving the other seven `ArtifactMemberRole` variants dead. | code-cited |
 | **Zero-download / imported models** | `aura_sr_v2` (`downloads: []`), user-imported checkpoints | **N/A** — never enter the closure (`entry_is_provably_non_hf_local`, `external_library_runtime.rs:761-802`); the API forces `local_ready` for anything under `<data_dir>/models` | code-cited |
 | Non-`huggingface` providers | none ship today | **N/A** — 298/298 `downloads[]` rows are `huggingface` | manifest scan |
 
-**Limitation worth stating in the product, not just here:** for the three soft-co-requisite models
+**Limitation worth stating in the product, not just here:** for the two soft-co-requisite models
 the "local copy" badge over-promises. The base model survives a disconnect; the optional component
 does not, so a request that needs it will fail while the badge says the model is local. This is
 documented in the user-facing troubleshooting section added by this story.
@@ -468,3 +468,140 @@ No-network-transfer evidence is a byte-exact fingerprint of both tiers plus the 
 taken before and after each local-only scenario (file list + sizes + mtimes, SHA-256 of the
 listing), with `HF_HUB_OFFLINE=1` exported to the worker for the reconnect run so that any
 attempted fetch fails loudly instead of silently succeeding.
+
+---
+
+# Addendum — closing the recorded gaps (2026-08-18)
+
+Written after the findings above were fixed and merged. **F-1 through F-5 landed in PR #2411**, now
+on `feature/sc-19703-resolved-model-hot-cache` (F-1 landed byte-identical to the patch recorded
+above; the memory matrix was re-fingerprinted mechanically and nothing staled). Everything below was
+re-run against that fixed head.
+
+This addendum closes the two things the original campaign recorded as gaps — the adversarial probes
+it designed but did not execute — re-measures F-3, and corrects one error in the matrix above.
+
+## Correction to the matrix above
+
+The soft-co-requisite row named **three** models. It is **two**: `qwen_image` and
+`acestep_v15_turbo`. `qwen_image_edit` is not a manifest id at all (the edit models ship as
+`qwen_image_edit_2511` and siblings, none of which carry a `required: "soft"` download). Verified by
+scanning every `"required": "soft"` occurrence in `config/manifests/builtin.models.jsonc` back to
+its owning `"id"`. The rows, the prose and the user-facing list in `apps/desktop/README.md` are all
+corrected; the substance of the finding is unchanged, and `qwen_image` is still the model that is
+excluded from the local tier on *both* counts (soft co-requisite **and** the only revision-less
+receipt on the real install).
+
+## Probe 6a — alias / realias rebind · **PASS**
+
+The sc-19709 fix, exercised against the real volume. A scratch symlink was bound first, then the
+configured path was switched to the direct `/Volumes` root and back again, restarting the API each
+time so the binding was re-probed from disk.
+
+| Step | Configured path | Probe | `sana_1600m` | Binding `configuredPath` | `canonicalPath` / `volumeId` | `boundAt` |
+|---|---|---|---|---|---|---|
+| 1. bind via symlink | `…/sw3/liblink` | `available` | `external_ready` | `…/sw3/liblink` | `/Volumes/Models/huggingface/hub` · `macos-volume:cd01d2ad…804bd` | `1787041411` |
+| 2. switch to direct root | `/Volumes/Models/huggingface/hub` | `available` | `external_ready` | **realiased →** `/Volumes/Models/huggingface/hub` | *unchanged* | **`1787041411` unchanged** |
+| 3. switch back to symlink | `…/sw3/liblink` | `available` | `external_ready` | **realiased →** `…/sw3/liblink` | *unchanged* | **`1787041411` unchanged** |
+
+Availability never left `external_ready`, no relocation prompt was raised, and nothing re-entered
+the download path. The ledger was realiased in both directions while canonical path, physical
+identity and `bound_at` were preserved — exactly the contract §7 of the handoff describes.
+
+One ordering detail worth knowing (not a defect): immediately after the switch, the
+`GET /api/v1/model-library` probe still reported the *previous* `configuredPath`, and the realias
+became visible on the next `/api/v1/models` read. The realias happens on the availability path
+(`bind_or_probe_validated`), not in the probe endpoint, so a UI that reads only the probe endpoint
+will show the old alias for one poll.
+
+## Probe 6b — decoy identity mismatch · **PASS (fails closed)**
+
+With the drive unmounted (`lsof` clean, `diskutil unmountDisk`, never forced), the *same* configured
+path was repointed at an HF-shaped decoy on internal disk: same `models--SceneWorks--Sana_1600M_1024px_mlx`
+directory, same `snapshots/ac421696…` revision directory, same four closure filenames — a credible
+impostor differing only in bytes and physical identity.
+
+| Assertion | Result |
+|---|---|
+| Probe status | `identity_mismatch`, `available: false` |
+| `sana_1600m` availability | `installed_external_unavailable` |
+| **`libraryPresent`** | **`true`** — the "present but wrong identity" signal, distinct from a plain disconnect |
+| Decoy adopted? | **No.** Binding still `canonicalPath: /Volumes/Models/huggingface/hub`, `volumeId: macos-volume:cd01d2ad…804bd`, `boundAt: 1787041411` — untouched |
+| Submission | `HTTP 503` `external_model_library_unavailable`, context carrying `configuredLibraryPath` (the decoy path), `expectedLibraryPath` (the real root), `expectedVolumeId`, and `libraryPresent: true` |
+| Wedge? | **No.** Restoring the symlink and remounting returned `sana_1600m` to `external_ready` with `boundAt` still `1787041411` |
+
+`libraryPresent: true` is what drives the relocation branch rather than the reconnect branch —
+`ModelLibraryDialog.jsx:50` reads `context.libraryPresent === true` as `mismatched` — so the
+choose-a-different-location lead is the one a user gets here, and the recovery is user-reachable
+rather than a dead end. The decoy was never adopted and the real binding was never overwritten.
+
+## F-3 re-measured · **improved 5.3×, NOT resolved**
+
+Same endpoint, same model, same machine, same unoptimized build; the only variable is the cache
+the request has to reason about.
+
+| Cache contents | `POST /api/v1/image/jobs` | Note |
+|---|---:|---|
+| empty | sub-second | original campaign |
+| 80 MB (1 entry) | **0.130 s** | fixed head |
+| 5.57 GB (1 entry) | **929.6 s** | **before the fix** |
+| 5.65 GB (2 entries) | **175.8 s** | fixed head, first measurement |
+| 5.65 GB (2 entries), system otherwise idle | **185.1 s / 175.0 s / 174.3 s** | three consecutive, **worker stopped entirely** |
+
+**929.6 s → ~175 s is a real 5.3× win, but a job submission still costs nearly three minutes on a
+5.65 GB cache, and it still scales with cache size.**
+
+I first assumed the residue was lock contention with the retention sweep — the worker was at 100 %
+CPU and one API sample showed `flock` with no hashing. **That was wrong, and the control disproved
+it:** with the worker killed outright, three consecutive submissions still took 174–185 s. The
+earlier sample had simply landed in an idle gap between requests.
+
+Re-sampled properly, mid-submission, with no worker running at all:
+
+```
+api cpu: 100.0
+sha2 compress samples: 13
+  12 preflight_payload_model_sources
+   2 validate_artifact_file
+```
+
+So a **full content re-hash still happens on the submission path** — `preflight_payload_model_sources`
+still reaches `validate_artifact_file`. The throughput is the tell: 5.65 GB / ~175 s ≈ 32 MB/s,
+which is one pass over the cached bytes at this build's software-SHA rate. Before the fix the same
+request burned roughly 5,600 CPU-seconds (929.6 s at ~600 % CPU); it now burns roughly 175
+(single-threaded). The fix removed most of the redundant passes; it did not remove the last one.
+
+Recommendation, unchanged in kind from the original finding: the submission path is deciding
+*availability*, not handing bytes to a loader, so it should not need a content pass at all — the
+lease boundary already re-verifies before the load. Until the last pass is gone, the feature still
+gets slower the more it is used.
+
+## F-4 and F-2 spot checks · **both confirmed fixed**
+
+- **F-4 — a promotion is visible without an API restart.** Immediately after the 5.57 GB Sana
+  bundle published, `GET /api/v1/models` returned `sana_1600m availability=local_ready` in
+  **1.13 s** with **no restart** — the exact condition that previously required one (the cached read
+  had said `installed_external_unavailable` while a fresh build said `local_ready`).
+  `person_detector` stayed `local_ready` alongside it.
+- **F-2 — the status endpoint survives maintenance.** `GET /api/v1/model-cache` was polled **34
+  times while the promotion was materializing** and answered every time; a later series taken while
+  the worker sat at 100 % CPU in a retention sweep returned **0.0046 / 0.0050 / 0.0051 / 0.0050 /
+  0.0050 / 0.0051 s**, and three more during the submission measurements returned **0.0046 /
+  0.0042 / 0.0042 s**. Previously this endpoint did not answer within 40 s during a sweep.
+
+Note the asymmetry the numbers expose: the **status** read was made cheap, but the **submission**
+path was not given the same treatment, which is why F-3 has a residue and F-2 does not.
+
+## Addendum verification
+
+| Check | Result |
+|---|---|
+| `npm run rust:check` (for the doc-comment split) | exit **0**, 3763 tests passed, 0 failed |
+| working tree after the run | clean apart from the three intended files |
+| drive at end | **mounted**, `VolumeUUID CD01D2AD-5CB6-480B-8A7E-322816A804BD` |
+
+One review minor from #2411 is also folded in here: the pre-existing doc block for
+`local_resolved_artifacts` had been left attached to the newly inserted `note_local_tier_freshness`
+(`apps/rust-api/src/model_sources.rs`), leaving the provider-agreement paragraphs describing the
+wrong function and `local_resolved_artifacts` with no documentation at all. The comment is split
+back so each block sits on the function it describes.

--- a/docs/resolved-cache-validation-sc19712.md
+++ b/docs/resolved-cache-validation-sc19712.md
@@ -623,11 +623,46 @@ back to `validate()` alone and reds the count assertion (`left: 1, right: 0`).
   mid-block, the API was at **0.0 % CPU with zero `sha2` frames** — the content pass really is gone
   — sitting on `preflight_payload_model_sources → local_resolved_artifacts` with a `flock` leaf,
   while the worker held 99 % CPU in `scan_entry`'s bundle re-hash. So what remains on the
-  submission path is **not work, it is lock-wait behind F-2's retention scan**. F-2's fix made the
+  submission path is **not work, it is lock-wait behind the checkpoint**. F-2's fix made the
   *status* read lock-free; the submission path was not given the same treatment, so the two
-  findings are now coupled: the residual submission latency is entirely a function of how long a
-  retention sweep holds the per-entry metadata lock (`retention.rs:646` + `:650`, still
-  `RehashEveryFile`). Worth folding into whatever eventually addresses the retention cost.
+  findings were coupled: the residual submission latency was entirely a function of how long a
+  checkpoint held the per-entry metadata lock.
+
+  ### Resolved in this PR
+
+  The 33.2 s / ~11-minute measurements above stand as the record of the state that was fixed.
+
+  The diagnosis corrects one detail of the attribution. The holder was **not** `scan_entry` — F-2
+  already scoped that lock to the journal read and dropped its classification to paths-and-sizes,
+  and it is unchanged here. Nor was it the pre-eviction source-completeness proof, which the epic
+  AC requires at full strength: `verify_source_complete` re-hashes every *source* file and has
+  always run with **no** lock held (`evict_candidate` establishes it unlocked, then re-proves under
+  fresh locks). Both were verified untouched.
+
+  The holder was `ResolvedCacheStore::list` — a path F-2 missed. `recover()`, the startup half of
+  every maintenance checkpoint, begins with `enumerate()`, and `list` took each entry's exclusive
+  metadata lock and held it across a full-strength `RehashEveryFile` validation of that entry's
+  bundle. `valid_local_artifacts` — the provider behind `preflight_payload_model_sources`, and so
+  behind every job submission — takes the same per-entry lock. That is exactly the observed
+  profile: worker at 99 % CPU hashing bundle bytes, API at 0 % CPU with zero `sha2` frames parked
+  on `flock`.
+
+  The fix is the one F-2 already applied to `scan_entry`: the lock is scoped to the journal READ
+  and the entry is judged unlocked. The verification itself is **not** weakened — `Runtime`
+  listings still validate at full strength, because that is the corruption detector recovery
+  depends on; it simply no longer runs underneath a lock that a reader needs. Nothing is read
+  twice: the judgement is made against the value the read returned, and every caller that *acts* on
+  a summary (`recover`, retention) re-proves it under fresh locks before mutating — the same
+  unlocked-proof / fresh-lock-re-proof shape `evict_candidate` uses. An entry being evicted still
+  cannot be admitted by a concurrent availability read: a tombstoned entry reads as
+  `JournalRead::Evicted`, which `valid_local_artifacts` skips, so the answer falls back to the
+  source tier, which the lease boundary makes safe.
+
+  Pinned by `a_full_strength_listing_never_parks_the_availability_read_behind_its_verification`,
+  which observes from inside the listing's own validation window that no entry's metadata lock is
+  held, and reds when the blocking hold is restored.
+
+  - post-fix measured, submission during a sweep: `<pending live re-measure>`
 
 ## F-4 and F-2 spot checks · **both confirmed fixed**
 

--- a/docs/resolved-cache-validation-sc19712.md
+++ b/docs/resolved-cache-validation-sc19712.md
@@ -662,7 +662,27 @@ back to `validate()` alone and reds the count assertion (`left: 1, right: 0`).
   which observes from inside the listing's own validation window that no entry's metadata lock is
   held, and reds when the blocking hold is restored.
 
-  - post-fix measured, submission during a sweep: `<pending live re-measure>`
+  - post-fix measured, submission during a sweep: **0.0086 s / 0.0083 s / 0.0085 s** — three
+    consecutive `POST /api/v1/image/jobs` taken while the worker held **96.5–100 % CPU** in
+    full-strength store maintenance over the same 5.65 GB / 2-entry cache, on `cf8230884`.
+    Alongside them, `GET /api/v1/model-cache` returned in **0.0045 s** and `GET /api/v1/models` in
+    **0.136 s**. Pre-fix the same measurement gave **33.2 s** for the first submission and the
+    second **never returned in the ~11 minutes it was given**.
+
+    Submission during a sweep is now indistinguishable from submission on an idle system
+    (0.0093–0.0104 s), so the sweep no longer parks the availability read at all.
+
+    The measurement is guarded rather than assumed. A first attempt produced a misleading number
+    because the expensive work the worker was doing turned out to be a **model load**, not a sweep:
+    the baseline submission earlier in the same script had been claimed, and the worker was inside
+    `acquire_complete` doing the lease-boundary content verification of the 5.57 GB bundle — which
+    is full-strength **by design** and legitimately holds that entry. That is a real behaviour and
+    worth stating plainly: **a submission naming a model whose bundle is concurrently being
+    verified at the lease boundary still waits**, because the load path deliberately kept its
+    content proof. It is not the sweep contention this fix addresses. The rerun therefore purges
+    every claimable job first and then samples the worker before measuring, aborting unless
+    load-path frames are zero; the run recorded above passed that guard with **load-path frames 0,
+    maintenance frames 3, sha2 13**.
 
 ## F-4 and F-2 spot checks · **both confirmed fixed**
 


### PR DESCRIPTION
Closes sc-19712. Runs the two adversarial probes the original acceptance record flagged as its own
gap, re-measures F-3 against the fixed head (#2411), corrects one error in the matrix, and folds in
a review minor.

Run against the real external volume — `/Volumes/Models`, VolumeUUID
`CD01D2AD-5CB6-480B-8A7E-322816A804BD` — on an isolated data dir. `~/SceneWorks/data` was never
written; the library is still byte-identical to its pre-campaign baseline (4399 files,
1,811,018,365,416 B, sha `72b94cffd042`). Drive left mounted.

## Probe 6a — alias / realias rebind · PASS

Bound through a scratch symlink, switched to the direct `/Volumes` root, then back, restarting the
API each time so the binding was re-probed from disk.

| Step | Configured path | Probe | `sana_1600m` | Binding `configuredPath` | `boundAt` |
|---|---|---|---|---|---|
| bind via symlink | `…/liblink` | `available` | `external_ready` | `…/liblink` | `1787041411` |
| switch to direct root | `/Volumes/…/hub` | `available` | `external_ready` | **realiased →** `/Volumes/…/hub` | **unchanged** |
| switch back | `…/liblink` | `available` | `external_ready` | **realiased →** `…/liblink` | **unchanged** |

Availability never left `external_ready`, no relocation prompt, nothing re-entered the download
path, and canonical path + physical identity + `bound_at` were preserved in both directions — the
sc-19709 contract. One ordering detail recorded as a note, not a defect: the realias lands on the
availability path, so `/api/v1/model-library` still shows the previous alias for one poll.

## Probe 6b — decoy identity mismatch · PASS (fails closed)

With the drive unmounted (`lsof` clean, never forced), the same configured path was pointed at an
HF-shaped decoy sharing the repo directory name, the `ac421696…` revision directory and all four
closure filenames — a credible impostor differing only in bytes and physical identity.

- probe `identity_mismatch`, `available: false`
- `sana_1600m` → `installed_external_unavailable`, **`libraryPresent: true`** — the present-but-wrong
  signal that drives the *relocation* branch rather than the reconnect one
  (`ModelLibraryDialog.jsx:50`), so the choose-a-different-location lead is what a user gets
- **decoy never adopted**: binding kept `canonicalPath: /Volumes/Models/huggingface/hub`,
  `volumeId: macos-volume:cd01d2ad…804bd`, `boundAt: 1787041411`
- `HTTP 503` context carried both the decoy path and the real `expectedLibraryPath` /
  `expectedVolumeId`
- **not a wedge**: restoring the symlink and remounting returned the model to `external_ready`

## F-3 re-measured — improved 5.3×, **not resolved**

| Cache | `POST /api/v1/image/jobs` |
|---|---:|
| empty | sub-second |
| 80 MB | **0.130 s** |
| 5.57 GB — **before the fix** | **929.6 s** |
| 5.65 GB — fixed head | **175.8 s** |
| 5.65 GB — worker stopped entirely, three consecutive | **185.1 / 175.0 / 174.3 s** |

A job submission still costs nearly three minutes on a 5.65 GB cache and still scales with cache
size.

I first blamed lock contention with the retention sweep — the worker was at 100 % CPU and one API
sample showed `flock` with no hashing. **The control disproved that**: with the worker killed
outright the submissions were unchanged. Re-sampled mid-submission with no worker running, the API
was at 100 % CPU in `preflight_payload_model_sources → validate_artifact_file → sha2`. So a full
content pass still happens on the submission path — 5.65 GB / ~175 s ≈ 32 MB/s, one pass at this
build's software-SHA rate. Before the fix the same request burned ~5,600 CPU-seconds (929.6 s at
~600 % CPU); it now burns ~175. Most redundant passes went; the last one did not.

The submission path decides *availability*, not bytes-to-a-loader, and the lease boundary already
re-verifies before the load — so it should not need a content pass at all.

## F-4 and F-2 spot checks — both confirmed fixed

- **F-4**: `sana_1600m` read `local_ready` **1.13 s** after its promotion published, with **no API
  restart** — the exact case that previously required one.
- **F-2**: `/api/v1/model-cache` answered all **34** polls during a materialization, and returned in
  **0.0042–0.0051 s** while the worker sat at 100 % CPU in a retention sweep. Previously it did not
  answer within 40 s.

The asymmetry is worth naming: the status read was made cheap, the submission path was not, which is
exactly why F-2 is closed and F-3 has a residue.

## Correction and review minor

- The soft-co-requisite row named **three** models; it is **two** — `qwen_image` and
  `acestep_v15_turbo`. `qwen_image_edit` is not a manifest id at all. Verified by scanning every
  `"required": "soft"` occurrence back to its owning `"id"`. Corrected in the matrix, the prose and
  the user-facing list in `apps/desktop/README.md`. `qwen_image` remains excluded on both counts.
- The pre-existing doc block for `local_resolved_artifacts` had been left attached to the newly
  inserted `note_local_tier_freshness` (`apps/rust-api/src/model_sources.rs`), describing the wrong
  function and leaving `local_resolved_artifacts` undocumented. Split so each block sits on its own
  function.

Verified: `npm run rust:check` exit **0**, 3763 tests passed, 0 failed; working tree clean apart
from the three intended files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
