### PR TITLE
fix(worker): cached-base admission seeds the reclaimable pool so stock gates see the evictable import

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/base_admission.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base_admission.rs
@@ -352,6 +352,11 @@ impl CachedCandleBaseFloorAdmission {
     /// Admit one cold load. `resident_reclaimable_weight_bytes` comes from the exact different-key
     /// cache entry that remains alive until this gate succeeds. A historical process-global peak is
     /// not valid credit: after large -> small, it can describe memory already returned to the driver.
+    ///
+    /// This gate never READS the process-global pool, but an admitted load still WRITES its weight
+    /// bytes there ([`crate::vram_gate::note_loaded_peak`]) — the lanes that do budget
+    /// `free + reclaimable_pool` must not stay blind to an evictable resident that arrived through
+    /// this lane.
     pub(super) fn admit(self, resident_reclaimable_weight_bytes: u64) -> WorkerResult<()> {
         let Some(floor_gb) = (self.source_weight_bytes > 0).then(|| {
             self.source_weight_bytes as f64 / BYTES_PER_GIB + crate::vram_gate::HEADROOM_GB
@@ -374,6 +379,19 @@ impl CachedCandleBaseFloorAdmission {
         let needed = Some(floor_gb);
         match crate::vram_gate::load_plan(needed, None, budget, false) {
             LoadPlan::Resident => {
+                // Record this occupancy in the process-global reclaimable high-water (sc-11023).
+                // The single-slot cache evicts this entry before any later different-model load,
+                // so the lanes that budget `free + reclaimable_pool` (the generic txt2img gate,
+                // `gate_with_evict_reclaim`) may credit it. Without this note, a fresh worker
+                // whose only loads came through this lane gates stock models against raw free
+                // while the import sits resident — a false TooBig reject for a load that fits
+                // once the cache evicts the import. Weights only, no headroom: evicting a
+                // resident generator cannot promise to reclaim that allowance (see
+                // `reclaimable_weight_bytes`).
+                crate::vram_gate::note_loaded_peak(
+                    &self.gpu_id,
+                    self.source_weight_bytes as f64 / BYTES_PER_GIB,
+                );
                 tracing::info!(
                     model = self.model,
                     lane = self.lane,
@@ -565,6 +583,42 @@ mod tests {
             LoadPlan::Resident,
             "precondition: the stale global high-water would have over-admitted"
         );
+    }
+
+    #[test]
+    fn cached_admission_notes_its_weights_into_the_reclaimable_pool() {
+        // A fresh worker whose only load came through the cached imported/ComfyUI lane must still
+        // leave a reclaimable high-water behind: the generic txt2img gate budgets
+        // `free + reclaimable_pool`, and a pool blind to this resident occupant falsely rejects a
+        // stock model that fits once the single-slot cache evicts the import (the "needs ~49 GB
+        // but GPU 0 has ~43 GB" reject with a ~23 GB Kreamania checkpoint resident).
+        let runtime = tokio::runtime::Runtime::new().expect("runtime builds");
+        let gpu_id = "base-admission-cached-note-gpu";
+        let admission = CachedCandleBaseFloorAdmission {
+            model: "kreamania_fixture".to_owned(),
+            lane: "Krea imported",
+            gpu_id: gpu_id.to_owned(),
+            source_weight_bytes: (6.0 * BYTES_PER_GIB) as u64,
+            runtime: runtime.handle().clone(),
+        };
+        admission.admit(0).expect("floor admission admits");
+        assert_eq!(
+            crate::vram_gate::reclaimable_pool_gb(gpu_id),
+            6.0,
+            "the admitted import's weight bytes (headroom excluded) seed the pool"
+        );
+
+        // The un-gateable zero-weight branch admits without a floor and records nothing.
+        let empty_gpu = "base-admission-cached-note-empty-gpu";
+        let admission = CachedCandleBaseFloorAdmission {
+            model: "kreamania_fixture".to_owned(),
+            lane: "Krea imported",
+            gpu_id: empty_gpu.to_owned(),
+            source_weight_bytes: 0,
+            runtime: runtime.handle().clone(),
+        };
+        admission.admit(0).expect("un-gateable admission admits");
+        assert_eq!(crate::vram_gate::reclaimable_pool_gb(empty_gpu), 0.0);
     }
 
     #[test]


### PR DESCRIPTION
## Symptom

Live false reject on the dev box (2026-08-19 15:14 UTC, `candle-worker.log`):

> krea_2_turbo at the bf16 tier needs ~49 GB of VRAM (with headroom) but GPU 0 has ~43 GB available. No smaller tier is installed — lower the output resolution or run on a GPU with more VRAM.

GPU 0 actually had ~53 GB held by the worker process itself — an imported Kreamania checkpoint resident in the single-slot generator cache (plus cudarc-pooled pages from the occupant it had replaced). Evicting it (which the cache does before any different-model load anyway) would have freed the load comfortably.

## Root cause

The sc-18306 cached-base admission lane (imported Krea / ComfyUI checkpoints — `CachedCandleBaseFloorAdmission::admit`) deliberately never **reads** the sc-11023 process-global reclaimable high-water (its own gate credits the exact resident cache entry instead, which is correct there). But it also never **wrote** to the pool. So after an app restart, a worker whose only loads came through this lane keeps `reclaimable_pool_gb == 0`, and every lane that budgets `free + reclaimable_pool` — the generic txt2img gate (`generate_candle_stream`) and `gate_with_evict_reclaim` (Qwen-Edit / Krea-control bespoke lanes) — gates stock models against raw free VRAM while the import sits resident. The reject numbers reproduce exactly: raw free 43 GB < 49.4 GB needed, while the evictable import held ~52 GB.

The state self-heals only by accident (the import idle-evicts after 5 min, or one stock load squeaks through raw and re-seeds the pool via its own `note_loaded_peak`) — which is why the identical job admitted at 15:18 after the Anubis-8B refiner idle-evicted.

## Fix

An admitted cached-base load now records its source weight bytes into `note_loaded_peak`, headroom excluded (eviction cannot promise to reclaim the transient allowance — same rule as the entry-bound `reclaimable_weight_bytes`). Weights-only is a conservative under-credit of what eviction actually frees; the pool remains monotone and clamped to `total_gb`, so this cannot over-admit beyond what sc-11023 already accepts for every other noting lane. The lane's own gate is unchanged and still credits only the exact resident entry.

Covers all four cached-base callers (Krea imported, FLUX.2/Qwen/Z-Image ComfyUI) — they share `admit()`.

## Known residual (opposite direction, not addressed here)

Stock/generic cache entries bind `reclaimable_weight_bytes: 0`, so an incoming *import* replacing a resident *stock* generator gets zero exact-entry credit and can still falsely reject when raw free < the import's floor. Rarer (import floors are small), and fixing it needs per-route sizing decisions — on-disk bytes are not a provable lower bound on resident VRAM for every generic route (ConvRot int8-over-bf16, sequential staging).

## Verification

- New regression test `cached_admission_notes_its_weights_into_the_reclaimable_pool` (fresh-pool seeding + the zero-weight un-gateable branch noting nothing); full `base_admission` module: 10/10 pass under `--features backend-candle` on the CUDA box.
- `cargo clippy -p sceneworks-worker --features backend-candle --all-targets -- -D warnings` clean (windows-candle lane config).
- `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
