### PR TITLE
fix(sc-20739): bind OpenPose terminal control evidence

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -1191,9 +1191,9 @@ jobs:
       # source-reviewed fixed cache root is censused from checked-in immutable download evidence
       # before transfer: there is no cache input,
       # snapshot/glob/ref-main fallback, matrix, child workflow, per-cell dispatch, or secret weight
-      # path. Exact archived artifact 9498929065 is revalidated under its frozen b646 provenance. Its
-      # 18 authentic PASS cells are imported while failed LTX cell 14 remains quarantined. The
-      # resulting 2-authority/28-file scope executes only ordinal 14 after its complete source/disk
+      # path. Exact archived 19-PASS artifact 9500244306 is revalidated under the final pinned
+      # 31e02510 provenance. Its authentic PASS cells 1-14 are imported while only the five OpenPose
+      # cells 15-19 are replaced with same-seed causal-control receipts after their complete source/disk
       # plan passes and network is forced
       # offline. Authorities are copied just in time, retained only through their exact last consumer,
       # rehashed before/after use, and durably cleaned. Exact authority files exclude derivative extras;
@@ -1249,7 +1249,7 @@ jobs:
             throw 'the fixed terminal cache root must be an existing ordinary directory'
           }
           node scripts/epic-20738-terminal-cuda-harness.mjs check
-      - name: Discover the exact audited 18-PASS recovery source
+      - name: Discover the exact audited 19-PASS OpenPose recovery source
         id: terminal_prefix
         continue-on-error: true
         if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.run_epic_20738_terminal_cuda && steps.terminal_node.outcome == 'success' && steps.terminal_npm.outcome == 'success' && steps.terminal_tests.outcome == 'success' && steps.terminal_validation.outcome == 'success' }}
@@ -1258,28 +1258,28 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $artifactId = '9498929065'
-          $artifactName = 'sc-20945-epic-20738-655414ef3e4dec1fe9142901caea538e73ac1490-32655428377-1'
-          $artifactSize = 16071005
-          $artifactDigest = 'sha256:fae791001dd4e2015ce0567290b9b0a1d67de9e503712d2b9a60a0f9af07ec9c'
-          $runId = '32655428377'
+          $artifactId = '9500244306'
+          $artifactName = 'sc-20945-epic-20738-7d7a3efa3088204311e3be01330f35702774feb6-32664618999-1'
+          $artifactSize = 17134718
+          $artifactDigest = 'sha256:9af191547befc7833f82f4d9057fff8abfe09b21eada2be2b4f252d73ae30818'
+          $runId = '32664618999'
           $runAttempt = '1'
-          $headSha = '655414ef3e4dec1fe9142901caea538e73ac1490'
-          $root = Join-Path $env:RUNNER_TEMP "sc-21306-pass18-recovery-candidates-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
+          $headSha = '7d7a3efa3088204311e3be01330f35702774feb6'
+          $root = Join-Path $env:RUNNER_TEMP "sc-20739-openpose-recovery-candidates-$env:GITHUB_RUN_ID-$env:GITHUB_RUN_ATTEMPT"
           New-Item -ItemType Directory -Path $root -ErrorAction Stop | Out-Null
           $artifact = gh api "repos/$env:GITHUB_REPOSITORY/actions/artifacts/$artifactId" | ConvertFrom-Json
-          if ($LASTEXITCODE -ne 0 -or $artifact.expired -or [string]$artifact.id -ne $artifactId -or $artifact.name -ne $artifactName -or [int64]$artifact.size_in_bytes -ne $artifactSize -or [string]$artifact.digest -ne $artifactDigest -or [string]$artifact.workflow_run.id -ne $runId -or [string]$artifact.workflow_run.head_sha -ne $headSha) { throw 'audited 18-PASS recovery artifact identity is missing, expired, or tampered' }
+          if ($LASTEXITCODE -ne 0 -or $artifact.expired -or [string]$artifact.id -ne $artifactId -or $artifact.name -ne $artifactName -or [int64]$artifact.size_in_bytes -ne $artifactSize -or [string]$artifact.digest -ne $artifactDigest -or [string]$artifact.workflow_run.id -ne $runId -or [string]$artifact.workflow_run.head_sha -ne $headSha) { throw 'audited 19-PASS OpenPose recovery artifact identity is missing, expired, or tampered' }
           $run = gh api "repos/$env:GITHUB_REPOSITORY/actions/runs/$runId" | ConvertFrom-Json
-          if ($LASTEXITCODE -ne 0 -or [string]$run.id -ne $runId -or [string]$run.run_attempt -ne $runAttempt -or [string]$run.head_sha -ne $headSha) { throw 'audited 18-PASS recovery workflow run identity drifted' }
+          if ($LASTEXITCODE -ne 0 -or [string]$run.id -ne $runId -or [string]$run.run_attempt -ne $runAttempt -or [string]$run.head_sha -ne $headSha) { throw 'audited 19-PASS OpenPose recovery workflow run identity drifted' }
           $candidate = Join-Path $root $artifactId
           $evidence = Join-Path $candidate 'evidence'
           New-Item -ItemType Directory -Path $evidence -Force | Out-Null
           gh run download $runId --name $artifactName --dir $evidence
-          if ($LASTEXITCODE -ne 0) { throw "failed to download audited 18-PASS recovery artifact $artifactId" }
+          if ($LASTEXITCODE -ne 0) { throw "failed to download audited 19-PASS OpenPose recovery artifact $artifactId" }
           $metadata = [ordered]@{
             artifactId = $artifactId; artifactName = $artifactName; artifactSize = $artifactSize; artifactDigest = $artifactDigest
             runId = $runId; runAttempt = $runAttempt; headSha = $headSha
-            inferenceSha = 'b646a6f89ba9f6b07efe53dd583d8a42e21e9871'
+            inferenceSha = '31e02510ad6e9e1a3c3d205058576329d724c60d'
             profile = 'epic-20738-candle-cuda-terminal-v1'
             cellSemanticsSha256 = '2fcd20e4909f0bd0ba6c78c6a85247267c354735f77f4ed4912d47941a8512c1'
             artifactSemanticsSha256 = '1e98392f71b1ad3d10d4bf18a6f23a497f5ffe588127ac59c54e53d392e6e255'

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -15108,8 +15108,8 @@
           "estimatedSizeBytes": 167335590,
           "footprint": { "diskSizeBytes": 167335590 }
         },
-        // Same soft, untiered OpenPose component as `sdxl`. It is provisioned for the Candle
-        // Lightning route while remaining optional for the current-pin MLX refusal.
+        // Same soft, untiered OpenPose component as `sdxl`. Both native providers accept the
+        // CFG-free Lightning ControlNet route at the pinned inference revision.
         {
           "provider": "huggingface",
           "repo": "xinsir/controlnet-openpose-sdxl-1.0",

--- a/config/terminal-evidence/epic-20738-receipt.schema.json
+++ b/config/terminal-evidence/epic-20738-receipt.schema.json
@@ -22,12 +22,15 @@
         "resolvedTier": { "enum": ["q4", "q8"] },
         "denseFallback": { "const": false },
         "loadSpecQuantBits": { "enum": [null, 4, 8] },
-        "referenceCounterfactuals": { "$ref": "#/$defs/scail2ReferenceCounterfactuals" }
+        "referenceCounterfactuals": { "$ref": "#/$defs/scail2ReferenceCounterfactuals" },
+        "controlCounterfactual": { "$ref": "#/$defs/openPoseControlCounterfactual" }
       },
       "allOf": [
         {
           "if": { "properties": { "kind": { "const": "sdxlOpenPose" } }, "required": ["kind"] },
-          "then": { "properties": { "loadSpecQuantBits": { "const": 4 } } },
+          "then": {
+            "properties": { "loadSpecQuantBits": { "const": 4 } }
+          },
           "else": {
             "if": { "properties": { "kind": { "const": "scail2" } }, "required": ["kind"] },
             "then": {
@@ -163,6 +166,29 @@
           "status": { "const": "passed" },
           "cell": {
             "type": "object",
+            "required": ["kind"],
+            "properties": { "kind": { "const": "sdxlOpenPose" } }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "cell": {
+            "type": "object",
+            "required": ["controlCounterfactual"],
+            "properties": { "controlCounterfactual": { "$ref": "#/$defs/openPoseControlCounterfactual" } }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "type": "object",
+        "required": ["status", "cell"],
+        "properties": {
+          "status": { "const": "passed" },
+          "cell": {
+            "type": "object",
             "required": ["id"],
             "properties": { "id": { "const": "scail2-multi-reference-q4" } }
           }
@@ -218,6 +244,28 @@
         { "allOf": [{ "$ref": "#/$defs/scail2ReferenceCounterfactual" }, { "type": "object", "properties": { "reference": { "const": 5 } } }] },
         { "allOf": [{ "$ref": "#/$defs/scail2ReferenceCounterfactual" }, { "type": "object", "properties": { "reference": { "const": 6 } } }] }
       ]
+    },
+    "openPoseControlCounterfactual": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "sameSeed", "meanAbsDelta", "deltaFloor", "witnesses"],
+      "properties": {
+        "kind": { "const": "mirroredPose" },
+        "sameSeed": { "const": true },
+        "meanAbsDelta": { "type": "number", "exclusiveMinimum": 0.01 },
+        "deltaFloor": { "const": 0.01 },
+        "witnesses": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["baselineControl", "counterfactualControl", "baselineOutput", "counterfactualOutput"],
+          "properties": {
+            "baselineControl": { "const": "input-openpose.png" },
+            "counterfactualControl": { "const": "input-openpose-counterfactual.png" },
+            "baselineOutput": { "const": "output.png" },
+            "counterfactualOutput": { "const": "counterfactual-output.png" }
+          }
+        }
+      }
     },
     "repository": {
       "type": "object",

--- a/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/mlx.rs
@@ -218,17 +218,15 @@ pub(crate) fn sdxl_control_mlx_candidate(payload: &Map<String, Value>) -> bool {
 /// `sdxl` engine on its few-step `lightning` (Euler-trailing) sampler, which the engine restricts to
 /// **txt2img** (it rejects an img2img/reference init — `mlx-gen-sdxl` "acceleration sampler is
 /// txt2img-only"). Plain text-to-image remains generating; a material pose carrier is also claimed by
-/// the named control lane so the worker can fail closed while the current provider still rejects the
-/// ControlNet + Lightning composition. Any non-pose `edit_image`, source, reference, or mask shape is
+/// the named control lane, where the worker executes the supported ControlNet + Lightning composition.
+/// Any non-pose `edit_image`, source, reference, or mask shape is
 /// refused and remains queued. LoRAs + quant are fine on the SDXL path, so they don't gate.
 pub(crate) fn realvisxl_lightning_mlx_eligible(payload: &Map<String, Value>) -> bool {
     realvisxl_lightning_mlx_lane(payload).is_some()
 }
 
 pub(crate) fn realvisxl_lightning_mlx_lane(payload: &Map<String, Value>) -> Option<MlxSdxlLane> {
-    // Material pose carriers are worker-owned before the legacy txt2img-only exclusions. The worker
-    // currently rejects this exact MLX provider composition explicitly; once inference supports
-    // ControlNet + Lightning, the same named lane becomes generating without changing precedence.
+    // Material pose carriers are worker-owned before the legacy txt2img-only exclusions.
     if sdxl_control_mlx_candidate(payload) {
         return Some(MlxSdxlLane::Control);
     }

--- a/crates/sceneworks-worker/src/epic_20738_terminal_cuda_smoke.rs
+++ b/crates/sceneworks-worker/src/epic_20738_terminal_cuda_smoke.rs
@@ -23,6 +23,11 @@ const OUTPUT_ENV: &str = "SCENEWORKS_EPIC_20738_OUTPUT_DIR";
 /// tiny relative to the 0..255 pixel domain: it detects an ignored reference without inventing a
 /// quality or measured-memory floor.
 const SCAIL2_REFERENCE_DELTA_FLOOR: f64 = 1e-6;
+/// A different whole-body pose at the same seed must change the rendered image by more than
+/// serialization-level noise.  0.01 is a mean one-8-bit-level change across 1% of channels: small
+/// enough to avoid treating this as an aesthetic metric, but large enough that an ignored Control
+/// conditioning vector (which is bit-identical at the fixed seed) cannot pass.
+const OPENPOSE_CONTROL_DELTA_FLOOR: f64 = 0.01;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -283,7 +288,7 @@ fn pattern_image(width: u32, height: u32, salt: u8) -> Image {
     }
 }
 
-fn pose_control_image(width: u32, height: u32) -> Image {
+fn pose_control_image(width: u32, height: u32, mirrored: bool) -> Image {
     let mut pixels = vec![0_u8; width as usize * height as usize * 3];
     let mut line = |start: (i32, i32), end: (i32, i32), color: [u8; 3]| {
         let (mut x, mut y) = start;
@@ -317,7 +322,10 @@ fn pose_control_image(width: u32, height: u32) -> Image {
             }
         }
     };
-    let scale = |x: u32, y: u32| ((x * width / 512) as i32, (y * height / 512) as i32);
+    let scale = |x: u32, y: u32| {
+        let x = if mirrored { 512 - x } else { x };
+        ((x * width / 512) as i32, (y * height / 512) as i32)
+    };
     for (start, end, color) in [
         (scale(256, 82), scale(256, 138), [255, 255, 255]),
         (scale(190, 158), scale(322, 158), [255, 128, 0]),
@@ -339,6 +347,29 @@ fn pose_control_image(width: u32, height: u32) -> Image {
         height,
         pixels,
     }
+}
+
+fn mean_image_abs_delta(baseline: &Image, counterfactual: &Image) -> f64 {
+    assert_eq!(
+        (baseline.width, baseline.height, baseline.pixels.len()),
+        (
+            counterfactual.width,
+            counterfactual.height,
+            counterfactual.pixels.len()
+        ),
+        "OpenPose counterfactual changed image shape"
+    );
+    assert!(
+        !baseline.pixels.is_empty(),
+        "OpenPose counterfactual has no pixels"
+    );
+    baseline
+        .pixels
+        .iter()
+        .zip(&counterfactual.pixels)
+        .map(|(left, right)| (f64::from(*left) - f64::from(*right)).abs())
+        .sum::<f64>()
+        / baseline.pixels.len() as f64
 }
 
 fn mask_image(width: u32, height: u32, pair: usize) -> Image {
@@ -454,7 +485,7 @@ fn generate_sdxl_openpose(cell: &Cell, primary: &Artifact, bits: u64, output: &P
     let generator = crate::inference_runtime::load("sdxl", &spec)
         .unwrap_or_else(|error| panic!("{} SDXL OpenPose load failed: {error}", cell.id));
     // Use an actual deterministic whole-body stick pose, not arbitrary pixels carrying Pose metadata.
-    let control_image = pose_control_image(cell.request.width, cell.request.height);
+    let control_image = pose_control_image(cell.request.width, cell.request.height, false);
     save_png(&control_image, &output.join("input-openpose.png"));
     let request = GenerationRequest {
         prompt: "a dancer holding the supplied pose, studio photograph".to_owned(),
@@ -479,6 +510,43 @@ fn generate_sdxl_openpose(cell: &Cell, primary: &Artifact, bits: u64, output: &P
             .expect("terminal SDXL OpenPose generation"),
         &cell.id,
     );
+    // Keep every non-control request input, including seed, fixed.  Mirroring the complete
+    // skeleton makes the intervention materially different while exercising the same production
+    // ControlNet route, so ignoring `Conditioning::Control` yields a zero delta deterministically.
+    let counterfactual_control = pose_control_image(cell.request.width, cell.request.height, true);
+    save_png(
+        &counterfactual_control,
+        &output.join("input-openpose-counterfactual.png"),
+    );
+    let counterfactual_request = GenerationRequest {
+        prompt: "a dancer holding the supplied pose, studio photograph".to_owned(),
+        width: cell.request.width,
+        height: cell.request.height,
+        count: 1,
+        seed: Some(cell.request.seed),
+        steps: Some(cell.request.steps),
+        guidance: cell.request.guidance,
+        sampler: cell.request.sampler.clone(),
+        conditioning: vec![Conditioning::Control {
+            image: counterfactual_control,
+            kind: ControlKind::Pose,
+            scale: Some(1.0),
+        }],
+        memory: family_generation_memory(&cell.kind, &cell.engine_id),
+        ..Default::default()
+    };
+    let counterfactual = image_output(
+        generator
+            .generate(&counterfactual_request, &mut |_| {})
+            .expect("terminal SDXL OpenPose counterfactual generation"),
+        &cell.id,
+    );
+    let mean_abs_delta = mean_image_abs_delta(&image, &counterfactual);
+    assert!(
+        mean_abs_delta.is_finite() && mean_abs_delta > OPENPOSE_CONTROL_DELTA_FLOOR,
+        "{} ignored material same-seed OpenPose control (delta {mean_abs_delta})",
+        cell.id
+    );
     let std = image_std(&image);
     assert!(
         std > DEGENERATE_STD_FLOOR_DEFAULT,
@@ -486,7 +554,25 @@ fn generate_sdxl_openpose(cell: &Cell, primary: &Artifact, bits: u64, output: &P
         cell.id
     );
     save_png(&image, &output.join("output.png"));
-    json!({ "kind": "sdxlOpenPose", "width": image.width, "height": image.height, "pixelStd": std })
+    save_png(&counterfactual, &output.join("counterfactual-output.png"));
+    json!({
+        "kind": "sdxlOpenPose",
+        "width": image.width,
+        "height": image.height,
+        "pixelStd": std,
+        "controlCounterfactual": {
+            "kind": "mirroredPose",
+            "sameSeed": true,
+            "meanAbsDelta": mean_abs_delta,
+            "deltaFloor": OPENPOSE_CONTROL_DELTA_FLOOR,
+            "witnesses": {
+                "baselineControl": "input-openpose.png",
+                "counterfactualControl": "input-openpose-counterfactual.png",
+                "baselineOutput": "output.png",
+                "counterfactualOutput": "counterfactual-output.png",
+            },
+        },
+    })
 }
 
 fn video_stats(frames: &[Image]) -> (f64, f64) {

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_control.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_control.rs
@@ -15,12 +15,6 @@ const SDXL_CONTROL_DEFAULT_GUIDANCE: f32 = 7.0;
 const SDXL_CONTROL_LIGHTNING_STEPS: u32 = 4;
 const SDXL_CONTROL_LIGHTNING_GUIDANCE: f32 = 1.0;
 
-// The currently pinned mlx-gen-sdxl provider rejects ControlNet whenever the `lightning`
-// acceleration sampler is selected. Keep the route itself exact and backend-neutral, but fail
-// before downloads/load on Mac until the inference follow-up makes this composition truthful.
-// Candle's registered SDXL control provider already implements the Lightning composition.
-const MLX_LIGHTNING_CONTROLNET_READY: bool = false;
-
 const SDXL_CONTROL_MODELS: &[&str] = &[
     "sdxl",
     "realvisxl",
@@ -62,19 +56,6 @@ fn sdxl_control_candidate(request: &ImageRequest) -> bool {
         return false;
     }
     has_material_sdxl_control_intent(&request.advanced)
-}
-
-fn validate_sdxl_control_backend(model: &str, backend: &str) -> WorkerResult<()> {
-    if backend == "mlx"
-        && model == "realvisxl_lightning"
-        && !MLX_LIGHTNING_CONTROLNET_READY
-    {
-        return Err(WorkerError::InvalidPayload(
-            "RealVisXL Lightning pose control is not available on the currently pinned MLX provider; refusing instead of exposing a broken Mac render path"
-                .to_owned(),
-        ));
-    }
-    Ok(())
 }
 
 /// The terminal CUDA campaign proved only the q4 composition. Missing selectors resolve to each
@@ -597,10 +578,9 @@ async fn generate_sdxl_control_stream(
     let request = &plan.request;
     let poses = validate_sdxl_control_request(request)?;
     // `backend` is the telemetry device label (`metal`, `cuda:0`, ...), not the provider family.
-    // Select the native provider from the compiled bundle so the MLX Lightning refusal cannot be
-    // bypassed by a device-specific label.
+    // Select the native provider from the compiled bundle; both current native implementations
+    // support the exact single-ControlNet Lightning composition.
     let native_backend = sdxl_control_native_backend();
-    validate_sdxl_control_backend(&request.model, native_backend)?;
     let weights_dir = if native_backend == "candle" {
         resolve_sdxl_control_candle_q4_weights_dir(request, settings)?
     } else {
@@ -1180,16 +1160,12 @@ mod sdxl_control_tests {
     }
 
     #[test]
-    fn current_mlx_lightning_gap_fails_closed_without_disabling_candle_or_other_models() {
-        assert!(validate_sdxl_control_backend("realvisxl_lightning", "mlx").is_err());
-        assert!(validate_sdxl_control_backend("realvisxl_lightning", "candle").is_ok());
+    fn native_lightning_control_route_is_available_on_both_supported_backends() {
         if cfg!(target_os = "macos") {
             assert_eq!(sdxl_control_native_backend(), "mlx");
         } else {
             assert_eq!(sdxl_control_native_backend(), "candle");
         }
-        for model in ["sdxl", "realvisxl", "illustrious_xl_v1", "illustrious_xl_v2"] {
-            assert!(validate_sdxl_control_backend(model, "mlx").is_ok());
-        }
+        assert!(is_sdxl_control_model("realvisxl_lightning"));
     }
 }

--- a/docs/epic-20738-terminal-cuda.md
+++ b/docs/epic-20738-terminal-cuda.md
@@ -318,3 +318,12 @@ The final promotion therefore removes the LTX-2.3 q8 exception, admits its q8 pr
 expands the exact q4-only SDXL OpenPose product set to SDXL, RealVisXL, RealVisXL Lightning,
 Illustrious XL v1, and Illustrious XL v2. Final cleanup reports zero staged and derived files and an
 absent temporary missing store.
+
+## OpenPose causal-control recovery
+
+The next terminal dispatch must import only PASS ordinals `[1-14]` from immutable artifact
+`9500244306` and execute only `[15-19]`: SDXL, RealVisXL, RealVisXL Lightning, Illustrious XL v1,
+and Illustrious XL v2 OpenPose. Each replacement uses the same seed and all non-control inputs with
+a mirrored whole-body pose, records both control/output witnesses, and requires a mean absolute
+pixel delta greater than `0.01`. The older five receipts remain immutable source evidence; they are
+not rewritten or promoted as causal-control proof.

--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -126,6 +126,23 @@ const PASS18_REMAINING_ARTIFACT_IDS = ["ltx23-q8", "ltx23-gemma"];
 const PASS18_REMAINING_AUTHORITIES = 2;
 const PASS18_REMAINING_FILES = 28;
 const PASS18_REMAINING_SOURCE_BYTES = 56_156_615_634;
+// The final 19/19 artifact is immutable source evidence.  The five OpenPose receipts lack the
+// later causal-control witness, so the next continuation imports only 1..14 and replaces exactly
+// 15..19 at the corrected pin.
+const OPENPOSE_RECOVERY_ARTIFACT_ID = "9500244306";
+const OPENPOSE_RECOVERY_ARTIFACT_NAME = "sc-20945-epic-20738-7d7a3efa3088204311e3be01330f35702774feb6-32664618999-1";
+const OPENPOSE_RECOVERY_ARTIFACT_SIZE = 17_134_718;
+const OPENPOSE_RECOVERY_ARTIFACT_DIGEST = "sha256:9af191547befc7833f82f4d9057fff8abfe09b21eada2be2b4f252d73ae30818";
+const OPENPOSE_RECOVERY_RUN_ID = "32664618999";
+const OPENPOSE_RECOVERY_RUN_ATTEMPT = "1";
+const OPENPOSE_RECOVERY_SCENEWORKS_HEAD = "7d7a3efa3088204311e3be01330f35702774feb6";
+const OPENPOSE_RECOVERY_IMPORTED_ORDINALS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
+const OPENPOSE_RECOVERY_EXECUTION_ORDINALS = [15, 16, 17, 18, 19];
+const OPENPOSE_RECOVERY_REMAINING_ARTIFACT_IDS = [
+  "sdxl-base-q4", "sdxl-openpose", "sdxl-tokenizer-l", "sdxl-tokenizer-bigg", "sdxl-vae-fix",
+  "realvisxl-q4", "realvisxl-lightning-q4", "illustrious-v1-q4", "illustrious-v2-q4",
+];
+const OPENPOSE_CONTROL_DELTA_FLOOR = 0.01;
 const RECOVERY_ORIGINAL_ARTIFACT_ID = "9477529627";
 const RECOVERY_ORIGINAL_ARTIFACT_NAME = "sc-20945-epic-20738-8886a9e69f26beec05688c81b414859bd102f6d0-32570707303-1";
 const RECOVERY_ORIGINAL_ARTIFACT_DIGEST = "sha256:f3164a32a485fdedd671f4e11f30038213d30a7eb2b541bda90bef30e63188f3";
@@ -469,6 +486,7 @@ export function validateRuntimeResult(runtimeResult, cell) {
   }
   validateRequestMemoryStrategy(runtimeResult.requestMemoryStrategy, cell);
   validateScail2ReferenceCounterfactuals(runtimeResult.metrics, cell, "runtime result");
+  validateOpenPoseControlCounterfactual(runtimeResult.metrics, cell, "runtime result");
   return runtimeResult;
 }
 
@@ -521,6 +539,47 @@ export function validateScail2ReferenceCounterfactuals(metrics, cell, label = "m
     }
   }
   return counterfactuals;
+}
+
+// The five OpenPose cells are causal tests, not merely nondegenerate-image checks. The candidate
+// keeps the seed and every non-control input fixed, swaps only to a mirrored whole-body pose, and
+// records both input and output witnesses. An implementation that drops Conditioning::Control
+// produces the same seeded bytes and fails the 0.01 mean-absolute-delta floor.
+export function validateOpenPoseControlCounterfactual(metrics, cell, label = "metrics") {
+  const isOpenPose = cell?.kind === "sdxlOpenPose";
+  if (!isOpenPose) {
+    if (metrics?.controlCounterfactual != null) {
+      fail(`${cell.id} ${label} carries unreviewed OpenPose control counterfactual evidence`);
+    }
+    return null;
+  }
+  object(metrics, `${cell.id} ${label}`);
+  const evidence = metrics.controlCounterfactual;
+  object(evidence, `${cell.id} ${label} OpenPose control counterfactual`);
+  exactKeys(
+    evidence,
+    ["kind", "sameSeed", "meanAbsDelta", "deltaFloor", "witnesses"],
+    `${cell.id} ${label} OpenPose control counterfactual`,
+  );
+  if (evidence.kind !== "mirroredPose" || evidence.sameSeed !== true
+    || evidence.deltaFloor !== OPENPOSE_CONTROL_DELTA_FLOOR
+    || !Number.isFinite(evidence.meanAbsDelta)
+    || evidence.meanAbsDelta <= OPENPOSE_CONTROL_DELTA_FLOOR) {
+    fail(`${cell.id} ${label} does not prove material same-seed OpenPose control influence`);
+  }
+  object(evidence.witnesses, `${cell.id} ${label} OpenPose witnesses`);
+  exactKeys(
+    evidence.witnesses,
+    ["baselineControl", "counterfactualControl", "baselineOutput", "counterfactualOutput"],
+    `${cell.id} ${label} OpenPose witnesses`,
+  );
+  if (evidence.witnesses.baselineControl !== "input-openpose.png"
+    || evidence.witnesses.counterfactualControl !== "input-openpose-counterfactual.png"
+    || evidence.witnesses.baselineOutput !== "output.png"
+    || evidence.witnesses.counterfactualOutput !== "counterfactual-output.png") {
+    fail(`${cell.id} ${label} OpenPose witnesses are not immutable position-bound files`);
+  }
+  return evidence;
 }
 
 function validateRequestMemoryStrategy(strategy, cell) {
@@ -1224,6 +1283,14 @@ function validateReceiptInternal(
   } else if (Object.hasOwn(receipt.cell, "referenceCounterfactuals")) {
     fail(`${receipt.cell.id} receipt carries counterfactual evidence outside the passed multi-reference cell`);
   }
+  if (receipt.status === "passed" && expectedCell.kind === "sdxlOpenPose") {
+    validateOpenPoseControlCounterfactual({
+      kind: "sdxlOpenPose",
+      controlCounterfactual: receipt.cell.controlCounterfactual,
+    }, expectedCell, "receipt");
+  } else if (Object.hasOwn(receipt.cell, "controlCounterfactual")) {
+    fail(`${receipt.cell.id} receipt carries OpenPose control evidence outside a passed OpenPose cell`);
+  }
   if (!receipt.repositories?.sceneworks?.clean || !receipt.repositories?.inference?.clean) {
     fail("receipt does not bind clean paired repositories");
   }
@@ -1715,10 +1782,12 @@ export async function importPrefixEvidence(prefix, output) {
   };
 }
 
-function validateRecoveryReceiptProvenance(receipt, cell, { headSha, runId, runAttempt }, label) {
+function validateRecoveryReceiptProvenance(
+  receipt, cell, { headSha, runId, runAttempt, inferenceSha = HISTORICAL_INFERENCE_PIN }, label,
+) {
   if (receipt.cell?.ordinal !== cell.ordinal || receipt.cell?.id !== cell.id
     || receipt.repositories?.sceneworks?.sha !== headSha || receipt.repositories?.sceneworks?.clean !== true
-    || receipt.repositories?.inference?.sha !== HISTORICAL_INFERENCE_PIN || receipt.repositories?.inference?.clean !== true
+    || receipt.repositories?.inference?.sha !== inferenceSha || receipt.repositories?.inference?.clean !== true
     || receipt.execution?.headSha !== headSha || receipt.execution?.runId !== runId
     || receipt.execution?.runAttempt !== runAttempt) {
     fail(`${label} is not bound to its exact audited provenance`);
@@ -2769,6 +2838,170 @@ export async function importPass18Recovery(prefix, output) {
     outcomes: prefix.receipts.map(({ cell, ordinalName }) => ({
       id: cell.id, status: "passed", receipt: `_imported-prefix/${ordinalName}/receipt.json`,
       error: null, emergencyReceiptError: null, source: "imported-pass18-recovery",
+    })),
+  };
+}
+
+function validateOpenPoseRecoveryMetadata(metadata) {
+  exactKeys(metadata, [
+    "artifactId", "artifactName", "artifactSize", "artifactDigest", "runId", "runAttempt", "headSha",
+    "inferenceSha", "profile", "cellSemanticsSha256", "artifactSemanticsSha256",
+  ], "OpenPose recovery source artifact metadata");
+  if (metadata.artifactId !== OPENPOSE_RECOVERY_ARTIFACT_ID
+    || metadata.artifactName !== OPENPOSE_RECOVERY_ARTIFACT_NAME
+    || metadata.artifactSize !== OPENPOSE_RECOVERY_ARTIFACT_SIZE
+    || metadata.artifactDigest !== OPENPOSE_RECOVERY_ARTIFACT_DIGEST
+    || metadata.runId !== OPENPOSE_RECOVERY_RUN_ID
+    || metadata.runAttempt !== OPENPOSE_RECOVERY_RUN_ATTEMPT
+    || metadata.headSha !== OPENPOSE_RECOVERY_SCENEWORKS_HEAD
+    || metadata.inferenceSha !== FROZEN_INFERENCE_PIN
+    || metadata.profile !== PROFILE_NAME
+    || metadata.cellSemanticsSha256 !== EXPECTED_CELL_SEMANTICS_SHA256
+    || metadata.artifactSemanticsSha256 !== EXPECTED_ARTIFACT_SEMANTICS_SHA256) {
+    fail("OpenPose recovery metadata does not bind exact artifact 9500244306");
+  }
+}
+
+function validateOpenPoseRecoverySummary(summary, currentProfile, metadata) {
+  if (summary?.schemaVersion !== 1 || summary.profile !== PROFILE_NAME
+    || summary.repositories?.sceneworks?.sha !== metadata.headSha
+    || summary.repositories?.sceneworks?.clean !== true
+    || summary.repositories?.inference?.sha !== FROZEN_INFERENCE_PIN
+    || summary.repositories?.inference?.clean !== true
+    || summary.execution?.runId !== metadata.runId
+    || summary.execution?.runAttempt !== metadata.runAttempt
+    || summary.execution?.headSha !== metadata.headSha
+    || summary.execution?.headRef !== "refs/heads/feature/sc-20738-candle-cuda-parity"
+    || summary.execution?.workflow !== "Windows Candle worker"
+    || summary.passed !== currentProfile.cells.length || summary.failed !== 0
+    || !Array.isArray(summary.campaignErrors) || summary.campaignErrors.length !== 0
+    || !Array.isArray(summary.receipts) || summary.receipts.length !== currentProfile.cells.length
+    || JSON.stringify(summary.lineage?.continuation?.executionOrdinals) !== JSON.stringify(PASS18_EXECUTION_ORDINALS)) {
+    fail("OpenPose recovery source summary does not bind the audited 19-PASS final run");
+  }
+  for (const [index, cell] of currentProfile.cells.entries()) {
+    const ordinal = index + 1;
+    const expectedPath = ordinal === 14
+      ? `14-${cell.id}/receipt.json`
+      : `_imported-prefix/${String(ordinal).padStart(2, "0")}-${cell.id}/receipt.json`;
+    const source = ordinal === 14 ? "continuation" : "imported-pass18-recovery";
+    const row = summary.receipts[index];
+    if (row?.id !== cell.id || row.status !== "passed" || row.receipt !== expectedPath
+      || row.source !== source || row.error !== null) {
+      fail(`OpenPose recovery source summary receipt ${ordinal} is not exact 19-PASS evidence`);
+    }
+  }
+}
+
+// Import the 14 non-OpenPose PASS receipts from the immutable 19/19 final artifact, then run
+// exactly the five cells whose old receipts lack causal ControlNet evidence.  The source OpenPose
+// receipts are intentionally quarantined rather than rewritten: the replacement campaign owns new
+// input/output hashes and a new receipt at its own immutable head.
+export async function selectOpenPoseRecovery(prefixCandidates, currentProfile) {
+  validateProfile(currentProfile);
+  const root = path.resolve(prefixCandidates);
+  const entries = await readdir(root, { withFileTypes: true });
+  if (entries.length !== 1 || !entries[0].isDirectory() || entries[0].isSymbolicLink()) {
+    fail("expected exactly one exact 19-PASS OpenPose recovery artifact candidate");
+  }
+  const candidate = path.join(root, entries[0].name);
+  const metadata = JSON.parse(await readFile(path.join(candidate, "artifact-metadata.json"), "utf8"));
+  validateOpenPoseRecoveryMetadata(metadata);
+  const evidenceRoot = path.join(candidate, "evidence");
+  const files = await ordinaryTreeFiles(evidenceRoot);
+  const allowedTop = new Set([
+    "_imported-prefix", `14-${EXPECTED_CELLS[13]}`,
+    "cache-preflight-initial.json", "cache-preflight.json", "campaign-summary.json",
+  ]);
+  if (files.some((file) => !allowedTop.has(path.relative(evidenceRoot, file).split(path.sep)[0]))) {
+    fail("OpenPose recovery source artifact contains evidence outside the exact audited campaign");
+  }
+  const summary = JSON.parse(await readFile(path.join(evidenceRoot, "campaign-summary.json"), "utf8"));
+  validateOpenPoseRecoverySummary(summary, currentProfile, metadata);
+
+  const receipts = [];
+  const compatibility = [];
+  for (const ordinal of OPENPOSE_RECOVERY_IMPORTED_ORDINALS) {
+    const index = ordinal - 1;
+    const cell = { ...currentProfile.cells[index], ordinal };
+    const ordinalName = `${String(ordinal).padStart(2, "0")}-${cell.id}`;
+    const cellDir = path.join(evidenceRoot, ...(ordinal === 14 ? [ordinalName] : ["_imported-prefix", ordinalName]));
+    const receipt = JSON.parse(await readFile(path.join(cellDir, "receipt.json"), "utf8"));
+    const provenance = ordinal <= IMPORTED_PREFIX_CELLS
+      ? { headSha: LEGACY_SCENEWORKS_HEAD, runId: "32570707303", runAttempt: "1" }
+      : ordinal <= RECOVERY_IMPORTED_PREFIX_CELLS
+        ? { headSha: RECOVERY_SCENEWORKS_HEAD, runId: RECOVERY_RUN_ID, runAttempt: RECOVERY_RUN_ATTEMPT }
+        : ordinal <= 13
+          ? { headSha: SPARSE_RECOVERY_SCENEWORKS_HEAD, runId: SPARSE_RECOVERY_RUN_ID, runAttempt: SPARSE_RECOVERY_RUN_ATTEMPT }
+          : { ...metadata, inferenceSha: FROZEN_INFERENCE_PIN };
+    validateRecoveryReceiptProvenance(receipt, cell, provenance, `OpenPose recovery imported receipt ${ordinalName}`);
+    if (ordinal <= IMPORTED_PREFIX_CELLS) {
+      validateTrustedLegacyImportedReceiptDocument(receipt);
+      const legacyProfile = legacyPrefixProfile(currentProfile);
+      validateReceiptInternal(receipt, { ...legacyProfile.cells[index], ordinal }, legacyProfile, null, TRUSTED_LEGACY_IMPORT_CONTEXT);
+    } else {
+      validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, receipt);
+      validateReceipt(receipt, cell, currentProfile);
+    }
+    const rehashed = await evidenceFiles(cellDir);
+    for (const field of ["inputs", "outputs", "logs"]) {
+      if (JSON.stringify(rehashed[field]) !== JSON.stringify(receipt[field])) {
+        fail(`OpenPose recovery imported receipt ${ordinalName} failed ${field} rehash`);
+      }
+    }
+    if (receipt.status !== "passed") fail(`OpenPose recovery imported receipt ${ordinalName} is not PASS`);
+    compatibility.push({
+      ordinal, cellId: cell.id, cellSemanticsSha256: canonicalSha256(currentProfile.cells[index]),
+    });
+    receipts.push({ cell: currentProfile.cells[index], ordinalName, receipt, root: cellDir });
+  }
+  return { candidate, evidenceRoot, metadata, receipts, compatibility, sourceLineage: summary.lineage };
+}
+
+export async function importOpenPoseRecovery(prefix, output) {
+  const destination = path.join(output, "_imported-prefix");
+  await mkdir(destination);
+  for (const receipt of prefix.receipts) {
+    await cp(receipt.root, path.join(destination, receipt.ordinalName), {
+      recursive: true, errorOnExist: true, force: false, dereference: false,
+    });
+  }
+  await ordinaryTreeFiles(destination);
+  for (const { ordinalName, receipt } of prefix.receipts) {
+    const rehashed = await evidenceFiles(path.join(destination, ordinalName));
+    for (const field of ["inputs", "outputs", "logs"]) {
+      if (JSON.stringify(rehashed[field]) !== JSON.stringify(receipt[field])) {
+        fail(`copied OpenPose recovery ${ordinalName} failed ${field} rehash`);
+      }
+    }
+  }
+  const lineage = {
+    kind: "terminal-openpose-counterfactual-recovery",
+    sourceArtifactId: prefix.metadata.artifactId,
+    sourceArtifactName: prefix.metadata.artifactName,
+    sourceArtifactSize: prefix.metadata.artifactSize,
+    sourceArtifactDigest: prefix.metadata.artifactDigest,
+    sourceRunId: prefix.metadata.runId,
+    sourceRunAttempt: prefix.metadata.runAttempt,
+    sourceHeadSha: prefix.metadata.headSha,
+    sourceInferenceSha: prefix.metadata.inferenceSha,
+    sourceProfile: prefix.metadata.profile,
+    sourceCellSemanticsSha256: prefix.metadata.cellSemanticsSha256,
+    targetCellSemanticsSha256: EXPECTED_CELL_SEMANTICS_SHA256,
+    sourceArtifactSemanticsSha256: prefix.metadata.artifactSemanticsSha256,
+    importedOrdinals: OPENPOSE_RECOVERY_IMPORTED_ORDINALS,
+    executionOrdinals: OPENPOSE_RECOVERY_EXECUTION_ORDINALS,
+    compatibility: prefix.compatibility,
+    priorLineage: prefix.sourceLineage,
+  };
+  await writeFile(path.join(destination, "lineage.json"), `${JSON.stringify(lineage, null, 2)}\n`, {
+    encoding: "utf8", flag: "wx",
+  });
+  return {
+    lineage,
+    outcomes: prefix.receipts.map(({ cell, ordinalName }) => ({
+      id: cell.id, status: "passed", receipt: `_imported-prefix/${ordinalName}/receipt.json`,
+      error: null, emergencyReceiptError: null, source: "imported-openpose-recovery",
     })),
   };
 }
@@ -3899,10 +4132,14 @@ export async function runCampaign(args, options = {}) {
   const allOrdinals = profile.cells.map((_, index) => index + 1);
   const legacyContinuationOrdinals = allOrdinals.slice(IMPORTED_PREFIX_CELLS);
   const requestedOrdinals = options.executionOrdinals ?? (options.importedPrefix
-    ? legacyContinuationOrdinals : PASS18_EXECUTION_ORDINALS);
+    ? legacyContinuationOrdinals : OPENPOSE_RECOVERY_EXECUTION_ORDINALS);
   const executionOrdinals = exactExecutionOrdinals(profile, requestedOrdinals);
   let imported = { lineage: null, outcomes: [] };
-  if (JSON.stringify(executionOrdinals) === JSON.stringify(PASS18_EXECUTION_ORDINALS)) {
+  if (JSON.stringify(executionOrdinals) === JSON.stringify(OPENPOSE_RECOVERY_EXECUTION_ORDINALS)) {
+    const selected = options.prefixSelection
+      ?? await selectOpenPoseRecovery(prefixCandidates, profile);
+    imported = options.importedPrefix ?? await importOpenPoseRecovery(selected, output);
+  } else if (JSON.stringify(executionOrdinals) === JSON.stringify(PASS18_EXECUTION_ORDINALS)) {
     const selected = options.prefixSelection
       ?? await selectPass18Recovery(prefixCandidates, profile);
     imported = options.importedPrefix ?? await importPass18Recovery(selected, output);
@@ -3937,6 +4174,11 @@ export async function runCampaign(args, options = {}) {
   const remainingFileCount = remainingArtifactIds.reduce(
     (sum, id) => sum + artifactExpectedFiles[id].length, 0,
   );
+  if (downloadEvidenceSha256 === CURRENT_DOWNLOAD_EVIDENCE_SHA256
+    && JSON.stringify(executionOrdinals) === JSON.stringify(OPENPOSE_RECOVERY_EXECUTION_ORDINALS)
+    && JSON.stringify(remainingArtifactIds) !== JSON.stringify(OPENPOSE_RECOVERY_REMAINING_ARTIFACT_IDS)) {
+    fail("OpenPose recovery scope drifted from its exact five-cell authority set");
+  }
   if (downloadEvidenceSha256 === CURRENT_DOWNLOAD_EVIDENCE_SHA256
     && JSON.stringify(executionOrdinals) === JSON.stringify(SPARSE_EXECUTION_ORDINALS)
     && (JSON.stringify(remainingArtifactIds) !== JSON.stringify(SPARSE_REMAINING_ARTIFACT_IDS)
@@ -4419,6 +4661,9 @@ export async function runCampaign(args, options = {}) {
           receipt.cell.loadSpecQuantBits = runtimeResult.loadSpecQuantBits;
           if (cell.kind === "scail2" && cell.capability === "multiReference") {
             receipt.cell.referenceCounterfactuals = structuredClone(runtimeResult.metrics.referenceCounterfactuals);
+          }
+          if (cell.kind === "sdxlOpenPose") {
+            receipt.cell.controlCounterfactual = structuredClone(runtimeResult.metrics.controlCounterfactual);
           }
           lifecycle.requestMemoryStrategy = structuredClone(runtimeResult.requestMemoryStrategy);
         } catch (error) {

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -33,11 +33,13 @@ import {
   safeRemoveTree,
   importSparseRecovery,
   importPass18Recovery,
+  importOpenPoseRecovery,
   importRecoveryContinuation,
   selectImportedPrefix,
   selectRecoveryContinuation,
   selectSparseRecovery,
   selectPass18Recovery,
+  selectOpenPoseRecovery,
   validateCampaignPaths,
   validateCachePreflightEvidence,
   validateDocumentWithSchema,
@@ -79,6 +81,21 @@ function scail2ReferenceCounterfactuals() {
       },
     };
   });
+}
+
+function openPoseControlCounterfactual() {
+  return {
+    kind: "mirroredPose",
+    sameSeed: true,
+    meanAbsDelta: 0.02,
+    deltaFloor: 0.01,
+    witnesses: {
+      baselineControl: "input-openpose.png",
+      counterfactualControl: "input-openpose-counterfactual.png",
+      baselineOutput: "output.png",
+      counterfactualOutput: "counterfactual-output.png",
+    },
+  };
 }
 
 function fixtureSidecarObstructions(sharedArtifacts) {
@@ -582,6 +599,9 @@ test("all 19 cells require the exact family loadSpec quant policy", () => {
         kind: "scail2",
         referencePairs: 6,
         referenceCounterfactuals: scail2ReferenceCounterfactuals(),
+      } : cell.kind === "sdxlOpenPose" ? {
+        kind: "sdxlOpenPose",
+        controlCounterfactual: openPoseControlCounterfactual(),
       } : { referenceCounterfactuals: null },
     };
     assert.equal(validateRuntimeResult(valid, cell), valid, cell.id);
@@ -653,6 +673,42 @@ test("SCAIL2 six-reference causal metrics reject missing, duplicate, nonfinite, 
   assert.throws(() => validateRuntimeResult(copied, cell), /position-bound/);
 });
 
+test("OpenPose causal metrics reject missing, trivial, and unbound mirrored-control evidence", () => {
+  const cell = profile().cells.find((candidate) => candidate.kind === "sdxlOpenPose");
+  const valid = {
+    kind: "sdxlOpenPose",
+    controlCounterfactual: openPoseControlCounterfactual(),
+  };
+  assert.equal(validateRuntimeResult({
+    requestedTier: cell.requestedTier,
+    resolvedTier: cell.requestedTier,
+    denseFallback: false,
+    loadSpecQuantBits: 4,
+    requestMemoryStrategy: {
+      strategy: "not-applicable", requestMemoryPresent: false,
+      stageResidency: false, streamTransformerBlocks: false,
+    },
+    metrics: valid,
+  }, cell).metrics, valid);
+  for (const mutate of [
+    (candidate) => { delete candidate.controlCounterfactual; },
+    (candidate) => { candidate.controlCounterfactual.meanAbsDelta = 0.01; },
+    (candidate) => { candidate.controlCounterfactual.witnesses.counterfactualOutput = "output.png"; },
+  ]) {
+    const mutated = structuredClone(valid);
+    mutate(mutated);
+    assert.throws(() => validateRuntimeResult({
+      requestedTier: cell.requestedTier, resolvedTier: cell.requestedTier, denseFallback: false,
+      loadSpecQuantBits: 4,
+      requestMemoryStrategy: {
+        strategy: "not-applicable", requestMemoryPresent: false,
+        stageResidency: false, streamTransformerBlocks: false,
+      },
+      metrics: mutated,
+    }, cell), /counterfactual|control influence|witnesses/);
+  }
+});
+
 function fixtureReceipt(status = "passed", cellIndex = 0, checked = profile()) {
   const cell = checked.cells[cellIndex];
   const artifacts = cell.artifactIds.map((artifactId) => {
@@ -700,6 +756,9 @@ function fixtureReceipt(status = "passed", cellIndex = 0, checked = profile()) {
   receipt.logs = [{ path: "controller.log", bytes: 7, sha256: "5".repeat(64) }];
   if (status === "passed" && cell.capability === "multiReference") {
     receipt.cell.referenceCounterfactuals = scail2ReferenceCounterfactuals();
+  }
+  if (status === "passed" && cell.kind === "sdxlOpenPose") {
+    receipt.cell.controlCounterfactual = openPoseControlCounterfactual();
   }
   const fluxArtifact = cell.artifactIds.find((artifactId) => artifactId.startsWith("flux1-"));
   receipt.authorityLifecycle = {
@@ -870,6 +929,16 @@ test("Draft 2020-12 schemas validate the profile and close adversarial receipt d
     assert.throws(
       () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, duplicateScailEvidenceFile),
       /must be equal to constant/,
+    );
+
+    const openPose = fixtureReceipt("passed", 14);
+    const openPoseFile = await writeReceipt("openpose-control.json", openPose);
+    assert.doesNotThrow(() => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, openPoseFile));
+    delete openPose.cell.controlCounterfactual;
+    const missingOpenPoseEvidenceFile = await writeReceipt("openpose-control-missing.json", openPose);
+    assert.throws(
+      () => validateDocumentWithSchema(RECEIPT_SCHEMA_PATH, missingOpenPoseEvidenceFile),
+      /must have required property 'controlCounterfactual'/,
     );
 
     const openInventory = fixtureReceipt();
@@ -1602,6 +1671,86 @@ async function writePass18RecoveryCandidate(root) {
   return { candidate, evidence, metadata, summary };
 }
 
+async function writeOpenPoseRecoveryCandidate(root) {
+  const pass18Root = path.join(path.dirname(root), `${path.basename(root)}-pass18-source`);
+  await mkdir(pass18Root);
+  await writePass18RecoveryCandidate(pass18Root);
+  const selectedPass18 = await selectPass18Recovery(pass18Root, profile(), {
+    validateCacheEvidence: async () => {},
+  });
+  const candidate = path.join(root, "9500244306");
+  const evidence = path.join(candidate, "evidence");
+  await mkdir(evidence, { recursive: true });
+  const imported = await importPass18Recovery(selectedPass18, evidence);
+  const metadata = {
+    artifactId: "9500244306",
+    artifactName: "sc-20945-epic-20738-7d7a3efa3088204311e3be01330f35702774feb6-32664618999-1",
+    artifactSize: 17_134_718,
+    artifactDigest: "sha256:9af191547befc7833f82f4d9057fff8abfe09b21eada2be2b4f252d73ae30818",
+    runId: "32664618999",
+    runAttempt: "1",
+    headSha: "7d7a3efa3088204311e3be01330f35702774feb6",
+    inferenceSha: "31e02510ad6e9e1a3c3d205058576329d724c60d",
+    profile: PROFILE_NAME,
+    cellSemanticsSha256: "2fcd20e4909f0bd0ba6c78c6a85247267c354735f77f4ed4912d47941a8512c1",
+    artifactSemanticsSha256: "1e98392f71b1ad3d10d4bf18a6f23a497f5ffe588127ac59c54e53d392e6e255",
+  };
+  await writeFile(path.join(candidate, "artifact-metadata.json"), `${JSON.stringify(metadata, null, 2)}\n`);
+  const checked = profile();
+  const cell = checked.cells[13];
+  const ordinalName = `14-${cell.id}`;
+  const cellDir = path.join(evidence, ordinalName);
+  await mkdir(cellDir);
+  await writeFile(path.join(cellDir, "cell.json"), `{"id":"${cell.id}"}\n`);
+  await writeFile(path.join(cellDir, "runtime-result.json"), "{}\n");
+  await writeFile(path.join(cellDir, "controller.log"), `audited ${cell.id}\n`);
+  const receipt = fixtureReceipt("passed", 13, checked);
+  receipt.repositories.sceneworks.sha = metadata.headSha;
+  receipt.repositories.inference.sha = metadata.inferenceSha;
+  receipt.execution.headSha = metadata.headSha;
+  receipt.execution.runId = metadata.runId;
+  receipt.execution.runAttempt = metadata.runAttempt;
+  const files = await hashedFiles(cellDir);
+  receipt.inputs = files.filter((file) => file.path === "cell.json");
+  receipt.outputs = files.filter((file) => file.path === "runtime-result.json");
+  receipt.logs = files.filter((file) => file.path === "controller.log");
+  await writeFile(path.join(cellDir, "receipt.json"), `${JSON.stringify(receipt, null, 2)}\n`);
+  await writeFile(path.join(evidence, "cache-preflight-initial.json"), "{}\n");
+  await writeFile(path.join(evidence, "cache-preflight.json"), "{}\n");
+  const cacheBytes = await readFile(path.join(evidence, "cache-preflight.json"));
+  const outcomes = [
+    ...imported.outcomes,
+    { id: cell.id, status: "passed", receipt: `${ordinalName}/receipt.json`, error: null, source: "continuation" },
+  ].sort((left, right) => checked.cells.findIndex((entry) => entry.id === left.id)
+    - checked.cells.findIndex((entry) => entry.id === right.id));
+  const empty = createHash("sha256").digest("hex");
+  const summary = {
+    schemaVersion: 1, profile: PROFILE_NAME,
+    repositories: { sceneworks: { sha: metadata.headSha, clean: true }, inference: { sha: metadata.inferenceSha, clean: true } },
+    execution: {
+      runId: metadata.runId, runAttempt: metadata.runAttempt, headSha: metadata.headSha,
+      headRef: "refs/heads/feature/sc-20738-candle-cuda-parity", workflow: "Windows Candle worker",
+      runnerName: "cuda-windows-3", runnerOs: "Windows", runnerArch: "X64",
+    },
+    receipts: outcomes,
+    lineage: { imported: imported.lineage, continuation: {
+      runId: metadata.runId, runAttempt: metadata.runAttempt, headSha: metadata.headSha,
+      inferenceSha: metadata.inferenceSha, profileCellSemanticsSha256: metadata.cellSemanticsSha256,
+      profileArtifactSemanticsSha256: metadata.artifactSemanticsSha256, executionOrdinals: [14],
+    } },
+    cachePreflight: { path: "cache-preflight.json", bytes: cacheBytes.length, sha256: createHash("sha256").update(cacheBytes).digest("hex") },
+    authorityLifecycle: [receipt.authorityLifecycle], diskFreeProbes: [],
+    finalAuthorityLifecycle: {
+      stage: { root: "fixture-stage", files: 0, bytes: 0, sha256: empty },
+      derived: { root: "fixture-derived", files: 0, bytes: 0, sha256: empty },
+      derivedNamespaces: [], missingStoreAbsent: true,
+    },
+    passed: 19, failed: 0, campaignErrors: [],
+  };
+  await writeFile(path.join(evidence, "campaign-summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+  return { candidate, evidence, metadata };
+}
+
 test("18-PASS recovery imports authentic PASS ordinals and keeps failed LTX cell 14 quarantined", async () => {
   const temporary = await mkdtemp(path.join(tmpdir(), "sc-21306-pass18-recovery-"));
   const skipCache = async () => {};
@@ -1660,6 +1809,28 @@ test("18-PASS recovery imports authentic PASS ordinals and keeps failed LTX cell
         selectPass18Recovery(root, profile(), { validateCacheEvidence: skipCache }), pattern, label,
       );
     }
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+});
+
+test("OpenPose recovery imports only 1 through 14 and replaces exactly the five causal-control cells", async () => {
+  const temporary = await mkdtemp(path.join(tmpdir(), "sc-20739-openpose-recovery-"));
+  try {
+    const validRoot = path.join(temporary, "valid");
+    await mkdir(validRoot);
+    const fixture = await writeOpenPoseRecoveryCandidate(validRoot);
+    const selected = await selectOpenPoseRecovery(validRoot, profile());
+    assert.equal(selected.metadata.artifactId, "9500244306");
+    assert.deepEqual(selected.receipts.map(({ cell }) => cell.id), profile().cells.slice(0, 14).map(({ id }) => id));
+    const output = path.join(temporary, "output");
+    await mkdir(output);
+    const imported = await importOpenPoseRecovery(selected, output);
+    assert.equal(imported.outcomes.length, 14);
+    assert.deepEqual(imported.lineage.executionOrdinals, [15, 16, 17, 18, 19]);
+    assert.equal((await readdir(path.join(output, "_imported-prefix"))).includes("15-sdxl-openpose"), false);
+    await writeFile(path.join(fixture.candidate, "artifact-metadata.json"), "{}\n");
+    await assert.rejects(() => selectOpenPoseRecovery(validRoot, profile()), /metadata|artifact 9500244306/);
   } finally {
     await rm(temporary, { recursive: true, force: true });
   }
@@ -2629,6 +2800,11 @@ test("continuation freezes census, downloads once, and JIT stages exact authorit
                 kind: "scail2",
                 referencePairs: 6,
                 referenceCounterfactuals: scail2ReferenceCounterfactuals(),
+              },
+            } : runtimeCell.kind === "sdxlOpenPose" ? {
+              metrics: {
+                kind: "sdxlOpenPose",
+                controlCounterfactual: openPoseControlCounterfactual(),
               },
             } : {}),
           };
@@ -3602,10 +3778,10 @@ test("schemas, clean Node dependencies, and workflow preserve the opt-in single-
   assert.match(terminalBlock, /HF_HUB_OFFLINE: "1"/);
   assert.match(terminalBlock, /TRANSFORMERS_OFFLINE: "1"/);
   assert.match(terminalBlock, /actions\/artifacts\/\$artifactId/);
-  assert.match(terminalBlock, /9498929065[\s\S]*?16071005[\s\S]*?fae791001dd4e2015ce0567290b9b0a1d67de9e503712d2b9a60a0f9af07ec9c/);
+  assert.match(terminalBlock, /9500244306[\s\S]*?17134718[\s\S]*?9af191547befc7833f82f4d9057fff8abfe09b21eada2be2b4f252d73ae30818/);
   assert.match(terminalBlock, /\$artifact\.expired[\s\S]*?\$artifact\.size_in_bytes[\s\S]*?\$artifact\.digest/);
   assert.match(terminalBlock, /gh run download \$runId --name \$artifactName --dir \$evidence/);
-  assert.match(terminalBlock, /655414ef3e4dec1fe9142901caea538e73ac1490/);
+  assert.match(terminalBlock, /7d7a3efa3088204311e3be01330f35702774feb6[\s\S]*?31e02510ad6e9e1a3c3d205058576329d724c60d/);
   assert.doesNotMatch(terminalBlock, /snapshot_download/);
   assert.match(terminalBlock, /python -m venv \$venv/);
   assert.match(terminalBlock, /pip install[^\n]*'huggingface_hub==0\.36\.0'/);
@@ -3617,6 +3793,7 @@ test("schemas, clean Node dependencies, and workflow preserve the opt-in single-
   const controller = await readFile("scripts/epic-20738-terminal-cuda-harness.mjs", "utf8");
   assert.match(controller, /SPARSE_EXECUTION_ORDINALS = \[14, 18, 19\][\s\S]*?SPARSE_REMAINING_AUTHORITIES = 8[\s\S]*?SPARSE_REMAINING_FILES = 70/);
   assert.match(controller, /PASS18_EXECUTION_ORDINALS = \[14\][\s\S]*?PASS18_REMAINING_AUTHORITIES = 2[\s\S]*?PASS18_REMAINING_FILES = 28/);
+  assert.match(controller, /OPENPOSE_RECOVERY_EXECUTION_ORDINALS = \[15, 16, 17, 18, 19\][\s\S]*?selectOpenPoseRecovery[\s\S]*?importOpenPoseRecovery/);
   assert.match(controller, /stale cell-10 sentinel/);
   assert.match(controller, /selectRecoveryContinuation[\s\S]*?importRecoveryContinuation/);
   assert.match(controller, /selectSparseRecovery[\s\S]*?importSparseRecovery/);


### PR DESCRIPTION
Closes the two blocking findings from epic 20738 terminal review cycle 1.\n\nLocal acceptance mapping:\n- E3 control influence: adds same-seed mirrored-pose counterfactual renders for the five SDXL OpenPose cells, requires a discriminating delta, and binds both witnesses plus recovery lineage into the immutable receipt schema.\n- E7 MLX parity: removes the stale RealVisXL Lightning refusal and aligns manifest/routing tests with CFG-free Lightning ControlNet support at pinned inference 31e02510.\n- Failed-candidate recovery: imports and rehashes immutable ordinals 1-14, then executes only OpenPose ordinals 15-19 in the replacement candidate.\n\nValidation:\n- npm run rust:check (derived facts, fmt, clippy -D warnings, workspace tests, build): pass\n- npm run check: pass\n- terminal harness: 32/32 pass; harness check pass\n- provisioning Python: 16/16 pass\n- mutation checks: delta comparator, required counterfactual schema, and recovery provenance each RED then restored GREEN\n- exact inference pin 31e02510 preserved\n\nNo hardware campaign was run on this branch. After merge and terminal source review cycle 2, the coordinator will dispatch the one sparse Windows CUDA failed-candidate recovery.