### PR TITLE
sc-20974: extend terminal campaign job timeout

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -343,9 +343,10 @@ jobs:
     # Krea q4's ~14 GB, so it is the branch that most
     # needs the long budget. Krea's two dispatch shapes keep their exact previous values --
     # five-rung + provision 240, five-rung alone 120, everything else 45.
-    # The LTX Eros acceptance capture (sc-18902, from main) keeps its own six-hour ceiling
-    # ahead of the provisioning branch.
-    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && inputs.run_ltx_eros_acceptance && 360 || github.event_name == 'workflow_dispatch' && inputs.run_epic_20738_terminal_cuda && 360 || github.event_name == 'workflow_dispatch' && inputs.provision_snapshot && 240 || github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && 120 || 45 }}
+    # The LTX Eros acceptance capture (sc-18902, from main) keeps its own six-hour ceiling.
+    # The strictly serial 19-cell epic-20738 terminal campaign gets a job-level twelve-hour
+    # ceiling; no individual step receives a timeout above GitHub's 360-minute step limit.
+    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && inputs.run_ltx_eros_acceptance && 360 || github.event_name == 'workflow_dispatch' && inputs.run_epic_20738_terminal_cuda && 720 || github.event_name == 'workflow_dispatch' && inputs.provision_snapshot && 240 || github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && 120 || 45 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Refuse combined manual measurement profiles

--- a/docs/epic-20738-terminal-cuda.md
+++ b/docs/epic-20738-terminal-cuda.md
@@ -35,6 +35,11 @@ Leave `run_five_rung_reference`, `provision_krea_snapshot`, and `run_ltx_eros_ac
 workflow rejects a combined dispatch. Its fixed terminal concurrency key admits only one campaign at
 a time across the Windows CUDA pool.
 
+The terminal dispatch arm gives this one strictly serial job a 720-minute hard timeout. That is a
+job-level budget below GitHub's five-day self-hosted execution limit, not a step timeout; no step is
+assigned a timeout above 360 minutes. The unrelated LTX Eros, provisioning, five-rung, and ordinary
+job budgets remain 360, 240, 120, and 45 minutes respectively.
+
 The job checks out exact source revisions and requires both checkouts to be clean. It installs the
 lockfile-pinned in-process Node Draft 2020-12 validator and creates a fresh Python environment only
 for the pinned anonymous artifact client, then downloads

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -276,18 +276,39 @@ test("windows-candle rebuilds the exact Krea snapshot path from the generalized 
   assert.match(workflow, /if \(\$isKrea -and \$env:KREA_ROOT_OVERRIDE\) \{/);
 });
 
-// sc-18677: the provisioning branch's timeout is the whole point of the change (a 144 GB fetch
-// under the ordinary 45m cap dies mid-download), and the doc claims Krea's two dispatch shapes
-// keep their exact previous budgets. Pin the whole expression the way the macOS twin above pins
-// its lane's -- otherwise a revert to a flat `timeout-minutes: 45` passes every other test here.
-test("windows-candle keeps the provisioning and five-rung timeout budgets", async () => {
+// sc-18677/sc-20974: the provisioning and terminal timeout arms are load-bearing. Pin the whole
+// expression the way the macOS twin above pins its lane's -- otherwise either a revert to the
+// ordinary 45m cap or the terminal campaign's observed 360m cutoff passes every other test here.
+test("windows-candle keeps the terminal, provisioning, and five-rung timeout budgets", async () => {
   const workflow = await source(".github/workflows/windows-candle.yml");
+  const runbook = await source("docs/epic-20738-terminal-cuda.md");
+  const timeoutContract =
+    /timeout-minutes: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.run_ltx_eros_acceptance && 360 \|\| github\.event_name == 'workflow_dispatch' && inputs\.run_epic_20738_terminal_cuda && 720 \|\| github\.event_name == 'workflow_dispatch' && inputs\.provision_snapshot && 240 \|\| github\.event_name == 'workflow_dispatch' && inputs\.run_five_rung_reference && 120 \|\| 45 \}\}/;
   assert.match(
     workflow,
-    // The LTX Eros acceptance arm (SC-18902, from main) and the terminal CUDA arm each keep
-    // their six-hour ceilings ahead of the unchanged provisioning / five-rung / default budgets.
-    /timeout-minutes: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.run_ltx_eros_acceptance && 360 \|\| github\.event_name == 'workflow_dispatch' && inputs\.run_epic_20738_terminal_cuda && 360 \|\| github\.event_name == 'workflow_dispatch' && inputs\.provision_snapshot && 240 \|\| github\.event_name == 'workflow_dispatch' && inputs\.run_five_rung_reference && 120 \|\| 45 \}\}/,
+    // The LTX Eros arm (SC-18902, from main) keeps six hours, while the strictly serial
+    // 19-cell terminal campaign gets twelve. Provisioning, five-rung, and default stay fixed.
+    timeoutContract,
   );
+  assert.match(
+    runbook,
+    /one strictly serial job a 720-minute hard timeout[\s\S]*no step is\s+assigned a timeout above 360 minutes/,
+    "the runbook must bind the job-level 720-minute budget without widening a step",
+  );
+
+  const terminalArm =
+    "github.event_name == 'workflow_dispatch' && inputs.run_epic_20738_terminal_cuda && 720";
+  for (const [name, mutated] of [
+    ["terminal timeout regressed to 360", workflow.replace(terminalArm, terminalArm.replace("720", "360"))],
+    ["terminal timeout arm removed", workflow.replace(` || ${terminalArm}`, "")],
+  ]) {
+    assert.notEqual(mutated, workflow, `${name} mutation must modify the workflow fixture`);
+    assert.throws(
+      () => assert.match(mutated, timeoutContract),
+      undefined,
+      `${name} must fail the exact timeout contract`,
+    );
+  }
 });
 
 test("windows-candle keeps the five-rung guards while decoupling provisioning", async () => {


### PR DESCRIPTION
## Scope

Follow-up for [sc-20974](https://app.shortcut.com/trefry/story/20974) after terminal campaign attempt 1.

Attempt 1 run/job 32514121353 / 96871758853 reached the six-hour job cap and was cancelled at 2026-08-22T00:40:27Z. Nine cells finalized before cancellation: three diagnostic FLUX functional passes and six deterministic Chroma harness failures; cell 10 was interrupted, cell 11 initialized only, and cells 12-19 were absent. No evidence was promoted and no replacement campaign is dispatched by this PR.

This exact reviewed three-file change:
- raises only the run_epic_20738_terminal_cuda job-level timeout from 360 to 720 minutes;
- keeps the single default-off job, strict serial 19-cell controller, fixed exclusivity/concurrency, and upload-before-verdict order;
- keeps the unrelated LTX Eros 360, provisioning 240, five-rung 120, and ordinary 45-minute arms unchanged;
- adds no step timeout above 360 minutes;
- updates the exact platform contract and runbook, including mutations that reject a terminal regression to 360 or removal of its timeout arm.

The frozen 19-cell semantic digest and 23-artifact authorities are unchanged. There are no product, facts, matrix, exception, profile, artifact, pin, runtime-worker, or measurement changes.

## Review and source-only validation

Independent review approved exact head 76d026204621e07252ceb2b23764ac9a636f4139.

- focused timeout mutation contract: 1/1
- platform review contracts: 71/71
- action-pin tests: 9/9; authoritative scan: 11 workflows
- terminal harness and inventory: 13/13
- terminal harness check: exact 19 serialized cells and immutable authorities
- windows-candle.yml YAML parse
- cargo fmt --all -- --check
- git diff --check

No GPU, weights, terminal dispatch, capability capture, or external evidence ingestion was run.