### PR TITLE
fix: normalize reviewed hydration paths (sc-21306)

### DIFF
--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -2911,6 +2911,11 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
     assert.deepEqual(hydrated.runtimeCells.map(({ id }) => id), [
       "ltx-2-3-q8", "illustrious-v1-openpose", "illustrious-v2-openpose",
     ], hydrated.result.summary.campaignErrors.join("\n"));
+    assert.deepEqual(hydrated.result.summary.campaignErrors, [], mode);
+    assert.equal(hydrated.cacheEvidence.evidencePhase, "final", mode);
+    assert.equal(hydrated.cacheEvidence.status, "passed", mode);
+    assert.equal(hydrated.cacheEvidence.error, null, mode);
+    assert.ok(hydrated.continuationReceipts.every(({ status }) => status === "passed"), mode);
     assert.equal(hydrated.cacheEvidence.downloadedFiles.length, expectedDownloads, mode);
     assert.equal(hydrated.cacheEvidence.networkDownloadCount, expectedDownloads, mode);
     assert.equal(hydrated.cacheEvidence.diskPlan.persistentMissingBytes, expectedPersistentBytes, mode);

--- a/scripts/provision-epic-20738-terminal-artifact.py
+++ b/scripts/provision-epic-20738-terminal-artifact.py
@@ -389,6 +389,34 @@ def _mkdir_confined(root: Path, relative: Path, label: str) -> Path:
     return current
 
 
+def _resolved_ordinary_download_file(path: Path, snapshot: Path, label: str) -> Path:
+    lexical = Path(os.path.abspath(path))
+    for current in lexical.parents:
+        try:
+            metadata = current.lstat()
+        except FileNotFoundError as error:
+            raise RuntimeError(f"{label} parent is missing: {str(current)!r}") from error
+        if not stat.S_ISDIR(metadata.st_mode) or _is_reparse(metadata):
+            raise RuntimeError(
+                f"{label} parent is not an ordinary non-reparse directory: {str(current)!r}"
+            )
+    try:
+        metadata = lexical.lstat()
+    except FileNotFoundError as error:
+        raise RuntimeError(f"{label} is missing: {str(lexical)!r}") from error
+    if not stat.S_ISREG(metadata.st_mode) or _is_reparse(metadata):
+        raise RuntimeError(
+            f"{label} is not an ordinary non-reparse file: {str(lexical)!r}"
+        )
+    resolved = lexical.resolve(strict=True)
+    if not _inside(snapshot, resolved):
+        raise RuntimeError(
+            f"{label} escaped the exact destination snapshot after strict resolution: "
+            f"{str(resolved)!r}"
+        )
+    return resolved
+
+
 def _receipt_path(root: Path, request: dict) -> Path:
     owner, name = request["repository"].split("/", 1)
     return root / "download-receipts" / f"{owner}--{name}@{request['revision']}.json"
@@ -480,10 +508,22 @@ def download_reviewed_missing(request: dict, cache_root: Path, missing_store: Pa
                 local_files_only=False,
             )
         )
-        if downloaded != destination or not destination.is_file():
-            raise RuntimeError("pinned missing-file download did not materialize the exact store path")
-        if destination.is_symlink() or _is_reparse(destination.lstat()):
-            raise RuntimeError("pinned missing-file download produced a reparse target")
+        resolved_snapshot = _ordinary_directory(
+            destination_snapshot, "exact campaign missing-file destination snapshot"
+        )
+        if not _inside(destination_root, resolved_snapshot):
+            raise RuntimeError("exact campaign missing-file destination snapshot escaped its store")
+        resolved_destination = _resolved_ordinary_download_file(
+            destination, resolved_snapshot, "pinned missing-file expected destination"
+        )
+        resolved_downloaded = _resolved_ordinary_download_file(
+            downloaded, resolved_snapshot, "pinned missing-file returned path"
+        )
+        if resolved_downloaded != resolved_destination:
+            raise RuntimeError(
+                "pinned missing-file download resolved to a different file: "
+                f"returned={str(resolved_downloaded)!r}, expected={str(resolved_destination)!r}"
+            )
         actual_sha = _sha256(destination)
         expected_sha = reviewed_sha or etag
         if destination.stat().st_size != metadata.size or actual_sha != expected_sha:

--- a/scripts/provision_epic_20738_terminal_artifact_test.py
+++ b/scripts/provision_epic_20738_terminal_artifact_test.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import os
 import socket
+import stat
 import sys
 import tempfile
 import types
@@ -424,6 +425,84 @@ class CacheOnlyProvisionTests(unittest.TestCase):
             )
             self.assertTrue(staged_result["complete"])
             self.assertEqual(staged_result["matchedFiles"], sorted(inventory))
+
+    def test_download_accepts_only_the_same_resolved_ordinary_confined_file(self) -> None:
+        payload = b"exact download"
+        inventory = {"config.json": (len(payload), hashlib.sha256(payload).hexdigest())}
+        authority = {(self.CURRENT_REPOSITORY, self.CURRENT_REVISION): inventory}
+
+        for mode, expected_error in [
+            ("normalized-alias", None),
+            ("different", "resolved to a different file"),
+            ("missing-destination", "expected destination is missing"),
+            ("missing-returned", "returned path is missing"),
+            ("escape", "returned path escaped the exact destination snapshot"),
+            ("reparse", "expected destination is not an ordinary non-reparse file"),
+        ]:
+            with self.subTest(mode=mode), tempfile.TemporaryDirectory() as directory, \
+                    tempfile.TemporaryDirectory() as stored, tempfile.TemporaryDirectory() as outside, \
+                    mock.patch.dict(MODULE.REVIEWED_HYDRATION_AUTHORITIES, authority, clear=True):
+                cache = Path(directory).resolve()
+                missing_store = Path(stored).resolve()
+                outside_file = Path(outside).resolve() / "outside.bin"
+
+                def url(**kwargs):
+                    return f"https://huggingface.invalid/{kwargs['filename']}"
+
+                def metadata(_url, token):
+                    self.assertFalse(token)
+                    return types.SimpleNamespace(
+                        commit_hash=self.CURRENT_REVISION,
+                        etag="c" * 40,
+                        size=len(payload),
+                    )
+
+                def download(**kwargs):
+                    destination = Path(kwargs["local_dir"]) / kwargs["filename"]
+                    if mode != "missing-destination":
+                        destination.write_bytes(payload)
+                    if mode == "normalized-alias":
+                        alias = str(
+                            destination.parent / ".." / destination.parent.name / destination.name
+                        )
+                        return alias.swapcase().replace("\\", "/") if os.name == "nt" else alias
+                    if mode in {"different", "missing-destination"}:
+                        different = destination.with_name("different.bin")
+                        different.write_bytes(payload)
+                        return str(different)
+                    if mode == "missing-returned":
+                        return str(destination.with_name("missing.bin"))
+                    if mode == "escape":
+                        outside_file.write_bytes(payload)
+                        return str(outside_file)
+                    return str(destination)
+
+                fake_hf = types.SimpleNamespace(
+                    __version__="0.36.0", hf_hub_url=url,
+                    get_hf_file_metadata=metadata, hf_hub_download=download,
+                )
+                reparse = mock.patch.object(
+                    MODULE,
+                    "_is_reparse",
+                    side_effect=lambda value: mode == "reparse" and stat.S_ISREG(value.st_mode),
+                )
+                with mock.patch.dict(sys.modules, {"huggingface_hub": fake_hf}), reparse:
+                    if expected_error is not None:
+                        with self.assertRaisesRegex(RuntimeError, expected_error):
+                            MODULE.download_reviewed_missing(
+                                self.current_request(inventory), cache, missing_store
+                            )
+                        continue
+                    downloaded = MODULE.download_reviewed_missing(
+                        self.current_request(inventory), cache, missing_store
+                    )
+                self.assertEqual(downloaded["downloadedFiles"], [{
+                    "path": "config.json",
+                    "bytes": len(payload),
+                    "sha256": hashlib.sha256(payload).hexdigest(),
+                    "lfsSha256": hashlib.sha256(payload).hexdigest(),
+                    "commitSha": self.CURRENT_REVISION,
+                }])
 
     def test_request_rejects_unreviewed_floating_or_escaping_fields(self) -> None:
         self.assertEqual(self.parse(self.request())["allowPatterns"], ["q4/*"])


### PR DESCRIPTION
Fixes the exact hydration return-path rejection from terminal run 32650781484.

- Compares strict resolved Windows paths instead of raw spelling.
- Requires both paths to be ordinary non-reparse files at the identical confined destination.
- Preserves exact commit, size, SHA, Flux, and multi-file checks.
- Adds equivalent-spelling and reject-path regressions.

Validation:
- Python provisioner: 15/15
- Harness and inventory: 29/29
- Harness self-check, Python compile, and diff check pass