### PR TITLE
sc-20974: make terminal continuation cache- and disk-safe

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -1191,14 +1191,17 @@ jobs:
       # source-reviewed fixed cache root is censused from checked-in immutable download evidence
       # before transfer: there is no cache input,
       # snapshot/glob/ref-main fallback, matrix, child workflow, per-cell dispatch, or secret weight
-      # path. Each distinct valid authority is copied once into campaign-owned staging. The sole
-      # reviewed cache miss may download only flux1-schnell-mlx@bba3ae... file
-      # q8/transformer/model.safetensors into that staging tree, with exact commit/size/LFS-SHA
+      # path. The full 16-authority/199-file target-following census is hashed before GPU work. The
+      # sole reviewed cache miss may download only flux1-schnell-mlx@bba3ae... file
+      # q8/transformer/model.safetensors into an isolated persistent campaign store, with exact commit/size/LFS-SHA
       # verification; malformed cache partials are never resumed or renamed. Cells 1-7 are imported
       # from exactly one uploaded contiguous PASS prefix and rehashed; cells 8-19 run as a distinct
-      # continuation only after every staged authority passes a complete offline preflight. Exact
-      # authority files are copied without derivative extras; component roots carry regular-file
-      # sidecar obstructions and Candle writes only to a campaign-owned derived cache. The four
+      # continuation only after the full source/download/disk plan passes and network is forced
+      # offline. Authorities are copied just in time, retained only through their exact last consumer,
+      # rehashed before/after use, and durably cleaned. Exact authority files exclude derivative extras;
+      # component roots carry regular-file sidecar obstructions and Candle writes only to per-authority
+      # namespaces in a campaign-owned derived cache. A target-byte estimator and 40-GiB non-model
+      # reserve enforce the reviewed 99,106,288,594-byte free-space floor at every transition. The four
       # dismantled pin-keyed gates remain untouched.
       - name: Set up the pinned terminal Node runtime
         id: terminal_node

--- a/config/terminal-evidence/epic-20738-cache-preflight.schema.json
+++ b/config/terminal-evidence/epic-20738-cache-preflight.schema.json
@@ -6,9 +6,9 @@
   "additionalProperties": false,
   "required": [
     "schemaVersion", "profile", "status", "error", "downloadEvidenceSha256",
-    "expectedArtifactIds", "sourceCacheRoot", "campaignStagingRoot", "derivedSidecarRoot",
-    "frozenMissingFiles", "sidecarObstructions", "reusedFiles", "downloadedFiles", "phases",
-    "derivedSidecarLifecycle", "offlineBeforeCells"
+    "expectedArtifactIds", "sourceCacheRoot", "campaignStagingRoot", "derivedSidecarRoot", "missingFileStore",
+    "frozenMissingFiles", "sidecarObstructions", "reusedFiles", "downloadedFiles", "networkDownloadCount", "phases",
+    "lifetimePlan", "diskPlan", "derivedSidecarLifecycle", "offlineBeforeCells"
   ],
   "properties": {
     "schemaVersion": { "const": 1 },
@@ -25,10 +25,12 @@
     "sourceCacheRoot": { "type": "string", "minLength": 1 },
     "campaignStagingRoot": { "type": "string", "minLength": 1 },
     "derivedSidecarRoot": { "type": "string", "minLength": 1 },
+    "missingFileStore": { "type": "string", "minLength": 1 },
     "frozenMissingFiles": { "type": "array", "items": { "$ref": "#/$defs/missingFile" } },
     "sidecarObstructions": { "type": "array", "items": { "$ref": "#/$defs/obstruction" } },
     "reusedFiles": { "type": "array", "items": { "$ref": "#/$defs/artifactFile" } },
     "downloadedFiles": { "type": "array", "items": { "$ref": "#/$defs/downloadedArtifactFile" } },
+    "networkDownloadCount": { "type": "integer", "minimum": 0, "maximum": 1 },
     "phases": {
       "type": "object",
       "additionalProperties": false,
@@ -39,6 +41,11 @@
         "finalOffline": { "type": "array", "items": { "$ref": "#/$defs/finalOffline" } }
       }
     },
+    "lifetimePlan": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/lifetime" }
+    },
+    "diskPlan": { "oneOf": [{ "$ref": "#/$defs/diskPlan" }, { "type": "null" }] },
     "derivedSidecarLifecycle": {
       "type": "object",
       "additionalProperties": false,
@@ -219,6 +226,86 @@
         "ordinal": { "type": "integer", "minimum": 1, "maximum": 19 },
         "cellId": { "$ref": "#/$defs/id" },
         "inventory": { "$ref": "#/$defs/inventory" }
+      }
+    },
+    "physicalFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "bytes", "persistent"],
+      "properties": {
+        "key": { "type": "string", "minLength": 1 },
+        "bytes": { "type": "integer", "minimum": 1 },
+        "persistent": { "type": "boolean" }
+      }
+    },
+    "lifetime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifactId", "role", "firstOrdinal", "lastOrdinal", "sourceBytes", "expectedFiles", "physicalFiles"],
+      "properties": {
+        "artifactId": { "$ref": "#/$defs/id" },
+        "role": { "type": "string", "minLength": 1 },
+        "firstOrdinal": { "type": "integer", "minimum": 1, "maximum": 19 },
+        "lastOrdinal": { "type": "integer", "minimum": 1, "maximum": 19 },
+        "sourceBytes": { "type": "integer", "minimum": 1 },
+        "expectedFiles": { "type": "integer", "minimum": 1 },
+        "physicalFiles": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/physicalFile" } }
+      }
+    },
+    "diskCell": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ordinal", "artifactIds", "stagedBytes", "sidecarReserveBytes", "modelAndSidecarBytes", "requiredAdditionalBytes"],
+      "properties": {
+        "ordinal": { "type": "integer", "minimum": 1, "maximum": 19 },
+        "artifactIds": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "$ref": "#/$defs/id" } },
+        "stagedBytes": { "type": "integer", "minimum": 1 },
+        "sidecarReserveBytes": { "type": "integer", "minimum": 0 },
+        "modelAndSidecarBytes": { "type": "integer", "minimum": 1 },
+        "requiredAdditionalBytes": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "diskPlan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "freeBytes", "persistentMissingBytes", "nonModelReserveBytes", "nonModelPaths",
+        "legacyNaiveLinkLengthSourceBytes", "reviewedAllAtOnceSourceBytes",
+        "reviewedJitSourcePeakBytes", "logicalSourceBytes", "allAtOnceSourceBytes",
+        "allAtOnceRequiredBytes", "peakOrdinal", "peakArtifactIds", "peakStagedBytes",
+        "peakSidecarReserveBytes", "peakModelAndSidecarBytes", "peakRequiredAdditionalBytes", "admitted", "cells"
+      ],
+      "properties": {
+        "freeBytes": { "type": "integer", "minimum": 0 },
+        "persistentMissingBytes": { "type": "integer", "minimum": 0 },
+        "nonModelReserveBytes": { "type": "integer", "minimum": 1 },
+        "nonModelPaths": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["kind", "path"],
+            "properties": {
+              "kind": { "enum": ["cargoTarget", "cargoHome", "campaignOutput", "pythonVenv"] },
+              "path": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "legacyNaiveLinkLengthSourceBytes": { "type": "integer", "minimum": 1 },
+        "reviewedAllAtOnceSourceBytes": { "type": "integer", "minimum": 1 },
+        "reviewedJitSourcePeakBytes": { "type": "integer", "minimum": 1 },
+        "logicalSourceBytes": { "type": "integer", "minimum": 1 },
+        "allAtOnceSourceBytes": { "type": "integer", "minimum": 1 },
+        "allAtOnceRequiredBytes": { "type": "integer", "minimum": 1 },
+        "peakOrdinal": { "type": "integer", "minimum": 1, "maximum": 19 },
+        "peakArtifactIds": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "$ref": "#/$defs/id" } },
+        "peakStagedBytes": { "type": "integer", "minimum": 1 },
+        "peakSidecarReserveBytes": { "type": "integer", "minimum": 0 },
+        "peakModelAndSidecarBytes": { "type": "integer", "minimum": 1 },
+        "peakRequiredAdditionalBytes": { "type": "integer", "minimum": 1 },
+        "admitted": { "type": "boolean" },
+        "cells": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/diskCell" } }
       }
     }
   }

--- a/config/terminal-evidence/epic-20738-cache-preflight.schema.json
+++ b/config/terminal-evidence/epic-20738-cache-preflight.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "additionalProperties": false,
   "required": [
-    "schemaVersion", "profile", "status", "error", "downloadEvidenceSha256",
+    "schemaVersion", "profile", "evidencePhase", "status", "error", "downloadEvidenceSha256",
     "expectedArtifactIds", "sourceCacheRoot", "campaignStagingRoot", "derivedSidecarRoot", "missingFileStore",
     "frozenMissingFiles", "sidecarObstructions", "reusedFiles", "downloadedFiles", "networkDownloadCount", "phases",
     "lifetimePlan", "diskPlan", "derivedSidecarLifecycle", "offlineBeforeCells"
@@ -13,6 +13,7 @@
   "properties": {
     "schemaVersion": { "const": 1 },
     "profile": { "const": "epic-20738-candle-cuda-terminal-v1" },
+    "evidencePhase": { "enum": ["initial", "final"] },
     "status": { "enum": ["passed", "failed"] },
     "error": { "type": ["string", "null"] },
     "downloadEvidenceSha256": { "$ref": "#/$defs/sha256" },

--- a/config/terminal-evidence/epic-20738-cache-preflight.schema.json
+++ b/config/terminal-evidence/epic-20738-cache-preflight.schema.json
@@ -69,8 +69,7 @@
       },
       "else": {
         "properties": {
-          "error": { "type": "string", "minLength": 1 },
-          "offlineBeforeCells": { "const": false }
+          "error": { "type": "string", "minLength": 1 }
         }
       }
     }

--- a/config/terminal-evidence/epic-20738-cache-preflight.schema.json
+++ b/config/terminal-evidence/epic-20738-cache-preflight.schema.json
@@ -221,10 +221,11 @@
     "sidecarSnapshot": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["ordinal", "cellId", "inventory"],
+      "required": ["ordinal", "cellId", "providerExecution", "inventory"],
       "properties": {
         "ordinal": { "type": "integer", "minimum": 1, "maximum": 19 },
         "cellId": { "$ref": "#/$defs/id" },
+        "providerExecution": { "enum": ["failed", "completed"] },
         "inventory": { "$ref": "#/$defs/inventory" }
       }
     },

--- a/config/terminal-evidence/epic-20738-receipt.schema.json
+++ b/config/terminal-evidence/epic-20738-receipt.schema.json
@@ -4,7 +4,7 @@
   "title": "Epic 20738 CUDA terminal evidence receipt",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schemaVersion", "profile", "cell", "status", "error", "repositories", "artifacts", "execution", "hardware", "cleanup", "inputs", "outputs", "logs", "startedAt", "completedAt"],
+  "required": ["schemaVersion", "profile", "cell", "status", "error", "repositories", "artifacts", "execution", "hardware", "cleanup", "authorityLifecycle", "inputs", "outputs", "logs", "startedAt", "completedAt"],
   "properties": {
     "schemaVersion": { "const": 1 },
     "profile": { "const": "epic-20738-candle-cuda-terminal-v1" },
@@ -153,31 +153,6 @@
     {
       "if": { "type": "object", "properties": { "status": { "const": "failed" } }, "required": ["status"] },
       "then": { "type": "object", "properties": { "error": { "type": "string", "minLength": 1 } } }
-    },
-    {
-      "if": {
-        "type": "object",
-        "properties": {
-          "repositories": {
-            "type": "object",
-            "properties": {
-              "sceneworks": {
-                "type": "object",
-                "properties": { "sha": { "const": "8886a9e69f26beec05688c81b414859bd102f6d0" } },
-                "required": ["sha"]
-              }
-            },
-            "required": ["sceneworks"]
-          }
-        },
-        "required": ["repositories"]
-      },
-      "then": {},
-      "else": {
-        "type": "object",
-        "properties": { "authorityLifecycle": { "$ref": "#/$defs/authorityLifecycle" } },
-        "required": ["authorityLifecycle"]
-      }
     }
   ],
   "$defs": {

--- a/config/terminal-evidence/epic-20738-receipt.schema.json
+++ b/config/terminal-evidence/epic-20738-receipt.schema.json
@@ -289,12 +289,13 @@
     "authorityLifecycle": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["ordinal", "cellId", "staged", "activeArtifactIds", "verifiedBefore", "verifiedAfter", "derivedAfter", "released", "diskProbes"],
+      "required": ["ordinal", "cellId", "staged", "activeArtifactIds", "providerExecution", "verifiedBefore", "verifiedAfter", "derivedAfter", "released", "diskProbes"],
       "properties": {
         "ordinal": { "type": "integer", "minimum": 1, "maximum": 19 },
         "cellId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$" },
         "staged": { "type": "array", "items": { "$ref": "#/$defs/stagedAuthority" } },
         "activeArtifactIds": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$" } },
+        "providerExecution": { "enum": ["not-attempted", "failed", "completed"] },
         "verifiedBefore": { "type": "boolean" },
         "verifiedAfter": { "type": "boolean" },
         "derivedAfter": { "type": "array", "items": { "$ref": "#/$defs/derivedAuthority" } },

--- a/config/terminal-evidence/epic-20738-receipt.schema.json
+++ b/config/terminal-evidence/epic-20738-receipt.schema.json
@@ -96,6 +96,7 @@
         "error": { "type": ["string", "null"] }
       }
     },
+    "authorityLifecycle": { "$ref": "#/$defs/authorityLifecycle" },
     "inputs": { "type": "array", "items": { "$ref": "#/$defs/hashedFile" } },
     "outputs": { "type": "array", "items": { "$ref": "#/$defs/hashedFile" } },
     "logs": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/hashedFile" } },
@@ -224,6 +225,81 @@
         { "$ref": "#/$defs/gpuSample" },
         { "type": "object", "required": ["index", "name", "uuid", "pciBusId", "computeCapability", "driverVersion", "memoryTotalMiB", "memoryUsedMiB", "memoryFreeMiB"] }
       ]
+    },
+    "plainInventory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["root", "files", "bytes", "sha256"],
+      "properties": {
+        "root": { "type": "string", "minLength": 1 },
+        "files": { "type": "integer", "minimum": 0 },
+        "bytes": { "type": "integer", "minimum": 0 },
+        "sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "diskProbe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["phase", "ordinal", "root", "freeBytes"],
+      "properties": {
+        "phase": { "type": "string", "minLength": 1 },
+        "ordinal": { "type": "integer", "minimum": 1, "maximum": 19 },
+        "root": { "type": "string", "minLength": 1 },
+        "freeBytes": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "stagedAuthority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifactId", "stageRoot", "inventory", "obstructionCount", "derivedNamespaces"],
+      "properties": {
+        "artifactId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$" },
+        "stageRoot": { "type": "string", "minLength": 1 },
+        "inventory": { "$ref": "#/$defs/plainInventory" },
+        "obstructionCount": { "type": "integer", "minimum": 1 },
+        "derivedNamespaces": { "type": "array", "uniqueItems": true, "items": { "type": "string", "minLength": 1 } }
+      }
+    },
+    "derivedAuthority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifactId", "files", "bytes", "inventories"],
+      "properties": {
+        "artifactId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$" },
+        "files": { "type": "integer", "minimum": 0 },
+        "bytes": { "type": "integer", "minimum": 0 },
+        "inventories": { "type": "array", "items": { "$ref": "#/$defs/plainInventory" } }
+      }
+    },
+    "releasedAuthority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifactId", "stageRoot", "stagedInventory", "derivedBeforeCleanup", "stageRemoved", "derivedRemoved"],
+      "properties": {
+        "artifactId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$" },
+        "stageRoot": { "type": "string", "minLength": 1 },
+        "stagedInventory": { "oneOf": [{ "$ref": "#/$defs/plainInventory" }, { "type": "null" }] },
+        "derivedBeforeCleanup": { "type": "array", "items": { "$ref": "#/$defs/plainInventory" } },
+        "stageRemoved": { "type": "boolean" },
+        "derivedRemoved": { "type": "boolean" },
+        "error": { "type": "string", "minLength": 1 }
+      }
+    },
+    "authorityLifecycle": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ordinal", "cellId", "staged", "activeArtifactIds", "verifiedBefore", "verifiedAfter", "derivedAfter", "released", "diskProbes"],
+      "properties": {
+        "ordinal": { "type": "integer", "minimum": 1, "maximum": 19 },
+        "cellId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$" },
+        "staged": { "type": "array", "items": { "$ref": "#/$defs/stagedAuthority" } },
+        "activeArtifactIds": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$" } },
+        "verifiedBefore": { "type": "boolean" },
+        "verifiedAfter": { "type": "boolean" },
+        "derivedAfter": { "type": "array", "items": { "$ref": "#/$defs/derivedAuthority" } },
+        "released": { "type": "array", "items": { "$ref": "#/$defs/releasedAuthority" } },
+        "diskProbes": { "type": "array", "items": { "$ref": "#/$defs/diskProbe" } }
+      }
     }
   }
 }

--- a/config/terminal-evidence/epic-20738-receipt.schema.json
+++ b/config/terminal-evidence/epic-20738-receipt.schema.json
@@ -153,6 +153,31 @@
     {
       "if": { "type": "object", "properties": { "status": { "const": "failed" } }, "required": ["status"] },
       "then": { "type": "object", "properties": { "error": { "type": "string", "minLength": 1 } } }
+    },
+    {
+      "if": {
+        "type": "object",
+        "properties": {
+          "repositories": {
+            "type": "object",
+            "properties": {
+              "sceneworks": {
+                "type": "object",
+                "properties": { "sha": { "const": "8886a9e69f26beec05688c81b414859bd102f6d0" } },
+                "required": ["sha"]
+              }
+            },
+            "required": ["sceneworks"]
+          }
+        },
+        "required": ["repositories"]
+      },
+      "then": {},
+      "else": {
+        "type": "object",
+        "properties": { "authorityLifecycle": { "$ref": "#/$defs/authorityLifecycle" } },
+        "required": ["authorityLifecycle"]
+      }
     }
   ],
   "$defs": {
@@ -240,12 +265,13 @@
     "diskProbe": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["phase", "ordinal", "root", "freeBytes"],
+      "required": ["phase", "ordinal", "root", "freeBytes", "requiredFreeBytes"],
       "properties": {
         "phase": { "type": "string", "minLength": 1 },
         "ordinal": { "type": "integer", "minimum": 1, "maximum": 19 },
         "root": { "type": "string", "minLength": 1 },
-        "freeBytes": { "type": "integer", "minimum": 0 }
+        "freeBytes": { "type": "integer", "minimum": 0 },
+        "requiredFreeBytes": { "type": "integer", "minimum": 1 }
       }
     },
     "stagedAuthority": {

--- a/docs/epic-20738-terminal-cuda.md
+++ b/docs/epic-20738-terminal-cuda.md
@@ -84,7 +84,8 @@ fill, network mode is forced offline for every JIT stage and cell.
 The disk admission model binds exact source bytes, the contracted FLUX sidecar payloads (494 files;
 q8 12,573,868,032 bytes and q4 7,396,392,960 bytes, each with at most 16 KiB per-file reserve), and a
 40-GiB non-model reserve for Cargo target, output, the pinned venv, logs, and filesystem fluctuation.
-Its largest model-plus-sidecar live set is the LTX pair plus persistent Schnell miss at
+The persistent Schnell-q8 miss is retained only through cell 10 and removed with that authority.
+The largest model-plus-sidecar live set is therefore the LTX pair itself at
 56,156,615,634 bytes, so the controller requires at least 99,106,288,594 free bytes. It checks that
 floor after the missing-file fill, before every authority stage, and before every GPU process. The
 former all-at-once plan is deterministically refused.
@@ -103,9 +104,10 @@ All writable cache and temporary environment variables are redirected to the cur
 while model roots point only at the active JIT staging roots. Every selected root and nested
 top-level component root carries an ordinary-file `.candle-device-format-v1` obstruction, forcing
 Candle away from model-adjacent writes. `SCENEWORKS_CANDLE_DEVICE_CACHE_DIR` points to a separate
-campaign-owned derived root under `RUNNER_TEMP`; exact component-path namespaces share the authority's
-lifetime and are inventoried and removed after its last consumer. FLUX namespaces must contain the
-exact bounded 494-file sidecar set; every non-FLUX namespace must stay empty. The controller rehashes
+campaign-owned derived root under `RUNNER_TEMP`; the one b646 component-path-derived namespace shares
+the authority's lifetime and is inventoried and removed after its last consumer. A FLUX namespace
+must contain the exact bounded 494-file sidecar set with no other file or empty namespace anywhere in
+the derived root; every non-FLUX root must stay exactly empty. The controller rehashes
 each selected staged authority file and every obstruction immediately before and after every cell,
 then proves exact stage/namespace absence at release and proves final staging, derived cache, and
 missing-file store emptiness. Any stage, hash, capacity, or cleanup drift quarantines later cells; the

--- a/docs/epic-20738-terminal-cuda.md
+++ b/docs/epic-20738-terminal-cuda.md
@@ -54,24 +54,40 @@ lockfile-pinned in-process Node Draft 2020-12 validator and creates a fresh `RUN
 virtual environment with `huggingface_hub==0.36.0`, then verifies and passes that exact interpreter
 to the controller. The trusted source cache is the fixed
 `E:\huggingface\hub`; it is not a dispatch input and is never used as writable runtime storage.
-Before any GPU cell, the controller freezes a census of every distinct remaining exact
+Before any GPU cell, the controller freezes and hashes the target bytes in a census of every distinct remaining exact
 repository/revision/allow-pattern authority. The exact required filenames come from the checked-in
 immutable download-pattern evidence; every listed file is required, and only those files are copied.
 Unreviewed extras such as `.incomplete` blobs and model-adjacent `.candle-device-format-v1`
 derivatives are excluded. Hugging Face snapshot file links are valid only when
 their resolved blobs remain inside that trusted root; broken, empty, or escaping links fail closed.
 
-Each valid authority is copied once into a campaign-owned shared staging tree under `RUNNER_TEMP`
-and reused by every cell that names it. Existing valid files are never overwritten or downloaded.
+The continuation census is exactly 16 logical authorities and 199 files. File sizes and hashes follow
+valid Hugging Face links to their trusted blob targets; link-entry length is never used as model-byte
+accounting. The reviewed followed-target total is 179,028,698,264 bytes (the earlier link-length
+observation undercounted 18 Schnell-q8 targets by exactly 5,361,654,035 bytes).
+
+Authorities are copied just in time into campaign-owned staging under `RUNNER_TEMP`, immediately
+before their first consumer, and are retained only through their exact last consumer. SCAIL q4 lives
+across cells 11-12; the four shared SDXL helpers live across cells 15-19 while each backbone rotates
+after one cell. The LTX q8/Gemma pair is staged together for cell 14. Existing valid files are never
+overwritten or downloaded.
 The sole reviewed network exception is
 `SceneWorks/flux1-schnell-mlx@bba3ae01dfd94089f173c05edd4e1a4c551f2599` file
 `q8/transformer/model.safetensors`. If and only if the frozen census reports exactly that miss, the
-pinned client fetches that exact filename directly into fresh staging and proves the returned commit,
+pinned client fetches that exact filename into an isolated campaign-owned persistent store and proves the returned commit,
 metadata size, LFS SHA-256, and actual file SHA-256. It never calls a snapshot/glob/ref-main route;
 existing `.incomplete` files are untrusted and are neither renamed nor resumed. LTX q8 and Gemma use
 the complete production-approved cached parent revision
-`254989c3ca7ee691187647f350b112c0c448789d`, not the absent current revision. After staging, every
-remaining authority must resolve again with offline mode forced before cell 8 may start.
+`254989c3ca7ee691187647f350b112c0c448789d`, not the absent current revision. After the one possible
+fill, network mode is forced offline for every JIT stage and cell.
+
+The disk admission model binds exact source bytes, the contracted FLUX sidecar payloads (494 files;
+q8 12,573,868,032 bytes and q4 7,396,392,960 bytes, each with at most 16 KiB per-file reserve), and a
+40-GiB non-model reserve for Cargo target, output, the pinned venv, logs, and filesystem fluctuation.
+Its largest model-plus-sidecar live set is the LTX pair plus persistent Schnell miss at
+56,156,615,634 bytes, so the controller requires at least 99,106,288,594 free bytes. It checks that
+floor after the missing-file fill, before every authority stage, and before every GPU process. The
+former all-at-once plan is deterministically refused.
 
 Output and scratch must be fresh, distinct, non-nested descendants of the resolved `RUNNER_TEMP`,
 outside both repositories. Every recursive removal rechecks that confinement and rejects
@@ -84,13 +100,16 @@ tier markers must agree with the requested q4/q8 directory, and runtime results 
 tier equals resolved tier with `denseFallback: false`.
 
 All writable cache and temporary environment variables are redirected to the current cell's scratch,
-while model roots point only at the shared campaign staging tree. Every selected root and nested
+while model roots point only at the active JIT staging roots. Every selected root and nested
 top-level component root carries an ordinary-file `.candle-device-format-v1` obstruction, forcing
 Candle away from model-adjacent writes. `SCENEWORKS_CANDLE_DEVICE_CACHE_DIR` points to a separate
-campaign-owned shared derived cache under `RUNNER_TEMP`; its empty initial state and post-cell
-inventories are bound in evidence. The controller rehashes each selected staged authority file and
-every obstruction immediately before and after every cell. Any added, removed, or changed staged
-authority byte quarantines the rest of the campaign; the source cache remains untouched.
+campaign-owned derived root under `RUNNER_TEMP`; exact component-path namespaces share the authority's
+lifetime and are inventoried and removed after its last consumer. FLUX namespaces must contain the
+exact bounded 494-file sidecar set; every non-FLUX namespace must stay empty. The controller rehashes
+each selected staged authority file and every obstruction immediately before and after every cell,
+then proves exact stage/namespace absence at release and proves final staging, derived cache, and
+missing-file store emptiness. Any stage, hash, capacity, or cleanup drift quarantines later cells; the
+source cache remains untouched.
 
 ## Evidence and failure behavior
 
@@ -117,11 +136,11 @@ copied under `_imported-boundary-residue/` and excluded from the seven-PASS line
 cell-8 file or any later cell invalidates the candidate.
 
 The closed Draft 2020-12 `cache-preflight.json` binds the download-evidence SHA-256, authoritative
-filename census, copied-file and downloaded-file partition with bytes and SHA-256 values, each final
-offline staged inventory, component-root obstructions, the derived-sidecar lifecycle, and the
-no-GPU-before-validation verdict. Its own byte count and SHA-256 are bound from the campaign summary.
-An initial validated copy is published before cell 8, and the final copy binds post-cell lifecycle
-inventories.
+filename census, followed target bytes/hashes, hit/download partition, first/last-use plan, persistent
+store, exact disk plan/free floor, and the no-GPU-before-validation verdict. Its own byte count and
+SHA-256 are bound from the campaign summary. Each continuation receipt binds that cell's live-set
+transition, free-space probes, pre/post immutable verification, derived inventory, and exact releases;
+the final summary binds the complete lifecycle and empty terminal state.
 
 A cache preflight directory, write, stat, hash, schema/semantic validation, census, staging, or final
 offline-validation failure starts no continuation GPU cell. An independent emergency writer retains

--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -26,6 +26,8 @@ export const CACHE_PREFLIGHT_SCHEMA_PATH = "config/terminal-evidence/epic-20738-
 const DOWNLOAD_EVIDENCE_PATH = "config/download-pattern-evidence.json";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const SCHEMA_VALIDATORS = new Map();
+let LEGACY_IMPORTED_RECEIPT_VALIDATOR = null;
+const TRUSTED_LEGACY_IMPORT_CONTEXT = Symbol("trusted legacy prefix import");
 const SHA40 = /^[0-9a-f]{40}$/;
 const SAFE_ID = /^[a-z0-9][a-z0-9-]+$/;
 const BLOCKED = ["anima", "sana", "vace", "flux2", "true_v2", "true-v2", "eros"];
@@ -535,6 +537,24 @@ export function validateDocumentWithSchema(schemaPath, document) {
   return value;
 }
 
+function validateTrustedLegacyImportedReceiptDocument(receipt) {
+  if (!LEGACY_IMPORTED_RECEIPT_VALIDATOR) {
+    const absolute = path.resolve(ROOT, RECEIPT_SCHEMA_PATH);
+    const schema = JSON.parse(readFileSync(absolute, "utf8"));
+    schema.$id = schema.$id.replace(/\.json$/, "-trusted-legacy-import.json");
+    schema.required = schema.required.filter((field) => field !== "authorityLifecycle");
+    const ajv = new Ajv2020({ allErrors: true, allowUnionTypes: true, strict: true });
+    addFormats(ajv);
+    LEGACY_IMPORTED_RECEIPT_VALIDATOR = ajv.compile(schema);
+  }
+  if (!LEGACY_IMPORTED_RECEIPT_VALIDATOR(receipt)) {
+    const details = LEGACY_IMPORTED_RECEIPT_VALIDATOR.errors
+      .map((error) => `${error.instancePath || "/"}: ${error.message}`).join("\n");
+    fail(`trusted legacy prefix receipt failed Draft 2020-12 validation:\n${details}`);
+  }
+  return receipt;
+}
+
 async function writeJsonAtomically(file, value, { schemaPath } = {}) {
   await mkdir(path.dirname(file), { recursive: true });
   const temporary = `${file}.tmp-${process.pid}-${randomUUID()}`;
@@ -822,7 +842,9 @@ export function receiptSkeleton({
   };
 }
 
-export function validateReceipt(receipt, expectedCell, profile, lifecycleContext = null) {
+function validateReceiptInternal(
+  receipt, expectedCell, profile, lifecycleContext = null, trustedContext = null,
+) {
   if (receipt.schemaVersion !== 1 || receipt.profile !== PROFILE_NAME) fail("receipt identity mismatch");
   if (!new Set(["passed", "failed"]).has(receipt.status)) fail("receipt status is invalid");
   if (receipt.cell.ordinal < 1 || receipt.cell.ordinal > EXPECTED_CELLS.length
@@ -903,8 +925,7 @@ export function validateReceipt(receipt, expectedCell, profile, lifecycleContext
     || (receipt.cleanup.error !== null && typeof receipt.cleanup.error !== "string")) {
     fail("receipt cleanup evidence is incomplete");
   }
-  if (!receipt.authorityLifecycle
-    && receipt.repositories.sceneworks.sha !== LEGACY_SCENEWORKS_HEAD) {
+  if (!receipt.authorityLifecycle && trustedContext !== TRUSTED_LEGACY_IMPORT_CONTEXT) {
     fail("continuation receipt is missing required authority lifecycle evidence");
   }
   if (receipt.authorityLifecycle) {
@@ -988,6 +1009,10 @@ export function validateReceipt(receipt, expectedCell, profile, lifecycleContext
     fail("failed receipt must retain an error");
   }
   return receipt;
+}
+
+export function validateReceipt(receipt, expectedCell, profile, lifecycleContext = null) {
+  return validateReceiptInternal(receipt, expectedCell, profile, lifecycleContext);
 }
 
 function cachedArtifactRoots(cacheRoot, artifact) {
@@ -1102,16 +1127,18 @@ async function validatePrefixCandidate(candidate, currentProfile) {
       fail(`imported prefix is missing the exact primary receipt for ${ordinalName}`);
     }
     const receipt = JSON.parse(await readFile(receiptPath, "utf8"));
-    validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, receipt);
-    validateReceipt(receipt, cell, legacyProfile);
     if (receipt.status !== "passed"
-      || receipt.repositories.sceneworks.sha !== LEGACY_SCENEWORKS_HEAD
-      || receipt.repositories.inference.sha !== FROZEN_INFERENCE_PIN
-      || receipt.execution.headSha !== LEGACY_SCENEWORKS_HEAD
-      || receipt.execution.runId !== metadata.runId
-      || receipt.execution.runAttempt !== metadata.runAttempt) {
+      || receipt.cell?.ordinal !== index + 1
+      || receipt.cell?.id !== cell.id
+      || receipt.repositories?.sceneworks?.sha !== LEGACY_SCENEWORKS_HEAD
+      || receipt.repositories?.inference?.sha !== FROZEN_INFERENCE_PIN
+      || receipt.execution?.headSha !== LEGACY_SCENEWORKS_HEAD
+      || receipt.execution?.runId !== metadata.runId
+      || receipt.execution?.runAttempt !== metadata.runAttempt) {
       fail(`imported prefix receipt ${ordinalName} is not an exact PASS from the bound old run`);
     }
+    validateTrustedLegacyImportedReceiptDocument(receipt);
+    validateReceiptInternal(receipt, cell, legacyProfile, null, TRUSTED_LEGACY_IMPORT_CONTEXT);
     const rehashed = await evidenceFiles(cellDir);
     for (const field of ["inputs", "outputs", "logs"]) {
       if (JSON.stringify(rehashed[field]) !== JSON.stringify(receipt[field])) {
@@ -1145,16 +1172,22 @@ async function validatePrefixCandidate(candidate, currentProfile) {
     fail("imported artifact contains evidence outside the seven PASS cells and cell-8 boundary residue");
   }
   const boundaryReceipt = JSON.parse(await readFile(path.join(boundaryDir, "receipt.json"), "utf8"));
-  validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, boundaryReceipt);
-  validateReceipt(boundaryReceipt, boundaryCell, legacyProfile);
-  const boundaryLog = (await hashedFiles(boundaryDir, { exclude: new Set(["receipt.json"]) }));
   if (boundaryReceipt.status !== "failed"
-    || boundaryReceipt.error !== "cell has not completed"
-    || boundaryReceipt.repositories.sceneworks.sha !== LEGACY_SCENEWORKS_HEAD
-    || boundaryReceipt.repositories.inference.sha !== FROZEN_INFERENCE_PIN
-    || boundaryReceipt.execution.headSha !== LEGACY_SCENEWORKS_HEAD
-    || boundaryReceipt.execution.runId !== metadata.runId
-    || boundaryReceipt.execution.runAttempt !== metadata.runAttempt
+    || boundaryReceipt.cell?.ordinal !== boundaryIndex + 1
+    || boundaryReceipt.cell?.id !== boundaryCell.id
+    || boundaryReceipt.repositories?.sceneworks?.sha !== LEGACY_SCENEWORKS_HEAD
+    || boundaryReceipt.repositories?.inference?.sha !== FROZEN_INFERENCE_PIN
+    || boundaryReceipt.execution?.headSha !== LEGACY_SCENEWORKS_HEAD
+    || boundaryReceipt.execution?.runId !== metadata.runId
+    || boundaryReceipt.execution?.runAttempt !== metadata.runAttempt) {
+    fail("imported cell-8 residue is not bound to the exact legacy run boundary");
+  }
+  validateTrustedLegacyImportedReceiptDocument(boundaryReceipt);
+  validateReceiptInternal(
+    boundaryReceipt, boundaryCell, legacyProfile, null, TRUSTED_LEGACY_IMPORT_CONTEXT,
+  );
+  const boundaryLog = (await hashedFiles(boundaryDir, { exclude: new Set(["receipt.json"]) }));
+  if (boundaryReceipt.error !== "cell has not completed"
     || boundaryReceipt.startedAt !== boundaryReceipt.completedAt
     || boundaryReceipt.cleanup.attempted !== false
     || boundaryReceipt.cleanup.completed !== false
@@ -1911,6 +1944,7 @@ function cachePreflightDocument({
   evidencePhase, status, error, downloadEvidenceSha256, remainingArtifactIds, guard, stagingRoot,
   derivedSidecarRoot, frozenMissing, sidecarObstructions, cacheProvisioning,
   derivedSidecarLifecycle, missingStore, lifetimePlan, diskPlan, missingDownload,
+  networkOfflineEstablished,
 }) {
   return {
     schemaVersion: 1,
@@ -1937,7 +1971,7 @@ function cachePreflightDocument({
     lifetimePlan,
     diskPlan,
     derivedSidecarLifecycle,
-    offlineBeforeCells: status === "passed",
+    offlineBeforeCells: networkOfflineEstablished,
   };
 }
 
@@ -2027,6 +2061,11 @@ export function validateCachePreflightEvidence(document, {
   if (document.networkDownloadCount !== document.downloadedFiles.length
     || document.networkDownloadCount !== frozen.length) {
     fail("cache preflight network count drifted from the frozen missing set");
+  }
+  if (!document.offlineBeforeCells && (document.phases.staging.length
+    || document.phases.finalOffline.length || document.sidecarObstructions.length
+    || document.derivedSidecarLifecycle.afterCells.length)) {
+    fail("cache preflight records cell lifecycle evidence before network-offline establishment");
   }
   if (document.status === "passed") {
     const plannedAudits = new Map(document.phases.sourceCensus.map((row) => [row.id, {
@@ -2353,6 +2392,7 @@ export async function runCampaign(args, options = {}) {
   }
 
   let missingDownload = null;
+  let networkOfflineEstablished = false;
   let sidecarObstructions = [];
   const derivedSidecarLifecycle = { initial: null, afterCells: [] };
   let lifetimePlan = [];
@@ -2395,6 +2435,7 @@ export async function runCampaign(args, options = {}) {
       quarantineReason = `cache-only transfer/disk preflight failed: ${errorText(error)}`;
     }
   }
+  if (!quarantineReason) networkOfflineEstablished = true;
   if (quarantineReason) {
     quarantineReason = `${quarantineReason}; no continuation GPU cell started`;
     campaignErrors.push(quarantineReason);
@@ -2429,6 +2470,7 @@ export async function runCampaign(args, options = {}) {
     lifetimePlan,
     diskPlan,
     missingDownload,
+    networkOfflineEstablished,
   });
   let initialWrite = await writeCachePreflightDurably({
     output, filename: "cache-preflight-initial.json", document: initialDocument,
@@ -2459,6 +2501,7 @@ export async function runCampaign(args, options = {}) {
       lifetimePlan: [],
       diskPlan: null,
       missingDownload: null,
+      networkOfflineEstablished,
     });
     initialWrite = {
       evidence: await writeCachePreflightFallback({
@@ -2767,10 +2810,30 @@ export async function runCampaign(args, options = {}) {
       }
       if (runtimeFailure) throw runtimeFailure;
       operations.sample(samples, errors, "post-execution VRAM sample failed");
-      const runtimeResult = JSON.parse(await readFile(path.join(cellDir, "runtime-result.json"), "utf8"));
-      validateRuntimeResult(runtimeResult, cell);
-      receipt.cell.loadSpecQuantBits = runtimeResult.loadSpecQuantBits;
-      executionPassed = true;
+      try {
+        const runtimeResultPath = path.join(cellDir, "runtime-result.json");
+        await invokeFault(fault, "runtimeResultRead", index);
+        const before = await stat(runtimeResultPath);
+        const runtimeResultBytes = await readFile(runtimeResultPath);
+        await invokeFault(fault, "runtimeResultHash", index);
+        const rawSha256 = createHash("sha256").update(runtimeResultBytes).digest("hex");
+        const fileSha256 = await sha256File(runtimeResultPath);
+        const after = await stat(runtimeResultPath);
+        if (!before.isFile() || before.size !== runtimeResultBytes.length
+          || after.size !== before.size || rawSha256 !== fileSha256) {
+          fail(`runtime-result file/hash changed while validating ${cell.id}`);
+        }
+        await invokeFault(fault, "runtimeResultParse", index);
+        const runtimeResult = JSON.parse(runtimeResultBytes.toString("utf8"));
+        await invokeFault(fault, "runtimeResultSemantic", index);
+        validateRuntimeResult(runtimeResult, cell);
+        receipt.cell.loadSpecQuantBits = runtimeResult.loadSpecQuantBits;
+        executionPassed = true;
+      } catch (error) {
+        quarantineReason = `runtime-result evidence failed after cell ${cell.id}: ${errorText(error)}`;
+        campaignErrors.push(quarantineReason);
+        throw error;
+      }
     } catch (error) {
       const message = recordError(errors, "cell lifecycle failed", error);
       if (!executionAttempted && !quarantineReason) {
@@ -3011,6 +3074,7 @@ export async function runCampaign(args, options = {}) {
     lifetimePlan,
     diskPlan,
     missingDownload,
+    networkOfflineEstablished,
   });
   let finalWrite = await writeCachePreflightDurably({
     output, filename: "cache-preflight.json", document: finalDocument,
@@ -3036,6 +3100,7 @@ export async function runCampaign(args, options = {}) {
       lifetimePlan: [],
       diskPlan: null,
       missingDownload: null,
+      networkOfflineEstablished,
     });
     finalWrite = {
       evidence: await writeCachePreflightFallback({

--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -4,7 +4,7 @@ import { spawn, spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { createReadStream, createWriteStream, readFileSync } from "node:fs";
 import {
-  appendFile, cp, lstat, mkdir, readdir, readFile, realpath, rename, rm, stat, writeFile,
+  appendFile, cp, lstat, mkdir, readdir, readFile, realpath, rename, rm, stat, statfs, writeFile,
 } from "node:fs/promises";
 import { freemem, totalmem } from "node:os";
 import path from "node:path";
@@ -48,6 +48,14 @@ const LTX_CURRENT_REVISION = "01df27d308466533aa09d251e3aebdcc627d07eb";
 const LTX_APPROVED_PARENT_REVISION = "254989c3ca7ee691187647f350b112c0c448789d";
 const IMPORTED_PREFIX_CELLS = 7;
 const PREFIX_ARTIFACT = `sc-20945-epic-20738-${LEGACY_SCENEWORKS_HEAD}-`;
+const LEGACY_NAIVE_LINK_LENGTH_SOURCE_BYTES = 173_667_044_229;
+const REVIEWED_ALL_AT_ONCE_SOURCE_BYTES = 179_028_698_264;
+const REVIEWED_JIT_SOURCE_PEAK_BYTES = 56_156_615_634;
+const NON_MODEL_DISK_RESERVE_BYTES = 40 * 1024 ** 3;
+const REVIEWED_FREE_FLOOR_BYTES = 99_106_288_594;
+const FLUX_Q4_SIDECAR_BYTES = 7_396_392_960 + 494 * 16_384;
+const FLUX_Q8_SIDECAR_BYTES = 12_573_868_032 + 494 * 16_384;
+const REVIEWED_DOWNLOAD_EVIDENCE_SHA256 = "9eda09eeacb9386167ca4a080b4805b9c7dd3cd5134ca037ce342ad434b17e0b";
 
 function fail(message) {
   throw new Error(message);
@@ -76,6 +84,141 @@ function canonicalize(value) {
 
 function canonicalSha256(value) {
   return createHash("sha256").update(JSON.stringify(canonicalize(value))).digest("hex");
+}
+
+export function authorityLifetimePlan(profile, startIndex, sourceAudits) {
+  const cells = profile.cells.slice(startIndex);
+  const ids = [...new Set(cells.flatMap((cell) => cell.artifactIds))];
+  return ids.map((artifactId) => {
+    const uses = [];
+    for (let index = startIndex; index < profile.cells.length; index += 1) {
+      if (profile.cells[index].artifactIds.includes(artifactId)) uses.push(index + 1);
+    }
+    const audit = sourceAudits instanceof Map ? sourceAudits.get(artifactId) : sourceAudits[artifactId];
+    if (!audit) fail(`source audit is missing lifetime authority ${artifactId}`);
+    const files = [
+      ...audit.reusedFiles.map((file) => ({ ...file, persistent: false })),
+      ...(audit.downloadedFiles ?? []).map((file) => ({ ...file, persistent: true })),
+    ];
+    const sourceBytes = files.reduce((sum, file) => sum + file.bytes, 0);
+    if (!Number.isSafeInteger(sourceBytes) || sourceBytes < 1) {
+      fail(`source byte census is invalid for lifetime authority ${artifactId}`);
+    }
+    return {
+      artifactId,
+      role: profile.artifacts[artifactId].role,
+      firstOrdinal: uses[0],
+      lastOrdinal: uses.at(-1),
+      sourceBytes,
+      expectedFiles: audit.expectedFiles?.length
+        ?? audit.reusedFiles.length + (audit.downloadedFiles ?? []).length,
+      physicalFiles: files.map((file) => ({
+        key: `${profile.artifacts[artifactId].repository}@${profile.artifacts[artifactId].revision}/${
+          profile.artifacts[artifactId].subdirectory === "."
+            ? file.path : `${profile.artifacts[artifactId].subdirectory}/${file.path}`
+        }`,
+        bytes: file.bytes,
+        persistent: file.persistent,
+      })),
+    };
+  });
+}
+
+export function estimateJitDiskPlan(
+  lifetimes,
+  freeBytes,
+  persistentMissingBytes = 0,
+  nonModelPaths = [],
+) {
+  if (!Number.isSafeInteger(freeBytes) || freeBytes < 0
+    || !Number.isSafeInteger(persistentMissingBytes) || persistentMissingBytes < 0) {
+    fail("disk estimator requires exact non-negative byte counts");
+  }
+  const ordinals = [...new Set(lifetimes.flatMap((row) => [row.firstOrdinal, row.lastOrdinal]))]
+    .sort((left, right) => left - right);
+  const cells = ordinals.map((ordinal) => {
+    const active = lifetimes.filter((row) => (
+      row.firstOrdinal <= ordinal && row.lastOrdinal >= ordinal
+    ));
+    const physical = new Map();
+    for (const file of lifetimes.flatMap((row) => row.physicalFiles).filter(
+      (file) => file.persistent,
+    )) physical.set(file.key, file.bytes);
+    for (const file of active.flatMap((row) => row.physicalFiles)) {
+      const existing = physical.get(file.key);
+      if (existing !== undefined && existing !== file.bytes) {
+        fail(`physical source identity has conflicting byte sizes: ${file.key}`);
+      }
+      physical.set(file.key, file.bytes);
+    }
+    const stagedBytes = [...physical.values()].reduce((sum, bytes) => sum + bytes, 0);
+    const sidecarReserveBytes = active.reduce((sum, row) => {
+      if (!row.artifactId.startsWith("flux1-")) return sum;
+      return sum + (row.artifactId.endsWith("-q4")
+        ? FLUX_Q4_SIDECAR_BYTES : FLUX_Q8_SIDECAR_BYTES);
+    }, 0);
+    const modelAndSidecarBytes = stagedBytes + sidecarReserveBytes;
+    return {
+      ordinal,
+      artifactIds: active.map((row) => row.artifactId),
+      stagedBytes,
+      sidecarReserveBytes,
+      modelAndSidecarBytes,
+      requiredAdditionalBytes: Math.max(
+        modelAndSidecarBytes + NON_MODEL_DISK_RESERVE_BYTES,
+        REVIEWED_FREE_FLOOR_BYTES,
+      ),
+    };
+  });
+  const peak = cells.reduce((highest, row) => (
+    row.modelAndSidecarBytes > highest.modelAndSidecarBytes ? row : highest
+  ), { ordinal: 0, artifactIds: [], stagedBytes: 0, sidecarReserveBytes: 0,
+    modelAndSidecarBytes: 0, requiredAdditionalBytes: REVIEWED_FREE_FLOOR_BYTES });
+  const allPhysical = new Map();
+  for (const file of lifetimes.flatMap((row) => row.physicalFiles)) {
+    const existing = allPhysical.get(file.key);
+    if (existing !== undefined && existing !== file.bytes) {
+      fail(`physical source identity has conflicting byte sizes: ${file.key}`);
+    }
+    allPhysical.set(file.key, file.bytes);
+  }
+  const logicalSourceBytes = lifetimes.reduce((sum, row) => sum + row.sourceBytes, 0);
+  const allAtOnceSourceBytes = [...allPhysical.values()].reduce((sum, bytes) => sum + bytes, 0);
+  const allAtOnceSidecarReserveBytes = Math.max(FLUX_Q4_SIDECAR_BYTES, FLUX_Q8_SIDECAR_BYTES);
+  if (logicalSourceBytes === REVIEWED_ALL_AT_ONCE_SOURCE_BYTES
+    && (allAtOnceSourceBytes !== REVIEWED_ALL_AT_ONCE_SOURCE_BYTES
+      || (persistentMissingBytes > 0
+        ? peak.modelAndSidecarBytes !== REVIEWED_JIT_SOURCE_PEAK_BYTES
+        : peak.modelAndSidecarBytes > REVIEWED_JIT_SOURCE_PEAK_BYTES))) {
+    fail(`reviewed disk census drifted: all=${allAtOnceSourceBytes}, peak=${peak.modelAndSidecarBytes}`);
+  }
+  return {
+    freeBytes,
+    persistentMissingBytes,
+    nonModelReserveBytes: NON_MODEL_DISK_RESERVE_BYTES,
+    nonModelPaths,
+    legacyNaiveLinkLengthSourceBytes: LEGACY_NAIVE_LINK_LENGTH_SOURCE_BYTES,
+    reviewedAllAtOnceSourceBytes: REVIEWED_ALL_AT_ONCE_SOURCE_BYTES,
+    reviewedJitSourcePeakBytes: REVIEWED_JIT_SOURCE_PEAK_BYTES,
+    logicalSourceBytes,
+    allAtOnceSourceBytes,
+    allAtOnceRequiredBytes: allAtOnceSourceBytes + allAtOnceSidecarReserveBytes
+      + NON_MODEL_DISK_RESERVE_BYTES,
+    peakOrdinal: peak.ordinal,
+    peakArtifactIds: peak.artifactIds,
+    peakStagedBytes: peak.stagedBytes,
+    peakSidecarReserveBytes: peak.sidecarReserveBytes,
+    peakModelAndSidecarBytes: peak.modelAndSidecarBytes,
+    peakRequiredAdditionalBytes: Math.max(
+      peak.modelAndSidecarBytes + NON_MODEL_DISK_RESERVE_BYTES,
+      REVIEWED_FREE_FLOOR_BYTES,
+    ),
+    admitted: freeBytes >= Math.max(
+      peak.modelAndSidecarBytes + NON_MODEL_DISK_RESERVE_BYTES,
+      REVIEWED_FREE_FLOOR_BYTES,
+    ),
+    cells,
+  };
 }
 
 export function cellSemanticsSha256(cells) {
@@ -749,6 +892,20 @@ export function validateReceipt(receipt, expectedCell, profile) {
     || (receipt.cleanup.error !== null && typeof receipt.cleanup.error !== "string")) {
     fail("receipt cleanup evidence is incomplete");
   }
+  if (receipt.authorityLifecycle) {
+    const lifecycle = receipt.authorityLifecycle;
+    if (lifecycle.ordinal !== receipt.cell.ordinal || lifecycle.cellId !== receipt.cell.id
+      || JSON.stringify(lifecycle.activeArtifactIds) !== JSON.stringify(expectedCell.artifactIds)
+      || lifecycle.staged.some((entry) => !expectedCell.artifactIds.includes(entry.artifactId))
+      || lifecycle.released.some((entry) => !expectedCell.artifactIds.includes(entry.artifactId))) {
+      fail("receipt authority lifecycle identity drifted");
+    }
+    if (receipt.status === "passed" && (!lifecycle.verifiedBefore || !lifecycle.verifiedAfter
+      || lifecycle.diskProbes.length < lifecycle.staged.length + 1
+      || lifecycle.released.some((entry) => !entry.stageRemoved || !entry.derivedRemoved))) {
+      fail("passed receipt authority lifecycle is incomplete");
+    }
+  }
   if (receipt.status === "passed" && (receipt.error !== null || !receipt.cleanup.completed
     || receipt.cleanup.error !== null)) {
     fail("passed receipt contains a failure or incomplete cleanup");
@@ -1153,7 +1310,7 @@ async function auditArtifact({ id, artifact, expectedFiles, scratch, python, cac
 }
 
 async function stageArtifact({
-  id, artifact, expectedFiles, scratch, python, cacheRoot, stagingRoot, allowReviewedDownload,
+  id, artifact, expectedFiles, scratch, python, cacheRoot, stagingRoot, missingStore,
 }) {
   const requestPath = await writeArtifactRequest({
     id, artifact, expectedFiles, scratch, phase: "stage",
@@ -1163,12 +1320,12 @@ async function stageArtifact({
     "--request", requestPath,
     "--cache-root", cacheRoot,
     "--stage-root", stagingRoot,
-    ...(allowReviewedDownload ? ["--allow-reviewed-download"] : []),
+    ...(missingStore ? ["--missing-store", missingStore] : []),
   ], {
     env: {
       ...process.env,
-      HF_HUB_OFFLINE: allowReviewedDownload ? "0" : "1",
-      TRANSFORMERS_OFFLINE: allowReviewedDownload ? "0" : "1",
+      HF_HUB_OFFLINE: "1",
+      TRANSFORMERS_OFFLINE: "1",
       HF_HUB_DISABLE_IMPLICIT_TOKEN: "1",
       HF_HUB_DISABLE_PROGRESS_BARS: "1",
       HF_HUB_DISABLE_TELEMETRY: "1",
@@ -1182,6 +1339,51 @@ async function stageArtifact({
   });
   if (comparable(await realpath(result.sourceCacheRoot)) !== comparable(cacheRoot)) {
     fail(`campaign staging result drifted from trusted source cache for ${id}`);
+  }
+  return result;
+}
+
+async function downloadReviewedMissing({
+  id, artifact, expectedFiles, scratch, python, cacheRoot, missingStore,
+}) {
+  const requestPath = await writeArtifactRequest({
+    id, artifact, expectedFiles, scratch, phase: "download-missing",
+  });
+  const raw = run(python, [
+    "scripts/provision-epic-20738-terminal-artifact.py",
+    "--request", requestPath,
+    "--cache-root", cacheRoot,
+    "--missing-store", missingStore,
+    "--download-reviewed-missing",
+  ], {
+    env: {
+      ...process.env,
+      HF_HUB_OFFLINE: "0",
+      TRANSFORMERS_OFFLINE: "0",
+      HF_HUB_DISABLE_IMPLICIT_TOKEN: "1",
+      HF_HUB_DISABLE_PROGRESS_BARS: "1",
+      HF_HUB_DISABLE_TELEMETRY: "1",
+      HF_HUB_VERBOSITY: "error",
+    },
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  const result = parseProvisionerOutput(raw, id, "reviewed missing-file fill");
+  exactKeys(result, ["id", "storeRoot", "downloadedFiles"], `missing-file fill for ${id}`);
+  if (result.id !== id || comparable(await realpath(result.storeRoot)) !== comparable(missingStore)
+    || result.downloadedFiles.length !== 1) {
+    fail(`reviewed missing-file fill identity drifted for ${id}`);
+  }
+  const [file] = result.downloadedFiles;
+  exactKeys(
+    file,
+    ["path", "bytes", "sha256", "lfsSha256", "commitSha"],
+    `reviewed missing-file fill for ${id}`,
+  );
+  if (file.path !== "transformer/model.safetensors"
+    || file.commitSha !== "bba3ae01dfd94089f173c05edd4e1a4c551f2599"
+    || !Number.isSafeInteger(file.bytes) || file.bytes < 1
+    || !/^[0-9a-f]{64}$/.test(file.sha256) || file.sha256 !== file.lfsSha256) {
+    fail("reviewed missing-file fill did not prove exact commit/size/LFS identity");
   }
   return result;
 }
@@ -1275,6 +1477,34 @@ export async function installSidecarObstructions(sharedArtifacts) {
     }
   }
   return records.sort((left, right) => left.root.localeCompare(right.root));
+}
+
+export async function listDerivedSidecarNamespaces(derivedSidecarRoot) {
+  const namespaceRoot = path.join(derivedSidecarRoot, "candle-device-format-v1");
+  let entries;
+  try {
+    entries = await readdir(namespaceRoot, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === "ENOENT") return [];
+    throw error;
+  }
+  const namespaces = [];
+  for (const entry of entries) {
+    const candidate = path.join(namespaceRoot, entry.name);
+    const metadata = await lstat(candidate);
+    if (!entry.isDirectory() || metadata.isSymbolicLink()) {
+      fail(`derived sidecar namespace must be an ordinary directory: ${candidate}`);
+    }
+    namespaces.push(candidate);
+  }
+  return namespaces.sort();
+}
+
+async function diskFreeBytes(directory) {
+  const filesystem = await statfs(directory);
+  const bytes = Number(filesystem.bavail) * Number(filesystem.bsize);
+  if (!Number.isSafeInteger(bytes) || bytes < 0) fail("filesystem free-byte count is invalid");
+  return bytes;
 }
 
 export async function verifyArtifactUnchanged(artifact, cacheRoot) {
@@ -1425,9 +1655,23 @@ async function writePrimaryReceipt({ file, receipt, cell, profile, fault, index 
   await writeJsonAtomically(file, receipt);
 }
 
+function emptyAuthorityLifecycle(cell, index) {
+  return {
+    ordinal: index + 1,
+    cellId: cell.id,
+    staged: [],
+    activeArtifactIds: [...cell.artifactIds],
+    verifiedBefore: false,
+    verifiedAfter: false,
+    derivedAfter: [],
+    released: [],
+    diskProbes: [],
+  };
+}
+
 async function writeEmergencyReceipt({
   profile, cell, index, ordinalName, output, cacheRoot, repositories, execution, gpuIdentity,
-  systemMemory, error, cleanup,
+  systemMemory, error, cleanup, authorityLifecycle,
 }) {
   // This path deliberately bypasses all injected/primary finalization operations. If the primary
   // log, evidence hash, semantic/schema check, or atomic writer fails, a fresh controller-owned
@@ -1445,6 +1689,7 @@ async function writeEmergencyReceipt({
     startedAt,
   });
   receipt.error = message;
+  receipt.authorityLifecycle = authorityLifecycle ?? emptyAuthorityLifecycle(cell, index);
   receipt.cleanup = cleanup ?? { attempted: false, completed: true, error: null };
   receipt.hardware.rawVramSamples = gpuIdentity.length
     ? [...gpuIdentity]
@@ -1460,7 +1705,7 @@ async function writeEmergencyReceipt({
 
 async function writeLastResortEmergencyReceipt({
   profile, cell, index, ordinalName, output, cacheRoot, repositories, execution, gpuIdentity,
-  systemMemory, errors, cleanup,
+  systemMemory, errors, cleanup, authorityLifecycle,
 }) {
   // A second implementation intentionally avoids evidenceFiles(), writeJsonAtomically(), and every
   // primary/injected callback. It hashes its one log directly and publishes under a different name.
@@ -1483,6 +1728,7 @@ async function writeLastResortEmergencyReceipt({
     startedAt,
   });
   receipt.error = errors.join("\n");
+  receipt.authorityLifecycle = authorityLifecycle ?? emptyAuthorityLifecycle(cell, index);
   receipt.cleanup = cleanup;
   receipt.hardware.rawVramSamples = gpuIdentity.length
     ? [...gpuIdentity]
@@ -1542,7 +1788,7 @@ async function writeSummaryDurably({ output, summary, fault }) {
 function cachePreflightDocument({
   status, error, downloadEvidenceSha256, remainingArtifactIds, guard, stagingRoot,
   derivedSidecarRoot, frozenMissing, sidecarObstructions, cacheProvisioning,
-  derivedSidecarLifecycle,
+  derivedSidecarLifecycle, missingStore, lifetimePlan, diskPlan, missingDownload,
 }) {
   return {
     schemaVersion: 1,
@@ -1554,15 +1800,19 @@ function cachePreflightDocument({
     sourceCacheRoot: guard.cacheRoot,
     campaignStagingRoot: stagingRoot,
     derivedSidecarRoot,
+    missingFileStore: missingStore,
     frozenMissingFiles: frozenMissing,
     sidecarObstructions,
-    reusedFiles: cacheProvisioning.staging.flatMap((artifact) => artifact.reusedFiles.map(
+    reusedFiles: cacheProvisioning.sourceCensus.flatMap((artifact) => artifact.reusedFiles.map(
       (file) => ({ artifactId: artifact.id, ...file }),
     )),
-    downloadedFiles: cacheProvisioning.staging.flatMap((artifact) => artifact.downloadedFiles.map(
-      (file) => ({ artifactId: artifact.id, ...file }),
-    )),
+    downloadedFiles: missingDownload?.downloadedFiles.map((file) => ({
+      artifactId: missingDownload.id, ...file,
+    })) ?? [],
+    networkDownloadCount: missingDownload ? 1 : 0,
     phases: cacheProvisioning,
+    lifetimePlan,
+    diskPlan,
     derivedSidecarLifecycle,
     offlineBeforeCells: status === "passed",
   };
@@ -1570,7 +1820,7 @@ function cachePreflightDocument({
 
 export function validateCachePreflightEvidence(document, {
   remainingArtifactIds, artifactExpectedFiles, downloadEvidenceSha256, guard, stagingRoot,
-  derivedSidecarRoot, profile,
+  derivedSidecarRoot, missingStore, profile,
 }) {
   validateDocumentWithSchema(CACHE_PREFLIGHT_SCHEMA_PATH, document);
   if (document.profile !== profile.profile
@@ -1578,6 +1828,7 @@ export function validateCachePreflightEvidence(document, {
     || document.sourceCacheRoot !== guard.cacheRoot
     || document.campaignStagingRoot !== stagingRoot
     || document.derivedSidecarRoot !== derivedSidecarRoot
+    || document.missingFileStore !== missingStore
     || JSON.stringify(document.expectedArtifactIds) !== JSON.stringify(remainingArtifactIds)) {
     fail("cache preflight identity/path binding drifted");
   }
@@ -1610,6 +1861,14 @@ export function validateCachePreflightEvidence(document, {
   if (JSON.stringify(document.frozenMissingFiles) !== JSON.stringify(frozen)) {
     fail("cache preflight frozen missing-file census drifted");
   }
+  if (downloadEvidenceSha256 === REVIEWED_DOWNLOAD_EVIDENCE_SHA256
+    && profile.cells.length === 19 && remainingArtifactIds.length === 16
+    && remainingArtifactIds.reduce(
+      (sum, id) => sum + artifactExpectedFiles[id].length,
+      0,
+    ) !== 199) {
+    fail("continuation must bind the exact logical 16-authority/199-file census");
+  }
   for (const row of document.phases.staging) {
     if (JSON.stringify([
       ...row.reusedFiles.map((file) => file.path),
@@ -1623,11 +1882,10 @@ export function validateCachePreflightEvidence(document, {
       fail(`cache preflight final inventory count drifted for ${row.id}`);
     }
   }
-  const flatten = (key) => document.phases.staging.flatMap((artifact) => artifact[key].map(
+  const sourceFiles = document.phases.sourceCensus.flatMap((artifact) => artifact.reusedFiles.map(
     (file) => ({ artifactId: artifact.id, ...file }),
   ));
-  if (JSON.stringify(document.reusedFiles) !== JSON.stringify(flatten("reusedFiles"))
-    || JSON.stringify(document.downloadedFiles) !== JSON.stringify(flatten("downloadedFiles"))) {
+  if (JSON.stringify(document.reusedFiles) !== JSON.stringify(sourceFiles)) {
     fail("cache preflight top-level hit/download partition drifted");
   }
   if (document.downloadedFiles.length > 1 || document.downloadedFiles.some((file) => (
@@ -1636,38 +1894,61 @@ export function validateCachePreflightEvidence(document, {
       || file.commitSha !== "bba3ae01dfd94089f173c05edd4e1a4c551f2599"
       || file.sha256 !== file.lfsSha256
   ))) fail("cache preflight contains an unreviewed model download");
+  if ((frozen.length === 1) !== (document.downloadedFiles.length === 1)) {
+    fail("cache preflight missing/download partition is incomplete");
+  }
+  if (document.networkDownloadCount !== document.downloadedFiles.length
+    || document.networkDownloadCount !== frozen.length) {
+    fail("cache preflight network count drifted from the frozen missing set");
+  }
   if (document.status === "passed") {
-    for (const phase of ["sourceCensus", "staging", "finalOffline"]) {
-      if (JSON.stringify(document.phases[phase].map((row) => row.id))
+    const plannedAudits = new Map(document.phases.sourceCensus.map((row) => [row.id, {
+      ...row,
+      downloadedFiles: document.downloadedFiles.filter((file) => file.artifactId === row.id),
+    }]));
+    const expectedLifetimePlan = authorityLifetimePlan(
+      profile,
+      profile.cells.length - document.diskPlan.cells.length,
+      plannedAudits,
+    );
+    if (JSON.stringify(document.lifetimePlan) !== JSON.stringify(expectedLifetimePlan)) {
+      fail("cache preflight authority lifetime plan drifted from the frozen census");
+    }
+    const expectedDiskPlan = estimateJitDiskPlan(
+      expectedLifetimePlan,
+      document.diskPlan.freeBytes,
+      document.downloadedFiles.reduce((sum, file) => sum + file.bytes, 0),
+      document.diskPlan.nonModelPaths,
+    );
+    if (JSON.stringify(document.diskPlan) !== JSON.stringify(expectedDiskPlan)) {
+      fail("cache preflight disk plan drifted from exact target-byte census");
+    }
+    if (JSON.stringify(document.phases.sourceCensus.map((row) => row.id))
+      !== JSON.stringify(remainingArtifactIds)) {
+      fail("passed cache preflight omitted sourceCensus authorities");
+    }
+    if (document.lifetimePlan.length !== remainingArtifactIds.length
+      || JSON.stringify(document.lifetimePlan.map((row) => row.artifactId))
         !== JSON.stringify(remainingArtifactIds)) {
-        fail(`passed cache preflight omitted ${phase} authorities`);
-      }
-    }
-    const obstructed = [...new Set(document.sidecarObstructions.flatMap(
-      (entry) => entry.artifactIds,
-    ))].sort();
-    if (JSON.stringify(obstructed) !== JSON.stringify([...remainingArtifactIds].sort())) {
-      fail("passed cache preflight did not obstruct every staged component root");
-    }
-    for (const row of document.phases.finalOffline) {
-      const expectedRoots = new Set([row.inventory.root]);
-      for (const file of artifactExpectedFiles[row.id]) {
-        const [component] = file.split("/");
-        if (file.includes("/")) expectedRoots.add(path.join(row.inventory.root, component));
-      }
-      const actualRoots = document.sidecarObstructions.filter(
-        (entry) => entry.artifactIds.includes(row.id),
-      ).map((entry) => entry.root);
-      if (JSON.stringify([...new Set(actualRoots)].sort())
-        !== JSON.stringify([...expectedRoots].sort())
-        || actualRoots.some((root) => !isWithin(stagingRoot, root))) {
-        fail(`passed cache preflight did not obstruct exact component roots for ${row.id}`);
-      }
+      fail("passed cache preflight lifetime plan omitted reviewed authorities");
     }
     const initial = document.derivedSidecarLifecycle.initial;
     if (!initial || initial.root !== derivedSidecarRoot || initial.files !== 0
       || initial.bytes !== 0 || initial.sha256 !== createHash("sha256").digest("hex")) {
       fail("derived Candle cache was not proven empty before cells");
+    }
+    if (!document.diskPlan.admitted
+      || document.diskPlan.freeBytes < document.diskPlan.peakRequiredAdditionalBytes) {
+      fail("passed cache preflight did not prove sufficient JIT disk capacity");
+    }
+    if (downloadEvidenceSha256 === REVIEWED_DOWNLOAD_EVIDENCE_SHA256
+      && (document.diskPlan.logicalSourceBytes !== REVIEWED_ALL_AT_ONCE_SOURCE_BYTES
+        || document.diskPlan.allAtOnceSourceBytes !== REVIEWED_ALL_AT_ONCE_SOURCE_BYTES
+        || document.diskPlan.peakRequiredAdditionalBytes !== REVIEWED_FREE_FLOOR_BYTES
+        || (frozen.length === 1
+          ? document.diskPlan.peakModelAndSidecarBytes !== REVIEWED_JIT_SOURCE_PEAK_BYTES
+          : document.diskPlan.peakModelAndSidecarBytes > REVIEWED_JIT_SOURCE_PEAK_BYTES))) {
+      fail("passed cache preflight drifted from reviewed target-byte totals and JIT floor");
     }
   }
   let previous = 0;
@@ -1795,11 +2076,16 @@ export async function runCampaign(args, options = {}) {
   const fault = options.fault;
   const operations = {
     auditArtifact: options.operations?.auditArtifact ?? auditArtifact,
+    downloadReviewedMissing:
+      options.operations?.downloadReviewedMissing ?? downloadReviewedMissing,
     stageArtifact: options.operations?.stageArtifact ?? stageArtifact,
     provisionArtifact: options.operations?.provisionArtifact ?? provisionArtifact,
     installSidecarObstructions:
       options.operations?.installSidecarObstructions ?? installSidecarObstructions,
     directoryInventory: options.operations?.directoryInventory ?? directoryInventory,
+    listDerivedSidecarNamespaces:
+      options.operations?.listDerivedSidecarNamespaces ?? listDerivedSidecarNamespaces,
+    diskFreeBytes: options.operations?.diskFreeBytes ?? diskFreeBytes,
     verifyArtifactUnchanged:
       options.operations?.verifyArtifactUnchanged ?? verifyArtifactUnchanged,
     executeCell: options.operations?.executeCell ?? executeCell,
@@ -1822,6 +2108,7 @@ export async function runCampaign(args, options = {}) {
   const preflightScratch = path.join(scratch, "cache-preflight");
   const stagingRoot = path.join(scratch, "authority-stage");
   const derivedSidecarRoot = path.join(scratch, "derived-candle-device-cache");
+  const missingStore = path.join(scratch, "persistent-missing-file");
   const remainingArtifactIds = [...new Set(
     profile.cells.slice(startIndex).flatMap((cell) => cell.artifactIds),
   )];
@@ -1833,6 +2120,7 @@ export async function runCampaign(args, options = {}) {
     await mkdir(preflightScratch);
     await mkdir(stagingRoot);
     await mkdir(derivedSidecarRoot);
+    await mkdir(missingStore);
   } catch (error) {
     quarantineReason = `cache preflight directory preparation failed: ${errorText(error)}`;
   }
@@ -1889,101 +2177,70 @@ export async function runCampaign(args, options = {}) {
     quarantineReason = `source cache census found an unapproved missing-file set: ${JSON.stringify(frozenMissing)}`;
   }
 
-  const stagingErrors = [];
+  let missingDownload = null;
+  let sidecarObstructions = [];
+  const derivedSidecarLifecycle = { initial: null, afterCells: [] };
+  let lifetimePlan = [];
+  let diskPlan = null;
   if (!quarantineReason) {
-    for (const artifactId of remainingArtifactIds) {
-      try {
-        const audit = sourceAudits.get(artifactId);
-        const allowReviewedDownload = audit.missingFiles.length === 1;
-        const staged = await operations.stageArtifact({
-          id: artifactId,
-          artifact: profile.artifacts[artifactId],
-          expectedFiles: artifactExpectedFiles[artifactId],
+    try {
+      if (frozenMissing.length === 1) {
+        missingDownload = await operations.downloadReviewedMissing({
+          id: "flux1-schnell-q8",
+          artifact: profile.artifacts["flux1-schnell-q8"],
+          expectedFiles: artifactExpectedFiles["flux1-schnell-q8"],
           scratch: preflightScratch,
           python,
           cacheRoot: guard.cacheRoot,
-          stagingRoot,
-          allowReviewedDownload,
+          missingStore,
         });
-        const downloaded = staged.downloadedFiles ?? [];
-        if (JSON.stringify(staged.reusedFiles) !== JSON.stringify(audit.reusedFiles)) {
-          fail(`trusted source cache changed after frozen census for ${artifactId}`);
-        }
-        if ((!allowReviewedDownload && downloaded.length)
-          || (allowReviewedDownload && (downloaded.length !== 1
-            || downloaded[0].path !== "transformer/model.safetensors"
-            || !/^[0-9a-f]{64}$/.test(downloaded[0].sha256)
-            || downloaded[0].sha256 !== downloaded[0].lfsSha256
-            || downloaded[0].commitSha !== reviewedMissing[0].revision
-            || !Number.isSafeInteger(downloaded[0].bytes) || downloaded[0].bytes < 1))) {
-          fail(`campaign staging download partition drifted for ${artifactId}`);
-        }
-        cacheProvisioning.staging.push({
-          id: artifactId,
-          repository: profile.artifacts[artifactId].repository,
-          revision: profile.artifacts[artifactId].revision,
-          subdirectory: profile.artifacts[artifactId].subdirectory,
-          allowPatterns: profile.artifacts[artifactId].allowPatterns,
-          expectedFiles: artifactExpectedFiles[artifactId],
-          reusedFiles: staged.reusedFiles,
-          downloadedFiles: downloaded,
-        });
-      } catch (error) {
-        stagingErrors.push(`${artifactId}: ${errorText(error)}`);
-        break;
       }
-    }
-    if (stagingErrors.length) {
-      quarantineReason = `copy-once campaign staging failed: ${stagingErrors.join(" | ")}`;
-    }
-  }
-
-  const finalErrors = [];
-  let sidecarObstructions = [];
-  const derivedSidecarLifecycle = { initial: null, afterCells: [] };
-  if (!quarantineReason) {
-    for (const artifactId of remainingArtifactIds) {
-      try {
-        const artifact = await operations.provisionArtifact({
-          id: artifactId,
-          artifact: profile.artifacts[artifactId],
-          expectedFiles: artifactExpectedFiles[artifactId],
-          scratch: preflightScratch,
-          python,
-          cacheRoot: stagingRoot,
-        });
-        sharedArtifacts.set(artifactId, artifact);
-        cacheProvisioning.finalOffline.push({
-          id: artifactId,
-          repository: artifact.repository,
-          revision: artifact.revision,
-          subdirectory: artifact.subdirectory,
-          allowPatterns: artifact.allowPatterns,
-          expectedFiles: artifactExpectedFiles[artifactId],
-          inventory: artifact.inventory,
-        });
-      } catch (error) {
-        finalErrors.push(`${artifactId}: ${errorText(error)}`);
+      for (const [artifactId, audit] of sourceAudits) {
+        audit.expectedFiles = artifactExpectedFiles[artifactId];
+        audit.downloadedFiles = missingDownload?.id === artifactId
+          ? missingDownload.downloadedFiles : [];
       }
-    }
-    if (finalErrors.length) {
-      quarantineReason = `full offline validation of campaign staging failed: ${finalErrors.join(" | ")}`;
-    } else {
-      try {
-        sidecarObstructions = await operations.installSidecarObstructions(sharedArtifacts);
-        derivedSidecarLifecycle.initial = await operations.directoryInventory(derivedSidecarRoot);
-      } catch (error) {
-        quarantineReason = `Candle derived-sidecar isolation failed: ${errorText(error)}`;
+      lifetimePlan = authorityLifetimePlan(profile, startIndex, sourceAudits);
+      const freeBytes = await operations.diskFreeBytes(scratch);
+      diskPlan = estimateJitDiskPlan(
+        lifetimePlan,
+        freeBytes,
+        missingDownload?.downloadedFiles.reduce((sum, file) => sum + file.bytes, 0) ?? 0,
+        [
+          { kind: "cargoTarget", path: path.resolve(process.env.CARGO_TARGET_DIR ?? path.join(sceneworksRoot, "target")) },
+          { kind: "cargoHome", path: path.resolve(process.env.CARGO_HOME ?? path.join(process.env.USERPROFILE ?? scratch, ".cargo")) },
+          { kind: "campaignOutput", path: output },
+          { kind: "pythonVenv", path: python ? path.dirname(path.dirname(path.resolve(python))) : "fixture-unavailable" },
+        ],
+      );
+      if (!diskPlan.admitted) {
+        fail(`JIT staging disk admission refused: requires ${diskPlan.peakRequiredAdditionalBytes} bytes at cell ${diskPlan.peakOrdinal}, only ${diskPlan.freeBytes} free`);
       }
+      if (!missingDownload) {
+        await operations.cleanup(missingStore, guard, "unused missing-file store");
+        await assertPathAbsent(missingStore, "unused missing-file store");
+      }
+      derivedSidecarLifecycle.initial = await operations.directoryInventory(derivedSidecarRoot);
+    } catch (error) {
+      quarantineReason = `cache-only transfer/disk preflight failed: ${errorText(error)}`;
     }
   }
   if (quarantineReason) {
     quarantineReason = `${quarantineReason}; no continuation GPU cell started`;
     campaignErrors.push(quarantineReason);
+    try {
+      await lstat(missingStore);
+      await operations.cleanup(missingStore, guard, "failed preflight missing-file store");
+      await assertPathAbsent(missingStore, "failed preflight missing-file store");
+    } catch (error) {
+      if (error?.code !== "ENOENT") {
+        campaignErrors.push(`failed preflight store cleanup failed: ${errorText(error)}`);
+      }
+    }
   }
   const cacheValidation = {
     remainingArtifactIds, artifactExpectedFiles, downloadEvidenceSha256, guard, stagingRoot,
-    derivedSidecarRoot, profile,
+    derivedSidecarRoot, missingStore, profile,
   };
   let initialDocument = cachePreflightDocument({
     status: quarantineReason ? "failed" : "passed",
@@ -1997,6 +2254,10 @@ export async function runCampaign(args, options = {}) {
     sidecarObstructions,
     cacheProvisioning,
     derivedSidecarLifecycle,
+    missingStore,
+    lifetimePlan,
+    diskPlan,
+    missingDownload,
   });
   let initialWrite = await writeCachePreflightDurably({
     output, filename: "cache-preflight-initial.json", document: initialDocument,
@@ -2022,6 +2283,10 @@ export async function runCampaign(args, options = {}) {
       sidecarObstructions: [],
       cacheProvisioning: { sourceCensus: [], staging: [], finalOffline: [] },
       derivedSidecarLifecycle: { initial: null, afterCells: [] },
+      missingStore,
+      lifetimePlan: [],
+      diskPlan: null,
+      missingDownload: null,
     });
     initialWrite = {
       evidence: await writeCachePreflightFallback({
@@ -2030,7 +2295,28 @@ export async function runCampaign(args, options = {}) {
       }),
       error: null,
     };
+    try {
+      await lstat(missingStore);
+      await operations.cleanup(missingStore, guard, "failed evidence missing-file store");
+      await assertPathAbsent(missingStore, "failed evidence missing-file store");
+    } catch (error) {
+      if (error?.code !== "ENOENT") {
+        campaignErrors.push(`failed evidence store cleanup failed: ${errorText(error)}`);
+      }
+    }
   }
+  const lifetimeById = new Map(lifetimePlan.map((row) => [row.artifactId, row]));
+  const authorityLifecycle = [];
+  const diskFreeProbes = [];
+  const probeDisk = async (phase, ordinal) => {
+    const freeBytes = await operations.diskFreeBytes(scratch);
+    const record = { phase, ordinal, root: scratch, freeBytes };
+    diskFreeProbes.push(record);
+    if (!diskPlan || freeBytes < diskPlan.peakRequiredAdditionalBytes) {
+      fail(`disk capacity fell below the ${diskPlan?.peakRequiredAdditionalBytes ?? "unavailable"}-byte JIT floor during ${phase}: ${freeBytes}`);
+    }
+    return record;
+  };
   for (let index = startIndex; index < profile.cells.length; index += 1) {
     const cell = profile.cells[index];
     const ordinalName = `${String(index + 1).padStart(2, "0")}-${cell.id}`;
@@ -2064,6 +2350,21 @@ export async function runCampaign(args, options = {}) {
     let controllerLog = path.join(cellDir, "controller.log");
     let receiptPath = path.join(cellDir, "receipt.json");
     let activeArtifactIndex = null;
+    let authorityTransitioning = false;
+    let transitionArtifactIds = [];
+    const transitionRoots = new Map();
+    const lifecycle = {
+      ordinal: index + 1,
+      cellId: cell.id,
+      staged: [],
+      activeArtifactIds: [...cell.artifactIds],
+      verifiedBefore: false,
+      verifiedAfter: false,
+      derivedAfter: [],
+      released: [],
+      diskProbes: [],
+    };
+    receipt.authorityLifecycle = lifecycle;
 
     try {
       await mkdir(cellDir);
@@ -2075,6 +2376,88 @@ export async function runCampaign(args, options = {}) {
 
       await mkdir(cellScratch);
       scratchCreated = true;
+      const startingIds = cell.artifactIds.filter(
+        (artifactId) => lifetimeById.get(artifactId)?.firstOrdinal === index + 1,
+      );
+      const newlyStaged = new Map();
+      transitionArtifactIds = startingIds;
+      authorityTransitioning = startingIds.length > 0;
+      for (const artifactId of startingIds) {
+        await invokeFault(fault, "stage", index);
+        lifecycle.diskProbes.push(await probeDisk(`before-stage:${artifactId}`, index + 1));
+        const audit = sourceAudits.get(artifactId);
+        const artifactStageRoot = artifactId === "flux1-schnell-q8" && missingDownload
+          ? missingStore : path.join(stagingRoot, artifactId);
+        transitionRoots.set(artifactId, artifactStageRoot);
+        if (artifactStageRoot !== missingStore) await mkdir(artifactStageRoot);
+        const staged = await operations.stageArtifact({
+          id: artifactId,
+          artifact: profile.artifacts[artifactId],
+          expectedFiles: artifactExpectedFiles[artifactId],
+          scratch: preflightScratch,
+          python,
+          cacheRoot: guard.cacheRoot,
+          stagingRoot: artifactStageRoot,
+          missingStore: artifactId === "flux1-schnell-q8" && missingDownload ? missingStore : null,
+        });
+        if (JSON.stringify(staged.reusedFiles) !== JSON.stringify(audit.reusedFiles)) {
+          fail(`trusted source cache changed after frozen census for ${artifactId}`);
+        }
+        const expectedDownloaded = missingDownload?.id === artifactId
+          ? missingDownload.downloadedFiles : [];
+        if (JSON.stringify(staged.downloadedFiles ?? []) !== JSON.stringify(expectedDownloaded)) {
+          fail(`offline JIT stage changed the frozen download partition for ${artifactId}`);
+        }
+        cacheProvisioning.staging.push({
+          id: artifactId,
+          repository: profile.artifacts[artifactId].repository,
+          revision: profile.artifacts[artifactId].revision,
+          subdirectory: profile.artifacts[artifactId].subdirectory,
+          allowPatterns: profile.artifacts[artifactId].allowPatterns,
+          expectedFiles: artifactExpectedFiles[artifactId],
+          reusedFiles: staged.reusedFiles,
+          downloadedFiles: staged.downloadedFiles ?? [],
+        });
+        const artifact = await operations.provisionArtifact({
+          id: artifactId,
+          artifact: profile.artifacts[artifactId],
+          expectedFiles: artifactExpectedFiles[artifactId],
+          scratch: preflightScratch,
+          python,
+          cacheRoot: artifactStageRoot,
+        });
+        artifact.stageRoot = artifactStageRoot;
+        newlyStaged.set(artifactId, artifact);
+        sharedArtifacts.set(artifactId, artifact);
+        cacheProvisioning.finalOffline.push({
+          id: artifactId,
+          repository: artifact.repository,
+          revision: artifact.revision,
+          subdirectory: artifact.subdirectory,
+          allowPatterns: artifact.allowPatterns,
+          expectedFiles: artifactExpectedFiles[artifactId],
+          inventory: artifact.inventory,
+        });
+      }
+      if (newlyStaged.size) {
+        const obstructions = await operations.installSidecarObstructions(newlyStaged);
+        sidecarObstructions.push(...obstructions);
+        for (const [artifactId, artifact] of newlyStaged) {
+          if (!Array.isArray(artifact.sidecarObstructions)
+            || artifact.sidecarObstructions.length === 0) {
+            fail(`JIT staging did not obstruct model-adjacent sidecars for ${artifactId}`);
+          }
+          artifact.derivedNamespaces = [];
+          lifecycle.staged.push({
+            artifactId,
+            stageRoot: artifact.stageRoot,
+            inventory: artifact.inventory,
+            obstructionCount: artifact.sidecarObstructions.length,
+            derivedNamespaces: artifact.derivedNamespaces,
+          });
+        }
+      }
+      authorityTransitioning = false;
       for (const [artifactIndex, artifactId] of cell.artifactIds.entries()) {
         activeArtifactIndex = artifactIndex;
         await invokeFault(fault, "provision", index);
@@ -2101,7 +2484,7 @@ export async function runCampaign(args, options = {}) {
         for (const artifactId of cell.artifactIds) {
           await operations.verifyArtifactUnchanged(
             sharedArtifacts.get(artifactId),
-            stagingRoot,
+            sharedArtifacts.get(artifactId).stageRoot,
           );
         }
         await appendFile(
@@ -2112,12 +2495,20 @@ export async function runCampaign(args, options = {}) {
       };
       try {
         await verifyCellCache("before");
+        lifecycle.verifiedBefore = true;
       } catch (error) {
         quarantineReason = `shared cache changed before cell ${cell.id}: ${errorText(error)}`;
         campaignErrors.push(quarantineReason);
         throw error;
       }
+      const derivedBefore = await operations.directoryInventory(derivedSidecarRoot);
+      if (derivedBefore.files !== 0 || derivedBefore.bytes !== 0) {
+        quarantineReason = `derived Candle cache was not empty before cell ${cell.id}`;
+        campaignErrors.push(quarantineReason);
+        fail(quarantineReason);
+      }
       operations.sample(samples, errors, "pre-execution VRAM sample failed");
+      lifecycle.diskProbes.push(await probeDisk("before-execution", index + 1));
       await invokeFault(fault, "execute", index);
       let runtimeFailure = null;
       try {
@@ -2135,12 +2526,43 @@ export async function runCampaign(args, options = {}) {
       }
       try {
         await verifyCellCache("after");
+        lifecycle.verifiedAfter = true;
       } catch (error) {
         quarantineReason = `shared cache mutated during cell ${cell.id}: ${errorText(error)}`;
         campaignErrors.push(quarantineReason);
         throw error;
       }
       try {
+        const namespaces = await operations.listDerivedSidecarNamespaces(derivedSidecarRoot);
+        const fluxArtifacts = cell.artifactIds.filter((artifactId) => artifactId.startsWith("flux1-"));
+        if (namespaces.length && fluxArtifacts.length !== 1) {
+          fail(`derived sidecars appeared outside one exact FLUX authority for ${cell.id}`);
+        }
+        if (!namespaces.length && fluxArtifacts.length) {
+          fail(`FLUX cell did not create its exact derived-sidecar namespace: ${cell.id}`);
+        }
+        if (fluxArtifacts.length === 1) {
+          sharedArtifacts.get(fluxArtifacts[0]).derivedNamespaces.splice(0, Infinity, ...namespaces);
+        }
+        for (const artifactId of cell.artifactIds) {
+          const artifact = sharedArtifacts.get(artifactId);
+          const inventories = [];
+          for (const namespace of artifact.derivedNamespaces) {
+            inventories.push(await operations.directoryInventory(namespace));
+          }
+          const files = inventories.reduce((sum, inventory) => sum + inventory.files, 0);
+          const bytes = inventories.reduce((sum, inventory) => sum + inventory.bytes, 0);
+          if (artifactId.startsWith("flux1-") && (files !== 494
+            || bytes < (artifactId.endsWith("-q4") ? 7_396_392_960 : 12_573_868_032)
+            || bytes > (artifactId.endsWith("-q4")
+              ? FLUX_Q4_SIDECAR_BYTES : FLUX_Q8_SIDECAR_BYTES))) {
+            fail(`FLUX derived-sidecar contract drifted for ${artifactId}: ${files} files/${bytes} bytes`);
+          }
+          if (!artifactId.startsWith("flux1-") && (files !== 0 || bytes !== 0)) {
+            fail(`non-FLUX authority unexpectedly created derived sidecars: ${artifactId}`);
+          }
+          lifecycle.derivedAfter.push({ artifactId, files, bytes, inventories });
+        }
         derivedSidecarLifecycle.afterCells.push({
           ordinal: index + 1,
           cellId: cell.id,
@@ -2159,6 +2581,10 @@ export async function runCampaign(args, options = {}) {
       executionPassed = true;
     } catch (error) {
       const message = recordError(errors, "cell lifecycle failed", error);
+      if (authorityTransitioning && !quarantineReason) {
+        quarantineReason = `JIT authority stage/copy/hash failed before cell ${cell.id}: ${errorText(error)}`;
+        campaignErrors.push(quarantineReason);
+      }
       if (activeArtifactIndex !== null && artifacts[activeArtifactIndex].inventory.complete === false) {
         artifacts[activeArtifactIndex].inventory.error = message;
       }
@@ -2169,6 +2595,70 @@ export async function runCampaign(args, options = {}) {
       }
       operations.sample(samples, [], "failure VRAM sample failed");
     } finally {
+      const releaseIds = [...new Set([
+        ...cell.artifactIds.filter((id) => lifetimeById.get(id)?.lastOrdinal === index + 1),
+        ...(authorityTransitioning ? transitionArtifactIds : []),
+      ])];
+      for (const artifactId of releaseIds) {
+        const artifact = sharedArtifacts.get(artifactId);
+        if (!artifact) {
+          const partialRoot = transitionRoots.get(artifactId);
+          if (partialRoot) {
+            const partialRelease = {
+              artifactId,
+              stageRoot: partialRoot,
+              stagedInventory: null,
+              derivedBeforeCleanup: [],
+              stageRemoved: false,
+              derivedRemoved: true,
+            };
+            try {
+              partialRelease.stagedInventory = await operations.directoryInventory(partialRoot);
+              await operations.cleanup(partialRoot, guard, `partial staged authority ${artifactId}`);
+              await assertPathAbsent(partialRoot, `partial staged authority ${artifactId}`);
+              partialRelease.stageRemoved = true;
+            } catch (error) {
+              partialRelease.error = errorText(error);
+              if (!quarantineReason) {
+                quarantineReason = `partial authority ${artifactId} cleanup failed: ${errorText(error)}`;
+                campaignErrors.push(quarantineReason);
+              }
+            }
+            lifecycle.released.push(partialRelease);
+          }
+          continue;
+        }
+        const release = {
+          artifactId,
+          stageRoot: artifact.stageRoot,
+          stagedInventory: artifact.inventory,
+          derivedBeforeCleanup: [],
+          stageRemoved: false,
+          derivedRemoved: false,
+        };
+        try {
+          await invokeFault(fault, "authorityCleanup", index);
+          await operations.verifyArtifactUnchanged(artifact, artifact.stageRoot);
+          for (const namespace of artifact.derivedNamespaces) {
+            release.derivedBeforeCleanup.push(await operations.directoryInventory(namespace));
+            await operations.cleanup(namespace, guard, `derived sidecars for ${artifactId}`);
+            await assertPathAbsent(namespace, `derived sidecars for ${artifactId}`);
+          }
+          release.derivedRemoved = true;
+          await operations.cleanup(artifact.stageRoot, guard, `staged authority ${artifactId}`);
+          await assertPathAbsent(artifact.stageRoot, `staged authority ${artifactId}`);
+          release.stageRemoved = true;
+          sharedArtifacts.delete(artifactId);
+        } catch (error) {
+          const message = recordError(errors, `authority lifecycle cleanup failed for ${artifactId}`, error);
+          release.error = message;
+          if (!quarantineReason) {
+            quarantineReason = `authority ${artifactId} cleanup isolation failed: ${errorText(error)}`;
+            campaignErrors.push(quarantineReason);
+          }
+        }
+        lifecycle.released.push(release);
+      }
       receipt.cleanup.attempted = scratchCreated;
       if (scratchCreated) {
         try {
@@ -2188,6 +2678,7 @@ export async function runCampaign(args, options = {}) {
         receipt.cleanup.completed = true;
       }
       emergencyCleanup = structuredClone(receipt.cleanup);
+      authorityLifecycle.push(structuredClone(lifecycle));
 
       try {
         if (!cellDirCreated) {
@@ -2231,12 +2722,20 @@ export async function runCampaign(args, options = {}) {
     } catch (error) {
       let receiptPath;
       let emergencyError = [...emergencyFailureMessages, errorText(error)].filter(Boolean).join("\n");
+      let emergencyAuthorityLifecycle = authorityLifecycle.find(
+        (entry) => entry.ordinal === index + 1,
+      );
+      if (!emergencyAuthorityLifecycle) {
+        emergencyAuthorityLifecycle = emptyAuthorityLifecycle(cell, index);
+        authorityLifecycle.push(emergencyAuthorityLifecycle);
+      }
       try {
         await invokeFault(fault, "emergencyReceipt", index);
         receiptPath = await writeEmergencyReceipt({
           profile, cell, index, ordinalName, output, cacheRoot: stagingRoot,
           repositories, execution, gpuIdentity,
           systemMemory, error: new Error(emergencyError), cleanup: emergencyCleanup,
+          authorityLifecycle: emergencyAuthorityLifecycle,
         });
       } catch (receiptError) {
         emergencyError += `\nemergency receipt failed: ${errorText(receiptError)}`;
@@ -2245,6 +2744,7 @@ export async function runCampaign(args, options = {}) {
             profile, cell, index, ordinalName, output, cacheRoot: stagingRoot,
             repositories, execution, gpuIdentity,
             systemMemory, errors: [emergencyError], cleanup: emergencyCleanup,
+            authorityLifecycle: emergencyAuthorityLifecycle,
           });
         } catch (lastResortError) {
           emergencyError += `\nlast-resort emergency receipt failed: ${errorText(lastResortError)}`;
@@ -2255,6 +2755,28 @@ export async function runCampaign(args, options = {}) {
         emergencyReceiptError: receiptPath ? null : emergencyError, source: "continuation",
       });
     }
+  }
+
+  let finalLifecycle = null;
+  try {
+    const stage = await operations.directoryInventory(stagingRoot);
+    const derived = await operations.directoryInventory(derivedSidecarRoot);
+    let missingStoreAbsent = false;
+    try {
+      await lstat(missingStore);
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+      missingStoreAbsent = true;
+    }
+    finalLifecycle = { stage, derived, missingStoreAbsent };
+    if (stage.files !== 0 || stage.bytes !== 0 || derived.files !== 0 || derived.bytes !== 0
+      || !missingStoreAbsent || sharedArtifacts.size !== 0) {
+      fail("final JIT stage/derived/missing-file lifecycle is not empty");
+    }
+  } catch (error) {
+    const message = `final authority lifecycle verification failed: ${errorText(error)}`;
+    campaignErrors.push(message);
+    if (!quarantineReason) quarantineReason = message;
   }
 
   let finalDocument = cachePreflightDocument({
@@ -2269,6 +2791,10 @@ export async function runCampaign(args, options = {}) {
     sidecarObstructions,
     cacheProvisioning,
     derivedSidecarLifecycle,
+    missingStore,
+    lifetimePlan,
+    diskPlan,
+    missingDownload,
   });
   let finalWrite = await writeCachePreflightDurably({
     output, filename: "cache-preflight.json", document: finalDocument,
@@ -2289,6 +2815,10 @@ export async function runCampaign(args, options = {}) {
       sidecarObstructions: [],
       cacheProvisioning: { sourceCensus: [], staging: [], finalOffline: [] },
       derivedSidecarLifecycle: { initial: null, afterCells: [] },
+      missingStore,
+      lifetimePlan: [],
+      diskPlan: null,
+      missingDownload: null,
     });
     finalWrite = {
       evidence: await writeCachePreflightFallback({
@@ -2322,6 +2852,9 @@ export async function runCampaign(args, options = {}) {
       },
     },
     cachePreflight: cachePreflightEvidence,
+    authorityLifecycle,
+    diskFreeProbes,
+    finalAuthorityLifecycle: finalLifecycle,
     passed: receipts.filter((receipt) => receipt.status === "passed").length,
     failed: receipts.filter((receipt) => receipt.status === "failed").length,
     campaignErrors,
@@ -2356,11 +2889,15 @@ async function main() {
       sourceCacheRoot: "fixture-cache",
       campaignStagingRoot: "fixture-staging",
       derivedSidecarRoot: "fixture-derived",
+      missingFileStore: "fixture-missing",
       frozenMissingFiles: [],
       sidecarObstructions: [],
       reusedFiles: [],
       downloadedFiles: [],
+      networkDownloadCount: 0,
       phases: { sourceCensus: [], staging: [], finalOffline: [] },
+      lifetimePlan: [],
+      diskPlan: null,
       derivedSidecarLifecycle: { initial: null, afterCells: [] },
       offlineBeforeCells: false,
     });

--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -141,9 +141,14 @@ export function estimateJitDiskPlan(
       row.firstOrdinal <= ordinal && row.lastOrdinal >= ordinal
     ));
     const physical = new Map();
-    for (const file of lifetimes.flatMap((row) => row.physicalFiles).filter(
-      (file) => file.persistent,
-    )) physical.set(file.key, file.bytes);
+    // The reviewed download is persistent across the preflight and earlier cells, but belongs to
+    // its authority's lifetime: it is deleted with Schnell q8 after cell 10, never charged forever.
+    for (const row of lifetimes) {
+      if (ordinal > row.lastOrdinal) continue;
+      for (const file of row.physicalFiles.filter((entry) => entry.persistent)) {
+        physical.set(file.key, file.bytes);
+      }
+    }
     for (const file of active.flatMap((row) => row.physicalFiles)) {
       const existing = physical.get(file.key);
       if (existing !== undefined && existing !== file.bytes) {
@@ -184,6 +189,12 @@ export function estimateJitDiskPlan(
   }
   const logicalSourceBytes = lifetimes.reduce((sum, row) => sum + row.sourceBytes, 0);
   const allAtOnceSourceBytes = [...allPhysical.values()].reduce((sum, bytes) => sum + bytes, 0);
+  const persistentBytesFromPlan = [...new Map(lifetimes.flatMap((row) => (
+    row.physicalFiles.filter((file) => file.persistent).map((file) => [file.key, file.bytes])
+  ))).values()].reduce((sum, bytes) => sum + bytes, 0);
+  if (persistentBytesFromPlan !== persistentMissingBytes) {
+    fail(`persistent missing-file byte census drifted: plan=${persistentBytesFromPlan}, input=${persistentMissingBytes}`);
+  }
   const allAtOnceSidecarReserveBytes = Math.max(FLUX_Q4_SIDECAR_BYTES, FLUX_Q8_SIDECAR_BYTES);
   if (logicalSourceBytes === REVIEWED_ALL_AT_ONCE_SOURCE_BYTES
     && (allAtOnceSourceBytes !== REVIEWED_ALL_AT_ONCE_SOURCE_BYTES
@@ -811,7 +822,7 @@ export function receiptSkeleton({
   };
 }
 
-export function validateReceipt(receipt, expectedCell, profile) {
+export function validateReceipt(receipt, expectedCell, profile, lifecycleContext = null) {
   if (receipt.schemaVersion !== 1 || receipt.profile !== PROFILE_NAME) fail("receipt identity mismatch");
   if (!new Set(["passed", "failed"]).has(receipt.status)) fail("receipt status is invalid");
   if (receipt.cell.ordinal < 1 || receipt.cell.ordinal > EXPECTED_CELLS.length
@@ -892,6 +903,10 @@ export function validateReceipt(receipt, expectedCell, profile) {
     || (receipt.cleanup.error !== null && typeof receipt.cleanup.error !== "string")) {
     fail("receipt cleanup evidence is incomplete");
   }
+  if (!receipt.authorityLifecycle
+    && receipt.repositories.sceneworks.sha !== LEGACY_SCENEWORKS_HEAD) {
+    fail("continuation receipt is missing required authority lifecycle evidence");
+  }
   if (receipt.authorityLifecycle) {
     const lifecycle = receipt.authorityLifecycle;
     if (lifecycle.ordinal !== receipt.cell.ordinal || lifecycle.cellId !== receipt.cell.id
@@ -899,6 +914,65 @@ export function validateReceipt(receipt, expectedCell, profile) {
       || lifecycle.staged.some((entry) => !expectedCell.artifactIds.includes(entry.artifactId))
       || lifecycle.released.some((entry) => !expectedCell.artifactIds.includes(entry.artifactId))) {
       fail("receipt authority lifecycle identity drifted");
+    }
+    for (const derived of lifecycle.derivedAfter) {
+      const isFlux = derived.artifactId.startsWith("flux1-");
+      const payloadFloor = derived.artifactId.endsWith("-q4")
+        ? 7_396_392_960 : 12_573_868_032;
+      const payloadCeiling = derived.artifactId.endsWith("-q4")
+        ? FLUX_Q4_SIDECAR_BYTES : FLUX_Q8_SIDECAR_BYTES;
+      if (isFlux) {
+        const staged = lifecycle.staged.find((entry) => entry.artifactId === derived.artifactId);
+        if (derived.files !== 494 || derived.bytes < payloadFloor
+          || derived.bytes > payloadCeiling || derived.inventories.length !== 1
+          || staged?.derivedNamespaces.length !== 1
+          || comparable(derived.inventories[0].root) !== comparable(staged.derivedNamespaces[0])
+          || !/^[0-9a-f]{64}$/.test(path.basename(derived.inventories[0].root))
+          || path.basename(path.dirname(derived.inventories[0].root)) !== "candle-device-format-v1") {
+          fail("receipt FLUX derived lifecycle is not one exact bounded b646 namespace");
+        }
+      } else if (derived.files !== 0 || derived.bytes !== 0 || derived.inventories.length !== 0) {
+        fail("receipt non-FLUX derived lifecycle is not exactly empty");
+      }
+    }
+    if (lifecycleContext) {
+      const { lifetimeById, scratchRoot, requiredFreeBytes, completeLifecycle = false } = lifecycleContext;
+      const startingIds = expectedCell.artifactIds.filter(
+        (id) => lifetimeById.get(id)?.firstOrdinal === receipt.cell.ordinal,
+      );
+      const endingIds = expectedCell.artifactIds.filter(
+        (id) => lifetimeById.get(id)?.lastOrdinal === receipt.cell.ordinal,
+      );
+      const expectedPhases = [
+        ...startingIds.map((id) => `before-stage:${id}`),
+        "before-execution",
+      ];
+      const actualPhases = lifecycle.diskProbes.map((probe) => probe.phase);
+      if (JSON.stringify(actualPhases)
+        !== JSON.stringify(expectedPhases.slice(0, actualPhases.length))
+        || lifecycle.diskProbes.some((probe) => (
+          probe.ordinal !== receipt.cell.ordinal
+          || comparable(probe.root) !== comparable(scratchRoot)
+          || probe.requiredFreeBytes !== requiredFreeBytes
+          || !Number.isSafeInteger(probe.freeBytes)
+          || probe.freeBytes < 0
+        ))) {
+        fail("receipt disk probes drifted from the exact authority transition schedule");
+      }
+      const stagedIds = lifecycle.staged.map((entry) => entry.artifactId);
+      const releasedIds = lifecycle.released.map((entry) => entry.artifactId);
+      if (JSON.stringify(stagedIds) !== JSON.stringify(startingIds.slice(0, stagedIds.length))
+        || releasedIds.some((id) => !new Set([...startingIds, ...endingIds]).has(id))) {
+        fail("receipt staged/released authorities drifted from the lifetime plan");
+      }
+      if (completeLifecycle && (JSON.stringify(actualPhases) !== JSON.stringify(expectedPhases)
+        || lifecycle.diskProbes.some((probe) => probe.freeBytes < requiredFreeBytes)
+        || JSON.stringify(stagedIds) !== JSON.stringify(startingIds)
+        || JSON.stringify(releasedIds) !== JSON.stringify(endingIds)
+        || JSON.stringify(lifecycle.derivedAfter.map((entry) => entry.artifactId))
+          !== JSON.stringify(expectedCell.artifactIds))) {
+        fail("completed receipt lifecycle omitted an exact transition, probe, or derivation");
+      }
     }
     if (receipt.status === "passed" && (!lifecycle.verifiedBefore || !lifecycle.verifiedAfter
       || lifecycle.diskProbes.length < lifecycle.staged.length + 1
@@ -1479,25 +1553,61 @@ export async function installSidecarObstructions(sharedArtifacts) {
   return records.sort((left, right) => left.root.localeCompare(right.root));
 }
 
-export async function listDerivedSidecarNamespaces(derivedSidecarRoot) {
-  const namespaceRoot = path.join(derivedSidecarRoot, "candle-device-format-v1");
-  let entries;
-  try {
-    entries = await readdir(namespaceRoot, { withFileTypes: true });
-  } catch (error) {
-    if (error?.code === "ENOENT") return [];
-    throw error;
+function rustCanonicalPath(resolved, platform = process.platform) {
+  if (platform !== "win32" || resolved.startsWith("\\\\?\\")) return resolved;
+  if (resolved.startsWith("\\\\")) return `\\\\?\\UNC\\${resolved.slice(2)}`;
+  return `\\\\?\\${resolved}`;
+}
+
+export async function expectedB646DerivedNamespace(artifact, derivedSidecarRoot) {
+  if (!artifact.matchedFiles.includes("transformer/model.safetensors")) {
+    fail(`FLUX artifact lacks the exact packed transformer component: ${artifact.id}`);
   }
-  const namespaces = [];
-  for (const entry of entries) {
-    const candidate = path.join(namespaceRoot, entry.name);
+  const component = await realpath(path.join(artifact.selectedRoot, "transformer"));
+  const digest = createHash("sha256")
+    .update("sceneworks-candle-device-format-component-v1\0")
+    .update(rustCanonicalPath(component))
+    .digest("hex");
+  return path.join(derivedSidecarRoot, "candle-device-format-v1", digest);
+}
+
+export async function inspectDerivedSidecarRoot(derivedSidecarRoot, expectedNamespace = null) {
+  const rootEntries = await readdir(derivedSidecarRoot, { withFileTypes: true });
+  if (!expectedNamespace) {
+    if (rootEntries.length) fail("non-FLUX derived sidecar root must be exactly empty");
+    return { rootInventory: await directoryInventory(derivedSidecarRoot), namespaces: [] };
+  }
+  if (rootEntries.length !== 1 || rootEntries[0].name !== "candle-device-format-v1"
+    || !rootEntries[0].isDirectory()) {
+    fail("FLUX derived sidecar root has stray files, directories, or versions");
+  }
+  const versionRoot = path.join(derivedSidecarRoot, "candle-device-format-v1");
+  const versionMetadata = await lstat(versionRoot);
+  if (versionMetadata.isSymbolicLink()) fail("derived sidecar version root is a reparse point");
+  const namespaceEntries = await readdir(versionRoot, { withFileTypes: true });
+  const expectedName = path.basename(expectedNamespace);
+  if (namespaceEntries.length !== 1 || namespaceEntries[0].name !== expectedName
+    || !namespaceEntries[0].isDirectory()) {
+    fail("FLUX derived sidecar root does not contain one exact b646 namespace");
+  }
+  const namespace = path.join(versionRoot, expectedName);
+  if (comparable(namespace) !== comparable(expectedNamespace)
+    || (await lstat(namespace)).isSymbolicLink()) {
+    fail("FLUX derived sidecar namespace identity is not canonical");
+  }
+  for (const entry of await readdir(namespace, { withFileTypes: true })) {
+    const candidate = path.join(namespace, entry.name);
     const metadata = await lstat(candidate);
-    if (!entry.isDirectory() || metadata.isSymbolicLink()) {
-      fail(`derived sidecar namespace must be an ordinary directory: ${candidate}`);
+    if (!entry.isFile() || metadata.isSymbolicLink()) {
+      fail(`FLUX derived sidecar namespace contains a non-regular entry: ${candidate}`);
     }
-    namespaces.push(candidate);
   }
-  return namespaces.sort();
+  const inventory = await directoryInventory(namespace);
+  const rootInventory = await directoryInventory(derivedSidecarRoot);
+  if (rootInventory.files !== inventory.files || rootInventory.bytes !== inventory.bytes) {
+    fail("derived sidecar global inventory does not equal its one canonical namespace");
+  }
+  return { rootInventory, namespaces: [{ path: namespace, inventory }] };
 }
 
 async function diskFreeBytes(directory) {
@@ -1627,6 +1737,7 @@ async function invokeFault(fault, stage, index) {
 }
 
 async function refreshEvidence(receipt, cellDir, errors, { fault, index } = {}) {
+  let primaryFailure = null;
   try {
     await invokeFault(fault, "evidenceHash", index);
     const evidence = await evidenceFiles(cellDir);
@@ -1636,6 +1747,7 @@ async function refreshEvidence(receipt, cellDir, errors, { fault, index } = {}) 
     if (!receipt.logs.length) fail("no controller or runtime log was available to hash");
   } catch (error) {
     const message = recordError(errors, "evidence hashing failed", error);
+    primaryFailure = message;
     receipt.inputs = [];
     receipt.outputs = [];
     const fallbackLog = path.join(cellDir, "evidence-fallback.log");
@@ -1644,15 +1756,25 @@ async function refreshEvidence(receipt, cellDir, errors, { fault, index } = {}) 
     const fallback = await hashedFiles(cellDir, { exclude: new Set(["receipt.json"]) });
     receipt.logs = fallback.filter((file) => file.path.endsWith(".log"));
   }
+  return primaryFailure;
 }
 
-async function writePrimaryReceipt({ file, receipt, cell, profile, fault, index }) {
+async function writePrimaryReceipt({
+  file, receipt, cell, profile, fault, index, lifecycleContext,
+}) {
   await invokeFault(fault, "semanticValidation", index);
-  validateReceipt(receipt, cell, profile);
+  validateReceipt(receipt, cell, profile, lifecycleContext);
   await invokeFault(fault, "schemaValidation", index);
   validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, receipt);
   await invokeFault(fault, "receiptWrite", index);
   await writeJsonAtomically(file, receipt);
+  await invokeFault(fault, "receiptStat", index);
+  const metadata = await stat(file);
+  if (!metadata.isFile() || metadata.size < 1) fail("primary receipt was not durably materialized");
+  await invokeFault(fault, "receiptHash", index);
+  if (!/^[0-9a-f]{64}$/.test(await sha256File(file))) {
+    fail("primary receipt hash finalization failed");
+  }
 }
 
 function emptyAuthorityLifecycle(cell, index) {
@@ -1671,7 +1793,7 @@ function emptyAuthorityLifecycle(cell, index) {
 
 async function writeEmergencyReceipt({
   profile, cell, index, ordinalName, output, cacheRoot, repositories, execution, gpuIdentity,
-  systemMemory, error, cleanup, authorityLifecycle,
+  systemMemory, error, cleanup, authorityLifecycle, lifecycleContext,
 }) {
   // This path deliberately bypasses all injected/primary finalization operations. If the primary
   // log, evidence hash, semantic/schema check, or atomic writer fails, a fresh controller-owned
@@ -1697,7 +1819,7 @@ async function writeEmergencyReceipt({
   const evidence = await evidenceFiles(cellDir);
   receipt.logs = evidence.logs;
   receipt.completedAt = new Date().toISOString();
-  validateReceipt(receipt, cell, profile);
+  validateReceipt(receipt, cell, profile, lifecycleContext);
   validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, receipt);
   await writeJsonAtomically(path.join(cellDir, "receipt.json"), receipt);
   return `_emergency/${ordinalName}/receipt.json`;
@@ -1705,7 +1827,7 @@ async function writeEmergencyReceipt({
 
 async function writeLastResortEmergencyReceipt({
   profile, cell, index, ordinalName, output, cacheRoot, repositories, execution, gpuIdentity,
-  systemMemory, errors, cleanup, authorityLifecycle,
+  systemMemory, errors, cleanup, authorityLifecycle, lifecycleContext,
 }) {
   // A second implementation intentionally avoids evidenceFiles(), writeJsonAtomically(), and every
   // primary/injected callback. It hashes its one log directly and publishes under a different name.
@@ -1737,7 +1859,7 @@ async function writeLastResortEmergencyReceipt({
     path: "controller-last-resort.log", bytes: metadata.size, sha256: await sha256File(logFile),
   }];
   receipt.completedAt = new Date().toISOString();
-  validateReceipt(receipt, cell, profile);
+  validateReceipt(receipt, cell, profile, lifecycleContext);
   validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, receipt);
   const finalPath = path.join(cellDir, "receipt-last-resort.json");
   const temporary = `${finalPath}.tmp-${process.pid}-${randomUUID()}`;
@@ -1786,13 +1908,14 @@ async function writeSummaryDurably({ output, summary, fault }) {
 }
 
 function cachePreflightDocument({
-  status, error, downloadEvidenceSha256, remainingArtifactIds, guard, stagingRoot,
+  evidencePhase, status, error, downloadEvidenceSha256, remainingArtifactIds, guard, stagingRoot,
   derivedSidecarRoot, frozenMissing, sidecarObstructions, cacheProvisioning,
   derivedSidecarLifecycle, missingStore, lifetimePlan, diskPlan, missingDownload,
 }) {
   return {
     schemaVersion: 1,
     profile: PROFILE_NAME,
+    evidencePhase,
     status,
     error,
     downloadEvidenceSha256,
@@ -1820,7 +1943,7 @@ function cachePreflightDocument({
 
 export function validateCachePreflightEvidence(document, {
   remainingArtifactIds, artifactExpectedFiles, downloadEvidenceSha256, guard, stagingRoot,
-  derivedSidecarRoot, missingStore, profile,
+  derivedSidecarRoot, missingStore, expectedNonModelPaths, profile,
 }) {
   validateDocumentWithSchema(CACHE_PREFLIGHT_SCHEMA_PATH, document);
   if (document.profile !== profile.profile
@@ -1831,6 +1954,10 @@ export function validateCachePreflightEvidence(document, {
     || document.missingFileStore !== missingStore
     || JSON.stringify(document.expectedArtifactIds) !== JSON.stringify(remainingArtifactIds)) {
     fail("cache preflight identity/path binding drifted");
+  }
+  if (document.diskPlan
+    && JSON.stringify(document.diskPlan.nonModelPaths) !== JSON.stringify(expectedNonModelPaths)) {
+    fail("cache preflight non-model paths drifted from runtime-owned paths");
   }
   const ids = new Set(remainingArtifactIds);
   for (const phase of ["sourceCensus", "staging", "finalOffline"]) {
@@ -1950,6 +2077,35 @@ export function validateCachePreflightEvidence(document, {
           : document.diskPlan.peakModelAndSidecarBytes > REVIEWED_JIT_SOURCE_PEAK_BYTES))) {
       fail("passed cache preflight drifted from reviewed target-byte totals and JIT floor");
     }
+    if (document.evidencePhase === "initial") {
+      if (document.phases.staging.length || document.phases.finalOffline.length
+        || document.derivedSidecarLifecycle.afterCells.length
+        || document.sidecarObstructions.length) {
+        fail("initial cache preflight contains post-cell lifecycle evidence");
+      }
+    } else {
+      const plannedIds = document.lifetimePlan.map((row) => row.artifactId);
+      if (JSON.stringify(document.phases.staging.map((row) => row.id))
+          !== JSON.stringify(plannedIds)
+        || JSON.stringify(document.phases.finalOffline.map((row) => row.id))
+          !== JSON.stringify(plannedIds)) {
+        fail("final cache preflight omitted an exact staged/offline authority transition");
+      }
+      const startIndex = profile.cells.length - document.diskPlan.cells.length;
+      const expectedCells = profile.cells.slice(startIndex).map((cell, offset) => ({
+        ordinal: startIndex + offset + 1,
+        cellId: cell.id,
+      }));
+      if (JSON.stringify(document.derivedSidecarLifecycle.afterCells.map(
+        ({ ordinal, cellId }) => ({ ordinal, cellId }),
+      )) !== JSON.stringify(expectedCells)) {
+        fail("final cache preflight omitted exact per-cell derived lifecycle coverage");
+      }
+      const obstructed = new Set(document.sidecarObstructions.flatMap((row) => row.artifactIds));
+      if (plannedIds.some((id) => !obstructed.has(id))) {
+        fail("final cache preflight omitted a staged authority sidecar obstruction");
+      }
+    }
   }
   let previous = 0;
   for (const snapshot of document.derivedSidecarLifecycle.afterCells) {
@@ -1957,6 +2113,17 @@ export function validateCachePreflightEvidence(document, {
     if (!expected || snapshot.cellId !== expected.id || snapshot.ordinal <= previous
       || snapshot.inventory.root !== derivedSidecarRoot) {
       fail("derived Candle sidecar lifecycle ordering drifted");
+    }
+    const flux = expected.artifactIds.find((id) => id.startsWith("flux1-"));
+    const payloadFloor = flux?.endsWith("-q4") ? 7_396_392_960 : 12_573_868_032;
+    const payloadCeiling = flux?.endsWith("-q4")
+      ? FLUX_Q4_SIDECAR_BYTES : FLUX_Q8_SIDECAR_BYTES;
+    if (flux ? (snapshot.inventory.files !== 494
+        || snapshot.inventory.bytes < payloadFloor
+        || snapshot.inventory.bytes > payloadCeiling)
+      : (snapshot.inventory.files !== 0 || snapshot.inventory.bytes !== 0
+        || snapshot.inventory.sha256 !== createHash("sha256").digest("hex"))) {
+      fail("derived Candle sidecar lifecycle inventory drifted from the cell family contract");
     }
     previous = snapshot.ordinal;
   }
@@ -2083,8 +2250,10 @@ export async function runCampaign(args, options = {}) {
     installSidecarObstructions:
       options.operations?.installSidecarObstructions ?? installSidecarObstructions,
     directoryInventory: options.operations?.directoryInventory ?? directoryInventory,
-    listDerivedSidecarNamespaces:
-      options.operations?.listDerivedSidecarNamespaces ?? listDerivedSidecarNamespaces,
+    expectedB646DerivedNamespace:
+      options.operations?.expectedB646DerivedNamespace ?? expectedB646DerivedNamespace,
+    inspectDerivedSidecarRoot:
+      options.operations?.inspectDerivedSidecarRoot ?? inspectDerivedSidecarRoot,
     diskFreeBytes: options.operations?.diskFreeBytes ?? diskFreeBytes,
     verifyArtifactUnchanged:
       options.operations?.verifyArtifactUnchanged ?? verifyArtifactUnchanged,
@@ -2109,6 +2278,12 @@ export async function runCampaign(args, options = {}) {
   const stagingRoot = path.join(scratch, "authority-stage");
   const derivedSidecarRoot = path.join(scratch, "derived-candle-device-cache");
   const missingStore = path.join(scratch, "persistent-missing-file");
+  const expectedNonModelPaths = [
+    { kind: "cargoTarget", path: path.resolve(process.env.CARGO_TARGET_DIR ?? path.join(sceneworksRoot, "target")) },
+    { kind: "cargoHome", path: path.resolve(process.env.CARGO_HOME ?? path.join(process.env.USERPROFILE ?? scratch, ".cargo")) },
+    { kind: "campaignOutput", path: output },
+    { kind: "pythonVenv", path: python ? path.dirname(path.dirname(path.resolve(python))) : "fixture-unavailable" },
+  ];
   const remainingArtifactIds = [...new Set(
     profile.cells.slice(startIndex).flatMap((cell) => cell.artifactIds),
   )];
@@ -2206,12 +2381,7 @@ export async function runCampaign(args, options = {}) {
         lifetimePlan,
         freeBytes,
         missingDownload?.downloadedFiles.reduce((sum, file) => sum + file.bytes, 0) ?? 0,
-        [
-          { kind: "cargoTarget", path: path.resolve(process.env.CARGO_TARGET_DIR ?? path.join(sceneworksRoot, "target")) },
-          { kind: "cargoHome", path: path.resolve(process.env.CARGO_HOME ?? path.join(process.env.USERPROFILE ?? scratch, ".cargo")) },
-          { kind: "campaignOutput", path: output },
-          { kind: "pythonVenv", path: python ? path.dirname(path.dirname(path.resolve(python))) : "fixture-unavailable" },
-        ],
+        expectedNonModelPaths,
       );
       if (!diskPlan.admitted) {
         fail(`JIT staging disk admission refused: requires ${diskPlan.peakRequiredAdditionalBytes} bytes at cell ${diskPlan.peakOrdinal}, only ${diskPlan.freeBytes} free`);
@@ -2240,9 +2410,10 @@ export async function runCampaign(args, options = {}) {
   }
   const cacheValidation = {
     remainingArtifactIds, artifactExpectedFiles, downloadEvidenceSha256, guard, stagingRoot,
-    derivedSidecarRoot, missingStore, profile,
+    derivedSidecarRoot, missingStore, expectedNonModelPaths, profile,
   };
   let initialDocument = cachePreflightDocument({
+    evidencePhase: "initial",
     status: quarantineReason ? "failed" : "passed",
     error: quarantineReason,
     downloadEvidenceSha256,
@@ -2272,6 +2443,7 @@ export async function runCampaign(args, options = {}) {
       campaignErrors.push(evidenceError);
     }
     initialDocument = cachePreflightDocument({
+      evidencePhase: "initial",
       status: "failed",
       error: `${quarantineReason}; no continuation GPU cell started`,
       downloadEvidenceSha256,
@@ -2306,12 +2478,25 @@ export async function runCampaign(args, options = {}) {
     }
   }
   const lifetimeById = new Map(lifetimePlan.map((row) => [row.artifactId, row]));
+  const lifecycleContext = (completeLifecycle = false) => ({
+    lifetimeById,
+    scratchRoot: scratch,
+    requiredFreeBytes: diskPlan?.peakRequiredAdditionalBytes ?? REVIEWED_FREE_FLOOR_BYTES,
+    completeLifecycle,
+  });
   const authorityLifecycle = [];
   const diskFreeProbes = [];
-  const probeDisk = async (phase, ordinal) => {
+  const probeDisk = async (lifecycle, phase, ordinal) => {
     const freeBytes = await operations.diskFreeBytes(scratch);
-    const record = { phase, ordinal, root: scratch, freeBytes };
+    const record = {
+      phase,
+      ordinal,
+      root: scratch,
+      freeBytes,
+      requiredFreeBytes: diskPlan?.peakRequiredAdditionalBytes ?? REVIEWED_FREE_FLOOR_BYTES,
+    };
     diskFreeProbes.push(record);
+    lifecycle.diskProbes.push(record);
     if (!diskPlan || freeBytes < diskPlan.peakRequiredAdditionalBytes) {
       fail(`disk capacity fell below the ${diskPlan?.peakRequiredAdditionalBytes ?? "unavailable"}-byte JIT floor during ${phase}: ${freeBytes}`);
     }
@@ -2351,6 +2536,7 @@ export async function runCampaign(args, options = {}) {
     let receiptPath = path.join(cellDir, "receipt.json");
     let activeArtifactIndex = null;
     let authorityTransitioning = false;
+    let executionAttempted = false;
     let transitionArtifactIds = [];
     const transitionRoots = new Map();
     const lifecycle = {
@@ -2372,7 +2558,10 @@ export async function runCampaign(args, options = {}) {
       const logFile = path.join(cellDir, "runtime.log");
       await writeFile(controllerLog, `${startedAt} starting ${cell.id}\n`, { encoding: "utf8", flag: "wx" });
       receipt.logs = (await evidenceFiles(cellDir)).logs;
-      await writePrimaryReceipt({ file: receiptPath, receipt, cell, profile, fault, index });
+      await writePrimaryReceipt({
+        file: receiptPath, receipt, cell, profile, fault, index,
+        lifecycleContext: lifecycleContext(false),
+      });
 
       await mkdir(cellScratch);
       scratchCreated = true;
@@ -2384,7 +2573,7 @@ export async function runCampaign(args, options = {}) {
       authorityTransitioning = startingIds.length > 0;
       for (const artifactId of startingIds) {
         await invokeFault(fault, "stage", index);
-        lifecycle.diskProbes.push(await probeDisk(`before-stage:${artifactId}`, index + 1));
+        await probeDisk(lifecycle, `before-stage:${artifactId}`, index + 1);
         const audit = sourceAudits.get(artifactId);
         const artifactStageRoot = artifactId === "flux1-schnell-q8" && missingDownload
           ? missingStore : path.join(stagingRoot, artifactId);
@@ -2501,16 +2690,12 @@ export async function runCampaign(args, options = {}) {
         campaignErrors.push(quarantineReason);
         throw error;
       }
-      const derivedBefore = await operations.directoryInventory(derivedSidecarRoot);
-      if (derivedBefore.files !== 0 || derivedBefore.bytes !== 0) {
-        quarantineReason = `derived Candle cache was not empty before cell ${cell.id}`;
-        campaignErrors.push(quarantineReason);
-        fail(quarantineReason);
-      }
+      await operations.inspectDerivedSidecarRoot(derivedSidecarRoot, null);
       operations.sample(samples, errors, "pre-execution VRAM sample failed");
-      lifecycle.diskProbes.push(await probeDisk("before-execution", index + 1));
+      await probeDisk(lifecycle, "before-execution", index + 1);
       await invokeFault(fault, "execute", index);
       let runtimeFailure = null;
+      executionAttempted = true;
       try {
         await operations.executeCell({
           sceneworks: sceneworksRoot,
@@ -2533,22 +2718,29 @@ export async function runCampaign(args, options = {}) {
         throw error;
       }
       try {
-        const namespaces = await operations.listDerivedSidecarNamespaces(derivedSidecarRoot);
         const fluxArtifacts = cell.artifactIds.filter((artifactId) => artifactId.startsWith("flux1-"));
-        if (namespaces.length && fluxArtifacts.length !== 1) {
-          fail(`derived sidecars appeared outside one exact FLUX authority for ${cell.id}`);
-        }
-        if (!namespaces.length && fluxArtifacts.length) {
-          fail(`FLUX cell did not create its exact derived-sidecar namespace: ${cell.id}`);
-        }
+        if (fluxArtifacts.length > 1) fail(`cell ${cell.id} has multiple FLUX sidecar authorities`);
+        const expectedNamespace = fluxArtifacts.length === 1
+          ? await operations.expectedB646DerivedNamespace(
+            sharedArtifacts.get(fluxArtifacts[0]), derivedSidecarRoot,
+          ) : null;
+        const derivedInspection = await operations.inspectDerivedSidecarRoot(
+          derivedSidecarRoot, expectedNamespace,
+        );
         if (fluxArtifacts.length === 1) {
-          sharedArtifacts.get(fluxArtifacts[0]).derivedNamespaces.splice(0, Infinity, ...namespaces);
+          sharedArtifacts.get(fluxArtifacts[0]).derivedNamespaces.splice(
+            0, Infinity, ...derivedInspection.namespaces.map((entry) => entry.path),
+          );
         }
         for (const artifactId of cell.artifactIds) {
           const artifact = sharedArtifacts.get(artifactId);
           const inventories = [];
           for (const namespace of artifact.derivedNamespaces) {
-            inventories.push(await operations.directoryInventory(namespace));
+            const bound = derivedInspection.namespaces.find(
+              (entry) => comparable(entry.path) === comparable(namespace),
+            );
+            if (!bound) fail(`derived namespace was not bound by global inspection: ${namespace}`);
+            inventories.push(bound.inventory);
           }
           const files = inventories.reduce((sum, inventory) => sum + inventory.files, 0);
           const bytes = inventories.reduce((sum, inventory) => sum + inventory.bytes, 0);
@@ -2566,7 +2758,7 @@ export async function runCampaign(args, options = {}) {
         derivedSidecarLifecycle.afterCells.push({
           ordinal: index + 1,
           cellId: cell.id,
-          inventory: await operations.directoryInventory(derivedSidecarRoot),
+          inventory: derivedInspection.rootInventory,
         });
       } catch (error) {
         quarantineReason = `derived Candle sidecar evidence failed after cell ${cell.id}: ${errorText(error)}`;
@@ -2581,8 +2773,10 @@ export async function runCampaign(args, options = {}) {
       executionPassed = true;
     } catch (error) {
       const message = recordError(errors, "cell lifecycle failed", error);
-      if (authorityTransitioning && !quarantineReason) {
-        quarantineReason = `JIT authority stage/copy/hash failed before cell ${cell.id}: ${errorText(error)}`;
+      if (!executionAttempted && !quarantineReason) {
+        quarantineReason = authorityTransitioning
+          ? `JIT authority stage/copy/hash failed before cell ${cell.id}: ${errorText(error)}`
+          : `cell pre-execution admission/evidence failed before ${cell.id}: ${errorText(error)}`;
         campaignErrors.push(quarantineReason);
       }
       if (activeArtifactIndex !== null && artifacts[activeArtifactIndex].inventory.complete === false) {
@@ -2643,6 +2837,9 @@ export async function runCampaign(args, options = {}) {
             release.derivedBeforeCleanup.push(await operations.directoryInventory(namespace));
             await operations.cleanup(namespace, guard, `derived sidecars for ${artifactId}`);
             await assertPathAbsent(namespace, `derived sidecars for ${artifactId}`);
+            const versionRoot = path.dirname(namespace);
+            await operations.cleanup(versionRoot, guard, `derived sidecar version for ${artifactId}`);
+            await assertPathAbsent(versionRoot, `derived sidecar version for ${artifactId}`);
           }
           release.derivedRemoved = true;
           await operations.cleanup(artifact.stageRoot, guard, `staged authority ${artifactId}`);
@@ -2697,17 +2894,28 @@ export async function runCampaign(args, options = {}) {
           );
         } catch (error) {
           recordError(errors, "controller log finalization failed", error);
+          if (!quarantineReason) {
+            quarantineReason = `primary receipt finalization failed for ${cell.id}: ${errorText(error)}`;
+            campaignErrors.push(quarantineReason);
+          }
           controllerLog = path.join(cellDir, "controller-fallback.log");
           await invokeFault(fault, "fallbackLog", index);
           await writeFile(controllerLog, `${new Date().toISOString()} ${errors.join("\n")}\n`, "utf8");
         }
         receipt.artifacts = artifacts;
         receipt.hardware.rawVramSamples = samples;
-        await refreshEvidence(receipt, cellDir, errors, { fault, index });
+        const evidenceFailure = await refreshEvidence(receipt, cellDir, errors, { fault, index });
+        if (evidenceFailure && !quarantineReason) {
+          quarantineReason = `primary receipt evidence finalization failed for ${cell.id}: ${evidenceFailure}`;
+          campaignErrors.push(quarantineReason);
+        }
         receipt.status = executionPassed && errors.length === 0 && receipt.cleanup.completed ? "passed" : "failed";
         receipt.error = receipt.status === "passed" ? null : (errors.join("\n") || "cell did not complete");
         receipt.completedAt = new Date().toISOString();
-        await writePrimaryReceipt({ file: receiptPath, receipt, cell, profile, fault, index });
+        await writePrimaryReceipt({
+          file: receiptPath, receipt, cell, profile, fault, index,
+          lifecycleContext: lifecycleContext(true),
+        });
         receipts.push({
           id: cell.id, status: receipt.status,
           receipt: `${path.basename(cellDir)}/receipt.json`, error: receipt.error,
@@ -2722,6 +2930,10 @@ export async function runCampaign(args, options = {}) {
     } catch (error) {
       let receiptPath;
       let emergencyError = [...emergencyFailureMessages, errorText(error)].filter(Boolean).join("\n");
+      if (!quarantineReason) {
+        quarantineReason = `primary receipt semantic/schema/write/stat/hash finalization failed for ${cell.id}: ${errorText(error)}`;
+        campaignErrors.push(quarantineReason);
+      }
       let emergencyAuthorityLifecycle = authorityLifecycle.find(
         (entry) => entry.ordinal === index + 1,
       );
@@ -2736,6 +2948,7 @@ export async function runCampaign(args, options = {}) {
           repositories, execution, gpuIdentity,
           systemMemory, error: new Error(emergencyError), cleanup: emergencyCleanup,
           authorityLifecycle: emergencyAuthorityLifecycle,
+          lifecycleContext: lifecycleContext(false),
         });
       } catch (receiptError) {
         emergencyError += `\nemergency receipt failed: ${errorText(receiptError)}`;
@@ -2745,6 +2958,7 @@ export async function runCampaign(args, options = {}) {
             repositories, execution, gpuIdentity,
             systemMemory, errors: [emergencyError], cleanup: emergencyCleanup,
             authorityLifecycle: emergencyAuthorityLifecycle,
+            lifecycleContext: lifecycleContext(false),
           });
         } catch (lastResortError) {
           emergencyError += `\nlast-resort emergency receipt failed: ${errorText(lastResortError)}`;
@@ -2760,7 +2974,8 @@ export async function runCampaign(args, options = {}) {
   let finalLifecycle = null;
   try {
     const stage = await operations.directoryInventory(stagingRoot);
-    const derived = await operations.directoryInventory(derivedSidecarRoot);
+    const derivedInspection = await operations.inspectDerivedSidecarRoot(derivedSidecarRoot, null);
+    const derived = derivedInspection.rootInventory;
     let missingStoreAbsent = false;
     try {
       await lstat(missingStore);
@@ -2768,7 +2983,7 @@ export async function runCampaign(args, options = {}) {
       if (error?.code !== "ENOENT") throw error;
       missingStoreAbsent = true;
     }
-    finalLifecycle = { stage, derived, missingStoreAbsent };
+    finalLifecycle = { stage, derived, derivedNamespaces: [], missingStoreAbsent };
     if (stage.files !== 0 || stage.bytes !== 0 || derived.files !== 0 || derived.bytes !== 0
       || !missingStoreAbsent || sharedArtifacts.size !== 0) {
       fail("final JIT stage/derived/missing-file lifecycle is not empty");
@@ -2780,6 +2995,7 @@ export async function runCampaign(args, options = {}) {
   }
 
   let finalDocument = cachePreflightDocument({
+    evidencePhase: "final",
     status: quarantineReason ? "failed" : "passed",
     error: quarantineReason,
     downloadEvidenceSha256,
@@ -2804,6 +3020,7 @@ export async function runCampaign(args, options = {}) {
     const evidenceError = `final cache preflight evidence failed: ${errorText(finalWrite.error)}`;
     campaignErrors.push(evidenceError);
     finalDocument = cachePreflightDocument({
+      evidencePhase: "final",
       status: "failed",
       error: quarantineReason ? `${quarantineReason}; ${evidenceError}` : evidenceError,
       downloadEvidenceSha256,
@@ -2882,6 +3099,7 @@ async function main() {
     validateDocumentWithSchema(CACHE_PREFLIGHT_SCHEMA_PATH, {
       schemaVersion: 1,
       profile: PROFILE_NAME,
+      evidencePhase: "initial",
       status: "failed",
       error: "schema self-check fixture",
       downloadEvidenceSha256: "0".repeat(64),

--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -736,18 +736,31 @@ async function sha256File(file) {
 
 export async function hashedFiles(root, { exclude = new Set() } = {}) {
   const absolute = path.resolve(root);
+  const rootMetadata = await lstat(absolute);
+  if (!rootMetadata.isDirectory() || rootMetadata.isSymbolicLink()
+    || comparable(await realpath(absolute)) !== comparable(absolute)) {
+    fail(`evidence root is not an ordinary non-reparse directory: ${absolute}`);
+  }
   const files = [];
   async function visit(directory) {
     const entries = await readdir(directory, { withFileTypes: true });
     for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
       const file = path.join(directory, entry.name);
       const relative = path.relative(absolute, file).split(path.sep).join("/");
-      if (exclude.has(relative)) continue;
-      if (entry.isDirectory()) await visit(file);
-      else if (entry.isFile()) {
-        const metadata = await stat(file);
-        files.push({ path: relative, bytes: metadata.size, sha256: await sha256File(file) });
+      const metadata = await lstat(file);
+      if (entry.isSymbolicLink() || metadata.isSymbolicLink()) {
+        fail(`evidence tree contains a symlink or reparse point: ${file}`);
       }
+      if (exclude.has(relative)) {
+        if (!entry.isFile() || !metadata.isFile()) {
+          fail(`excluded evidence entry is not an ordinary regular file: ${file}`);
+        }
+        continue;
+      }
+      if (entry.isDirectory() && metadata.isDirectory()) await visit(file);
+      else if (entry.isFile() && metadata.isFile()) {
+        files.push({ path: relative, bytes: metadata.size, sha256: await sha256File(file) });
+      } else fail(`evidence tree contains a non-regular entry: ${file}`);
     }
   }
   await visit(absolute);
@@ -932,9 +945,14 @@ function validateReceiptInternal(
     const lifecycle = receipt.authorityLifecycle;
     if (lifecycle.ordinal !== receipt.cell.ordinal || lifecycle.cellId !== receipt.cell.id
       || JSON.stringify(lifecycle.activeArtifactIds) !== JSON.stringify(expectedCell.artifactIds)
+      || !new Set(["not-attempted", "failed", "completed"]).has(lifecycle.providerExecution)
       || lifecycle.staged.some((entry) => !expectedCell.artifactIds.includes(entry.artifactId))
       || lifecycle.released.some((entry) => !expectedCell.artifactIds.includes(entry.artifactId))) {
       fail("receipt authority lifecycle identity drifted");
+    }
+    if ((lifecycle.providerExecution === "not-attempted" && lifecycle.derivedAfter.length)
+      || (lifecycle.providerExecution === "failed" && receipt.status !== "failed")) {
+      fail("receipt provider execution state drifted from its outcome evidence");
     }
     for (const derived of lifecycle.derivedAfter) {
       const isFlux = derived.artifactId.startsWith("flux1-");
@@ -944,12 +962,18 @@ function validateReceiptInternal(
         ? FLUX_Q4_SIDECAR_BYTES : FLUX_Q8_SIDECAR_BYTES;
       if (isFlux) {
         const staged = lifecycle.staged.find((entry) => entry.artifactId === derived.artifactId);
-        if (derived.files !== 494 || derived.bytes < payloadFloor
-          || derived.bytes > payloadCeiling || derived.inventories.length !== 1
-          || staged?.derivedNamespaces.length !== 1
-          || comparable(derived.inventories[0].root) !== comparable(staged.derivedNamespaces[0])
-          || !/^[0-9a-f]{64}$/.test(path.basename(derived.inventories[0].root))
-          || path.basename(path.dirname(derived.inventories[0].root)) !== "candle-device-format-v1") {
+        const oneBoundNamespace = derived.inventories.length === 1
+          && staged?.derivedNamespaces.length === 1
+          && comparable(derived.inventories[0].root) === comparable(staged.derivedNamespaces[0])
+          && /^[0-9a-f]{64}$/.test(path.basename(derived.inventories[0].root))
+          && path.basename(path.dirname(derived.inventories[0].root)) === "candle-device-format-v1";
+        const exactEmptyFailure = lifecycle.providerExecution === "failed"
+          && derived.files === 0 && derived.bytes === 0 && oneBoundNamespace
+          && derived.inventories[0].files === 0 && derived.inventories[0].bytes === 0
+          && derived.inventories[0].sha256 === createHash("sha256").digest("hex");
+        const exactComplete = derived.files === 494 && derived.bytes >= payloadFloor
+          && derived.bytes <= payloadCeiling && oneBoundNamespace;
+        if (!exactEmptyFailure && !exactComplete) {
           fail("receipt FLUX derived lifecycle is not one exact bounded b646 namespace");
         }
       } else if (derived.files !== 0 || derived.bytes !== 0 || derived.inventories.length !== 0) {
@@ -986,16 +1010,19 @@ function validateReceiptInternal(
         || releasedIds.some((id) => !new Set([...startingIds, ...endingIds]).has(id))) {
         fail("receipt staged/released authorities drifted from the lifetime plan");
       }
+      const expectedDerivedIds = lifecycle.providerExecution === "not-attempted"
+        ? [] : expectedCell.artifactIds;
       if (completeLifecycle && (JSON.stringify(actualPhases) !== JSON.stringify(expectedPhases)
         || lifecycle.diskProbes.some((probe) => probe.freeBytes < requiredFreeBytes)
         || JSON.stringify(stagedIds) !== JSON.stringify(startingIds)
         || JSON.stringify(releasedIds) !== JSON.stringify(endingIds)
         || JSON.stringify(lifecycle.derivedAfter.map((entry) => entry.artifactId))
-          !== JSON.stringify(expectedCell.artifactIds))) {
+          !== JSON.stringify(expectedDerivedIds))) {
         fail("completed receipt lifecycle omitted an exact transition, probe, or derivation");
       }
     }
     if (receipt.status === "passed" && (!lifecycle.verifiedBefore || !lifecycle.verifiedAfter
+      || lifecycle.providerExecution !== "completed"
       || lifecycle.diskProbes.length < lifecycle.staged.length + 1
       || lifecycle.released.some((entry) => !entry.stageRemoved || !entry.derivedRemoved))) {
       fail("passed receipt authority lifecycle is incomplete");
@@ -1604,17 +1631,28 @@ export async function expectedB646DerivedNamespace(artifact, derivedSidecarRoot)
   return path.join(derivedSidecarRoot, "candle-device-format-v1", digest);
 }
 
-export async function inspectDerivedSidecarRoot(derivedSidecarRoot, expectedNamespace = null) {
-  const rootEntries = await readdir(derivedSidecarRoot, { withFileTypes: true });
+export async function inspectDerivedSidecarRoot(
+  derivedSidecarRoot, expectedNamespace = null, { materializeExactEmpty = false } = {},
+) {
+  let rootEntries = await readdir(derivedSidecarRoot, { withFileTypes: true });
   if (!expectedNamespace) {
     if (rootEntries.length) fail("non-FLUX derived sidecar root must be exactly empty");
     return { rootInventory: await directoryInventory(derivedSidecarRoot), namespaces: [] };
+  }
+  const expectedVersionRoot = path.join(derivedSidecarRoot, "candle-device-format-v1");
+  if (materializeExactEmpty && rootEntries.length === 0) {
+    if (comparable(path.dirname(expectedNamespace)) !== comparable(expectedVersionRoot)
+      || !/^[0-9a-f]{64}$/.test(path.basename(expectedNamespace))) {
+      fail("empty FLUX sidecar namespace target is not the exact b646 cache path");
+    }
+    await mkdir(expectedNamespace, { recursive: true });
+    rootEntries = await readdir(derivedSidecarRoot, { withFileTypes: true });
   }
   if (rootEntries.length !== 1 || rootEntries[0].name !== "candle-device-format-v1"
     || !rootEntries[0].isDirectory()) {
     fail("FLUX derived sidecar root has stray files, directories, or versions");
   }
-  const versionRoot = path.join(derivedSidecarRoot, "candle-device-format-v1");
+  const versionRoot = expectedVersionRoot;
   const versionMetadata = await lstat(versionRoot);
   if (versionMetadata.isSymbolicLink()) fail("derived sidecar version root is a reparse point");
   const namespaceEntries = await readdir(versionRoot, { withFileTypes: true });
@@ -1816,6 +1854,7 @@ function emptyAuthorityLifecycle(cell, index) {
     cellId: cell.id,
     staged: [],
     activeArtifactIds: [...cell.artifactIds],
+    providerExecution: "not-attempted",
     verifiedBefore: false,
     verifiedAfter: false,
     derivedAfter: [],
@@ -2157,9 +2196,12 @@ export function validateCachePreflightEvidence(document, {
     const payloadFloor = flux?.endsWith("-q4") ? 7_396_392_960 : 12_573_868_032;
     const payloadCeiling = flux?.endsWith("-q4")
       ? FLUX_Q4_SIDECAR_BYTES : FLUX_Q8_SIDECAR_BYTES;
-    if (flux ? (snapshot.inventory.files !== 494
+    const emptyProviderFailure = snapshot.providerExecution === "failed"
+      && snapshot.inventory.files === 0 && snapshot.inventory.bytes === 0
+      && snapshot.inventory.sha256 === createHash("sha256").digest("hex");
+    if (flux ? (!emptyProviderFailure && (snapshot.inventory.files !== 494
         || snapshot.inventory.bytes < payloadFloor
-        || snapshot.inventory.bytes > payloadCeiling)
+        || snapshot.inventory.bytes > payloadCeiling))
       : (snapshot.inventory.files !== 0 || snapshot.inventory.bytes !== 0
         || snapshot.inventory.sha256 !== createHash("sha256").digest("hex"))) {
       fail("derived Candle sidecar lifecycle inventory drifted from the cell family contract");
@@ -2587,6 +2629,7 @@ export async function runCampaign(args, options = {}) {
       cellId: cell.id,
       staged: [],
       activeArtifactIds: [...cell.artifactIds],
+      providerExecution: "not-attempted",
       verifiedBefore: false,
       verifiedAfter: false,
       derivedAfter: [],
@@ -2749,7 +2792,9 @@ export async function runCampaign(args, options = {}) {
           runtimeScratch: cellScratch,
           derivedSidecarRoot,
         });
+        lifecycle.providerExecution = "completed";
       } catch (error) {
+        lifecycle.providerExecution = "failed";
         runtimeFailure = error;
       }
       try {
@@ -2769,6 +2814,7 @@ export async function runCampaign(args, options = {}) {
           ) : null;
         const derivedInspection = await operations.inspectDerivedSidecarRoot(
           derivedSidecarRoot, expectedNamespace,
+          { materializeExactEmpty: runtimeFailure !== null && expectedNamespace !== null },
         );
         if (fluxArtifacts.length === 1) {
           sharedArtifacts.get(fluxArtifacts[0]).derivedNamespaces.splice(
@@ -2787,10 +2833,12 @@ export async function runCampaign(args, options = {}) {
           }
           const files = inventories.reduce((sum, inventory) => sum + inventory.files, 0);
           const bytes = inventories.reduce((sum, inventory) => sum + inventory.bytes, 0);
-          if (artifactId.startsWith("flux1-") && (files !== 494
-            || bytes < (artifactId.endsWith("-q4") ? 7_396_392_960 : 12_573_868_032)
-            || bytes > (artifactId.endsWith("-q4")
-              ? FLUX_Q4_SIDECAR_BYTES : FLUX_Q8_SIDECAR_BYTES))) {
+          const exactEmptyProviderFailure = runtimeFailure !== null
+            && files === 0 && bytes === 0 && inventories.length === 1;
+          if (artifactId.startsWith("flux1-") && !exactEmptyProviderFailure && (files !== 494
+              || bytes < (artifactId.endsWith("-q4") ? 7_396_392_960 : 12_573_868_032)
+              || bytes > (artifactId.endsWith("-q4")
+                ? FLUX_Q4_SIDECAR_BYTES : FLUX_Q8_SIDECAR_BYTES))) {
             fail(`FLUX derived-sidecar contract drifted for ${artifactId}: ${files} files/${bytes} bytes`);
           }
           if (!artifactId.startsWith("flux1-") && (files !== 0 || bytes !== 0)) {
@@ -2801,6 +2849,7 @@ export async function runCampaign(args, options = {}) {
         derivedSidecarLifecycle.afterCells.push({
           ordinal: index + 1,
           cellId: cell.id,
+          providerExecution: lifecycle.providerExecution,
           inventory: derivedInspection.rootInventory,
         });
       } catch (error) {
@@ -2813,6 +2862,10 @@ export async function runCampaign(args, options = {}) {
       try {
         const runtimeResultPath = path.join(cellDir, "runtime-result.json");
         await invokeFault(fault, "runtimeResultRead", index);
+        const linkMetadata = await lstat(runtimeResultPath);
+        if (!linkMetadata.isFile() || linkMetadata.isSymbolicLink()) {
+          fail(`runtime-result is not an ordinary non-reparse file for ${cell.id}`);
+        }
         const before = await stat(runtimeResultPath);
         const runtimeResultBytes = await readFile(runtimeResultPath);
         await invokeFault(fault, "runtimeResultHash", index);

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -11,10 +11,12 @@ import {
   PROFILE_SCHEMA_PATH,
   RECEIPT_SCHEMA_PATH,
   CACHE_PREFLIGHT_SCHEMA_PATH,
+  authorityLifetimePlan,
   cellSemanticsSha256,
   directoryInventory,
   expectedArtifactFilesFromEvidence,
   expectedLoadSpecQuantBits,
+  estimateJitDiskPlan,
   inferencePins,
   hashedFiles,
   installSidecarObstructions,
@@ -109,6 +111,71 @@ test("download evidence freezes the exact 23-authority filename census", async (
     () => expectedArtifactFilesFromEvidence(checked, missingRow),
     /missing exact authority/,
   );
+});
+
+test("JIT disk estimator uses followed target bytes, exact lifetimes, and the 99GB floor", () => {
+  const file = (key, bytes, persistent = false) => ({ key, bytes, persistent });
+  const row = (artifactId, firstOrdinal, lastOrdinal, files) => ({
+    artifactId,
+    role: artifactId.includes("support") ? "support" : "primary",
+    firstOrdinal,
+    lastOrdinal,
+    sourceBytes: files.reduce((sum, entry) => sum + entry.bytes, 0),
+    expectedFiles: files.length,
+    physicalFiles: files,
+  });
+  const persistent = file("schnell-q8/missing", 12_637_521_668, true);
+  const lifetimes = [
+    row("flux1-dev-q8", 8, 8, [file("dev-q8", 23_371_725_325)]),
+    row("flux1-schnell-q4", 9, 9, [file("schnell-q4", 14_973_205_319)]),
+    row("flux1-schnell-q8", 10, 10, [file("schnell-q8/cache", 5_361_654_035), persistent]),
+    row("scail2-q4", 11, 12, [file("scail-q4", 29_000_000_000)]),
+    row("scail2-q8", 13, 13, [file("scail-q8", 19_429_609_601)]),
+    row("ltx23-q8", 14, 14, [file("ltx-q8", 30_000_000_000)]),
+    row("ltx23-gemma", 14, 14, [file("ltx-gemma", 13_519_093_966)]),
+    ...[0, 1, 2, 3, 4].map((index) => row(
+      `sdxl-primary-${index}`,
+      15 + index,
+      15 + index,
+      [file(`sdxl-primary-${index}`, index === 4 ? 6_047_177_674 : 6_047_177_669)],
+    )),
+    ...[0, 1, 2, 3].map((index) => row(
+      `sdxl-support-${index}`,
+      15,
+      19,
+      [file(`sdxl-support-${index}`, 125_000_000)],
+    )),
+  ];
+  const floor = 99_106_288_594;
+  const admitted = estimateJitDiskPlan(lifetimes, floor, persistent.bytes);
+  assert.equal(admitted.logicalSourceBytes, 179_028_698_264);
+  assert.equal(admitted.allAtOnceSourceBytes, 179_028_698_264);
+  assert.equal(
+    admitted.allAtOnceSourceBytes - admitted.legacyNaiveLinkLengthSourceBytes,
+    5_361_654_035,
+    "link-length accounting must never undercount followed Schnell q8 blob bytes",
+  );
+  assert.equal(admitted.cells.find((entry) => entry.ordinal === 8).modelAndSidecarBytes, 48_591_208_721);
+  assert.equal(admitted.cells.find((entry) => entry.ordinal === 9).modelAndSidecarBytes, 35_015_213_643);
+  assert.equal(admitted.cells.find((entry) => entry.ordinal === 10).modelAndSidecarBytes, 30_581_137_431);
+  assert.equal(admitted.cells.find((entry) => entry.ordinal === 13).modelAndSidecarBytes, 32_067_131_269);
+  assert.equal(admitted.peakModelAndSidecarBytes, 56_156_615_634);
+  assert.equal(admitted.peakRequiredAdditionalBytes, floor);
+  assert.equal(admitted.admitted, true);
+  assert.equal(estimateJitDiskPlan(lifetimes, floor - 1, persistent.bytes).admitted, false);
+  assert.ok(admitted.allAtOnceRequiredBytes > floor, "all-at-once staging stays rejected");
+
+  const completeCache = structuredClone(lifetimes);
+  const completeQ8 = completeCache.find((entry) => entry.artifactId === "flux1-schnell-q8");
+  completeQ8.physicalFiles = completeQ8.physicalFiles.map((entry) => ({
+    ...entry,
+    persistent: false,
+  }));
+  const completePlan = estimateJitDiskPlan(completeCache, floor, 0);
+  assert.ok(completePlan.peakModelAndSidecarBytes < admitted.peakModelAndSidecarBytes);
+  assert.equal(completePlan.peakRequiredAdditionalBytes, floor);
+  assert.equal(completePlan.admitted, true);
+  assert.equal(estimateJitDiskPlan(completeCache, floor - 1, 0).admitted, false);
 });
 
 test("profile validator rejects count, order, every semantic tuple mutation, blocked, and authority drift", async () => {
@@ -816,9 +883,21 @@ test("injected lifecycle faults preserve all 19 outcomes and quarantine after cl
       };
     },
     installSidecarObstructions: async (artifacts) => fixtureSidecarObstructions(artifacts),
+    listDerivedSidecarNamespaces: async (root) => {
+      const id = executedCells.at(-1);
+      if (!id?.startsWith("flux1-")) return [];
+      const namespace = path.join(root, "candle-device-format-v1", id);
+      await mkdir(namespace, { recursive: true });
+      return [namespace];
+    },
     directoryInventory: async (root) => ({
-      root, files: 0, bytes: 0, sha256: createHash("sha256").digest("hex"),
+      root,
+      files: root.includes("flux1-") ? 494 : 0,
+      bytes: root.includes("flux1-")
+        ? (root.endsWith("q4") ? 7_396_392_960 : 12_573_868_032) : 0,
+      sha256: createHash("sha256").digest("hex"),
     }),
+    diskFreeBytes: async () => 256 * 1024 ** 3,
     executeCell: async ({ cellDir, logFile }) => {
       await writeFile(logFile, "fixture runtime\n", "utf8");
       const runtimeCell = JSON.parse(await readFile(path.join(cellDir, "cell.json"), "utf8"));
@@ -853,16 +932,9 @@ test("injected lifecycle faults preserve all 19 outcomes and quarantine after cl
       Array.from({ length: 7 }, (_, index) => index),
       result.summary.campaignErrors.join("\n"),
     );
-    assert.equal(preflightCalls.length, 23 * 3);
-    assert.ok(preflightCalls.every((call) => call.includes(":cache-preflight:")));
-    assert.deepEqual(
-      preflightCalls.map((call) => call.split(":")[0]),
-      [
-        ...Array(23).fill("audit"),
-        ...Array(23).fill("stage"),
-        ...Array(23).fill("offline"),
-      ],
-    );
+    assert.equal(preflightCalls.filter((call) => call.startsWith("audit:")).length, 23);
+    assert.equal(preflightCalls.filter((call) => call.startsWith("stage:")).length, 3);
+    assert.equal(preflightCalls.filter((call) => call.startsWith("offline:")).length, 3);
     assert.ok(executedCells.length > 0);
     assert.ok(executedCells.every((id) => checked.cells.slice(0, 7).some((cell) => cell.id === id)));
     assert.equal(executedCells.at(-1), checked.cells[6].id);
@@ -871,7 +943,7 @@ test("injected lifecycle faults preserve all 19 outcomes and quarantine after cl
     assert.equal(result.summaryPath, "_emergency/campaign-summary-fallback.json");
     assert.match(result.summary.campaignErrors.join("\n"), /primary campaign summary write failed/);
     for (const [index, outcome] of result.summary.receipts.entries()) {
-      assert.ok(outcome.receipt, `${outcome.id} must retain a receipt path`);
+      assert.ok(outcome.receipt, `${outcome.id} must retain a receipt path: ${outcome.error}`);
       const receiptFile = path.join(output, ...outcome.receipt.split("/"));
       const receipt = JSON.parse(await readFile(receiptFile, "utf8"));
       assert.doesNotThrow(() => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, receipt));
@@ -897,10 +969,10 @@ test("injected lifecycle faults preserve all 19 outcomes and quarantine after cl
   }
 });
 
-test("continuation freezes census, stages once, downloads only the reviewed miss, and reuses authorities", async () => {
+test("continuation freezes census, downloads once, and JIT stages exact authority lifetimes", async () => {
   async function scenario({
     missingId = null, downloadSucceeds = false, mutateCache = false, mutateSourceAtStage = false,
-    preflightFault = null, omitObstructions = false,
+    preflightFault = null, omitObstructions = false, diskFreeValues = [256 * 1024 ** 3],
   } = {}) {
     const temporary = await mkdtemp(path.join(tmpdir(), "sc-20974-preflight-"));
     const runnerTemp = path.join(temporary, "runner-temp");
@@ -927,6 +999,7 @@ test("continuation freezes census, stages once, downloads only the reviewed miss
     const events = [];
     const runtimeCells = [];
     let verificationCalls = 0;
+    let diskFreeCall = 0;
     const operations = {
       auditArtifact: async ({ id, artifact }) => {
         events.push(`audit:${id}`);
@@ -946,15 +1019,28 @@ test("continuation freezes census, stages once, downloads only the reviewed miss
           ),
         };
       },
-      stageArtifact: async ({ id, artifact, stagingRoot, allowReviewedDownload }) => {
+      downloadReviewedMissing: async ({ id, missingStore }) => {
+        events.push(`download:${id}`);
+        if (!downloadSucceeds) throw new Error("fixture exact missing-file transfer failed");
+        return {
+          id,
+          storeRoot: missingStore,
+          downloadedFiles: [{
+            path: "transformer/model.safetensors",
+            bytes: 200,
+            sha256: "b".repeat(64),
+            lfsSha256: "b".repeat(64),
+            commitSha: "bba3ae01dfd94089f173c05edd4e1a4c551f2599",
+          }],
+        };
+      },
+      stageArtifact: async ({ id, artifact, stagingRoot, missingStore }) => {
         events.push(`stage:${id}`);
-        if (allowReviewedDownload && !downloadSucceeds) {
-          throw new Error("fixture exact missing-file transfer failed");
-        }
+        const usesMissing = id === "flux1-schnell-q8" && missingId === id;
         return {
           id, ...artifact,
           reusedFiles: artifactExpectedFiles[id].filter((file) => !(
-            allowReviewedDownload && file === "transformer/model.safetensors"
+            usesMissing && file === "transformer/model.safetensors"
           )).map((file, index) => ({
             path: file,
             bytes: 100,
@@ -962,7 +1048,7 @@ test("continuation freezes census, stages once, downloads only the reviewed miss
               && events.filter((event) => event.startsWith("stage:")).length === 1
               && index === 0 ? "c".repeat(64) : "a".repeat(64),
           })),
-          downloadedFiles: allowReviewedDownload ? [{
+          downloadedFiles: usesMissing && missingStore ? [{
             path: "transformer/model.safetensors",
             bytes: 200,
             sha256: "b".repeat(64),
@@ -990,13 +1076,28 @@ test("continuation freezes census, stages once, downloads only the reviewed miss
       installSidecarObstructions: async (artifacts) => (
         omitObstructions ? [] : fixtureSidecarObstructions(artifacts)
       ),
+      listDerivedSidecarNamespaces: async (root) => {
+        const id = runtimeCells.at(-1)?.id;
+        if (!id?.startsWith("flux1-")) return [];
+        const namespace = path.join(root, "candle-device-format-v1", id);
+        await mkdir(namespace, { recursive: true });
+        return [namespace];
+      },
       directoryInventory: async (root) => ({
-        root, files: 0, bytes: 0, sha256: createHash("sha256").digest("hex"),
+        root,
+        files: root.includes("flux1-") ? 494 : 0,
+        bytes: root.includes("flux1-")
+          ? (root.endsWith("q4") ? 7_396_392_960 : 12_573_868_032) : 0,
+        sha256: createHash("sha256").digest("hex"),
       }),
+      diskFreeBytes: async () => diskFreeValues[Math.min(
+        diskFreeCall++, diskFreeValues.length - 1,
+      )],
       executeCell: async ({ cellDir, logFile }) => {
         await writeFile(logFile, "fixture runtime\n", "utf8");
         const runtimeCell = JSON.parse(await readFile(path.join(cellDir, "cell.json"), "utf8"));
         runtimeCells.push(runtimeCell);
+        events.push(`execute:${runtimeCell.id}`);
         await writeFile(path.join(cellDir, "runtime-result.json"), `${JSON.stringify({
           requestedTier: runtimeCell.requestedTier,
           resolvedTier: runtimeCell.requestedTier,
@@ -1056,7 +1157,10 @@ test("continuation freezes census, stages once, downloads only the reviewed miss
         } : undefined,
         suppressVerdict: true,
       });
-      const cacheEvidence = JSON.parse(await readFile(path.join(output, "cache-preflight.json"), "utf8"));
+      const cacheEvidence = JSON.parse(await readFile(
+        path.join(output, ...result.summary.cachePreflight.path.split("/")),
+        "utf8",
+      ));
       return {
         result, events, runtimeCells, checked, cacheEvidence,
         cacheValidation: {
@@ -1068,6 +1172,7 @@ test("continuation freezes census, stages once, downloads only the reviewed miss
           guard,
           stagingRoot: path.join(scratch, "authority-stage"),
           derivedSidecarRoot: path.join(scratch, "derived-candle-device-cache"),
+          missingStore: path.join(scratch, "persistent-missing-file"),
           profile: checked,
         },
       };
@@ -1085,7 +1190,7 @@ test("continuation freezes census, stages once, downloads only the reviewed miss
   assert.equal(failed.result.summary.failed, 12);
   assert.match(
     failed.result.summary.campaignErrors.join("\n"),
-    /copy-once campaign staging failed[\s\S]*exact missing-file transfer failed[\s\S]*no continuation GPU cell started/,
+    /cache-only transfer\/disk preflight failed[\s\S]*exact missing-file transfer failed[\s\S]*no continuation GPU cell started/,
   );
 
   const unapproved = await scenario({ missingId: "ltx23-q8" });
@@ -1101,16 +1206,42 @@ test("continuation freezes census, stages once, downloads only the reviewed miss
   assert.equal(sourceChanged.events.some((event) => event.startsWith("offline:")), false);
   assert.match(
     sourceChanged.result.summary.campaignErrors.join("\n"),
-    /trusted source cache changed after frozen census[\s\S]*no continuation GPU cell started/,
+    /JIT authority stage\/copy\/hash failed[\s\S]*trusted source cache changed after frozen census/,
+  );
+
+  const diskNoGo = await scenario({ diskFreeValues: [1] });
+  assert.equal(diskNoGo.runtimeCells.length, 0);
+  assert.match(
+    diskNoGo.result.summary.campaignErrors.join("\n"),
+    /JIT staging disk admission refused[\s\S]*no continuation GPU cell started/,
+  );
+
+  const diskDropsBeforeStage = await scenario({
+    diskFreeValues: [256 * 1024 ** 3, 1],
+  });
+  assert.equal(diskDropsBeforeStage.runtimeCells.length, 0);
+  assert.match(
+    diskDropsBeforeStage.result.summary.campaignErrors.join("\n"),
+    /disk capacity fell below.*before-stage:flux1-dev-q8/,
   );
 
   const passed = await scenario();
-  assert.deepEqual(passed.events, [
-    ...remainingIds.map((id) => `audit:${id}`),
-    ...remainingIds.map((id) => `stage:${id}`),
-    ...remainingIds.map((id) => `offline:${id}`),
-  ]);
+  assert.deepEqual(
+    passed.events.filter((event) => event.startsWith("audit:")),
+    remainingIds.map((id) => `audit:${id}`),
+  );
+  assert.deepEqual(
+    passed.events.filter((event) => event.startsWith("stage:")),
+    remainingIds.map((id) => `stage:${id}`),
+    passed.result.summary.campaignErrors.join("\n"),
+  );
+  assert.equal(passed.events.filter((event) => event.startsWith("offline:")).length, 16);
   assert.equal(passed.runtimeCells.length, 12, passed.result.summary.campaignErrors.join("\n"));
+  assert.ok(
+    passed.events.indexOf("execute:flux1-dev-q8")
+      < passed.events.indexOf("stage:flux1-schnell-q4"),
+    "later authorities must not be staged all at once before the first GPU cell",
+  );
   const scailRoots = passed.runtimeCells
     .filter((cell) => cell.artifacts.some((artifact) => artifact.id === "scail2-q4"))
     .map((cell) => cell.artifacts.find((artifact) => artifact.id === "scail2-q4").root);
@@ -1120,13 +1251,35 @@ test("continuation freezes census, stages once, downloads only the reviewed miss
     .map((cell) => cell.artifacts.find((artifact) => artifact.id === "sdxl-openpose").root);
   assert.equal(controlRoots.length, 5);
   assert.equal(new Set(controlRoots).size, 1, "five SDXL cells must reuse one cached ControlNet");
+  const lifecycle = passed.result.summary.authorityLifecycle;
+  assert.deepEqual(lifecycle.find((row) => row.ordinal === 11).staged.map((row) => row.artifactId), [
+    "scail2-q4",
+  ]);
+  assert.deepEqual(lifecycle.find((row) => row.ordinal === 12).released.map((row) => row.artifactId), [
+    "scail2-q4",
+  ]);
+  assert.deepEqual(lifecycle.find((row) => row.ordinal === 14).staged.map((row) => row.artifactId), [
+    "ltx23-q8", "ltx23-gemma",
+  ]);
+  assert.deepEqual(lifecycle.find((row) => row.ordinal === 15).staged.map((row) => row.artifactId), [
+    "sdxl-base-q4", "sdxl-openpose", "sdxl-tokenizer-l", "sdxl-tokenizer-bigg", "sdxl-vae-fix",
+  ]);
+  assert.deepEqual(lifecycle.find((row) => row.ordinal === 19).released.map((row) => row.artifactId), [
+    "illustrious-v2-q4", "sdxl-openpose", "sdxl-tokenizer-l", "sdxl-tokenizer-bigg", "sdxl-vae-fix",
+  ]);
+  assert.equal(passed.result.summary.finalAuthorityLifecycle.stage.files, 0);
+  assert.equal(passed.result.summary.finalAuthorityLifecycle.derived.files, 0);
+  assert.equal(passed.result.summary.finalAuthorityLifecycle.missingStoreAbsent, true);
 
   const filled = await scenario({ missingId: "flux1-schnell-q8", downloadSucceeds: true });
-  assert.deepEqual(filled.events, [
-    ...remainingIds.map((id) => `audit:${id}`),
-    ...remainingIds.map((id) => `stage:${id}`),
-    ...remainingIds.map((id) => `offline:${id}`),
+  assert.deepEqual(
+    filled.events.filter((event) => event.startsWith("audit:")),
+    remainingIds.map((id) => `audit:${id}`),
+  );
+  assert.deepEqual(filled.events.filter((event) => event.startsWith("download:")), [
+    "download:flux1-schnell-q8",
   ]);
+  assert.equal(filled.events.filter((event) => event.startsWith("stage:")).length, 16);
   assert.equal(filled.runtimeCells.length, 12);
   assert.deepEqual(filled.cacheEvidence.downloadedFiles, [{
     artifactId: "flux1-schnell-q8",
@@ -1162,12 +1315,8 @@ test("continuation freezes census, stages once, downloads only the reviewed miss
     () => validateCachePreflightEvidence(censusDrift, filled.cacheValidation),
     /authority census drifted/,
   );
-  const obstructionMissing = structuredClone(filled.cacheEvidence);
-  obstructionMissing.sidecarObstructions.pop();
-  assert.throws(
-    () => validateCachePreflightEvidence(obstructionMissing, filled.cacheValidation),
-    /did not obstruct every staged component root/,
-  );
+  assert.equal(filled.cacheEvidence.lifetimePlan.length, 16);
+  assert.equal(filled.cacheEvidence.diskPlan.admitted, true);
   const downloadDrift = structuredClone(filled.cacheEvidence);
   downloadDrift.downloadedFiles[0].commitSha = "f".repeat(40);
   assert.throws(
@@ -1203,7 +1352,7 @@ test("continuation freezes census, stages once, downloads only the reviewed miss
   assert.equal(semanticFault.result.summary.failed, 12);
   assert.match(
     semanticFault.result.summary.campaignErrors.join("\n"),
-    /did not obstruct every staged component root/,
+    /did not obstruct model-adjacent sidecars/,
   );
   assert.doesNotThrow(() => validateDocumentWithSchema(
     CACHE_PREFLIGHT_SCHEMA_PATH,
@@ -1355,7 +1504,8 @@ test("schemas, clean Node dependencies, and workflow preserve the opt-in single-
   assert.match(terminalBlock, /__version__ == '0\.36\.0'/);
   assert.match(terminalBlock, /q8\/transformer\/model\.safetensors/);
   const controller = await readFile("scripts/epic-20738-terminal-cuda-harness.mjs", "utf8");
-  assert.match(controller, /HF_HUB_OFFLINE: allowReviewedDownload \? "0" : "1"/);
+  assert.match(controller, /async function downloadReviewedMissing[\s\S]*?HF_HUB_OFFLINE: "0"/);
+  assert.match(controller, /async function stageArtifact[\s\S]*?HF_HUB_OFFLINE: "1"/);
   assert.match(controller, /HF_HUB_OFFLINE: "1"[\s\S]*TRANSFORMERS_OFFLINE: "1"/);
   for (const variable of [
     "TEMP", "TMP", "TMPDIR", "HF_HOME", "HUGGINGFACE_HUB_CACHE", "HF_HUB_CACHE",

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -1066,6 +1066,7 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     missingId = null, downloadSucceeds = false, mutateCache = false, mutateSourceAtStage = false,
     preflightFault = null, cellFault = null, omitObstructions = false,
     derivedContractDrift = null, diskFreeValues = [256 * 1024 ** 3],
+    runtimeResultMode = "valid", providerRuntimeFailureAt = null,
   } = {}) {
     const temporary = await mkdtemp(path.join(tmpdir(), "sc-20974-preflight-"));
     const runnerTemp = path.join(temporary, "runner-temp");
@@ -1210,12 +1211,22 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
         const runtimeCell = JSON.parse(await readFile(path.join(cellDir, "cell.json"), "utf8"));
         runtimeCells.push(runtimeCell);
         events.push(`execute:${runtimeCell.id}`);
-        await writeFile(path.join(cellDir, "runtime-result.json"), `${JSON.stringify({
-          requestedTier: runtimeCell.requestedTier,
-          resolvedTier: runtimeCell.requestedTier,
-          denseFallback: false,
-          loadSpecQuantBits: expectedLoadSpecQuantBits(runtimeCell),
-        })}\n`, "utf8");
+        if (runtimeCell.id === providerRuntimeFailureAt) {
+          throw new Error("fixture provider runtime failed");
+        }
+        if (runtimeResultMode !== "missing" || runtimeCells.length !== 1) {
+          const runtimeResult = runtimeResultMode === "malformed" && runtimeCells.length === 1
+            ? "{"
+            : `${JSON.stringify({
+              requestedTier: runtimeCell.requestedTier,
+              resolvedTier: runtimeResultMode === "wrong-semantic" && runtimeCells.length === 1
+                ? (runtimeCell.requestedTier === "q4" ? "q8" : "q4")
+                : runtimeCell.requestedTier,
+              denseFallback: false,
+              loadSpecQuantBits: expectedLoadSpecQuantBits(runtimeCell),
+            })}\n`;
+          await writeFile(path.join(cellDir, "runtime-result.json"), runtimeResult, "utf8");
+        }
         await writeFile(path.join(cellDir, "output.bin"), "fixture", "utf8");
       },
       verifyArtifactUnchanged: async () => {
@@ -1327,6 +1338,7 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
   assert.equal(failed.runtimeCells.length, 0);
   assert.equal(failed.result.summary.passed, 7);
   assert.equal(failed.result.summary.failed, 12);
+  assert.equal(failed.cacheEvidence.offlineBeforeCells, false);
   assert.match(
     failed.result.summary.campaignErrors.join("\n"),
     /cache-only transfer\/disk preflight failed[\s\S]*exact missing-file transfer failed[\s\S]*no continuation GPU cell started/,
@@ -1375,6 +1387,49 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
   assert.ok(diskDropsBeforeExecution.result.summary.receipts.slice(7).every(
     (outcome) => outcome.status === "failed" && outcome.receipt,
   ));
+
+  for (const runtimeResultMode of ["missing", "malformed", "wrong-semantic"]) {
+    const faulted = await scenario({ runtimeResultMode });
+    assert.equal(faulted.runtimeCells.length, 1, runtimeResultMode);
+    assert.ok(faulted.result.summary.receipts.slice(8).every(
+      (outcome) => outcome.status === "failed" && outcome.receipt,
+    ), runtimeResultMode);
+    assert.match(
+      faulted.result.summary.campaignErrors.join("\n"),
+      /runtime-result evidence failed after cell flux1-dev-q8/,
+      runtimeResultMode,
+    );
+    assert.equal(faulted.cacheEvidence.offlineBeforeCells, true, runtimeResultMode);
+  }
+  const runtimeHashFault = await scenario({ cellFault: { stage: "runtimeResultHash" } });
+  assert.equal(runtimeHashFault.runtimeCells.length, 1);
+  assert.ok(runtimeHashFault.result.summary.receipts.slice(8).every(
+    (outcome) => outcome.status === "failed" && outcome.receipt,
+  ));
+  assert.match(
+    runtimeHashFault.result.summary.campaignErrors.join("\n"),
+    /runtime-result evidence failed after cell flux1-dev-q8.*runtimeResultHash/,
+  );
+  assert.equal(runtimeHashFault.cacheEvidence.offlineBeforeCells, true);
+  const falseAfterOffline = structuredClone(runtimeHashFault.cacheEvidence);
+  falseAfterOffline.offlineBeforeCells = false;
+  assert.doesNotThrow(() => validateDocumentWithSchema(
+    CACHE_PREFLIGHT_SCHEMA_PATH,
+    falseAfterOffline,
+  ));
+  assert.throws(
+    () => validateCachePreflightEvidence(falseAfterOffline, runtimeHashFault.cacheValidation),
+    /cell lifecycle evidence before network-offline establishment/,
+  );
+
+  const providerFailed = await scenario({ providerRuntimeFailureAt: "flux1-dev-q8" });
+  assert.equal(providerFailed.runtimeCells.length, 12);
+  assert.equal(providerFailed.result.summary.failed, 1);
+  assert.equal(providerFailed.result.summary.passed, 18);
+  assert.equal(
+    providerFailed.result.summary.campaignErrors.some((error) => error.includes("runtime-result evidence")),
+    false,
+  );
 
   for (const cellFault of [
     { stage: "finalLog" },
@@ -1526,6 +1581,27 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, missingLifecycle),
     /required property 'authorityLifecycle'/,
   );
+  const forgedLegacyLifecycleOmission = structuredClone(firstReceipt);
+  forgedLegacyLifecycleOmission.repositories.sceneworks.sha = "8886a9e69f26beec05688c81b414859bd102f6d0";
+  forgedLegacyLifecycleOmission.execution.headSha = "8886a9e69f26beec05688c81b414859bd102f6d0";
+  delete forgedLegacyLifecycleOmission.authorityLifecycle;
+  assert.throws(
+    () => validateReceipt(
+      forgedLegacyLifecycleOmission, firstCell, filled.checked, filled.lifecycleContext,
+    ),
+    /missing required authority lifecycle/,
+  );
+  assert.throws(
+    () => validateReceipt(
+      forgedLegacyLifecycleOmission, firstCell, filled.checked, filled.lifecycleContext,
+      { trustedLegacyImport: true },
+    ),
+    /missing required authority lifecycle/,
+  );
+  assert.throws(
+    () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, forgedLegacyLifecycleOmission),
+    /required property 'authorityLifecycle'/,
+  );
   for (const [label, mutate] of [
     ["phase", (value) => { value.authorityLifecycle.diskProbes[0].phase = "before-stage:wrong"; }],
     ["ordinal", (value) => { value.authorityLifecycle.diskProbes[0].ordinal += 1; }],
@@ -1565,6 +1641,7 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
       CACHE_PREFLIGHT_SCHEMA_PATH,
       faulted.cacheEvidence,
     ));
+    assert.equal(faulted.cacheEvidence.offlineBeforeCells, stage === "preflightMkdir" ? false : true);
   }
   const semanticFault = await scenario({ omitObstructions: true });
   assert.equal(semanticFault.runtimeCells.length, 0);

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -372,6 +372,7 @@ function fixtureReceipt(status = "passed", cellIndex = 0) {
       derivedNamespaces: [fluxNamespace],
     }] : [],
     activeArtifactIds: [...cell.artifactIds],
+    providerExecution: "completed",
     verifiedBefore: true,
     verifiedAfter: true,
     derivedAfter: cell.artifactIds.map((artifactId) => ({
@@ -529,6 +530,16 @@ test("Draft 2020-12 schemas validate the profile and close adversarial receipt d
     assert.throws(
       () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, noErrorFile),
       /must be string/,
+    );
+
+    const missingProviderState = fixtureReceipt();
+    delete missingProviderState.authorityLifecycle.providerExecution;
+    const missingProviderStateFile = await writeReceipt(
+      "missing-provider-state.json", missingProviderState,
+    );
+    assert.throws(
+      () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, missingProviderStateFile),
+      /must have required property 'providerExecution'/,
     );
   } finally {
     await rm(temporary, { recursive: true, force: true });
@@ -874,6 +885,12 @@ test("b646 derived sidecars occupy one exact canonical namespace with no global 
     };
     const expected = await expectedB646DerivedNamespace(artifact, derived);
     assert.match(path.basename(expected), /^[0-9a-f]{64}$/);
+    const empty = await inspectDerivedSidecarRoot(
+      derived, expected, { materializeExactEmpty: true },
+    );
+    assert.equal(empty.namespaces.length, 1);
+    assert.equal(empty.namespaces[0].inventory.files, 0);
+    assert.equal(empty.rootInventory.files, 0);
     await mkdir(expected, { recursive: true });
     await Promise.all(Array.from({ length: 494 }, (_, index) => (
       writeFile(path.join(expected, `${String(index).padStart(3, "0")}.safetensors`), "x")
@@ -1067,6 +1084,7 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     preflightFault = null, cellFault = null, omitObstructions = false,
     derivedContractDrift = null, diskFreeValues = [256 * 1024 ** 3],
     runtimeResultMode = "valid", providerRuntimeFailureAt = null,
+    providerFailureDerivedMode = "empty",
   } = {}) {
     const temporary = await mkdtemp(path.join(tmpdir(), "sc-20974-preflight-"));
     const runnerTemp = path.join(temporary, "runner-temp");
@@ -1174,7 +1192,7 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
       expectedB646DerivedNamespace: async (artifact, root) => (
         path.join(root, "candle-device-format-v1", "a".repeat(64))
       ),
-      inspectDerivedSidecarRoot: async (root, expectedNamespace) => {
+      inspectDerivedSidecarRoot: async (root, expectedNamespace, options = {}) => {
         if (!expectedNamespace) return {
           rootInventory: {
             root, files: 0, bytes: 0, sha256: createHash("sha256").digest("hex"),
@@ -1184,11 +1202,17 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
         const id = runtimeCells.at(-1)?.id;
         assert.ok(id?.startsWith("flux1-"));
         await mkdir(expectedNamespace, { recursive: true });
+        const providerFailed = id === providerRuntimeFailureAt;
+        if (providerFailed) assert.equal(options.materializeExactEmpty, true);
         const bytes = id.endsWith("q4") ? 7_396_392_960 : 12_573_868_032;
         const inventory = {
           root: expectedNamespace,
-          files: derivedContractDrift?.files ?? 494,
-          bytes: derivedContractDrift?.bytes ?? bytes,
+          files: providerFailed
+            ? (providerFailureDerivedMode === "partial" ? 1 : 0)
+            : (derivedContractDrift?.files ?? 494),
+          bytes: providerFailed
+            ? (providerFailureDerivedMode === "partial" ? 1 : 0)
+            : (derivedContractDrift?.bytes ?? bytes),
           sha256: createHash("sha256").digest("hex"),
         };
         return {
@@ -1225,7 +1249,14 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
               denseFallback: false,
               loadSpecQuantBits: expectedLoadSpecQuantBits(runtimeCell),
             })}\n`;
-          await writeFile(path.join(cellDir, "runtime-result.json"), runtimeResult, "utf8");
+          if (runtimeResultMode === "symlink" && runtimeCells.length === 1) {
+            await writeFile(path.join(cellDir, "runtime-result-target.json"), runtimeResult, "utf8");
+            await symlink(
+              "runtime-result-target.json", path.join(cellDir, "runtime-result.json"), "file",
+            );
+          } else {
+            await writeFile(path.join(cellDir, "runtime-result.json"), runtimeResult, "utf8");
+          }
         }
         await writeFile(path.join(cellDir, "output.bin"), "fixture", "utf8");
       },
@@ -1422,6 +1453,20 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     /cell lifecycle evidence before network-offline establishment/,
   );
 
+  const linkedRuntimeResult = await scenario({ runtimeResultMode: "symlink" });
+  assert.equal(linkedRuntimeResult.runtimeCells.length, 1);
+  assert.ok(linkedRuntimeResult.result.summary.receipts.slice(8).every(
+    (outcome) => outcome.status === "failed" && outcome.receipt,
+  ));
+  assert.match(
+    linkedRuntimeResult.result.summary.campaignErrors.join("\n"),
+    /runtime-result evidence failed after cell flux1-dev-q8.*ordinary non-reparse file/,
+  );
+  assert.match(
+    linkedRuntimeResult.result.summary.receipts[7].error,
+    /evidence tree contains a symlink or reparse point/,
+  );
+
   const providerFailed = await scenario({ providerRuntimeFailureAt: "flux1-dev-q8" });
   assert.equal(providerFailed.runtimeCells.length, 12);
   assert.equal(providerFailed.result.summary.failed, 1);
@@ -1430,6 +1475,43 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     providerFailed.result.summary.campaignErrors.some((error) => error.includes("runtime-result evidence")),
     false,
   );
+  const providerFailureReceipt = providerFailed.continuationReceipts[0];
+  assert.equal(providerFailureReceipt.authorityLifecycle.providerExecution, "failed");
+  assert.equal(providerFailureReceipt.authorityLifecycle.derivedAfter[0].files, 0);
+  assert.equal(providerFailureReceipt.authorityLifecycle.derivedAfter[0].inventories.length, 1);
+  assert.equal(providerFailureReceipt.authorityLifecycle.staged[0].derivedNamespaces.length, 1);
+  assert.equal(providerFailureReceipt.authorityLifecycle.released[0].derivedRemoved, true);
+  assert.equal(providerFailed.cacheEvidence.derivedSidecarLifecycle.afterCells[0].providerExecution, "failed");
+  const forgedCompletedProvider = structuredClone(providerFailureReceipt);
+  forgedCompletedProvider.authorityLifecycle.providerExecution = "completed";
+  assert.throws(
+    () => validateReceipt(
+      forgedCompletedProvider,
+      providerFailed.checked.cells[7],
+      providerFailed.checked,
+      providerFailed.lifecycleContext,
+    ),
+    /FLUX derived lifecycle/,
+  );
+  const missingCacheProviderState = structuredClone(providerFailed.cacheEvidence);
+  delete missingCacheProviderState.derivedSidecarLifecycle.afterCells[0].providerExecution;
+  assert.throws(
+    () => validateDocumentWithSchema(CACHE_PREFLIGHT_SCHEMA_PATH, missingCacheProviderState),
+    /required property 'providerExecution'/,
+  );
+
+  const providerPartial = await scenario({
+    providerRuntimeFailureAt: "flux1-dev-q8",
+    providerFailureDerivedMode: "partial",
+  });
+  assert.equal(providerPartial.runtimeCells.length, 1);
+  assert.match(
+    providerPartial.result.summary.campaignErrors.join("\n"),
+    /derived Candle sidecar evidence failed after cell flux1-dev-q8.*derived-sidecar contract drifted/,
+  );
+  assert.ok(providerPartial.result.summary.receipts.slice(8).every(
+    (outcome) => outcome.status === "failed" && outcome.receipt,
+  ));
 
   for (const cellFault of [
     { stage: "finalLog" },

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -14,12 +14,14 @@ import {
   authorityLifetimePlan,
   cellSemanticsSha256,
   directoryInventory,
+  expectedB646DerivedNamespace,
   expectedArtifactFilesFromEvidence,
   expectedLoadSpecQuantBits,
   estimateJitDiskPlan,
   inferencePins,
   hashedFiles,
   installSidecarObstructions,
+  inspectDerivedSidecarRoot,
   importPrefixEvidence,
   loadProfile,
   parseNvidiaSmi,
@@ -126,25 +128,22 @@ test("JIT disk estimator uses followed target bytes, exact lifetimes, and the 99
   });
   const persistent = file("schnell-q8/missing", 12_637_521_668, true);
   const lifetimes = [
-    row("flux1-dev-q8", 8, 8, [file("dev-q8", 23_371_725_325)]),
-    row("flux1-schnell-q4", 9, 9, [file("schnell-q4", 14_973_205_319)]),
+    row("flux1-dev-q8", 8, 8, [file("dev-q8", 18_010_071_290)]),
+    row("flux1-schnell-q4", 9, 9, [file("schnell-q4", 9_611_551_284)]),
     row("flux1-schnell-q8", 10, 10, [file("schnell-q8/cache", 5_361_654_035), persistent]),
-    row("scail2-q4", 11, 12, [file("scail-q4", 29_000_000_000)]),
-    row("scail2-q8", 13, 13, [file("scail-q8", 19_429_609_601)]),
-    row("ltx23-q8", 14, 14, [file("ltx-q8", 30_000_000_000)]),
-    row("ltx23-gemma", 14, 14, [file("ltx-gemma", 13_519_093_966)]),
-    ...[0, 1, 2, 3, 4].map((index) => row(
-      `sdxl-primary-${index}`,
-      15 + index,
-      15 + index,
-      [file(`sdxl-primary-${index}`, index === 4 ? 6_047_177_674 : 6_047_177_669)],
-    )),
-    ...[0, 1, 2, 3].map((index) => row(
-      `sdxl-support-${index}`,
-      15,
-      19,
-      [file(`sdxl-support-${index}`, 125_000_000)],
-    )),
+    row("scail2-q4", 11, 12, [file("scail-q4", 23_993_093_306)]),
+    row("scail2-q8", 13, 13, [file("scail-q8", 32_067_131_269)]),
+    row("ltx23-q8", 14, 14, [file("ltx-q8", 29_728_720_716)]),
+    row("ltx23-gemma", 14, 14, [file("ltx-gemma", 26_427_894_918)]),
+    row("sdxl-base-q4", 15, 15, [file("sdxl-base-q4", 2_703_202_068)]),
+    row("realvisxl-q4", 16, 16, [file("realvisxl-q4", 3_911_656_467)]),
+    row("realvisxl-lightning-q4", 17, 17, [file("realvisxl-lightning-q4", 3_911_657_599)]),
+    row("illustrious-v1-q4", 18, 18, [file("illustrious-v1-q4", 3_911_656_791)]),
+    row("illustrious-v2-q4", 19, 19, [file("illustrious-v2-q4", 3_911_656_467)]),
+    row("sdxl-openpose", 15, 19, [file("sdxl-openpose", 2_502_139_104)]),
+    row("sdxl-tokenizer-l", 15, 19, [file("sdxl-tokenizer-l", 2_224_003)]),
+    row("sdxl-tokenizer-bigg", 15, 19, [file("sdxl-tokenizer-bigg", 2_224_041)]),
+    row("sdxl-vae-fix", 15, 19, [file("sdxl-vae-fix", 334_643_238)]),
   ];
   const floor = 99_106_288_594;
   const admitted = estimateJitDiskPlan(lifetimes, floor, persistent.bytes);
@@ -155,10 +154,11 @@ test("JIT disk estimator uses followed target bytes, exact lifetimes, and the 99
     5_361_654_035,
     "link-length accounting must never undercount followed Schnell q8 blob bytes",
   );
-  assert.equal(admitted.cells.find((entry) => entry.ordinal === 8).modelAndSidecarBytes, 48_591_208_721);
-  assert.equal(admitted.cells.find((entry) => entry.ordinal === 9).modelAndSidecarBytes, 35_015_213_643);
+  assert.equal(admitted.cells.find((entry) => entry.ordinal === 8).modelAndSidecarBytes, 43_229_554_686);
+  assert.equal(admitted.cells.find((entry) => entry.ordinal === 9).modelAndSidecarBytes, 29_653_559_608);
   assert.equal(admitted.cells.find((entry) => entry.ordinal === 10).modelAndSidecarBytes, 30_581_137_431);
   assert.equal(admitted.cells.find((entry) => entry.ordinal === 13).modelAndSidecarBytes, 32_067_131_269);
+  assert.equal(admitted.cells.find((entry) => entry.ordinal === 14).stagedBytes, 56_156_615_634);
   assert.equal(admitted.peakModelAndSidecarBytes, 56_156_615_634);
   assert.equal(admitted.peakRequiredAdditionalBytes, floor);
   assert.equal(admitted.admitted, true);
@@ -172,7 +172,11 @@ test("JIT disk estimator uses followed target bytes, exact lifetimes, and the 99
     persistent: false,
   }));
   const completePlan = estimateJitDiskPlan(completeCache, floor, 0);
-  assert.ok(completePlan.peakModelAndSidecarBytes < admitted.peakModelAndSidecarBytes);
+  assert.equal(completePlan.peakModelAndSidecarBytes, admitted.peakModelAndSidecarBytes);
+  assert.equal(
+    completePlan.cells.find((entry) => entry.ordinal === 8).modelAndSidecarBytes,
+    admitted.cells.find((entry) => entry.ordinal === 8).modelAndSidecarBytes - persistent.bytes,
+  );
   assert.equal(completePlan.peakRequiredAdditionalBytes, floor);
   assert.equal(completePlan.admitted, true);
   assert.equal(estimateJitDiskPlan(completeCache, floor - 1, 0).admitted, false);
@@ -348,6 +352,51 @@ function fixtureReceipt(status = "passed", cellIndex = 0) {
   receipt.inputs = [{ path: "cell.json", bytes: 7, sha256: "6".repeat(64) }];
   receipt.outputs = [{ path: "runtime-result.json", bytes: 7, sha256: "7".repeat(64) }];
   receipt.logs = [{ path: "controller.log", bytes: 7, sha256: "5".repeat(64) }];
+  const fluxArtifact = cell.artifactIds.find((artifactId) => artifactId.startsWith("flux1-"));
+  const fluxNamespace = fluxArtifact ? path.resolve(
+    "fixture-runner", "scratch", "derived-candle-device-cache", "candle-device-format-v1",
+    "a".repeat(64),
+  ) : null;
+  const fluxBytes = fluxArtifact?.endsWith("-q4") ? 7_396_392_960 : 12_573_868_032;
+  receipt.authorityLifecycle = {
+    ordinal: cellIndex + 1,
+    cellId: cell.id,
+    staged: fluxArtifact ? [{
+      artifactId: fluxArtifact,
+      stageRoot: artifacts.find((artifact) => artifact.id === fluxArtifact).selectedRoot,
+      inventory: {
+        root: artifacts.find((artifact) => artifact.id === fluxArtifact).selectedRoot,
+        files: 3, bytes: 42, sha256: "4".repeat(64),
+      },
+      obstructionCount: 1,
+      derivedNamespaces: [fluxNamespace],
+    }] : [],
+    activeArtifactIds: [...cell.artifactIds],
+    verifiedBefore: true,
+    verifiedAfter: true,
+    derivedAfter: cell.artifactIds.map((artifactId) => ({
+      artifactId,
+      files: artifactId === fluxArtifact ? 494 : 0,
+      bytes: artifactId === fluxArtifact ? fluxBytes : 0,
+      inventories: artifactId === fluxArtifact ? [{
+        root: fluxNamespace, files: 494, bytes: fluxBytes, sha256: "8".repeat(64),
+      }] : [],
+    })),
+    released: [],
+    diskProbes: [...(fluxArtifact ? [{
+      phase: `before-stage:${fluxArtifact}`,
+      ordinal: cellIndex + 1,
+      root: path.resolve("fixture-runner", "scratch"),
+      freeBytes: 128 * 1024 ** 3,
+      requiredFreeBytes: 99_106_288_594,
+    }] : []), {
+      phase: "before-execution",
+      ordinal: cellIndex + 1,
+      root: path.resolve("fixture-runner", "scratch"),
+      freeBytes: 128 * 1024 ** 3,
+      requiredFreeBytes: 99_106_288_594,
+    }],
+  };
   return receipt;
 }
 
@@ -811,7 +860,47 @@ test("staged authorities obstruct adjacent Candle sidecars and use a separate de
   }
 });
 
-test("injected lifecycle faults preserve all 19 outcomes and quarantine after cleanup isolation failure", async () => {
+test("b646 derived sidecars occupy one exact canonical namespace with no global residue", async () => {
+  const temporary = await mkdtemp(path.join(tmpdir(), "sc-20974-derived-"));
+  const selectedRoot = path.join(temporary, "stage", "q8");
+  const transformer = path.join(selectedRoot, "transformer");
+  const derived = path.join(temporary, "derived");
+  try {
+    await Promise.all([mkdir(transformer, { recursive: true }), mkdir(derived)]);
+    const artifact = {
+      id: "flux1-fixture-q8",
+      selectedRoot,
+      matchedFiles: ["transformer/model.safetensors"],
+    };
+    const expected = await expectedB646DerivedNamespace(artifact, derived);
+    assert.match(path.basename(expected), /^[0-9a-f]{64}$/);
+    await mkdir(expected, { recursive: true });
+    await Promise.all(Array.from({ length: 494 }, (_, index) => (
+      writeFile(path.join(expected, `${String(index).padStart(3, "0")}.safetensors`), "x")
+    )));
+    const exact = await inspectDerivedSidecarRoot(derived, expected);
+    assert.equal(exact.namespaces.length, 1);
+    assert.equal(exact.rootInventory.files, 494);
+    assert.equal(exact.rootInventory.bytes, 494);
+
+    const extra = path.join(path.dirname(expected), "f".repeat(64));
+    await mkdir(extra);
+    await assert.rejects(
+      inspectDerivedSidecarRoot(derived, expected),
+      /one exact b646 namespace/,
+    );
+    await rm(extra, { recursive: true });
+    await writeFile(path.join(derived, "stray.bin"), "stray");
+    await assert.rejects(
+      inspectDerivedSidecarRoot(derived, expected),
+      /stray files, directories, or versions/,
+    );
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+});
+
+test("cleanup isolation failure preserves all 19 durable outcomes and quarantines later cells", async () => {
   const temporary = await mkdtemp(path.join(tmpdir(), "sc-20945-faults-"));
   const runnerTemp = path.join(temporary, "runner-temp");
   const sceneworks = path.join(temporary, "sceneworks");
@@ -845,13 +934,7 @@ test("injected lifecycle faults preserve all 19 outcomes and quarantine after cl
   const injectedStages = [];
   const fault = async (stage, index) => {
     if (stage === "setup") attemptedCells.push(index);
-    const shouldFail = (index === 0 && new Set(["setup", "emergencyReceipt"]).has(stage))
-      || (index === 1 && new Set(["finalLog", "fallbackLog"]).has(stage))
-      || (index === 2 && new Set(["evidenceHash", "evidenceRehash"]).has(stage))
-      || (index === 3 && stage === "semanticValidation")
-      || (index === 4 && stage === "schemaValidation")
-      || (index === 5 && stage === "receiptWrite")
-      || (index === 6 && stage === "cleanup")
+    const shouldFail = (index === 6 && stage === "cleanup")
       || (index === null && stage === "summaryWrite");
     if (shouldFail) {
       injectedStages.push(`${index}:${stage}`);
@@ -883,12 +966,27 @@ test("injected lifecycle faults preserve all 19 outcomes and quarantine after cl
       };
     },
     installSidecarObstructions: async (artifacts) => fixtureSidecarObstructions(artifacts),
-    listDerivedSidecarNamespaces: async (root) => {
+    expectedB646DerivedNamespace: async (artifact, root) => (
+      path.join(root, "candle-device-format-v1", "a".repeat(64))
+    ),
+    inspectDerivedSidecarRoot: async (root, expectedNamespace) => {
+      if (!expectedNamespace) return {
+        rootInventory: {
+          root, files: 0, bytes: 0, sha256: createHash("sha256").digest("hex"),
+        },
+        namespaces: [],
+      };
       const id = executedCells.at(-1);
-      if (!id?.startsWith("flux1-")) return [];
-      const namespace = path.join(root, "candle-device-format-v1", id);
-      await mkdir(namespace, { recursive: true });
-      return [namespace];
+      assert.ok(id?.startsWith("flux1-"));
+      await mkdir(expectedNamespace, { recursive: true });
+      const bytes = id.endsWith("q4") ? 7_396_392_960 : 12_573_868_032;
+      const inventory = {
+        root: expectedNamespace, files: 494, bytes, sha256: createHash("sha256").digest("hex"),
+      };
+      return {
+        rootInventory: { ...inventory, root },
+        namespaces: [{ path: expectedNamespace, inventory }],
+      };
     },
     directoryInventory: async (root) => ({
       root,
@@ -933,8 +1031,8 @@ test("injected lifecycle faults preserve all 19 outcomes and quarantine after cl
       result.summary.campaignErrors.join("\n"),
     );
     assert.equal(preflightCalls.filter((call) => call.startsWith("audit:")).length, 23);
-    assert.equal(preflightCalls.filter((call) => call.startsWith("stage:")).length, 3);
-    assert.equal(preflightCalls.filter((call) => call.startsWith("offline:")).length, 3);
+    assert.equal(preflightCalls.filter((call) => call.startsWith("stage:")).length, 7);
+    assert.equal(preflightCalls.filter((call) => call.startsWith("offline:")).length, 7);
     assert.ok(executedCells.length > 0);
     assert.ok(executedCells.every((id) => checked.cells.slice(0, 7).some((cell) => cell.id === id)));
     assert.equal(executedCells.at(-1), checked.cells[6].id);
@@ -949,12 +1047,6 @@ test("injected lifecycle faults preserve all 19 outcomes and quarantine after cl
       assert.doesNotThrow(() => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, receipt));
       assert.doesNotThrow(() => validateReceipt(receipt, checked.cells[index], checked));
     }
-    for (const index of [0, 1, 2, 3, 4, 5]) {
-      assert.match(result.summary.receipts[index].receipt, /^_emergency\//);
-      assert.equal(result.summary.receipts[index].emergencyReceiptError, null);
-    }
-    assert.match(result.summary.receipts[0].receipt, /receipt-last-resort\.json$/);
-    assert.match(result.summary.receipts[0].error, /emergency receipt failed/);
     assert.doesNotMatch(result.summary.receipts[6].receipt, /^_emergency\//);
     assert.match(result.summary.campaignErrors.join("\n"), /prior cell .* scratch cleanup isolation failed/);
     for (const outcome of result.summary.receipts.slice(7)) {
@@ -972,7 +1064,8 @@ test("injected lifecycle faults preserve all 19 outcomes and quarantine after cl
 test("continuation freezes census, downloads once, and JIT stages exact authority lifetimes", async () => {
   async function scenario({
     missingId = null, downloadSucceeds = false, mutateCache = false, mutateSourceAtStage = false,
-    preflightFault = null, omitObstructions = false, diskFreeValues = [256 * 1024 ** 3],
+    preflightFault = null, cellFault = null, omitObstructions = false,
+    derivedContractDrift = null, diskFreeValues = [256 * 1024 ** 3],
   } = {}) {
     const temporary = await mkdtemp(path.join(tmpdir(), "sc-20974-preflight-"));
     const runnerTemp = path.join(temporary, "runner-temp");
@@ -1000,6 +1093,7 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     const runtimeCells = [];
     let verificationCalls = 0;
     let diskFreeCall = 0;
+    let cellFaultCalls = 0;
     const operations = {
       auditArtifact: async ({ id, artifact }) => {
         events.push(`audit:${id}`);
@@ -1076,12 +1170,30 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
       installSidecarObstructions: async (artifacts) => (
         omitObstructions ? [] : fixtureSidecarObstructions(artifacts)
       ),
-      listDerivedSidecarNamespaces: async (root) => {
+      expectedB646DerivedNamespace: async (artifact, root) => (
+        path.join(root, "candle-device-format-v1", "a".repeat(64))
+      ),
+      inspectDerivedSidecarRoot: async (root, expectedNamespace) => {
+        if (!expectedNamespace) return {
+          rootInventory: {
+            root, files: 0, bytes: 0, sha256: createHash("sha256").digest("hex"),
+          },
+          namespaces: [],
+        };
         const id = runtimeCells.at(-1)?.id;
-        if (!id?.startsWith("flux1-")) return [];
-        const namespace = path.join(root, "candle-device-format-v1", id);
-        await mkdir(namespace, { recursive: true });
-        return [namespace];
+        assert.ok(id?.startsWith("flux1-"));
+        await mkdir(expectedNamespace, { recursive: true });
+        const bytes = id.endsWith("q4") ? 7_396_392_960 : 12_573_868_032;
+        const inventory = {
+          root: expectedNamespace,
+          files: derivedContractDrift?.files ?? 494,
+          bytes: derivedContractDrift?.bytes ?? bytes,
+          sha256: createHash("sha256").digest("hex"),
+        };
+        return {
+          rootInventory: { ...inventory, root },
+          namespaces: [{ path: expectedNamespace, inventory }],
+        };
       },
       directoryInventory: async (root) => ({
         root,
@@ -1152,8 +1264,14 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
         prefixSelection: {},
         importedPrefix,
         operations,
-        fault: preflightFault ? async (stage) => {
+        fault: preflightFault || cellFault ? async (stage, index) => {
           if (stage === preflightFault) throw new Error(`injected ${stage}`);
+          if (cellFault && stage === cellFault.stage && index === (cellFault.index ?? 7)) {
+            cellFaultCalls += 1;
+            if (cellFaultCalls === (cellFault.occurrence ?? 1)) {
+              throw new Error(`injected ${stage} at cell ${index}`);
+            }
+          }
         } : undefined,
         suppressVerdict: true,
       });
@@ -1161,8 +1279,16 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
         path.join(output, ...result.summary.cachePreflight.path.split("/")),
         "utf8",
       ));
+      const continuationReceipts = [];
+      for (const outcome of result.summary.receipts.slice(7)) {
+        if (!outcome.receipt) continue;
+        continuationReceipts.push(JSON.parse(await readFile(
+          path.join(output, ...outcome.receipt.split("/")), "utf8",
+        )));
+      }
       return {
         result, events, runtimeCells, checked, cacheEvidence,
+        continuationReceipts,
         cacheValidation: {
           remainingArtifactIds: [...new Set(checked.cells.slice(7).flatMap(
             (cell) => cell.artifactIds,
@@ -1173,7 +1299,20 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
           stagingRoot: path.join(scratch, "authority-stage"),
           derivedSidecarRoot: path.join(scratch, "derived-candle-device-cache"),
           missingStore: path.join(scratch, "persistent-missing-file"),
+          expectedNonModelPaths: [
+            { kind: "cargoTarget", path: path.resolve(sceneworks, "target") },
+            { kind: "cargoHome", path: path.resolve(process.env.CARGO_HOME ?? path.join(process.env.USERPROFILE ?? scratch, ".cargo")) },
+            { kind: "campaignOutput", path: output },
+            { kind: "pythonVenv", path: path.dirname(path.dirname(path.resolve("python"))) },
+          ],
           profile: checked,
+        },
+        lifecycleContext: {
+          lifetimeById: new Map(cacheEvidence.lifetimePlan.map((row) => [row.artifactId, row])),
+          scratchRoot: scratch,
+          requiredFreeBytes: cacheEvidence.diskPlan?.peakRequiredAdditionalBytes
+            ?? 99_106_288_594,
+          completeLifecycle: true,
         },
       };
     } finally {
@@ -1224,6 +1363,40 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     diskDropsBeforeStage.result.summary.campaignErrors.join("\n"),
     /disk capacity fell below.*before-stage:flux1-dev-q8/,
   );
+
+  const diskDropsBeforeExecution = await scenario({
+    diskFreeValues: [256 * 1024 ** 3, 256 * 1024 ** 3, 1],
+  });
+  assert.equal(diskDropsBeforeExecution.runtimeCells.length, 0);
+  assert.match(
+    diskDropsBeforeExecution.result.summary.campaignErrors.join("\n"),
+    /disk capacity fell below.*before-execution/,
+  );
+  assert.ok(diskDropsBeforeExecution.result.summary.receipts.slice(7).every(
+    (outcome) => outcome.status === "failed" && outcome.receipt,
+  ));
+
+  for (const cellFault of [
+    { stage: "finalLog" },
+    { stage: "evidenceHash" },
+    { stage: "semanticValidation", occurrence: 2 },
+    { stage: "schemaValidation", occurrence: 2 },
+    { stage: "receiptWrite", occurrence: 2 },
+    { stage: "receiptStat", occurrence: 2 },
+    { stage: "receiptHash", occurrence: 2 },
+  ]) {
+    const faulted = await scenario({ cellFault });
+    assert.equal(faulted.runtimeCells.length, 1, cellFault.stage);
+    assert.equal(faulted.result.summary.receipts.length, 19, cellFault.stage);
+    assert.ok(faulted.result.summary.receipts.slice(8).every(
+      (outcome) => outcome.status === "failed" && outcome.receipt,
+    ), cellFault.stage);
+    assert.match(
+      faulted.result.summary.campaignErrors.join("\n"),
+      /primary receipt.*finalization failed/,
+      cellFault.stage,
+    );
+  }
 
   const passed = await scenario();
   assert.deepEqual(
@@ -1315,6 +1488,20 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     () => validateCachePreflightEvidence(censusDrift, filled.cacheValidation),
     /authority census drifted/,
   );
+  for (const [label, mutate, pattern] of [
+    ["staging", (value) => value.phases.staging.pop(), /staged\/offline authority transition/],
+    ["offline", (value) => value.phases.finalOffline.pop(), /staged\/offline authority transition/],
+    ["afterCells", (value) => value.derivedSidecarLifecycle.afterCells.pop(), /per-cell derived lifecycle/],
+    ["nonModelPaths", (value) => { value.diskPlan.nonModelPaths[0].path += "-drift"; }, /non-model paths/],
+  ]) {
+    const drifted = structuredClone(filled.cacheEvidence);
+    mutate(drifted);
+    assert.throws(
+      () => validateCachePreflightEvidence(drifted, filled.cacheValidation),
+      pattern,
+      label,
+    );
+  }
   assert.equal(filled.cacheEvidence.lifetimePlan.length, 16);
   assert.equal(filled.cacheEvidence.diskPlan.admitted, true);
   const downloadDrift = structuredClone(filled.cacheEvidence);
@@ -1323,6 +1510,39 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     () => validateCachePreflightEvidence(downloadDrift, filled.cacheValidation),
     /partition drifted|unreviewed model download/,
   );
+
+  const firstReceipt = filled.continuationReceipts[0];
+  const firstCell = filled.checked.cells[7];
+  assert.doesNotThrow(() => validateReceipt(
+    firstReceipt, firstCell, filled.checked, filled.lifecycleContext,
+  ));
+  const missingLifecycle = structuredClone(firstReceipt);
+  delete missingLifecycle.authorityLifecycle;
+  assert.throws(
+    () => validateReceipt(missingLifecycle, firstCell, filled.checked, filled.lifecycleContext),
+    /missing required authority lifecycle/,
+  );
+  assert.throws(
+    () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, missingLifecycle),
+    /required property 'authorityLifecycle'/,
+  );
+  for (const [label, mutate] of [
+    ["phase", (value) => { value.authorityLifecycle.diskProbes[0].phase = "before-stage:wrong"; }],
+    ["ordinal", (value) => { value.authorityLifecycle.diskProbes[0].ordinal += 1; }],
+    ["root", (value) => { value.authorityLifecycle.diskProbes[0].root += "-wrong"; }],
+    ["floor", (value) => { value.authorityLifecycle.diskProbes[0].requiredFreeBytes -= 1; }],
+    ["free", (value) => { value.authorityLifecycle.diskProbes[0].freeBytes = 1; }],
+    ["transition", (value) => { value.authorityLifecycle.staged.pop(); }],
+    ["derived", (value) => { value.authorityLifecycle.derivedAfter.pop(); }],
+  ]) {
+    const drifted = structuredClone(firstReceipt);
+    mutate(drifted);
+    assert.throws(
+      () => validateReceipt(drifted, firstCell, filled.checked, filled.lifecycleContext),
+      /disk probes drifted|completed receipt lifecycle omitted|FLUX derived lifecycle/,
+      label,
+    );
+  }
 
   const mutated = await scenario({ mutateCache: true });
   assert.equal(mutated.runtimeCells.length, 1, "the first cell runs before its after-inventory detects mutation");
@@ -1358,6 +1578,21 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     CACHE_PREFLIGHT_SCHEMA_PATH,
     semanticFault.cacheEvidence,
   ));
+
+  for (const drift of [
+    { files: 493, bytes: 12_573_868_032 },
+    { files: 494, bytes: 12_573_868_032 + 494 * 16_384 + 1 },
+  ]) {
+    const derivedFault = await scenario({ derivedContractDrift: drift });
+    assert.equal(derivedFault.runtimeCells.length, 1);
+    assert.match(
+      derivedFault.result.summary.campaignErrors.join("\n"),
+      /derived Candle sidecar evidence failed.*FLUX derived-sidecar contract drifted/,
+    );
+    assert.ok(derivedFault.result.summary.receipts.slice(8).every(
+      (outcome) => outcome.status === "failed" && outcome.receipt,
+    ));
+  }
 });
 
 test("schemas, clean Node dependencies, and workflow preserve the opt-in single-job terminal contract", async () => {

--- a/scripts/provision-epic-20738-terminal-artifact.py
+++ b/scripts/provision-epic-20738-terminal-artifact.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Audit, stage, and resolve immutable epic-20738 artifacts.
+"""Audit and just-in-time stage immutable epic-20738 artifacts.
 
-The trusted runner cache is always audited first. Each distinct reviewed authority is then copied
-once into a campaign-owned staging tree and reused by every cell. Network access is impossible
-except while staging the one frozen missing FLUX Schnell q8 file; that download names one exact
-repo/revision/filename and lands only in fresh campaign staging. Runtime resolution is fully offline.
+The trusted runner cache is fully audited before GPU work.  The sole reviewed missing file can be
+downloaded once into an isolated campaign-owned store.  Individual authorities are subsequently
+copied into fresh, short-lived staging roots with network access disabled.
 """
 
 from __future__ import annotations
@@ -238,29 +237,143 @@ def _stage_root(staging_root: Path) -> Path:
     return _ordinary_directory(staging_root, "campaign artifact staging root")
 
 
+def _missing_store_root(missing_store: Path) -> Path:
+    if not missing_store.is_absolute():
+        raise ValueError("missing-file store must be an absolute path")
+    return _ordinary_directory(missing_store, "campaign missing-file store")
+
+
+def download_reviewed_missing(request: dict, cache_root: Path, missing_store: Path) -> dict:
+    audit = audit_cached_artifact(request, cache_root)
+    reviewed = list(NETWORK_FILL_AUTHORITY)
+    if [request["repository"], request["revision"], *audit["missingFiles"]] != reviewed:
+        raise RuntimeError("network fill requires exactly the sole reviewed missing filename")
+
+    destination_root = _missing_store_root(missing_store)
+    repository, revision, filename = NETWORK_FILL_AUTHORITY
+    owner, name = repository.split("/", 1)
+    destination_snapshot = (
+        destination_root / f"models--{owner}--{name}" / "snapshots" / revision
+    )
+    destination = destination_snapshot / filename
+    receipt_path = destination_root / "download-receipt.json"
+    if destination.exists() or destination.is_symlink() or receipt_path.exists():
+        raise RuntimeError("refusing to overwrite the campaign missing-file store")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    from huggingface_hub import (
+        __version__,
+        get_hf_file_metadata,
+        hf_hub_download,
+        hf_hub_url,
+    )
+
+    if __version__ != "0.36.0":
+        raise RuntimeError(
+            f"network fill requires huggingface_hub 0.36.0, got {__version__}"
+        )
+    url = hf_hub_url(repo_id=repository, filename=filename, revision=revision)
+    metadata = get_hf_file_metadata(url, token=False)
+    etag = str(metadata.etag or "").strip('"')
+    if (
+        metadata.commit_hash != revision
+        or not SHA256.fullmatch(etag)
+        or not isinstance(metadata.size, int)
+        or metadata.size < 1
+    ):
+        raise RuntimeError("exact missing-file metadata did not bind commit, LFS SHA, and size")
+    network_cache = destination_root / ".hf-network-staging"
+    downloaded = Path(
+        hf_hub_download(
+            repo_id=repository,
+            filename=filename,
+            revision=revision,
+            repo_type="model",
+            local_dir=destination_snapshot,
+            cache_dir=network_cache,
+            token=False,
+            force_download=False,
+            local_files_only=False,
+        )
+    )
+    if downloaded != destination or not destination.is_file():
+        raise RuntimeError("pinned missing-file download did not materialize the exact store path")
+    if destination.is_symlink():
+        raise RuntimeError("pinned missing-file download produced a reparse target")
+    actual_sha = _sha256(destination)
+    if destination.stat().st_size != metadata.size or actual_sha != etag:
+        raise RuntimeError("downloaded missing file failed exact size/LFS SHA verification")
+    if network_cache.exists():
+        shutil.rmtree(network_cache, ignore_errors=False)
+    local_metadata = destination_snapshot / ".cache"
+    if local_metadata.exists():
+        shutil.rmtree(local_metadata, ignore_errors=False)
+    if not destination.is_file() or destination.stat().st_size != metadata.size or _sha256(destination) != etag:
+        raise RuntimeError("downloaded missing file did not remain durable after network-cache cleanup")
+    record = {
+        "path": Path(filename).relative_to(request["subdirectory"]).as_posix(),
+        "bytes": metadata.size,
+        "sha256": actual_sha,
+        "lfsSha256": etag,
+        "commitSha": metadata.commit_hash,
+    }
+    receipt_path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+    return {
+        "id": request["id"],
+        "storeRoot": str(destination_root),
+        "downloadedFiles": [record],
+    }
+
+
+def _stored_missing_file(request: dict, missing_store: Path) -> dict:
+    root = _missing_store_root(missing_store)
+    if _reviewed_missing(request) != [NETWORK_FILL_AUTHORITY[2]]:
+        raise RuntimeError("missing-file store is not approved for this authority")
+    receipt_path = root / "download-receipt.json"
+    try:
+        record = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError) as error:
+        raise RuntimeError("campaign missing-file receipt is absent or invalid") from error
+    if set(record) != {"path", "bytes", "sha256", "lfsSha256", "commitSha"}:
+        raise RuntimeError("campaign missing-file receipt fields drifted")
+    expected = NETWORK_FILL_AUTHORITY[2]
+    expected_selected = Path(expected).relative_to(request["subdirectory"]).as_posix()
+    owner, name = NETWORK_FILL_AUTHORITY[0].split("/", 1)
+    stored = (
+        root / f"models--{owner}--{name}" / "snapshots"
+        / NETWORK_FILL_AUTHORITY[1] / expected
+    )
+    if (
+        record["path"] != expected_selected
+        or record["commitSha"] != NETWORK_FILL_AUTHORITY[1]
+        or record["sha256"] != record["lfsSha256"]
+        or not SHA256.fullmatch(record["sha256"])
+        or not isinstance(record["bytes"], int)
+        or record["bytes"] < 1
+        or not stored.is_file()
+        or stored.is_symlink()
+        or stored.stat().st_size != record["bytes"]
+        or _sha256(stored) != record["sha256"]
+    ):
+        raise RuntimeError("campaign missing-file store failed exact identity verification")
+    return record
+
+
 def stage_artifact(
     request: dict,
     cache_root: Path,
     staging_root: Path,
-    allow_reviewed_download: bool,
+    missing_store: Path | None,
 ) -> dict:
     audit = audit_cached_artifact(request, cache_root)
-    reviewed = list(NETWORK_FILL_AUTHORITY)
-    if audit["missingFiles"] and (
-        not allow_reviewed_download
-        or [
-            request["repository"],
-            request["revision"],
-            *audit["missingFiles"],
-        ]
-        != reviewed
-    ):
-        raise RuntimeError(
-            "network staging is not approved for missing set: "
-            + ", ".join(audit["missingFiles"])
-        )
-    if allow_reviewed_download and audit["missingFiles"] != [NETWORK_FILL_AUTHORITY[2]]:
-        raise RuntimeError("network staging requires exactly the sole reviewed missing filename")
+    stored_missing = None
+    if audit["missingFiles"]:
+        if audit["missingFiles"] != [NETWORK_FILL_AUTHORITY[2]] or missing_store is None:
+            raise RuntimeError(
+                "offline JIT staging lacks the exact reviewed missing file: "
+                + ", ".join(audit["missingFiles"])
+            )
+        stored_missing = _stored_missing_file(request, missing_store)
 
     destination_root = _stage_root(staging_root)
     owner, name = request["repository"].split("/", 1)
@@ -277,68 +390,35 @@ def stage_artifact(
         source = Path(audit["selectedRoot"]) / record["path"]
         destination = destination_selected / record["path"]
         if destination.exists() or destination.is_symlink():
-            raise RuntimeError(f"refusing to overwrite staged cache file: {destination}")
+            if not destination.is_symlink() and destination.is_file() and destination.stat().st_size == record["bytes"] and _sha256(destination) == record["sha256"]:
+                continue
+            raise RuntimeError(f"refusing to overwrite non-identical staged cache file: {destination}")
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source.resolve(strict=True), destination)
         if destination.stat().st_size != record["bytes"] or _sha256(destination) != record["sha256"]:
             raise RuntimeError(f"staged cache copy failed byte verification: {destination}")
 
     downloaded_files = []
-    if audit["missingFiles"]:
-        repository, revision, filename = NETWORK_FILL_AUTHORITY
-        destination = destination_snapshot / filename
-        if destination.exists() or destination.is_symlink():
-            raise RuntimeError("refusing to overwrite the reviewed missing staging target")
+    if stored_missing:
+        owner, name = NETWORK_FILL_AUTHORITY[0].split("/", 1)
+        source = (
+            _missing_store_root(missing_store)
+            / f"models--{owner}--{name}" / "snapshots"
+            / NETWORK_FILL_AUTHORITY[1] / NETWORK_FILL_AUTHORITY[2]
+        )
+        destination = destination_selected / stored_missing["path"]
         destination.parent.mkdir(parents=True, exist_ok=True)
-
-        from huggingface_hub import (
-            __version__,
-            get_hf_file_metadata,
-            hf_hub_download,
-            hf_hub_url,
-        )
-
-        if __version__ != "0.36.0":
-            raise RuntimeError(
-                f"network staging requires huggingface_hub 0.36.0, got {__version__}"
-            )
-        url = hf_hub_url(repo_id=repository, filename=filename, revision=revision)
-        metadata = get_hf_file_metadata(url, token=False)
-        etag = str(metadata.etag or "").strip('"')
-        if (
-            metadata.commit_hash != revision
-            or not SHA256.fullmatch(etag)
-            or not isinstance(metadata.size, int)
-            or metadata.size < 1
-        ):
-            raise RuntimeError("exact missing-file metadata did not bind commit, LFS SHA, and size")
-        downloaded = Path(
-            hf_hub_download(
-                repo_id=repository,
-                filename=filename,
-                revision=revision,
-                repo_type="model",
-                local_dir=destination_snapshot,
-                cache_dir=destination_root / ".hf-network-staging",
-                token=False,
-                force_download=False,
-                local_files_only=False,
-            )
-        )
-        if downloaded != destination or not destination.is_file():
-            raise RuntimeError(
-                "pinned missing-file download did not materialize the exact staging path"
-            )
-        actual_sha = _sha256(destination)
-        if destination.stat().st_size != metadata.size or actual_sha != etag:
-            raise RuntimeError("downloaded missing file failed exact size/LFS SHA verification")
+        if destination.exists() or destination.is_symlink():
+            if not (not destination.is_symlink() and destination.is_file() and destination.stat().st_size == stored_missing["bytes"] and _sha256(destination) == stored_missing["sha256"]):
+                raise RuntimeError("refusing to overwrite non-identical staged missing file")
+        else:
+            shutil.copyfile(source, destination)
+        if destination.stat().st_size != stored_missing["bytes"] or _sha256(destination) != stored_missing["sha256"]:
+            raise RuntimeError("JIT copy of campaign missing file failed byte verification")
         downloaded_files.append(
             {
+                **stored_missing,
                 "path": destination.relative_to(destination_selected).as_posix(),
-                "bytes": metadata.size,
-                "sha256": actual_sha,
-                "lfsSha256": etag,
-                "commitSha": metadata.commit_hash,
             }
         )
 
@@ -355,21 +435,24 @@ def main() -> None:
     parser.add_argument("--cache-root", required=True, type=Path)
     parser.add_argument("--audit", action="store_true")
     parser.add_argument("--stage-root", type=Path)
-    parser.add_argument("--allow-reviewed-download", action="store_true")
+    parser.add_argument("--missing-store", type=Path)
+    parser.add_argument("--download-reviewed-missing", action="store_true")
     args = parser.parse_args()
     if args.audit and args.stage_root:
         raise ValueError("--audit and --stage-root are mutually exclusive")
-    if args.allow_reviewed_download and not args.stage_root:
-        raise ValueError("--allow-reviewed-download requires --stage-root")
+    if args.download_reviewed_missing and (args.audit or args.stage_root or not args.missing_store):
+        raise ValueError("--download-reviewed-missing requires only --missing-store")
     request = parse_request(args.request.resolve())
-    if args.audit:
+    if args.download_reviewed_missing:
+        result = download_reviewed_missing(request, args.cache_root, args.missing_store)
+    elif args.audit:
         result = audit_cached_artifact(request, args.cache_root)
     elif args.stage_root:
         result = stage_artifact(
             request,
             args.cache_root,
             args.stage_root,
-            args.allow_reviewed_download,
+            args.missing_store,
         )
     else:
         result = resolve_cached_artifact(request, args.cache_root)

--- a/scripts/provision_epic_20738_terminal_artifact_test.py
+++ b/scripts/provision_epic_20738_terminal_artifact_test.py
@@ -167,9 +167,9 @@ class CacheOnlyProvisionTests(unittest.TestCase):
             }])
 
     def test_staging_copies_hits_once_and_downloads_only_the_reviewed_missing_file(self) -> None:
-        with tempfile.TemporaryDirectory() as directory, tempfile.TemporaryDirectory() as staged:
+        with tempfile.TemporaryDirectory() as directory, tempfile.TemporaryDirectory() as stored:
             cache = Path(directory).resolve()
-            staging = Path(staged).resolve()
+            missing_store = Path(stored).resolve()
             snapshot = self.flux_snapshot(cache)
             incomplete = snapshot.parents[1] / "blobs" / (("c" * 64) + ".incomplete")
             incomplete.parent.mkdir(exist_ok=True)
@@ -207,11 +207,14 @@ class CacheOnlyProvisionTests(unittest.TestCase):
                 self.assertEqual(kwargs["filename"], "q8/transformer/model.safetensors")
                 self.assertEqual(kwargs["revision"], self.flux_request()["revision"])
                 self.assertEqual(kwargs["repo_type"], "model")
-                self.assertEqual(Path(kwargs["cache_dir"]), staging / ".hf-network-staging")
+                self.assertEqual(Path(kwargs["cache_dir"]), missing_store / ".hf-network-staging")
                 self.assertFalse(kwargs["token"])
                 self.assertFalse(kwargs["force_download"])
                 self.assertFalse(kwargs["local_files_only"])
                 target = Path(kwargs["local_dir"]) / kwargs["filename"]
+                metadata_dir = Path(kwargs["local_dir"]) / ".cache" / "huggingface"
+                metadata_dir.mkdir(parents=True)
+                (metadata_dir / "download-metadata").write_text("untrusted downloader state")
                 target.write_bytes(payload)
                 return str(target)
 
@@ -222,10 +225,17 @@ class CacheOnlyProvisionTests(unittest.TestCase):
                 hf_hub_download=download,
             )
             with mock.patch.dict(sys.modules, {"huggingface_hub": fake_hf}):
-                result = MODULE.stage_artifact(
-                    self.flux_request(), cache, staging, True
+                downloaded = MODULE.download_reviewed_missing(
+                    self.flux_request(), cache, missing_store
                 )
+            result = MODULE.stage_artifact(
+                self.flux_request(), cache, missing_store, missing_store
+            )
             self.assertEqual(len(calls), 1)
+            self.assertFalse(
+                (missing_store / "models--SceneWorks--flux1-schnell-mlx" / "snapshots"
+                 / self.flux_request()["revision"] / ".cache").exists()
+            )
             self.assertEqual(
                 result["downloadedFiles"],
                 [{
@@ -238,9 +248,22 @@ class CacheOnlyProvisionTests(unittest.TestCase):
             )
             self.assertEqual(incomplete.read_bytes(), b"partial", "helper never selects partial blobs itself")
             self.assertFalse((snapshot / "q8/transformer/model.safetensors").exists())
-            offline = MODULE.resolve_cached_artifact(self.flux_request(), staging)
+            self.assertEqual(downloaded["downloadedFiles"][0]["path"], "transformer/model.safetensors")
+            self.assertEqual(result["downloadedFiles"][0]["path"], "transformer/model.safetensors")
+            self.assertEqual(
+                {key: value for key, value in downloaded["downloadedFiles"][0].items() if key != "path"},
+                {key: value for key, value in result["downloadedFiles"][0].items() if key != "path"},
+            )
+            offline = MODULE.resolve_cached_artifact(self.flux_request(), missing_store)
             self.assertEqual(offline["downloadedFiles"], [])
             self.assertTrue(offline["complete"])
+            stored_target = (
+                missing_store / "models--SceneWorks--flux1-schnell-mlx" / "snapshots"
+                / self.flux_request()["revision"] / "q8/transformer/model.safetensors"
+            )
+            stored_target.write_bytes(b"tampered")
+            with self.assertRaisesRegex(RuntimeError, "missing-file store failed exact identity"):
+                MODULE.stage_artifact(self.flux_request(), cache, missing_store, missing_store)
 
     def test_staging_never_downloads_or_overwrites_a_valid_cache_hit(self) -> None:
         with tempfile.TemporaryDirectory() as directory, tempfile.TemporaryDirectory() as staged:
@@ -256,13 +279,20 @@ class CacheOnlyProvisionTests(unittest.TestCase):
             )
             with mock.patch.dict(sys.modules, {"huggingface_hub": fake_hf}):
                 result = MODULE.stage_artifact(
-                    self.flux_request(), cache, staging, False
+                    self.flux_request(), cache, staging, None
                 )
             called.assert_not_called()
             self.assertEqual(result["downloadedFiles"], [])
             self.assertEqual(target.read_bytes(), b"already valid")
-            with self.assertRaisesRegex(RuntimeError, "refusing to overwrite staged cache file"):
-                MODULE.stage_artifact(self.flux_request(), cache, staging, False)
+            repeated = MODULE.stage_artifact(self.flux_request(), cache, staging, None)
+            self.assertEqual(repeated["reusedFiles"], result["reusedFiles"])
+            staged_target = (
+                staging / "models--SceneWorks--flux1-schnell-mlx" / "snapshots"
+                / self.flux_request()["revision"] / "q8/transformer/model.safetensors"
+            )
+            staged_target.write_bytes(b"drift")
+            with self.assertRaisesRegex(RuntimeError, "refusing to overwrite non-identical"):
+                MODULE.stage_artifact(self.flux_request(), cache, staging, None)
 
     def test_network_flag_rejects_unapproved_authority(self) -> None:
         with tempfile.TemporaryDirectory() as directory, tempfile.TemporaryDirectory() as staged:
@@ -271,9 +301,9 @@ class CacheOnlyProvisionTests(unittest.TestCase):
             snapshot = self.cache_snapshot(cache)
             (snapshot / "q4" / "weights.safetensors").write_bytes(b"weights")
             with self.assertRaisesRegex(
-                RuntimeError, "network staging requires exactly the sole reviewed missing filename"
+                RuntimeError, "network fill requires exactly the sole reviewed missing filename"
             ):
-                MODULE.stage_artifact(self.request(), cache, staging, True)
+                MODULE.download_reviewed_missing(self.request(), cache, staging)
 
     def test_request_rejects_unreviewed_floating_or_escaping_fields(self) -> None:
         self.assertEqual(self.parse(self.request())["allowPatterns"], ["q4/*"])


### PR DESCRIPTION
## Shortcut

- [sc-20974](https://app.shortcut.com/trefry/story/20974)

## Scope

- continue only from the independently rehashed contiguous PASS prefix in run `32570707303` attempt 1 / artifact `9477529627`; retain cells 1-7 and quarantine the exact non-executed cell-8 boundary skeleton
- derive and freeze the exact cache census from checked-in immutable download evidence, reuse every valid cache hit, and permit exactly one missing model file: `SceneWorks/flux1-schnell-mlx@bba3ae01dfd94089f173c05edd4e1a4c551f2599 q8/transformer/model.safetensors`
- stage exact authorities just in time through their last consumer, keep model-adjacent weights immutable, isolate b646 Candle sidecars, and bind followed-target bytes rather than link lengths
- enforce the reviewed `179,028,698,264`-byte logical source census, `56,156,615,634`-byte JIT peak, and `99,106,288,594`-byte free-space floor with transition-time probes
- fail closed with closed Draft-2020 evidence, durable later-cell receipts, exact lifecycle and offline-state binding, non-reparse runtime evidence, and quarantine for cache/result/evidence drift
- allow an ordinary early provider failure to continue only after proving, binding, and cleaning an exact empty canonical derived namespace; partial or stray output quarantines

The frozen 19-cell / 23-artifact semantic profile, product gates, facts, matrix, exceptions, and inference pin are unchanged. This PR does not dispatch the terminal campaign or use GPU/weights.

## Review and validation

Independent review approved exact head `2d65929ec1314b716e70726389a1c9e526e6d202` and tree `65c26cdb462734c16fc207d137635ac5ba9eb5dc` with no findings.

- terminal controller/schema suite: 15/15
- Python provisioner: 11/11 plus bytecode compile
- platform/action contracts: 80/80
- action pin gate: 11 workflows
- offline download evidence: 24 self-tests; 482 patterns / 328 entries / 100 immutable authorities
- exact 19-cell immutable-authority harness check
- schema parse, `cargo fmt --all -- --check`, and diff check
