### PR TITLE
feat(web): unify the linked-library and managed checkpoint import (sc-20650)

### DIFF
--- a/apps/web/src/App.models.test.jsx
+++ b/apps/web/src/App.models.test.jsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App, eventUrl } from "./main.jsx";
 import { liveElapsedSeconds } from "./formatting.js";
-import { withModelManagerContext, FakeEventSource, response, settle, field, loraPanel, modelImportPanel, buttonInside, changeField, changeFile, selectModelTab, familyFilter } from "./main.testSupport.jsx";
+import { withModelManagerContext, FakeEventSource, response, settle, field, loraPanel, modelImportPanel, openModelImportPanel, checkpointImportSection, buttonInside, changeField, changeFile, selectModelTab, familyFilter } from "./main.testSupport.jsx";
 
 // sc-12068: model / LoRA deletes confirm through the shared desktop-safe appConfirm dialog
 // rather than the raw window.confirm, which silently no-ops inside the Tauri WebView. Mock it
@@ -1277,10 +1277,13 @@ describe("SceneWorks app shell", () => {
     // sc-14069: a base checkpoint is an image model, so the import affordance lives on the
     // Image Models tab where a user looks for it — no longer the LoRAs tab scaffold home.
     await selectModelTab("Image");
-    const panel = modelImportPanel(container);
+    // sc-20650: the affordance is now the unified checkpoint-import panel, collapsed by default on
+    // this busy page. Opening it and choosing "Add to SceneWorks" reaches the managed form, whose
+    // Upload source still leads with the "Model File" picker and a fixed image Type.
+    expect(checkpointImportSection(container)).not.toBeNull();
+    expect(modelImportPanel(container)).toBeNull();
+    const panel = await openModelImportPanel(container, act);
     expect(panel).not.toBeNull();
-    expect(panel.textContent).toContain("Import model");
-    // File mode leads: the "Model File" picker is mounted, not a Source URL input.
     expect(field(panel, "Model File")).toBeTruthy();
     expect(field(panel, "Source URL")).toBeFalsy();
     expect(field(panel, "Type").value).toBe("image");
@@ -1308,11 +1311,11 @@ describe("SceneWorks app shell", () => {
     });
 
     await selectModelTab("Image");
-    expect(modelImportPanel(container)).not.toBeNull();
+    expect(checkpointImportSection(container)).not.toBeNull();
     // The LoRAs tab keeps its own "Import LoRA" panel but no longer hosts the model importer.
     await selectModelTab("LoRAs");
     expect(loraPanel(container)).not.toBeNull();
-    expect(modelImportPanel(container)).toBeNull();
+    expect(checkpointImportSection(container)).toBeNull();
   });
 
   it("POSTs the pointed-at checkpoint as an image import, leaving family to auto-detect (sc-14020)", async () => {
@@ -1336,7 +1339,7 @@ describe("SceneWorks app shell", () => {
     });
 
     await selectModelTab("Image");
-    const panel = modelImportPanel(container);
+    const panel = await openModelImportPanel(container, act);
     const file = new File([new Uint8Array([1, 2, 3])], "krea2-checkpoint.safetensors");
     await changeFile(field(panel, "Model File"), file);
     await act(async () => {
@@ -1353,6 +1356,10 @@ describe("SceneWorks app shell", () => {
     expect(payload.modelType).toBeUndefined();
     // No family override — the backend detector classifies the file (Krea 2 today).
     expect(payload.family).toBeUndefined();
+    // sc-20650: the request now STATES its ownership and its source instead of leaving the server
+    // to infer them from whichever flat field happened to be set.
+    expect(payload.ownershipMode).toBe("managed");
+    expect(payload.source).toEqual({ kind: "upload" });
   });
 
   it("surfaces the detected Krea 2 family on a successful checkpoint import (sc-14020)", async () => {
@@ -1376,7 +1383,7 @@ describe("SceneWorks app shell", () => {
     });
 
     await selectModelTab("Image");
-    const panel = modelImportPanel(container);
+    const panel = await openModelImportPanel(container, act);
     await changeFile(field(panel, "Model File"), new File([new Uint8Array([1])], "krea2.safetensors"));
     await act(async () => {
       buttonInside(panel, "Queue Import").click();
@@ -1414,7 +1421,7 @@ describe("SceneWorks app shell", () => {
     });
 
     await selectModelTab("Image");
-    const panel = modelImportPanel(container);
+    const panel = await openModelImportPanel(container, act);
     await changeFile(field(panel, "Model File"), new File([new Uint8Array([1])], "qwen.safetensors"));
     await act(async () => {
       buttonInside(panel, "Queue Import").click();
@@ -1511,7 +1518,7 @@ describe("SceneWorks app shell", () => {
     });
 
     await selectModelTab("Image");
-    expect(container.textContent).toContain("Model imports in progress");
+    expect(container.textContent).toContain("Imports in progress");
     expect(container.textContent).toContain("Model Import");
     expect(container.textContent).toContain("Downloading");
   });

--- a/apps/web/src/checkpointLibrary.js
+++ b/apps/web/src/checkpointLibrary.js
@@ -215,7 +215,11 @@ export function checkpointLibraryRefusal(error) {
   }
   const reason = error?.context?.reason;
   if (typeof reason !== "string" || reason === "") return null;
-  return { code, reason, message: String(error.message ?? ""), action: REFUSAL_ACTION[reason] ?? null };
+  // A typed refusal that carried no sentence still has to SAY something: this message is rendered
+  // straight into the panel's `role="status"` region, and an empty string there is a refusal the
+  // user never learns about. The reason code is the least the store already told us.
+  const message = String(error.message ?? "").trim() || `[checkpoint-plan:${reason}]`;
+  return { code, reason, message, action: REFUSAL_ACTION[reason] ?? null };
 }
 
 // Everything the UI needs to render ANY failure of this seam, typed or not.

--- a/apps/web/src/checkpointLibrary.js
+++ b/apps/web/src/checkpointLibrary.js
@@ -1,0 +1,417 @@
+import { apiFetch } from "./api.js";
+
+// The client half of the universal checkpoint-import seam (epic 20398, sc-20650).
+//
+// Two ownerships, ONE flow. "Use existing model library" (linked) references a user's own library
+// in place; "Add to SceneWorks" (managed) copies bytes into app-owned storage. They differ only in
+// what they name — a `(rootId, relativePath)` pair versus a transfer source — and both end at
+// `POST /api/v1/models/import`, which queues the same job the same progress card renders. Nothing
+// here re-implements a second import path.
+//
+// THREE properties this module owns, none of them cosmetic:
+//
+// 1. **A typed refusal is never swallowed into a default.** Every plan-store rejection arrives as
+//    `code: "checkpoint_library_rejected"` with the store's own stable kebab-case code in
+//    `context.reason`, and a message that already reads `[checkpoint-plan:<code>] …`. The UI
+//    branches on the CODE and shows the store's own sentence; `describeRefusal` never invents a
+//    "something went wrong" fallback, because a refusal the user cannot name is a refusal the user
+//    cannot act on.
+// 2. **The corrective action comes from the seam.** `Needs Relink` and `Needs Rescan` are states the
+//    server computed; the client maps state → affordance and never re-derives availability from a
+//    path or a missing file.
+// 3. **Removal is ownership-discriminated.** Deleting a managed model tears down bytes SceneWorks
+//    wrote. Forgetting a linked library drops SceneWorks' own plan documents and NEVER touches the
+//    user's files. Those are different promises and they get different words.
+
+export const OWNERSHIP_LINKED = "linked";
+export const OWNERSHIP_MANAGED = "managed";
+
+// The two ownership choices, in the order the screen offers them. Linked leads: a user who already
+// has a checkpoint collection should not have to copy it to use it.
+export const OWNERSHIP_CHOICES = Object.freeze([
+  Object.freeze({
+    id: OWNERSHIP_LINKED,
+    label: "Use existing model library",
+    summary: "Point SceneWorks at a folder you already keep checkpoints in. Nothing is copied or moved.",
+  }),
+  Object.freeze({
+    id: OWNERSHIP_MANAGED,
+    label: "Add to SceneWorks",
+    summary: "Bring a checkpoint in from a file, a folder, a URL, Hugging Face or Civitai. SceneWorks stores and owns the copy.",
+  }),
+]);
+
+// The five managed inputs. `kind` is the discriminant `ModelImportSourceV1` deserializes
+// (`apps/rust-api/src/dto.rs`), so these strings are a wire contract, not labels.
+export const MANAGED_SOURCES = Object.freeze([
+  Object.freeze({ kind: "upload", label: "Upload", field: "file", hint: "A checkpoint file on this device." }),
+  Object.freeze({ kind: "localPath", label: "Local copy", field: "path", hint: "A file or folder already on this machine. The source is only read." }),
+  Object.freeze({ kind: "url", label: "URL", field: "url", hint: "A direct download link." }),
+  Object.freeze({ kind: "huggingFace", label: "Hugging Face", field: "repo", hint: "An owner/name repo. Gated repos use your stored Hugging Face token." }),
+  Object.freeze({ kind: "civitai", label: "Civitai", field: "url", hint: "A Civitai download link. Records the model version and file ids." }),
+]);
+
+// Hosts whose stored credential a managed source consumes. Used to tell the user, before they
+// queue, that this source will need a token they have not stored yet — rather than letting the
+// download fail with a 401 twenty minutes in.
+export const MANAGED_SOURCE_CREDENTIAL_HOST = Object.freeze({
+  huggingFace: "huggingface.co",
+  civitai: "civitai.com",
+});
+
+// The two typed codes `checkpoint_library.rs` answers with.
+export const CHECKPOINT_LIBRARY_REJECTED_CODE = "checkpoint_library_rejected";
+export const CHECKPOINT_LIBRARY_NOT_PERMITTED_CODE = "checkpoint_library_not_permitted";
+
+// The linked states `LinkedCheckpointStateV1` serializes (snake_case on the wire).
+export const LINKED_READY = "ready";
+export const LINKED_NEEDS_RELINK = "needs_relink";
+export const LINKED_NEEDS_RESCAN = "needs_rescan";
+
+// ---------------------------------------------------------------------------------------------
+// Transport. One function per route; no client invents an endpoint.
+// ---------------------------------------------------------------------------------------------
+
+export function fetchLibraryRoots(token, options) {
+  return apiFetch("/api/v1/models/library-roots", token, options);
+}
+
+export function approveLibraryRoot(token, { path, label } = {}) {
+  return apiFetch("/api/v1/models/library-roots", token, {
+    method: "POST",
+    body: JSON.stringify(label ? { path, label } : { path }),
+  });
+}
+
+// Rename and relink are the same route and are independent: the server applies whichever halves are
+// present and refuses a body carrying neither, so an empty edit is a refusal rather than a no-op.
+export function updateLibraryRoot(token, rootId, { label, path } = {}) {
+  const body = {};
+  if (label != null) body.label = label;
+  if (path != null) body.path = path;
+  return apiFetch(`/api/v1/models/library-roots/${encodeURIComponent(rootId)}`, token, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+export function removeLibraryRoot(token, rootId) {
+  return apiFetch(`/api/v1/models/library-roots/${encodeURIComponent(rootId)}`, token, {
+    method: "DELETE",
+  });
+}
+
+export function scanLibraryRoot(token, rootId, options) {
+  return apiFetch(`/api/v1/models/library-roots/${encodeURIComponent(rootId)}/scan`, token, options);
+}
+
+export function rescanLibraryCheckpoint(token, rootId, relativePath) {
+  return apiFetch(`/api/v1/models/library-roots/${encodeURIComponent(rootId)}/rescan`, token, {
+    method: "POST",
+    body: JSON.stringify({ relativePath }),
+  });
+}
+
+// ---------------------------------------------------------------------------------------------
+// Request bodies
+// ---------------------------------------------------------------------------------------------
+
+// A linked import names its checkpoint by `(rootId, relativePath)` and NOTHING else. It must not
+// carry `ownershipMode` — the served enum has only `managed`, and `"linked"` is deliberately
+// refused there (dto.rs `OwnershipModeV1`) — nor a repo/URL/path/discriminated source, which the
+// route rejects outright.
+export function linkedImportBody({ rootId, relativePath, name, type = "image", family } = {}) {
+  const body = { linkedRootId: rootId, linkedRelativePath: relativePath, type };
+  if (name) body.name = name;
+  if (family) body.family = family;
+  return body;
+}
+
+// A managed import states its source with the discriminated `source` object rather than leaving the
+// server to infer it from whichever flat field happens to be set. `upload` carries no path: the
+// staged path is filled in server-side from the multipart `file` part and is never accepted from
+// client JSON, so the file rides as `file` and the metadata says only `kind`.
+export function managedImportBody(input = {}) {
+  const { kind, name, type = "image", family } = input;
+  const body = { ownershipMode: OWNERSHIP_MANAGED, type };
+  if (name) body.name = name;
+  if (family) body.family = family;
+  switch (kind) {
+    case "upload":
+      body.source = { kind: "upload" };
+      break;
+    case "localPath":
+      body.source = { kind: "localPath", path: input.path ?? "" };
+      break;
+    case "url":
+      body.source = { kind: "url", url: input.url ?? "" };
+      if (input.expectedSha256) body.source.expectedSha256 = input.expectedSha256;
+      break;
+    case "huggingFace":
+      body.source = { kind: "huggingFace", repo: input.repo ?? "" };
+      if (input.revision) body.source.revision = input.revision;
+      if (input.files?.length) body.source.files = input.files;
+      break;
+    case "civitai":
+      body.source = { kind: "civitai", url: input.url ?? "" };
+      if (input.modelVersionId) body.source.modelVersionId = input.modelVersionId;
+      if (input.fileId) body.source.fileId = input.fileId;
+      if (input.expectedSha256) body.source.expectedSha256 = input.expectedSha256;
+      break;
+    default:
+      throw new Error(`Unknown managed import source: ${kind}`);
+  }
+  return body;
+}
+
+// What the submit button must not let through, stated per source so the user is told WHICH field is
+// missing instead of watching a disabled button and guessing. Returns "" when the form can be sent.
+export function managedSourceProblem(input = {}) {
+  switch (input.kind) {
+    case "upload":
+      return input.file ? "" : "Choose a checkpoint file to upload.";
+    case "localPath":
+      return input.path?.trim() ? "" : "Enter the path of the file or folder to copy.";
+    case "url":
+      return input.url?.trim() ? "" : "Enter a download URL.";
+    case "huggingFace":
+      return input.repo?.trim() ? "" : "Enter a Hugging Face repo as owner/name.";
+    case "civitai":
+      return input.url?.trim() ? "" : "Enter a Civitai download URL.";
+    default:
+      return "Choose where the checkpoint comes from.";
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Refusals
+// ---------------------------------------------------------------------------------------------
+
+// Which lifecycle action clears a given store refusal, keyed on the store's own `code()`. Anything
+// absent here has no one-click corrective action — which is different from having no explanation,
+// and is why `describeRefusal` still surfaces the server's sentence for those.
+const REFUSAL_ACTION = Object.freeze({
+  "root-unavailable": "relink",
+  "unknown-root": "relink",
+  "source-missing": "rescan",
+  "source-drifted": "rescan",
+  "plan-tampered": "rescan",
+  "missing-plan": "rescan",
+});
+
+export const REFUSAL_ACTION_LABEL = Object.freeze({
+  relink: "Relink library",
+  rescan: "Rescan checkpoint",
+});
+
+// The typed shape of a checkpoint-library refusal, or `null` for anything that is not one.
+//
+// Both halves are required: a bare `code` could survive a contract change that dropped the payload,
+// and a reason with no code could come from an unrelated route.
+export function checkpointLibraryRefusal(error) {
+  const code = error?.code;
+  if (code !== CHECKPOINT_LIBRARY_REJECTED_CODE && code !== CHECKPOINT_LIBRARY_NOT_PERMITTED_CODE) {
+    return null;
+  }
+  const reason = error?.context?.reason;
+  if (typeof reason !== "string" || reason === "") return null;
+  return { code, reason, message: String(error.message ?? ""), action: REFUSAL_ACTION[reason] ?? null };
+}
+
+// Everything the UI needs to render ANY failure of this seam, typed or not.
+//
+// There is no "something went wrong" branch on purpose. A typed refusal is shown with the store's
+// own `[checkpoint-plan:<code>] …` sentence — the actionable detail for an unrunnable source is the
+// inspector's diagnostics inside that sentence, and for drift it is the two digests — and an
+// untyped failure is shown with whatever message it carried. Collapsing either into a generic
+// string is how a user ends up with a model that will not load and no way to find out why.
+export function describeRefusal(error) {
+  const typed = checkpointLibraryRefusal(error);
+  if (typed) return typed;
+  const message = String(error?.message ?? "").trim();
+  return {
+    code: error?.code ?? null,
+    reason: null,
+    message: message || "The request could not be completed.",
+    action: null,
+  };
+}
+
+// A local-only refusal: approving and relinking name an absolute host path, so the server refuses
+// them from a LAN peer. The copy has to say that, not "forbidden".
+export function isLocalOnlyRefusal(error) {
+  return error?.code === CHECKPOINT_LIBRARY_NOT_PERMITTED_CODE;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Linked state → affordance
+// ---------------------------------------------------------------------------------------------
+
+// The corrective action for a persisted linked checkpoint's state (AC2). `Needs Relink` and
+// `Needs Rescan` are NOT "missing" and must never render as "not installed": the plans are intact,
+// the user has one button to press, and saying otherwise invites a re-download of bytes they
+// already have.
+export function linkedCorrection(status) {
+  switch (status?.state) {
+    case LINKED_NEEDS_RELINK:
+      return {
+        action: "relink",
+        label: REFUSAL_ACTION_LABEL.relink,
+        headline: "Needs relink",
+        summary: "The folder holding this library is not available right now — it was moved, renamed, or its drive is not attached. Nothing was lost.",
+        detail: status.detail ?? "",
+      };
+    case LINKED_NEEDS_RESCAN:
+      return {
+        action: "rescan",
+        label: REFUSAL_ACTION_LABEL.rescan,
+        headline: "Needs rescan",
+        summary: "This checkpoint's file changed since SceneWorks last read it. Rescanning re-reads it in place and keeps the same model.",
+        detail: status.detail ?? "",
+      };
+    case LINKED_READY:
+      return null;
+    default:
+      return null;
+  }
+}
+
+// Index the linked statuses a set of scans reports, keyed by checkpoint id, so a catalog row can
+// find its own state in one lookup. Both `candidates[].status` and `unmatched[]` are folded in —
+// an unmatched entry is a persisted checkpoint the scan did NOT see, which is exactly the case that
+// must not silently vanish from the catalog.
+export function linkedStatusIndex(scans = []) {
+  const index = new Map();
+  for (const scan of scans) {
+    if (!scan) continue;
+    for (const candidate of scan.candidates ?? []) {
+      if (candidate?.status?.checkpointId) index.set(candidate.status.checkpointId, candidate.status);
+    }
+    for (const status of scan.unmatched ?? []) {
+      if (status?.checkpointId) index.set(status.checkpointId, status);
+    }
+  }
+  return index;
+}
+
+// The persisted checkpoint id a catalog row carries, or null for a row that is not plan-backed.
+// Stamped by the worker as `importPlan.checkpointId` once a full-content compile succeeded, so its
+// presence is what makes a row plan-backed at all.
+export function modelCheckpointId(model) {
+  const id = model?.importPlan?.checkpointId;
+  return typeof id === "string" && id !== "" ? id : null;
+}
+
+// Which ownership a catalog row was installed under, read off its persisted checkpoint id — the
+// same discriminator the server uses (`managed/<installId>` vs `linked/<rootId>/<relativePath>`).
+// `null` for a row that predates plan-backed import; those keep the pre-epic delete behaviour.
+export function modelOwnership(model) {
+  const id = modelCheckpointId(model);
+  if (id === null) return null;
+  if (id.startsWith("managed/")) return OWNERSHIP_MANAGED;
+  if (id.startsWith("linked/")) return OWNERSHIP_LINKED;
+  return null;
+}
+
+// The linked state of a catalog row, given the scan index. `null` when the row is not linked or the
+// scans have not loaded — the caller falls back to its ordinary install-state rendering.
+export function modelLinkedStatus(model, index) {
+  const id = modelCheckpointId(model);
+  if (id === null || !id.startsWith("linked/")) return null;
+  return index?.get?.(id) ?? null;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Provenance
+// ---------------------------------------------------------------------------------------------
+
+const PROVIDER_LABEL = Object.freeze({
+  "linked-library": "Linked library",
+  huggingface: "Hugging Face",
+  civitai: "Civitai",
+  url: "URL",
+  local: "Local copy",
+  upload: "Upload",
+});
+
+// Where a plan-backed row's bytes came from, in the words the import used. Reads the persisted
+// manifest `source` block; returns `null` when the row records none, so the UI omits the line
+// rather than printing "unknown".
+export function modelProvenance(model) {
+  const source = model?.source;
+  if (!source || typeof source !== "object") return null;
+  const provider = typeof source.provider === "string" ? source.provider : null;
+  if (!provider) return null;
+  const reference =
+    source.rootId && source.relativePath
+      ? `${source.relativePath}`
+      : source.repo || source.url || source.path || null;
+  return {
+    provider,
+    label: PROVIDER_LABEL[provider] ?? provider,
+    reference: reference ? String(reference) : null,
+    rootId: source.rootId ? String(source.rootId) : null,
+    relativePath: source.relativePath ? String(source.relativePath) : null,
+  };
+}
+
+// ---------------------------------------------------------------------------------------------
+// Duplicates
+// ---------------------------------------------------------------------------------------------
+
+// The checkpoint ids an import found already installed with the same content digest. The server
+// records them and completes the import anyway — the same bytes under two names is legal — so this
+// is a WARNING, never a failure, and it names the existing entries so the user can delete one.
+export function duplicateCheckpointIds(job) {
+  const ids = job?.result?.duplicateCheckpointIds;
+  return Array.isArray(ids) ? ids.filter((id) => typeof id === "string" && id !== "") : [];
+}
+
+export function duplicateWarningText(job) {
+  const ids = duplicateCheckpointIds(job);
+  if (ids.length === 0) return "";
+  return ids.length === 1
+    ? `These are the same bytes as a checkpoint you already have (${ids[0]}). Both entries were kept.`
+    : `These are the same bytes as ${ids.length} checkpoints you already have (${ids.join(", ")}). All entries were kept.`;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Removal copy — the two ownerships promise different things
+// ---------------------------------------------------------------------------------------------
+
+// What deleting this catalog row actually does, discriminated on ownership.
+//
+// The managed sentence is a deletion warning. The linked sentence is the opposite reassurance, and
+// getting them the wrong way round is the single most damaging copy defect in this screen: a user
+// told "this deletes the files" about a linked entry keeps a model they no longer want, and a user
+// told "your files are untouched" about a managed entry loses bytes they thought were safe.
+export function removalCopy(model) {
+  const ownership = modelOwnership(model);
+  const name = model?.name ?? model?.id ?? "this model";
+  if (ownership === OWNERSHIP_LINKED) {
+    return {
+      ownership,
+      title: "Remove from SceneWorks?",
+      confirmLabel: "Remove",
+      message: `${name} lives in your own model library. Removing it drops SceneWorks' record of it — the file itself is never opened, moved or deleted. You can add it again by rescanning the library.`,
+    };
+  }
+  return {
+    ownership: ownership ?? OWNERSHIP_MANAGED,
+    title: "Delete model?",
+    confirmLabel: "Delete",
+    message: `${name} was copied into SceneWorks' own storage. Deleting it removes those files from this machine. Anything you imported it from is untouched.`,
+  };
+}
+
+// The same discrimination for a whole library root. Forgetting a library is not deleting it, and
+// the count of dropped records is the honest thing to name.
+export function rootRemovalCopy(root, scan) {
+  const label = root?.displayLabel ?? root?.label ?? root?.path ?? "this library";
+  const count = (scan?.candidates ?? []).filter((candidate) => candidate?.status).length;
+  return {
+    title: "Forget this library?",
+    confirmLabel: "Forget library",
+    message: `SceneWorks will forget ${label}${count ? ` and the ${count} checkpoint${count === 1 ? "" : "s"} it has records for` : ""}. The folder and every file in it are left exactly as they are — SceneWorks never writes to a linked library.`,
+  };
+}

--- a/apps/web/src/checkpointLibrary.test.js
+++ b/apps/web/src/checkpointLibrary.test.js
@@ -197,6 +197,17 @@ describe("refusals", () => {
     expect(described.reason).toBe("source-drifted");
   });
 
+  // The message is rendered straight into the panel's `role="status"` region. A typed refusal that
+  // arrived with no sentence used to put an EMPTY string there — a refusal the user never learns
+  // about at all.
+  it("never renders a typed refusal as an empty sentence", () => {
+    for (const message of [undefined, "", "   "]) {
+      const refusal = checkpointLibraryRefusal({ ...rejected, message });
+      expect(refusal.message).toBe("[checkpoint-plan:source-drifted]");
+      expect(describeRefusal({ ...rejected, message }).message).toBe("[checkpoint-plan:source-drifted]");
+    }
+  });
+
   it("keeps an untyped failure's own message", () => {
     expect(describeRefusal(new Error("network down")).message).toBe("network down");
     expect(describeRefusal(null).message).toBe("The request could not be completed.");

--- a/apps/web/src/checkpointLibrary.test.js
+++ b/apps/web/src/checkpointLibrary.test.js
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CHECKPOINT_LIBRARY_NOT_PERMITTED_CODE,
+  CHECKPOINT_LIBRARY_REJECTED_CODE,
+  LINKED_NEEDS_RELINK,
+  LINKED_NEEDS_RESCAN,
+  LINKED_READY,
+  MANAGED_SOURCES,
+  OWNERSHIP_CHOICES,
+  OWNERSHIP_LINKED,
+  OWNERSHIP_MANAGED,
+  approveLibraryRoot,
+  checkpointLibraryRefusal,
+  describeRefusal,
+  duplicateCheckpointIds,
+  duplicateWarningText,
+  fetchLibraryRoots,
+  isLocalOnlyRefusal,
+  linkedCorrection,
+  linkedImportBody,
+  linkedStatusIndex,
+  managedImportBody,
+  managedSourceProblem,
+  modelCheckpointId,
+  modelLinkedStatus,
+  modelOwnership,
+  modelProvenance,
+  removalCopy,
+  removeLibraryRoot,
+  rescanLibraryCheckpoint,
+  rootRemovalCopy,
+  scanLibraryRoot,
+  updateLibraryRoot,
+} from "./checkpointLibrary.js";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({}) });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function lastRequest() {
+  const [url, init] = fetchMock.mock.calls.at(-1);
+  return { url, init, body: init?.body ? JSON.parse(init.body) : null };
+}
+
+describe("ownership choices", () => {
+  it("offers exactly the two named ownership choices, linked first", () => {
+    expect(OWNERSHIP_CHOICES.map((choice) => choice.id)).toEqual([OWNERSHIP_LINKED, OWNERSHIP_MANAGED]);
+    expect(OWNERSHIP_CHOICES.map((choice) => choice.label)).toEqual([
+      "Use existing model library",
+      "Add to SceneWorks",
+    ]);
+  });
+
+  it("offers all five managed inputs, keyed by the wire discriminants", () => {
+    expect(MANAGED_SOURCES.map((source) => source.kind)).toEqual([
+      "upload",
+      "localPath",
+      "url",
+      "huggingFace",
+      "civitai",
+    ]);
+  });
+});
+
+describe("transport", () => {
+  it("addresses every library-root route the API serves", async () => {
+    await fetchLibraryRoots("tok");
+    expect(lastRequest().url).toContain("/api/v1/models/library-roots");
+
+    await approveLibraryRoot("tok", { path: "/Volumes/Models", label: "Drive" });
+    expect(lastRequest()).toMatchObject({
+      init: { method: "POST" },
+      body: { path: "/Volumes/Models", label: "Drive" },
+    });
+
+    await updateLibraryRoot("tok", "root-a b", { path: "/Volumes/New" });
+    expect(lastRequest().url).toContain("/api/v1/models/library-roots/root-a%20b");
+    expect(lastRequest().init.method).toBe("PATCH");
+    expect(lastRequest().body).toEqual({ path: "/Volumes/New" });
+
+    await removeLibraryRoot("tok", "root-a");
+    expect(lastRequest().init.method).toBe("DELETE");
+
+    await scanLibraryRoot("tok", "root-a");
+    expect(lastRequest().url).toContain("/api/v1/models/library-roots/root-a/scan");
+
+    await rescanLibraryCheckpoint("tok", "root-a", "sdxl/model.safetensors");
+    expect(lastRequest().url).toContain("/api/v1/models/library-roots/root-a/rescan");
+    expect(lastRequest().body).toEqual({ relativePath: "sdxl/model.safetensors" });
+  });
+
+  it("omits an absent label rather than sending null", async () => {
+    await approveLibraryRoot("tok", { path: "/Volumes/Models" });
+    expect(lastRequest().body).toEqual({ path: "/Volumes/Models" });
+  });
+});
+
+describe("request bodies", () => {
+  it("names a linked import by root id and relative path and nothing else", () => {
+    const body = linkedImportBody({ rootId: "root-a", relativePath: "sdxl/model.safetensors", name: "My SDXL" });
+    expect(body).toEqual({
+      linkedRootId: "root-a",
+      linkedRelativePath: "sdxl/model.safetensors",
+      type: "image",
+      name: "My SDXL",
+    });
+    // The route refuses a linked body that also names a transfer, and `ownershipMode: "linked"` is
+    // not a served value.
+    expect(body).not.toHaveProperty("ownershipMode");
+    expect(body).not.toHaveProperty("source");
+    expect(body).not.toHaveProperty("repo");
+    expect(body).not.toHaveProperty("sourceUrl");
+  });
+
+  it("builds one discriminated source per managed input", () => {
+    expect(managedImportBody({ kind: "upload" })).toMatchObject({
+      ownershipMode: OWNERSHIP_MANAGED,
+      source: { kind: "upload" },
+    });
+    expect(managedImportBody({ kind: "upload" }).source).not.toHaveProperty("stagedPath");
+    expect(managedImportBody({ kind: "localPath", path: "/tmp/x" }).source).toEqual({
+      kind: "localPath",
+      path: "/tmp/x",
+    });
+    expect(managedImportBody({ kind: "url", url: "https://x/y.safetensors", expectedSha256: "ab" }).source).toEqual({
+      kind: "url",
+      url: "https://x/y.safetensors",
+      expectedSha256: "ab",
+    });
+    expect(managedImportBody({ kind: "huggingFace", repo: "org/m", revision: "main" }).source).toEqual({
+      kind: "huggingFace",
+      repo: "org/m",
+      revision: "main",
+    });
+    expect(managedImportBody({ kind: "civitai", url: "https://civitai.com/x", modelVersionId: "9", fileId: "3" }).source).toEqual({
+      kind: "civitai",
+      url: "https://civitai.com/x",
+      modelVersionId: "9",
+      fileId: "3",
+    });
+  });
+
+  it("refuses to build a body for an unknown source instead of defaulting to one", () => {
+    expect(() => managedImportBody({ kind: "ftp" })).toThrow(/Unknown managed import source/);
+  });
+
+  it("names the missing field per source", () => {
+    expect(managedSourceProblem({ kind: "upload" })).toMatch(/file/i);
+    expect(managedSourceProblem({ kind: "upload", file: {} })).toBe("");
+    expect(managedSourceProblem({ kind: "huggingFace", repo: "  " })).toMatch(/owner\/name/);
+    expect(managedSourceProblem({ kind: "huggingFace", repo: "org/m" })).toBe("");
+    expect(managedSourceProblem({ kind: "civitai", url: "" })).toMatch(/Civitai/);
+    expect(managedSourceProblem({})).toMatch(/where the checkpoint comes from/);
+  });
+});
+
+describe("refusals", () => {
+  const rejected = {
+    code: CHECKPOINT_LIBRARY_REJECTED_CODE,
+    context: { reason: "source-drifted" },
+    message: "[checkpoint-plan:source-drifted] recorded ab… now cd…",
+  };
+
+  it("surfaces the store's own code and sentence", () => {
+    const refusal = checkpointLibraryRefusal(rejected);
+    expect(refusal).toMatchObject({ reason: "source-drifted", action: "rescan" });
+    expect(refusal.message).toContain("[checkpoint-plan:source-drifted]");
+  });
+
+  it("is null for a code without a reason and for a reason without the code", () => {
+    expect(checkpointLibraryRefusal({ code: CHECKPOINT_LIBRARY_REJECTED_CODE })).toBeNull();
+    expect(checkpointLibraryRefusal({ context: { reason: "source-drifted" } })).toBeNull();
+    expect(checkpointLibraryRefusal({ code: "some_other_code", context: { reason: "x" } })).toBeNull();
+  });
+
+  it("maps root-unavailable to relink and source-missing to rescan", () => {
+    expect(checkpointLibraryRefusal({ ...rejected, context: { reason: "root-unavailable" } }).action).toBe("relink");
+    expect(checkpointLibraryRefusal({ ...rejected, context: { reason: "source-missing" } }).action).toBe("rescan");
+    // A refusal with no one-click correction still carries its reason — it is explained, not hidden.
+    const contract = checkpointLibraryRefusal({ ...rejected, context: { reason: "unrunnable-source" } });
+    expect(contract.action).toBeNull();
+    expect(contract.reason).toBe("unrunnable-source");
+  });
+
+  it("never collapses a typed refusal into a generic message", () => {
+    const described = describeRefusal(rejected);
+    expect(described.message).toContain("[checkpoint-plan:source-drifted]");
+    expect(described.message).not.toMatch(/something went wrong/i);
+    expect(described.reason).toBe("source-drifted");
+  });
+
+  it("keeps an untyped failure's own message", () => {
+    expect(describeRefusal(new Error("network down")).message).toBe("network down");
+    expect(describeRefusal(null).message).toBe("The request could not be completed.");
+  });
+
+  it("recognises the local-only refusal", () => {
+    expect(isLocalOnlyRefusal({ code: CHECKPOINT_LIBRARY_NOT_PERMITTED_CODE })).toBe(true);
+    expect(isLocalOnlyRefusal(rejected)).toBe(false);
+  });
+});
+
+describe("linked state", () => {
+  it("gives Needs Relink and Needs Rescan a corrective action, not a missing verdict", () => {
+    const relink = linkedCorrection({ state: LINKED_NEEDS_RELINK, detail: "[checkpoint-plan:root-unavailable] …" });
+    expect(relink).toMatchObject({ action: "relink", label: "Relink library", headline: "Needs relink" });
+    expect(relink.summary).not.toMatch(/missing|not installed|uninstalled/i);
+    expect(relink.detail).toContain("[checkpoint-plan:root-unavailable]");
+
+    const rescan = linkedCorrection({ state: LINKED_NEEDS_RESCAN, detail: "" });
+    expect(rescan).toMatchObject({ action: "rescan", label: "Rescan checkpoint", headline: "Needs rescan" });
+    expect(rescan.summary).not.toMatch(/missing|not installed|uninstalled/i);
+  });
+
+  it("has no correction for a ready checkpoint", () => {
+    expect(linkedCorrection({ state: LINKED_READY })).toBeNull();
+    expect(linkedCorrection(null)).toBeNull();
+  });
+
+  it("indexes both matched candidates and unmatched persisted checkpoints", () => {
+    const index = linkedStatusIndex([
+      {
+        candidates: [{ status: { checkpointId: "linked/root-a/a.safetensors", state: LINKED_READY } }, { status: null }],
+        unmatched: [{ checkpointId: "linked/root-a/gone.safetensors", state: LINKED_NEEDS_RESCAN }],
+      },
+      null,
+    ]);
+    expect(index.get("linked/root-a/a.safetensors").state).toBe(LINKED_READY);
+    // The disappeared one must still be findable: it is a catalog row the user can act on.
+    expect(index.get("linked/root-a/gone.safetensors").state).toBe(LINKED_NEEDS_RESCAN);
+  });
+
+  it("reads ownership off the persisted checkpoint id", () => {
+    expect(modelOwnership({ importPlan: { checkpointId: "linked/root-a/x.safetensors" } })).toBe(OWNERSHIP_LINKED);
+    expect(modelOwnership({ importPlan: { checkpointId: "managed/install-1" } })).toBe(OWNERSHIP_MANAGED);
+    expect(modelOwnership({})).toBeNull();
+    expect(modelCheckpointId({ importPlan: { checkpointId: "" } })).toBeNull();
+  });
+
+  it("finds a linked row's state and leaves a managed row alone", () => {
+    const index = linkedStatusIndex([
+      { candidates: [{ status: { checkpointId: "linked/root-a/x.safetensors", state: LINKED_NEEDS_RELINK } }] },
+    ]);
+    expect(modelLinkedStatus({ importPlan: { checkpointId: "linked/root-a/x.safetensors" } }, index).state).toBe(
+      LINKED_NEEDS_RELINK,
+    );
+    expect(modelLinkedStatus({ importPlan: { checkpointId: "managed/install-1" } }, index)).toBeNull();
+  });
+});
+
+describe("provenance", () => {
+  it("names a linked row's library and a fetched row's source", () => {
+    expect(
+      modelProvenance({ source: { provider: "linked-library", rootId: "root-a", relativePath: "sdxl/m.safetensors" } }),
+    ).toMatchObject({ label: "Linked library", reference: "sdxl/m.safetensors", rootId: "root-a" });
+    expect(modelProvenance({ source: { provider: "huggingface", repo: "org/m" } })).toMatchObject({
+      label: "Hugging Face",
+      reference: "org/m",
+    });
+    expect(modelProvenance({ source: { provider: "civitai", url: "https://civitai.com/x" } }).label).toBe("Civitai");
+  });
+
+  it("is null when the row records none, rather than printing 'unknown'", () => {
+    expect(modelProvenance({})).toBeNull();
+    expect(modelProvenance({ source: {} })).toBeNull();
+  });
+});
+
+describe("duplicates", () => {
+  it("reads the ids off the completed job result", () => {
+    expect(duplicateCheckpointIds({ result: { duplicateCheckpointIds: ["managed/a", "", 4] } })).toEqual(["managed/a"]);
+    expect(duplicateCheckpointIds({ result: {} })).toEqual([]);
+    expect(duplicateWarningText({ result: { duplicateCheckpointIds: ["managed/a"] } })).toContain("managed/a");
+    expect(duplicateWarningText({ result: { duplicateCheckpointIds: ["a", "b"] } })).toContain("2 checkpoints");
+    expect(duplicateWarningText({})).toBe("");
+  });
+});
+
+describe("removal copy", () => {
+  it("promises the opposite things for linked and managed, and never crosses them", () => {
+    const linked = removalCopy({ name: "My SDXL", importPlan: { checkpointId: "linked/root-a/x.safetensors" } });
+    expect(linked.ownership).toBe(OWNERSHIP_LINKED);
+    expect(linked.confirmLabel).toBe("Remove");
+    expect(linked.message).toMatch(/never opened, moved or deleted/);
+    expect(linked.message).not.toMatch(/removes those files from this machine/);
+
+    const managed = removalCopy({ name: "Fetched", importPlan: { checkpointId: "managed/install-1" } });
+    expect(managed.ownership).toBe(OWNERSHIP_MANAGED);
+    expect(managed.confirmLabel).toBe("Delete");
+    expect(managed.message).toMatch(/removes those files from this machine/);
+    expect(managed.message).not.toMatch(/never opened, moved or deleted/);
+  });
+
+  it("treats a row with no plan as managed, which is the safe default for a delete warning", () => {
+    expect(removalCopy({ name: "Legacy" }).ownership).toBe(OWNERSHIP_MANAGED);
+  });
+
+  it("says a forgotten library keeps every file", () => {
+    const copy = rootRemovalCopy({ displayLabel: "Drive" }, { candidates: [{ status: {} }, { status: null }] });
+    expect(copy.message).toContain("Drive");
+    expect(copy.message).toContain("1 checkpoint");
+    expect(copy.message).toMatch(/left exactly as they are/);
+    expect(copy.confirmLabel).toBe("Forget library");
+  });
+});

--- a/apps/web/src/components/CheckpointImportPanel.desktop.test.jsx
+++ b/apps/web/src/components/CheckpointImportPanel.desktop.test.jsx
@@ -1,0 +1,131 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The desktop-bridge half of AC1 (epic 20398, sc-20650).
+//
+// `runtime.js` derives `isDesktop` from `window.__TAURI__` AT MODULE LOAD, and the panel's default
+// `pickFolder` is derived from it at module load too. So the bridge has to be installed BEFORE the
+// module graph is imported — hence the per-test `vi.resetModules()` + dynamic import, the same
+// pattern ModelManagerScreen.test.jsx uses for the keychain transport.
+//
+// Two claims, and the second is the one that would rot silently: the desktop build reaches the
+// NATIVE folder chooser rather than asking the user to type an absolute path, and a remote browser
+// on the same build reaches the typed field instead of a dead button that can never resolve.
+
+const ROOT = { rootId: "root-a", path: "/Volumes/Models", label: "", displayLabel: "Models" };
+
+const LIBRARY = () => ({
+  fetchRoots: vi.fn(async () => ({ roots: [] })),
+  approve: vi.fn(async () => ROOT),
+  update: vi.fn(async () => ROOT),
+  remove: vi.fn(async () => ({ root: ROOT, removedCheckpoints: [] })),
+  scan: vi.fn(async () => ({ root: ROOT, available: true, candidates: [], unmatched: [], diagnostics: [] })),
+  rescan: vi.fn(async () => ({ state: "ready" })),
+});
+
+describe("CheckpointImportPanel desktop bridge", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    delete window.__TAURI__;
+    vi.restoreAllMocks();
+  });
+
+  async function mount(props) {
+    const { AppContext } = await import("../context/AppContext.js");
+    const { CheckpointImportPanel } = await import("./CheckpointImportPanel.jsx");
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{ jobs: [], models: [], workersById: {}, visibleWorkers: [] }}>
+          <CheckpointImportPanel defaultOpen library={LIBRARY()} onImportModel={vi.fn()} token="tok" {...props} />
+        </AppContext.Provider>,
+      );
+    });
+  }
+
+  function buttonNamed(name) {
+    return [...container.querySelectorAll("button")].find((node) => node.textContent.trim() === name);
+  }
+
+  async function click(node) {
+    expect(node, "the control under test exists").toBeTruthy();
+    await act(async () => node.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+  }
+
+  it("picks the library folder through the desktop bridge's choose_folder command", async () => {
+    const invoke = vi.fn(async (command) => (command === "choose_folder" ? "/Volumes/Picked" : null));
+    window.__TAURI__ = { core: { invoke } };
+    const library = LIBRARY();
+    await mount({ library });
+
+    await click(buttonNamed("Choose folder"));
+    expect(invoke).toHaveBeenCalledWith("choose_folder", undefined);
+
+    await click(buttonNamed("Add library"));
+    expect(library.approve).toHaveBeenCalledWith("tok", { path: "/Volumes/Picked", label: undefined });
+  });
+
+  it("picks the managed local-copy source through the same bridge", async () => {
+    const invoke = vi.fn(async () => "/Users/me/checkpoints");
+    window.__TAURI__ = { core: { invoke } };
+    const onImportModel = vi.fn(async () => ({ payload: { modelId: "m" } }));
+    await mount({ onImportModel });
+
+    await click([...container.querySelectorAll('[role="radio"]')].find((node) => node.textContent.startsWith("Add to SceneWorks")));
+    await click(buttonNamed("Local copy"));
+    await click(buttonNamed("Choose source folder"));
+    expect(invoke).toHaveBeenCalledWith("choose_folder", undefined);
+
+    await click(buttonNamed("Queue Import"));
+    expect(onImportModel).toHaveBeenCalledWith({
+      ownershipMode: "managed",
+      type: "image",
+      source: { kind: "localPath", path: "/Users/me/checkpoints" },
+    });
+  });
+
+  it("survives a cancelled native picker without wedging the form", async () => {
+    // The chooser resolves null when the user dismisses it, and rejects if the ACL grant is
+    // missing. Neither may leave the panel stuck or clear a path the user already typed.
+    const invoke = vi.fn(async () => {
+      throw new Error("forbidden");
+    });
+    window.__TAURI__ = { core: { invoke } };
+    const library = LIBRARY();
+    await mount({ library });
+
+    await click(buttonNamed("Choose folder"));
+    await click(buttonNamed("Add library"));
+    // No path was ever chosen, so the panel refuses rather than posting an empty one.
+    expect(library.approve).not.toHaveBeenCalled();
+    expect(container.querySelector('[role="status"]').textContent).toMatch(/folder your checkpoints live in/);
+  });
+
+  it("falls back to a typed path in a remote browser (no bridge)", async () => {
+    const library = LIBRARY();
+    await mount({ library });
+    expect(buttonNamed("Choose folder")).toBeUndefined();
+    const input = [...container.querySelectorAll("label")]
+      .find((node) => node.textContent.trim().startsWith("Library folder"))
+      .querySelector("input");
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+    await act(async () => {
+      setter.call(input, "/srv/models");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await click(buttonNamed("Add library"));
+    expect(library.approve).toHaveBeenCalledWith("tok", { path: "/srv/models", label: undefined });
+  });
+});

--- a/apps/web/src/components/CheckpointImportPanel.jsx
+++ b/apps/web/src/components/CheckpointImportPanel.jsx
@@ -84,7 +84,10 @@ export function CheckpointImportPanel({
   token,
   families = [],
   models = [],
-  credentials = [],
+  // `null` means "not looked up", which is NOT the same as "looked up and none stored". The
+  // credential notice only speaks when the caller actually read the keychain, so a screen that
+  // never loads credentials cannot make the panel claim a credential is missing.
+  credentials = null,
   macCapabilities,
   pendingJobs = [],
   completedJobs = [],
@@ -93,6 +96,7 @@ export function CheckpointImportPanel({
   onRetryJob,
   onOpenQueue,
   onRefreshCatalog,
+  onOpenSettings,
   compact = false,
   defaultOpen = false,
   library = DEFAULT_LIBRARY,
@@ -101,8 +105,14 @@ export function CheckpointImportPanel({
 }) {
   const [open, setOpen] = useState(defaultOpen);
   const [ownership, setOwnership] = useState(OWNERSHIP_LINKED);
-  const [message, setMessage] = useState(NEUTRAL);
-  const [busy, setBusy] = useState("");
+  // TWO independent operation tracks, because they run concurrently and neither may speak for the
+  // other. A library scan resolving mid-import used to clear `busy` (re-enabling the submit button
+  // under a running import) and overwrite the import's error with its own success — which took the
+  // "Try again" button away while `lastAttempt` was still the thing that failed.
+  const [message, setMessage] = useState(NEUTRAL); // library-lifecycle track
+  const [busy, setBusy] = useState(""); // library-lifecycle track
+  const [importMessage, setImportMessage] = useState(NEUTRAL); // import track
+  const [importBusy, setImportBusy] = useState(false); // import track
 
   // Linked state.
   const [roots, setRoots] = useState([]);
@@ -169,6 +179,11 @@ export function CheckpointImportPanel({
 
   const runScan = useCallback(
     async (rootId) => {
+      // Drop the previous root's result BEFORE the await: `activeRootId` moves synchronously, so
+      // leaving the old `scan` on screen would render one root's candidates under another root's
+      // id. Nothing rendered from `scan` reads `activeRootId` any more, and nothing is rendered at
+      // all until the new root's answer arrives.
+      setScan(null);
       setActiveRootId(rootId);
       setBusy(`scan:${rootId}`);
       try {
@@ -317,8 +332,8 @@ export function CheckpointImportPanel({
   async function submit(attempt) {
     if (!onImportModel) return;
     setLastAttempt(attempt);
-    setBusy("import");
-    setMessage({ ...NEUTRAL, tone: "neutral", text: attempt.file ? "Uploading the checkpoint before queueing." : "Validating and queueing." });
+    setImportBusy(true);
+    setImportMessage({ ...NEUTRAL, tone: "neutral", text: attempt.file ? "Uploading the checkpoint before queueing." : "Validating and queueing." });
     try {
       const job = await onImportModel(attempt.file ? { ...attempt.body, file: attempt.file } : attempt.body);
       const modelId = job?.payload?.modelId;
@@ -327,7 +342,7 @@ export function CheckpointImportPanel({
       // leaves the user unable to predict.
       const resolvedFamily = job?.payload?.manifestEntry?.family;
       const detected = !attempt.body.family && resolvedFamily ? ` Detected family: ${normalizeLoraFamily(resolvedFamily)}.` : "";
-      setMessage({
+      setImportMessage({
         ...NEUTRAL,
         tone: "success",
         text: `${modelId ? `Import queued for ${modelId}.` : "Import queued."}${detected}`,
@@ -335,9 +350,9 @@ export function CheckpointImportPanel({
       if (attempt.file) setFileInputKey((current) => current + 1);
       setManaged((current) => ({ ...current, file: null, path: "", url: "", repo: "", name: "" }));
     } catch (error) {
-      setMessage(failureMessage(error));
+      setImportMessage(failureMessage(error));
     } finally {
-      setBusy("");
+      setImportBusy(false);
     }
   }
 
@@ -345,10 +360,14 @@ export function CheckpointImportPanel({
   // is not on screen here, so reading it would let a value the user cannot see decide how their
   // checkpoint is classified. The compile detects it from the bytes, which is the better answer
   // anyway.
+  //
+  // The root id comes from the RENDERED scan, never from `activeRootId`: starting a second root's
+  // scan moves `activeRootId` immediately, and a click landing in that window would otherwise post
+  // the candidate the user is looking at under the other root's id.
   function submitLinked(candidate) {
     return submit({
       body: linkedImportBody({
-        rootId: activeRootId,
+        rootId: scan?.root?.rootId ?? "",
         relativePath: candidate.candidate.relativePath,
         name: candidate.candidate.relativePath.split("/").pop(),
       }),
@@ -359,7 +378,7 @@ export function CheckpointImportPanel({
     event?.preventDefault?.();
     const problem = managedSourceProblem(managed);
     if (problem) {
-      setMessage({ ...NEUTRAL, tone: "error", text: problem });
+      setImportMessage({ ...NEUTRAL, tone: "error", text: problem });
       return;
     }
     return submit({ body: managedImportBody(managed), file: managed.kind === "upload" ? managed.file : null });
@@ -367,7 +386,8 @@ export function CheckpointImportPanel({
 
   const managedSource = MANAGED_SOURCES.find((source) => source.kind === managed.kind) ?? MANAGED_SOURCES[0];
   const credentialHost = MANAGED_SOURCE_CREDENTIAL_HOST[managed.kind] ?? null;
-  const credentialMissing = credentialHost ? !hasPresentCredential(credentials, credentialHost) : false;
+  const credentialsKnown = Array.isArray(credentials);
+  const credentialMissing = credentialHost && credentialsKnown ? !hasPresentCredential(credentials, credentialHost) : false;
 
   return (
     <section aria-labelledby={headingId} className={compact ? "checkpoint-import compact" : "checkpoint-import"}>
@@ -406,12 +426,19 @@ export function CheckpointImportPanel({
             ? renderLinked()
             : renderManaged()}
 
-          <p aria-live="polite" className={toneClass(message.tone)} role="status">
+          <p aria-live="polite" className={`${toneClass(message.tone)} checkpoint-library-status`} role="status">
             {message.text}
           </p>
           {message.detail ? <p className="checkpoint-import-detail">{message.detail}</p> : null}
-          {message.tone === "error" && lastAttempt ? (
-            <button disabled={busy === "import"} onClick={() => submit(lastAttempt)} type="button">
+          <p aria-live="polite" className={`${toneClass(importMessage.tone)} checkpoint-import-status`} role="status">
+            {importMessage.text}
+          </p>
+          {importMessage.detail ? <p className="checkpoint-import-detail">{importMessage.detail}</p> : null}
+          {/* Gated on the IMPORT track's tone: "Try again" re-POSTs `lastAttempt`, so offering it
+              beside a library failure (a relink that was refused, say) would re-send an unrelated
+              import the user has moved on from. */}
+          {importMessage.tone === "error" && lastAttempt ? (
+            <button disabled={importBusy} onClick={() => submit(lastAttempt)} type="button">
               Try again
             </button>
           ) : null}
@@ -592,6 +619,8 @@ export function CheckpointImportPanel({
   }
 
   function renderCandidate(entry) {
+    // Same rule as `submitLinked`: the correction acts on the root whose scan is ON SCREEN.
+    const renderedRootId = scan?.root?.rootId ?? "";
     const candidate = entry.candidate ?? {};
     const correction = linkedCorrection(entry.status);
     const model = entry.status ? modelsByCheckpoint.get(entry.status.checkpointId) : null;
@@ -629,11 +658,11 @@ export function CheckpointImportPanel({
             <p>{correction.summary}</p>
             {correction.detail ? <p className="checkpoint-import-detail">{correction.detail}</p> : null}
             <button
-              disabled={busy === `rescan:${candidate.relativePath}` || busy === `relink:${activeRootId}`}
+              disabled={busy === `rescan:${candidate.relativePath}` || busy === `relink:${renderedRootId}`}
               onClick={() =>
                 correction.action === "relink"
-                  ? relinkRoot(activeRootId)
-                  : rescanCheckpoint(activeRootId, candidate.relativePath)
+                  ? relinkRoot(renderedRootId)
+                  : rescanCheckpoint(renderedRootId, candidate.relativePath)
               }
               type="button"
             >
@@ -642,14 +671,14 @@ export function CheckpointImportPanel({
           </div>
         ) : null}
         {entry.selectable ? (
-          <button disabled={busy === "import"} onClick={() => submitLinked(entry)} type="button">
+          <button disabled={importBusy} onClick={() => submitLinked(entry)} type="button">
             Use this checkpoint
           </button>
         ) : correction ? null : (
           <p className="checkpoint-candidate-unselectable">
             SceneWorks has only read this file’s header. Selecting it reads the whole file first, which is what makes it
             safe to run.
-            <button disabled={busy === "import"} onClick={() => submitLinked(entry)} type="button">
+            <button disabled={importBusy} onClick={() => submitLinked(entry)} type="button">
               Validate and use
             </button>
           </p>
@@ -811,15 +840,29 @@ export function CheckpointImportPanel({
               value={managed.name}
             />
           </label>
-          <button disabled={busy === "import"} type="submit">
-            {busy === "import" ? "Queueing…" : "Queue Import"}
+          <button disabled={importBusy} type="submit">
+            {importBusy ? "Queueing…" : "Queue Import"}
           </button>
         </div>
-        {credentialHost && credentialMissing ? (
-          <p className="inline-note checkpoint-credential-notice">
-            No {credentialHost} credential is stored. A gated or paid download will be refused until you add one in
-            Settings.
-          </p>
+        {/* Only speaks when the caller actually read the keychain (`credentials` is an array).
+            With `null` — a screen that never looked — the panel says nothing rather than telling
+            the user a credential is missing it never went looking for. */}
+        {credentialHost && credentialsKnown ? (
+          credentialMissing ? (
+            <p className="inline-note checkpoint-credential-notice">
+              No {credentialHost} credential is stored. A gated or paid download will be refused until you add one in
+              Settings.
+              {onOpenSettings ? (
+                <button onClick={onOpenSettings} type="button">
+                  Add token in Settings
+                </button>
+              ) : null}
+            </p>
+          ) : (
+            <p className="inline-note checkpoint-credential-notice">
+              A {credentialHost} credential is stored. Gated and paid downloads will use it.
+            </p>
+          )
         ) : null}
       </form>
     );

--- a/apps/web/src/components/CheckpointImportPanel.jsx
+++ b/apps/web/src/components/CheckpointImportPanel.jsx
@@ -341,13 +341,16 @@ export function CheckpointImportPanel({
     }
   }
 
+  // A linked import carries no family override: the family select lives in the managed pane, which
+  // is not on screen here, so reading it would let a value the user cannot see decide how their
+  // checkpoint is classified. The compile detects it from the bytes, which is the better answer
+  // anyway.
   function submitLinked(candidate) {
     return submit({
       body: linkedImportBody({
         rootId: activeRootId,
         relativePath: candidate.candidate.relativePath,
         name: candidate.candidate.relativePath.split("/").pop(),
-        family: managed.family || undefined,
       }),
     });
   }

--- a/apps/web/src/components/CheckpointImportPanel.jsx
+++ b/apps/web/src/components/CheckpointImportPanel.jsx
@@ -1,0 +1,824 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { WorkerProgressCard } from "./WorkerProgressCard.jsx";
+import { appConfirm } from "../appConfirm.jsx";
+import { formatBytes } from "../formatting.js";
+import { hasPresentCredential } from "../credentials.js";
+import { isDesktop, tauriInvoke } from "../runtime.js";
+import { macModelBlock } from "../macGating.js";
+import { modelCapabilityChips } from "../modelCapabilities.js";
+import { normalizeLoraFamily } from "../presetUtils.js";
+import {
+  MANAGED_SOURCES,
+  MANAGED_SOURCE_CREDENTIAL_HOST,
+  OWNERSHIP_CHOICES,
+  OWNERSHIP_LINKED,
+  approveLibraryRoot,
+  describeRefusal,
+  duplicateWarningText,
+  fetchLibraryRoots,
+  isLocalOnlyRefusal,
+  linkedCorrection,
+  linkedImportBody,
+  managedImportBody,
+  managedSourceProblem,
+  modelCheckpointId,
+  removeLibraryRoot,
+  rescanLibraryCheckpoint,
+  rootRemovalCopy,
+  scanLibraryRoot,
+  updateLibraryRoot,
+} from "../checkpointLibrary.js";
+
+// The one "add a model" experience, for both ownerships and both shells (epic 20398, sc-20650).
+//
+// It is ONE component on purpose. The two ownerships share the validation surface, the queued-job
+// progress cards, cancel, retry and the refusal rendering; the only thing that differs is what the
+// user names — a checkpoint inside a library they already keep, or a transfer SceneWorks performs.
+// Two panels would have meant two places for a refusal to be swallowed, and the epic's whole point
+// is that a checkpoint's ownership is a choice rather than a fork in the product.
+//
+// Everything the panel needs from the outside is injected, which is what lets the tests drive the
+// full flow — including the desktop bridge — without a transport:
+//   `library`     — the six library-root routes.
+//   `pickFolder`  — the native folder chooser. Defaults to the desktop bridge's `choose_folder` and
+//                   is absent in a remote browser, where the path is typed instead.
+//   `onImportModel` — the app's existing `createModelImportJob`. BOTH ownerships end here.
+//
+// The panel opens COLLAPSED. The Model Manager is a busy page and this is a disclosure on it; it is
+// a button + labelled region rather than a `<details>` element so the open state is assertable by
+// role and so the screen's "no collapsible cards" invariant is untouched.
+
+const DEFAULT_LIBRARY = {
+  fetchRoots: fetchLibraryRoots,
+  approve: approveLibraryRoot,
+  update: updateLibraryRoot,
+  remove: removeLibraryRoot,
+  scan: scanLibraryRoot,
+  rescan: rescanLibraryCheckpoint,
+};
+
+const NEUTRAL = Object.freeze({ tone: "neutral", text: "", detail: "", reason: null });
+
+function toneClass(tone) {
+  if (tone === "success") return "inline-success";
+  if (tone === "error") return "inline-warning";
+  return "inline-note";
+}
+
+// Every failure that reaches the user goes through here, so no call site can quietly turn a typed
+// refusal into a default. `detail` carries the store's `[checkpoint-plan:<code>] …` sentence, which
+// is where the actionable evidence lives (the inspector's diagnostics, the two drift digests).
+function failureMessage(error) {
+  const described = describeRefusal(error);
+  return {
+    tone: "error",
+    text: isLocalOnlyRefusal(error)
+      ? "A model library can only be added or relinked from SceneWorks running on this machine."
+      : described.message,
+    detail: isLocalOnlyRefusal(error) ? described.message : "",
+    reason: described.reason,
+  };
+}
+
+export function CheckpointImportPanel({
+  token,
+  families = [],
+  models = [],
+  credentials = [],
+  macCapabilities,
+  pendingJobs = [],
+  completedJobs = [],
+  onImportModel,
+  onCancelJob,
+  onRetryJob,
+  onOpenQueue,
+  onRefreshCatalog,
+  compact = false,
+  defaultOpen = false,
+  library = DEFAULT_LIBRARY,
+  pickFolder = isDesktop ? () => tauriInvoke("choose_folder") : null,
+  headingId = "checkpoint-import-heading",
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const [ownership, setOwnership] = useState(OWNERSHIP_LINKED);
+  const [message, setMessage] = useState(NEUTRAL);
+  const [busy, setBusy] = useState("");
+
+  // Linked state.
+  const [roots, setRoots] = useState([]);
+  const [rootsLoaded, setRootsLoaded] = useState(false);
+  const [activeRootId, setActiveRootId] = useState("");
+  const [scan, setScan] = useState(null);
+  const [pathDraft, setPathDraft] = useState("");
+  const [labelDraft, setLabelDraft] = useState("");
+  const [renaming, setRenaming] = useState("");
+
+  // Managed state. `type` is image-only for the same reason the pre-epic form fixed it: the import
+  // route writes this type verbatim into the user manifest and never reconciles it against the
+  // detected family, so offering the others would let an image checkpoint be mis-typed (sc-14020).
+  const [managed, setManaged] = useState({
+    kind: "upload",
+    file: null,
+    path: "",
+    url: "",
+    repo: "",
+    revision: "",
+    expectedSha256: "",
+    modelVersionId: "",
+    fileId: "",
+    name: "",
+    family: "",
+    type: "image",
+  });
+  const [fileInputKey, setFileInputKey] = useState(0);
+  // The last submission, kept so "Try again" re-sends exactly what failed rather than whatever the
+  // form happens to hold by then.
+  const [lastAttempt, setLastAttempt] = useState(null);
+
+  const modelsByCheckpoint = useMemo(() => {
+    const index = new Map();
+    for (const model of models) {
+      const id = modelCheckpointId(model);
+      if (id) index.set(id, model);
+    }
+    return index;
+  }, [models]);
+
+  const loadRoots = useCallback(async () => {
+    setBusy("roots");
+    try {
+      const response = await library.fetchRoots(token);
+      const next = Array.isArray(response?.roots) ? response.roots : [];
+      setRoots(next);
+      setRootsLoaded(true);
+      setMessage((current) => (current.tone === "error" ? NEUTRAL : current));
+      return next;
+    } catch (error) {
+      setMessage(failureMessage(error));
+      setRootsLoaded(true);
+      return null;
+    } finally {
+      setBusy("");
+    }
+  }, [library, token]);
+
+  useEffect(() => {
+    if (!open || ownership !== OWNERSHIP_LINKED || rootsLoaded) return;
+    loadRoots();
+  }, [open, ownership, rootsLoaded, loadRoots]);
+
+  const runScan = useCallback(
+    async (rootId) => {
+      setActiveRootId(rootId);
+      setBusy(`scan:${rootId}`);
+      try {
+        const result = await library.scan(token, rootId);
+        setScan(result);
+        setMessage(NEUTRAL);
+        return result;
+      } catch (error) {
+        setScan(null);
+        setMessage(failureMessage(error));
+        return null;
+      } finally {
+        setBusy("");
+      }
+    },
+    [library, token],
+  );
+
+  // A library the user has to press a button to look inside is a library whose Needs Relink /
+  // Needs Rescan state they never see. The first root scans as soon as the roots load, so the
+  // states that require an action are on screen at the moment the panel opens.
+  useEffect(() => {
+    if (!open || ownership !== OWNERSHIP_LINKED || !rootsLoaded) return;
+    if (activeRootId || roots.length === 0) return;
+    runScan(roots[0].rootId);
+  }, [open, ownership, rootsLoaded, activeRootId, roots, runScan]);
+
+  async function choosePath(setter) {
+    if (!pickFolder) return;
+    const picked = await pickFolder().catch(() => null);
+    if (picked) setter(String(picked));
+  }
+
+  async function addLibrary() {
+    const path = pathDraft.trim();
+    if (!path) {
+      setMessage({ ...NEUTRAL, tone: "error", text: "Choose the folder your checkpoints live in." });
+      return;
+    }
+    setBusy("approve");
+    try {
+      const root = await library.approve(token, { path, label: labelDraft.trim() || undefined });
+      setPathDraft("");
+      setLabelDraft("");
+      const next = await loadRoots();
+      setMessage({ ...NEUTRAL, tone: "success", text: `Added ${root?.displayLabel ?? path}.` });
+      if (root?.rootId) await runScan(root.rootId);
+      return next;
+    } catch (error) {
+      setMessage(failureMessage(error));
+      return null;
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function relinkRoot(rootId) {
+    let path = pathDraft.trim();
+    if (pickFolder) {
+      const picked = await pickFolder().catch(() => null);
+      if (picked) path = String(picked);
+    }
+    if (!path) {
+      setMessage({ ...NEUTRAL, tone: "error", text: "Choose where this library lives now." });
+      return;
+    }
+    setBusy(`relink:${rootId}`);
+    try {
+      await library.update(token, rootId, { path });
+      setPathDraft("");
+      await loadRoots();
+      await runScan(rootId);
+      setMessage({ ...NEUTRAL, tone: "success", text: "Library relinked. Its checkpoints are selectable again." });
+      onRefreshCatalog?.();
+    } catch (error) {
+      setMessage(failureMessage(error));
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function renameRoot(rootId) {
+    const label = labelDraft.trim();
+    if (!label) {
+      setMessage({ ...NEUTRAL, tone: "error", text: "Enter a name for this library." });
+      return;
+    }
+    setBusy(`rename:${rootId}`);
+    try {
+      await library.update(token, rootId, { label });
+      setRenaming("");
+      setLabelDraft("");
+      await loadRoots();
+      setMessage({ ...NEUTRAL, tone: "success", text: "Library renamed." });
+    } catch (error) {
+      setMessage(failureMessage(error));
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function forgetRoot(root) {
+    const copy = rootRemovalCopy(root, activeRootId === root.rootId ? scan : null);
+    if (!(await appConfirm({ ...copy, cancelLabel: "Cancel", tone: "danger" }))) return;
+    setBusy(`forget:${root.rootId}`);
+    try {
+      const result = await library.remove(token, root.rootId);
+      if (activeRootId === root.rootId) {
+        setActiveRootId("");
+        setScan(null);
+      }
+      await loadRoots();
+      const dropped = result?.removedCheckpoints?.length ?? 0;
+      setMessage({
+        ...NEUTRAL,
+        tone: "success",
+        text: `SceneWorks forgot this library${dropped ? ` and ${dropped} checkpoint record${dropped === 1 ? "" : "s"}` : ""}. Your files were not touched.`,
+      });
+      onRefreshCatalog?.();
+    } catch (error) {
+      setMessage(failureMessage(error));
+    } finally {
+      setBusy("");
+    }
+  }
+
+  async function rescanCheckpoint(rootId, relativePath) {
+    setBusy(`rescan:${relativePath}`);
+    try {
+      const status = await library.rescan(token, rootId, relativePath);
+      await runScan(rootId);
+      setMessage(
+        status?.state === "ready"
+          ? { ...NEUTRAL, tone: "success", text: `${relativePath} is selectable again.` }
+          : { ...NEUTRAL, tone: "error", text: status?.detail || `${relativePath} still cannot be used.`, reason: status?.state ?? null },
+      );
+      onRefreshCatalog?.();
+    } catch (error) {
+      setMessage(failureMessage(error));
+    } finally {
+      setBusy("");
+    }
+  }
+
+  // BOTH ownerships submit here. One queue, one progress surface, one retry.
+  async function submit(attempt) {
+    if (!onImportModel) return;
+    setLastAttempt(attempt);
+    setBusy("import");
+    setMessage({ ...NEUTRAL, tone: "neutral", text: attempt.file ? "Uploading the checkpoint before queueing." : "Validating and queueing." });
+    try {
+      const job = await onImportModel(attempt.file ? { ...attempt.body, file: attempt.file } : attempt.body);
+      const modelId = job?.payload?.modelId;
+      // The detector's verdict, when the user left family on Auto-detect (sc-14020). Reported
+      // because "which family did this turn out to be" is the one thing an auto-detected import
+      // leaves the user unable to predict.
+      const resolvedFamily = job?.payload?.manifestEntry?.family;
+      const detected = !attempt.body.family && resolvedFamily ? ` Detected family: ${normalizeLoraFamily(resolvedFamily)}.` : "";
+      setMessage({
+        ...NEUTRAL,
+        tone: "success",
+        text: `${modelId ? `Import queued for ${modelId}.` : "Import queued."}${detected}`,
+      });
+      if (attempt.file) setFileInputKey((current) => current + 1);
+      setManaged((current) => ({ ...current, file: null, path: "", url: "", repo: "", name: "" }));
+    } catch (error) {
+      setMessage(failureMessage(error));
+    } finally {
+      setBusy("");
+    }
+  }
+
+  function submitLinked(candidate) {
+    return submit({
+      body: linkedImportBody({
+        rootId: activeRootId,
+        relativePath: candidate.candidate.relativePath,
+        name: candidate.candidate.relativePath.split("/").pop(),
+        family: managed.family || undefined,
+      }),
+    });
+  }
+
+  function submitManaged(event) {
+    event?.preventDefault?.();
+    const problem = managedSourceProblem(managed);
+    if (problem) {
+      setMessage({ ...NEUTRAL, tone: "error", text: problem });
+      return;
+    }
+    return submit({ body: managedImportBody(managed), file: managed.kind === "upload" ? managed.file : null });
+  }
+
+  const managedSource = MANAGED_SOURCES.find((source) => source.kind === managed.kind) ?? MANAGED_SOURCES[0];
+  const credentialHost = MANAGED_SOURCE_CREDENTIAL_HOST[managed.kind] ?? null;
+  const credentialMissing = credentialHost ? !hasPresentCredential(credentials, credentialHost) : false;
+
+  return (
+    <section aria-labelledby={headingId} className={compact ? "checkpoint-import compact" : "checkpoint-import"}>
+      <h3 className="checkpoint-import-heading" id={headingId}>
+        Add a model
+      </h3>
+      <button
+        aria-controls="checkpoint-import-body"
+        aria-expanded={open}
+        className="checkpoint-import-toggle"
+        onClick={() => setOpen((current) => !current)}
+        type="button"
+      >
+        {open ? "Hide options" : "Add a model"}
+      </button>
+
+      {open ? (
+        <div className="checkpoint-import-body" id="checkpoint-import-body">
+          <div aria-label="Model ownership" className="checkpoint-ownership" role="radiogroup">
+            {OWNERSHIP_CHOICES.map((choice) => (
+              <button
+                aria-checked={ownership === choice.id}
+                className={ownership === choice.id ? "checkpoint-ownership-choice active" : "checkpoint-ownership-choice"}
+                key={choice.id}
+                onClick={() => setOwnership(choice.id)}
+                role="radio"
+                type="button"
+              >
+                <span className="checkpoint-ownership-label">{choice.label}</span>
+                <span className="checkpoint-ownership-summary">{choice.summary}</span>
+              </button>
+            ))}
+          </div>
+
+          {ownership === OWNERSHIP_LINKED
+            ? renderLinked()
+            : renderManaged()}
+
+          <p aria-live="polite" className={toneClass(message.tone)} role="status">
+            {message.text}
+          </p>
+          {message.detail ? <p className="checkpoint-import-detail">{message.detail}</p> : null}
+          {message.tone === "error" && lastAttempt ? (
+            <button disabled={busy === "import"} onClick={() => submit(lastAttempt)} type="button">
+              Try again
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {/* Progress and duplicate warnings sit OUTSIDE the disclosure. An import already running is
+          not an option the user is choosing between — collapsing it away would hide a job that is
+          consuming the machine, and hide the cancel button that stops it. */}
+      {pendingJobs.length ? (
+        <div className="checkpoint-import-progress">
+          <strong>Imports in progress</strong>
+          <div className="local-job-stack">
+            {pendingJobs.map((job) => (
+              <WorkerProgressCard
+                job={job}
+                key={job.id}
+                onCancel={onCancelJob}
+                onOpenQueue={onOpenQueue}
+                onRetry={onRetryJob}
+              />
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {completedJobs
+        .map((job) => ({ job, warning: duplicateWarningText(job) }))
+        .filter((entry) => entry.warning)
+        .map((entry) => (
+          <p className="inline-note checkpoint-duplicate-warning" key={entry.job.id} role="note">
+            {entry.warning}
+          </p>
+        ))}
+    </section>
+  );
+
+  function renderLinked() {
+    return (
+      <div className="checkpoint-linked">
+        <div className="checkpoint-linked-add">
+          <label>
+            Library folder
+            <input
+              disabled={busy === "approve"}
+              onChange={(event) => setPathDraft(event.target.value)}
+              placeholder={pickFolder ? "Choose a folder" : "/Volumes/Models/checkpoints"}
+              value={pathDraft}
+            />
+          </label>
+          {pickFolder ? (
+            <button onClick={() => choosePath(setPathDraft)} type="button">
+              Choose folder
+            </button>
+          ) : null}
+          <label>
+            Name
+            <input
+              disabled={busy === "approve"}
+              onChange={(event) => setLabelDraft(event.target.value)}
+              placeholder="Optional"
+              value={labelDraft}
+            />
+          </label>
+          <button disabled={busy === "approve"} onClick={addLibrary} type="button">
+            Add library
+          </button>
+        </div>
+
+        {roots.length === 0 && rootsLoaded ? (
+          <p className="checkpoint-empty">
+            No linked libraries yet. Point SceneWorks at a folder of checkpoints — the files stay where they are.
+          </p>
+        ) : null}
+
+        <ul aria-label="Linked libraries" className="checkpoint-root-list">
+          {roots.map((root) => (
+            <li className="checkpoint-root" key={root.rootId}>
+              <div className="checkpoint-root-head">
+                <span className="checkpoint-root-label">{root.displayLabel ?? root.label ?? root.path}</span>
+                <span className="checkpoint-root-path">{root.path}</span>
+              </div>
+              <div className="checkpoint-root-actions">
+                <button disabled={busy === `scan:${root.rootId}`} onClick={() => runScan(root.rootId)} type="button">
+                  {busy === `scan:${root.rootId}` ? "Scanning…" : "Rescan library"}
+                </button>
+                <button disabled={busy === `relink:${root.rootId}`} onClick={() => relinkRoot(root.rootId)} type="button">
+                  Relink library
+                </button>
+                <button onClick={() => { setRenaming(root.rootId); setLabelDraft(root.label ?? ""); }} type="button">
+                  Rename
+                </button>
+                <button disabled={busy === `forget:${root.rootId}`} onClick={() => forgetRoot(root)} type="button">
+                  Remove library
+                </button>
+              </div>
+              {renaming === root.rootId ? (
+                <div className="checkpoint-root-rename">
+                  <label>
+                    New name
+                    <input onChange={(event) => setLabelDraft(event.target.value)} value={labelDraft} />
+                  </label>
+                  <button disabled={busy === `rename:${root.rootId}`} onClick={() => renameRoot(root.rootId)} type="button">
+                    Save name
+                  </button>
+                  <button onClick={() => setRenaming("")} type="button">
+                    Cancel rename
+                  </button>
+                </div>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+
+        {scan ? renderScan() : null}
+      </div>
+    );
+  }
+
+  function renderScan() {
+    // The root directory is not there. Every checkpoint under it is Needs Relink — a lifecycle
+    // state with a button, NOT a missing model. Saying "not installed" here would invite the user
+    // to re-download bytes that are sitting on a drive they only have to plug back in.
+    if (scan.available === false) {
+      return (
+        <div className="checkpoint-scan checkpoint-scan-unavailable" role="group" aria-label="Library needs relink">
+          <p className="checkpoint-state-headline">Needs relink</p>
+          <p>
+            This library’s folder is not available right now — it was moved, renamed, or its drive is not attached.
+            Nothing was lost, and its models are all still installed.
+          </p>
+          <button disabled={busy === `relink:${scan.root.rootId}`} onClick={() => relinkRoot(scan.root.rootId)} type="button">
+            Relink library
+          </button>
+        </div>
+      );
+    }
+    const candidates = scan.candidates ?? [];
+    return (
+      <div className="checkpoint-scan">
+        <ul aria-label="Checkpoints in this library" className="checkpoint-candidate-list">
+          {candidates.map((entry) => renderCandidate(entry))}
+        </ul>
+        {candidates.length === 0 ? <p className="checkpoint-empty">No checkpoints found in this library.</p> : null}
+        {(scan.unmatched ?? []).length ? (
+          <div className="checkpoint-unmatched" role="group" aria-label="Checkpoints no longer found">
+            <p className="checkpoint-state-headline">Needs rescan</p>
+            <p>
+              SceneWorks has records for these checkpoints but did not find them in the library this time. They were
+              renamed, moved, or replaced, and their SceneWorks records are intact.
+            </p>
+            <ul>
+              {scan.unmatched.map((status) => (
+                <li key={status.checkpointId}>
+                  <span>{status.relativePath}</span>
+                  <button
+                    disabled={busy === `rescan:${status.relativePath}`}
+                    onClick={() => rescanCheckpoint(status.rootId, status.relativePath)}
+                    type="button"
+                  >
+                    Rescan checkpoint
+                  </button>
+                  {status.detail ? <span className="checkpoint-import-detail">{status.detail}</span> : null}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+        {(scan.diagnostics ?? []).length ? (
+          <ul aria-label="Library scan notes" className="checkpoint-diagnostics">
+            {scan.diagnostics.map((diagnostic, index) => (
+              <li key={`${diagnostic.code ?? "note"}-${index}`}>{diagnostic.message ?? diagnostic.code}</li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    );
+  }
+
+  function renderCandidate(entry) {
+    const candidate = entry.candidate ?? {};
+    const correction = linkedCorrection(entry.status);
+    const model = entry.status ? modelsByCheckpoint.get(entry.status.checkpointId) : null;
+    const chips = model ? modelCapabilityChips(model) : [];
+    const block = model ? macModelBlock(model, macCapabilities) : null;
+    return (
+      <li className="checkpoint-candidate" key={entry.checkpointId ?? candidate.relativePath}>
+        <div className="checkpoint-candidate-head">
+          <span className="checkpoint-candidate-path">{candidate.relativePath}</span>
+          <span className="checkpoint-candidate-meta">
+            {[
+              candidate.container,
+              candidate.sizeBytes ? formatBytes(candidate.sizeBytes) : null,
+              candidate.headerFamily,
+              candidate.headerRole,
+              candidate.quantization,
+            ]
+              .filter(Boolean)
+              .join(" · ")}
+          </span>
+        </div>
+        {chips.length ? (
+          <ul aria-label={`${candidate.relativePath} capabilities`} className="model-capabilities">
+            {chips.map((chip) => (
+              <li className="chip" key={chip}>
+                {chip}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        {block?.blocked ? <p className="inline-warning checkpoint-eligibility">{block.text}</p> : null}
+        {correction ? (
+          <div className="checkpoint-candidate-correction" role="group" aria-label={`${candidate.relativePath} ${correction.headline}`}>
+            <p className="checkpoint-state-headline">{correction.headline}</p>
+            <p>{correction.summary}</p>
+            {correction.detail ? <p className="checkpoint-import-detail">{correction.detail}</p> : null}
+            <button
+              disabled={busy === `rescan:${candidate.relativePath}` || busy === `relink:${activeRootId}`}
+              onClick={() =>
+                correction.action === "relink"
+                  ? relinkRoot(activeRootId)
+                  : rescanCheckpoint(activeRootId, candidate.relativePath)
+              }
+              type="button"
+            >
+              {correction.label}
+            </button>
+          </div>
+        ) : null}
+        {entry.selectable ? (
+          <button disabled={busy === "import"} onClick={() => submitLinked(entry)} type="button">
+            Use this checkpoint
+          </button>
+        ) : correction ? null : (
+          <p className="checkpoint-candidate-unselectable">
+            SceneWorks has only read this file’s header. Selecting it reads the whole file first, which is what makes it
+            safe to run.
+            <button disabled={busy === "import"} onClick={() => submitLinked(entry)} type="button">
+              Validate and use
+            </button>
+          </p>
+        )}
+      </li>
+    );
+  }
+
+  function renderManaged() {
+    return (
+      <form aria-label="Add to SceneWorks" className="checkpoint-managed" onSubmit={submitManaged}>
+        <div aria-label="Where the checkpoint comes from" className="segmented-control compact-segment" role="radiogroup">
+          {MANAGED_SOURCES.map((source) => (
+            <button
+              aria-checked={managed.kind === source.kind}
+              className={managed.kind === source.kind ? "active" : ""}
+              key={source.kind}
+              onClick={() => setManaged((current) => ({ ...current, kind: source.kind }))}
+              role="radio"
+              type="button"
+            >
+              {source.label}
+            </button>
+          ))}
+        </div>
+        <p className="checkpoint-source-hint">{managedSource.hint}</p>
+
+        <div className="models-import-grid">
+          {managed.kind === "upload" ? (
+            <label>
+              Model File
+              <span className="file-picker-row">
+                <span className="file-upload-button">
+                  Choose
+                  <input
+                    accept=".safetensors,.ckpt,.pt,.bin"
+                    key={fileInputKey}
+                    onChange={(event) => setManaged((current) => ({ ...current, file: event.target.files?.[0] ?? null }))}
+                    type="file"
+                  />
+                </span>
+                <span className="selected-file-name">{managed.file?.name ?? "No file selected"}</span>
+              </span>
+            </label>
+          ) : null}
+          {managed.kind === "localPath" ? (
+            <label>
+              Source path
+              <input
+                onChange={(event) => setManaged((current) => ({ ...current, path: event.target.value }))}
+                placeholder="/Users/you/Downloads/model.safetensors"
+                value={managed.path}
+              />
+            </label>
+          ) : null}
+          {managed.kind === "localPath" && pickFolder ? (
+            <button
+              onClick={() => choosePath((value) => setManaged((current) => ({ ...current, path: value })))}
+              type="button"
+            >
+              Choose source folder
+            </button>
+          ) : null}
+          {managed.kind === "url" || managed.kind === "civitai" ? (
+            <label>
+              {managed.kind === "civitai" ? "Civitai URL" : "Source URL"}
+              <input
+                onChange={(event) => setManaged((current) => ({ ...current, url: event.target.value }))}
+                placeholder="https://..."
+                value={managed.url}
+              />
+            </label>
+          ) : null}
+          {managed.kind === "civitai" ? (
+            <>
+              <label>
+                Model version id
+                <input
+                  onChange={(event) => setManaged((current) => ({ ...current, modelVersionId: event.target.value }))}
+                  placeholder="Optional"
+                  value={managed.modelVersionId}
+                />
+              </label>
+              <label>
+                File id
+                <input
+                  onChange={(event) => setManaged((current) => ({ ...current, fileId: event.target.value }))}
+                  placeholder="Optional"
+                  value={managed.fileId}
+                />
+              </label>
+            </>
+          ) : null}
+          {managed.kind === "huggingFace" ? (
+            <>
+              <label>
+                Hugging Face repo
+                <input
+                  onChange={(event) => setManaged((current) => ({ ...current, repo: event.target.value }))}
+                  placeholder="owner/name"
+                  value={managed.repo}
+                />
+              </label>
+              <label>
+                Revision
+                <input
+                  onChange={(event) => setManaged((current) => ({ ...current, revision: event.target.value }))}
+                  placeholder="Optional"
+                  value={managed.revision}
+                />
+              </label>
+            </>
+          ) : null}
+          {managed.kind === "url" || managed.kind === "civitai" ? (
+            <label>
+              Expected SHA-256
+              <input
+                onChange={(event) => setManaged((current) => ({ ...current, expectedSha256: event.target.value }))}
+                placeholder="Optional"
+                value={managed.expectedSha256}
+              />
+            </label>
+          ) : null}
+          <label>
+            Type
+            {/* Image-only, exactly as the pre-epic form was: the import route writes this value
+                verbatim into the user manifest and never reconciles it against the detected family
+                (sc-14020). */}
+            <select aria-readonly="true" disabled value="image">
+              <option value="image">Image</option>
+            </select>
+          </label>
+          <label>
+            Family
+            <select
+              disabled={!families.length}
+              onChange={(event) => setManaged((current) => ({ ...current, family: event.target.value }))}
+              value={managed.family}
+            >
+              {families.length ? (
+                <>
+                  <option value="">Auto-detect</option>
+                  {families.map((family) => (
+                    <option key={family} value={family}>
+                      {family}
+                    </option>
+                  ))}
+                </>
+              ) : (
+                <option value="">No known families</option>
+              )}
+            </select>
+          </label>
+          <label>
+            Name
+            <input
+              onChange={(event) => setManaged((current) => ({ ...current, name: event.target.value }))}
+              placeholder="Optional"
+              value={managed.name}
+            />
+          </label>
+          <button disabled={busy === "import"} type="submit">
+            {busy === "import" ? "Queueing…" : "Queue Import"}
+          </button>
+        </div>
+        {credentialHost && credentialMissing ? (
+          <p className="inline-note checkpoint-credential-notice">
+            No {credentialHost} credential is stored. A gated or paid download will be refused until you add one in
+            Settings.
+          </p>
+        ) : null}
+      </form>
+    );
+  }
+}

--- a/apps/web/src/components/CheckpointImportPanel.test.jsx
+++ b/apps/web/src/components/CheckpointImportPanel.test.jsx
@@ -1,0 +1,426 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppContext } from "../context/AppContext.js";
+import { CheckpointImportPanel } from "./CheckpointImportPanel.jsx";
+
+// Drives the WHOLE unified experience — both ownerships, the linked lifecycle, the five managed
+// inputs, cancel, retry, typed-refusal surfacing, and the accessibility contract — against injected
+// transports. Nothing here asserts on a snapshot: every accessibility claim queries a role or an
+// accessible name, because a snapshot passes just as happily when the roles are gone.
+
+vi.mock("../appConfirm.jsx", () => ({ appConfirm: vi.fn(async () => true) }));
+
+const { appConfirm } = await import("../appConfirm.jsx");
+
+const ROOT = { rootId: "root-a", path: "/Volumes/Models", label: "", displayLabel: "Models" };
+
+function readyScan(overrides = {}) {
+  return {
+    root: ROOT,
+    available: true,
+    candidates: [
+      {
+        checkpointId: "linked/root-a/sdxl.safetensors",
+        candidate: { relativePath: "sdxl.safetensors", container: "safetensors", sizeBytes: 6543210, headerFamily: "sdxl" },
+        status: { checkpointId: "linked/root-a/sdxl.safetensors", rootId: "root-a", relativePath: "sdxl.safetensors", state: "ready", detail: null },
+        selectable: true,
+      },
+    ],
+    unmatched: [],
+    diagnostics: [],
+    ...overrides,
+  };
+}
+
+function apiError(message, { code, reason, status = 409 } = {}) {
+  const error = new Error(message);
+  error.status = status;
+  error.code = code;
+  error.context = reason ? { reason } : null;
+  return error;
+}
+
+function libraryStub(overrides = {}) {
+  return {
+    fetchRoots: vi.fn(async () => ({ roots: [ROOT] })),
+    approve: vi.fn(async () => ROOT),
+    update: vi.fn(async () => ROOT),
+    remove: vi.fn(async () => ({ root: ROOT, removedCheckpoints: ["linked/root-a/sdxl.safetensors"] })),
+    scan: vi.fn(async () => readyScan()),
+    rescan: vi.fn(async () => ({ checkpointId: "linked/root-a/sdxl.safetensors", rootId: "root-a", relativePath: "sdxl.safetensors", state: "ready", detail: null })),
+    ...overrides,
+  };
+}
+
+describe("CheckpointImportPanel", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    appConfirm.mockClear();
+    appConfirm.mockResolvedValue(true);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render(props = {}) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{ jobs: [], models: [], workersById: {}, visibleWorkers: [] }}>
+          <CheckpointImportPanel
+            defaultOpen
+            library={libraryStub()}
+            onImportModel={async () => ({ payload: { modelId: "imported" } })}
+            token="tok"
+            {...props}
+          />
+        </AppContext.Provider>,
+      );
+    });
+  }
+
+  function byRole(role, name) {
+    return [...container.querySelectorAll(`[role="${role}"], ${role === "button" ? "button" : role}`)].find((node) =>
+      name ? accessibleName(node) === name || accessibleName(node).includes(name) : true,
+    );
+  }
+
+  function accessibleName(node) {
+    return (node.getAttribute("aria-label") ?? node.textContent ?? "").trim();
+  }
+
+  function buttonNamed(name) {
+    return [...container.querySelectorAll("button")].find((node) => node.textContent.trim() === name);
+  }
+
+  async function click(node) {
+    expect(node, "the control under test exists").toBeTruthy();
+    await act(async () => {
+      node.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+  }
+
+  async function type(input, value) {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+    await act(async () => {
+      setter.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+
+  function labelled(text) {
+    return [...container.querySelectorAll("label")]
+      .find((node) => node.textContent.trim().startsWith(text))
+      ?.querySelector("input, select");
+  }
+
+  function status() {
+    return container.querySelector('[role="status"]')?.textContent ?? "";
+  }
+
+  // ------------------------------------------------------------------- AC1: the two choices
+
+  it("offers both ownership choices as one radio group, linked selected first", async () => {
+    await render();
+    const group = container.querySelector('[role="radiogroup"][aria-label="Model ownership"]');
+    expect(group).toBeTruthy();
+    const options = [...group.querySelectorAll('[role="radio"]')];
+    expect(options.map((node) => node.querySelector(".checkpoint-ownership-label").textContent)).toEqual([
+      "Use existing model library",
+      "Add to SceneWorks",
+    ]);
+    expect(options[0].getAttribute("aria-checked")).toBe("true");
+    expect(options[1].getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("is collapsed until asked, and the toggle reports its own state", async () => {
+    await render({ defaultOpen: false });
+    const toggle = container.querySelector(".checkpoint-import-toggle");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector('[role="radiogroup"]')).toBeNull();
+    await click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(container.querySelector('[role="radiogroup"][aria-label="Model ownership"]')).toBeTruthy();
+  });
+
+  it("reaches all five managed inputs from the Add to SceneWorks choice", async () => {
+    await render();
+    await click(byRole("radio", "Add to SceneWorks"));
+    const sources = container.querySelector('[role="radiogroup"][aria-label="Where the checkpoint comes from"]');
+    expect([...sources.querySelectorAll('[role="radio"]')].map((node) => node.textContent)).toEqual([
+      "Upload",
+      "Local copy",
+      "URL",
+      "Hugging Face",
+      "Civitai",
+    ]);
+  });
+
+  it("runs both ownerships through the same import submission", async () => {
+    const onImportModel = vi.fn(async () => ({ payload: { modelId: "m" } }));
+    await render({ onImportModel });
+    await click(buttonNamed("Use this checkpoint"));
+    expect(onImportModel).toHaveBeenCalledWith({
+      linkedRootId: "root-a",
+      linkedRelativePath: "sdxl.safetensors",
+      type: "image",
+      name: "sdxl.safetensors",
+    });
+
+    await click(byRole("radio", "Add to SceneWorks"));
+    await click(buttonNamed("Hugging Face"));
+    await type(labelled("Hugging Face repo"), "org/model");
+    await click(buttonNamed("Queue Import"));
+    expect(onImportModel).toHaveBeenLastCalledWith({
+      ownershipMode: "managed",
+      type: "image",
+      source: { kind: "huggingFace", repo: "org/model" },
+    });
+  });
+
+  // ------------------------------------------------------- AC1: linked-library management
+
+  it("adds, rescans, relinks, renames and removes a library root", async () => {
+    const library = libraryStub();
+    await render({ library });
+    await type(labelled("Library folder"), "/Volumes/Models");
+    await click(buttonNamed("Add library"));
+    expect(library.approve).toHaveBeenCalledWith("tok", { path: "/Volumes/Models", label: undefined });
+
+    await click(buttonNamed("Rescan library"));
+    expect(library.scan).toHaveBeenCalledWith("tok", "root-a");
+
+    await type(labelled("Library folder"), "/Volumes/Moved");
+    await click(buttonNamed("Relink library"));
+    expect(library.update).toHaveBeenCalledWith("tok", "root-a", { path: "/Volumes/Moved" });
+
+    await click(buttonNamed("Rename"));
+    await type(labelled("New name"), "Big drive");
+    await click(buttonNamed("Save name"));
+    expect(library.update).toHaveBeenLastCalledWith("tok", "root-a", { label: "Big drive" });
+
+    await click(buttonNamed("Remove library"));
+    expect(library.remove).toHaveBeenCalledWith("tok", "root-a");
+  });
+
+  it("uses the desktop bridge folder picker when one is available", async () => {
+    const pickFolder = vi.fn(async () => "/Volumes/Picked");
+    const library = libraryStub();
+    await render({ library, pickFolder });
+    await click(buttonNamed("Choose folder"));
+    expect(pickFolder).toHaveBeenCalled();
+    await click(buttonNamed("Add library"));
+    expect(library.approve).toHaveBeenCalledWith("tok", { path: "/Volumes/Picked", label: undefined });
+  });
+
+  it("types the path instead when there is no bridge (remote browser)", async () => {
+    const library = libraryStub();
+    await render({ library, pickFolder: null });
+    expect(buttonNamed("Choose folder")).toBeUndefined();
+    await type(labelled("Library folder"), "/srv/models");
+    await click(buttonNamed("Add library"));
+    expect(library.approve).toHaveBeenCalledWith("tok", { path: "/srv/models", label: undefined });
+  });
+
+  // --------------------------------------------- AC2: corrective action, not "missing"
+
+  it("shows Needs Relink with a relink button instead of calling the library missing", async () => {
+    const library = libraryStub({ scan: vi.fn(async () => readyScan({ available: false, candidates: [] })) });
+    await render({ library });
+    const region = container.querySelector('[role="group"][aria-label="Library needs relink"]');
+    expect(region).toBeTruthy();
+    expect(region.textContent).toContain("Needs relink");
+    expect(region.textContent).not.toMatch(/uninstalled|not installed|missing/i);
+    expect([...region.querySelectorAll("button")].map((node) => node.textContent)).toContain("Relink library");
+  });
+
+  it("shows Needs Rescan on a drifted checkpoint with the store's own diagnostic", async () => {
+    const drifted = readyScan();
+    drifted.candidates[0].status = {
+      ...drifted.candidates[0].status,
+      state: "needs_rescan",
+      detail: "[checkpoint-plan:source-drifted] recorded ab… now cd…",
+    };
+    drifted.candidates[0].selectable = false;
+    const library = libraryStub({ scan: vi.fn(async () => drifted) });
+    await render({ library });
+    const region = container.querySelector('[role="group"][aria-label="sdxl.safetensors Needs rescan"]');
+    expect(region).toBeTruthy();
+    expect(region.textContent).toContain("[checkpoint-plan:source-drifted]");
+    expect(region.textContent).not.toMatch(/uninstalled|not installed/i);
+    await click([...region.querySelectorAll("button")].find((node) => node.textContent === "Rescan checkpoint"));
+    expect(library.rescan).toHaveBeenCalledWith("tok", "root-a", "sdxl.safetensors");
+  });
+
+  it("keeps persisted checkpoints the scan no longer sees, with a rescan affordance", async () => {
+    const library = libraryStub({
+      scan: vi.fn(async () =>
+        readyScan({
+          candidates: [],
+          unmatched: [
+            { checkpointId: "linked/root-a/gone.safetensors", rootId: "root-a", relativePath: "gone.safetensors", state: "needs_rescan", detail: "[checkpoint-plan:source-missing] gone" },
+          ],
+        }),
+      ),
+    });
+    await render({ library });
+    const region = container.querySelector('[role="group"][aria-label="Checkpoints no longer found"]');
+    expect(region.textContent).toContain("gone.safetensors");
+    expect(region.textContent).toContain("[checkpoint-plan:source-missing]");
+    expect(region.textContent).not.toMatch(/uninstalled/i);
+  });
+
+  it("shows capabilities and backend eligibility for a compiled checkpoint", async () => {
+    await render({
+      models: [
+        {
+          id: "my-sdxl",
+          capabilities: ["text_to_image", "style_variations"],
+          macSupport: { supported: false, reason: "torch_only" },
+          importPlan: { checkpointId: "linked/root-a/sdxl.safetensors" },
+        },
+      ],
+      macCapabilities: { macGatingActive: true },
+    });
+    const chips = [...container.querySelectorAll('[aria-label="sdxl.safetensors capabilities"] .chip')].map((node) => node.textContent);
+    // The retired mode is dropped rather than advertised as something the studios can run.
+    expect(chips).toEqual(["Text to Image"]);
+    expect(container.querySelector(".checkpoint-eligibility").textContent).toBeTruthy();
+  });
+
+  it("warns about duplicate checkpoints without calling the import a failure", async () => {
+    await render({
+      completedJobs: [{ id: "j1", result: { duplicateCheckpointIds: ["managed/install-9"] } }],
+    });
+    const note = container.querySelector(".checkpoint-duplicate-warning");
+    expect(note.textContent).toContain("managed/install-9");
+    expect(note.textContent).not.toMatch(/failed|error/i);
+  });
+
+  it("names the library it is forgetting and promises the files are untouched", async () => {
+    const library = libraryStub();
+    await render({ library });
+    await click(buttonNamed("Remove library"));
+    expect(appConfirm).toHaveBeenCalled();
+    const copy = appConfirm.mock.calls[0][0];
+    expect(copy.confirmLabel).toBe("Forget library");
+    expect(copy.message).toMatch(/left exactly as they are/);
+    expect(status()).toMatch(/Your files were not touched/);
+  });
+
+  it("does not remove a library when the confirmation is declined", async () => {
+    appConfirm.mockResolvedValue(false);
+    const library = libraryStub();
+    await render({ library });
+    await click(buttonNamed("Remove library"));
+    expect(library.remove).not.toHaveBeenCalled();
+  });
+
+  // ------------------------------------------------------- AC3: error, retry, cancel, a11y
+
+  it("surfaces the typed refusal reason rather than a generic failure", async () => {
+    const library = libraryStub({
+      approve: vi.fn(async () => {
+        throw apiError("[checkpoint-plan:root-not-approvable] /nope cannot be approved as a root: not a directory", {
+          code: "checkpoint_library_rejected",
+          reason: "root-not-approvable",
+          status: 400,
+        });
+      }),
+    });
+    await render({ library, pickFolder: null });
+    await type(labelled("Library folder"), "/nope");
+    await click(buttonNamed("Add library"));
+    expect(status()).toContain("[checkpoint-plan:root-not-approvable]");
+    expect(status()).not.toMatch(/something went wrong/i);
+  });
+
+  it("explains the local-only refusal in its own words and keeps the server sentence", async () => {
+    const library = libraryStub({
+      approve: vi.fn(async () => {
+        throw apiError("A model library can only be added or relinked from SceneWorks running on this machine.", {
+          code: "checkpoint_library_not_permitted",
+          reason: "not_a_local_client",
+          status: 403,
+        });
+      }),
+    });
+    await render({ library, pickFolder: null });
+    await type(labelled("Library folder"), "/srv/models");
+    await click(buttonNamed("Add library"));
+    expect(status()).toMatch(/running on this machine/);
+  });
+
+  it("retries the exact submission that failed, not whatever the form holds later", async () => {
+    const onImportModel = vi
+      .fn()
+      .mockRejectedValueOnce(apiError("[checkpoint-plan:unrunnable-source] no loader", {
+        code: "checkpoint_library_rejected",
+        reason: "unrunnable-source",
+      }))
+      .mockResolvedValueOnce({ payload: { modelId: "m" } });
+    await render({ onImportModel });
+    await click(buttonNamed("Use this checkpoint"));
+    expect(status()).toContain("[checkpoint-plan:unrunnable-source]");
+    await click(buttonNamed("Try again"));
+    expect(onImportModel).toHaveBeenCalledTimes(2);
+    expect(onImportModel.mock.calls[1][0]).toEqual(onImportModel.mock.calls[0][0]);
+    expect(status()).toContain("Import queued");
+  });
+
+  it("hands a queued import to the progress card so it can be cancelled", async () => {
+    const onCancelJob = vi.fn();
+    await render({
+      pendingJobs: [{ id: "job-1", type: "model_import", status: "running", payload: { modelId: "m" } }],
+      onCancelJob,
+    });
+    const cancel = [...container.querySelectorAll("button")].find((node) => /cancel/i.test(node.textContent));
+    expect(cancel).toBeTruthy();
+    await click(cancel);
+    expect(onCancelJob).toHaveBeenCalled();
+  });
+
+  it("refuses an empty managed form by naming the missing field", async () => {
+    const onImportModel = vi.fn();
+    await render({ onImportModel });
+    await click(byRole("radio", "Add to SceneWorks"));
+    await click(buttonNamed("Queue Import"));
+    expect(onImportModel).not.toHaveBeenCalled();
+    expect(status()).toMatch(/file/i);
+  });
+
+  it("warns when the selected source needs a credential that is not stored", async () => {
+    await render({ credentials: [] });
+    await click(byRole("radio", "Add to SceneWorks"));
+    await click(buttonNamed("Civitai"));
+    expect(container.querySelector(".checkpoint-credential-notice").textContent).toContain("civitai.com");
+    await click(buttonNamed("Hugging Face"));
+    expect(container.querySelector(".checkpoint-credential-notice").textContent).toContain("huggingface.co");
+  });
+
+  it("drops the credential notice once the credential is stored", async () => {
+    await render({ credentials: [{ host: "civitai.com", present: true }] });
+    await click(byRole("radio", "Add to SceneWorks"));
+    await click(buttonNamed("Civitai"));
+    expect(container.querySelector(".checkpoint-credential-notice")).toBeNull();
+  });
+
+  it("labels every region and announces outcomes in a live region", async () => {
+    await render();
+    expect(container.querySelector("section").getAttribute("aria-labelledby")).toBe("checkpoint-import-heading");
+    expect(container.querySelector("#checkpoint-import-heading").textContent).toBe("Add a model");
+    expect(container.querySelector('[aria-label="Linked libraries"]')).toBeTruthy();
+    expect(container.querySelector('[aria-label="Checkpoints in this library"]')).toBeTruthy();
+    const live = container.querySelector('[role="status"]');
+    expect(live.getAttribute("aria-live")).toBe("polite");
+  });
+});

--- a/apps/web/src/components/CheckpointImportPanel.test.jsx
+++ b/apps/web/src/components/CheckpointImportPanel.test.jsx
@@ -123,8 +123,19 @@ describe("CheckpointImportPanel", () => {
       ?.querySelector("input, select");
   }
 
+  // The panel has TWO status regions — the library-lifecycle track and the import track — because
+  // the two run concurrently and neither may overwrite the other. Assertions that only care that a
+  // sentence reached the user read both.
   function status() {
-    return container.querySelector('[role="status"]')?.textContent ?? "";
+    return [...container.querySelectorAll('[role="status"]')].map((node) => node.textContent).join(" ");
+  }
+
+  function importStatus() {
+    return container.querySelector(".checkpoint-import-status")?.textContent ?? "";
+  }
+
+  function libraryStatus() {
+    return container.querySelector(".checkpoint-library-status")?.textContent ?? "";
   }
 
   // ------------------------------------------------------------------- AC1: the two choices
@@ -407,11 +418,221 @@ describe("CheckpointImportPanel", () => {
     expect(container.querySelector(".checkpoint-credential-notice").textContent).toContain("huggingface.co");
   });
 
-  it("drops the credential notice once the credential is stored", async () => {
+  it("reports the stored credential positively rather than dropping the notice", async () => {
     await render({ credentials: [{ host: "civitai.com", present: true }] });
     await click(byRole("radio", "Add to SceneWorks"));
     await click(buttonNamed("Civitai"));
+    const notice = container.querySelector(".checkpoint-credential-notice");
+    expect(notice.textContent).toMatch(/A civitai\.com credential is stored/);
+    expect(notice.textContent).not.toMatch(/No civitai\.com credential/);
+  });
+
+  // The notice must distinguish "looked and found none" from "never looked". A caller that does
+  // not read the keychain gets silence — the old `credentials = []` default made every such screen
+  // claim a credential was missing.
+  it("says nothing about credentials when the caller never read them", async () => {
+    await render({});
+    await click(byRole("radio", "Add to SceneWorks"));
+    await click(buttonNamed("Civitai"));
     expect(container.querySelector(".checkpoint-credential-notice")).toBeNull();
+  });
+
+  it("offers a way to reach Settings from the missing-credential notice", async () => {
+    const onOpenSettings = vi.fn();
+    await render({ credentials: [], onOpenSettings });
+    await click(byRole("radio", "Add to SceneWorks"));
+    await click(buttonNamed("Civitai"));
+    await click(buttonNamed("Add token in Settings"));
+    expect(onOpenSettings).toHaveBeenCalled();
+  });
+
+  // --------------------------------------------- AC3 (cont.): the two tracks never speak for each other
+
+  it("keeps the import guard closed when a library scan resolves mid-import", async () => {
+    let releaseScan;
+    let releaseImport;
+    const library = libraryStub({
+      scan: vi.fn(async () => {
+        // First scan (the mount auto-scan) resolves immediately; the second is held open so it can
+        // be made to resolve DURING the import.
+        if (library.scan.mock.calls.length > 1) {
+          await new Promise((resolve) => {
+            releaseScan = resolve;
+          });
+        }
+        return readyScan();
+      }),
+    });
+    const onImportModel = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          releaseImport = () => resolve({ payload: { modelId: "m" } });
+        }),
+    );
+    await render({ library, onImportModel });
+
+    await click(buttonNamed("Use this checkpoint"));
+    // A second root scan starts while the import is still in flight, then finishes first.
+    await click(buttonNamed("Rescan library"));
+    await act(async () => {
+      releaseScan?.();
+    });
+
+    // The import is still running, so its button is still disabled: a scan's `finally` no longer
+    // clears the import guard, which is what allowed a double submit.
+    const reuse = buttonNamed("Use this checkpoint");
+    expect(reuse.disabled).toBe(true);
+    await click(reuse);
+    expect(onImportModel).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      releaseImport?.();
+    });
+    expect(importStatus()).toContain("Import queued");
+  });
+
+  it("keeps an import error and its Try again through a later successful scan", async () => {
+    const library = libraryStub();
+    const onImportModel = vi.fn(async () => {
+      throw apiError("[checkpoint-plan:unrunnable-source] no loader", {
+        code: "checkpoint_library_rejected",
+        reason: "unrunnable-source",
+      });
+    });
+    await render({ library, onImportModel });
+    await click(buttonNamed("Use this checkpoint"));
+    expect(importStatus()).toContain("[checkpoint-plan:unrunnable-source]");
+
+    await click(buttonNamed("Rescan library"));
+    // The scan succeeded and said so on its OWN track; the import's failure is still on screen and
+    // still actionable.
+    expect(importStatus()).toContain("[checkpoint-plan:unrunnable-source]");
+    expect(buttonNamed("Try again")).toBeTruthy();
+  });
+
+  // "Try again" re-POSTs `lastAttempt`. Gating it on any error tone meant a LIBRARY failure that
+  // happened after a perfectly successful import offered to re-send that import.
+  it("does not offer Try again beside a library failure after a successful import", async () => {
+    const library = libraryStub({
+      update: vi.fn(async () => {
+        throw apiError("[checkpoint-plan:root-unavailable] /gone is not there", {
+          code: "checkpoint_library_rejected",
+          reason: "root-unavailable",
+        });
+      }),
+    });
+    const onImportModel = vi.fn(async () => ({ payload: { modelId: "m" } }));
+    await render({ library, onImportModel, pickFolder: null });
+
+    await click(buttonNamed("Use this checkpoint"));
+    expect(importStatus()).toContain("Import queued");
+    expect(buttonNamed("Try again")).toBeFalsy();
+
+    await type(labelled("Library folder"), "/gone");
+    await click(buttonNamed("Relink library"));
+    expect(libraryStatus()).toContain("[checkpoint-plan:root-unavailable]");
+    // The import track still reads "queued", so there is nothing to retry.
+    expect(importStatus()).toContain("Import queued");
+    expect(buttonNamed("Try again")).toBeFalsy();
+  });
+
+  it("still offers Try again on the import's own error while a library message is showing", async () => {
+    const onImportModel = vi.fn(async () => {
+      throw apiError("[checkpoint-plan:unrunnable-source] no loader", {
+        code: "checkpoint_library_rejected",
+        reason: "unrunnable-source",
+      });
+    });
+    await render({ onImportModel });
+    await click(buttonNamed("Use this checkpoint"));
+    await click(buttonNamed("Remove library"));
+    expect(libraryStatus()).toMatch(/Your files were not touched/);
+    expect(buttonNamed("Try again")).toBeTruthy();
+  });
+
+  it("imports the RENDERED root, not one whose scan is still in flight", async () => {
+    const SECOND = { rootId: "root-b", path: "/Volumes/Other", label: "", displayLabel: "Other" };
+    let releaseSecond;
+    const library = libraryStub({
+      fetchRoots: vi.fn(async () => ({ roots: [ROOT, SECOND] })),
+      scan: vi.fn(async (_token, rootId) => {
+        if (rootId === "root-b") {
+          await new Promise((resolve) => {
+            releaseSecond = resolve;
+          });
+          return readyScan({ root: SECOND });
+        }
+        return readyScan();
+      }),
+    });
+    const onImportModel = vi.fn(async () => ({ payload: { modelId: "m" } }));
+    await render({ library, onImportModel });
+
+    // Start root-b's scan; `activeRootId` moves to root-b immediately while root-b's answer is
+    // still pending.
+    const rescanButtons = [...container.querySelectorAll("button")].filter((node) => node.textContent === "Rescan library");
+    await click(rescanButtons[1]);
+    // Nothing from the stale root is rendered any more, so there is no wrong-root candidate to
+    // click at all.
+    expect(buttonNamed("Use this checkpoint")).toBeFalsy();
+
+    await act(async () => {
+      releaseSecond?.();
+    });
+    await click(buttonNamed("Use this checkpoint"));
+    expect(onImportModel.mock.calls[0][0].linkedRootId).toBe("root-b");
+  });
+
+  // The candidate actions act on the root the RENDERED scan names, not on whatever id the panel
+  // last asked about. The scan is the authority on which root its candidates belong to.
+  it("acts on the root the rendered scan names, not the id the panel last requested", async () => {
+    const canonical = { rootId: "root-a-canonical", path: "/Volumes/Models", displayLabel: "Models" };
+    const library = libraryStub({
+      scan: vi.fn(async () =>
+        readyScan({
+          root: canonical,
+          candidates: [
+            {
+              checkpointId: "linked/root-a/drifted.safetensors",
+              candidate: { relativePath: "drifted.safetensors" },
+              status: { checkpointId: "linked/root-a/drifted.safetensors", rootId: "root-a-canonical", relativePath: "drifted.safetensors", state: "needs_rescan", detail: "[checkpoint-plan:source-drifted] digests differ" },
+              selectable: false,
+            },
+            {
+              checkpointId: "linked/root-a/sdxl.safetensors",
+              candidate: { relativePath: "sdxl.safetensors" },
+              status: { checkpointId: "linked/root-a/sdxl.safetensors", rootId: "root-a-canonical", relativePath: "sdxl.safetensors", state: "ready", detail: null },
+              selectable: true,
+            },
+          ],
+        }),
+      ),
+    });
+    const onImportModel = vi.fn(async () => ({ payload: { modelId: "m" } }));
+    await render({ library, onImportModel });
+
+    await click(buttonNamed("Rescan checkpoint"));
+    expect(library.rescan).toHaveBeenCalledWith("tok", "root-a-canonical", "drifted.safetensors");
+
+    await click(buttonNamed("Use this checkpoint"));
+    expect(onImportModel.mock.calls[0][0].linkedRootId).toBe("root-a-canonical");
+  });
+
+  // The panel's lifecycle actions change the same records the host screen's catalog renders, so
+  // each one tells the host to re-read them.
+  it("asks the host to refresh its catalog after relink, forget and rescan", async () => {
+    const onRefreshCatalog = vi.fn();
+    const library = libraryStub({
+      scan: vi.fn(async () => readyScan({ unmatched: [{ checkpointId: "c", rootId: "root-a", relativePath: "gone.safetensors", state: "needs_rescan", detail: null }] })),
+    });
+    await render({ library, onRefreshCatalog, pickFolder: null });
+    await type(labelled("Library folder"), "/Volumes/Moved");
+    await click(buttonNamed("Relink library"));
+    expect(onRefreshCatalog).toHaveBeenCalledTimes(1);
+    await click(buttonNamed("Rescan checkpoint"));
+    expect(onRefreshCatalog).toHaveBeenCalledTimes(2);
+    await click(buttonNamed("Remove library"));
+    expect(onRefreshCatalog).toHaveBeenCalledTimes(3);
   });
 
   it("labels every region and announces outcomes in a live region", async () => {

--- a/apps/web/src/hooks/useModelsAndLoras.js
+++ b/apps/web/src/hooks/useModelsAndLoras.js
@@ -241,9 +241,14 @@ export function useModelsAndLoras({
       // multipart field names (e.g. `type`, not `modelType`) or the value is silently dropped
       // and the import defaults to `image` (sc-14020).
       Object.entries(metadata).forEach(([key, value]) => {
-        if (value != null && value !== "") {
-          body.append(key, value);
+        if (value == null || value === "") {
+          return;
         }
+        // The multipart parser reads `source` as a JSON DOCUMENT (models.rs
+        // `model_import_request_from_multipart` runs `serde_json::from_str` on it), so an object
+        // appended verbatim would arrive as the literal "[object Object]" and be refused as an
+        // invalid import source. Every other field is a scalar and is unchanged (epic 20398).
+        body.append(key, typeof value === "object" && !(value instanceof Blob) ? JSON.stringify(value) : value);
       });
       body.append("file", file);
     } else {

--- a/apps/web/src/main.testSupport.jsx
+++ b/apps/web/src/main.testSupport.jsx
@@ -264,8 +264,33 @@ export function familyFilter(container) {
   return container.querySelector(".models-family-select");
 }
 
+// The unified checkpoint-import panel (epic 20398, sc-20650) replaced the old standalone
+// "Import model" form. It opens COLLAPSED and leads with the linked-library choice, so a test that
+// wants the managed (upload / URL / HF / Civitai) form has to open the disclosure and pick
+// "Add to SceneWorks" first — `openModelImportPanel` does both. `modelImportPanel` returns the
+// managed form once it is on screen, and null when the whole section is absent.
 export function modelImportPanel(container) {
-  return container.querySelector("form[aria-label='Import model']");
+  return container.querySelector("form[aria-label='Add to SceneWorks']");
+}
+
+export function checkpointImportSection(container) {
+  return container.querySelector(".model-import-panel-section");
+}
+
+export async function openModelImportPanel(container, act) {
+  const section = checkpointImportSection(container);
+  if (!section) return null;
+  const toggle = section.querySelector(".checkpoint-import-toggle");
+  if (toggle?.getAttribute("aria-expanded") === "false") {
+    await act(async () => toggle.click());
+  }
+  const managed = [...section.querySelectorAll('[role="radio"]')].find((node) =>
+    node.textContent.startsWith("Add to SceneWorks"),
+  );
+  if (managed && managed.getAttribute("aria-checked") === "false") {
+    await act(async () => managed.click());
+  }
+  return modelImportPanel(container);
 }
 
 export function buttonInside(scope, label) {

--- a/apps/web/src/modelCapabilities.js
+++ b/apps/web/src/modelCapabilities.js
@@ -1,0 +1,39 @@
+// Capability descriptors shown as chips on a model card. With models grouped by `type`, the chips
+// are what tell the user what a card actually does (plain text-to-image vs editing vs character
+// reference, etc.). Unknown keys fall back to a humanized form so a new capability still reads
+// sensibly without a code change.
+//
+// Extracted from ModelManagerScreen (epic 20398, sc-20650) so the checkpoint-import panel can show
+// the SAME chips for a checkpoint the user is about to select, rather than a second, drifting copy.
+export const CAPABILITY_LABELS = {
+  text_to_image: "Text to Image",
+  image_to_image: "Image to Image",
+  edit_image: "Image Edit",
+  character_image: "Character",
+  vqa: "Visual Q&A",
+  interleave: "Interleaved",
+  image_to_video: "Image to Video",
+  text_to_video: "Text to Video",
+  // sc-8445: Krea Realtime advertises text/image/video-to-video, and without this row its third
+  // chip fell to the humanized fallback ("video to video") — visibly out of style beside the two
+  // title-cased siblings on the same card.
+  video_to_video: "Video to Video",
+  first_last_frame: "First / Last Frame",
+  extend_clip: "Extend Clip",
+  video_bridge: "Video Bridge",
+  replace_person: "Replace Person",
+};
+
+// Modes the app has retired. A stale imported/catalog record may still carry the token; turning it
+// back into a visible affordance would advertise something no studio can run.
+export const RETIRED_MODEL_CAPABILITIES = new Set(["style_variations"]);
+
+export function capabilityLabel(capability) {
+  return CAPABILITY_LABELS[capability] ?? String(capability).replaceAll("_", " ");
+}
+
+// The live capability chips for a catalog row, retired tokens dropped.
+export function modelCapabilityChips(model) {
+  const capabilities = Array.isArray(model?.capabilities) ? model.capabilities : [];
+  return capabilities.filter((capability) => !RETIRED_MODEL_CAPABILITIES.has(capability)).map(capabilityLabel);
+}

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -42,6 +42,22 @@ import {
 import { hostMemoryGbForBackend } from "../hostMemory.js";
 import { tierLabel } from "../quantTier.js";
 import { blanketFloorGb, suggestTier, tierFits } from "../tierSuggestion.js";
+import { RETIRED_MODEL_CAPABILITIES, capabilityLabel } from "../modelCapabilities.js";
+import { CheckpointImportPanel } from "../components/CheckpointImportPanel.jsx";
+import {
+  describeRefusal,
+  fetchLibraryRoots,
+  linkedCorrection,
+  linkedStatusIndex,
+  modelLinkedStatus,
+  modelOwnership,
+  modelProvenance,
+  removalCopy,
+  rescanLibraryCheckpoint,
+  scanLibraryRoot,
+  updateLibraryRoot,
+} from "../checkpointLibrary.js";
+import { isDesktop, tauriInvoke } from "../runtime.js";
 
 function matchesFamily(item, familyFilter) {
   if (familyFilter === "all") {
@@ -132,12 +148,6 @@ function mlxStatusText(model) {
   }
 }
 
-const MODEL_TYPE_OPTIONS = [
-  { value: "image", label: "Image" },
-  { value: "video", label: "Video" },
-  { value: "audio", label: "Audio" },
-  { value: "utility", label: "Utility" },
-];
 const MODEL_TAB_TYPES = [
   ["image", "Image Models"],
   ["video", "Video Models"],
@@ -156,34 +166,6 @@ const MODEL_TAB_TYPES = [
 // an accepted one queues a `model_import` job whose completion refetches the catalog and
 // surfaces the new `catalogScope:"user"` model (a Krea 2 base checkpoint today).
 const MODEL_IMPORT_ENABLED = true;
-
-// Capability descriptors shown as chips on each model card. With models now grouped
-// by `type`, the chips are what tell the user what a card actually does (plain
-// text-to-image vs editing vs character reference, etc.). Unknown keys fall back to
-// a humanized form so a new capability still reads sensibly without a code change.
-const CAPABILITY_LABELS = {
-  text_to_image: "Text to Image",
-  image_to_image: "Image to Image",
-  edit_image: "Image Edit",
-  character_image: "Character",
-  vqa: "Visual Q&A",
-  interleave: "Interleaved",
-  image_to_video: "Image to Video",
-  text_to_video: "Text to Video",
-  // sc-8445: Krea Realtime advertises text/image/video-to-video, and without this row its third
-  // chip fell to the humanized fallback ("video to video") — visibly out of style beside the two
-  // title-cased siblings on the same card.
-  video_to_video: "Video to Video",
-  first_last_frame: "First / Last Frame",
-  extend_clip: "Extend Clip",
-  video_bridge: "Video Bridge",
-  replace_person: "Replace Person",
-};
-const RETIRED_MODEL_CAPABILITIES = new Set(["style_variations"]);
-
-function capabilityLabel(capability) {
-  return CAPABILITY_LABELS[capability] ?? String(capability).replaceAll("_", " ");
-}
 
 // Audio capability chips (epic 13400 / sc-13406): audio-type models describe what they
 // do through the manifest `audio` sub-block rather than the generic `capabilities[]`, so
@@ -568,6 +550,7 @@ export function ModelManagerScreen() {
   const {
     activeProject,
     jobs,
+    token = "",
     loras,
     models,
     jobAction,
@@ -642,19 +625,6 @@ export function ModelManagerScreen() {
   const [loraEditSuggestions, setLoraEditSuggestions] = useState([]);
   const [savingLora, setSavingLora] = useState(false);
   const [loraEditError, setLoraEditError] = useState("");
-  const [importingModel, setImportingModel] = useState(false);
-  const [modelImportMessage, setModelImportMessage] = useState({ tone: "neutral", text: "" });
-  // Point-at-file import (sc-14020) leads with the file picker; URL stays available via the
-  // segmented toggle. `type` defaults to image — the only importable base checkpoint today.
-  const [modelImportForm, setModelImportForm] = useState({
-    mode: "file",
-    sourceUrl: "",
-    file: null,
-    name: "",
-    type: "image",
-    family: "",
-  });
-  const [modelFileInputKey, setModelFileInputKey] = useState(0);
   const [deletingItem, setDeletingItem] = useState("");
   const [deleteMessage, setDeleteMessage] = useState({ tone: "neutral", text: "" });
   // Resolved-model hot cache (epic 19703, sc-19711). ONE status read backs every card's local-copy
@@ -663,6 +633,11 @@ export function ModelManagerScreen() {
   // whatever state the screen happened to open on. A settled cache costs exactly the one mount
   // read it always did, which is what keeps the per-row cost sc-19708 removed from coming back.
   const [modelCache, setModelCache] = useState(null);
+  // Linked-library state for the catalog rows (epic 20398, sc-20650). ONE scan per approved root,
+  // read on mount, indexed by checkpoint id. A card whose linked checkpoint is Needs Relink /
+  // Needs Rescan must show the corrective ACTION — the state comes from this seam and is never
+  // re-derived from a path, and the card must never render such a model as missing.
+  const [linkedStatuses, setLinkedStatuses] = useState(() => new Map());
   // Cache key of the entry whose keep/remove request is in flight, so its buttons disable.
   const [cacheBusyKey, setCacheBusyKey] = useState("");
   // Why the local-copy controls are absent, when they are. Held apart from `deleteMessage` so an
@@ -1012,59 +987,32 @@ export function ModelManagerScreen() {
     }
   }
 
-  async function importModel(event) {
-    event.preventDefault();
-    const isFileImport = modelImportForm.mode === "file";
-    if ((!isFileImport && !modelImportForm.sourceUrl.trim()) || (isFileImport && !modelImportForm.file) || !onImportModel) {
-      return;
-    }
-    setImportingModel(true);
-    setModelImportMessage({
-      tone: "neutral",
-      text: isFileImport ? "Uploading model file before queueing import." : "",
-    });
-    try {
-      const familyOverride = modelImportForm.family ? { family: modelImportForm.family } : {};
-      const job = await onImportModel({
-        ...(isFileImport ? { file: modelImportForm.file } : { sourceUrl: modelImportForm.sourceUrl.trim() }),
-        name: modelImportForm.name.trim() || undefined,
-        // Send the model type under `type` — the literal field name the backend's multipart parser
-        // reads (models.rs `model_import_request_from_multipart`) and that JSON deserialization
-        // accepts via `#[serde(alias = "type")]` on `ModelImportRequest`. Keying this `modelType`
-        // was silently dropped on file uploads (multipart has no serde aliasing), defaulting every
-        // imported checkpoint to `image` regardless of selection (sc-14020).
-        type: modelImportForm.type,
-        ...familyOverride,
-      });
-      const modelId = job?.payload?.modelId;
-      const resolvedFamily = job?.payload?.manifestEntry?.family;
-      const detectionNote =
-        !modelImportForm.family && resolvedFamily
-          ? ` Detected family: ${normalizeLoraFamily(resolvedFamily)}.`
-          : "";
-      setModelImportForm((current) => ({ ...current, sourceUrl: "", file: null, name: "" }));
-      setModelFileInputKey((current) => current + 1);
-      setModelImportMessage({
-        tone: "success",
-        text: `${modelId ? `Model import queued for ${modelId}.` : "Model import queued."}${detectionNote}`,
-      });
-    } catch (err) {
-      setModelImportMessage({ tone: "error", text: err.message });
-    } finally {
-      setImportingModel(false);
-    }
-  }
-
   async function deleteModel(model) {
     if (!onDeleteModel || model.removable === false) {
       return;
     }
+    // Ownership-aware confirmation (epic 20398, sc-20650). A LINKED model's bytes are the user's
+    // own library copy, which this route never owned and never touches; a MANAGED model's bytes
+    // were copied into SceneWorks' storage and really do go away. Those are opposite promises, so
+    // they get opposite words — showing the managed warning over a linked entry would frighten a
+    // user out of a safe removal, and the reverse would lose them files.
+    //
+    // Only a PLAN-BACKED row has a known ownership. A built-in catalog entry, or any row imported
+    // before this epic, keeps the pre-epic sentence: it is the accurate one for a delete whose
+    // teardown is the built-in-identity-preserving sweep, and guessing "managed" over it would
+    // overstate what the delete does.
+    const ownership = modelOwnership(model);
+    const legacyMessage = deleteConfirmation("model", model, recipePresets);
+    const ownershipCopy = ownership ? removalCopy(model) : null;
+    const presetNote = legacyMessage
+      .split("\n\n")
+      .filter((line) => line.startsWith("Referenced by presets:") || line.startsWith("Those presets"));
     // Desktop-safe confirm (sc-12068) — window.confirm no-ops in the Tauri WebView.
     if (
       !(await appConfirm({
-        title: "Delete model?",
-        message: deleteConfirmation("model", model, recipePresets),
-        confirmLabel: "Delete",
+        title: ownershipCopy?.title ?? "Delete model?",
+        message: ownershipCopy ? [ownershipCopy.message, ...presetNote].join("\n\n") : legacyMessage,
+        confirmLabel: ownershipCopy?.confirmLabel ?? "Delete",
         cancelLabel: "Cancel",
         tone: "danger",
       }))
@@ -1174,11 +1122,8 @@ export function ModelManagerScreen() {
   const pendingLoraImportJobs = jobs.filter((job) => job.type === "lora_import" && !isSupersededLoraImport(job, completedImportTimes));
   const localLoraImportJobs = pendingLoraImportJobs.filter((job) => job.status !== "completed" && matchesFamily(job, familyFilter));
   const pendingModelImportJobs = jobs.filter((job) => job.type === "model_import" && job.status !== "completed");
-  const isModelFileImport = modelImportForm.mode === "file";
-  const modelImportDisabled =
-    importingModel ||
-    !onImportModel ||
-    (isModelFileImport ? !modelImportForm.file : !modelImportForm.sourceUrl.trim());
+  // Completed imports, for the duplicate-checkpoint warning the job result carries (sc-20650).
+  const completedModelImportJobs = jobs.filter((job) => job.type === "model_import" && job.status === "completed");
   const hiddenImportCount =
     familyFilter === "all" ? 0 : pendingLoraImportJobs.filter((job) => job.status !== "completed" && !matchesFamily(job, familyFilter)).length;
   const isFileImport = importForm.mode === "file";
@@ -1208,6 +1153,88 @@ export function ModelManagerScreen() {
   const loraGroups = [...loraGroupMap.entries()]
     .sort(([a], [b]) => (a === "compatible" ? 1 : b === "compatible" ? -1 : a.localeCompare(b)))
     .map(([family, items]) => ({ family, items }));
+
+  // Re-read every approved root's scan. Called after a relink or a rescan so the card's verdict is
+  // the seam's fresh answer rather than an optimistic local flip.
+  const refreshLinkedStatuses = useCallback(async () => {
+    try {
+      const response = await fetchLibraryRoots(token);
+      const roots = Array.isArray(response?.roots) ? response.roots : [];
+      if (roots.length === 0) {
+        setLinkedStatuses(new Map());
+        return;
+      }
+      const scans = await Promise.all(roots.map((root) => scanLibraryRoot(token, root.rootId).catch(() => null)));
+      setLinkedStatuses(linkedStatusIndex(scans.filter(Boolean)));
+    } catch {
+      // See the mount effect: an enrichment read, silent by design.
+    }
+  }, [token]);
+
+  // The two corrective actions a non-Ready linked card offers. Both surface the store's own typed
+  // refusal on failure — `describeRefusal` has no generic branch, so a rejection the user has to
+  // act on can never arrive as "something went wrong".
+  async function relinkLinkedModel(status) {
+    const picked = isDesktop ? await tauriInvoke("choose_folder").catch(() => null) : null;
+    if (!picked) {
+      setDeleteMessage({
+        tone: "error",
+        text: isDesktop
+          ? "Choose the folder this library lives in now."
+          : "Relinking a library names a folder on the host, so it has to be done from SceneWorks on that machine.",
+      });
+      return;
+    }
+    setDeletingItem(`relink:${status.checkpointId}`);
+    try {
+      await updateLibraryRoot(token, status.rootId, { path: String(picked) });
+      await refreshLinkedStatuses();
+      setDeleteMessage({ tone: "success", text: "Library relinked. Its models are selectable again." });
+    } catch (error) {
+      setDeleteMessage({ tone: "error", text: describeRefusal(error).message });
+    } finally {
+      setDeletingItem("");
+    }
+  }
+
+  async function rescanLinkedModel(status) {
+    setDeletingItem(`rescan:${status.checkpointId}`);
+    try {
+      const next = await rescanLibraryCheckpoint(token, status.rootId, status.relativePath);
+      await refreshLinkedStatuses();
+      setDeleteMessage(
+        next?.state === "ready"
+          ? { tone: "success", text: `${status.relativePath} is usable again.` }
+          : { tone: "error", text: next?.detail || `${status.relativePath} still cannot be used.` },
+      );
+    } catch (error) {
+      setDeleteMessage({ tone: "error", text: describeRefusal(error).message });
+    } finally {
+      setDeletingItem("");
+    }
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await fetchLibraryRoots(token);
+        const roots = Array.isArray(response?.roots) ? response.roots : [];
+        if (roots.length === 0 || cancelled) return;
+        const scans = await Promise.all(
+          roots.map((root) => scanLibraryRoot(token, root.rootId).catch(() => null)),
+        );
+        if (!cancelled) setLinkedStatuses(linkedStatusIndex(scans.filter(Boolean)));
+      } catch {
+        // A deployment with no linked libraries answers here; the cards simply keep their ordinary
+        // install-state rendering. Deliberately silent: this is an enrichment read, and a banner
+        // for it would fire on every install that has never used a linked library.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
 
   function renderModelCard(model) {
     const downloadJobs = downloadJobsFor(model);
@@ -1282,8 +1309,26 @@ export function ModelManagerScreen() {
     const macBlock = macModelBlock(model, macCapabilities);
     // Header install-status badge: warn tones for an incomplete cache, accent for installed,
     // neutral for missing.
-    const statusClass = incomplete ? "status-badge warning" : installed ? "status-badge installed" : "status-badge";
-    const statusText = incomplete ? "incomplete" : installed ? "installed" : "missing";
+    // A linked checkpoint whose library is detached, or whose file drifted, is NOT missing: the
+    // plans are intact and there is exactly one button to press (AC2, epic 20398). Rendering it as
+    // "missing" invites the user to re-download bytes they already own.
+    const linkedStatus = modelLinkedStatus(model, linkedStatuses);
+    const linkedFix = linkedCorrection(linkedStatus);
+    const provenance = modelProvenance(model);
+    const statusClass = linkedFix
+      ? "status-badge warning"
+      : incomplete
+        ? "status-badge warning"
+        : installed
+          ? "status-badge installed"
+          : "status-badge";
+    const statusText = linkedFix
+      ? linkedFix.headline.toLowerCase()
+      : incomplete
+        ? "incomplete"
+        : installed
+          ? "installed"
+          : "missing";
     // Where this model's files actually resolve from, straight off the typed judgement the one
     // shared resolver produced (sc-19708). NEVER re-derived here from paths or error text — that
     // discipline is the whole reason a second, drifting availability opinion can't exist.
@@ -1355,6 +1400,30 @@ export function ModelManagerScreen() {
           <p className="model-card-attribution">{model.ui.attribution}</p>
         ) : null}
         <p className="model-card-description">{model.ui?.description ?? model.family ?? model.id}</p>
+        {provenance ? (
+          <p className="model-card-provenance">
+            Source: {provenance.label}
+            {provenance.reference ? ` · ${provenance.reference}` : ""}
+          </p>
+        ) : null}
+        {linkedFix ? (
+          <div
+            aria-label={`${model.name ?? model.id} ${linkedFix.headline}`}
+            className="model-card-linked-fix"
+            role="group"
+          >
+            <p className="checkpoint-state-headline">{linkedFix.headline}</p>
+            <p>{linkedFix.summary}</p>
+            {linkedFix.detail ? <p className="checkpoint-import-detail">{linkedFix.detail}</p> : null}
+            <button
+              disabled={deletingItem === `relink:${linkedStatus.checkpointId}` || deletingItem === `rescan:${linkedStatus.checkpointId}`}
+              onClick={() => (linkedFix.action === "relink" ? relinkLinkedModel(linkedStatus) : rescanLinkedModel(linkedStatus))}
+              type="button"
+            >
+              {linkedFix.label}
+            </button>
+          </div>
+        ) : null}
         {capabilities.length ? (
           <ul className="model-capabilities">
             {capabilities.map((capability) => (
@@ -1928,127 +1997,20 @@ export function ModelManagerScreen() {
       return null;
     }
     return (
-      <section className="model-import-panel-section">
-        {MODEL_IMPORT_ENABLED && (
-          <form className="models-accent-band models-import-panel" aria-label="Import model" onSubmit={importModel}>
-            <div className="models-accent-band-head">
-              <span className="models-accent-dot" aria-hidden="true" />
-              <p className="eyebrow">Import model</p>
-              <span className="models-accent-band-caption">
-                Point at a base checkpoint file — auto-detects family (Krea 2 today)
-              </span>
-            </div>
-            <div className="segmented-control compact-segment" aria-label="Model import source">
-              <button
-                className={modelImportForm.mode === "url" ? "active" : ""}
-                disabled={importingModel}
-                onClick={() => setModelImportForm((current) => ({ ...current, mode: "url" }))}
-                type="button"
-              >
-                URL
-              </button>
-              <button
-                className={modelImportForm.mode === "file" ? "active" : ""}
-                disabled={importingModel}
-                onClick={() => setModelImportForm((current) => ({ ...current, mode: "file" }))}
-                type="button"
-              >
-                Upload
-              </button>
-            </div>
-            <div className="models-import-grid">
-              <label>
-                Type
-                {/* Base-checkpoint import only produces image models today (a Krea 2 DiT).
-                    `queue_model_import_job` (models.rs) writes this type verbatim into the
-                    user manifest and never reconciles it against the detected family, so
-                    offering video/audio/utility here would let an image checkpoint be
-                    mis-typed. Constrain to Image (disabled) until more base-checkpoint types
-                    are importable, then drop the image-only filter to restore the full
-                    MODEL_TYPE_OPTIONS selector (sc-14020). */}
-                <select disabled value={modelImportForm.type} aria-readonly="true">
-                  {MODEL_TYPE_OPTIONS.filter((option) => option.value === "image").map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label>
-                Family
-                <select
-                  disabled={importingModel || !families.length}
-                  onChange={(event) => setModelImportForm((current) => ({ ...current, family: event.target.value }))}
-                  value={modelImportForm.family}
-                >
-                  {families.length ? (
-                    <>
-                      <option value="">Auto-detect</option>
-                      {families.map((family) => (
-                        <option key={family} value={family}>
-                          {family}
-                        </option>
-                      ))}
-                    </>
-                  ) : (
-                    <option value="">No known families</option>
-                  )}
-                </select>
-              </label>
-              {isModelFileImport ? (
-                <label>
-                  Model File
-                  <span className="file-picker-row">
-                    <span className="file-upload-button">
-                      Choose
-                      <input
-                        accept=".safetensors,.ckpt,.pt,.bin"
-                        disabled={importingModel}
-                        key={modelFileInputKey}
-                        onChange={(event) => setModelImportForm((current) => ({ ...current, file: event.target.files?.[0] ?? null }))}
-                        type="file"
-                      />
-                    </span>
-                    <span className="selected-file-name">{modelImportForm.file?.name ?? "No file selected"}</span>
-                  </span>
-                </label>
-              ) : (
-                <label>
-                  Source URL
-                  <input
-                    disabled={importingModel}
-                    onChange={(event) => setModelImportForm((current) => ({ ...current, sourceUrl: event.target.value }))}
-                    placeholder="https://..."
-                    value={modelImportForm.sourceUrl}
-                  />
-                </label>
-              )}
-              <label>
-                Name
-                <input
-                  disabled={importingModel}
-                  onChange={(event) => setModelImportForm((current) => ({ ...current, name: event.target.value }))}
-                  placeholder="Optional"
-                  value={modelImportForm.name}
-                />
-              </label>
-              <button disabled={modelImportDisabled} type="submit">
-                {importingModel ? (isModelFileImport ? "Uploading" : "Queueing...") : "Queue Import"}
-              </button>
-            </div>
-            {modelImportMessage.text ? <p className={modelImportMessage.tone === "success" ? "inline-success" : "inline-warning"}>{modelImportMessage.text}</p> : null}
-          </form>
-        )}
-        {pendingModelImportJobs.length ? (
-          <div className="lora-import-progress">
-            <strong>Model imports in progress</strong>
-            <div className="local-job-stack">
-              {pendingModelImportJobs.map((job) => (
-                <WorkerProgressCard job={job} key={job.id} onCancel={onCancelJob} onOpenQueue={onOpenQueue} />
-              ))}
-            </div>
-          </div>
-        ) : null}
+      <section className="model-import-panel-section models-accent-band">
+        <CheckpointImportPanel
+          completedJobs={completedModelImportJobs}
+          credentials={credentials}
+          families={families}
+          macCapabilities={macCapabilities}
+          models={models}
+          onCancelJob={onCancelJob}
+          onImportModel={onImportModel}
+          onOpenQueue={onOpenQueue}
+          onRetryJob={(job, payload) => onResumeDownloadJob(job, payload)}
+          pendingJobs={pendingModelImportJobs}
+          token={token}
+        />
       </section>
     );
   }

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -673,7 +673,9 @@ export function ModelManagerScreen() {
   const [pendingUpdate, setPendingUpdate] = useState({});
   // Gated-model credential presence (sc-1898): only fetched when the catalog has a
   // gated model, so non-gated deployments make no extra credential request.
-  const [credentials, setCredentials] = useState([]);
+  // `null` until the keychain is actually read: the import panel distinguishes "no credential" from
+  // "never looked", and starting at `[]` would flash "no credential is stored" before the answer.
+  const [credentials, setCredentials] = useState(null);
   // Per-model license acknowledgments (sc-7872), seeded from localStorage so a
   // returning user keeps prior accepts. Keyed by model id; toggling the gated
   // notice checkbox both updates this map and persists to localStorage.
@@ -752,8 +754,12 @@ export function ModelManagerScreen() {
     );
   }, [importForm.family]);
 
+  // The import panel's managed pane offers civitai.com and Hugging Face sources on EVERY catalog,
+  // gated or not, and it has to say whether a credential for the chosen host is stored. Keying this
+  // read on `hasGatedModel` alone made the panel report "no credential is stored" on an ordinary
+  // catalog even when one was — so the read also runs whenever the panel is mounted.
   useEffect(() => {
-    if (!hasGatedModel) {
+    if (!hasGatedModel && !MODEL_IMPORT_ENABLED) {
       return undefined;
     }
     let cancelled = false;
@@ -2007,6 +2013,11 @@ export function ModelManagerScreen() {
           onCancelJob={onCancelJob}
           onImportModel={onImportModel}
           onOpenQueue={onOpenQueue}
+          // Relink / forget / rescan from inside the panel change the SAME linked statuses the
+          // catalog cards render; without this the cards keep saying "Needs relink" after the
+          // panel has already fixed it.
+          onOpenSettings={() => setActiveView("Settings")}
+          onRefreshCatalog={refreshLinkedStatuses}
           onRetryJob={(job, payload) => onResumeDownloadJob(job, payload)}
           pendingJobs={pendingModelImportJobs}
           token={token}

--- a/apps/web/src/screens/ModelManagerScreen.linkedOwnership.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.linkedOwnership.test.jsx
@@ -35,6 +35,12 @@ vi.mock("../checkpointLibrary.js", async (importOriginal) => {
 const appConfirm = vi.fn(async () => true);
 vi.mock("../appConfirm.jsx", () => ({ appConfirm: (...args) => appConfirm(...args) }));
 
+const loadCredentials = vi.fn(async () => []);
+vi.mock("../credentials.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, loadCredentials: (...args) => loadCredentials(...args) };
+});
+
 const LINKED_MODEL = {
   id: "my_sdxl",
   name: "My SDXL",
@@ -81,6 +87,8 @@ describe("ModelManagerScreen linked state and ownership-aware removal (sc-20650)
     update.mockResolvedValue({ rootId: "root-a" });
     scanResult.mockReset();
     scanResult.mockReturnValue({ root: { rootId: "root-a" }, available: true, candidates: [], unmatched: [], diagnostics: [] });
+    loadCredentials.mockReset();
+    loadCredentials.mockResolvedValue([]);
     deleteModel = vi.fn(async () => ({ removedManifestEntry: true }));
     window.__TAURI__ = { core: { invoke: vi.fn(async () => "/Volumes/Moved") } };
     vi.resetModules();
@@ -219,6 +227,48 @@ describe("ModelManagerScreen linked state and ownership-aware removal (sc-20650)
     expect(copy.confirmLabel).toBe("Delete");
     expect(copy.message).toMatch(/removes those files from this machine/);
     expect(copy.message).not.toMatch(/never opened, moved or deleted/);
+  });
+
+  // The panel and the catalog cards read the SAME linked statuses. A relink performed inside the
+  // panel therefore has to re-read them for the cards too, or the card keeps saying "Needs relink"
+  // about a library that is attached again.
+  it("refreshes the catalog cards after a relink performed inside the import panel", async () => {
+    scanResult.mockReturnValue({
+      root: { rootId: "root-a" },
+      available: false,
+      candidates: [],
+      unmatched: [statusFor("needs_relink", "[checkpoint-plan:root-unavailable] not there")],
+      diagnostics: [],
+    });
+    await render([LINKED_MODEL]);
+    expect(card("My SDXL").querySelector('[role="group"][aria-label="My SDXL Needs relink"]')).toBeTruthy();
+
+    const panel = container.querySelector(".checkpoint-import");
+    await click(buttonIn(panel, "Add a model"));
+    await act(async () => {});
+    // The relink succeeds and the library comes back attached.
+    scanResult.mockReturnValue({ root: { rootId: "root-a" }, available: true, candidates: [], unmatched: [], diagnostics: [] });
+    await click(buttonIn(container.querySelector(".checkpoint-import"), "Relink library"));
+    await act(async () => {});
+
+    expect(update).toHaveBeenCalledWith("tok", "root-a", { path: "/Volumes/Moved" });
+    expect(card("My SDXL").querySelector('[role="group"][aria-label="My SDXL Needs relink"]')).toBeNull();
+  });
+
+  // The panel's managed pane offers civitai.com / Hugging Face on EVERY catalog, so the credential
+  // read cannot be keyed on the catalog happening to contain a gated model.
+  it("reads credentials on an ungated catalog so the panel does not misreport them", async () => {
+    loadCredentials.mockResolvedValue([{ host: "civitai.com", present: true }]);
+    // No `gated` model anywhere: pre-fix this catalog never made the keychain call at all.
+    await render([LINKED_MODEL]);
+    const panel = container.querySelector(".checkpoint-import");
+    await click(buttonIn(panel, "Add a model"));
+    await act(async () => {});
+    await click([...container.querySelectorAll('[role="radio"]')].find((node) => node.textContent.startsWith("Add to SceneWorks")));
+    await click(buttonIn(container.querySelector(".checkpoint-import"), "Civitai"));
+    expect(loadCredentials).toHaveBeenCalled();
+    const notice = container.querySelector(".checkpoint-credential-notice");
+    expect(notice.textContent).toMatch(/A civitai\.com credential is stored/);
   });
 
   it("leaves a row with no import plan on the pre-epic confirmation", async () => {

--- a/apps/web/src/screens/ModelManagerScreen.linkedOwnership.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.linkedOwnership.test.jsx
@@ -1,0 +1,232 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// AC2 on the CATALOG CARD (epic 20398, sc-20650).
+//
+// Two claims, both of which the pre-epic screen got wrong by construction because it had no way to
+// know a checkpoint's ownership:
+//
+//   1. A linked checkpoint whose library is detached, or whose file drifted, must render its
+//      CORRECTIVE ACTION — "Needs relink" / "Needs rescan" with the button that clears it — not the
+//      "missing" badge every uninstalled row gets. A user shown "missing" re-downloads bytes they
+//      already own on a drive they only have to plug in.
+//   2. Deleting a LINKED row and deleting a MANAGED row promise opposite things, so they must say
+//      opposite things. Crossing them is the most damaging copy defect on this screen.
+//
+// The transport is mocked; the pure state→affordance mapping is the real module, so a change to
+// what `linkedCorrection` decides is visible here rather than papered over by a hand-written stub.
+
+const scanResult = vi.fn();
+const rescan = vi.fn();
+const update = vi.fn();
+
+vi.mock("../checkpointLibrary.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    fetchLibraryRoots: vi.fn(async () => ({ roots: [{ rootId: "root-a", path: "/Volumes/Models", displayLabel: "Models" }] })),
+    scanLibraryRoot: vi.fn(async () => scanResult()),
+    rescanLibraryCheckpoint: vi.fn((...args) => rescan(...args)),
+    updateLibraryRoot: vi.fn((...args) => update(...args)),
+  };
+});
+
+const appConfirm = vi.fn(async () => true);
+vi.mock("../appConfirm.jsx", () => ({ appConfirm: (...args) => appConfirm(...args) }));
+
+const LINKED_MODEL = {
+  id: "my_sdxl",
+  name: "My SDXL",
+  type: "image",
+  family: "sdxl",
+  catalogScope: "user",
+  installState: "missing",
+  capabilities: ["text_to_image"],
+  importPlan: { checkpointId: "linked/root-a/sdxl.safetensors" },
+  source: { provider: "linked-library", rootId: "root-a", relativePath: "sdxl.safetensors" },
+  ui: { description: "A checkpoint in my own library." },
+};
+
+const MANAGED_MODEL = {
+  id: "fetched",
+  name: "Fetched Model",
+  type: "image",
+  family: "sdxl",
+  catalogScope: "user",
+  installState: "installed",
+  importPlan: { checkpointId: "managed/install-1" },
+  source: { provider: "civitai", url: "https://civitai.com/x" },
+  ui: { description: "A checkpoint SceneWorks copied in." },
+};
+
+function statusFor(state, detail) {
+  return { checkpointId: "linked/root-a/sdxl.safetensors", rootId: "root-a", relativePath: "sdxl.safetensors", state, detail };
+}
+
+describe("ModelManagerScreen linked state and ownership-aware removal (sc-20650)", () => {
+  let container;
+  let root;
+  let ModelManagerScreen;
+  let AppContext;
+  let deleteModel;
+
+  beforeEach(async () => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    appConfirm.mockClear();
+    appConfirm.mockResolvedValue(true);
+    rescan.mockReset();
+    rescan.mockResolvedValue(statusFor("ready", null));
+    update.mockReset();
+    update.mockResolvedValue({ rootId: "root-a" });
+    scanResult.mockReset();
+    scanResult.mockReturnValue({ root: { rootId: "root-a" }, available: true, candidates: [], unmatched: [], diagnostics: [] });
+    deleteModel = vi.fn(async () => ({ removedManifestEntry: true }));
+    window.__TAURI__ = { core: { invoke: vi.fn(async () => "/Volumes/Moved") } };
+    vi.resetModules();
+    ({ AppContext } = await import("../context/AppContext.js"));
+    ({ ModelManagerScreen } = await import("./ModelManagerScreen.jsx"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    delete window.__TAURI__;
+    vi.restoreAllMocks();
+  });
+
+  async function render(models) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider
+          value={{
+            activeProject: null,
+            jobs: [],
+            loras: [],
+            models,
+            presets: [],
+            token: "tok",
+            jobAction: () => {},
+            setActiveView: () => {},
+            deleteLora: () => {},
+            deleteModel,
+            createModelDownloadJob: () => {},
+            createModelConvertJob: () => {},
+            createLoraImportJob: () => {},
+            createModelImportJob: () => {},
+          }}
+        >
+          <ModelManagerScreen />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  function card(name) {
+    return [...container.querySelectorAll(".model-card")].find((node) => node.textContent.includes(name));
+  }
+
+  function buttonIn(scope, name) {
+    return [...scope.querySelectorAll("button")].find((node) => node.textContent.trim() === name);
+  }
+
+  async function click(node) {
+    expect(node, "the control under test exists").toBeTruthy();
+    await act(async () => node.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+  }
+
+  it("renders Needs relink with a relink button instead of the missing badge", async () => {
+    scanResult.mockReturnValue({
+      root: { rootId: "root-a" },
+      available: false,
+      candidates: [],
+      unmatched: [statusFor("needs_relink", "[checkpoint-plan:root-unavailable] /Volumes/Models is not available")],
+      diagnostics: [],
+    });
+    await render([LINKED_MODEL]);
+    const node = card("My SDXL");
+    const badge = node.querySelector(".model-card-status .status-badge");
+    expect(badge.textContent).toBe("needs relink");
+    expect(node.querySelector(".model-card-status").textContent).not.toContain("missing");
+    const fix = node.querySelector('[role="group"][aria-label="My SDXL Needs relink"]');
+    expect(fix).toBeTruthy();
+    expect(fix.textContent).toContain("[checkpoint-plan:root-unavailable]");
+    expect(buttonIn(fix, "Relink library")).toBeTruthy();
+  });
+
+  it("renders Needs rescan and clears it through the rescan route", async () => {
+    scanResult.mockReturnValue({
+      root: { rootId: "root-a" },
+      available: true,
+      candidates: [
+        {
+          checkpointId: "linked/root-a/sdxl.safetensors",
+          candidate: { relativePath: "sdxl.safetensors" },
+          status: statusFor("needs_rescan", "[checkpoint-plan:source-drifted] digests differ"),
+          selectable: false,
+        },
+      ],
+      unmatched: [],
+      diagnostics: [],
+    });
+    await render([LINKED_MODEL]);
+    const node = card("My SDXL");
+    expect(node.querySelector(".model-card-status .status-badge").textContent).toBe("needs rescan");
+    const fix = node.querySelector('[role="group"][aria-label="My SDXL Needs rescan"]');
+    await click(buttonIn(fix, "Rescan checkpoint"));
+    expect(rescan).toHaveBeenCalledWith("tok", "root-a", "sdxl.safetensors");
+  });
+
+  it("relinks through the library route with the folder the desktop bridge returned", async () => {
+    scanResult.mockReturnValue({
+      root: { rootId: "root-a" },
+      available: false,
+      candidates: [],
+      unmatched: [statusFor("needs_relink", "")],
+      diagnostics: [],
+    });
+    await render([LINKED_MODEL]);
+    await click(buttonIn(card("My SDXL"), "Relink library"));
+    expect(update).toHaveBeenCalledWith("tok", "root-a", { path: "/Volumes/Moved" });
+  });
+
+  it("names the source a plan-backed row was imported from", async () => {
+    await render([LINKED_MODEL, MANAGED_MODEL]);
+    expect(card("My SDXL").querySelector(".model-card-provenance").textContent).toContain("Linked library");
+    expect(card("Fetched Model").querySelector(".model-card-provenance").textContent).toContain("Civitai");
+  });
+
+  it("promises a linked delete never touches the user's files", async () => {
+    await render([LINKED_MODEL]);
+    await click(buttonIn(card("My SDXL"), "Delete"));
+    const copy = appConfirm.mock.calls.at(-1)[0];
+    expect(copy.title).toBe("Remove from SceneWorks?");
+    expect(copy.confirmLabel).toBe("Remove");
+    expect(copy.message).toMatch(/never opened, moved or deleted/);
+    expect(copy.message).not.toMatch(/removes those files from this machine/);
+    expect(deleteModel).toHaveBeenCalled();
+  });
+
+  it("warns that a managed delete removes the files, and says so only there", async () => {
+    await render([MANAGED_MODEL]);
+    await click(buttonIn(card("Fetched Model"), "Delete"));
+    const copy = appConfirm.mock.calls.at(-1)[0];
+    expect(copy.title).toBe("Delete model?");
+    expect(copy.confirmLabel).toBe("Delete");
+    expect(copy.message).toMatch(/removes those files from this machine/);
+    expect(copy.message).not.toMatch(/never opened, moved or deleted/);
+  });
+
+  it("leaves a row with no import plan on the pre-epic confirmation", async () => {
+    // A built-in catalog entry has no ownership to discriminate on; guessing "managed" over it
+    // would overstate what its delete actually does.
+    await render([{ ...MANAGED_MODEL, id: "builtin", name: "Builtin", importPlan: undefined, source: undefined, catalogScope: "builtin" }]);
+    await click(buttonIn(card("Builtin"), "Delete"));
+    const copy = appConfirm.mock.calls.at(-1)[0];
+    expect(copy.message).toContain("Built-in catalog identity stays protected");
+  });
+});

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -298,7 +298,9 @@ describe("ModelManagerScreen gated-model notice", () => {
 
   it("renders no gated notice for a non-gated model", async () => {
     await render([PLAIN_MODEL]);
-    expect(invoke).not.toHaveBeenCalledWith("list_credentials", undefined);
+    // The keychain IS read on every catalog now — the import panel's Civitai / Hugging Face
+    // sources are offered whether or not the catalog holds a gated model (sc-20650). What must
+    // stay absent is the CARD's credential UI.
     expect(container.textContent).not.toContain("Gated download");
     expect(container.querySelector(".model-gated-notice")).toBeNull();
   });
@@ -403,8 +405,9 @@ describe("ModelManagerScreen gated-model notice", () => {
     await render([LICENSE_ACK_ONLY_MODEL]);
     await selectTab(container, "Video Models");
     expect(container.querySelector(".model-gated-notice")).toBeTruthy();
-    // The credential half is entirely absent.
-    expect(invoke).not.toHaveBeenCalledWith("list_credentials", undefined);
+    // The credential half is entirely absent FROM THE CARD. (The keychain read itself is no longer
+    // keyed on the catalog holding a gated model: the import panel's Civitai / Hugging Face sources
+    // need it on every catalog — sc-20650. The card must still show none of it.)
     expect(container.textContent).not.toContain("Gated download");
     expect(container.textContent).not.toContain("Add token in Settings");
     expect(container.textContent).not.toContain("Request access on Hugging Face");

--- a/apps/web/src/simple/SimpleModelManager.checkpointImport.test.jsx
+++ b/apps/web/src/simple/SimpleModelManager.checkpointImport.test.jsx
@@ -19,6 +19,7 @@ describe("SimpleModelManager checkpoint import (sc-20650)", () => {
   let createModelImportJob;
 
   beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
     ({ container, root } = mountRoot());
     createModelImportJob = vi.fn(async () => ({ payload: { modelId: "imported" } }));
   });
@@ -116,6 +117,36 @@ describe("SimpleModelManager checkpoint import (sc-20650)", () => {
     const cancel = [...container.querySelectorAll("button")].find((node) => /cancel/i.test(node.textContent));
     await click(cancel);
     expect(jobAction).toHaveBeenCalledWith(expect.objectContaining({ id: "job-1" }), "cancel");
+  });
+
+  // Simple mounts the SAME panel, so it has to feed it the same inputs. Without a `families` list
+  // the Family select is permanently disabled and reads "No known families" — a reduced copy of the
+  // panel, which is exactly what mounting the shared component is supposed to prevent.
+  it("offers the real family list in the managed pane", async () => {
+    await render({
+      models: [
+        { id: "z", name: "Z-Image", type: "image", installState: "installed", loraCompatibility: { families: ["sdxl"] } },
+        { id: "f", name: "Flux", type: "image", installState: "installed", loraCompatibility: { families: ["flux2"] } },
+      ],
+    });
+    await click(section().querySelector(".checkpoint-import-toggle"));
+    await click([...container.querySelectorAll('[role="radio"]')].find((node) => node.textContent.startsWith("Add to SceneWorks")));
+    const family = [...container.querySelectorAll("label")]
+      .find((node) => node.textContent.trim().startsWith("Family"))
+      .querySelector("select");
+    expect(family.disabled).toBe(false);
+    expect([...family.options].map((option) => option.value)).toEqual(["", "flux2", "sdxl"]);
+  });
+
+  // Simple never reads the keychain, so the panel must not claim a credential is missing on its
+  // behalf. (Simple renders no linked-status badge of its own; its catalog refresh is wired to the
+  // context's `refreshData`, asserted through the panel's own onRefreshCatalog contract.)
+  it("makes no credential claim it never checked", async () => {
+    await render();
+    await click(section().querySelector(".checkpoint-import-toggle"));
+    await click([...container.querySelectorAll('[role="radio"]')].find((node) => node.textContent.startsWith("Add to SceneWorks")));
+    await click(buttonNamed("Civitai"));
+    expect(container.querySelector(".checkpoint-credential-notice")).toBeNull();
   });
 
   it("surfaces a duplicate-checkpoint warning from a completed import", async () => {

--- a/apps/web/src/simple/SimpleModelManager.checkpointImport.test.jsx
+++ b/apps/web/src/simple/SimpleModelManager.checkpointImport.test.jsx
@@ -1,0 +1,127 @@
+import React, { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppContext } from "../context/AppContext.js";
+import { SimpleModelManager } from "./SimpleModelManager.jsx";
+import { SimpleUiContext } from "./SimpleUiContext.js";
+import { mountRoot, unmountRoot } from "../testUtils/dom.js";
+
+// AC1 for the Simple shell (epic 20398, sc-20650): the two ownership choices, the linked-library
+// lifecycle and the five managed inputs must be reachable from Simple as well — not just from the
+// advanced Models screen. Simple hands off almost everything to the advanced shell, so this is the
+// test that keeps the ONE exception honest.
+//
+// Driven through the real component and the real AppContext, with only the library transport and
+// the desktop bridge injected — so what is asserted is what a Simple user can actually reach.
+
+describe("SimpleModelManager checkpoint import (sc-20650)", () => {
+  let container;
+  let root;
+  let createModelImportJob;
+
+  beforeEach(() => {
+    ({ container, root } = mountRoot());
+    createModelImportJob = vi.fn(async () => ({ payload: { modelId: "imported" } }));
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.restoreAllMocks();
+  });
+
+  async function render(context = {}) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider
+          value={{
+            models: [],
+            loras: [],
+            jobs: [],
+            token: "tok",
+            createModelDownloadJob: vi.fn(),
+            createLoraDownloadJob: vi.fn(),
+            createModelImportJob,
+            jobAction: vi.fn(),
+            macCapabilities: {},
+            visibleWorkers: [],
+            workersById: {},
+            ...context,
+          }}
+        >
+          <SimpleUiContext.Provider value={{ toast: vi.fn(), openInAdvanced: vi.fn() }}>
+            <SimpleModelManager />
+          </SimpleUiContext.Provider>
+        </AppContext.Provider>,
+      );
+    });
+  }
+
+  function section() {
+    return container.querySelector(".checkpoint-import");
+  }
+
+  async function click(node) {
+    expect(node, "the control under test exists").toBeTruthy();
+    await act(async () => node.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+  }
+
+  function buttonNamed(name) {
+    return [...container.querySelectorAll("button")].find((node) => node.textContent.trim() === name);
+  }
+
+  it("offers the two ownership choices from Simple, collapsed until asked", async () => {
+    await render();
+    expect(section()).toBeTruthy();
+    expect(section().classList.contains("compact")).toBe(true);
+    const toggle = section().querySelector(".checkpoint-import-toggle");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    // Collapsed means the catalog is still the page's subject.
+    expect(container.querySelector('[role="radiogroup"]')).toBeNull();
+
+    await click(toggle);
+    const choices = [...container.querySelectorAll('[aria-label="Model ownership"] [role="radio"]')];
+    expect(choices.map((node) => node.querySelector(".checkpoint-ownership-label").textContent)).toEqual([
+      "Use existing model library",
+      "Add to SceneWorks",
+    ]);
+  });
+
+  it("reaches all five managed inputs from Simple", async () => {
+    await render();
+    await click(section().querySelector(".checkpoint-import-toggle"));
+    await click([...container.querySelectorAll('[role="radio"]')].find((node) => node.textContent.startsWith("Add to SceneWorks")));
+    const sources = container.querySelector('[aria-label="Where the checkpoint comes from"]');
+    expect([...sources.querySelectorAll('[role="radio"]')].map((node) => node.textContent)).toEqual([
+      "Upload",
+      "Local copy",
+      "URL",
+      "Hugging Face",
+      "Civitai",
+    ]);
+  });
+
+  it("keeps the catalog rows Simple already had", async () => {
+    await render({ models: [{ id: "z", name: "Z-Image", type: "image", installState: "installed" }] });
+    expect(container.textContent).toContain("Z-Image");
+    expect(buttonNamed("Manage")).toBeTruthy();
+  });
+
+  it("shows a running import and its cancel control without opening the disclosure", async () => {
+    const jobAction = vi.fn();
+    await render({
+      jobs: [{ id: "job-1", type: "model_import", status: "running", payload: { modelId: "m" } }],
+      jobAction,
+    });
+    expect(section().querySelector(".checkpoint-import-toggle").getAttribute("aria-expanded")).toBe("false");
+    expect(container.textContent).toContain("Imports in progress");
+    const cancel = [...container.querySelectorAll("button")].find((node) => /cancel/i.test(node.textContent));
+    await click(cancel);
+    expect(jobAction).toHaveBeenCalledWith(expect.objectContaining({ id: "job-1" }), "cancel");
+  });
+
+  it("surfaces a duplicate-checkpoint warning from a completed import", async () => {
+    await render({
+      jobs: [{ id: "job-2", type: "model_import", status: "completed", result: { duplicateCheckpointIds: ["managed/i-1"] } }],
+    });
+    expect(container.querySelector(".checkpoint-duplicate-warning").textContent).toContain("managed/i-1");
+  });
+});

--- a/apps/web/src/simple/SimpleModelManager.jsx
+++ b/apps/web/src/simple/SimpleModelManager.jsx
@@ -8,6 +8,7 @@ import {
   borrowedLicenseAcknowledgmentBlocked,
   licenseAcknowledgmentBlocked,
 } from "../licenseAcknowledgment.js";
+import { modelLoraFamilies } from "../presetUtils.js";
 import { blanketFloorGb, declaredFloorHostGb, installedFloorHostGb } from "../tierSuggestion.js";
 import { workerAdvertises } from "./simpleJobs.js";
 import { useSimpleUi } from "./SimpleUiContext.js";
@@ -48,6 +49,7 @@ export function SimpleModelManager() {
     createModelImportJob,
     jobAction,
     macCapabilities,
+    refreshData,
     visibleWorkers = [],
   } = useAppContext();
   const { toast, openInAdvanced } = useSimpleUi();
@@ -143,17 +145,33 @@ export function SimpleModelManager() {
 
   const modelImportJobs = useMemo(() => jobs.filter((job) => job.type === "model_import"), [jobs]);
 
+  // The SAME family list the advanced screen's import form offers, derived the same way: from each
+  // model's LoRA-compatibility set rather than its `family` identity, because that is what the
+  // import validator keys off. Without it Simple's Family select was permanently disabled — a
+  // reduced copy of the panel, which is exactly what mounting the shared component is meant to
+  // prevent.
+  const families = useMemo(
+    () => Array.from(new Set(models.flatMap((model) => modelLoraFamilies(model)).filter(Boolean))).sort(),
+    [models],
+  );
+
   return (
     <div className="su-screen su-screen--tight">
       <CheckpointImportPanel
         compact
         completedJobs={modelImportJobs.filter((job) => job.status === "completed")}
+        families={families}
         headingId="simple-checkpoint-import-heading"
         macCapabilities={macCapabilities}
         models={models}
         onCancelJob={jobAction ? (job) => jobAction(job, "cancel") : undefined}
         onImportModel={createModelImportJob}
         onOpenQueue={() => openInAdvanced("Queue")}
+        onOpenSettings={() => openInAdvanced("Settings")}
+        // Simple renders no linked-status badge of its own, but its rows ARE the catalog: a relink
+        // or forget inside the panel changes which models exist and whether they are usable, so the
+        // catalog has to be re-read rather than left showing the pre-relink answer.
+        onRefreshCatalog={refreshData}
         onRetryJob={jobAction ? (job, payload) => jobAction(job, "retry", { body: payload ?? {} }) : undefined}
         pendingJobs={modelImportJobs.filter((job) => !terminalStatuses.has(job.status))}
         token={token}

--- a/apps/web/src/simple/SimpleModelManager.jsx
+++ b/apps/web/src/simple/SimpleModelManager.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import { CheckpointImportPanel } from "../components/CheckpointImportPanel.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import { terminalStatuses } from "../constants.js";
@@ -15,7 +16,14 @@ import { useSimpleUi } from "./SimpleUiContext.js";
 // LoRAs) of one-line rows — glyph, name, "size · needs N GB", and a right-aligned
 // Manage (installed) or Download (missing) action.
 //
-// "Manage" hands off to the full Models screen (openInAdvanced — which switches the SHELL
+// Adding a model is the ONE exception to that handoff (epic 20398, sc-20650). Choosing between
+// "Use existing model library" and "Add to SceneWorks" is the first decision a new user makes about
+// their models, and a Simple shell that could only send them to the advanced screen for it would
+// make the reduced shell unusable for exactly the person it exists for. It renders the SAME panel
+// the advanced screen does — one experience, not a reduced second copy — collapsed by default so
+// the catalog stays the page's subject.
+//
+// Everything else: "Manage" hands off to the full Models screen (openInAdvanced — which switches the SHELL
 // as well as the view, since pointing the workspace at a screen while Simple is rendering
 // would be inert): per-tier downloads, conversion, repair, import and delete are exactly
 // the surface Simple is meant to hide, and duplicating a reduced version of them here would
@@ -34,8 +42,11 @@ export function SimpleModelManager() {
     models = [],
     loras = [],
     jobs = [],
+    token = "",
     createModelDownloadJob,
     createLoraDownloadJob,
+    createModelImportJob,
+    jobAction,
     macCapabilities,
     visibleWorkers = [],
   } = useAppContext();
@@ -130,8 +141,23 @@ export function SimpleModelManager() {
     toast(job ? `Downloading ${row.name}…` : `Could not start the ${row.name} download`);
   }
 
+  const modelImportJobs = useMemo(() => jobs.filter((job) => job.type === "model_import"), [jobs]);
+
   return (
     <div className="su-screen su-screen--tight">
+      <CheckpointImportPanel
+        compact
+        completedJobs={modelImportJobs.filter((job) => job.status === "completed")}
+        headingId="simple-checkpoint-import-heading"
+        macCapabilities={macCapabilities}
+        models={models}
+        onCancelJob={jobAction ? (job) => jobAction(job, "cancel") : undefined}
+        onImportModel={createModelImportJob}
+        onOpenQueue={() => openInAdvanced("Queue")}
+        onRetryJob={jobAction ? (job, payload) => jobAction(job, "retry", { body: payload ?? {} }) : undefined}
+        pendingJobs={modelImportJobs.filter((job) => !terminalStatuses.has(job.status))}
+        token={token}
+      />
       <div className="su-tabs su-scroll" role="tablist">
         {TABS.map((entry) => (
           <button

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -17936,3 +17936,208 @@ button.audio-wave {
 .workflow-fix-inputs > .workflow-fix-detail {
   margin: 0;
 }
+
+/* ---------- Unified checkpoint import (epic 20398, sc-20650) -----------------
+   One panel for both ownerships — "Use existing model library" (linked, the
+   files stay where they are) and "Add to SceneWorks" (managed, SceneWorks owns
+   the copy). It opens COLLAPSED on the Model Manager, which is a busy page, so
+   the catalog stays the screen's subject until the user asks to add something. */
+.checkpoint-import {
+  display: grid;
+  gap: 12px;
+}
+
+.checkpoint-import-heading {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.checkpoint-import-toggle {
+  justify-self: start;
+}
+
+.checkpoint-import-body {
+  display: grid;
+  gap: 14px;
+}
+
+/* The ownership choice is the panel's first decision, so it reads as two cards
+   rather than a segmented micro-control: each carries a sentence saying what
+   happens to the user's files, which is the whole basis for choosing. */
+.checkpoint-ownership {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 10px;
+}
+
+.checkpoint-ownership-choice {
+  display: grid;
+  gap: 4px;
+  text-align: left;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.checkpoint-ownership-choice.active {
+  border-color: color-mix(in oklch, var(--accent) 55%, var(--border));
+  background: color-mix(in oklch, var(--accent) 8%, var(--surface));
+}
+
+.checkpoint-ownership-label {
+  font-weight: 600;
+}
+
+.checkpoint-ownership-summary,
+.checkpoint-source-hint {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.checkpoint-linked,
+.checkpoint-managed,
+.checkpoint-scan {
+  display: grid;
+  gap: 12px;
+}
+
+.checkpoint-linked-add {
+  display: grid;
+  grid-template-columns: minmax(220px, 2fr) auto minmax(140px, 1fr) auto;
+  gap: 8px;
+  align-items: end;
+}
+
+.checkpoint-linked-add label {
+  display: grid;
+  gap: 7px;
+}
+
+.checkpoint-root-list,
+.checkpoint-candidate-list,
+.checkpoint-diagnostics {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.checkpoint-root,
+.checkpoint-candidate {
+  display: grid;
+  gap: 6px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.checkpoint-root-head,
+.checkpoint-candidate-head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.checkpoint-root-label,
+.checkpoint-candidate-path {
+  font-weight: 600;
+}
+
+.checkpoint-root-path,
+.checkpoint-candidate-meta,
+.checkpoint-candidate-unselectable {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.checkpoint-root-actions,
+.checkpoint-root-rename {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: end;
+}
+
+/* Needs Relink / Needs Rescan. Warning-toned, never danger-toned: nothing is
+   lost and nothing was uninstalled — there is one action to take. */
+.checkpoint-scan-unavailable,
+.checkpoint-unmatched,
+.checkpoint-candidate-correction,
+.model-card-linked-fix {
+  display: grid;
+  gap: 6px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in oklch, var(--warning, #d08700) 35%, var(--border));
+  background: color-mix(in oklch, var(--warning, #d08700) 7%, var(--surface));
+}
+
+.checkpoint-scan-unavailable button,
+.checkpoint-unmatched button,
+.checkpoint-candidate-correction button,
+.model-card-linked-fix button {
+  justify-self: start;
+}
+
+.checkpoint-state-headline {
+  margin: 0;
+  font-weight: 600;
+}
+
+/* The store's own `[checkpoint-plan:<code>] …` sentence. Monospaced because it
+   carries digests and paths the user may need to read exactly. */
+.checkpoint-import-detail {
+  margin: 0;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.76rem;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
+.checkpoint-unmatched ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.checkpoint-unmatched li {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.checkpoint-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.checkpoint-import-progress {
+  display: grid;
+  gap: 8px;
+}
+
+.model-card-provenance {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+/* Simple shell: the same panel, tightened to the reduced shell's rhythm. */
+.checkpoint-import.compact {
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.checkpoint-import.compact .checkpoint-linked-add,
+.checkpoint-import.compact .models-import-grid {
+  grid-template-columns: 1fr;
+}


### PR DESCRIPTION
Builds the unified "Use existing model library" / "Add to SceneWorks" experience on top of the linked-library API (sc-20635) and the managed-import contract (sc-20636), both already on the feature branch. Web/TS only — no Rust, no worker, no bespoke-lane files.

One panel (`CheckpointImportPanel`) serves both ownerships in the advanced Model Manager, the Simple shell and the desktop build. Two panels would have meant two places for a refusal to be swallowed.

## AC mapping

**AC1 — both ownership choices, one flow, everywhere.**
`apps/web/src/checkpointLibrary.js` is the client for all six `library-roots` routes plus the two request-body shapes. `CheckpointImportPanel.jsx` renders the ownership radiogroup (linked first), the linked-library lifecycle (add / rescan library / rescan checkpoint / relink / rename / remove root) and all five managed inputs (upload, local copy, URL, Hugging Face, Civitai, the last two with a stored-credential notice keyed on the host the download will use). Both ownerships submit through the app's existing `createModelImportJob` to `POST /api/v1/models/import`, so they share one queue, one `WorkerProgressCard`, one cancel and one retry. Rendered from `ModelManagerScreen` (Image tab) and from `SimpleModelManager`; the desktop build reaches the native chooser via the existing `choose_folder` Tauri command for both the library root and the managed local-copy source, and a remote browser falls back to a typed path — which is also where the server's local-peer refusal is explained in its own words.

**AC2 — corrective action, not "missing".**
The Model Manager reads one scan per approved root and indexes the linked statuses by checkpoint id. A card whose linked checkpoint is `needs_relink` / `needs_rescan` renders that headline, the store's own `[checkpoint-plan:<code>] …` diagnostic, and the button that clears it — its status badge reads "needs relink"/"needs rescan", never "missing". Provenance (`source.provider` + reference) shows on every plan-backed card; capabilities and Mac-eligibility already showed there and now also show for a compiled candidate inside the panel. Duplicate warnings come from the completed job's `duplicateCheckpointIds` and are worded as a warning, not a failure. Removal copy is discriminated on the persisted checkpoint id: a linked row gets "Remove from SceneWorks?" and the promise that the file is never opened, moved or deleted; a managed row keeps "Delete model?" and the warning that the files go away. A row with no `importPlan` has no ownership to discriminate on and keeps the pre-epic built-in-catalog confirmation.

**AC3 — cancel, retry, error, accessibility, both flows.**
`checkpointLibrary.test.js` (25), `CheckpointImportPanel.test.jsx` (22), `CheckpointImportPanel.desktop.test.jsx` (4), `SimpleModelManager.checkpointImport.test.jsx` (5), `ModelManagerScreen.linkedOwnership.test.jsx` (7). Accessibility is asserted by role and accessible name — radiogroups, labelled regions, `aria-expanded` on the disclosure, `role="status"` + `aria-live="polite"` on the outcome — never by snapshot.

## Notable decisions

* **`describeRefusal` has no generic branch.** A typed refusal keeps the store's own sentence (the actionable evidence for an unrunnable source is the inspector's diagnostics inside it; for drift, the two digests); an untyped failure keeps its own message. Nothing collapses to "something went wrong".
* **`ownershipMode` is `managed`-only on the wire.** `dto.rs` serves exactly one value and deliberately refuses `"linked"`, so `linkedImportBody` sends `linkedRootId`/`linkedRelativePath` and nothing else — no ownership field, no source, no repo — which is what the route requires.
* **The panel opens collapsed** on both busy pages, but a running import and its cancel button sit *outside* the disclosure: an import consuming the machine is not an option the user is choosing between.
* **Preserved every existing control.** The old standalone import form's URL / Upload / Type / Family / Name / Queue Import are all present in the managed pane (Type is still the fixed, disabled `image` for the sc-14020 reason), plus the detected-family note on success. `capabilityLabel` moved to `modelCapabilities.js` so the panel and the card share one map rather than drifting copies.

## Adjacent fix

`createModelImportJob` appended metadata to `FormData` verbatim, so the discriminated `source` object would have arrived at the multipart parser as the literal `"[object Object]"` — that parser runs `serde_json::from_str` on the field, so every upload import under the new contract would have 400'd. Object values are now JSON-stringified; scalars are unchanged.

## Verification

* `apps/web` vitest: **4090 passed / 270 files**, whole suite.
* `npm run check`: **684 passed / 0 failed**.
* `npx eslint src` clean.
* No Rust touched, so the three cargo configs were not required.
* Mutation runs — 12 handler/branch flips, each RED against a 63-test green baseline: swapped linked/managed removal copy; refusal collapsed to a generic string; `NeedsRelink` mapped to no correction; `ownershipMode`/`source` dropped from the managed body; `ownershipMode: "linked"` added to the linked body; retry re-sending the current form instead of the failed attempt; desktop `pickFolder` never consulted; library removal skipping its confirmation; card keeping the "missing" badge; card offering no corrective action; the linked ownership renamed; progress hidden while collapsed.

## Review fixes (d86ff4a95)

Eight review findings, each with a test whose mutation was run to red.

* **One `busy` + one `message` for two concurrent tracks.** Every operation's `finally` cleared `busy`, so a library scan resolving mid-import re-enabled the import guard (double submit), and a scan's success wiped the import's error — removing "Try again" while `lastAttempt` still held the thing that failed. Split into `importBusy`/`importMessage` (submit / submitLinked / submitManaged / Try again) and library `busy`/`message`, each with its own `role="status"` region. `runScan` never writes the import track.
* **"Try again" rendered on ANY error tone.** It re-POSTs `lastAttempt`, so a later library failure would have re-sent an old import. Gated on `importMessage.tone === "error" && lastAttempt`.
* **Wrong-root window.** `runScan` moved `activeRootId` synchronously while still rendering the previous root's `scan`, and the candidate actions read `activeRootId`. `runScan` now drops the stale scan before awaiting, and `submitLinked`, `rescanCheckpoint` and the candidate correction all act on `scan.root.rootId` — the root the rendered scan names.
* **`onRefreshCatalog` was never passed.** Panel relink / forget / rescan left the catalog cards on "Needs relink". Wired to `refreshLinkedStatuses` from `ModelManagerScreen` and to the context's `refreshData` from `SimpleModelManager` (Simple renders no linked badge of its own, but its rows *are* the catalog).
* **Credentials were only read when the catalog held a gated model,** so the panel claimed "No civitai.com credential is stored" on ordinary catalogs that had one. The read now runs whenever the import panel is mounted; the panel defaults `credentials` to `null` ("never looked", says nothing) and reports a stored credential positively instead of falling silent.
* **Simple mounted the panel without `families`,** permanently disabling the Family select — a reduced copy contradicting the file's own comment. It now derives the same LoRA-compatibility family list `ModelManagerScreen` does.
* **Settings had no navigation.** The missing-credential notice carries the same `Add token in Settings` button `LicenseGateNotice` uses (`setActiveView("Settings")` / `openInAdvanced("Settings")`).
* **A typed refusal with an empty detail** rendered as an empty `role="status"`. It falls back to `[checkpoint-plan:<reason>]`.
* **`SimpleModelManager.checkpointImport.test.jsx` was missing `IS_REACT_ACT_ENVIRONMENT`,** so `act()` was not batching. Added; the suite now runs with zero act warnings.

`ModelManagerScreen.test.jsx` dropped two `list_credentials` "was not called" assertions, which the unconditional read makes false by design; the card-level claims they guarded (no "Gated download", no "Add token in Settings", no "Request access on Hugging Face" on that card) are unchanged and still asserted.

Mutations run for these fixes, each RED on exactly its own test and restored: scan's `finally` clearing `importBusy`; scan's success clearing `importMessage`; Try-again gated on either tone; `setScan(null)` removed; candidate actions back on `activeRootId`; `credentials` defaulted to `[]`; the positive credential notice removed; the Settings button removed; `onRefreshCatalog?.()` calls removed from the panel; `onRefreshCatalog` unwired from `ModelManagerScreen`; the credential read re-keyed on `hasGatedModel`; `families` unwired from Simple; the empty-message fallback removed.

Re-verified: `apps/web` vitest **4104 passed / 270 files**, `npm run check` **684 passed / 0 failed**, `npx eslint src` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

