### PR TITLE
feat(core): inspect universal checkpoints (sc-20632)

### DIFF
--- a/crates/sceneworks-core/src/checkpoint_inspector.rs
+++ b/crates/sceneworks-core/src/checkpoint_inspector.rs
@@ -1,0 +1,2685 @@
+//! Deterministic, CPU-only inspection of community checkpoint containers.
+//!
+//! Discovery and runnable validation are deliberately separate. Discovery performs a bounded
+//! directory walk and reads only container descriptors (the safetensors JSON header or GGUF
+//! magic). Runnable validation then parses descriptor contents strictly, validates every declared
+//! tensor range, and streams every artifact through SHA-256. This keeps catalog discovery cheap
+//! while ensuring an emitted [`CheckpointInventoryV1`] is bound to the exact bytes a loader will
+//! consume. Inspection does not retain file handles or lock community-owned files: a later consumer
+//! must verify each locator's recorded digest against the bytes it opens before loading them.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::fmt;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+
+use serde::de::{Error as _, MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::base_weights::{classify_base_header, BaseWeightDetection};
+use crate::checkpoint_import::{
+    CheckpointCatalogRecordV1, CheckpointInventoryV1, ImportLayerV1, ImportPlanV1,
+    ManagedProvenanceV1, SourceLocatorV1,
+};
+
+const MAX_DISCOVERY_ENTRIES: usize = 4096;
+const MAX_DISCOVERY_DEPTH: usize = 8;
+const MAX_SAFETENSORS_HEADER_BYTES: u64 = 100_000_000;
+const MAX_JSON_DESCRIPTOR_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_GGUF_DESCRIPTOR_BYTES: u64 = 128 * 1024 * 1024;
+const MAX_GGUF_ITEMS: u64 = 1_000_000;
+const MAX_GGUF_STRING_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_GGUF_ARRAY_DEPTH: usize = 16;
+const HASH_BUFFER_BYTES: usize = 1024 * 1024;
+const MAX_AGGREGATE_TENSOR_NAMES: usize = 65_536;
+const MAX_AGGREGATE_TENSOR_NAME_BYTES: usize = 32 * 1024 * 1024;
+const MAX_AGGREGATE_EVIDENCE_STRING_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckpointLayoutV1 {
+    SingleFile,
+    FusedCheckpoint,
+    ComponentDirectory,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckpointContainerV1 {
+    Safetensors,
+    Gguf,
+    JsonDescriptor,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckpointDiagnosticSeverityV1 {
+    Error,
+    Warning,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckpointDiagnosticCodeV1 {
+    SourceNotFound,
+    PathEscapesRoot,
+    DiscoveryLimitExceeded,
+    NoWeightCandidates,
+    UnsupportedContainer,
+    HeaderTooLarge,
+    TruncatedHeader,
+    TruncatedData,
+    DuplicateKey,
+    MalformedMetadata,
+    InvalidTensorRange,
+    UnsupportedTensorType,
+    MissingSidecar,
+    IndexTensorMismatch,
+    AmbiguousComponentRole,
+    MissingFamilyEvidence,
+    FamilyDialectConflict,
+    SourceChangedDuringInspection,
+    Io,
+    ContractViolation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckpointDiagnosticV1 {
+    pub severity: CheckpointDiagnosticSeverityV1,
+    pub code: CheckpointDiagnosticCodeV1,
+    pub relative_path: Option<String>,
+    pub message: String,
+}
+
+impl CheckpointDiagnosticV1 {
+    fn error(
+        code: CheckpointDiagnosticCodeV1,
+        relative_path: Option<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            severity: CheckpointDiagnosticSeverityV1::Error,
+            code,
+            relative_path,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckpointCandidateV1 {
+    pub relative_path: String,
+    pub container: CheckpointContainerV1,
+    pub size_bytes: u64,
+    pub header_role: Option<String>,
+    pub header_family: Option<String>,
+    pub quantization: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckpointDiscoveryV1 {
+    pub layout: Option<CheckpointLayoutV1>,
+    pub candidates: Vec<CheckpointCandidateV1>,
+    pub descriptor_paths: Vec<String>,
+    pub diagnostics: Vec<CheckpointDiagnosticV1>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CheckpointOwnershipV1 {
+    Linked {
+        root_id: String,
+    },
+    Managed {
+        install_id: String,
+        provenance: ManagedProvenanceV1,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CheckpointInspectionRequestV1 {
+    pub checkpoint_id: String,
+    pub root_path: PathBuf,
+    pub relative_path: PathBuf,
+    pub ownership: CheckpointOwnershipV1,
+}
+
+impl CheckpointInspectionRequestV1 {
+    pub fn linked(
+        checkpoint_id: impl Into<String>,
+        root_path: impl Into<PathBuf>,
+        relative_path: impl Into<PathBuf>,
+        root_id: impl Into<String>,
+    ) -> Result<Self, String> {
+        Self::new(
+            checkpoint_id.into(),
+            root_path.into(),
+            relative_path.into(),
+            CheckpointOwnershipV1::Linked {
+                root_id: root_id.into(),
+            },
+        )
+    }
+
+    pub fn managed(
+        checkpoint_id: impl Into<String>,
+        root_path: impl Into<PathBuf>,
+        relative_path: impl Into<PathBuf>,
+        install_id: impl Into<String>,
+        provenance: ManagedProvenanceV1,
+    ) -> Result<Self, String> {
+        Self::new(
+            checkpoint_id.into(),
+            root_path.into(),
+            relative_path.into(),
+            CheckpointOwnershipV1::Managed {
+                install_id: install_id.into(),
+                provenance,
+            },
+        )
+    }
+
+    fn new(
+        checkpoint_id: String,
+        root_path: PathBuf,
+        relative_path: PathBuf,
+        ownership: CheckpointOwnershipV1,
+    ) -> Result<Self, String> {
+        if checkpoint_id.trim().is_empty() {
+            return Err("checkpoint id must not be blank".to_owned());
+        }
+        if !safe_relative_path(&relative_path) {
+            return Err("checkpoint path must be a non-empty confined relative path".to_owned());
+        }
+        match &ownership {
+            CheckpointOwnershipV1::Linked { root_id } if root_id.trim().is_empty() => {
+                return Err("linked root id must not be blank".to_owned());
+            }
+            CheckpointOwnershipV1::Managed {
+                install_id,
+                provenance,
+            } => {
+                if install_id.trim().is_empty() {
+                    return Err("managed install id must not be blank".to_owned());
+                }
+                provenance.validate().map_err(|error| error.to_string())?;
+            }
+            _ => {}
+        }
+        Ok(Self {
+            checkpoint_id,
+            root_path,
+            relative_path,
+            ownership,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckpointArtifactEvidenceV1 {
+    pub relative_path: String,
+    pub container: CheckpointContainerV1,
+    pub role: Option<String>,
+    pub family: Option<String>,
+    pub dialect: Option<String>,
+    /// SHA-256 from the authoritative final exact-byte pass.
+    ///
+    /// This is durable locator evidence, not a filesystem lock. Any consumer that opens the path
+    /// later must hash the bytes it will load and reject a digest mismatch.
+    pub sha256: String,
+    pub size_bytes: u64,
+    pub declared_tensor_bytes: Option<u64>,
+    pub tensor_names: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckpointInspectionV1 {
+    pub layout: Option<CheckpointLayoutV1>,
+    pub fingerprint: Option<String>,
+    pub inventory: CheckpointInventoryV1,
+    pub plans: Vec<ImportPlanV1>,
+    pub evidence: Vec<CheckpointArtifactEvidenceV1>,
+    pub diagnostics: Vec<CheckpointDiagnosticV1>,
+}
+
+impl CheckpointInspectionV1 {
+    pub fn is_runnable(&self) -> bool {
+        !self.inventory.records.is_empty()
+            && self
+                .diagnostics
+                .iter()
+                .all(|item| item.severity != CheckpointDiagnosticSeverityV1::Error)
+    }
+}
+
+/// Stable inspection boundary exposed for deterministic fault-injection tests.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CheckpointInspectionEventV1 {
+    FirstExactBytePassComplete,
+    SecondExactBytePassComplete,
+}
+
+#[derive(Clone)]
+struct ResolvedInput {
+    canonical_root: PathBuf,
+    canonical_target: PathBuf,
+}
+
+#[derive(Default)]
+struct DiscoveryFiles {
+    weights: Vec<PathBuf>,
+    descriptors: Vec<PathBuf>,
+    diagnostics: Vec<CheckpointDiagnosticV1>,
+}
+
+pub fn discover_checkpoint(request: &CheckpointInspectionRequestV1) -> CheckpointDiscoveryV1 {
+    let Some(resolved) = resolve_input(request) else {
+        return CheckpointDiscoveryV1 {
+            layout: None,
+            candidates: Vec::new(),
+            descriptor_paths: Vec::new(),
+            diagnostics: vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::SourceNotFound,
+                path_to_portable_string(&request.relative_path),
+                format!(
+                    "checkpoint source '{}' does not exist or its root is unavailable",
+                    request.relative_path.display()
+                ),
+            )],
+        };
+    };
+
+    if !resolved
+        .canonical_target
+        .starts_with(&resolved.canonical_root)
+    {
+        return CheckpointDiscoveryV1 {
+            layout: None,
+            candidates: Vec::new(),
+            descriptor_paths: Vec::new(),
+            diagnostics: vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::PathEscapesRoot,
+                path_to_portable_string(&request.relative_path),
+                "checkpoint source resolves outside its declared root",
+            )],
+        };
+    }
+
+    let direct_file = resolved.canonical_target.is_file();
+    let files = if direct_file {
+        discover_direct_file(&resolved)
+    } else if resolved.canonical_target.is_dir() {
+        discover_directory(&resolved)
+    } else {
+        DiscoveryFiles {
+            diagnostics: vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::UnsupportedContainer,
+                relative_to_root(&resolved, &resolved.canonical_target),
+                "checkpoint source is neither a regular file nor a directory",
+            )],
+            ..DiscoveryFiles::default()
+        }
+    };
+
+    let mut diagnostics = files.diagnostics;
+    let mut candidates = Vec::new();
+    for path in files.weights {
+        match discover_weight(&resolved, &path) {
+            Ok(candidate) => candidates.push(candidate),
+            Err(diagnostic) => diagnostics.push(diagnostic),
+        }
+    }
+    candidates.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    let mut descriptor_paths = files
+        .descriptors
+        .iter()
+        .filter_map(|path| relative_to_root(&resolved, path))
+        .collect::<Vec<_>>();
+    descriptor_paths.sort();
+    descriptor_paths.dedup();
+
+    if candidates.is_empty() {
+        diagnostics.push(CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::NoWeightCandidates,
+            path_to_portable_string(&request.relative_path),
+            "no safetensors or GGUF checkpoint candidates were found",
+        ));
+    }
+
+    let layout = if candidates.is_empty() {
+        None
+    } else if !direct_file {
+        Some(CheckpointLayoutV1::ComponentDirectory)
+    } else if candidates[0].container == CheckpointContainerV1::Safetensors
+        && candidates[0].header_role.as_deref() == Some("checkpoint")
+    {
+        Some(CheckpointLayoutV1::FusedCheckpoint)
+    } else {
+        Some(CheckpointLayoutV1::SingleFile)
+    };
+    sort_diagnostics(&mut diagnostics);
+    CheckpointDiscoveryV1 {
+        layout,
+        candidates,
+        descriptor_paths,
+        diagnostics,
+    }
+}
+
+pub fn inspect_checkpoint(request: &CheckpointInspectionRequestV1) -> CheckpointInspectionV1 {
+    inspect_checkpoint_with_hook(request, |_| {})
+}
+
+/// Test seam for mutating an artifact before the authoritative final exact-byte pass.
+#[doc(hidden)]
+pub fn inspect_checkpoint_with_hook(
+    request: &CheckpointInspectionRequestV1,
+    mut hook: impl FnMut(CheckpointInspectionEventV1),
+) -> CheckpointInspectionV1 {
+    let discovery = discover_checkpoint(request);
+    let mut result = CheckpointInspectionV1 {
+        layout: discovery.layout,
+        fingerprint: None,
+        inventory: empty_inventory(),
+        plans: Vec::new(),
+        evidence: Vec::new(),
+        diagnostics: discovery.diagnostics.clone(),
+    };
+    let Some(resolved) = resolve_input(request) else {
+        return result;
+    };
+    if !resolved
+        .canonical_target
+        .starts_with(&resolved.canonical_root)
+    {
+        return result;
+    }
+
+    let first_pass = inspect_discovered_pass(&resolved, &discovery);
+    hook(CheckpointInspectionEventV1::FirstExactBytePassComplete);
+    let second_pass = inspect_discovered_pass(&resolved, &discovery);
+    hook(CheckpointInspectionEventV1::SecondExactBytePassComplete);
+    let final_pass = inspect_discovered_pass(&resolved, &discovery);
+    result.diagnostics.extend(final_pass.diagnostics);
+    compare_exact_byte_passes(
+        &first_pass.observations,
+        &second_pass.observations,
+        &mut result.diagnostics,
+    );
+    compare_exact_byte_passes(
+        &second_pass.observations,
+        &final_pass.observations,
+        &mut result.diagnostics,
+    );
+    result.evidence = final_pass.evidence;
+    let backbone_families = final_pass.backbone_families;
+
+    if result.evidence.iter().all(|item| !item.sha256.is_empty()) && !result.evidence.is_empty() {
+        result.fingerprint = Some(inspection_fingerprint(&result.evidence));
+    }
+
+    let already_has_family_diagnostic = result.diagnostics.iter().any(|item| {
+        matches!(
+            item.code,
+            CheckpointDiagnosticCodeV1::MissingFamilyEvidence
+                | CheckpointDiagnosticCodeV1::FamilyDialectConflict
+        )
+    });
+    if backbone_families.is_empty()
+        && !discovery.candidates.is_empty()
+        && !already_has_family_diagnostic
+    {
+        result.diagnostics.push(CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::MissingFamilyEvidence,
+            path_to_portable_string(&request.relative_path),
+            "no checkpoint family or architecture evidence was found in the weight or descriptor contents",
+        ));
+    } else if backbone_families.len() > 1 {
+        result.diagnostics.push(CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::FamilyDialectConflict,
+            path_to_portable_string(&request.relative_path),
+            format!(
+                "checkpoint artifacts disagree about the model family: {}",
+                backbone_families
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        ));
+    }
+
+    let final_discovery = discover_checkpoint(request);
+    if final_discovery.layout != discovery.layout
+        || final_discovery.candidates != discovery.candidates
+        || final_discovery.descriptor_paths != discovery.descriptor_paths
+    {
+        result.diagnostics.push(CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::SourceChangedDuringInspection,
+            path_to_portable_string(&request.relative_path),
+            "checkpoint files changed while inspection was in progress; retry against a stationary source",
+        ));
+    }
+    revalidate_artifact_observations(&resolved, &final_pass.observations, &mut result.diagnostics);
+
+    sort_diagnostics(&mut result.diagnostics);
+    if result
+        .diagnostics
+        .iter()
+        .any(|item| item.severity == CheckpointDiagnosticSeverityV1::Error)
+    {
+        return result;
+    }
+
+    let Some(fingerprint) = result.fingerprint.clone() else {
+        return result;
+    };
+    let family = backbone_families
+        .into_iter()
+        .next()
+        .expect("family was validated above");
+    match compile_inventory(request, &family, &fingerprint, &result.evidence) {
+        Ok((inventory, plan)) => {
+            result.inventory = inventory;
+            result.plans.push(plan);
+        }
+        Err(error) => result.diagnostics.push(CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::ContractViolation,
+            path_to_portable_string(&request.relative_path),
+            format!("validated checkpoint could not compile to the v1 contracts: {error}"),
+        )),
+    }
+    sort_diagnostics(&mut result.diagnostics);
+    result
+}
+
+#[derive(Default)]
+struct InspectionPass {
+    evidence: Vec<CheckpointArtifactEvidenceV1>,
+    observations: Vec<ArtifactObservation>,
+    diagnostics: Vec<CheckpointDiagnosticV1>,
+    backbone_families: BTreeSet<String>,
+    aggregate_tensor_names: usize,
+    aggregate_tensor_name_bytes: usize,
+    aggregate_evidence_string_bytes: usize,
+    evidence_budget_exhausted: bool,
+}
+
+impl InspectionPass {
+    fn retain_evidence(&mut self, evidence: CheckpointArtifactEvidenceV1) -> bool {
+        let tensor_names = evidence.tensor_names.len();
+        let tensor_name_bytes = evidence
+            .tensor_names
+            .iter()
+            .try_fold(0_usize, |total, name| total.checked_add(name.len()));
+        let evidence_string_bytes = [
+            Some(evidence.relative_path.len()),
+            evidence.role.as_ref().map(String::len),
+            evidence.family.as_ref().map(String::len),
+            evidence.dialect.as_ref().map(String::len),
+            Some(evidence.sha256.len()),
+            tensor_name_bytes,
+        ]
+        .into_iter()
+        .flatten()
+        .try_fold(0_usize, usize::checked_add);
+        let next_tensor_names = self.aggregate_tensor_names.checked_add(tensor_names);
+        let next_tensor_name_bytes =
+            tensor_name_bytes.and_then(|bytes| self.aggregate_tensor_name_bytes.checked_add(bytes));
+        let next_evidence_string_bytes = evidence_string_bytes
+            .and_then(|bytes| self.aggregate_evidence_string_bytes.checked_add(bytes));
+        let within_budget = next_tensor_names
+            .zip(next_tensor_name_bytes)
+            .zip(next_evidence_string_bytes)
+            .is_some_and(|((names, name_bytes), evidence_bytes)| {
+                names <= MAX_AGGREGATE_TENSOR_NAMES
+                    && name_bytes <= MAX_AGGREGATE_TENSOR_NAME_BYTES
+                    && evidence_bytes <= MAX_AGGREGATE_EVIDENCE_STRING_BYTES
+            });
+        if !within_budget {
+            if !self.evidence_budget_exhausted {
+                self.diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::DiscoveryLimitExceeded,
+                    Some(evidence.relative_path),
+                    format!(
+                        "checkpoint inspection exceeded the aggregate evidence budget of {MAX_AGGREGATE_TENSOR_NAMES} tensor names, {MAX_AGGREGATE_TENSOR_NAME_BYTES} tensor-name UTF-8 bytes, or {MAX_AGGREGATE_EVIDENCE_STRING_BYTES} total evidence UTF-8 bytes"
+                    ),
+                ));
+                self.evidence_budget_exhausted = true;
+            }
+            return false;
+        }
+        self.aggregate_tensor_names = next_tensor_names.expect("budget arithmetic checked above");
+        self.aggregate_tensor_name_bytes =
+            next_tensor_name_bytes.expect("budget arithmetic checked above");
+        self.aggregate_evidence_string_bytes =
+            next_evidence_string_bytes.expect("budget arithmetic checked above");
+        self.evidence.push(evidence);
+        true
+    }
+}
+
+struct ArtifactObservation {
+    relative_path: String,
+    container: CheckpointContainerV1,
+    canonical_path: PathBuf,
+    snapshot: ArtifactSnapshot,
+}
+
+fn inspect_discovered_pass(
+    resolved: &ResolvedInput,
+    discovery: &CheckpointDiscoveryV1,
+) -> InspectionPass {
+    let mut pass = InspectionPass::default();
+    let candidate_by_path = discovery
+        .candidates
+        .iter()
+        .map(|candidate| (candidate.relative_path.clone(), candidate))
+        .collect::<BTreeMap<_, _>>();
+    let mut tensor_tables = BTreeMap::new();
+    let mut indices = Vec::new();
+
+    for candidate in &discovery.candidates {
+        let Some(path) =
+            resolve_confined_artifact(resolved, &candidate.relative_path, &mut pass.diagnostics)
+        else {
+            continue;
+        };
+        let path_role = infer_role_from_path(
+            path.strip_prefix(&resolved.canonical_target)
+                .unwrap_or(path.as_path()),
+        );
+        let prefix_limit = match candidate.container {
+            CheckpointContainerV1::Safetensors => MAX_SAFETENSORS_HEADER_BYTES + 9,
+            CheckpointContainerV1::Gguf => MAX_GGUF_DESCRIPTOR_BYTES + 1,
+            CheckpointContainerV1::JsonDescriptor => unreachable!("weight candidate is JSON"),
+        };
+        let mut snapshot = match snapshot_file(&path, prefix_limit) {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                pass.diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::Io,
+                    Some(candidate.relative_path.clone()),
+                    format!("failed to read checkpoint artifact: {error}"),
+                ));
+                continue;
+            }
+        };
+        let validation = match candidate.container {
+            CheckpointContainerV1::Safetensors => validate_safetensors(
+                &snapshot.prefix,
+                snapshot.size_bytes,
+                Some(candidate.relative_path.clone()),
+            ),
+            CheckpointContainerV1::Gguf => validate_gguf(
+                &snapshot.prefix,
+                snapshot.size_bytes,
+                Some(candidate.relative_path.clone()),
+            ),
+            CheckpointContainerV1::JsonDescriptor => unreachable!("weight candidate is JSON"),
+        };
+        let mut family = candidate.header_family.clone();
+        let mut dialect = candidate.quantization.clone();
+        let mut declared_tensor_bytes = None;
+        let mut validated_role = candidate.header_role.clone();
+        let mut tensor_names = Vec::new();
+        match validation {
+            Ok(validated) => {
+                family = validated.family;
+                dialect = validated.dialect;
+                validated_role = validated.role;
+                declared_tensor_bytes = validated.declared_tensor_bytes;
+                tensor_names = validated.tensor_names;
+            }
+            Err(mut diagnostics) => pass.diagnostics.append(&mut diagnostics),
+        }
+        if candidate.container == CheckpointContainerV1::Gguf
+            && path_role.is_none()
+            && resolved.canonical_target.is_file()
+        {
+            validated_role = Some("checkpoint".to_owned());
+        }
+        let role = reconcile_role(
+            &candidate.relative_path,
+            path_role,
+            validated_role.as_deref(),
+            &mut pass.diagnostics,
+        );
+        if matches!(role.as_deref(), Some("transformer" | "checkpoint")) {
+            if let Some(family) = &family {
+                if !is_auxiliary_family(family) {
+                    pass.backbone_families.insert(family.clone());
+                }
+            }
+        }
+        let evidence = CheckpointArtifactEvidenceV1 {
+            relative_path: candidate.relative_path.clone(),
+            container: candidate.container,
+            role,
+            family,
+            dialect,
+            sha256: snapshot.sha256.clone(),
+            size_bytes: snapshot.size_bytes,
+            declared_tensor_bytes,
+            tensor_names,
+        };
+        let retained = pass.retain_evidence(evidence);
+        if retained && candidate.container == CheckpointContainerV1::Safetensors {
+            let tensor_names = &pass
+                .evidence
+                .last()
+                .expect("retained evidence was just appended")
+                .tensor_names;
+            tensor_tables.insert(
+                candidate.relative_path.clone(),
+                tensor_names.iter().cloned().collect::<BTreeSet<_>>(),
+            );
+        }
+        snapshot.prefix = Vec::new();
+        pass.observations.push(ArtifactObservation {
+            relative_path: candidate.relative_path.clone(),
+            container: candidate.container,
+            canonical_path: path,
+            snapshot,
+        });
+    }
+
+    for descriptor_path in &discovery.descriptor_paths {
+        let Some(path) =
+            resolve_confined_artifact(resolved, descriptor_path, &mut pass.diagnostics)
+        else {
+            continue;
+        };
+        let mut snapshot = match snapshot_file(&path, MAX_JSON_DESCRIPTOR_BYTES + 1) {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                pass.diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::Io,
+                    Some(descriptor_path.clone()),
+                    format!("failed to read JSON descriptor: {error}"),
+                ));
+                continue;
+            }
+        };
+        match validate_json_descriptor(
+            resolved,
+            &path,
+            descriptor_path,
+            &snapshot.prefix,
+            snapshot.size_bytes,
+            &mut pass.diagnostics,
+        ) {
+            Ok(descriptor) => {
+                if descriptor.contributes_backbone_family {
+                    if let Some(family) = &descriptor.family {
+                        pass.backbone_families.insert(family.clone());
+                    }
+                }
+                if let Some(index) = descriptor.index {
+                    indices.push(index);
+                }
+                let _retained = pass.retain_evidence(CheckpointArtifactEvidenceV1 {
+                    relative_path: descriptor_path.clone(),
+                    container: CheckpointContainerV1::JsonDescriptor,
+                    role: Some("descriptor".to_owned()),
+                    family: descriptor.family,
+                    dialect: descriptor.dialect,
+                    sha256: snapshot.sha256.clone(),
+                    size_bytes: snapshot.size_bytes,
+                    declared_tensor_bytes: None,
+                    tensor_names: Vec::new(),
+                });
+            }
+            Err(diagnostic) => pass.diagnostics.push(diagnostic),
+        }
+        snapshot.prefix = Vec::new();
+        pass.observations.push(ArtifactObservation {
+            relative_path: descriptor_path.clone(),
+            container: CheckpointContainerV1::JsonDescriptor,
+            canonical_path: path,
+            snapshot,
+        });
+    }
+
+    validate_safetensors_indices(
+        &indices,
+        &candidate_by_path,
+        &tensor_tables,
+        &mut pass.diagnostics,
+    );
+    pass.evidence
+        .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    pass.observations
+        .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+    sort_diagnostics(&mut pass.diagnostics);
+    pass
+}
+
+fn validate_safetensors_indices(
+    indices: &[SafetensorsIndexDeclaration],
+    candidates: &BTreeMap<String, &CheckpointCandidateV1>,
+    tensor_tables: &BTreeMap<String, BTreeSet<String>>,
+    diagnostics: &mut Vec<CheckpointDiagnosticV1>,
+) {
+    let mut all_references = BTreeSet::new();
+    let mut shard_owner = BTreeMap::<String, String>::new();
+    for index in indices {
+        let referenced_shards = index.weight_map.values().cloned().collect::<BTreeSet<_>>();
+        for shard in &referenced_shards {
+            all_references.insert(shard.clone());
+            if let Some(previous) = shard_owner.insert(shard.clone(), index.descriptor_path.clone())
+            {
+                diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::IndexTensorMismatch,
+                    Some(index.descriptor_path.clone()),
+                    format!(
+                        "safetensors shard '{shard}' is claimed by both '{previous}' and '{}'",
+                        index.descriptor_path
+                    ),
+                ));
+            }
+            match candidates.get(shard) {
+                Some(candidate)
+                    if candidate.container == CheckpointContainerV1::Safetensors
+                        && tensor_tables.contains_key(shard) => {}
+                Some(_) => diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::IndexTensorMismatch,
+                    Some(index.descriptor_path.clone()),
+                    format!(
+                        "safetensors index shard '{shard}' did not yield a valid safetensors tensor table"
+                    ),
+                )),
+                None => diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::MissingSidecar,
+                    Some(index.descriptor_path.clone()),
+                    format!(
+                        "safetensors index shard '{shard}' was not discovered as an importable weight artifact"
+                    ),
+                )),
+            }
+        }
+
+        let mut tensor_locations = BTreeMap::<String, Vec<String>>::new();
+        for shard in &referenced_shards {
+            if let Some(tensors) = tensor_tables.get(shard) {
+                for tensor in tensors {
+                    tensor_locations
+                        .entry(tensor.clone())
+                        .or_default()
+                        .push(shard.clone());
+                }
+            }
+        }
+        for (tensor, locations) in &tensor_locations {
+            if locations.len() > 1 {
+                diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::IndexTensorMismatch,
+                    Some(index.descriptor_path.clone()),
+                    format!(
+                        "tensor '{tensor}' exists in multiple indexed shards: {}",
+                        locations.join(", ")
+                    ),
+                ));
+            }
+        }
+
+        for (tensor, shard) in &index.weight_map {
+            if !tensor_tables
+                .get(shard)
+                .is_some_and(|tensors| tensors.contains(tensor))
+            {
+                diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::IndexTensorMismatch,
+                    Some(index.descriptor_path.clone()),
+                    format!(
+                        "weight_map tensor '{tensor}' does not exist in its declared shard '{shard}'"
+                    ),
+                ));
+            }
+        }
+        for shard in &referenced_shards {
+            let expected = index
+                .weight_map
+                .iter()
+                .filter(|(_, declared_shard)| *declared_shard == shard)
+                .map(|(tensor, _)| tensor.clone())
+                .collect::<BTreeSet<_>>();
+            if let Some(actual) = tensor_tables.get(shard) {
+                for tensor in actual.difference(&expected) {
+                    diagnostics.push(CheckpointDiagnosticV1::error(
+                        CheckpointDiagnosticCodeV1::IndexTensorMismatch,
+                        Some(index.descriptor_path.clone()),
+                        format!("shard '{shard}' tensor '{tensor}' is missing from weight_map"),
+                    ));
+                }
+                for tensor in expected.difference(actual) {
+                    diagnostics.push(CheckpointDiagnosticV1::error(
+                        CheckpointDiagnosticCodeV1::IndexTensorMismatch,
+                        Some(index.descriptor_path.clone()),
+                        format!("weight_map contains extra tensor '{tensor}' for shard '{shard}'"),
+                    ));
+                }
+            }
+        }
+    }
+
+    for candidate in candidates.values() {
+        if looks_like_shard(&candidate.relative_path)
+            && !all_references.contains(&candidate.relative_path)
+        {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MissingSidecar,
+                Some(candidate.relative_path.clone()),
+                "sharded safetensors file is not named by any *.safetensors.index.json sidecar",
+            ));
+        }
+    }
+}
+
+fn compare_exact_byte_passes(
+    first: &[ArtifactObservation],
+    second: &[ArtifactObservation],
+    diagnostics: &mut Vec<CheckpointDiagnosticV1>,
+) {
+    let first_by_path = first
+        .iter()
+        .map(|item| (item.relative_path.as_str(), item))
+        .collect::<BTreeMap<_, _>>();
+    let second_by_path = second
+        .iter()
+        .map(|item| (item.relative_path.as_str(), item))
+        .collect::<BTreeMap<_, _>>();
+    let paths = first_by_path
+        .keys()
+        .chain(second_by_path.keys())
+        .copied()
+        .collect::<BTreeSet<_>>();
+    for path in paths {
+        let stable = match (first_by_path.get(path), second_by_path.get(path)) {
+            (Some(first), Some(second)) => {
+                first.container == second.container
+                    && first.canonical_path == second.canonical_path
+                    && first.snapshot.sha256 == second.snapshot.sha256
+                    && first.snapshot.size_bytes == second.snapshot.size_bytes
+                    && first.snapshot.stable
+                    && second.snapshot.stable
+                    && first.snapshot.after == second.snapshot.before
+            }
+            _ => false,
+        };
+        if !stable {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::SourceChangedDuringInspection,
+                Some(path.to_owned()),
+                "checkpoint artifact identity or exact bytes changed between verification passes; retry against a stationary source",
+            ));
+        }
+    }
+}
+
+fn revalidate_artifact_observations(
+    resolved: &ResolvedInput,
+    observations: &[ArtifactObservation],
+    diagnostics: &mut Vec<CheckpointDiagnosticV1>,
+) {
+    for observation in observations {
+        let joined = resolved
+            .canonical_root
+            .join(portable_to_path(&observation.relative_path));
+        let unchanged = std::fs::canonicalize(&joined)
+            .ok()
+            .filter(|path| path == &observation.canonical_path)
+            .and_then(|path| File::open(path).ok())
+            .and_then(|file| file.metadata().ok())
+            .map(|metadata| FileStamp::from_metadata(&metadata))
+            .is_some_and(|stamp| stamp == observation.snapshot.after);
+        if !unchanged {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::SourceChangedDuringInspection,
+                Some(observation.relative_path.clone()),
+                "checkpoint artifact identity or metadata changed after its final exact-byte pass; retry against a stationary source",
+            ));
+        }
+    }
+}
+
+fn compile_inventory(
+    request: &CheckpointInspectionRequestV1,
+    family: &str,
+    fingerprint: &str,
+    evidence: &[CheckpointArtifactEvidenceV1],
+) -> Result<(CheckpointInventoryV1, ImportPlanV1), String> {
+    let mut layers = Vec::with_capacity(evidence.len());
+    for artifact in evidence {
+        let source = match &request.ownership {
+            CheckpointOwnershipV1::Linked { root_id } => SourceLocatorV1::linked(
+                root_id.clone(),
+                artifact.relative_path.clone(),
+                artifact.sha256.clone(),
+            ),
+            CheckpointOwnershipV1::Managed {
+                install_id,
+                provenance,
+            } => SourceLocatorV1::managed(
+                install_id.clone(),
+                artifact.relative_path.clone(),
+                artifact.sha256.clone(),
+                provenance.clone(),
+            ),
+        }
+        .map_err(|error| error.to_string())?;
+        layers.push(ImportLayerV1 {
+            layer_id: format!("artifact:{}", artifact.relative_path),
+            role: artifact
+                .role
+                .clone()
+                .unwrap_or_else(|| "artifact".to_owned()),
+            target_path: artifact.relative_path.clone(),
+            source,
+        });
+    }
+    let mut plan_id_hasher = Sha256::new();
+    plan_id_hasher.update(b"sceneworks.checkpoint.plan-id.v1\0");
+    plan_id_hasher.update(request.checkpoint_id.as_bytes());
+    plan_id_hasher.update(b"\0");
+    plan_id_hasher.update(fingerprint.as_bytes());
+    let plan_id = format!("checkpoint-plan-{:x}", plan_id_hasher.finalize());
+    let plan = ImportPlanV1::new(plan_id, family, layers).map_err(|error| error.to_string())?;
+    let record = CheckpointCatalogRecordV1::from_plan(request.checkpoint_id.clone(), &plan)
+        .map_err(|error| error.to_string())?;
+    let inventory = CheckpointInventoryV1::new(vec![record]).map_err(|error| error.to_string())?;
+    Ok((inventory, plan))
+}
+
+fn resolve_input(request: &CheckpointInspectionRequestV1) -> Option<ResolvedInput> {
+    let canonical_root = std::fs::canonicalize(&request.root_path).ok()?;
+    let canonical_target =
+        std::fs::canonicalize(canonical_root.join(&request.relative_path)).ok()?;
+    Some(ResolvedInput {
+        canonical_root,
+        canonical_target,
+    })
+}
+
+fn resolve_confined_artifact(
+    resolved: &ResolvedInput,
+    relative_path: &str,
+    diagnostics: &mut Vec<CheckpointDiagnosticV1>,
+) -> Option<PathBuf> {
+    let joined = resolved
+        .canonical_root
+        .join(portable_to_path(relative_path));
+    let canonical = match std::fs::canonicalize(&joined) {
+        Ok(canonical) => canonical,
+        Err(error) => {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::SourceChangedDuringInspection,
+                Some(relative_path.to_owned()),
+                format!("checkpoint artifact disappeared during inspection: {error}"),
+            ));
+            return None;
+        }
+    };
+    if !canonical.starts_with(&resolved.canonical_root) {
+        diagnostics.push(CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::PathEscapesRoot,
+            Some(relative_path.to_owned()),
+            "checkpoint artifact resolves outside its declared root",
+        ));
+        return None;
+    }
+    Some(canonical)
+}
+
+fn discover_direct_file(resolved: &ResolvedInput) -> DiscoveryFiles {
+    let path = resolved.canonical_target.clone();
+    if is_json_descriptor(&path) {
+        DiscoveryFiles {
+            descriptors: vec![path],
+            ..DiscoveryFiles::default()
+        }
+    } else {
+        DiscoveryFiles {
+            weights: vec![path],
+            ..DiscoveryFiles::default()
+        }
+    }
+}
+
+fn discover_directory(resolved: &ResolvedInput) -> DiscoveryFiles {
+    let mut result = DiscoveryFiles::default();
+    let mut stack = vec![(resolved.canonical_target.clone(), 0_usize)];
+    let mut seen_dirs = HashSet::new();
+    let mut visited_entries = 0_usize;
+
+    while let Some((directory, depth)) = stack.pop() {
+        let Ok(canonical_directory) = std::fs::canonicalize(&directory) else {
+            continue;
+        };
+        if !canonical_directory.starts_with(&resolved.canonical_root)
+            || !seen_dirs.insert(canonical_directory.clone())
+        {
+            continue;
+        }
+        let Ok(read_dir) = std::fs::read_dir(&canonical_directory) else {
+            result.diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::Io,
+                relative_to_root(resolved, &canonical_directory),
+                "checkpoint directory could not be read",
+            ));
+            continue;
+        };
+        for entry in read_dir {
+            if visited_entries >= MAX_DISCOVERY_ENTRIES {
+                result.diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::DiscoveryLimitExceeded,
+                    relative_to_root(resolved, &resolved.canonical_target),
+                    format!(
+                        "checkpoint discovery exceeded its {MAX_DISCOVERY_ENTRIES}-entry bound"
+                    ),
+                ));
+                return result;
+            }
+            visited_entries += 1;
+            let Ok(entry) = entry else {
+                result.diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::Io,
+                    relative_to_root(resolved, &canonical_directory),
+                    "checkpoint directory entry could not be read",
+                ));
+                continue;
+            };
+            let path = entry.path();
+            if is_hidden_path(&path) {
+                continue;
+            }
+            let Ok(canonical) = std::fs::canonicalize(&path) else {
+                continue;
+            };
+            if !canonical.starts_with(&resolved.canonical_root) {
+                result.diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::PathEscapesRoot,
+                    relative_to_root(resolved, &path),
+                    "checkpoint entry resolves outside its declared root",
+                ));
+                continue;
+            }
+            if canonical.is_dir() {
+                if depth < MAX_DISCOVERY_DEPTH {
+                    stack.push((canonical, depth + 1));
+                } else {
+                    result.diagnostics.push(CheckpointDiagnosticV1::error(
+                        CheckpointDiagnosticCodeV1::DiscoveryLimitExceeded,
+                        relative_to_root(resolved, &canonical),
+                        format!(
+                            "checkpoint discovery exceeded its depth bound of {MAX_DISCOVERY_DEPTH}"
+                        ),
+                    ));
+                }
+                continue;
+            }
+            if is_weight_extension(&canonical) {
+                result.weights.push(canonical);
+            } else if is_json_descriptor(&canonical) {
+                result.descriptors.push(canonical);
+            }
+        }
+    }
+    result.weights.sort();
+    result.descriptors.sort();
+    result
+}
+
+fn discover_weight(
+    resolved: &ResolvedInput,
+    path: &Path,
+) -> Result<CheckpointCandidateV1, CheckpointDiagnosticV1> {
+    let relative_path = relative_to_root(resolved, path).ok_or_else(|| {
+        CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::PathEscapesRoot,
+            None,
+            "checkpoint candidate has no confined portable relative path",
+        )
+    })?;
+    let size_bytes = std::fs::metadata(path)
+        .map(|item| item.len())
+        .map_err(|error| {
+            CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::Io,
+                Some(relative_path.clone()),
+                format!("checkpoint candidate metadata could not be read: {error}"),
+            )
+        })?;
+    let mut magic = [0_u8; 4];
+    let is_gguf = File::open(path)
+        .and_then(|mut file| file.read_exact(&mut magic))
+        .is_ok()
+        && &magic == b"GGUF";
+    if is_gguf {
+        return Ok(CheckpointCandidateV1 {
+            relative_path,
+            container: CheckpointContainerV1::Gguf,
+            size_bytes,
+            header_role: None,
+            header_family: None,
+            quantization: Some("gguf".to_owned()),
+        });
+    }
+    let header = discover_safetensors_header(path, size_bytes).map_err(|error| {
+        CheckpointDiagnosticV1::error(error.code, Some(relative_path.clone()), error.message)
+    })?;
+    match classify_base_header(&header) {
+        BaseWeightDetection::Recognized(verdict) => Ok(CheckpointCandidateV1 {
+            relative_path,
+            container: CheckpointContainerV1::Safetensors,
+            size_bytes,
+            header_role: Some(verdict.component.as_str().to_owned()),
+            header_family: verdict.family,
+            quantization: Some(verdict.quant.as_str().to_owned()),
+        }),
+        BaseWeightDetection::Unrecognized { .. } => Ok(CheckpointCandidateV1 {
+            relative_path,
+            container: CheckpointContainerV1::Safetensors,
+            size_bytes,
+            header_role: None,
+            header_family: None,
+            quantization: None,
+        }),
+    }
+}
+
+struct SafetensorsDiscoveryError {
+    code: CheckpointDiagnosticCodeV1,
+    message: String,
+}
+
+fn discover_safetensors_header(
+    path: &Path,
+    file_len: u64,
+) -> Result<Value, SafetensorsDiscoveryError> {
+    let mut file = File::open(path).map_err(|error| SafetensorsDiscoveryError {
+        code: CheckpointDiagnosticCodeV1::Io,
+        message: format!("safetensors candidate could not be opened: {error}"),
+    })?;
+    let mut length_bytes = [0_u8; 8];
+    file.read_exact(&mut length_bytes)
+        .map_err(|_| SafetensorsDiscoveryError {
+            code: CheckpointDiagnosticCodeV1::TruncatedHeader,
+            message: "safetensors candidate is truncated before its header length".to_owned(),
+        })?;
+    let header_len = u64::from_le_bytes(length_bytes);
+    if header_len == 0 || header_len > MAX_SAFETENSORS_HEADER_BYTES {
+        return Err(SafetensorsDiscoveryError {
+            code: CheckpointDiagnosticCodeV1::HeaderTooLarge,
+            message: format!(
+                "safetensors header length {header_len} is outside the discovery bound"
+            ),
+        });
+    }
+    if 8_u64
+        .checked_add(header_len)
+        .map_or(true, |end| end > file_len)
+    {
+        return Err(SafetensorsDiscoveryError {
+            code: CheckpointDiagnosticCodeV1::TruncatedHeader,
+            message: "safetensors descriptor bytes are truncated".to_owned(),
+        });
+    }
+    let mut header = vec![0_u8; header_len as usize];
+    file.read_exact(&mut header)
+        .map_err(|_| SafetensorsDiscoveryError {
+            code: CheckpointDiagnosticCodeV1::TruncatedHeader,
+            message: "safetensors descriptor bytes are truncated".to_owned(),
+        })?;
+    serde_json::from_slice(&header).map_err(|error| SafetensorsDiscoveryError {
+        code: CheckpointDiagnosticCodeV1::MalformedMetadata,
+        message: format!("safetensors descriptor is malformed JSON: {error}"),
+    })
+}
+
+#[derive(Default)]
+struct ValidatedArtifact {
+    role: Option<String>,
+    family: Option<String>,
+    dialect: Option<String>,
+    declared_tensor_bytes: Option<u64>,
+    tensor_names: Vec<String>,
+}
+
+fn validate_safetensors(
+    prefix: &[u8],
+    file_len: u64,
+    relative_path: Option<String>,
+) -> Result<ValidatedArtifact, Vec<CheckpointDiagnosticV1>> {
+    let Some(header_len_bytes) = prefix.get(..8) else {
+        return Err(vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::TruncatedHeader,
+            relative_path,
+            "safetensors file is truncated before its 8-byte header length",
+        )]);
+    };
+    let header_len = u64::from_le_bytes(header_len_bytes.try_into().unwrap());
+    if header_len == 0 || header_len > MAX_SAFETENSORS_HEADER_BYTES {
+        return Err(vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::HeaderTooLarge,
+            relative_path,
+            format!(
+                "safetensors header length {header_len} is outside the 1..={MAX_SAFETENSORS_HEADER_BYTES} bound"
+            ),
+        )]);
+    }
+    let Some(data_start) = 8_u64.checked_add(header_len) else {
+        return Err(vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::InvalidTensorRange,
+            relative_path,
+            "safetensors header length overflows the file address space",
+        )]);
+    };
+    if data_start > file_len {
+        return Err(vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::TruncatedHeader,
+            relative_path,
+            format!(
+                "safetensors header ends at byte {data_start}, beyond the {file_len}-byte file"
+            ),
+        )]);
+    }
+    let Some(header) = prefix.get(8..data_start as usize) else {
+        return Err(vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::TruncatedHeader,
+            relative_path,
+            "safetensors descriptor bytes are truncated",
+        )]);
+    };
+    let value = strict_json(header).map_err(|error| {
+        vec![CheckpointDiagnosticV1::error(
+            error.code,
+            relative_path.clone(),
+            format!("invalid safetensors descriptor: {}", error.message),
+        )]
+    })?;
+    let Some(entries) = value.as_object() else {
+        return Err(vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::MalformedMetadata,
+            relative_path,
+            "safetensors descriptor must be a JSON object",
+        )]);
+    };
+
+    let mut diagnostics = Vec::new();
+    if let Some(metadata) = entries.get("__metadata__") {
+        match metadata.as_object() {
+            Some(metadata) if metadata.values().all(Value::is_string) => {}
+            _ => diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                relative_path.clone(),
+                "safetensors __metadata__ must be an object containing only string values",
+            )),
+        }
+    }
+    let data_len = file_len - data_start;
+    let mut ranges = Vec::new();
+    for (name, tensor) in entries {
+        if name == "__metadata__" {
+            continue;
+        }
+        if name.is_empty() {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                relative_path.clone(),
+                "safetensors tensor names must not be empty",
+            ));
+            continue;
+        }
+        let Some(tensor) = tensor.as_object() else {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                relative_path.clone(),
+                format!("tensor '{name}' descriptor must be an object"),
+            ));
+            continue;
+        };
+        let Some(bits_per_element) = tensor
+            .get("dtype")
+            .and_then(Value::as_str)
+            .and_then(safetensors_dtype_bits)
+        else {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::UnsupportedTensorType,
+                relative_path.clone(),
+                format!("tensor '{name}' has a missing or unsupported dtype"),
+            ));
+            continue;
+        };
+        let Some(shape) = tensor.get("shape").and_then(Value::as_array) else {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                relative_path.clone(),
+                format!("tensor '{name}' has no valid shape array"),
+            ));
+            continue;
+        };
+        let element_count = shape.iter().try_fold(1_u64, |count, dimension| {
+            count.checked_mul(dimension.as_u64()?)
+        });
+        let Some(expected_bits) =
+            element_count.and_then(|count| count.checked_mul(bits_per_element))
+        else {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::InvalidTensorRange,
+                relative_path.clone(),
+                format!("tensor '{name}' shape overflows its declared byte size"),
+            ));
+            continue;
+        };
+        if expected_bits % 8 != 0 {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::InvalidTensorRange,
+                relative_path.clone(),
+                format!("tensor '{name}' contains {expected_bits} bits, which is not byte-aligned"),
+            ));
+            continue;
+        }
+        let expected_bytes = expected_bits / 8;
+        let Some(offsets) = tensor.get("data_offsets").and_then(Value::as_array) else {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                relative_path.clone(),
+                format!("tensor '{name}' has no valid data_offsets pair"),
+            ));
+            continue;
+        };
+        let [start, end] = offsets.as_slice() else {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                relative_path.clone(),
+                format!("tensor '{name}' data_offsets must contain exactly two integers"),
+            ));
+            continue;
+        };
+        let (Some(start), Some(end)) = (start.as_u64(), end.as_u64()) else {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                relative_path.clone(),
+                format!("tensor '{name}' data_offsets must be unsigned integers"),
+            ));
+            continue;
+        };
+        if start > end || end.saturating_sub(start) != expected_bytes {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::InvalidTensorRange,
+                relative_path.clone(),
+                format!(
+                    "tensor '{name}' range [{start}, {end}) does not match its {expected_bytes}-byte dtype/shape"
+                ),
+            ));
+        } else if end > data_len {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::TruncatedData,
+                relative_path.clone(),
+                format!(
+                    "tensor '{name}' ends at data byte {end}, beyond the {data_len}-byte tensor body"
+                ),
+            ));
+        } else {
+            ranges.push((start, end, name.clone()));
+        }
+    }
+    if ranges.is_empty() {
+        diagnostics.push(CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::MalformedMetadata,
+            relative_path.clone(),
+            "safetensors descriptor declares no valid tensors",
+        ));
+    } else {
+        ranges.sort_by_key(|(start, _, _)| *start);
+        let mut expected_start = 0_u64;
+        for (start, end, name) in &ranges {
+            if *start != expected_start {
+                diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::InvalidTensorRange,
+                    relative_path.clone(),
+                    format!(
+                        "tensor '{name}' begins at {start}; expected contiguous offset {expected_start}"
+                    ),
+                ));
+            }
+            expected_start = *end;
+        }
+        if expected_start < data_len {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::InvalidTensorRange,
+                relative_path.clone(),
+                format!(
+                    "safetensors descriptor accounts for {expected_start} bytes but the tensor body contains {data_len}"
+                ),
+            ));
+        }
+    }
+    if !diagnostics.is_empty() {
+        return Err(diagnostics);
+    }
+    let (role, family, dialect) = match classify_base_header(&value) {
+        BaseWeightDetection::Recognized(verdict) => (
+            Some(verdict.component.as_str().to_owned()),
+            verdict.family,
+            Some(verdict.quant.as_str().to_owned()),
+        ),
+        BaseWeightDetection::Unrecognized { .. } => (None, None, None),
+    };
+    let mut tensor_names = entries
+        .keys()
+        .filter(|name| name.as_str() != "__metadata__")
+        .cloned()
+        .collect::<Vec<_>>();
+    tensor_names.sort();
+    Ok(ValidatedArtifact {
+        role,
+        family,
+        dialect,
+        declared_tensor_bytes: Some(data_len),
+        tensor_names,
+    })
+}
+
+fn safetensors_dtype_bits(dtype: &str) -> Option<u64> {
+    match dtype {
+        "F4" => Some(4),
+        "F6_E2M3" | "F6_E3M2" => Some(6),
+        "BOOL" | "U8" | "I8" | "F8_E4M3" | "F8_E5M2" | "F8_E8M0" | "F8_E4M3FNUZ"
+        | "F8_E5M2FNUZ" => Some(8),
+        "U16" | "I16" | "F16" | "BF16" => Some(16),
+        "U32" | "I32" | "F32" => Some(32),
+        "U64" | "I64" | "F64" | "C64" => Some(64),
+        _ => None,
+    }
+}
+
+#[derive(Default)]
+struct JsonDescriptorEvidence {
+    family: Option<String>,
+    dialect: Option<String>,
+    contributes_backbone_family: bool,
+    index: Option<SafetensorsIndexDeclaration>,
+}
+
+struct SafetensorsIndexDeclaration {
+    descriptor_path: String,
+    weight_map: BTreeMap<String, String>,
+}
+
+fn validate_json_descriptor(
+    resolved: &ResolvedInput,
+    path: &Path,
+    relative_path: &str,
+    raw: &[u8],
+    size_bytes: u64,
+    diagnostics: &mut Vec<CheckpointDiagnosticV1>,
+) -> Result<JsonDescriptorEvidence, CheckpointDiagnosticV1> {
+    if size_bytes > MAX_JSON_DESCRIPTOR_BYTES {
+        return Err(CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::HeaderTooLarge,
+            Some(relative_path.to_owned()),
+            format!(
+                "JSON descriptor is {} bytes, above the {MAX_JSON_DESCRIPTOR_BYTES}-byte bound",
+                size_bytes
+            ),
+        ));
+    }
+    let value = strict_json(raw).map_err(|error| {
+        CheckpointDiagnosticV1::error(
+            error.code,
+            Some(relative_path.to_owned()),
+            format!("invalid JSON descriptor: {}", error.message),
+        )
+    })?;
+    let Some(object) = value.as_object() else {
+        return Err(CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::MalformedMetadata,
+            Some(relative_path.to_owned()),
+            "JSON descriptor must contain an object at its root",
+        ));
+    };
+
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    let mut index = None;
+    if filename.ends_with(".safetensors.index.json") {
+        let Some(weight_map) = object.get("weight_map").and_then(Value::as_object) else {
+            return Err(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                Some(relative_path.to_owned()),
+                "safetensors index descriptor must contain an object weight_map",
+            ));
+        };
+        if weight_map.is_empty() {
+            return Err(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                Some(relative_path.to_owned()),
+                "safetensors index weight_map must not be empty",
+            ));
+        }
+        let mut canonical_weight_map = BTreeMap::new();
+        for (tensor, shard) in weight_map {
+            if tensor.is_empty() {
+                diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::MalformedMetadata,
+                    Some(relative_path.to_owned()),
+                    "safetensors index tensor names must not be empty",
+                ));
+                continue;
+            }
+            let Some(shard) = shard.as_str() else {
+                diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::MalformedMetadata,
+                    Some(relative_path.to_owned()),
+                    format!("safetensors index entry '{tensor}' must name a shard string"),
+                ));
+                continue;
+            };
+            let shard_path = Path::new(shard);
+            if !safe_relative_path(shard_path) {
+                diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::PathEscapesRoot,
+                    Some(relative_path.to_owned()),
+                    format!("safetensors index entry '{tensor}' uses unsafe shard path '{shard}'"),
+                ));
+                continue;
+            }
+            if !shard_path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("safetensors"))
+            {
+                diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::MalformedMetadata,
+                    Some(relative_path.to_owned()),
+                    format!(
+                        "safetensors index entry '{tensor}' must reference a .safetensors shard"
+                    ),
+                ));
+                continue;
+            }
+            let absolute = path
+                .parent()
+                .unwrap_or(&resolved.canonical_target)
+                .join(shard_path);
+            if !absolute.is_file() {
+                diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::MissingSidecar,
+                    Some(relative_path.to_owned()),
+                    format!("safetensors index references missing shard '{shard}'"),
+                ));
+            } else if let Ok(canonical) = std::fs::canonicalize(&absolute) {
+                if !canonical.starts_with(&resolved.canonical_root) {
+                    diagnostics.push(CheckpointDiagnosticV1::error(
+                        CheckpointDiagnosticCodeV1::PathEscapesRoot,
+                        Some(relative_path.to_owned()),
+                        format!(
+                            "safetensors index shard '{shard}' resolves outside the declared root"
+                        ),
+                    ));
+                } else if let Some(canonical_relative) = relative_to_root(resolved, &canonical) {
+                    canonical_weight_map.insert(tensor.clone(), canonical_relative);
+                }
+            } else {
+                diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::Io,
+                    Some(relative_path.to_owned()),
+                    format!("safetensors index shard '{shard}' could not be resolved"),
+                ));
+            }
+        }
+        index = Some(SafetensorsIndexDeclaration {
+            descriptor_path: relative_path.to_owned(),
+            weight_map: canonical_weight_map,
+        });
+    }
+
+    if filename == "model_index.json" {
+        for (component_name, declaration) in object {
+            if component_name.starts_with('_') || declaration.is_null() {
+                continue;
+            }
+            let is_component = declaration
+                .as_array()
+                .is_some_and(|values| values.len() >= 2 && values[0].is_string());
+            if !is_component {
+                continue;
+            }
+            if !safe_relative_path(Path::new(component_name)) {
+                diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::PathEscapesRoot,
+                    Some(relative_path.to_owned()),
+                    format!("model_index.json declares unsafe component path '{component_name}'"),
+                ));
+                continue;
+            }
+            let component_path = path
+                .parent()
+                .unwrap_or(&resolved.canonical_target)
+                .join(component_name);
+            if !component_path.is_dir() {
+                diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::MissingSidecar,
+                    Some(relative_path.to_owned()),
+                    format!(
+                        "model_index.json declares component '{component_name}' but its directory is missing"
+                    ),
+                ));
+            } else if std::fs::canonicalize(&component_path)
+                .ok()
+                .map_or(true, |canonical| {
+                    !canonical.starts_with(&resolved.canonical_root)
+                })
+            {
+                diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::PathEscapesRoot,
+                    Some(relative_path.to_owned()),
+                    format!(
+                        "model_index.json component '{component_name}' resolves outside the declared root"
+                    ),
+                ));
+            } else if !component_path.join("config.json").is_file() {
+                diagnostics.push(CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::MissingSidecar,
+                    Some(relative_path.to_owned()),
+                    format!("model_index.json component '{component_name}' is missing config.json"),
+                ));
+            }
+        }
+    }
+
+    let mut dialects = Vec::new();
+    for key in ["_class_name", "model_type", "architecture", "architectures"] {
+        if let Some(value) = object.get(key) {
+            collect_strings(value, &mut dialects);
+        }
+    }
+    dialects.sort();
+    dialects.dedup();
+    let families = dialects
+        .iter()
+        .filter_map(|value| normalize_family(value))
+        .collect::<BTreeSet<_>>();
+    if families.len() > 1 {
+        return Err(CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::FamilyDialectConflict,
+            Some(relative_path.to_owned()),
+            format!(
+                "JSON descriptor contains conflicting model-family evidence: {}",
+                families.into_iter().collect::<Vec<_>>().join(", ")
+            ),
+        ));
+    }
+    let family = families.into_iter().next();
+    let relative = portable_to_path(relative_path);
+    let contributes_backbone_family = filename == "model_index.json"
+        || infer_role_from_path(relative.parent().unwrap_or(Path::new("")))
+            .is_some_and(|role| matches!(role, "transformer" | "checkpoint"));
+    Ok(JsonDescriptorEvidence {
+        family,
+        dialect: (!dialects.is_empty()).then(|| dialects.join(",")),
+        contributes_backbone_family,
+        index,
+    })
+}
+
+fn collect_strings(value: &Value, output: &mut Vec<String>) {
+    if let Some(value) = value.as_str() {
+        output.push(value.to_owned());
+    } else if let Some(values) = value.as_array() {
+        for value in values {
+            collect_strings(value, output);
+        }
+    }
+}
+
+fn normalize_family(value: &str) -> Option<String> {
+    let lower = value.to_ascii_lowercase();
+    for (needle, family) in [
+        ("stable diffusion xl", "sdxl"),
+        ("stablediffusionxl", "sdxl"),
+        ("sdxl", "sdxl"),
+        ("qwenimage", "qwen-image"),
+        ("qwen_image", "qwen-image"),
+        ("qwen-image", "qwen-image"),
+        ("flux2", "flux2"),
+        ("flux.2", "flux2"),
+        ("flux", "flux"),
+        ("wan", "wan-video"),
+        ("z_image", "z-image"),
+        ("z-image", "z-image"),
+        ("mageflow", "mage-flow"),
+        ("mage_flow", "mage-flow"),
+        ("mage-flow", "mage-flow"),
+        ("krea", "krea_2"),
+        ("ltx", "ltx-video"),
+        ("ideogram", "ideogram"),
+        ("anima", "anima"),
+        ("cosmos", "anima"),
+    ] {
+        if lower.contains(needle) {
+            return Some(family.to_owned());
+        }
+    }
+    None
+}
+
+fn is_auxiliary_family(family: &str) -> bool {
+    matches!(family, "t5" | "qwen3" | "gemma")
+}
+
+fn reconcile_role(
+    relative_path: &str,
+    path_role: Option<&'static str>,
+    header_role: Option<&str>,
+    diagnostics: &mut Vec<CheckpointDiagnosticV1>,
+) -> Option<String> {
+    match (path_role, header_role) {
+        (Some(path_role), Some(header_role)) if path_role != header_role => {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::AmbiguousComponentRole,
+                Some(relative_path.to_owned()),
+                format!(
+                    "component path implies role '{path_role}' but its descriptor implies '{header_role}'"
+                ),
+            ));
+            None
+        }
+        (Some(role), _) => Some(role.to_owned()),
+        (_, Some(role)) => Some(role.to_owned()),
+        (None, None) => {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::AmbiguousComponentRole,
+                Some(relative_path.to_owned()),
+                "component role is ambiguous: neither its path nor descriptor identifies transformer, text encoder, VAE, or fused checkpoint",
+            ));
+            None
+        }
+    }
+}
+
+fn infer_role_from_path(path: &Path) -> Option<&'static str> {
+    let names = path
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => value.to_str().map(str::to_ascii_lowercase),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    for name in names.iter().rev() {
+        match name.as_str() {
+            "transformer" | "transformers" | "unet" | "diffusion_models" => {
+                return Some("transformer")
+            }
+            "text_encoder" | "text_encoders" | "text_encoder_2" => return Some("text_encoder"),
+            "vae" => return Some("vae"),
+            "checkpoints" => return Some("checkpoint"),
+            _ => {}
+        }
+    }
+    None
+}
+
+fn inspection_fingerprint(evidence: &[CheckpointArtifactEvidenceV1]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"sceneworks.checkpoint.inspection.v1\0");
+    for artifact in evidence {
+        hasher.update((artifact.relative_path.len() as u64).to_le_bytes());
+        hasher.update(artifact.relative_path.as_bytes());
+        hasher.update([0]);
+        hasher.update(artifact.sha256.as_bytes());
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ArtifactSnapshot {
+    sha256: String,
+    size_bytes: u64,
+    prefix: Vec<u8>,
+    before: FileStamp,
+    after: FileStamp,
+    stable: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct FileStamp {
+    len: u64,
+    modified: Option<std::time::SystemTime>,
+    created: Option<std::time::SystemTime>,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    change_seconds: i64,
+    #[cfg(unix)]
+    change_nanoseconds: i64,
+    #[cfg(windows)]
+    creation_time: u64,
+    #[cfg(windows)]
+    last_write_time: u64,
+}
+
+impl FileStamp {
+    fn from_metadata(metadata: &std::fs::Metadata) -> Self {
+        #[cfg(unix)]
+        use std::os::unix::fs::MetadataExt as _;
+        #[cfg(windows)]
+        use std::os::windows::fs::MetadataExt as _;
+
+        Self {
+            len: metadata.len(),
+            modified: metadata.modified().ok(),
+            created: metadata.created().ok(),
+            #[cfg(unix)]
+            device: metadata.dev(),
+            #[cfg(unix)]
+            inode: metadata.ino(),
+            #[cfg(unix)]
+            change_seconds: metadata.ctime(),
+            #[cfg(unix)]
+            change_nanoseconds: metadata.ctime_nsec(),
+            #[cfg(windows)]
+            creation_time: metadata.creation_time(),
+            #[cfg(windows)]
+            last_write_time: metadata.last_write_time(),
+        }
+    }
+}
+
+fn snapshot_file(path: &Path, prefix_limit: u64) -> std::io::Result<ArtifactSnapshot> {
+    let mut file = File::open(path)?;
+    let before = FileStamp::from_metadata(&file.metadata()?);
+    let mut buffer = vec![0_u8; HASH_BUFFER_BYTES];
+    let mut hasher = Sha256::new();
+    let mut prefix = Vec::new();
+    let mut size_bytes = 0_u64;
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+        size_bytes = size_bytes.checked_add(read as u64).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "artifact size overflows u64",
+            )
+        })?;
+        let remaining = prefix_limit.saturating_sub(prefix.len() as u64) as usize;
+        prefix.extend_from_slice(&buffer[..read.min(remaining)]);
+    }
+    let after = FileStamp::from_metadata(&file.metadata()?);
+    let stable = before == after && size_bytes == after.len;
+    Ok(ArtifactSnapshot {
+        sha256: format!("{:x}", hasher.finalize()),
+        size_bytes,
+        prefix,
+        before,
+        after,
+        stable,
+    })
+}
+
+fn empty_inventory() -> CheckpointInventoryV1 {
+    CheckpointInventoryV1::new(Vec::new()).expect("empty v1 inventory is valid")
+}
+
+fn safe_relative_path(path: &Path) -> bool {
+    let mut saw_component = false;
+    for component in path.components() {
+        match component {
+            Component::Normal(value) => {
+                let Some(value) = value.to_str() else {
+                    return false;
+                };
+                if value.is_empty()
+                    || value.contains(['/', '\\', ':'])
+                    || value.chars().any(char::is_control)
+                {
+                    return false;
+                }
+                saw_component = true;
+            }
+            _ => return false,
+        }
+    }
+    saw_component
+}
+
+fn is_hidden_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with('.'))
+}
+
+fn is_weight_extension(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("safetensors") || extension.eq_ignore_ascii_case("gguf")
+        })
+}
+
+fn is_json_descriptor(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("json"))
+}
+
+fn looks_like_shard(relative_path: &str) -> bool {
+    let lower = relative_path.to_ascii_lowercase();
+    lower.ends_with(".safetensors")
+        && lower.rsplit('/').next().is_some_and(|name| {
+            let Some((left, right)) = name.rsplit_once("-of-") else {
+                return false;
+            };
+            left.rsplit_once('-').is_some_and(|(_, index)| {
+                !index.is_empty()
+                    && index.chars().all(|character| character.is_ascii_digit())
+                    && right.strip_suffix(".safetensors").is_some_and(|count| {
+                        !count.is_empty()
+                            && count.chars().all(|character| character.is_ascii_digit())
+                    })
+            })
+        })
+}
+
+fn path_to_portable_string(path: &Path) -> Option<String> {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        let Component::Normal(value) = component else {
+            return None;
+        };
+        parts.push(value.to_str()?.to_owned());
+    }
+    (!parts.is_empty()).then(|| parts.join("/"))
+}
+
+fn relative_to_root(resolved: &ResolvedInput, path: &Path) -> Option<String> {
+    let relative = path.strip_prefix(&resolved.canonical_root).ok()?;
+    path_to_portable_string(relative)
+}
+
+fn portable_to_path(path: &str) -> PathBuf {
+    path.split('/').collect()
+}
+
+fn sort_diagnostics(diagnostics: &mut Vec<CheckpointDiagnosticV1>) {
+    diagnostics.sort_by(|left, right| {
+        (
+            left.severity,
+            left.code,
+            left.relative_path.as_deref(),
+            left.message.as_str(),
+        )
+            .cmp(&(
+                right.severity,
+                right.code,
+                right.relative_path.as_deref(),
+                right.message.as_str(),
+            ))
+    });
+    diagnostics.dedup();
+}
+
+struct StrictJsonError {
+    code: CheckpointDiagnosticCodeV1,
+    message: String,
+}
+
+fn strict_json(raw: &[u8]) -> Result<Value, StrictJsonError> {
+    serde_json::from_slice::<StrictValue>(raw)
+        .map(|value| value.0)
+        .map_err(|error| {
+            let message = error.to_string();
+            let code = if message.contains("duplicate key") {
+                CheckpointDiagnosticCodeV1::DuplicateKey
+            } else {
+                CheckpointDiagnosticCodeV1::MalformedMetadata
+            };
+            StrictJsonError { code, message }
+        })
+}
+
+struct StrictValue(Value);
+
+impl<'de> Deserialize<'de> for StrictValue {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_any(StrictValueVisitor)
+    }
+}
+
+struct StrictValueVisitor;
+
+impl<'de> Visitor<'de> for StrictValueVisitor {
+    type Value = StrictValue;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON value without duplicate object keys")
+    }
+
+    fn visit_bool<E: serde::de::Error>(self, value: bool) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Bool(value)))
+    }
+
+    fn visit_i64<E: serde::de::Error>(self, value: i64) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Number(value.into())))
+    }
+
+    fn visit_u64<E: serde::de::Error>(self, value: u64) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Number(value.into())))
+    }
+
+    fn visit_f64<E: serde::de::Error>(self, value: f64) -> Result<Self::Value, E> {
+        serde_json::Number::from_f64(value)
+            .map(Value::Number)
+            .map(StrictValue)
+            .ok_or_else(|| E::custom("non-finite JSON number"))
+    }
+
+    fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::String(value.to_owned())))
+    }
+
+    fn visit_string<E: serde::de::Error>(self, value: String) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::String(value)))
+    }
+
+    fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Null))
+    }
+
+    fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+        Ok(StrictValue(Value::Null))
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut sequence: A) -> Result<Self::Value, A::Error> {
+        let mut values = Vec::new();
+        while let Some(value) = sequence.next_element::<StrictValue>()? {
+            values.push(value.0);
+        }
+        Ok(StrictValue(Value::Array(values)))
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+        let mut values = serde_json::Map::new();
+        while let Some(key) = map.next_key::<String>()? {
+            if values.contains_key(&key) {
+                return Err(A::Error::custom(format!("duplicate key '{key}'")));
+            }
+            let value = map.next_value::<StrictValue>()?;
+            values.insert(key, value.0);
+        }
+        Ok(StrictValue(Value::Object(values)))
+    }
+}
+
+#[derive(Clone)]
+enum GgufMetadataValue {
+    Uint32(u32),
+    String(String),
+    Other,
+}
+
+#[derive(Clone)]
+struct GgufTensorInfo {
+    name: String,
+    dimensions: Vec<u64>,
+    tensor_type: u32,
+    offset: u64,
+}
+
+fn validate_gguf(
+    prefix: &[u8],
+    file_len: u64,
+    relative_path: Option<String>,
+) -> Result<ValidatedArtifact, Vec<CheckpointDiagnosticV1>> {
+    let mut reader = ByteReader::new(prefix);
+    if reader.take(4) != Some(b"GGUF".as_slice()) {
+        return Err(vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::MalformedMetadata,
+            relative_path,
+            "GGUF container does not start with GGUF magic",
+        )]);
+    }
+    let version = reader.u32().ok_or_else(|| {
+        vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::TruncatedHeader,
+            relative_path.clone(),
+            "GGUF descriptor is truncated before its version",
+        )]
+    })?;
+    if !matches!(version, 2 | 3) {
+        return Err(vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::MalformedMetadata,
+            relative_path,
+            format!("unsupported GGUF version {version}; expected v2 or v3"),
+        )]);
+    }
+    let tensor_count = reader.u64().ok_or_else(|| {
+        vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::TruncatedHeader,
+            relative_path.clone(),
+            "GGUF descriptor is truncated before its tensor count",
+        )]
+    })?;
+    let metadata_count = reader.u64().ok_or_else(|| {
+        vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::TruncatedHeader,
+            relative_path.clone(),
+            "GGUF descriptor is truncated before its metadata count",
+        )]
+    })?;
+    if tensor_count > MAX_GGUF_ITEMS || metadata_count > MAX_GGUF_ITEMS {
+        return Err(vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::HeaderTooLarge,
+            relative_path,
+            format!(
+                "GGUF declares {tensor_count} tensors and {metadata_count} metadata entries; each is bounded at {MAX_GGUF_ITEMS}"
+            ),
+        )]);
+    }
+    let mut metadata = BTreeMap::new();
+    for _ in 0..metadata_count {
+        let key = reader.string().map_err(|message| {
+            vec![gguf_parse_diagnostic(
+                relative_path.clone(),
+                message,
+                file_len,
+                prefix.len(),
+            )]
+        })?;
+        if !valid_gguf_metadata_key(&key) {
+            return Err(vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                relative_path,
+                format!(
+                    "GGUF metadata key '{key}' must be <=65535 ASCII bytes with lower_snake_case segments separated by dots"
+                ),
+            )]);
+        }
+        if metadata.contains_key(&key) {
+            return Err(vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::DuplicateKey,
+                relative_path,
+                format!("GGUF metadata contains duplicate key '{key}'"),
+            )]);
+        }
+        let value_type = reader.u32().ok_or_else(|| {
+            vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::TruncatedHeader,
+                relative_path.clone(),
+                format!("GGUF metadata key '{key}' has no value type"),
+            )]
+        })?;
+        let value = reader.metadata_value(value_type, 0).map_err(|message| {
+            vec![gguf_parse_diagnostic(
+                relative_path.clone(),
+                message,
+                file_len,
+                prefix.len(),
+            )]
+        })?;
+        metadata.insert(key, value);
+    }
+    let mut tensors = Vec::with_capacity(tensor_count as usize);
+    let mut tensor_names = BTreeSet::new();
+    for _ in 0..tensor_count {
+        let name = reader.string().map_err(|message| {
+            vec![gguf_parse_diagnostic(
+                relative_path.clone(),
+                message,
+                file_len,
+                prefix.len(),
+            )]
+        })?;
+        if name.is_empty() || name.len() > 64 {
+            return Err(vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                relative_path,
+                format!("GGUF tensor name must contain 1..=64 UTF-8 bytes, found {name:?}"),
+            )]);
+        }
+        if !tensor_names.insert(name.clone()) {
+            return Err(vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::DuplicateKey,
+                relative_path,
+                format!("GGUF descriptor contains duplicate tensor name '{name}'"),
+            )]);
+        }
+        let dimensions = reader.u32().ok_or_else(|| {
+            vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::TruncatedHeader,
+                relative_path.clone(),
+                format!("GGUF tensor '{name}' is missing its dimension count"),
+            )]
+        })?;
+        if dimensions == 0 || dimensions > 4 {
+            return Err(vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                relative_path,
+                format!("GGUF tensor '{name}' has invalid dimension count {dimensions}"),
+            )]);
+        }
+        let mut shape = Vec::with_capacity(dimensions as usize);
+        for _ in 0..dimensions {
+            shape.push(reader.u64().ok_or_else(|| {
+                vec![CheckpointDiagnosticV1::error(
+                    CheckpointDiagnosticCodeV1::TruncatedHeader,
+                    relative_path.clone(),
+                    format!("GGUF tensor '{name}' has a truncated shape"),
+                )]
+            })?);
+        }
+        let tensor_type = reader.u32().ok_or_else(|| {
+            vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::TruncatedHeader,
+                relative_path.clone(),
+                format!("GGUF tensor '{name}' has no tensor type"),
+            )]
+        })?;
+        let offset = reader.u64().ok_or_else(|| {
+            vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::TruncatedHeader,
+                relative_path.clone(),
+                format!("GGUF tensor '{name}' has no data offset"),
+            )]
+        })?;
+        tensors.push(GgufTensorInfo {
+            name,
+            dimensions: shape,
+            tensor_type,
+            offset,
+        });
+    }
+    let alignment = match metadata.get("general.alignment") {
+        Some(GgufMetadataValue::Uint32(value)) => u64::from(*value),
+        Some(_) => {
+            return Err(vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                relative_path,
+                "GGUF general.alignment must have metadata type uint32",
+            )])
+        }
+        None => 32,
+    };
+    if alignment < 8 || alignment % 8 != 0 {
+        return Err(vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::MalformedMetadata,
+            relative_path,
+            format!("GGUF alignment {alignment} must be a non-zero uint32 multiple of 8"),
+        )]);
+    }
+    let has_quantized_tensors = tensors.iter().any(|tensor| {
+        ggml_type_layout(tensor.tensor_type).is_some_and(|(block_size, _)| block_size > 1)
+    });
+    match metadata.get("general.quantization_version") {
+        Some(GgufMetadataValue::Uint32(version)) if matches!(*version, 1 | 2) => {}
+        Some(GgufMetadataValue::Uint32(version)) => {
+            return Err(vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                relative_path,
+                format!(
+                    "GGUF general.quantization_version {version} is unsupported; expected 1 or 2"
+                ),
+            )])
+        }
+        Some(_) => {
+            return Err(vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                relative_path,
+                "GGUF general.quantization_version must have metadata type uint32",
+            )])
+        }
+        None if has_quantized_tensors => {
+            return Err(vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MalformedMetadata,
+                relative_path,
+                "quantized GGUF tensors require uint32 general.quantization_version metadata",
+            )])
+        }
+        None => {}
+    }
+    let descriptor_end = reader.position() as u64;
+    let padding = (alignment - (descriptor_end % alignment)) % alignment;
+    let data_start = descriptor_end.checked_add(padding).ok_or_else(|| {
+        vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::InvalidTensorRange,
+            relative_path.clone(),
+            "GGUF descriptor alignment overflows the file address space",
+        )]
+    })?;
+    if data_start > MAX_GGUF_DESCRIPTOR_BYTES {
+        return Err(vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::HeaderTooLarge,
+            relative_path,
+            format!("GGUF descriptor ends at byte {data_start}, above the bound"),
+        )]);
+    }
+    if data_start > file_len {
+        return Err(vec![CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::TruncatedHeader,
+            relative_path,
+            format!("GGUF tensor data begins at {data_start}, beyond the {file_len}-byte file"),
+        )]);
+    }
+    let data_len = file_len - data_start;
+    let mut ranges = Vec::new();
+    let mut diagnostics = Vec::new();
+    for tensor in tensors {
+        let Some((block_size, type_size)) = ggml_type_layout(tensor.tensor_type) else {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::UnsupportedTensorType,
+                relative_path.clone(),
+                format!(
+                    "GGUF tensor '{}' uses unsupported ggml tensor type {}",
+                    tensor.name, tensor.tensor_type
+                ),
+            ));
+            continue;
+        };
+        let elements = tensor
+            .dimensions
+            .iter()
+            .try_fold(1_u64, |count, dimension| count.checked_mul(*dimension));
+        let Some(elements) = elements else {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::InvalidTensorRange,
+                relative_path.clone(),
+                format!("GGUF tensor '{}' dimensions overflow", tensor.name),
+            ));
+            continue;
+        };
+        let first_dimension = tensor.dimensions.first().copied().unwrap_or(0);
+        if elements == 0 || first_dimension % block_size != 0 {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::InvalidTensorRange,
+                relative_path.clone(),
+                format!(
+                    "GGUF tensor '{}' has first dimension {first_dimension}, incompatible with block size {block_size}",
+                    tensor.name,
+                ),
+            ));
+            continue;
+        }
+        let byte_len = (elements / block_size).checked_mul(type_size);
+        let end = byte_len.and_then(|length| tensor.offset.checked_add(length));
+        let Some(end) = end else {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::InvalidTensorRange,
+                relative_path.clone(),
+                format!("GGUF tensor '{}' range overflows u64", tensor.name),
+            ));
+            continue;
+        };
+        if tensor.offset % alignment != 0 {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::InvalidTensorRange,
+                relative_path.clone(),
+                format!(
+                    "GGUF tensor '{}' offset {} is not aligned to {alignment}",
+                    tensor.name, tensor.offset
+                ),
+            ));
+        }
+        if end > data_len {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::InvalidTensorRange,
+                relative_path.clone(),
+                format!(
+                    "GGUF tensor '{}' range [{}, {end}) exceeds the {data_len}-byte data section",
+                    tensor.name, tensor.offset
+                ),
+            ));
+        }
+        ranges.push((tensor.offset, end, tensor.name));
+    }
+    ranges.sort_by_key(|(start, _, _)| *start);
+    let mut previous_end = 0_u64;
+    for (start, end, name) in &ranges {
+        if *start < previous_end {
+            diagnostics.push(CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::InvalidTensorRange,
+                relative_path.clone(),
+                format!("GGUF tensor '{name}' overlaps the preceding tensor range"),
+            ));
+        }
+        previous_end = previous_end.max(*end);
+    }
+    if ranges.is_empty() {
+        diagnostics.push(CheckpointDiagnosticV1::error(
+            CheckpointDiagnosticCodeV1::MalformedMetadata,
+            relative_path.clone(),
+            "GGUF descriptor declares no valid tensors",
+        ));
+    }
+    if !diagnostics.is_empty() {
+        return Err(diagnostics);
+    }
+    let architecture = match metadata.get("general.architecture") {
+        Some(GgufMetadataValue::String(value))
+            if !value.is_empty()
+                && value
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit()) =>
+        {
+            value.clone()
+        }
+        _ => {
+            return Err(vec![CheckpointDiagnosticV1::error(
+                CheckpointDiagnosticCodeV1::MissingFamilyEvidence,
+                relative_path,
+                "GGUF general.architecture must be a non-empty lowercase ASCII [a-z0-9]+ string",
+            )])
+        }
+    };
+    let family =
+        normalize_family(&architecture).unwrap_or_else(|| architecture.to_ascii_lowercase());
+    Ok(ValidatedArtifact {
+        role: None,
+        family: Some(family),
+        dialect: Some(format!("gguf-v{version}")),
+        declared_tensor_bytes: Some(previous_end),
+        tensor_names: tensor_names.into_iter().collect(),
+    })
+}
+
+fn valid_gguf_metadata_key(key: &str) -> bool {
+    !key.is_empty()
+        && key.len() <= 65_535
+        && key.is_ascii()
+        && key.split('.').all(|segment| {
+            !segment.is_empty()
+                && !segment.starts_with('_')
+                && !segment.ends_with('_')
+                && !segment.contains("__")
+                && segment
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+        })
+}
+
+fn gguf_parse_diagnostic(
+    relative_path: Option<String>,
+    message: String,
+    file_len: u64,
+    captured_bytes: usize,
+) -> CheckpointDiagnosticV1 {
+    let code = if message.contains("exceeds")
+        || (message.contains("truncated") && file_len > captured_bytes as u64)
+    {
+        CheckpointDiagnosticCodeV1::HeaderTooLarge
+    } else if message.contains("truncated") {
+        CheckpointDiagnosticCodeV1::TruncatedHeader
+    } else {
+        CheckpointDiagnosticCodeV1::MalformedMetadata
+    };
+    CheckpointDiagnosticV1::error(
+        code,
+        relative_path,
+        format!("invalid GGUF descriptor: {message}"),
+    )
+}
+
+fn ggml_type_layout(tensor_type: u32) -> Option<(u64, u64)> {
+    match tensor_type {
+        0 => Some((1, 4)),   // F32
+        1 => Some((1, 2)),   // F16
+        2 => Some((32, 18)), // Q4_0
+        3 => Some((32, 20)), // Q4_1
+        6 => Some((32, 22)), // Q5_0
+        7 => Some((32, 24)), // Q5_1
+        8 => Some((32, 34)), // Q8_0
+        9 => Some((32, 36)), // Q8_1
+        10 => Some((256, 84)),
+        11 => Some((256, 110)),
+        12 => Some((256, 144)),
+        13 => Some((256, 176)),
+        14 => Some((256, 210)),
+        15 => Some((256, 292)),
+        16 => Some((256, 66)),
+        17 => Some((256, 74)),
+        18 => Some((256, 98)),
+        19 => Some((256, 50)),
+        20 => Some((32, 18)),
+        21 => Some((256, 110)),
+        22 => Some((256, 82)),
+        23 => Some((256, 136)),
+        24 => Some((1, 1)), // I8
+        25 => Some((1, 2)), // I16
+        26 => Some((1, 4)), // I32
+        27 => Some((1, 8)), // I64
+        28 => Some((1, 8)), // F64
+        29 => Some((256, 56)),
+        30 => Some((1, 2)),    // BF16
+        34 => Some((256, 54)), // TQ1_0
+        35 => Some((256, 66)), // TQ2_0
+        39 => Some((32, 17)),  // MXFP4
+        40 => Some((64, 36)),  // NVFP4
+        41 => Some((128, 18)), // Q1_0
+        42 => Some((64, 18)),  // Q2_0
+        _ => None,
+    }
+}
+
+struct ByteReader<'a> {
+    bytes: &'a [u8],
+    position: usize,
+}
+
+impl<'a> ByteReader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, position: 0 }
+    }
+
+    fn position(&self) -> usize {
+        self.position
+    }
+
+    fn take(&mut self, count: usize) -> Option<&'a [u8]> {
+        let end = self.position.checked_add(count)?;
+        let value = self.bytes.get(self.position..end)?;
+        self.position = end;
+        Some(value)
+    }
+
+    fn u8(&mut self) -> Option<u8> {
+        Some(*self.take(1)?.first()?)
+    }
+
+    fn u16(&mut self) -> Option<u16> {
+        Some(u16::from_le_bytes(self.take(2)?.try_into().ok()?))
+    }
+
+    fn u32(&mut self) -> Option<u32> {
+        Some(u32::from_le_bytes(self.take(4)?.try_into().ok()?))
+    }
+
+    fn u64(&mut self) -> Option<u64> {
+        Some(u64::from_le_bytes(self.take(8)?.try_into().ok()?))
+    }
+
+    fn string(&mut self) -> Result<String, String> {
+        let length = self
+            .u64()
+            .ok_or_else(|| "truncated string length".to_owned())?;
+        if length > MAX_GGUF_STRING_BYTES {
+            return Err(format!(
+                "string length {length} exceeds the {MAX_GGUF_STRING_BYTES}-byte bound"
+            ));
+        }
+        let bytes = self
+            .take(length as usize)
+            .ok_or_else(|| format!("truncated {length}-byte string"))?;
+        std::str::from_utf8(bytes)
+            .map(str::to_owned)
+            .map_err(|_| "string is not valid UTF-8".to_owned())
+    }
+
+    fn metadata_value(
+        &mut self,
+        value_type: u32,
+        depth: usize,
+    ) -> Result<GgufMetadataValue, String> {
+        if depth > MAX_GGUF_ARRAY_DEPTH {
+            return Err(format!(
+                "metadata array nesting exceeds depth {MAX_GGUF_ARRAY_DEPTH}"
+            ));
+        }
+        match value_type {
+            0 => self.u8().map(|_| GgufMetadataValue::Other),
+            1 => self.u8().map(|_| GgufMetadataValue::Other),
+            2 => self.u16().map(|_| GgufMetadataValue::Other),
+            3 => self.u16().map(|_| GgufMetadataValue::Other),
+            4 => self.u32().map(GgufMetadataValue::Uint32),
+            5 | 6 => self.u32().map(|_| GgufMetadataValue::Other),
+            7 => {
+                let value = self
+                    .u8()
+                    .ok_or_else(|| "truncated boolean metadata value".to_owned())?;
+                if value > 1 {
+                    return Err(format!(
+                        "boolean metadata value must be 0 or 1, found {value}"
+                    ));
+                }
+                return Ok(GgufMetadataValue::Other);
+            }
+            8 => return self.string().map(GgufMetadataValue::String),
+            9 => {
+                let element_type = self
+                    .u32()
+                    .ok_or_else(|| "truncated metadata array element type".to_owned())?;
+                let count = self
+                    .u64()
+                    .ok_or_else(|| "truncated metadata array count".to_owned())?;
+                if count > MAX_GGUF_ITEMS {
+                    return Err(format!(
+                        "metadata array count {count} exceeds the {MAX_GGUF_ITEMS} bound"
+                    ));
+                }
+                for _ in 0..count {
+                    self.metadata_value(element_type, depth + 1)?;
+                }
+                return Ok(GgufMetadataValue::Other);
+            }
+            10 => self.u64().map(|_| GgufMetadataValue::Other),
+            11 | 12 => self.u64().map(|_| GgufMetadataValue::Other),
+            _ => return Err(format!("unsupported GGUF metadata value type {value_type}")),
+        }
+        .ok_or_else(|| "truncated metadata value".to_owned())
+    }
+}

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod builtin_manifests;
 pub mod catalog_store;
 pub mod character_store;
 pub mod checkpoint_import;
+pub mod checkpoint_inspector;
 pub mod contracts;
 pub mod control_weights;
 pub mod credentials;

--- a/crates/sceneworks-core/tests/checkpoint_inspector.rs
+++ b/crates/sceneworks-core/tests/checkpoint_inspector.rs
@@ -1,0 +1,1430 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use sceneworks_core::checkpoint_import::{ManagedProvenanceV1, SourceLocatorV1};
+use sceneworks_core::checkpoint_inspector::{
+    discover_checkpoint, inspect_checkpoint, inspect_checkpoint_with_hook,
+    CheckpointDiagnosticCodeV1, CheckpointInspectionEventV1, CheckpointInspectionRequestV1,
+    CheckpointLayoutV1,
+};
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use tempfile::TempDir;
+
+fn linked_request(root: &Path, relative_path: &str) -> CheckpointInspectionRequestV1 {
+    CheckpointInspectionRequestV1::linked(
+        "community-checkpoint",
+        root,
+        relative_path,
+        "comfy-primary",
+    )
+    .expect("valid request")
+}
+
+fn write_safetensors(path: &Path, entries: &[(&str, &str)], metadata: Option<Value>) {
+    let mut header = Map::new();
+    if let Some(metadata) = metadata {
+        header.insert("__metadata__".to_owned(), metadata);
+    }
+    let mut offset = 0_u64;
+    for (name, dtype) in entries {
+        let width = match *dtype {
+            "F16" | "BF16" => 2,
+            "F32" => 4,
+            _ => 1,
+        };
+        header.insert(
+            (*name).to_owned(),
+            json!({
+                "dtype": dtype,
+                "shape": [1],
+                "data_offsets": [offset, offset + width],
+            }),
+        );
+        offset += width;
+    }
+    let encoded = serde_json::to_vec(&Value::Object(header)).unwrap();
+    let mut bytes = (encoded.len() as u64).to_le_bytes().to_vec();
+    bytes.extend(encoded);
+    bytes.resize(bytes.len() + offset as usize, 0x5a);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, bytes).unwrap();
+}
+
+fn qwen_transformer_entries() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("model.diffusion_model.img_in.weight", "F8_E4M3"),
+        (
+            "model.diffusion_model.transformer_blocks.0.attn.add_q_proj.weight",
+            "F8_E4M3",
+        ),
+        (
+            "model.diffusion_model.transformer_blocks.0.attn.to_q.weight",
+            "F8_E4M3",
+        ),
+        (
+            "model.diffusion_model.transformer_blocks.0.img_mlp.net.0.proj.weight",
+            "F8_E4M3",
+        ),
+        (
+            "model.diffusion_model.transformer_blocks.0.txt_mlp.net.0.proj.weight",
+            "F8_E4M3",
+        ),
+        (
+            "model.diffusion_model.transformer_blocks.0.img_mod.1.weight",
+            "F8_E4M3",
+        ),
+    ]
+}
+
+fn sdxl_fused_entries() -> Vec<(&'static str, &'static str)> {
+    vec![
+        (
+            "model.diffusion_model.input_blocks.7.0.out_layers.3.weight",
+            "F16",
+        ),
+        (
+            "model.diffusion_model.middle_block.1.transformer_blocks.0.attn1.to_q.weight",
+            "F16",
+        ),
+        (
+            "conditioner.embedders.0.transformer.text_model.embeddings.token_embedding.weight",
+            "F16",
+        ),
+        (
+            "conditioner.embedders.1.model.transformer.resblocks.9.attn.in_proj_weight",
+            "F16",
+        ),
+        ("first_stage_model.encoder.conv_in.weight", "F16"),
+        ("first_stage_model.decoder.conv_out.weight", "F16"),
+    ]
+}
+
+fn vae_entries() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("encoder.conv_in.weight", "F32"),
+        ("encoder.down.0.block.0.conv1.weight", "F32"),
+        ("encoder.mid.attn_1.q.weight", "F32"),
+        ("decoder.conv_out.weight", "F32"),
+        ("decoder.up.0.block.0.conv1.weight", "F32"),
+        ("decoder.mid.attn_1.q.weight", "F32"),
+    ]
+}
+
+fn push_u32(bytes: &mut Vec<u8>, value: u32) {
+    bytes.extend(value.to_le_bytes());
+}
+
+fn push_u64(bytes: &mut Vec<u8>, value: u64) {
+    bytes.extend(value.to_le_bytes());
+}
+
+fn push_gguf_string(bytes: &mut Vec<u8>, value: &str) {
+    push_u64(bytes, value.len() as u64);
+    bytes.extend(value.as_bytes());
+}
+
+fn write_tiny_gguf(path: &Path, architecture: &str) -> usize {
+    let mut bytes = b"GGUF".to_vec();
+    push_u32(&mut bytes, 3);
+    push_u64(&mut bytes, 1); // tensor count
+    push_u64(&mut bytes, 2); // metadata count
+
+    push_gguf_string(&mut bytes, "general.architecture");
+    push_u32(&mut bytes, 8); // string
+    push_gguf_string(&mut bytes, architecture);
+    push_gguf_string(&mut bytes, "general.alignment");
+    push_u32(&mut bytes, 4); // u32
+    push_u32(&mut bytes, 32);
+
+    push_gguf_string(&mut bytes, "model.weight");
+    push_u32(&mut bytes, 1); // dimensions
+    push_u64(&mut bytes, 1);
+    push_u32(&mut bytes, 0); // F32
+    let tensor_offset_position = bytes.len();
+    push_u64(&mut bytes, 0); // relative data offset
+
+    let aligned = bytes.len().div_ceil(32) * 32;
+    bytes.resize(aligned, 0);
+    bytes.extend(1_f32.to_le_bytes());
+    fs::write(path, bytes).unwrap();
+    tensor_offset_position
+}
+
+fn write_duplicate_metadata_gguf(path: &Path) {
+    let mut bytes = b"GGUF".to_vec();
+    push_u32(&mut bytes, 3);
+    push_u64(&mut bytes, 0);
+    push_u64(&mut bytes, 2);
+    for value in ["flux", "qwen"] {
+        push_gguf_string(&mut bytes, "general.architecture");
+        push_u32(&mut bytes, 8);
+        push_gguf_string(&mut bytes, value);
+    }
+    fs::write(path, bytes).unwrap();
+}
+
+fn write_quantized_gguf(
+    path: &Path,
+    first_dimension: u64,
+    second_dimension: u64,
+    tensor_type: u32,
+    block_bytes: usize,
+) {
+    write_quantized_gguf_fixture(
+        path,
+        3,
+        32,
+        Some(2),
+        first_dimension,
+        second_dimension,
+        tensor_type,
+        block_bytes,
+        "model.weight",
+    );
+}
+
+#[derive(Clone, Copy)]
+struct GgufFixtureOffsets {
+    alignment: usize,
+    quantization_version: Option<usize>,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_quantized_gguf_fixture(
+    path: &Path,
+    version: u32,
+    alignment: u32,
+    quantization_version: Option<u32>,
+    first_dimension: u64,
+    second_dimension: u64,
+    tensor_type: u32,
+    block_bytes: usize,
+    tensor_name: &str,
+) -> GgufFixtureOffsets {
+    let mut bytes = b"GGUF".to_vec();
+    push_u32(&mut bytes, version);
+    push_u64(&mut bytes, 1); // tensor count
+    push_u64(
+        &mut bytes,
+        if quantization_version.is_some() { 3 } else { 2 },
+    );
+
+    push_gguf_string(&mut bytes, "general.architecture");
+    push_u32(&mut bytes, 8); // string
+    push_gguf_string(&mut bytes, "flux");
+    push_gguf_string(&mut bytes, "general.alignment");
+    push_u32(&mut bytes, 4); // u32
+    let alignment_offset = bytes.len();
+    push_u32(&mut bytes, alignment);
+    let quantization_version_offset = quantization_version.map(|version| {
+        push_gguf_string(&mut bytes, "general.quantization_version");
+        push_u32(&mut bytes, 4); // u32
+        let offset = bytes.len();
+        push_u32(&mut bytes, version);
+        offset
+    });
+
+    push_gguf_string(&mut bytes, tensor_name);
+    push_u32(&mut bytes, 2); // dimensions
+    push_u64(&mut bytes, first_dimension);
+    push_u64(&mut bytes, second_dimension);
+    push_u32(&mut bytes, tensor_type);
+    push_u64(&mut bytes, 0); // relative data offset
+
+    let alignment = alignment as usize;
+    let aligned = bytes.len() + (alignment - (bytes.len() % alignment)) % alignment;
+    bytes.resize(aligned, 0);
+    bytes.resize(bytes.len() + block_bytes, 0x5a);
+    fs::write(path, bytes).unwrap();
+    GgufFixtureOffsets {
+        alignment: alignment_offset,
+        quantization_version: quantization_version_offset,
+    }
+}
+
+fn write_raw_safetensors(path: &Path, header: &[u8], body: &[u8]) {
+    let mut bytes = (header.len() as u64).to_le_bytes().to_vec();
+    bytes.extend(header);
+    bytes.extend(body);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, bytes).unwrap();
+}
+
+fn write_safetensors_index(path: &Path, mappings: &[(&str, &str)]) {
+    let weight_map = mappings
+        .iter()
+        .map(|(tensor, shard)| ((*tensor).to_owned(), json!(shard)))
+        .collect::<Map<String, Value>>();
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(
+        path,
+        serde_json::to_vec(&json!({ "weight_map": weight_map })).unwrap(),
+    )
+    .unwrap();
+}
+
+fn overwrite_u32(path: &Path, offset: usize, value: u32) {
+    let mut bytes = fs::read(path).unwrap();
+    bytes[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+    fs::write(path, bytes).unwrap();
+}
+
+fn replace_bytes(path: &Path, needle: &[u8], replacement: &[u8]) {
+    assert_eq!(needle.len(), replacement.len());
+    let mut bytes = fs::read(path).unwrap();
+    let offset = bytes
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .expect("fixture contains bytes to replace");
+    bytes[offset..offset + replacement.len()].copy_from_slice(replacement);
+    fs::write(path, bytes).unwrap();
+}
+
+fn sha256_file(path: &Path) -> String {
+    format!("{:x}", Sha256::digest(fs::read(path).unwrap()))
+}
+
+fn restore_modified_time(path: &Path, modified: std::time::SystemTime) {
+    fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .unwrap()
+        .set_times(std::fs::FileTimes::new().set_modified(modified))
+        .unwrap();
+}
+
+#[cfg(unix)]
+fn symlink_file(target: &Path, link: &Path) {
+    std::os::unix::fs::symlink(target, link).unwrap();
+}
+
+#[cfg(windows)]
+fn symlink_file(target: &Path, link: &Path) {
+    std::os::windows::fs::symlink_file(target, link).unwrap();
+}
+
+#[cfg(windows)]
+struct WindowsDirectoryJunction(PathBuf);
+
+#[cfg(windows)]
+impl WindowsDirectoryJunction {
+    fn create(path: &Path, target: &Path) -> Self {
+        let output = std::process::Command::new("cmd")
+            .args(["/D", "/C", "mklink", "/J"])
+            .arg(path)
+            .arg(target)
+            .output()
+            .expect("launch cmd.exe to create checkpoint fixture junction");
+        assert!(
+            output.status.success(),
+            "mklink /J failed with {}\nstdout: {}\nstderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        use std::os::windows::fs::MetadataExt as _;
+        assert_ne!(
+            fs::symlink_metadata(path).unwrap().file_attributes() & 0x400,
+            0,
+            "mklink /J fixture must be a reparse point"
+        );
+        Self(path.to_owned())
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsDirectoryJunction {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.0);
+    }
+}
+
+fn has_code(
+    result: &sceneworks_core::checkpoint_inspector::CheckpointInspectionV1,
+    code: CheckpointDiagnosticCodeV1,
+) -> bool {
+    result.diagnostics.iter().any(|item| item.code == code)
+}
+
+#[test]
+fn safetensors_single_file_and_fused_checkpoint_share_the_inventory_contract() {
+    let temp = TempDir::new().unwrap();
+    write_safetensors(
+        &temp.path().join("qwen.safetensors"),
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    write_safetensors(
+        &temp.path().join("sdxl.safetensors"),
+        &sdxl_fused_entries(),
+        Some(json!({"format": "pt"})),
+    );
+
+    let single = inspect_checkpoint(&linked_request(temp.path(), "qwen.safetensors"));
+    let fused = inspect_checkpoint(&linked_request(temp.path(), "sdxl.safetensors"));
+
+    assert!(single.is_runnable(), "{:?}", single.diagnostics);
+    assert!(fused.is_runnable(), "{:?}", fused.diagnostics);
+    assert_eq!(single.layout, Some(CheckpointLayoutV1::SingleFile));
+    assert_eq!(fused.layout, Some(CheckpointLayoutV1::FusedCheckpoint));
+    assert_eq!(
+        single.inventory.schema_version,
+        fused.inventory.schema_version
+    );
+    assert_eq!(single.inventory.records.len(), 1);
+    assert_eq!(fused.inventory.records.len(), 1);
+    assert_eq!(single.plans.len(), 1);
+    assert_eq!(fused.plans.len(), 1);
+}
+
+#[test]
+fn gguf_and_component_directory_produce_the_same_inventory_shape() {
+    let temp = TempDir::new().unwrap();
+    write_tiny_gguf(&temp.path().join("model.gguf"), "flux");
+
+    let directory = temp.path().join("diffusers");
+    write_safetensors(
+        &directory.join("transformer/model.safetensors"),
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    write_safetensors(
+        &directory.join("vae/model.safetensors"),
+        &vae_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    fs::write(
+        directory.join("model_index.json"),
+        br#"{"_class_name":"QwenImagePipeline","transformer":["diffusers","QwenImageTransformer2DModel"],"vae":["diffusers","AutoencoderKL"]}"#,
+    )
+    .unwrap();
+    fs::write(
+        directory.join("transformer/config.json"),
+        br#"{"_class_name":"QwenImageTransformer2DModel"}"#,
+    )
+    .unwrap();
+    fs::write(
+        directory.join("vae/config.json"),
+        br#"{"_class_name":"AutoencoderKL"}"#,
+    )
+    .unwrap();
+
+    let gguf = inspect_checkpoint(&linked_request(temp.path(), "model.gguf"));
+    let components = inspect_checkpoint(&linked_request(temp.path(), "diffusers"));
+
+    assert!(gguf.is_runnable(), "{:?}", gguf.diagnostics);
+    assert!(components.is_runnable(), "{:?}", components.diagnostics);
+    assert_eq!(gguf.layout, Some(CheckpointLayoutV1::SingleFile));
+    assert_eq!(
+        components.layout,
+        Some(CheckpointLayoutV1::ComponentDirectory)
+    );
+    assert_eq!(gguf.inventory.records.len(), 1);
+    assert_eq!(components.inventory.records.len(), 1);
+    assert!(components
+        .evidence
+        .iter()
+        .any(|item| item.relative_path.ends_with("model_index.json")));
+    assert!(components
+        .evidence
+        .iter()
+        .any(|item| item.role.as_deref() == Some("vae")));
+}
+
+#[test]
+fn discovery_is_header_only_but_runnable_validation_checks_declared_ranges() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("truncated.safetensors");
+    write_safetensors(
+        &path,
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    let bytes = fs::read(&path).unwrap();
+    fs::write(&path, &bytes[..bytes.len() - 1]).unwrap();
+
+    let request = linked_request(temp.path(), "truncated.safetensors");
+    let discovery = discover_checkpoint(&request);
+    assert_eq!(discovery.candidates.len(), 1);
+    assert!(!discovery
+        .diagnostics
+        .iter()
+        .any(|item| item.code == CheckpointDiagnosticCodeV1::TruncatedData));
+
+    let inspected = inspect_checkpoint(&request);
+    assert!(has_code(
+        &inspected,
+        CheckpointDiagnosticCodeV1::TruncatedData
+    ));
+    assert!(inspected.inventory.records.is_empty());
+}
+
+#[test]
+fn duplicate_keys_and_malformed_metadata_are_typed_and_actionable() {
+    let temp = TempDir::new().unwrap();
+    let duplicate_header = br#"{"model.diffusion_model.img_in.weight":{"dtype":"U8","shape":[1],"data_offsets":[0,1]},"model.diffusion_model.img_in.weight":{"dtype":"U8","shape":[1],"data_offsets":[0,1]}}"#;
+    let mut duplicate = (duplicate_header.len() as u64).to_le_bytes().to_vec();
+    duplicate.extend(duplicate_header);
+    duplicate.push(1);
+    fs::write(temp.path().join("duplicate.safetensors"), duplicate).unwrap();
+
+    write_safetensors(
+        &temp.path().join("bad-metadata.safetensors"),
+        &qwen_transformer_entries(),
+        Some(json!({"format": 7})),
+    );
+
+    let duplicate = inspect_checkpoint(&linked_request(temp.path(), "duplicate.safetensors"));
+    let malformed = inspect_checkpoint(&linked_request(temp.path(), "bad-metadata.safetensors"));
+    assert!(has_code(
+        &duplicate,
+        CheckpointDiagnosticCodeV1::DuplicateKey
+    ));
+    assert!(duplicate
+        .diagnostics
+        .iter()
+        .any(|item| item.message.contains("model.diffusion_model.img_in.weight")));
+    assert!(has_code(
+        &malformed,
+        CheckpointDiagnosticCodeV1::MalformedMetadata
+    ));
+    assert!(malformed
+        .diagnostics
+        .iter()
+        .any(|item| item.message.contains("string values")));
+}
+
+#[test]
+fn missing_index_shards_and_ambiguous_component_roles_are_diagnostics() {
+    let temp = TempDir::new().unwrap();
+    let indexed = temp.path().join("indexed");
+    write_safetensors(
+        &indexed.join("model-00001-of-00002.safetensors"),
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    fs::write(
+        indexed.join("model.safetensors.index.json"),
+        br#"{"metadata":{},"weight_map":{"one":"model-00001-of-00002.safetensors","two":"model-00002-of-00002.safetensors"}}"#,
+    )
+    .unwrap();
+
+    let conflicting = temp.path().join("conflicting");
+    write_safetensors(
+        &conflicting.join("vae/not-a-vae.safetensors"),
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+
+    let missing = inspect_checkpoint(&linked_request(temp.path(), "indexed"));
+    let ambiguous = inspect_checkpoint(&linked_request(temp.path(), "conflicting"));
+    assert!(has_code(
+        &missing,
+        CheckpointDiagnosticCodeV1::MissingSidecar
+    ));
+    assert!(missing
+        .diagnostics
+        .iter()
+        .any(|item| item.message.contains("model-00002-of-00002.safetensors")));
+    assert!(has_code(
+        &ambiguous,
+        CheckpointDiagnosticCodeV1::AmbiguousComponentRole
+    ));
+    assert!(ambiguous
+        .diagnostics
+        .iter()
+        .any(|item| { item.message.contains("vae") && item.message.contains("transformer") }));
+}
+
+#[test]
+fn unchanged_bytes_are_deterministic_and_changed_bytes_rotate_the_fingerprint() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().join("model.safetensors");
+    write_safetensors(
+        &path,
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    let request = linked_request(temp.path(), "model.safetensors");
+
+    let first = inspect_checkpoint(&request);
+    let second = inspect_checkpoint(&request);
+    assert!(first.is_runnable(), "{:?}", first.diagnostics);
+    assert_eq!(first.fingerprint, second.fingerprint);
+    assert_eq!(
+        first.inventory.canonical_json().unwrap(),
+        second.inventory.canonical_json().unwrap()
+    );
+    assert_eq!(
+        first.plans[0].canonical_json().unwrap(),
+        second.plans[0].canonical_json().unwrap()
+    );
+
+    let mut bytes = fs::read(&path).unwrap();
+    *bytes.last_mut().unwrap() ^= 0xff;
+    fs::write(&path, bytes).unwrap();
+    let changed = inspect_checkpoint(&request);
+    assert!(changed.is_runnable(), "{:?}", changed.diagnostics);
+    assert_ne!(first.fingerprint, changed.fingerprint);
+    assert_ne!(
+        first.inventory.canonical_json().unwrap(),
+        changed.inventory.canonical_json().unwrap()
+    );
+}
+
+#[test]
+fn descriptor_duplicate_keys_and_invalid_gguf_ranges_fail_closed() {
+    let temp = TempDir::new().unwrap();
+    let directory = temp.path().join("descriptor");
+    write_safetensors(
+        &directory.join("transformer/model.safetensors"),
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    fs::write(
+        directory.join("transformer/config.json"),
+        br#"{"_class_name":"QwenImageTransformer2DModel","_class_name":"Other"}"#,
+    )
+    .unwrap();
+
+    let tensor_offset_position = write_tiny_gguf(&temp.path().join("bad.gguf"), "flux");
+    let bad_path = temp.path().join("bad.gguf");
+    let mut bytes = fs::read(&bad_path).unwrap();
+    bytes[tensor_offset_position..tensor_offset_position + 8]
+        .copy_from_slice(&u64::MAX.to_le_bytes());
+    fs::write(&bad_path, bytes).unwrap();
+
+    let descriptor = inspect_checkpoint(&linked_request(temp.path(), "descriptor"));
+    let gguf = inspect_checkpoint(&linked_request(temp.path(), "bad.gguf"));
+    assert!(has_code(
+        &descriptor,
+        CheckpointDiagnosticCodeV1::DuplicateKey
+    ));
+    assert!(has_code(
+        &gguf,
+        CheckpointDiagnosticCodeV1::InvalidTensorRange
+    ));
+}
+
+#[test]
+fn path_confinement_errors_are_typed_and_do_not_read_outside_the_root() {
+    let temp = TempDir::new().unwrap();
+    let request = CheckpointInspectionRequestV1::linked(
+        "escape",
+        temp.path(),
+        PathBuf::from("../outside.safetensors"),
+        "comfy-primary",
+    );
+    assert!(request.is_err());
+}
+
+#[test]
+fn gguf_component_path_supplies_role_without_overriding_embedded_architecture() {
+    let temp = TempDir::new().unwrap();
+    let directory = temp.path().join("comfy");
+    fs::create_dir_all(directory.join("unet")).unwrap();
+    write_tiny_gguf(&directory.join("unet/model.gguf"), "flux");
+
+    let result = inspect_checkpoint(&linked_request(temp.path(), "comfy"));
+    assert!(result.is_runnable(), "{:?}", result.diagnostics);
+    assert_eq!(result.layout, Some(CheckpointLayoutV1::ComponentDirectory));
+    assert_eq!(result.evidence[0].role.as_deref(), Some("transformer"));
+    assert_eq!(result.evidence[0].family.as_deref(), Some("flux"));
+}
+
+#[test]
+fn managed_sources_compile_managed_locators_for_every_artifact() {
+    let temp = TempDir::new().unwrap();
+    write_safetensors(
+        &temp.path().join("model.safetensors"),
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    let request = CheckpointInspectionRequestV1::managed(
+        "managed-community-model",
+        temp.path(),
+        "model.safetensors",
+        "install-42",
+        ManagedProvenanceV1 {
+            source: "civitai".to_owned(),
+            reference: Some("model-version-7".to_owned()),
+        },
+    )
+    .unwrap();
+
+    let result = inspect_checkpoint(&request);
+    assert!(result.is_runnable(), "{:?}", result.diagnostics);
+    assert!(result.plans[0]
+        .layers
+        .iter()
+        .all(|layer| matches!(layer.source, SourceLocatorV1::Managed { .. })));
+}
+
+#[test]
+fn descriptor_byte_changes_rotate_directory_fingerprint_and_plan_identity() {
+    let temp = TempDir::new().unwrap();
+    let directory = temp.path().join("diffusers");
+    write_safetensors(
+        &directory.join("transformer/model.safetensors"),
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    let config = directory.join("transformer/config.json");
+    fs::write(
+        &config,
+        br#"{"_class_name":"QwenImageTransformer2DModel","revision":"one"}"#,
+    )
+    .unwrap();
+    let request = linked_request(temp.path(), "diffusers");
+    let first = inspect_checkpoint(&request);
+    fs::write(
+        &config,
+        br#"{"_class_name":"QwenImageTransformer2DModel","revision":"two"}"#,
+    )
+    .unwrap();
+    let second = inspect_checkpoint(&request);
+
+    assert!(first.is_runnable(), "{:?}", first.diagnostics);
+    assert!(second.is_runnable(), "{:?}", second.diagnostics);
+    assert_ne!(first.fingerprint, second.fingerprint);
+    assert_ne!(first.plans[0].plan_id, second.plans[0].plan_id);
+}
+
+#[test]
+fn duplicate_gguf_metadata_and_unsafe_index_paths_fail_closed() {
+    let temp = TempDir::new().unwrap();
+    write_duplicate_metadata_gguf(&temp.path().join("duplicate.gguf"));
+
+    let indexed = temp.path().join("indexed");
+    write_safetensors(
+        &indexed.join("model-00001-of-00001.safetensors"),
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    fs::write(
+        indexed.join("model.safetensors.index.json"),
+        br#"{"weight_map":{"weight":"../outside.safetensors"}}"#,
+    )
+    .unwrap();
+
+    let duplicate = inspect_checkpoint(&linked_request(temp.path(), "duplicate.gguf"));
+    let unsafe_index = inspect_checkpoint(&linked_request(temp.path(), "indexed"));
+    assert!(has_code(
+        &duplicate,
+        CheckpointDiagnosticCodeV1::DuplicateKey
+    ));
+    assert!(has_code(
+        &unsafe_index,
+        CheckpointDiagnosticCodeV1::PathEscapesRoot
+    ));
+    assert!(unsafe_index.inventory.records.is_empty());
+}
+
+#[test]
+fn safetensors_indices_are_bijections_over_the_actual_shard_tensor_tables() {
+    let temp = TempDir::new().unwrap();
+    let shard_name = "model-00001-of-00001.safetensors";
+
+    let valid = temp.path().join("valid/transformer");
+    let qwen_entries = qwen_transformer_entries();
+    write_safetensors(
+        &valid.join(shard_name),
+        &qwen_entries,
+        Some(json!({"format": "pt"})),
+    );
+    let valid_mappings = qwen_entries
+        .iter()
+        .map(|(tensor, _)| (*tensor, shard_name))
+        .collect::<Vec<_>>();
+    write_safetensors_index(&valid.join("model.safetensors.index.json"), &valid_mappings);
+    let valid = inspect_checkpoint(&linked_request(temp.path(), "valid"));
+    assert!(valid.is_runnable(), "{:?}", valid.diagnostics);
+    let shard_evidence = valid
+        .evidence
+        .iter()
+        .find(|item| item.relative_path.ends_with(shard_name))
+        .expect("shard evidence");
+    let mut expected_tensor_names = qwen_entries
+        .iter()
+        .map(|(name, _)| (*name).to_owned())
+        .collect::<Vec<_>>();
+    expected_tensor_names.sort();
+    assert_eq!(shard_evidence.tensor_names, expected_tensor_names);
+
+    let bogus = temp.path().join("bogus/transformer");
+    write_safetensors(&bogus.join(shard_name), &[("actual.weight", "F16")], None);
+    write_safetensors_index(
+        &bogus.join("model.safetensors.index.json"),
+        &[("bogus.weight", shard_name)],
+    );
+
+    let incomplete = temp.path().join("incomplete/transformer");
+    write_safetensors(
+        &incomplete.join(shard_name),
+        &[("actual.one", "F16"), ("actual.two", "F16")],
+        None,
+    );
+    write_safetensors_index(
+        &incomplete.join("model.safetensors.index.json"),
+        &[("actual.one", shard_name)],
+    );
+
+    let duplicate = temp.path().join("duplicate/transformer");
+    let shard_one = "model-00001-of-00002.safetensors";
+    let shard_two = "model-00002-of-00002.safetensors";
+    write_safetensors(
+        &duplicate.join(shard_one),
+        &[("shared.weight", "F16")],
+        None,
+    );
+    write_safetensors(
+        &duplicate.join(shard_two),
+        &[("shared.weight", "F16"), ("other.weight", "F16")],
+        None,
+    );
+    write_safetensors_index(
+        &duplicate.join("model.safetensors.index.json"),
+        &[("shared.weight", shard_one), ("other.weight", shard_two)],
+    );
+
+    let bogus = inspect_checkpoint(&linked_request(temp.path(), "bogus"));
+    let incomplete = inspect_checkpoint(&linked_request(temp.path(), "incomplete"));
+    let duplicate = inspect_checkpoint(&linked_request(temp.path(), "duplicate"));
+    for result in [&bogus, &incomplete, &duplicate] {
+        assert!(has_code(
+            result,
+            CheckpointDiagnosticCodeV1::IndexTensorMismatch
+        ));
+        assert!(result.inventory.records.is_empty());
+    }
+    assert!(bogus.diagnostics.iter().any(|item| item
+        .message
+        .contains("does not exist in its declared shard")));
+    assert!(incomplete
+        .diagnostics
+        .iter()
+        .any(|item| item.message.contains("is missing from weight_map")));
+    assert!(duplicate
+        .diagnostics
+        .iter()
+        .any(|item| item.message.contains("exists in multiple indexed shards")));
+}
+
+#[test]
+fn same_size_mutation_between_complete_passes_is_typed_and_uses_verified_bytes() {
+    let temp = TempDir::new().unwrap();
+    let directory = temp.path().join("mutable");
+    let transformer = directory.join("transformer/model.safetensors");
+    write_safetensors(
+        &transformer,
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    write_safetensors(
+        &directory.join("vae/model.safetensors"),
+        &vae_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    let original_size = fs::metadata(&transformer).unwrap().len();
+    let request = linked_request(temp.path(), "mutable");
+    let changed = inspect_checkpoint_with_hook(&request, |event| {
+        if event == CheckpointInspectionEventV1::FirstExactBytePassComplete {
+            replace_bytes(&transformer, &[0x5a], &[0x5b]);
+        }
+    });
+    assert_eq!(fs::metadata(&transformer).unwrap().len(), original_size);
+    assert!(has_code(
+        &changed,
+        CheckpointDiagnosticCodeV1::SourceChangedDuringInspection
+    ));
+    assert!(!changed.is_runnable());
+    assert!(changed.inventory.records.is_empty());
+
+    let stable = inspect_checkpoint(&request);
+    assert!(stable.is_runnable(), "{:?}", stable.diagnostics);
+    assert_eq!(changed.fingerprint, stable.fingerprint);
+    assert_eq!(changed.evidence, stable.evidence);
+}
+
+#[test]
+fn mutation_after_the_second_pass_is_caught_by_final_identity_revalidation() {
+    let temp = TempDir::new().unwrap();
+    let artifact = temp.path().join("mutable.safetensors");
+    write_safetensors(
+        &artifact,
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    let original_size = fs::metadata(&artifact).unwrap().len();
+    let changed = inspect_checkpoint_with_hook(
+        &linked_request(temp.path(), "mutable.safetensors"),
+        |event| {
+            if event == CheckpointInspectionEventV1::SecondExactBytePassComplete {
+                replace_bytes(&artifact, &[0x5a], &[0x5b]);
+            }
+        },
+    );
+    assert_eq!(fs::metadata(&artifact).unwrap().len(), original_size);
+    assert!(has_code(
+        &changed,
+        CheckpointDiagnosticCodeV1::SourceChangedDuringInspection
+    ));
+    assert!(!changed.is_runnable());
+    assert!(changed.inventory.records.is_empty());
+}
+
+#[test]
+fn timestamp_restored_same_size_mutation_uses_authoritative_final_bytes() {
+    let temp = TempDir::new().unwrap();
+    let artifact = temp.path().join("timestamp-restored.safetensors");
+    write_safetensors(
+        &artifact,
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    let original_size = fs::metadata(&artifact).unwrap().len();
+    let original_modified = fs::metadata(&artifact).unwrap().modified().unwrap();
+    let changed = inspect_checkpoint_with_hook(
+        &linked_request(temp.path(), "timestamp-restored.safetensors"),
+        |event| {
+            if event == CheckpointInspectionEventV1::SecondExactBytePassComplete {
+                replace_bytes(&artifact, &[0x5a], &[0x5b]);
+                restore_modified_time(&artifact, original_modified);
+            }
+        },
+    );
+
+    assert_eq!(fs::metadata(&artifact).unwrap().len(), original_size);
+    assert_eq!(
+        fs::metadata(&artifact).unwrap().modified().unwrap(),
+        original_modified,
+        "the regression must defeat metadata-only revalidation deterministically"
+    );
+    assert!(has_code(
+        &changed,
+        CheckpointDiagnosticCodeV1::SourceChangedDuringInspection
+    ));
+    assert!(!changed.is_runnable());
+    assert!(changed.inventory.records.is_empty());
+    assert_eq!(changed.evidence.len(), 1);
+    assert_eq!(
+        changed.evidence[0].sha256,
+        sha256_file(&artifact),
+        "even a rejected inspection returns only evidence derived from the final verified bytes"
+    );
+
+    let stable = inspect_checkpoint(&linked_request(
+        temp.path(),
+        "timestamp-restored.safetensors",
+    ));
+    assert!(stable.is_runnable(), "{:?}", stable.diagnostics);
+    assert_eq!(changed.evidence, stable.evidence);
+    assert_eq!(changed.fingerprint, stable.fingerprint);
+}
+
+#[test]
+fn discovery_limits_are_typed_instead_of_silently_truncating_the_inventory() {
+    let temp = TempDir::new().unwrap();
+    let directory = temp.path().join("too-many");
+    fs::create_dir_all(&directory).unwrap();
+    for index in 0..4200 {
+        fs::create_dir(directory.join(format!("empty-{index:04}"))).unwrap();
+    }
+    let discovery = discover_checkpoint(&linked_request(temp.path(), "too-many"));
+    assert!(discovery
+        .diagnostics
+        .iter()
+        .any(|item| item.code == CheckpointDiagnosticCodeV1::DiscoveryLimitExceeded));
+}
+
+#[test]
+fn aggregate_tensor_name_evidence_budget_fails_closed_across_artifacts() {
+    let temp = TempDir::new().unwrap();
+    let directory = temp.path().join("aggregate-evidence/transformer");
+    let left_names = (0..40_000)
+        .map(|index| format!("left.{index:05}.weight"))
+        .collect::<Vec<_>>();
+    let right_names = (0..40_000)
+        .map(|index| format!("right.{index:05}.weight"))
+        .collect::<Vec<_>>();
+    let mut left_entries = qwen_transformer_entries();
+    left_entries.extend(left_names.iter().map(|name| (name.as_str(), "U8")));
+    let right_entries = right_names
+        .iter()
+        .map(|name| (name.as_str(), "U8"))
+        .collect::<Vec<_>>();
+    write_safetensors(&directory.join("left.safetensors"), &left_entries, None);
+    write_safetensors(&directory.join("right.safetensors"), &right_entries, None);
+
+    let inspected = inspect_checkpoint(&linked_request(temp.path(), "aggregate-evidence"));
+    let budget_diagnostics = inspected
+        .diagnostics
+        .iter()
+        .filter(|item| item.code == CheckpointDiagnosticCodeV1::DiscoveryLimitExceeded)
+        .collect::<Vec<_>>();
+    assert_eq!(budget_diagnostics.len(), 1, "{:?}", inspected.diagnostics);
+    assert_eq!(
+        budget_diagnostics[0].message,
+        "checkpoint inspection exceeded the aggregate evidence budget of 65536 tensor names, 33554432 tensor-name UTF-8 bytes, or 67108864 total evidence UTF-8 bytes"
+    );
+    assert!(!inspected.is_runnable());
+    assert!(inspected.inventory.records.is_empty());
+}
+
+#[test]
+fn family_evidence_conflicts_and_declared_tensor_geometry_fail_closed() {
+    let temp = TempDir::new().unwrap();
+    let conflict = temp.path().join("family-conflict");
+    write_raw_safetensors(
+        &conflict.join("transformer/model.safetensors"),
+        br#"{"opaque.weight":{"dtype":"U8","shape":[1],"data_offsets":[0,1]}}"#,
+        &[0x5a],
+    );
+    fs::write(
+        conflict.join("model_index.json"),
+        br#"{"_class_name":"FluxTransformer2DModel","architectures":["QwenImageTransformer2DModel"]}"#,
+    )
+    .unwrap();
+    write_tiny_gguf(&temp.path().join("invalid-family.gguf"), "FLUX");
+
+    write_raw_safetensors(
+        &temp.path().join("overlap.safetensors"),
+        br#"{"model.diffusion_model.img_in.weight":{"dtype":"U8","shape":[1],"data_offsets":[0,1]},"model.diffusion_model.transformer_blocks.0.attn.to_q.weight":{"dtype":"U8","shape":[1],"data_offsets":[0,1]}}"#,
+        &[0x5a],
+    );
+    write_raw_safetensors(
+        &temp.path().join("shape-mismatch.safetensors"),
+        br#"{"model.diffusion_model.img_in.weight":{"dtype":"F16","shape":[2],"data_offsets":[0,2]}}"#,
+        &[0x5a; 2],
+    );
+    write_quantized_gguf(&temp.path().join("bad-quant.gguf"), 1, 32, 2, 18); // Q4_0: total count is divisible by 32, but the first dimension is not.
+
+    let family = inspect_checkpoint(&linked_request(temp.path(), "family-conflict"));
+    let invalid_family = inspect_checkpoint(&linked_request(temp.path(), "invalid-family.gguf"));
+    let overlap = inspect_checkpoint(&linked_request(temp.path(), "overlap.safetensors"));
+    let mismatch = inspect_checkpoint(&linked_request(temp.path(), "shape-mismatch.safetensors"));
+    let quant = inspect_checkpoint(&linked_request(temp.path(), "bad-quant.gguf"));
+
+    let family_diagnostics = family
+        .diagnostics
+        .iter()
+        .filter(|item| {
+            matches!(
+                item.code,
+                CheckpointDiagnosticCodeV1::FamilyDialectConflict
+                    | CheckpointDiagnosticCodeV1::MissingFamilyEvidence
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(family_diagnostics.len(), 1, "{:?}", family.diagnostics);
+    assert_eq!(
+        family_diagnostics[0].code,
+        CheckpointDiagnosticCodeV1::FamilyDialectConflict
+    );
+    assert_eq!(
+        family_diagnostics[0].message,
+        "JSON descriptor contains conflicting model-family evidence: flux, qwen-image"
+    );
+    let invalid_family_diagnostics = invalid_family
+        .diagnostics
+        .iter()
+        .filter(|item| {
+            matches!(
+                item.code,
+                CheckpointDiagnosticCodeV1::FamilyDialectConflict
+                    | CheckpointDiagnosticCodeV1::MissingFamilyEvidence
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        invalid_family_diagnostics.len(),
+        1,
+        "{:?}",
+        invalid_family.diagnostics
+    );
+    assert_eq!(
+        invalid_family_diagnostics[0].code,
+        CheckpointDiagnosticCodeV1::MissingFamilyEvidence
+    );
+    assert_eq!(
+        invalid_family_diagnostics[0].message,
+        "GGUF general.architecture must be a non-empty lowercase ASCII [a-z0-9]+ string"
+    );
+    for result in [&overlap, &mismatch, &quant] {
+        assert!(has_code(
+            result,
+            CheckpointDiagnosticCodeV1::InvalidTensorRange
+        ));
+        assert!(result.inventory.records.is_empty());
+    }
+    assert!(quant
+        .diagnostics
+        .iter()
+        .any(|item| item.message.contains("first dimension 1")));
+}
+
+#[test]
+fn current_gguf_types_and_truncated_descriptors_receive_exact_validation() {
+    let temp = TempDir::new().unwrap();
+    write_quantized_gguf(&temp.path().join("mxfp4.gguf"), 32, 1, 39, 17);
+    let mut truncated = b"GGUF".to_vec();
+    push_u32(&mut truncated, 3);
+    fs::write(temp.path().join("truncated.gguf"), truncated).unwrap();
+
+    let modern = inspect_checkpoint(&linked_request(temp.path(), "mxfp4.gguf"));
+    let truncated = inspect_checkpoint(&linked_request(temp.path(), "truncated.gguf"));
+
+    assert!(modern.is_runnable(), "{:?}", modern.diagnostics);
+    assert_eq!(modern.evidence[0].declared_tensor_bytes, Some(17));
+    assert!(has_code(
+        &truncated,
+        CheckpointDiagnosticCodeV1::TruncatedHeader
+    ));
+    assert!(!has_code(
+        &truncated,
+        CheckpointDiagnosticCodeV1::HeaderTooLarge
+    ));
+}
+
+#[test]
+fn gguf_v2_alignment_names_and_quantization_metadata_follow_the_current_spec() {
+    let temp = TempDir::new().unwrap();
+    write_quantized_gguf_fixture(
+        &temp.path().join("valid-v2-alignment-24.gguf"),
+        2,
+        24,
+        Some(2),
+        32,
+        1,
+        39,
+        17,
+        "model.weight",
+    );
+    write_quantized_gguf_fixture(
+        &temp.path().join("bad-alignment.gguf"),
+        3,
+        1,
+        Some(2),
+        32,
+        1,
+        39,
+        17,
+        "model.weight",
+    );
+    write_quantized_gguf_fixture(
+        &temp.path().join("missing-quantization-version.gguf"),
+        3,
+        32,
+        None,
+        32,
+        1,
+        39,
+        17,
+        "model.weight",
+    );
+    write_quantized_gguf_fixture(
+        &temp.path().join("zero-quantization-version.gguf"),
+        3,
+        32,
+        Some(0),
+        32,
+        1,
+        39,
+        17,
+        "model.weight",
+    );
+    write_quantized_gguf_fixture(
+        &temp.path().join("future-quantization-version.gguf"),
+        3,
+        32,
+        Some(3),
+        32,
+        1,
+        39,
+        17,
+        "model.weight",
+    );
+
+    let wrong_alignment_type = temp.path().join("wrong-alignment-type.gguf");
+    let wrong_type_offsets = write_quantized_gguf_fixture(
+        &wrong_alignment_type,
+        3,
+        32,
+        Some(2),
+        32,
+        1,
+        39,
+        17,
+        "model.weight",
+    );
+    overwrite_u32(&wrong_alignment_type, wrong_type_offsets.alignment - 4, 5); // i32
+
+    let invalid_key = temp.path().join("invalid-metadata-key.gguf");
+    write_quantized_gguf_fixture(&invalid_key, 3, 32, Some(2), 32, 1, 39, 17, "model.weight");
+    replace_bytes(&invalid_key, b"general.alignment", b"General.alignment");
+
+    let long_tensor_name = "x".repeat(65);
+    write_quantized_gguf_fixture(
+        &temp.path().join("long-tensor-name.gguf"),
+        3,
+        32,
+        Some(2),
+        32,
+        1,
+        39,
+        17,
+        &long_tensor_name,
+    );
+
+    let valid = inspect_checkpoint(&linked_request(temp.path(), "valid-v2-alignment-24.gguf"));
+    assert!(valid.is_runnable(), "{:?}", valid.diagnostics);
+    assert_eq!(valid.evidence[0].declared_tensor_bytes, Some(17));
+    for path in [
+        "bad-alignment.gguf",
+        "missing-quantization-version.gguf",
+        "zero-quantization-version.gguf",
+        "future-quantization-version.gguf",
+        "wrong-alignment-type.gguf",
+        "invalid-metadata-key.gguf",
+        "long-tensor-name.gguf",
+    ] {
+        let result = inspect_checkpoint(&linked_request(temp.path(), path));
+        assert!(
+            has_code(&result, CheckpointDiagnosticCodeV1::MalformedMetadata),
+            "{path}: {:?}",
+            result.diagnostics
+        );
+        assert!(result.inventory.records.is_empty(), "{path}");
+    }
+}
+
+#[test]
+fn gguf_metadata_mutations_between_exact_byte_passes_are_never_runnable() {
+    let temp = TempDir::new().unwrap();
+    let alignment_path = temp.path().join("alignment.gguf");
+    let alignment_offsets = write_quantized_gguf_fixture(
+        &alignment_path,
+        3,
+        24,
+        Some(2),
+        32,
+        1,
+        39,
+        17,
+        "model.weight",
+    );
+    let alignment =
+        inspect_checkpoint_with_hook(&linked_request(temp.path(), "alignment.gguf"), |event| {
+            if event == CheckpointInspectionEventV1::FirstExactBytePassComplete {
+                overwrite_u32(&alignment_path, alignment_offsets.alignment, 32);
+            }
+        });
+    assert!(has_code(
+        &alignment,
+        CheckpointDiagnosticCodeV1::SourceChangedDuringInspection
+    ));
+    assert!(!alignment.is_runnable());
+
+    let quantization_path = temp.path().join("quantization.gguf");
+    let quantization_offsets = write_quantized_gguf_fixture(
+        &quantization_path,
+        3,
+        32,
+        Some(2),
+        32,
+        1,
+        39,
+        17,
+        "model.weight",
+    );
+    let quantization_offset = quantization_offsets
+        .quantization_version
+        .expect("quantization version offset");
+    let quantization =
+        inspect_checkpoint_with_hook(&linked_request(temp.path(), "quantization.gguf"), |event| {
+            if event == CheckpointInspectionEventV1::FirstExactBytePassComplete {
+                overwrite_u32(&quantization_path, quantization_offset, 1);
+            }
+        });
+    assert!(has_code(
+        &quantization,
+        CheckpointDiagnosticCodeV1::SourceChangedDuringInspection
+    ));
+    assert!(!quantization.is_runnable());
+}
+
+#[test]
+fn oversized_safetensors_headers_preserve_the_discovery_diagnostic() {
+    let temp = TempDir::new().unwrap();
+    fs::write(
+        temp.path().join("oversized.safetensors"),
+        100_000_001_u64.to_le_bytes(),
+    )
+    .unwrap();
+
+    let discovery = discover_checkpoint(&linked_request(temp.path(), "oversized.safetensors"));
+    let inspected = inspect_checkpoint(&linked_request(temp.path(), "oversized.safetensors"));
+    for diagnostics in [&discovery.diagnostics, &inspected.diagnostics] {
+        assert!(diagnostics
+            .iter()
+            .any(|item| item.code == CheckpointDiagnosticCodeV1::HeaderTooLarge));
+        assert!(!diagnostics
+            .iter()
+            .any(|item| item.code == CheckpointDiagnosticCodeV1::MalformedMetadata));
+    }
+}
+
+#[test]
+fn canonical_link_confinement_accepts_internal_and_rejects_escaping_reparse_targets() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path().join("root");
+    let internal_target = root.join("shared/model.safetensors");
+    write_safetensors(
+        &internal_target,
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    let internal_dir = root.join("internal/transformer");
+    fs::create_dir_all(&internal_dir).unwrap();
+    symlink_file(&internal_target, &internal_dir.join("model.safetensors"));
+
+    let external_target = temp.path().join("outside.safetensors");
+    write_safetensors(
+        &external_target,
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    let escaping_dir = root.join("escaping/transformer");
+    fs::create_dir_all(&escaping_dir).unwrap();
+    symlink_file(&external_target, &escaping_dir.join("model.safetensors"));
+
+    let internal = inspect_checkpoint(&linked_request(&root, "internal"));
+    let escaping = inspect_checkpoint(&linked_request(&root, "escaping"));
+    assert!(internal.is_runnable(), "{:?}", internal.diagnostics);
+    assert!(has_code(
+        &escaping,
+        CheckpointDiagnosticCodeV1::PathEscapesRoot
+    ));
+    assert!(escaping.inventory.records.is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn unix_directory_symlinks_are_confined_on_linux_and_wsl() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path().join("root");
+    let internal_target = root.join("shared/transformer");
+    write_safetensors(
+        &internal_target.join("model.safetensors"),
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    fs::create_dir_all(root.join("internal")).unwrap();
+    std::os::unix::fs::symlink(&internal_target, root.join("internal/transformer")).unwrap();
+
+    let external_target = temp.path().join("outside/transformer");
+    write_safetensors(
+        &external_target.join("model.safetensors"),
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    fs::create_dir_all(root.join("escaping")).unwrap();
+    std::os::unix::fs::symlink(&external_target, root.join("escaping/transformer")).unwrap();
+
+    let internal = inspect_checkpoint(&linked_request(&root, "internal"));
+    let escaping = inspect_checkpoint(&linked_request(&root, "escaping"));
+    assert!(internal.is_runnable(), "{:?}", internal.diagnostics);
+    assert!(has_code(
+        &escaping,
+        CheckpointDiagnosticCodeV1::PathEscapesRoot
+    ));
+    assert!(escaping.inventory.records.is_empty());
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_directory_junctions_are_confined_as_reparse_points() {
+    let temp = TempDir::new().unwrap();
+    let root = temp.path().join("root");
+    let internal_target = root.join("shared");
+    write_safetensors(
+        &internal_target.join("transformer/model.safetensors"),
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    fs::create_dir_all(&root).unwrap();
+    let _internal = WindowsDirectoryJunction::create(&root.join("internal"), &internal_target);
+
+    let external_target = temp.path().join("outside");
+    write_safetensors(
+        &external_target.join("transformer/model.safetensors"),
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    let _escaping = WindowsDirectoryJunction::create(&root.join("escaping"), &external_target);
+
+    let internal = inspect_checkpoint(&linked_request(&root, "internal"));
+    let escaping = inspect_checkpoint(&linked_request(&root, "escaping"));
+    assert!(internal.is_runnable(), "{:?}", internal.diagnostics);
+    assert!(has_code(
+        &escaping,
+        CheckpointDiagnosticCodeV1::PathEscapesRoot
+    ));
+    assert!(escaping.inventory.records.is_empty());
+}
+
+#[test]
+fn descriptor_family_fallback_and_indexed_hidden_shards_are_fail_closed() {
+    let temp = TempDir::new().unwrap();
+    let descriptor_family = temp.path().join("descriptor-family");
+    write_raw_safetensors(
+        &descriptor_family.join("transformer/model.safetensors"),
+        br#"{"opaque.weight":{"dtype":"F4","shape":[2],"data_offsets":[0,1]}}"#,
+        &[0x5a],
+    );
+    fs::write(
+        descriptor_family.join("transformer/config.json"),
+        br#"{"_class_name":"FluxTransformer2DModel"}"#,
+    )
+    .unwrap();
+
+    let hidden = temp.path().join("hidden-index");
+    write_safetensors(
+        &hidden.join(".model-00001-of-00001.safetensors"),
+        &qwen_transformer_entries(),
+        Some(json!({"format": "pt"})),
+    );
+    fs::write(
+        hidden.join("model.safetensors.index.json"),
+        br#"{"weight_map":{"weight":".model-00001-of-00001.safetensors"}}"#,
+    )
+    .unwrap();
+    write_raw_safetensors(
+        &temp.path().join("misaligned-f4.safetensors"),
+        br#"{"opaque.weight":{"dtype":"F4","shape":[1],"data_offsets":[0,1]}}"#,
+        &[0x5a],
+    );
+
+    let fallback = inspect_checkpoint(&linked_request(temp.path(), "descriptor-family"));
+    let hidden = inspect_checkpoint(&linked_request(temp.path(), "hidden-index"));
+    let misaligned = inspect_checkpoint(&linked_request(temp.path(), "misaligned-f4.safetensors"));
+
+    assert!(fallback.is_runnable(), "{:?}", fallback.diagnostics);
+    assert_eq!(fallback.plans[0].family, "flux");
+    assert!(has_code(
+        &hidden,
+        CheckpointDiagnosticCodeV1::MissingSidecar
+    ));
+    assert!(hidden.diagnostics.iter().any(|item| item
+        .message
+        .contains("not discovered as an importable weight artifact")));
+    assert!(has_code(
+        &misaligned,
+        CheckpointDiagnosticCodeV1::InvalidTensorRange
+    ));
+    assert!(misaligned
+        .diagnostics
+        .iter()
+        .any(|item| item.message.contains("not byte-aligned")));
+}


### PR DESCRIPTION
## Shortcut

[sc-20632 — Inspect and validate universal checkpoint containers](https://app.shortcut.com/trefry/story/20632)

## Scope and acceptance closure

- Adds bounded, header-only discovery for single-file, fused, component-directory, sharded safetensors, and GGUF checkpoints.
- Strictly validates safetensors headers, tensor dtypes/shapes/ranges, exact body accounting, duplicate JSON keys, and exact index-to-shard tensor-table bijections.
- Strictly validates current GGUF v2/v3 metadata and tensor tables, including standardized key/name constraints, architecture evidence, uint32 multiple-of-8 alignment with general modulo arithmetic, supported tensor type/block layouts, and required supported quantization-version metadata for quantized tensors.
- Normalizes all descriptor architecture/dialect evidence to a family set and fails closed on conflicts.
- Streams bounded directory traversal across files and directories, preserves typed oversized/truncated-header diagnostics, and confines files, symlinks, junctions, and reparse targets to the declared root.
- Performs two complete exact-byte SHA-256 passes with open-handle identity/stability observations, cross-pass comparison, final discovery comparison, and post-pass identity revalidation. Returned evidence and fingerprint come from the verified final pass; concurrent same-size mutations never produce a runnable plan.
- Emits deterministic artifact evidence, fingerprint, v1 inventory, and import plans for linked and managed ownership without loading model tensors or invoking inference.

## Validation and review

- Independent adversarial review: **PASS**, high confidence, no findings.
- Windows focused checkpoint inspector: **23/23 passed**, including actual NTFS symlink/reparse confinement.
- Ubuntu 24.04 WSL focused checkpoint inspector: **26/26 passed**, including Unix file/directory symlink confinement and mutation/resource probes.
- Full `sceneworks-core` suite: **passed** (1,089 library tests plus all integration and doc tests; only declared ignored tests skipped).
- sc-20631 import-contract regression suite: **35/35 passed**.
- Formatting, strict all-target clippy (`-D warnings`), tracked/untracked diff checks, and normal core docs: **passed**. Normal docs retain only repository-pre-existing rustdoc link warnings.
- All validation was CPU-only. No GPU calibration, memory matrix, canary, or other measurement campaign was run.

## Boundaries

- No inference repository or inference pin changes.
- No API, catalog routing, persistence, loader execution, or measurement changes.
- This story establishes inspection evidence and import-plan contracts. Later materialization/execution consumers must reverify each artifact digest against the contract before consuming its bytes.

## Exact refs

- Base: `feature/sc-20398-universal-checkpoint-import` at `a623704d2613d4b833f10defd7309ac98d328959`
- Head: `story/sc-20632-epic-20398-universal-checkpoint-import` at `46fe39a8e0359033e2b911bd7609e95cccda4057`