### PR TITLE
fix(tests): pin the spawned binaries' Hugging Face cache inside the test root

### DIFF
--- a/tests/rust_api_harness.py
+++ b/tests/rust_api_harness.py
@@ -11,10 +11,12 @@ of truth for those fixtures so they can't diverge again.
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import threading
 import time
+from pathlib import Path
 
 import httpx
 
@@ -155,6 +157,41 @@ class SpawnedProcess:
 
     def wait(self, timeout: float | None = None) -> int:
         return self._popen.wait(timeout=timeout)
+
+
+def spawn_env(root: Path) -> dict[str, str]:
+    """The base environment for a spawned API/worker binary, with the Hugging Face
+    cache pinned inside ``root``.
+
+    A live-binary spawn inherits the developer's ambient environment, and a real
+    workstation carries `HF_HOME` (or `HF_HUB_CACHE` / `HUGGINGFACE_HUB_CACHE`)
+    pointing at a multi-terabyte Hugging Face cache. The spawned binary resolves
+    those three vars AHEAD of `SCENEWORKS_DATA_DIR`
+    (`sceneworks_core::hf_home::huggingface_hub_cache_dir`), so without a pin the
+    model catalog's install-state sweep probes the HOST's cache instead of the
+    test's temp data dir -- install state stops being a property of the fixture and
+    becomes a property of whatever the developer happens to have downloaded.
+
+    Unsetting the three is NOT sufficient: `ensure_default_huggingface_home()` then
+    defaults `HF_HOME` to the OS Hugging Face home (`~/.cache/huggingface`), which
+    is still a shared, host-owned directory. Pinning `HF_HUB_CACHE` (top precedence)
+    at `<root>/data/cache/huggingface/hub` instead reproduces exactly the
+    `<data_dir>/cache/huggingface/hub` fallback the binary uses under a clean
+    environment, so the spawn is hermetic rather than merely env-less.
+
+    CI runners have an empty HF cache, so an unpinned spawn is green there and red
+    only on a developer box. Measured on Windows against a 2.2 TB ambient cache, the
+    first `POST /api/v1/image/jobs` in the e2e LoRA test spent 22.6s in that sweep
+    and blew the request's 5s timeout; pinned, the same call takes 0.43s. The parity
+    harness has pinned it since sc-19708 (an unpinned golden recorded WHOSE machine
+    ran it) while the e2e harness did not -- this is the one implementation both use
+    so the isolation cannot drift back out of either.
+    """
+    env = os.environ.copy()
+    env["HF_HUB_CACHE"] = str(Path(root) / "data" / "cache" / "huggingface" / "hub")
+    for inherited in ("HUGGINGFACE_HUB_CACHE", "HF_HOME"):
+        env.pop(inherited, None)
+    return env
 
 
 def spawn_process(command, *, cwd, env) -> SpawnedProcess:

--- a/tests/test_rust_api_contract_snapshots.py
+++ b/tests/test_rust_api_contract_snapshots.py
@@ -23,6 +23,7 @@ from rust_api_harness import (
     PNG_1X1,
     enable_api_listening_log,
     safetensors_bytes,
+    spawn_env,
     spawn_process,
     wait_for_health,
 )
@@ -199,7 +200,20 @@ class ServerApiHarness:
         self.root = root
         self.runtime = "rust"
         write_contract_manifests(root / "config")
-        env = os.environ.copy()
+        # sc-19708: the catalog now reports the configured model-library root
+        # (`modelResolution.configuredLibraryPath`). That root is environment-derived — the API
+        # resolves HF_HUB_CACHE / HUGGINGFACE_HUB_CACHE / HF_HOME and otherwise falls back to the
+        # OS Hugging Face home under $HOME — so without a pin the golden would record WHOSE
+        # machine recorded it (a macOS dev box bakes in /Users/<name>/..., which then fails on
+        # every Linux runner, and re-recording there just flips which machine is broken).
+        # HF_HUB_CACHE has top precedence, so pinning it under `root` makes the value identical on
+        # every machine and lets the existing per-runtime redaction render it <runtime-root>/...,
+        # exactly like every other path in the contract. It also keeps the contract run off the
+        # developer's real Hugging Face cache. The assertion still discriminates: the field must
+        # be present, a string, and this exact configured root. The pin lives in the shared
+        # `spawn_env` helper; the e2e harness lacked it and paid a 22.6s install-state sweep
+        # against the host cache on a developer box.
+        env = spawn_env(root)
         env.update(
             {
                 "SCENEWORKS_API_HOST": "127.0.0.1",
@@ -215,20 +229,6 @@ class ServerApiHarness:
                 "SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE": "1",
             }
         )
-        # sc-19708: the catalog now reports the configured model-library root
-        # (`modelResolution.configuredLibraryPath`). That root is environment-derived — the API
-        # resolves HF_HUB_CACHE / HUGGINGFACE_HUB_CACHE / HF_HOME and otherwise falls back to the
-        # OS Hugging Face home under $HOME — so without a pin the golden would record WHOSE
-        # machine recorded it (a macOS dev box bakes in /Users/<name>/..., which then fails on
-        # every Linux runner, and re-recording there just flips which machine is broken).
-        # HF_HUB_CACHE has top precedence, so pinning it under `root` makes the value identical on
-        # every machine and lets the existing per-runtime redaction render it <runtime-root>/...,
-        # exactly like every other path in the contract. It also keeps the contract run off the
-        # developer's real Hugging Face cache. The assertion still discriminates: the field must
-        # be present, a string, and this exact configured root.
-        env["HF_HUB_CACHE"] = str(root / "data" / "cache" / "huggingface" / "hub")
-        for inherited in ("HUGGINGFACE_HUB_CACHE", "HF_HOME"):
-            env.pop(inherited, None)
         enable_api_listening_log(env)
         rust_binary = os.getenv("SCENEWORKS_RUST_API_BINARY")
         command = (

--- a/tests/test_rust_api_harness.py
+++ b/tests/test_rust_api_harness.py
@@ -1,4 +1,7 @@
-from rust_api_harness import enable_api_listening_log, listening_url_from_log
+import os
+from pathlib import Path
+
+from rust_api_harness import enable_api_listening_log, listening_url_from_log, spawn_env
 
 
 def test_listening_url_from_text_and_json_tracing_output():
@@ -21,3 +24,54 @@ def test_api_listening_event_survives_restrictive_ambient_logging():
     env = {"RUST_LOG": "warn"}
     enable_api_listening_log(env)
     assert env["RUST_LOG"] == "warn,sceneworks_rust_api::server=info"
+
+
+def test_spawn_env_pins_the_huggingface_cache_inside_the_test_root(monkeypatch, tmp_path):
+    """A spawned binary must not resolve its Hugging Face cache from the ambient
+    environment. `huggingface_hub_cache_dir` reads HF_HUB_CACHE /
+    HUGGINGFACE_HUB_CACHE / HF_HOME AHEAD of SCENEWORKS_DATA_DIR, so an inherited
+    value silently re-points the model catalog's install-state sweep at the HOST's
+    cache: "installed" then reflects whatever the developer downloaded rather than
+    what the fixture staged. It is green on an empty CI runner and red only on a real
+    workstation -- measured, a 22.6s sweep that blew the e2e LoRA test's 5s request
+    timeout, against 0.43s pinned."""
+    host_cache = tmp_path / "host-cache"
+    for inherited in ("HF_HUB_CACHE", "HUGGINGFACE_HUB_CACHE", "HF_HOME"):
+        monkeypatch.setenv(inherited, str(host_cache))
+
+    root = tmp_path / "root"
+    env = spawn_env(root)
+
+    # Positive pin, not merely an unset: with all three cleared the binary's
+    # `ensure_default_huggingface_home()` defaults HF_HOME to ~/.cache/huggingface,
+    # which is still a shared host directory. This value is the same
+    # `<data_dir>/cache/huggingface/hub` the binary falls back to on a clean env.
+    assert env["HF_HUB_CACHE"] == str(root / "data" / "cache" / "huggingface" / "hub")
+    # The lower-precedence vars must be absent rather than overridden -- the worker
+    # and the hf tooling it shells out to read HF_HOME directly.
+    assert "HUGGINGFACE_HUB_CACHE" not in env
+    assert "HF_HOME" not in env
+    # Still the ambient environment otherwise: the spawn needs PATH, the binary-path
+    # exports, and the rest of the developer's/CI's env.
+    assert env.get("PATH") == os.environ.get("PATH")
+
+
+def test_live_binary_spawn_sites_do_not_inherit_the_ambient_environment():
+    """Both live-binary harnesses must build their spawn env through `spawn_env`.
+
+    This is the drift that produced the bug: the parity harness pinned the Hugging
+    Face cache (sc-19708, so a golden could not record WHOSE machine ran it) while
+    the e2e harness kept a bare ambient copy, leaving one suite hermetic and the
+    other host-dependent. A new spawn site that reaches for the ambient environment
+    reintroduces it, and CI -- with an empty HF cache -- cannot see that happen."""
+    for module in ("test_rust_api_worker_smoke.py", "test_rust_api_contract_snapshots.py"):
+        source = (Path(__file__).parent / module).read_text(encoding="utf-8")
+        # Held as booleans so a failure reports the claim, not a 200-line dump of the
+        # module under inspection.
+        inherits_ambient_env = "os.environ.copy()" in source
+        spawns_through_helper = "spawn_env(" in source
+        assert not inherits_ambient_env, (
+            f"{module} builds a spawn environment from the ambient env; use "
+            "rust_api_harness.spawn_env(root) so the Hugging Face cache stays pinned"
+        )
+        assert spawns_through_helper, f"{module} no longer spawns through spawn_env"

--- a/tests/test_rust_api_worker_smoke.py
+++ b/tests/test_rust_api_worker_smoke.py
@@ -24,6 +24,7 @@ from rust_api_harness import (
     enable_api_listening_log,
     SpawnedProcess,
     minimal_safetensors as _minimal_safetensors,
+    spawn_env,
     spawn_process,
     wait_for_health,
 )
@@ -248,7 +249,10 @@ def rust_api(tmp_path):
         "SCENEWORKS_RUST_API_BINARY", "sceneworks-rust-api", "the Rust API smoke test"
     )
 
-    env = os.environ.copy()
+    # `spawn_env`, not the ambient environment: the API resolves the HF cache vars
+    # ahead of SCENEWORKS_DATA_DIR, so an unpinned spawn probes the developer's real
+    # Hugging Face cache for install state instead of this test's temp data dir.
+    env = spawn_env(tmp_path)
     env.update(
         {
             "SCENEWORKS_API_HOST": "127.0.0.1",
@@ -512,7 +516,7 @@ def test_rust_worker_claims_and_completes_lora_import_against_rust_api_binary(ru
     source = tmp_path / "data" / "loras" / "tiny.safetensors"
     source.parent.mkdir(parents=True, exist_ok=True)
     source.write_bytes(_minimal_safetensors())
-    env = os.environ.copy()
+    env = spawn_env(tmp_path)
     env.update(
         {
             "SCENEWORKS_API_URL": rust_api,
@@ -563,7 +567,7 @@ def test_rust_worker_completes_ffmpeg_frame_and_timeline_jobs_against_rust_api_b
         "SCENEWORKS_RUST_WORKER_BINARY", "sceneworks-rust-worker", "the Rust worker smoke test"
     )
 
-    env = os.environ.copy()
+    env = spawn_env(tmp_path)
     env.update(
         {
             "SCENEWORKS_API_URL": rust_api,


### PR DESCRIPTION
## What

`tests/test_rust_api_worker_smoke.py::test_character_image_angle_and_pose_sets_carry_loras_through_worker` is deterministically red on the Windows dev box (`httpx.ReadTimeout` on the first `POST /api/v1/image/jobs`) and green in CI at the same commit. This makes the e2e/parity harnesses hermetic with respect to the Hugging Face cache, which is the actual cause.

## Root cause

Not load, and not a Windows defect.

The e2e harness built its spawn environment with a bare `os.environ.copy()`, so the box's ambient `HF_HOME=E:\huggingface` reached the spawned API. `sceneworks_core::hf_home::huggingface_hub_cache_dir` resolves `HF_HUB_CACHE` / `HUGGINGFACE_HUB_CACHE` / `HF_HOME` **ahead of** `SCENEWORKS_DATA_DIR`, so the model catalog's install-state sweep probed the developer's real 2.2 TB cache instead of the fixture's temp data dir.

Measured, per request, same binary and same box:

| | first `POST /image/jobs` | second |
|---|---|---|
| ambient `HF_HOME` set | **22.62s** | 0.34s |
| `HF_HOME` unset | 0.43s | 0.24s |

The request's timeout is 5s, so the first call fails and the second (served from the cached catalog snapshot) never runs. CI runners have an empty HF cache, which is the only reason this was invisible there — `parity-rust` on `ca77dc1b6` runs the test and passes it (`4 passed, 1 skipped` in 4.73s).

This also means install state in these suites was a property of whatever the developer happened to have downloaded, not of what the fixture staged — the timeout is just the loudest symptom.

## Fix

The **parity** harness has pinned the cache since sc-19708 (an unpinned golden recorded whose machine ran it). The **e2e** harness never did — the two files drifted, which is exactly what `rust_api_harness.py` exists to prevent.

Lift the pin into a shared `rust_api_harness.spawn_env(root)` and route all four live-binary spawn sites through it (1 parity + 3 e2e).

Unsetting the three vars is **not** sufficient: `ensure_default_huggingface_home()` then defaults `HF_HOME` to the shared `~/.cache/huggingface`. The pin is therefore positive, and resolves to the same `<data_dir>/cache/huggingface/hub` the binary falls back to under a clean environment.

Request timeouts are left at 5s. The pinned path answers in well under a second, so raising them would only have hidden the leak; nothing here is a genuinely slow path that needs a configurable bound.

## Tests

Two guards in `tests/test_rust_api_harness.py`, both unmarked so they run in the existing fast step on every platform. Each was verified by hand-mutation rather than by passing:

| mutation | result |
|---|---|
| strip the pin out of `spawn_env` | unit guard reds **and** the e2e LoRA test reproduces the original `ReadTimeout` |
| revert one spawn site to `os.environ.copy()` | source-level guard reds with a one-line message |

## Verification

Windows, quiet box, with the hostile `HF_HOME` deliberately left set — all three CI pytest steps:

- `-m "not e2e and not parity"` → **99 passed**
- `-m e2e` → **5 passed** (the target test 3/3 across repeat runs, ~2.9s)
- `-m parity` → **14 passed**, goldens unchanged

Before the fix, on the same quiet box, the target test failed 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
