### PR TITLE
SC-20764: pin LTX T2V overlay identity variants

### DIFF
--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -72,14 +72,21 @@ fn video_admission_overlay_keys_the_resolved_provider_video_mode() {
     input.enhance_prompt = true;
     assert_eq!(
         video_admission_overlay(&input).as_deref(),
-        Some("enhancer+provider_video_mode:no_audio"),
-        "enhancer and provider mode remain separate exact identity axes"
+        Some("enhancer:standard+provider_video_mode:no_audio"),
+        "standard prompt enhancement and provider mode remain exact identity axes"
+    );
+
+    input.use_uncensored_enhancer = true;
+    assert_eq!(
+        video_admission_overlay(&input).as_deref(),
+        Some("enhancer:uncensored+provider_video_mode:no_audio"),
+        "uncensored enhancement must not borrow standard prompt-enhancement evidence"
     );
 
     input.video_mode = None;
     assert_eq!(
         video_admission_overlay(&input).as_deref(),
-        Some("enhancer"),
+        Some("enhancer:uncensored"),
         "removing the request-only mode must not erase the loaded enhancer axis"
     );
 }

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -68,6 +68,20 @@ fn video_admission_overlay_keys_the_resolved_provider_video_mode() {
         Some("provider_video_mode:no_audio"),
         "the provider-only no-audio carrier must not inherit the null-overlay T2V curve"
     );
+
+    input.enhance_prompt = true;
+    assert_eq!(
+        video_admission_overlay(&input).as_deref(),
+        Some("enhancer+provider_video_mode:no_audio"),
+        "enhancer and provider mode remain separate exact identity axes"
+    );
+
+    input.video_mode = None;
+    assert_eq!(
+        video_admission_overlay(&input).as_deref(),
+        Some("enhancer"),
+        "removing the request-only mode must not erase the loaded enhancer axis"
+    );
 }
 
 /// Closure currency must use the resolved provider id, not the catalog alias. On macOS the Wan

--- a/crates/sceneworks-worker/src/video_jobs/wan.rs
+++ b/crates/sceneworks-worker/src/video_jobs/wan.rs
@@ -1492,11 +1492,10 @@ pub(super) fn video_admission_overlay(input: &VideoGenInput) -> Option<String> {
     if !input.adapters.is_empty() {
         overlays.push(format!("adapters:{}", input.adapters.len()));
     }
-    if input.enhance_prompt
-        || input.use_uncensored_enhancer
-        || input.uncensored_enhancer_dir.is_some()
-    {
-        overlays.push("enhancer".to_owned());
+    if input.use_uncensored_enhancer || input.uncensored_enhancer_dir.is_some() {
+        overlays.push("enhancer:uncensored".to_owned());
+    } else if input.enhance_prompt {
+        overlays.push("enhancer:standard".to_owned());
     }
     if let Some(video_mode) = input.video_mode.as_deref() {
         overlays.push(format!("provider_video_mode:{video_mode}"));


### PR DESCRIPTION
Adds paired SceneWorks coverage for the canonical LTX T2V admission overlay identity.

- Preserves separate enhancer and provider video-mode axes.
- Keeps no_audio from borrowing the plain null-overlay curve.
- Existing shared selector, exact identity evidence gate, lifecycle, and fail-open behavior remain in the merged SC-20763 foundation.

Validation: cargo test -p sceneworks-worker video_admission --lib; cargo fmt --all -- --check.