### PR TITLE
SC-19057: transport Candle provider argv without PowerShell JSON quoting

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -1288,15 +1288,49 @@ jobs:
           INFERENCE_REVISION: ${{ inputs.inference_revision }}
         run: |
           $env:SCENEWORKS_WAN_ROOT = $env:SCENEWORKS_PROVISIONED_ROOT
-          $adapter = (Resolve-Path -LiteralPath 'target\release\memory-candle-adapter.exe').Path
-          $provider = ConvertTo-Json -Compress -InputObject @($adapter)
+          $providerCommandFile = Join-Path $env:RUNNER_TEMP "sc-19057-provider-command-$($env:GITHUB_RUN_ID)-$($env:GITHUB_RUN_ATTEMPT).json"
+          $providerCommandTemporary = "$providerCommandFile.tmp"
+          $providerTransportReceipt = Join-Path $env:SC19057_EVIDENCE_DIR 'provider-command-transport.json'
+          $expectedAdapter = Join-Path $env:GITHUB_WORKSPACE 'target\release\memory-candle-adapter.exe'
+          $transport = [ordered]@{
+            schemaVersion = 1
+            story = 'SC-19057'
+            status = 'STARTED'
+            runnerName = $env:RUNNER_NAME
+            runId = $env:GITHUB_RUN_ID
+            runAttempt = $env:GITHUB_RUN_ATTEMPT
+            head = $env:GITHUB_SHA
+            providerExecutable = $expectedAdapter
+            providerCommandFile = $providerCommandFile
+          }
+          $transport | ConvertTo-Json -Depth 3 | Out-File -LiteralPath $providerTransportReceipt -Encoding utf8
+          try {
+            $adapter = (Resolve-Path -LiteralPath $expectedAdapter).Path
+            $transport.providerExecutable = $adapter
+            if ((Test-Path -LiteralPath $providerCommandFile) -or (Test-Path -LiteralPath $providerCommandTemporary)) {
+              throw "SC-19057 provider command transport already exists for this exact attempt"
+            }
+            $providerJson = ConvertTo-Json -Compress -InputObject @([string]$adapter)
+            $utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+            [System.IO.File]::WriteAllText($providerCommandTemporary, "$providerJson`n", $utf8WithoutBom)
+            Move-Item -LiteralPath $providerCommandTemporary -Destination $providerCommandFile
+            $transport.status = 'READY'
+            $transport.providerCommandFileSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $providerCommandFile).Hash.ToLowerInvariant()
+            $transport | ConvertTo-Json -Depth 3 | Out-File -LiteralPath $providerTransportReceipt -Encoding utf8
+          } catch {
+            $transport.status = 'FAIL'
+            $transport.error = $_.Exception.Message
+            $transport | ConvertTo-Json -Depth 3 | Out-File -LiteralPath $providerTransportReceipt -Encoding utf8
+            throw
+          }
           $capture = Join-Path $env:SC19057_EVIDENCE_DIR 'wan-candle-video-sc-19057.json'
           $receipt = Join-Path $env:SC19057_EVIDENCE_DIR 'wan-candle-video-sc-19057.acceptance.json'
           node scripts\memory-calibration-harness.mjs run `
             --config docs\calibration\sc-19057\wan-candle-video-capture-plan.json `
             --backend candle `
             --fresh-per-case `
-            --provider-command $provider `
+            --provider-cmd-json-file $providerCommandFile `
+            --provider-executable $adapter `
             --sceneworks-repo $env:GITHUB_WORKSPACE `
             --inference-repo "$env:GITHUB_WORKSPACE\.calibration\inference" `
             --output $capture
@@ -1593,7 +1627,9 @@ jobs:
           $allowedRoot = [System.IO.Path]::GetFullPath($env:RUNNER_TEMP).TrimEnd('\') + '\'
           $targets = @(
             (Join-Path $env:GITHUB_WORKSPACE '.calibration'),
-            (Join-Path $env:RUNNER_TEMP "sc-19057-wan-$($env:GITHUB_RUN_ID)-$($env:GITHUB_RUN_ATTEMPT)")
+            (Join-Path $env:RUNNER_TEMP "sc-19057-wan-$($env:GITHUB_RUN_ID)-$($env:GITHUB_RUN_ATTEMPT)"),
+            (Join-Path $env:RUNNER_TEMP "sc-19057-provider-command-$($env:GITHUB_RUN_ID)-$($env:GITHUB_RUN_ATTEMPT).json"),
+            (Join-Path $env:RUNNER_TEMP "sc-19057-provider-command-$($env:GITHUB_RUN_ID)-$($env:GITHUB_RUN_ATTEMPT).json.tmp")
           )
           foreach ($target in $targets) {
             if (-not $target) { continue }

--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -1751,9 +1751,12 @@ set to an absolute runner-local cache path. It does not change the sealed artifa
 Do not dispatch while another CUDA/real-weight workflow occupies the shared physical lane. The job
 checks out both exact sources, verifies the closure ledger before capture, anonymously provisions
 and hashes the 25-file/17,338,835,457-byte q4 artifact, maps all three `SCENEWORKS_WAN_*` variables,
+atomically writes the exact one-element provider argv to bounded runner scratch (PowerShell native
+argv does not preserve inline JSON quotes), authenticates it against the resolved release adapter,
 captures outside the checkout, validates exact 6/6 acceptance, and uploads the raw bundle plus plan,
-artifact inventory, acceptance receipt, run identity, and SHA-256 manifest. Its bounded cleanup
-removes only job scratch and the nested inference checkout; the exact q4 hub cache is retained.
+artifact inventory, provider-transport preflight, acceptance receipt, run identity, and SHA-256
+manifest. Its bounded cleanup removes the exact transport file, job scratch, and nested inference
+checkout; the exact q4 hub cache is retained.
 
 ### 12f. Verify the receipt before believing it
 

--- a/docs/memory-calibration-harness.md
+++ b/docs/memory-calibration-harness.md
@@ -94,6 +94,14 @@ stdin and expects one JSON response on stdout:
 3. `{ "action": "run_batch", "planned": [...], ... }` → `{ "modelLoads": 1, "fragments": [...] }`
 4. `{ "action": "assess_batch", "planned": [...] }` → an explicit reuse-eligibility verdict
 
+On a native shell that does not preserve JSON quotes across its process boundary, write the argv
+array atomically to an absolute file outside both repository checkouts and the capture-output
+directory, then use `--provider-cmd-json-file <file> --provider-executable <absolute executable>`.
+The file form is deliberately narrower than inline `--provider-command`: it accepts exactly one
+non-empty absolute argv string, rejects symlink/reparse aliases and repository/evidence paths, and
+requires that string to resolve to the independently supplied executable identity. Supplying both
+forms, neither form, extra argv entries, or a substituted executable fails before provider startup.
+
 `modelLoadPolicy: "batch_rungs"` plus a shared `modelLoadGroup` schedules pending cases for one
 target, backend, and fixture in canonical rung order. When multiple parameter points are pending for
 one rung, the runner selects one for the batch; a returned complete sweep can then retire the others.

--- a/scripts/memory-calibration-harness.mjs
+++ b/scripts/memory-calibration-harness.mjs
@@ -1864,6 +1864,9 @@ export async function readExactProviderCommandFile(
     fail("provider command file must contain exactly one argv string");
   }
   text(parsed[0], "provider command file argv[0]");
+  if (parsed[0].includes("\0")) {
+    fail("provider command file argv[0] must not contain NUL bytes");
+  }
   if (!path.isAbsolute(parsed[0])) {
     fail("provider command file argv[0] must be an absolute executable path");
   }

--- a/scripts/memory-calibration-harness.mjs
+++ b/scripts/memory-calibration-harness.mjs
@@ -2,7 +2,7 @@
 
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, readFile, realpath, rename, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, realpath, rename, writeFile } from "node:fs/promises";
 import { createReadStream, readFileSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
@@ -1808,6 +1808,120 @@ export async function atomicWrite(file, value) {
   await rename(temporary, destination);
 }
 
+function sameFilesystemPath(left, right) {
+  return process.platform === "win32"
+    ? left.toLowerCase() === right.toLowerCase()
+    : left === right;
+}
+
+function isWithin(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+export async function readExactProviderCommandFile(
+  file,
+  { expectedExecutable, forbiddenRoots = [] } = {},
+) {
+  if (!file || !path.isAbsolute(file)) {
+    fail("--provider-cmd-json-file must be an absolute path");
+  }
+  if (!expectedExecutable || !path.isAbsolute(expectedExecutable)) {
+    fail("--provider-executable must be an absolute path with --provider-cmd-json-file");
+  }
+  const commandFile = path.resolve(file);
+  let metadata;
+  let canonicalCommandFile;
+  try {
+    [metadata, canonicalCommandFile] = await Promise.all([lstat(commandFile), realpath(commandFile)]);
+  } catch (error) {
+    fail(`could not inspect provider command file ${commandFile}: ${error.message}`);
+  }
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    fail("provider command file must be a regular non-symlink file");
+  }
+  if (!sameFilesystemPath(canonicalCommandFile, commandFile)) {
+    fail("provider command file path must not traverse a symlink or reparse point");
+  }
+  for (const root of forbiddenRoots.filter(Boolean).map((candidate) => path.resolve(candidate))) {
+    let canonicalRoot;
+    try {
+      canonicalRoot = await realpath(root);
+    } catch (error) {
+      fail(`could not authenticate forbidden provider-command root ${root}: ${error.message}`);
+    }
+    if (isWithin(canonicalRoot, canonicalCommandFile)) {
+      fail(`provider command file must be outside ${canonicalRoot}`);
+    }
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(await readFile(commandFile, "utf8"));
+  } catch (error) {
+    fail(`provider command file must contain valid JSON: ${error.message}`);
+  }
+  if (!Array.isArray(parsed) || parsed.length !== 1) {
+    fail("provider command file must contain exactly one argv string");
+  }
+  text(parsed[0], "provider command file argv[0]");
+  if (!path.isAbsolute(parsed[0])) {
+    fail("provider command file argv[0] must be an absolute executable path");
+  }
+  const commandPath = path.resolve(parsed[0]);
+  const expectedPath = path.resolve(expectedExecutable);
+  let commandMetadata;
+  let expectedMetadata;
+  let canonicalCommand;
+  let canonicalExpected;
+  try {
+    [commandMetadata, expectedMetadata, canonicalCommand, canonicalExpected] = await Promise.all([
+      lstat(commandPath),
+      lstat(expectedPath),
+      realpath(commandPath),
+      realpath(expectedPath),
+    ]);
+  } catch (error) {
+    fail(`could not authenticate provider executable identity: ${error.message}`);
+  }
+  if (!commandMetadata.isFile() || commandMetadata.isSymbolicLink()
+      || !expectedMetadata.isFile() || expectedMetadata.isSymbolicLink()) {
+    fail("provider executable identity must name a regular non-symlink file");
+  }
+  if (!sameFilesystemPath(commandPath, expectedPath)
+      || !sameFilesystemPath(canonicalCommand, canonicalExpected)) {
+    fail("provider command file argv[0] does not match --provider-executable");
+  }
+  return [canonicalExpected];
+}
+
+async function providerCommandFromArgs({ args, forbiddenRoots = [] }) {
+  const exactValue = (flag) => {
+    const indexes = args.flatMap((candidate, index) => candidate === flag ? [index] : []);
+    if (indexes.length > 1) fail(`${flag} may be supplied only once`);
+    if (!indexes.length) return undefined;
+    const candidate = args[indexes[0] + 1];
+    if (!candidate || candidate.startsWith("--")) fail(`${flag} requires one value`);
+    return candidate;
+  };
+  const inline = exactValue("--provider-command");
+  const file = exactValue("--provider-cmd-json-file");
+  const expectedExecutable = exactValue("--provider-executable");
+  if (Boolean(inline) === Boolean(file)) {
+    fail("supply exactly one of --provider-command or --provider-cmd-json-file");
+  }
+  if (file) {
+    return readExactProviderCommandFile(file, { expectedExecutable, forbiddenRoots });
+  }
+  if (expectedExecutable || args.includes("--provider-cmd-json-file")) {
+    fail("--provider-executable is valid only with --provider-cmd-json-file");
+  }
+  try {
+    return JSON.parse(inline);
+  } catch (error) {
+    fail(`--provider-command must be valid JSON: ${error.message}`);
+  }
+}
+
 async function main() {
   const [command, ...args] = process.argv.slice(2);
   const value = (flag) => {
@@ -1858,11 +1972,17 @@ async function main() {
   }
   if (command === "run") {
     const outputPath = value("--output");
+    const sceneWorksRepo = path.resolve(value("--sceneworks-repo"));
+    const inferenceRepo = path.resolve(value("--inference-repo"));
+    const providerCommand = await providerCommandFromArgs({
+      args,
+      forbiddenRoots: [sceneWorksRepo, inferenceRepo, path.dirname(path.resolve(outputPath))],
+    });
     const output = await runProviderPlan({
       config: await readJson(value("--config")),
-      providerCommand: JSON.parse(value("--provider-command")),
-      sceneWorksRepo: path.resolve(value("--sceneworks-repo")),
-      inferenceRepo: path.resolve(value("--inference-repo")),
+      providerCommand,
+      sceneWorksRepo,
+      inferenceRepo,
       resume: value("--resume") ? await readJson(value("--resume")) : undefined,
       backend: value("--backend"),
       providerName: value("--provider"),

--- a/scripts/memory-calibration-harness.test.mjs
+++ b/scripts/memory-calibration-harness.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile, spawn } from "node:child_process";
-import { mkdir, mkdtemp, readFile, realpath, readdir, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -32,22 +32,199 @@ const execFileAsync = promisify(execFile);
 
 const HARNESS_PATH = fileURLToPath(new URL("./memory-calibration-harness.mjs", import.meta.url));
 
-async function assertProviderFileCliRejects({ commandFile, expectedExecutable, message }) {
-  const evidence = path.join(path.dirname(commandFile), "evidence");
+async function assertProviderFileCliRejects({
+  commandFile,
+  expectedExecutable,
+  message,
+  evidence = path.join(path.dirname(commandFile), "evidence"),
+  sceneWorksRepo = fileURLToPath(new URL("..", import.meta.url)),
+  inferenceRepo = sceneWorksRepo,
+  env = process.env,
+  marker,
+}) {
   await mkdir(evidence, { recursive: true });
+  if (marker) await rm(marker, { force: true });
   await assert.rejects(
     execFileAsync(process.execPath, [
       HARNESS_PATH,
       "run",
       "--provider-cmd-json-file", commandFile,
       "--provider-executable", expectedExecutable,
-      "--sceneworks-repo", fileURLToPath(new URL("..", import.meta.url)),
-      "--inference-repo", fileURLToPath(new URL("..", import.meta.url)),
+      "--sceneworks-repo", sceneWorksRepo,
+      "--inference-repo", inferenceRepo,
       "--output", path.join(evidence, "capture.json"),
       "--config", path.join(path.dirname(commandFile), "must-not-be-read.json"),
-    ]),
+    ], { env }),
     message,
   );
+  if (marker) {
+    await assert.rejects(readFile(marker, "utf8"), { code: "ENOENT" });
+  }
+}
+
+async function createProviderCliFixture() {
+  const scratch = await realpath(await mkdtemp(path.join(tmpdir(), "memory-provider-cli-e2e-")));
+  const sceneWorksRepo = path.join(scratch, "SceneWorks");
+  const inferenceRepo = path.join(scratch, "inference");
+  const evidence = path.join(scratch, "evidence");
+  await mkdir(path.join(sceneWorksRepo, "docs/generated"), { recursive: true });
+  await mkdir(path.join(sceneWorksRepo, "config"), { recursive: true });
+  await mkdir(path.join(inferenceRepo, "crates/fixture/src"), { recursive: true });
+  await mkdir(evidence, { recursive: true });
+  await writeFile(
+    path.join(sceneWorksRepo, "docs/generated/memory-matrix.json"),
+    JSON.stringify({ generatedFrom: { sceneWorksRevision: `source-tree:${"1".repeat(64)}` } }),
+  );
+  await writeFile(
+    path.join(sceneWorksRepo, "config/inference-provider-closures.json"),
+    JSON.stringify({
+      providers: {
+        "candle:fixture": { crate: "crates/fixture", digest: "2".repeat(64) },
+      },
+    }),
+  );
+  await writeFile(
+    path.join(inferenceRepo, "Cargo.toml"),
+    '[workspace]\nmembers = ["crates/fixture"]\nresolver = "2"\n',
+  );
+  await writeFile(
+    path.join(inferenceRepo, "Cargo.lock"),
+    'version = 3\n\n[[package]]\nname = "fixture"\nversion = "0.1.0"\n',
+  );
+  await writeFile(
+    path.join(inferenceRepo, "crates/fixture/Cargo.toml"),
+    '[package]\nname = "fixture"\nversion = "0.1.0"\nedition = "2021"\n',
+  );
+  await writeFile(
+    path.join(inferenceRepo, "crates/fixture/src/lib.rs"),
+    'pub const PROVIDER: &str = "fixture";\n',
+  );
+  for (const repo of [sceneWorksRepo, inferenceRepo]) {
+    await execFileAsync("git", ["init", repo]);
+    await execFileAsync("git", ["-C", repo, "config", "user.email", "fixture@example.invalid"]);
+    await execFileAsync("git", ["-C", repo, "config", "user.name", "Fixture"]);
+    await execFileAsync("git", ["-C", repo, "add", "."]);
+    await execFileAsync("git", ["-C", repo, "commit", "-m", "fixture"]);
+  }
+  const config = path.join(scratch, "plan.json");
+  await writeFile(config, JSON.stringify({
+    providers: [{
+      evidenceScope: "fixture",
+      backend: "candle",
+      loadShape: "eager_materialization",
+      target: {
+        modelId: "fixture",
+        provider: "fixture",
+        tier: "q4",
+        mode: "text_to_image",
+        overlay: "none",
+        geometry: { width: 1024, height: 1024, batch: 1, frames: 1 },
+      },
+      rung: "bounded_decode",
+      engagedRungs: ["resident", "bounded_decode"],
+      calibrationFingerprint: "provider-command-file-e2e-v1",
+      fixture: "provider-command-file-e2e",
+      cases: [{
+        parameters: { decodeTileEdge: 512, decodeOverlap: 128 },
+        expectedResult: "passed",
+      }],
+    }],
+  }));
+  const marker = path.join(scratch, "provider-invocations.txt");
+  const preload = path.join(scratch, "provider-preload.cjs");
+  await writeFile(preload, String.raw`
+if (process.argv.length === 1 && process.env.MEMORY_PROVIDER_MARKER) {
+  const fs = require("node:fs");
+  const request = JSON.parse(fs.readFileSync(0, "utf8"));
+  fs.appendFileSync(process.env.MEMORY_PROVIDER_MARKER, request.action + "\n");
+  if (request.action === "probe") {
+    process.stdout.write(JSON.stringify({ hardware: {
+      probe: "spawned provider-command transport fixture",
+      memoryBytes: 51539607552,
+      deviceId: "fixture:0",
+      name: "Fixture CUDA",
+      computeCapability: "9.0",
+      driverVersion: "999.1",
+      runtimeVersion: "12.8"
+    } }));
+    process.exit(0);
+  }
+  const planned = request.planned;
+  const parameters = planned.strategy.parameters;
+  const phase = (value) => ({ activeBytes: value, allocatorBytes: value + 10, reclaimableBytes: 10 });
+  process.stdout.write(JSON.stringify({
+    status: "complete",
+    strategy: planned.strategy,
+    loadShape: planned.loadShape,
+    artifact: { repository: "SceneWorks/fixture", resolvedRevision: "cccccccccccccccccccccccccccccccccccccccc", variant: "q4" },
+    sweep: {
+      axes: [{ parameter: "decodeTileEdge", testedValues: [384, 512] }],
+      cases: [
+        { parameters: { ...parameters, decodeTileEdge: 384 }, result: "passed" },
+        { parameters: { ...parameters, decodeTileEdge: 512 }, result: "passed" }
+      ],
+      rangeVerified: true
+    },
+    scenarios: [
+      { name: "exact_fit", result: "passed", predictedBytes: 200, effectiveBudgetBytes: 200 },
+      { name: "unknown_budget", result: "passed" },
+      { name: "stale_evidence", result: "passed" },
+      { name: "warm_repeat", result: "passed" },
+      { name: "cancel", result: "passed", cleanupVerified: true, warmFollowUpPassed: true },
+      { name: "error", result: "passed", cleanupVerified: true, warmFollowUpPassed: true },
+      { name: "loadability", result: "passed" },
+      { name: "overlay", result: "not_applicable", reason: "fixture has no overlay" }
+    ],
+    predictedPeakBytes: { conditioning: 100, denoise: 200, decode: 150, overall: 200 },
+    observedMemory: { conditioning: phase(100), denoise: phase(200), decode: phase(150), overall: phase(200) },
+    quality: {
+      contract: "tolerance", identicalLatents: true, result: "passed",
+      maximumError: 0.01, meanError: 0.001,
+      maximumErrorThreshold: 0.08, meanErrorThreshold: 0.01
+    },
+    negativeMutation: {
+      parameters: { decodeTileEdge: 256, decodeOverlap: 32 }, measured: true,
+      result: "failed_as_expected", maximumError: 0.09, meanError: 0.02
+    },
+    loadability: { result: "passed", resolvedPathFingerprint: "fixture@resolved:q4" },
+    capturedAt: "2026-08-22T12:00:00Z"
+  }));
+  process.exit(0);
+}
+`);
+  return {
+    scratch,
+    sceneWorksRepo,
+    inferenceRepo,
+    evidence,
+    config,
+    marker,
+    env: {
+      ...process.env,
+      NODE_OPTIONS: `--require=${preload}`,
+      MEMORY_PROVIDER_MARKER: marker,
+    },
+  };
+}
+
+async function runProviderCliFixture(fixture, providerArgs, outputName) {
+  await rm(fixture.marker, { force: true });
+  const output = path.join(fixture.evidence, outputName);
+  await execFileAsync(process.execPath, [
+    HARNESS_PATH,
+    "run",
+    ...providerArgs,
+    "--config", fixture.config,
+    "--backend", "candle",
+    "--fresh-per-case",
+    "--sceneworks-repo", fixture.sceneWorksRepo,
+    "--inference-repo", fixture.inferenceRepo,
+    "--output", output,
+  ], { env: fixture.env });
+  return {
+    bundle: JSON.parse(await readFile(output, "utf8")),
+    invocations: (await readFile(fixture.marker, "utf8")).trim().split("\n"),
+  };
 }
 
 test("file-backed provider argv preserves one exact executable without native-shell JSON quoting", async () => {
@@ -60,28 +237,64 @@ test("file-backed provider argv preserves one exact executable without native-sh
   );
 });
 
+test("spawned CLI connects both file-backed and legacy inline provider commands to a complete record", async () => {
+  const fixture = await createProviderCliFixture();
+  const commandFile = path.join(fixture.scratch, "provider-command.json");
+  await writeFile(commandFile, `${JSON.stringify([process.execPath])}\n`);
+  const fileBacked = await runProviderCliFixture(fixture, [
+    "--provider-cmd-json-file", commandFile,
+    "--provider-executable", process.execPath,
+  ], "file-backed.json");
+  assert.deepEqual(fileBacked.invocations, ["probe", "run"]);
+  assert.equal(fileBacked.bundle.records.length, 1);
+  assert.equal(fileBacked.bundle.records[0].status, "complete");
+
+  const inline = await runProviderCliFixture(fixture, [
+    "--provider-command", JSON.stringify([process.execPath]),
+  ], "inline.json");
+  assert.deepEqual(inline.invocations, ["probe", "run"]);
+  assert.equal(inline.bundle.records.length, 1);
+  assert.equal(inline.bundle.records[0].status, "complete");
+});
+
 test("spawned provider transport parsing rejects PowerShell quote loss and every in-file substitution", async () => {
-  const scratch = await realpath(await mkdtemp(path.join(tmpdir(), "memory-provider-command-cli-")));
-  const evidence = path.join(scratch, "evidence");
-  await mkdir(evidence, { recursive: true });
+  const fixture = await createProviderCliFixture();
+  const { scratch, evidence, sceneWorksRepo, inferenceRepo, env, marker } = fixture;
   const spawnHarness = (providerArgs) => execFileAsync(process.execPath, [
     HARNESS_PATH,
     "run",
     ...providerArgs,
-    "--sceneworks-repo", fileURLToPath(new URL("..", import.meta.url)),
-    "--inference-repo", fileURLToPath(new URL("..", import.meta.url)),
+    "--sceneworks-repo", sceneWorksRepo,
+    "--inference-repo", inferenceRepo,
     "--output", path.join(evidence, "capture.json"),
     "--config", path.join(scratch, "must-not-be-read.json"),
-  ]);
+  ], { env });
+  const assertZeroSpawnRejects = async (providerArgs, message, label) => {
+    await rm(marker, { force: true });
+    await assert.rejects(spawnHarness(providerArgs), message, label);
+    await assert.rejects(readFile(marker, "utf8"), { code: "ENOENT" });
+  };
   const cases = [
     ["malformed", "{not-json", /must contain valid JSON/],
     ["non-array", JSON.stringify(process.execPath), /exactly one argv string/],
+    ["empty", "[]", /exactly one argv string/],
+    ["non-string", JSON.stringify([42]), /argv\[0\] must be a non-empty string/],
     ["multiple", JSON.stringify([process.execPath, "--unexpected"]), /exactly one argv string/],
+    ["nul", JSON.stringify([`${process.execPath}\0suffix`]), /must not contain NUL bytes/],
   ];
   for (const [name, body, message] of cases) {
     const commandFile = path.join(scratch, `${name}.json`);
     await writeFile(commandFile, body);
-    await assertProviderFileCliRejects({ commandFile, expectedExecutable: process.execPath, message });
+    await assertProviderFileCliRejects({
+      commandFile,
+      expectedExecutable: process.execPath,
+      message,
+      evidence,
+      sceneWorksRepo,
+      inferenceRepo,
+      env,
+      marker,
+    });
   }
 
   const substitutedExecutable = path.join(scratch, "memory-candle-adapter-lookalike.exe");
@@ -92,13 +305,50 @@ test("spawned provider transport parsing rejects PowerShell quote loss and every
     commandFile: substituted,
     expectedExecutable: process.execPath,
     message: /does not match --provider-executable/,
+    evidence,
+    sceneWorksRepo,
+    inferenceRepo,
+    env,
+    marker,
   });
 
-  await assert.rejects(
-    spawnHarness([
-      "--provider-command", String.raw`[D:\actions-runner-2\_work\SceneWorks\target\release\memory-candle-adapter.exe]`,
-    ]),
+  const symlinkTarget = path.join(scratch, "symlink-target.json");
+  const symlinked = path.join(scratch, "symlinked.json");
+  await writeFile(symlinkTarget, JSON.stringify([process.execPath]));
+  await symlink(symlinkTarget, symlinked);
+  await assertProviderFileCliRejects({
+    commandFile: symlinked,
+    expectedExecutable: process.execPath,
+    message: /regular non-symlink file/,
+    evidence,
+    sceneWorksRepo,
+    inferenceRepo,
+    env,
+    marker,
+  });
+
+  for (const [label, commandFile, message] of [
+    ["checkout command file", path.join(sceneWorksRepo, "provider-command.json"), /must be outside/],
+    ["evidence command file", path.join(evidence, "provider-command.json"), /must be outside/],
+  ]) {
+    await writeFile(commandFile, JSON.stringify([process.execPath]));
+    await assertProviderFileCliRejects({
+      commandFile,
+      expectedExecutable: process.execPath,
+      message,
+      evidence,
+      sceneWorksRepo,
+      inferenceRepo,
+      env,
+      marker,
+    });
+  }
+
+  await assertZeroSpawnRejects([
+    "--provider-command", String.raw`[D:\actions-runner-2\_work\SceneWorks\target\release\memory-candle-adapter.exe]`,
+  ],
     /--provider-command must be valid JSON/,
+    "PowerShell quote stripping",
   );
 
   const valid = path.join(scratch, "valid.json");
@@ -120,7 +370,7 @@ test("spawned provider transport parsing rejects PowerShell quote loss and every
       "--provider-executable", process.execPath,
     ], /--provider-cmd-json-file requires one value/],
   ]) {
-    await assert.rejects(spawnHarness(providerArgs), message, label);
+    await assertZeroSpawnRejects(providerArgs, message, label);
   }
 });
 

--- a/scripts/memory-calibration-harness.test.mjs
+++ b/scripts/memory-calibration-harness.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile, spawn } from "node:child_process";
-import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -12,7 +12,8 @@ import {
   HARNESS_VERSION, RUNG_REUSE_TOLERANCE, SCHEMA_VERSION, assessProviderReuse, atomicWrite, canonicalJson,
   projectPhaseMetricsToSchemaV5,
   compareRungReuse, evidenceSemantics, expandPlan, logicalCaseId, mergeBundles, recordId,
-  physicalMlxSessionId, runProviderPlan, validateBundle, validateRecord, validateSourceSessionFiles,
+  physicalMlxSessionId, readExactProviderCommandFile, runProviderPlan, validateBundle, validateRecord,
+  validateSourceSessionFiles,
 } from "./memory-calibration-harness.mjs";
 import {
   calibrationBinding,
@@ -28,6 +29,100 @@ const stubClosureDigest = async (provider) =>
 
 
 const execFileAsync = promisify(execFile);
+
+const HARNESS_PATH = fileURLToPath(new URL("./memory-calibration-harness.mjs", import.meta.url));
+
+async function assertProviderFileCliRejects({ commandFile, expectedExecutable, message }) {
+  const evidence = path.join(path.dirname(commandFile), "evidence");
+  await mkdir(evidence, { recursive: true });
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      HARNESS_PATH,
+      "run",
+      "--provider-cmd-json-file", commandFile,
+      "--provider-executable", expectedExecutable,
+      "--sceneworks-repo", fileURLToPath(new URL("..", import.meta.url)),
+      "--inference-repo", fileURLToPath(new URL("..", import.meta.url)),
+      "--output", path.join(evidence, "capture.json"),
+      "--config", path.join(path.dirname(commandFile), "must-not-be-read.json"),
+    ]),
+    message,
+  );
+}
+
+test("file-backed provider argv preserves one exact executable without native-shell JSON quoting", async () => {
+  const scratch = await realpath(await mkdtemp(path.join(tmpdir(), "memory-provider-command-")));
+  const commandFile = path.join(scratch, "provider command.json");
+  await writeFile(commandFile, `${JSON.stringify([process.execPath])}\n`);
+  assert.deepEqual(
+    await readExactProviderCommandFile(commandFile, { expectedExecutable: process.execPath }),
+    [await realpath(process.execPath)],
+  );
+});
+
+test("spawned provider transport parsing rejects PowerShell quote loss and every in-file substitution", async () => {
+  const scratch = await realpath(await mkdtemp(path.join(tmpdir(), "memory-provider-command-cli-")));
+  const evidence = path.join(scratch, "evidence");
+  await mkdir(evidence, { recursive: true });
+  const spawnHarness = (providerArgs) => execFileAsync(process.execPath, [
+    HARNESS_PATH,
+    "run",
+    ...providerArgs,
+    "--sceneworks-repo", fileURLToPath(new URL("..", import.meta.url)),
+    "--inference-repo", fileURLToPath(new URL("..", import.meta.url)),
+    "--output", path.join(evidence, "capture.json"),
+    "--config", path.join(scratch, "must-not-be-read.json"),
+  ]);
+  const cases = [
+    ["malformed", "{not-json", /must contain valid JSON/],
+    ["non-array", JSON.stringify(process.execPath), /exactly one argv string/],
+    ["multiple", JSON.stringify([process.execPath, "--unexpected"]), /exactly one argv string/],
+  ];
+  for (const [name, body, message] of cases) {
+    const commandFile = path.join(scratch, `${name}.json`);
+    await writeFile(commandFile, body);
+    await assertProviderFileCliRejects({ commandFile, expectedExecutable: process.execPath, message });
+  }
+
+  const substitutedExecutable = path.join(scratch, "memory-candle-adapter-lookalike.exe");
+  await writeFile(substitutedExecutable, "not the authenticated executable");
+  const substituted = path.join(scratch, "substituted.json");
+  await writeFile(substituted, JSON.stringify([substitutedExecutable]));
+  await assertProviderFileCliRejects({
+    commandFile: substituted,
+    expectedExecutable: process.execPath,
+    message: /does not match --provider-executable/,
+  });
+
+  await assert.rejects(
+    spawnHarness([
+      "--provider-command", String.raw`[D:\actions-runner-2\_work\SceneWorks\target\release\memory-candle-adapter.exe]`,
+    ]),
+    /--provider-command must be valid JSON/,
+  );
+
+  const valid = path.join(scratch, "valid.json");
+  await writeFile(valid, JSON.stringify([process.execPath]));
+  for (const [label, providerArgs, message] of [
+    ["both transports", [
+      "--provider-command", JSON.stringify([process.execPath]),
+      "--provider-cmd-json-file", valid,
+      "--provider-executable", process.execPath,
+    ], /supply exactly one/],
+    ["neither transport", [], /supply exactly one/],
+    ["duplicate file flag", [
+      "--provider-cmd-json-file", valid,
+      "--provider-cmd-json-file", valid,
+      "--provider-executable", process.execPath,
+    ], /--provider-cmd-json-file may be supplied only once/],
+    ["missing file value", [
+      "--provider-cmd-json-file",
+      "--provider-executable", process.execPath,
+    ], /--provider-cmd-json-file requires one value/],
+  ]) {
+    await assert.rejects(spawnHarness(providerArgs), message, label);
+  }
+});
 
 test("diagnostic LTX safety canary output is structurally non-ingestible", () => {
   for (const [id, status] of [

--- a/scripts/sc19057-wan-capture-workflow.test.mjs
+++ b/scripts/sc19057-wan-capture-workflow.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 
 const WORKFLOW_URL = new URL("../.github/workflows/windows-candle.yml", import.meta.url);
 const INVENTORY_URL = new URL("./inventory-sc19057-wan-artifact.mjs", import.meta.url);
+const PROVIDER_HARNESS_URL = new URL("./memory-calibration-harness.mjs", import.meta.url);
 
 function stepBody(workflow, name) {
   const start = workflow.indexOf(`      - name: ${name}\n`);
@@ -59,6 +60,29 @@ function assertInventorySourceContract(source) {
   assert.match(source, /status: "STARTED"/);
   assert.match(source, /status: "PASS"/);
   assert.match(source, /status: "FAIL"/);
+}
+
+function assertProviderTransportSourceContract(source) {
+  assert.match(source, /export async function readExactProviderCommandFile/);
+  assert.match(source, /if \(!file \|\| !path\.isAbsolute\(file\)\)/);
+  assert.match(source, /--provider-cmd-json-file must be an absolute path/);
+  assert.match(source, /--provider-executable must be an absolute path with --provider-cmd-json-file/);
+  assert.match(source, /lstat\(commandFile\)/);
+  assert.match(source, /!metadata\.isFile\(\) \|\| metadata\.isSymbolicLink\(\)/);
+  assert.match(source, /canonicalCommandFile.*realpath\(commandFile\)/s);
+  assert.match(source, /sameFilesystemPath\(canonicalCommandFile, commandFile\)/);
+  assert.match(source, /canonicalRoot = await realpath\(root\)/);
+  assert.match(source, /isWithin\(canonicalRoot, canonicalCommandFile\)/);
+  assert.match(source, /!Array\.isArray\(parsed\) \|\| parsed\.length !== 1/);
+  assert.match(source, /path\.isAbsolute\(parsed\[0\]\)/);
+  assert.match(source, /lstat\(commandPath\)/);
+  assert.match(source, /realpath\(commandPath\)/);
+  assert.match(source, /sameFilesystemPath\(commandPath, expectedPath\)/);
+  assert.match(source, /sameFilesystemPath\(canonicalCommand, canonicalExpected\)/);
+  assert.match(source, /forbiddenRoots: \[sceneWorksRepo, inferenceRepo, path\.dirname\(path\.resolve\(outputPath\)\)\]/);
+  assert.match(source, /indexes\.length > 1/);
+  assert.match(source, /candidate\.startsWith\("--"\)/);
+  assert.match(source, /Boolean\(inline\) === Boolean\(file\)/);
 }
 
 function assertWorkflowContract(workflow) {
@@ -143,10 +167,22 @@ function assertWorkflowContract(workflow) {
   assert.match(capture, /SCENEWORKS_WAN_REPOSITORY: \$\{\{ inputs\.provision_repository \}\}/);
   assert.match(capture, /SCENEWORKS_WAN_REVISION: \$\{\{ inputs\.provision_revision \}\}/);
   assert.match(capture, /\$env:SCENEWORKS_WAN_ROOT = \$env:SCENEWORKS_PROVISIONED_ROOT/);
-  assert.match(capture, /ConvertTo-Json -Compress -InputObject @\(\$adapter\)/);
+  assert.match(capture, /\$providerCommandFile = Join-Path \$env:RUNNER_TEMP "sc-19057-provider-command-\$\(\$env:GITHUB_RUN_ID\)-\$\(\$env:GITHUB_RUN_ATTEMPT\)\.json"/);
+  assert.match(capture, /\$providerCommandTemporary = "\$providerCommandFile\.tmp"/);
+  assert.match(capture, /provider-command-transport\.json/);
+  assert.match(capture, /status = 'STARTED'/);
+  assert.match(capture, /ConvertTo-Json -Compress -InputObject @\(\[string\]\$adapter\)/);
+  assert.match(capture, /New-Object System\.Text\.UTF8Encoding\(\$false\)/);
+  assert.match(capture, /\[System\.IO\.File\]::WriteAllText\(\$providerCommandTemporary, "\$providerJson`n", \$utf8WithoutBom\)/);
+  assert.match(capture, /Move-Item -LiteralPath \$providerCommandTemporary -Destination \$providerCommandFile/);
+  assert.match(capture, /providerCommandFileSha256 = \(Get-FileHash -Algorithm SHA256 -LiteralPath \$providerCommandFile\)/);
+  assert.match(capture, /status = 'FAIL'/);
   assert.match(capture, /--config docs\\calibration\\sc-19057\\wan-candle-video-capture-plan\.json/);
   assert.match(capture, /--backend candle/);
   assert.match(capture, /--fresh-per-case/);
+  assert.match(capture, /--provider-cmd-json-file \$providerCommandFile/);
+  assert.match(capture, /--provider-executable \$adapter/);
+  assert.doesNotMatch(capture, /--provider-command(?:\s|$)/);
   assert.match(capture, /memory-calibration-harness\.mjs check --input \$capture/);
   assert.match(capture, /validate-sc19057-wan-capture\.mjs/);
   assert.match(capture, /--sceneworks-revision \$env:GITHUB_SHA/);
@@ -170,7 +206,17 @@ function assertWorkflowContract(workflow) {
   assert.match(cleanup, /if: \$\{\{ always\(\) && github\.event_name == 'workflow_dispatch' && inputs\.run_sc19057_wan_capture \}\}/);
   assert.match(cleanup, /refusing cleanup outside bounded job scratch/);
   assert.match(cleanup, /Remove-Item -LiteralPath \$full -Recurse -Force/);
+  assert.match(cleanup, /sc-19057-provider-command-\$\(\$env:GITHUB_RUN_ID\)-\$\(\$env:GITHUB_RUN_ATTEMPT\)\.json/);
+  assert.match(cleanup, /sc-19057-provider-command-\$\(\$env:GITHUB_RUN_ID\)-\$\(\$env:GITHUB_RUN_ATTEMPT\)\.json\.tmp/);
   assert.doesNotMatch(cleanup, /SCENEWORKS_PROVISIONED_ROOT|PROVISION_CACHE_DIR/);
+
+  const receiptAt = capture.indexOf("$transport | ConvertTo-Json -Depth 3 | Out-File -LiteralPath $providerTransportReceipt -Encoding utf8");
+  const adapterResolveAt = capture.indexOf("$adapter = (Resolve-Path -LiteralPath $expectedAdapter).Path");
+  const transportWriteAt = capture.indexOf("[System.IO.File]::WriteAllText");
+  const harnessAt = capture.indexOf("node scripts\\memory-calibration-harness.mjs run");
+  assert.ok(receiptAt >= 0 && receiptAt < adapterResolveAt, "transport failure receipt must precede adapter resolution");
+  assert.ok(adapterResolveAt < transportWriteAt, "adapter identity must be resolved before the atomic write");
+  assert.ok(transportWriteAt < harnessAt, "atomic provider transport must be complete before capture starts");
 
   const acceptAt = workflow.indexOf("validate-sc19057-wan-capture.mjs");
   const uploadAt = workflow.indexOf("name: Upload the sealed SC-19057 capture attempt");
@@ -180,6 +226,7 @@ function assertWorkflowContract(workflow) {
 test("windows-candle exposes one exact mutually-exclusive manual SC-19057 mode", async () => {
   assertWorkflowContract(await readFile(WORKFLOW_URL, "utf8"));
   assertInventorySourceContract(await readFile(INVENTORY_URL, "utf8"));
+  assertProviderTransportSourceContract(await readFile(PROVIDER_HARNESS_URL, "utf8"));
 });
 
 test("the workflow contract kills routing artifact capture and cleanup disconnects", async () => {
@@ -197,6 +244,13 @@ test("the workflow contract kills routing artifact capture and cleanup disconnec
     ["disconnected resolved inventory", (text) => text.replace("node scripts\\inventory-sc19057-wan-artifact.mjs", "node scripts\\unsafe-link-length.mjs")],
     ["non-release adapter", (text) => text.replaceAll("cargo build --release --locked", "cargo build --locked")],
     ["missing fresh isolation", (text) => text.replace("            --fresh-per-case `\n", "")],
+    ["inline JSON native argv", (text) => text.replace("            --provider-cmd-json-file $providerCommandFile `", "            --provider-command $providerJson `")],
+    ["multiple provider argv", (text) => text.replace("@([string]$adapter)", "@([string]$adapter, '--unexpected')")],
+    ["BOM provider JSON", (text) => text.replace("System.Text.UTF8Encoding($false)", "System.Text.UTF8Encoding($true)")],
+    ["provider path substitution", (text) => text.replace("--provider-executable $adapter", "--provider-executable 'lookalike.exe'")],
+    ["non-atomic provider transport", (text) => text.replace("Move-Item -LiteralPath $providerCommandTemporary -Destination $providerCommandFile", "Copy-Item -LiteralPath $providerCommandTemporary -Destination $providerCommandFile")],
+    ["late provider failure evidence", (text) => text.replace("$transport | ConvertTo-Json -Depth 3 | Out-File -LiteralPath $providerTransportReceipt -Encoding utf8\n          try {", "try {")],
+    ["transport cleanup disconnected", (text) => text.replace("sc-19057-provider-command-$($env:GITHUB_RUN_ID)-$($env:GITHUB_RUN_ATTEMPT).json.tmp", "disconnected-provider-command.tmp")],
     ["missing 6/6 validator", (text) => text.replace("validate-sc19057-wan-capture.mjs", "accept-any-capture.mjs")],
     ["unsafe raw-log arm", (text) => text.replace("            --fresh-per-case `\n", "            --fresh-per-case --raw-log-dir logs `\n")],
     ["automatic capture", (text) => text.replace("github.event_name == 'workflow_dispatch' && inputs.run_sc19057_wan_capture", "github.event_name == 'push'")],
@@ -204,6 +258,28 @@ test("the workflow contract kills routing artifact capture and cleanup disconnec
   ];
   for (const [label, mutate] of mutations) {
     assert.throws(() => assertWorkflowContract(mutate(workflow)), undefined, label);
+  }
+});
+
+test("the harness source contract kills provider schema path and identity bypasses", async () => {
+  const source = await readFile(PROVIDER_HARNESS_URL, "utf8");
+  const mutations = [
+    ["relative command file", (text) => text.replace("!file || !path.isAbsolute(file)", "!file")],
+    ["linked command file", (text) => text.replace("!metadata.isFile() || metadata.isSymbolicLink()", "!metadata.isFile()")],
+    ["linked command parent", (text) => text.replace("!sameFilesystemPath(canonicalCommandFile, commandFile)", "false")],
+    ["lexical forbidden root", (text) => text.replace("isWithin(canonicalRoot, canonicalCommandFile)", "isWithin(root, commandFile)")],
+    ["multiple argv", (text) => text.replace("parsed.length !== 1", "parsed.length === 0")],
+    ["relative executable", (text) => text.replace("!path.isAbsolute(parsed[0])", "false")],
+    ["unresolved identity", (text) => text.replace("realpath(commandPath)", "commandPath")],
+    ["lexical identity alias", (text) => text.replace("!sameFilesystemPath(commandPath, expectedPath)", "false")],
+    ["identity mismatch", (text) => text.replace("!sameFilesystemPath(canonicalCommand, canonicalExpected)", "false")],
+    ["checkout transport", (text) => text.replace("forbiddenRoots: [sceneWorksRepo, inferenceRepo, path.dirname(path.resolve(outputPath))]", "forbiddenRoots: []")],
+    ["duplicate flags", (text) => text.replace("indexes.length > 1", "false")],
+    ["missing flag value", (text) => text.replace('candidate.startsWith("--")', "false")],
+    ["ambiguous provider modes", (text) => text.replace("Boolean(inline) === Boolean(file)", "false")],
+  ];
+  for (const [label, mutate] of mutations) {
+    assert.throws(() => assertProviderTransportSourceContract(mutate(source)), undefined, label);
   }
 });
 

--- a/scripts/sc19057-wan-capture-workflow.test.mjs
+++ b/scripts/sc19057-wan-capture-workflow.test.mjs
@@ -74,6 +74,7 @@ function assertProviderTransportSourceContract(source) {
   assert.match(source, /canonicalRoot = await realpath\(root\)/);
   assert.match(source, /isWithin\(canonicalRoot, canonicalCommandFile\)/);
   assert.match(source, /!Array\.isArray\(parsed\) \|\| parsed\.length !== 1/);
+  assert.match(source, /parsed\[0\]\.includes\("\\0"\)/);
   assert.match(source, /path\.isAbsolute\(parsed\[0\]\)/);
   assert.match(source, /lstat\(commandPath\)/);
   assert.match(source, /realpath\(commandPath\)/);
@@ -83,6 +84,10 @@ function assertProviderTransportSourceContract(source) {
   assert.match(source, /indexes\.length > 1/);
   assert.match(source, /candidate\.startsWith\("--"\)/);
   assert.match(source, /Boolean\(inline\) === Boolean\(file\)/);
+  assert.match(
+    source,
+    /const providerCommand = await providerCommandFromArgs\([\s\S]*?const output = await runProviderPlan\(\{\s*config:[\s\S]*?providerCommand,\s*sceneWorksRepo,\s*inferenceRepo,/,
+  );
 }
 
 function assertWorkflowContract(workflow) {
@@ -269,6 +274,7 @@ test("the harness source contract kills provider schema path and identity bypass
     ["linked command parent", (text) => text.replace("!sameFilesystemPath(canonicalCommandFile, commandFile)", "false")],
     ["lexical forbidden root", (text) => text.replace("isWithin(canonicalRoot, canonicalCommandFile)", "isWithin(root, commandFile)")],
     ["multiple argv", (text) => text.replace("parsed.length !== 1", "parsed.length === 0")],
+    ["NUL argv", (text) => text.replace('parsed[0].includes("\\0")', "false")],
     ["relative executable", (text) => text.replace("!path.isAbsolute(parsed[0])", "false")],
     ["unresolved identity", (text) => text.replace("realpath(commandPath)", "commandPath")],
     ["lexical identity alias", (text) => text.replace("!sameFilesystemPath(commandPath, expectedPath)", "false")],
@@ -277,6 +283,8 @@ test("the harness source contract kills provider schema path and identity bypass
     ["duplicate flags", (text) => text.replace("indexes.length > 1", "false")],
     ["missing flag value", (text) => text.replace('candidate.startsWith("--")', "false")],
     ["ambiguous provider modes", (text) => text.replace("Boolean(inline) === Boolean(file)", "false")],
+    ["provider command disconnected", (text) => text.replace("      providerCommand,\n      sceneWorksRepo,", "      providerCommand: [],\n      sceneWorksRepo,")],
+    ["provider command substituted", (text) => text.replace("      providerCommand,\n      sceneWorksRepo,", "      providerCommand: [process.execPath],\n      sceneWorksRepo,")],
   ];
   for (const [label, mutate] of mutations) {
     assert.throws(() => assertProviderTransportSourceContract(mutate(source)), undefined, label);


### PR DESCRIPTION
## Outcome

Repairs the provider-command transport failure from run 32560882425 / job 97002118520 without changing the SC-19057 six-case plan, adapter, capture, acceptance, or promotion semantics.

- adds a fail-closed `--provider-cmd-json-file` run mode that accepts exactly one absolute argv string
- authenticates the command file and executable as regular non-symlink files, rejects reparse aliases, repository/evidence placement, duplicate/missing/ambiguous flags, NUL input, and path substitution
- writes the exact one-element adapter argv atomically as UTF-8 without BOM in bounded Windows runner scratch
- emits STARTED/READY/FAIL provider-transport evidence before any transport gate and retains its command-file SHA-256
- cleans the exact final and temporary transport files in the existing always-cleanup step
- includes spawned end-to-end CLI proofs for both file-backed and legacy inline modes: the intended fixture provider records `probe -> run` and produces one complete record
- every malformed/empty/non-string/NUL/multi-arg/substitution/symlink/checkout/evidence/quote-loss/flag adversary proves zero provider spawn via the same marker
- source mutations disconnecting or substituting the parsed command before `runProviderPlan` fail load-bearing contracts

The failed attempt artifact 9473037316 remains provenance-only (25 files / 17,338,835,457 bytes, zero capture rows). This PR creates no capture data and performs no dispatch.

## Validation

- `node --test scripts/memory-calibration-harness.test.mjs scripts/sc19057-wan-capture-workflow.test.mjs` — 69/69
- `npm run check` — 770/770
- `actionlint .github/workflows/windows-candle.yml`
- `npm run check:rust-derived-docs`
- `npm run rust:fmt`
- `npm run rust:lint` — strict `-D warnings`
- `npm run rust:check:candle` — non-macOS backend-candle worker/sidecar/adapter all-target typecheck green
- `git diff --check`

Base: `5e0f39281f32cab481ab121b8be7419735c2548d`