### PR TITLE
docs(CLAUDE.md): both repos' main and feature/* rulesets are strict: false

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,10 +14,12 @@ here.
   Read its *Current state* section before acting on any branch protection
   assumption. As of 2026-08-11 **neither SceneWorks nor inference has a merge
   queue** — both were removed the same day after the queue was measured catching
-  zero integration failures in 103 groups while adding ~21m per merge. `main` is
-  `strict: false` in both; `feature/*` is `strict: true` in both. Any procedure
-  or memory that mentions staging, activating, or recovering a per-branch queue
-  ruleset is obsolete.
+  zero integration failures in 103 groups while adding ~21m per merge. `main`
+  and `feature/*` are `strict: false` in both repos (inference `main` drifted
+  back to `strict: true` twice and was reset on 2026-08-23 — do not re-enable
+  it; a strict policy forces a full CI re-run of every open PR after each
+  merge). Any procedure or memory that mentions staging, activating, or
+  recovering a per-branch queue ruleset is obsolete.
 
   Likewise, the pin-keyed verification gates were **deliberately dismantled**
   on 2026-08-15/16 (sc-19758, sc-19751, `e14171984`): disabled or unwired check


### PR DESCRIPTION
Doc-only. The *Current state* pointer in CLAUDE.md said `feature/*` is `strict: true` in both repos. The live rulesets (and FEATURE_DEVELOPMENT.md §Current state) have `feature/*` non-strict in both; the ruleset that *was* strict — inference `main` (`Require MR`, 20481541) — was reset to `strict: false` on 2026-08-23 after its history showed it drifting back to strict twice (08-15, and 08-21 ninety seconds after being set false). Records the state and "do not re-enable".

Context: today's CI-efficiency work (inference #756/#759/#761/#762).

🤖 Generated with [Claude Code](https://claude.com/claude-code)