### PR TITLE
fix(worker): scope model download progress to selected files

### DIFF
--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -973,6 +973,9 @@ pub(crate) async fn download_snapshot(
             tokio::fs::create_dir_all(parent).await?;
         }
         let _lock = DownloadLock::acquire_async(&target_path).await?;
+        progress
+            .record_existing_file(&target_path, file.size)
+            .await?;
         download_file(
             context,
             &file.download_url,
@@ -1030,6 +1033,7 @@ pub(crate) async fn download_snapshot_into_cache(
             .unwrap_or_else(|| blob_fallback_name(&file.path));
         let blob_path = blobs_dir.join(&etag);
         let _lock = DownloadLock::acquire_async(&blob_path).await?;
+        progress.record_existing_file(&blob_path, file.size).await?;
         download_file(
             context,
             &file.download_url,
@@ -2265,6 +2269,23 @@ impl<'a> DownloadProgress<'a> {
         self.transferred_bytes = self.transferred_bytes.saturating_add(bytes);
     }
 
+    /// Add only the bytes already present for the exact snapshot file about to be handled.
+    ///
+    /// Snapshot callers used to seed `started_bytes` from the whole destination directory. That is
+    /// incorrect for filtered Hugging Face repositories: downloading `q4/*` would count cached q8,
+    /// bf16, and stale blobs in the numerator while [`HuggingFaceSnapshot::total_bytes`] contained
+    /// only q4 in the denominator. Account after taking the per-file download lock so a peer cannot
+    /// change the target between the size check and the cache-hit/resume decision.
+    async fn record_existing_file(
+        &mut self,
+        path: &Path,
+        expected_size: Option<u64>,
+    ) -> WorkerResult<()> {
+        let bytes = existing_download_bytes(path, expected_size).await?;
+        self.started_bytes = self.started_bytes.saturating_add(bytes);
+        Ok(())
+    }
+
     /// Reset the stall watchdog to "made progress just now", granting the next
     /// (re)connect a full stall window before it can be judged hung. Called at the
     /// start of each attempt so the idle gap spent re-issuing the request is not
@@ -2773,5 +2794,37 @@ mod stall_watchdog_tests {
         assert!(progress.is_stalled(Duration::from_millis(1), DOWNLOAD_STALL_MIN_PROGRESS));
         progress.reset_stall_clock();
         assert!(!progress.is_stalled(Duration::from_secs(3600), DOWNLOAD_STALL_MIN_PROGRESS));
+    }
+}
+
+/// Snapshot progress must use the same selected-file scope as the snapshot total. In particular,
+/// another precision tier in the shared Hugging Face `blobs/` directory is not progress toward the
+/// tier currently being downloaded.
+#[cfg(test)]
+mod snapshot_progress_tests {
+    use super::DownloadProgress;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn ignores_unrelated_cached_blobs() {
+        let cache = tempfile::tempdir().expect("cache dir");
+        let selected = cache.path().join("selected-blob");
+        let unrelated = cache.path().join("unrelated-bf16-blob");
+        std::fs::write(&selected, b"q4!").expect("selected partial blob");
+        std::fs::write(&unrelated, vec![0_u8; 64]).expect("unrelated cached tier");
+
+        let mut progress =
+            DownloadProgress::new("owner/model", 0, Some(10), Duration::from_secs(5));
+        progress
+            .record_existing_file(&selected, Some(10))
+            .await
+            .expect("selected bytes are counted");
+
+        let payload = progress.payload();
+        assert!(
+            payload.message.contains("3 B of 10 B (7 B left)"),
+            "only the selected blob belongs in snapshot progress: {}",
+            payload.message
+        );
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -539,7 +539,7 @@ async fn ensure_distill_lora_cached(
     }
     let mut progress = DownloadProgress::new(
         repo,
-        directory_size(&repo_dir.join("blobs")).await,
+        0,
         snapshot.total_bytes(),
         progress_report_interval(settings),
     );

--- a/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
@@ -519,7 +519,7 @@ async fn ensure_qwen_lightning_lora_cached(
     }
     let mut progress = crate::downloads::DownloadProgress::new(
         repo,
-        crate::directory_size(&repo_dir.join("blobs")).await,
+        0,
         snapshot.total_bytes(),
         crate::progress_report_interval(settings),
     );

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -202,7 +202,7 @@ pub(crate) async fn run_model_download_job(
 
     let mut progress = DownloadProgress::new(
         repo,
-        directory_size(&repo_dir.join("blobs")).await,
+        0,
         snapshot.total_bytes(),
         progress_report_interval(settings),
     );
@@ -442,7 +442,7 @@ pub(crate) async fn run_lora_download_job(
 
     let mut progress = DownloadProgress::new(
         repo,
-        directory_size(&repo_dir.join("blobs")).await,
+        0,
         snapshot.total_bytes(),
         progress_report_interval(settings),
     );
@@ -4029,7 +4029,7 @@ pub(crate) async fn ensure_hf_files_cached(
     if !snapshot.files.is_empty() {
         let mut progress = DownloadProgress::new(
             repo,
-            directory_size(&repo_dir.join("blobs")).await,
+            0,
             snapshot.total_bytes(),
             progress_report_interval(settings),
         );
@@ -4273,7 +4273,7 @@ pub(crate) async fn run_lora_import_job(
             HuggingFaceSnapshot::resolve(http_client, settings, repo, revision, &files).await?;
         let mut progress = DownloadProgress::new(
             repo,
-            directory_size(&target_dir).await,
+            0,
             snapshot.total_bytes(),
             progress_report_interval(settings),
         );
@@ -4687,7 +4687,7 @@ pub(crate) async fn run_model_import_job(
             HuggingFaceSnapshot::resolve(http_client, settings, repo, revision, &files).await?;
         let mut progress = DownloadProgress::new(
             repo,
-            directory_size(&target_dir).await,
+            0,
             snapshot.total_bytes(),
             progress_report_interval(settings),
         );

--- a/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
+++ b/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
@@ -586,7 +586,7 @@ async fn download_snapshot_resumes_existing_partial_blob() {
     };
     let mut progress = DownloadProgress::new(
         "owner/model",
-        4,
+        0,
         snapshot.total_bytes(),
         Duration::from_secs(3600),
     );
@@ -636,7 +636,7 @@ async fn download_snapshot_fresh_retry_discards_partial_blob() {
     };
     let mut progress = DownloadProgress::new(
         "owner/model",
-        3,
+        0,
         snapshot.total_bytes(),
         Duration::from_secs(3600),
     );

--- a/crates/sceneworks-worker/src/util.rs
+++ b/crates/sceneworks-worker/src/util.rs
@@ -1,43 +1,5 @@
-//! Small worker-wide utilities: byte/time formatting, asset ids, HF auth, and directory sizing.
+//! Small worker-wide utilities: byte/time formatting, asset ids, and HF auth.
 use super::*;
-
-pub(crate) async fn directory_size(path: &Path) -> u64 {
-    let mut total = 0_u64;
-    let mut stack = vec![path.to_path_buf()];
-    while let Some(path) = stack.pop() {
-        let mut entries = match tokio::fs::read_dir(&path).await {
-            Ok(entries) => entries,
-            Err(error) => {
-                // A missing directory is the normal start-of-a-fresh-download state (the HF
-                // `blobs/` dir does not exist until the first file lands), so it means "0 bytes
-                // so far", not a failure — don't log it at error level. Only surface genuine I/O
-                // problems (permissions, etc.).
-                if error.kind() != std::io::ErrorKind::NotFound {
-                    tracing::warn!(
-                        event = "rust_worker_directory_size_failed",
-                        path = %path.display(),
-                        error = %error,
-                        "failed to read a directory while sizing a download"
-                    );
-                }
-                continue;
-            }
-        };
-        while let Ok(Some(entry)) = entries.next_entry().await {
-            let Ok(file_type) = entry.file_type().await else {
-                continue;
-            };
-            if file_type.is_dir() {
-                stack.push(entry.path());
-            } else if file_type.is_file() && entry.file_name() != INSTALL_MARKER {
-                if let Ok(metadata) = entry.metadata().await {
-                    total = total.saturating_add(metadata.len());
-                }
-            }
-        }
-    }
-    total
-}
 
 pub fn format_bytes(value: u64) -> String {
     let mut size = value as f64;


### PR DESCRIPTION
## Summary

- count cached/resumed bytes only for snapshot files selected by the current download
- apply the scoped accounting to model, LoRA, import, and on-demand Hugging Face snapshot paths
- remove the obsolete whole-directory sizing helper and add a regression test for unrelated cached tiers

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p sceneworks-worker snapshot_progress_tests::ignores_unrelated_cached_blobs --lib`
- `cargo test -p sceneworks-worker download_snapshot --lib` (7 passed, 1 network test ignored)
- `cargo test -p sceneworks-worker download_progress_payload_matches_python_shape --lib`
- `cargo clippy -p sceneworks-worker --all-targets -- -D warnings`