### PR TITLE
docs(routing): advise the safe generator form in the matrix drift panic

### DIFF
--- a/crates/sceneworks-core/src/jobs_store/routing/matrix.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/matrix.rs
@@ -3276,7 +3276,7 @@ mod tests {
         let actual = backend_capability_matrix().expect("capability matrix generates");
         checked_in_matrix_matches_live(expected, actual).unwrap_or_else(|error| {
             panic!(
-                "backend capability matrix drifted ({error}); run `{GENERATOR} > config/backend-capabilities/matrix.json` only for an intentional capability recapture"
+                "backend capability matrix drifted ({error}); run `{GENERATOR} -- config/backend-capabilities/matrix.json` only for an intentional capability recapture"
             )
         });
     }


### PR DESCRIPTION
## Problem

`checked_in_matrix_matches_all_authoritative_sources` panics with advice to run:

```
cargo run -p sceneworks-core --bin dump-backend-capability-matrix > config/backend-capabilities/matrix.json
```

Shell redirection truncates `config/backend-capabilities/matrix.json` to zero bytes **before** cargo runs. Any build or generation failure therefore leaves the checked-in artifact empty — and because `matrix.rs:3229` pulls it in with `include_str!`, an empty artifact breaks compilation of the entire `sceneworks-core` crate, not just the test that printed the advice.

## Fix

Point the panic at the positional-argument form the binary already supports:

```
cargo run -p sceneworks-core --bin dump-backend-capability-matrix -- config/backend-capabilities/matrix.json
```

`dump-backend-capability-matrix.rs` reads the destination from `args_os().nth(1)` and only calls `std::fs::write` **after** `backend_capability_matrix()` returns `Ok` — a failed generation leaves the artifact untouched. With no argument it still prints to stdout, so the redirect form remains possible; it is simply no longer what the code recommends.

The advised string is now byte-identical to what `config/backend-capabilities/README.md` has documented all along.

## Why `GENERATOR` itself is unchanged

`GENERATOR` (`matrix.rs:110`) has a second call site: `matrix.rs:419` sets `generated_by: GENERATOR.to_owned()`, which serializes into `matrix.json`'s `generatedBy` field (`"cargo run -p sceneworks-core --bin dump-backend-capability-matrix"`) and is byte-compared by this same drift test. Appending the path to the const would red the test and force an artifact recapture. So the ` -- <path>` suffix lives in the message string only.

## Scope

Message text only. No change to the generator, the test's assertions, or any matrix content.

## Verification

- `cargo test -p sceneworks-core --lib checked_in_matrix_matches_all_authoritative_sources` — 1 passed, 0 failed
- `npm run rust:check` — green locally
- `git diff --stat` — 1 file changed, 1 insertion(+), 1 deletion(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
