### PR TITLE
sync(sc-18304): merge main (CUDA context lease around cold-load snapshots)

### DIFF
--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -76,6 +76,53 @@ fn capture_backend_committed_bytes() -> WorkerResult<u64> {
 
 static GENERATOR_WORKER: OnceLock<mpsc::Sender<GeneratorJob>> = OnceLock::new();
 
+/// A CUDA primary-context lease held for the span of one cold load.
+///
+/// `mem_get_info` is a bare `cuMemGetInfo_v2`: it reports the CURRENT context's device and fails
+/// with `CUDA_ERROR_INVALID_CONTEXT` when the calling thread has no context bound. The generator
+/// cache runs on a dedicated OS thread that binds one only as a side effect of building the candle
+/// device — which happens INSIDE the load, after the pre-load snapshot. So the snapshot has to
+/// establish the context itself, and must hold the lease across the load: the primary context is
+/// refcounted, and dropping the last reference destroys it out from under the thread that still has
+/// it current (a later `mem_get_info` then fails with `CUDA_ERROR_CONTEXT_IS_DESTROYED`).
+///
+/// Holding it only for the load keeps eviction reclaim intact — the generator's own reference is the
+/// last one, so dropping the cached generator still tears the context down.
+///
+/// Device 0 is this worker's GPU: the `auto` supervisor spawns each per-GPU child with
+/// `CUDA_VISIBLE_DEVICES=<its gpu id>`, which is the same assumption
+/// `runtime_cuda::media::default_device()` makes when the load builds its device.
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle", not(test)))]
+type BackendLoadContext =
+    std::sync::Arc<runtime_cuda::media::candle_core::cuda::cudarc::driver::CudaContext>;
+
+#[cfg(all(not(target_os = "macos"), feature = "backend-candle", not(test)))]
+fn bind_backend_load_context() -> WorkerResult<BackendLoadContext> {
+    let context = runtime_cuda::media::candle_core::cuda::cudarc::driver::CudaContext::new(0)
+        .map_err(|error| {
+            crate::WorkerError::Engine(format!(
+                "CUDA context for the generator load failed: {error}"
+            ))
+        })?;
+    context.bind_to_thread().map_err(|error| {
+        crate::WorkerError::Engine(format!(
+            "binding the CUDA context to the generator cache thread failed: {error}"
+        ))
+    })?;
+    Ok(context)
+}
+
+// The MLX, non-candle, and unit-seam builds take no lease: Metal needs no per-thread context and
+// the seams create no device at all. Still a guard value rather than `()`, so the call sites read
+// the same on every platform.
+#[cfg(any(target_os = "macos", not(feature = "backend-candle"), test))]
+struct BackendLoadContext;
+
+#[cfg(any(target_os = "macos", not(feature = "backend-candle"), test))]
+fn bind_backend_load_context() -> WorkerResult<BackendLoadContext> {
+    Ok(BackendLoadContext)
+}
+
 const fn provider_resident_delta(
     pre_load_committed_bytes: u64,
     post_load_committed_bytes: u64,
@@ -750,6 +797,9 @@ where
     let load = move || {
         let spec = crate::mlx_fit_gate::apply_residency_policy(spec, engine_id)?;
         let load_policy = spec.offload_policy;
+        // Held across the load so the two snapshots share one live primary context (see
+        // `bind_backend_load_context`).
+        let _backend_context = bind_backend_load_context()?;
         let external_committed_bytes = capture_backend_committed_bytes()?;
         let generator = load_generator(engine_id, &spec)
             .map_err(|error| crate::classify_engine_error(&load_error_context, error))?;
@@ -822,6 +872,9 @@ where
     let load = move || {
         let spec = crate::mlx_fit_gate::apply_residency_policy(spec, engine_id)?;
         let load_policy = spec.offload_policy;
+        // Held across the load so the two snapshots share one live primary context (see
+        // `bind_backend_load_context`).
+        let _backend_context = bind_backend_load_context()?;
         let external_committed_bytes = capture_backend_committed_bytes()?;
         let generator = load_generator(engine_id, &spec)
             .map_err(|error| crate::classify_engine_error(&load_error_context, error))?;
@@ -896,6 +949,9 @@ where
             // cached generator has been evicted, then retain this exact load's committed delta for
             // admission. Passing zero here would make a Candle contract double-charge its already
             // resident weights and would not be a truthful same-snapshot budget.
+            // Held across the load so the two snapshots share one live primary context (see
+            // `bind_backend_load_context`).
+            let _backend_context = bind_backend_load_context()?;
             let external_committed_bytes = capture_backend_committed_bytes()?;
             let generator = load()?;
             let post_load_committed_bytes = capture_backend_committed_bytes()?;

--- a/crates/sceneworks-worker/src/generator_cache_context_gpu_smoke.rs
+++ b/crates/sceneworks-worker/src/generator_cache_context_gpu_smoke.rs
@@ -1,0 +1,69 @@
+//! Hardware-gated evidence for the CUDA primary-context lease the generator cache's cold load takes
+//! (`crate::generator_cache::bind_backend_load_context`). `#[ignore]`d — run by hand on a real CUDA
+//! box.
+//!
+//! The cold load brackets `crate::inference_runtime::load` with two `mem_get_info` snapshots to
+//! attribute the load's committed bytes. `mem_get_info` is a bare `cuMemGetInfo_v2`: it reports the
+//! CURRENT context's device, and the generator cache runs on a dedicated OS thread that binds a
+//! context only as a side effect of building the candle device — INSIDE the load, after the pre-load
+//! snapshot. Shipping that snapshot without a lease broke every candle image and video generation
+//! with `CUDA_ERROR_INVALID_CONTEXT` before the load was ever attempted.
+//!
+//! No unit test can see this: the seams stub `capture_backend_committed_bytes` and
+//! `bind_backend_load_context` to constants precisely because they create no CUDA context. So this
+//! pins the DRIVER behaviour the helper encodes, against the same cudarc the load uses.
+//!
+//! ```text
+//! cargo test -p sceneworks-worker --features backend-candle --lib \
+//!   generator_cache_context -- --ignored --nocapture
+//! ```
+
+use runtime_cuda::media::candle_core::cuda::cudarc::driver::{result, CudaContext};
+
+/// A thread that has never bound a context cannot take a VRAM snapshot; one that holds the lease
+/// can; and the lease must outlive the snapshots, because releasing the last reference destroys the
+/// primary context out from under the thread that still has it current.
+#[test]
+#[ignore = "needs a real CUDA device"]
+fn the_cold_load_lease_is_what_makes_a_vram_snapshot_readable() {
+    // The load path calls `cuInit` (via the candle device); the preflight already did so process-wide
+    // in production. Establish the same starting state: driver up, no context current on this thread.
+    result::init().expect("cuInit must succeed on a CUDA box");
+
+    std::thread::Builder::new()
+        .name("generator-cache-context-smoke".to_owned())
+        .spawn(|| {
+            let unbound = result::mem_get_info().expect_err(
+                "a thread with no bound context must NOT be able to read device memory — if this \
+                 ever starts succeeding, the lease is no longer load-bearing and this smoke is stale",
+            );
+            println!("[unbound] {unbound:?}");
+            assert!(
+                format!("{unbound:?}").contains("CUDA_ERROR_INVALID_CONTEXT"),
+                "the unbound read must fail as an invalid context, got: {unbound:?}"
+            );
+
+            let context = CudaContext::new(0).expect("retain the primary context for device 0");
+            context.bind_to_thread().expect("bind it to this thread");
+            let (free, total) = result::mem_get_info()
+                .expect("with the lease held the pre-load snapshot must read the device");
+            println!("[leased] free={free} total={total}");
+            assert!(total > 0 && free <= total, "the snapshot must be coherent");
+
+            // Why the lease spans the whole load rather than each snapshot: the primary context is
+            // refcounted, and dropping the last reference destroys it while this thread still has it
+            // current. Taking and releasing it per snapshot would leave the post-load read reading a
+            // corpse.
+            drop(context);
+            let destroyed = result::mem_get_info()
+                .expect_err("releasing the last reference must destroy the context");
+            println!("[released] {destroyed:?}");
+            assert!(
+                format!("{destroyed:?}").contains("CUDA_ERROR_CONTEXT_IS_DESTROYED"),
+                "a released primary context must surface as destroyed, got: {destroyed:?}"
+            );
+        })
+        .expect("spawn the smoke thread")
+        .join()
+        .expect("the smoke thread must not panic");
+}

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -379,6 +379,13 @@ mod ltx_eros_gpu_smoke;
 // hardware evidence backing `macOnly: false` / `candle_routed = true`.
 #[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
 mod sana_candle_gpu_smoke;
+// Hardware-gated evidence for the CUDA primary-context lease the generator cache takes around a
+// cold load. Test-only + candle-only; proves an unbound thread cannot read device memory at all,
+// that the lease makes the pre-load snapshot readable, and that releasing it destroys the context —
+// the three facts `generator_cache::bind_backend_load_context` is built on, none of which a unit
+// seam can see (the seams stub both helpers away).
+#[cfg(all(test, not(target_os = "macos"), feature = "backend-candle"))]
+mod generator_cache_context_gpu_smoke;
 // Hardware-gated evidence that a FAILED `cuda_preflight` does not poison the process (sc-16260 AC 4).
 // Test-only + candle-only; hides the devices with `CUDA_VISIBLE_DEVICES=-1`, probes (must fail),
 // restores visibility and probes again in the SAME process — the exact move `recheck_gpu_health`


### PR DESCRIPTION
Two commits from main (#2419): a CUDA context leased around the cold-load VRAM snapshots, composed with the epic's loaded-policy line in both cold loaders. Direct push to the feature branch is blocked by the sc-18418 ruleset, hence this PR. Worker generator_cache tests green; both Rust lanes typecheck; fmt clean.

Unblocks #2418 (final integration), which is CONFLICTING until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)