### PR TITLE
fix(web,api): default a new LoRA to 1.0 for every family

### DIFF
--- a/apps/rust-api/src/recipe_presets.rs
+++ b/apps/rust-api/src/recipe_presets.rs
@@ -1006,13 +1006,26 @@ pub(crate) fn preset_lora_id(preset_lora: &Value) -> Option<&str> {
         .or_else(|| preset_lora.get("id").and_then(Value::as_str))
 }
 
+/// The apply weight a LoRA starts at when nothing explicit is recorded for it — ONE neutral 1.0
+/// for every family. There is deliberately no per-family table: the sole exception used to be
+/// krea-2 at 1.5 (sc-7579 / sc-7932 — Krea 2's distilled, CFG-free Turbo attenuates Raw-trained
+/// LoRAs), which overshot in practice and landed fresh picks over-applied. A model that genuinely
+/// wants a different starting point should ship `defaultWeight` on its LoRA manifest entry rather
+/// than reintroduce a family branch here.
+///
+/// ⚠️ Mirrors the web `DEFAULT_LORA_WEIGHT` (`apps/web/src/presetUtils.js`) and MUST stay in
+/// lockstep with it: this is the weight a preset actually APPLIES, while the web constant is the
+/// weight the studio SHOWS on the slider. A divergence means a run silently uses a scale the user
+/// never picked.
+pub(crate) const DEFAULT_LORA_WEIGHT: f64 = 1.0;
+
 pub(crate) fn preset_lora_weight(lora: &Value, preset_lora: &Value) -> f64 {
     preset_lora
         .get("weight")
         .and_then(Value::as_f64)
         .or_else(|| lora.get("defaultWeight").and_then(Value::as_f64))
         .or_else(|| lora.get("weight").and_then(Value::as_f64))
-        .unwrap_or(0.8)
+        .unwrap_or(DEFAULT_LORA_WEIGHT)
 }
 
 pub(crate) fn serialize_preset_lora(lora: &Value, preset_lora: &Value, lora_id: &str) -> Value {

--- a/apps/rust-api/src/tests/recipe_presets.rs
+++ b/apps/rust-api/src/tests/recipe_presets.rs
@@ -9,6 +9,50 @@ fn text_to_image_preset_defaults_exclude_retired_style_mode() {
     );
 }
 
+/// Parity guard for the web `loraWeight` fallback (`apps/web/src/presetUtils.js`): the weight a
+/// preset APPLIES must match the weight the studio SHOWS, or a run silently uses a scale the user
+/// never picked. ONE default for every family — krea-2 used to be special-cased and deliberately
+/// no longer is.
+#[test]
+fn preset_lora_weight_defaults_to_one_for_every_family() {
+    use crate::recipe_presets::preset_lora_weight;
+    use serde_json::json;
+
+    let none = json!({});
+
+    for lora in [
+        json!({ "id": "s", "family": "sdxl" }),
+        json!({ "id": "k", "family": "krea_2" }),
+        json!({ "id": "k", "family": "krea-2" }),
+        json!({ "id": "k", "family": "krea2" }),
+        json!({ "id": "w", "families": ["wan-video"] }),
+        json!({ "id": "c", "compatibleFamilies": ["flux"] }),
+        json!({ "id": "c", "compatibility": { "families": ["ltx-video"] } }),
+        json!({ "id": "bare" }),
+    ] {
+        assert_eq!(preset_lora_weight(&lora, &none), 1.0, "{lora}");
+    }
+
+    // An explicit value still wins, in the web's precedence order:
+    // preset weight -> catalog defaultWeight -> the LoRA's own weight.
+    let krea = json!({ "id": "k", "family": "krea_2" });
+    assert_eq!(preset_lora_weight(&krea, &json!({ "weight": 2.0 })), 2.0);
+    assert_eq!(
+        preset_lora_weight(
+            &json!({ "id": "k", "family": "krea_2", "defaultWeight": 1.3 }),
+            &none
+        ),
+        1.3
+    );
+    assert_eq!(
+        preset_lora_weight(
+            &json!({ "id": "s", "family": "sdxl", "weight": 0.7 }),
+            &none
+        ),
+        0.7
+    );
+}
+
 #[tokio::test]
 async fn recipe_preset_crud_routes_persist_global_and_project_presets() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");

--- a/apps/web/src/App.character.test.jsx
+++ b/apps/web/src/App.character.test.jsx
@@ -1166,7 +1166,7 @@ describe("SceneWorks app shell", () => {
       expect.objectContaining({
         mode: "character_image",
         model: "instantid_realvisxl",
-        loras: [expect.objectContaining({ id: "kelsie-lora", weight: 0.8 })],
+        loras: [expect.objectContaining({ id: "kelsie-lora", weight: 1.0 })],
       }),
     );
   });
@@ -1242,7 +1242,7 @@ describe("SceneWorks app shell", () => {
       expect.objectContaining({
         mode: "character_image",
         model: "instantid_realvisxl",
-        loras: [expect.objectContaining({ id: "kelsie-lora", weight: 0.8 })],
+        loras: [expect.objectContaining({ id: "kelsie-lora", weight: 1.0 })],
       }),
     );
   });

--- a/apps/web/src/App.imageGeneration.test.jsx
+++ b/apps/web/src/App.imageGeneration.test.jsx
@@ -2250,7 +2250,7 @@ describe("SceneWorks app shell", () => {
     expect(pickNames).toContain("LTX Style");
     expect(pickNames).not.toContain("Z Glow");
 
-    // Adding a LoRA drops in a slot with its weight slider, defaulting to the LoRA weight (0.8).
+    // Adding a LoRA drops in a slot with its weight slider, defaulting to the global 1.0.
     await act(async () => {
       [...document.body.querySelectorAll(".lora-pick-row")]
         .find((button) => button.textContent.includes("LTX Style"))
@@ -2265,7 +2265,7 @@ describe("SceneWorks app shell", () => {
     // LoRA stuck at the old center of 0 generated at scale 0 and looked "not applied").
     expect(weightSlider.getAttribute("min")).toBe("-2");
     expect(weightSlider.getAttribute("max")).toBe("2");
-    expect(document.body.querySelector(".lora-slot-weight-value").textContent).toBe("0.80");
+    expect(document.body.querySelector(".lora-slot-weight-value").textContent).toBe("1.00");
     await changeField(weightSlider, "0.5");
 
     const generate = [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Render clip");

--- a/apps/web/src/App.videoPresets.test.jsx
+++ b/apps/web/src/App.videoPresets.test.jsx
@@ -290,7 +290,7 @@ describe("SceneWorks app shell", () => {
         // presetLorasResolvedClientSide so the server won't re-merge it.
         prompt: "Camera slowly pushes in while the scene comes alive",
         presetLorasResolvedClientSide: true,
-        loras: [expect.objectContaining({ id: "video_motion", weight: 0.8 })],
+        loras: [expect.objectContaining({ id: "video_motion", weight: 1.0 })],
         advanced: expect.objectContaining({
           resolution: "1280x720",
         }),

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -381,17 +381,21 @@ export function presetLoraId(presetLora) {
   return typeof presetLora === "string" ? presetLora : presetLora?.id ?? presetLora?.loraId;
 }
 
-// Krea 2's distilled, CFG-free Turbo attenuates Raw-trained LoRAs (sc-7579 / sc-7932): the generic
-// 0.8 default under-expresses on the few-step student, so a krea-2-family LoRA defaults to a higher
-// apply weight (real-weight-validated coherent through scale 4). This is still a DEFAULT — an explicit
-// preset weight, a stored `defaultWeight`, or the LoRA's own `weight` still wins. Family token is the
-// normalized form (`normalizeLoraFamily`: krea_2 → krea-2).
-const KREA_LORA_DEFAULT_WEIGHT = 1.5;
+// The apply weight a LoRA starts at when nothing explicit is recorded for it — ONE neutral 1.0 for
+// every family. There is deliberately no per-family table: the sole exception used to be krea-2 at
+// 1.5 (sc-7579 / sc-7932 — Krea 2's distilled, CFG-free Turbo attenuates Raw-trained LoRAs), which
+// overshot in practice and landed fresh picks over-applied. A model that genuinely wants a
+// different starting point should ship `defaultWeight` on the LoRA's own manifest entry rather than
+// reintroduce a family branch here.
+//
+// ⚠️ Mirrored by the API's `DEFAULT_LORA_WEIGHT` (apps/rust-api/src/recipe_presets.rs); the two MUST
+// agree or a preset applies at a weight the studio never showed. This is still a DEFAULT — an
+// explicit preset weight, a stored `defaultWeight`, or the LoRA's own `weight` still wins.
+const DEFAULT_LORA_WEIGHT = 1.0;
 
 export function loraWeight(lora, presetLora = {}) {
-  const fallback = loraFamilies(lora).includes("krea-2") ? KREA_LORA_DEFAULT_WEIGHT : 0.8;
-  const value = Number(presetLora.weight ?? lora?.defaultWeight ?? lora?.weight ?? fallback);
-  return Number.isFinite(value) ? value : fallback;
+  const value = Number(presetLora.weight ?? lora?.defaultWeight ?? lora?.weight ?? DEFAULT_LORA_WEIGHT);
+  return Number.isFinite(value) ? value : DEFAULT_LORA_WEIGHT;
 }
 
 // Resolve a preset's declared LoRAs into [{ id, weight }] entries ready to seed into the

--- a/apps/web/src/presetUtils.test.jsx
+++ b/apps/web/src/presetUtils.test.jsx
@@ -353,27 +353,27 @@ describe("finiteNumberOrUndefined", () => {
 });
 
 describe("loraWeight", () => {
-  it("defaults a generic LoRA to 0.8", () => {
-    expect(loraWeight({ id: "sdxl_style", family: "sdxl" })).toBe(0.8);
-    expect(loraWeight(null)).toBe(0.8);
+  it("defaults every LoRA to 1.0 regardless of family", () => {
+    // ONE default, no per-family table — krea-2 used to be special-cased (1.5, then 1.0) and
+    // deliberately no longer is. Covers each family-bearing shape extractFamilies() reads.
+    expect(loraWeight({ id: "sdxl_style", family: "sdxl" })).toBe(1.0);
+    expect(loraWeight({ id: "k", family: "krea_2" })).toBe(1.0);
+    expect(loraWeight({ id: "k", compatibility: { families: ["krea_2"] } })).toBe(1.0);
+    expect(loraWeight({ id: "w", families: ["wan-video"] })).toBe(1.0);
+    expect(loraWeight({ id: "f" })).toBe(1.0);
+    expect(loraWeight(null)).toBe(1.0);
   });
 
-  it("defaults a krea-2-family LoRA higher (1.5) for the distilled-Turbo attenuation (sc-7932)", () => {
-    // The family token is normalized (krea_2 -> krea-2), and the bump applies via any of the
-    // family-bearing shapes extractFamilies() reads.
-    expect(loraWeight({ id: "k", family: "krea_2" })).toBe(1.5);
-    expect(loraWeight({ id: "k", compatibility: { families: ["krea_2"] } })).toBe(1.5);
-  });
-
-  it("lets an explicit weight win over the krea-2 family default", () => {
-    expect(loraWeight({ id: "k", family: "krea_2", defaultWeight: 1.0 })).toBe(1.0);
+  it("lets an explicit weight win over the default", () => {
+    expect(loraWeight({ id: "k", family: "krea_2", defaultWeight: 1.3 })).toBe(1.3);
     expect(loraWeight({ id: "k", family: "krea_2", weight: 0.7 })).toBe(0.7);
     expect(loraWeight({ id: "k", family: "krea_2" }, { weight: 2.0 })).toBe(2.0);
+    expect(loraWeight({ id: "g", family: "sdxl", defaultWeight: 0.6 })).toBe(0.6);
   });
 
-  it("falls back to the family default when an explicit value is non-finite", () => {
-    expect(loraWeight({ id: "k", family: "krea_2", defaultWeight: "nope" })).toBe(1.5);
-    expect(loraWeight({ id: "g", family: "sdxl", defaultWeight: "nope" })).toBe(0.8);
+  it("falls back to the default when an explicit value is non-finite", () => {
+    expect(loraWeight({ id: "k", family: "krea_2", defaultWeight: "nope" })).toBe(1.0);
+    expect(loraWeight({ id: "g", family: "sdxl", defaultWeight: "nope" })).toBe(1.0);
   });
 });
 

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -583,7 +583,7 @@ export function CharacterStudio() {
       name: lora.name ?? lora.id,
       sourcePath: lora.installedPath ?? lora.source?.path ?? null,
       triggerWords: lora.triggerWords ?? [],
-      defaultWeight: lora.defaultWeight ?? 0.8,
+      defaultWeight: lora.defaultWeight ?? 1.0,
       compatibility: { families: extractFamilies(lora) },
       scope: lora.scope ?? "global",
     });

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -10,6 +10,7 @@ import {
   MAX_PRESET_LORAS,
   compactModeList,
   loraMatchesModel,
+  loraWeight,
   presetLoraId,
   presetLoras,
   presetSaveValidation,
@@ -483,7 +484,9 @@ export function PresetManagerScreen() {
         return current;
       }
       const source = loras.find((lora) => lora.id === id);
-      const weight = source?.defaultWeight ?? source?.weight ?? 0.8;
+      // Through the shared resolver, not a hand-rolled copy of its precedence chain: this seeds
+      // the SAME starting weight the studio pickers show, and can't drift from the default again.
+      const weight = loraWeight(source);
       return { ...current, loras: [...current.loras, { id, weight: String(weight) }] };
     });
   }
@@ -588,7 +591,7 @@ export function PresetManagerScreen() {
       defaults,
       loras: form.loras.map((lora) => ({
         id: lora.id,
-        weight: Number.isFinite(Number(lora.weight)) ? Number(lora.weight) : 0.8,
+        weight: Number.isFinite(Number(lora.weight)) ? Number(lora.weight) : 1.0,
       })),
       ui: { description: form.description.trim() },
     };

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -83,7 +83,7 @@ export function editableLora(link) {
   return {
     name: link?.name ?? "",
     triggerWords: (link?.triggerWords ?? []).join(", "),
-    defaultWeight: link?.defaultWeight ?? 0.8,
+    defaultWeight: link?.defaultWeight ?? 1.0,
     families: extractFamilies(link).join(", "),
     scope: link?.scope ?? "project",
   };

--- a/apps/web/src/simple/SimpleLora.test.jsx
+++ b/apps/web/src/simple/SimpleLora.test.jsx
@@ -232,8 +232,8 @@ describe("Simple studios — LoRA field", () => {
       "1 selected · installed and compatible",
     );
     expect(container.querySelector(".su-lora-add-count").textContent).toBe("· 1 available");
-    // Weight defaults to the LoRA's own default (0.8 here, via `loraWeight`).
-    expect(container.querySelector(".su-lora-weight-value").textContent).toBe("0.80");
+    // This LoRA declares no `defaultWeight`, so the slider seeds from the global 1.0 (`loraWeight`).
+    expect(container.querySelector(".su-lora-weight-value").textContent).toBe("1.00");
   });
 
   it("seeds the slider from the LoRA's declared defaultWeight", async () => {
@@ -260,7 +260,7 @@ describe("Simple studios — LoRA field", () => {
     expect(slotNames(container)).toEqual([]);
     // Re-adding starts from the LoRA's own default again, not the override we just cleared.
     await addLora(container, "Cinematic Grain 35mm");
-    expect(container.querySelector(".su-lora-weight-value").textContent).toBe("0.80");
+    expect(container.querySelector(".su-lora-weight-value").textContent).toBe("1.00");
   });
 
   it("appends a trigger keyword to the prompt when its chip is clicked", async () => {
@@ -378,7 +378,7 @@ describe("Simple studios — LoRA field", () => {
     await addLora(container, "Slow Dolly");
     await click(container.querySelector(".su-generate"));
     const request = context.createVideoJob.mock.calls[0][0];
-    expect(request.loras).toEqual([expect.objectContaining({ id: "lora_wan", weight: 0.8 })]);
+    expect(request.loras).toEqual([expect.objectContaining({ id: "lora_wan", weight: 1.0 })]);
   });
 });
 

--- a/config/backend-capabilities/matrix.json
+++ b/config/backend-capabilities/matrix.json
@@ -59,7 +59,7 @@
     "workerUtilityDispatch": "017142f8ac644fa2d275e35b94827af4f60644340956dfb84576d7e940737f0d",
     "workerVideoBernini": "352991ae26c8d842c9af1c37e9c6d3261ae6554debe5089744ef8e7972fd15ed",
     "workerVideoCandle": "4527f7c7f42bac9d65daa2004f993657391ec3cdc872bac0bc9e2c012c93e949",
-    "workerVideoDispatch": "f29a1c62603f4556397c5fddb6672be445e458520784bc849215d2e951ce86bd",
+    "workerVideoDispatch": "fbc7954bfc17e5ab77f66a0659e2895bdfff7db9eaf41249441e446550a8faa3",
     "workerVideoKreaRealtime": "590b65273e5d87c350feec0f677ee05295aa05835cac12348e2f5520fc1724e7",
     "workerVideoLtx": "35c4f69f9bb82aeb065dbcbab5ebc1386dc4d8b061c5567c8656e1d7257c7030",
     "workerVideoMochi": "5a0868693b1cbf1c08a6acfc5151c3e3542d812b7cec6f73bfa53d701883dcbc",

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1667,7 +1667,10 @@ fn lora_weight(lora: &Value) -> f64 {
                 .as_f64()
                 .or_else(|| value.as_str()?.trim().parse().ok())
         })
-        .unwrap_or(0.8)
+        // Last resort only — the API always stamps a weight onto the spec. Matches the API/web
+        // default (`DEFAULT_LORA_WEIGHT`) so a weightless payload can't apply at a scale no
+        // surface would have shown.
+        .unwrap_or(1.0)
 }
 
 #[cfg(any(

--- a/crates/sceneworks-worker/src/video_jobs/mod.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mod.rs
@@ -1962,7 +1962,8 @@ fn lora_scale(lora: &Value) -> f32 {
                 .as_f64()
                 .or_else(|| value.as_str()?.trim().parse().ok())
         })
-        .unwrap_or(0.8) as f32
+        // Last resort only — see `image_jobs::lora_weight`; matches the API/web default.
+        .unwrap_or(1.0) as f32
 }
 
 /// Resolve a LoRA spec's file (a directory → its first `.safetensors`, recursively via core's


### PR DESCRIPTION
## What does this PR do?

Adding a LoRA to an image generation seeded its weight at **1.5** on Krea 2 and **0.8** everywhere else. Both were wrong — a fresh pick should start at a neutral **1.0**.

`loraWeight()` in `apps/web/src/presetUtils.js` is the single fallback every LoRA picker routes through (Simple studio, the advanced `generationStudio`, `LoraPickerField`, the editor rail). It carried one family special case: `krea-2` at 1.5, added under sc-7579 / sc-7932 because Krea 2's distilled, CFG-free Turbo attenuates Raw-trained LoRAs and the generic 0.8 under-expressed on the few-step student. That bump overshot in practice and landed fresh picks over-applied.

Rather than retune it, **the family branch is deleted**. There is now one default, 1.0, and no per-family table. A model that genuinely wants a different starting point should ship `defaultWeight` on its own LoRA manifest entry rather than reintroduce a branch here — both constants carry a comment saying so.

### The API had already diverged

`preset_lora_weight` in `apps/rust-api/src/recipe_presets.rs` never had the krea-2 branch, so it *applied* 0.8 while the studio *displayed* 1.5 — a preset ran at a weight the user never saw, invisible in the gallery attribution. Both sides now share the same value and each comment names the other as its mirror.

### Three hand-rolled duplicates of the same fallback

These would otherwise have kept seeding 0.8 behind the new default:

- **`PresetManagerScreen`** re-implemented the resolver's precedence chain (`defaultWeight ?? weight ?? 0.8`). It now calls `loraWeight(source)`, so it can't drift again; its save-path coercion fallback moves to 1.0 too.
- **Character LoRA links** seeded 0.8 in the form (`characterPanels.jsx`, `CharacterStudio.jsx`) while the DB column has always defaulted to 1.0 (`character_store.rs:783`) — so this also settles a pre-existing form-vs-storage mismatch.
- **Worker last-resort parse** for a spec carrying no weight at all (`image_jobs.rs`, `video_jobs/mod.rs`). The API always stamps a weight, so this only fires on a malformed payload, but it should not disagree with the surfaces.

I swept every remaining `0.8` adjacent to a weight/scale/lora identifier; what's left is test fixtures with explicit values plus ControlNet and InstantID IP-adapter scales, which are unrelated knobs.

## Reviewer notes

**`config/backend-capabilities/matrix.json` is regenerated**, because `crates/sceneworks-worker/src/video_jobs/mod.rs` is one of the sources `include_str!`'d and hashed into it — editing it fails `sceneworks-core`'s `checked_in_matrix_matches_all_authoritative_sources`. The diff is a single line, the `workerVideoDispatch` provenance hash; zero behavioural rows moved. `check:memory-matrix` and `check:tier-integrity` both pass, so it does not cascade to the memory matrix or the calibration cost model.

**Behaviour change worth a second opinion:** every non-krea LoRA now starts at 1.0 instead of 0.8, which shifts the starting point for existing workflows. Explicit weights are untouched — a preset weight, a stored `defaultWeight`, or the LoRA's own `weight` all still win over the default, in that order, on both sides.

Test-side, seven web tests were asserting the old 0.8 default (Simple LoRA slider, the advanced picker slot, the character angle-set/pose payloads, a video preset). They are updated, and their comments corrected to say the value comes from the global default rather than "the LoRA's own default". The web test and a new Rust parity test both pin all three krea spellings and every family-bearing field shape, so a reintroduced family branch fails on both sides.

## Related issue

No tracker item — reported directly.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

Marked as changing existing behaviour: the default starting weight moves for every family. No API or schema shape changed.

## How was this tested?

- [ ] macOS (Apple Silicon / MLX)
- [x] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (web UI, docs, shared crate)

Web (all green):

- `npm --prefix apps/web run test` — 244 files / 3656 tests pass
- `npm --prefix apps/web run lint` — clean
- `npm --prefix apps/web run build` — succeeds (the >500 kB chunk warning is pre-existing)

Rust, per crate:

- `cargo test -p sceneworks-core` 938 pass, `-p sceneworks-worker` 819 pass, `-p sceneworks-mcp` pass, `-p sceneworks-rust-api` 561 pass
- `cargo fmt --all --check` clean
- `cargo clippy --all-targets -- -D warnings` clean on all three touched crates
- `npm run check:rust-derived-docs` passes

The pytest e2e (`tests/test_rust_api_worker_smoke.py:458`) sends an explicit `"weight": 0.8` and asserts it round-trips, so it is unaffected — explicit still wins over the default.

### Pre-existing failures, not caused by this PR

Each confirmed by stashing and re-running on a clean tree:

- `models::download_receipt_tests::ltx_eros_legacy_install_is_cleanup_only_and_reclaimable_off_macos` and `..._mixed_trash_failure_retains_a_retryable_cleanup_tombstone` — Windows `InvalidFilename` (os error 123)
- The `run-ltx-safety-canary` block inside `npm run check` — spawns `/bin/sh` and asserts POSIX file modes, unrunnable on Windows
- `store_util::tests::atomic_write_tolerates_concurrent_writers_to_same_path` failed once under full-suite load and passes in isolation (flake)

### Not run locally

`npm run rust:check` could not complete end-to-end here: its `cargo test` / `cargo build` steps are workspace-wide, and `sceneworks-desktop`'s build script fails in a git worktree without the staged resources hardlinked from the main checkout. I ran fmt, clippy, `check:rust-derived-docs` and the tests for each touched crate individually instead, so the only gap is the desktop crate, which this change does not reach. CI covers it.

## Checklist

- [ ] I ran `npm run rust:check` (if I touched Rust) and it passed — see *Not run locally* above; ran its constituent steps per crate
- [x] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build` (if I touched the web app)
- [x] I ran `npm run check` (scaffold checks) — only the pre-existing Windows-only `run-ltx-safety-canary` failures above
- [x] I updated documentation where relevant — the rationale lives in the two constants' comments
- [x] All my commits are signed off (`git commit -s`)
- [x] My PR is focused on a single logical change
