### PR TITLE
chore: sync main into epic 20738

### DIFF
--- a/.github/workflows/macos-mlx.yml
+++ b/.github/workflows/macos-mlx.yml
@@ -95,6 +95,8 @@ on:
       # The native producer below delegates its content comparison to this script. A script-only
       # change must exercise the lane it governs.
       - "scripts/compare-engine-capability-facts.mjs"
+      # Both jobs below run this to fetch the prebuilt libmlx; an edit to it must exercise them.
+      - "scripts/fetch-prebuilt-mlx.sh"
       - "Cargo.toml"
       - "Cargo.lock"
       # sc-17703 (Michael's call — a deliberate under-trigger fix): rust-toolchain.toml
@@ -366,6 +368,26 @@ jobs:
             sudo xcodebuild -downloadComponent MetalToolchain
           fi
           xcrun metal --version || true
+      - name: Fetch prebuilt MLX (sc-21382)
+        # pmetal-mlx-sys's cmake build of libmlx is ≈6 min on a hosted runner on every cache miss
+        # (plus a network fetch of MLX). The SceneWorks/mlx-rs fork publishes that build per
+        # commit (`prebuilt-<sha12>` releases, cell = target × deployment target × Debug/Release);
+        # scripts/fetch-prebuilt-mlx.sh picks the asset for the mlx-rs rev pinned in Cargo.lock
+        # (it moves with the inference pin) and this job's MACOSX_DEPLOYMENT_TARGET, and build.rs
+        # links it from PMETAL_MLX_PREBUILT_DIR only after checking the manifest against its own
+        # key -- a mismatch FAILS the build. The one failure tolerated here is "no prebuilt
+        # published for this rev" (exit 1): the right answer then is the source build, surfaced
+        # as a workflow annotation. Anything else is an error. Same step as inference ci.yml.
+        run: |
+          set +e
+          scripts/fetch-prebuilt-mlx.sh --github-env
+          rc=$?
+          set -e
+          if [ "$rc" = 1 ]; then
+            echo "::warning title=prebuilt MLX unavailable::no prebuilt for the pinned mlx-rs rev; building libmlx from source (see step log)"
+          elif [ "$rc" != 0 ]; then
+            exit "$rc"
+          fi
       - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
@@ -537,6 +559,26 @@ jobs:
         with:
           toolchain: "1.97.1"
           components: clippy
+      - name: Fetch prebuilt MLX (sc-21382)
+        # pmetal-mlx-sys's cmake build of libmlx is ≈6 min on every cache miss; this self-hosted runner keeps the extracted tarball in ~/.cache/pmetal/prebuilt across runs
+        # (plus a network fetch of MLX). The SceneWorks/mlx-rs fork publishes that build per
+        # commit (`prebuilt-<sha12>` releases, cell = target × deployment target × Debug/Release);
+        # scripts/fetch-prebuilt-mlx.sh picks the asset for the mlx-rs rev pinned in Cargo.lock
+        # (it moves with the inference pin) and this job's MACOSX_DEPLOYMENT_TARGET, and build.rs
+        # links it from PMETAL_MLX_PREBUILT_DIR only after checking the manifest against its own
+        # key -- a mismatch FAILS the build. The one failure tolerated here is "no prebuilt
+        # published for this rev" (exit 1): the right answer then is the source build, surfaced
+        # as a workflow annotation. Anything else is an error. Same step as inference ci.yml.
+        run: |
+          set +e
+          scripts/fetch-prebuilt-mlx.sh --github-env
+          rc=$?
+          set -e
+          if [ "$rc" = 1 ]; then
+            echo "::warning title=prebuilt MLX unavailable::no prebuilt for the pinned mlx-rs rev; building libmlx from source (see step log)"
+          elif [ "$rc" != 0 ]; then
+            exit "$rc"
+          fi
       - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,13 @@
 - Follow [FEATURE_DEVELOPMENT.md](FEATURE_DEVELOPMENT.md) for epic integration
   branches, story PR targets, mirrored inference work, final merge ordering, and
   the CI protections required before using this workflow.
-- Read its *Current state* section before assuming anything about branch
-  protection. As of 2026-08-11 neither SceneWorks nor inference has a merge
-  queue; `main` is `strict: false` and `feature/*` is `strict: true` in both.
-  Queue staging/activation/recovery procedures are obsolete in both repositories.
+- Its *Current repository state* table is the branch-protection reference.
+  Neither repository has a merge queue; `feature/*` is `strict: false` and
+  merge-commit only in both; SceneWorks `main` is `strict: false`, inference
+  `main` is `strict: true`. The skills (`shortcut-plan`, `sceneworks-epic`,
+  `shortcut-story`) are the executable procedure; the document is the contract.
+  Per story: one implementation, one adversarial review against story-local AC,
+  one fix pass, merge on green, one-line closeout — nothing more.
 - The pin-keyed verification gates were **deliberately dismantled** on
   2026-08-15/16 (sc-19758, sc-19751, `e14171984`). A script that exists but is
   disabled or unwired is the designed state — never a blocker, never something

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,10 +14,12 @@ here.
   Read its *Current state* section before acting on any branch protection
   assumption. As of 2026-08-11 **neither SceneWorks nor inference has a merge
   queue** — both were removed the same day after the queue was measured catching
-  zero integration failures in 103 groups while adding ~21m per merge. `main` is
-  `strict: false` in both; `feature/*` is `strict: true` in both. Any procedure
-  or memory that mentions staging, activating, or recovering a per-branch queue
-  ruleset is obsolete.
+  zero integration failures in 103 groups while adding ~21m per merge. `main`
+  and `feature/*` are `strict: false` in both repos (inference `main` drifted
+  back to `strict: true` twice and was reset on 2026-08-23 — do not re-enable
+  it; a strict policy forces a full CI re-run of every open PR after each
+  merge). Any procedure or memory that mentions staging, activating, or
+  recovering a per-branch queue ruleset is obsolete.
 
   Likewise, the pin-keyed verification gates were **deliberately dismantled**
   on 2026-08-15/16 (sc-19758, sc-19751, `e14171984`): disabled or unwired check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,21 +11,22 @@ here.
   branches, story PR targets, mirrored inference work, final merge ordering, and
   the current ruleset/CI state.
 
-  Read its *Current state* section before acting on any branch protection
-  assumption. As of 2026-08-11 **neither SceneWorks nor inference has a merge
-  queue** — both were removed the same day after the queue was measured catching
-  zero integration failures in 103 groups while adding ~21m per merge. `main` is
-  `strict: false` in both; `feature/*` is `strict: true` in both. Any procedure
+  Read its *Current repository state* table before acting on any branch
+  protection assumption. **Neither SceneWorks nor inference has a merge queue**
+  (removed 2026-08-11 after catching zero integration failures in 103 groups).
+  `feature/*` is `strict: false` and merge-commit only in both; SceneWorks
+  `main` is `strict: false`, inference `main` is `strict: true`. Any procedure
   or memory that mentions staging, activating, or recovering a per-branch queue
-  ruleset is obsolete.
+  ruleset, a per-story pin bump, a per-story validation matrix, or more than
+  one review + one fix pass per story is obsolete.
 
   Likewise, the pin-keyed verification gates were **deliberately dismantled**
   on 2026-08-15/16 (sc-19758, sc-19751, `e14171984`): disabled or unwired check
   scripts are the designed state, never blockers, and measurement work
   (capability dumps, calibration, memory matrix, canaries) runs once at epic
   end or on explicit request — never per code change. Read the *Gate teardown*
-  note in FEATURE_DEVELOPMENT.md's *Current state* before acting on any
-  regenerate-or-measure instruction found in prose or memory.
+  section of FEATURE_DEVELOPMENT.md before acting on any regenerate-or-measure
+  instruction found in prose or memory.
 
 - **[RELEASING.md](RELEASING.md)** — release, hotfix, inference-pin, publication,
   and failed-candidate recovery.

--- a/FEATURE_DEVELOPMENT.md
+++ b/FEATURE_DEVELOPMENT.md
@@ -1,40 +1,57 @@
 # SceneWorks feature development workflow
 
-This is the official process for implementing a substantial SceneWorks feature
-from a Shortcut epic while keeping incomplete work isolated from `main` and
-`release/next`. It supports multiple concurrent feature epics and coordinated
-changes in the private `SceneWorks/inference` repository.
+How a substantial feature goes from a Shortcut epic to `main` in SceneWorks
+(and, when the feature touches engines, in the private `SceneWorks/inference`
+repository) without incomplete work reaching `main` or `release/next`.
 
-This document defines the intended process and the CI/ruleset work required to
-enforce it. Do not treat feature branches as fully protected until the
-implementation checklist in [CI and repository configuration](#ci-and-repository-configuration)
-has been completed and verified in both repositories.
+This document is the **process contract**. The executable procedure lives in the
+skills, which are the authority when the two disagree:
 
-Release and hotfix work remains governed by [RELEASING.md](RELEASING.md).
-Promoting completed features from `main` into `release/next` and cutting a minor
-release is a separate process and is not defined here.
+- `shortcut-plan` — slice the epic (strict numbered requirements on the epic,
+  1–3 story-local acceptance bullets per story, 5–12 stories, one terminal
+  integration story).
+- `sceneworks-epic` — drive the epic (waves, lanes, one review + one fix pass
+  per story, one feature-end review, one pin bump, one measurement campaign).
+- `shortcut-story` — work a single story.
+
+Release and hotfix work is governed by [RELEASING.md](RELEASING.md). Promoting a
+completed feature from `main` into `release/next` is part of that process, not
+this one.
+
+## Cost model — why the procedure is shaped this way
+
+Measured 2026-08-23 (epics 17137 and 20762): over 90% of epic wall-clock and
+token spend was process — repeated reviews, epic-wide acceptance criteria
+re-litigated on every story, per-story evidence gathering, pin bumps that shipped
+no behaviour, closeout narratives — not code. The procedure below is built for
+this per-story budget and nothing more:
+
+> one implementation → one adversarial review against the story's **local** AC →
+> one self-verifying fix pass → merge on green required CI → one-line closeout.
+
+Everything epic-wide (every advertised mode, exact identity, fail-closed
+behaviour, telemetry agreement, real-weight evidence) is checked **once**, at
+feature end. Anything in this document that appears to ask for more than that per
+story is a mistake in the document.
 
 ## Core invariants
 
-1. Every substantial feature starts with an approved Shortcut epic containing
-   implementation-ready requirements, an implementation plan, and executable
-   stories.
-2. Each epic has one protected SceneWorks integration branch named
-   `feature/sc-<epic-id>-<epic-slug>` created from current `origin/main`.
-3. If the epic changes inference, the inference repository has a branch with
-   the exact same name, also created from its current `origin/main`.
-4. Story branches start from the owning feature branch and merge back only
-   through reviewed PRs targeting that feature branch.
-5. Every story merge leaves the feature branch buildable, internally
-   consistent, and green. Incomplete does not mean broken.
-6. No incomplete feature branch merges into `main`.
-7. A SceneWorks feature that uses inference permanently pins a commit reachable
-   from inference `main`, never a deleted feature branch.
-8. The epic remains open until the final SceneWorks feature PR is merged into
-   `main` and post-merge state and CI are verified.
-9. Feature branches never merge directly into `release/next`. Release promotion
-   happens only after the feature is complete on `main`.
-10. Use isolated worktrees or clones. Never disturb an unrelated dirty checkout.
+1. Every substantial feature starts with an approved Shortcut epic planned with
+   `shortcut-plan`.
+2. Each epic has one SceneWorks integration branch
+   `feature/sc-<epic-id>-<epic-slug>` created from `origin/main`; if the epic
+   changes inference, inference has a branch with the **identical name** from its
+   own `origin/main`.
+3. Story branches start from the owning feature branch and merge back only
+   through PRs targeting that feature branch. Every story merge leaves the
+   feature branch buildable and green. Incomplete does not mean broken.
+4. No incomplete feature branch merges into `main`; feature branches never merge
+   directly into `release/next`; one feature branch never merges into another.
+5. A SceneWorks branch on `main` pins an inference commit reachable from
+   inference `main`, never a deleted feature branch. The epic lands **exactly one**
+   pin bump, at the end, to an inference `main` revision.
+6. Always work in an isolated worktree or clone. Never commit on `main` or on a
+   `feature/*` branch directly.
 
 ## Branch model
 
@@ -42,55 +59,99 @@ release is a separate process and is not defined here.
 | --- | --- | --- |
 | `main` | Completed features and normal development | Permanent, protected |
 | `feature/sc-<epic-id>-<epic-slug>` | Combined implementation of one epic | Epic start through verified main merge |
-| `story/sc-<story-id>-epic-<epic-id>-<epic-slug>` | One story in the epic | Story start through verified feature-branch merge |
-| `sync/sc-<epic-id>-main-<date>` | Reviewed synchronization of `main` into a feature branch | Delete after merge |
+| `story/sc-<story-id>-epic-<epic-id>-<epic-slug>` | One story in the epic | Story start through feature-branch merge |
+| `sync/sc-<epic-id>-main-<date>` | Merge of `main` into a feature branch | Delete after merge |
 | `release/next` | Candidate for the next release | Governed by `RELEASING.md` |
 
-Use lower-case kebab-case slugs. The story branch must repeat the owning epic id
-and the feature branch's canonical slug exactly. For example,
-`feature/sc-123-name` accepts `story/sc-456-epic-123-name`; a Shortcut-generated
-branch name or a story-title slug is not sufficient unless it already matches
-this repository policy. Do not try to nest story branches below the exact
-feature branch name, such as `feature/sc-123-name/sc-456-story`: Git refs cannot
-contain both a branch and a directory at the same path.
+Lower-case kebab-case slugs. The story branch repeats the owning epic id and the
+feature branch's slug exactly (`feature/sc-123-name` ⇒
+`story/sc-456-epic-123-name`); a Shortcut-generated branch name is not
+sufficient. Do not nest (`feature/sc-123-name/sc-456`): Git refs cannot be both a
+branch and a directory. inference enforces this topology in CI
+(`scripts/ci/feature_epic_policy.py`); SceneWorks relies on the same convention.
+A story that changes both repositories uses the same story branch name in both.
 
-If one story changes both repositories, use the same story branch name in
-SceneWorks and inference. A branch name records ownership; the Shortcut epic
-and story remain the requirements and status sources of truth.
+## Current repository state (verified 2026-08-23 — re-query before relying on it)
 
-## 1. Prepare the epic
+| | SceneWorks | inference |
+| --- | --- | --- |
+| `main` rulesets | `Require MR` 17708030 + `Main Ruleset` 20886480 | `Require MR` 20481541 |
+| `main` required checks | `web`, `parity`, `candle`, `build-windows`, `check-linux`, `check-macos`, `macOS build, lint and workspace tests (hosted)` | `CI gate` |
+| `main` up-to-date required | **no** (`strict: false`) | **yes** (`strict: true`) |
+| `main` merge methods | merge / squash / rebase | merge commit only |
+| `feature/*` base policy | 20638194 — same 7 checks, `strict: false`, **merge commit only** | 20638200 — `CI gate`, `strict: false`, merge commit only |
+| `feature/*` deletion guard | 20638197 (deletion rule only, no bypass actors) | 20638201 (same) |
+| merge queue | **none** (removed 2026-08-11) | **none** (removed 2026-08-11) |
 
-Before creating branches:
+Consequences:
 
-1. Re-fetch the live Shortcut epic and every proposed story.
-2. Reconcile the requirements and plan with current SceneWorks and inference
-   source, open PRs, current pins, and platform constraints.
-3. Ensure every implementation-plan item is represented by a story or task.
-4. Record dependencies between stories and between repositories.
-5. Add an explicit final integration/acceptance story covering the whole epic,
-   cross-repository pins, documentation, migrations, and runtime evidence.
-6. Define the validation matrix, including required MLX, candle/CUDA, desktop,
-   server, real-weight, migration, and compatibility evidence. Matrix evidence
-   is gathered once, at epic completion — not re-proven per story (see *Gate
-   teardown* under **CI and repository configuration**).
-7. Record the intended feature branch name in the epic.
+- `gh pr merge --squash` fails on a feature-target PR in either repository. Use
+  `--merge`.
+- A story PR whose base advanced is still mergeable (`strict: false`); update the
+  branch only when the base change can affect the story. An inference
+  feature→`main` PR must be up to date (`strict: true`).
+- `feature/*` protection is ruleset-managed; the legacy branch-protection
+  endpoint returns 404 for a feature branch even though it is protected. Both
+  wildcard rulesets are permanent — there is no per-epic ruleset to stage,
+  verify, or recover.
+- The `Main Ruleset` requires code-owner review, but the repository has no
+  `CODEOWNERS` file, so it currently requires nothing.
+- `release/next` is covered by no ruleset in either repository.
 
-Do not create an epic branch as a substitute for incomplete requirements.
+### CI triggers that matter
+
+- A push to a `story/*` or `sync/*` branch with **no open PR fires nothing** in
+  either repository. Push as soon as work is committable. The PR is what costs a
+  CI cycle: in SceneWorks five workflows bounded by the ~37-minute macOS lane on
+  every PR-head update; in inference the ~20–40-minute `CI gate`.
+- `macos-mlx.yml` runs its hosted half on PRs to `main` and `feature/*`; the
+  self-hosted `nax-worker` job runs only on PRs whose base is `main` (the final
+  feature PR) — not per story.
+- `windows-candle.yml` runs only on PRs to `main` whose diff touches its path
+  anchor. It is not a required check. The final feature PR triggers it when the
+  diff is candle-relevant; nothing else does.
+- Required workflows keep `merge_group:` (costs nothing; keeps a queue a
+  one-line re-enable) and use a `changes` gate job instead of a workflow-level
+  `paths:` filter (a path-filtered required check stays Pending forever).
+
+### Gate teardown (2026-08-15/16) — binding on agents
+
+The pin-keyed verification gates were deliberately dismantled (sc-19758
+`68670a3ee`: four `check.yml` steps `if: false`; sc-19751: license coverage
+reports and exits 0; `e14171984`: a pin bump no longer invalidates capability
+dumps). The jobs and scripts are retained on purpose.
+
+- A script that exists in `scripts/` but is disabled or unwired is the designed
+  state. Do not wire it up, re-enable it, treat it as a requirement, or file a
+  story about it.
+- Measurement campaigns — capability dumps, memory-matrix regeneration,
+  calibration captures, VRAM/canary runs — run **once, at the end of an epic**,
+  immediately after its single pin bump, or on explicit request. Never per story,
+  never per pin movement. Records demoted to floors during development is the
+  accepted state.
+- Story "done" = the code, its tests, one adversarial review + one fix pass, and
+  green required CI on the PR. Nothing more unless the story *is* a measurement
+  story.
+- Tests over measured corpora assert shape and invariants, never exact
+  populations or pinned counts. A re-capture that trips a pinned count means the
+  test is wrong; rewrite it to shape in the same PR.
+
+## 1. Plan the epic
+
+Use `shortcut-plan`. The epic description carries the numbered requirements
+(E1…En) and the epic acceptance tests, written once. Each story carries 1–3
+story-local observable bullets plus `Inherits epic requirements: E…`. Slice by
+mechanism (N parameter cells = one story with a table); target 5–12 stories; walking
+skeleton first; one terminal integration story owns the pin bump, the single
+measurement campaign, the feature-end review, and feature→`main`.
+
+Do not define a per-story validation matrix. The epic's acceptance tests are the
+matrix, and they run once at feature end.
+
+Record in the epic: the intended feature branch name, whether inference is in
+scope, and the current SceneWorks inference pin.
 
 ## 2. Create the integration branches
-
-Use current remote state and a clean checkout.
-
-Run the complete read-only preflight for every applicable repository before the
-first mutation: capture the current `origin/main` SHA; verify both wildcard
-ruleset layers; and verify every configured required context on that exact
-commit is terminal `success`, `skipped`, or `neutral` from the expected GitHub
-Actions app. Pending, missing, wrong-app, or failed contexts are a stop
-condition. Persist the plan before mutating anything.
-
-Neither repository has a merge queue, so there is no per-branch queue ruleset to
-stage and no ordering constraint on ref creation. Create the branch at the
-captured immutable SHA under the active wildcard base and deletion guards:
 
 ```bash
 git fetch origin
@@ -98,48 +159,31 @@ git switch -c feature/sc-<epic-id>-<epic-slug> origin/main
 git push -u origin feature/sc-<epic-id>-<epic-slug>
 ```
 
-Create the inference branch only when inference changes are part of the approved
-scope, using the identical commands and branch name against that remote.
-
-Then verify that **two** layers aggregate in each applicable repository: the
-wildcard base policy and the wildcard deletion guard. Do not create a per-branch
-queue ruleset in either repository; both had one and both had it removed after
-measurement showed it bought nothing (see *Current state* under **CI and
-repository configuration**).
-
-Only after every applicable repository reaches that verified state may bootstrap
-create a workspace or declare success. Do not loosen
-`do_not_enforce_on_create=false` or silently choose an older commit to make
-branch creation succeed. An unexpected ref SHA, duplicate matching ref or
-ruleset, payload drift, or an unrecognized partial state fails closed. A partial
-success in one repository is resumed after revalidation; it is not force-deleted
-or rewritten. Do not begin story merges while a branch allows unreviewed direct
-pushes, lacks required checks, or can be deleted.
-
-Add the following to the Shortcut epic:
-
-- SceneWorks branch URL and starting main SHA;
-- inference branch URL and starting main SHA, when present;
-- current SceneWorks inference pin;
-- required CI/runtime lanes; and
-- the final integration story.
+Repeat with the identical name in inference only when inference changes are in
+scope. Confirm the remote ref exists (`git ls-remote origin feature/sc-<epic-id>-*`)
+and add the branch URL(s) and starting `main` SHA(s) to the epic. That is the whole
+step: the wildcard rulesets apply automatically, and a red `main` at branch time is
+not a stop condition — the feature branch will re-merge `main` before it lands.
 
 ## 3. Deliver a story
 
-Treat each story as a small PR even though its base is an epic branch.
-
-1. Re-fetch the live story, current feature head, related PRs, and current code.
-2. Revalidate that the story is still required and that its dependencies are
-   already integrated or explicitly ordered.
-3. Move the story to In Progress immediately before editing.
-4. Create `story/sc-<story-id>-epic-<epic-id>-<epic-slug>` from the latest remote
-   feature branch in an isolated worktree or clone. The epic id and slug must
-   match the target feature branch exactly.
-5. Implement the complete story, focused regression tests, generated artifacts,
-   and required cross-repository work. Do not silently defer required capability.
-6. Run focused checks and the complete applicable repository gates.
-7. Perform a fresh adversarial review and resolve every valid finding.
-8. Open the PR against the feature branch, not `main`:
+1. Re-fetch the story; revalidation is the implementer's first step, not a
+   separate pass or a comment. Move the story to **In Progress**.
+2. If the story's AC restates epic invariants, contains process bullets, or gates
+   on terminal evidence, normalise it to 1–3 local bullets +
+   `Inherits E…` before briefing anyone (`shortcut-plan` rules; one comment).
+3. In an isolated worktree, create
+   `story/sc-<story-id>-epic-<epic-id>-<epic-slug>` from the latest remote
+   feature branch.
+4. Implement the complete story — code, focused tests, generated artifacts
+   current CI requires. Run the repository gate (`npm run rust:check` in
+   SceneWorks; the applicable lane commands in inference). **Push as soon as it
+   is committable** (free); open the PR when it is green locally.
+5. **One** adversarial review by a fresh agent against the story's local AC.
+   **One** fix pass that self-verifies (mutation per touched assertion). No
+   re-review unless a blocker is still `partial` — then one more pass, then
+   surface it.
+6. Open the PR against the feature branch:
 
    ```bash
    gh pr create \
@@ -147,498 +191,136 @@ Treat each story as a small PR even though its base is an epic branch.
      --head story/sc-<story-id>-epic-<epic-id>-<epic-slug>
    ```
 
-9. Merge through the feature branch's required checks. Neither repository has a
-   merge queue, and both `feature/*` rulesets are non-strict. Base advancement
-   alone therefore does not require a rebase or make a previously green story
-   PR ineligible to merge. Reconcile current base state whenever it can affect
-   the story or its generated artifacts, and require fresh exact-head checks
-   after any resulting branch update. Verify the remote merge rather than
-   treating a green check as completion.
-10. Validate the acceptance criteria against the new combined feature head.
-11. Add a Shortcut closeout comment containing the PR, merge commit, tests,
-    runtime evidence, limitations, and tracked follow-ups.
-12. Move the story to Done only when its complete acceptance criteria are
-    satisfied on the integrated feature branch. Story Done means accepted into
-    the epic; it does not mean the feature has reached `main` or a release.
+7. Merge (merge commit) when every required check on the PR head is green.
+   Poll until nothing is pending; do not rely on `gh pr checks --watch`. Do not
+   update the branch merely because the base moved.
+8. Closeout comment (`[author: claude]`): PR link, one line of what shipped,
+   test count. Move to **Done** and read the state back. Done means accepted
+   into the feature branch; it does not mean the feature reached `main`.
+   **Terminal evidence never holds a code story open** — pin bumps, campaigns,
+   real-weight runs, and feature→`main` belong to the terminal story.
 
-Delete only the merged story branch. The feature branch remains active.
+Delete the merged story branch. Do not re-validate the story's AC against the
+merged feature head or rerun any matrix; the feature-end review covers the
+combined branch once.
 
 ### Cross-repository stories
 
-For a story that changes inference:
+A story that changes inference and SceneWorks is **two PRs in sequence**,
+inference first. The SceneWorks side **does not bump the pin**:
 
-1. Branch from the inference feature branch and merge the inference story PR
-   back into that branch.
-2. Record the exact merged inference feature SHA.
-3. On the SceneWorks story branch, update the pin with the repository-owned
-   script:
+- To build SceneWorks against the new engine for discovery, run
+  `node scripts/bump-inference.mjs --sha <inference-feature-sha40>` in the
+  worktree, build and test, then revert every pin site
+  (`git checkout -- Cargo.toml Cargo.lock crates/sceneworks-worker/Cargo.toml crates/sceneworks-memory-adapter/Cargo.toml`)
+  and commit only the story. Report what was verified against in the PR.
+- Schedule SceneWorks stories that need the new engine **after** the epic's
+  single pin bump (§5), where they get real CI against the landed pin.
+- A mid-epic bump costs a full SceneWorks CI cycle for no behaviour, a
+  `Cargo.lock` edit every in-flight branch must merge, staled calibration
+  records, and pins a SHA that may never reach inference `main`. If the schedule
+  seems to need one, the schedule is wrong.
 
-   ```bash
-   node scripts/bump-inference.mjs --sha <inference-feature-sha40>
-   ```
-
-4. Regenerate the pin-derived artifacts that `bump-inference.mjs` and current
-   CI actually require — as of the 2026-08-15/16 gate teardown that is a short
-   list, and a pin bump no longer invalidates capability dumps or obligates any
-   measurement work (see *Gate teardown* under **CI and repository
-   configuration**).
-5. Merge the SceneWorks story PR only after inference and SceneWorks validation
-   both pass at the exact paired revisions.
-
-The inference feature branch must remain reachable while SceneWorks points to
-it. Never delete or rewrite it during the epic.
+The inference feature branch must remain reachable until the SceneWorks feature
+is on `main`. Never delete or rewrite it during the epic.
 
 ## 4. Keep long-running branches current
 
-Shared feature branches are never rebased or force-pushed. Synchronize them by
-merging current `main` through a reviewed PR:
+Feature branches are never rebased or force-pushed. Merge `main` in through a PR
+(the ruleset requires one):
 
 ```bash
 git fetch origin
-git switch -c sync/sc-<epic-id>-main-<date> \
-  origin/feature/sc-<epic-id>-<epic-slug>
+git switch -c sync/sc-<epic-id>-main-<date> origin/feature/sc-<epic-id>-<epic-slug>
 git merge origin/main
 git push -u origin sync/sc-<epic-id>-main-<date>
-gh pr create \
-  --base feature/sc-<epic-id>-<epic-slug> \
-  --head sync/sc-<epic-id>-main-<date>
+gh pr create --base feature/sc-<epic-id>-<epic-slug> --head sync/sc-<epic-id>-main-<date>
 ```
 
-Synchronize:
+Green required CI **is** the review of a sync PR; no adversarial review, no
+matrix rerun. Synchronize when a story actually depends on something that landed
+on `main`, when a hotfix on `main` conflicts with the branch, and once before
+feature end (§5). Not on a schedule, not "whenever drift increases". Resolve
+conflicts toward the epic's architecture. If inference is in scope, synchronize
+inference `main` into its feature branch the same way; do not bump the SceneWorks
+pin for it.
 
-- after a relevant hotfix reaches `main`;
-- before starting a story whose dependencies changed on `main`;
-- whenever drift materially increases conflict risk;
-- before whole-epic acceptance testing; and
-- immediately before the final PR to `main`.
+## 5. Finish the epic (the terminal story)
 
-Resolve conflicts against the feature's approved architecture and rerun the
-combined validation matrix. If inference is involved, synchronize inference
-`main` into its feature branch first, update the SceneWorks pin to that new
-feature head, and validate the pair again.
+Ordered because SceneWorks consumes inference by exact commit:
 
-Never merge one feature branch directly into another. If epic B depends on epic
-A, complete A into `main`, then synchronize `main` into B. Record the dependency
-in both epics.
+1. Freeze new story merges in both feature branches. Synchronize both from their
+   respective `main` (§4).
+2. **Feature-end review**, once, after the last code story merges: the full
+   `feature/*` vs `main` diff in each repository against the epic's numbered
+   requirements and acceptance tests, at the session model. Fix → re-review
+   loops allowed here, cap 3, each round one batched PR into the feature branch.
+   Stories that land after the pin bump (step 4) get their ordinary per-story
+   review; the feature-end review is not repeated for them.
+3. Merge inference `feature/sc-<epic-id>-<slug>` → inference `main` through `CI
+   gate` (`strict: true`: the branch must contain current `main`). Record the
+   resulting inference `main` merge commit. An open PR is not a merged dependency.
+4. **The epic's one pin bump**: on a `story/*` branch off the SceneWorks feature
+   branch, `node scripts/bump-inference.mjs --sha <inference-main-sha40>`,
+   regenerate only what current CI on the PR requires, merge through the feature
+   branch. Then run any SceneWorks stories that were waiting on the new engine.
+5. **The epic's one measurement campaign**, if the epic calls for one,
+   immediately after the bump (the bump stales the records; bump-then-capture is
+   the only ordering that yields current evidence).
+6. Open one PR from the SceneWorks feature branch to `main`. Body: epic link and
+   story list, final inference pin and the inference `main` PR, migrations and
+   compatibility decisions, known limitations. The PR itself runs `nax-worker`
+   and (when the diff is candle-relevant) `windows-candle.yml`; do not dispatch
+   them separately beforehand. If `main` advanced while the PR sat open, merge
+   it in and let the checks re-run.
+7. After the merge: re-fetch and verify the remote merge commit, add the epic
+   closeout comment, move the epic to **Done**, delete the SceneWorks feature
+   branch, delete the inference feature branch once nothing pins it, remove the
+   epic's worktrees.
 
-## 5. Complete an inference-backed epic
-
-Cross-repository finalization is ordered because SceneWorks consumes inference
-by exact commit SHA:
-
-1. Freeze new story merges in both feature branches.
-2. Synchronize inference `main` into the inference feature branch.
-3. Synchronize SceneWorks `main` into the SceneWorks feature branch.
-4. Update SceneWorks to the final inference feature head and run the complete
-   paired validation and final adversarial review.
-5. Open the inference feature PR against inference `main` and merge it through
-   the required CI. inference `main` is `strict: false` and has no queue, so if
-   inference `main` moved after those checks went green, merge it in and let them
-   re-run before merging.
-6. Record the exact resulting inference `main` commit. An open PR is not a merged
-   dependency.
-7. Update the SceneWorks feature branch to that inference-main commit with
-   `bump-inference.mjs` and regenerate the derived artifacts current CI
-   requires at the final pin. The epic's single measurement campaign, if the
-   epic calls for one, runs here — after this bump, never earlier (see *Gate
-   teardown* under **CI and repository configuration**).
-8. Rerun the complete SceneWorks validation matrix and final review. The pin
-   change after the inference merge invalidates earlier final-CI claims.
-9. Proceed to the SceneWorks final merge only when inference `main`, the
-   SceneWorks pin, generated evidence, and validated source all agree.
-
-Keep the inference feature branch until the SceneWorks feature is verified on
-`main`, even though the permanent pin is now reachable from inference `main`.
-
-## 6. Merge the completed feature into main
-
-Open one PR from the SceneWorks feature branch to `main`. Its body must contain:
-
-- the Shortcut epic and complete story list;
-- requirements and acceptance-criterion mapping;
-- SceneWorks and inference base/final SHAs;
-- the final inference pin and inference main PR, when applicable;
-- migrations and compatibility decisions;
-- complete local, hosted, platform, and real-weight evidence;
-- independent-review verdicts; and
-- explicit limitations and separately tracked follow-ups.
-
-Before merging, verify:
-
-- every required story is Done and no epic blocker remains;
-- both feature branches include current respective `main`;
-- the final integration/acceptance story passed against the combined head;
-- the SceneWorks pin is reachable from inference `main`;
-- required CI reports on the actual feature-to-main PR head; and
-- no unrelated changes entered through synchronization.
-
-Merge through the protected `main` ruleset. SceneWorks `main` has **no merge
-queue** and does **not** require the branch to be up to date (`strict: false`),
-so nothing re-verifies this PR against a `main` that moved after its checks went
-green — if `main` advanced while the final PR sat open, merge it in and let the
-required checks re-run before merging. Afterward, re-fetch and verify the exact
-remote merge commit, post-merge state, and any required runtime or deployment
-evidence. Only then:
-
-1. add the epic closeout comment;
-2. move the epic to Done;
-3. delete the SceneWorks feature branch through the authorized cleanup path;
-4. delete the inference feature branch if nothing still pins it; and
-5. remove local worktrees owned by the epic.
+Deleting a `feature/*` branch requires a temporary bypass actor on the
+deletion-guard ruleset (it holds only the deletion rule, so the bypass weakens
+nothing else); restore `bypass_actors: []` afterwards. A merged, unpinned
+feature branch left in place is inert — deletion is hygiene, not a gate.
 
 Merging the feature into `main` does not change `release/next` and does not
 publish a release.
 
 ## Failure, abandonment, and scope changes
 
-- Keep a red feature branch open and tracked until it is repaired; do not merge
-  an incomplete epic to make the branch disappear.
-- If the epic is abandoned, document the decision and retained work in
-  Shortcut, verify that no SceneWorks ref pins its inference branch, then delete
-  both branches through the authorized cleanup path.
-- Extract reusable work through a separately scoped story and PR to `main`.
-  Never merge a partial epic wholesale.
-- Add newly discovered required work to the epic immediately. Do not hide it in
-  a TODO or declare the epic complete around it.
-- If requirements change enough to invalidate the implementation plan, update
-  the epic and stories before continuing.
+- Keep a red feature branch open and tracked until repaired; never merge an
+  incomplete epic to make the branch disappear.
+- Discovered work inside the epic's subject: fix it in the same PR or a second PR
+  the same session. Outside the subject: still fix it, batched into one PR. File
+  a story only for the three genuine blockers (hardware, a credential only the
+  owner can set, a decision only the owner can make).
+- If the epic is abandoned, record the decision and retained work in Shortcut,
+  verify no SceneWorks ref pins its inference branch, then delete both branches.
+  Extract reusable work through a separately scoped PR to `main`; never merge a
+  partial epic wholesale.
+- If requirements change enough to invalidate the plan, update the epic and
+  stories before continuing.
 
-## CI and repository configuration
+## Appendix — CI contract for feature branches
 
-### Current state verified on 2026-08-15
+These are the properties the workflows and rulesets must keep satisfying;
+`scripts/platform-review-contracts.test.mjs` enforces the workflow half.
 
-#### Gate teardown (2026-08-15/16) — read before regenerating anything
-
-The pin-keyed verification gates are **deliberately dismantled**:
-
-- sc-19758 (`68670a3ee`): four `check.yml` steps are switched off with `if: false`
-  — the per-lane inference closure-digest verification, the NC-weights source
-  scan, the About→Licenses guard, and the gen-core version-skew guard. The jobs
-  and their scripts are retained **on purpose** (the `parity` aggregator asserts
-  a member floor, and re-enabling any of them is deleting one line).
-  `release.yml` still scans built bundles for NC weights.
-- sc-19751: `check-license-coverage.mjs` reports and exits 0; `--strict` gates
-  only during a deliberate compliance pass.
-- `e14171984` (PR #2360): an inference pin bump **no longer invalidates
-  capability dumps**. A dump is stale only when a provider's declared
-  capabilities actually change; a media/audio revision disagreement is recorded
-  (`audioInferenceRevision`), not refused, and `bump-inference.mjs` no longer
-  fails a bump on a stale facts file.
-
-Consequences, binding on agents:
-
-- **A script that exists in `scripts/` but is disabled or unwired is the
-  designed state, not a blocker.** Do not wire it up, re-enable an `if: false`,
-  treat its existence as a requirement, or file a story about it.
-- **Measurement campaigns — capability dumps, memory-matrix regeneration,
-  calibration captures, VRAM/canary runs — run once, at the end of an epic**
-  (immediately after its single pin bump), or when explicitly requested. Never
-  per story and never per pin movement. Calibration records demoted to floors
-  during development is the accepted state.
-- Where older prose in this document says to regenerate or validate "every"
-  pin-derived artifact, the operative authority is **what current CI on the
-  actual PR requires**, which after the teardown is much less than the lists
-  suggest.
-- Story "done" = the code, its tests, adversarial review, and green required CI
-  on the PR. Nothing more unless the story itself is a measurement story.
-- **Tests over measured corpora** (calibration records and evidence, capability
-  dumps, session logs, survey populations) **assert shape and invariants —
-  schema validity, non-emptiness, resolving cross-references, per-item
-  properties — never exact populations, pinned ids, or historical counts.** A
-  pinned count over a corpus that is supposed to churn cannot fail on a bug and
-  is guaranteed to fail on every legitimate re-capture; it is a gate on
-  measurement wearing a test's clothes. When a re-capture trips one, the defect
-  is in the test: rewrite that assertion and its siblings to shape in the same
-  PR rather than hand-updating the numbers. (Golden/parity fixtures that pin a
-  fixed input's output are a different, legitimate class.)
-
-#### Merge queues
-
-**Neither repository has a merge queue.** Both were removed on 2026-08-11 —
-SceneWorks first, inference the same day — and the two are now structurally
-identical.
-
-| | SceneWorks | inference |
-| --- | --- | --- |
-| `main` ruleset | `Require MR` (17708030) | `Require MR` (20481541) |
-| queue on `main` | **none** | **none** |
-| up-to-date required on `main` | no (`strict: false`) | no (`strict: false`) |
-| `feature/*` base policy | 20638194 | 20638200 |
-| queue on `feature/*` | **none** | **none** |
-| `feature/*` up-to-date | no (`strict: false`) | no (`strict: false`) |
-| deletion guard | 20638197 | 20638201 |
-
-Both `main` rulesets carry `deletion`, `non_fast_forward`, `pull_request`, and
-required status checks. Both `feature/*` base policies carry `non_fast_forward`,
-`pull_request`, and required status checks at `strict: false`.
-
-Feature protection is ruleset-managed. A request to the legacy direct branch
-protection endpoint for a concrete feature branch can therefore return HTTP 404
-even while the wildcard rulesets are active. Inspect the repository rulesets
-and their effective `feature/*` match instead of treating that 404 as proof that
-the branch is unprotected.
-
-The deliberate remaining differences are policy, not structure: SceneWorks
-requires code-owner review and allows merge/squash/rebase; inference requires no
-code-owner review and allows merge commits only. Required contexts differ by
-repository — SceneWorks requires `web`, `parity`, `candle`, `build-windows`,
-`check-linux`, `check-macos`, and `macOS build, lint and workspace tests
-(hosted)`; inference requires `CI gate`. inference also retains a **disabled**
-`No Force-Push` ruleset (18886583) with no SceneWorks equivalent.
-
-#### Why there is no queue
-
-Removed after measurement, not preference. Over 5.4 days the SceneWorks queue
-produced **103 merge groups and caught zero integration failures**, while adding
-a median 21m (mean 35m, p90 43m) to every merge. Every group contained exactly
-one PR — `min_entries_to_merge: 1` forms a group the instant one entry arrives,
-so `max_entries_to_build` never engaged, `min_entries_to_merge_wait_minutes` was
-inert, nothing was ever amortized, and the entire cost was additive. Its only
-observable effects were two evictions, on PRs that then took 1h32m and 5h33m.
-inference ran the identical configuration, including the same
-`min_entries_to_merge: 1`, and was removed to match.
-
-Do not re-add a queue to either repository without new evidence. A merge queue
-earns its cost through batching under concurrency; at these merge rates it
-batched nothing. The `merge_group:` triggers remain in the workflows deliberately
-so re-enabling is a one-line ruleset change — and a required lane *without* that
-trigger strands a queued group until the response timeout evicts its entries.
-
-#### Consequences for this document
-
-- Every step that stages, activates, or recovers an exact per-branch queue
-  ruleset is obsolete in **both** repositories. Feature branches have **two**
-  layers, not three, and ref creation needs no transaction in either repo.
-- `release/next` is covered by **no ruleset in either repository** — no required
-  checks, no PR requirement, no force-push or deletion guard. It is the least
-  protected branch in the hotfix path.
-
-Workflow triggers, verified the same day:
-
-- SceneWorks `check.yml`, `desktop-macos-check.yml`, `desktop-linux-check.yml`,
-  and `desktop-windows.yml` trigger for arbitrary pull-request bases and
-  `merge_group`.
-- SceneWorks `macos-mlx.yml` now targets `pull_request: branches: [main,
-  "feature/*"]` with no PR path filter, so its required status reports on
-  feature-target PRs. `platform-review-contracts.test.mjs` enforces this.
-- SceneWorks `windows-candle.yml` still restricts ordinary PRs to `main`, keeps
-  a PR path filter, and has no `merge_group` trigger. It is deliberately not a
-  required check; a contract test asserts it stays out of the required set.
-- Inference `ci.yml` supports arbitrary pull requests and `merge_group`, and its
-  `CI gate` is required on `feature/*`.
-
-Re-query live rules and workflow files before implementation; this section is a
-dated snapshot, not a substitute for current inspection.
-
-### Ruleset and workflow requirements
-
-These layers already exist in both repositories (see *Current state* above); this
-section is the contract they must keep satisfying, and the recipe for any future
-repository or feature branch.
-
-#### 1. Feature-branch rulesets
-
-GitHub rulesets use `fnmatch`, so the durable wildcard layers target `feature/*`,
-which intentionally matches the one-slash branch format defined above.
-
-**Two layers in each repository** — the wildcard base policy and the wildcard
-deletion guard. There is no queue layer in either repository, so there is no
-exact-branch ruleset, no staging transaction, and no per-epic ruleset lifecycle
-to manage.
-
-Should a queue ever be reintroduced, the constraint that shaped the old
-three-layer design still applies and is worth recording: GitHub's ruleset API
-rejects `merge_queue` when the condition contains a wildcard (`Invalid rule
-'merge_queue': Wildcard ref names are not supported when merge queue is
-enabled`), and an active exact queue rule rejects initial creation of its
-matching ref with `Changes must be made through the merge queue`. A queue
-therefore cannot live in the wildcard base policy, and its exact ruleset and ref
-have to be staged disabled, created, then activated as one recoverable
-transaction. Do not reintroduce that machinery without first fixing the batching
-parameters that made the queue worthless.
-
-SceneWorks must require at least the same integration contexts currently
-required on `main`:
-
-- `web`
-- `parity`
-- `candle`
-- `build-windows`
-- `check-linux`
-- `check-macos`
-- `macOS build, lint and workspace tests (hosted)`
-
-Inference must require `CI gate`.
-
-The wildcard base-policy ruleset in each repository must have no bypass actors and
-must:
-
-- require pull requests;
-- block force pushes and non-fast-forward updates;
-- require code-owner/review behavior consistent with each repository's `main`;
-- require current-head status checks;
-- use merge commits so story and synchronization provenance is retained.
-
-Note the batch-size trap that removed both repositories' queues:
-`min_entries_to_merge: 1` forms a group the instant a single entry arrives, so
-`max_entries_to_build` never engages, `min_entries_to_merge_wait_minutes` is
-inert, and the queue amortizes nothing while charging a full verification pass
-per PR. Both repositories ran exactly that configuration. If a queue is ever
-reintroduced, set the batching parameters so a group can actually hold several
-entries, and measure group sizes before trusting it — do not pay for a group of
-one.
-
-The wildcard deletion-guard ruleset must contain only the deletion rule and
-normally have no bypass actors. After every non-cleanup assertion passes on a
-disposable proof branch, or after the post-merge checklist succeeds, freeze the
-target branch and require no open PR. With no queue in either repository,
-deletion is gated only by the deletion guard itself.
-
-An administrator may then temporarily add one closed maintainer team or cleanup
-automation as the deletion guard's exact cleanup actor. If neither exists, one
-explicitly named repository administrator may be the temporary actor; record
-its immutable actor ID, the approved proof-or-completed branch names, and the
-start/end of the cleanup window. Delete only those branches and restore
-`bypass_actors: []` immediately in a finally-style cleanup step, whether the
-deletion succeeds or fails. If deletion fails, keep the branch explicitly unsafe,
-expose no workspace, admit no PR, and record an incident for recovery. Never
-leave deletion authority active during an epic. Bypass is ruleset-wide: never put
-the deletion rule and its cleanup bypass in the base policy, because that would
-also let the cleanup actor bypass pull-request, status-check, or
-non-fast-forward protections. If the ref is absent, audit the restored guard. Use
-this same bounded cleanup only after an explicit abandonment decision.
-
-Evaluate mode, when available, is an optional preview of matched refs and rule
-evaluations; it cannot prove enforced denials. Activate both layers on disposable
-branches before running those enforcement tests, and do not create the real epic
-branches until the complete proof matrix passes.
-GitHub's ruleset pattern and bypass behavior is documented in
-[Creating rulesets for a repository](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/creating-rulesets-for-a-repository).
-
-#### 2. Make every required SceneWorks check report
-
-At minimum:
-
-1. Keep `macos-mlx.yml` ordinary PR targeting on both `main` and `feature/*`.
-   Repository contract tests must reject a required workflow whose base filter
-   would prevent its status from reporting on a feature-target PR.
-2. Audit every required workflow and job condition for assumptions about
-   `main`, `pull_request.base.sha`, or `github.event.before`. A merge-group run
-   must use `github.event.merge_group.base_sha` where a base is required.
-3. Ensure path-irrelevant required jobs report success through an always-created
-   change-selection job. Do not use a workflow-level `paths` filter for a
-   required check, because an absent workflow leaves the requirement pending.
-4. Keep `merge_group` on every required workflow even though neither repository
-   has a queue. The trigger costs nothing while no such event fires, and it keeps
-   re-enabling a queue a one-line ruleset change; a required lane without it
-   strands a queued group until `check_response_timeout_minutes` evicts its
-   entries, which re-orders the queue silently rather than failing.
-   GitHub requires that trigger for checks used by a merge queue; see
-   [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group).
-5. Keep concurrency keyed so one PR or merge-group run cannot cancel another
-   required verdict.
-
-Do not add duplicate `push: feature/*` builds merely because the branches are
-new. With no queue in either repository, the integration verdict is the
-required-check run on the exact PR head itself. Because `feature/*` is
-non-strict, that verdict does not prove the head contains a base commit that
-advanced later. Reconcile the live base when its changes can affect the story,
-but do not rebase solely to satisfy an up-to-date policy that no longer exists.
-Add post-merge feature pushes only when they prove a separate property.
-
-#### 3. Decide the privileged runtime policy
-
-`windows-candle.yml` and `macos-mlx.yml`'s `nax-worker` supply authoritative
-CUDA-linked and Apple matrix-unit runtime coverage, but they run on scarce,
-self-hosted hardware and are not feature-branch required checks. Use this
-policy:
-
-- feature-target story and synchronization PRs run the required hosted checks,
-  including `macOS build, lint and workspace tests (hosted)`;
-- `nax-worker` does not auto-run for PRs targeting `feature/*`, nor for merge
-  groups should a queue ever be reintroduced; it continues to run for the final
-  same-repo integration PR targeting `main`;
-- `windows-candle.yml` remains limited to ordinary PRs targeting `main`, keeps
-  its PR path filter, and carries no `merge_group` trigger, so it stays out of
-  the required set; and
-- at the frozen final feature head, explicitly dispatch both privileged
-  workflows and record their exact head SHA and successful run URLs in the epic
-  before opening the final PR to `main`.
-
-Apply the same rule to privileged inference real-weight lanes: ordinary CI may
-select their impact without having authority or hardware to execute them. An
-epic that requires real-weight evidence cannot close on a compile-only lane.
-
-#### 4. Validate inference feature branches
-
-After adding the inference ruleset:
-
-- prove that a story PR to `feature/*` produces `CI gate`;
-- prove that base advancement alone does not block an otherwise mergeable story
-  PR (`strict: false`, no queue), while any explicit branch update produces a
-  fresh exact-head `CI gate` verdict;
-- prove that a SceneWorks PR can fetch an exact commit reachable only from the
-  active private inference feature branch;
-- prove that `bump-inference.mjs` regenerates and validates all pin-derived
-  artifacts at that revision; and
-- prove that deletion is blocked until authorized cleanup.
-
-#### 5. Add policy automation
-
-Implement small fail-closed automation rather than relying only on memory:
-
-- a feature bootstrap command or agent skill that creates and records mirrored
-  branches from exact main SHAs and verifies both wildcard layers in each
-  repository;
-- a PR policy check that rejects a feature story targeting `main` or the wrong
-  epic branch;
-- a check that rejects a final SceneWorks feature PR while its inference pin is
-  reachable only from `feature/*`;
-- an epic closeout audit covering story state, open PRs, current-main ancestry,
-  CI conclusions, exact pins, and branch cleanup eligibility; and
-- a future minor-release workflow that promotes completed `main` into
-  `release/next` without conflating feature completion with release publication.
-
-### CI acceptance test
-
-Before declaring the feature process operational, create disposable mirrored
-feature branches and exercise all of the following:
-
-1. A docs-only SceneWorks story PR reports every required status without a
-   permanently pending path-filtered check.
-2. A web/Rust story PR runs the expected hosted matrix.
-3. An MLX-sensitive PR runs the required macOS/MLX context.
-4. A candle-sensitive PR produces the hosted candle verdict and the chosen CUDA
-   runtime evidence.
-5. An inference story PR produces `CI gate`, merges, and can be pinned by the
-   SceneWorks feature branch.
-6. A story PR whose base has moved remains eligible under `strict: false` in
-   both repositories. Verify that base advancement alone does not force a
-   rebase, and that deliberately updating the story branch triggers required
-   checks on the new exact head. With no queue validating a speculative merge
-   commit, those checks attest only the exact PR head; they are the required
-   merge verdict, not evidence that the head was tested with a base that
-   advanced later.
-7. Creating a feature ref succeeds directly under the two wildcard layers, in
-   both repositories, with no queue ruleset staged.
-8. Direct and force pushes to feature branches fail.
-9. An unauthorized deletion fails, while the authorized post-epic cleanup path
-   succeeds without bypassing the base policy.
-10. The final inference-first merge and SceneWorks pin transition succeed without
-   leaving `main` dependent on a feature-only inference commit.
-
-Capture the disposable PRs and run URLs in the CI implementation PR. Only after
-this test passes should agents treat the feature process as fully automated.
-
-## Success criteria
-
-A feature epic is complete only when:
-
-- all required stories are accepted on the combined feature branch;
-- the final integration story and full validation matrix pass;
-- inference changes are merged to inference `main` and SceneWorks pins that
-  exact reachable revision;
-- the SceneWorks feature PR is merged to `main` through required CI;
-- live post-merge state is verified;
-- the Shortcut epic is closed with evidence; and
-- mirrored feature branches are removed through the authorized cleanup path.
+- SceneWorks `feature/*` requires the same seven contexts as `main`; inference
+  `feature/*` requires `CI gate`. Both base policies: pull request required,
+  merge commits only, non-fast-forward blocked, no bypass actors.
+- Every required workflow triggers on `pull_request` for any base and keeps
+  `merge_group:`; none uses a workflow-level `paths:` filter (use a `changes`
+  gate job that reports success when irrelevant).
+- `macos-mlx.yml` targets `pull_request: branches: [main, "feature/*"]`;
+  `nax-worker` is gated to `base.ref == main` and same-repo heads.
+- `windows-candle.yml` stays limited to PRs targeting `main`, keeps its path
+  filter, and stays out of the required set.
+- Concurrency groups are keyed so one PR run cannot cancel another's verdict.
+- Merge queues were removed from both repositories on 2026-08-11 after 103
+  groups caught zero integration failures at a median +21 minutes per merge
+  (`min_entries_to_merge: 1` formed a group per PR, so nothing batched). Do not
+  re-add one without new evidence; if ever reintroduced, a wildcard ruleset
+  cannot carry `merge_queue`, so it needs an exact-branch ruleset staged
+  disabled, the ref created, then activated. The `merge_group:` triggers are
+  retained so that remains a ruleset-only change.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -127,6 +127,14 @@ fail-closed remediation it prints. In particular, do not hand-edit a license,
 provenance, compatibility, capability, or calibration digest to make a stale
 audit appear current.
 
+If the new inference pin moves the `mlx-rs` fork revision in `Cargo.lock`, the
+macOS lanes' `Fetch prebuilt MLX` step looks for the fork's `prebuilt-<sha12>`
+release for that revision (`scripts/fetch-prebuilt-mlx.sh`; the fork publishes
+it on every push to its `main`). Until it exists the lanes build libmlx from
+source once per cache miss and say so with a workflow annotation — check
+`https://github.com/SceneWorks/mlx-rs/releases/tag/prebuilt-<sha12>` if the
+macOS job is slower than usual after a bump (sc-21382).
+
 Review the complete diff and run the repository checks plus relevant backend
 tests. Push the branch and open a PR against SceneWorks `release/next`. The pin
 PR must merge before the version bump is finalized.

--- a/apps/desktop/src/settings.rs
+++ b/apps/desktop/src/settings.rs
@@ -9,7 +9,9 @@ use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 
-use crate::setup::{default_data_dir, settings_file, shared_huggingface_home};
+use crate::setup::{
+    default_data_dir, huggingface_home_selection, settings_file, shared_huggingface_home,
+};
 
 const KEYRING_SERVICE: &str = "SceneWorks";
 /// Pre-migration account that held the single Hugging Face token. Retained only so
@@ -866,6 +868,14 @@ pub struct StorageSetup {
     data_dir_default: String,
     hf_home: Option<String>,
     hf_home_default: String,
+    /// The cache home the sidecars will actually receive at their next spawn — ambient `HF_HOME`
+    /// first (e.g. `tauri dev`, a shell-profile export), then the persisted override, then the
+    /// platform default. This is what Settings displays: the row exists to tell the user where
+    /// SceneWorks is really reading from.
+    hf_home_active: String,
+    /// True when an ambient `HF_HOME` is what decides `hf_home_active`; the persisted override is
+    /// then inert and Settings says so instead of offering a change that would not take effect.
+    hf_home_from_environment: bool,
     storage_configured: bool,
     setup_completed: bool,
 }
@@ -873,11 +883,14 @@ pub struct StorageSetup {
 #[tauri::command]
 pub fn get_storage_setup() -> StorageSetup {
     let settings = load_settings();
+    let (hf_home_active, hf_home_from_environment) = huggingface_home_selection();
     StorageSetup {
         data_dir: settings.data_dir,
         data_dir_default: default_data_dir().to_string_lossy().into_owned(),
         hf_home: settings.hf_home,
         hf_home_default: shared_huggingface_home().to_string_lossy().into_owned(),
+        hf_home_active: hf_home_active.to_string_lossy().into_owned(),
+        hf_home_from_environment,
         storage_configured: settings.storage_configured,
         setup_completed: settings.setup_completed,
     }

--- a/apps/desktop/src/setup.rs
+++ b/apps/desktop/src/setup.rs
@@ -612,14 +612,28 @@ fn inject_resolved_cache_env(
 }
 
 fn huggingface_home() -> PathBuf {
+    huggingface_home_selection().0
+}
+
+/// The cache home the sidecars will actually receive at their next spawn, plus whether an ambient
+/// `HF_HOME` in the desktop's own environment is what decides it. When it is, the persisted
+/// Settings override is inert — Settings shows the active path and says so instead of offering a
+/// change that would silently not take effect (`get_storage_setup`).
+pub fn huggingface_home_selection() -> (PathBuf, bool) {
+    let linux_absolute = cfg!(all(unix, not(target_os = "macos")));
     let ambient = std::env::var("HF_HOME").ok();
+    let ambient_wins = ambient
+        .as_deref()
+        .and_then(|value| crate::settings::storage_override_path(value, linux_absolute))
+        .is_some();
     let persisted = crate::settings::load_settings().hf_home;
-    select_huggingface_home(
+    let home = select_huggingface_home(
         ambient.as_deref(),
         persisted.as_deref(),
         shared_huggingface_home(),
-        cfg!(all(unix, not(target_os = "macos"))),
-    )
+        linux_absolute,
+    );
+    (home, ambient_wins)
 }
 
 /// Seed the builtin model/LoRA/recipe-preset catalogs into the desktop's

--- a/apps/rust-api/src/model_library.rs
+++ b/apps/rust-api/src/model_library.rs
@@ -26,9 +26,9 @@ use axum::extract::{ConnectInfo, State};
 use axum::http::StatusCode;
 use axum::Json;
 use sceneworks_core::model_artifacts::external_library::{
-    probe_model_source_library, resolve_relocation_target, ExternalLibraryBindingStore,
-    ExternalLibraryError, LibraryRelocationError, LibraryRelocationRejection,
-    ModelSourceLibraryStatus, RelocationTarget,
+    probe_model_source_library, resolve_fresh_cache_home, resolve_relocation_target,
+    ExternalLibraryBindingStore, ExternalLibraryError, LibraryRelocationError,
+    LibraryRelocationRejection, ModelSourceLibraryStatus, RelocationTarget,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -88,6 +88,12 @@ pub(crate) struct RelocateModelLibraryResponse {
 
 /// `POST /api/v1/model-library/relocate` — adopt a new library root without redownloading.
 ///
+/// Two shapes, decided by the installation's durable install evidence: with evidence, the picked
+/// folder must be a library carrying every recorded model (the recovery prompt's "my drive moved"
+/// case); without any, it is a fresh cache home — any existing directory, whose `hub` child is
+/// created on adopt — so the Settings "change model library" control works before the first
+/// download exactly like the first-run storage step does.
+///
 /// Local-only (see [`require_local_peer`]): it takes an absolute host path, and its typed refusals
 /// would otherwise be a filesystem-existence oracle for any token-holding LAN client — which could
 /// also re-point a shared server's library out from under everyone else.
@@ -104,19 +110,52 @@ pub(crate) async fn relocate_model_library(
     let dry_run = request.dry_run;
     let data_dir = state.settings.data_dir.clone();
     tokio::task::spawn_blocking(move || {
-        let target = resolve_relocation_target(std::path::Path::new(&picked))
-            .map_err(rejection_to_api_error)?;
         let store = ExternalLibraryBindingStore::new(&data_dir).map_err(|error| {
             relocation_failed("model library binding ledger is unavailable", &error)
         })?;
+        let has_evidence = store.has_install_evidence().map_err(|error| {
+            relocation_failed("model library install evidence could not be read", &error)
+        })?;
+        // The fresh-home shape additionally requires that no library was ever bound: evidence
+        // detection is receipt/ledger-based, so an install whose receipts became unreadable must
+        // not slide into binding an arbitrary folder — an existing binding is itself proof this
+        // installation already had a library, and the strict shape judges the candidate.
+        let bound = store
+            .load()
+            .map_err(|error| relocation_failed("model library binding could not be read", &error))?
+            .is_some();
+        let fresh = !has_evidence && !bound;
+        let target = if fresh {
+            resolve_fresh_cache_home(std::path::Path::new(&picked))
+        } else {
+            resolve_relocation_target(std::path::Path::new(&picked))
+        }
+        .map_err(rejection_to_api_error)?;
         if dry_run {
+            // A fresh home's `hub` may not exist yet (it is created on adopt), so the dry run
+            // validates the home directory itself: with no install evidence that is the same
+            // canonical-directory + volume-identity check the adopt makes, moving every ordinary
+            // refusal ahead of both durable writes. Writability of the folder is the one thing a
+            // write-free dry run cannot prove.
             store
-                .validate_relocation(&target.library_root)
+                .validate_relocation(if fresh {
+                    &target.hf_home
+                } else {
+                    &target.library_root
+                })
                 .map_err(relocation_error_to_api_error)?;
             return Ok(Json(RelocateModelLibraryResponse {
                 target,
                 adopted: false,
             }));
+        }
+        if fresh {
+            std::fs::create_dir_all(&target.library_root).map_err(|error| {
+                relocation_failed(
+                    "model library folder could not be created",
+                    &ExternalLibraryError(error.to_string()),
+                )
+            })?;
         }
         store
             .relocate_binding(&target.library_root)
@@ -193,11 +232,6 @@ fn rejection_to_api_error(rejection: LibraryRelocationRejection) -> ApiError {
              that contains them, or reconnect the original drive.",
             repositories.join(", ")
         ),
-        LibraryRelocationRejection::NoInstalledModels => {
-            "SceneWorks has no record of any installed models, so there is nothing to relocate. \
-             Reconnect the original library, or download the models you need."
-                .to_owned()
-        }
         LibraryRelocationRejection::HubDirectoryExpected => {
             "SceneWorks reads models from a `hub` folder inside the Hugging Face cache. Choose the \
              folder that contains `hub` (or the `hub` folder itself)."

--- a/apps/rust-api/src/tests/model_library.rs
+++ b/apps/rust-api/src/tests/model_library.rs
@@ -360,6 +360,81 @@ async fn relocating_to_the_moved_library_adopts_it_and_names_the_home_to_persist
         .is_some_and(|root| Path::new(root) == relocated_home.join("hub")));
 }
 
+/// The Settings "change model library" path before anything is installed: with no install
+/// evidence there is nothing to protect, so an EMPTY folder is accepted as a fresh cache home — the
+/// dry run confirms it without creating anything, the adopt creates `hub` and binds it, and the
+/// response names the `HF_HOME` the shell must persist (the picked folder itself).
+#[tokio::test]
+async fn a_fresh_install_adopts_an_empty_folder_as_its_cache_home() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let _env = isolate_hf_cache();
+    let settings = test_settings(&temp_dir);
+    let data_dir = settings.data_dir.clone();
+    std::fs::create_dir_all(&data_dir).expect("data dir creates");
+    let store = ExternalLibraryBindingStore::new(&data_dir).expect("binding store");
+    assert!(!store.has_install_evidence().expect("evidence reads"));
+    let fresh_home = temp_dir.path().join("fresh-cache");
+    std::fs::create_dir_all(&fresh_home).expect("fresh home creates");
+    let app = create_app(settings).expect("app creates");
+
+    let (status, body) = request_with_peer(
+        app.clone(),
+        "POST",
+        "/api/v1/model-library/relocate",
+        json!({ "path": fresh_home.to_string_lossy(), "dryRun": true }),
+        LOCAL_PEER,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["adopted"], false);
+    assert!(!fresh_home.join("hub").exists(), "a dry run writes nothing");
+    assert!(store.load().expect("binding reads").is_none());
+
+    let (status, body) = request_with_peer(
+        app.clone(),
+        "POST",
+        "/api/v1/model-library/relocate",
+        json!({ "path": fresh_home.to_string_lossy() }),
+        LOCAL_PEER,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["adopted"], true);
+    assert!(body["hfHome"]
+        .as_str()
+        .is_some_and(|home| Path::new(home) == fresh_home));
+    assert!(body["libraryRoot"]
+        .as_str()
+        .is_some_and(|root| Path::new(root) == fresh_home.join("hub")));
+    assert!(
+        fresh_home.join("hub").is_dir(),
+        "adopt creates the hub root"
+    );
+    let binding = store
+        .load()
+        .expect("binding reads")
+        .expect("the fresh home is bound");
+    assert_eq!(
+        binding.canonical_path,
+        fresh_home
+            .join("hub")
+            .canonicalize()
+            .expect("hub canonicalizes")
+    );
+
+    // A folder that does not exist is still refused, typed, even with nothing installed.
+    let (status, body) = request_with_peer(
+        app.clone(),
+        "POST",
+        "/api/v1/model-library/relocate",
+        json!({ "path": temp_dir.path().join("absent").to_string_lossy() }),
+        LOCAL_PEER,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert_eq!(body["context"]["reason"], "not_a_directory");
+}
+
 /// Write a one-model manifest whose single download row is spelled out by the caller, so a test can
 /// vary exactly the declaration under test (a pinned revision, an optional co-requisite) without
 /// inheriting [`single_model_manifest`]'s fixed shape.

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -71,6 +71,7 @@ import { appConfirm, ConfirmHost } from "./appConfirm.jsx";
 import { ModelLibraryDialog } from "./components/ModelLibraryDialog.jsx";
 import { ModelLibraryRestartDialog } from "./components/ModelLibraryRestartDialog.jsx";
 import {
+  adoptModelLibrary,
   createModelLibraryGate,
   fetchModelLibraryStatus,
   relocateModelLibrary,
@@ -721,45 +722,54 @@ export function App() {
   // one blocked action and resumes it at most once, so a reconnect (or an impatient second click)
   // can never turn one blocked generation into two jobs. Registered as the module-level handler so
   // every submission path — and the studios' selection check — reaches it without prop threading.
+  // The relocation sequence's three seams, built once and shared by the blocked-action prompt
+  // (below) and the Settings → Storage "Model library" control, which relocates with no blocked
+  // action to resume but with exactly the same two-write ordering and undo.
+  const modelLibraryRelocator = useMemo(
+    () => ({
+      validate: (path) => validateModelLibrary(token, path),
+      adopt: (path) => relocateModelLibrary(token, path),
+      // Durable persistence of a relocated library is desktop state: the API hands back the exact
+      // HF_HOME the shell must store, in the same field, file and normalization as the first-run
+      // storage step. Returns an undo so the gate can restore the previous location if the
+      // server's re-bind then fails — the two copies must never disagree.
+      //
+      // Fails CLOSED when the previous location cannot be read, BEFORE the first durable write:
+      // without a previous location there is no undo, so a re-bind failure afterwards would leave
+      // the shell pointed at the new library while the gate reported the previous location still
+      // in use — the disagreement this undo path exists to prevent, with the wrong message on top.
+      persist: async (target) => {
+        // Nothing to persist — the browser shell keeps no copy of the location. A NO-OP undo, not
+        // `null`: the gate treats a missing undo as "changed and unrestorable", and here nothing
+        // changed, so the previous location genuinely is still in use.
+        if (!isDesktopShell || !target?.hfHome) return () => {};
+        let before = null;
+        try {
+          before = await tauriInvoke("get_storage_setup");
+        } catch (error) {
+          throw new Error(
+            `The current model library location could not be read, so nothing was changed. ${String(error)}`.trim(),
+          );
+        }
+        const previous = before?.hfHome ?? before?.hfHomeDefault ?? null;
+        if (!previous) {
+          throw new Error(
+            "The current model library location could not be read, so nothing was changed.",
+          );
+        }
+        await tauriInvoke("set_model_library", { path: target.hfHome });
+        return () => tauriInvoke("set_model_library", { path: previous });
+      },
+    }),
+    [token],
+  );
   const modelLibraryGate = useMemo(
     () =>
       createModelLibraryGate({
         probe: () => fetchModelLibraryStatus(token),
-        validate: (path) => validateModelLibrary(token, path),
-        adopt: (path) => relocateModelLibrary(token, path),
-        // Durable persistence of a relocated library is desktop state: the API hands back the exact
-        // HF_HOME the shell must store, in the same field, file and normalization as the first-run
-        // storage step. Returns an undo so the gate can restore the previous location if the
-        // server's re-bind then fails — the two copies must never disagree.
-        //
-        // Fails CLOSED when the previous location cannot be read, BEFORE the first durable write:
-        // without a previous location there is no undo, so a re-bind failure afterwards would leave
-        // the shell pointed at the new library while the gate reported the previous location still
-        // in use — the disagreement this undo path exists to prevent, with the wrong message on top.
-        persist: async (target) => {
-          // Nothing to persist — the browser shell keeps no copy of the location. A NO-OP undo, not
-          // `null`: the gate treats a missing undo as "changed and unrestorable", and here nothing
-          // changed, so the previous location genuinely is still in use.
-          if (!isDesktopShell || !target?.hfHome) return () => {};
-          let before = null;
-          try {
-            before = await tauriInvoke("get_storage_setup");
-          } catch (error) {
-            throw new Error(
-              `The current model library location could not be read, so nothing was changed. ${String(error)}`.trim(),
-            );
-          }
-          const previous = before?.hfHome ?? before?.hfHomeDefault ?? null;
-          if (!previous) {
-            throw new Error(
-              "The current model library location could not be read, so nothing was changed.",
-            );
-          }
-          await tauriInvoke("set_model_library", { path: target.hfHome });
-          return () => tauriInvoke("set_model_library", { path: previous });
-        },
+        ...modelLibraryRelocator,
       }),
-    [token],
+    [token, modelLibraryRelocator],
   );
   const modelLibraryState = useSyncExternalStore(
     modelLibraryGate.subscribe,
@@ -785,7 +795,9 @@ export function App() {
     if (!picked) return;
     const adopted = await modelLibraryGate.relocate(picked);
     if (adopted?.hfHome) {
-      setModelLibraryRelocation(adopted);
+      // `droppedSubmission`: the prompt path dropped whatever the user was submitting; the restart
+      // disclosure says so. The Settings path below has no submission to drop.
+      setModelLibraryRelocation({ ...adopted, droppedSubmission: true });
       // The notice outlives the dialog, so "Later" still leaves the reason visible.
       pushNotice(
         "general",
@@ -793,6 +805,21 @@ export function App() {
       );
     }
   }, [modelLibraryGate, pushNotice]);
+  // Settings → Storage → Model library → Change…: the same relocation (validate, persist, re-bind,
+  // undo on failure) and the same restart disclosure as the prompt, with no blocked action. Resolves
+  // to the adopted target, `null` when the picker was dismissed; rejects with the user-facing
+  // message when the folder was refused or a write failed, for the Settings screen to show inline.
+  // Unlike the prompt path there is no `modelLibraryPickerOpen` bracket: that flag only pauses the
+  // gate's auto re-probe, and with no blocked action pending there is nothing a re-probe could
+  // resume behind the native dialog.
+  const changeModelLibrary = useCallback(async () => {
+    if (!isDesktopShell) return null;
+    const picked = await tauriInvoke("choose_folder").catch(() => null);
+    if (!picked) return null;
+    const adopted = await adoptModelLibrary(modelLibraryRelocator, picked);
+    setModelLibraryRelocation({ ...adopted, droppedSubmission: false });
+    return adopted;
+  }, [modelLibraryRelocator]);
   // The drop guard that stops a stray file from navigating the webview (issue #1308) is
   // installed further down, next to `useWorkflowDrop` — it now hands the unclaimed file to
   // the workflow inspector (sc-15951), which needs the active project and `importAsset`.
@@ -3937,6 +3964,7 @@ export function App() {
             embedWorkflow={embedWorkflow}
             lockedToSimple={uiModeLocked}
             onAccentChange={changeAccent}
+            onChangeModelLibrary={changeModelLibrary}
             onEmbedWorkflowChange={changeEmbedWorkflow}
             onSimpleDefaultChange={changeSimpleUiDefault}
             sharingFocusRequest={settingsSharingFocusRequest}

--- a/apps/web/src/App.modelLibraryRelocate.test.jsx
+++ b/apps/web/src/App.modelLibraryRelocate.test.jsx
@@ -80,6 +80,8 @@ describe("App model library relocation + restart disclosure (sc-19709)", () => {
           setupCompleted: true,
           hfHome: "/Volumes/Models/hf",
           hfHomeDefault: "/Users/me/.cache/huggingface",
+          hfHomeActive: "/Volumes/Models/hf",
+          hfHomeFromEnvironment: false,
         });
       }
       if (command === "choose_folder") return Promise.resolve("/Volumes/Models 1/hf");
@@ -210,6 +212,50 @@ describe("App model library relocation + restart disclosure (sc-19709)", () => {
     await settle();
     const restarts = invoke.mock.calls.filter(([command]) => command === "restart_app");
     expect(restarts).toHaveLength(1);
+  });
+
+  // The same relocation, started from Settings → Storage instead of the unavailable-library
+  // prompt: no submission was dropped, so the disclosure must not claim one was.
+  it("relocates from Settings and discloses the restart without inventing a dropped job", async () => {
+    root = createRoot(container);
+    await act(async () => root.render(<App />));
+    await settle();
+
+    const settingsNav = [...document.body.querySelectorAll(".nav-label")].find(
+      (item) => item.textContent === "Settings",
+    );
+    await act(async () => settingsNav.closest("button").click());
+    await settle();
+    const settingsTab = [...document.body.querySelectorAll(".mode-tab")].find(
+      (tab) => tab.textContent.trim() === "Settings",
+    );
+    await act(async () => settingsTab.click());
+    await settle();
+
+    const row = [...document.body.querySelectorAll(".settings-row-title")]
+      .find((title) => title.textContent.includes("Model library"))
+      .closest("div").parentElement;
+    const change = [...row.querySelectorAll("button")].find(
+      (item) => item.textContent.trim() === "Change…",
+    );
+    await act(async () => change.click());
+    await settle();
+
+    expect(relocateRequests).toEqual([
+      { path: "/Volumes/Models 1/hf", dryRun: true },
+      { path: "/Volumes/Models 1/hf" },
+    ]);
+    expect(invoke).toHaveBeenCalledWith("set_model_library", {
+      path: "/Volumes/Models 1/hf",
+    });
+    const disclosure = dialogs()[0];
+    expect(disclosure).toBeTruthy();
+    expect(disclosure.textContent).toContain("after it restarts");
+    expect(disclosure.textContent).toContain("/Volumes/Models 1/hf");
+    expect(disclosure.textContent).not.toContain("was not queued");
+    expect(document.body.textContent).toContain(
+      "Model library updated — restart SceneWorks to apply.",
+    );
   });
 
   it("Later dismisses the disclosure and leaves no queued generation", async () => {

--- a/apps/web/src/components/ModelLibraryRestartDialog.jsx
+++ b/apps/web/src/components/ModelLibraryRestartDialog.jsx
@@ -67,10 +67,13 @@ export function ModelLibraryRestartDialog({
       </p>
       {/* Say what happened to the work they were doing. From the user's seat they pressed Generate,
           answered a dialog, and got a settings message: without this line, the missing job reads as
-          a bug rather than the deliberate consequence of relocating. */}
-      <p className="discard-confirm-body">
-        The generation you started was not queued. Submit it again after SceneWorks restarts.
-      </p>
+          a bug rather than the deliberate consequence of relocating. Only when there WAS a
+          submission — a relocation started from Settings dropped nothing. */}
+      {relocation.droppedSubmission ? (
+        <p className="discard-confirm-body">
+          The generation you started was not queued. Submit it again after SceneWorks restarts.
+        </p>
+      ) : null}
       <p className="model-library-path">
         <span className="model-library-path-label">New location</span>
         <code>{relocation.hfHome ?? relocation.libraryRoot}</code>

--- a/apps/web/src/components/ModelLibraryRestartDialog.test.jsx
+++ b/apps/web/src/components/ModelLibraryRestartDialog.test.jsx
@@ -7,6 +7,8 @@ const RELOCATION = {
   libraryRoot: "/Volumes/Models 1/hf/hub",
   hfHome: "/Volumes/Models 1/hf",
   status: { available: true },
+  // The prompt path: the user was submitting something when the library was found unavailable.
+  droppedSubmission: true,
 };
 
 describe("ModelLibraryRestartDialog (sc-19709)", () => {
@@ -66,6 +68,17 @@ describe("ModelLibraryRestartDialog (sc-19709)", () => {
     expect(dialog.querySelector('[role="status"]').getAttribute("aria-live")).toBe(
       "polite",
     );
+  });
+
+  // A relocation started from Settings → Storage dropped nothing: telling that user a generation
+  // "was not queued" would invent a job they never started.
+  it("omits the dropped-submission line for a relocation that had no submission", async () => {
+    const dialog = await render({
+      relocation: { ...RELOCATION, droppedSubmission: false },
+    });
+    expect(dialog.textContent).toContain("after it restarts");
+    expect(dialog.textContent).toContain("/Volumes/Models 1/hf");
+    expect(dialog.textContent).not.toContain("was not queued");
   });
 
   it("invokes the relaunch exactly once, however many times the button is clicked", async () => {

--- a/apps/web/src/modelLibrary.js
+++ b/apps/web/src/modelLibrary.js
@@ -131,10 +131,9 @@ const IDLE = Object.freeze({
   relocated: null,
 });
 
-/// A blocked-action gate: at most one pending action, resumed at most once.
+// Adopt a different model library root — the ONE relocation sequence, shared by the blocked-action
+// prompt below and the Settings "Model library" control (which has no blocked action to resume).
 //
-// Injected so the state machine is testable without a transport:
-//   `probe`    — the seam's library status; a retry gates on its `available`.
 //   `validate` — check a candidate root, writing nothing anywhere.
 //   `adopt`    — re-bind the server's durable identity to that root.
 //   `persist`  — store the client's own copy of the location. It must either return an undo that
@@ -144,7 +143,61 @@ const IDLE = Object.freeze({
 // Relocation has TWO durable writes in different places (the shell's `HF_HOME` and the server's
 // binding ledger) and they must not be allowed to disagree: `validate` first so every ordinary
 // refusal happens before either, then `persist`, then `adopt`, and if `adopt` fails the persist is
-// undone. What the user is told always matches what actually happened.
+// undone. Resolves to the adopted target; rejects with an Error whose message says what actually
+// happened (and nothing else — a raw transport/filesystem message never reaches the user alone).
+export async function adoptModelLibrary({ validate, adopt, persist } = {}, path) {
+  // 1. Validate. Nothing is written, so a refusal here leaves everything as it was and the user
+  //    simply picks again.
+  let target = null;
+  try {
+    target = (await validate?.(path)) ?? { hfHome: path, libraryRoot: path };
+  } catch (error) {
+    throw new Error(error?.message || "That library could not be used.");
+  }
+
+  // 2. Persist the client's copy, then 3. re-bind the server's. If the re-bind fails, undo the
+  //    persist so the two cannot disagree — and say what actually happened either way.
+  let undoPersist = null;
+  // Whether `persist` got far enough to have written anything. A `persist` that THREW wrote
+  // nothing (it is required to fail before its own durable write), so the previous location
+  // really is still in use; one that returned is the only case where restoring is in question.
+  let persisted = false;
+  try {
+    if (persist) {
+      undoPersist = (await persist(target)) ?? null;
+      persisted = true;
+    }
+    await adopt?.(path);
+  } catch (error) {
+    let restored = true;
+    if (persisted) {
+      if (typeof undoPersist === "function") {
+        try {
+          await undoPersist();
+        } catch {
+          restored = false;
+        }
+      } else {
+        // Persisted, but handed back no undo: the client's copy has changed and cannot be put
+        // back. Claiming "the previous location is still in use" here would be a lie, and the
+        // two copies would be left disagreeing with the user told otherwise.
+        restored = false;
+      }
+    }
+    throw new Error(
+      restored
+        ? `SceneWorks could not finish moving the model library, so the previous location is still in use. ${error?.message ?? ""}`.trim()
+        : "SceneWorks could not finish moving the model library, and could not restore the previous location. Set the model library folder in Settings.",
+    );
+  }
+  return target;
+}
+
+/// A blocked-action gate: at most one pending action, resumed at most once.
+//
+// Injected so the state machine is testable without a transport:
+//   `probe`    — the seam's library status; a retry gates on its `available`.
+//   `validate` / `adopt` / `persist` — the relocation sequence, see `adoptModelLibrary`.
 export function createModelLibraryGate({ probe, validate, adopt, persist } = {}) {
   let state = IDLE;
   // The single pending action. It is REMOVED from this slot before it runs, so no second caller —
@@ -229,61 +282,15 @@ export function createModelLibraryGate({ probe, validate, adopt, persist } = {})
       const action = takePending();
       const attempt = ++epoch;
       emit({ status: "relocating", hint: "", error: "" });
-
-      // 1. Validate. Nothing is written, so a refusal here leaves the blocked action intact and
-      //    the user simply picks again.
       let target = null;
       try {
-        target = (await validate?.(path)) ?? { hfHome: path, libraryRoot: path };
+        target = await adoptModelLibrary({ validate, adopt, persist }, path);
       } catch (error) {
+        // A refusal (validate) or a failed write (persist/adopt, already undone where possible)
+        // leaves the blocked action intact and reports what happened; the user simply picks again.
         if (attempt !== epoch) return null;
         pending = action;
-        emit({
-          status: "blocked",
-          hint: "",
-          error: error?.message || "That library could not be used.",
-        });
-        return null;
-      }
-
-      // 2. Persist the client's copy, then 3. re-bind the server's. If the re-bind fails, undo the
-      //    persist so the two cannot disagree — and say what actually happened either way.
-      let undoPersist = null;
-      // Whether `persist` got far enough to have written anything. A `persist` that THREW wrote
-      // nothing (it is required to fail before its own durable write), so the previous location
-      // really is still in use; one that returned is the only case where restoring is in question.
-      let persisted = false;
-      try {
-        if (persist) {
-          undoPersist = (await persist(target)) ?? null;
-          persisted = true;
-        }
-        await adopt?.(path);
-      } catch (error) {
-        let restored = true;
-        if (persisted) {
-          if (typeof undoPersist === "function") {
-            try {
-              await undoPersist();
-            } catch {
-              restored = false;
-            }
-          } else {
-            // Persisted, but handed back no undo: the client's copy has changed and cannot be put
-            // back. Claiming "the previous location is still in use" here would be a lie, and the
-            // two copies would be left disagreeing with the user told otherwise.
-            restored = false;
-          }
-        }
-        if (attempt !== epoch) return null;
-        pending = action;
-        emit({
-          status: "blocked",
-          hint: "",
-          error: restored
-            ? `SceneWorks could not finish moving the model library, so the previous location is still in use. ${error?.message ?? ""}`.trim()
-            : "SceneWorks could not finish moving the model library, and could not restore the previous location. Set the model library folder in Settings.",
-        });
+        emit({ status: "blocked", hint: "", error: error.message });
         return null;
       }
       if (attempt !== epoch) return null;

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -81,6 +81,11 @@ export function SettingsScreen({
   lockedToSimple = false,
   embedWorkflow = true,
   onEmbedWorkflowChange,
+  // Settings → Storage → Model library → Change…. Owned by App.jsx (it shares the relocation
+  // sequence and the restart disclosure with the unavailable-library prompt, sc-19709): runs the
+  // native picker, validates + persists + re-binds, and opens the restart dialog. Resolves to the
+  // adopted target, `null` when the picker was dismissed; rejects with the message to show.
+  onChangeModelLibrary,
   sharingFocusRequest = 0,
 }) {
   // theme/changeTheme and the worker registry come from the app context (the same values the
@@ -88,6 +93,10 @@ export function SettingsScreen({
   // App.jsx, which owns them alongside the sidebar's mode switch.
   const { theme, changeTheme, visibleWorkers = [], macCapabilities } = useAppContext();
   const [settings, setSettings] = useState(null);
+  // The first-run storage snapshot, read only for `hfHomeDefault`: the model library row shows the
+  // folder the app is ACTUALLY reading from when no override is set, not "Default location" — the
+  // whole point of the row is telling a user whose cache moved where SceneWorks still thinks it is.
+  const [storageSetup, setStorageSetup] = useState(null);
   const [gpu, setGpu] = useState(null);
   const [credentials, setCredentials] = useState([]);
   const [newHost, setNewHost] = useState("");
@@ -142,13 +151,16 @@ export function SettingsScreen({
   const refresh = useCallback(async () => {
     try {
       if (isDesktop) {
-        const [loadedSettings, gpuInfo, storedCredentials, remoteAccess] = await Promise.all([
-          invoke("get_app_settings"),
-          invoke("get_gpu_info"),
-          invoke("list_credentials"),
-          invoke("get_remote_access"),
-        ]);
+        const [loadedSettings, gpuInfo, storedCredentials, remoteAccess, storage] =
+          await Promise.all([
+            invoke("get_app_settings"),
+            invoke("get_gpu_info"),
+            invoke("list_credentials"),
+            invoke("get_remote_access"),
+            invoke("get_storage_setup"),
+          ]);
         setSettings(loadedSettings);
+        setStorageSetup(storage);
         setGpu(gpuInfo);
         setCredentials(storedCredentials ?? []);
         if (remoteAccess) {
@@ -259,6 +271,43 @@ export function SettingsScreen({
   async function revealDataDir() {
     if (settings?.dataDir) {
       await invoke("reveal_in_os", { path: settings.dataDir });
+    }
+  }
+
+  // The Hugging Face cache home SceneWorks is ACTUALLY reading models from, as the shell resolves
+  // it for the sidecar spawn (ambient `HF_HOME` first, then the persisted override, then the
+  // platform default). The persisted override alone would lie whenever an ambient `HF_HOME` wins —
+  // which is exactly when it matters, so the row shows the resolved path and, in that case, says
+  // the environment owns it instead of offering a change that would not take effect.
+  const modelLibraryFromEnvironment = storageSetup?.hfHomeFromEnvironment === true;
+  const modelLibraryPath =
+    storageSetup?.hfHomeActive ?? settings?.hfHome ?? storageSetup?.hfHomeDefault ?? null;
+
+  async function changeModelLibrary() {
+    try {
+      const adopted = await onChangeModelLibrary?.();
+      if (adopted?.hfHome) {
+        // The shell persisted the override inside the relocation; re-read it rather than guessing.
+        const [reloaded, storage] = await Promise.all([
+          invoke("get_app_settings"),
+          invoke("get_storage_setup"),
+        ]);
+        setSettings(reloaded);
+        setStorageSetup(storage);
+        setStatus("Model library updated — restart SceneWorks to apply.");
+      }
+    } catch (error) {
+      setStatus(error?.message || String(error));
+    }
+  }
+
+  async function revealModelLibrary() {
+    if (!modelLibraryPath) return;
+    try {
+      await invoke("reveal_in_os", { path: modelLibraryPath });
+    } catch (error) {
+      // Most likely: the default cache home was never created because nothing was downloaded yet.
+      setStatus(error?.message || String(error));
     }
   }
 
@@ -695,6 +744,45 @@ export function SettingsScreen({
                       type="button"
                       onClick={revealDataDir}
                       disabled={!settings?.dataDir}
+                    >
+                      Reveal in {gpu?.platform === "windows" ? "Explorer" : "Finder"}
+                    </button>
+                  </div>
+                </div>
+                {/* The Hugging Face cache home (`HF_HOME`) — where downloaded model weights live.
+                    Changing it runs the sc-19709 relocation: the folder is checked first (with
+                    models installed it must hold every one this install recorded, so nothing is
+                    orphaned; before anything is installed any folder is acceptable), then the
+                    override is persisted and the library re-bound. Like the data directory, the
+                    sidecars pick it up at their next spawn, so it needs a restart. */}
+                <div>
+                  <div className="settings-row-title">Model library (Hugging Face cache)</div>
+                  <div className="settings-row-sub">
+                    Downloaded model weights. Choose the Hugging Face cache folder (the one
+                    containing <code>hub</code>) — if you moved your cache to another drive, point
+                    SceneWorks at it here. Needs a restart.
+                  </div>
+                  <div className="settings-path">{modelLibraryPath ?? "…"}</div>
+                  {modelLibraryFromEnvironment ? (
+                    <div className="settings-row-sub">
+                      Set by the <code>HF_HOME</code> environment variable, which overrides
+                      anything chosen here. Unset it to change the location from Settings.
+                    </div>
+                  ) : null}
+                  <div className="settings-button-row">
+                    <button
+                      className="settings-btn"
+                      type="button"
+                      onClick={changeModelLibrary}
+                      disabled={!onChangeModelLibrary || modelLibraryFromEnvironment}
+                    >
+                      Change…
+                    </button>
+                    <button
+                      className="settings-btn"
+                      type="button"
+                      onClick={revealModelLibrary}
+                      disabled={!modelLibraryPath}
                     >
                       Reveal in {gpu?.platform === "windows" ? "Explorer" : "Finder"}
                     </button>

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -282,8 +282,14 @@ export function SettingsScreen({
   const modelLibraryFromEnvironment = storageSetup?.hfHomeFromEnvironment === true;
   const modelLibraryPath =
     storageSetup?.hfHomeActive ?? settings?.hfHome ?? storageSetup?.hfHomeDefault ?? null;
+  // Outcome of the last Change…/Reveal, rendered INLINE at the row. The screen's shared status
+  // line sits at the top of the panel — off-screen when the user is scrolled down at the Storage
+  // group — so a relocation refusal there reads as a silent no-op (the sc-21389 field failure:
+  // the API refused with a typed 409 and the user saw "nothing happened").
+  const [modelLibraryNotice, setModelLibraryNotice] = useState("");
 
   async function changeModelLibrary() {
+    setModelLibraryNotice("");
     try {
       const adopted = await onChangeModelLibrary?.();
       if (adopted?.hfHome) {
@@ -294,10 +300,10 @@ export function SettingsScreen({
         ]);
         setSettings(reloaded);
         setStorageSetup(storage);
-        setStatus("Model library updated — restart SceneWorks to apply.");
+        setModelLibraryNotice("Model library updated — restart SceneWorks to apply.");
       }
     } catch (error) {
-      setStatus(error?.message || String(error));
+      setModelLibraryNotice(error?.message || String(error));
     }
   }
 
@@ -307,7 +313,7 @@ export function SettingsScreen({
       await invoke("reveal_in_os", { path: modelLibraryPath });
     } catch (error) {
       // Most likely: the default cache home was never created because nothing was downloaded yet.
-      setStatus(error?.message || String(error));
+      setModelLibraryNotice(error?.message || String(error));
     }
   }
 
@@ -768,6 +774,11 @@ export function SettingsScreen({
                       Set by the <code>HF_HOME</code> environment variable, which overrides
                       anything chosen here. Unset it to change the location from Settings.
                     </div>
+                  ) : null}
+                  {modelLibraryNotice ? (
+                    <p aria-live="polite" className="settings-status" role="status">
+                      {modelLibraryNotice}
+                    </p>
                   ) : null}
                   <div className="settings-button-row">
                     <button

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -164,7 +164,12 @@ describe("SettingsScreen model library location", () => {
       (button) => button.textContent.trim() === "Change…",
     );
     await click(change[1]);
-    expect(container.textContent).toContain(
+    // The refusal renders INSIDE the model library row — the top-of-panel status line can be
+    // scrolled out of view, which made a refusal look like a silent no-op.
+    const row = [...container.querySelectorAll(".settings-row-title")]
+      .find((title) => title.textContent.includes("Model library"))
+      .closest("div").parentElement;
+    expect(row.querySelector('[role="status"]').textContent).toContain(
       "That folder does not contain a SceneWorks model library.",
     );
     expect(container.textContent).toContain("/Users/me/.cache/huggingface");

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -59,6 +59,156 @@ async function openTab(container, label) {
 const buttonByText = (container, label) =>
   [...container.querySelectorAll("button")].find((button) => button.textContent.trim() === label);
 
+// Settings → Storage → Model library (the Hugging Face cache home). The row tells the user where
+// SceneWorks is ACTUALLY reading models from (override, else the platform default — never a bare
+// "Default location"), and Change… hands off to App's relocation sequence (sc-19709), which is
+// injected as `onChangeModelLibrary` so the screen never re-implements the two-write ordering.
+describe("SettingsScreen model library location", () => {
+  let container;
+  let root;
+  let invoke;
+  let SettingsScreen;
+  let appSettings;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    appSettings = {};
+    invoke = vi.fn(async (command) => {
+      switch (command) {
+        case "get_app_settings":
+          return appSettings;
+        case "get_storage_setup":
+          return {
+            dataDirDefault: "/Users/me/Library/Application Support/SceneWorks",
+            hfHome: appSettings.hfHome ?? null,
+            hfHomeDefault: "/Users/me/.cache/huggingface",
+            // The shell resolves what the sidecars will actually receive: ambient env, then the
+            // persisted override, then the default. The mock mirrors that (no ambient here).
+            hfHomeActive: appSettings.hfHome ?? "/Users/me/.cache/huggingface",
+            hfHomeFromEnvironment: false,
+            storageConfigured: true,
+            setupCompleted: true,
+          };
+        case "get_gpu_info":
+          return { platform: "macos", devices: [] };
+        case "list_credentials":
+          return [];
+        default:
+          return null;
+      }
+    });
+    window.__TAURI__ = { core: { invoke } };
+    vi.resetModules();
+    SettingsScreen = await loadScreen();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    delete window.__TAURI__;
+    vi.restoreAllMocks();
+  });
+
+  async function render(props) {
+    await renderScreen(root, SettingsScreen, props);
+    await openTab(container, "Settings");
+  }
+
+  it("shows the platform default cache home when no override is set", async () => {
+    await render({ onChangeModelLibrary: vi.fn() });
+    expect(container.textContent).toContain("Model library (Hugging Face cache)");
+    expect(container.textContent).toContain("/Users/me/.cache/huggingface");
+    expect(container.textContent).not.toContain("Default location/Users/me/.cache");
+  });
+
+  it("shows the persisted override and reveals it", async () => {
+    appSettings = { hfHome: "/Volumes/Models/huggingface" };
+    await render({ onChangeModelLibrary: vi.fn() });
+    expect(container.textContent).toContain("/Volumes/Models/huggingface");
+    const reveal = [...container.querySelectorAll("button")].filter(
+      (button) => button.textContent.trim() === "Reveal in Finder",
+    );
+    // Data directory (disabled: no override) then the model library.
+    expect(reveal).toHaveLength(2);
+    await click(reveal[1]);
+    expect(invoke).toHaveBeenCalledWith("reveal_in_os", { path: "/Volumes/Models/huggingface" });
+  });
+
+  it("relocates through the injected sequence, re-reads settings and asks for a restart", async () => {
+    const onChangeModelLibrary = vi.fn(async () => {
+      appSettings = { hfHome: "/Volumes/Models/huggingface" };
+      return { hfHome: "/Volumes/Models/huggingface", libraryRoot: "/Volumes/Models/huggingface/hub" };
+    });
+    await render({ onChangeModelLibrary });
+    const change = [...container.querySelectorAll("button")].filter(
+      (button) => button.textContent.trim() === "Change…",
+    );
+    expect(change).toHaveLength(2);
+    await click(change[1]);
+    expect(onChangeModelLibrary).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("/Volumes/Models/huggingface");
+    expect(container.textContent).toContain("Model library updated — restart SceneWorks to apply.");
+  });
+
+  it("shows the refusal inline and keeps the current location when the folder is rejected", async () => {
+    const onChangeModelLibrary = vi.fn(async () => {
+      throw new Error("That folder does not contain a SceneWorks model library.");
+    });
+    await render({ onChangeModelLibrary });
+    const change = [...container.querySelectorAll("button")].filter(
+      (button) => button.textContent.trim() === "Change…",
+    );
+    await click(change[1]);
+    expect(container.textContent).toContain(
+      "That folder does not contain a SceneWorks model library.",
+    );
+    expect(container.textContent).toContain("/Users/me/.cache/huggingface");
+    expect(container.textContent).not.toContain("restart SceneWorks to apply");
+  });
+
+  // `tauri dev` / a shell-profile export: an ambient `HF_HOME` beats the persisted override at
+  // spawn, so the row must show the path actually in use and must not offer a change that would
+  // silently never take effect.
+  it("shows the environment-owned location and disables Change…", async () => {
+    appSettings = { hfHome: "/Volumes/Models/huggingface" };
+    const fromEnv = invoke.getMockImplementation();
+    invoke.mockImplementation(async (command) => {
+      if (command === "get_storage_setup") {
+        return {
+          ...(await fromEnv(command)),
+          hfHomeActive: "/tmp/dev-hf-home",
+          hfHomeFromEnvironment: true,
+        };
+      }
+      return fromEnv(command);
+    });
+    await render({ onChangeModelLibrary: vi.fn() });
+    expect(container.textContent).toContain("/tmp/dev-hf-home");
+    expect(container.textContent).toContain("HF_HOME");
+    expect(container.textContent).toContain("environment variable");
+    const change = [...container.querySelectorAll("button")].filter(
+      (button) => button.textContent.trim() === "Change…",
+    );
+    expect(change[1].disabled).toBe(true);
+  });
+
+  it("does nothing when the picker is dismissed", async () => {
+    const onChangeModelLibrary = vi.fn(async () => null);
+    await render({ onChangeModelLibrary });
+    const change = [...container.querySelectorAll("button")].filter(
+      (button) => button.textContent.trim() === "Change…",
+    );
+    await click(change[1]);
+    expect(onChangeModelLibrary).toHaveBeenCalledTimes(1);
+    expect(container.textContent).not.toContain("restart SceneWorks to apply");
+  });
+});
+
 describe("SettingsScreen service credentials", () => {
   let container;
   let root;

--- a/crates/sceneworks-core/src/model_artifacts/external_library.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library.rs
@@ -516,19 +516,8 @@ impl ExternalLibraryBindingStore {
                     LibraryRelocationRejection::NotAModelLibrary,
                 ));
             }
-            let mut missing = Vec::new();
-            for closure in &closures {
-                if validate_requirements_at_root(&canonical_before, closure).is_err() {
-                    missing.extend(
-                        closure
-                            .iter()
-                            .map(|requirement| requirement.repository.clone()),
-                    );
-                }
-            }
+            let missing = requirements_missing_for_relocation(&canonical_before, &closures);
             if !missing.is_empty() {
-                missing.sort();
-                missing.dedup();
                 return Err(LibraryRelocationError::Rejected(
                     LibraryRelocationRejection::MissingInstalledModels {
                         repositories: missing,
@@ -1042,6 +1031,135 @@ pub fn resolve_relocation_target(
         }),
         _ => Err(LibraryRelocationRejection::HubDirectoryExpected),
     }
+}
+
+/// How one evidence requirement reads at a candidate library root, for relocation only.
+///
+/// Availability and binding keep using [`validate_requirements_at_root`]'s exact rule; relocation
+/// needs the middle case: the per-tier delete (`remove_tier_artifacts`) reclaims a quant tier's
+/// bytes but never rewrites the download receipt or prunes the validated-closure ledger, so a real,
+/// healthy library legitimately lacks WHOLE variants its evidence still records. Demanding them
+/// byte-exactly makes every install that ever deleted a tier un-relocatable (the sc-21389 field
+/// failure: 18 repos refused, all deleted-`q4` tiers).
+enum RequirementPresence {
+    /// Some snapshot carries every file — the requirement is installed here.
+    Present,
+    /// Not a single one of the requirement's files exists in any candidate snapshot: the shape a
+    /// whole-tier delete leaves behind. Tolerated when the same repository proves itself through
+    /// another fully present requirement; refused otherwise (an entirely absent model is the
+    /// wrong-folder signal, not tier reclaim).
+    WhollyAbsent,
+    /// Partially present (or unreadable): torn content is never what tier reclaim produces, so it
+    /// stays a refusal regardless of siblings.
+    Missing,
+}
+
+fn requirement_presence_at_root(
+    canonical_root: &Path,
+    requirement: &ExternalArtifactRequirement,
+) -> RequirementPresence {
+    let Some(repo_name) = safe_repo_dir_name(&requirement.repository) else {
+        return RequirementPresence::Missing;
+    };
+    let repo_root = canonical_root.join(format!("models--{repo_name}"));
+    let Ok(canonical_repo) = std::fs::canonicalize(&repo_root) else {
+        return RequirementPresence::Missing;
+    };
+    if !canonical_repo.starts_with(canonical_root) {
+        return RequirementPresence::Missing;
+    }
+    // Same snapshot universe as `validate_requirements_at_root`: the receipted revision when
+    // pinned, every snapshot otherwise. A pinned revision whose snapshot directory is gone
+    // contributes zero files, i.e. reads WhollyAbsent — the same judgement as a deleted tier.
+    let snapshots: Vec<PathBuf> = if let Some(revision) = requirement.revision.as_deref() {
+        vec![canonical_repo.join("snapshots").join(revision)]
+    } else {
+        match std::fs::read_dir(canonical_repo.join("snapshots")) {
+            Ok(entries) => entries
+                .filter_map(Result::ok)
+                .filter_map(|entry| {
+                    entry
+                        .file_type()
+                        .ok()
+                        .filter(|kind| kind.is_dir())
+                        .map(|_| entry.path())
+                })
+                .collect(),
+            Err(_) => return RequirementPresence::Missing,
+        }
+    };
+    let file_exists = |snapshot: &Path, relative: &Path| {
+        std::fs::canonicalize(snapshot.join(relative))
+            .map(|canonical| canonical.is_file() && canonical.starts_with(&canonical_repo))
+            .unwrap_or(false)
+    };
+    let mut any_file_present = false;
+    for snapshot in &snapshots {
+        let mut all = true;
+        for relative in &requirement.files {
+            if file_exists(snapshot, relative) {
+                any_file_present = true;
+            } else {
+                all = false;
+            }
+        }
+        if all {
+            return RequirementPresence::Present;
+        }
+    }
+    if any_file_present {
+        RequirementPresence::Missing
+    } else {
+        RequirementPresence::WhollyAbsent
+    }
+}
+
+/// The repositories a relocation candidate is judged to be missing, deleted-tier drift excluded.
+///
+/// A requirement that is [`RequirementPresence::WhollyAbsent`] is dropped when the SAME repository
+/// has a [`RequirementPresence::Present`] requirement anywhere in the evidence (its other quant
+/// tier, typically): after adoption that variant truthfully reads uninstalled, exactly as it does
+/// today. Everything else — a partially present requirement, a malformed closure, a repository
+/// whose every requirement is absent — still refuses, so a decoy or wrong folder fails closed.
+fn requirements_missing_for_relocation(
+    canonical_root: &Path,
+    closures: &[Vec<ExternalArtifactRequirement>],
+) -> Vec<String> {
+    let mut present_repositories = std::collections::HashSet::new();
+    let mut wholly_absent = Vec::new();
+    let mut missing = Vec::new();
+    for closure in closures {
+        if validate_requirements_shape(closure).is_err() {
+            missing.extend(
+                closure
+                    .iter()
+                    .map(|requirement| requirement.repository.clone()),
+            );
+            continue;
+        }
+        for requirement in closure {
+            match requirement_presence_at_root(canonical_root, requirement) {
+                RequirementPresence::Present => {
+                    present_repositories.insert(requirement.repository.clone());
+                }
+                RequirementPresence::WhollyAbsent => {
+                    wholly_absent.push(requirement.repository.clone());
+                }
+                RequirementPresence::Missing => missing.push(requirement.repository.clone()),
+            }
+        }
+    }
+    missing.extend(
+        wholly_absent
+            .into_iter()
+            .filter(|repository| !present_repositories.contains(repository)),
+    );
+    // Note the asymmetry: a torn (partially present) requirement refuses even when the same
+    // repository is fully present through another one — tier reclaim never leaves partial files,
+    // so torn content is never explainable as drift.
+    missing.sort();
+    missing.dedup();
+    missing
 }
 
 /// The relocation TOCTOU rule, pure so it can be asserted directly: the exact canonical path AND

--- a/crates/sceneworks-core/src/model_artifacts/external_library.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library.rs
@@ -453,9 +453,11 @@ impl ExternalLibraryBindingStore {
     /// never loses installed state — it only re-points the durable identity at where the library
     /// now lives.
     ///
-    /// It fails CLOSED in both directions: a library missing any recorded install is refused, and
-    /// an installation with no evidence at all is refused outright rather than binding whatever
-    /// Hugging-Face-shaped directory it was handed.
+    /// It fails CLOSED for every installed model: a library missing any recorded install is refused.
+    /// An installation with no install evidence at all has nothing to protect and nothing to check a
+    /// candidate against, so it binds the chosen directory as-is (the Settings "change model
+    /// library" path for a user who has not downloaded anything yet) — the same choice the first-run
+    /// storage step makes, with the volume identity recorded so later installs are judged against it.
     pub fn relocate_binding(
         &self,
         library_root: &Path,
@@ -489,6 +491,15 @@ impl ExternalLibraryBindingStore {
         self.check_relocation_unlocked(library_root).map(|_| ())
     }
 
+    /// Whether this installation has any durable install evidence (validated closures or download
+    /// receipts). Decides which relocation shape applies: with evidence, the candidate must be a
+    /// library carrying every recorded model; without it, any directory is an acceptable fresh
+    /// cache home.
+    pub fn has_install_evidence(&self) -> Result<bool, ExternalLibraryError> {
+        let _lock = self.lock_shared()?;
+        Ok(!self.installed_evidence_closures()?.is_empty())
+    }
+
     fn check_relocation_unlocked(
         &self,
         library_root: &Path,
@@ -497,34 +508,33 @@ impl ExternalLibraryBindingStore {
         let closures = self
             .installed_evidence_closures()
             .map_err(LibraryRelocationError::Failed)?;
-        if closures.is_empty() {
-            return Err(LibraryRelocationError::Rejected(
-                LibraryRelocationRejection::NoInstalledModels,
-            ));
-        }
-        if !has_repository_layout(&canonical_before) {
-            return Err(LibraryRelocationError::Rejected(
-                LibraryRelocationRejection::NotAModelLibrary,
-            ));
-        }
-        let mut missing = Vec::new();
-        for closure in &closures {
-            if validate_requirements_at_root(&canonical_before, closure).is_err() {
-                missing.extend(
-                    closure
-                        .iter()
-                        .map(|requirement| requirement.repository.clone()),
-                );
+        // No evidence: nothing can be orphaned and there is nothing to check, so only the identity
+        // read below stands between the operator and the folder they chose.
+        if !closures.is_empty() {
+            if !has_repository_layout(&canonical_before) {
+                return Err(LibraryRelocationError::Rejected(
+                    LibraryRelocationRejection::NotAModelLibrary,
+                ));
             }
-        }
-        if !missing.is_empty() {
-            missing.sort();
-            missing.dedup();
-            return Err(LibraryRelocationError::Rejected(
-                LibraryRelocationRejection::MissingInstalledModels {
-                    repositories: missing,
-                },
-            ));
+            let mut missing = Vec::new();
+            for closure in &closures {
+                if validate_requirements_at_root(&canonical_before, closure).is_err() {
+                    missing.extend(
+                        closure
+                            .iter()
+                            .map(|requirement| requirement.repository.clone()),
+                    );
+                }
+            }
+            if !missing.is_empty() {
+                missing.sort();
+                missing.dedup();
+                return Err(LibraryRelocationError::Rejected(
+                    LibraryRelocationRejection::MissingInstalledModels {
+                        repositories: missing,
+                    },
+                ));
+            }
         }
         let identity_before = physical_identity(&canonical_before).map_err(|error| {
             LibraryRelocationError::Rejected(LibraryRelocationRejection::IdentityUnavailable {
@@ -923,10 +933,6 @@ pub enum LibraryRelocationRejection {
     /// The layout is right, but models this install recorded as present are not in that library.
     /// Accepting it would silently orphan installed weights, so it fails closed.
     MissingInstalledModels { repositories: Vec<String> },
-    /// This installation has no durable install evidence at all — no receipts, no validated
-    /// closures — so there is nothing to relocate and nothing to check a candidate against.
-    /// Binding an arbitrary Hugging-Face-shaped directory here would be a guess, not a relocation.
-    NoInstalledModels,
     /// The library validates, but the app cannot express it as a Hugging Face cache home: the
     /// configured root is always `<HF_HOME>/hub`, so the operator must choose the folder that
     /// CONTAINS `hub` (or the `hub` folder itself).
@@ -961,6 +967,39 @@ impl std::fmt::Display for LibraryRelocationError {
 pub struct RelocationTarget {
     pub library_root: PathBuf,
     pub hf_home: PathBuf,
+}
+
+/// Map a folder the operator picked to the pair of paths a FRESH cache home needs — the shape used
+/// when this installation has no install evidence (see
+/// [`ExternalLibraryBindingStore::has_install_evidence`]). No repository layout is required: the
+/// picked folder is the cache home (its `hub` child is the library root, created by the caller
+/// when it adopts), unless the folder is itself named `hub`, in which case its parent is the home.
+/// Everything else about the home/hub pairing matches [`resolve_relocation_target`].
+pub fn resolve_fresh_cache_home(
+    picked: &Path,
+) -> Result<RelocationTarget, LibraryRelocationRejection> {
+    let picked = absolute_lexical(picked).map_err(|_| LibraryRelocationRejection::NotADirectory)?;
+    let canonical =
+        std::fs::canonicalize(&picked).map_err(|_| LibraryRelocationRejection::NotADirectory)?;
+    if !canonical.is_dir() {
+        return Err(LibraryRelocationRejection::NotADirectory);
+    }
+    let is_hub = picked
+        .file_name()
+        .is_some_and(|name| name.eq_ignore_ascii_case("hub"));
+    if is_hub {
+        return match picked.parent() {
+            Some(home) => Ok(RelocationTarget {
+                hf_home: home.to_path_buf(),
+                library_root: picked,
+            }),
+            None => Err(LibraryRelocationRejection::HubDirectoryExpected),
+        };
+    }
+    Ok(RelocationTarget {
+        library_root: picked.join("hub"),
+        hf_home: picked,
+    })
 }
 
 /// Map a folder the operator picked to the pair of paths relocation needs.

--- a/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
@@ -653,6 +653,105 @@ fn relocation_binds_a_plain_directory_when_there_is_no_install_evidence() {
     assert!(store.has_install_evidence().unwrap());
 }
 
+/// The sc-21389 field failure: the per-tier delete reclaims a quant tier's bytes but never rewrites
+/// the download receipt (or prunes the ledger), so a real library legitimately lacks WHOLE variants
+/// its evidence records. Relocation must read that as drift — the repo proves itself through its
+/// other, fully present tier — not as a wrong folder.
+#[test]
+fn relocation_tolerates_a_receipted_tier_the_app_deleted() {
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    let library = temp.path().join("moved").join("hub");
+    // The library carries the bf16 tier; the q4 tier was reclaimed (its files simply do not
+    // exist), yet BOTH tiers are still receipted. (`seed_snapshot` writes flat files; a quant
+    // tier is a subdirectory, so lay it out directly.)
+    let seeded = library
+        .join(format!(
+            "models--{}",
+            safe_repo_dir_name("owner/model").unwrap()
+        ))
+        .join("snapshots")
+        .join(REVISION);
+    std::fs::create_dir_all(seeded.join("bf16")).unwrap();
+    std::fs::write(seeded.join("bf16/model.safetensors"), b"weights").unwrap();
+    let store = ExternalLibraryBindingStore::new(&data).unwrap();
+    let q4 = ExternalArtifactRequirement {
+        variant: "q4".to_owned(),
+        files: vec![
+            PathBuf::from("q4/model.safetensors"),
+            PathBuf::from("q4/README.md"),
+        ],
+        ..requirement("owner/model", "bf16/model.safetensors")
+    };
+    store
+        .bind_or_probe_validated(
+            &library,
+            &[requirement("owner/model", "bf16/model.safetensors")],
+        )
+        .unwrap();
+    let mut with_stale_q4 = temp.path().join("data").join("models");
+    with_stale_q4.push(".sceneworks-external-library-closures.json");
+    // Append the stale q4 closure the way history did: it was validated once, then the tier was
+    // deleted from disk. Writing it through the file keeps the store's own append path honest.
+    let mut ledger: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&with_stale_q4).unwrap()).unwrap();
+    ledger["closures"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::to_value(vec![q4.clone()]).unwrap());
+    std::fs::write(&with_stale_q4, serde_json::to_vec(&ledger).unwrap()).unwrap();
+
+    // The deleted tier alone must not refuse the true library…
+    store.validate_relocation(&library).unwrap();
+    store.relocate_binding(&library).unwrap();
+
+    // …but a TORN tier still does, even with the healthy sibling present: tier reclaim never
+    // leaves partial files, so partial content stays the wrong-folder signal.
+    let snapshot = library
+        .join("models--owner--model")
+        .join("snapshots")
+        .join(REVISION);
+    std::fs::create_dir_all(snapshot.join("q4")).unwrap();
+    std::fs::write(snapshot.join("q4/README.md"), b"docs").unwrap();
+    let error = store.validate_relocation(&library).unwrap_err();
+    assert_eq!(
+        error,
+        LibraryRelocationError::Rejected(LibraryRelocationRejection::MissingInstalledModels {
+            repositories: vec!["owner/model".to_owned()],
+        })
+    );
+}
+
+/// A repository whose EVERY evidence requirement is absent is still the wrong-folder signal:
+/// deleted-tier tolerance needs the repo to prove itself through some fully present variant.
+#[test]
+fn relocation_still_refuses_a_repository_that_is_entirely_absent() {
+    let temp = TempDir::new().unwrap();
+    let data = temp.path().join("data");
+    let library = temp.path().join("original").join("hub");
+    seed_snapshot(&library, "owner/model", "model.safetensors");
+    seed_snapshot(&library, "owner/other", "model.safetensors");
+    let store = ExternalLibraryBindingStore::new(&data).unwrap();
+    store
+        .bind_or_probe_validated(&library, &[requirement("owner/model", "model.safetensors")])
+        .unwrap();
+    store
+        .bind_or_probe_validated(&library, &[requirement("owner/other", "model.safetensors")])
+        .unwrap();
+
+    // A candidate carrying only ONE of the two recorded models: the other repo is wholly absent,
+    // with no present sibling variant to explain it as tier reclaim.
+    let decoy = temp.path().join("decoy").join("hub");
+    seed_snapshot(&decoy, "owner/model", "model.safetensors");
+    let error = store.validate_relocation(&decoy).unwrap_err();
+    assert_eq!(
+        error,
+        LibraryRelocationError::Rejected(LibraryRelocationRejection::MissingInstalledModels {
+            repositories: vec!["owner/other".to_owned()],
+        })
+    );
+}
+
 /// The fresh-home shape: a plain folder is the cache home (its `hub` child is the library root);
 /// a folder named `hub` is the library root (its parent the home). No layout is required.
 #[test]

--- a/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
@@ -619,23 +619,65 @@ fn write_download_receipt(data_dir: &Path, repo: &str, file: &str) {
     .unwrap();
 }
 
-/// Nothing installed means nothing to relocate. Binding whatever Hugging-Face-shaped directory the
-/// operator happened to pick would be a guess, and it would silently become the identity every
-/// later install is judged against.
+/// Nothing installed means nothing can be orphaned and nothing to check a candidate against: an
+/// EMPTY directory (no `models--*` layout at all) binds as a fresh cache home, and the recorded
+/// identity is then what every later install is judged against — the Settings "change model
+/// library" path for a user who has not downloaded anything yet.
 #[test]
-fn relocation_refuses_outright_when_there_is_no_install_evidence() {
+fn relocation_binds_a_plain_directory_when_there_is_no_install_evidence() {
     let temp = TempDir::new().unwrap();
     let data = temp.path().join("data");
-    let candidate = temp.path().join("someones-cache").join("hub");
+    let candidate = temp.path().join("fresh-cache").join("hub");
     std::fs::create_dir_all(&candidate).unwrap();
-    seed_snapshot(&candidate, "someone/unrelated", "model.safetensors");
 
     let store = ExternalLibraryBindingStore::new(&data).unwrap();
+    assert!(!store.has_install_evidence().unwrap());
+    store.validate_relocation(&candidate).unwrap();
+    let binding = store.relocate_binding(&candidate).unwrap();
+    assert_eq!(binding.canonical_path, candidate.canonicalize().unwrap());
+    assert_eq!(store.load().unwrap(), Some(binding.clone()));
     assert_eq!(
-        store.relocate_binding(&candidate).unwrap_err(),
-        LibraryRelocationError::Rejected(LibraryRelocationRejection::NoInstalledModels)
+        probe_binding(&candidate, &binding).status,
+        ExternalLibraryProbeStatus::Available
     );
-    assert!(store.load().unwrap().is_none());
+    // A later install at that root is judged against the binding just written, not a fresh one.
+    seed_snapshot(&candidate, "owner/model", "model.safetensors");
+    let (bound, probe) = store
+        .bind_or_probe_validated(
+            &candidate,
+            &[requirement("owner/model", "model.safetensors")],
+        )
+        .unwrap();
+    assert_eq!(bound.physical_identity, binding.physical_identity);
+    assert_eq!(probe.status, ExternalLibraryProbeStatus::Available);
+    assert!(store.has_install_evidence().unwrap());
+}
+
+/// The fresh-home shape: a plain folder is the cache home (its `hub` child is the library root);
+/// a folder named `hub` is the library root (its parent the home). No layout is required.
+#[test]
+fn resolve_fresh_cache_home_pairs_home_and_hub_without_a_layout() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("fresh");
+    std::fs::create_dir_all(home.join("hub")).unwrap();
+    assert_eq!(
+        resolve_fresh_cache_home(&home).unwrap(),
+        RelocationTarget {
+            library_root: home.join("hub"),
+            hf_home: home.clone(),
+        }
+    );
+    assert_eq!(
+        resolve_fresh_cache_home(&home.join("hub")).unwrap(),
+        RelocationTarget {
+            library_root: home.join("hub"),
+            hf_home: home.clone(),
+        }
+    );
+    assert_eq!(
+        resolve_fresh_cache_home(&temp.path().join("absent")).unwrap_err(),
+        LibraryRelocationRejection::NotADirectory
+    );
 }
 
 /// THE fail-open this exists to prevent. Evidence can be RECEIPTS ONLY — an install that predates

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -973,6 +973,9 @@ pub(crate) async fn download_snapshot(
             tokio::fs::create_dir_all(parent).await?;
         }
         let _lock = DownloadLock::acquire_async(&target_path).await?;
+        progress
+            .record_existing_file(&target_path, file.size)
+            .await?;
         download_file(
             context,
             &file.download_url,
@@ -1030,6 +1033,7 @@ pub(crate) async fn download_snapshot_into_cache(
             .unwrap_or_else(|| blob_fallback_name(&file.path));
         let blob_path = blobs_dir.join(&etag);
         let _lock = DownloadLock::acquire_async(&blob_path).await?;
+        progress.record_existing_file(&blob_path, file.size).await?;
         download_file(
             context,
             &file.download_url,
@@ -2265,6 +2269,23 @@ impl<'a> DownloadProgress<'a> {
         self.transferred_bytes = self.transferred_bytes.saturating_add(bytes);
     }
 
+    /// Add only the bytes already present for the exact snapshot file about to be handled.
+    ///
+    /// Snapshot callers used to seed `started_bytes` from the whole destination directory. That is
+    /// incorrect for filtered Hugging Face repositories: downloading `q4/*` would count cached q8,
+    /// bf16, and stale blobs in the numerator while [`HuggingFaceSnapshot::total_bytes`] contained
+    /// only q4 in the denominator. Account after taking the per-file download lock so a peer cannot
+    /// change the target between the size check and the cache-hit/resume decision.
+    async fn record_existing_file(
+        &mut self,
+        path: &Path,
+        expected_size: Option<u64>,
+    ) -> WorkerResult<()> {
+        let bytes = existing_download_bytes(path, expected_size).await?;
+        self.started_bytes = self.started_bytes.saturating_add(bytes);
+        Ok(())
+    }
+
     /// Reset the stall watchdog to "made progress just now", granting the next
     /// (re)connect a full stall window before it can be judged hung. Called at the
     /// start of each attempt so the idle gap spent re-issuing the request is not
@@ -2773,5 +2794,37 @@ mod stall_watchdog_tests {
         assert!(progress.is_stalled(Duration::from_millis(1), DOWNLOAD_STALL_MIN_PROGRESS));
         progress.reset_stall_clock();
         assert!(!progress.is_stalled(Duration::from_secs(3600), DOWNLOAD_STALL_MIN_PROGRESS));
+    }
+}
+
+/// Snapshot progress must use the same selected-file scope as the snapshot total. In particular,
+/// another precision tier in the shared Hugging Face `blobs/` directory is not progress toward the
+/// tier currently being downloaded.
+#[cfg(test)]
+mod snapshot_progress_tests {
+    use super::DownloadProgress;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn ignores_unrelated_cached_blobs() {
+        let cache = tempfile::tempdir().expect("cache dir");
+        let selected = cache.path().join("selected-blob");
+        let unrelated = cache.path().join("unrelated-bf16-blob");
+        std::fs::write(&selected, b"q4!").expect("selected partial blob");
+        std::fs::write(&unrelated, vec![0_u8; 64]).expect("unrelated cached tier");
+
+        let mut progress =
+            DownloadProgress::new("owner/model", 0, Some(10), Duration::from_secs(5));
+        progress
+            .record_existing_file(&selected, Some(10))
+            .await
+            .expect("selected bytes are counted");
+
+        let payload = progress.payload();
+        assert!(
+            payload.message.contains("3 B of 10 B (7 B left)"),
+            "only the selected blob belongs in snapshot progress: {}",
+            payload.message
+        );
     }
 }

--- a/crates/sceneworks-worker/src/image_jobs/qwen.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen.rs
@@ -539,7 +539,7 @@ async fn ensure_distill_lora_cached(
     }
     let mut progress = DownloadProgress::new(
         repo,
-        directory_size(&repo_dir.join("blobs")).await,
+        0,
         snapshot.total_bytes(),
         progress_report_interval(settings),
     );

--- a/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
+++ b/crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs
@@ -519,7 +519,7 @@ async fn ensure_qwen_lightning_lora_cached(
     }
     let mut progress = crate::downloads::DownloadProgress::new(
         repo,
-        crate::directory_size(&repo_dir.join("blobs")).await,
+        0,
         snapshot.total_bytes(),
         crate::progress_report_interval(settings),
     );

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -202,7 +202,7 @@ pub(crate) async fn run_model_download_job(
 
     let mut progress = DownloadProgress::new(
         repo,
-        directory_size(&repo_dir.join("blobs")).await,
+        0,
         snapshot.total_bytes(),
         progress_report_interval(settings),
     );
@@ -442,7 +442,7 @@ pub(crate) async fn run_lora_download_job(
 
     let mut progress = DownloadProgress::new(
         repo,
-        directory_size(&repo_dir.join("blobs")).await,
+        0,
         snapshot.total_bytes(),
         progress_report_interval(settings),
     );
@@ -4029,7 +4029,7 @@ pub(crate) async fn ensure_hf_files_cached(
     if !snapshot.files.is_empty() {
         let mut progress = DownloadProgress::new(
             repo,
-            directory_size(&repo_dir.join("blobs")).await,
+            0,
             snapshot.total_bytes(),
             progress_report_interval(settings),
         );
@@ -4273,7 +4273,7 @@ pub(crate) async fn run_lora_import_job(
             HuggingFaceSnapshot::resolve(http_client, settings, repo, revision, &files).await?;
         let mut progress = DownloadProgress::new(
             repo,
-            directory_size(&target_dir).await,
+            0,
             snapshot.total_bytes(),
             progress_report_interval(settings),
         );
@@ -4687,7 +4687,7 @@ pub(crate) async fn run_model_import_job(
             HuggingFaceSnapshot::resolve(http_client, settings, repo, revision, &files).await?;
         let mut progress = DownloadProgress::new(
             repo,
-            directory_size(&target_dir).await,
+            0,
             snapshot.total_bytes(),
             progress_report_interval(settings),
         );

--- a/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
+++ b/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
@@ -586,7 +586,7 @@ async fn download_snapshot_resumes_existing_partial_blob() {
     };
     let mut progress = DownloadProgress::new(
         "owner/model",
-        4,
+        0,
         snapshot.total_bytes(),
         Duration::from_secs(3600),
     );
@@ -636,7 +636,7 @@ async fn download_snapshot_fresh_retry_discards_partial_blob() {
     };
     let mut progress = DownloadProgress::new(
         "owner/model",
-        3,
+        0,
         snapshot.total_bytes(),
         Duration::from_secs(3600),
     );

--- a/crates/sceneworks-worker/src/util.rs
+++ b/crates/sceneworks-worker/src/util.rs
@@ -1,43 +1,5 @@
-//! Small worker-wide utilities: byte/time formatting, asset ids, HF auth, and directory sizing.
+//! Small worker-wide utilities: byte/time formatting, asset ids, and HF auth.
 use super::*;
-
-pub(crate) async fn directory_size(path: &Path) -> u64 {
-    let mut total = 0_u64;
-    let mut stack = vec![path.to_path_buf()];
-    while let Some(path) = stack.pop() {
-        let mut entries = match tokio::fs::read_dir(&path).await {
-            Ok(entries) => entries,
-            Err(error) => {
-                // A missing directory is the normal start-of-a-fresh-download state (the HF
-                // `blobs/` dir does not exist until the first file lands), so it means "0 bytes
-                // so far", not a failure — don't log it at error level. Only surface genuine I/O
-                // problems (permissions, etc.).
-                if error.kind() != std::io::ErrorKind::NotFound {
-                    tracing::warn!(
-                        event = "rust_worker_directory_size_failed",
-                        path = %path.display(),
-                        error = %error,
-                        "failed to read a directory while sizing a download"
-                    );
-                }
-                continue;
-            }
-        };
-        while let Ok(Some(entry)) = entries.next_entry().await {
-            let Ok(file_type) = entry.file_type().await else {
-                continue;
-            };
-            if file_type.is_dir() {
-                stack.push(entry.path());
-            } else if file_type.is_file() && entry.file_name() != INSTALL_MARKER {
-                if let Ok(metadata) = entry.metadata().await {
-                    total = total.saturating_add(metadata.len());
-                }
-            }
-        }
-    }
-    total
-}
 
 pub fn format_bytes(value: u64) -> String {
     let mut size = value as f64;

--- a/scripts/fetch-prebuilt-mlx.sh
+++ b/scripts/fetch-prebuilt-mlx.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Fetch the prebuilt MLX archives for the mlx-rs revision pinned in Cargo.lock (sc-21382).
+#
+# pmetal-mlx-sys's build.rs runs a ~6 minute cmake build of libmlx (plus a network fetch of MLX)
+# on every cold build. The SceneWorks/mlx-rs fork publishes that build's `build/lib` per commit
+# as a GitHub Release `prebuilt-<sha12>` (see its .github/workflows/prebuilt.yml); build.rs links
+# it when PMETAL_MLX_PREBUILT_DIR points at the extracted directory, after checking the
+# directory's manifest against its own key. A wrong or stale directory FAILS the build, it does
+# not fall back -- so this script is allowed to be dumb: pick the asset by key, verify its
+# sha256, extract, print the directory.
+#
+# Usage:
+#   scripts/fetch-prebuilt-mlx.sh [--deployment-target 26.2] [--build-type Debug|Release]
+#                                 [--target aarch64-apple-darwin] [--dest DIR] [--github-env]
+#
+#   deployment target defaults to $MACOSX_DEPLOYMENT_TARGET, else the value in .cargo/config.toml
+#   build type defaults to Debug (what `cargo build`/`cargo test` consume; --release is Release)
+#   target defaults to the host triple
+#   dest defaults to ${PMETAL_MLX_PREBUILT_CACHE:-$HOME/.cache/pmetal/prebuilt}/<sha12>/<cell>
+#   --github-env appends PMETAL_MLX_PREBUILT_DIR=<dir> to $GITHUB_ENV for later CI steps
+#
+# Prints `PMETAL_MLX_PREBUILT_DIR=<dir>` on success. Exit codes: 1 = no release/asset for this
+# rev+cell (e.g. the fork rev was just bumped and prebuilt-mlx has not published yet -- the one
+# case where building from source is the right answer); 2 = usage/environment; 3 = the asset
+# exists but is corrupt or is not the cell it claims to be (never tolerate that). Local use:
+#
+#   eval "$(scripts/fetch-prebuilt-mlx.sh)" && export PMETAL_MLX_PREBUILT_DIR && cargo build ...
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RELEASE_REPO="${PMETAL_MLX_PREBUILT_REPO:-SceneWorks/mlx-rs}"
+FEATURES="accelerate-metal" # the crate defaults; any other feature set builds from source
+
+deployment_target="${MACOSX_DEPLOYMENT_TARGET:-}"
+build_type="Debug"
+target=""
+dest=""
+github_env=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --deployment-target) deployment_target="$2"; shift 2 ;;
+    --build-type) build_type="$2"; shift 2 ;;
+    --target) target="$2"; shift 2 ;;
+    --dest) dest="$2"; shift 2 ;;
+    --github-env) github_env=1; shift ;;
+    -h|--help) sed -n '2,26p' "$0"; exit 0 ;;
+    *) echo "fetch-prebuilt-mlx: unknown argument $1" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$deployment_target" ]; then
+  deployment_target="$(sed -n 's/^MACOSX_DEPLOYMENT_TARGET *= *"\([0-9.]*\)".*/\1/p' "$ROOT/.cargo/config.toml" | head -1)"
+  [ -n "$deployment_target" ] || { echo "fetch-prebuilt-mlx: cannot determine the deployment target (set MACOSX_DEPLOYMENT_TARGET or pass --deployment-target)" >&2; exit 2; }
+fi
+case "$build_type" in Debug|Release) ;; *) echo "fetch-prebuilt-mlx: --build-type must be Debug or Release" >&2; exit 2 ;; esac
+[ -n "$target" ] || target="$(rustc -vV | sed -n 's/^host: //p')"
+
+rev="$(sed -n 's|^source = "git+https://github.com/[^/]*/mlx-rs?rev=\([0-9a-f]\{40\}\)#.*|\1|p' "$ROOT/Cargo.lock" | head -1)"
+[ -n "$rev" ] || { echo "fetch-prebuilt-mlx: no mlx-rs git revision in $ROOT/Cargo.lock" >&2; exit 2; }
+sha12="${rev:0:12}"
+
+cell="${target}-dt${deployment_target}-${build_type}-${FEATURES}"
+asset="pmetal-mlx-${sha12}-${cell}.tar.zst"
+[ -n "$dest" ] || dest="${PMETAL_MLX_PREBUILT_CACHE:-$HOME/.cache/pmetal/prebuilt}/${sha12}/${cell}"
+manifest="$dest/pmetal-mlx-prebuilt.txt"
+
+emit() {
+  echo "PMETAL_MLX_PREBUILT_DIR=$dest"
+  if [ "$github_env" = 1 ]; then
+    [ -n "${GITHUB_ENV:-}" ] || { echo "fetch-prebuilt-mlx: --github-env but GITHUB_ENV is unset" >&2; exit 2; }
+    echo "PMETAL_MLX_PREBUILT_DIR=$dest" >> "$GITHUB_ENV"
+  fi
+}
+
+if [ -f "$manifest" ] && [ -f "$dest/libmlx.a" ] && [ -f "$dest/libmlxc.a" ] && [ -f "$dest/mlx.metallib" ]; then
+  echo "fetch-prebuilt-mlx: using cached $dest" >&2
+  emit
+  exit 0
+fi
+
+command -v zstd >/dev/null || { echo "fetch-prebuilt-mlx: zstd is required to extract $asset (brew install zstd)" >&2; exit 2; }
+base="https://github.com/${RELEASE_REPO}/releases/download/prebuilt-${sha12}"
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/pmetal-mlx-prebuilt.XXXXXX")"
+trap 'rm -rf "$tmp"' EXIT
+echo "fetch-prebuilt-mlx: $base/$asset" >&2
+if ! curl -fsSL --retry 3 -o "$tmp/$asset" "$base/$asset" || ! curl -fsSL --retry 3 -o "$tmp/$asset.sha256" "$base/$asset.sha256"; then
+  echo "fetch-prebuilt-mlx: no prebuilt for mlx-rs $sha12 cell $cell at $base (run the fork's prebuilt-mlx workflow for that commit, or build from source)" >&2
+  exit 1
+fi
+(cd "$tmp" && shasum -a 256 -c "$asset.sha256" >&2) || { echo "fetch-prebuilt-mlx: sha256 mismatch for $asset" >&2; exit 3; }
+mkdir -p "$dest"
+zstd -dc "$tmp/$asset" | tar -x -C "$dest"
+for f in libmlx.a libmlxc.a mlx.metallib pmetal-mlx-prebuilt.txt; do
+  [ -f "$dest/$f" ] || { echo "fetch-prebuilt-mlx: $asset did not contain $f" >&2; rm -rf "$dest"; exit 3; }
+done
+grep -qx "deployment_target=${deployment_target}" "$manifest" || { echo "fetch-prebuilt-mlx: $asset manifest does not say deployment_target=${deployment_target}:" >&2; cat "$manifest" >&2; rm -rf "$dest"; exit 3; }
+grep -qx "build_type=${build_type}" "$manifest" || { echo "fetch-prebuilt-mlx: $asset manifest does not say build_type=${build_type}" >&2; rm -rf "$dest"; exit 3; }
+echo "fetch-prebuilt-mlx: extracted to $dest" >&2
+emit

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1743,6 +1743,7 @@ test("every workspace path a self-hosted lane watches maps to a package that lan
         // and not symmetry for its own sake.
         "config/engine-capabilities/audio/capabilities.candle.json",
         "scripts/compare-engine-capability-facts.mjs", // invoked directly by the native verification step
+        "scripts/fetch-prebuilt-mlx.sh", // both jobs run it to fetch the prebuilt libmlx (sc-21382)
         "Cargo.toml", // workspace graph + lints: changes what every invocation here resolves
         "Cargo.lock", // dependency pins, incl. the MLX revision the whole lane compiles
         "rust-toolchain.toml", // governs the toolchain cargo resolves under the dtolnay install


### PR DESCRIPTION
Final required main-to-feature synchronization before epic 20738 promotion.\n\nPreserves both independent overlap changes:\n- main's zero-based model/LoRA download progress behavior\n- epic 20738's component-resolution and terminal CUDA workflow contracts\n\nLocal validation:\n- platform review contracts: 71/71 pass\n- worker download tests: 7 pass, 1 ignored\n- LoRA tests: 3/3 pass\n- npm check and derived-doc checks: pass\n- neither clippy: pass\n- Candle pre-push typecheck: documented allow-skip because local nvcc cannot find cl.exe\n\nNo terminal hardware campaign rerun; the synchronized main changes do not touch the accepted campaign source surface.