### PR TITLE
sc-21280: bind start-10 terminal cache census

### DIFF
--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -60,6 +60,13 @@ const RECOVERY_RUN_ATTEMPT = "1";
 const RECOVERY_SCENEWORKS_HEAD = "62be42127e2b4ff07321e2c369de92fc6edef526";
 const RECOVERY_REMAINING_AUTHORITIES = 14;
 const RECOVERY_REMAINING_FILES = 160;
+const RECOVERY_REMAINING_SOURCE_BYTES = 151_407_075_690;
+const RECOVERY_REMAINING_ARTIFACT_IDS = [
+  "flux1-schnell-q8", "scail2-q4", "scail2-q8", "ltx23-q8", "ltx23-gemma",
+  "sdxl-base-q4", "sdxl-openpose", "sdxl-tokenizer-l", "sdxl-tokenizer-bigg",
+  "sdxl-vae-fix", "realvisxl-q4", "realvisxl-lightning-q4", "illustrious-v1-q4",
+  "illustrious-v2-q4",
+];
 const RECOVERY_ORIGINAL_ARTIFACT_ID = "9477529627";
 const RECOVERY_ORIGINAL_ARTIFACT_NAME = "sc-20945-epic-20738-8886a9e69f26beec05688c81b414859bd102f6d0-32570707303-1";
 const RECOVERY_ORIGINAL_ARTIFACT_DIGEST = "sha256:f3164a32a485fdedd671f4e11f30038213d30a7eb2b541bda90bef30e63188f3";
@@ -2732,14 +2739,31 @@ export function validateCachePreflightEvidence(document, {
       || document.diskPlan.freeBytes < document.diskPlan.peakRequiredAdditionalBytes) {
       fail("passed cache preflight did not prove sufficient JIT disk capacity");
     }
-    if (downloadEvidenceSha256 === REVIEWED_DOWNLOAD_EVIDENCE_SHA256
-      && (document.diskPlan.logicalSourceBytes !== REVIEWED_ALL_AT_ONCE_SOURCE_BYTES
-        || document.diskPlan.allAtOnceSourceBytes !== REVIEWED_ALL_AT_ONCE_SOURCE_BYTES
-        || document.diskPlan.peakRequiredAdditionalBytes !== REVIEWED_FREE_FLOOR_BYTES
-        || (frozen.length === 1
-          ? document.diskPlan.peakModelAndSidecarBytes !== REVIEWED_JIT_SOURCE_PEAK_BYTES
-          : document.diskPlan.peakModelAndSidecarBytes > REVIEWED_JIT_SOURCE_PEAK_BYTES))) {
-      fail("passed cache preflight drifted from reviewed target-byte totals and JIT floor");
+    if (downloadEvidenceSha256 === REVIEWED_DOWNLOAD_EVIDENCE_SHA256) {
+      const startIndex = profile.cells.length - document.diskPlan.cells.length;
+      const expectedRemainingIds = [...new Set(profile.cells.slice(startIndex).flatMap(
+        (cell) => cell.artifactIds,
+      ))];
+      const expectedFileCount = expectedRemainingIds.reduce(
+        (sum, id) => sum + artifactExpectedFiles[id].length, 0,
+      );
+      const startTen = startIndex === RECOVERY_IMPORTED_PREFIX_CELLS;
+      if (JSON.stringify(remainingArtifactIds) !== JSON.stringify(expectedRemainingIds)
+        || (startTen && (JSON.stringify(expectedRemainingIds)
+          !== JSON.stringify(RECOVERY_REMAINING_ARTIFACT_IDS)
+          || expectedFileCount !== RECOVERY_REMAINING_FILES))) {
+        fail("passed cache preflight continuation start/census drifted from the reviewed profile");
+      }
+      const expectedSourceBytes = startTen
+        ? RECOVERY_REMAINING_SOURCE_BYTES : REVIEWED_ALL_AT_ONCE_SOURCE_BYTES;
+      if (document.diskPlan.reviewedAllAtOnceSourceBytes !== REVIEWED_ALL_AT_ONCE_SOURCE_BYTES
+        || document.diskPlan.reviewedJitSourcePeakBytes !== REVIEWED_JIT_SOURCE_PEAK_BYTES
+        || document.diskPlan.logicalSourceBytes !== expectedSourceBytes
+        || document.diskPlan.allAtOnceSourceBytes !== expectedSourceBytes
+        || document.diskPlan.peakModelAndSidecarBytes !== REVIEWED_JIT_SOURCE_PEAK_BYTES
+        || document.diskPlan.peakRequiredAdditionalBytes !== REVIEWED_FREE_FLOOR_BYTES) {
+        fail("passed cache preflight drifted from reviewed target-byte totals and JIT floor");
+      }
     }
     if (document.evidencePhase === "initial") {
       if (document.phases.staging.length || document.phases.finalOffline.length

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -1033,6 +1033,102 @@ test("recovery continuation imports only audited PASS cells and rejects ambiguit
   }
 });
 
+test("start-10 cache preflight binds the reviewed remaining census without weakening global references", async () => {
+  const temporary = await mkdtemp(path.join(tmpdir(), "sc-21280-start10-census-"));
+  try {
+    const fixture = await writeRecoveryCandidate(temporary);
+    const initial = JSON.parse(await readFile(path.join(fixture.evidence, "cache-preflight-initial.json"), "utf8"));
+    const checked = profile();
+    const ids = [...new Set(checked.cells.slice(9).flatMap((cell) => cell.artifactIds))];
+    const sourceCensus = initial.phases.sourceCensus.filter((row) => ids.includes(row.id));
+    const plannedAudits = new Map(sourceCensus.map((row) => [row.id, {
+      ...row,
+      downloadedFiles: initial.downloadedFiles.filter((file) => file.artifactId === row.id).map(
+        ({ artifactId, ...file }) => file,
+      ),
+    }]));
+    const lifetimePlan = authorityLifetimePlan(checked, 9, plannedAudits);
+    const diskPlan = estimateJitDiskPlan(
+      lifetimePlan, initial.diskPlan.freeBytes,
+      initial.downloadedFiles.reduce((sum, file) => sum + file.bytes, 0),
+      initial.diskPlan.nonModelPaths,
+    );
+    const startTen = {
+      ...initial,
+      expectedArtifactIds: ids,
+      phases: { ...initial.phases, sourceCensus },
+      reusedFiles: sourceCensus.flatMap((row) => row.reusedFiles.map(
+        (file) => ({ artifactId: row.id, ...file }),
+      )),
+      frozenMissingFiles: sourceCensus.flatMap((row) => row.missingFiles.map((file) => ({
+        artifactId: row.id, repository: row.repository, revision: row.revision, file,
+      }))),
+      lifetimePlan,
+      diskPlan,
+    };
+    const validation = {
+      remainingArtifactIds: ids,
+      artifactExpectedFiles: Object.fromEntries(sourceCensus.map((row) => [row.id, row.expectedFiles])),
+      downloadEvidenceSha256: startTen.downloadEvidenceSha256,
+      guard: { cacheRoot: startTen.sourceCacheRoot },
+      stagingRoot: startTen.campaignStagingRoot,
+      derivedSidecarRoot: startTen.derivedSidecarRoot,
+      missingStore: startTen.missingFileStore,
+      expectedNonModelPaths: startTen.diskPlan.nonModelPaths,
+      profile: checked,
+    };
+    assert.equal(startTen.diskPlan.cells.length, 10);
+    assert.equal(startTen.diskPlan.logicalSourceBytes, 151_407_075_690);
+    assert.equal(startTen.diskPlan.allAtOnceSourceBytes, 151_407_075_690);
+    assert.equal(startTen.diskPlan.reviewedAllAtOnceSourceBytes, 179_028_698_264);
+    assert.equal(startTen.diskPlan.peakModelAndSidecarBytes, 56_156_615_634);
+    assert.equal(startTen.diskPlan.peakRequiredAdditionalBytes, 99_106_288_594);
+    assert.doesNotThrow(() => validateCachePreflightEvidence(startTen, validation));
+
+    const shiftedIds = [...new Set(checked.cells.slice(10).flatMap((cell) => cell.artifactIds))];
+    const shiftedCensus = sourceCensus.filter((row) => shiftedIds.includes(row.id));
+    const shiftedAudits = new Map(shiftedCensus.map((row) => [row.id, {
+      ...row, downloadedFiles: [],
+    }]));
+    const shifted = structuredClone(startTen);
+    shifted.expectedArtifactIds = shiftedIds;
+    shifted.phases.sourceCensus = shiftedCensus;
+    shifted.reusedFiles = shiftedCensus.flatMap((row) => row.reusedFiles.map(
+      (file) => ({ artifactId: row.id, ...file }),
+    ));
+    shifted.frozenMissingFiles = [];
+    shifted.downloadedFiles = [];
+    shifted.networkDownloadCount = 0;
+    shifted.lifetimePlan = authorityLifetimePlan(checked, 10, shiftedAudits);
+    shifted.diskPlan = estimateJitDiskPlan(
+      shifted.lifetimePlan, initial.diskPlan.freeBytes, 0, initial.diskPlan.nonModelPaths,
+    );
+    const shiftedValidation = {
+      ...validation,
+      remainingArtifactIds: shiftedIds,
+      artifactExpectedFiles: Object.fromEntries(shiftedCensus.map((row) => [row.id, row.expectedFiles])),
+    };
+    assert.throws(
+      () => validateCachePreflightEvidence(shifted, shiftedValidation),
+      /target-byte totals/,
+      "a forged later start cannot repurpose the reviewed start-10 total",
+    );
+
+    for (const [label, mutate, pattern] of [
+      ["census", (value) => { value.phases.sourceCensus.reverse(); }, /top-level hit\/download partition|omitted sourceCensus|start\/census/],
+      ["total", (value) => { value.diskPlan.logicalSourceBytes += 1; }, /disk plan|target-byte totals/],
+      ["peak", (value) => { value.diskPlan.peakModelAndSidecarBytes -= 1; }, /disk plan|target-byte totals/],
+      ["floor", (value) => { value.diskPlan.peakRequiredAdditionalBytes -= 1; }, /disk plan|target-byte totals/],
+    ]) {
+      const drifted = structuredClone(startTen);
+      mutate(drifted);
+      assert.throws(() => validateCachePreflightEvidence(drifted, validation), pattern, label);
+    }
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+});
+
 test("prefix discovery accepts exactly one rehashed contiguous old-profile PASS prefix", async () => {
   const temporary = await mkdtemp(path.join(tmpdir(), "sc-20945-prefix-"));
   try {


### PR DESCRIPTION
Closes sc-21280. Binds the audited start-10 continuation to the exact ordered 14-authority, 160-file, 151,407,075,690-byte remaining census while preserving the 179,028,698,264-byte global reference, 56,156,615,634-byte JIT peak, and 99,106,288,594-byte floor. Adds direct validator regressions for forged later starts and census/total/peak/floor drift. Non-GPU validation: 25 harness and inventory tests, 11 provisioning tests, 71 platform contracts, frozen profile check, and clean adversarial review.