### PR TITLE
fix(sc-21306): accept canonical Windows hydration paths

### DIFF
--- a/scripts/provision-epic-20738-terminal-artifact.py
+++ b/scripts/provision-epic-20738-terminal-artifact.py
@@ -389,8 +389,25 @@ def _mkdir_confined(root: Path, relative: Path, label: str) -> Path:
     return current
 
 
+def _without_windows_extended_prefix(path: Path, label: str) -> Path:
+    if os.name != "nt":
+        return path
+    value = str(path)
+    folded = value.casefold()
+    if folded.startswith("\\\\?\\unc\\"):
+        return Path(f"\\\\{value[8:]}")
+    if folded.startswith("\\\\?\\"):
+        ordinary = value[4:]
+        if re.match(r"^[A-Za-z]:\\", ordinary):
+            return Path(ordinary)
+        raise RuntimeError(
+            f"{label} uses an unsupported Windows device namespace: {value!r}"
+        )
+    return path
+
+
 def _resolved_ordinary_download_file(path: Path, snapshot: Path, label: str) -> Path:
-    lexical = Path(os.path.abspath(path))
+    lexical = Path(os.path.abspath(_without_windows_extended_prefix(path, label)))
     for current in lexical.parents:
         try:
             metadata = current.lstat()

--- a/scripts/provision_epic_20738_terminal_artifact_test.py
+++ b/scripts/provision_epic_20738_terminal_artifact_test.py
@@ -433,6 +433,7 @@ class CacheOnlyProvisionTests(unittest.TestCase):
 
         for mode, expected_error in [
             ("normalized-alias", None),
+            ("extended-drive", None),
             ("different", "resolved to a different file"),
             ("missing-destination", "expected destination is missing"),
             ("missing-returned", "returned path is missing"),
@@ -466,6 +467,8 @@ class CacheOnlyProvisionTests(unittest.TestCase):
                             destination.parent / ".." / destination.parent.name / destination.name
                         )
                         return alias.swapcase().replace("\\", "/") if os.name == "nt" else alias
+                    if mode == "extended-drive":
+                        return f"\\\\?\\{destination}"
                     if mode in {"different", "missing-destination"}:
                         different = destination.with_name("different.bin")
                         different.write_bytes(payload)
@@ -503,6 +506,25 @@ class CacheOnlyProvisionTests(unittest.TestCase):
                     "lfsSha256": hashlib.sha256(payload).hexdigest(),
                     "commitSha": self.CURRENT_REVISION,
                 }])
+
+    @unittest.skipUnless(os.name == "nt", "Windows extended path spellings are Windows-only")
+    def test_windows_extended_prefix_normalizes_only_drive_and_unc_paths(self) -> None:
+        self.assertEqual(
+            MODULE._without_windows_extended_prefix(
+                Path(r"\\?\D:\runner\snapshot\q4\model_index.json"), "fixture"
+            ),
+            Path(r"D:\runner\snapshot\q4\model_index.json"),
+        )
+        self.assertEqual(
+            MODULE._without_windows_extended_prefix(
+                Path(r"\\?\UNC\server\share\snapshot\q4\model_index.json"), "fixture"
+            ),
+            Path(r"\\server\share\snapshot\q4\model_index.json"),
+        )
+        with self.assertRaisesRegex(RuntimeError, "unsupported Windows device namespace"):
+            MODULE._without_windows_extended_prefix(
+                Path(r"\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy1\escape"), "fixture"
+            )
 
     def test_request_rejects_unreviewed_floating_or_escaping_fields(self) -> None:
         self.assertEqual(self.parse(self.request())["allowPatterns"], ["q4/*"])


### PR DESCRIPTION
## Summary
- normalize Windows extended drive and UNC spellings before strict hydration-path validation
- preserve fail-closed confinement, missing-file, device-namespace, and reparse checks
- add focused coverage for the exact runner spelling from run 32653234498

## Validation
- provisioner tests: 16/16
- focused campaign/inventory tests: 2/2
- harness self-check
- Python compilation and diff check

Shortcut: sc-21306