### PR TITLE
ci(macos-mlx): fetch the prebuilt libmlx for the pinned mlx-rs rev (sc-21382)

### DIFF
--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -95,6 +95,8 @@ on:
       # The native producer below delegates its content comparison to this script. A script-only
       # change must exercise the lane it governs.
       - "scripts/compare-engine-capability-facts.mjs"
+      # Both jobs below run this to fetch the prebuilt libmlx; an edit to it must exercise them.
+      - "scripts/fetch-prebuilt-mlx.sh"
       - "Cargo.toml"
       - "Cargo.lock"
       # sc-17703 (Michael's call — a deliberate under-trigger fix): rust-toolchain.toml
@@ -366,6 +368,26 @@ jobs:
             sudo xcodebuild -downloadComponent MetalToolchain
           fi
           xcrun metal --version || true
+      - name: Fetch prebuilt MLX (sc-21382)
+        # pmetal-mlx-sys's cmake build of libmlx is ≈6 min on a hosted runner on every cache miss
+        # (plus a network fetch of MLX). The SceneWorks/mlx-rs fork publishes that build per
+        # commit (`prebuilt-<sha12>` releases, cell = target × deployment target × Debug/Release);
+        # scripts/fetch-prebuilt-mlx.sh picks the asset for the mlx-rs rev pinned in Cargo.lock
+        # (it moves with the inference pin) and this job's MACOSX_DEPLOYMENT_TARGET, and build.rs
+        # links it from PMETAL_MLX_PREBUILT_DIR only after checking the manifest against its own
+        # key -- a mismatch FAILS the build. The one failure tolerated here is "no prebuilt
+        # published for this rev" (exit 1): the right answer then is the source build, surfaced
+        # as a workflow annotation. Anything else is an error. Same step as inference ci.yml.
+        run: |
+          set +e
+          scripts/fetch-prebuilt-mlx.sh --github-env
+          rc=$?
+          set -e
+          if [ "$rc" = 1 ]; then
+            echo "::warning title=prebuilt MLX unavailable::no prebuilt for the pinned mlx-rs rev; building libmlx from source (see step log)"
+          elif [ "$rc" != 0 ]; then
+            exit "$rc"
+          fi
       - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
@@ -537,6 +559,26 @@ jobs:
         with:
           toolchain: "1.97.1"
           components: clippy
+      - name: Fetch prebuilt MLX (sc-21382)
+        # pmetal-mlx-sys's cmake build of libmlx is ≈6 min on every cache miss; this self-hosted runner keeps the extracted tarball in ~/.cache/pmetal/prebuilt across runs
+        # (plus a network fetch of MLX). The SceneWorks/mlx-rs fork publishes that build per
+        # commit (`prebuilt-<sha12>` releases, cell = target × deployment target × Debug/Release);
+        # scripts/fetch-prebuilt-mlx.sh picks the asset for the mlx-rs rev pinned in Cargo.lock
+        # (it moves with the inference pin) and this job's MACOSX_DEPLOYMENT_TARGET, and build.rs
+        # links it from PMETAL_MLX_PREBUILT_DIR only after checking the manifest against its own
+        # key -- a mismatch FAILS the build. The one failure tolerated here is "no prebuilt
+        # published for this rev" (exit 1): the right answer then is the source build, surfaced
+        # as a workflow annotation. Anything else is an error. Same step as inference ci.yml.
+        run: |
+          set +e
+          scripts/fetch-prebuilt-mlx.sh --github-env
+          rc=$?
+          set -e
+          if [ "$rc" = 1 ]; then
+            echo "::warning title=prebuilt MLX unavailable::no prebuilt for the pinned mlx-rs rev; building libmlx from source (see step log)"
+          elif [ "$rc" != 0 ]; then
+            exit "$rc"
+          fi
       - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -127,6 +127,14 @@ fail-closed remediation it prints. In particular, do not hand-edit a license,
 provenance, compatibility, capability, or calibration digest to make a stale
 audit appear current.
 
+If the new inference pin moves the `mlx-rs` fork revision in `Cargo.lock`, the
+macOS lanes' `Fetch prebuilt MLX` step looks for the fork's `prebuilt-<sha12>`
+release for that revision (`scripts/fetch-prebuilt-mlx.sh`; the fork publishes
+it on every push to its `main`). Until it exists the lanes build libmlx from
+source once per cache miss and say so with a workflow annotation — check
+`https://github.com/SceneWorks/mlx-rs/releases/tag/prebuilt-<sha12>` if the
+macOS job is slower than usual after a bump (sc-21382).
+
 Review the complete diff and run the repository checks plus relevant backend
 tests. Push the branch and open a PR against SceneWorks `release/next`. The pin
 PR must merge before the version bump is finalized.

--- a/scripts/fetch-prebuilt-mlx.sh
+++ b/scripts/fetch-prebuilt-mlx.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Fetch the prebuilt MLX archives for the mlx-rs revision pinned in Cargo.lock (sc-21382).
+#
+# pmetal-mlx-sys's build.rs runs a ~6 minute cmake build of libmlx (plus a network fetch of MLX)
+# on every cold build. The SceneWorks/mlx-rs fork publishes that build's `build/lib` per commit
+# as a GitHub Release `prebuilt-<sha12>` (see its .github/workflows/prebuilt.yml); build.rs links
+# it when PMETAL_MLX_PREBUILT_DIR points at the extracted directory, after checking the
+# directory's manifest against its own key. A wrong or stale directory FAILS the build, it does
+# not fall back -- so this script is allowed to be dumb: pick the asset by key, verify its
+# sha256, extract, print the directory.
+#
+# Usage:
+#   scripts/fetch-prebuilt-mlx.sh [--deployment-target 26.2] [--build-type Debug|Release]
+#                                 [--target aarch64-apple-darwin] [--dest DIR] [--github-env]
+#
+#   deployment target defaults to $MACOSX_DEPLOYMENT_TARGET, else the value in .cargo/config.toml
+#   build type defaults to Debug (what `cargo build`/`cargo test` consume; --release is Release)
+#   target defaults to the host triple
+#   dest defaults to ${PMETAL_MLX_PREBUILT_CACHE:-$HOME/.cache/pmetal/prebuilt}/<sha12>/<cell>
+#   --github-env appends PMETAL_MLX_PREBUILT_DIR=<dir> to $GITHUB_ENV for later CI steps
+#
+# Prints `PMETAL_MLX_PREBUILT_DIR=<dir>` on success. Exit codes: 1 = no release/asset for this
+# rev+cell (e.g. the fork rev was just bumped and prebuilt-mlx has not published yet -- the one
+# case where building from source is the right answer); 2 = usage/environment; 3 = the asset
+# exists but is corrupt or is not the cell it claims to be (never tolerate that). Local use:
+#
+#   eval "$(scripts/fetch-prebuilt-mlx.sh)" && export PMETAL_MLX_PREBUILT_DIR && cargo build ...
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RELEASE_REPO="${PMETAL_MLX_PREBUILT_REPO:-SceneWorks/mlx-rs}"
+FEATURES="accelerate-metal" # the crate defaults; any other feature set builds from source
+
+deployment_target="${MACOSX_DEPLOYMENT_TARGET:-}"
+build_type="Debug"
+target=""
+dest=""
+github_env=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --deployment-target) deployment_target="$2"; shift 2 ;;
+    --build-type) build_type="$2"; shift 2 ;;
+    --target) target="$2"; shift 2 ;;
+    --dest) dest="$2"; shift 2 ;;
+    --github-env) github_env=1; shift ;;
+    -h|--help) sed -n '2,26p' "$0"; exit 0 ;;
+    *) echo "fetch-prebuilt-mlx: unknown argument $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$deployment_target" ]; then
+  deployment_target="$(sed -n 's/^MACOSX_DEPLOYMENT_TARGET *= *"\([0-9.]*\)".*/\1/p' "$ROOT/.cargo/config.toml" | head -1)"
+  [ -n "$deployment_target" ] || { echo "fetch-prebuilt-mlx: cannot determine the deployment target (set MACOSX_DEPLOYMENT_TARGET or pass --deployment-target)" >&2; exit 2; }
+fi
+case "$build_type" in Debug|Release) ;; *) echo "fetch-prebuilt-mlx: --build-type must be Debug or Release" >&2; exit 2 ;; esac
+[ -n "$target" ] || target="$(rustc -vV | sed -n 's/^host: //p')"
+
+rev="$(sed -n 's|^source = "git+https://github.com/[^/]*/mlx-rs?rev=\([0-9a-f]\{40\}\)#.*|\1|p' "$ROOT/Cargo.lock" | head -1)"
+[ -n "$rev" ] || { echo "fetch-prebuilt-mlx: no mlx-rs git revision in $ROOT/Cargo.lock" >&2; exit 2; }
+sha12="${rev:0:12}"
+
+cell="${target}-dt${deployment_target}-${build_type}-${FEATURES}"
+asset="pmetal-mlx-${sha12}-${cell}.tar.zst"
+[ -n "$dest" ] || dest="${PMETAL_MLX_PREBUILT_CACHE:-$HOME/.cache/pmetal/prebuilt}/${sha12}/${cell}"
+manifest="$dest/pmetal-mlx-prebuilt.txt"
+
+emit() {
+  echo "PMETAL_MLX_PREBUILT_DIR=$dest"
+  if [ "$github_env" = 1 ]; then
+    [ -n "${GITHUB_ENV:-}" ] || { echo "fetch-prebuilt-mlx: --github-env but GITHUB_ENV is unset" >&2; exit 2; }
+    echo "PMETAL_MLX_PREBUILT_DIR=$dest" >> "$GITHUB_ENV"
+  fi
+}
+
+if [ -f "$manifest" ] && [ -f "$dest/libmlx.a" ] && [ -f "$dest/libmlxc.a" ] && [ -f "$dest/mlx.metallib" ]; then
+  echo "fetch-prebuilt-mlx: using cached $dest" >&2
+  emit
+  exit 0
+fi
+
+command -v zstd >/dev/null || { echo "fetch-prebuilt-mlx: zstd is required to extract $asset (brew install zstd)" >&2; exit 2; }
+base="https://github.com/${RELEASE_REPO}/releases/download/prebuilt-${sha12}"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/pmetal-mlx-prebuilt.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+echo "fetch-prebuilt-mlx: $base/$asset" >&2
+if ! curl -fsSL --retry 3 -o "$tmp/$asset" "$base/$asset" || ! curl -fsSL --retry 3 -o "$tmp/$asset.sha256" "$base/$asset.sha256"; then
+  echo "fetch-prebuilt-mlx: no prebuilt for mlx-rs $sha12 cell $cell at $base (run the fork's prebuilt-mlx workflow for that commit, or build from source)" >&2
+  exit 1
+fi
+(cd "$tmp" && shasum -a 256 -c "$asset.sha256" >&2) || { echo "fetch-prebuilt-mlx: sha256 mismatch for $asset" >&2; exit 3; }
+mkdir -p "$dest"
+zstd -dc "$tmp/$asset" | tar -x -C "$dest"
+for f in libmlx.a libmlxc.a mlx.metallib pmetal-mlx-prebuilt.txt; do
+  [ -f "$dest/$f" ] || { echo "fetch-prebuilt-mlx: $asset did not contain $f" >&2; rm -rf "$dest"; exit 3; }
+done
+grep -qx "deployment_target=${deployment_target}" "$manifest" || { echo "fetch-prebuilt-mlx: $asset manifest does not say deployment_target=${deployment_target}:" >&2; cat "$manifest" >&2; rm -rf "$dest"; exit 3; }
+grep -qx "build_type=${build_type}" "$manifest" || { echo "fetch-prebuilt-mlx: $asset manifest does not say build_type=${build_type}" >&2; rm -rf "$dest"; exit 3; }
+echo "fetch-prebuilt-mlx: extracted to $dest" >&2
+emit

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1743,6 +1743,7 @@ test("every workspace path a self-hosted lane watches maps to a package that lan
         // and not symmetry for its own sake.
         "config/engine-capabilities/audio/capabilities.candle.json",
         "scripts/compare-engine-capability-facts.mjs", // invoked directly by the native verification step
+        "scripts/fetch-prebuilt-mlx.sh", // both jobs run it to fetch the prebuilt libmlx (sc-21382)
         "Cargo.toml", // workspace graph + lints: changes what every invocation here resolves
         "Cargo.lock", // dependency pins, incl. the MLX revision the whole lane compiles
         "rust-toolchain.toml", // governs the toolchain cargo resolves under the dtolnay install


### PR DESCRIPTION
Shortcut: [sc-21382](https://app.shortcut.com/trefry/story/21382) · siblings: [mlx-rs#27](https://github.com/SceneWorks/mlx-rs/pull/27)/[#28](https://github.com/SceneWorks/mlx-rs/pull/28), [inference#764](https://github.com/SceneWorks/inference/pull/764)

Both macOS MLX jobs (hosted `macos-26` at deployment target 15.0, self-hosted NAX at 26.2) run `scripts/fetch-prebuilt-mlx.sh` before the cargo steps: it picks the `SceneWorks/mlx-rs` `prebuilt-<sha12>` release asset for the mlx-rs rev pinned in `Cargo.lock` (which moves with the inference pin) and this job's cell, verifies its sha256, extracts under `~/.cache/pmetal/prebuilt` and exports `PMETAL_MLX_PREBUILT_DIR`; the fork's build.rs links it only after checking the manifest against its own key — a mismatch fails the build.

"No prebuilt for this rev" (exit 1) is the one tolerated failure, surfaced as a workflow annotation. **The current pin (`7151a9b2`) predates the publishing workflow, so this PR's own run takes exactly that path** — libmlx builds from source as today, with the annotation. The step becomes active at the next inference pin bump (which pulls fork rev `bd8f0e3c` or later, for which prebuilts exist).

Also: the script joins `mlx_paths` so edits to it exercise both jobs, and RELEASING.md documents the post-pin-bump check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)