### PR TITLE
test(core): give the eviction swap test the witness the staging ones just got

### DIFF
--- a/crates/sceneworks-core/src/resolved_cache/retention_tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/retention_tests.rs
@@ -1232,7 +1232,32 @@ fn eviction_removal_never_follows_a_swapped_symlink_outside_the_root() {
 
     let report = store.enforce_retention(&policy(1, 1), FAR_FUTURE).unwrap();
     assert!(report.evicted.is_empty());
-    assert_eq!(report.failed.len(), 1);
+    // The swap has to be what the removal refused. An eviction that never reached the removal at
+    // all — the entry was held back, or it failed earlier — also leaves the sentinel alone and
+    // still lands in `failed`, so without this the assertions below pass for the wrong reason: the
+    // hook only runs inside `remove_entry_at`, so an entry path that is now a symlink is the
+    // witness that the removal stood on the swapped path and still refused to follow it. This is
+    // the same precondition trap that reddened
+    // `stale_cleanup_directory_swap_never_follows_an_external_symlink` on the hosted macOS lane;
+    // this test reaches its removable state through `materialize_complete` and `stamp_activity`,
+    // both checked, so only the witness was missing.
+    assert!(
+        std::fs::symlink_metadata(&entry)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the removal must have reached the swapped entry path: {report:?}"
+    );
+    // Which entry failed, not merely that something did.
+    assert_eq!(
+        report
+            .failed
+            .iter()
+            .map(|(cache_key, _)| cache_key.as_str())
+            .collect::<Vec<_>>(),
+        vec![candidate.cache_key.as_str()],
+        "the refusal's own text is the host's errno, so only the entry it names is pinned"
+    );
     assert_eq!(std::fs::read(&sentinel).unwrap(), b"untouched");
     assert!(external.is_dir());
     // The removal failed, so nothing may claim it completed: the audit trail records completed


### PR DESCRIPTION
## What does this PR do?

Follow-on to #2444. That PR hardened the two `cleanup_stale_staging` directory-swap tests — the unix symlink one and the windows junction one — after the symlink one went red on the hosted macOS lane of PR #2442. Each now establishes its non-live precondition explicitly instead of inheriting it from the warn-only `ResolvedCacheReservation::drop`, and each asserts the path is a symlink/reparse point afterwards as the witness that the sweep actually reached the swapped path.

`eviction_removal_never_follows_a_swapped_symlink_outside_the_root` in `retention_tests.rs` is the third member of that family — same one-shot `set_remove_entry_after_stat_hook`, same swap, same external sentinel — and was left untouched.

**Its precondition is fine.** It reaches its removable state through `materialize_complete` and `stamp_activity`, both checked, so the warn-only-drop flake class that hit the staging tests cannot reach it. I verified that rather than assuming it.

**Its witness was missing.** `assert_eq!(report.failed.len(), 1)` also holds for an eviction that never reached `remove_entry_at` at all: such an entry still lands in `failed`, and it also leaves the sentinel alone. So the remaining assertions would pass for the wrong reason and the swap refusal itself would go unproven. This PR adds the same symlink witness #2444 added, and pins `failed` to the cache key it names rather than a bare count.

The refusal's own text stays deliberately unpinned — it is the host's errno, not ours. Worth recording: the swap lands *after* the `statat` has already typed the path as a directory, so the refusal actually comes from the `O_NOFOLLOW | O_DIRECTORY` open failing (`ENOTDIR` on Linux, `ELOOP` elsewhere). The `"refusing to remove linked managed path"` branch in `remove_entry_at` is *not* the one this scenario exercises.

## Related issue

No story id — hosted macOS flake found during the sc-19048 sync, PR #2442. Code originates in sc-19712.

## Type of change

- [x] Refactor / chore (no user-facing behavior change) — test-only

## How was this tested?

- [x] Not platform-specific (shared crate) — though the test itself is `#[cfg(unix)]`

`cargo test -p sceneworks-core` (full), `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --check` all green on **both** Linux (WSL Ubuntu 24.04) and Windows. Linux mattered: the Windows toolchain never compiles this `#[cfg(unix)]` test at all.

## Checklist

- [x] `npm run rust:check` — `check:rust-derived-docs`, `rust:fmt`, `rust:lint` all pass. `rust:test` has 2 failures in `sceneworks-rust-api` (`ltx_eros_legacy_install_is_cleanup_only_and_reclaimable_off_macos`, `ltx_eros_mixed_trash_failure_retains_a_retryable_cleanup_tombstone`) — **pre-existing on this Windows box**, confirmed by stashing this change and reproducing them on pristine `main`. Unrelated to this diff, which touches one `#[cfg(test)]` module in another crate.
- [x] `npm run check` — the Windows run reds a large block of `run-ltx-safety-canary.test.mjs` on `spawn /bin/sh ENOENT` and POSIX file-mode assertions; that file is 38/38 green under WSL. Environment artifact, not this change.
- [ ] Web app — not touched
- [x] Documentation — the reasoning lives in the test's own comments
- [x] Commits signed off
- [x] Single logical change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
