### PR TITLE
Fix model-library relocation: tolerate deleted-tier drift; refusal visible at the row (sc-21389)

### DIFF
--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -282,8 +282,14 @@ export function SettingsScreen({
   const modelLibraryFromEnvironment = storageSetup?.hfHomeFromEnvironment === true;
   const modelLibraryPath =
     storageSetup?.hfHomeActive ?? settings?.hfHome ?? storageSetup?.hfHomeDefault ?? null;
+  // Outcome of the last Change…/Reveal, rendered INLINE at the row. The screen's shared status
+  // line sits at the top of the panel — off-screen when the user is scrolled down at the Storage
+  // group — so a relocation refusal there reads as a silent no-op (the sc-21389 field failure:
+  // the API refused with a typed 409 and the user saw "nothing happened").
+  const [modelLibraryNotice, setModelLibraryNotice] = useState("");
 
   async function changeModelLibrary() {
+    setModelLibraryNotice("");
     try {
       const adopted = await onChangeModelLibrary?.();
       if (adopted?.hfHome) {
@@ -294,10 +300,10 @@ export function SettingsScreen({
         ]);
         setSettings(reloaded);
         setStorageSetup(storage);
-        setStatus("Model library updated — restart SceneWorks to apply.");
+        setModelLibraryNotice("Model library updated — restart SceneWorks to apply.");
       }
     } catch (error) {
-      setStatus(error?.message || String(error));
+      setModelLibraryNotice(error?.message || String(error));
     }
   }
 
@@ -307,7 +313,7 @@ export function SettingsScreen({
       await invoke("reveal_in_os", { path: modelLibraryPath });
     } catch (error) {
       // Most likely: the default cache home was never created because nothing was downloaded yet.
-      setStatus(error?.message || String(error));
+      setModelLibraryNotice(error?.message || String(error));
     }
   }
 
@@ -768,6 +774,11 @@ export function SettingsScreen({
                       Set by the <code>HF_HOME</code> environment variable, which overrides
                       anything chosen here. Unset it to change the location from Settings.
                     </div>
+                  ) : null}
+                  {modelLibraryNotice ? (
+                    <p aria-live="polite" className="settings-status" role="status">
+                      {modelLibraryNotice}
+                    </p>
                   ) : null}
                   <div className="settings-button-row">
                     <button

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -164,7 +164,12 @@ describe("SettingsScreen model library location", () => {
       (button) => button.textContent.trim() === "Change…",
     );
     await click(change[1]);
-    expect(container.textContent).toContain(
+    // The refusal renders INSIDE the model library row — the top-of-panel status line can be
+    // scrolled out of view, which made a refusal look like a silent no-op.
+    const row = [...container.querySelectorAll(".settings-row-title")]
+      .find((title) => title.textContent.includes("Model library"))
+      .closest("div").parentElement;
+    expect(row.querySelector('[role="status"]').textContent).toContain(
       "That folder does not contain a SceneWorks model library.",
     );
     expect(container.textContent).toContain("/Users/me/.cache/huggingface");

--- a/crates/sceneworks-core/src/model_artifacts/external_library.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library.rs
@@ -516,19 +516,8 @@ impl ExternalLibraryBindingStore {
                     LibraryRelocationRejection::NotAModelLibrary,
                 ));
             }
-            let mut missing = Vec::new();
-            for closure in &closures {
-                if validate_requirements_at_root(&canonical_before, closure).is_err() {
-                    missing.extend(
-                        closure
-                            .iter()
-                            .map(|requirement| requirement.repository.clone()),
-                    );
-                }
-            }
+            let missing = requirements_missing_for_relocation(&canonical_before, &closures);
             if !missing.is_empty() {
-                missing.sort();
-                missing.dedup();
                 return Err(LibraryRelocationError::Rejected(
                     LibraryRelocationRejection::MissingInstalledModels {
                         repositories: missing,
@@ -1042,6 +1031,135 @@ pub fn resolve_relocation_target(
         }),
         _ => Err(LibraryRelocationRejection::HubDirectoryExpected),
     }
+}
+
+/// How one evidence requirement reads at a candidate library root, for relocation only.
+///
+/// Availability and binding keep using [`validate_requirements_at_root`]'s exact rule; relocation
+/// needs the middle case: the per-tier delete (`remove_tier_artifacts`) reclaims a quant tier's
+/// bytes but never rewrites the download receipt or prunes the validated-closure ledger, so a real,
+/// healthy library legitimately lacks WHOLE variants its evidence still records. Demanding them
+/// byte-exactly makes every install that ever deleted a tier un-relocatable (the sc-21389 field
+/// failure: 18 repos refused, all deleted-`q4` tiers).
+enum RequirementPresence {
+    /// Some snapshot carries every file — the requirement is installed here.
+    Present,
+    /// Not a single one of the requirement's files exists in any candidate snapshot: the shape a
+    /// whole-tier delete leaves behind. Tolerated when the same repository proves itself through
+    /// another fully present requirement; refused otherwise (an entirely absent model is the
+    /// wrong-folder signal, not tier reclaim).
+    WhollyAbsent,
+    /// Partially present (or unreadable): torn content is never what tier reclaim produces, so it
+    /// stays a refusal regardless of siblings.
+    Missing,
+}
+
+fn requirement_presence_at_root(
+    canonical_root: &Path,
+    requirement: &ExternalArtifactRequirement,
+) -> RequirementPresence {
+    let Some(repo_name) = safe_repo_dir_name(&requirement.repository) else {
+        return RequirementPresence::Missing;
+    };
+    let repo_root = canonical_root.join(format!("models--{repo_name}"));
+    let Ok(canonical_repo) = std::fs::canonicalize(&repo_root) else {
+        return RequirementPresence::Missing;
+    };
+    if !canonical_repo.starts_with(canonical_root) {
+        return RequirementPresence::Missing;
+    }
+    // Same snapshot universe as `validate_requirements_at_root`: the receipted revision when
+    // pinned, every snapshot otherwise. A pinned revision whose snapshot directory is gone
+    // contributes zero files, i.e. reads WhollyAbsent — the same judgement as a deleted tier.
+    let snapshots: Vec<PathBuf> = if let Some(revision) = requirement.revision.as_deref() {
+        vec![canonical_repo.join("snapshots").join(revision)]
+    } else {
+        match std::fs::read_dir(canonical_repo.join("snapshots")) {
+            Ok(entries) => entries
+                .filter_map(Result::ok)
+                .filter_map(|entry| {
+                    entry
+                        .file_type()
+                        .ok()
+                        .filter(|kind| kind.is_dir())
+                        .map(|_| entry.path())
+                })
+                .collect(),
+            Err(_) => return RequirementPresence::Missing,
+        }
+    };
+    let file_exists = |snapshot: &Path, relative: &Path| {
+        std::fs::canonicalize(snapshot.join(relative))
+            .map(|canonical| canonical.is_file() && canonical.starts_with(&canonical_repo))
+            .unwrap_or(false)
+    };
+    let mut any_file_present = false;
+    for snapshot in &snapshots {
+        let mut all = true;
+        for relative in &requirement.files {
+            if file_exists(snapshot, relative) {
+                any_file_present = true;
+            } else {
+                all = false;
+            }
+        }
+        if all {
+            return RequirementPresence::Present;
+        }
+    }
+    if any_file_present {
+        RequirementPresence::Missing
+    } else {
+        RequirementPresence::WhollyAbsent
+    }
+}
+
+/// The repositories a relocation candidate is judged to be missing, deleted-tier drift excluded.
+///
+/// A requirement that is [`RequirementPresence::WhollyAbsent`] is dropped when the SAME repository
+/// has a [`RequirementPresence::Present`] requirement anywhere in the evidence (its other quant
+/// tier, typically): after adoption that variant truthfully reads uninstalled, exactly as it does
+/// today. Everything else — a partially present requirement, a malformed closure, a repository
+/// whose every requirement is absent — still refuses, so a decoy or wrong folder fails closed.
+fn requirements_missing_for_relocation(
+    canonical_root: &Path,
+    closures: &[Vec<ExternalArtifactRequirement>],
+) -> Vec<String> {
+    let mut present_repositories = std::collections::HashSet::new();
+    let mut wholly_absent = Vec::new();
+    let mut missing = Vec::new();
+    for closure in closures {
+        if validate_requirements_shape(closure).is_err() {
+            missing.extend(
+                closure
+                    .iter()
+                    .map(|requirement| requirement.repository.clone()),
+            );
+            continue;
+        }
+        for requirement in closure {
+            match requirement_presence_at_root(canonical_root, requirement) {
+                RequirementPresence::Present => {
+                    present_repositories.insert(requirement.repository.clone());
+                }
+                RequirementPresence::WhollyAbsent => {
+                    wholly_absent.push(requirement.repository.clone());
+                }
+                RequirementPresence::Missing => missing.push(requirement.repository.clone()),
+            }
+        }
+    }
+    missing.extend(
+        wholly_absent
+            .into_iter()
+            .filter(|repository| !present_repositories.contains(repository)),
+    );
+    // Note the asymmetry: a torn (partially present) requirement refuses even when the same
+    // repository is fully present through another one — tier reclaim never leaves partial files,
+    // so torn content is never explainable as drift.
+    missing.sort();
+    missing.dedup();
+    missing
 }
 
 /// The relocation TOCTOU rule, pure so it can be asserted directly: the exact canonical path AND

--- a/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
@@ -653,6 +653,105 @@ fn relocation_binds_a_plain_directory_when_there_is_no_install_evidence() {
     assert!(store.has_install_evidence().unwrap());
 }
 
+/// The sc-21389 field failure: the per-tier delete reclaims a quant tier's bytes but never rewrites
+/// the download receipt (or prunes the ledger), so a real library legitimately lacks WHOLE variants
+/// its evidence records. Relocation must read that as drift — the repo proves itself through its
+/// other, fully present tier — not as a wrong folder.
+#[test]
+fn relocation_tolerates_a_receipted_tier_the_app_deleted() {
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    let library = temp.path().join("moved").join("hub");
+    // The library carries the bf16 tier; the q4 tier was reclaimed (its files simply do not
+    // exist), yet BOTH tiers are still receipted. (`seed_snapshot` writes flat files; a quant
+    // tier is a subdirectory, so lay it out directly.)
+    let seeded = library
+        .join(format!(
+            "models--{}",
+            safe_repo_dir_name("owner/model").unwrap()
+        ))
+        .join("snapshots")
+        .join(REVISION);
+    std::fs::create_dir_all(seeded.join("bf16")).unwrap();
+    std::fs::write(seeded.join("bf16/model.safetensors"), b"weights").unwrap();
+    let store = ExternalLibraryBindingStore::new(&data).unwrap();
+    let q4 = ExternalArtifactRequirement {
+        variant: "q4".to_owned(),
+        files: vec![
+            PathBuf::from("q4/model.safetensors"),
+            PathBuf::from("q4/README.md"),
+        ],
+        ..requirement("owner/model", "bf16/model.safetensors")
+    };
+    store
+        .bind_or_probe_validated(
+            &library,
+            &[requirement("owner/model", "bf16/model.safetensors")],
+        )
+        .unwrap();
+    let mut with_stale_q4 = temp.path().join("data").join("models");
+    with_stale_q4.push(".sceneworks-external-library-closures.json");
+    // Append the stale q4 closure the way history did: it was validated once, then the tier was
+    // deleted from disk. Writing it through the file keeps the store's own append path honest.
+    let mut ledger: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&with_stale_q4).unwrap()).unwrap();
+    ledger["closures"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::to_value(vec![q4.clone()]).unwrap());
+    std::fs::write(&with_stale_q4, serde_json::to_vec(&ledger).unwrap()).unwrap();
+
+    // The deleted tier alone must not refuse the true library…
+    store.validate_relocation(&library).unwrap();
+    store.relocate_binding(&library).unwrap();
+
+    // …but a TORN tier still does, even with the healthy sibling present: tier reclaim never
+    // leaves partial files, so partial content stays the wrong-folder signal.
+    let snapshot = library
+        .join("models--owner--model")
+        .join("snapshots")
+        .join(REVISION);
+    std::fs::create_dir_all(snapshot.join("q4")).unwrap();
+    std::fs::write(snapshot.join("q4/README.md"), b"docs").unwrap();
+    let error = store.validate_relocation(&library).unwrap_err();
+    assert_eq!(
+        error,
+        LibraryRelocationError::Rejected(LibraryRelocationRejection::MissingInstalledModels {
+            repositories: vec!["owner/model".to_owned()],
+        })
+    );
+}
+
+/// A repository whose EVERY evidence requirement is absent is still the wrong-folder signal:
+/// deleted-tier tolerance needs the repo to prove itself through some fully present variant.
+#[test]
+fn relocation_still_refuses_a_repository_that_is_entirely_absent() {
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    let library = temp.path().join("original").join("hub");
+    seed_snapshot(&library, "owner/model", "model.safetensors");
+    seed_snapshot(&library, "owner/other", "model.safetensors");
+    let store = ExternalLibraryBindingStore::new(&data).unwrap();
+    store
+        .bind_or_probe_validated(&library, &[requirement("owner/model", "model.safetensors")])
+        .unwrap();
+    store
+        .bind_or_probe_validated(&library, &[requirement("owner/other", "model.safetensors")])
+        .unwrap();
+
+    // A candidate carrying only ONE of the two recorded models: the other repo is wholly absent,
+    // with no present sibling variant to explain it as tier reclaim.
+    let decoy = temp.path().join("decoy").join("hub");
+    seed_snapshot(&decoy, "owner/model", "model.safetensors");
+    let error = store.validate_relocation(&decoy).unwrap_err();
+    assert_eq!(
+        error,
+        LibraryRelocationError::Rejected(LibraryRelocationRejection::MissingInstalledModels {
+            repositories: vec!["owner/other".to_owned()],
+        })
+    );
+}
+
 /// The fresh-home shape: a plain folder is the cache home (its `hub` child is the library root);
 /// a folder named `hub` is the library root (its parent the home). No layout is required.
 #[test]


### PR DESCRIPTION
[sc-21389](https://app.shortcut.com/trefry/story/21389) — follow-up to #2531, which shipped the Settings control; first real use hit two defects.

## Field failure
Relocating to the real moved library was refused with `MissingInstalledModels` naming 18 repos (two 409s in `api.log`). Every one was a **q4 tier deleted through the app's own per-tier disk reclaim**: `remove_tier_artifacts` frees the tier's bytes but never rewrites the download receipt or prunes the closure ledger, so the install evidence permanently overstates what is on disk and the exact-closure check made every install that ever deleted a tier un-relocatable. Second defect: the refusal rendered only in the status line at the top of the Settings panel — off-screen at the Storage group — so the typed refusal read as a silent no-op.

## Fix
- **Relocation only** (availability and binding keep the exact rule): each evidence requirement is classified at the candidate root. Fully present passes; a **wholly absent** requirement is tolerated when the same repository proves itself through another fully present requirement (the deleted tier truthfully reads uninstalled after adoption, as it does today); **partially present** content and **entirely absent repositories** still refuse — tier reclaim never leaves partial files, so torn content and missing repos remain the wrong-folder signal. Decoy/unrelated-folder tests pass unchanged.
- The Change…/Reveal outcome (refusal or restart reminder) renders **inline at the Model library row** as a live region.

## Verification
- Ran the real `validate_relocation` read-only against the actual failing state (real data dir + `/Volumes/Models/huggingface/hub`): refused with the 18-repo rejection before the change, **VALIDATES OK** after (temporary diagnostic example, not committed).
- New tests: deleted-tier tolerated end-to-end (validate + re-bind), torn tier still refused even with a healthy sibling, entirely-absent repo still refused.
- Suites: core 32, rust-api 15 (re-run after merging main), web SettingsScreen/App-relocate/gate suites green; fmt, clippy `-D warnings`, eslint clean; full workspace `cargo test` + full vitest (4,035) green pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)