### PR TITLE
fix(harness): bind FLUX evidence to runtime memory strategy (sc-20974)

### DIFF
--- a/config/terminal-evidence/epic-20738-cache-preflight.schema.json
+++ b/config/terminal-evidence/epic-20738-cache-preflight.schema.json
@@ -221,11 +221,12 @@
     "sidecarSnapshot": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["ordinal", "cellId", "providerExecution", "derivedDisposition", "inventory"],
+      "required": ["ordinal", "cellId", "providerExecution", "requestMemoryStrategy", "derivedDisposition", "inventory"],
       "properties": {
         "ordinal": { "type": "integer", "minimum": 1, "maximum": 19 },
         "cellId": { "$ref": "#/$defs/id" },
         "providerExecution": { "enum": ["failed", "completed"] },
+        "requestMemoryStrategy": { "$ref": "#/$defs/requestMemoryStrategy" },
         "derivedDisposition": {
           "enum": [
             "not-applicable",
@@ -236,6 +237,30 @@
         },
         "inventory": { "$ref": "#/$defs/inventory" }
       }
+    },
+    "requestMemoryStrategy": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["strategy", "requestMemoryPresent", "stageResidency", "streamTransformerBlocks"],
+          "properties": {
+            "strategy": {
+              "enum": [
+                "not-applicable",
+                "default-resident",
+                "explicit-resident",
+                "staged-resident",
+                "bounded-transformer"
+              ]
+            },
+            "requestMemoryPresent": { "type": "boolean" },
+            "stageResidency": { "type": "boolean" },
+            "streamTransformerBlocks": { "type": "boolean" }
+          }
+        },
+        { "type": "null" }
+      ]
     },
     "physicalFile": {
       "type": "object",

--- a/config/terminal-evidence/epic-20738-cache-preflight.schema.json
+++ b/config/terminal-evidence/epic-20738-cache-preflight.schema.json
@@ -257,7 +257,35 @@
             "requestMemoryPresent": { "type": "boolean" },
             "stageResidency": { "type": "boolean" },
             "streamTransformerBlocks": { "type": "boolean" }
-          }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": { "streamTransformerBlocks": { "const": true } },
+                "required": ["streamTransformerBlocks"]
+              },
+              "then": {
+                "properties": {
+                  "strategy": { "const": "bounded-transformer" },
+                  "requestMemoryPresent": { "const": true },
+                  "stageResidency": { "const": true }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": { "strategy": { "const": "bounded-transformer" } },
+                "required": ["strategy"]
+              },
+              "then": {
+                "properties": {
+                  "requestMemoryPresent": { "const": true },
+                  "stageResidency": { "const": true },
+                  "streamTransformerBlocks": { "const": true }
+                }
+              }
+            }
+          ]
         },
         { "type": "null" }
       ]

--- a/config/terminal-evidence/epic-20738-cache-preflight.schema.json
+++ b/config/terminal-evidence/epic-20738-cache-preflight.schema.json
@@ -221,11 +221,19 @@
     "sidecarSnapshot": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["ordinal", "cellId", "providerExecution", "inventory"],
+      "required": ["ordinal", "cellId", "providerExecution", "derivedDisposition", "inventory"],
       "properties": {
         "ordinal": { "type": "integer", "minimum": 1, "maximum": 19 },
         "cellId": { "$ref": "#/$defs/id" },
         "providerExecution": { "enum": ["failed", "completed"] },
+        "derivedDisposition": {
+          "enum": [
+            "not-applicable",
+            "resident-empty",
+            "bounded-transformer-sidecars",
+            "provider-failed-empty"
+          ]
+        },
         "inventory": { "$ref": "#/$defs/inventory" }
       }
     },

--- a/config/terminal-evidence/epic-20738-receipt.schema.json
+++ b/config/terminal-evidence/epic-20738-receipt.schema.json
@@ -268,7 +268,35 @@
             "requestMemoryPresent": { "type": "boolean" },
             "stageResidency": { "type": "boolean" },
             "streamTransformerBlocks": { "type": "boolean" }
-          }
+          },
+          "allOf": [
+            {
+              "if": {
+                "properties": { "streamTransformerBlocks": { "const": true } },
+                "required": ["streamTransformerBlocks"]
+              },
+              "then": {
+                "properties": {
+                  "strategy": { "const": "bounded-transformer" },
+                  "requestMemoryPresent": { "const": true },
+                  "stageResidency": { "const": true }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": { "strategy": { "const": "bounded-transformer" } },
+                "required": ["strategy"]
+              },
+              "then": {
+                "properties": {
+                  "requestMemoryPresent": { "const": true },
+                  "stageResidency": { "const": true },
+                  "streamTransformerBlocks": { "const": true }
+                }
+              }
+            }
+          ]
         },
         { "type": "null" }
       ]

--- a/config/terminal-evidence/epic-20738-receipt.schema.json
+++ b/config/terminal-evidence/epic-20738-receipt.schema.json
@@ -249,6 +249,30 @@
         "requiredFreeBytes": { "type": "integer", "minimum": 1 }
       }
     },
+    "requestMemoryStrategy": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["strategy", "requestMemoryPresent", "stageResidency", "streamTransformerBlocks"],
+          "properties": {
+            "strategy": {
+              "enum": [
+                "not-applicable",
+                "default-resident",
+                "explicit-resident",
+                "staged-resident",
+                "bounded-transformer"
+              ]
+            },
+            "requestMemoryPresent": { "type": "boolean" },
+            "stageResidency": { "type": "boolean" },
+            "streamTransformerBlocks": { "type": "boolean" }
+          }
+        },
+        { "type": "null" }
+      ]
+    },
     "stagedAuthority": {
       "type": "object",
       "additionalProperties": false,
@@ -297,13 +321,14 @@
     "authorityLifecycle": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["ordinal", "cellId", "staged", "activeArtifactIds", "providerExecution", "verifiedBefore", "verifiedAfter", "derivedAfter", "released", "diskProbes"],
+      "required": ["ordinal", "cellId", "staged", "activeArtifactIds", "providerExecution", "requestMemoryStrategy", "verifiedBefore", "verifiedAfter", "derivedAfter", "released", "diskProbes"],
       "properties": {
         "ordinal": { "type": "integer", "minimum": 1, "maximum": 19 },
         "cellId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$" },
         "staged": { "type": "array", "items": { "$ref": "#/$defs/stagedAuthority" } },
         "activeArtifactIds": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$" } },
         "providerExecution": { "enum": ["not-attempted", "failed", "completed"] },
+        "requestMemoryStrategy": { "$ref": "#/$defs/requestMemoryStrategy" },
         "verifiedBefore": { "type": "boolean" },
         "verifiedAfter": { "type": "boolean" },
         "derivedAfter": { "type": "array", "items": { "$ref": "#/$defs/derivedAuthority" } },

--- a/config/terminal-evidence/epic-20738-receipt.schema.json
+++ b/config/terminal-evidence/epic-20738-receipt.schema.json
@@ -264,9 +264,17 @@
     "derivedAuthority": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["artifactId", "files", "bytes", "inventories"],
+      "required": ["artifactId", "derivedDisposition", "files", "bytes", "inventories"],
       "properties": {
         "artifactId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$" },
+        "derivedDisposition": {
+          "enum": [
+            "not-applicable",
+            "resident-empty",
+            "bounded-transformer-sidecars",
+            "provider-failed-empty"
+          ]
+        },
         "files": { "type": "integer", "minimum": 0 },
         "bytes": { "type": "integer", "minimum": 0 },
         "inventories": { "type": "array", "items": { "$ref": "#/$defs/plainInventory" } }

--- a/crates/sceneworks-worker/src/epic_20738_terminal_cuda_smoke.rs
+++ b/crates/sceneworks-worker/src/epic_20738_terminal_cuda_smoke.rs
@@ -101,6 +101,55 @@ fn family_generation_memory(kind: &str, engine_id: &str) -> Option<gen_core::Gen
     }
 }
 
+fn request_memory_strategy_value(
+    is_flux: bool,
+    memory: Option<&gen_core::GenerationMemory>,
+) -> Value {
+    if !is_flux {
+        assert!(
+            memory.is_none(),
+            "non-FLUX terminal memory policy needs an explicit reviewed evidence contract"
+        );
+        return json!({
+            "strategy": "not-applicable",
+            "requestMemoryPresent": false,
+            "stageResidency": false,
+            "streamTransformerBlocks": false,
+        });
+    }
+    match memory {
+        None => json!({
+            "strategy": "default-resident",
+            "requestMemoryPresent": false,
+            "stageResidency": false,
+            "streamTransformerBlocks": false,
+        }),
+        Some(memory) => {
+            let strategy = if memory.stream_transformer_blocks {
+                "bounded-transformer"
+            } else if memory.stage_residency {
+                "staged-resident"
+            } else {
+                "explicit-resident"
+            };
+            json!({
+                "strategy": strategy,
+                "requestMemoryPresent": true,
+                "stageResidency": memory.stage_residency,
+                "streamTransformerBlocks": memory.stream_transformer_blocks,
+            })
+        }
+    }
+}
+
+fn family_request_memory_strategy(kind: &str, engine_id: &str) -> Value {
+    let memory = family_generation_memory(kind, engine_id);
+    request_memory_strategy_value(
+        kind == "image" && matches!(engine_id, "flux1_dev" | "flux1_schnell"),
+        memory.as_ref(),
+    )
+}
+
 fn primary_load_spec(cell: &Cell, primary: &Artifact) -> LoadSpec {
     let spec = LoadSpec::new(WeightsSource::Dir(primary.root.clone()))
         .with_resolved_route(cell.model_id.clone());
@@ -638,6 +687,7 @@ fn epic_20738_terminal_cuda_cell() {
         other => panic!("unreviewed terminal cell kind {other}"),
     };
     let quant = family_load_spec_quant_bits(&cell.kind, &cell.engine_id, &cell.requested_tier);
+    let request_memory_strategy = family_request_memory_strategy(&cell.kind, &cell.engine_id);
     let result = json!({
         "schemaVersion": 1,
         "cell": cell.id,
@@ -645,6 +695,7 @@ fn epic_20738_terminal_cuda_cell() {
         "resolvedTier": primary.subdirectory,
         "denseFallback": false,
         "loadSpecQuantBits": quant,
+        "requestMemoryStrategy": request_memory_strategy,
         "metrics": metrics,
     });
     std::fs::write(
@@ -792,11 +843,54 @@ mod cpu_contract_tests {
                 family_generation_memory(kind, engine_id).is_none(),
                 "{id} must keep GenerationRequest.memory at its reviewed default"
             );
+            let expected_strategy = if engine_id.starts_with("flux1_") {
+                "default-resident"
+            } else {
+                "not-applicable"
+            };
+            assert_eq!(
+                family_request_memory_strategy(kind, engine_id),
+                json!({
+                    "strategy": expected_strategy,
+                    "requestMemoryPresent": false,
+                    "stageResidency": false,
+                    "streamTransformerBlocks": false,
+                }),
+                "{id} runtime evidence must describe the exact request used"
+            );
         }
         assert!(
             std::panic::catch_unwind(|| family_generation_memory("image", "unreviewed_engine"))
                 .is_err(),
             "an unreviewed family must not silently inherit the default request-memory contract"
+        );
+
+        let staged = gen_core::GenerationMemory {
+            stage_residency: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            request_memory_strategy_value(true, Some(&staged)),
+            json!({
+                "strategy": "staged-resident",
+                "requestMemoryPresent": true,
+                "stageResidency": true,
+                "streamTransformerBlocks": false,
+            })
+        );
+        let bounded = gen_core::GenerationMemory {
+            stage_residency: true,
+            stream_transformer_blocks: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            request_memory_strategy_value(true, Some(&bounded)),
+            json!({
+                "strategy": "bounded-transformer",
+                "requestMemoryPresent": true,
+                "stageResidency": true,
+                "streamTransformerBlocks": true,
+            })
         );
     }
 

--- a/crates/sceneworks-worker/src/epic_20738_terminal_cuda_smoke.rs
+++ b/crates/sceneworks-worker/src/epic_20738_terminal_cuda_smoke.rs
@@ -86,6 +86,21 @@ fn family_load_spec_quant_bits(kind: &str, engine_id: &str, requested_tier: &str
     }
 }
 
+/// The reviewed terminal requests deliberately leave the production request-memory policy at its
+/// default. In particular, FLUX on an ample CUDA device is resident/non-streamed and therefore does
+/// not create bounded-transformer sidecars. This helper makes that absence reviewable and rejects a
+/// new family before it can silently inherit a different harness policy.
+fn family_generation_memory(kind: &str, engine_id: &str) -> Option<gen_core::GenerationMemory> {
+    match (kind, engine_id) {
+        ("image", "chroma1_base" | "chroma1_flash" | "chroma1_hd")
+        | ("image", "flux1_dev" | "flux1_schnell")
+        | ("ltx", "ltx_2_3_distilled")
+        | ("sdxlOpenPose", "sdxl")
+        | ("scail2", "scail2_14b") => None,
+        _ => panic!("unreviewed terminal request-memory family {kind}/{engine_id}"),
+    }
+}
+
 fn primary_load_spec(cell: &Cell, primary: &Artifact) -> LoadSpec {
     let spec = LoadSpec::new(WeightsSource::Dir(primary.root.clone()))
         .with_resolved_route(cell.model_id.clone());
@@ -311,6 +326,7 @@ fn generate_image(cell: &Cell, primary: &Artifact, output: &Path) -> Value {
         guidance: cell.request.guidance,
         true_cfg: cell.request.true_cfg,
         sampler: cell.request.sampler.clone(),
+        memory: family_generation_memory(&cell.kind, &cell.engine_id),
         ..Default::default()
     };
     let image = image_output(
@@ -397,6 +413,7 @@ fn generate_sdxl_openpose(cell: &Cell, primary: &Artifact, bits: u64, output: &P
             kind: ControlKind::Pose,
             scale: Some(1.0),
         }],
+        memory: family_generation_memory(&cell.kind, &cell.engine_id),
         ..Default::default()
     };
     let image = image_output(
@@ -508,6 +525,7 @@ fn generate_scail2(cell: &Cell, primary: &Artifact, output: &Path) -> Value {
         seed: Some(cell.request.seed),
         conditioning,
         video_mode: Some("animation".to_owned()),
+        memory: family_generation_memory(&cell.kind, &cell.engine_id),
         ..Default::default()
     };
     let output_value = generator
@@ -546,6 +564,7 @@ fn generate_ltx(cell: &Cell, primary: &Artifact, output: &Path) -> Value {
         fps: cell.request.fps,
         steps: Some(cell.request.steps),
         seed: Some(cell.request.seed),
+        memory: family_generation_memory(&cell.kind, &cell.engine_id),
         ..Default::default()
     };
     let generated = generator
@@ -742,6 +761,43 @@ mod cpu_contract_tests {
                 "{id} load-quant policy"
             );
         }
+    }
+
+    #[test]
+    fn family_request_memory_policy_keeps_all_19_terminal_cells_at_default() {
+        let cases = [
+            ("chroma1-base-q4", "image", "chroma1_base"),
+            ("chroma1-base-q8", "image", "chroma1_base"),
+            ("chroma1-flash-q4", "image", "chroma1_flash"),
+            ("chroma1-flash-q8", "image", "chroma1_flash"),
+            ("chroma1-hd-q4", "image", "chroma1_hd"),
+            ("chroma1-hd-q8", "image", "chroma1_hd"),
+            ("flux1-dev-q4", "image", "flux1_dev"),
+            ("flux1-dev-q8", "image", "flux1_dev"),
+            ("flux1-schnell-q4", "image", "flux1_schnell"),
+            ("flux1-schnell-q8", "image", "flux1_schnell"),
+            ("scail2-q4", "scail2", "scail2_14b"),
+            ("scail2-multi-reference-q4", "scail2", "scail2_14b"),
+            ("scail2-q8", "scail2", "scail2_14b"),
+            ("ltx-2-3-q8", "ltx", "ltx_2_3_distilled"),
+            ("sdxl-openpose", "sdxlOpenPose", "sdxl"),
+            ("realvisxl-openpose", "sdxlOpenPose", "sdxl"),
+            ("realvisxl-lightning-openpose", "sdxlOpenPose", "sdxl"),
+            ("illustrious-v1-openpose", "sdxlOpenPose", "sdxl"),
+            ("illustrious-v2-openpose", "sdxlOpenPose", "sdxl"),
+        ];
+        assert_eq!(cases.len(), 19);
+        for (id, kind, engine_id) in cases {
+            assert!(
+                family_generation_memory(kind, engine_id).is_none(),
+                "{id} must keep GenerationRequest.memory at its reviewed default"
+            );
+        }
+        assert!(
+            std::panic::catch_unwind(|| family_generation_memory("image", "unreviewed_engine"))
+                .is_err(),
+            "an unreviewed family must not silently inherit the default request-memory contract"
+        );
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/epic_20738_terminal_cuda_smoke.rs
+++ b/crates/sceneworks-worker/src/epic_20738_terminal_cuda_smoke.rs
@@ -126,6 +126,10 @@ fn request_memory_strategy_value(
         }),
         Some(memory) => {
             let strategy = if memory.stream_transformer_blocks {
+                assert!(
+                    memory.stage_residency,
+                    "bounded-transformer terminal memory requires staged residency"
+                );
                 "bounded-transformer"
             } else if memory.stage_residency {
                 "staged-resident"
@@ -891,6 +895,18 @@ mod cpu_contract_tests {
                 "stageResidency": true,
                 "streamTransformerBlocks": true,
             })
+        );
+        let streamed_without_staging = gen_core::GenerationMemory {
+            stage_residency: false,
+            stream_transformer_blocks: true,
+            ..Default::default()
+        };
+        assert!(
+            std::panic::catch_unwind(|| {
+                request_memory_strategy_value(true, Some(&streamed_without_staging))
+            })
+            .is_err(),
+            "bounded-transformer evidence must reject streaming without staged residency"
         );
     }
 

--- a/docs/epic-20738-terminal-cuda.md
+++ b/docs/epic-20738-terminal-cuda.md
@@ -81,8 +81,9 @@ the complete production-approved cached parent revision
 `254989c3ca7ee691187647f350b112c0c448789d`, not the absent current revision. After the one possible
 fill, network mode is forced offline for every JIT stage and cell.
 
-The disk admission model binds exact source bytes, the contracted FLUX sidecar payloads (494 files;
-q8 12,573,868,032 bytes and q4 7,396,392,960 bytes, each with at most 16 KiB per-file reserve), and a
+The disk admission model binds exact source bytes, the conservative streamed-FLUX sidecar ceilings
+(494 files; q8 12,573,868,032 bytes and q4 7,396,392,960 bytes, each with at most 16 KiB per-file
+reserve), and a
 40-GiB non-model reserve for Cargo target, output, the pinned venv, logs, and filesystem fluctuation.
 The persistent Schnell-q8 miss is retained only through cell 10 and removed with that authority.
 The largest model-plus-sidecar live set is therefore the LTX pair itself at
@@ -104,10 +105,14 @@ All writable cache and temporary environment variables are redirected to the cur
 while model roots point only at the active JIT staging roots. Every selected root and nested
 top-level component root carries an ordinary-file `.candle-device-format-v1` obstruction, forcing
 Candle away from model-adjacent writes. `SCENEWORKS_CANDLE_DEVICE_CACHE_DIR` points to a separate
-campaign-owned derived root under `RUNNER_TEMP`; the one b646 component-path-derived namespace shares
-the authority's lifetime and is inventoried and removed after its last consumer. A FLUX namespace
-must contain the exact bounded 494-file sidecar set with no other file or empty namespace anywhere in
-the derived root; every non-FLUX root must stay exactly empty. The controller rehashes
+campaign-owned derived root under `RUNNER_TEMP`. The terminal request leaves `GenerationRequest.memory`
+at its production default: on an ample device, a successful resident/non-streamed FLUX request must
+leave the canonical derived root exactly empty. If the provider instead exercises its bounded
+transformer path, exactly one b646 component-path-derived namespace shares the authority's lifetime
+and must contain the reviewed bounded 494-file sidecar set. Partial, stray, multiple, wrong, or
+non-regular derived entries fail closed in either case; every non-FLUX root must stay exactly empty.
+An early provider failure may retain only its separately labeled exact-empty namespace evidence. The
+controller rehashes
 each selected staged authority file and every obstruction immediately before and after every cell,
 then proves exact stage/namespace absence at release and proves final staging, derived cache, and
 missing-file store emptiness. Any stage, hash, capacity, or cleanup drift quarantines later cells; the
@@ -141,7 +146,9 @@ The closed Draft 2020-12 `cache-preflight.json` binds the download-evidence SHA-
 filename census, followed target bytes/hashes, hit/download partition, first/last-use plan, persistent
 store, exact disk plan/free floor, and the no-GPU-before-validation verdict. Its own byte count and
 SHA-256 are bound from the campaign summary. Each continuation receipt binds that cell's live-set
-transition, free-space probes, pre/post immutable verification, derived inventory, and exact releases;
+transition, free-space probes, pre/post immutable verification, the exact derived disposition
+(`resident-empty`, `bounded-transformer-sidecars`, `provider-failed-empty`, or `not-applicable`),
+derived inventory, and exact releases;
 the final summary binds the complete lifecycle and empty terminal state.
 
 A cache preflight directory, write, stat, hash, schema/semantic validation, census, staging, or final

--- a/docs/epic-20738-terminal-cuda.md
+++ b/docs/epic-20738-terminal-cuda.md
@@ -99,7 +99,10 @@ The Node controller awaits one fresh `sceneworks-worker` process for each cell w
 `--test-threads=1`; it never starts cells in parallel and exposes no per-cell dispatch input. The Rust
 entrypoint constructs the production load spec and deterministic request in reviewable code. Packed
 tier markers must agree with the requested q4/q8 directory, and runtime results must say requested
-tier equals resolved tier with `denseFallback: false`.
+tier equals resolved tier with `denseFallback: false`. The same runtime result carries a closed
+request-memory record: current FLUX cells report `default-resident`, `requestMemoryPresent: false`,
+`stageResidency: false`, and `streamTransformerBlocks: false`; non-FLUX cells report exact
+`not-applicable`.
 
 All writable cache and temporary environment variables are redirected to the current cell's scratch,
 while model roots point only at the active JIT staging roots. Every selected root and nested
@@ -112,7 +115,10 @@ transformer path, exactly one b646 component-path-derived namespace shares the a
 and must contain the reviewed bounded 494-file sidecar set. Partial, stray, multiple, wrong, or
 non-regular derived entries fail closed in either case; every non-FLUX root must stay exactly empty.
 An early provider failure may retain only its separately labeled exact-empty namespace evidence. The
-controller rehashes
+controller validates the runtime request-memory record before accepting a successful derived
+disposition: default/explicit/staged resident strategies pair only with exact empty evidence, while
+`bounded-transformer` with `streamTransformerBlocks: true` pairs only with the canonical 494-file
+namespace. A provider failure has no runtime-result strategy claim. The controller rehashes
 each selected staged authority file and every obstruction immediately before and after every cell,
 then proves exact stage/namespace absence at release and proves final staging, derived cache, and
 missing-file store emptiness. Any stage, hash, capacity, or cleanup drift quarantines later cells; the
@@ -148,7 +154,7 @@ store, exact disk plan/free floor, and the no-GPU-before-validation verdict. Its
 SHA-256 are bound from the campaign summary. Each continuation receipt binds that cell's live-set
 transition, free-space probes, pre/post immutable verification, the exact derived disposition
 (`resident-empty`, `bounded-transformer-sidecars`, `provider-failed-empty`, or `not-applicable`),
-derived inventory, and exact releases;
+its closed request-memory strategy, derived inventory, and exact releases;
 the final summary binds the complete lifecycle and empty terminal state.
 
 A cache preflight directory, write, stat, hash, schema/semantic validation, census, staging, or final

--- a/docs/epic-20738-terminal-cuda.md
+++ b/docs/epic-20738-terminal-cuda.md
@@ -117,8 +117,9 @@ non-regular derived entries fail closed in either case; every non-FLUX root must
 An early provider failure may retain only its separately labeled exact-empty namespace evidence. The
 controller validates the runtime request-memory record before accepting a successful derived
 disposition: default/explicit/staged resident strategies pair only with exact empty evidence, while
-`bounded-transformer` with `streamTransformerBlocks: true` pairs only with the canonical 494-file
-namespace. A provider failure has no runtime-result strategy claim. The controller rehashes
+`bounded-transformer` requires the exact present/staged/streamed tuple (`true/true/true`) and pairs
+only with the canonical 494-file namespace. Streamed-without-staged residency is invalid. A provider
+failure has no runtime-result strategy claim. The controller rehashes
 each selected staged authority file and every obstruction immediately before and after every cell,
 then proves exact stage/namespace absence at release and proves final staging, derived cache, and
 missing-file store emptiness. Any stage, hash, capacity, or cleanup drift quarantines later cells; the

--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -57,6 +57,10 @@ const NON_MODEL_DISK_RESERVE_BYTES = 40 * 1024 ** 3;
 const REVIEWED_FREE_FLOOR_BYTES = 99_106_288_594;
 const FLUX_Q4_SIDECAR_BYTES = 7_396_392_960 + 494 * 16_384;
 const FLUX_Q8_SIDECAR_BYTES = 12_573_868_032 + 494 * 16_384;
+const DERIVED_DISPOSITION_NOT_APPLICABLE = "not-applicable";
+const DERIVED_DISPOSITION_RESIDENT = "resident-empty";
+const DERIVED_DISPOSITION_BOUNDED = "bounded-transformer-sidecars";
+const DERIVED_DISPOSITION_PROVIDER_FAILED = "provider-failed-empty";
 const REVIEWED_DOWNLOAD_EVIDENCE_SHA256 = "9eda09eeacb9386167ca4a080b4805b9c7dd3cd5134ca037ce342ad434b17e0b";
 
 function fail(message) {
@@ -971,12 +975,19 @@ function validateReceiptInternal(
           && derived.files === 0 && derived.bytes === 0 && oneBoundNamespace
           && derived.inventories[0].files === 0 && derived.inventories[0].bytes === 0
           && derived.inventories[0].sha256 === createHash("sha256").digest("hex");
+        const exactResident = lifecycle.providerExecution === "completed"
+          && derived.files === 0 && derived.bytes === 0 && derived.inventories.length === 0
+          && staged?.derivedNamespaces.length === 0;
         const exactComplete = derived.files === 494 && derived.bytes >= payloadFloor
           && derived.bytes <= payloadCeiling && oneBoundNamespace;
-        if (!exactEmptyFailure && !exactComplete) {
-          fail("receipt FLUX derived lifecycle is not one exact bounded b646 namespace");
+        const expectedDisposition = exactResident ? DERIVED_DISPOSITION_RESIDENT
+          : exactEmptyFailure ? DERIVED_DISPOSITION_PROVIDER_FAILED
+            : exactComplete ? DERIVED_DISPOSITION_BOUNDED : null;
+        if (!expectedDisposition || derived.derivedDisposition !== expectedDisposition) {
+          fail("receipt FLUX derived lifecycle is neither exact resident-empty nor one exact bounded b646 namespace");
         }
-      } else if (derived.files !== 0 || derived.bytes !== 0 || derived.inventories.length !== 0) {
+      } else if (derived.derivedDisposition !== DERIVED_DISPOSITION_NOT_APPLICABLE
+        || derived.files !== 0 || derived.bytes !== 0 || derived.inventories.length !== 0) {
         fail("receipt non-FLUX derived lifecycle is not exactly empty");
       }
     }
@@ -1632,7 +1643,8 @@ export async function expectedB646DerivedNamespace(artifact, derivedSidecarRoot)
 }
 
 export async function inspectDerivedSidecarRoot(
-  derivedSidecarRoot, expectedNamespace = null, { materializeExactEmpty = false } = {},
+  derivedSidecarRoot, expectedNamespace = null,
+  { materializeExactEmpty = false, allowExactEmpty = false } = {},
 ) {
   let rootEntries = await readdir(derivedSidecarRoot, { withFileTypes: true });
   if (!expectedNamespace) {
@@ -1640,6 +1652,9 @@ export async function inspectDerivedSidecarRoot(
     return { rootInventory: await directoryInventory(derivedSidecarRoot), namespaces: [] };
   }
   const expectedVersionRoot = path.join(derivedSidecarRoot, "candle-device-format-v1");
+  if (allowExactEmpty && rootEntries.length === 0) {
+    return { rootInventory: await directoryInventory(derivedSidecarRoot), namespaces: [] };
+  }
   if (materializeExactEmpty && rootEntries.length === 0) {
     if (comparable(path.dirname(expectedNamespace)) !== comparable(expectedVersionRoot)
       || !/^[0-9a-f]{64}$/.test(path.basename(expectedNamespace))) {
@@ -2199,11 +2214,19 @@ export function validateCachePreflightEvidence(document, {
     const emptyProviderFailure = snapshot.providerExecution === "failed"
       && snapshot.inventory.files === 0 && snapshot.inventory.bytes === 0
       && snapshot.inventory.sha256 === createHash("sha256").digest("hex");
-    if (flux ? (!emptyProviderFailure && (snapshot.inventory.files !== 494
-        || snapshot.inventory.bytes < payloadFloor
-        || snapshot.inventory.bytes > payloadCeiling))
-      : (snapshot.inventory.files !== 0 || snapshot.inventory.bytes !== 0
-        || snapshot.inventory.sha256 !== createHash("sha256").digest("hex"))) {
+    const emptyResident = snapshot.providerExecution === "completed"
+      && snapshot.inventory.files === 0 && snapshot.inventory.bytes === 0
+      && snapshot.inventory.sha256 === createHash("sha256").digest("hex");
+    const exactBounded = flux && snapshot.inventory.files === 494
+      && snapshot.inventory.bytes >= payloadFloor
+      && snapshot.inventory.bytes <= payloadCeiling;
+    const expectedDisposition = !flux ? DERIVED_DISPOSITION_NOT_APPLICABLE
+      : emptyResident ? DERIVED_DISPOSITION_RESIDENT
+        : emptyProviderFailure ? DERIVED_DISPOSITION_PROVIDER_FAILED
+          : exactBounded ? DERIVED_DISPOSITION_BOUNDED : null;
+    if (!expectedDisposition || snapshot.derivedDisposition !== expectedDisposition
+      || (!flux && (snapshot.inventory.files !== 0 || snapshot.inventory.bytes !== 0
+        || snapshot.inventory.sha256 !== createHash("sha256").digest("hex")))) {
       fail("derived Candle sidecar lifecycle inventory drifted from the cell family contract");
     }
     previous = snapshot.ordinal;
@@ -2814,7 +2837,10 @@ export async function runCampaign(args, options = {}) {
           ) : null;
         const derivedInspection = await operations.inspectDerivedSidecarRoot(
           derivedSidecarRoot, expectedNamespace,
-          { materializeExactEmpty: runtimeFailure !== null && expectedNamespace !== null },
+          {
+            materializeExactEmpty: runtimeFailure !== null && expectedNamespace !== null,
+            allowExactEmpty: runtimeFailure === null && expectedNamespace !== null,
+          },
         );
         if (fluxArtifacts.length === 1) {
           sharedArtifacts.get(fluxArtifacts[0]).derivedNamespaces.splice(
@@ -2835,21 +2861,38 @@ export async function runCampaign(args, options = {}) {
           const bytes = inventories.reduce((sum, inventory) => sum + inventory.bytes, 0);
           const exactEmptyProviderFailure = runtimeFailure !== null
             && files === 0 && bytes === 0 && inventories.length === 1;
-          if (artifactId.startsWith("flux1-") && !exactEmptyProviderFailure && (files !== 494
-              || bytes < (artifactId.endsWith("-q4") ? 7_396_392_960 : 12_573_868_032)
-              || bytes > (artifactId.endsWith("-q4")
-                ? FLUX_Q4_SIDECAR_BYTES : FLUX_Q8_SIDECAR_BYTES))) {
+          const exactResident = runtimeFailure === null
+            && files === 0 && bytes === 0 && inventories.length === 0;
+          const exactBounded = files === 494
+            && bytes >= (artifactId.endsWith("-q4") ? 7_396_392_960 : 12_573_868_032)
+            && bytes <= (artifactId.endsWith("-q4")
+              ? FLUX_Q4_SIDECAR_BYTES : FLUX_Q8_SIDECAR_BYTES)
+            && inventories.length === 1;
+          const derivedDisposition = artifactId.startsWith("flux1-")
+            ? exactResident ? DERIVED_DISPOSITION_RESIDENT
+              : exactEmptyProviderFailure ? DERIVED_DISPOSITION_PROVIDER_FAILED
+                : exactBounded ? DERIVED_DISPOSITION_BOUNDED : null
+            : DERIVED_DISPOSITION_NOT_APPLICABLE;
+          if (artifactId.startsWith("flux1-") && !derivedDisposition) {
             fail(`FLUX derived-sidecar contract drifted for ${artifactId}: ${files} files/${bytes} bytes`);
           }
-          if (!artifactId.startsWith("flux1-") && (files !== 0 || bytes !== 0)) {
+          if (!artifactId.startsWith("flux1-") && (files !== 0 || bytes !== 0
+              || inventories.length !== 0)) {
             fail(`non-FLUX authority unexpectedly created derived sidecars: ${artifactId}`);
           }
-          lifecycle.derivedAfter.push({ artifactId, files, bytes, inventories });
+          lifecycle.derivedAfter.push({
+            artifactId, derivedDisposition, files, bytes, inventories,
+          });
         }
+        const derivedDisposition = fluxArtifacts.length === 0
+          ? DERIVED_DISPOSITION_NOT_APPLICABLE
+          : lifecycle.derivedAfter.find((entry) => entry.artifactId === fluxArtifacts[0])
+            ?.derivedDisposition;
         derivedSidecarLifecycle.afterCells.push({
           ordinal: index + 1,
           cellId: cell.id,
           providerExecution: lifecycle.providerExecution,
+          derivedDisposition,
           inventory: derivedInspection.rootInventory,
         });
       } catch (error) {

--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -61,6 +61,9 @@ const DERIVED_DISPOSITION_NOT_APPLICABLE = "not-applicable";
 const DERIVED_DISPOSITION_RESIDENT = "resident-empty";
 const DERIVED_DISPOSITION_BOUNDED = "bounded-transformer-sidecars";
 const DERIVED_DISPOSITION_PROVIDER_FAILED = "provider-failed-empty";
+const REQUEST_MEMORY_STRATEGY_KEYS = [
+  "requestMemoryPresent", "stageResidency", "strategy", "streamTransformerBlocks",
+];
 const REVIEWED_DOWNLOAD_EVIDENCE_SHA256 = "9eda09eeacb9386167ca4a080b4805b9c7dd3cd5134ca037ce342ad434b17e0b";
 
 function fail(message) {
@@ -282,7 +285,48 @@ export function validateRuntimeResult(runtimeResult, cell) {
     || runtimeResult.loadSpecQuantBits !== expectedQuant) {
     fail(`${cell.id} runtime result did not prove family loadSpecQuantBits=${expectedQuant}`);
   }
+  validateRequestMemoryStrategy(runtimeResult.requestMemoryStrategy, cell);
   return runtimeResult;
+}
+
+function validateRequestMemoryStrategy(strategy, cell) {
+  object(strategy, `${cell.id} request memory strategy`);
+  if (JSON.stringify(Object.keys(strategy).sort()) !== JSON.stringify(REQUEST_MEMORY_STRATEGY_KEYS)) {
+    fail(`${cell.id} request memory strategy is not a closed exact record`);
+  }
+  const isFlux = cell.kind === "image"
+    && new Set(["flux1_dev", "flux1_schnell"]).has(cell.engineId);
+  const booleans = typeof strategy.requestMemoryPresent === "boolean"
+    && typeof strategy.stageResidency === "boolean"
+    && typeof strategy.streamTransformerBlocks === "boolean";
+  if (!booleans) fail(`${cell.id} request memory strategy booleans are missing or malformed`);
+  if (!isFlux) {
+    if (strategy.strategy !== "not-applicable" || strategy.requestMemoryPresent
+      || strategy.stageResidency || strategy.streamTransformerBlocks) {
+      fail(`${cell.id} non-FLUX request memory strategy is not exact not-applicable`);
+    }
+    return strategy;
+  }
+  const exact = (name, present, stage, stream) => strategy.strategy === name
+    && strategy.requestMemoryPresent === present
+    && strategy.stageResidency === stage
+    && strategy.streamTransformerBlocks === stream;
+  if (exact("default-resident", false, false, false)
+    || exact("explicit-resident", true, false, false)
+    || exact("staged-resident", true, true, false)
+    || (strategy.strategy === "bounded-transformer" && strategy.requestMemoryPresent
+      && strategy.streamTransformerBlocks)) {
+    return strategy;
+  }
+  fail(`${cell.id} FLUX request memory strategy is not an exact supported policy`);
+}
+
+function dispositionForMemoryStrategy(strategy) {
+  if (strategy.strategy === "not-applicable") return DERIVED_DISPOSITION_NOT_APPLICABLE;
+  if (strategy.strategy === "bounded-transformer") return DERIVED_DISPOSITION_BOUNDED;
+  if (new Set(["default-resident", "explicit-resident", "staged-resident"])
+    .has(strategy.strategy)) return DERIVED_DISPOSITION_RESIDENT;
+  fail(`unreviewed request memory strategy ${strategy.strategy}`);
 }
 
 export function loadProfile(profilePath = PROFILE_PATH) {
@@ -958,6 +1002,13 @@ function validateReceiptInternal(
       || (lifecycle.providerExecution === "failed" && receipt.status !== "failed")) {
       fail("receipt provider execution state drifted from its outcome evidence");
     }
+    let expectedSuccessDisposition = null;
+    if (lifecycle.providerExecution === "completed") {
+      validateRequestMemoryStrategy(lifecycle.requestMemoryStrategy, expectedCell);
+      expectedSuccessDisposition = dispositionForMemoryStrategy(lifecycle.requestMemoryStrategy);
+    } else if (lifecycle.requestMemoryStrategy !== null) {
+      fail("receipt without completed provider execution cannot claim a request memory strategy");
+    }
     for (const derived of lifecycle.derivedAfter) {
       const isFlux = derived.artifactId.startsWith("flux1-");
       const payloadFloor = derived.artifactId.endsWith("-q4")
@@ -976,9 +1027,12 @@ function validateReceiptInternal(
           && derived.inventories[0].files === 0 && derived.inventories[0].bytes === 0
           && derived.inventories[0].sha256 === createHash("sha256").digest("hex");
         const exactResident = lifecycle.providerExecution === "completed"
+          && expectedSuccessDisposition === DERIVED_DISPOSITION_RESIDENT
           && derived.files === 0 && derived.bytes === 0 && derived.inventories.length === 0
           && staged?.derivedNamespaces.length === 0;
-        const exactComplete = derived.files === 494 && derived.bytes >= payloadFloor
+        const exactComplete = lifecycle.providerExecution === "completed"
+          && expectedSuccessDisposition === DERIVED_DISPOSITION_BOUNDED
+          && derived.files === 494 && derived.bytes >= payloadFloor
           && derived.bytes <= payloadCeiling && oneBoundNamespace;
         const expectedDisposition = exactResident ? DERIVED_DISPOSITION_RESIDENT
           : exactEmptyFailure ? DERIVED_DISPOSITION_PROVIDER_FAILED
@@ -1870,6 +1924,7 @@ function emptyAuthorityLifecycle(cell, index) {
     staged: [],
     activeArtifactIds: [...cell.artifactIds],
     providerExecution: "not-attempted",
+    requestMemoryStrategy: null,
     verifiedBefore: false,
     verifiedAfter: false,
     derivedAfter: [],
@@ -2214,10 +2269,21 @@ export function validateCachePreflightEvidence(document, {
     const emptyProviderFailure = snapshot.providerExecution === "failed"
       && snapshot.inventory.files === 0 && snapshot.inventory.bytes === 0
       && snapshot.inventory.sha256 === createHash("sha256").digest("hex");
+    let expectedSuccessDisposition = null;
+    if (snapshot.providerExecution === "completed") {
+      validateRequestMemoryStrategy(snapshot.requestMemoryStrategy, expected);
+      expectedSuccessDisposition = dispositionForMemoryStrategy(snapshot.requestMemoryStrategy);
+    } else if (snapshot.requestMemoryStrategy !== null) {
+      fail("failed provider cache lifecycle cannot claim a request memory strategy");
+    }
     const emptyResident = snapshot.providerExecution === "completed"
+      && expectedSuccessDisposition === (flux
+        ? DERIVED_DISPOSITION_RESIDENT : DERIVED_DISPOSITION_NOT_APPLICABLE)
       && snapshot.inventory.files === 0 && snapshot.inventory.bytes === 0
       && snapshot.inventory.sha256 === createHash("sha256").digest("hex");
-    const exactBounded = flux && snapshot.inventory.files === 494
+    const exactBounded = flux && snapshot.providerExecution === "completed"
+      && expectedSuccessDisposition === DERIVED_DISPOSITION_BOUNDED
+      && snapshot.inventory.files === 494
       && snapshot.inventory.bytes >= payloadFloor
       && snapshot.inventory.bytes <= payloadCeiling;
     const expectedDisposition = !flux ? DERIVED_DISPOSITION_NOT_APPLICABLE
@@ -2653,6 +2719,7 @@ export async function runCampaign(args, options = {}) {
       staged: [],
       activeArtifactIds: [...cell.artifactIds],
       providerExecution: "not-attempted",
+      requestMemoryStrategy: null,
       verifiedBefore: false,
       verifiedAfter: false,
       derivedAfter: [],
@@ -2828,6 +2895,36 @@ export async function runCampaign(args, options = {}) {
         campaignErrors.push(quarantineReason);
         throw error;
       }
+      if (runtimeFailure === null) {
+        try {
+          const runtimeResultPath = path.join(cellDir, "runtime-result.json");
+          await invokeFault(fault, "runtimeResultRead", index);
+          const linkMetadata = await lstat(runtimeResultPath);
+          if (!linkMetadata.isFile() || linkMetadata.isSymbolicLink()) {
+            fail(`runtime-result is not an ordinary non-reparse file for ${cell.id}`);
+          }
+          const before = await stat(runtimeResultPath);
+          const runtimeResultBytes = await readFile(runtimeResultPath);
+          await invokeFault(fault, "runtimeResultHash", index);
+          const rawSha256 = createHash("sha256").update(runtimeResultBytes).digest("hex");
+          const fileSha256 = await sha256File(runtimeResultPath);
+          const after = await stat(runtimeResultPath);
+          if (!before.isFile() || before.size !== runtimeResultBytes.length
+            || after.size !== before.size || rawSha256 !== fileSha256) {
+            fail(`runtime-result file/hash changed while validating ${cell.id}`);
+          }
+          await invokeFault(fault, "runtimeResultParse", index);
+          const runtimeResult = JSON.parse(runtimeResultBytes.toString("utf8"));
+          await invokeFault(fault, "runtimeResultSemantic", index);
+          validateRuntimeResult(runtimeResult, cell);
+          receipt.cell.loadSpecQuantBits = runtimeResult.loadSpecQuantBits;
+          lifecycle.requestMemoryStrategy = structuredClone(runtimeResult.requestMemoryStrategy);
+        } catch (error) {
+          quarantineReason = `runtime-result evidence failed after cell ${cell.id}: ${errorText(error)}`;
+          campaignErrors.push(quarantineReason);
+          throw error;
+        }
+      }
       try {
         const fluxArtifacts = cell.artifactIds.filter((artifactId) => artifactId.startsWith("flux1-"));
         if (fluxArtifacts.length > 1) fail(`cell ${cell.id} has multiple FLUX sidecar authorities`);
@@ -2862,8 +2959,13 @@ export async function runCampaign(args, options = {}) {
           const exactEmptyProviderFailure = runtimeFailure !== null
             && files === 0 && bytes === 0 && inventories.length === 1;
           const exactResident = runtimeFailure === null
+            && dispositionForMemoryStrategy(lifecycle.requestMemoryStrategy)
+              === DERIVED_DISPOSITION_RESIDENT
             && files === 0 && bytes === 0 && inventories.length === 0;
-          const exactBounded = files === 494
+          const exactBounded = runtimeFailure === null
+            && dispositionForMemoryStrategy(lifecycle.requestMemoryStrategy)
+              === DERIVED_DISPOSITION_BOUNDED
+            && files === 494
             && bytes >= (artifactId.endsWith("-q4") ? 7_396_392_960 : 12_573_868_032)
             && bytes <= (artifactId.endsWith("-q4")
               ? FLUX_Q4_SIDECAR_BYTES : FLUX_Q8_SIDECAR_BYTES)
@@ -2892,6 +2994,7 @@ export async function runCampaign(args, options = {}) {
           ordinal: index + 1,
           cellId: cell.id,
           providerExecution: lifecycle.providerExecution,
+          requestMemoryStrategy: lifecycle.requestMemoryStrategy,
           derivedDisposition,
           inventory: derivedInspection.rootInventory,
         });
@@ -2902,34 +3005,7 @@ export async function runCampaign(args, options = {}) {
       }
       if (runtimeFailure) throw runtimeFailure;
       operations.sample(samples, errors, "post-execution VRAM sample failed");
-      try {
-        const runtimeResultPath = path.join(cellDir, "runtime-result.json");
-        await invokeFault(fault, "runtimeResultRead", index);
-        const linkMetadata = await lstat(runtimeResultPath);
-        if (!linkMetadata.isFile() || linkMetadata.isSymbolicLink()) {
-          fail(`runtime-result is not an ordinary non-reparse file for ${cell.id}`);
-        }
-        const before = await stat(runtimeResultPath);
-        const runtimeResultBytes = await readFile(runtimeResultPath);
-        await invokeFault(fault, "runtimeResultHash", index);
-        const rawSha256 = createHash("sha256").update(runtimeResultBytes).digest("hex");
-        const fileSha256 = await sha256File(runtimeResultPath);
-        const after = await stat(runtimeResultPath);
-        if (!before.isFile() || before.size !== runtimeResultBytes.length
-          || after.size !== before.size || rawSha256 !== fileSha256) {
-          fail(`runtime-result file/hash changed while validating ${cell.id}`);
-        }
-        await invokeFault(fault, "runtimeResultParse", index);
-        const runtimeResult = JSON.parse(runtimeResultBytes.toString("utf8"));
-        await invokeFault(fault, "runtimeResultSemantic", index);
-        validateRuntimeResult(runtimeResult, cell);
-        receipt.cell.loadSpecQuantBits = runtimeResult.loadSpecQuantBits;
-        executionPassed = true;
-      } catch (error) {
-        quarantineReason = `runtime-result evidence failed after cell ${cell.id}: ${errorText(error)}`;
-        campaignErrors.push(quarantineReason);
-        throw error;
-      }
+      executionPassed = true;
     } catch (error) {
       const message = recordError(errors, "cell lifecycle failed", error);
       if (!executionAttempted && !quarantineReason) {

--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -314,8 +314,7 @@ function validateRequestMemoryStrategy(strategy, cell) {
   if (exact("default-resident", false, false, false)
     || exact("explicit-resident", true, false, false)
     || exact("staged-resident", true, true, false)
-    || (strategy.strategy === "bounded-transformer" && strategy.requestMemoryPresent
-      && strategy.streamTransformerBlocks)) {
+    || exact("bounded-transformer", true, true, true)) {
     return strategy;
   }
   fail(`${cell.id} FLUX request memory strategy is not an exact supported policy`);

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -295,6 +295,20 @@ test("all 19 cells require the exact family loadSpec quant policy", () => {
       },
     };
     assert.equal(validateRuntimeResult(valid, cell), valid, cell.id);
+    if (cell.engineId.startsWith("flux1_")) {
+      const streamedWithoutStaging = structuredClone(valid);
+      streamedWithoutStaging.requestMemoryStrategy = {
+        strategy: "bounded-transformer",
+        requestMemoryPresent: true,
+        stageResidency: false,
+        streamTransformerBlocks: true,
+      };
+      assert.throws(
+        () => validateRuntimeResult(streamedWithoutStaging, cell),
+        /request memory strategy/,
+        `${cell.id} must reject streamed memory without staged residency`,
+      );
+    }
     const missing = { ...valid };
     delete missing.loadSpecQuantBits;
     assert.throws(() => validateRuntimeResult(missing, cell), /loadSpecQuantBits/, cell.id);
@@ -1313,6 +1327,11 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
             requestMemoryPresent: true,
             stageResidency: true,
             streamTransformerBlocks: false,
+          } : runtimeMemoryMode === "bounded-no-stage" ? {
+            strategy: "bounded-transformer",
+            requestMemoryPresent: true,
+            stageResidency: false,
+            streamTransformerBlocks: true,
           } : runtimeMemoryMode === "wrong" ? {
             strategy: "bounded-transformer",
             requestMemoryPresent: true,
@@ -1523,7 +1542,7 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     );
     assert.equal(faulted.cacheEvidence.offlineBeforeCells, true, runtimeResultMode);
   }
-  for (const runtimeMemoryMode of ["missing", "missing-field", "wrong"]) {
+  for (const runtimeMemoryMode of ["missing", "missing-field", "wrong", "bounded-no-stage"]) {
     const faulted = await scenario({ runtimeMemoryMode });
     assert.equal(faulted.runtimeCells.length, 1, runtimeMemoryMode);
     assert.ok(faulted.result.summary.receipts.slice(8).every(
@@ -1760,6 +1779,36 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
   assert.equal(
     bounded.cacheEvidence.derivedSidecarLifecycle.afterCells[0].derivedDisposition,
     "bounded-transformer-sidecars",
+  );
+
+  const boundedReceiptWithoutStaging = structuredClone(bounded.continuationReceipts[0]);
+  boundedReceiptWithoutStaging.authorityLifecycle.requestMemoryStrategy.stageResidency = false;
+  assert.throws(
+    () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, boundedReceiptWithoutStaging),
+    /must be equal to constant/,
+  );
+  assert.throws(
+    () => validateReceipt(
+      boundedReceiptWithoutStaging,
+      bounded.checked.cells[7],
+      bounded.checked,
+      bounded.lifecycleContext,
+    ),
+    /request memory strategy/,
+  );
+
+  const boundedCacheWithoutStaging = structuredClone(bounded.cacheEvidence);
+  boundedCacheWithoutStaging.derivedSidecarLifecycle.afterCells[0]
+    .requestMemoryStrategy.stageResidency = false;
+  assert.throws(
+    () => validateDocumentWithSchema(CACHE_PREFLIGHT_SCHEMA_PATH, boundedCacheWithoutStaging),
+    /must be equal to constant/,
+  );
+  assert.throws(
+    () => validateCachePreflightEvidence(
+      boundedCacheWithoutStaging, bounded.cacheValidation,
+    ),
+    /request memory strategy|must be equal to constant/,
   );
 
   const residentReceiptWithBoundedInventory = structuredClone(residentReceipt);

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -287,6 +287,12 @@ test("all 19 cells require the exact family loadSpec quant policy", () => {
       resolvedTier: cell.requestedTier,
       denseFallback: false,
       loadSpecQuantBits: expected,
+      requestMemoryStrategy: {
+        strategy: cell.engineId.startsWith("flux1_") ? "default-resident" : "not-applicable",
+        requestMemoryPresent: false,
+        stageResidency: false,
+        streamTransformerBlocks: false,
+      },
     };
     assert.equal(validateRuntimeResult(valid, cell), valid, cell.id);
     const missing = { ...valid };
@@ -353,11 +359,6 @@ function fixtureReceipt(status = "passed", cellIndex = 0) {
   receipt.outputs = [{ path: "runtime-result.json", bytes: 7, sha256: "7".repeat(64) }];
   receipt.logs = [{ path: "controller.log", bytes: 7, sha256: "5".repeat(64) }];
   const fluxArtifact = cell.artifactIds.find((artifactId) => artifactId.startsWith("flux1-"));
-  const fluxNamespace = fluxArtifact ? path.resolve(
-    "fixture-runner", "scratch", "derived-candle-device-cache", "candle-device-format-v1",
-    "a".repeat(64),
-  ) : null;
-  const fluxBytes = fluxArtifact?.endsWith("-q4") ? 7_396_392_960 : 12_573_868_032;
   receipt.authorityLifecycle = {
     ordinal: cellIndex + 1,
     cellId: cell.id,
@@ -369,21 +370,30 @@ function fixtureReceipt(status = "passed", cellIndex = 0) {
         files: 3, bytes: 42, sha256: "4".repeat(64),
       },
       obstructionCount: 1,
-      derivedNamespaces: [fluxNamespace],
+      derivedNamespaces: [],
     }] : [],
     activeArtifactIds: [...cell.artifactIds],
     providerExecution: "completed",
+    requestMemoryStrategy: fluxArtifact ? {
+      strategy: "default-resident",
+      requestMemoryPresent: false,
+      stageResidency: false,
+      streamTransformerBlocks: false,
+    } : {
+      strategy: "not-applicable",
+      requestMemoryPresent: false,
+      stageResidency: false,
+      streamTransformerBlocks: false,
+    },
     verifiedBefore: true,
     verifiedAfter: true,
     derivedAfter: cell.artifactIds.map((artifactId) => ({
       artifactId,
       derivedDisposition: artifactId === fluxArtifact
-        ? "bounded-transformer-sidecars" : "not-applicable",
-      files: artifactId === fluxArtifact ? 494 : 0,
-      bytes: artifactId === fluxArtifact ? fluxBytes : 0,
-      inventories: artifactId === fluxArtifact ? [{
-        root: fluxNamespace, files: 494, bytes: fluxBytes, sha256: "8".repeat(64),
-      }] : [],
+        ? "resident-empty" : "not-applicable",
+      files: 0,
+      bytes: 0,
+      inventories: [],
     })),
     released: [],
     diskProbes: [...(fluxArtifact ? [{
@@ -542,6 +552,25 @@ test("Draft 2020-12 schemas validate the profile and close adversarial receipt d
     assert.throws(
       () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, missingProviderStateFile),
       /must have required property 'providerExecution'/,
+    );
+
+    const missingRequestMemory = fixtureReceipt();
+    delete missingRequestMemory.authorityLifecycle.requestMemoryStrategy;
+    const missingRequestMemoryFile = await writeReceipt(
+      "missing-request-memory.json", missingRequestMemory,
+    );
+    assert.throws(
+      () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, missingRequestMemoryFile),
+      /must have required property 'requestMemoryStrategy'/,
+    );
+    const missingRequestMemoryField = fixtureReceipt();
+    delete missingRequestMemoryField.authorityLifecycle.requestMemoryStrategy.stageResidency;
+    const missingRequestMemoryFieldFile = await writeReceipt(
+      "missing-request-memory-field.json", missingRequestMemoryField,
+    );
+    assert.throws(
+      () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, missingRequestMemoryFieldFile),
+      /must have required property 'stageResidency'/,
     );
   } finally {
     await rm(temporary, { recursive: true, force: true });
@@ -993,8 +1022,8 @@ test("cleanup isolation failure preserves all 19 durable outcomes and quarantine
     expectedB646DerivedNamespace: async (artifact, root) => (
       path.join(root, "candle-device-format-v1", "a".repeat(64))
     ),
-    inspectDerivedSidecarRoot: async (root, expectedNamespace) => {
-      if (!expectedNamespace) return {
+    inspectDerivedSidecarRoot: async (root, expectedNamespace, options = {}) => {
+      if (!expectedNamespace || options.allowExactEmpty) return {
         rootInventory: {
           root, files: 0, bytes: 0, sha256: createHash("sha256").digest("hex"),
         },
@@ -1024,11 +1053,19 @@ test("cleanup isolation failure preserves all 19 durable outcomes and quarantine
       await writeFile(logFile, "fixture runtime\n", "utf8");
       const runtimeCell = JSON.parse(await readFile(path.join(cellDir, "cell.json"), "utf8"));
       executedCells.push(runtimeCell.id);
+      const flux = runtimeCell.kind === "image"
+        && new Set(["flux1_dev", "flux1_schnell"]).has(runtimeCell.engineId);
       await writeFile(path.join(cellDir, "runtime-result.json"), `${JSON.stringify({
         requestedTier: runtimeCell.requestedTier,
         resolvedTier: runtimeCell.requestedTier,
         denseFallback: false,
         loadSpecQuantBits: expectedLoadSpecQuantBits(runtimeCell),
+        requestMemoryStrategy: {
+          strategy: flux ? "default-resident" : "not-applicable",
+          requestMemoryPresent: false,
+          stageResidency: false,
+          streamTransformerBlocks: false,
+        },
       })}\n`, "utf8");
       await writeFile(path.join(cellDir, "output.bin"), "fixture", "utf8");
     },
@@ -1091,7 +1128,8 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     preflightFault = null, cellFault = null, omitObstructions = false,
     derivedContractDrift = null, diskFreeValues = [256 * 1024 ** 3],
     runtimeResultMode = "valid", providerRuntimeFailureAt = null,
-    providerFailureDerivedMode = "empty", successfulFluxDerivedMode = "bounded",
+    providerFailureDerivedMode = "empty", successfulFluxDerivedMode = "resident",
+    runtimeMemoryMode = "current",
   } = {}) {
     const temporary = await mkdtemp(path.join(tmpdir(), "sc-20974-preflight-"));
     const runnerTemp = path.join(temporary, "runner-temp");
@@ -1258,16 +1296,50 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
           throw new Error("fixture provider runtime failed");
         }
         if (runtimeResultMode !== "missing" || runtimeCells.length !== 1) {
+          const isFlux = runtimeCell.kind === "image"
+            && new Set(["flux1_dev", "flux1_schnell"]).has(runtimeCell.engineId);
+          const requestMemoryStrategy = !isFlux ? {
+            strategy: "not-applicable",
+            requestMemoryPresent: false,
+            stageResidency: false,
+            streamTransformerBlocks: false,
+          } : runtimeMemoryMode === "bounded" ? {
+            strategy: "bounded-transformer",
+            requestMemoryPresent: true,
+            stageResidency: true,
+            streamTransformerBlocks: true,
+          } : runtimeMemoryMode === "staged" ? {
+            strategy: "staged-resident",
+            requestMemoryPresent: true,
+            stageResidency: true,
+            streamTransformerBlocks: false,
+          } : runtimeMemoryMode === "wrong" ? {
+            strategy: "bounded-transformer",
+            requestMemoryPresent: true,
+            stageResidency: true,
+            streamTransformerBlocks: false,
+          } : {
+            strategy: "default-resident",
+            requestMemoryPresent: false,
+            stageResidency: false,
+            streamTransformerBlocks: false,
+          };
+          const runtimeResultObject = {
+            requestedTier: runtimeCell.requestedTier,
+            resolvedTier: runtimeResultMode === "wrong-semantic" && runtimeCells.length === 1
+              ? (runtimeCell.requestedTier === "q4" ? "q8" : "q4")
+              : runtimeCell.requestedTier,
+            denseFallback: false,
+            loadSpecQuantBits: expectedLoadSpecQuantBits(runtimeCell),
+            requestMemoryStrategy,
+          };
+          if (runtimeMemoryMode === "missing") delete runtimeResultObject.requestMemoryStrategy;
+          if (runtimeMemoryMode === "missing-field") {
+            delete runtimeResultObject.requestMemoryStrategy.streamTransformerBlocks;
+          }
           const runtimeResult = runtimeResultMode === "malformed" && runtimeCells.length === 1
             ? "{"
-            : `${JSON.stringify({
-              requestedTier: runtimeCell.requestedTier,
-              resolvedTier: runtimeResultMode === "wrong-semantic" && runtimeCells.length === 1
-                ? (runtimeCell.requestedTier === "q4" ? "q8" : "q4")
-                : runtimeCell.requestedTier,
-              denseFallback: false,
-              loadSpecQuantBits: expectedLoadSpecQuantBits(runtimeCell),
-            })}\n`;
+            : `${JSON.stringify(runtimeResultObject)}\n`;
           if (runtimeResultMode === "symlink" && runtimeCells.length === 1) {
             await writeFile(path.join(cellDir, "runtime-result-target.json"), runtimeResult, "utf8");
             await symlink(
@@ -1451,6 +1523,18 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     );
     assert.equal(faulted.cacheEvidence.offlineBeforeCells, true, runtimeResultMode);
   }
+  for (const runtimeMemoryMode of ["missing", "missing-field", "wrong"]) {
+    const faulted = await scenario({ runtimeMemoryMode });
+    assert.equal(faulted.runtimeCells.length, 1, runtimeMemoryMode);
+    assert.ok(faulted.result.summary.receipts.slice(8).every(
+      (outcome) => outcome.status === "failed" && outcome.receipt,
+    ), runtimeMemoryMode);
+    assert.match(
+      faulted.result.summary.campaignErrors.join("\n"),
+      /runtime-result evidence failed after cell flux1-dev-q8.*request memory strategy/,
+      runtimeMemoryMode,
+    );
+  }
   const runtimeHashFault = await scenario({ cellFault: { stage: "runtimeResultHash" } });
   assert.equal(runtimeHashFault.runtimeCells.length, 1);
   assert.ok(runtimeHashFault.result.summary.receipts.slice(8).every(
@@ -1496,6 +1580,7 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
   );
   const providerFailureReceipt = providerFailed.continuationReceipts[0];
   assert.equal(providerFailureReceipt.authorityLifecycle.providerExecution, "failed");
+  assert.equal(providerFailureReceipt.authorityLifecycle.requestMemoryStrategy, null);
   assert.equal(
     providerFailureReceipt.authorityLifecycle.derivedAfter[0].derivedDisposition,
     "provider-failed-empty",
@@ -1505,8 +1590,18 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
   assert.equal(providerFailureReceipt.authorityLifecycle.staged[0].derivedNamespaces.length, 1);
   assert.equal(providerFailureReceipt.authorityLifecycle.released[0].derivedRemoved, true);
   assert.equal(providerFailed.cacheEvidence.derivedSidecarLifecycle.afterCells[0].providerExecution, "failed");
+  assert.equal(
+    providerFailed.cacheEvidence.derivedSidecarLifecycle.afterCells[0].requestMemoryStrategy,
+    null,
+  );
   const forgedCompletedProvider = structuredClone(providerFailureReceipt);
   forgedCompletedProvider.authorityLifecycle.providerExecution = "completed";
+  forgedCompletedProvider.authorityLifecycle.requestMemoryStrategy = {
+    strategy: "default-resident",
+    requestMemoryPresent: false,
+    stageResidency: false,
+    streamTransformerBlocks: false,
+  };
   assert.throws(
     () => validateReceipt(
       forgedCompletedProvider,
@@ -1595,11 +1690,17 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
   assert.equal(passed.runtimeCells.length, 12, passed.result.summary.campaignErrors.join("\n"));
   assert.equal(
     passed.continuationReceipts[0].authorityLifecycle.derivedAfter[0].derivedDisposition,
-    "bounded-transformer-sidecars",
+    "resident-empty",
   );
   assert.equal(
     passed.cacheEvidence.derivedSidecarLifecycle.afterCells[0].derivedDisposition,
-    "bounded-transformer-sidecars",
+    "resident-empty",
+  );
+  const missingCacheRequestMemory = structuredClone(passed.cacheEvidence);
+  delete missingCacheRequestMemory.derivedSidecarLifecycle.afterCells[0].requestMemoryStrategy;
+  assert.throws(
+    () => validateDocumentWithSchema(CACHE_PREFLIGHT_SCHEMA_PATH, missingCacheRequestMemory),
+    /required property 'requestMemoryStrategy'/,
   );
   assert.ok(
     passed.events.indexOf("execute:flux1-dev-q8")
@@ -1635,13 +1736,7 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
   assert.equal(passed.result.summary.finalAuthorityLifecycle.derived.files, 0);
   assert.equal(passed.result.summary.finalAuthorityLifecycle.missingStoreAbsent, true);
 
-  const resident = await scenario({ successfulFluxDerivedMode: "resident" });
-  assert.equal(resident.runtimeCells.length, 12, resident.result.summary.campaignErrors.join("\n"));
-  assert.equal(resident.result.summary.failed, 0);
-  assert.equal(resident.result.summary.passed, 19);
-  assert.equal(resident.runtimeCells[1].id, "flux1-schnell-q4");
-  const residentReceipt = resident.continuationReceipts[0];
-  assert.equal(residentReceipt.authorityLifecycle.providerExecution, "completed");
+  const residentReceipt = passed.continuationReceipts[0];
   assert.equal(
     residentReceipt.authorityLifecycle.derivedAfter[0].derivedDisposition,
     "resident-empty",
@@ -1650,8 +1745,92 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
   assert.equal(residentReceipt.authorityLifecycle.derivedAfter[0].inventories.length, 0);
   assert.equal(residentReceipt.authorityLifecycle.staged[0].derivedNamespaces.length, 0);
   assert.equal(residentReceipt.authorityLifecycle.released[0].derivedRemoved, true);
+
+  const bounded = await scenario({
+    successfulFluxDerivedMode: "bounded", runtimeMemoryMode: "bounded",
+  });
+  assert.equal(bounded.runtimeCells.length, 12, bounded.result.summary.campaignErrors.join("\n"));
+  assert.equal(bounded.result.summary.failed, 0);
+  assert.equal(bounded.result.summary.passed, 19);
+  assert.equal(bounded.runtimeCells[1].id, "flux1-schnell-q4");
   assert.equal(
-    resident.cacheEvidence.derivedSidecarLifecycle.afterCells[0].derivedDisposition,
+    bounded.continuationReceipts[0].authorityLifecycle.derivedAfter[0].derivedDisposition,
+    "bounded-transformer-sidecars",
+  );
+  assert.equal(
+    bounded.cacheEvidence.derivedSidecarLifecycle.afterCells[0].derivedDisposition,
+    "bounded-transformer-sidecars",
+  );
+
+  const residentReceiptWithBoundedInventory = structuredClone(residentReceipt);
+  residentReceiptWithBoundedInventory.authorityLifecycle.staged[0].derivedNamespaces =
+    structuredClone(bounded.continuationReceipts[0].authorityLifecycle.staged[0].derivedNamespaces);
+  residentReceiptWithBoundedInventory.authorityLifecycle.derivedAfter =
+    structuredClone(bounded.continuationReceipts[0].authorityLifecycle.derivedAfter);
+  assert.throws(
+    () => validateReceipt(
+      residentReceiptWithBoundedInventory,
+      passed.checked.cells[7],
+      passed.checked,
+      passed.lifecycleContext,
+    ),
+    /neither exact resident-empty nor one exact bounded/,
+  );
+  const boundedReceiptWithEmptyInventory = structuredClone(bounded.continuationReceipts[0]);
+  boundedReceiptWithEmptyInventory.authorityLifecycle.staged[0].derivedNamespaces = [];
+  boundedReceiptWithEmptyInventory.authorityLifecycle.derivedAfter =
+    structuredClone(residentReceipt.authorityLifecycle.derivedAfter);
+  assert.throws(
+    () => validateReceipt(
+      boundedReceiptWithEmptyInventory,
+      bounded.checked.cells[7],
+      bounded.checked,
+      bounded.lifecycleContext,
+    ),
+    /neither exact resident-empty nor one exact bounded/,
+  );
+
+  const residentCacheWithBoundedInventory = structuredClone(passed.cacheEvidence);
+  Object.assign(residentCacheWithBoundedInventory.derivedSidecarLifecycle.afterCells[0], {
+    derivedDisposition: "bounded-transformer-sidecars",
+    inventory: {
+      ...residentCacheWithBoundedInventory.derivedSidecarLifecycle.afterCells[0].inventory,
+      files: 494,
+      bytes: 12_573_868_032,
+      sha256: "8".repeat(64),
+    },
+  });
+  assert.throws(
+    () => validateCachePreflightEvidence(
+      residentCacheWithBoundedInventory, passed.cacheValidation,
+    ),
+    /derived Candle sidecar lifecycle inventory drifted/,
+  );
+  const boundedCacheWithEmptyInventory = structuredClone(bounded.cacheEvidence);
+  Object.assign(boundedCacheWithEmptyInventory.derivedSidecarLifecycle.afterCells[0], {
+    derivedDisposition: "resident-empty",
+    inventory: {
+      ...boundedCacheWithEmptyInventory.derivedSidecarLifecycle.afterCells[0].inventory,
+      files: 0,
+      bytes: 0,
+      sha256: createHash("sha256").digest("hex"),
+    },
+  });
+  assert.throws(
+    () => validateCachePreflightEvidence(
+      boundedCacheWithEmptyInventory, bounded.cacheValidation,
+    ),
+    /derived Candle sidecar lifecycle inventory drifted/,
+  );
+
+  const stagedResident = await scenario({ runtimeMemoryMode: "staged" });
+  assert.equal(stagedResident.runtimeCells.length, 12);
+  assert.equal(
+    stagedResident.continuationReceipts[0].authorityLifecycle.requestMemoryStrategy.strategy,
+    "staged-resident",
+  );
+  assert.equal(
+    stagedResident.continuationReceipts[0].authorityLifecycle.derivedAfter[0].derivedDisposition,
     "resident-empty",
   );
 
@@ -1816,7 +1995,11 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     { files: 493, bytes: 12_573_868_032 },
     { files: 494, bytes: 12_573_868_032 + 494 * 16_384 + 1 },
   ]) {
-    const derivedFault = await scenario({ derivedContractDrift: drift });
+    const derivedFault = await scenario({
+      derivedContractDrift: drift,
+      successfulFluxDerivedMode: "bounded",
+      runtimeMemoryMode: "bounded",
+    });
     assert.equal(derivedFault.runtimeCells.length, 1);
     assert.match(
       derivedFault.result.summary.campaignErrors.join("\n"),
@@ -1835,6 +2018,21 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
   assert.ok(strayDerived.result.summary.receipts.slice(8).every(
     (outcome) => outcome.status === "failed" && outcome.receipt,
   ));
+  for (const [label, options] of [
+    ["resident-with-sidecars", { successfulFluxDerivedMode: "bounded" }],
+    ["bounded-with-empty", { runtimeMemoryMode: "bounded" }],
+  ]) {
+    const mismatch = await scenario(options);
+    assert.equal(mismatch.runtimeCells.length, 1, label);
+    assert.match(
+      mismatch.result.summary.campaignErrors.join("\n"),
+      /derived Candle sidecar evidence failed.*FLUX derived-sidecar contract drifted/,
+      label,
+    );
+    assert.ok(mismatch.result.summary.receipts.slice(8).every(
+      (outcome) => outcome.status === "failed" && outcome.receipt,
+    ), label);
+  }
 });
 
 test("schemas, clean Node dependencies, and workflow preserve the opt-in single-job terminal contract", async () => {

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -377,6 +377,8 @@ function fixtureReceipt(status = "passed", cellIndex = 0) {
     verifiedAfter: true,
     derivedAfter: cell.artifactIds.map((artifactId) => ({
       artifactId,
+      derivedDisposition: artifactId === fluxArtifact
+        ? "bounded-transformer-sidecars" : "not-applicable",
       files: artifactId === fluxArtifact ? 494 : 0,
       bytes: artifactId === fluxArtifact ? fluxBytes : 0,
       inventories: artifactId === fluxArtifact ? [{
@@ -885,6 +887,11 @@ test("b646 derived sidecars occupy one exact canonical namespace with no global 
     };
     const expected = await expectedB646DerivedNamespace(artifact, derived);
     assert.match(path.basename(expected), /^[0-9a-f]{64}$/);
+    const resident = await inspectDerivedSidecarRoot(
+      derived, expected, { allowExactEmpty: true },
+    );
+    assert.equal(resident.namespaces.length, 0);
+    assert.equal(resident.rootInventory.files, 0);
     const empty = await inspectDerivedSidecarRoot(
       derived, expected, { materializeExactEmpty: true },
     );
@@ -1084,7 +1091,7 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     preflightFault = null, cellFault = null, omitObstructions = false,
     derivedContractDrift = null, diskFreeValues = [256 * 1024 ** 3],
     runtimeResultMode = "valid", providerRuntimeFailureAt = null,
-    providerFailureDerivedMode = "empty",
+    providerFailureDerivedMode = "empty", successfulFluxDerivedMode = "bounded",
   } = {}) {
     const temporary = await mkdtemp(path.join(tmpdir(), "sc-20974-preflight-"));
     const runnerTemp = path.join(temporary, "runner-temp");
@@ -1201,9 +1208,21 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
         };
         const id = runtimeCells.at(-1)?.id;
         assert.ok(id?.startsWith("flux1-"));
-        await mkdir(expectedNamespace, { recursive: true });
         const providerFailed = id === providerRuntimeFailureAt;
         if (providerFailed) assert.equal(options.materializeExactEmpty, true);
+        if (!providerFailed && successfulFluxDerivedMode === "resident") {
+          assert.equal(options.allowExactEmpty, true);
+          return {
+            rootInventory: {
+              root, files: 0, bytes: 0, sha256: createHash("sha256").digest("hex"),
+            },
+            namespaces: [],
+          };
+        }
+        if (!providerFailed && successfulFluxDerivedMode === "stray") {
+          throw new Error("fixture FLUX derived sidecar root has stray files");
+        }
+        await mkdir(expectedNamespace, { recursive: true });
         const bytes = id.endsWith("q4") ? 7_396_392_960 : 12_573_868_032;
         const inventory = {
           root: expectedNamespace,
@@ -1477,6 +1496,10 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
   );
   const providerFailureReceipt = providerFailed.continuationReceipts[0];
   assert.equal(providerFailureReceipt.authorityLifecycle.providerExecution, "failed");
+  assert.equal(
+    providerFailureReceipt.authorityLifecycle.derivedAfter[0].derivedDisposition,
+    "provider-failed-empty",
+  );
   assert.equal(providerFailureReceipt.authorityLifecycle.derivedAfter[0].files, 0);
   assert.equal(providerFailureReceipt.authorityLifecycle.derivedAfter[0].inventories.length, 1);
   assert.equal(providerFailureReceipt.authorityLifecycle.staged[0].derivedNamespaces.length, 1);
@@ -1498,6 +1521,29 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
   assert.throws(
     () => validateDocumentWithSchema(CACHE_PREFLIGHT_SCHEMA_PATH, missingCacheProviderState),
     /required property 'providerExecution'/,
+  );
+  const missingCacheDisposition = structuredClone(providerFailed.cacheEvidence);
+  delete missingCacheDisposition.derivedSidecarLifecycle.afterCells[0].derivedDisposition;
+  assert.throws(
+    () => validateDocumentWithSchema(CACHE_PREFLIGHT_SCHEMA_PATH, missingCacheDisposition),
+    /required property 'derivedDisposition'/,
+  );
+  const missingDisposition = structuredClone(providerFailureReceipt);
+  delete missingDisposition.authorityLifecycle.derivedAfter[0].derivedDisposition;
+  assert.throws(
+    () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, missingDisposition),
+    /required property 'derivedDisposition'/,
+  );
+  const wrongDisposition = structuredClone(providerFailureReceipt);
+  wrongDisposition.authorityLifecycle.derivedAfter[0].derivedDisposition = "resident-empty";
+  assert.throws(
+    () => validateReceipt(
+      wrongDisposition,
+      providerFailed.checked.cells[7],
+      providerFailed.checked,
+      providerFailed.lifecycleContext,
+    ),
+    /FLUX derived lifecycle/,
   );
 
   const providerPartial = await scenario({
@@ -1547,6 +1593,14 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
   );
   assert.equal(passed.events.filter((event) => event.startsWith("offline:")).length, 16);
   assert.equal(passed.runtimeCells.length, 12, passed.result.summary.campaignErrors.join("\n"));
+  assert.equal(
+    passed.continuationReceipts[0].authorityLifecycle.derivedAfter[0].derivedDisposition,
+    "bounded-transformer-sidecars",
+  );
+  assert.equal(
+    passed.cacheEvidence.derivedSidecarLifecycle.afterCells[0].derivedDisposition,
+    "bounded-transformer-sidecars",
+  );
   assert.ok(
     passed.events.indexOf("execute:flux1-dev-q8")
       < passed.events.indexOf("stage:flux1-schnell-q4"),
@@ -1580,6 +1634,26 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
   assert.equal(passed.result.summary.finalAuthorityLifecycle.stage.files, 0);
   assert.equal(passed.result.summary.finalAuthorityLifecycle.derived.files, 0);
   assert.equal(passed.result.summary.finalAuthorityLifecycle.missingStoreAbsent, true);
+
+  const resident = await scenario({ successfulFluxDerivedMode: "resident" });
+  assert.equal(resident.runtimeCells.length, 12, resident.result.summary.campaignErrors.join("\n"));
+  assert.equal(resident.result.summary.failed, 0);
+  assert.equal(resident.result.summary.passed, 19);
+  assert.equal(resident.runtimeCells[1].id, "flux1-schnell-q4");
+  const residentReceipt = resident.continuationReceipts[0];
+  assert.equal(residentReceipt.authorityLifecycle.providerExecution, "completed");
+  assert.equal(
+    residentReceipt.authorityLifecycle.derivedAfter[0].derivedDisposition,
+    "resident-empty",
+  );
+  assert.equal(residentReceipt.authorityLifecycle.derivedAfter[0].files, 0);
+  assert.equal(residentReceipt.authorityLifecycle.derivedAfter[0].inventories.length, 0);
+  assert.equal(residentReceipt.authorityLifecycle.staged[0].derivedNamespaces.length, 0);
+  assert.equal(residentReceipt.authorityLifecycle.released[0].derivedRemoved, true);
+  assert.equal(
+    resident.cacheEvidence.derivedSidecarLifecycle.afterCells[0].derivedDisposition,
+    "resident-empty",
+  );
 
   const filled = await scenario({ missingId: "flux1-schnell-q8", downloadSucceeds: true });
   assert.deepEqual(
@@ -1752,6 +1826,15 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
       (outcome) => outcome.status === "failed" && outcome.receipt,
     ));
   }
+  const strayDerived = await scenario({ successfulFluxDerivedMode: "stray" });
+  assert.equal(strayDerived.runtimeCells.length, 1);
+  assert.match(
+    strayDerived.result.summary.campaignErrors.join("\n"),
+    /derived Candle sidecar evidence failed.*stray files/,
+  );
+  assert.ok(strayDerived.result.summary.receipts.slice(8).every(
+    (outcome) => outcome.status === "failed" && outcome.receipt,
+  ));
 });
 
 test("schemas, clean Node dependencies, and workflow preserve the opt-in single-job terminal contract", async () => {


### PR DESCRIPTION
## Summary
- bind terminal FLUX derived-cache evidence to the request memory strategy recorded by the runtime result
- accept resident and staged non-streaming success only with an exactly empty derived cache
- require the exact present/staged/streamed tuple and one canonical 494-file namespace for bounded-transformer success
- keep provider-failed-empty distinct and quarantine malformed, stray, multiple, cross-paired, reparse, or nonregular evidence

## Scope
This is the reviewed recovery for Shortcut sc-20974 and campaign run 32589301151. It preserves the frozen 19-cell/23-authority profile, inference pin, product gates, facts, matrices, exceptions, and memory measurements. No GPU or real-weight work was run by this PR.

## Independent review
PASS on exact immutable range `377cc11270ce464e20c0731573005683a92e79a8..49f712903b3a9b13dad23a546c927ffe2b9a8219`; no findings or scope gaps. Reviewed tree: `e85a23ed58d1f07f19ddf545f1cab1d5de006a0d`.

## Local validation
- `node scripts/epic-20738-terminal-cuda-harness.mjs check`
- `node --test scripts/epic-20738-terminal-cuda-harness.test.mjs scripts/hash-artifact-inventory.test.mjs` (21/21)
- `python -m unittest scripts/provision_epic_20738_terminal_artifact_test.py` (11/11)
- `cargo fmt --all -- --check`
- exact base/head `git diff --check`

Shortcut: https://app.shortcut.com/trefry/story/20974
Epic: https://app.shortcut.com/trefry/epic/20738