### PR TITLE
test(rust-api): seed manifest file globs as concrete filenames so the Eros tests pass on Windows

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -3122,6 +3122,27 @@ mod download_receipt_tests {
             .unwrap_or_else(|| panic!("builtin entry {model_id} present"))
     }
 
+    /// Manifest `files` entries are match patterns, not literal names — Eros's shared Gemma
+    /// encoder ships as `"gemma/*"`. Seeding must write a CONCRETE file the pattern matches:
+    /// `snapshot_contains_pattern` globs the snapshot, so any real name under `gemma/` reads
+    /// exactly like the literal `*` file this helper used to write. That literal only ever worked
+    /// because `*` is a legal filename on macOS/Linux; on Windows `fs::write` fails with
+    /// `ERROR_INVALID_NAME` (os error 123), which reddened the seeded-cache Eros tests on the dev
+    /// box while the Linux `cargo test` lane stayed green.
+    fn seeded_file_path(pattern: &str) -> String {
+        pattern
+            .split('/')
+            .map(|segment| match segment {
+                "*" => "seeded.safetensors".to_owned(),
+                segment if pattern_contains_glob(segment) => {
+                    segment.replace('*', "seeded").replace('?', "0")
+                }
+                segment => segment.to_owned(),
+            })
+            .collect::<Vec<_>>()
+            .join("/")
+    }
+
     fn seed_manifest_download(data_dir: &FsPath, download: &Value) {
         let repo = download.get("repo").and_then(Value::as_str).unwrap();
         let revision = download.get("revision").and_then(Value::as_str).unwrap();
@@ -3130,7 +3151,7 @@ mod download_receipt_tests {
             .join("snapshots")
             .join(revision);
         for file in string_array_field(download, "files") {
-            let path = snapshot.join(file);
+            let path = snapshot.join(seeded_file_path(&file));
             std::fs::create_dir_all(path.parent().unwrap()).unwrap();
             std::fs::write(path, b"legacy Eros weights").unwrap();
         }
@@ -3152,8 +3173,8 @@ mod download_receipt_tests {
     /// `apply_model_catalog_entry`, yet the snapshot pipeline still runs size enrichment on it.
     /// The refresh must no-op for tombstones while staying a hard error for real entries —
     /// this exact mismatch 500'd the whole catalog for machines holding legacy Eros weights.
-    /// (Platform-neutral twin of the seeded-cache Eros tests below, which cannot run on Windows:
-    /// their setup writes the literal `gemma/*` manifest pattern as a filename.)
+    /// (Platform-neutral twin of the seeded-cache Eros tests below, which reach the same tombstone
+    /// through a real on-disk install — see `seeded_file_path` for why that seeding is glob-aware.)
     #[test]
     fn size_refresh_tolerates_a_cleanup_tombstone_without_variants() {
         let mut tombstone = json!({
@@ -4599,7 +4620,7 @@ mod download_receipt_tests {
                     .join(revision);
                 std::fs::create_dir_all(&snapshot).unwrap();
                 for file in string_array_field(co_requisite, "files") {
-                    let path = snapshot.join(&file);
+                    let path = snapshot.join(seeded_file_path(&file));
                     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
                     std::fs::write(path, b"weights").unwrap();
                 }
@@ -4637,7 +4658,7 @@ mod download_receipt_tests {
             let legacy_repo = huggingface_repo_cache_path(data_dir, rename.legacy_repo).unwrap();
             let legacy_snapshot = legacy_repo.join("snapshots").join(clip_revision);
             for file in &clip_files {
-                let path = legacy_snapshot.join(file);
+                let path = legacy_snapshot.join(seeded_file_path(file));
                 std::fs::create_dir_all(path.parent().unwrap()).unwrap();
                 #[cfg(unix)]
                 {
@@ -4743,7 +4764,7 @@ mod download_receipt_tests {
                 .join(codec_rev);
             std::fs::create_dir_all(&codec_snapshot).unwrap();
             for file in string_array_field(codec, "files") {
-                let path = codec_snapshot.join(&file);
+                let path = codec_snapshot.join(seeded_file_path(&file));
                 std::fs::create_dir_all(path.parent().unwrap()).unwrap();
                 std::fs::write(path, b"weights").unwrap();
             }


### PR DESCRIPTION
## What does this PR do?

Fixes two `sceneworks-rust-api` unit tests that fail on Windows against pristine `main`, making `npm run rust:check` permanently red on the Windows dev box:

- `models::download_receipt_tests::ltx_eros_legacy_install_is_cleanup_only_and_reclaimable_off_macos`
- `models::download_receipt_tests::ltx_eros_mixed_trash_failure_retains_a_retryable_cleanup_tombstone`

**Root cause — a test-helper bug, not a product bug.** `seed_manifest_download` wrote each manifest `downloads[].files` entry to disk *verbatim*, but those entries are **match patterns, not literal names**. Eros's shared Gemma co-requisite declares `"files": ["gemma/*"]`, so seeding a full legacy install called `fs::write(<snapshot>/gemma/*)`:

```
panicked at apps\rust-api\src\models.rs:3135:58:
called `Result::unwrap()` on an `Err` value: Os { code: 123, kind: InvalidFilename }
```

`*` is a legal filename on macOS/Linux, and because `snapshot_contains_pattern` globs the snapshot, the literal `*` file even satisfied its own pattern — so the helper worked everywhere it actually ran. On Windows `*` is `ERROR_INVALID_NAME`. Only the two tests that seed with `include_co_requisites = true` fail; the co-requisite-only test passes because the download it picks declares a plain filename.

**Fix.** New `seeded_file_path()` rewrites glob segments to a concrete name (`gemma/*` → `gemma/seeded.safetensors`) before seeding. Behaviour is unchanged off Windows: the seeded file still matches the pattern, and the tests' install-detection assertions (the row is retained, then disappears after delete) still discriminate — this is not a false green.

The three sibling seeding sites in the same module — MMAudio component co-requisites, the legacy CLIP rename snapshot, and the codec repo — are routed through the same helper. They pass today only because those manifests happen to declare literal filenames; one glob added to any of them would redden Windows again just as invisibly.

Also corrects a stale comment claiming these tests "cannot run on Windows" — nothing gated them, so they simply failed.

## Related issue

No tracker item; reported directly as a broken Windows baseline.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## Reviewer note: why CI never caught this

**No CI lane runs `cargo test` for `sceneworks-rust-api` on Windows.**

- `.github/workflows/check.yml` runs `npm run rust:check` (which contains `cargo test`) on `ubuntu-latest`.
- `.github/workflows/windows-candle.yml` runs `cargo test` for `-p sceneworks-worker` and `-p sceneworks-memory-adapter` only; for rust-api it runs `cargo check -p sceneworks-rust-api --features backend-candle` and nothing else.

So the tests were genuinely green in every lane they ran in, and the failure was dev-box-only. Any Windows-only rust-api test bug is structurally invisible to CI — worth keeping in mind when reviewing manifest-driven test fixtures.

This change is test-only (a `#[cfg(test)]` module); no production code paths are touched.

## How was this tested?

- [ ] macOS (Apple Silicon / MLX)
- [x] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [ ] Not platform-specific (web UI, docs, shared crate)

Verified on the Windows dev box:

- `cargo test -p sceneworks-rust-api --lib ltx_eros` — was `2 passed; 2 failed`, now **4 passed; 0 failed**
- `cargo test -p sceneworks-rust-api --lib` — **622 passed; 0 failed; 3 ignored**, both with and without `HF_HOME` set (the module uses the `isolate_hf_cache()` guard)
- `cargo fmt -p sceneworks-rust-api -- --check` — clean
- `cargo clippy -p sceneworks-rust-api --all-targets -- -D warnings` — clean

- `npm run rust:check` (the full workspace chain: `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, workspace `cargo test`, `cargo build`) — **passed end to end on Windows**, reaching and completing the final `cargo build` step.

That last run is the one that matters here: making `npm run rust:check` green on Windows is the entire point of this PR. It was red on pristine `main` on this box before the change.

## Checklist

- [x] I ran `npm run rust:check` (if I touched Rust) and it passed
- [ ] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build` (if I touched the web app) — no web changes
- [ ] I ran `npm run check` (scaffold checks) — no manifest, workflow, or scaffold changes
- [x] I updated documentation where relevant (corrected the stale in-file comment)
- [ ] All my commits are signed off (`git commit -s`) — matching this repo's existing commit convention
- [x] My PR is focused on a single logical change
