### PR TITLE
SC-19054: harden Windows Candle verifier and cleanup

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -953,6 +953,42 @@ jobs:
           # Export the bounded attempt path before any check or mkdir can fail. The always upload
           # and cleanup steps must still be able to find scratch left by an interrupted seal.
           "SC19054_EVIDENCE_DIR=$evidence" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          function Resolve-Sc19054ScratchPath([string]$Candidate, [string]$RunnerTemp) {
+            if ([string]::IsNullOrWhiteSpace($Candidate) -or [string]::IsNullOrWhiteSpace($RunnerTemp)) {
+              throw 'SC-19054 scratch validation requires a candidate and RUNNER_TEMP'
+            }
+            $resolved = [System.IO.Path]::GetFullPath($Candidate)
+            $trimChars = [char[]]@([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+            $tempRoot = [System.IO.Path]::GetFullPath($RunnerTemp).TrimEnd($trimChars)
+            $parent = [System.IO.Path]::GetDirectoryName($resolved)
+            $leaf = [System.IO.Path]::GetFileName($resolved)
+            if (-not [string]::Equals($parent, $tempRoot, [StringComparison]::OrdinalIgnoreCase) -or
+                $leaf -notmatch '^sc19054-flux-acceptance-[0-9]+-[0-9]+$') {
+              throw "refusing an untrusted SC-19054 scratch path: $resolved"
+            }
+            if ((Test-Path -LiteralPath $resolved) -and
+                ((Get-Item -LiteralPath $resolved -Force).Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+              throw "refusing an SC-19054 scratch reparse point: $resolved"
+            }
+            return $resolved
+          }
+          $evidence = Resolve-Sc19054ScratchPath $evidence $env:RUNNER_TEMP
+          $expectedEvidence = [System.IO.Path]::GetFullPath(
+            (Join-Path $env:RUNNER_TEMP "sc19054-flux-acceptance-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT")
+          )
+          if (-not [string]::Equals($evidence, $expectedEvidence, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "SC-19054 evidence path does not match this exact run attempt: $evidence"
+          }
+          # A failed always-cleanup used to strand one exact attempt directory. Reclaim only direct
+          # RUNNER_TEMP children with the complete SC-19054 run/attempt shape; model and Cargo
+          # caches cannot match this namespace or parent constraint.
+          Get-ChildItem -LiteralPath $env:RUNNER_TEMP -Directory -Force |
+            Where-Object { $_.Name -match '^sc19054-flux-acceptance-[0-9]+-[0-9]+$' } |
+            ForEach-Object {
+              $stale = Resolve-Sc19054ScratchPath $_.FullName $env:RUNNER_TEMP
+              Write-Host "Removing stale SC-19054 scratch: $stale"
+              Remove-Item -LiteralPath $stale -Recurse -Force
+            }
           if (Test-Path -LiteralPath $evidence) {
             throw "refusing stale SC-19054 evidence directory: $evidence"
           }
@@ -1031,12 +1067,24 @@ jobs:
           $events = @(Select-String -LiteralPath $logPath -Pattern '^SC19054_ADMISSION_EVENT=(\{.*\})$')
           if ($events.Count -ne 1) { throw "expected exactly one admission event, found $($events.Count)" }
           $event = $events[0].Matches[0].Groups[1].Value | ConvertFrom-Json
+          # The Rust acceptance contract already allows strictly less than 1e-9 GiB of arithmetic
+          # delta. Preserve that same narrow boundary through JSON/PowerShell deserialization: the
+          # failed receipt's larger delta was 9.46224e-10 GiB, while 1e-9 or more remains a failure.
+          $peakToleranceGb = 0.000000001
+          function Test-Sc19054Peak([object]$Actual, [double]$Expected) {
+            if ($null -eq $Actual) { return $false }
+            $value = [double]$Actual
+            return (-not [double]::IsNaN($value) -and
+                    -not [double]::IsInfinity($value) -and
+                    [Math]::Abs($value - $Expected) -lt $peakToleranceGb)
+          }
           if ($event.event -ne 'sc19054_candle_admission_selected' -or
               $event.modelId -ne 'flux_schnell' -or $event.engineId -ne 'flux1_schnell' -or
               $event.tier -ne 'q4' -or $event.geometry.width -ne 1024 -or $event.geometry.height -ne 1024 -or
               $event.budgetGb -ne 24 -or $event.sequentialCapable -ne $true -or
               $event.oldPlan -ne 'resident' -or $event.selectedPlan -ne 'sequential' -or
-              $event.widenedResidentPeakGb -ne 24.232 -or $event.widenedSequentialPeakGb -ne 21.216) {
+              -not (Test-Sc19054Peak $event.widenedResidentPeakGb 24.232) -or
+              -not (Test-Sc19054Peak $event.widenedSequentialPeakGb 21.216)) {
             throw "SC-19054 admission event does not match the exact acceptance cell: $($event | ConvertTo-Json -Compress -Depth 5)"
           }
           $receipt = Get-Content -LiteralPath $receiptPath -Raw | ConvertFrom-Json
@@ -1073,11 +1121,28 @@ jobs:
         shell: powershell
         run: |
           if (-not $env:SC19054_EVIDENCE_DIR -or -not $env:RUNNER_TEMP) { exit 0 }
-          $evidence = [System.IO.Path]::GetFullPath($env:SC19054_EVIDENCE_DIR)
-          $temp = [System.IO.Path]::GetFullPath($env:RUNNER_TEMP).TrimEnd('\\') + '\\'
-          if (-not $evidence.StartsWith($temp, [StringComparison]::OrdinalIgnoreCase) -or
-              -not (Split-Path -Leaf $evidence).StartsWith('sc19054-flux-acceptance-')) {
-            throw "refusing to clean an untrusted SC-19054 path: $evidence"
+          function Resolve-Sc19054ScratchPath([string]$Candidate, [string]$RunnerTemp) {
+            $resolved = [System.IO.Path]::GetFullPath($Candidate)
+            $trimChars = [char[]]@([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+            $tempRoot = [System.IO.Path]::GetFullPath($RunnerTemp).TrimEnd($trimChars)
+            $parent = [System.IO.Path]::GetDirectoryName($resolved)
+            $leaf = [System.IO.Path]::GetFileName($resolved)
+            if (-not [string]::Equals($parent, $tempRoot, [StringComparison]::OrdinalIgnoreCase) -or
+                $leaf -notmatch '^sc19054-flux-acceptance-[0-9]+-[0-9]+$') {
+              throw "refusing to clean an untrusted SC-19054 path: $resolved"
+            }
+            if ((Test-Path -LiteralPath $resolved) -and
+                ((Get-Item -LiteralPath $resolved -Force).Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+              throw "refusing to clean an SC-19054 reparse point: $resolved"
+            }
+            return $resolved
+          }
+          $evidence = Resolve-Sc19054ScratchPath $env:SC19054_EVIDENCE_DIR $env:RUNNER_TEMP
+          $expectedEvidence = [System.IO.Path]::GetFullPath(
+            (Join-Path $env:RUNNER_TEMP "sc19054-flux-acceptance-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT")
+          )
+          if (-not [string]::Equals($evidence, $expectedEvidence, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "refusing to clean an SC-19054 path from another run attempt: $evidence"
           }
           if (Test-Path -LiteralPath $evidence) { Remove-Item -LiteralPath $evidence -Recurse -Force }
       # sc-17592, the off-Mac mirror of macos-mlx.yml's MLX step. THE ONLY PR LANE THAT CAN PRODUCE

--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -966,11 +966,48 @@ jobs:
                 $leaf -notmatch '^sc19054-flux-acceptance-[0-9]+-[0-9]+$') {
               throw "refusing an untrusted SC-19054 scratch path: $resolved"
             }
-            if ((Test-Path -LiteralPath $resolved) -and
-                ((Get-Item -LiteralPath $resolved -Force).Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
-              throw "refusing an SC-19054 scratch reparse point: $resolved"
-            }
             return $resolved
+          }
+          function Remove-Sc19054ScratchTree([string]$ScratchPath) {
+            if (-not (Test-Path -LiteralPath $ScratchPath)) { return }
+            $root = Get-Item -LiteralPath $ScratchPath -Force
+            if (-not $root.PSIsContainer -or
+                ($root.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+              throw "refusing an invalid SC-19054 scratch root: $ScratchPath"
+            }
+            $rootFiles = @('identity.json', 'model-files.json', 'acceptance.log', 'SHA256SUMS.txt')
+            $outputFiles = @('sc19054-flux-acceptance.json', 'sc19054-flux-schnell-q4-1024.png')
+            $output = Join-Path $ScratchPath 'output'
+            foreach ($item in @(Get-ChildItem -LiteralPath $ScratchPath -Force)) {
+              if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+                throw "refusing an SC-19054 scratch reparse point: $($item.FullName)"
+              }
+              if ($item.PSIsContainer) {
+                if ($item.Name -ne 'output') {
+                  throw "refusing an unexpected SC-19054 scratch directory: $($item.FullName)"
+                }
+                foreach ($child in @(Get-ChildItem -LiteralPath $item.FullName -Force)) {
+                  if ($child.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+                    throw "refusing an SC-19054 output reparse point: $($child.FullName)"
+                  }
+                  if ($child.PSIsContainer -or $outputFiles -notcontains $child.Name) {
+                    throw "refusing an unexpected SC-19054 output entry: $($child.FullName)"
+                  }
+                }
+              } elseif ($rootFiles -notcontains $item.Name) {
+                throw "refusing an unexpected SC-19054 scratch file: $($item.FullName)"
+              }
+            }
+            # The complete inventory above is closed and contains no links or nested directories.
+            # Delete only inventoried leaves, then their empty parents; never recursively delete.
+            if (Test-Path -LiteralPath $output) {
+              Get-ChildItem -LiteralPath $output -File -Force |
+                ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force }
+              Remove-Item -LiteralPath $output -Force
+            }
+            Get-ChildItem -LiteralPath $ScratchPath -File -Force |
+              ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force }
+            Remove-Item -LiteralPath $ScratchPath -Force
           }
           $evidence = Resolve-Sc19054ScratchPath $evidence $env:RUNNER_TEMP
           $expectedEvidence = [System.IO.Path]::GetFullPath(
@@ -979,16 +1016,16 @@ jobs:
           if (-not [string]::Equals($evidence, $expectedEvidence, [StringComparison]::OrdinalIgnoreCase)) {
             throw "SC-19054 evidence path does not match this exact run attempt: $evidence"
           }
-          # A failed always-cleanup used to strand one exact attempt directory. Reclaim only direct
-          # RUNNER_TEMP children with the complete SC-19054 run/attempt shape; model and Cargo
-          # caches cannot match this namespace or parent constraint.
-          Get-ChildItem -LiteralPath $env:RUNNER_TEMP -Directory -Force |
-            Where-Object { $_.Name -match '^sc19054-flux-acceptance-[0-9]+-[0-9]+$' } |
-            ForEach-Object {
-              $stale = Resolve-Sc19054ScratchPath $_.FullName $env:RUNNER_TEMP
-              Write-Host "Removing stale SC-19054 scratch: $stale"
-              Remove-Item -LiteralPath $stale -Recurse -Force
-            }
+          # Run 32551460830 attempt 1 completed and uploaded artifact 9470472931 before its broken
+          # cleanup rejected this exact path. Reclaim that one known residue only. Other SC-19054
+          # directories may belong to concurrent SHA-keyed listeners sharing the physical host.
+          $completedResidue = Resolve-Sc19054ScratchPath (
+            (Join-Path $env:RUNNER_TEMP 'sc19054-flux-acceptance-32551460830-1')
+          ) $env:RUNNER_TEMP
+          if (Test-Path -LiteralPath $completedResidue) {
+            Write-Host "Removing completed SC-19054 residue: $completedResidue"
+            Remove-Sc19054ScratchTree $completedResidue
+          }
           if (Test-Path -LiteralPath $evidence) {
             throw "refusing stale SC-19054 evidence directory: $evidence"
           }
@@ -1131,11 +1168,46 @@ jobs:
                 $leaf -notmatch '^sc19054-flux-acceptance-[0-9]+-[0-9]+$') {
               throw "refusing to clean an untrusted SC-19054 path: $resolved"
             }
-            if ((Test-Path -LiteralPath $resolved) -and
-                ((Get-Item -LiteralPath $resolved -Force).Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
-              throw "refusing to clean an SC-19054 reparse point: $resolved"
-            }
             return $resolved
+          }
+          function Remove-Sc19054ScratchTree([string]$ScratchPath) {
+            if (-not (Test-Path -LiteralPath $ScratchPath)) { return }
+            $root = Get-Item -LiteralPath $ScratchPath -Force
+            if (-not $root.PSIsContainer -or
+                ($root.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+              throw "refusing an invalid SC-19054 scratch root: $ScratchPath"
+            }
+            $rootFiles = @('identity.json', 'model-files.json', 'acceptance.log', 'SHA256SUMS.txt')
+            $outputFiles = @('sc19054-flux-acceptance.json', 'sc19054-flux-schnell-q4-1024.png')
+            $output = Join-Path $ScratchPath 'output'
+            foreach ($item in @(Get-ChildItem -LiteralPath $ScratchPath -Force)) {
+              if ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+                throw "refusing an SC-19054 scratch reparse point: $($item.FullName)"
+              }
+              if ($item.PSIsContainer) {
+                if ($item.Name -ne 'output') {
+                  throw "refusing an unexpected SC-19054 scratch directory: $($item.FullName)"
+                }
+                foreach ($child in @(Get-ChildItem -LiteralPath $item.FullName -Force)) {
+                  if ($child.Attributes -band [System.IO.FileAttributes]::ReparsePoint) {
+                    throw "refusing an SC-19054 output reparse point: $($child.FullName)"
+                  }
+                  if ($child.PSIsContainer -or $outputFiles -notcontains $child.Name) {
+                    throw "refusing an unexpected SC-19054 output entry: $($child.FullName)"
+                  }
+                }
+              } elseif ($rootFiles -notcontains $item.Name) {
+                throw "refusing an unexpected SC-19054 scratch file: $($item.FullName)"
+              }
+            }
+            if (Test-Path -LiteralPath $output) {
+              Get-ChildItem -LiteralPath $output -File -Force |
+                ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force }
+              Remove-Item -LiteralPath $output -Force
+            }
+            Get-ChildItem -LiteralPath $ScratchPath -File -Force |
+              ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force }
+            Remove-Item -LiteralPath $ScratchPath -Force
           }
           $evidence = Resolve-Sc19054ScratchPath $env:SC19054_EVIDENCE_DIR $env:RUNNER_TEMP
           $expectedEvidence = [System.IO.Path]::GetFullPath(
@@ -1144,7 +1216,7 @@ jobs:
           if (-not [string]::Equals($evidence, $expectedEvidence, [StringComparison]::OrdinalIgnoreCase)) {
             throw "refusing to clean an SC-19054 path from another run attempt: $evidence"
           }
-          if (Test-Path -LiteralPath $evidence) { Remove-Item -LiteralPath $evidence -Recurse -Force }
+          Remove-Sc19054ScratchTree $evidence
       # sc-17592, the off-Mac mirror of macos-mlx.yml's MLX step. THE ONLY PR LANE THAT CAN PRODUCE
       # capabilities.candle.json, so it is the only place the checked-in file can be checked against
       # a real registry rather than taken on trust. (desktop-windows.yml builds the candle sidecar on

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -777,7 +777,14 @@ function assertSc19054FluxAcceptanceContract({ workflow, rust }, context = "SC-1
   for (const body of [seal, cleanup]) {
     assert.match(body, /\[string\]::Equals\(\$parent, \$tempRoot, \[StringComparison\]::OrdinalIgnoreCase\)/);
     assert.match(body, /\^sc19054-flux-acceptance-\[0-9\]\+-\[0-9\]\+\$/);
-    assert.match(body, /\.Attributes -band \[System\.IO\.FileAttributes\]::ReparsePoint/);
+    assert.ok(
+      (body.match(/\.Attributes -band \[System\.IO\.FileAttributes\]::ReparsePoint/g) ?? []).length >= 3,
+      `${context}: cleanup must reject root, direct-child, and output-child reparse points`,
+    );
+    assert.match(body, /\$child\.PSIsContainer -or \$outputFiles -notcontains \$child\.Name/);
+    assert.match(body, /\$rootFiles = @\('identity\.json', 'model-files\.json', 'acceptance\.log', 'SHA256SUMS\.txt'\)/);
+    assert.match(body, /\$outputFiles = @\('sc19054-flux-acceptance\.json', 'sc19054-flux-schnell-q4-1024\.png'\)/);
+    assert.doesNotMatch(body, /Remove-Item[^\n]*-Recurse/, `${context}: deletion must be inventoried and non-recursive`);
     assert.match(
       body,
       /Join-Path \$env:RUNNER_TEMP "sc19054-flux-acceptance-\$env:GITHUB_RUN_ID-\$env:GITHUB_RUN_ATTEMPT"/,
@@ -787,9 +794,16 @@ function assertSc19054FluxAcceptanceContract({ workflow, rust }, context = "SC-1
   }
   assert.match(
     seal,
-    /Get-ChildItem -LiteralPath \$env:RUNNER_TEMP -Directory -Force[\s\S]*Where-Object \{ \$_.Name -match '\^sc19054-flux-acceptance-\[0-9\]\+-\[0-9\]\+\$' \}[\s\S]*Remove-Item -LiteralPath \$stale -Recurse -Force/,
-    `${context}: the next exact dispatch must reclaim only bounded prior SC-19054 scratch`,
+    /Join-Path \$env:RUNNER_TEMP 'sc19054-flux-acceptance-32551460830-1'/,
+    `${context}: the next dispatch must reclaim only the one uploaded completed residue`,
   );
+  assert.match(seal, /Remove-Sc19054ScratchTree \$completedResidue/);
+  assert.doesNotMatch(
+    seal,
+    /Get-ChildItem -LiteralPath \$env:RUNNER_TEMP/,
+    `${context}: cleanup must never enumerate concurrent SC-19054 sibling attempts`,
+  );
+  assert.match(cleanup, /Remove-Sc19054ScratchTree \$evidence/);
 
   for (const exact of [
     'const MODEL_ID: &str = "flux_schnell";',
@@ -854,6 +868,9 @@ test("SC-19054 FLUX acceptance binds the exact admission cell to one real Candle
     ["cleanup admits nested paths", "workflow", "-not [string]::Equals($parent, $tempRoot, [StringComparison]::OrdinalIgnoreCase) -or", "$false -or"],
     ["cleanup admits near-name paths", "workflow", "^sc19054-flux-acceptance-[0-9]+-[0-9]+$", "^sc19054-flux-acceptance-"],
     ["cleanup follows reparse points", "workflow", ".Attributes -band [System.IO.FileAttributes]::ReparsePoint", ".Attributes -band [System.IO.FileAttributes]::Normal"],
+    ["cleanup admits a nested output directory", "workflow", "$child.PSIsContainer -or $outputFiles -notcontains $child.Name", "$false -or $outputFiles -notcontains $child.Name"],
+    ["cleanup deletes recursively", "workflow", "Remove-Item -LiteralPath $ScratchPath -Force", "Remove-Item -LiteralPath $ScratchPath -Recurse -Force"],
+    ["cleanup sweeps another completed attempt", "workflow", "sc19054-flux-acceptance-32551460830-1", "sc19054-flux-acceptance-32551460831-1"],
     ["cleanup accepts a wrong attempt", "workflow", "[string]::Equals($evidence, $expectedEvidence, [StringComparison]::OrdinalIgnoreCase)", "$true"],
   ];
   for (const [name, key, from, to] of mutations) {
@@ -894,7 +911,7 @@ test("SC-19054 FLUX acceptance binds the exact admission cell to one real Candle
   assert.equal(withinPeakTolerance(24.2320000011, 24.232), false);
   assert.equal(withinPeakTolerance(Number.NaN, 24.232), false);
 
-  // Independent Windows-path model of the production guard: canonical prefix plus exact parent
+  // Independent Windows-path model of the production guard: exact canonical parent equality
   // prevents both prefix siblings and nested deletions; the closed leaf grammar excludes caches
   // and lookalikes. The first case is the exact path the failed always-cleanup rejected.
   const isBoundedScratch = (candidate, runnerTemp) => {
@@ -920,6 +937,42 @@ test("SC-19054 FLUX acceptance binds the exact admission cell to one real Candle
     windowsPath.resolve(runnerTemp, `sc19054-flux-acceptance-${runId}-${attempt}`).toLowerCase();
   assert.equal(isExactAttempt(failedAttempt, "32551460830", "1"), true);
   assert.equal(isExactAttempt(failedAttempt, "32551460830", "2"), false);
+  const knownResidue = windowsPath.resolve(runnerTemp, "sc19054-flux-acceptance-32551460830-1");
+  assert.equal(windowsPath.resolve(failedAttempt), knownResidue);
+  assert.notEqual(
+    windowsPath.resolve(runnerTemp, "sc19054-flux-acceptance-32551460831-1"),
+    knownResidue,
+    "a concurrent sibling attempt must never be swept with the one known completed residue",
+  );
+  const closedInventoryAccepts = (rootEntries, outputEntries) =>
+    rootEntries.every(
+      ({ name, directory, reparse }) =>
+        !reparse &&
+        (directory
+          ? name === "output"
+          : ["identity.json", "model-files.json", "acceptance.log", "SHA256SUMS.txt"].includes(name)),
+    ) &&
+    outputEntries.every(
+      ({ name, directory, reparse }) =>
+        !reparse &&
+        !directory &&
+        ["sc19054-flux-acceptance.json", "sc19054-flux-schnell-q4-1024.png"].includes(name),
+    );
+  assert.equal(
+    closedInventoryAccepts(
+      [{ name: "output", directory: true, reparse: false }],
+      [{ name: "sc19054-flux-acceptance.json", directory: false, reparse: false }],
+    ),
+    true,
+  );
+  assert.equal(
+    closedInventoryAccepts(
+      [{ name: "output", directory: true, reparse: false }],
+      [{ name: "escape", directory: true, reparse: true }],
+    ),
+    false,
+    "a nested reparse escape must fail the complete inventory before any deletion",
+  );
 });
 
 // sc-18691 AC2. Decoupling must not turn a genuine provisioning failure into a silent skip. With

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { readFile, readdir } from "node:fs/promises";
+import { win32 as windowsPath } from "node:path";
 import test from "node:test";
 
 import { SOURCE_PATHS } from "./generate-memory-matrix.mjs";
@@ -752,8 +753,10 @@ function assertSc19054FluxAcceptanceContract({ workflow, rust }, context = "SC-1
     "$event.sequentialCapable -ne $true",
     "$event.oldPlan -ne 'resident'",
     "$event.selectedPlan -ne 'sequential'",
-    "$event.widenedResidentPeakGb -ne 24.232",
-    "$event.widenedSequentialPeakGb -ne 21.216",
+    "$peakToleranceGb = 0.000000001",
+    "[Math]::Abs($value - $Expected) -lt $peakToleranceGb",
+    "-not (Test-Sc19054Peak $event.widenedResidentPeakGb 24.232)",
+    "-not (Test-Sc19054Peak $event.widenedSequentialPeakGb 21.216)",
     "$receipt.runtime.stageResidency -ne $true",
     "$receipt.runtime.backend -ne 'candle'",
     "$receipt.runtime.vramCapGb -ne 24",
@@ -771,7 +774,22 @@ function assertSc19054FluxAcceptanceContract({ workflow, rust }, context = "SC-1
     /if: \$\{\{ always\(\) && github\.event_name == 'workflow_dispatch' && inputs\.run_sc19054_flux_acceptance \}\}/,
   );
   assert.match(cleanup, /\$env:SC19054_EVIDENCE_DIR/);
-  assert.match(cleanup, /StartsWith\('sc19054-flux-acceptance-'\)/);
+  for (const body of [seal, cleanup]) {
+    assert.match(body, /\[string\]::Equals\(\$parent, \$tempRoot, \[StringComparison\]::OrdinalIgnoreCase\)/);
+    assert.match(body, /\^sc19054-flux-acceptance-\[0-9\]\+-\[0-9\]\+\$/);
+    assert.match(body, /\.Attributes -band \[System\.IO\.FileAttributes\]::ReparsePoint/);
+    assert.match(
+      body,
+      /Join-Path \$env:RUNNER_TEMP "sc19054-flux-acceptance-\$env:GITHUB_RUN_ID-\$env:GITHUB_RUN_ATTEMPT"/,
+    );
+    assert.match(body, /\[string\]::Equals\(\$evidence, \$expectedEvidence, \[StringComparison\]::OrdinalIgnoreCase\)/);
+    assert.doesNotMatch(body, /\.StartsWith\(/, `${context}: scratch trust must use exact canonical parent/path equality`);
+  }
+  assert.match(
+    seal,
+    /Get-ChildItem -LiteralPath \$env:RUNNER_TEMP -Directory -Force[\s\S]*Where-Object \{ \$_.Name -match '\^sc19054-flux-acceptance-\[0-9\]\+-\[0-9\]\+\$' \}[\s\S]*Remove-Item -LiteralPath \$stale -Recurse -Force/,
+    `${context}: the next exact dispatch must reclaim only bounded prior SC-19054 scratch`,
+  );
 
   for (const exact of [
     'const MODEL_ID: &str = "flux_schnell";',
@@ -829,6 +847,14 @@ test("SC-19054 FLUX acceptance binds the exact admission cell to one real Candle
     ["hardcoded sequential capability", "rust", "admission_contract(descriptor.capabilities.supports_sequential_offload)", "admission_contract(true)"],
     ["disconnected admission", "rust", "let execution = acceptance_execution(&root, admission);", "let execution = acceptance_execution(&root, admission_contract(true));"],
     ["request drops selected memory", "rust", "memory: Some(execution.memory)", "memory: None"],
+    ["removed peak tolerance", "workflow", "$peakToleranceGb = 0.000000001", "$peakToleranceGb = 0"],
+    ["broadened peak tolerance", "workflow", "$peakToleranceGb = 0.000000001", "$peakToleranceGb = 0.000001"],
+    ["resident peak unchecked", "workflow", "-not (Test-Sc19054Peak $event.widenedResidentPeakGb 24.232)", "$false"],
+    ["sequential peak unchecked", "workflow", "-not (Test-Sc19054Peak $event.widenedSequentialPeakGb 21.216)", "$false"],
+    ["cleanup admits nested paths", "workflow", "-not [string]::Equals($parent, $tempRoot, [StringComparison]::OrdinalIgnoreCase) -or", "$false -or"],
+    ["cleanup admits near-name paths", "workflow", "^sc19054-flux-acceptance-[0-9]+-[0-9]+$", "^sc19054-flux-acceptance-"],
+    ["cleanup follows reparse points", "workflow", ".Attributes -band [System.IO.FileAttributes]::ReparsePoint", ".Attributes -band [System.IO.FileAttributes]::Normal"],
+    ["cleanup accepts a wrong attempt", "workflow", "[string]::Equals($evidence, $expectedEvidence, [StringComparison]::OrdinalIgnoreCase)", "$true"],
   ];
   for (const [name, key, from, to] of mutations) {
     const mutated = { ...documents, [key]: documents[key].replaceAll(from, to) };
@@ -856,6 +882,44 @@ test("SC-19054 FLUX acceptance binds the exact admission cell to one real Candle
     /bounded evidence path must reach GITHUB_ENV/,
     "cleanup must retain the attempt path when the first failable seal check aborts",
   );
+
+  // The exact failed Windows receipt is inside the Rust contract's strict 1e-9 GiB delta, while
+  // the boundary and anything beyond it remain hard failures. This pins the numeric policy
+  // independently of the PowerShell spelling above.
+  const withinPeakTolerance = (actual, expected) =>
+    Number.isFinite(actual) && Math.abs(actual - expected) < 0.000000001;
+  assert.ok(withinPeakTolerance(24.23200000077486, 24.232));
+  assert.ok(withinPeakTolerance(21.216000000946224, 21.216));
+  assert.equal(withinPeakTolerance(24.232000001, 24.232), false);
+  assert.equal(withinPeakTolerance(24.2320000011, 24.232), false);
+  assert.equal(withinPeakTolerance(Number.NaN, 24.232), false);
+
+  // Independent Windows-path model of the production guard: canonical prefix plus exact parent
+  // prevents both prefix siblings and nested deletions; the closed leaf grammar excludes caches
+  // and lookalikes. The first case is the exact path the failed always-cleanup rejected.
+  const isBoundedScratch = (candidate, runnerTemp) => {
+    const resolved = windowsPath.resolve(candidate);
+    const tempRoot = windowsPath.resolve(runnerTemp).replace(/[\\/]+$/, "");
+    return (
+      windowsPath.dirname(resolved).toLowerCase() === tempRoot.toLowerCase() &&
+      /^sc19054-flux-acceptance-[0-9]+-[0-9]+$/.test(windowsPath.basename(resolved))
+    );
+  };
+  const runnerTemp = "D:\\actions-runner-2\\_work\\_temp";
+  const failedAttempt = `${runnerTemp}\\sc19054-flux-acceptance-32551460830-1`;
+  assert.ok(
+    isBoundedScratch(failedAttempt, runnerTemp),
+  );
+  assert.equal(isBoundedScratch(`${runnerTemp}\\nested\\sc19054-flux-acceptance-1-1`, runnerTemp), false);
+  assert.equal(isBoundedScratch(`${runnerTemp}-other\\sc19054-flux-acceptance-1-1`, runnerTemp), false);
+  assert.equal(isBoundedScratch(`${runnerTemp}\\sc19054-flux-acceptance-1-1-cache`, runnerTemp), false);
+  assert.equal(isBoundedScratch(`${runnerTemp}\\sc19057-wan-capture-32551460830-1`, runnerTemp), false);
+  assert.equal(isBoundedScratch("C:\\Users\\Michael\\.cache\\huggingface", runnerTemp), false);
+  const isExactAttempt = (candidate, runId, attempt) =>
+    windowsPath.resolve(candidate).toLowerCase() ===
+    windowsPath.resolve(runnerTemp, `sc19054-flux-acceptance-${runId}-${attempt}`).toLowerCase();
+  assert.equal(isExactAttempt(failedAttempt, "32551460830", "1"), true);
+  assert.equal(isExactAttempt(failedAttempt, "32551460830", "2"), false);
 });
 
 // sc-18691 AC2. Decoupling must not turn a genuine provisioning failure into a silent skip. With


### PR DESCRIPTION
## Summary

- match the existing Rust SC-19054 contract with a strict `< 1e-9 GiB` tolerance for only the two derived widened peak fields; all non-derived receipt and event fields remain exact
- canonicalize scratch paths and require an exact direct `RUNNER_TEMP` child, closed SC-19054 run/attempt leaf, and exact active run/attempt path
- reclaim only the one known completed residue `sc19054-flux-acceptance-32551460830-1`; never enumerate or sweep other SC-19054 attempts on the shared physical runner
- inventory a closed set of acceptance files, reject root/direct-child/output-child reparse points and all unexpected or nested entries, then remove individual files and empty directories without recursive deletion
- add mutation-sensitive workflow contracts for tolerance removal/widening, omitted peak checks, concurrent siblings, nested/reparse escapes, recursive deletion, unsafe paths, and wrong attempts

## Failure evidence

Failing run/job: `32551460830` / `96978796880`; artifact `9470472931` (`sc-19054-flux-candle-32551460830-1`). The real render and receipt passed. PowerShell exact equality rejected f32/JSON values `24.23200000077486` and `21.216000000946224`; cleanup then rejected the valid path `D:\actions-runner-2\_work\_temp\sc19054-flux-acceptance-32551460830-1`. The GitHub artifact was downloaded and retained outside the repository before implementing the exact one-shot cleanup.

## Validation

- `actionlint .github/workflows/windows-candle.yml`
- `node --test scripts/platform-review-contracts.test.mjs scripts/sc19057-wan-capture-workflow.test.mjs` (78/78)
- `npm run check` (750/750)
- `npm run rust:check:candle`
- `cargo clippy --all-targets -- -D warnings`
- `npm run check:rust-derived-docs`
- `cargo fmt --all -- --check`
- `git diff --check`

CPU-only validation; no CUDA/MLX device work, real-weight render, calibration, or terminal workflow was dispatched.