### PR TITLE
Resolve an installed snapshot by its on-disk name, not as a pinned revision

### DIFF
--- a/apps/rust-api/src/recipe_presets.rs
+++ b/apps/rust-api/src/recipe_presets.rs
@@ -1006,13 +1006,26 @@ pub(crate) fn preset_lora_id(preset_lora: &Value) -> Option<&str> {
         .or_else(|| preset_lora.get("id").and_then(Value::as_str))
 }
 
+/// The apply weight a LoRA starts at when nothing explicit is recorded for it — ONE neutral 1.0
+/// for every family. There is deliberately no per-family table: the sole exception used to be
+/// krea-2 at 1.5 (sc-7579 / sc-7932 — Krea 2's distilled, CFG-free Turbo attenuates Raw-trained
+/// LoRAs), which overshot in practice and landed fresh picks over-applied. A model that genuinely
+/// wants a different starting point should ship `defaultWeight` on its LoRA manifest entry rather
+/// than reintroduce a family branch here.
+///
+/// ⚠️ Mirrors the web `DEFAULT_LORA_WEIGHT` (`apps/web/src/presetUtils.js`) and MUST stay in
+/// lockstep with it: this is the weight a preset actually APPLIES, while the web constant is the
+/// weight the studio SHOWS on the slider. A divergence means a run silently uses a scale the user
+/// never picked.
+pub(crate) const DEFAULT_LORA_WEIGHT: f64 = 1.0;
+
 pub(crate) fn preset_lora_weight(lora: &Value, preset_lora: &Value) -> f64 {
     preset_lora
         .get("weight")
         .and_then(Value::as_f64)
         .or_else(|| lora.get("defaultWeight").and_then(Value::as_f64))
         .or_else(|| lora.get("weight").and_then(Value::as_f64))
-        .unwrap_or(0.8)
+        .unwrap_or(DEFAULT_LORA_WEIGHT)
 }
 
 pub(crate) fn serialize_preset_lora(lora: &Value, preset_lora: &Value, lora_id: &str) -> Value {

--- a/apps/rust-api/src/tests/recipe_presets.rs
+++ b/apps/rust-api/src/tests/recipe_presets.rs
@@ -9,6 +9,50 @@ fn text_to_image_preset_defaults_exclude_retired_style_mode() {
     );
 }
 
+/// Parity guard for the web `loraWeight` fallback (`apps/web/src/presetUtils.js`): the weight a
+/// preset APPLIES must match the weight the studio SHOWS, or a run silently uses a scale the user
+/// never picked. ONE default for every family — krea-2 used to be special-cased and deliberately
+/// no longer is.
+#[test]
+fn preset_lora_weight_defaults_to_one_for_every_family() {
+    use crate::recipe_presets::preset_lora_weight;
+    use serde_json::json;
+
+    let none = json!({});
+
+    for lora in [
+        json!({ "id": "s", "family": "sdxl" }),
+        json!({ "id": "k", "family": "krea_2" }),
+        json!({ "id": "k", "family": "krea-2" }),
+        json!({ "id": "k", "family": "krea2" }),
+        json!({ "id": "w", "families": ["wan-video"] }),
+        json!({ "id": "c", "compatibleFamilies": ["flux"] }),
+        json!({ "id": "c", "compatibility": { "families": ["ltx-video"] } }),
+        json!({ "id": "bare" }),
+    ] {
+        assert_eq!(preset_lora_weight(&lora, &none), 1.0, "{lora}");
+    }
+
+    // An explicit value still wins, in the web's precedence order:
+    // preset weight -> catalog defaultWeight -> the LoRA's own weight.
+    let krea = json!({ "id": "k", "family": "krea_2" });
+    assert_eq!(preset_lora_weight(&krea, &json!({ "weight": 2.0 })), 2.0);
+    assert_eq!(
+        preset_lora_weight(
+            &json!({ "id": "k", "family": "krea_2", "defaultWeight": 1.3 }),
+            &none
+        ),
+        1.3
+    );
+    assert_eq!(
+        preset_lora_weight(
+            &json!({ "id": "s", "family": "sdxl", "weight": 0.7 }),
+            &none
+        ),
+        0.7
+    );
+}
+
 #[tokio::test]
 async fn recipe_preset_crud_routes_persist_global_and_project_presets() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");

--- a/apps/web/src/App.character.test.jsx
+++ b/apps/web/src/App.character.test.jsx
@@ -1166,7 +1166,7 @@ describe("SceneWorks app shell", () => {
       expect.objectContaining({
         mode: "character_image",
         model: "instantid_realvisxl",
-        loras: [expect.objectContaining({ id: "kelsie-lora", weight: 0.8 })],
+        loras: [expect.objectContaining({ id: "kelsie-lora", weight: 1.0 })],
       }),
     );
   });
@@ -1242,7 +1242,7 @@ describe("SceneWorks app shell", () => {
       expect.objectContaining({
         mode: "character_image",
         model: "instantid_realvisxl",
-        loras: [expect.objectContaining({ id: "kelsie-lora", weight: 0.8 })],
+        loras: [expect.objectContaining({ id: "kelsie-lora", weight: 1.0 })],
       }),
     );
   });

--- a/apps/web/src/App.imageGeneration.test.jsx
+++ b/apps/web/src/App.imageGeneration.test.jsx
@@ -2250,7 +2250,7 @@ describe("SceneWorks app shell", () => {
     expect(pickNames).toContain("LTX Style");
     expect(pickNames).not.toContain("Z Glow");
 
-    // Adding a LoRA drops in a slot with its weight slider, defaulting to the LoRA weight (0.8).
+    // Adding a LoRA drops in a slot with its weight slider, defaulting to the global 1.0.
     await act(async () => {
       [...document.body.querySelectorAll(".lora-pick-row")]
         .find((button) => button.textContent.includes("LTX Style"))
@@ -2265,7 +2265,7 @@ describe("SceneWorks app shell", () => {
     // LoRA stuck at the old center of 0 generated at scale 0 and looked "not applied").
     expect(weightSlider.getAttribute("min")).toBe("-2");
     expect(weightSlider.getAttribute("max")).toBe("2");
-    expect(document.body.querySelector(".lora-slot-weight-value").textContent).toBe("0.80");
+    expect(document.body.querySelector(".lora-slot-weight-value").textContent).toBe("1.00");
     await changeField(weightSlider, "0.5");
 
     const generate = [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Render clip");

--- a/apps/web/src/App.videoPresets.test.jsx
+++ b/apps/web/src/App.videoPresets.test.jsx
@@ -290,7 +290,7 @@ describe("SceneWorks app shell", () => {
         // presetLorasResolvedClientSide so the server won't re-merge it.
         prompt: "Camera slowly pushes in while the scene comes alive",
         presetLorasResolvedClientSide: true,
-        loras: [expect.objectContaining({ id: "video_motion", weight: 0.8 })],
+        loras: [expect.objectContaining({ id: "video_motion", weight: 1.0 })],
         advanced: expect.objectContaining({
           resolution: "1280x720",
         }),

--- a/apps/web/src/presetUtils.js
+++ b/apps/web/src/presetUtils.js
@@ -381,17 +381,21 @@ export function presetLoraId(presetLora) {
   return typeof presetLora === "string" ? presetLora : presetLora?.id ?? presetLora?.loraId;
 }
 
-// Krea 2's distilled, CFG-free Turbo attenuates Raw-trained LoRAs (sc-7579 / sc-7932): the generic
-// 0.8 default under-expresses on the few-step student, so a krea-2-family LoRA defaults to a higher
-// apply weight (real-weight-validated coherent through scale 4). This is still a DEFAULT — an explicit
-// preset weight, a stored `defaultWeight`, or the LoRA's own `weight` still wins. Family token is the
-// normalized form (`normalizeLoraFamily`: krea_2 → krea-2).
-const KREA_LORA_DEFAULT_WEIGHT = 1.5;
+// The apply weight a LoRA starts at when nothing explicit is recorded for it — ONE neutral 1.0 for
+// every family. There is deliberately no per-family table: the sole exception used to be krea-2 at
+// 1.5 (sc-7579 / sc-7932 — Krea 2's distilled, CFG-free Turbo attenuates Raw-trained LoRAs), which
+// overshot in practice and landed fresh picks over-applied. A model that genuinely wants a
+// different starting point should ship `defaultWeight` on the LoRA's own manifest entry rather than
+// reintroduce a family branch here.
+//
+// ⚠️ Mirrored by the API's `DEFAULT_LORA_WEIGHT` (apps/rust-api/src/recipe_presets.rs); the two MUST
+// agree or a preset applies at a weight the studio never showed. This is still a DEFAULT — an
+// explicit preset weight, a stored `defaultWeight`, or the LoRA's own `weight` still wins.
+const DEFAULT_LORA_WEIGHT = 1.0;
 
 export function loraWeight(lora, presetLora = {}) {
-  const fallback = loraFamilies(lora).includes("krea-2") ? KREA_LORA_DEFAULT_WEIGHT : 0.8;
-  const value = Number(presetLora.weight ?? lora?.defaultWeight ?? lora?.weight ?? fallback);
-  return Number.isFinite(value) ? value : fallback;
+  const value = Number(presetLora.weight ?? lora?.defaultWeight ?? lora?.weight ?? DEFAULT_LORA_WEIGHT);
+  return Number.isFinite(value) ? value : DEFAULT_LORA_WEIGHT;
 }
 
 // Resolve a preset's declared LoRAs into [{ id, weight }] entries ready to seed into the

--- a/apps/web/src/presetUtils.test.jsx
+++ b/apps/web/src/presetUtils.test.jsx
@@ -353,27 +353,27 @@ describe("finiteNumberOrUndefined", () => {
 });
 
 describe("loraWeight", () => {
-  it("defaults a generic LoRA to 0.8", () => {
-    expect(loraWeight({ id: "sdxl_style", family: "sdxl" })).toBe(0.8);
-    expect(loraWeight(null)).toBe(0.8);
+  it("defaults every LoRA to 1.0 regardless of family", () => {
+    // ONE default, no per-family table — krea-2 used to be special-cased (1.5, then 1.0) and
+    // deliberately no longer is. Covers each family-bearing shape extractFamilies() reads.
+    expect(loraWeight({ id: "sdxl_style", family: "sdxl" })).toBe(1.0);
+    expect(loraWeight({ id: "k", family: "krea_2" })).toBe(1.0);
+    expect(loraWeight({ id: "k", compatibility: { families: ["krea_2"] } })).toBe(1.0);
+    expect(loraWeight({ id: "w", families: ["wan-video"] })).toBe(1.0);
+    expect(loraWeight({ id: "f" })).toBe(1.0);
+    expect(loraWeight(null)).toBe(1.0);
   });
 
-  it("defaults a krea-2-family LoRA higher (1.5) for the distilled-Turbo attenuation (sc-7932)", () => {
-    // The family token is normalized (krea_2 -> krea-2), and the bump applies via any of the
-    // family-bearing shapes extractFamilies() reads.
-    expect(loraWeight({ id: "k", family: "krea_2" })).toBe(1.5);
-    expect(loraWeight({ id: "k", compatibility: { families: ["krea_2"] } })).toBe(1.5);
-  });
-
-  it("lets an explicit weight win over the krea-2 family default", () => {
-    expect(loraWeight({ id: "k", family: "krea_2", defaultWeight: 1.0 })).toBe(1.0);
+  it("lets an explicit weight win over the default", () => {
+    expect(loraWeight({ id: "k", family: "krea_2", defaultWeight: 1.3 })).toBe(1.3);
     expect(loraWeight({ id: "k", family: "krea_2", weight: 0.7 })).toBe(0.7);
     expect(loraWeight({ id: "k", family: "krea_2" }, { weight: 2.0 })).toBe(2.0);
+    expect(loraWeight({ id: "g", family: "sdxl", defaultWeight: 0.6 })).toBe(0.6);
   });
 
-  it("falls back to the family default when an explicit value is non-finite", () => {
-    expect(loraWeight({ id: "k", family: "krea_2", defaultWeight: "nope" })).toBe(1.5);
-    expect(loraWeight({ id: "g", family: "sdxl", defaultWeight: "nope" })).toBe(0.8);
+  it("falls back to the default when an explicit value is non-finite", () => {
+    expect(loraWeight({ id: "k", family: "krea_2", defaultWeight: "nope" })).toBe(1.0);
+    expect(loraWeight({ id: "g", family: "sdxl", defaultWeight: "nope" })).toBe(1.0);
   });
 });
 

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -583,7 +583,7 @@ export function CharacterStudio() {
       name: lora.name ?? lora.id,
       sourcePath: lora.installedPath ?? lora.source?.path ?? null,
       triggerWords: lora.triggerWords ?? [],
-      defaultWeight: lora.defaultWeight ?? 0.8,
+      defaultWeight: lora.defaultWeight ?? 1.0,
       compatibility: { families: extractFamilies(lora) },
       scope: lora.scope ?? "global",
     });

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -10,6 +10,7 @@ import {
   MAX_PRESET_LORAS,
   compactModeList,
   loraMatchesModel,
+  loraWeight,
   presetLoraId,
   presetLoras,
   presetSaveValidation,
@@ -483,7 +484,9 @@ export function PresetManagerScreen() {
         return current;
       }
       const source = loras.find((lora) => lora.id === id);
-      const weight = source?.defaultWeight ?? source?.weight ?? 0.8;
+      // Through the shared resolver, not a hand-rolled copy of its precedence chain: this seeds
+      // the SAME starting weight the studio pickers show, and can't drift from the default again.
+      const weight = loraWeight(source);
       return { ...current, loras: [...current.loras, { id, weight: String(weight) }] };
     });
   }
@@ -588,7 +591,7 @@ export function PresetManagerScreen() {
       defaults,
       loras: form.loras.map((lora) => ({
         id: lora.id,
-        weight: Number.isFinite(Number(lora.weight)) ? Number(lora.weight) : 0.8,
+        weight: Number.isFinite(Number(lora.weight)) ? Number(lora.weight) : 1.0,
       })),
       ui: { description: form.description.trim() },
     };

--- a/apps/web/src/screens/characterPanels.jsx
+++ b/apps/web/src/screens/characterPanels.jsx
@@ -83,7 +83,7 @@ export function editableLora(link) {
   return {
     name: link?.name ?? "",
     triggerWords: (link?.triggerWords ?? []).join(", "),
-    defaultWeight: link?.defaultWeight ?? 0.8,
+    defaultWeight: link?.defaultWeight ?? 1.0,
     families: extractFamilies(link).join(", "),
     scope: link?.scope ?? "project",
   };

--- a/apps/web/src/simple/SimpleLora.test.jsx
+++ b/apps/web/src/simple/SimpleLora.test.jsx
@@ -232,8 +232,8 @@ describe("Simple studios — LoRA field", () => {
       "1 selected · installed and compatible",
     );
     expect(container.querySelector(".su-lora-add-count").textContent).toBe("· 1 available");
-    // Weight defaults to the LoRA's own default (0.8 here, via `loraWeight`).
-    expect(container.querySelector(".su-lora-weight-value").textContent).toBe("0.80");
+    // This LoRA declares no `defaultWeight`, so the slider seeds from the global 1.0 (`loraWeight`).
+    expect(container.querySelector(".su-lora-weight-value").textContent).toBe("1.00");
   });
 
   it("seeds the slider from the LoRA's declared defaultWeight", async () => {
@@ -260,7 +260,7 @@ describe("Simple studios — LoRA field", () => {
     expect(slotNames(container)).toEqual([]);
     // Re-adding starts from the LoRA's own default again, not the override we just cleared.
     await addLora(container, "Cinematic Grain 35mm");
-    expect(container.querySelector(".su-lora-weight-value").textContent).toBe("0.80");
+    expect(container.querySelector(".su-lora-weight-value").textContent).toBe("1.00");
   });
 
   it("appends a trigger keyword to the prompt when its chip is clicked", async () => {
@@ -378,7 +378,7 @@ describe("Simple studios — LoRA field", () => {
     await addLora(container, "Slow Dolly");
     await click(container.querySelector(".su-generate"));
     const request = context.createVideoJob.mock.calls[0][0];
-    expect(request.loras).toEqual([expect.objectContaining({ id: "lora_wan", weight: 0.8 })]);
+    expect(request.loras).toEqual([expect.objectContaining({ id: "lora_wan", weight: 1.0 })]);
   });
 });
 

--- a/config/backend-capabilities/matrix.json
+++ b/config/backend-capabilities/matrix.json
@@ -59,7 +59,7 @@
     "workerUtilityDispatch": "017142f8ac644fa2d275e35b94827af4f60644340956dfb84576d7e940737f0d",
     "workerVideoBernini": "352991ae26c8d842c9af1c37e9c6d3261ae6554debe5089744ef8e7972fd15ed",
     "workerVideoCandle": "4527f7c7f42bac9d65daa2004f993657391ec3cdc872bac0bc9e2c012c93e949",
-    "workerVideoDispatch": "f29a1c62603f4556397c5fddb6672be445e458520784bc849215d2e951ce86bd",
+    "workerVideoDispatch": "fbc7954bfc17e5ab77f66a0659e2895bdfff7db9eaf41249441e446550a8faa3",
     "workerVideoKreaRealtime": "590b65273e5d87c350feec0f677ee05295aa05835cac12348e2f5520fc1724e7",
     "workerVideoLtx": "35c4f69f9bb82aeb065dbcbab5ebc1386dc4d8b061c5567c8656e1d7257c7030",
     "workerVideoMochi": "5a0868693b1cbf1c08a6acfc5151c3e3542d812b7cec6f73bfa53d701883dcbc",

--- a/crates/sceneworks-core/src/model_artifacts.rs
+++ b/crates/sceneworks-core/src/model_artifacts.rs
@@ -930,6 +930,51 @@ impl ArtifactSourceLibrary {
         ))
     }
 
+    /// Resolve an installed snapshot **directory** by the name it already carries on disk.
+    ///
+    /// This is discovery over the local library, not admission of caller input, and the two have
+    /// different contracts. [`Self::discover_snapshot`] mints a pinned [`ArtifactIdentity`], so it
+    /// must reject a mutable revision — a payload that asks for `main` may not be answered with
+    /// whatever `main` happens to mean today. A name read out of `refs/*` or a `snapshots/`
+    /// directory entry is not such a request: it is a fact about what is installed, and the
+    /// caller wants the path, not an identity.
+    ///
+    /// Demanding an immutable name here would make a real, fully materialized install
+    /// **invisible**: [`crate::hf_home`]'s downloader names the snapshot `snapshots/<revision>`
+    /// whenever the endpoint omits `X-Repo-Commit` (`downloads.rs`, the mirror/proxy case), so
+    /// such a repository would silently read as not-installed on every lane.
+    ///
+    /// Confinement is still enforced — the name must be exactly one normal path component, the
+    /// property `safe_join` provided before this seam existed. An immutable name is delegated to
+    /// [`Self::discover_snapshot`] unchanged, so the leased local-tier redirect (sc-19707) keeps
+    /// serving every snapshot that can actually be covered by a bundle; bundles are keyed on a
+    /// pinned identity, so a mutable name has none to match by construction.
+    pub fn discover_installed_snapshot_path(
+        &self,
+        repository: &str,
+        revision: &str,
+    ) -> Result<PathBuf, ArtifactContractError> {
+        if validate_immutable_revision(revision).is_ok() {
+            return self
+                .discover_snapshot(repository, Some(revision))
+                .map(|(_, path)| path);
+        }
+        let repo_root = self.repository_root(repository)?;
+        validate_relative_path(Path::new(revision), "artifact source snapshot name")?;
+        if Path::new(revision).components().count() != 1 {
+            return Err(ArtifactContractError(format!(
+                "artifact source snapshot name {revision:?} is not a single confined component"
+            )));
+        }
+        let snapshot = repo_root.join("snapshots").join(revision);
+        if !snapshot.is_dir() {
+            return Err(ArtifactContractError(format!(
+                "source snapshot {repository}@{revision} is not installed"
+            )));
+        }
+        Ok(snapshot)
+    }
+
     pub fn discover_snapshot_reference(
         &self,
         repository: &str,
@@ -1740,6 +1785,72 @@ mod tests {
         assert_eq!(snapshot, repo.join("snapshots").join(REV));
         assert!(library
             .discover_snapshot("SceneWorks/model", Some("main"))
+            .is_err());
+    }
+
+    /// Discovery over the local library resolves an installed snapshot by the name it carries ON
+    /// DISK, including a mutable one — the identity-minting entry point above must keep rejecting
+    /// that same name as a *request*.
+    ///
+    /// The two contracts got conflated when snapshot discovery was routed through the typed seam,
+    /// which made every snapshot directory not named by a 40-hex commit resolve to nothing. The
+    /// downloader materializes `snapshots/<revision>` whenever the endpoint omits `X-Repo-Commit`,
+    /// so that silently un-installed a genuinely complete model.
+    #[test]
+    fn installed_snapshot_discovery_accepts_a_mutable_on_disk_name() {
+        let root = tempfile::tempdir().unwrap();
+        let library = ArtifactSourceLibrary::new(root.path()).unwrap();
+        let repo = library.repository_root("SceneWorks/model").unwrap();
+        let mutable = repo.join("snapshots").join("main");
+        std::fs::create_dir_all(&mutable).unwrap();
+        std::fs::write(mutable.join("model.safetensors"), b"model").unwrap();
+
+        assert_eq!(
+            library
+                .discover_installed_snapshot_path("SceneWorks/model", "main")
+                .unwrap(),
+            mutable,
+        );
+        // …while the same name as a caller-supplied revision stays rejected: this widens discovery,
+        // not admission.
+        assert!(library
+            .discover_snapshot("SceneWorks/model", Some("main"))
+            .is_err());
+
+        // Not only ref-shaped names: the seeded turnkey fixtures the candle image lanes resolve
+        // against are named `installed` / `installed-revision`, and they are what the narrowing
+        // actually un-installed.
+        let seeded = repo.join("snapshots").join("installed-revision");
+        std::fs::create_dir_all(seeded.join("q4")).unwrap();
+        assert_eq!(
+            library
+                .discover_installed_snapshot_path("SceneWorks/model", "installed-revision")
+                .unwrap(),
+            seeded,
+        );
+
+        // An immutable name still goes through the identity-minting path.
+        let pinned = repo.join("snapshots").join(REV);
+        std::fs::create_dir_all(&pinned).unwrap();
+        assert_eq!(
+            library
+                .discover_installed_snapshot_path("SceneWorks/model", REV)
+                .unwrap(),
+            pinned,
+        );
+
+        // Confinement survives: a traversing or multi-component name is refused rather than joined,
+        // and an uninstalled name resolves to nothing.
+        for name in ["..", "../escape", "a/b", "sub/main"] {
+            assert!(
+                library
+                    .discover_installed_snapshot_path("SceneWorks/model", name)
+                    .is_err(),
+                "{name:?} must not resolve to a snapshot directory"
+            );
+        }
+        assert!(library
+            .discover_installed_snapshot_path("SceneWorks/model", "absent")
             .is_err());
     }
 

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1667,7 +1667,10 @@ fn lora_weight(lora: &Value) -> f64 {
                 .as_f64()
                 .or_else(|| value.as_str()?.trim().parse().ok())
         })
-        .unwrap_or(0.8)
+        // Last resort only — the API always stamps a weight onto the spec. Matches the API/web
+        // default (`DEFAULT_LORA_WEIGHT`) so a weightless payload can't apply at a scale no
+        // surface would have shown.
+        .unwrap_or(1.0)
 }
 
 #[cfg(any(

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -3460,10 +3460,15 @@ fn resolve_huggingface_snapshot_dir(data_dir: &Path, repo: &str) -> Option<PathB
         let revision = rev.trim();
         let candidate = snapshots.join(revision);
         if snapshot_has_any_file(&candidate) {
+            // The name is read off disk, so it is resolved as an installed snapshot rather than
+            // admitted as a caller-supplied revision: an install materialized under a mutable name
+            // (the endpoint omitted `X-Repo-Commit`) is still installed. Demanding an immutable
+            // name here returned `None` for it — and, because this arm returns, without even
+            // trying the fallback scan below.
             return resolver
-                .discover_source_snapshot(repo, Some(revision))
-                .ok()
-                .map(|(_, path)| path);
+                .source_library()
+                .discover_installed_snapshot_path(repo, revision)
+                .ok();
         }
     }
     // Fallback: the cached snapshot with the most files, so an empty/partial one never wins over a
@@ -3481,9 +3486,9 @@ fn resolve_huggingface_snapshot_dir(data_dir: &Path, repo: &str) -> Option<PathB
         .and_then(|(_, path)| {
             let revision = path.file_name()?.to_str()?;
             resolver
-                .discover_source_snapshot(repo, Some(revision))
+                .source_library()
+                .discover_installed_snapshot_path(repo, revision)
                 .ok()
-                .map(|(_, path)| path)
         });
     if from_source_library.is_some() {
         return from_source_library;
@@ -6062,6 +6067,55 @@ mod co_requisite_tests {
             resolve_huggingface_snapshot_dir(data_dir.path(), repo).expect("still resolves"),
             populated,
             "a populated refs/main must resolve to exactly that snapshot"
+        );
+    }
+
+    /// A snapshot directory whose name is not a 40-hex commit is still an installed snapshot.
+    ///
+    /// Routing discovery through the typed artifact seam (sc-19704) started admitting the on-disk
+    /// directory name as if it were a caller-supplied revision, so `ArtifactSourceLibrary`'s
+    /// immutability rule applied to it and every such snapshot resolved to `None` — the model read
+    /// as not installed, silently, on every lane. This is reachable in production:
+    /// `downloads::download_snapshot_into_cache` falls back to
+    /// `commit.unwrap_or_else(|| revision.to_owned())`, so an endpoint that omits `X-Repo-Commit`
+    /// materializes a complete install under `snapshots/main`.
+    ///
+    /// Both arms are asserted because the `refs/main` arm *returns*: when it rejected the name it
+    /// did not fall through to the scan, so a repository with a valid `refs/main` resolved to
+    /// nothing even though the populated snapshot was sitting right there.
+    #[test]
+    fn snapshot_resolution_accepts_a_snapshot_named_by_a_mutable_revision() {
+        let _env = isolate_hf_cache();
+        let data_dir = tempfile::tempdir().expect("temp data dir");
+        let repo = "SceneWorks/krea-2-raw-mlx";
+        let repo_dir =
+            huggingface_repo_cache_path(data_dir.path(), repo).expect("repo cache path resolves");
+        let snapshot = repo_dir.join("snapshots").join("main");
+        std::fs::create_dir_all(snapshot.join("q8/transformer")).expect("snapshot tree");
+        std::fs::write(
+            snapshot.join("q8/transformer/diffusion_pytorch_model.safetensors"),
+            b"real",
+        )
+        .expect("write weight");
+
+        // The scan arm: no `refs/main` at all, exactly like the seeded turnkey fixtures the candle
+        // image lanes resolve against.
+        assert_eq!(
+            resolve_huggingface_snapshot_dir(data_dir.path(), repo)
+                .expect("a populated snapshot exists, so resolution must succeed"),
+            snapshot,
+            "a snapshot directory named by a mutable revision is still installed"
+        );
+
+        // The `refs/main` fast-path arm, which is what a real mirror-endpoint install looks like:
+        // the pointer and the snapshot directory both carry the mutable name.
+        std::fs::create_dir_all(repo_dir.join("refs")).expect("create refs");
+        std::fs::write(repo_dir.join("refs").join("main"), "main").expect("write refs/main");
+        assert_eq!(
+            resolve_huggingface_snapshot_dir(data_dir.path(), repo)
+                .expect("refs/main names a populated snapshot, so resolution must succeed"),
+            snapshot,
+            "a refs/main naming a populated mutable snapshot must resolve to exactly that snapshot"
         );
     }
 

--- a/crates/sceneworks-worker/src/video_jobs/mod.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mod.rs
@@ -1962,7 +1962,8 @@ fn lora_scale(lora: &Value) -> f32 {
                 .as_f64()
                 .or_else(|| value.as_str()?.trim().parse().ok())
         })
-        .unwrap_or(0.8) as f32
+        // Last resort only — see `image_jobs::lora_weight`; matches the API/web default.
+        .unwrap_or(1.0) as f32
 }
 
 /// Resolve a LoRA spec's file (a directory → its first `.safetensors`, recursively via core's


### PR DESCRIPTION
Fixes the only red lane on the epic's feature→main PR #2415: `candle-worker`
(run 32136737141) — 1528 passed, 4 failed, all in `image_jobs::tests`:

- `flux2_edit_candle_base_resolves_the_packed_turnkey_tier`
- `krea_convrot_pose_route_is_claimed_by_the_immutable_dit_identity`
- `sensenova_q8_floor_keeps_the_capability_downtier_off_q4`
- `sensenova_weights_resolution_takes_the_standard_tier_descent`

## Root cause

Not Windows path semantics. The break is platform-independent, in the shared
resolution seam.

`crates/sceneworks-worker/src/model_jobs.rs:3448` `resolve_huggingface_snapshot_dir`
was routed through the typed artifact seam by sc-19704 (`50ff3b514`). Both of its
discovery arms began calling `discover_source_snapshot(repo, Some(revision))` —
an entry point that **admits its argument as a caller-supplied request** and
therefore runs `validate_immutable_revision`, demanding a lowercase 40-hex commit
(`crates/sceneworks-core/src/model_artifacts.rs:912`).

The name it now receives is not a request. It is read off disk: out of
`refs/main`, or out of a `snapshots/` directory entry. So **any snapshot
directory whose name is not a commit hash resolved to `None`** — the model read
as not installed, with no error raised.

All four tests seed their turnkey under `snapshots/installed` or
`snapshots/installed-revision` and funnel through the same one function
(`resolve_weights_dir` → `huggingface_snapshot_dir`; `resolve_tier_dir` and
`resolve_krea_convrot_dit` likewise). That is why the failures span
sensenova/flux2/krea and why `left: None`.

**This is a production defect, not only a fixture mismatch.**
`downloads::download_snapshot_into_cache` (`downloads.rs:1050`) sets
`let commit = commit.unwrap_or_else(|| revision.to_owned());`, so an endpoint
that omits `X-Repo-Commit` (mirror/proxy) materializes a genuinely complete
install under `snapshots/main` — which this narrowing silently un-installs on
every platform. The `refs/main` arm compounded it by *returning* on rejection,
so such a repository never even reached the fallback scan.

The narrowing was never a stated requirement. sc-19704's acceptance criteria say
"**preserve exact** pinned-revision behavior … and path-confinement rules", and
its mutable-revision criterion is about a mutable revision not *bypassing the
contract* — i.e. admission, which this PR leaves untouched.

## Why the lane had never caught it

The four tests are `#[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]`.
No macOS run compiles them, and `windows-candle` triggers only on PRs targeting
`main` — so the epic's story PRs (which target the feature branch) never ran
them. The epic's own story briefs did not run `npm run rust:check:candle`
either, though note that script **typechecks and cannot execute** candle tests,
so even running it would have said nothing here.

## The fix

`ArtifactSourceLibrary::discover_installed_snapshot_path` separates the two
contracts the seam had conflated — discovery of what is installed, versus
admission of what a caller asked for:

- an **immutable** name delegates to `discover_snapshot` unchanged, so the
  pinned identity and the sc-19707 leased local-tier redirect still apply
  (bundles are keyed on a pinned identity, so a mutable name has none to match
  by construction);
- a **mutable** name is confined to exactly one normal path component — the
  property `safe_join` provided before this seam existed — and resolves to the
  path only.

`huggingface_pinned_snapshot_dir`, which takes a payload-supplied revision over
the LAN jobs API, is **untouched** and still rejects a mutable one. No
model-name branches; the change is entirely in the shared seam.

## Verification

Local, on macOS:

- `npm run rust:check` → exit **0** (core 1083 passed / 2 ignored; worker 1600
  passed / 210 ignored; fmt + clippy `-D warnings` + build).
- `npm run rust:check:candle` → exit **0** — "the candle cfg typechecks, incl.
  test targets, under -D warnings".
- New all-platform regression tests, both **mutation-checked individually**:
  - `model_artifacts::tests::installed_snapshot_discovery_accepts_a_mutable_on_disk_name`
  - `model_jobs::co_requisite_tests::snapshot_resolution_accepts_a_snapshot_named_by_a_mutable_revision`
  - Mutation A (helper forced strict) → both red. Mutation B (`refs/main` arm
    reverted) → red at the `refs/main` assertion only. Mutation C (scan arm
    reverted) → red at the scan assertion only. Restored + `touch`ed, then
    re-verified green.

**Pending Windows.** I cannot run the four candle tests locally — they are
`not(target_os = "macos")`-gated, and `rust:check:candle` typechecks without
linking or executing. The claim that they now pass is **reasoned, not observed**:
all four reach `None` through this one function, and the new worker test
exercises exactly that function with a non-hex snapshot name on macOS (the
approach `check-candle-build.mjs` itself recommends). The authoritative check is
re-running `candle-worker` on #2415 after this merges.

## Absorbs `origin/main`

This branch also merges `origin/main` (`feca4476b`, PR #2416 + `4c68bd9ab`
"fix(web,api): default a new LoRA to 1.0 for every family"), which the epic
feature branch was 2 commits behind. Merging this PR therefore makes the feature
branch transitively current with `main` and clears the BEHIND state on #2415.

The merge was clean, and clean proves nothing, so the incoming Rust surface was
enumerated rather than assumed: `apps/rust-api/src/recipe_presets.rs`
(`DEFAULT_LORA_WEIGHT`), `crates/sceneworks-worker/src/image_jobs.rs`
(`lora_weight`) and `crates/sceneworks-worker/src/video_jobs/mod.rs`
(`lora_scale`) — all three are LoRA default-weight constants, sharing no symbol
with the snapshot-resolution seam this PR touches. Both gates were then re-run
on the **merged** result: `npm run rust:check` exit 0 (core 1083 passed / 2
ignored, worker 1600 passed / 210 ignored) and `npm run rust:check:candle`
exit 0.
