### PR TITLE
fix(worker): grammatical uncataloged VRAM-reject message (sc-20531)

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base_admission.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base_admission.rs
@@ -118,7 +118,8 @@ fn reject_message(
     let evidence = if catalog_evidence {
         "the per-tier catalog peak (including headroom)"
     } else {
-        "at least the uncataloged load's on-disk weights plus headroom; activations are not measured"
+        "a floor from the uncataloged load's on-disk weights plus headroom (activations are not \
+         measured)"
     };
     WorkerError::InvalidPayload(format!(
         "{model}{tier} cannot run through the {lane} lane: {evidence} needs ~{} GB of VRAM, but GPU \
@@ -563,6 +564,29 @@ mod tests {
             crate::vram_gate::load_plan(Some(12.0), None, Some(stale_historical), false),
             LoadPlan::Resident,
             "precondition: the stale global high-water would have over-admitted"
+        );
+    }
+
+    #[test]
+    fn cataloged_reject_message_is_the_full_grammatical_sentence() {
+        let error = reject_message("bernini_image", "candle", Some("q4"), 84.0, 77.0, "0", true);
+        assert_eq!(
+            error.to_string(),
+            "bernini_image at the q4 tier cannot run through the candle lane: the per-tier catalog \
+             peak (including headroom) needs ~84 GB of VRAM, but GPU 0 has ~77 GB available. Select \
+             a smaller checkpoint/tier or use a GPU with more VRAM."
+        );
+    }
+
+    #[test]
+    fn uncataloged_reject_message_is_the_full_grammatical_sentence() {
+        let error = reject_message("bernini_image", "candle", None, 84.0, 77.0, "0", false);
+        assert_eq!(
+            error.to_string(),
+            "bernini_image cannot run through the candle lane: a floor from the uncataloged load's \
+             on-disk weights plus headroom (activations are not measured) needs ~84 GB of VRAM, but \
+             GPU 0 has ~77 GB available. Select a smaller checkpoint/tier or use a GPU with more \
+             VRAM."
         );
     }
 


### PR DESCRIPTION
## Summary

`bernini_image` was correctly rejected for VRAM, but the assembled message read as a run-on ("...at least the uncataloged load's on-disk weights plus headroom; activations are not measured needs ~84 GB of VRAM..."). `reject_message` (`crates/sceneworks-worker/src/image_jobs/base_admission.rs:108`) interpolates an `evidence` fragment into a slot expecting a noun phrase. The cataloged branch already supplies a noun phrase; the uncataloged branch supplied a full sentence with an embedded semicolon.

Fix: the uncataloged evidence fragment is now a noun phrase — `"a floor from the uncataloged load's on-disk weights plus headroom (activations are not measured)"` — so the assembled sentence reads grammatically:

> `bernini_image cannot run through the candle lane: a floor from the uncataloged load's on-disk weights plus headroom (activations are not measured) needs ~84 GB of VRAM, but GPU 0 has ~77 GB available. Select a smaller checkpoint/tier or use a GPU with more VRAM.`

The cataloged branch's message text is byte-for-byte unchanged. Message text only — the admission/rejection logic does not move.

## AC mapping

1. Uncataloged branch reads as grammatical English — done (noun-phrase evidence fragment, no embedded sentence/semicolon).
2. Caveat survives — done: "a floor from ... on-disk weights plus headroom" + "(activations are not measured)" both present, parenthetical instead of a semicolon-joined clause.
3. Cataloged branch unchanged — done: only the `else` arm of the `catalog_evidence` conditional changed; the `if` arm and the format string are untouched.
4. Full-string assertion test for both branches — done: `cataloged_reject_message_is_the_full_grammatical_sentence` and `uncataloged_reject_message_is_the_full_grammatical_sentence` in `base_admission.rs` assert the complete `WorkerError::InvalidPayload` display string for both `catalog_evidence` values.

Out of scope (per story): whether `bernini_image` would fit on a cold, idle GPU — not addressed here.

## Test plan

- [x] `cargo test -p sceneworks-worker --lib --features backend-candle base_admission` — 9/9 pass (PowerShell, MSVC 14.44 vcvars, `HF_HOME` unset)
- [x] `cargo clippy -p sceneworks-worker --lib --all-targets -- -D warnings` and with `--features backend-candle` — clean
- [x] `cargo fmt -p sceneworks-worker -- --check` — clean
- [x] `npm run check` (Git Bash) — 593 pass / 41 pre-existing failures, all in `memory-calibration-watchdog.test.mjs` and `run-ltx-safety-canary.test.mjs` (POSIX `/bin/ps`/`/bin/sh` unavailable on this Windows box), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)