### PR TITLE
test(worker): pin the Windows verbatim install-path shape of imported entries (sc-20524)

### DIFF
--- a/crates/sceneworks-worker/src/external_library_runtime.rs
+++ b/crates/sceneworks-worker/src/external_library_runtime.rs
@@ -2616,6 +2616,34 @@ mod tests {
         });
     }
 
+    /// The real manifest written on Windows carries `paths.model` in VERBATIM (`\\?\C:\...`)
+    /// form — the model-import job canonicalizes the install dir before recording it. That is
+    /// the exact user-reported shape (kreamania_v5/v6), so pin it verbatim.
+    #[cfg(windows)]
+    #[test]
+    fn imported_entry_with_verbatim_install_path_clears_the_guard() {
+        let temp = TempDir::new().unwrap();
+        let settings = settings(temp.path().join("data"));
+        let library = temp.path().join("external-hf");
+        let mut entry = imported_entry(&settings.data_dir, "kreamania_v5");
+        let install = settings.data_dir.join("models/imports/kreamania_v5");
+        let verbatim = std::fs::canonicalize(&install).unwrap();
+        assert!(
+            verbatim.to_string_lossy().starts_with(r"\\?\"),
+            "canonicalize must produce the verbatim form this test exists to pin"
+        );
+        entry["paths"]["model"] = json!(verbatim);
+        let payload = json!({ "model": "kreamania_v5", "modelManifestEntry": entry })
+            .as_object()
+            .unwrap()
+            .clone();
+        with_library(&library, || {
+            RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap_or_else(
+                |error| panic!("verbatim install path must clear the guard: {error}"),
+            );
+        });
+    }
+
     /// Reading only `source.path` must not become "read nothing": a `source.path` that escapes
     /// the app-managed roots is still a rejection, and a benign-looking `source` block never
     /// launders an entry whose real `paths` point outside.


### PR DESCRIPTION
## Why

Investigating the reported KreaMania v5/v6 failure ("non-HF model source must be inside an app-managed directory.") showed the bug itself is already fixed on main by #2424 (sc-20524) — the failing jobs in the local jobs DB carry exactly the manifest shape that fix covers, and the installed desktop build producing the failures was compiled ~7h before #2424 merged.

One gap remained: the real `user.models.jsonc` written on Windows records `paths.model` in **verbatim** form (`\?\C:\...`), and no guard test covered that spelling — the sc-20524 fixtures use plain `TempDir` paths. `Path::starts_with` treats `VerbatimDisk` and `Disk` prefixes as unequal, so a future confinement change that stops canonicalizing either side would reject every Windows import while staying green on the existing fixtures.

## What

One Windows-only test pinning the exact user-reported kreamania_v5 entry shape with a canonicalized (verbatim) install path through `RuntimeSourceGuard::begin`.

## Verification

`cargo test -p sceneworks-worker --lib external_library_runtime` — 33 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)