### PR TITLE
fix(core): match the Anima metadata id at a token boundary, not a prefix

### DIFF
--- a/crates/sceneworks-core/src/lora_family.rs
+++ b/crates/sceneworks-core/src/lora_family.rs
@@ -1759,6 +1759,28 @@ fn contains_token(haystack: &str, needle: &str) -> bool {
     })
 }
 
+/// Whether `haystack` contains `needle` as a **whole token** — bounded by a non-alphanumeric byte
+/// (or the string edge) on *both* sides.
+///
+/// [`contains_token`] only guards the leading edge, which is all the Mage arm needs: its needles
+/// (`mage-flow`, `mageflow`) are not prefixes of some other family's name. The Anima arm is the
+/// opposite case (SceneWorks#1670): `anima` *is* a prefix of `animagine-xl-3.1` and `animatediff`,
+/// two unrelated SDXL/SD1.5 architectures, so the trailing edge has to be checked too — a
+/// leading-edge-only match would claim both and hard-reject legitimate SDXL LoRAs.
+///
+/// Byte indexing is safe for any input, for the same reason as [`contains_token`]: `match_indices`
+/// yields char-boundary offsets, and a UTF-8 continuation byte on either side is not
+/// ASCII-alphanumeric, so a multi-byte neighbour reads as a boundary rather than panicking.
+fn contains_delimited_token(haystack: &str, needle: &str) -> bool {
+    let bytes = haystack.as_bytes();
+    haystack.match_indices(needle).any(|(position, matched)| {
+        let leading = position == 0 || !bytes[position - 1].is_ascii_alphanumeric();
+        let end = position + matched.len();
+        let trailing = end == bytes.len() || !bytes[end].is_ascii_alphanumeric();
+        leading && trailing
+    })
+}
+
 fn metadata_value_to_family(value: &str) -> Option<String> {
     let normalized = value.trim().to_ascii_lowercase();
     if normalized.is_empty() {
@@ -1795,9 +1817,15 @@ fn metadata_value_to_family(value: &str) -> Option<String> {
     // architectures embed that substring — Animagine XL (`animagine-xl-3.1`) and AnimateDiff
     // (`animatediff`) most notably — and mapping one of those to `anima` would hard-reject a
     // perfectly good SDXL LoRA, the exact failure mode this whole path exists to avoid.
-    if normalized == "anima"
-        || normalized.starts_with("anima_")
-        || normalized.starts_with("anima-")
+    //
+    // The boundary is checked on BOTH edges ([`contains_delimited_token`]), not anchored to the
+    // start of the value. Every other arm here uses `contains`, so every other arm tolerates the
+    // org prefix that real stamps carry: `ss_base_model_version` / `modelspec.architecture` are
+    // routinely a Hugging Face repo id (`SceneWorks/anima-turbo`, `nvidia/anima_base`) or a path'd
+    // weight file (`loras/anima-aesthetic-v1.0.safetensors`). A `starts_with("anima-")` test misses
+    // all of those, dropping them to key detection — where a metadata-less Anima file reads as Wan
+    // and the import is hard-rejected, which is exactly the report in SceneWorks#1670.
+    if contains_delimited_token(&normalized, "anima")
         || normalized.contains("cosmos-predict")
         || normalized.contains("cosmos_predict")
         || normalized.contains("cosmospredict")
@@ -3770,6 +3798,28 @@ mod tests {
     }
 
     #[test]
+    fn contains_delimited_token_requires_a_boundary_on_both_edges() {
+        // Leading edge: string start and any non-alphanumeric byte.
+        assert!(super::contains_delimited_token("anima", "anima"));
+        assert!(super::contains_delimited_token(
+            "nvidia/anima_base",
+            "anima"
+        ));
+        assert!(super::contains_delimited_token("a.anima.b", "anima"));
+        // Trailing edge: this is the half `contains_token` does not check.
+        assert!(!super::contains_delimited_token("animagine", "anima"));
+        assert!(!super::contains_delimited_token("org/animatediff", "anima"));
+        assert!(super::contains_token("animagine", "anima"));
+        // A later delimited occurrence still counts even when an earlier one is glued.
+        assert!(super::contains_delimited_token(
+            "animatediff-anima",
+            "anima"
+        ));
+        // Multi-byte neighbours read as boundaries rather than panicking on a byte index.
+        assert!(super::contains_delimited_token("日anima日", "anima"));
+    }
+
+    #[test]
     fn anima_metadata_base_ids_detect_without_tensor_evidence() {
         // A trainer that stamps the Anima training base / weight file names the family outright,
         // so detection never has to lean on the Wan-shaped tensor keys (SceneWorks#1670).
@@ -3779,6 +3829,15 @@ mod tests {
             "anima_turbo",
             "anima-aesthetic-v1.0",
             "cosmos-predict2-2b",
+            // Org-qualified and path'd spellings. `ss_base_model_version` / `modelspec.architecture`
+            // routinely carry a Hugging Face repo id or a relative weight path rather than the bare
+            // catalog id, and the anima arm used to be anchored to the START of the value — so every
+            // one of these fell through to key detection, where a metadata-less Anima file reads as
+            // Wan and the import is hard-rejected (SceneWorks#1670).
+            "SceneWorks/anima-turbo",
+            "nvidia/anima_base",
+            "loras/anima-aesthetic-v1.0.safetensors",
+            "models\\anima-base-v1.0.safetensors",
         ] {
             assert_eq!(
                 super::metadata_value_to_family(value).as_deref(),
@@ -3799,6 +3858,17 @@ mod tests {
         assert_eq!(
             super::metadata_value_to_family("sdxl_animagine_v3").as_deref(),
             Some("sdxl")
+        );
+        // The trailing edge is what rules these out, so it has to survive the org prefix that the
+        // leading edge now tolerates — otherwise widening the arm to accept `nvidia/anima_base`
+        // would swallow `cagliostrolab/animagine-xl-3.1` along with it.
+        assert_eq!(
+            super::metadata_value_to_family("cagliostrolab/animagine-xl-3.1"),
+            None
+        );
+        assert_eq!(
+            super::metadata_value_to_family("guoyww/animatediff-motion-adapter-v1-5-2"),
+            None
         );
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes one concrete path by which an Anima LoRA is rejected as `wan-video` at import.

`metadata_value_to_family` in `crates/sceneworks-core/src/lora_family.rs` reads the trainer-stamped base-model id (`baseModel`, `base_model`, `ss_base_model_version`, `modelspec.architecture`, `modelspec.implementation`) and maps it to a family. Its Anima arm was anchored to the **start** of the value:

```rust
if normalized == "anima"
    || normalized.starts_with("anima_")
    || normalized.starts_with("anima-")
```

Every sibling arm in that function (`chroma`, `krea`, `ideogram`, `flux`, `ltx`, `wan`, …) uses `contains`, so every sibling arm tolerates the org prefix that real stamps carry. These fields routinely hold a Hugging Face repo id or a path'd weight file rather than a bare catalog id, so all of the following missed the arm entirely:

- `SceneWorks/anima-turbo`
- `nvidia/anima_base`
- `loras/anima-aesthetic-v1.0.safetensors`

Those values fell through to tensor-key detection — and Anima's Cosmos-Predict2 DiT is Wan-shaped, so a file whose keys carry no distinguishing marker reads as a confident `wan-video` and the import is hard-rejected with exactly the message in the linked issue:

> LoRA file appears to be a wan-video model, but family was declared as anima. Re-import with family wan-video or pick a different file.

The fix matches `anima` as a whole delimited token instead. The trailing edge still has to be checked — `anima` is a prefix of the unrelated SDXL/SD1.5 `animagine-xl-3.1` and `animatediff`, and claiming those would hard-reject legitimate SDXL LoRAs, which is the failure mode the original anchoring was defending against. The existing `contains_token` helper guards only the *leading* edge (all the Mage-Flow arm needs, since `mage-flow`/`mageflow` are not prefixes of another family), so this adds a sibling `contains_delimited_token` for the both-edge rule rather than loosening `contains_token` and changing Mage behavior.

Scope note: this is one demonstrable defect on the reported code path, not a claim that it is *the* cause of the reporter's specific file. The reporter was on 0.8.0 and the file itself was never shared, so the tensor-key half of the detector can't be checked against it. The other half of that issue (the reporter's earlier #1516) is untouched here.

## Related issue

Refs #1670

(Not `Closes` — see the scope note above; the issue also carries a second, unrelated report that this does not address.)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

Pure string-matching logic in a shared crate, so it is covered by unit tests rather than a platform run.

- Extended `anima_metadata_base_ids_detect_without_tensor_evidence` with the org-qualified and path'd spellings. **Verified this test fails on the pre-fix logic** (`sceneworks/anima-turbo` → `None`) and passes after.
- Extended `anima_metadata_match_does_not_swallow_animagine_or_animatediff` with `cagliostrolab/animagine-xl-3.1` and `guoyww/animatediff-motion-adapter-v1-5-2` — the org prefix that the leading edge now tolerates must not let those through the trailing edge.
- Added `contains_delimited_token_requires_a_boundary_on_both_edges` covering both edges, a later delimited occurrence after a glued one, and multi-byte neighbours (the helper indexes bytes).
- `cargo test -p sceneworks-core --lib lora_family` — 122 passed, 0 failed.

- [ ] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (web UI, docs, shared crate)

## Checklist

- [ ] I ran `npm run rust:check` (if I touched Rust) and it passed — ran its per-crate equivalents for the touched crate instead: `cargo fmt -p sceneworks-core -- --check`, `cargo clippy -p sceneworks-core --lib --tests` (clean), `cargo test -p sceneworks-core --lib`. The full-workspace `rust:test`/`rust:build` legs were not run.
- [ ] I ran the web-app checks — not applicable, no web changes.
- [ ] I ran `npm run check` (scaffold checks) — not run; no scaffold, manifest, or script changes.
- [x] I updated documentation where relevant (the arm's rustdoc/comments now record why the boundary is two-sided)
- [x] All my commits are signed off
- [x] My PR is focused on a single logical change

Full-suite note: `cargo test -p sceneworks-core --lib` also reports one failure, `project_store::tests::create_project_on_unwritable_projects_dir_reports_storage_not_writable`. It fails identically on a clean `main` checkout in this container — the test drops permissions on a directory and the container runs as root, so the write it expects to fail succeeds. Unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Um5B9K5v2CCMcfdNCWGwek)_