### PR TITLE
fix(sc-20572): SubmissionsIgnored is a poisoned queue, not an OOM, and no reset clears it

### DIFF
--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -632,6 +632,13 @@ async fn spawn_inprocess_utility_worker(
                 count,
                 "SceneWorks utility worker running in-process (loopback)"
             );
+            // sc-20572 review: these in-process loops share the same `gpu_poison::global()` latch
+            // as the standalone worker's `run_worker_loop`. If it ever latched here, each loop
+            // would read it as an `Ok(())` exit meant for an external process supervisor to
+            // restart — but there is no such supervisor for a tokio task in this process, so the
+            // loop would simply stop claiming jobs forever. Unreachable today: this API process
+            // runs no MLX cache jobs, so nothing here can ever record a `SubmissionsIgnored`
+            // poisoning in the first place. Left as a comment, not code, for that reason.
             tokio::spawn(async move { sceneworks_worker::run_worker_loop(settings).await })
         })
         .collect();

--- a/crates/sceneworks-worker/src/cache_thread.rs
+++ b/crates/sceneworks-worker/src/cache_thread.rs
@@ -32,6 +32,7 @@ use std::time::{Duration, SystemTime};
 
 use tokio::sync::oneshot;
 
+use crate::gpu_poison::{self, ContainedPanic, GpuPoisonState};
 use crate::{WorkerError, WorkerResult};
 
 /// A unit of work handed to a cache worker thread: a boxed closure that runs against the resident
@@ -359,6 +360,63 @@ pub(crate) struct SeamMessages {
     pub worker_dropped: &'static str,
 }
 
+/// Refuse a job outright when the GPU driver is already ignoring this process's submissions
+/// (sc-20572). `None` in the normal case, so this costs one uncontended mutex read per job.
+///
+/// This is the half that stops the burn. Once a poisoning is latched every queued job would hand
+/// the driver another command buffer it has already decided to ignore — which is exactly what
+/// produced ~8 identical failures over 2.5 minutes before libc++abi `abort()`ed the worker. The
+/// refusal happens before `load`/`run` are even entered, so no further Metal work is submitted
+/// while the worker winds down for its restart.
+fn refuse_if_poisoned(poison: &GpuPoisonState) -> Option<WorkerError> {
+    poison.refusal_message().map(WorkerError::Engine)
+}
+
+/// Turn a contained panic into the error this job reports, and decide what happens to the resident
+/// model (sc-20572).
+///
+/// Two distinct outcomes:
+///
+/// * **Ignored submissions** (`kIOGPUCommandBufferCallbackErrorSubmissionsIgnored`) — the resident
+///   model is deliberately LEFT IN PLACE and no backend cache release is attempted. Evicting is not
+///   a recovery for a poisoned command queue (it was measured reporting a successful reset before
+///   each of the identical failures that followed), and both the drop and the release would submit
+///   more Metal work into a channel the driver is refusing. The error text names the cascade, the
+///   scope and this process's first failure instead of guessing at memory.
+/// * **Anything else** — the pre-existing containment, unchanged: evict the resident (post-abort
+///   backend state really is suspect for an ordinary engine panic), release the backend cache, and
+///   report with the lane's own `panic_reset` prefix. The out-of-memory guess in that prefix is
+///   right for a genuine first failure, which is the only class that still reaches it.
+fn contained_panic_error<K, M>(
+    cache: &mut CacheThread<K, M>,
+    msgs: SeamMessages,
+    payload: &str,
+    poison: &GpuPoisonState,
+) -> WorkerError
+where
+    K: Clone + PartialEq,
+{
+    match poison.record_contained_panic(payload) {
+        ContainedPanic::PoisonedQueue { scope, message } => {
+            tracing::error!(
+                event = "mlx_command_queue_poisoned",
+                scope = scope.as_str(),
+                firstFailure = %poison.first_failure().unwrap_or_default(),
+                driverError = %payload,
+                "the GPU driver is ignoring this worker's Metal submissions; the worker cannot \
+                 serve further jobs and is restarting"
+            );
+            WorkerError::Engine(message)
+        }
+        ContainedPanic::Unclassified => {
+            if cache.evict().is_some() {
+                release_backend_cache_after_evict();
+            }
+            WorkerError::Engine(format!("{}: {}", msgs.panic_reset, payload))
+        }
+    }
+}
+
 /// Run `run` against the cached (or freshly-loaded) model for `key` on the dedicated cache `worker`
 /// thread, and await the result. The model lives on the worker thread — `load` builds it there and
 /// `run` executes there (so it may hold a `!Send` reference) — and only the `R` result crosses back.
@@ -414,10 +472,16 @@ where
 {
     let (reply_tx, reply_rx) = oneshot::channel::<WorkerResult<R>>();
     let job: CacheJob<K, M> = Box::new(move |cache: &mut CacheThread<K, M>| {
+        // sc-20572: never submit into a command queue the driver is already ignoring.
+        if let Some(error) = refuse_if_poisoned(gpu_poison::global()) {
+            let _ = reply_tx.send(Err(error));
+            return;
+        }
         // Contain a panic from inside the load/run so it fails THIS job with a clean error instead of
         // unwinding out of the shared cache thread and stopping every subsequent request (sc-6067).
-        // The cached model is evicted on panic — post-abort backend state is suspect, so the next
-        // job reloads fresh.
+        // The cached model is evicted on an ordinary panic — post-abort backend state is suspect, so
+        // the next job reloads fresh. An ignored-submission poisoning is the exception (sc-20572):
+        // see `contained_panic_error`.
         let result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             cache.with_model_access_after_cold_admission(
                 key,
@@ -427,17 +491,20 @@ where
                 msgs.entry_missing,
             )
         })) {
-            Ok(result) => result,
-            Err(panic) => {
-                if cache.evict().is_some() {
-                    release_backend_cache_after_evict();
+            Ok(result) => {
+                if result.is_ok() {
+                    // sc-20572: proof this process can drive the GPU, which is what later
+                    // distinguishes a poisoning it caused from one that predates it.
+                    gpu_poison::global().note_gpu_work_completed();
                 }
-                Err(WorkerError::Engine(format!(
-                    "{}: {}",
-                    msgs.panic_reset,
-                    panic_message(panic.as_ref())
-                )))
+                result
             }
+            Err(panic) => Err(contained_panic_error(
+                cache,
+                msgs,
+                &panic_message(panic.as_ref()),
+                gpu_poison::global(),
+            )),
         };
         let _ = reply_tx.send(result);
     });
@@ -470,6 +537,11 @@ where
 {
     let (reply_tx, reply_rx) = oneshot::channel::<WorkerResult<R>>();
     let job: CacheJob<K, M> = Box::new(move |cache: &mut CacheThread<K, M>| {
+        // sc-20572: never submit into a command queue the driver is already ignoring.
+        if let Some(error) = refuse_if_poisoned(gpu_poison::global()) {
+            let _ = reply_tx.send(Err(error));
+            return;
+        }
         let result = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let request_active = || {
                 // A Tokio task can be aborted/dropped without first tripping its engine cancel
@@ -492,17 +564,19 @@ where
                 msgs.entry_missing,
             )
         })) {
-            Ok(result) => result,
-            Err(panic) => {
-                if cache.evict().is_some() {
-                    release_backend_cache_after_evict();
+            Ok(result) => {
+                if result.is_ok() {
+                    // sc-20572: proof this process can drive the GPU (see the sibling seam).
+                    gpu_poison::global().note_gpu_work_completed();
                 }
-                Err(WorkerError::Engine(format!(
-                    "{}: {}",
-                    msgs.panic_reset,
-                    panic_message(panic.as_ref())
-                )))
+                result
             }
+            Err(panic) => Err(contained_panic_error(
+                cache,
+                msgs,
+                &panic_message(panic.as_ref()),
+                gpu_poison::global(),
+            )),
         };
         let _ = reply_tx.send(result);
     });
@@ -1074,6 +1148,99 @@ mod tests {
         assert_eq!(
             Fingerprint::of(&dir.path().join("missing")),
             Fingerprint::Unavailable
+        );
+    }
+
+    /// The exact payload mlx-rs hands the containment when the driver is refusing this process's
+    /// submissions (2026-08-19 production log).
+    const IGNORED_SUBMISSION: &str = "called `Result::unwrap()` on an `Err` value: \
+                                      Exception(\"[METAL] Command buffer execution failed: Ignored \
+                                      (for causing prior/excessive GPU errors) \
+                                      (00000004:kIOGPUCommandBufferCallbackErrorSubmissionsIgnored)\")";
+
+    /// sc-20572. An ignored-submission poisoning must NOT be contained the way an ordinary engine
+    /// panic is: the resident model stays put (a reset is not a recovery here and only submits more
+    /// Metal work), and the message must stop claiming memory and a reset. Driven against a local
+    /// `GpuPoisonState` so the process-global latch is untouched — latching it here would refuse
+    /// every later job in this test binary, which is precisely the production behaviour being added.
+    #[test]
+    fn an_ignored_submission_panic_keeps_the_resident_and_reports_the_poisoning() {
+        let poison = gpu_poison::GpuPoisonState::new();
+        poison.note_gpu_work_completed();
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut cache = CacheThread::<u32, DropProbe>::new(false);
+        cache.install(7, DropProbe(drops.clone()));
+
+        let error =
+            contained_panic_error(&mut cache, TEST_SEAM_MESSAGES, IGNORED_SUBMISSION, &poison);
+
+        let WorkerError::Engine(message) = error else {
+            panic!("a contained panic must surface as an engine error");
+        };
+        assert!(
+            !message.starts_with(TEST_SEAM_MESSAGES.panic_reset),
+            "the ignored submission must not inherit the reset-and-blame-memory prefix: {message}"
+        );
+        assert!(
+            message.contains("kIOGPUCommandBufferCallbackErrorSubmissionsIgnored"),
+            "{message}"
+        );
+        assert_eq!(
+            cache.resident_key(),
+            Some(&7),
+            "a poisoned command queue is not recovered by dropping the resident model"
+        );
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+        assert_eq!(poison.poisoned(), Some(gpu_poison::PoisonScope::Process));
+    }
+
+    /// sc-20572 counterpart: everything that is NOT an ignored submission keeps the pre-existing
+    /// containment exactly — evict the resident, report with the lane's own prefix, leave the
+    /// worker able to claim the next job.
+    #[test]
+    fn an_ordinary_panic_still_evicts_and_keeps_the_existing_prefix() {
+        let poison = gpu_poison::GpuPoisonState::new();
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut cache = CacheThread::<u32, DropProbe>::new(false);
+        cache.install(7, DropProbe(drops.clone()));
+
+        let error = contained_panic_error(
+            &mut cache,
+            TEST_SEAM_MESSAGES,
+            "[metal::malloc] Attempting to allocate 41231237120 bytes",
+            &poison,
+        );
+
+        let WorkerError::Engine(message) = error else {
+            panic!("a contained panic must surface as an engine error");
+        };
+        assert!(
+            message.starts_with(TEST_SEAM_MESSAGES.panic_reset),
+            "{message}"
+        );
+        assert!(cache.is_empty(), "an ordinary engine panic still evicts");
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            poison.poisoned(),
+            None,
+            "an ordinary panic must not make the worker refuse later jobs"
+        );
+        assert!(refuse_if_poisoned(&poison).is_none());
+    }
+
+    /// sc-20572: once a poisoning is latched, a later job is refused before `load`/`run` are
+    /// entered — the loop that burned ~8 jobs in 2.5 minutes cannot form.
+    #[test]
+    fn a_latched_poisoning_refuses_the_next_job_before_any_gpu_work() {
+        let poison = gpu_poison::GpuPoisonState::new();
+        assert!(refuse_if_poisoned(&poison).is_none(), "clean worker serves");
+        poison.record_contained_panic(IGNORED_SUBMISSION);
+        let Some(WorkerError::Engine(message)) = refuse_if_poisoned(&poison) else {
+            panic!("a latched poisoning must refuse the next job");
+        };
+        assert!(
+            message.contains("refused without touching the GPU"),
+            "{message}"
         );
     }
 

--- a/crates/sceneworks-worker/src/cache_thread.rs
+++ b/crates/sceneworks-worker/src/cache_thread.rs
@@ -1194,6 +1194,44 @@ mod tests {
         assert_eq!(poison.poisoned(), Some(gpu_poison::PoisonScope::Process));
     }
 
+    /// sc-20572 review: pins the exact read `contained_panic_error` uses to build the
+    /// `mlx_command_queue_poisoned` event's `firstFailure` field
+    /// (`poison.first_failure().unwrap_or_default()`) — it must come back empty when the ignored
+    /// submission IS this process's first contained panic, matching `docs/observability.md`
+    /// ("empty when the ignored submission was the first thing it saw"), and must surface a
+    /// genuinely earlier fault when one exists.
+    #[test]
+    fn first_failure_emitted_on_the_event_is_empty_only_when_the_poisoning_is_the_first_thing_seen()
+    {
+        let poison = gpu_poison::GpuPoisonState::new();
+        let mut cache = CacheThread::<u32, DropProbe>::new(false);
+        cache.install(7, DropProbe(Arc::new(AtomicUsize::new(0))));
+
+        contained_panic_error(&mut cache, TEST_SEAM_MESSAGES, IGNORED_SUBMISSION, &poison);
+        assert_eq!(
+            poison.first_failure().unwrap_or_default(),
+            "",
+            "the event's firstFailure must be empty when the ignored submission was the first \
+             thing this process saw"
+        );
+
+        let poison = gpu_poison::GpuPoisonState::new();
+        let mut cache = CacheThread::<u32, DropProbe>::new(false);
+        cache.install(7, DropProbe(Arc::new(AtomicUsize::new(0))));
+        contained_panic_error(
+            &mut cache,
+            TEST_SEAM_MESSAGES,
+            "[metal::malloc] Attempting to allocate 41231237120 bytes",
+            &poison,
+        );
+        contained_panic_error(&mut cache, TEST_SEAM_MESSAGES, IGNORED_SUBMISSION, &poison);
+        assert_eq!(
+            poison.first_failure().unwrap_or_default(),
+            "[metal::malloc] Attempting to allocate 41231237120 bytes",
+            "a genuine earlier fault must still surface on the event"
+        );
+    }
+
     /// sc-20572 counterpart: everything that is NOT an ignored submission keeps the pre-existing
     /// containment exactly — evict the resident, report with the lane's own prefix, leave the
     /// worker able to claim the next job.

--- a/crates/sceneworks-worker/src/generator_cache.rs
+++ b/crates/sceneworks-worker/src/generator_cache.rs
@@ -774,6 +774,14 @@ pub(crate) fn spawn_gpu_telemetry(_config_dir: PathBuf) {}
 
 /// User-facing message strings for the generator cache seam, preserving the exact wording the worker
 /// emitted before the `cache_thread` extraction (sc-11191, F-019).
+///
+/// **`panic_reset` no longer covers every contained panic (sc-20572).** Both of its claims — that
+/// memory is the likely cause, and that resetting the cached generator dealt with it — are true only
+/// of a genuine FIRST failure. They were wrong, and actively misleading, for
+/// `kIOGPUCommandBufferCallbackErrorSubmissionsIgnored`: the driver refusing this process's
+/// submissions after earlier GPU errors, where no reset recovers anything and the worker has to
+/// restart. That class is now detected, scoped and worded separately in [`crate::gpu_poison`], and
+/// never reaches this prefix — which is why the prefix itself is unchanged.
 const GENERATOR_SEAM_MESSAGES: SeamMessages = SeamMessages {
     entry_missing: "Generator cache entry missing after load.",
     panic_reset: "MLX generation panicked and was contained (the engine likely ran out of memory; \

--- a/crates/sceneworks-worker/src/gpu_poison.rs
+++ b/crates/sceneworks-worker/src/gpu_poison.rs
@@ -137,12 +137,20 @@ impl GpuPoisonState {
     /// that produced one owns the poisoning that follows. (A contained panic that had nothing to do
     /// with the GPU also sets it. That biases toward [`PoisonScope::Process`], the less alarming
     /// verdict, and it is corrected by the restart: the fresh process starts with no such history.)
+    ///
+    /// A `SubmissionsIgnored` payload is deliberately NEVER recorded as the first failure (review
+    /// finding, sc-20572): `first_failure` exists to answer "what actually explains the cascade",
+    /// and when the cascade IS the first thing this process saw there is no such explanation yet —
+    /// recording it here would make `first_failure()` (and the `firstFailure` event field, and the
+    /// refusal text) echo the poisoning back as its own cause, contradicting
+    /// `docs/observability.md`'s "empty when the ignored submission was the first thing it saw".
     pub(crate) fn record_contained_panic(&self, payload: &str) -> ContainedPanic {
-        let first_failure = self.record_first_failure(payload);
         if !is_submissions_ignored(payload) {
             self.drove_gpu.store(true, Ordering::SeqCst);
+            self.record_first_failure(payload);
             return ContainedPanic::Unclassified;
         }
+        let first_failure = self.first_failure();
         let observed = if self.drove_gpu.load(Ordering::SeqCst) {
             PoisonScope::Process
         } else {
@@ -189,14 +197,15 @@ impl GpuPoisonState {
             .clone()
     }
 
-    /// Store `payload` as the first contained failure if nothing is stored yet, and return whatever
-    /// is stored (which is `payload` itself on the first call).
-    fn record_first_failure(&self, payload: &str) -> Option<String> {
+    /// Store `payload` as the first contained failure if nothing is stored yet. Only called for
+    /// non-poison payloads (see [`Self::record_contained_panic`]) — a `SubmissionsIgnored` payload
+    /// must never land here, or it would become its own "first failure".
+    fn record_first_failure(&self, payload: &str) {
         let mut first = self
             .first_failure
             .lock()
             .unwrap_or_else(PoisonError::into_inner);
-        Some(first.get_or_insert_with(|| payload.to_owned()).clone())
+        first.get_or_insert_with(|| payload.to_owned());
     }
 }
 
@@ -239,8 +248,9 @@ fn refusal_message(scope: PoisonScope, first_failure: Option<&str>) -> String {
 
 /// The user-facing error for the job that ran into the poisoning.
 ///
-/// `first_failure` is this process's first contained failure; it is surfaced only when it differs
-/// from `payload`, because that is exactly the case where the cascade is hiding the real cause.
+/// `first_failure` is this process's first contained failure — genuinely earlier than `payload`,
+/// never `payload` itself, because [`GpuPoisonState::record_contained_panic`] never records a
+/// `SubmissionsIgnored` payload as the first failure in the first place (sc-20572 review).
 fn poisoned_queue_message(
     scope: PoisonScope,
     first_failure: Option<&str>,
@@ -254,7 +264,7 @@ fn poisoned_queue_message(
          clear a poisoned command queue. ",
     );
     message.push_str(scope_remedy(scope));
-    match first_failure.filter(|first| *first != payload) {
+    match first_failure {
         Some(first) => {
             message.push_str(" The first failure in this worker process was: ");
             message.push_str(first);
@@ -371,6 +381,44 @@ mod tests {
             !message.contains("The first failure in this worker process was:"),
             "the ignored submission must not be presented as the cause of itself: {message}"
         );
+    }
+
+    /// sc-20572 review: when the ignored submission itself is the FIRST contained panic this
+    /// process ever saw, `first_failure()` must stay empty — not echo the poisoning back as its
+    /// own cause. This is the exact source the `mlx_command_queue_poisoned` event's `firstFailure`
+    /// field reads (`cache_thread::contained_panic_error`), so pinning it here pins the event too.
+    #[test]
+    fn first_contained_panic_being_the_poison_leaves_first_failure_empty() {
+        let state = GpuPoisonState::new();
+        poisoned_message(&state, IGNORED);
+        assert_eq!(
+            state.first_failure(),
+            None,
+            "a self-caused poisoning must not record itself as the first failure"
+        );
+        let refusal = state.refusal_message().expect("latched");
+        assert!(
+            !refusal.contains("The first failure in this worker process was:"),
+            "the refusal text must not blame the cascade on itself either: {refusal}"
+        );
+    }
+
+    /// sc-20572 review counterpart: a genuine EARLIER contained fault must still be surfaced, in
+    /// both `first_failure()` and the later-job refusal text (not just the per-job cascade
+    /// message, which `the_cascade_message_surfaces_the_first_failure_not_just_the_ignored_submission`
+    /// already covers).
+    #[test]
+    fn a_genuine_earlier_failure_is_surfaced_in_first_failure_and_refusal() {
+        let state = GpuPoisonState::new();
+        state.record_contained_panic(METAL_OOM);
+        poisoned_message(&state, IGNORED);
+        assert_eq!(state.first_failure().as_deref(), Some(METAL_OOM));
+        let refusal = state.refusal_message().expect("latched");
+        assert!(
+            refusal.contains("The first failure in this worker process was:"),
+            "{refusal}"
+        );
+        assert!(refusal.contains("41231237120 bytes"), "{refusal}");
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/gpu_poison.rs
+++ b/crates/sceneworks-worker/src/gpu_poison.rs
@@ -1,0 +1,468 @@
+//! Metal command-queue poisoning: detection, scope discrimination, containment (sc-20572).
+//!
+//! # What this is about
+//!
+//! When a Metal command buffer fails badly enough, the macOS GPU driver stops accepting the
+//! offending client's submissions altogether and completes every later command buffer with
+//! `kIOGPUCommandBufferCallbackErrorSubmissionsIgnored` — literally *"ignored for causing
+//! prior/excessive GPU errors"*. mlx-rs surfaces that as an `Exception`, which the engine
+//! `.unwrap()`s, which the model-cache seam contains as a panic
+//! ([`crate::cache_thread::run_cached_with_access_after_cold_admission`]).
+//!
+//! Two things were wrong with how that was contained, both measured in production on 2026-08-19:
+//!
+//! 1. **It was reported as an out-of-memory condition.** `SubmissionsIgnored` is *never* the first
+//!    error — it is the driver refusing a channel it already failed something on. The OOM guess is
+//!    right for the FIRST failure (a `[metal::malloc]` throw really is an allocation failure) and
+//!    wrong for every ignored submission after it, and it sends diagnosis to the wrong place. So
+//!    this class is attributed on its own terms, and the process's *first* contained failure — the
+//!    one that actually explains the cascade — is surfaced alongside it.
+//! 2. **It claimed the cached generator was reset, as though that recovered anything.** Dropping
+//!    the resident model does not un-poison a command queue: the driver's refusal is keyed on the
+//!    process, not on any allocation the cache holds. Measured: ~8 back-to-back jobs (bernini →
+//!    boogu → krea_2_raw) each hit the containment, each reported a successful reset, and each
+//!    failed identically over 2.5 minutes, until libc++abi hit an uncaught `std::runtime_error` and
+//!    `abort()`ed the worker. The process respawn is what actually recovered it. So a reset is
+//!    never the response here: the resident model is left alone, every subsequent job is refused
+//!    WITHOUT touching the GPU, and the worker exits for its supervisor to restart.
+//!
+//! # The two scopes, and why the message must not pick a reboot on its own
+//!
+//! The identical error string covers two situations that look the same in the log:
+//!
+//! * **Process-poisoned** — this process blew its own allocation; other Metal clients keep
+//!   rendering; a process restart clears it, and **no reboot is involved**.
+//! * **Host-wedged** — the GPU client class itself is wedged (the `pkill`-mid-render trigger seen
+//!   on 2026-08-17); fresh processes fail too, and only a reboot clears it.
+//!
+//! The authoritative discriminator is cross-process and therefore outside this worker: *is a
+//! DIFFERENT MLX process completing GPU work?* On 08-19 a concurrent real-weights run was logging
+//! healthy forwards throughout, which is what proved the scope was per-process. This module
+//! therefore never *asserts* a reboot. It reports the evidence it actually holds — whether THIS
+//! process had driven the GPU before the poisoning — and, when that evidence points away from this
+//! process, it hands the operator the cross-process check to run before concluding anything about
+//! the host.
+//!
+//! # Why both scopes still restart the worker
+//!
+//! The restart is the only recovery available in-process, it is what demonstrably fixed the
+//! measured incident, and it doubles as the operator-visible discriminator: a fresh process that
+//! fails the same way is the "fresh processes fail too" evidence for a host wedge. Parking the
+//! worker alive-but-idle on the host-suspected branch instead would strand it on any
+//! misclassification, and the classification here is deliberately evidence-poor (see
+//! [`GpuPoisonState::note_gpu_work_completed`]). The scope changes what the operator is TOLD, not
+//! whether the worker comes back.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, PoisonError};
+
+/// The Metal command-buffer callback error the driver reports once it is refusing a process's
+/// submissions: `kIOGPUCommandBufferCallbackErrorSubmissionsIgnored`. Matched case-insensitively on
+/// the distinctive tail so the full enum name, a bare `SubmissionsIgnored`, and any surrounding
+/// mlx-rs `Exception(...)` framing all hit.
+const SUBMISSIONS_IGNORED: &str = "submissionsignored";
+
+/// Which scope the evidence points at for an observed command-queue poisoning.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PoisonScope {
+    /// This process had already driven the GPU (completed work, or produced a contained fault of
+    /// its own) before the driver started ignoring it. The poisoned submission channel is therefore
+    /// this process's, and a restart clears it. No reboot.
+    Process,
+    /// This process had driven no GPU work at all before the driver started ignoring it, so the
+    /// errors being blamed came from before it started. A restart is not known to clear this; the
+    /// operator must run the cross-process discriminator before concluding the host needs a reboot.
+    HostSuspected,
+}
+
+impl PoisonScope {
+    /// Stable token for the structured log field.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Process => "process",
+            Self::HostSuspected => "host_suspected",
+        }
+    }
+}
+
+/// What a contained panic turned out to be.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ContainedPanic {
+    /// The driver is ignoring this process's submissions. Carries the fully-composed user-facing
+    /// text, so no caller has to re-derive the wording (or re-derive it differently).
+    PoisonedQueue { scope: PoisonScope, message: String },
+    /// Anything else — an ordinary engine panic, including a genuine first-failure Metal OOM. The
+    /// caller keeps its existing containment (evict the resident, report with its own prefix).
+    Unclassified,
+}
+
+/// Whether `payload` is the driver's ignored-submission report.
+fn is_submissions_ignored(payload: &str) -> bool {
+    payload.to_ascii_lowercase().contains(SUBMISSIONS_IGNORED)
+}
+
+/// Per-process state backing the detection. Instantiable so the decisions are unit-testable against
+/// a fresh instance instead of only through the process-global [`global`].
+pub(crate) struct GpuPoisonState {
+    drove_gpu: AtomicBool,
+    first_failure: Mutex<Option<String>>,
+    scope: Mutex<Option<PoisonScope>>,
+}
+
+impl GpuPoisonState {
+    pub(crate) const fn new() -> Self {
+        Self {
+            drove_gpu: AtomicBool::new(false),
+            first_failure: Mutex::new(None),
+            scope: Mutex::new(None),
+        }
+    }
+
+    /// Record that this process has successfully completed GPU work.
+    ///
+    /// This is the whole basis of the scope discrimination, so it is deliberately conservative:
+    /// only a model-cache run that returned `Ok` sets it. A path that drives MLX outside those
+    /// seams (LoRA training, for instance) does not, which can leave a genuinely process-scoped
+    /// poisoning classified as [`PoisonScope::HostSuspected`]. That direction is the safe one — the
+    /// host-suspected text tells the operator the restart is being made precisely so they can see
+    /// whether a fresh process gets through, and both scopes restart either way.
+    pub(crate) fn note_gpu_work_completed(&self) {
+        self.drove_gpu.store(true, Ordering::SeqCst);
+    }
+
+    /// Classify one contained panic payload, recording whatever it implies for later jobs.
+    ///
+    /// Non-poison faults count as this process having driven the GPU: a contained engine panic is
+    /// exactly the kind of "prior GPU error" a later `SubmissionsIgnored` is blaming, so a process
+    /// that produced one owns the poisoning that follows. (A contained panic that had nothing to do
+    /// with the GPU also sets it. That biases toward [`PoisonScope::Process`], the less alarming
+    /// verdict, and it is corrected by the restart: the fresh process starts with no such history.)
+    pub(crate) fn record_contained_panic(&self, payload: &str) -> ContainedPanic {
+        let first_failure = self.record_first_failure(payload);
+        if !is_submissions_ignored(payload) {
+            self.drove_gpu.store(true, Ordering::SeqCst);
+            return ContainedPanic::Unclassified;
+        }
+        let observed = if self.drove_gpu.load(Ordering::SeqCst) {
+            PoisonScope::Process
+        } else {
+            PoisonScope::HostSuspected
+        };
+        // The FIRST verdict latches. Everything after the poisoning happens in a process the driver
+        // is already refusing, so later faults carry no evidence about how it started — and the
+        // `drove_gpu` flag they would be read against is meaningless by then.
+        let mut latch = self.scope.lock().unwrap_or_else(PoisonError::into_inner);
+        let scope = *latch.get_or_insert(observed);
+        ContainedPanic::PoisonedQueue {
+            scope,
+            message: poisoned_queue_message(scope, first_failure.as_deref(), payload),
+        }
+    }
+
+    /// The latched scope, once a poisoning has been observed. `None` until then.
+    pub(crate) fn poisoned(&self) -> Option<PoisonScope> {
+        *self.scope.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// The latched scope paired with the text an operator should read, once a poisoning has been
+    /// observed. The worker loop wants both — the scope as a log field, the text as the `Unhealthy`
+    /// status reason — and taking them together keeps them from being read a turn apart.
+    pub(crate) fn poisoned_status(&self) -> Option<(PoisonScope, String)> {
+        let scope = self.poisoned()?;
+        Some((
+            scope,
+            refusal_message(scope, self.first_failure().as_deref()),
+        ))
+    }
+
+    /// User-facing text for a job arriving AFTER the latch: it is refused outright rather than
+    /// handed to a GPU that will only produce another ignored submission.
+    pub(crate) fn refusal_message(&self) -> Option<String> {
+        Some(self.poisoned_status()?.1)
+    }
+
+    /// The first contained failure this process saw — the one that actually explains the cascade.
+    pub(crate) fn first_failure(&self) -> Option<String> {
+        self.first_failure
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+
+    /// Store `payload` as the first contained failure if nothing is stored yet, and return whatever
+    /// is stored (which is `payload` itself on the first call).
+    fn record_first_failure(&self, payload: &str) -> Option<String> {
+        let mut first = self
+            .first_failure
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        Some(first.get_or_insert_with(|| payload.to_owned()).clone())
+    }
+}
+
+/// What the operator should do about a poisoning of this scope. Shared by every message this module
+/// composes so the job error, the refusal and the worker's status reason cannot drift apart.
+fn scope_remedy(scope: PoisonScope) -> &'static str {
+    match scope {
+        PoisonScope::Process => {
+            "This worker had already driven the GPU before the poisoning, so the refused submission \
+             channel is this process's own: it is restarting now, which clears it. No reboot is \
+             needed."
+        }
+        PoisonScope::HostSuspected => {
+            "This worker had completed no GPU work before the poisoning, so the errors the driver \
+             is refusing over came from before it started and a restart may not clear them. The \
+             worker is restarting so you can see whether a fresh process gets through. If it fails \
+             the same way again, check whether a DIFFERENT MLX process is still completing GPU work \
+             before concluding the host needs a reboot: if another process renders fine the scope is \
+             per-process, but if every fresh process fails then the GPU client class is wedged \
+             host-wide and only a reboot clears it."
+        }
+    }
+}
+
+/// The user-facing text for a job refused because the latch is already set.
+fn refusal_message(scope: PoisonScope, first_failure: Option<&str>) -> String {
+    let mut message = String::from(
+        "MLX generation was refused without touching the GPU: the driver is ignoring this worker's \
+         Metal command submissions after prior GPU errors \
+         (kIOGPUCommandBufferCallbackErrorSubmissionsIgnored), so any work handed to it now would \
+         fail the same way. ",
+    );
+    message.push_str(scope_remedy(scope));
+    if let Some(first) = first_failure {
+        message.push_str(" The first failure in this worker process was: ");
+        message.push_str(first);
+    }
+    message
+}
+
+/// The user-facing error for the job that ran into the poisoning.
+///
+/// `first_failure` is this process's first contained failure; it is surfaced only when it differs
+/// from `payload`, because that is exactly the case where the cascade is hiding the real cause.
+fn poisoned_queue_message(
+    scope: PoisonScope,
+    first_failure: Option<&str>,
+    payload: &str,
+) -> String {
+    let mut message = String::from(
+        "MLX generation could not run: the GPU driver is ignoring this worker's Metal command \
+         submissions after prior GPU errors (kIOGPUCommandBufferCallbackErrorSubmissionsIgnored). \
+         That is the cascade, not the original fault — an ignored submission is never the first \
+         error and is not an out-of-memory condition, and resetting the cached generator cannot \
+         clear a poisoned command queue. ",
+    );
+    message.push_str(scope_remedy(scope));
+    match first_failure.filter(|first| *first != payload) {
+        Some(first) => {
+            message.push_str(" The first failure in this worker process was: ");
+            message.push_str(first);
+        }
+        None => message.push_str(
+            " No earlier failure was recorded in this worker process, so the errors being refused \
+             over are not ones it reported.",
+        ),
+    }
+    message.push_str(" Driver error: ");
+    message.push_str(payload);
+    message
+}
+
+/// The process-global state the production seams consult.
+pub(crate) fn global() -> &'static GpuPoisonState {
+    static STATE: GpuPoisonState = GpuPoisonState::new();
+    &STATE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact shape mlx-rs hands the containment, from the 2026-08-19 production log.
+    const IGNORED: &str =
+        "called `Result::unwrap()` on an `Err` value: Exception(\"[METAL] Command \
+                           buffer execution failed: Ignored (for causing prior/excessive GPU \
+                           errors) \
+                           (00000004:kIOGPUCommandBufferCallbackErrorSubmissionsIgnored)\")";
+    const METAL_OOM: &str = "[metal::malloc] Attempting to allocate 41231237120 bytes which is \
+                             greater than the maximum allowed buffer size";
+
+    fn poisoned_message(state: &GpuPoisonState, payload: &str) -> String {
+        match state.record_contained_panic(payload) {
+            ContainedPanic::PoisonedQueue { message, .. } => message,
+            ContainedPanic::Unclassified => panic!("expected a poisoned-queue classification"),
+        }
+    }
+
+    fn scope_of(state: &GpuPoisonState, payload: &str) -> PoisonScope {
+        match state.record_contained_panic(payload) {
+            ContainedPanic::PoisonedQueue { scope, .. } => scope,
+            ContainedPanic::Unclassified => panic!("expected a poisoned-queue classification"),
+        }
+    }
+
+    #[test]
+    fn an_ordinary_engine_panic_is_not_a_poisoned_queue_and_does_not_latch() {
+        let state = GpuPoisonState::new();
+        assert_eq!(
+            state.record_contained_panic(METAL_OOM),
+            ContainedPanic::Unclassified
+        );
+        assert_eq!(
+            state.poisoned(),
+            None,
+            "a first-failure Metal OOM must not make the worker refuse later jobs"
+        );
+        assert_eq!(state.refusal_message(), None);
+    }
+
+    #[test]
+    fn ignored_submissions_after_completed_gpu_work_are_scoped_to_this_process() {
+        let state = GpuPoisonState::new();
+        state.note_gpu_work_completed();
+        assert_eq!(scope_of(&state, IGNORED), PoisonScope::Process);
+        assert_eq!(state.poisoned(), Some(PoisonScope::Process));
+    }
+
+    #[test]
+    fn ignored_submissions_in_a_process_that_never_drove_the_gpu_suspect_the_host() {
+        let state = GpuPoisonState::new();
+        assert_eq!(scope_of(&state, IGNORED), PoisonScope::HostSuspected);
+        assert_eq!(state.poisoned(), Some(PoisonScope::HostSuspected));
+    }
+
+    #[test]
+    fn an_earlier_contained_fault_scopes_a_later_poisoning_to_this_process() {
+        let state = GpuPoisonState::new();
+        assert_eq!(
+            state.record_contained_panic(METAL_OOM),
+            ContainedPanic::Unclassified
+        );
+        assert_eq!(
+            scope_of(&state, IGNORED),
+            PoisonScope::Process,
+            "the fault this process already produced is the 'prior GPU error' being refused over"
+        );
+    }
+
+    #[test]
+    fn the_cascade_message_surfaces_the_first_failure_not_just_the_ignored_submission() {
+        let state = GpuPoisonState::new();
+        state.record_contained_panic(METAL_OOM);
+        let message = poisoned_message(&state, IGNORED);
+        assert!(
+            message.contains("The first failure in this worker process was:"),
+            "{message}"
+        );
+        assert!(message.contains("41231237120 bytes"), "{message}");
+        assert_eq!(state.first_failure().as_deref(), Some(METAL_OOM));
+    }
+
+    #[test]
+    fn a_poisoning_with_no_earlier_fault_says_so_instead_of_repeating_itself() {
+        let state = GpuPoisonState::new();
+        let message = poisoned_message(&state, IGNORED);
+        assert!(
+            message.contains("No earlier failure was recorded in this worker process"),
+            "{message}"
+        );
+        assert!(
+            !message.contains("The first failure in this worker process was:"),
+            "the ignored submission must not be presented as the cause of itself: {message}"
+        );
+    }
+
+    #[test]
+    fn no_composed_message_blames_memory_or_claims_a_reset_recovered_anything() {
+        for scope in [PoisonScope::Process, PoisonScope::HostSuspected] {
+            let state = GpuPoisonState::new();
+            if scope == PoisonScope::Process {
+                state.note_gpu_work_completed();
+            }
+            let job = poisoned_message(&state, IGNORED);
+            let refusal = state.refusal_message().expect("latched");
+            for message in [job, refusal] {
+                assert!(
+                    !message.contains("ran out of memory"),
+                    "{scope:?} attribution still blames memory: {message}"
+                );
+                assert!(
+                    !message.contains("generator was reset"),
+                    "{scope:?} attribution still claims a reset: {message}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_process_scoped_remedy_rules_a_reboot_out_and_the_host_scoped_one_gates_it() {
+        let process = GpuPoisonState::new();
+        process.note_gpu_work_completed();
+        let process_message = poisoned_message(&process, IGNORED);
+        assert!(
+            process_message.contains("No reboot is needed"),
+            "{process_message}"
+        );
+
+        let host = GpuPoisonState::new();
+        let host_message = poisoned_message(&host, IGNORED);
+        assert!(
+            host_message.contains("DIFFERENT MLX process"),
+            "the host-suspected remedy must hand over the cross-process discriminator: \
+             {host_message}"
+        );
+        assert!(
+            host_message.contains("before concluding the host needs a reboot"),
+            "the discriminator must gate the reboot, not follow it: {host_message}"
+        );
+    }
+
+    #[test]
+    fn the_first_verdict_latches_and_later_faults_cannot_re_scope_it() {
+        let state = GpuPoisonState::new();
+        assert_eq!(scope_of(&state, IGNORED), PoisonScope::HostSuspected);
+        // A later job on the poisoned queue looks identical, and by then the process has "driven
+        // the GPU" only in the sense that it produced faults on a channel already being refused.
+        state.note_gpu_work_completed();
+        assert_eq!(scope_of(&state, IGNORED), PoisonScope::HostSuspected);
+        assert_eq!(state.poisoned(), Some(PoisonScope::HostSuspected));
+    }
+
+    #[test]
+    fn a_latched_worker_refuses_later_jobs_without_touching_the_gpu() {
+        let state = GpuPoisonState::new();
+        state.note_gpu_work_completed();
+        state.record_contained_panic(IGNORED);
+        let refusal = state.refusal_message().expect("latched");
+        assert!(
+            refusal.contains("refused without touching the GPU"),
+            "{refusal}"
+        );
+        assert!(refusal.contains("No reboot is needed"), "{refusal}");
+        assert_eq!(
+            state.poisoned_status(),
+            Some((PoisonScope::Process, refusal)),
+            "the worker loop must read the same scope and text the refusal reports"
+        );
+    }
+
+    #[test]
+    fn the_driver_error_is_recognized_by_its_enum_name_in_any_case() {
+        for payload in [
+            "kIOGPUCommandBufferCallbackErrorSubmissionsIgnored",
+            "00000004:KIOGPUCOMMANDBUFFERCALLBACKERRORSUBMISSIONSIGNORED",
+            "submissionsignored",
+            IGNORED,
+        ] {
+            assert!(is_submissions_ignored(payload), "{payload}");
+        }
+        for payload in [
+            METAL_OOM,
+            "[METAL] Command buffer execution failed: Caused GPU Timeout Error",
+            "submissions ignored",
+        ] {
+            assert!(!is_submissions_ignored(payload), "{payload}");
+        }
+    }
+}

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -100,6 +100,13 @@ mod credentials_ipc;
 // production seams are cfg'd out, so allow dead_code there (mirrors the generator_cache precedent).
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 mod cache_thread;
+// Metal command-queue poisoning (sc-20572): the detection, scope discrimination and containment for
+// `kIOGPUCommandBufferCallbackErrorSubmissionsIgnored` — the driver refusing a process's
+// submissions after prior GPU errors. Consulted by the model-cache seam (which is where the panic
+// is contained) and by the worker loop (which stops claiming and exits for a restart). All-targets
+// like `cache_thread`; only the macOS/MLX lane can actually produce the error.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+mod gpu_poison;
 // The single pre-loader model-source guard (sc-19708): every dispatched job's generic model
 // carriers are reduced to this platform's exact requirement closure and judged through the one
 // shared availability resolver before any handler constructs a loader.
@@ -1407,6 +1414,30 @@ pub async fn run_worker_loop(settings: Settings) -> WorkerResult<()> {
     let mut maintenance_task = Some(spawn_retention_checkpoint(settings.data_dir.clone(), true));
     let mut next_retention_checkpoint = Instant::now() + RESOLVED_CACHE_RETENTION_INTERVAL;
     loop {
+        // sc-20572: the GPU driver has started ignoring this process's Metal submissions. Nothing
+        // this worker can do in-process clears that — the cached generator was already left alone
+        // rather than uselessly reset, and every queued job is being refused untouched — so stop
+        // claiming and exit for the supervisor to restart the process, which is what actually
+        // recovered the measured incident. The scope shapes the reason text, not the action: see
+        // `gpu_poison` for why a host-suspected poisoning restarts too.
+        if let Some((scope, reason)) = gpu_poison::global().poisoned_status() {
+            tracing::error!(
+                event = "mlx_command_queue_poisoned_exit",
+                scope = scope.as_str(),
+                reason = %reason,
+                "exiting so this worker is restarted with a clean GPU context"
+            );
+            // Best-effort, and deliberately `Unhealthy` rather than `Offline`: the reason is what
+            // an operator reads off the worker row while the restart is in flight, and the API's
+            // `Unhealthy` backstop refuses any claim that races it.
+            let _ =
+                heartbeat_with_reason(&api, &settings, WorkerStatus::Unhealthy, None, Some(reason))
+                    .await;
+            // `Ok` so the supervisor reads a clean exit and simply respawns. The failing job has
+            // already posted its own terminal error; a non-zero exit would have the desktop
+            // supervisor attribute a SECOND, fabricated failure to it (sc-18182).
+            return Ok(());
+        }
         if !health.is_usable() && Instant::now() >= next_gpu_recheck {
             next_gpu_recheck = Instant::now() + GPU_HEALTH_RECHECK;
             recheck_gpu_health(&api, &settings, &mut health).await?;

--- a/crates/sceneworks-worker/src/person_segment_sam3.rs
+++ b/crates/sceneworks-worker/src/person_segment_sam3.rs
@@ -34,6 +34,7 @@ use runtime_macos::providers::sam3::{
     VideoFrameOutput,
 };
 
+use crate::gpu_poison::{self, ContainedPanic, GpuPoisonState};
 use crate::person_segment_sam3_common::{
     check_segment_canceled, frame_mask_for_object, mask_to_frame, normalize_chw, paint_order,
     per_frame_masks, select_object, BoxNorm, Sam3FrameOutput, SegmentProgress, CANCEL_MESSAGE,
@@ -297,17 +298,23 @@ impl Sam3Executor {
 /// `Engine` error instead of killing the shared thread (which would strand every later click); the
 /// thread therefore survives job panics and only exits at worker shutdown. A dead thread or dropped
 /// reply is reported as an error rather than hanging the caller.
+///
+/// sc-20572 review: SAM3 drives MLX Metal same as the model-cache seam, so a panic here can be the
+/// SAME `SubmissionsIgnored` poisoning `cache_thread` classifies — but until this fix this seam
+/// discarded the panic payload entirely, so a poisoning first surfacing in a SAM3 click reported
+/// only the generic "thread panicked" message (burning smart-select clicks with no diagnosis until
+/// a later cache-seam job happened to latch it) and successful SAM3 runs never counted as this
+/// process having driven the GPU (biasing later scope discrimination toward `HostSuspected` even
+/// when this same process just did GPU work). The panic/classify/record logic now goes through the
+/// shared [`gpu_poison`] seam identically to `cache_thread::contained_panic_error`; the split into
+/// [`run_sam3_job_with_poison`] keeps that logic directly unit-testable against a local
+/// `GpuPoisonState`, the same way `cache_thread`'s tests drive `contained_panic_error` directly.
 fn run_on_sam3_thread<T: Send + 'static>(
     job: impl FnOnce() -> WorkerResult<T> + Send + 'static,
 ) -> WorkerResult<T> {
     let (reply_tx, reply_rx) = std::sync::mpsc::channel::<WorkerResult<T>>();
     let boxed: Sam3Job = Box::new(move || {
-        let outcome =
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(job)).unwrap_or_else(|_| {
-                Err(WorkerError::Engine(
-                    "sam3 smart-select thread panicked".into(),
-                ))
-            });
+        let outcome = run_sam3_job_with_poison(job, gpu_poison::global());
         // The caller may have gone away (its task dropped); a closed reply channel is not an error.
         let _ = reply_tx.send(outcome);
     });
@@ -315,6 +322,60 @@ fn run_on_sam3_thread<T: Send + 'static>(
     reply_rx
         .recv()
         .map_err(|_| WorkerError::Engine("sam3 smart-select thread dropped the reply".into()))?
+}
+
+/// The synchronous body of a sam3-thread job (sc-20572 review): run `job`, contain any panic
+/// through the shared gpu-poison seam, and record successful GPU-driving work as evidence for
+/// later scope discrimination — the same contract `cache_thread`'s cache-seam jobs already keep.
+/// Split out of [`run_on_sam3_thread`] so it needs neither the executor thread nor a Metal device
+/// to test: it takes `poison` by reference instead of reading [`gpu_poison::global`] directly, so
+/// tests inject a local [`GpuPoisonState`] the way `cache_thread`'s tests drive
+/// `contained_panic_error` — no process-global latch touched, no GPU involved.
+fn run_sam3_job_with_poison<T>(
+    job: impl FnOnce() -> WorkerResult<T>,
+    poison: &GpuPoisonState,
+) -> WorkerResult<T> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(job)) {
+        Ok(result) => {
+            if result.is_ok() {
+                // sc-20572: proof this process can drive the GPU, mirroring the model-cache seam
+                // (`cache_thread::run_cached_with_access_after_cold_admission`). Without this, a
+                // successful SAM3-only session never contributes evidence and a poisoning that
+                // later surfaces elsewhere in the same process defaults to `HostSuspected`.
+                poison.note_gpu_work_completed();
+            }
+            result
+        }
+        Err(panic) => Err(sam3_panic_error(
+            crate::cache_thread::panic_message(panic.as_ref()),
+            poison,
+        )),
+    }
+}
+
+/// Turn a caught sam3-thread panic payload into the `WorkerError` this seam reports, classifying
+/// it through the shared gpu-poison seam exactly like `cache_thread::contained_panic_error`
+/// (sc-20572 review). A `SubmissionsIgnored` poisoning gets the same scoped, cascade-aware message
+/// the cache seam produces; anything else keeps SAM3's existing conservative surface — the raw
+/// panic payload is never echoed back to the caller, only the fixed "thread panicked" text, same
+/// as before this fix.
+fn sam3_panic_error(payload: String, poison: &GpuPoisonState) -> WorkerError {
+    match poison.record_contained_panic(&payload) {
+        ContainedPanic::PoisonedQueue { scope, message } => {
+            tracing::error!(
+                event = "mlx_command_queue_poisoned",
+                scope = scope.as_str(),
+                firstFailure = %poison.first_failure().unwrap_or_default(),
+                driverError = %payload,
+                "the GPU driver is ignoring this worker's Metal submissions during sam3 \
+                 smart-select; the worker cannot serve further jobs and is restarting"
+            );
+            WorkerError::Engine(message)
+        }
+        ContainedPanic::Unclassified => {
+            WorkerError::Engine("sam3 smart-select thread panicked".into())
+        }
+    }
 }
 
 /// Load the shared dense checkpoint into the process-wide [`WEIGHTS`] cache (poison-recovery) and run
@@ -820,6 +881,85 @@ mod tests {
             matches!(error, WorkerError::Engine(ref message) if message.contains("3x3") && message.contains("8 values"))
         );
     }
+
+    /// The exact payload mlx-rs hands the containment when the driver is refusing this process's
+    /// submissions — same shape `cache_thread`'s sibling test uses (2026-08-19 production log).
+    const IGNORED_SUBMISSION: &str = "called `Result::unwrap()` on an `Err` value: \
+                                      Exception(\"[METAL] Command buffer execution failed: Ignored \
+                                      (for causing prior/excessive GPU errors) \
+                                      (00000004:kIOGPUCommandBufferCallbackErrorSubmissionsIgnored)\")";
+
+    /// sc-20572 review: an ordinary SAM3 panic must keep its existing conservative surface — the
+    /// raw payload text is never echoed back to the caller, only the fixed "thread panicked"
+    /// message, exactly as before this fix. Driven against a local `GpuPoisonState` (no thread, no
+    /// Metal device) the same way `cache_thread::contained_panic_error` is tested directly.
+    #[test]
+    fn an_ordinary_sam3_panic_keeps_the_generic_message_and_does_not_latch() {
+        let poison = GpuPoisonState::new();
+        let outcome: WorkerResult<()> = run_sam3_job_with_poison(
+            || -> WorkerResult<()> { panic!("some internal mlx-gen-sam3 detail") },
+            &poison,
+        );
+        let Err(WorkerError::Engine(message)) = outcome else {
+            panic!("a contained panic must surface as an engine error");
+        };
+        assert_eq!(message, "sam3 smart-select thread panicked");
+        assert!(
+            !message.contains("mlx-gen-sam3 detail"),
+            "the raw panic payload must not be echoed back: {message}"
+        );
+        assert_eq!(poison.poisoned(), None);
+    }
+
+    /// sc-20572 review: a `SubmissionsIgnored` panic surfacing FIRST inside a SAM3 smart-select
+    /// click must be classified and latched through the same seam `cache_thread` uses — not
+    /// discarded into the generic "thread panicked" message that used to burn clicks with no
+    /// diagnosis until a later cache-seam job happened to latch it.
+    #[test]
+    fn a_poisoning_first_seen_on_the_sam3_thread_is_classified_and_latches() {
+        let poison = GpuPoisonState::new();
+        let outcome: WorkerResult<()> = run_sam3_job_with_poison(
+            || -> WorkerResult<()> { panic!("{IGNORED_SUBMISSION}") },
+            &poison,
+        );
+        let Err(WorkerError::Engine(message)) = outcome else {
+            panic!("a contained panic must surface as an engine error");
+        };
+        assert!(
+            message.contains("kIOGPUCommandBufferCallbackErrorSubmissionsIgnored"),
+            "{message}"
+        );
+        assert_eq!(
+            poison.poisoned(),
+            Some(gpu_poison::PoisonScope::HostSuspected),
+            "no prior GPU work was recorded on this thread"
+        );
+        assert_eq!(
+            poison.first_failure(),
+            None,
+            "the poisoning must not record itself as the first failure"
+        );
+    }
+
+    /// sc-20572 review: a successful SAM3 run must count as this process having driven the GPU,
+    /// same as a successful model-cache run — otherwise a poisoning that surfaces later in the same
+    /// process is misclassified `HostSuspected` even though this process demonstrably rendered.
+    #[test]
+    fn a_successful_sam3_run_marks_this_process_as_having_driven_the_gpu() {
+        let poison = GpuPoisonState::new();
+        let ok: WorkerResult<u32> = run_sam3_job_with_poison(|| Ok(42), &poison);
+        assert_eq!(ok.unwrap(), 42);
+
+        // Now classify a poisoning: because `note_gpu_work_completed` fired above, it must scope
+        // to `Process`, not `HostSuspected`.
+        let outcome: WorkerResult<()> = run_sam3_job_with_poison(
+            || -> WorkerResult<()> { panic!("{IGNORED_SUBMISSION}") },
+            &poison,
+        );
+        assert!(outcome.is_err());
+        assert_eq!(poison.poisoned(), Some(gpu_poison::PoisonScope::Process));
+    }
+
     // The checkpoint filenames now live in the shared module; the real-weights smokes below join them
     // onto a snapshot dir to build the model/tokenizer paths. `MASK_GRID` sizes the synthetic mask
     // fixtures (the production paths call it inside the shared `person_segment_sam3_common` helpers).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -150,6 +150,39 @@ shared code) when it drops its resident generator after the idle timeout: `engin
 level. It correlates with the worker releasing cached GPU allocations (Metal/MLX or
 CUDA) before the next generation cold-loads weights again.
 
+### Poisoned Metal command queue — `mlx_command_queue_poisoned` / `mlx_command_queue_poisoned_exit` (Rust MLX worker, sc-20572)
+
+Emitted at **error** level when the macOS GPU driver starts refusing this worker
+process's Metal submissions and completes its command buffers with
+`kIOGPUCommandBufferCallbackErrorSubmissionsIgnored` — literally *"ignored for causing
+prior/excessive GPU errors"*. It is never the first error: something else already failed
+on that channel, so the event carries `firstFailure` (this process's first contained
+failure, which is what actually explains the cascade) alongside the raw `driverError`.
+
+`mlx_command_queue_poisoned` fires once, from the model-cache containment seam, for the
+job that ran into it. `mlx_command_queue_poisoned_exit` fires from the worker loop
+immediately afterwards, carrying the same reason as the `Unhealthy` heartbeat, just
+before the worker exits so its supervisor restarts it with a clean GPU context. Between
+the two, every queued job is refused **without** being handed to the GPU.
+
+| field | meaning |
+| --- | --- |
+| `scope` | `process` \| `host_suspected` — see below |
+| `firstFailure` | this process's first contained failure (empty when the ignored submission was the first thing it saw) |
+| `driverError` | the raw contained payload |
+| `reason` | (`_exit` only) the user-facing text also sent as the `Unhealthy` status reason |
+
+- `process` — the worker had already driven the GPU before the poisoning (a completed
+  cache run, or a contained fault of its own), so the refused submission channel is this
+  process's. The restart clears it and **no reboot is involved**.
+- `host_suspected` — the worker had completed no GPU work at all first, so the errors
+  being refused over predate it. It still restarts, because a fresh process that fails
+  identically is exactly the evidence for a host wedge. **Before concluding the host needs
+  a reboot, run the cross-process discriminator**: check whether a *different* MLX process
+  is completing GPU work. If one is, the scope is per-process after all; if every fresh
+  process fails, the GPU client class is wedged host-wide and only a reboot clears it.
+  `cargo test` passing proves nothing here — it passes under a host wedge too.
+
 ### Warm execution-policy decision — `generator_cache_warm_policy_decision` (Rust worker, sc-18317)
 
 Emitted once per request evaluation on a warm cache hit whose request asks for an

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -159,11 +159,16 @@ prior/excessive GPU errors"*. It is never the first error: something else alread
 on that channel, so the event carries `firstFailure` (this process's first contained
 failure, which is what actually explains the cascade) alongside the raw `driverError`.
 
-`mlx_command_queue_poisoned` fires once, from the model-cache containment seam, for the
-job that ran into it. `mlx_command_queue_poisoned_exit` fires from the worker loop
-immediately afterwards, carrying the same reason as the `Unhealthy` heartbeat, just
-before the worker exits so its supervisor restarts it with a clean GPU context. Between
-the two, every queued job is refused **without** being handed to the GPU.
+`mlx_command_queue_poisoned` fires once, from one of two containment seams that classify
+a caught panic through the shared `gpu_poison` state: the model-cache containment seam
+(`cache_thread.rs`) for a cache-job panic, or the dedicated SAM3 smart-select thread
+(`person_segment_sam3.rs`'s `sam3_panic_error`, which logs its own "...during sam3
+smart-select" message) for a panic caught there. `mlx_command_queue_poisoned_exit` fires
+from the worker loop immediately afterwards, carrying the same reason as the `Unhealthy`
+heartbeat, just before the worker exits so its supervisor restarts it with a clean GPU
+context. Between the two, every queued job is refused **without** being handed to the
+GPU. It still fires only once per poisoning: the latch refuses any further cache or SAM3
+job outright, and the worker exits before another segment job can be claimed.
 
 | field | meaning |
 | --- | --- |


### PR DESCRIPTION
Fixes sc-20572.

## The defect

Measured in production 2026-08-19. When the macOS GPU driver starts refusing a
process's Metal submissions it completes every later command buffer with
`kIOGPUCommandBufferCallbackErrorSubmissionsIgnored` — *"ignored for causing
prior/excessive GPU errors"*. The model-cache containment seam met that with:

```
MLX generation panicked and was contained (the engine likely ran out of memory;
the cached generator was reset): … kIOGPUCommandBufferCallbackErrorSubmissionsIgnored …
```

Both halves are wrong for this class:

1. **"likely ran out of memory"** — an ignored submission is *never* the first error.
   The OOM guess is right for the first failure (a real `[metal::malloc]` throw) and
   wrong for every ignored submission after it, and it sends diagnosis to the wrong place.
2. **"the cached generator was reset"** — evicting the resident model does not un-poison
   a command queue. ~8 back-to-back jobs (bernini → boogu → krea_2_raw) each hit the
   containment, each reported a successful reset, and each failed identically over
   2.5 minutes, until libc++abi hit an uncaught `std::runtime_error` and `abort()`ed the
   worker. The process respawn is what actually recovered it.

## What changed

New `crates/sceneworks-worker/src/gpu_poison.rs` — detection, scope discrimination and
the composed user-facing text — consulted from the containment seam
(`cache_thread.rs`) and the worker loop (`lib.rs`).

**Attribution.** `SubmissionsIgnored` is classified on its own terms. The error names the
cascade explicitly ("that is the cascade, not the original fault — an ignored submission
is never the first error and is not an out-of-memory condition"), and surfaces this
process's **first** contained failure — the one that actually explains it — instead of
only the ignored submission. Everything that is *not* an ignored submission keeps the
pre-existing containment byte-for-byte, prefix included: the OOM guess is right for a
genuine first failure, which is now the only class that reaches it.

**No reset.** The resident model is deliberately left in place and no backend-cache
release is attempted on this class. Dropping the resident is not a recovery, and both the
drop and the release would submit more Metal work into a channel the driver is refusing.

**Scope discrimination.** The identical error string covers two situations:

- `process` — this worker had already driven the GPU (a completed cache run, or a
  contained fault of its own — exactly the "prior GPU error" being blamed) before the
  poisoning. The refused channel is this process's; the restart clears it; **no reboot**.
- `host_suspected` — this worker had completed no GPU work at all first, so the errors
  being refused over predate it. The message says the restart may not clear it and hands
  over the cross-process discriminator — *is a different MLX process still completing GPU
  work?* — **before** the word reboot is used as a conclusion. The code never asserts a
  reboot on its own; the authoritative discriminator is out-of-process (on 08-19 a
  concurrent `ltx_2_5_tiers_real_weights` run logging healthy forwards is what proved the
  scope was per-process).

**No job-burning loop, then a restart.** The latch is checked at the top of the cache-job
seam, so any queued job is refused *without being handed to the GPU*. On its next turn
the worker loop logs `mlx_command_queue_poisoned_exit`, posts an `Unhealthy` heartbeat
carrying the same reason, and returns `Ok(())` so the supervisor respawns it with a clean
GPU context. `Ok` deliberately: the failing job already posted its own terminal error, and
a non-zero exit would have the desktop supervisor attribute a second, fabricated failure
to it (sc-18182).

**Why `host_suspected` restarts too.** The scope changes what the operator is told, not
whether the worker comes back. The restart is the only recovery available in-process, it
is what demonstrably fixed the measured incident, and a fresh process that fails
identically *is* the "fresh processes fail too" evidence for a host wedge. Parking the
worker alive-but-idle on that branch would strand it on any misclassification, and the
in-process evidence is deliberately weak (see `note_gpu_work_completed`, which only a
completed cache run sets — a poisoning caused by a path outside those seams classifies as
`host_suspected`, the safe direction).

## Scope vs. the story's criteria

| Criterion | Status |
| --- | --- |
| Detect `kIOGPUCommandBufferCallbackErrorSubmissionsIgnored` specifically | done — case-insensitive on the enum tail; nothing else widened into this class |
| Stop attributing it to memory | done — the OOM prefix is now unreachable for this class, asserted by test |
| Stop claiming a reset recovered it | done — no evict, no backend release, and the wording is gone |
| Say the GPU context is poisoned and the worker is restarting | done — job error, refusal text and `Unhealthy` reason all say it, from one shared remedy string |
| Surface the *first* error instead of the cascade | done — recorded per process, included when it differs from the payload |
| Fail the worker fast rather than accepting jobs it cannot serve | done — refusal before `load`/`run`, then exit for restart |
| Two scopes discriminated, reboot never proposed without the cross-process check | done — `process` / `host_suspected`, discriminator gates the word |
| Do not widen | no other Metal error class is folded in; the non-poison path is unchanged |

## Tests

`crates/sceneworks-worker/src/gpu_poison.rs` (11) — an ordinary engine panic is not
classified and does not latch; ignored submissions after completed GPU work are
`process`; in a process that never drove the GPU they are `host_suspected`; an earlier
contained fault re-scopes a later poisoning to `process`; the cascade message carries the
first failure; a poisoning with no earlier fault says so rather than presenting itself as
its own cause; no composed message blames memory or claims a reset; the `process` remedy
rules a reboot out while the `host_suspected` one gates it behind the cross-process
discriminator; the first verdict latches; a latched worker refuses without touching the
GPU; the enum name is recognised in any case (and near-misses are not).

`crates/sceneworks-worker/src/cache_thread.rs` (3) — an ignored-submission panic keeps
the resident model and drops the reset-and-blame-memory prefix; an ordinary panic still
evicts and keeps that prefix; a latched poisoning refuses the next job before any GPU
work. Driven against a local `GpuPoisonState` so the process-global latch is untouched —
latching it in-process would refuse every later job in the test binary, which is exactly
the production behaviour being added.

**Mutation-checked, one guard at a time** (flip → confirm red → restore → `touch`). All
nine killed: detection token never matches (12 red); scope always `process` (3);
prior-fault-does-not-count (1); verdict re-scopes instead of latching (1); first-failure
filter dropped (1); remedies swapped between scopes (2); poisoned branch evicts anyway
(1); ordinary panic stops evicting (1); refusal gate always allows the job through (1).

`npm run rust:check` green.

## Device verification (coordinator-run)

Serialized on the Mac; **not** run by the implementing agent (CPU-only lane). Note the
story's warning: `cargo test --lib` passing proves nothing here — it passes under a host
wedge too. Only a sustained render command buffer discriminates.

> ⚠️ **Never induce the fault by `pkill`ing an MLX render mid-command-buffer.** That is
> the 2026-08-17 trigger and it wedges the GPU client class until a reboot. Nothing below
> requires it.

### A. Wiring, with no GPU fault at all (zero risk — do this one)

Apply a **temporary, uncommitted** scaffold to `cache_thread.rs`, as the first statement
inside the `catch_unwind` closure of `run_cached_with_access_after_cold_admission` (it must
be *inside* the closure so our arm catches it, not the `run_cache_worker` backstop):

```rust
{
    static N: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
    if let Ok(trip) = std::env::var("SC20572_FAKE_POISON") {
        let n = N.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
        if trip.parse::<usize>() == Ok(n) {
            panic!(
                "called `Result::unwrap()` on an `Err` value: Exception(\"[METAL] Command \
                 buffer execution failed: Ignored (for causing prior/excessive GPU errors) \
                 (00000004:kIOGPUCommandBufferCallbackErrorSubmissionsIgnored)\")"
            );
        }
    }
}
```

1. **`host_suspected` branch** — run the app / native MLX worker with
   `SC20572_FAKE_POISON=1`, submit one image job. Expect, in `mlx-worker.log`:
   - the job fails with text containing "the GPU driver is ignoring this worker's Metal
     command submissions", and containing **neither** "ran out of memory" **nor**
     "generator was reset";
   - `mlx_command_queue_poisoned` at error with `scope=host_suspected` and an empty
     `firstFailure`;
   - the message names the cross-process check ("DIFFERENT MLX process") before the word
     reboot;
   - `mlx_command_queue_poisoned_exit`, then the worker exits **0** and the desktop
     supervisor respawns it (`restarting mlx worker in 1s`).
2. **`process` branch** — same build, `SC20572_FAKE_POISON=2`. The first job renders
   normally (proving `note_gpu_work_completed` fires on the real success path), the second
   trips the scaffold. Expect `scope=process`, `firstFailure` empty, and the remedy reading
   "No reboot is needed".
3. **Service resumes** — after either restart, submit a normal image job and confirm it
   completes on the fresh worker. This is the story's Done-when: one accurate error, a
   fast restart, and no cascade of misattributed failures.
4. **Revert the scaffold** (`git checkout crates/sceneworks-worker/src/cache_thread.rs`)
   and rebuild before anything else.

The refusal-before-GPU gate is unit-tested rather than device-observable: the worker runs
one job at a time and exits on its next loop turn, so a second cache job only queues
behind it when a concurrent lane (e.g. a refine-model request) is in flight.

### B. Regression, real weights, no scaffold

5. Run two or three ordinary MLX renders (any warm model) and confirm: unchanged
   behaviour, warm-cache reuse intact, **no** `mlx_command_queue_poisoned*` event, worker
   keeps claiming.
6. Provoke a genuine *first-failure* Metal OOM (e.g. a deliberately low
   `SCENEWORKS_GPU_MEMORY_LIMIT_BYTES`, or a known over-admitting tier). Confirm it still
   reads the old `MLX generation panicked and was contained (the engine likely ran out of
   memory; the cached generator was reset)` prefix, the generator **is** evicted, no poison
   event fires, and the worker keeps serving the next job. A `metal::malloc` throw does not
   poison the queue, so this is safe.

### C. Optional, operator's call — the natural reproduction

7. If the coordinator wants end-to-end evidence on a real driver refusal, the bernini
   over-admission that produced the 08-19 incident is the natural trigger (it is
   process-scoped: the 08-19 occurrence recovered on respawn, with a concurrent MLX
   process rendering fine throughout). Expect exactly one `mlx_command_queue_poisoned`
   with `scope=process`, `firstFailure` carrying the real `[metal::malloc]` cause, then
   the exit and respawn. Skip this if a wedge risk is not acceptable — step A already
   covers every branch of the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review round (2026-08-19): fixed

Three issues from adversarial review, resolved in a follow-up commit (core mechanism —
classification reach, latch-refuse-exit chain, byte-identical non-poison path, supervisor
respawn with backoff — was verified correct and untouched):

1. **[major] Self-attributed first failure.** `record_contained_panic` recorded the
   incoming payload as `first_failure` *before* classifying it, so when a
   `SubmissionsIgnored` panic was itself the first contained panic this process saw,
   `first_failure()` — and therefore the `mlx_command_queue_poisoned` event's
   `firstFailure` field, and the refusal/exit text — echoed the poisoning back as its own
   cause instead of staying empty. Fixed at the single recording site in
   `gpu_poison.rs::record_contained_panic` (a `SubmissionsIgnored` payload is never passed
   to `record_first_failure`); downstream sites (`poisoned_queue_message`,
   `refusal_message`) no longer need their own filtering. New tests:
   `gpu_poison::tests::first_contained_panic_being_the_poison_leaves_first_failure_empty`,
   `a_genuine_earlier_failure_is_surfaced_in_first_failure_and_refusal`, and
   `cache_thread::tests::first_failure_emitted_on_the_event_is_empty_only_when_the_poisoning_is_the_first_thing_seen`
   pinning the exact `contained_panic_error` → `firstFailure` read the event uses.
   Mutation-checked (guard flipped → 2 tests red → restored → `touch`).
2. **[minor, same root cause]** `refusal_message`/`poisoned_status` inherited the same
   bug via `first_failure()` — fixed by the same change; covered by the same new
   `gpu_poison` tests (asserting the refusal text as well as the raw getter).
3. **[minor→fixed in place] SAM3 seam never classified poisonings or recorded GPU-driving
   evidence.** `person_segment_sam3.rs`'s dedicated smart-select thread caught panics with
   its own `catch_unwind` that discarded the payload entirely ("sam3 smart-select thread
   panicked"), so a poisoning first surfacing in a SAM3 click was never classified/latched
   (burning clicks with a vague message until a cache-seam job happened to latch it), and
   a successful SAM3 run never called `note_gpu_work_completed`, biasing later scope
   discrimination toward `host_suspected` even when the same process had just driven the
   GPU. Fixed by routing the caught payload through the same `gpu_poison`
   classify/record/latch seam `cache_thread::contained_panic_error` uses
   (`sam3_panic_error`), and marking `drove_gpu` on a successful run
   (`run_sam3_job_with_poison`) — split out from `run_on_sam3_thread` specifically so it's
   unit-testable against a local `GpuPoisonState` without the executor thread or a Metal
   device. Non-poison panics keep SAM3's existing conservative surface unchanged: the raw
   payload is still never echoed to the caller, only the fixed "thread panicked" text. New
   tests: `person_segment_sam3::tests::an_ordinary_sam3_panic_keeps_the_generic_message_and_does_not_latch`,
   `a_poisoning_first_seen_on_the_sam3_thread_is_classified_and_latches`,
   `a_successful_sam3_run_marks_this_process_as_having_driven_the_gpu`. Mutation-checked
   (payload-discard reintroduced → 2 tests red → restored → `touch`).
4. **[minor] `apps/rust-api/src/lib.rs`** — added the requested comment at the
   `tokio::spawn(... run_worker_loop ...)` call in `spawn_inprocess_utility_worker`: the
   in-process CPU utility loops share `gpu_poison::global()` with any MLX cache work in
   this process, so a latch there would `Ok`-exit every loop with no external supervisor
   to restart them. Unreachable today (this API process runs no MLX cache jobs, so nothing
   can ever record a `SubmissionsIgnored` poisoning here) — comment only, no behavior
   change.

**Effect on the device-verification plan below:** steps A.1/A.2's "empty `firstFailure`"
expectations were written against the *intended* behavior and are unaffected in wording —
they were simply not yet guaranteed by the code before this commit; they are now. Add SAM3
smart-select clicks (box/point) to the plan's scope alongside the cache-seam image jobs
used in A/B/C: the same `SC20572_FAKE_POISON`-style scaffold, injected at the top of
`run_sam3_job_with_poison`'s wrapped `job()` call instead of the cache-job closure, would
exercise the SAM3-originated poisoning path the same way A.1/A.2 exercise the cache-seam
one. Not required to close this story — the seam is now covered by the CPU-only unit tests
above — but worth a line in the device plan's scope if the coordinator runs it.

`npm run rust:check` green (fmt, clippy, `cargo test` across the workspace, `cargo build`).
`cargo test -p sceneworks-worker --lib` — 1756 passed, 0 failed, 210 ignored (real-weight/
GPU smokes).
