### PR TITLE
fix: hydrate reviewed terminal authorities (sc-21306)

### DIFF
--- a/config/terminal-evidence/epic-20738-cache-preflight.schema.json
+++ b/config/terminal-evidence/epic-20738-cache-preflight.schema.json
@@ -31,7 +31,7 @@
     "sidecarObstructions": { "type": "array", "items": { "$ref": "#/$defs/obstruction" } },
     "reusedFiles": { "type": "array", "items": { "$ref": "#/$defs/artifactFile" } },
     "downloadedFiles": { "type": "array", "items": { "$ref": "#/$defs/downloadedArtifactFile" } },
-    "networkDownloadCount": { "type": "integer", "minimum": 0, "maximum": 1 },
+    "networkDownloadCount": { "type": "integer", "minimum": 0, "maximum": 39 },
     "phases": {
       "type": "object",
       "additionalProperties": false,

--- a/config/terminal-evidence/epic-20738-cache-preflight.schema.json
+++ b/config/terminal-evidence/epic-20738-cache-preflight.schema.json
@@ -333,7 +333,8 @@
       "required": [
         "freeBytes", "persistentMissingBytes", "nonModelReserveBytes", "nonModelPaths",
         "legacyNaiveLinkLengthSourceBytes", "reviewedAllAtOnceSourceBytes",
-        "reviewedJitSourcePeakBytes", "logicalSourceBytes", "allAtOnceSourceBytes",
+        "preHydrationJitSourcePeakBytes", "reviewedJitSourcePeakBytes",
+        "logicalSourceBytes", "allAtOnceSourceBytes",
         "allAtOnceRequiredBytes", "peakOrdinal", "peakArtifactIds", "peakStagedBytes",
         "peakSidecarReserveBytes", "peakModelAndSidecarBytes", "peakRequiredAdditionalBytes", "admitted", "cells"
       ],
@@ -356,6 +357,7 @@
         },
         "legacyNaiveLinkLengthSourceBytes": { "type": "integer", "minimum": 1 },
         "reviewedAllAtOnceSourceBytes": { "type": "integer", "minimum": 1 },
+        "preHydrationJitSourcePeakBytes": { "type": "integer", "minimum": 1 },
         "reviewedJitSourcePeakBytes": { "type": "integer", "minimum": 1 },
         "logicalSourceBytes": { "type": "integer", "minimum": 1 },
         "allAtOnceSourceBytes": { "type": "integer", "minimum": 1 },

--- a/docs/epic-20738-terminal-cuda.md
+++ b/docs/epic-20738-terminal-cuda.md
@@ -91,11 +91,16 @@ Authorities are copied just in time into campaign-owned staging under `RUNNER_TE
 before their first selected consumer, and are retained only through their exact last selected
 consumer. The LTX q8/Gemma pair is staged together for cell 14. The four shared SDXL helpers live
 across sparse cells 18-19 while the two Illustrious primaries rotate after one cell. Existing valid
-files are never overwritten or downloaded. Because Schnell is outside this sparse scope, any missing
-file fails preflight; the campaign performs zero network downloads and forces offline mode before
-the first selected cell. LTX q8 and Gemma use the complete production-approved cached parent revision
-`254989c3ca7ee691187647f350b112c0c448789d`, not the absent current revision. Network mode stays
-offline for every JIT stage and cell.
+files are never overwritten or downloaded. The exact current Illustrious v1/v2 q4 snapshots may be
+fully or partially absent: their frozen 19-file inventories are the only sparse authorities approved
+for hydration. Every present file must match its reviewed size and SHA-256, and every missing file is
+downloaded by exact repository, revision, path, size, and content SHA (plus LFS SHA where applicable)
+into the isolated campaign store.
+Unexpected entries, old revisions, file-list/evidence drift, corrupt bytes, and unsafe links fail the
+source census before transfer. LTX q8 and Gemma use the complete production-approved cached parent
+revision `254989c3ca7ee691187647f350b112c0c448789d`, not the absent current revision. Network mode
+stays offline after the reviewed fill, for every JIT stage and cell; the combined staged authority is
+audited again without weakening the post-download byte checks.
 
 The disk admission model binds exact source bytes, the conservative streamed-FLUX sidecar ceilings
 (494 files; q8 12,573,868,032 bytes and q4 7,396,392,960 bytes, each with at most 16 KiB per-file

--- a/docs/epic-20738-terminal-cuda.md
+++ b/docs/epic-20738-terminal-cuda.md
@@ -106,10 +106,13 @@ The disk admission model binds exact source bytes, the conservative streamed-FLU
 (494 files; q8 12,573,868,032 bytes and q4 7,396,392,960 bytes, each with at most 16 KiB per-file
 reserve), and a
 40-GiB non-model reserve for Cargo target, output, the pinned venv, logs, and filesystem fluctuation.
-The largest model-plus-sidecar live set is therefore the LTX pair itself at
-56,156,615,634 bytes, so the controller requires at least 99,106,288,594 free bytes. It checks that
-floor after the missing-file fill, before every authority stage, and before every GPU process. The
-former all-at-once plan is deterministically refused.
+Before hydration, the largest model-plus-sidecar live set is the LTX pair at 56,156,615,634 bytes.
+A fully absent pair of current Illustrious q4 snapshots adds 3,911,656,986 and 3,911,656,662
+persistent bytes before ordinal 14, producing the reviewed 63,979,929,282-byte physical peak. With
+the 40-GiB reserve, the controller therefore requires at least 106,929,602,242 free bytes. It checks
+that floor after the missing-file fill, before every authority stage, and before every GPU process.
+Each downloaded authority store becomes that authority's stage root and is released at its exact
+ordinal-18/19 lifetime boundary. The former all-at-once plan is deterministically refused.
 
 Output and scratch must be fresh, distinct, non-nested descendants of the resolved `RUNNER_TEMP`,
 outside both repositories. Every recursive removal rechecks that confinement and rejects

--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -61,9 +61,16 @@ const ILLUSTRIOUS_CURRENT_AUTHORITIES = new Map([
   ["illustrious-v1-q4", "778c3f02b7703b0c2755d0c0447592897193c6b5"],
   ["illustrious-v2-q4", "672e9851ede4dc856fa945649b6691975c9d74a3"],
 ]);
+const REVIEWED_FLUX_MISSING = {
+  artifactId: "flux1-schnell-q8",
+  repository: "SceneWorks/flux1-schnell-mlx",
+  revision: "bba3ae01dfd94089f173c05edd4e1a4c551f2599",
+  file: "q8/transformer/model.safetensors",
+};
 const ILLUSTRIOUS_Q4_MARKER = {
   bits: 4, groupSize: 64, components: ["text_encoder", "text_encoder_2", "unet"],
 };
+const ILLUSTRIOUS_Q4_FILE_LIST_SHA256 = "13ff6afbd67d66ae25a7e6eaa88f8f3313d9d1694ea482845c2995b0ffe44a59";
 const IMPORTED_PREFIX_CELLS = 7;
 const RECOVERY_IMPORTED_PREFIX_CELLS = 9;
 const PREFIX_ARTIFACT = `sc-20945-epic-20738-${LEGACY_SCENEWORKS_HEAD}-`;
@@ -126,6 +133,52 @@ const REQUEST_MEMORY_STRATEGY_KEYS = [
 const CURRENT_DOWNLOAD_EVIDENCE_SHA256 = "1fa06ef39a0e2c321a4fa15fa1128c0157ba8cf22fd868ac54c6cefaec13a5ee";
 const LEGACY_DOWNLOAD_EVIDENCE_SHA256 = "9eda09eeacb9386167ca4a080b4805b9c7dd3cd5134ca037ce342ad434b17e0b";
 const SCAIL2_REFERENCE_DELTA_FLOOR = 1e-6;
+
+export function reviewedMissingDownloadPlan({
+  frozenMissing, profile, artifactExpectedFiles, downloadEvidenceSha256,
+}) {
+  const groups = new Map();
+  for (const row of frozenMissing) {
+    const group = groups.get(row.artifactId) ?? [];
+    group.push(row);
+    groups.set(row.artifactId, group);
+  }
+  const plan = [];
+  for (const [artifactId, rows] of groups) {
+    const artifact = profile.artifacts[artifactId];
+    if (!artifact) fail(`reviewed missing-file plan referenced unknown authority ${artifactId}`);
+    if (artifactId === REVIEWED_FLUX_MISSING.artifactId) {
+      if (rows.length !== 1 || JSON.stringify(rows[0]) !== JSON.stringify(REVIEWED_FLUX_MISSING)) {
+        fail("Flux hydration drifted from the sole reviewed missing file");
+      }
+    } else {
+      const revision = ILLUSTRIOUS_CURRENT_AUTHORITIES.get(artifactId);
+      const expected = artifactExpectedFiles[artifactId];
+      const prefix = "q4/";
+      const rowFiles = rows.map((row) => row.file);
+      const missingSet = new Set(rowFiles.map((file) => (
+        file.startsWith(prefix) ? file.slice(prefix.length) : file
+      )));
+      const canonicalMissing = expected?.filter((file) => missingSet.has(file)).map(
+        (file) => `${prefix}${file}`,
+      );
+      if (downloadEvidenceSha256 !== CURRENT_DOWNLOAD_EVIDENCE_SHA256
+        || artifact.revision !== revision || artifact.subdirectory !== "q4"
+        || JSON.stringify(artifact.allowPatterns) !== JSON.stringify(["q4/*"])
+        || !Array.isArray(expected)
+        || canonicalSha256(expected) !== ILLUSTRIOUS_Q4_FILE_LIST_SHA256
+        || missingSet.size !== rows.length
+        || JSON.stringify(rowFiles) !== JSON.stringify(canonicalMissing)
+        || rows.some((row) => row.repository !== artifact.repository
+          || row.revision !== revision || !row.file.startsWith(prefix)
+          || !expected.includes(row.file.slice(prefix.length)))) {
+        fail(`Illustrious hydration drifted from exact current q4 authority ${artifactId}`);
+      }
+    }
+    plan.push({ id: artifactId, missingFiles: rows.map((row) => row.file) });
+  }
+  return plan;
+}
 
 function fail(message) {
   throw new Error(message);
@@ -253,8 +306,8 @@ export function estimateJitDiskPlan(
       row.firstOrdinal <= ordinal && row.lastOrdinal >= ordinal
     ));
     const physical = new Map();
-    // The reviewed download is persistent across the preflight and earlier cells, but belongs to
-    // its authority's lifetime: it is deleted with Schnell q8 after cell 10, never charged forever.
+    // Reviewed downloads persist across preflight and earlier cells, then become their authority's
+    // stage root and are deleted at that authority's exact release boundary.
     for (const row of lifetimes) {
       if (ordinal > row.lastOrdinal) continue;
       for (const file of row.physicalFiles.filter((entry) => entry.persistent)) {
@@ -2389,9 +2442,17 @@ async function validateProvisionResult({
     `${phase} result for ${id}`,
   );
   const expected = cachedArtifactRoots(cacheRoot, artifact);
+  const exactRoot = async (candidate, wanted) => {
+    try {
+      return comparable(await realpath(candidate)) === comparable(wanted);
+    } catch (error) {
+      if (error?.code !== "ENOENT" || !allowIncomplete) throw error;
+      return comparable(path.resolve(candidate)) === comparable(wanted);
+    }
+  };
   if (result.id !== id || comparable(await realpath(result.cacheRoot)) !== comparable(cacheRoot)
-    || comparable(await realpath(result.snapshotRoot)) !== comparable(expected.snapshotRoot)
-    || comparable(await realpath(result.selectedRoot)) !== comparable(expected.selectedRoot)
+    || !await exactRoot(result.snapshotRoot, expected.snapshotRoot)
+    || !await exactRoot(result.selectedRoot, expected.selectedRoot)
     || (staged && typeof result.sourceCacheRoot !== "string")) {
     fail(`${phase} result drifted from exact authority ${id}`);
   }
@@ -2399,7 +2460,7 @@ async function validateProvisionResult({
     || result.missingFiles.some((file) => typeof file !== "string" || !file)
     || result.complete !== (result.missingFiles.length === 0)
     || (!allowIncomplete && !result.complete)
-    || !Array.isArray(result.matchedFiles) || result.matchedFiles.length === 0
+    || !Array.isArray(result.matchedFiles) || (!allowIncomplete && result.matchedFiles.length === 0)
     || result.matchedFiles.some((file) => typeof file !== "string" || !file)
     || !Array.isArray(result.selectedFiles)
     || result.selectedFiles.some((file) => typeof file !== "string" || !file)
@@ -2500,7 +2561,7 @@ async function stageArtifact({
 }
 
 async function downloadReviewedMissing({
-  id, artifact, expectedFiles, scratch, python, cacheRoot, missingStore,
+  id, artifact, expectedFiles, missingFiles, scratch, python, cacheRoot, missingStore,
 }) {
   const requestPath = await writeArtifactRequest({
     id, artifact, expectedFiles, scratch, phase: "download-missing",
@@ -2526,20 +2587,23 @@ async function downloadReviewedMissing({
   const result = parseProvisionerOutput(raw, id, "reviewed missing-file fill");
   exactKeys(result, ["id", "storeRoot", "downloadedFiles"], `missing-file fill for ${id}`);
   if (result.id !== id || comparable(await realpath(result.storeRoot)) !== comparable(missingStore)
-    || result.downloadedFiles.length !== 1) {
+    || result.downloadedFiles.length !== missingFiles.length) {
     fail(`reviewed missing-file fill identity drifted for ${id}`);
   }
-  const [file] = result.downloadedFiles;
-  exactKeys(
-    file,
-    ["path", "bytes", "sha256", "lfsSha256", "commitSha"],
-    `reviewed missing-file fill for ${id}`,
-  );
-  if (file.path !== "transformer/model.safetensors"
-    || file.commitSha !== "bba3ae01dfd94089f173c05edd4e1a4c551f2599"
-    || !Number.isSafeInteger(file.bytes) || file.bytes < 1
-    || !/^[0-9a-f]{64}$/.test(file.sha256) || file.sha256 !== file.lfsSha256) {
-    fail("reviewed missing-file fill did not prove exact commit/size/LFS identity");
+  const prefix = artifact.subdirectory === "." ? "" : `${artifact.subdirectory}/`;
+  for (const [index, file] of result.downloadedFiles.entries()) {
+    exactKeys(
+      file,
+      ["path", "bytes", "sha256", "lfsSha256", "commitSha"],
+      `reviewed missing-file fill for ${id}`,
+    );
+    const expectedPath = prefix && missingFiles[index].startsWith(prefix)
+      ? missingFiles[index].slice(prefix.length) : missingFiles[index];
+    if (file.path !== expectedPath || file.commitSha !== artifact.revision
+      || !Number.isSafeInteger(file.bytes) || file.bytes < 1
+      || !/^[0-9a-f]{64}$/.test(file.sha256) || file.sha256 !== file.lfsSha256) {
+      fail("reviewed missing-file fill did not prove exact commit/path/size/LFS identity");
+    }
   }
   return result;
 }
@@ -3009,7 +3073,7 @@ async function writeSummaryDurably({ output, summary, fault }) {
 function cachePreflightDocument({
   evidencePhase, status, error, downloadEvidenceSha256, remainingArtifactIds, guard, stagingRoot,
   derivedSidecarRoot, frozenMissing, sidecarObstructions, cacheProvisioning,
-  derivedSidecarLifecycle, missingStore, lifetimePlan, diskPlan, missingDownload,
+  derivedSidecarLifecycle, missingStore, lifetimePlan, diskPlan, missingDownloads,
   networkOfflineEstablished,
 }) {
   return {
@@ -3029,10 +3093,12 @@ function cachePreflightDocument({
     reusedFiles: cacheProvisioning.sourceCensus.flatMap((artifact) => artifact.reusedFiles.map(
       (file) => ({ artifactId: artifact.id, ...file }),
     )),
-    downloadedFiles: missingDownload?.downloadedFiles.map((file) => ({
-      artifactId: missingDownload.id, ...file,
-    })) ?? [],
-    networkDownloadCount: missingDownload ? 1 : 0,
+    downloadedFiles: missingDownloads.flatMap((download) => download.downloadedFiles.map((file) => ({
+      artifactId: download.id, ...file,
+    }))),
+    networkDownloadCount: missingDownloads.reduce(
+      (count, download) => count + download.downloadedFiles.length, 0,
+    ),
     phases: cacheProvisioning,
     lifetimePlan,
     diskPlan,
@@ -3121,13 +3187,26 @@ export function validateCachePreflightEvidence(document, {
   if (JSON.stringify(document.reusedFiles) !== JSON.stringify(sourceFiles)) {
     fail("cache preflight top-level hit/download partition drifted");
   }
-  if (document.downloadedFiles.length > 1 || document.downloadedFiles.some((file) => (
-    file.artifactId !== "flux1-schnell-q8"
-      || file.path !== "transformer/model.safetensors"
-      || file.commitSha !== "bba3ae01dfd94089f173c05edd4e1a4c551f2599"
+  const reviewedPlan = reviewedMissingDownloadPlan({
+    frozenMissing: frozen, profile, artifactExpectedFiles, downloadEvidenceSha256,
+  });
+  const expectedDownloads = reviewedPlan.flatMap(({ id, missingFiles }) => {
+    const artifact = profile.artifacts[id];
+    const prefix = artifact.subdirectory === "." ? "" : `${artifact.subdirectory}/`;
+    return missingFiles.map((file) => ({
+      artifactId: id,
+      path: prefix && file.startsWith(prefix) ? file.slice(prefix.length) : file,
+      commitSha: artifact.revision,
+    }));
+  });
+  if (document.downloadedFiles.length !== expectedDownloads.length
+    || document.downloadedFiles.some((file, index) => (
+      file.artifactId !== expectedDownloads[index].artifactId
+      || file.path !== expectedDownloads[index].path
+      || file.commitSha !== expectedDownloads[index].commitSha
       || file.sha256 !== file.lfsSha256
-  ))) fail("cache preflight contains an unreviewed model download");
-  if ((frozen.length === 1) !== (document.downloadedFiles.length === 1)) {
+    ))) fail("cache preflight contains an unreviewed model download");
+  if (frozen.length !== document.downloadedFiles.length) {
     fail("cache preflight missing/download partition is incomplete");
   }
   if (document.networkDownloadCount !== document.downloadedFiles.length
@@ -3515,8 +3594,8 @@ export async function runCampaign(args, options = {}) {
     }
   }
 
-  // The source census is frozen before transfer. A complete cache uses no network; the only
-  // incomplete census allowed is this one exact file, never a snapshot/glob/ref-main fallback.
+  // The source census is frozen before transfer. Only exact reviewed missing-file plans may use
+  // the network; present bytes never fall back to another snapshot, glob, or mutable ref.
   const frozenMissing = cacheProvisioning.sourceCensus.flatMap((artifact) => (
     artifact.missingFiles.map((file) => ({
       artifactId: artifact.id,
@@ -3525,23 +3604,22 @@ export async function runCampaign(args, options = {}) {
       file,
     }))
   ));
-  const reviewedMissing = [{
-    artifactId: "flux1-schnell-q8",
-    repository: "SceneWorks/flux1-schnell-mlx",
-    revision: "bba3ae01dfd94089f173c05edd4e1a4c551f2599",
-    file: "q8/transformer/model.safetensors",
-  }];
+  let reviewedDownloadPlan = [];
   if (quarantineReason) {
     // Preserve the first fail-closed setup error.
   } else if (censusErrors.length) {
     quarantineReason = `source cache census failed before transfer: ${censusErrors.join(" | ")}`;
-  } else if (frozenMissing.length > 1
-    || (frozenMissing.length === 1
-      && JSON.stringify(frozenMissing) !== JSON.stringify(reviewedMissing))) {
-    quarantineReason = `source cache census found an unapproved missing-file set: ${JSON.stringify(frozenMissing)}`;
+  } else {
+    try {
+      reviewedDownloadPlan = reviewedMissingDownloadPlan({
+        frozenMissing, profile, artifactExpectedFiles, downloadEvidenceSha256,
+      });
+    } catch (error) {
+      quarantineReason = `source cache census found an unapproved missing-file set: ${error instanceof Error ? error.message : String(error)}`;
+    }
   }
 
-  let missingDownload = null;
+  const missingDownloads = [];
   let networkOfflineEstablished = false;
   let sidecarObstructions = [];
   const derivedSidecarLifecycle = { initial: null, afterCells: [] };
@@ -3549,34 +3627,39 @@ export async function runCampaign(args, options = {}) {
   let diskPlan = null;
   if (!quarantineReason) {
     try {
-      if (frozenMissing.length === 1) {
-        missingDownload = await operations.downloadReviewedMissing({
-          id: "flux1-schnell-q8",
-          artifact: profile.artifacts["flux1-schnell-q8"],
-          expectedFiles: artifactExpectedFiles["flux1-schnell-q8"],
+      for (const plan of reviewedDownloadPlan) {
+        const authorityMissingStore = path.join(missingStore, plan.id);
+        await mkdir(authorityMissingStore);
+        missingDownloads.push(await operations.downloadReviewedMissing({
+          id: plan.id,
+          artifact: profile.artifacts[plan.id],
+          expectedFiles: artifactExpectedFiles[plan.id],
+          missingFiles: plan.missingFiles,
           scratch: preflightScratch,
           python,
           cacheRoot: guard.cacheRoot,
-          missingStore,
-        });
+          missingStore: authorityMissingStore,
+        }));
       }
       for (const [artifactId, audit] of sourceAudits) {
         audit.expectedFiles = artifactExpectedFiles[artifactId];
-        audit.downloadedFiles = missingDownload?.id === artifactId
-          ? missingDownload.downloadedFiles : [];
+        audit.downloadedFiles = missingDownloads.find((download) => download.id === artifactId)
+          ?.downloadedFiles ?? [];
       }
       lifetimePlan = authorityLifetimePlan(profile, executionOrdinals, sourceAudits);
       const freeBytes = await operations.diskFreeBytes(scratch);
       diskPlan = estimateJitDiskPlan(
         lifetimePlan,
         freeBytes,
-        missingDownload?.downloadedFiles.reduce((sum, file) => sum + file.bytes, 0) ?? 0,
+        missingDownloads.reduce((sum, download) => sum + download.downloadedFiles.reduce(
+          (subtotal, file) => subtotal + file.bytes, 0,
+        ), 0),
         expectedNonModelPaths,
       );
       if (!diskPlan.admitted) {
         fail(`JIT staging disk admission refused: requires ${diskPlan.peakRequiredAdditionalBytes} bytes at cell ${diskPlan.peakOrdinal}, only ${diskPlan.freeBytes} free`);
       }
-      if (!missingDownload) {
+      if (missingDownloads.length === 0) {
         await operations.cleanup(missingStore, guard, "unused missing-file store");
         await assertPathAbsent(missingStore, "unused missing-file store");
       }
@@ -3619,7 +3702,7 @@ export async function runCampaign(args, options = {}) {
     missingStore,
     lifetimePlan,
     diskPlan,
-    missingDownload,
+    missingDownloads,
     networkOfflineEstablished,
   });
   let initialWrite = await writeCachePreflightDurably({
@@ -3650,7 +3733,7 @@ export async function runCampaign(args, options = {}) {
       missingStore,
       lifetimePlan: [],
       diskPlan: null,
-      missingDownload: null,
+      missingDownloads: [],
       networkOfflineEstablished,
     });
     initialWrite = {
@@ -3771,10 +3854,10 @@ export async function runCampaign(args, options = {}) {
         await invokeFault(fault, "stage", index);
         await probeDisk(lifecycle, `before-stage:${artifactId}`, index + 1);
         const audit = sourceAudits.get(artifactId);
-        const artifactStageRoot = artifactId === "flux1-schnell-q8" && missingDownload
-          ? missingStore : path.join(stagingRoot, artifactId);
+        const artifactDownload = missingDownloads.find((download) => download.id === artifactId);
+        const artifactStageRoot = artifactDownload?.storeRoot ?? path.join(stagingRoot, artifactId);
         transitionRoots.set(artifactId, artifactStageRoot);
-        if (artifactStageRoot !== missingStore) await mkdir(artifactStageRoot);
+        if (!artifactDownload) await mkdir(artifactStageRoot);
         const staged = await operations.stageArtifact({
           id: artifactId,
           artifact: profile.artifacts[artifactId],
@@ -3783,13 +3866,12 @@ export async function runCampaign(args, options = {}) {
           python,
           cacheRoot: guard.cacheRoot,
           stagingRoot: artifactStageRoot,
-          missingStore: artifactId === "flux1-schnell-q8" && missingDownload ? missingStore : null,
+          missingStore: artifactDownload?.storeRoot ?? null,
         });
         if (JSON.stringify(staged.reusedFiles) !== JSON.stringify(audit.reusedFiles)) {
           fail(`trusted source cache changed after frozen census for ${artifactId}`);
         }
-        const expectedDownloaded = missingDownload?.id === artifactId
-          ? missingDownload.downloadedFiles : [];
+        const expectedDownloaded = artifactDownload?.downloadedFiles ?? [];
         assertExactDownloadedFilePartition(
           staged.downloadedFiles ?? [], expectedDownloaded,
           `offline JIT stage downloaded-file partition for ${artifactId}`,
@@ -4230,6 +4312,17 @@ export async function runCampaign(args, options = {}) {
     }
   }
 
+  if (missingDownloads.length) {
+    try {
+      await operations.cleanup(missingStore, guard, "reviewed missing-file store");
+      await assertPathAbsent(missingStore, "reviewed missing-file store");
+    } catch (error) {
+      const message = `reviewed missing-file store cleanup failed: ${errorText(error)}`;
+      campaignErrors.push(message);
+      if (!quarantineReason) quarantineReason = message;
+    }
+  }
+
   let finalLifecycle = null;
   try {
     const stage = await operations.directoryInventory(stagingRoot);
@@ -4269,7 +4362,7 @@ export async function runCampaign(args, options = {}) {
     missingStore,
     lifetimePlan,
     diskPlan,
-    missingDownload,
+    missingDownloads,
     networkOfflineEstablished,
   });
   let finalWrite = await writeCachePreflightDurably({
@@ -4295,7 +4388,7 @@ export async function runCampaign(args, options = {}) {
       missingStore,
       lifetimePlan: [],
       diskPlan: null,
-      missingDownload: null,
+      missingDownloads: [],
       networkOfflineEstablished,
     });
     finalWrite = {

--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -118,9 +118,11 @@ const RECOVERY_BOUNDARY_LOG = {
 const LEGACY_NAIVE_LINK_LENGTH_SOURCE_BYTES = 173_667_044_229;
 const REVIEWED_ALL_AT_ONCE_SOURCE_BYTES = 179_028_698_654;
 const LEGACY_REVIEWED_ALL_AT_ONCE_SOURCE_BYTES = 179_028_698_264;
-const REVIEWED_JIT_SOURCE_PEAK_BYTES = 56_156_615_634;
+const PRE_HYDRATION_JIT_SOURCE_PEAK_BYTES = 56_156_615_634;
+const REVIEWED_JIT_SOURCE_PEAK_BYTES = 63_979_929_282;
 const NON_MODEL_DISK_RESERVE_BYTES = 40 * 1024 ** 3;
-const REVIEWED_FREE_FLOOR_BYTES = 99_106_288_594;
+const PRE_HYDRATION_FREE_FLOOR_BYTES = 99_106_288_594;
+const REVIEWED_FREE_FLOOR_BYTES = 106_929_602_242;
 const FLUX_Q4_SIDECAR_BYTES = 7_396_392_960 + 494 * 16_384;
 const FLUX_Q8_SIDECAR_BYTES = 12_573_868_032 + 494 * 16_384;
 const DERIVED_DISPOSITION_NOT_APPLICABLE = "not-applicable";
@@ -360,12 +362,17 @@ export function estimateJitDiskPlan(
   if (persistentBytesFromPlan !== persistentMissingBytes) {
     fail(`persistent missing-file byte census drifted: plan=${persistentBytesFromPlan}, input=${persistentMissingBytes}`);
   }
+  const currentIllustriousHydrationBytes = lifetimes.filter((row) => (
+    ILLUSTRIOUS_CURRENT_AUTHORITIES.has(row.artifactId)
+  )).flatMap((row) => row.physicalFiles).filter((file) => file.persistent)
+    .reduce((sum, file) => sum + file.bytes, 0);
+  const modeledJitPeakBytes = PRE_HYDRATION_JIT_SOURCE_PEAK_BYTES
+    + currentIllustriousHydrationBytes;
   const allAtOnceSidecarReserveBytes = Math.max(FLUX_Q4_SIDECAR_BYTES, FLUX_Q8_SIDECAR_BYTES);
   if (logicalSourceBytes === reviewedAllAtOnceSourceBytes
     && (allAtOnceSourceBytes !== reviewedAllAtOnceSourceBytes
-      || (persistentMissingBytes > 0
-        ? peak.modelAndSidecarBytes !== REVIEWED_JIT_SOURCE_PEAK_BYTES
-        : peak.modelAndSidecarBytes > REVIEWED_JIT_SOURCE_PEAK_BYTES))) {
+      || modeledJitPeakBytes > REVIEWED_JIT_SOURCE_PEAK_BYTES
+      || peak.modelAndSidecarBytes !== modeledJitPeakBytes)) {
     fail(`reviewed disk census drifted: all=${allAtOnceSourceBytes}, peak=${peak.modelAndSidecarBytes}`);
   }
   return {
@@ -375,6 +382,7 @@ export function estimateJitDiskPlan(
     nonModelPaths,
     legacyNaiveLinkLengthSourceBytes: LEGACY_NAIVE_LINK_LENGTH_SOURCE_BYTES,
     reviewedAllAtOnceSourceBytes,
+    preHydrationJitSourcePeakBytes: PRE_HYDRATION_JIT_SOURCE_PEAK_BYTES,
     reviewedJitSourcePeakBytes: REVIEWED_JIT_SOURCE_PEAK_BYTES,
     logicalSourceBytes,
     allAtOnceSourceBytes,
@@ -1958,7 +1966,7 @@ function validateRecoverySummary(summary, currentProfile, metadata) {
     exactKeys(probe, ["phase", "ordinal", "root", "freeBytes", "requiredFreeBytes"], `recovery disk probe ${index + 1}`);
     if (probe.phase !== expectedProbePhases[index][0] || probe.ordinal !== expectedProbePhases[index][1]
       || !Number.isSafeInteger(probe.freeBytes) || !Number.isSafeInteger(probe.requiredFreeBytes)
-      || probe.requiredFreeBytes !== REVIEWED_FREE_FLOOR_BYTES) {
+      || probe.requiredFreeBytes !== PRE_HYDRATION_FREE_FLOOR_BYTES) {
       fail(`recovery disk probe ${index + 1} does not bind the audited partial-run lifecycle`);
     }
   }
@@ -3298,11 +3306,19 @@ export function validateCachePreflightEvidence(document, {
           : legacyEvidence ? LEGACY_REVIEWED_ALL_AT_ONCE_SOURCE_BYTES : REVIEWED_ALL_AT_ONCE_SOURCE_BYTES;
       const expectedAllAtOnceSourceBytes = legacyEvidence
         ? LEGACY_REVIEWED_ALL_AT_ONCE_SOURCE_BYTES : REVIEWED_ALL_AT_ONCE_SOURCE_BYTES;
+      const currentIllustriousHydrationBytes = document.downloadedFiles.filter((file) => (
+        ILLUSTRIOUS_CURRENT_AUTHORITIES.has(file.artifactId)
+      )).reduce((sum, file) => sum + file.bytes, 0);
+      const expectedJitPeakBytes = PRE_HYDRATION_JIT_SOURCE_PEAK_BYTES
+        + currentIllustriousHydrationBytes;
       if (document.diskPlan.reviewedAllAtOnceSourceBytes !== expectedAllAtOnceSourceBytes
+        || document.diskPlan.preHydrationJitSourcePeakBytes
+          !== PRE_HYDRATION_JIT_SOURCE_PEAK_BYTES
         || document.diskPlan.reviewedJitSourcePeakBytes !== REVIEWED_JIT_SOURCE_PEAK_BYTES
         || document.diskPlan.logicalSourceBytes !== expectedSourceBytes
         || document.diskPlan.allAtOnceSourceBytes !== expectedSourceBytes
-        || document.diskPlan.peakModelAndSidecarBytes !== REVIEWED_JIT_SOURCE_PEAK_BYTES
+        || expectedJitPeakBytes > REVIEWED_JIT_SOURCE_PEAK_BYTES
+        || document.diskPlan.peakModelAndSidecarBytes !== expectedJitPeakBytes
         || document.diskPlan.peakRequiredAdditionalBytes !== REVIEWED_FREE_FLOOR_BYTES) {
         fail("passed cache preflight drifted from reviewed target-byte totals and JIT floor");
       }

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -28,6 +28,7 @@ import {
   loadProfile,
   parseNvidiaSmi,
   receiptSkeleton,
+  reviewedMissingDownloadPlan,
   runCampaign,
   safeRemoveTree,
   importSparseRecovery,
@@ -212,6 +213,56 @@ test("current and legacy Illustrious download selectors fail closed independentl
     () => expectedArtifactFilesFromEvidence(legacy, missingLegacy),
     /missing exact authority SceneWorks\/illustrious-xl-v1-mlx@c5a92a9/,
   );
+});
+
+test("current Illustrious hydration plans bind full and partial exact q4 censuses", async () => {
+  const checked = profile();
+  const current = expectedCurrentArtifactFilesFromEvidenceBytes(
+    checked, await readFile("config/download-pattern-evidence.json"),
+  );
+  const id = "illustrious-v1-q4";
+  const artifact = checked.artifacts[id];
+  const frozen = current.artifactExpectedFiles[id].map((file) => ({
+    artifactId: id,
+    repository: artifact.repository,
+    revision: artifact.revision,
+    file: `q4/${file}`,
+  }));
+  assert.deepEqual(reviewedMissingDownloadPlan({
+    frozenMissing: frozen,
+    profile: checked,
+    artifactExpectedFiles: current.artifactExpectedFiles,
+    downloadEvidenceSha256: current.downloadEvidenceSha256,
+  }), [{ id, missingFiles: frozen.map(({ file }) => file) }]);
+  assert.deepEqual(reviewedMissingDownloadPlan({
+    frozenMissing: frozen.slice(3, 7),
+    profile: checked,
+    artifactExpectedFiles: current.artifactExpectedFiles,
+    downloadEvidenceSha256: current.downloadEvidenceSha256,
+  })[0].missingFiles, frozen.slice(3, 7).map(({ file }) => file));
+
+  assert.throws(() => reviewedMissingDownloadPlan({
+    frozenMissing: frozen,
+    profile: checked,
+    artifactExpectedFiles: current.artifactExpectedFiles,
+    downloadEvidenceSha256: "9eda09eeacb9386167ca4a080b4805b9c7dd3cd5134ca037ce342ad434b17e0b",
+  }), /exact current q4 authority/);
+  const driftedFiles = structuredClone(current.artifactExpectedFiles);
+  driftedFiles[id] = driftedFiles[id].slice(1);
+  assert.throws(() => reviewedMissingDownloadPlan({
+    frozenMissing: frozen,
+    profile: checked,
+    artifactExpectedFiles: driftedFiles,
+    downloadEvidenceSha256: current.downloadEvidenceSha256,
+  }), /exact current q4 authority/);
+  const unexpected = structuredClone(frozen);
+  unexpected[0].file = "q4/unexpected.bin";
+  assert.throws(() => reviewedMissingDownloadPlan({
+    frozenMissing: unexpected,
+    profile: checked,
+    artifactExpectedFiles: current.artifactExpectedFiles,
+    downloadEvidenceSha256: current.downloadEvidenceSha256,
+  }), /exact current q4 authority/);
 });
 
 test("download evidence freezes the exact 23-authority filename census", async () => {

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -313,7 +313,7 @@ test("downloaded-file partition compares exact semantics but ignores object inse
   );
 });
 
-test("JIT disk estimator uses followed target bytes, exact lifetimes, and the 99GB floor", () => {
+test("JIT disk estimator uses followed targets, exact lifetimes, and the hydrated floor", () => {
   const file = (key, bytes, persistent = false) => ({ key, bytes, persistent });
   const row = (artifactId, firstOrdinal, lastOrdinal, files) => ({
     artifactId,
@@ -343,7 +343,7 @@ test("JIT disk estimator uses followed target bytes, exact lifetimes, and the 99
     row("sdxl-tokenizer-bigg", 15, 19, [file("sdxl-tokenizer-bigg", 2_224_041)]),
     row("sdxl-vae-fix", 15, 19, [file("sdxl-vae-fix", 334_643_238)]),
   ];
-  const floor = 99_106_288_594;
+  const floor = 106_929_602_242;
   const admitted = estimateJitDiskPlan(lifetimes, floor, persistent.bytes);
   assert.equal(admitted.logicalSourceBytes, 179_028_698_654);
   assert.equal(admitted.allAtOnceSourceBytes, 179_028_698_654);
@@ -357,6 +357,8 @@ test("JIT disk estimator uses followed target bytes, exact lifetimes, and the 99
   assert.equal(admitted.cells.find((entry) => entry.ordinal === 10).modelAndSidecarBytes, 30_581_137_431);
   assert.equal(admitted.cells.find((entry) => entry.ordinal === 13).modelAndSidecarBytes, 32_067_131_269);
   assert.equal(admitted.cells.find((entry) => entry.ordinal === 14).stagedBytes, 56_156_615_634);
+  assert.equal(admitted.preHydrationJitSourcePeakBytes, 56_156_615_634);
+  assert.equal(admitted.reviewedJitSourcePeakBytes, 63_979_929_282);
   assert.equal(admitted.peakModelAndSidecarBytes, 56_156_615_634);
   assert.equal(admitted.peakRequiredAdditionalBytes, floor);
   assert.equal(admitted.admitted, true);
@@ -407,11 +409,13 @@ test("sparse execution lifetimes cover only 14, 18, and 19 while retaining share
     assert.equal(lifetime.firstOrdinal, 18);
     assert.equal(lifetime.lastOrdinal, 19);
   }
-  const plan = estimateJitDiskPlan(lifetimes, 99_106_288_594, 0);
+  const plan = estimateJitDiskPlan(lifetimes, 106_929_602_242, 0);
   assert.deepEqual(plan.cells.map(({ ordinal }) => ordinal), [14, 18, 19]);
   assert.equal(plan.logicalSourceBytes, 66_821_159_668);
   assert.equal(plan.peakModelAndSidecarBytes, 56_156_615_634);
-  assert.equal(plan.peakRequiredAdditionalBytes, 99_106_288_594);
+  assert.equal(plan.preHydrationJitSourcePeakBytes, 56_156_615_634);
+  assert.equal(plan.reviewedJitSourcePeakBytes, 63_979_929_282);
+  assert.equal(plan.peakRequiredAdditionalBytes, 106_929_602_242);
 });
 
 test("profile validator rejects count, order, every semantic tuple mutation, blocked, and authority drift", async () => {
@@ -738,13 +742,13 @@ function fixtureReceipt(status = "passed", cellIndex = 0, checked = profile()) {
       ordinal: cellIndex + 1,
       root: path.resolve("fixture-runner", "scratch"),
       freeBytes: 128 * 1024 ** 3,
-      requiredFreeBytes: 99_106_288_594,
+      requiredFreeBytes: 106_929_602_242,
     }] : []), {
       phase: "before-execution",
       ordinal: cellIndex + 1,
       root: path.resolve("fixture-runner", "scratch"),
       freeBytes: 128 * 1024 ** 3,
-      requiredFreeBytes: 99_106_288_594,
+      requiredFreeBytes: 106_929_602_242,
     }],
   };
   return receipt;
@@ -1625,8 +1629,10 @@ test("start-10 cache preflight binds the reviewed remaining census without weake
     assert.equal(startTen.diskPlan.logicalSourceBytes, 151_407_075_690);
     assert.equal(startTen.diskPlan.allAtOnceSourceBytes, 151_407_075_690);
     assert.equal(startTen.diskPlan.reviewedAllAtOnceSourceBytes, 179_028_698_264);
+    assert.equal(startTen.diskPlan.preHydrationJitSourcePeakBytes, 56_156_615_634);
+    assert.equal(startTen.diskPlan.reviewedJitSourcePeakBytes, 63_979_929_282);
     assert.equal(startTen.diskPlan.peakModelAndSidecarBytes, 56_156_615_634);
-    assert.equal(startTen.diskPlan.peakRequiredAdditionalBytes, 99_106_288_594);
+    assert.equal(startTen.diskPlan.peakRequiredAdditionalBytes, 106_929_602_242);
     assert.doesNotThrow(() => validateCachePreflightEvidence(startTen, validation));
 
     const shiftedIds = [...new Set(checked.cells.slice(10).flatMap((cell) => cell.artifactIds))];
@@ -2124,7 +2130,7 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     derivedContractDrift = null, diskFreeValues = [256 * 1024 ** 3],
     runtimeResultMode = "valid", providerRuntimeFailureAt = null,
     providerFailureDerivedMode = "empty", successfulFluxDerivedMode = "resident",
-    runtimeMemoryMode = "current", sparse = false,
+    runtimeMemoryMode = "current", sparse = false, illustriousHydration = null,
   } = {}) {
     const temporary = await mkdtemp(path.join(tmpdir(), "sc-20974-preflight-"));
     const runnerTemp = path.join(temporary, "runner-temp");
@@ -2140,14 +2146,98 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     await mkdir(output);
     await mkdir(scratch);
     const checked = profile();
-    const artifactExpectedFiles = Object.fromEntries(Object.keys(checked.artifacts).map(
+    let downloadEvidenceSha256 = "d".repeat(64);
+    let artifactExpectedFiles = Object.fromEntries(Object.keys(checked.artifacts).map(
       (id) => [id, id === "flux1-schnell-q8"
         ? ["model_index.json", "transformer/model.safetensors"]
         : ["model_index.json"]],
     ));
+    if (illustriousHydration) {
+      const current = expectedCurrentArtifactFilesFromEvidenceBytes(
+        checked, await readFile("config/download-pattern-evidence.json"),
+      );
+      artifactExpectedFiles = current.artifactExpectedFiles;
+      downloadEvidenceSha256 = current.downloadEvidenceSha256;
+    }
     if (missingId && missingId !== "flux1-schnell-q8") {
       artifactExpectedFiles[missingId] = ["unreviewed-missing.safetensors"];
     }
+    const sparseSourceBytes = new Map([
+      ["ltx23-q8", 29_728_720_716],
+      ["ltx23-gemma", 26_427_894_918],
+      ["illustrious-v1-q4", 3_911_656_986],
+      ["illustrious-v2-q4", 3_911_656_662],
+      ["sdxl-openpose", 2_502_139_104],
+      ["sdxl-tokenizer-l", 2_224_003],
+      ["sdxl-tokenizer-bigg", 2_224_041],
+      ["sdxl-vae-fix", 334_643_238],
+    ]);
+    const illustriousMissing = new Map();
+    const illustriousDownloadedBytes = new Map();
+    if (illustriousHydration) {
+      for (const id of ["illustrious-v1-q4", "illustrious-v2-q4"]) {
+        const selectedFiles = illustriousHydration === "full"
+          ? artifactExpectedFiles[id] : ["model_index.json"];
+        const total = illustriousHydration === "full"
+          ? sparseSourceBytes.get(id) : 708;
+        const bytes = new Map(selectedFiles.map((file, index) => [
+          file, index === 0 ? total - (selectedFiles.length - 1) : 1,
+        ]));
+        illustriousMissing.set(id, selectedFiles.map((file) => `q4/${file}`));
+        illustriousDownloadedBytes.set(id, bytes);
+      }
+    }
+    const missingFilesFor = (id, artifact) => {
+      if (illustriousMissing.has(id)) return illustriousMissing.get(id);
+      if (id !== missingId) return [];
+      return [id === "flux1-schnell-q8"
+        ? "q8/transformer/model.safetensors"
+        : `${artifact.subdirectory}/unreviewed-missing.safetensors`];
+    };
+    const fixtureAudit = (id, artifact) => {
+      const missingFiles = missingFilesFor(id, artifact);
+      const prefix = artifact.subdirectory === "." ? "" : `${artifact.subdirectory}/`;
+      const missingSelected = new Set(missingFiles.map((file) => (
+        prefix && file.startsWith(prefix) ? file.slice(prefix.length) : file
+      )));
+      const presentFiles = artifactExpectedFiles[id].filter((file) => !missingSelected.has(file));
+      const downloadedBytes = illustriousDownloadedBytes.get(id);
+      const missingBytes = downloadedBytes
+        ? [...downloadedBytes.values()].reduce((sum, bytes) => sum + bytes, 0)
+        : id === missingId && id === "flux1-schnell-q8" ? 200 : 0;
+      const sourceBytes = illustriousHydration && sparseSourceBytes.has(id)
+        ? sparseSourceBytes.get(id) : presentFiles.length * 100 + missingBytes;
+      const presentBytes = sourceBytes - missingBytes;
+      return {
+        missingFiles,
+        reusedFiles: presentFiles.map((file, index) => ({
+          path: file,
+          bytes: index === 0 ? presentBytes - (presentFiles.length - 1) : 1,
+          sha256: "a".repeat(64),
+        })),
+      };
+    };
+    const fixtureDownloads = (id, artifact, missingFiles) => {
+      if (illustriousDownloadedBytes.has(id)) {
+        return missingFiles.map((file) => {
+          const selected = file.slice(`${artifact.subdirectory}/`.length);
+          return {
+            path: selected,
+            bytes: illustriousDownloadedBytes.get(id).get(selected),
+            sha256: "b".repeat(64),
+            lfsSha256: "b".repeat(64),
+            commitSha: artifact.revision,
+          };
+        });
+      }
+      return [{
+        path: "transformer/model.safetensors",
+        bytes: 200,
+        sha256: "b".repeat(64),
+        lfsSha256: "b".repeat(64),
+        commitSha: "bba3ae01dfd94089f173c05edd4e1a4c551f2599",
+      }];
+    };
     const events = [];
     const runtimeCells = [];
     let verificationCalls = 0;
@@ -2156,58 +2246,36 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     const operations = {
       auditArtifact: async ({ id, artifact }) => {
         events.push(`audit:${id}`);
-        const missingFiles = id === missingId
-          ? [id === "flux1-schnell-q8"
-            ? "q8/transformer/model.safetensors"
-            : `${artifact.subdirectory}/unreviewed-missing.safetensors`]
-          : [];
-        const missingSelected = new Set(missingFiles.map((file) => (
-          file.startsWith(`${artifact.subdirectory}/`)
-            ? file.slice(artifact.subdirectory.length + 1) : file
-        )));
+        const { missingFiles, reusedFiles } = fixtureAudit(id, artifact);
         return {
           id, ...artifact, complete: missingFiles.length === 0, missingFiles,
-          reusedFiles: artifactExpectedFiles[id].filter((file) => !missingSelected.has(file)).map(
-            (file) => ({ path: file, bytes: 100, sha256: "a".repeat(64) }),
-          ),
+          reusedFiles,
         };
       },
-      downloadReviewedMissing: async ({ id, missingStore }) => {
+      downloadReviewedMissing: async ({ id, artifact, missingFiles, missingStore }) => {
         events.push(`download:${id}`);
         if (!downloadSucceeds) throw new Error("fixture exact missing-file transfer failed");
         return {
           id,
           storeRoot: missingStore,
-          downloadedFiles: [{
-            path: "transformer/model.safetensors",
-            bytes: 200,
-            sha256: "b".repeat(64),
-            lfsSha256: "b".repeat(64),
-            commitSha: "bba3ae01dfd94089f173c05edd4e1a4c551f2599",
-          }],
+          downloadedFiles: fixtureDownloads(id, artifact, missingFiles),
         };
       },
       stageArtifact: async ({ id, artifact, stagingRoot, missingStore }) => {
         events.push(`stage:${id}`);
-        const usesMissing = id === "flux1-schnell-q8" && missingId === id;
+        const { missingFiles, reusedFiles } = fixtureAudit(id, artifact);
+        const usesMissing = missingFiles.length > 0;
+        if (usesMissing) assert.equal(stagingRoot, missingStore);
         return {
           id, ...artifact,
-          reusedFiles: artifactExpectedFiles[id].filter((file) => !(
-            usesMissing && file === "transformer/model.safetensors"
-          )).map((file, index) => ({
-            path: file,
-            bytes: 100,
+          reusedFiles: reusedFiles.map((file, index) => ({
+            ...file,
             sha256: mutateSourceAtStage
               && events.filter((event) => event.startsWith("stage:")).length === 1
-              && index === 0 ? "c".repeat(64) : "a".repeat(64),
+              && index === 0 ? "c".repeat(64) : file.sha256,
           })),
-          downloadedFiles: usesMissing && missingStore ? [{
-            path: "transformer/model.safetensors",
-            bytes: 200,
-            sha256: "b".repeat(64),
-            lfsSha256: "b".repeat(64),
-            commitSha: "bba3ae01dfd94089f173c05edd4e1a4c551f2599",
-          }] : [],
+          downloadedFiles: usesMissing && missingStore
+            ? fixtureDownloads(id, artifact, missingFiles) : [],
           selectedRoot: path.join(stagingRoot, id, artifact.subdirectory),
         };
       },
@@ -2402,7 +2470,7 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
           sceneworksRoot: sceneworks,
           python: "python",
           artifactExpectedFiles,
-          downloadEvidenceSha256: "d".repeat(64),
+          downloadEvidenceSha256,
         },
         prefixSelection: {},
         importedPrefix,
@@ -2438,7 +2506,7 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
             (ordinal) => checked.cells[ordinal - 1].artifactIds,
           ))],
           artifactExpectedFiles,
-          downloadEvidenceSha256: "d".repeat(64),
+          downloadEvidenceSha256,
           guard,
           stagingRoot: path.join(scratch, "authority-stage"),
           derivedSidecarRoot: path.join(scratch, "derived-candle-device-cache"),
@@ -2455,7 +2523,7 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
           lifetimeById: new Map(cacheEvidence.lifetimePlan.map((row) => [row.artifactId, row])),
           scratchRoot: scratch,
           requiredFreeBytes: cacheEvidence.diskPlan?.peakRequiredAdditionalBytes
-            ?? 99_106_288_594,
+            ?? 106_929_602_242,
           completeLifecycle: true,
         },
       };
@@ -2774,6 +2842,45 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
       "sdxl-tokenizer-bigg", "sdxl-vae-fix",
     ],
   );
+
+  for (const [mode, expectedPersistentBytes, expectedPeak, expectedDownloads] of [
+    ["full", 7_823_313_648, 63_979_929_282, 38],
+    ["partial", 1_416, 56_156_617_050, 2],
+  ]) {
+    const hydrated = await scenario({
+      sparse: true, illustriousHydration: mode, downloadSucceeds: true,
+    });
+    assert.deepEqual(hydrated.events.filter((event) => event.startsWith("download:")), [
+      "download:illustrious-v1-q4", "download:illustrious-v2-q4",
+    ], mode);
+    assert.deepEqual(hydrated.runtimeCells.map(({ id }) => id), [
+      "ltx-2-3-q8", "illustrious-v1-openpose", "illustrious-v2-openpose",
+    ], hydrated.result.summary.campaignErrors.join("\n"));
+    assert.equal(hydrated.cacheEvidence.downloadedFiles.length, expectedDownloads, mode);
+    assert.equal(hydrated.cacheEvidence.networkDownloadCount, expectedDownloads, mode);
+    assert.equal(hydrated.cacheEvidence.diskPlan.persistentMissingBytes, expectedPersistentBytes, mode);
+    assert.equal(hydrated.cacheEvidence.diskPlan.preHydrationJitSourcePeakBytes, 56_156_615_634, mode);
+    assert.equal(hydrated.cacheEvidence.diskPlan.reviewedJitSourcePeakBytes, 63_979_929_282, mode);
+    assert.equal(hydrated.cacheEvidence.diskPlan.logicalSourceBytes, 66_821_159_668, mode);
+    assert.equal(hydrated.cacheEvidence.diskPlan.peakOrdinal, 14, mode);
+    assert.equal(hydrated.cacheEvidence.diskPlan.peakModelAndSidecarBytes, expectedPeak, mode);
+    assert.equal(hydrated.cacheEvidence.diskPlan.peakRequiredAdditionalBytes, 106_929_602_242, mode);
+    assert.equal(hydrated.cacheEvidence.diskPlan.admitted, true, mode);
+    for (const [ordinal, id] of [[18, "illustrious-v1-q4"], [19, "illustrious-v2-q4"]]) {
+      const lifecycle = hydrated.result.summary.authorityLifecycle.find((row) => (
+        row.ordinal === ordinal
+      ));
+      const expectedStore = path.join(hydrated.cacheValidation.missingStore, id);
+      assert.equal(lifecycle.staged.find((row) => row.artifactId === id).stageRoot, expectedStore, mode);
+      const release = lifecycle.released.find((row) => row.artifactId === id);
+      assert.equal(release.stageRoot, expectedStore, mode);
+      assert.equal(release.stageRemoved, true, mode);
+    }
+    assert.equal(hydrated.result.summary.finalAuthorityLifecycle.missingStoreAbsent, true, mode);
+    assert.doesNotThrow(() => validateCachePreflightEvidence(
+      hydrated.cacheEvidence, hydrated.cacheValidation,
+    ), mode);
+  }
 
   const residentReceipt = passed.continuationReceipts[0];
   assert.equal(

--- a/scripts/provision-epic-20738-terminal-artifact.py
+++ b/scripts/provision-epic-20738-terminal-artifact.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Audit and just-in-time stage immutable epic-20738 artifacts.
 
-The trusted runner cache is fully audited before GPU work.  The sole reviewed missing file can be
-downloaded once into an isolated campaign-owned store.  Individual authorities are subsequently
-copied into fresh, short-lived staging roots with network access disabled.
+The trusted runner cache is fully audited before GPU work. Reviewed missing files can be downloaded
+once into an isolated campaign-owned store. Individual authorities are subsequently copied into
+fresh, short-lived staging roots with network access disabled.
 """
 
 from __future__ import annotations
@@ -26,6 +26,43 @@ NETWORK_FILL_AUTHORITY = (
     "bba3ae01dfd94089f173c05edd4e1a4c551f2599",
     "q8/transformer/model.safetensors",
 )
+
+# Exact published q4 inventories reviewed for sc-21306. A current Illustrious snapshot may be
+# absent or incomplete, but every present and downloaded byte is bound here before terminal use.
+_SHARED_ILLUSTRIOUS_Q4 = {
+    "model_index.json": (708, "f15de0dfcd39efb54005fe7110fc07580dc7b90e73b2a7fb2ad4500381592e96"),
+    "scheduler/scheduler_config.json": (526, "4276ecb13fc42b6667fe47bac67a376e99e4c26d477e189c4630dd7037a25a9a"),
+    "text_encoder/config.json": (649, "f87b89e4249e027632236caba75d1140e14fd4c2ce4b4e554f2912b234e72cf9"),
+    "text_encoder_2/config.json": (659, "3b96bc14843360d24e864f7d1ac6d83e95cad8f68209e7e503cefa9a4f65b18b"),
+    "tokenizer/merges.txt": (573514, "0bc7695944744789d6fd6d0ab754bcbbb9e36f1c182df0a006d619ce70a1e052"),
+    "tokenizer/special_tokens_map.json": (496, "c8227988aadac941e93b5ffef08b4add8ccbdb26404a62b3e41f61eef119b252"),
+    "tokenizer/tokenizer_config.json": (734, "2edbd316072af0382bb999f82b007ad8af159d6277648e29b7747d72c3add791"),
+    "tokenizer/vocab.json": (1109372, "fd67774a869730a6b27bf53d3e434e72054f2a825873c7af3bece183bb1f791e"),
+    "tokenizer_2/merges.txt": (573514, "0bc7695944744789d6fd6d0ab754bcbbb9e36f1c182df0a006d619ce70a1e052"),
+    "tokenizer_2/special_tokens_map.json": (484, "a83f5831a70d1d21c057186d35aaa504894103d24ee905baa99bc7e83ceb70ee"),
+    "tokenizer_2/tokenizer_config.json": (893, "6e6c80bd367c7b39df2d7add74577ffd79d0840f3aa96e3b5893b95230743bcf"),
+    "tokenizer_2/vocab.json": (1109372, "fd67774a869730a6b27bf53d3e434e72054f2a825873c7af3bece183bb1f791e"),
+    "unet/config.json": (1915, "aeb34c12f61f1edd9f7e17d8332f91197bacad70754bfaa450836137c40c8c4d"),
+    "vae/config.json": (807, "5d301324288c14277bab2b284004b91b81faffc800202ddba59e401c82683959"),
+}
+REVIEWED_HYDRATION_AUTHORITIES = {
+    ("SceneWorks/illustrious-xl-v1-mlx", "778c3f02b7703b0c2755d0c0447592897193c6b5"): {
+        **_SHARED_ILLUSTRIOUS_Q4,
+        "text_encoder/model.safetensors": (200319411, "13e30e7c01f6c629a91732835d5fc6bd112ac8c949b7ac0f9bc5924336a4163a"),
+        "text_encoder_2/model.safetensors": (610429154, "0fd5337422027e90951c2f7e1aa277817baafa2bb23ad0173154d57fcd1470ba"),
+        "unet/diffusion_pytorch_model.safetensors": (2595556100, "f04b0c61537821e6057d420295ee9a4e94b45c497055823d38a6d9cd613c68b8"),
+        "vae/diffusion_pytorch_model.fp16.safetensors": (167335384, "3304e1f0f639f7ad9b3c7ac96ff65db855f8e841cc039f232896e6910b5a9591"),
+        "vae/diffusion_pytorch_model.safetensors": (334643294, "a91793eaf162d3531017f59decf47890e2abb6a376e709bb33542ebe8d4cfe0f"),
+    },
+    ("SceneWorks/illustrious-xl-v2-mlx", "672e9851ede4dc856fa945649b6691975c9d74a3"): {
+        **_SHARED_ILLUSTRIOUS_Q4,
+        "text_encoder/model.safetensors": (200319411, "20988f339be7d4851b9dbda25d614143c02d3f0485d3f4225b5d222463f33e2e"),
+        "text_encoder_2/model.safetensors": (610429154, "7337dc56d6801e727c825b8699ba9f35c043909ba818ded018bc5f81acff3a95"),
+        "unet/diffusion_pytorch_model.safetensors": (2595555776, "f3548787d6760d8eab11d1eb644b946b1eb90dbc08f697f5f919a83e03d4557f"),
+        "vae/diffusion_pytorch_model.fp16.safetensors": (167335384, "8858c565cc9f13282b028069e92a6a4b4ebc1693a98e30176bbff16d7a230f51"),
+        "vae/diffusion_pytorch_model.safetensors": (334643294, "b0a960def5b0ff715be74a7a82202a80300f8b06a3bc08e364af3647b6d7a653"),
+    },
+}
 
 
 def parse_request(path: Path) -> dict:
@@ -103,29 +140,69 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _context(request: dict, cache_root: Path) -> tuple[Path, Path, Path]:
+def _hydration_inventory(request: dict) -> dict[str, tuple[int, str]] | None:
+    inventory = REVIEWED_HYDRATION_AUTHORITIES.get(
+        (request["repository"], request["revision"])
+    )
+    if inventory is None:
+        return None
+    if request["subdirectory"] != "q4" or request["allowPatterns"] != ["q4/*"]:
+        raise RuntimeError("reviewed hydration subdirectory/allow-pattern authority drifted")
+    if request["expectedFiles"] != sorted(inventory):
+        raise RuntimeError("reviewed hydration exact file-list authority drifted")
+    return inventory
+
+
+def _optional_ordinary_directory(path: Path, label: str) -> Path | None:
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return None
+    return _ordinary_directory(path, label)
+
+
+def _context(
+    request: dict, cache_root: Path, *, allow_absent: bool = False
+) -> tuple[Path, Path, Path, bool]:
     if not cache_root.is_absolute():
         raise ValueError("cache root must be an absolute path")
     trusted_root = _ordinary_directory(cache_root, "trusted cache root")
     owner, name = request["repository"].split("/", 1)
-    repository_root = _ordinary_directory(
-        trusted_root / f"models--{owner}--{name}", "exact cached repository"
-    )
+    repository_path = trusted_root / f"models--{owner}--{name}"
+    repository_root = _optional_ordinary_directory(repository_path, "exact cached repository")
+    if repository_root is None:
+        if not allow_absent:
+            _ordinary_directory(repository_path, "exact cached repository")
+        snapshot = repository_path / "snapshots" / request["revision"]
+        return trusted_root, snapshot, snapshot / request["subdirectory"], False
     if not _inside(trusted_root, repository_root):
         raise RuntimeError("cached repository escaped the trusted cache root")
-    snapshots = _ordinary_directory(repository_root / "snapshots", "cached snapshots directory")
-    snapshot = _ordinary_directory(
-        snapshots / request["revision"],
-        f"exact cached revision {request['revision']}",
+    snapshots_path = repository_root / "snapshots"
+    snapshots = _optional_ordinary_directory(snapshots_path, "cached snapshots directory")
+    if snapshots is None:
+        if not allow_absent:
+            _ordinary_directory(snapshots_path, "cached snapshots directory")
+        snapshot = snapshots_path / request["revision"]
+        return trusted_root, snapshot, snapshot / request["subdirectory"], False
+    snapshot_path = snapshots / request["revision"]
+    snapshot = _optional_ordinary_directory(
+        snapshot_path, f"exact cached revision {request['revision']}"
     )
+    if snapshot is None:
+        if not allow_absent:
+            _ordinary_directory(snapshot_path, f"exact cached revision {request['revision']}")
+        return trusted_root, snapshot_path, snapshot_path / request["subdirectory"], False
     if snapshot.parent != snapshots or not _inside(trusted_root, snapshot):
         raise RuntimeError("exact cached revision escaped the trusted cache root")
-    selected = _ordinary_directory(
-        snapshot / request["subdirectory"], "selected cached artifact subdirectory"
-    )
+    selected_path = snapshot / request["subdirectory"]
+    selected = _optional_ordinary_directory(selected_path, "selected cached artifact subdirectory")
+    if selected is None:
+        if not allow_absent:
+            _ordinary_directory(selected_path, "selected cached artifact subdirectory")
+        return trusted_root, snapshot, selected_path, False
     if not _inside(snapshot, selected, allow_equal=True):
         raise RuntimeError("selected artifact subdirectory escaped the exact snapshot")
-    return trusted_root, snapshot, selected
+    return trusted_root, snapshot, selected, True
 
 
 def _reviewed_missing(request: dict) -> list[str]:
@@ -138,6 +215,55 @@ def _reviewed_missing(request: dict) -> list[str]:
     ):
         return [filename]
     return []
+
+
+def _strict_selected_census(selected: Path, expected_files: list[str]) -> None:
+    allowed_files = set(expected_files)
+    allowed_directories = {
+        Path(*Path(filename).parts[:index]).as_posix()
+        for filename in expected_files
+        for index in range(1, len(Path(filename).parts))
+    }
+    pending = [selected]
+    while pending:
+        directory = pending.pop()
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                lexical = Path(entry.path)
+                relative = lexical.relative_to(selected).as_posix()
+                metadata = entry.stat(follow_symlinks=False)
+                if _is_reparse(metadata):
+                    if relative not in allowed_files:
+                        raise RuntimeError(f"unexpected symlink/reparse entry in reviewed snapshot: {lexical}")
+                elif stat.S_ISDIR(metadata.st_mode):
+                    if relative not in allowed_directories:
+                        raise RuntimeError(f"unexpected directory in reviewed snapshot: {lexical}")
+                    pending.append(lexical)
+                elif stat.S_ISREG(metadata.st_mode):
+                    if relative not in allowed_files:
+                        raise RuntimeError(f"unexpected file in reviewed snapshot: {lexical}")
+                else:
+                    raise RuntimeError(f"unsafe filesystem entry in reviewed snapshot: {lexical}")
+
+
+def _lexically_absent(selected: Path, relative_selected: str) -> bool:
+    current = selected
+    try:
+        current.lstat()
+    except FileNotFoundError:
+        return True
+    parts = Path(relative_selected).parts
+    for index, segment in enumerate(parts):
+        current = current / segment
+        try:
+            metadata = current.lstat()
+        except FileNotFoundError:
+            return True
+        if index < len(parts) - 1 and (
+            not stat.S_ISDIR(metadata.st_mode) or _is_reparse(metadata)
+        ):
+            raise RuntimeError(f"expected artifact parent is unsafe: {current}")
+    return False
 
 
 def _expected_file(
@@ -173,7 +299,12 @@ def _expected_file(
 
 
 def audit_cached_artifact(request: dict, cache_root: Path) -> dict:
-    trusted_root, snapshot, selected = _context(request, cache_root)
+    hydration_inventory = _hydration_inventory(request)
+    trusted_root, snapshot, selected, selected_exists = _context(
+        request, cache_root, allow_absent=hydration_inventory is not None
+    )
+    if hydration_inventory is not None and selected_exists:
+        _strict_selected_census(selected, request["expectedFiles"])
     reviewed_missing = _reviewed_missing(request)
     files = []
     missing = []
@@ -181,6 +312,9 @@ def audit_cached_artifact(request: dict, cache_root: Path) -> dict:
         relative_snapshot = (
             Path(request["subdirectory"]) / relative_selected
         ).as_posix() if request["subdirectory"] != "." else relative_selected
+        if hydration_inventory is not None and _lexically_absent(selected, relative_selected):
+            missing.append(relative_snapshot)
+            continue
         try:
             files.append(
                 _expected_file(
@@ -188,10 +322,7 @@ def audit_cached_artifact(request: dict, cache_root: Path) -> dict:
                 )
             )
         except (FileNotFoundError, RuntimeError) as error:
-            if relative_snapshot in reviewed_missing and (
-                isinstance(error, FileNotFoundError)
-                or "broken" in str(error).lower()
-            ):
+            if relative_snapshot in reviewed_missing and isinstance(error, FileNotFoundError):
                 missing.append(relative_snapshot)
                 continue
             raise RuntimeError(
@@ -199,13 +330,11 @@ def audit_cached_artifact(request: dict, cache_root: Path) -> dict:
             ) from error
     matched_records = []
     for lexical, relative, size in files:
-        matched_records.append(
-            {
-                "path": lexical.relative_to(selected).as_posix(),
-                "bytes": size,
-                "sha256": _sha256(lexical.resolve(strict=True)),
-            }
-        )
+        selected_path = lexical.relative_to(selected).as_posix()
+        digest = _sha256(lexical.resolve(strict=True))
+        if hydration_inventory is not None and hydration_inventory[selected_path] != (size, digest):
+            raise RuntimeError(f"reviewed hydration source byte identity drifted: {relative}")
+        matched_records.append({"path": selected_path, "bytes": size, "sha256": digest})
     matched_records.sort(key=lambda record: record["path"])
     return {
         "id": request["id"],
@@ -243,23 +372,67 @@ def _missing_store_root(missing_store: Path) -> Path:
     return _ordinary_directory(missing_store, "campaign missing-file store")
 
 
+def _mkdir_confined(root: Path, relative: Path, label: str) -> Path:
+    current = root
+    for segment in relative.parts:
+        current = current / segment
+        try:
+            metadata = current.lstat()
+        except FileNotFoundError:
+            current.mkdir()
+            metadata = current.lstat()
+        if not stat.S_ISDIR(metadata.st_mode) or _is_reparse(metadata):
+            raise RuntimeError(f"{label} contains an unsafe directory: {current}")
+        resolved = current.resolve(strict=True)
+        if not _inside(root, resolved):
+            raise RuntimeError(f"{label} escaped its campaign root: {current}")
+    return current
+
+
+def _receipt_path(root: Path, request: dict) -> Path:
+    owner, name = request["repository"].split("/", 1)
+    return root / "download-receipts" / f"{owner}--{name}@{request['revision']}.json"
+
+
+def _approved_download_inventory(
+    request: dict, missing_files: list[str]
+) -> dict[str, tuple[int | None, str | None]]:
+    hydration = _hydration_inventory(request)
+    prefix = "" if request["subdirectory"] == "." else f"{request['subdirectory']}/"
+    if hydration is not None:
+        approved = {
+            f"{prefix}{filename}": identity for filename, identity in hydration.items()
+        }
+        if not missing_files or any(filename not in approved for filename in missing_files):
+            raise RuntimeError("network fill escaped the reviewed hydration inventory")
+        return {filename: approved[filename] for filename in missing_files}
+    if [request["repository"], request["revision"], *missing_files] != list(
+        NETWORK_FILL_AUTHORITY
+    ):
+        raise RuntimeError("network fill requires an exact reviewed missing-file plan")
+    return {NETWORK_FILL_AUTHORITY[2]: (None, None)}
+
+
 def download_reviewed_missing(request: dict, cache_root: Path, missing_store: Path) -> dict:
     audit = audit_cached_artifact(request, cache_root)
-    reviewed = list(NETWORK_FILL_AUTHORITY)
-    if [request["repository"], request["revision"], *audit["missingFiles"]] != reviewed:
-        raise RuntimeError("network fill requires exactly the sole reviewed missing filename")
+    approved = _approved_download_inventory(request, audit["missingFiles"])
 
     destination_root = _missing_store_root(missing_store)
-    repository, revision, filename = NETWORK_FILL_AUTHORITY
+    repository, revision = request["repository"], request["revision"]
     owner, name = repository.split("/", 1)
     destination_snapshot = (
         destination_root / f"models--{owner}--{name}" / "snapshots" / revision
     )
-    destination = destination_snapshot / filename
-    receipt_path = destination_root / "download-receipt.json"
-    if destination.exists() or destination.is_symlink() or receipt_path.exists():
+    receipt_path = _receipt_path(destination_root, request)
+    if receipt_path.exists() or receipt_path.is_symlink():
         raise RuntimeError("refusing to overwrite the campaign missing-file store")
-    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination_snapshot.exists() or destination_snapshot.is_symlink():
+        raise RuntimeError("campaign missing-file authority store is ambiguous or already populated")
+    _mkdir_confined(
+        destination_root,
+        destination_snapshot.relative_to(destination_root),
+        "campaign missing-file authority store",
+    )
 
     from huggingface_hub import (
         __version__,
@@ -272,91 +445,122 @@ def download_reviewed_missing(request: dict, cache_root: Path, missing_store: Pa
         raise RuntimeError(
             f"network fill requires huggingface_hub 0.36.0, got {__version__}"
         )
-    url = hf_hub_url(repo_id=repository, filename=filename, revision=revision)
-    metadata = get_hf_file_metadata(url, token=False)
-    etag = str(metadata.etag or "").strip('"')
-    if (
-        metadata.commit_hash != revision
-        or not SHA256.fullmatch(etag)
-        or not isinstance(metadata.size, int)
-        or metadata.size < 1
-    ):
-        raise RuntimeError("exact missing-file metadata did not bind commit, LFS SHA, and size")
     network_cache = destination_root / ".hf-network-staging"
-    downloaded = Path(
-        hf_hub_download(
-            repo_id=repository,
-            filename=filename,
-            revision=revision,
-            repo_type="model",
-            local_dir=destination_snapshot,
-            cache_dir=network_cache,
-            token=False,
-            force_download=False,
-            local_files_only=False,
+    records = []
+    for filename, (reviewed_size, reviewed_sha) in approved.items():
+        destination = destination_snapshot / filename
+        url = hf_hub_url(repo_id=repository, filename=filename, revision=revision)
+        metadata = get_hf_file_metadata(url, token=False)
+        etag = str(metadata.etag or "").strip('"')
+        if (
+            metadata.commit_hash != revision
+            or not isinstance(metadata.size, int)
+            or metadata.size < 1
+            or (reviewed_size is not None and metadata.size != reviewed_size)
+            or (reviewed_sha is None and not SHA256.fullmatch(etag))
+            or (reviewed_sha is not None and not re.fullmatch(r"[0-9a-f]{40}|[0-9a-f]{64}", etag))
+            or (reviewed_sha is not None and len(etag) == 64 and etag != reviewed_sha)
+        ):
+            raise RuntimeError("exact missing-file metadata did not bind reviewed commit/etag/size")
+        _mkdir_confined(
+            destination_snapshot,
+            destination.parent.relative_to(destination_snapshot),
+            "campaign missing-file destination",
         )
-    )
-    if downloaded != destination or not destination.is_file():
-        raise RuntimeError("pinned missing-file download did not materialize the exact store path")
-    if destination.is_symlink():
-        raise RuntimeError("pinned missing-file download produced a reparse target")
-    actual_sha = _sha256(destination)
-    if destination.stat().st_size != metadata.size or actual_sha != etag:
-        raise RuntimeError("downloaded missing file failed exact size/LFS SHA verification")
+        downloaded = Path(
+            hf_hub_download(
+                repo_id=repository,
+                filename=filename,
+                revision=revision,
+                repo_type="model",
+                local_dir=destination_snapshot,
+                cache_dir=network_cache,
+                token=False,
+                force_download=False,
+                local_files_only=False,
+            )
+        )
+        if downloaded != destination or not destination.is_file():
+            raise RuntimeError("pinned missing-file download did not materialize the exact store path")
+        if destination.is_symlink() or _is_reparse(destination.lstat()):
+            raise RuntimeError("pinned missing-file download produced a reparse target")
+        actual_sha = _sha256(destination)
+        expected_sha = reviewed_sha or etag
+        if destination.stat().st_size != metadata.size or actual_sha != expected_sha:
+            raise RuntimeError("downloaded missing file failed exact size/content SHA verification")
+        records.append({
+            "path": Path(filename).relative_to(request["subdirectory"]).as_posix(),
+            "bytes": metadata.size,
+            "sha256": actual_sha,
+            # The legacy receipt field carries the audited content SHA. For LFS files it is also
+            # the remote LFS etag; ordinary Git files are independently bound by commit and size.
+            "lfsSha256": actual_sha,
+            "commitSha": metadata.commit_hash,
+        })
     if network_cache.exists():
         shutil.rmtree(network_cache, ignore_errors=False)
     local_metadata = destination_snapshot / ".cache"
     if local_metadata.exists():
         shutil.rmtree(local_metadata, ignore_errors=False)
-    if not destination.is_file() or destination.stat().st_size != metadata.size or _sha256(destination) != etag:
-        raise RuntimeError("downloaded missing file did not remain durable after network-cache cleanup")
-    record = {
-        "path": Path(filename).relative_to(request["subdirectory"]).as_posix(),
-        "bytes": metadata.size,
-        "sha256": actual_sha,
-        "lfsSha256": etag,
-        "commitSha": metadata.commit_hash,
-    }
-    receipt_path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+    for record in records:
+        destination = destination_snapshot / request["subdirectory"] / record["path"]
+        if (
+            not destination.is_file()
+            or destination.is_symlink()
+            or destination.stat().st_size != record["bytes"]
+            or _sha256(destination) != record["sha256"]
+        ):
+            raise RuntimeError("downloaded missing file did not remain durable after cleanup")
+    _mkdir_confined(
+        destination_root,
+        receipt_path.parent.relative_to(destination_root),
+        "campaign download receipt store",
+    )
+    receipt_path.write_text(json.dumps(records, sort_keys=True) + "\n", encoding="utf-8")
     return {
         "id": request["id"],
         "storeRoot": str(destination_root),
-        "downloadedFiles": [record],
+        "downloadedFiles": records,
     }
 
 
-def _stored_missing_file(request: dict, missing_store: Path) -> dict:
+def _stored_missing_files(
+    request: dict, missing_store: Path, missing_files: list[str]
+) -> list[dict]:
     root = _missing_store_root(missing_store)
-    if _reviewed_missing(request) != [NETWORK_FILL_AUTHORITY[2]]:
-        raise RuntimeError("missing-file store is not approved for this authority")
-    receipt_path = root / "download-receipt.json"
+    approved = _approved_download_inventory(request, missing_files)
+    receipt_path = _receipt_path(root, request)
     try:
-        record = json.loads(receipt_path.read_text(encoding="utf-8"))
+        records = json.loads(receipt_path.read_text(encoding="utf-8"))
     except (FileNotFoundError, json.JSONDecodeError) as error:
         raise RuntimeError("campaign missing-file receipt is absent or invalid") from error
-    if set(record) != {"path", "bytes", "sha256", "lfsSha256", "commitSha"}:
-        raise RuntimeError("campaign missing-file receipt fields drifted")
-    expected = NETWORK_FILL_AUTHORITY[2]
-    expected_selected = Path(expected).relative_to(request["subdirectory"]).as_posix()
-    owner, name = NETWORK_FILL_AUTHORITY[0].split("/", 1)
-    stored = (
-        root / f"models--{owner}--{name}" / "snapshots"
-        / NETWORK_FILL_AUTHORITY[1] / expected
-    )
-    if (
-        record["path"] != expected_selected
-        or record["commitSha"] != NETWORK_FILL_AUTHORITY[1]
-        or record["sha256"] != record["lfsSha256"]
-        or not SHA256.fullmatch(record["sha256"])
-        or not isinstance(record["bytes"], int)
-        or record["bytes"] < 1
-        or not stored.is_file()
-        or stored.is_symlink()
-        or stored.stat().st_size != record["bytes"]
-        or _sha256(stored) != record["sha256"]
-    ):
-        raise RuntimeError("campaign missing-file store failed exact identity verification")
-    return record
+    if not isinstance(records, list) or len(records) != len(approved):
+        raise RuntimeError("campaign missing-file receipt census drifted")
+    owner, name = request["repository"].split("/", 1)
+    expected_records = []
+    for (filename, (reviewed_size, reviewed_sha)), record in zip(approved.items(), records):
+        expected_selected = Path(filename).relative_to(request["subdirectory"]).as_posix()
+        stored = root / f"models--{owner}--{name}" / "snapshots" / request["revision"] / filename
+        if (
+            not isinstance(record, dict)
+            or set(record) != {"path", "bytes", "sha256", "lfsSha256", "commitSha"}
+            or record["path"] != expected_selected
+            or record["commitSha"] != request["revision"]
+            or record["sha256"] != record["lfsSha256"]
+            or not SHA256.fullmatch(record["sha256"])
+            or not isinstance(record["bytes"], int)
+            or record["bytes"] < 1
+            or (reviewed_size is not None and record["bytes"] != reviewed_size)
+            or (reviewed_sha is not None and record["sha256"] != reviewed_sha)
+            or not stored.is_file()
+            or stored.is_symlink()
+            or _is_reparse(stored.lstat())
+            or stored.stat().st_size != record["bytes"]
+            or _sha256(stored) != record["sha256"]
+        ):
+            raise RuntimeError("campaign missing-file store failed exact identity verification")
+        expected_records.append(record)
+    return expected_records
 
 
 def stage_artifact(
@@ -366,14 +570,14 @@ def stage_artifact(
     missing_store: Path | None,
 ) -> dict:
     audit = audit_cached_artifact(request, cache_root)
-    stored_missing = None
+    stored_missing = []
     if audit["missingFiles"]:
-        if audit["missingFiles"] != [NETWORK_FILL_AUTHORITY[2]] or missing_store is None:
+        if missing_store is None:
             raise RuntimeError(
-                "offline JIT staging lacks the exact reviewed missing file: "
+                "offline JIT staging lacks the exact reviewed missing file(s): "
                 + ", ".join(audit["missingFiles"])
             )
-        stored_missing = _stored_missing_file(request, missing_store)
+        stored_missing = _stored_missing_files(request, missing_store, audit["missingFiles"])
 
     destination_root = _stage_root(staging_root)
     owner, name = request["repository"].split("/", 1)
@@ -399,25 +603,22 @@ def stage_artifact(
             raise RuntimeError(f"staged cache copy failed byte verification: {destination}")
 
     downloaded_files = []
-    if stored_missing:
-        owner, name = NETWORK_FILL_AUTHORITY[0].split("/", 1)
-        source = (
-            _missing_store_root(missing_store)
-            / f"models--{owner}--{name}" / "snapshots"
-            / NETWORK_FILL_AUTHORITY[1] / NETWORK_FILL_AUTHORITY[2]
-        )
-        destination = destination_selected / stored_missing["path"]
+    for stored_record, missing_snapshot_path in zip(stored_missing, audit["missingFiles"]):
+        owner, name = request["repository"].split("/", 1)
+        source = _missing_store_root(missing_store) / f"models--{owner}--{name}" / "snapshots" / request["revision"] / missing_snapshot_path
+        stored_missing_record = stored_record
+        destination = destination_selected / stored_missing_record["path"]
         destination.parent.mkdir(parents=True, exist_ok=True)
         if destination.exists() or destination.is_symlink():
-            if not (not destination.is_symlink() and destination.is_file() and destination.stat().st_size == stored_missing["bytes"] and _sha256(destination) == stored_missing["sha256"]):
+            if not (not destination.is_symlink() and destination.is_file() and destination.stat().st_size == stored_missing_record["bytes"] and _sha256(destination) == stored_missing_record["sha256"]):
                 raise RuntimeError("refusing to overwrite non-identical staged missing file")
         else:
             shutil.copyfile(source, destination)
-        if destination.stat().st_size != stored_missing["bytes"] or _sha256(destination) != stored_missing["sha256"]:
+        if destination.stat().st_size != stored_missing_record["bytes"] or _sha256(destination) != stored_missing_record["sha256"]:
             raise RuntimeError("JIT copy of campaign missing file failed byte verification")
         downloaded_files.append(
             {
-                **stored_missing,
+                **stored_missing_record,
                 "path": destination.relative_to(destination_selected).as_posix(),
             }
         )

--- a/scripts/provision_epic_20738_terminal_artifact_test.py
+++ b/scripts/provision_epic_20738_terminal_artifact_test.py
@@ -20,6 +20,8 @@ SPEC.loader.exec_module(MODULE)
 
 class CacheOnlyProvisionTests(unittest.TestCase):
     REVISION = "a" * 40
+    CURRENT_REPOSITORY = "SceneWorks/illustrious-xl-v1-mlx"
+    CURRENT_REVISION = "778c3f02b7703b0c2755d0c0447592897193c6b5"
 
     def request(self) -> dict:
         return {
@@ -67,6 +69,22 @@ class CacheOnlyProvisionTests(unittest.TestCase):
         (snapshot / "q8" / "transformer").mkdir(parents=True)
         (snapshot / "q8" / "model_index.json").write_bytes(b"{}")
         return snapshot
+
+    def current_request(self, inventory: dict) -> dict:
+        return {
+            "id": "illustrious-v1-q4",
+            "repository": self.CURRENT_REPOSITORY,
+            "revision": self.CURRENT_REVISION,
+            "subdirectory": "q4",
+            "allowPatterns": ["q4/*"],
+            "expectedFiles": sorted(inventory),
+        }
+
+    def current_selected(self, root: Path) -> Path:
+        return (
+            root / "models--SceneWorks--illustrious-xl-v1-mlx" / "snapshots"
+            / self.CURRENT_REVISION / "q4"
+        )
 
     def test_cache_hit_resolves_only_exact_allow_list_without_copy_or_network(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -301,9 +319,112 @@ class CacheOnlyProvisionTests(unittest.TestCase):
             snapshot = self.cache_snapshot(cache)
             (snapshot / "q4" / "weights.safetensors").write_bytes(b"weights")
             with self.assertRaisesRegex(
-                RuntimeError, "network fill requires exactly the sole reviewed missing filename"
+                RuntimeError, "network fill requires an exact reviewed missing-file plan"
             ):
                 MODULE.download_reviewed_missing(self.request(), cache, staging)
+
+    def test_reviewed_current_snapshot_can_be_fully_absent_or_partially_hydrated(self) -> None:
+        config = b"exact config"
+        weights = b"exact weights"
+        inventory = {
+            "config.json": (len(config), hashlib.sha256(config).hexdigest()),
+            "unet/model.safetensors": (len(weights), hashlib.sha256(weights).hexdigest()),
+        }
+        authority = {(self.CURRENT_REPOSITORY, self.CURRENT_REVISION): inventory}
+        with tempfile.TemporaryDirectory() as directory, mock.patch.dict(
+            MODULE.REVIEWED_HYDRATION_AUTHORITIES, authority, clear=True
+        ):
+            cache = Path(directory).resolve()
+            absent = MODULE.audit_cached_artifact(self.current_request(inventory), cache)
+            self.assertFalse(absent["complete"])
+            self.assertEqual(absent["reusedFiles"], [])
+            self.assertEqual(absent["missingFiles"], ["q4/config.json", "q4/unet/model.safetensors"])
+
+            selected = self.current_selected(cache)
+            selected.mkdir(parents=True)
+            (selected / "config.json").write_bytes(config)
+            partial = MODULE.audit_cached_artifact(self.current_request(inventory), cache)
+            self.assertEqual([row["path"] for row in partial["reusedFiles"]], ["config.json"])
+            self.assertEqual(partial["missingFiles"], ["q4/unet/model.safetensors"])
+
+    def test_reviewed_current_snapshot_rejects_corrupt_unexpected_and_unsafe_entries(self) -> None:
+        payload = b"exact"
+        inventory = {"weights.safetensors": (len(payload), hashlib.sha256(payload).hexdigest())}
+        authority = {(self.CURRENT_REPOSITORY, self.CURRENT_REVISION): inventory}
+        with tempfile.TemporaryDirectory() as directory, tempfile.TemporaryDirectory() as outside_directory, mock.patch.dict(
+            MODULE.REVIEWED_HYDRATION_AUTHORITIES, authority, clear=True
+        ):
+            cache = Path(directory).resolve()
+            selected = self.current_selected(cache)
+            selected.mkdir(parents=True)
+            target = selected / "weights.safetensors"
+            target.write_bytes(b"drift")
+            with self.assertRaisesRegex(RuntimeError, "source byte identity drifted"):
+                MODULE.audit_cached_artifact(self.current_request(inventory), cache)
+            target.write_bytes(payload)
+            unexpected = selected / "unexpected.bin"
+            unexpected.write_bytes(b"unreviewed")
+            with self.assertRaisesRegex(RuntimeError, "unexpected file"):
+                MODULE.audit_cached_artifact(self.current_request(inventory), cache)
+            unexpected.unlink()
+            target.unlink()
+            outside = Path(outside_directory).resolve() / "outside.bin"
+            outside.write_bytes(payload)
+            try:
+                os.symlink(outside, target)
+            except OSError as error:
+                self.skipTest(f"symlink/reparse fixture unavailable: {error}")
+            with self.assertRaisesRegex(RuntimeError, "escaped trusted cache root"):
+                MODULE.audit_cached_artifact(self.current_request(inventory), cache)
+
+    def test_reviewed_current_partial_snapshot_downloads_only_missing_bytes_then_audits_stage(self) -> None:
+        first, second = b"cached exact", b"download exact"
+        inventory = {
+            "config.json": (len(second), hashlib.sha256(second).hexdigest()),
+            "unet/model.safetensors": (len(first), hashlib.sha256(first).hexdigest()),
+        }
+        authority = {(self.CURRENT_REPOSITORY, self.CURRENT_REVISION): inventory}
+        with tempfile.TemporaryDirectory() as directory, tempfile.TemporaryDirectory() as stored, tempfile.TemporaryDirectory() as staged, mock.patch.dict(
+            MODULE.REVIEWED_HYDRATION_AUTHORITIES, authority, clear=True
+        ):
+            cache = Path(directory).resolve()
+            missing_store = Path(stored).resolve()
+            staging = Path(staged).resolve()
+            selected = self.current_selected(cache)
+            (selected / "unet").mkdir(parents=True)
+            (selected / "unet" / "model.safetensors").write_bytes(first)
+
+            def url(**kwargs):
+                return f"https://huggingface.invalid/{kwargs['filename']}"
+
+            def metadata(_url, token):
+                self.assertFalse(token)
+                return types.SimpleNamespace(
+                    commit_hash=self.CURRENT_REVISION,
+                    etag="c" * 40,
+                    size=len(second),
+                )
+
+            def download(**kwargs):
+                self.assertEqual(kwargs["filename"], "q4/config.json")
+                target = Path(kwargs["local_dir"]) / kwargs["filename"]
+                target.write_bytes(second)
+                return str(target)
+
+            fake_hf = types.SimpleNamespace(
+                __version__="0.36.0", hf_hub_url=url,
+                get_hf_file_metadata=metadata, hf_hub_download=download,
+            )
+            with mock.patch.dict(sys.modules, {"huggingface_hub": fake_hf}):
+                downloaded = MODULE.download_reviewed_missing(
+                    self.current_request(inventory), cache, missing_store
+                )
+            self.assertEqual([row["path"] for row in downloaded["downloadedFiles"]], ["config.json"])
+            staged_result = MODULE.stage_artifact(
+                self.current_request(inventory), cache, staging, missing_store
+            )
+            self.assertTrue(staged_result["complete"])
+            self.assertEqual(staged_result["matchedFiles"], sorted(inventory))
 
     def test_request_rejects_unreviewed_floating_or_escaping_fields(self) -> None:
         self.assertEqual(self.parse(self.request())["allowPatterns"], ["q4/*"])

--- a/scripts/provision_epic_20738_terminal_artifact_test.py
+++ b/scripts/provision_epic_20738_terminal_artifact_test.py
@@ -384,12 +384,11 @@ class CacheOnlyProvisionTests(unittest.TestCase):
             "unet/model.safetensors": (len(first), hashlib.sha256(first).hexdigest()),
         }
         authority = {(self.CURRENT_REPOSITORY, self.CURRENT_REVISION): inventory}
-        with tempfile.TemporaryDirectory() as directory, tempfile.TemporaryDirectory() as stored, tempfile.TemporaryDirectory() as staged, mock.patch.dict(
+        with tempfile.TemporaryDirectory() as directory, tempfile.TemporaryDirectory() as stored, mock.patch.dict(
             MODULE.REVIEWED_HYDRATION_AUTHORITIES, authority, clear=True
         ):
             cache = Path(directory).resolve()
             missing_store = Path(stored).resolve()
-            staging = Path(staged).resolve()
             selected = self.current_selected(cache)
             (selected / "unet").mkdir(parents=True)
             (selected / "unet" / "model.safetensors").write_bytes(first)
@@ -421,7 +420,7 @@ class CacheOnlyProvisionTests(unittest.TestCase):
                 )
             self.assertEqual([row["path"] for row in downloaded["downloadedFiles"]], ["config.json"])
             staged_result = MODULE.stage_artifact(
-                self.current_request(inventory), cache, staging, missing_store
+                self.current_request(inventory), cache, missing_store, missing_store
             )
             self.assertTrue(staged_result["complete"])
             self.assertEqual(staged_result["matchedFiles"], sorted(inventory))


### PR DESCRIPTION
Fixes the exact pre-execution failure from terminal run 32644319969.

- Hydrates fully or partially absent reviewed Illustrious v1/v2 q4 snapshots.
- Keeps authority, revision, file list, size, SHA, path safety, cleanup, and post-download audits fail-closed.
- Accounts for the 7,823,313,648 hydrated bytes in the exact physical peak and disk floor.
- Adds full and partial production-path sparse recovery coverage for cells 14, 18, and 19.

Validation:
- Python provisioner: 14/14
- Terminal harness: 23/23
- Platform contracts: 71/71
- Harness check and diff check pass