### PR TITLE
test(core): pin the stale-staging swap tests to a forced interrupted reservation

### DIFF
--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -66,6 +66,37 @@ fn source_snapshot(candidate: &PromotionCandidate) -> &Path {
     }
 }
 
+/// Park a fixture entry in the non-live state `cleanup_stale_staging` requires before it will
+/// touch a staging directory at all.
+///
+/// This is a PRECONDITION for the two directory-swap tests below, never their subject.
+/// `ResolvedCacheReservation::drop` records the interruption on a best-effort basis: it *warns*
+/// and leaves the entry `Materializing`, still owned by this live session, whenever its metadata
+/// write cannot complete — a transient open/read/write failure under the descriptor and IO
+/// pressure of a loaded hosted runner is the documented case (see the note on
+/// `ResolvedCacheStore::read_eviction_marker`, which was made descriptor-cheap for exactly this
+/// reason). `cleanup_stale_staging` then correctly *skips* the entry fail-closed and returns
+/// `Ok(0)`, the swap hook never runs, and a test that only asserts "the sweep returned an error"
+/// reads that skip as "the symlink was followed". That is what reddened
+/// `stale_cleanup_directory_swap_never_follows_an_external_symlink` on the hosted macOS lane.
+///
+/// Forcing the transition here costs no coverage: the drop-marks-interrupted contract is owned by
+/// `materialization::tests::stale_staging_cleanup_requires_artifact_and_session_authority` and by
+/// `reservation_is_exclusive_unrelated_keys_progress_and_drop_interrupts`, which assert it
+/// directly instead of inheriting it as setup.
+fn force_interrupted_reservation(store: &ResolvedCacheStore, cache_key: &str) {
+    store
+        .update_metadata(cache_key, |metadata| {
+            metadata.state = ResolvedCacheEntryState::Interrupted;
+            metadata.reservation_id = None;
+            metadata.reservation_owner = None;
+            metadata.session_id = None;
+            metadata.recovery_status = RecoveryStatus::InterruptedReservation;
+            Ok(())
+        })
+        .expect("the fixture entry must be parkable as an interrupted reservation");
+}
+
 #[cfg(unix)]
 #[test]
 fn stale_cleanup_directory_swap_never_follows_an_external_symlink() {
@@ -83,6 +114,7 @@ fn stale_cleanup_directory_swap_never_follows_an_external_symlink() {
     let staging = reservation.staging_path().to_owned();
     std::fs::write(staging.join("partial"), b"partial").unwrap();
     drop(reservation);
+    force_interrupted_reservation(&store, &candidate.cache_key);
 
     let external = scratch.path().join("external");
     std::fs::create_dir(&external).unwrap();
@@ -96,6 +128,18 @@ fn stale_cleanup_directory_swap_never_follows_an_external_symlink() {
     });
 
     assert!(store.cleanup_stale_staging().is_err());
+    // The swap has to be what the sweep refused. A sweep that never reached the removal at all
+    // (it skipped the entry, or failed earlier) also returns without deleting the sentinel, so
+    // without this the assertions below pass for the wrong reason: the hook only runs inside
+    // `remove_entry_at`, so a staging path that is now a symlink is the witness that the sweep
+    // stood on the swapped path and still refused to follow it.
+    assert!(
+        std::fs::symlink_metadata(&staging)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the removal must have reached the swapped staging path"
+    );
     assert_eq!(std::fs::read(&sentinel).unwrap(), b"untouched");
     assert!(external.is_dir());
     std::fs::remove_file(staging).unwrap();
@@ -292,6 +336,7 @@ fn stale_cleanup_directory_swap_never_follows_an_external_junction() {
     let staging = reservation.staging_path().to_owned();
     std::fs::write(staging.join("partial"), b"partial").unwrap();
     drop(reservation);
+    force_interrupted_reservation(&store, &candidate.cache_key);
 
     let external = scratch.path().join("external");
     std::fs::create_dir(&external).unwrap();
@@ -306,6 +351,15 @@ fn stale_cleanup_directory_swap_never_follows_an_external_junction() {
     });
 
     assert!(store.cleanup_stale_staging().is_err());
+    // The swap has to be what the sweep refused. A sweep that never reached the removal at all
+    // (it skipped the entry, or failed earlier) also returns without deleting the sentinel, so
+    // without this the assertions below pass for the wrong reason: the hook only runs inside
+    // `windows_confined_directory`, so a staging path that is now a reparse point is the witness
+    // that the sweep stood on the swapped path and still refused to follow it.
+    assert!(
+        metadata_is_reparse_point(&std::fs::symlink_metadata(&staging).unwrap()),
+        "the removal must have reached the swapped staging path"
+    );
     assert_eq!(std::fs::read(&sentinel).unwrap(), b"untouched");
     assert!(external.is_dir());
     std::fs::remove_dir(staging).unwrap();


### PR DESCRIPTION
## The flake

`sceneworks-core`'s `stale_cleanup_directory_swap_never_follows_an_external_symlink`
failed once on the hosted macOS lane (PR #2442's first run), then passed on the base
branch's run 18 minutes later and on every run since. CI panic:

```
panicked at crates/sceneworks-core/src/resolved_cache/tests.rs:98:5:
assertion failed: store.cleanup_stale_staging().is_err()
```

## Root cause: test-side, an inherited precondition

`cleanup_stale_staging` only removes a staging directory whose entry is no longer a
live reservation. The test obtained that state as a side effect of
`drop(reservation)` — but `ResolvedCacheReservation::drop` records the interruption
best-effort by design: it **warns** and leaves the entry `Materializing`, still owned
by this live session, whenever its metadata write cannot complete. That is exactly the
transient descriptor/IO pressure class the `read_eviction_marker` doc comment already
records for this same test on this same lane.

When that happens, `cleanup_stale_staging` correctly **skips** the entry fail-closed
and returns `Ok(0)`, the swap hook never runs — and `assert!(...is_err())` reads that
fail-closed skip as "the symlink was followed".

### Reproduced deterministically

Making `mark_interrupted_on_drop` return an error reproduces the CI panic verbatim on
the Windows sibling test (`...never_follows_an_external_junction`, same body):

```
panicked at crates\sceneworks-core\src\resolved_cache\tests.rs:308:5:
assertion failed: store.cleanup_stale_staging().is_err()
```

Six other `resolved_cache` tests share the same dependency on the drop's marking — but
for them the drop→interrupted transition *is* the subject, so they are left alone.

## Why the production code is not changed

The sweep's refusal to delete a staging directory that the durable journal still calls
live is correct fail-closed behaviour. The obvious alternative — an in-process registry
of live reservation ids — would delete staging out from under the crash-simulation
paths that deliberately leak reservations, so it would trade a test flake for a real
hazard.

## The fix

Both directory-swap tests (unix symlink, windows junction) now:

1. **Force** the interrupted state via `update_metadata` after the drop instead of
   inheriting it. Staleness is a precondition here, not the subject.
2. **Assert the sweep actually reached the swapped path** — the staging path must be a
   symlink (unix) / reparse point (windows) afterwards. The hook only runs inside the
   removal, so this is the witness that the refusal came from the swap defense and not
   from never getting there.

## Mutation evidence

| mutation | before | after |
| --- | --- | --- |
| `mark_interrupted_on_drop` returns `Err` (the flake condition) | RED, exact CI panic | GREEN |
| `cleanup_stale_staging` returns `Err` before the removal | GREEN (passes for the wrong reason) | RED — `the removal must have reached the swapped staging path` |

Both mutations were applied and reverted locally; the working tree ends clean.

## Gates (local, Windows)

- `cargo fmt --all -- --check` — clean
- `cargo test -p sceneworks-core --lib` — 1087 passed, 0 failed
- `cargo clippy -p sceneworks-core --all-targets -- -D warnings` — clean
- `npm run check` (Git Bash) — 83 failures, byte-identical to the count on the pristine
  tree; all are pre-existing Windows-environment failures in the node script tests
  (`spawn /bin/sh ENOENT`, POSIX mode bits) and untouched by a Rust-only change.

The unix variant cannot execute on this box (`#[cfg(unix)]`); its Windows sibling has an
identical body and exercised every step above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
