### PR TITLE
fix(harness): bind epic 20738 load quant policy (sc-20974)

### DIFF
--- a/config/terminal-evidence/epic-20738-receipt.schema.json
+++ b/config/terminal-evidence/epic-20738-receipt.schema.json
@@ -11,7 +11,7 @@
     "cell": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "ordinal", "modelId", "engineId", "kind", "requestedTier", "resolvedTier", "denseFallback"],
+      "required": ["id", "ordinal", "modelId", "engineId", "kind", "requestedTier", "resolvedTier", "denseFallback", "loadSpecQuantBits"],
       "properties": {
         "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$" },
         "ordinal": { "type": "integer", "minimum": 1, "maximum": 19 },
@@ -20,8 +20,24 @@
         "kind": { "enum": ["image", "scail2", "ltx", "sdxlOpenPose"] },
         "requestedTier": { "enum": ["q4", "q8"] },
         "resolvedTier": { "enum": ["q4", "q8"] },
-        "denseFallback": { "const": false }
-      }
+        "denseFallback": { "const": false },
+        "loadSpecQuantBits": { "enum": [null, 4, 8] }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "kind": { "const": "sdxlOpenPose" } }, "required": ["kind"] },
+          "then": { "properties": { "loadSpecQuantBits": { "const": 4 } } },
+          "else": {
+            "if": { "properties": { "kind": { "const": "scail2" } }, "required": ["kind"] },
+            "then": {
+              "if": { "properties": { "requestedTier": { "const": "q4" } }, "required": ["requestedTier"] },
+              "then": { "properties": { "loadSpecQuantBits": { "const": 4 } } },
+              "else": { "properties": { "loadSpecQuantBits": { "const": 8 } } }
+            },
+            "else": { "properties": { "loadSpecQuantBits": { "const": null } } }
+          }
+        }
+      ]
     },
     "status": { "enum": ["passed", "failed"] },
     "error": { "type": ["string", "null"] },

--- a/crates/sceneworks-worker/src/epic_20738_terminal_cuda_smoke.rs
+++ b/crates/sceneworks-worker/src/epic_20738_terminal_cuda_smoke.rs
@@ -66,6 +66,37 @@ struct Cell {
     artifacts: Vec<Artifact>,
 }
 
+/// The terminal profile selects immutable packed roots. Only SDXL's production loader still uses
+/// an advisory Q4 selector, and Candle SCAIL carries the exact selected tier as its production load
+/// hint. Chroma, FLUX, and LTX consume the selected packed root without asking the provider to
+/// quantize it again. Keep this policy pure and shared by both the load-spec builder and the runtime
+/// receipt so the evidence cannot describe a different load than the one the worker requested.
+fn family_load_spec_quant_bits(kind: &str, engine_id: &str, requested_tier: &str) -> Option<u64> {
+    match (kind, engine_id) {
+        ("image", "chroma1_base" | "chroma1_flash" | "chroma1_hd")
+        | ("image", "flux1_dev" | "flux1_schnell")
+        | ("ltx", "ltx_2_3_distilled") => None,
+        ("sdxlOpenPose", "sdxl") => Some(4),
+        ("scail2", "scail2_14b") => match requested_tier {
+            "q4" => Some(4),
+            "q8" => Some(8),
+            tier => panic!("unreviewed terminal SCAIL tier {tier}"),
+        },
+        _ => panic!("unreviewed terminal load-quant family {kind}/{engine_id}"),
+    }
+}
+
+fn primary_load_spec(cell: &Cell, primary: &Artifact) -> LoadSpec {
+    let spec = LoadSpec::new(WeightsSource::Dir(primary.root.clone()))
+        .with_resolved_route(cell.model_id.clone());
+    match family_load_spec_quant_bits(&cell.kind, &cell.engine_id, &cell.requested_tier) {
+        None => spec,
+        Some(4) => spec.with_quant(Quant::Q4),
+        Some(8) => spec.with_quant(Quant::Q8),
+        Some(bits) => panic!("unreviewed terminal load quant q{bits}"),
+    }
+}
+
 fn required_env(name: &str) -> String {
     std::env::var(name)
         .unwrap_or_else(|_| panic!("{name} is required by the terminal CUDA controller"))
@@ -262,14 +293,8 @@ fn image_output(output: GenerationOutput, context: &str) -> Image {
     }
 }
 
-fn generate_image(cell: &Cell, primary: &Artifact, bits: u64, output: &Path) -> Value {
-    let mut spec = LoadSpec::new(WeightsSource::Dir(primary.root.clone()))
-        .with_resolved_route(cell.model_id.clone());
-    // FLUX.1's packed artifact marker is authoritative and its final consumer intentionally carries
-    // quant=None. Chroma and SDXL retain their registered packed-load quant selector.
-    if !cell.engine_id.starts_with("flux1_") {
-        spec = spec.with_quant(if bits == 4 { Quant::Q4 } else { Quant::Q8 });
-    }
+fn generate_image(cell: &Cell, primary: &Artifact, output: &Path) -> Value {
+    let spec = primary_load_spec(cell, primary);
     let generator = crate::inference_runtime::load(&cell.engine_id, &spec)
         .unwrap_or_else(|error| panic!("{} load failed: {error}", cell.id));
     let request = GenerationRequest {
@@ -318,8 +343,7 @@ fn generate_sdxl_openpose(cell: &Cell, primary: &Artifact, bits: u64, output: &P
     let tokenizer_l = artifact(cell, "tokenizer_clip_l");
     let tokenizer_bigg = artifact(cell, "tokenizer_clip_bigg");
     let vae = artifact(cell, "vae_fp16_fix");
-    let spec = LoadSpec::new(WeightsSource::Dir(primary.root.clone()))
-        .with_quant(Quant::Q4)
+    let spec = primary_load_spec(cell, primary)
         .with_control(WeightsSource::File(exact_file(
             &control.root,
             "diffusion_pytorch_model.safetensors",
@@ -462,11 +486,15 @@ fn generate_scail2(cell: &Cell, primary: &Artifact, output: &Path) -> Value {
         mode: ReplacementMode::default(),
     });
     assert_eq!(conditioning.len(), pair_count * 2 + 1);
-    let spec = LoadSpec::new(WeightsSource::Dir(primary.root.clone()))
-        .with_resolved_route(cell.model_id.clone());
+    let spec = primary_load_spec(cell, primary);
+    let exact_tier_hint = match cell.requested_tier.as_str() {
+        "q4" => matches!(spec.quantize.as_ref(), Some(Quant::Q4)),
+        "q8" => matches!(spec.quantize.as_ref(), Some(Quant::Q8)),
+        _ => false,
+    };
     assert!(
-        spec.quantize.is_none(),
-        "SCAIL2 prepacked tiers must load with quant=None"
+        exact_tier_hint,
+        "Candle SCAIL2 must retain its exact production tier hint"
     );
     let generator = crate::inference_runtime::load("scail2_14b", &spec)
         .unwrap_or_else(|error| panic!("{} SCAIL2 load failed: {error}", cell.id));
@@ -502,9 +530,8 @@ fn generate_scail2(cell: &Cell, primary: &Artifact, output: &Path) -> Value {
 
 fn generate_ltx(cell: &Cell, primary: &Artifact, output: &Path) -> Value {
     let text_encoder = artifact(cell, "text_encoder");
-    let spec = LoadSpec::new(WeightsSource::Dir(primary.root.clone()))
-        .with_text_encoder(WeightsSource::Dir(text_encoder.root.clone()))
-        .with_resolved_route(cell.model_id.clone());
+    let spec = primary_load_spec(cell, primary)
+        .with_text_encoder(WeightsSource::Dir(text_encoder.root.clone()));
     assert!(
         spec.quantize.is_none(),
         "LTX prepacked q8 must load with quant=None"
@@ -585,18 +612,13 @@ fn epic_20738_terminal_cuda_cell() {
     .expect("write generated inputs");
 
     let metrics = match cell.kind.as_str() {
-        "image" => generate_image(&cell, primary, bits, &output),
+        "image" => generate_image(&cell, primary, &output),
         "sdxlOpenPose" => generate_sdxl_openpose(&cell, primary, bits, &output),
         "scail2" => generate_scail2(&cell, primary, &output),
         "ltx" => generate_ltx(&cell, primary, &output),
         other => panic!("unreviewed terminal cell kind {other}"),
     };
-    let quant =
-        if cell.engine_id.starts_with("flux1_") || matches!(cell.kind.as_str(), "scail2" | "ltx") {
-            Value::Null
-        } else {
-            json!(bits)
-        };
+    let quant = family_load_spec_quant_bits(&cell.kind, &cell.engine_id, &cell.requested_tier);
     let result = json!({
         "schemaVersion": 1,
         "cell": cell.id,
@@ -663,5 +685,100 @@ mod cpu_contract_tests {
             &mut bits,
         );
         assert_eq!(bits, vec![4]);
+    }
+
+    #[test]
+    fn family_load_quant_policy_covers_all_19_terminal_cells() {
+        let cases = [
+            ("chroma1-base-q4", "image", "chroma1_base", "q4", None),
+            ("chroma1-base-q8", "image", "chroma1_base", "q8", None),
+            ("chroma1-flash-q4", "image", "chroma1_flash", "q4", None),
+            ("chroma1-flash-q8", "image", "chroma1_flash", "q8", None),
+            ("chroma1-hd-q4", "image", "chroma1_hd", "q4", None),
+            ("chroma1-hd-q8", "image", "chroma1_hd", "q8", None),
+            ("flux1-dev-q4", "image", "flux1_dev", "q4", None),
+            ("flux1-dev-q8", "image", "flux1_dev", "q8", None),
+            ("flux1-schnell-q4", "image", "flux1_schnell", "q4", None),
+            ("flux1-schnell-q8", "image", "flux1_schnell", "q8", None),
+            ("scail2-q4", "scail2", "scail2_14b", "q4", Some(4)),
+            (
+                "scail2-multi-reference-q4",
+                "scail2",
+                "scail2_14b",
+                "q4",
+                Some(4),
+            ),
+            ("scail2-q8", "scail2", "scail2_14b", "q8", Some(8)),
+            ("ltx-2-3-q8", "ltx", "ltx_2_3_distilled", "q8", None),
+            ("sdxl-openpose", "sdxlOpenPose", "sdxl", "q4", Some(4)),
+            ("realvisxl-openpose", "sdxlOpenPose", "sdxl", "q4", Some(4)),
+            (
+                "realvisxl-lightning-openpose",
+                "sdxlOpenPose",
+                "sdxl",
+                "q4",
+                Some(4),
+            ),
+            (
+                "illustrious-v1-openpose",
+                "sdxlOpenPose",
+                "sdxl",
+                "q4",
+                Some(4),
+            ),
+            (
+                "illustrious-v2-openpose",
+                "sdxlOpenPose",
+                "sdxl",
+                "q4",
+                Some(4),
+            ),
+        ];
+        assert_eq!(cases.len(), 19);
+        for (id, kind, engine_id, requested_tier, expected) in cases {
+            assert_eq!(
+                family_load_spec_quant_bits(kind, engine_id, requested_tier),
+                expected,
+                "{id} load-quant policy"
+            );
+        }
+    }
+
+    #[test]
+    fn chroma_prepacked_root_builds_a_none_quant_load_spec_before_device_load() {
+        let cell = Cell {
+            id: "chroma1-base-q4".to_owned(),
+            kind: "image".to_owned(),
+            model_id: "chroma1_base".to_owned(),
+            engine_id: "chroma1_base".to_owned(),
+            requested_tier: "q4".to_owned(),
+            capability: None,
+            request: Request {
+                width: 32,
+                height: 32,
+                steps: 1,
+                seed: 1,
+                frames: None,
+                fps: None,
+                guidance: None,
+                true_cfg: None,
+                sampler: None,
+                reference_pairs: None,
+            },
+            artifacts: Vec::new(),
+        };
+        let primary = Artifact {
+            id: "chroma1-base-q4".to_owned(),
+            role: "primary".to_owned(),
+            repository: "SceneWorks/chroma1-base-candle".to_owned(),
+            revision: "0".repeat(40),
+            subdirectory: "q4".to_owned(),
+            root: PathBuf::from("fixture/chroma1_base/q4"),
+        };
+        let spec = primary_load_spec(&cell, &primary);
+        assert!(
+            spec.quantize.is_none(),
+            "the exact prepacked Chroma root must reach the provider without a load-time requant"
+        );
     }
 }

--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -82,6 +82,39 @@ export function cellSemanticsSha256(cells) {
   return canonicalSha256(tuples);
 }
 
+// Match the worker's family policy for immutable packed roots. The selected tier remains q4/q8
+// evidence, while this value records whether the final LoadSpec asks the provider to quantize at
+// load. SDXL keeps its production advisory Q4 selector, and Candle SCAIL carries the exact requested
+// Q4/Q8 tier hint used by its production cold-load plan.
+export function expectedLoadSpecQuantBits(cell) {
+  const family = `${cell?.kind ?? ""}/${cell?.engineId ?? ""}`;
+  if (cell?.kind === "sdxlOpenPose" && cell.engineId === "sdxl") return 4;
+  if (cell?.kind === "scail2" && cell.engineId === "scail2_14b") {
+    if (cell.requestedTier === "q4") return 4;
+    if (cell.requestedTier === "q8") return 8;
+    fail(`unreviewed terminal SCAIL tier ${cell.requestedTier}`);
+  }
+  if ((cell?.kind === "image" && new Set([
+    "chroma1_base", "chroma1_flash", "chroma1_hd", "flux1_dev", "flux1_schnell",
+  ]).has(cell.engineId))
+    || (cell?.kind === "ltx" && cell.engineId === "ltx_2_3_distilled")) return null;
+  fail(`unreviewed terminal load-quant family ${family}`);
+}
+
+export function validateRuntimeResult(runtimeResult, cell) {
+  object(runtimeResult, `${cell.id} runtime result`);
+  const expectedQuant = expectedLoadSpecQuantBits(cell);
+  if (runtimeResult.requestedTier !== cell.requestedTier
+    || runtimeResult.resolvedTier !== cell.requestedTier || runtimeResult.denseFallback !== false) {
+    fail(`${cell.id} runtime result did not prove exact-tier/no-fallback execution`);
+  }
+  if (!Object.hasOwn(runtimeResult, "loadSpecQuantBits")
+    || runtimeResult.loadSpecQuantBits !== expectedQuant) {
+    fail(`${cell.id} runtime result did not prove family loadSpecQuantBits=${expectedQuant}`);
+  }
+  return runtimeResult;
+}
+
 export function loadProfile(profilePath = PROFILE_PATH) {
   return JSON.parse(readFileSync(profilePath, "utf8"));
 }
@@ -502,6 +535,7 @@ export function receiptSkeleton({
     cell: {
       id: cell.id, ordinal, modelId: cell.modelId, engineId: cell.engineId, kind: cell.kind,
       requestedTier: cell.requestedTier, resolvedTier: cell.requestedTier, denseFallback: false,
+      loadSpecQuantBits: expectedLoadSpecQuantBits(cell),
     },
     status: "failed",
     error: "cell has not completed",
@@ -536,6 +570,11 @@ export function validateReceipt(receipt, expectedCell, profile) {
   }
   if (receipt.cell.requestedTier !== receipt.cell.resolvedTier || receipt.cell.denseFallback !== false) {
     fail(`${receipt.cell.id} receipt permits a dense or cross-tier fallback`);
+  }
+  const expectedQuant = expectedLoadSpecQuantBits(expectedCell);
+  if (!Object.hasOwn(receipt.cell, "loadSpecQuantBits")
+    || receipt.cell.loadSpecQuantBits !== expectedQuant) {
+    fail(`${receipt.cell.id} receipt does not bind family loadSpecQuantBits=${expectedQuant}`);
   }
   if (!receipt.repositories?.sceneworks?.clean || !receipt.repositories?.inference?.clean) {
     fail("receipt does not bind clean paired repositories");
@@ -1007,10 +1046,8 @@ export async function runCampaign(args, options = {}) {
       await operations.executeCell({ sceneworks: sceneworksRoot, cellFile, cellDir, logFile, samples });
       operations.sample(samples, errors, "post-execution VRAM sample failed");
       const runtimeResult = JSON.parse(await readFile(path.join(cellDir, "runtime-result.json"), "utf8"));
-      if (runtimeResult.requestedTier !== cell.requestedTier
-        || runtimeResult.resolvedTier !== cell.requestedTier || runtimeResult.denseFallback !== false) {
-        fail(`${cell.id} runtime result did not prove exact-tier/no-fallback execution`);
-      }
+      validateRuntimeResult(runtimeResult, cell);
+      receipt.cell.loadSpecQuantBits = runtimeResult.loadSpecQuantBits;
       executionPassed = true;
     } catch (error) {
       const message = recordError(errors, "cell lifecycle failed", error);

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -10,6 +10,7 @@ import {
   PROFILE_SCHEMA_PATH,
   RECEIPT_SCHEMA_PATH,
   cellSemanticsSha256,
+  expectedLoadSpecQuantBits,
   inferencePins,
   loadProfile,
   parseNvidiaSmi,
@@ -21,6 +22,7 @@ import {
   validateManifestAuthorities,
   validateProfile,
   validateReceipt,
+  validateRuntimeResult,
 } from "./epic-20738-terminal-cuda-harness.mjs";
 import { stripJsoncComments } from "./lib/jsonc.mjs";
 
@@ -131,24 +133,68 @@ test("profile validator rejects count, order, every semantic tuple mutation, blo
   assert.throws(() => validateProfile(artifactDefinitionDrift), /artifact definitions drifted/);
 });
 
-function fixtureReceipt(status = "passed") {
+test("all 19 cells require the exact family loadSpec quant policy", () => {
   const checked = profile();
-  const cell = checked.cells[0];
-  const artifact = checked.artifacts[cell.artifactIds[0]];
-  const selectedRoot = path.resolve("fixture-runner", "scratch", "01-chroma1-base-q4", "artifacts", cell.artifactIds[0], artifact.subdirectory);
+  const sdxlCells = new Set([
+    "sdxl-openpose", "realvisxl-openpose", "realvisxl-lightning-openpose",
+    "illustrious-v1-openpose", "illustrious-v2-openpose",
+  ]);
+  assert.equal(checked.cells.length, 19);
+  for (const [index, cell] of checked.cells.entries()) {
+    const expected = sdxlCells.has(cell.id)
+      ? 4
+      : cell.kind === "scail2" ? Number(cell.requestedTier.slice(1)) : null;
+    assert.equal(expectedLoadSpecQuantBits(cell), expected, cell.id);
+    const valid = {
+      requestedTier: cell.requestedTier,
+      resolvedTier: cell.requestedTier,
+      denseFallback: false,
+      loadSpecQuantBits: expected,
+    };
+    assert.equal(validateRuntimeResult(valid, cell), valid, cell.id);
+    const missing = { ...valid };
+    delete missing.loadSpecQuantBits;
+    assert.throws(() => validateRuntimeResult(missing, cell), /loadSpecQuantBits/, cell.id);
+    assert.throws(
+      () => validateRuntimeResult({ ...valid, loadSpecQuantBits: expected === null ? 4 : null }, cell),
+      /loadSpecQuantBits/,
+      cell.id,
+    );
+    const receipt = fixtureReceipt("passed", index);
+    assert.equal(validateReceipt(receipt, cell, checked), receipt, cell.id);
+    delete receipt.cell.loadSpecQuantBits;
+    assert.throws(() => validateReceipt(receipt, cell, checked), /loadSpecQuantBits/, cell.id);
+    receipt.cell.loadSpecQuantBits = expected === null ? 4 : null;
+    assert.throws(() => validateReceipt(receipt, cell, checked), /loadSpecQuantBits/, cell.id);
+  }
+});
+
+function fixtureReceipt(status = "passed", cellIndex = 0) {
+  const checked = profile();
+  const cell = checked.cells[cellIndex];
+  const artifacts = cell.artifactIds.map((artifactId) => {
+    const artifact = checked.artifacts[artifactId];
+    const selectedRoot = path.resolve(
+      "fixture-runner", "scratch", `${String(cellIndex + 1).padStart(2, "0")}-${cell.id}`,
+      "artifacts", artifactId, artifact.subdirectory,
+    );
+    return {
+      id: artifactId, role: artifact.role, repository: artifact.repository,
+      revision: artifact.revision, subdirectory: artifact.subdirectory,
+      selectedRoot, allowPatterns: artifact.allowPatterns,
+      inventory: {
+        root: selectedRoot, complete: true, sha256: "4".repeat(64), files: 3, bytes: 42, error: null,
+      },
+    };
+  });
   const receipt = receiptSkeleton({
     cell,
-    ordinal: 1,
+    ordinal: cellIndex + 1,
     repositories: {
       sceneworks: { sha: "1".repeat(40), clean: true },
       inference: { sha: "2".repeat(40), clean: true },
     },
-    artifacts: [{
-      id: cell.artifactIds[0], role: artifact.role, repository: artifact.repository,
-      revision: artifact.revision, subdirectory: artifact.subdirectory,
-      selectedRoot, allowPatterns: artifact.allowPatterns,
-      inventory: { root: selectedRoot, complete: true, sha256: "4".repeat(64), files: 3, bytes: 42, error: null },
-    }],
+    artifacts,
     execution: {
       runId: "123", runAttempt: "2", headSha: "1".repeat(40), workflow: "Windows Candle worker",
       headRef: "refs/heads/story/sc-20945-epic-20738-candle-cuda-parity",
@@ -183,6 +229,12 @@ test("receipt fixture binds paired clean sources, exact tier, artifacts, runner,
   const dense = fixtureReceipt();
   dense.cell.denseFallback = true;
   assert.throws(() => validateFixture(dense), /dense or cross-tier/);
+  const missingQuant = fixtureReceipt();
+  delete missingQuant.cell.loadSpecQuantBits;
+  assert.throws(() => validateFixture(missingQuant), /loadSpecQuantBits/);
+  const wrongQuant = fixtureReceipt();
+  wrongQuant.cell.loadSpecQuantBits = 4;
+  assert.throws(() => validateFixture(wrongQuant), /loadSpecQuantBits/);
   const dirty = fixtureReceipt();
   dirty.repositories.inference.clean = false;
   assert.throws(() => validateFixture(dirty), /clean paired/);
@@ -238,6 +290,32 @@ test("Draft 2020-12 schemas validate the profile and close adversarial receipt d
     };
     const valid = await writeReceipt("valid.json", fixtureReceipt());
     assert.doesNotThrow(() => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, valid));
+
+    const missingQuant = fixtureReceipt();
+    delete missingQuant.cell.loadSpecQuantBits;
+    const missingQuantFile = await writeReceipt("missing-load-quant.json", missingQuant);
+    assert.throws(
+      () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, missingQuantFile),
+      /must have required property 'loadSpecQuantBits'/,
+    );
+
+    const wrongQuant = fixtureReceipt();
+    wrongQuant.cell.loadSpecQuantBits = 4;
+    const wrongQuantFile = await writeReceipt("wrong-load-quant.json", wrongQuant);
+    assert.throws(
+      () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, wrongQuantFile),
+      /must be equal to constant/,
+    );
+
+    const scailQ8 = fixtureReceipt("passed", 12);
+    const scailQ8File = await writeReceipt("scail-q8.json", scailQ8);
+    assert.doesNotThrow(() => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, scailQ8File));
+    scailQ8.cell.loadSpecQuantBits = 4;
+    const wrongScailQ8File = await writeReceipt("wrong-scail-q8.json", scailQ8);
+    assert.throws(
+      () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, wrongScailQ8File),
+      /must be equal to constant/,
+    );
 
     const openInventory = fixtureReceipt();
     openInventory.artifacts[0].inventory.injected = true;
@@ -419,6 +497,7 @@ test("injected lifecycle faults preserve all 19 outcomes and quarantine after cl
         requestedTier: runtimeCell.requestedTier,
         resolvedTier: runtimeCell.requestedTier,
         denseFallback: false,
+        loadSpecQuantBits: expectedLoadSpecQuantBits(runtimeCell),
       })}\n`, "utf8");
       await writeFile(path.join(cellDir, "output.bin"), "fixture", "utf8");
     },
@@ -566,6 +645,7 @@ test("schemas, clean Node dependencies, and workflow preserve the opt-in single-
   assert.equal(profileSchema.properties.cells.minItems, 19);
   assert.equal(profileSchema.properties.cells.maxItems, 19);
   assert.deepEqual(receiptSchema.properties.cell.properties.denseFallback, { const: false });
+  assert.deepEqual(receiptSchema.properties.cell.properties.loadSpecQuantBits, { enum: [null, 4, 8] });
   assert.equal(receiptSchema.$defs.inventory.additionalProperties, false);
   assert.equal(receiptSchema.$defs.gpuSample.additionalProperties, false);
   assert.equal(receiptSchema.properties.profile.const, PROFILE_NAME);


### PR DESCRIPTION
Source-only repair for sc-20974 after terminal campaign attempt 1 timed out at six hours.

Root cause:
- The terminal harness passed advisory Q4/Q8 load quantization for Chroma immutable prepacked roots. Chroma must load those exact roots with quantize=None, so all six Chroma cells failed diagnostically before device execution.
- The controller checked requested/resolved tier and dense fallback but did not require the family-specific LoadSpec quant contract.

Fix:
- One pure Rust family policy drives both LoadSpec construction and runtime-result loadSpecQuantBits.
- Chroma, FLUX, and LTX use null; Candle SCAIL uses the exact requested 4/8 production hint; SDXL keeps advisory 4.
- Controller, receipt validation, JSON schema, and fixtures reject missing or wrong family values across all 19 cells.

Attempt 1 limitations:
- Conclusively cancelled at the six-hour timeout with no artifact upload.
- Nine cells finalized: six Chroma diagnostic failures and three FLUX passes; cells 10-19 were incomplete.
- No evidence from that attempt is ingested as terminal success, and this PR does not dispatch a second campaign.

Reviewed evidence:
- Exact approved head cca17cda51fd4559be076cb2976eb246e134a5fc on base a89d8e49da908c7d4dac585c46fd3e3e016b7fc4.
- Candle harness CPU tests 4/4; Node/controller tests 9/9; memory matrix tests 118/118; source-control tests 5/5; test-list tests 4/4; harness profile check, memory generator check, fmt, and diff all pass.
- Frozen 19-cell and 23-artifact semantic digests are unchanged. No production routing, model authorities, product gates, facts, exceptions, or memory semantics change.

No GPU, weights, terminal dispatch, capability measurement, or evidence ingestion is part of this PR.