### PR TITLE
Settings: override the HF cache / model library location (sc-21389)

### DIFF
--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 
-use crate::setup::{default_data_dir, settings_file, shared_huggingface_home};
+use crate::setup::{
+    default_data_dir, huggingface_home_selection, settings_file, shared_huggingface_home,
+};
 
 const KEYRING_SERVICE: &str = "SceneWorks";
 /// Pre-migration account that held the single Hugging Face token. Retained only so
@@ -866,6 +868,14 @@ pub struct StorageSetup {
     data_dir_default: String,
     hf_home: Option<String>,
     hf_home_default: String,
+    /// The cache home the sidecars will actually receive at their next spawn — ambient `HF_HOME`
+    /// first (e.g. `tauri dev`, a shell-profile export), then the persisted override, then the
+    /// platform default. This is what Settings displays: the row exists to tell the user where
+    /// SceneWorks is really reading from.
+    hf_home_active: String,
+    /// True when an ambient `HF_HOME` is what decides `hf_home_active`; the persisted override is
+    /// then inert and Settings says so instead of offering a change that would not take effect.
+    hf_home_from_environment: bool,
     storage_configured: bool,
     setup_completed: bool,
 }
@@ -873,11 +883,14 @@ pub struct StorageSetup {
 #[tauri::command]
 pub fn get_storage_setup() -> StorageSetup {
     let settings = load_settings();
+    let (hf_home_active, hf_home_from_environment) = huggingface_home_selection();
     StorageSetup {
         data_dir: settings.data_dir,
         data_dir_default: default_data_dir().to_string_lossy().into_owned(),
         hf_home: settings.hf_home,
         hf_home_default: shared_huggingface_home().to_string_lossy().into_owned(),
+        hf_home_active: hf_home_active.to_string_lossy().into_owned(),
+        hf_home_from_environment,
         storage_configured: settings.storage_configured,
         setup_completed: settings.setup_completed,
     }

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -612,14 +612,28 @@ fn inject_resolved_cache_env(
 }
 
 fn huggingface_home() -> PathBuf {
+    huggingface_home_selection().0
+}
+
+/// The cache home the sidecars will actually receive at their next spawn, plus whether an ambient
+/// `HF_HOME` in the desktop's own environment is what decides it. When it is, the persisted
+/// Settings override is inert — Settings shows the active path and says so instead of offering a
+/// change that would silently not take effect (`get_storage_setup`).
+pub fn huggingface_home_selection() -> (PathBuf, bool) {
+    let linux_absolute = cfg!(all(unix, not(target_os = "macos")));
     let ambient = std::env::var("HF_HOME").ok();
+    let ambient_wins = ambient
+        .as_deref()
+        .and_then(|value| crate::settings::storage_override_path(value, linux_absolute))
+        .is_some();
     let persisted = crate::settings::load_settings().hf_home;
-    select_huggingface_home(
+    let home = select_huggingface_home(
         ambient.as_deref(),
         persisted.as_deref(),
         shared_huggingface_home(),
-        cfg!(all(unix, not(target_os = "macos"))),
-    )
+        linux_absolute,
+    );
+    (home, ambient_wins)
 }
 
 /// Seed the builtin model/LoRA/recipe-preset catalogs into the desktop's

--- a/apps/rust-api/src/model_library.rs
+++ b/apps/rust-api/src/model_library.rs
@@ -26,9 +26,9 @@ use axum::extract::{ConnectInfo, State};
 use axum::http::StatusCode;
 use axum::Json;
 use sceneworks_core::model_artifacts::external_library::{
-    probe_model_source_library, resolve_relocation_target, ExternalLibraryBindingStore,
-    ExternalLibraryError, LibraryRelocationError, LibraryRelocationRejection,
-    ModelSourceLibraryStatus, RelocationTarget,
+    probe_model_source_library, resolve_fresh_cache_home, resolve_relocation_target,
+    ExternalLibraryBindingStore, ExternalLibraryError, LibraryRelocationError,
+    LibraryRelocationRejection, ModelSourceLibraryStatus, RelocationTarget,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -88,6 +88,12 @@ pub(crate) struct RelocateModelLibraryResponse {
 
 /// `POST /api/v1/model-library/relocate` — adopt a new library root without redownloading.
 ///
+/// Two shapes, decided by the installation's durable install evidence: with evidence, the picked
+/// folder must be a library carrying every recorded model (the recovery prompt's "my drive moved"
+/// case); without any, it is a fresh cache home — any existing directory, whose `hub` child is
+/// created on adopt — so the Settings "change model library" control works before the first
+/// download exactly like the first-run storage step does.
+///
 /// Local-only (see [`require_local_peer`]): it takes an absolute host path, and its typed refusals
 /// would otherwise be a filesystem-existence oracle for any token-holding LAN client — which could
 /// also re-point a shared server's library out from under everyone else.
@@ -104,19 +110,52 @@ pub(crate) async fn relocate_model_library(
     let dry_run = request.dry_run;
     let data_dir = state.settings.data_dir.clone();
     tokio::task::spawn_blocking(move || {
-        let target = resolve_relocation_target(std::path::Path::new(&picked))
-            .map_err(rejection_to_api_error)?;
         let store = ExternalLibraryBindingStore::new(&data_dir).map_err(|error| {
             relocation_failed("model library binding ledger is unavailable", &error)
         })?;
+        let has_evidence = store.has_install_evidence().map_err(|error| {
+            relocation_failed("model library install evidence could not be read", &error)
+        })?;
+        // The fresh-home shape additionally requires that no library was ever bound: evidence
+        // detection is receipt/ledger-based, so an install whose receipts became unreadable must
+        // not slide into binding an arbitrary folder — an existing binding is itself proof this
+        // installation already had a library, and the strict shape judges the candidate.
+        let bound = store
+            .load()
+            .map_err(|error| relocation_failed("model library binding could not be read", &error))?
+            .is_some();
+        let fresh = !has_evidence && !bound;
+        let target = if fresh {
+            resolve_fresh_cache_home(std::path::Path::new(&picked))
+        } else {
+            resolve_relocation_target(std::path::Path::new(&picked))
+        }
+        .map_err(rejection_to_api_error)?;
         if dry_run {
+            // A fresh home's `hub` may not exist yet (it is created on adopt), so the dry run
+            // validates the home directory itself: with no install evidence that is the same
+            // canonical-directory + volume-identity check the adopt makes, moving every ordinary
+            // refusal ahead of both durable writes. Writability of the folder is the one thing a
+            // write-free dry run cannot prove.
             store
-                .validate_relocation(&target.library_root)
+                .validate_relocation(if fresh {
+                    &target.hf_home
+                } else {
+                    &target.library_root
+                })
                 .map_err(relocation_error_to_api_error)?;
             return Ok(Json(RelocateModelLibraryResponse {
                 target,
                 adopted: false,
             }));
+        }
+        if fresh {
+            std::fs::create_dir_all(&target.library_root).map_err(|error| {
+                relocation_failed(
+                    "model library folder could not be created",
+                    &ExternalLibraryError(error.to_string()),
+                )
+            })?;
         }
         store
             .relocate_binding(&target.library_root)
@@ -193,11 +232,6 @@ fn rejection_to_api_error(rejection: LibraryRelocationRejection) -> ApiError {
              that contains them, or reconnect the original drive.",
             repositories.join(", ")
         ),
-        LibraryRelocationRejection::NoInstalledModels => {
-            "SceneWorks has no record of any installed models, so there is nothing to relocate. \
-             Reconnect the original library, or download the models you need."
-                .to_owned()
-        }
         LibraryRelocationRejection::HubDirectoryExpected => {
             "SceneWorks reads models from a `hub` folder inside the Hugging Face cache. Choose the \
              folder that contains `hub` (or the `hub` folder itself)."

--- a/apps/rust-api/src/tests/model_library.rs
+++ b/apps/rust-api/src/tests/model_library.rs
@@ -360,6 +360,81 @@ async fn relocating_to_the_moved_library_adopts_it_and_names_the_home_to_persist
         .is_some_and(|root| Path::new(root) == relocated_home.join("hub")));
 }
 
+/// The Settings "change model library" path before anything is installed: with no install
+/// evidence there is nothing to protect, so an EMPTY folder is accepted as a fresh cache home — the
+/// dry run confirms it without creating anything, the adopt creates `hub` and binds it, and the
+/// response names the `HF_HOME` the shell must persist (the picked folder itself).
+#[tokio::test]
+async fn a_fresh_install_adopts_an_empty_folder_as_its_cache_home() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let _env = isolate_hf_cache();
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    std::fs::create_dir_all(&data_dir).expect("data dir creates");
+    let store = ExternalLibraryBindingStore::new(&data_dir).expect("binding store");
+    assert!(!store.has_install_evidence().expect("evidence reads"));
+    let fresh_home = temp_dir.path().join("fresh-cache");
+    std::fs::create_dir_all(&fresh_home).expect("fresh home creates");
+    let app = create_app(settings).expect("app creates");
+
+    let (status, body) = request_with_peer(
+        app.clone(),
+        "POST",
+        "/api/v1/model-library/relocate",
+        json!({ "path": fresh_home.to_string_lossy(), "dryRun": true }),
+        LOCAL_PEER,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["adopted"], false);
+    assert!(!fresh_home.join("hub").exists(), "a dry run writes nothing");
+    assert!(store.load().expect("binding reads").is_none());
+
+    let (status, body) = request_with_peer(
+        app.clone(),
+        "POST",
+        "/api/v1/model-library/relocate",
+        json!({ "path": fresh_home.to_string_lossy() }),
+        LOCAL_PEER,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["adopted"], true);
+    assert!(body["hfHome"]
+        .as_str()
+        .is_some_and(|home| Path::new(home) == fresh_home));
+    assert!(body["libraryRoot"]
+        .as_str()
+        .is_some_and(|root| Path::new(root) == fresh_home.join("hub")));
+    assert!(
+        fresh_home.join("hub").is_dir(),
+        "adopt creates the hub root"
+    );
+    let binding = store
+        .load()
+        .expect("binding reads")
+        .expect("the fresh home is bound");
+    assert_eq!(
+        binding.canonical_path,
+        fresh_home
+            .join("hub")
+            .canonicalize()
+            .expect("hub canonicalizes")
+    );
+
+    // A folder that does not exist is still refused, typed, even with nothing installed.
+    let (status, body) = request_with_peer(
+        app.clone(),
+        "POST",
+        "/api/v1/model-library/relocate",
+        json!({ "path": temp_dir.path().join("absent").to_string_lossy() }),
+        LOCAL_PEER,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert_eq!(body["context"]["reason"], "not_a_directory");
+}
+
 /// Write a one-model manifest whose single download row is spelled out by the caller, so a test can
 /// vary exactly the declaration under test (a pinned revision, an optional co-requisite) without
 /// inheriting [`single_model_manifest`]'s fixed shape.

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -71,6 +71,7 @@ import { appConfirm, ConfirmHost } from "./appConfirm.jsx";
 import { ModelLibraryDialog } from "./components/ModelLibraryDialog.jsx";
 import { ModelLibraryRestartDialog } from "./components/ModelLibraryRestartDialog.jsx";
 import {
+  adoptModelLibrary,
   createModelLibraryGate,
   fetchModelLibraryStatus,
   relocateModelLibrary,
@@ -721,45 +722,54 @@ export function App() {
   // one blocked action and resumes it at most once, so a reconnect (or an impatient second click)
   // can never turn one blocked generation into two jobs. Registered as the module-level handler so
   // every submission path — and the studios' selection check — reaches it without prop threading.
+  // The relocation sequence's three seams, built once and shared by the blocked-action prompt
+  // (below) and the Settings → Storage "Model library" control, which relocates with no blocked
+  // action to resume but with exactly the same two-write ordering and undo.
+  const modelLibraryRelocator = useMemo(
+    () => ({
+      validate: (path) => validateModelLibrary(token, path),
+      adopt: (path) => relocateModelLibrary(token, path),
+      // Durable persistence of a relocated library is desktop state: the API hands back the exact
+      // HF_HOME the shell must store, in the same field, file and normalization as the first-run
+      // storage step. Returns an undo so the gate can restore the previous location if the
+      // server's re-bind then fails — the two copies must never disagree.
+      //
+      // Fails CLOSED when the previous location cannot be read, BEFORE the first durable write:
+      // without a previous location there is no undo, so a re-bind failure afterwards would leave
+      // the shell pointed at the new library while the gate reported the previous location still
+      // in use — the disagreement this undo path exists to prevent, with the wrong message on top.
+      persist: async (target) => {
+        // Nothing to persist — the browser shell keeps no copy of the location. A NO-OP undo, not
+        // `null`: the gate treats a missing undo as "changed and unrestorable", and here nothing
+        // changed, so the previous location genuinely is still in use.
+        if (!isDesktopShell || !target?.hfHome) return () => {};
+        let before = null;
+        try {
+          before = await tauriInvoke("get_storage_setup");
+        } catch (error) {
+          throw new Error(
+            `The current model library location could not be read, so nothing was changed. ${String(error)}`.trim(),
+          );
+        }
+        const previous = before?.hfHome ?? before?.hfHomeDefault ?? null;
+        if (!previous) {
+          throw new Error(
+            "The current model library location could not be read, so nothing was changed.",
+          );
+        }
+        await tauriInvoke("set_model_library", { path: target.hfHome });
+        return () => tauriInvoke("set_model_library", { path: previous });
+      },
+    }),
+    [token],
+  );
   const modelLibraryGate = useMemo(
     () =>
       createModelLibraryGate({
         probe: () => fetchModelLibraryStatus(token),
-        validate: (path) => validateModelLibrary(token, path),
-        adopt: (path) => relocateModelLibrary(token, path),
-        // Durable persistence of a relocated library is desktop state: the API hands back the exact
-        // HF_HOME the shell must store, in the same field, file and normalization as the first-run
-        // storage step. Returns an undo so the gate can restore the previous location if the
-        // server's re-bind then fails — the two copies must never disagree.
-        //
-        // Fails CLOSED when the previous location cannot be read, BEFORE the first durable write:
-        // without a previous location there is no undo, so a re-bind failure afterwards would leave
-        // the shell pointed at the new library while the gate reported the previous location still
-        // in use — the disagreement this undo path exists to prevent, with the wrong message on top.
-        persist: async (target) => {
-          // Nothing to persist — the browser shell keeps no copy of the location. A NO-OP undo, not
-          // `null`: the gate treats a missing undo as "changed and unrestorable", and here nothing
-          // changed, so the previous location genuinely is still in use.
-          if (!isDesktopShell || !target?.hfHome) return () => {};
-          let before = null;
-          try {
-            before = await tauriInvoke("get_storage_setup");
-          } catch (error) {
-            throw new Error(
-              `The current model library location could not be read, so nothing was changed. ${String(error)}`.trim(),
-            );
-          }
-          const previous = before?.hfHome ?? before?.hfHomeDefault ?? null;
-          if (!previous) {
-            throw new Error(
-              "The current model library location could not be read, so nothing was changed.",
-            );
-          }
-          await tauriInvoke("set_model_library", { path: target.hfHome });
-          return () => tauriInvoke("set_model_library", { path: previous });
-        },
+        ...modelLibraryRelocator,
       }),
-    [token],
+    [token, modelLibraryRelocator],
   );
   const modelLibraryState = useSyncExternalStore(
     modelLibraryGate.subscribe,
@@ -785,7 +795,9 @@ export function App() {
     if (!picked) return;
     const adopted = await modelLibraryGate.relocate(picked);
     if (adopted?.hfHome) {
-      setModelLibraryRelocation(adopted);
+      // `droppedSubmission`: the prompt path dropped whatever the user was submitting; the restart
+      // disclosure says so. The Settings path below has no submission to drop.
+      setModelLibraryRelocation({ ...adopted, droppedSubmission: true });
       // The notice outlives the dialog, so "Later" still leaves the reason visible.
       pushNotice(
         "general",
@@ -793,6 +805,21 @@ export function App() {
       );
     }
   }, [modelLibraryGate, pushNotice]);
+  // Settings → Storage → Model library → Change…: the same relocation (validate, persist, re-bind,
+  // undo on failure) and the same restart disclosure as the prompt, with no blocked action. Resolves
+  // to the adopted target, `null` when the picker was dismissed; rejects with the user-facing
+  // message when the folder was refused or a write failed, for the Settings screen to show inline.
+  // Unlike the prompt path there is no `modelLibraryPickerOpen` bracket: that flag only pauses the
+  // gate's auto re-probe, and with no blocked action pending there is nothing a re-probe could
+  // resume behind the native dialog.
+  const changeModelLibrary = useCallback(async () => {
+    if (!isDesktopShell) return null;
+    const picked = await tauriInvoke("choose_folder").catch(() => null);
+    if (!picked) return null;
+    const adopted = await adoptModelLibrary(modelLibraryRelocator, picked);
+    setModelLibraryRelocation({ ...adopted, droppedSubmission: false });
+    return adopted;
+  }, [modelLibraryRelocator]);
   // The drop guard that stops a stray file from navigating the webview (issue #1308) is
   // installed further down, next to `useWorkflowDrop` — it now hands the unclaimed file to
   // the workflow inspector (sc-15951), which needs the active project and `importAsset`.
@@ -3937,6 +3964,7 @@ export function App() {
             embedWorkflow={embedWorkflow}
             lockedToSimple={uiModeLocked}
             onAccentChange={changeAccent}
+            onChangeModelLibrary={changeModelLibrary}
             onEmbedWorkflowChange={changeEmbedWorkflow}
             onSimpleDefaultChange={changeSimpleUiDefault}
             sharingFocusRequest={settingsSharingFocusRequest}

--- a/apps/web/src/App.modelLibraryRelocate.test.jsx
+++ b/apps/web/src/App.modelLibraryRelocate.test.jsx
@@ -80,6 +80,8 @@ describe("App model library relocation + restart disclosure (sc-19709)", () => {
           setupCompleted: true,
           hfHome: "/Volumes/Models/hf",
           hfHomeDefault: "/Users/me/.cache/huggingface",
+          hfHomeActive: "/Volumes/Models/hf",
+          hfHomeFromEnvironment: false,
         });
       }
       if (command === "choose_folder") return Promise.resolve("/Volumes/Models 1/hf");
@@ -210,6 +212,50 @@ describe("App model library relocation + restart disclosure (sc-19709)", () => {
     await settle();
     const restarts = invoke.mock.calls.filter(([command]) => command === "restart_app");
     expect(restarts).toHaveLength(1);
+  });
+
+  // The same relocation, started from Settings → Storage instead of the unavailable-library
+  // prompt: no submission was dropped, so the disclosure must not claim one was.
+  it("relocates from Settings and discloses the restart without inventing a dropped job", async () => {
+    root = createRoot(container);
+    await act(async () => root.render(<App />));
+    await settle();
+
+    const settingsNav = [...document.body.querySelectorAll(".nav-label")].find(
+      (item) => item.textContent === "Settings",
+    );
+    await act(async () => settingsNav.closest("button").click());
+    await settle();
+    const settingsTab = [...document.body.querySelectorAll(".mode-tab")].find(
+      (tab) => tab.textContent.trim() === "Settings",
+    );
+    await act(async () => settingsTab.click());
+    await settle();
+
+    const row = [...document.body.querySelectorAll(".settings-row-title")]
+      .find((title) => title.textContent.includes("Model library"))
+      .closest("div").parentElement;
+    const change = [...row.querySelectorAll("button")].find(
+      (item) => item.textContent.trim() === "Change…",
+    );
+    await act(async () => change.click());
+    await settle();
+
+    expect(relocateRequests).toEqual([
+      { path: "/Volumes/Models 1/hf", dryRun: true },
+      { path: "/Volumes/Models 1/hf" },
+    ]);
+    expect(invoke).toHaveBeenCalledWith("set_model_library", {
+      path: "/Volumes/Models 1/hf",
+    });
+    const disclosure = dialogs()[0];
+    expect(disclosure).toBeTruthy();
+    expect(disclosure.textContent).toContain("after it restarts");
+    expect(disclosure.textContent).toContain("/Volumes/Models 1/hf");
+    expect(disclosure.textContent).not.toContain("was not queued");
+    expect(document.body.textContent).toContain(
+      "Model library updated — restart SceneWorks to apply.",
+    );
   });
 
   it("Later dismisses the disclosure and leaves no queued generation", async () => {

--- a/apps/web/src/components/ModelLibraryRestartDialog.jsx
+++ b/apps/web/src/components/ModelLibraryRestartDialog.jsx
@@ -67,10 +67,13 @@ export function ModelLibraryRestartDialog({
       </p>
       {/* Say what happened to the work they were doing. From the user's seat they pressed Generate,
           answered a dialog, and got a settings message: without this line, the missing job reads as
-          a bug rather than the deliberate consequence of relocating. */}
-      <p className="discard-confirm-body">
-        The generation you started was not queued. Submit it again after SceneWorks restarts.
-      </p>
+          a bug rather than the deliberate consequence of relocating. Only when there WAS a
+          submission — a relocation started from Settings dropped nothing. */}
+      {relocation.droppedSubmission ? (
+        <p className="discard-confirm-body">
+          The generation you started was not queued. Submit it again after SceneWorks restarts.
+        </p>
+      ) : null}
       <p className="model-library-path">
         <span className="model-library-path-label">New location</span>
         <code>{relocation.hfHome ?? relocation.libraryRoot}</code>

--- a/apps/web/src/components/ModelLibraryRestartDialog.test.jsx
+++ b/apps/web/src/components/ModelLibraryRestartDialog.test.jsx
@@ -7,6 +7,8 @@ const RELOCATION = {
   libraryRoot: "/Volumes/Models 1/hf/hub",
   hfHome: "/Volumes/Models 1/hf",
   status: { available: true },
+  // The prompt path: the user was submitting something when the library was found unavailable.
+  droppedSubmission: true,
 };
 
 describe("ModelLibraryRestartDialog (sc-19709)", () => {
@@ -66,6 +68,17 @@ describe("ModelLibraryRestartDialog (sc-19709)", () => {
     expect(dialog.querySelector('[role="status"]').getAttribute("aria-live")).toBe(
       "polite",
     );
+  });
+
+  // A relocation started from Settings → Storage dropped nothing: telling that user a generation
+  // "was not queued" would invent a job they never started.
+  it("omits the dropped-submission line for a relocation that had no submission", async () => {
+    const dialog = await render({
+      relocation: { ...RELOCATION, droppedSubmission: false },
+    });
+    expect(dialog.textContent).toContain("after it restarts");
+    expect(dialog.textContent).toContain("/Volumes/Models 1/hf");
+    expect(dialog.textContent).not.toContain("was not queued");
   });
 
   it("invokes the relaunch exactly once, however many times the button is clicked", async () => {

--- a/apps/web/src/modelLibrary.js
+++ b/apps/web/src/modelLibrary.js
@@ -131,10 +131,9 @@ const IDLE = Object.freeze({
   relocated: null,
 });
 
-/// A blocked-action gate: at most one pending action, resumed at most once.
+// Adopt a different model library root — the ONE relocation sequence, shared by the blocked-action
+// prompt below and the Settings "Model library" control (which has no blocked action to resume).
 //
-// Injected so the state machine is testable without a transport:
-//   `probe`    — the seam's library status; a retry gates on its `available`.
 //   `validate` — check a candidate root, writing nothing anywhere.
 //   `adopt`    — re-bind the server's durable identity to that root.
 //   `persist`  — store the client's own copy of the location. It must either return an undo that
@@ -144,7 +143,61 @@ const IDLE = Object.freeze({
 // Relocation has TWO durable writes in different places (the shell's `HF_HOME` and the server's
 // binding ledger) and they must not be allowed to disagree: `validate` first so every ordinary
 // refusal happens before either, then `persist`, then `adopt`, and if `adopt` fails the persist is
-// undone. What the user is told always matches what actually happened.
+// undone. Resolves to the adopted target; rejects with an Error whose message says what actually
+// happened (and nothing else — a raw transport/filesystem message never reaches the user alone).
+export async function adoptModelLibrary({ validate, adopt, persist } = {}, path) {
+  // 1. Validate. Nothing is written, so a refusal here leaves everything as it was and the user
+  //    simply picks again.
+  let target = null;
+  try {
+    target = (await validate?.(path)) ?? { hfHome: path, libraryRoot: path };
+  } catch (error) {
+    throw new Error(error?.message || "That library could not be used.");
+  }
+
+  // 2. Persist the client's copy, then 3. re-bind the server's. If the re-bind fails, undo the
+  //    persist so the two cannot disagree — and say what actually happened either way.
+  let undoPersist = null;
+  // Whether `persist` got far enough to have written anything. A `persist` that THREW wrote
+  // nothing (it is required to fail before its own durable write), so the previous location
+  // really is still in use; one that returned is the only case where restoring is in question.
+  let persisted = false;
+  try {
+    if (persist) {
+      undoPersist = (await persist(target)) ?? null;
+      persisted = true;
+    }
+    await adopt?.(path);
+  } catch (error) {
+    let restored = true;
+    if (persisted) {
+      if (typeof undoPersist === "function") {
+        try {
+          await undoPersist();
+        } catch {
+          restored = false;
+        }
+      } else {
+        // Persisted, but handed back no undo: the client's copy has changed and cannot be put
+        // back. Claiming "the previous location is still in use" here would be a lie, and the
+        // two copies would be left disagreeing with the user told otherwise.
+        restored = false;
+      }
+    }
+    throw new Error(
+      restored
+        ? `SceneWorks could not finish moving the model library, so the previous location is still in use. ${error?.message ?? ""}`.trim()
+        : "SceneWorks could not finish moving the model library, and could not restore the previous location. Set the model library folder in Settings.",
+    );
+  }
+  return target;
+}
+
+/// A blocked-action gate: at most one pending action, resumed at most once.
+//
+// Injected so the state machine is testable without a transport:
+//   `probe`    — the seam's library status; a retry gates on its `available`.
+//   `validate` / `adopt` / `persist` — the relocation sequence, see `adoptModelLibrary`.
 export function createModelLibraryGate({ probe, validate, adopt, persist } = {}) {
   let state = IDLE;
   // The single pending action. It is REMOVED from this slot before it runs, so no second caller —
@@ -229,61 +282,15 @@ export function createModelLibraryGate({ probe, validate, adopt, persist } = {})
       const action = takePending();
       const attempt = ++epoch;
       emit({ status: "relocating", hint: "", error: "" });
-
-      // 1. Validate. Nothing is written, so a refusal here leaves the blocked action intact and
-      //    the user simply picks again.
       let target = null;
       try {
-        target = (await validate?.(path)) ?? { hfHome: path, libraryRoot: path };
+        target = await adoptModelLibrary({ validate, adopt, persist }, path);
       } catch (error) {
+        // A refusal (validate) or a failed write (persist/adopt, already undone where possible)
+        // leaves the blocked action intact and reports what happened; the user simply picks again.
         if (attempt !== epoch) return null;
         pending = action;
-        emit({
-          status: "blocked",
-          hint: "",
-          error: error?.message || "That library could not be used.",
-        });
-        return null;
-      }
-
-      // 2. Persist the client's copy, then 3. re-bind the server's. If the re-bind fails, undo the
-      //    persist so the two cannot disagree — and say what actually happened either way.
-      let undoPersist = null;
-      // Whether `persist` got far enough to have written anything. A `persist` that THREW wrote
-      // nothing (it is required to fail before its own durable write), so the previous location
-      // really is still in use; one that returned is the only case where restoring is in question.
-      let persisted = false;
-      try {
-        if (persist) {
-          undoPersist = (await persist(target)) ?? null;
-          persisted = true;
-        }
-        await adopt?.(path);
-      } catch (error) {
-        let restored = true;
-        if (persisted) {
-          if (typeof undoPersist === "function") {
-            try {
-              await undoPersist();
-            } catch {
-              restored = false;
-            }
-          } else {
-            // Persisted, but handed back no undo: the client's copy has changed and cannot be put
-            // back. Claiming "the previous location is still in use" here would be a lie, and the
-            // two copies would be left disagreeing with the user told otherwise.
-            restored = false;
-          }
-        }
-        if (attempt !== epoch) return null;
-        pending = action;
-        emit({
-          status: "blocked",
-          hint: "",
-          error: restored
-            ? `SceneWorks could not finish moving the model library, so the previous location is still in use. ${error?.message ?? ""}`.trim()
-            : "SceneWorks could not finish moving the model library, and could not restore the previous location. Set the model library folder in Settings.",
-        });
+        emit({ status: "blocked", hint: "", error: error.message });
         return null;
       }
       if (attempt !== epoch) return null;

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -81,6 +81,11 @@ export function SettingsScreen({
   lockedToSimple = false,
   embedWorkflow = true,
   onEmbedWorkflowChange,
+  // Settings → Storage → Model library → Change…. Owned by App.jsx (it shares the relocation
+  // sequence and the restart disclosure with the unavailable-library prompt, sc-19709): runs the
+  // native picker, validates + persists + re-binds, and opens the restart dialog. Resolves to the
+  // adopted target, `null` when the picker was dismissed; rejects with the message to show.
+  onChangeModelLibrary,
   sharingFocusRequest = 0,
 }) {
   // theme/changeTheme and the worker registry come from the app context (the same values the
@@ -88,6 +93,10 @@ export function SettingsScreen({
   // App.jsx, which owns them alongside the sidebar's mode switch.
   const { theme, changeTheme, visibleWorkers = [], macCapabilities } = useAppContext();
   const [settings, setSettings] = useState(null);
+  // The first-run storage snapshot, read only for `hfHomeDefault`: the model library row shows the
+  // folder the app is ACTUALLY reading from when no override is set, not "Default location" — the
+  // whole point of the row is telling a user whose cache moved where SceneWorks still thinks it is.
+  const [storageSetup, setStorageSetup] = useState(null);
   const [gpu, setGpu] = useState(null);
   const [credentials, setCredentials] = useState([]);
   const [newHost, setNewHost] = useState("");
@@ -142,13 +151,16 @@ export function SettingsScreen({
   const refresh = useCallback(async () => {
     try {
       if (isDesktop) {
-        const [loadedSettings, gpuInfo, storedCredentials, remoteAccess] = await Promise.all([
-          invoke("get_app_settings"),
-          invoke("get_gpu_info"),
-          invoke("list_credentials"),
-          invoke("get_remote_access"),
-        ]);
+        const [loadedSettings, gpuInfo, storedCredentials, remoteAccess, storage] =
+          await Promise.all([
+            invoke("get_app_settings"),
+            invoke("get_gpu_info"),
+            invoke("list_credentials"),
+            invoke("get_remote_access"),
+            invoke("get_storage_setup"),
+          ]);
         setSettings(loadedSettings);
+        setStorageSetup(storage);
         setGpu(gpuInfo);
         setCredentials(storedCredentials ?? []);
         if (remoteAccess) {
@@ -259,6 +271,43 @@ export function SettingsScreen({
   async function revealDataDir() {
     if (settings?.dataDir) {
       await invoke("reveal_in_os", { path: settings.dataDir });
+    }
+  }
+
+  // The Hugging Face cache home SceneWorks is ACTUALLY reading models from, as the shell resolves
+  // it for the sidecar spawn (ambient `HF_HOME` first, then the persisted override, then the
+  // platform default). The persisted override alone would lie whenever an ambient `HF_HOME` wins —
+  // which is exactly when it matters, so the row shows the resolved path and, in that case, says
+  // the environment owns it instead of offering a change that would not take effect.
+  const modelLibraryFromEnvironment = storageSetup?.hfHomeFromEnvironment === true;
+  const modelLibraryPath =
+    storageSetup?.hfHomeActive ?? settings?.hfHome ?? storageSetup?.hfHomeDefault ?? null;
+
+  async function changeModelLibrary() {
+    try {
+      const adopted = await onChangeModelLibrary?.();
+      if (adopted?.hfHome) {
+        // The shell persisted the override inside the relocation; re-read it rather than guessing.
+        const [reloaded, storage] = await Promise.all([
+          invoke("get_app_settings"),
+          invoke("get_storage_setup"),
+        ]);
+        setSettings(reloaded);
+        setStorageSetup(storage);
+        setStatus("Model library updated — restart SceneWorks to apply.");
+      }
+    } catch (error) {
+      setStatus(error?.message || String(error));
+    }
+  }
+
+  async function revealModelLibrary() {
+    if (!modelLibraryPath) return;
+    try {
+      await invoke("reveal_in_os", { path: modelLibraryPath });
+    } catch (error) {
+      // Most likely: the default cache home was never created because nothing was downloaded yet.
+      setStatus(error?.message || String(error));
     }
   }
 
@@ -695,6 +744,45 @@ export function SettingsScreen({
                       type="button"
                       onClick={revealDataDir}
                       disabled={!settings?.dataDir}
+                    >
+                      Reveal in {gpu?.platform === "windows" ? "Explorer" : "Finder"}
+                    </button>
+                  </div>
+                </div>
+                {/* The Hugging Face cache home (`HF_HOME`) — where downloaded model weights live.
+                    Changing it runs the sc-19709 relocation: the folder is checked first (with
+                    models installed it must hold every one this install recorded, so nothing is
+                    orphaned; before anything is installed any folder is acceptable), then the
+                    override is persisted and the library re-bound. Like the data directory, the
+                    sidecars pick it up at their next spawn, so it needs a restart. */}
+                <div>
+                  <div className="settings-row-title">Model library (Hugging Face cache)</div>
+                  <div className="settings-row-sub">
+                    Downloaded model weights. Choose the Hugging Face cache folder (the one
+                    containing <code>hub</code>) — if you moved your cache to another drive, point
+                    SceneWorks at it here. Needs a restart.
+                  </div>
+                  <div className="settings-path">{modelLibraryPath ?? "…"}</div>
+                  {modelLibraryFromEnvironment ? (
+                    <div className="settings-row-sub">
+                      Set by the <code>HF_HOME</code> environment variable, which overrides
+                      anything chosen here. Unset it to change the location from Settings.
+                    </div>
+                  ) : null}
+                  <div className="settings-button-row">
+                    <button
+                      className="settings-btn"
+                      type="button"
+                      onClick={changeModelLibrary}
+                      disabled={!onChangeModelLibrary || modelLibraryFromEnvironment}
+                    >
+                      Change…
+                    </button>
+                    <button
+                      className="settings-btn"
+                      type="button"
+                      onClick={revealModelLibrary}
+                      disabled={!modelLibraryPath}
                     >
                       Reveal in {gpu?.platform === "windows" ? "Explorer" : "Finder"}
                     </button>

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -59,6 +59,156 @@ async function openTab(container, label) {
 const buttonByText = (container, label) =>
   [...container.querySelectorAll("button")].find((button) => button.textContent.trim() === label);
 
+// Settings → Storage → Model library (the Hugging Face cache home). The row tells the user where
+// SceneWorks is ACTUALLY reading models from (override, else the platform default — never a bare
+// "Default location"), and Change… hands off to App's relocation sequence (sc-19709), which is
+// injected as `onChangeModelLibrary` so the screen never re-implements the two-write ordering.
+describe("SettingsScreen model library location", () => {
+  let container;
+  let root;
+  let invoke;
+  let SettingsScreen;
+  let appSettings;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    appSettings = {};
+    invoke = vi.fn(async (command) => {
+      switch (command) {
+        case "get_app_settings":
+          return appSettings;
+        case "get_storage_setup":
+          return {
+            dataDirDefault: "/Users/me/Library/Application Support/SceneWorks",
+            hfHome: appSettings.hfHome ?? null,
+            hfHomeDefault: "/Users/me/.cache/huggingface",
+            // The shell resolves what the sidecars will actually receive: ambient env, then the
+            // persisted override, then the default. The mock mirrors that (no ambient here).
+            hfHomeActive: appSettings.hfHome ?? "/Users/me/.cache/huggingface",
+            hfHomeFromEnvironment: false,
+            storageConfigured: true,
+            setupCompleted: true,
+          };
+        case "get_gpu_info":
+          return { platform: "macos", devices: [] };
+        case "list_credentials":
+          return [];
+        default:
+          return null;
+      }
+    });
+    window.__TAURI__ = { core: { invoke } };
+    vi.resetModules();
+    SettingsScreen = await loadScreen();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    delete window.__TAURI__;
+    vi.restoreAllMocks();
+  });
+
+  async function render(props) {
+    await renderScreen(root, SettingsScreen, props);
+    await openTab(container, "Settings");
+  }
+
+  it("shows the platform default cache home when no override is set", async () => {
+    await render({ onChangeModelLibrary: vi.fn() });
+    expect(container.textContent).toContain("Model library (Hugging Face cache)");
+    expect(container.textContent).toContain("/Users/me/.cache/huggingface");
+    expect(container.textContent).not.toContain("Default location/Users/me/.cache");
+  });
+
+  it("shows the persisted override and reveals it", async () => {
+    appSettings = { hfHome: "/Volumes/Models/huggingface" };
+    await render({ onChangeModelLibrary: vi.fn() });
+    expect(container.textContent).toContain("/Volumes/Models/huggingface");
+    const reveal = [...container.querySelectorAll("button")].filter(
+      (button) => button.textContent.trim() === "Reveal in Finder",
+    );
+    // Data directory (disabled: no override) then the model library.
+    expect(reveal).toHaveLength(2);
+    await click(reveal[1]);
+    expect(invoke).toHaveBeenCalledWith("reveal_in_os", { path: "/Volumes/Models/huggingface" });
+  });
+
+  it("relocates through the injected sequence, re-reads settings and asks for a restart", async () => {
+    const onChangeModelLibrary = vi.fn(async () => {
+      appSettings = { hfHome: "/Volumes/Models/huggingface" };
+      return { hfHome: "/Volumes/Models/huggingface", libraryRoot: "/Volumes/Models/huggingface/hub" };
+    });
+    await render({ onChangeModelLibrary });
+    const change = [...container.querySelectorAll("button")].filter(
+      (button) => button.textContent.trim() === "Change…",
+    );
+    expect(change).toHaveLength(2);
+    await click(change[1]);
+    expect(onChangeModelLibrary).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("/Volumes/Models/huggingface");
+    expect(container.textContent).toContain("Model library updated — restart SceneWorks to apply.");
+  });
+
+  it("shows the refusal inline and keeps the current location when the folder is rejected", async () => {
+    const onChangeModelLibrary = vi.fn(async () => {
+      throw new Error("That folder does not contain a SceneWorks model library.");
+    });
+    await render({ onChangeModelLibrary });
+    const change = [...container.querySelectorAll("button")].filter(
+      (button) => button.textContent.trim() === "Change…",
+    );
+    await click(change[1]);
+    expect(container.textContent).toContain(
+      "That folder does not contain a SceneWorks model library.",
+    );
+    expect(container.textContent).toContain("/Users/me/.cache/huggingface");
+    expect(container.textContent).not.toContain("restart SceneWorks to apply");
+  });
+
+  // `tauri dev` / a shell-profile export: an ambient `HF_HOME` beats the persisted override at
+  // spawn, so the row must show the path actually in use and must not offer a change that would
+  // silently never take effect.
+  it("shows the environment-owned location and disables Change…", async () => {
+    appSettings = { hfHome: "/Volumes/Models/huggingface" };
+    const fromEnv = invoke.getMockImplementation();
+    invoke.mockImplementation(async (command) => {
+      if (command === "get_storage_setup") {
+        return {
+          ...(await fromEnv(command)),
+          hfHomeActive: "/tmp/dev-hf-home",
+          hfHomeFromEnvironment: true,
+        };
+      }
+      return fromEnv(command);
+    });
+    await render({ onChangeModelLibrary: vi.fn() });
+    expect(container.textContent).toContain("/tmp/dev-hf-home");
+    expect(container.textContent).toContain("HF_HOME");
+    expect(container.textContent).toContain("environment variable");
+    const change = [...container.querySelectorAll("button")].filter(
+      (button) => button.textContent.trim() === "Change…",
+    );
+    expect(change[1].disabled).toBe(true);
+  });
+
+  it("does nothing when the picker is dismissed", async () => {
+    const onChangeModelLibrary = vi.fn(async () => null);
+    await render({ onChangeModelLibrary });
+    const change = [...container.querySelectorAll("button")].filter(
+      (button) => button.textContent.trim() === "Change…",
+    );
+    await click(change[1]);
+    expect(onChangeModelLibrary).toHaveBeenCalledTimes(1);
+    expect(container.textContent).not.toContain("restart SceneWorks to apply");
+  });
+});
+
 describe("SettingsScreen service credentials", () => {
   let container;
   let root;

--- a/crates/sceneworks-core/src/model_artifacts/external_library.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library.rs
@@ -453,9 +453,11 @@ impl ExternalLibraryBindingStore {
     /// never loses installed state — it only re-points the durable identity at where the library
     /// now lives.
     ///
-    /// It fails CLOSED in both directions: a library missing any recorded install is refused, and
-    /// an installation with no evidence at all is refused outright rather than binding whatever
-    /// Hugging-Face-shaped directory it was handed.
+    /// It fails CLOSED for every installed model: a library missing any recorded install is refused.
+    /// An installation with no install evidence at all has nothing to protect and nothing to check a
+    /// candidate against, so it binds the chosen directory as-is (the Settings "change model
+    /// library" path for a user who has not downloaded anything yet) — the same choice the first-run
+    /// storage step makes, with the volume identity recorded so later installs are judged against it.
     pub fn relocate_binding(
         &self,
         library_root: &Path,
@@ -489,6 +491,15 @@ impl ExternalLibraryBindingStore {
         self.check_relocation_unlocked(library_root).map(|_| ())
     }
 
+    /// Whether this installation has any durable install evidence (validated closures or download
+    /// receipts). Decides which relocation shape applies: with evidence, the candidate must be a
+    /// library carrying every recorded model; without it, any directory is an acceptable fresh
+    /// cache home.
+    pub fn has_install_evidence(&self) -> Result<bool, ExternalLibraryError> {
+        let _lock = self.lock_shared()?;
+        Ok(!self.installed_evidence_closures()?.is_empty())
+    }
+
     fn check_relocation_unlocked(
         &self,
         library_root: &Path,
@@ -497,34 +508,33 @@ impl ExternalLibraryBindingStore {
         let closures = self
             .installed_evidence_closures()
             .map_err(LibraryRelocationError::Failed)?;
-        if closures.is_empty() {
-            return Err(LibraryRelocationError::Rejected(
-                LibraryRelocationRejection::NoInstalledModels,
-            ));
-        }
-        if !has_repository_layout(&canonical_before) {
-            return Err(LibraryRelocationError::Rejected(
-                LibraryRelocationRejection::NotAModelLibrary,
-            ));
-        }
-        let mut missing = Vec::new();
-        for closure in &closures {
-            if validate_requirements_at_root(&canonical_before, closure).is_err() {
-                missing.extend(
-                    closure
-                        .iter()
-                        .map(|requirement| requirement.repository.clone()),
-                );
+        // No evidence: nothing can be orphaned and there is nothing to check, so only the identity
+        // read below stands between the operator and the folder they chose.
+        if !closures.is_empty() {
+            if !has_repository_layout(&canonical_before) {
+                return Err(LibraryRelocationError::Rejected(
+                    LibraryRelocationRejection::NotAModelLibrary,
+                ));
             }
-        }
-        if !missing.is_empty() {
-            missing.sort();
-            missing.dedup();
-            return Err(LibraryRelocationError::Rejected(
-                LibraryRelocationRejection::MissingInstalledModels {
-                    repositories: missing,
-                },
-            ));
+            let mut missing = Vec::new();
+            for closure in &closures {
+                if validate_requirements_at_root(&canonical_before, closure).is_err() {
+                    missing.extend(
+                        closure
+                            .iter()
+                            .map(|requirement| requirement.repository.clone()),
+                    );
+                }
+            }
+            if !missing.is_empty() {
+                missing.sort();
+                missing.dedup();
+                return Err(LibraryRelocationError::Rejected(
+                    LibraryRelocationRejection::MissingInstalledModels {
+                        repositories: missing,
+                    },
+                ));
+            }
         }
         let identity_before = physical_identity(&canonical_before).map_err(|error| {
             LibraryRelocationError::Rejected(LibraryRelocationRejection::IdentityUnavailable {
@@ -923,10 +933,6 @@ pub enum LibraryRelocationRejection {
     /// The layout is right, but models this install recorded as present are not in that library.
     /// Accepting it would silently orphan installed weights, so it fails closed.
     MissingInstalledModels { repositories: Vec<String> },
-    /// This installation has no durable install evidence at all — no receipts, no validated
-    /// closures — so there is nothing to relocate and nothing to check a candidate against.
-    /// Binding an arbitrary Hugging-Face-shaped directory here would be a guess, not a relocation.
-    NoInstalledModels,
     /// The library validates, but the app cannot express it as a Hugging Face cache home: the
     /// configured root is always `<HF_HOME>/hub`, so the operator must choose the folder that
     /// CONTAINS `hub` (or the `hub` folder itself).
@@ -961,6 +967,39 @@ impl std::fmt::Display for LibraryRelocationError {
 pub struct RelocationTarget {
     pub library_root: PathBuf,
     pub hf_home: PathBuf,
+}
+
+/// Map a folder the operator picked to the pair of paths a FRESH cache home needs — the shape used
+/// when this installation has no install evidence (see
+/// [`ExternalLibraryBindingStore::has_install_evidence`]). No repository layout is required: the
+/// picked folder is the cache home (its `hub` child is the library root, created by the caller
+/// when it adopts), unless the folder is itself named `hub`, in which case its parent is the home.
+/// Everything else about the home/hub pairing matches [`resolve_relocation_target`].
+pub fn resolve_fresh_cache_home(
+    picked: &Path,
+) -> Result<RelocationTarget, LibraryRelocationRejection> {
+    let picked = absolute_lexical(picked).map_err(|_| LibraryRelocationRejection::NotADirectory)?;
+    let canonical =
+        std::fs::canonicalize(&picked).map_err(|_| LibraryRelocationRejection::NotADirectory)?;
+    if !canonical.is_dir() {
+        return Err(LibraryRelocationRejection::NotADirectory);
+    }
+    let is_hub = picked
+        .file_name()
+        .is_some_and(|name| name.eq_ignore_ascii_case("hub"));
+    if is_hub {
+        return match picked.parent() {
+            Some(home) => Ok(RelocationTarget {
+                hf_home: home.to_path_buf(),
+                library_root: picked,
+            }),
+            None => Err(LibraryRelocationRejection::HubDirectoryExpected),
+        };
+    }
+    Ok(RelocationTarget {
+        library_root: picked.join("hub"),
+        hf_home: picked,
+    })
 }
 
 /// Map a folder the operator picked to the pair of paths relocation needs.

--- a/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
@@ -619,23 +619,65 @@ fn write_download_receipt(data_dir: &Path, repo: &str, file: &str) {
     .unwrap();
 }
 
-/// Nothing installed means nothing to relocate. Binding whatever Hugging-Face-shaped directory the
-/// operator happened to pick would be a guess, and it would silently become the identity every
-/// later install is judged against.
+/// Nothing installed means nothing can be orphaned and nothing to check a candidate against: an
+/// EMPTY directory (no `models--*` layout at all) binds as a fresh cache home, and the recorded
+/// identity is then what every later install is judged against — the Settings "change model
+/// library" path for a user who has not downloaded anything yet.
 #[test]
-fn relocation_refuses_outright_when_there_is_no_install_evidence() {
+fn relocation_binds_a_plain_directory_when_there_is_no_install_evidence() {
     let temp = TempDir::new().unwrap();
     let data = temp.path().join("data");
-    let candidate = temp.path().join("someones-cache").join("hub");
+    let candidate = temp.path().join("fresh-cache").join("hub");
     std::fs::create_dir_all(&candidate).unwrap();
-    seed_snapshot(&candidate, "someone/unrelated", "model.safetensors");
 
     let store = ExternalLibraryBindingStore::new(&data).unwrap();
+    assert!(!store.has_install_evidence().unwrap());
+    store.validate_relocation(&candidate).unwrap();
+    let binding = store.relocate_binding(&candidate).unwrap();
+    assert_eq!(binding.canonical_path, candidate.canonicalize().unwrap());
+    assert_eq!(store.load().unwrap(), Some(binding.clone()));
     assert_eq!(
-        store.relocate_binding(&candidate).unwrap_err(),
-        LibraryRelocationError::Rejected(LibraryRelocationRejection::NoInstalledModels)
+        probe_binding(&candidate, &binding).status,
+        ExternalLibraryProbeStatus::Available
     );
-    assert!(store.load().unwrap().is_none());
+    // A later install at that root is judged against the binding just written, not a fresh one.
+    seed_snapshot(&candidate, "owner/model", "model.safetensors");
+    let (bound, probe) = store
+        .bind_or_probe_validated(
+            &candidate,
+            &[requirement("owner/model", "model.safetensors")],
+        )
+        .unwrap();
+    assert_eq!(bound.physical_identity, binding.physical_identity);
+    assert_eq!(probe.status, ExternalLibraryProbeStatus::Available);
+    assert!(store.has_install_evidence().unwrap());
+}
+
+/// The fresh-home shape: a plain folder is the cache home (its `hub` child is the library root);
+/// a folder named `hub` is the library root (its parent the home). No layout is required.
+#[test]
+fn resolve_fresh_cache_home_pairs_home_and_hub_without_a_layout() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("fresh");
+    std::fs::create_dir_all(home.join("hub")).unwrap();
+    assert_eq!(
+        resolve_fresh_cache_home(&home).unwrap(),
+        RelocationTarget {
+            library_root: home.join("hub"),
+            hf_home: home.clone(),
+        }
+    );
+    assert_eq!(
+        resolve_fresh_cache_home(&home.join("hub")).unwrap(),
+        RelocationTarget {
+            library_root: home.join("hub"),
+            hf_home: home.clone(),
+        }
+    );
+    assert_eq!(
+        resolve_fresh_cache_home(&temp.path().join("absent")).unwrap_err(),
+        LibraryRelocationRejection::NotADirectory
+    );
 }
 
 /// THE fail-open this exists to prevent. Evidence can be RECEIPTS ONLY — an install that predates


### PR DESCRIPTION
[sc-21389](https://app.shortcut.com/trefry/story/21389)

## Problem
Settings → Storage has a Data directory control but no way to change the Hugging Face cache location. A user who moved their HF cache to an external drive has no recovery path unless a model happens to hit the sc-19709 unavailable-library prompt — whose fallback error even says "Set the model library folder in Settings", a control that did not exist.

## What this does
- **Settings → Storage → "Model library (Hugging Face cache)"** row (desktop only, like the data directory): shows the cache home the sidecars will *actually* receive at next spawn (ambient `HF_HOME` > persisted override > platform default — new `hfHomeActive`/`hfHomeFromEnvironment` on `StorageSetup`, resolved by the same `select_huggingface_home` the spawn path uses), plus **Change…** and **Reveal**. When an ambient `HF_HOME` owns the location, the row says so and Change… is disabled rather than persisting an override that would silently never take effect.
- **Change…** reuses the sc-19709 relocation sequence end to end: dry-run validate → shell `set_model_library` persist → API re-bind, with the persist undone if the re-bind fails. The sequence is extracted from the gate into `adoptModelLibrary` (behavior-preserving — same ordering, same user-facing strings; all 18 gate tests unchanged) so the prompt and Settings share one implementation. Success opens the existing restart disclosure; its "generation was not queued" line is now conditional (`droppedSubmission`) since the Settings path drops nothing.
- **API/core**: with no install evidence **and** no durable binding, `POST /api/v1/model-library/relocate` now accepts any existing directory as a fresh cache home (`resolve_fresh_cache_home`; `hub` created on adopt; the home's canonical-dir + volume-identity checks still run write-free on dry run). The `NoInstalledModels` refusal only made sense from the recovery prompt, where evidence always exists; from Settings it made the control a dead end before the first download. With installed models the fail-closed checks (layout + every recorded model present) are byte-for-byte unchanged — covered by the existing decoy/unrelated-folder tests.

## Known limitations (deliberate, unchanged from sc-19709)
- A user **with** installed models cannot point at an empty folder (that would orphan the installed weights); the typed refusal tells them to pick the folder holding their models.
- There is no control to clear the override back to the platform default (`set_model_library` rejects an empty path by design).

## Verification
- Full workspace `cargo test` green (2,600+), `cargo fmt --check`, workspace clippy `-D warnings`, `sceneworks-desktop` check/clippy/tests (97) green.
- Web: full vitest suite 4,035 green, incl. new coverage: Settings row (default/override/env-owned/refusal/dismissed picker), App-level end-to-end Settings relocation (dry-run→persist→adopt order, restart disclosure without the dropped-job line), restart-dialog conditional line, API fresh-home adopt (dry run writes nothing, adopt creates+binds `hub`, absent folder still typed-refused), core fresh-bind + later-install identity continuity.
- One adversarial review pass (Opus) + one fix pass: ambient-`HF_HOME` blind spot, fresh-path dry-run validation, Reveal error surfacing, fresh-path binding guard, doc/comment nits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)