### PR TITLE
fix(sc-20739): validate sparse recovery preflight

### DIFF
--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -142,6 +142,18 @@ const OPENPOSE_RECOVERY_REMAINING_ARTIFACT_IDS = [
   "sdxl-base-q4", "sdxl-openpose", "sdxl-tokenizer-l", "sdxl-tokenizer-bigg", "sdxl-vae-fix",
   "realvisxl-q4", "realvisxl-lightning-q4", "illustrious-v1-q4", "illustrious-v2-q4",
 ];
+const OPENPOSE_RECOVERY_REMAINING_AUTHORITIES = 9;
+const OPENPOSE_RECOVERY_REMAINING_FILES = 101;
+// The failed 32679720253 candidate is diagnostic only. Its frozen census establishes this exact
+// five-cell recovery plan; it must never be treated as accepted terminal evidence.
+const OPENPOSE_RECOVERY_SOURCE_BYTES = 21_191_060_168;
+const OPENPOSE_RECOVERY_PEAK_ORDINAL = 17;
+const OPENPOSE_RECOVERY_PEAK_ARTIFACT_IDS = [
+  "sdxl-openpose", "sdxl-tokenizer-l", "sdxl-tokenizer-bigg", "sdxl-vae-fix",
+  "realvisxl-lightning-q4",
+];
+const OPENPOSE_RECOVERY_PEAK_STAGED_BYTES = 14_576_195_187;
+const OPENPOSE_RECOVERY_FREE_FLOOR_BYTES = 106_929_602_242;
 const OPENPOSE_CONTROL_DELTA_FLOOR = 0.01;
 const RECOVERY_ORIGINAL_ARTIFACT_ID = "9477529627";
 const RECOVERY_ORIGINAL_ARTIFACT_NAME = "sc-20945-epic-20738-8886a9e69f26beec05688c81b414859bd102f6d0-32570707303-1";
@@ -330,6 +342,8 @@ export function estimateJitDiskPlan(
   persistentMissingBytes = 0,
   nonModelPaths = [],
   reviewedAllAtOnceSourceBytes = REVIEWED_ALL_AT_ONCE_SOURCE_BYTES,
+  reviewedJitSourcePeakBytes = REVIEWED_JIT_SOURCE_PEAK_BYTES,
+  reviewedFreeFloorBytes = REVIEWED_FREE_FLOOR_BYTES,
 ) {
   if (!Number.isSafeInteger(freeBytes) || freeBytes < 0
     || !Number.isSafeInteger(persistentMissingBytes) || persistentMissingBytes < 0
@@ -373,14 +387,14 @@ export function estimateJitDiskPlan(
       modelAndSidecarBytes,
       requiredAdditionalBytes: Math.max(
         modelAndSidecarBytes + NON_MODEL_DISK_RESERVE_BYTES,
-        REVIEWED_FREE_FLOOR_BYTES,
+        reviewedFreeFloorBytes,
       ),
     };
   });
   const peak = cells.reduce((highest, row) => (
     row.modelAndSidecarBytes > highest.modelAndSidecarBytes ? row : highest
   ), { ordinal: 0, artifactIds: [], stagedBytes: 0, sidecarReserveBytes: 0,
-    modelAndSidecarBytes: 0, requiredAdditionalBytes: REVIEWED_FREE_FLOOR_BYTES });
+    modelAndSidecarBytes: 0, requiredAdditionalBytes: reviewedFreeFloorBytes });
   const allPhysical = new Map();
   for (const file of lifetimes.flatMap((row) => row.physicalFiles)) {
     const existing = allPhysical.get(file.key);
@@ -404,9 +418,10 @@ export function estimateJitDiskPlan(
   const modeledJitPeakBytes = PRE_HYDRATION_JIT_SOURCE_PEAK_BYTES
     + currentIllustriousHydrationBytes;
   const allAtOnceSidecarReserveBytes = Math.max(FLUX_Q4_SIDECAR_BYTES, FLUX_Q8_SIDECAR_BYTES);
-  if (logicalSourceBytes === reviewedAllAtOnceSourceBytes
+  if (reviewedAllAtOnceSourceBytes === REVIEWED_ALL_AT_ONCE_SOURCE_BYTES
+    && logicalSourceBytes === reviewedAllAtOnceSourceBytes
     && (allAtOnceSourceBytes !== reviewedAllAtOnceSourceBytes
-      || modeledJitPeakBytes > REVIEWED_JIT_SOURCE_PEAK_BYTES
+      || modeledJitPeakBytes > reviewedJitSourcePeakBytes
       || peak.modelAndSidecarBytes !== modeledJitPeakBytes)) {
     fail(`reviewed disk census drifted: all=${allAtOnceSourceBytes}, peak=${peak.modelAndSidecarBytes}`);
   }
@@ -418,7 +433,7 @@ export function estimateJitDiskPlan(
     legacyNaiveLinkLengthSourceBytes: LEGACY_NAIVE_LINK_LENGTH_SOURCE_BYTES,
     reviewedAllAtOnceSourceBytes,
     preHydrationJitSourcePeakBytes: PRE_HYDRATION_JIT_SOURCE_PEAK_BYTES,
-    reviewedJitSourcePeakBytes: REVIEWED_JIT_SOURCE_PEAK_BYTES,
+    reviewedJitSourcePeakBytes,
     logicalSourceBytes,
     allAtOnceSourceBytes,
     allAtOnceRequiredBytes: allAtOnceSourceBytes + allAtOnceSidecarReserveBytes
@@ -430,14 +445,63 @@ export function estimateJitDiskPlan(
     peakModelAndSidecarBytes: peak.modelAndSidecarBytes,
     peakRequiredAdditionalBytes: Math.max(
       peak.modelAndSidecarBytes + NON_MODEL_DISK_RESERVE_BYTES,
-      REVIEWED_FREE_FLOOR_BYTES,
+      reviewedFreeFloorBytes,
     ),
     admitted: freeBytes >= Math.max(
       peak.modelAndSidecarBytes + NON_MODEL_DISK_RESERVE_BYTES,
-      REVIEWED_FREE_FLOOR_BYTES,
+      reviewedFreeFloorBytes,
     ),
     cells,
   };
+}
+
+function isExactOrdinals(actual, expected) {
+  return JSON.stringify(actual) === JSON.stringify(expected);
+}
+
+function reviewedRecoveryDiskPlan(executionOrdinals) {
+  if (isExactOrdinals(executionOrdinals, OPENPOSE_RECOVERY_EXECUTION_ORDINALS)) {
+    return {
+      sourceBytes: OPENPOSE_RECOVERY_SOURCE_BYTES,
+      jitPeakBytes: OPENPOSE_RECOVERY_PEAK_STAGED_BYTES,
+      freeFloorBytes: OPENPOSE_RECOVERY_FREE_FLOOR_BYTES,
+    };
+  }
+  return {
+    sourceBytes: REVIEWED_ALL_AT_ONCE_SOURCE_BYTES,
+    jitPeakBytes: REVIEWED_JIT_SOURCE_PEAK_BYTES,
+    freeFloorBytes: REVIEWED_FREE_FLOOR_BYTES,
+  };
+}
+
+// The OpenPose continuation is deliberately a closed selector, not a permissive small-campaign
+// mode. Every byte and authority below is bound to the diagnostic census from run 32679720253.
+export function assertExactOpenPoseRecoveryPreflight({
+  executionOrdinals, remainingArtifactIds, artifactExpectedFiles, lifetimePlan, diskPlan,
+}) {
+  if (!isExactOrdinals(executionOrdinals, OPENPOSE_RECOVERY_EXECUTION_ORDINALS)) {
+    fail("OpenPose recovery execution vector is not the exact reviewed [15,16,17,18,19] selector");
+  }
+  if (JSON.stringify(remainingArtifactIds) !== JSON.stringify(OPENPOSE_RECOVERY_REMAINING_ARTIFACT_IDS)
+    || remainingArtifactIds.length !== OPENPOSE_RECOVERY_REMAINING_AUTHORITIES
+    || remainingArtifactIds.reduce((sum, id) => sum + artifactExpectedFiles[id].length, 0)
+      !== OPENPOSE_RECOVERY_REMAINING_FILES
+    || JSON.stringify(lifetimePlan.map((row) => row.artifactId))
+      !== JSON.stringify(OPENPOSE_RECOVERY_REMAINING_ARTIFACT_IDS)) {
+    fail("OpenPose recovery authority set drifted from the exact five-cell plan");
+  }
+  if (diskPlan.reviewedAllAtOnceSourceBytes !== OPENPOSE_RECOVERY_SOURCE_BYTES
+    || diskPlan.logicalSourceBytes !== OPENPOSE_RECOVERY_SOURCE_BYTES
+    || diskPlan.allAtOnceSourceBytes !== OPENPOSE_RECOVERY_SOURCE_BYTES
+    || diskPlan.peakOrdinal !== OPENPOSE_RECOVERY_PEAK_ORDINAL
+    || JSON.stringify(diskPlan.peakArtifactIds) !== JSON.stringify(OPENPOSE_RECOVERY_PEAK_ARTIFACT_IDS)
+    || diskPlan.peakStagedBytes !== OPENPOSE_RECOVERY_PEAK_STAGED_BYTES
+    || diskPlan.peakSidecarReserveBytes !== 0
+    || diskPlan.peakModelAndSidecarBytes !== OPENPOSE_RECOVERY_PEAK_STAGED_BYTES
+    || diskPlan.reviewedJitSourcePeakBytes !== OPENPOSE_RECOVERY_PEAK_STAGED_BYTES
+    || diskPlan.peakRequiredAdditionalBytes !== OPENPOSE_RECOVERY_FREE_FLOOR_BYTES) {
+    fail("OpenPose recovery disk/JIT plan drifted from the exact five-cell census");
+  }
 }
 
 export function cellSemanticsSha256(cells) {
@@ -1111,6 +1175,18 @@ export async function safeRemoveTree(candidate, guard, label = "cleanup target")
   // This confinement/reparse check intentionally sits immediately beside the only recursive remove.
   await rm(target, { recursive: true, force: false });
   await assertPathAbsent(target, label);
+}
+
+// A downloaded authority can release its own persistent store at its lifetime boundary. The final
+// store sweep therefore treats only an already-absent store as success; every other cleanup error
+// remains a campaign failure and final lifecycle inventory still proves the absence.
+export async function cleanupMissingFileStore(operations, missingStore, guard, label) {
+  try {
+    await operations.cleanup(missingStore, guard, label);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  await assertPathAbsent(missingStore, label);
 }
 
 async function assertPathAbsent(target, label) {
@@ -3711,7 +3787,12 @@ export function validateCachePreflightEvidence(document, {
   derivedSidecarRoot, missingStore, expectedNonModelPaths, profile, executionOrdinals = null,
 }) {
   validateDocumentWithSchema(CACHE_PREFLIGHT_SCHEMA_PATH, document);
+  const plannedOrdinals = executionOrdinals ?? document.diskPlan?.cells.map((cell) => cell.ordinal);
+  const exactOpenPoseRecovery = isExactOrdinals(
+    plannedOrdinals, OPENPOSE_RECOVERY_EXECUTION_ORDINALS,
+  );
   if (document.diskPlan
+    && !exactOpenPoseRecovery
     && document.diskPlan.preHydrationJitSourcePeakBytes
       !== PRE_HYDRATION_JIT_SOURCE_PEAK_BYTES) {
     fail("current cache preflight disk plan omitted or drifted from the pre-hydration JIT peak");
@@ -3844,13 +3925,16 @@ export function validateCachePreflightEvidence(document, {
     if (JSON.stringify(document.lifetimePlan) !== JSON.stringify(expectedLifetimePlan)) {
       fail("cache preflight authority lifetime plan drifted from the frozen census");
     }
+    const reviewedPlan = reviewedRecoveryDiskPlan(plannedExecutionOrdinals);
     const expectedDiskPlan = estimateJitDiskPlan(
       expectedLifetimePlan,
       document.diskPlan.freeBytes,
       document.downloadedFiles.reduce((sum, file) => sum + file.bytes, 0),
       document.diskPlan.nonModelPaths,
       downloadEvidenceSha256 === LEGACY_DOWNLOAD_EVIDENCE_SHA256
-        ? LEGACY_REVIEWED_ALL_AT_ONCE_SOURCE_BYTES : REVIEWED_ALL_AT_ONCE_SOURCE_BYTES,
+        ? LEGACY_REVIEWED_ALL_AT_ONCE_SOURCE_BYTES : reviewedPlan.sourceBytes,
+      reviewedPlan.jitPeakBytes,
+      reviewedPlan.freeFloorBytes,
     );
     if (JSON.stringify(document.diskPlan) !== JSON.stringify(expectedDiskPlan)) {
       fail("cache preflight disk plan drifted from exact target-byte census");
@@ -3873,8 +3957,17 @@ export function validateCachePreflightEvidence(document, {
       || document.diskPlan.freeBytes < document.diskPlan.peakRequiredAdditionalBytes) {
       fail("passed cache preflight did not prove sufficient JIT disk capacity");
     }
+    if (exactOpenPoseRecovery) {
+      assertExactOpenPoseRecoveryPreflight({
+        executionOrdinals: plannedExecutionOrdinals,
+        remainingArtifactIds,
+        artifactExpectedFiles,
+        lifetimePlan: document.lifetimePlan,
+        diskPlan: document.diskPlan,
+      });
+    }
     if (new Set([CURRENT_DOWNLOAD_EVIDENCE_SHA256, LEGACY_DOWNLOAD_EVIDENCE_SHA256])
-      .has(downloadEvidenceSha256)) {
+      .has(downloadEvidenceSha256) && !exactOpenPoseRecovery) {
       const expectedRemainingIds = [...new Set(plannedExecutionOrdinals.flatMap(
         (ordinal) => profile.cells[ordinal - 1].artifactIds,
       ))];
@@ -4179,6 +4272,9 @@ export async function runCampaign(args, options = {}) {
     && JSON.stringify(remainingArtifactIds) !== JSON.stringify(OPENPOSE_RECOVERY_REMAINING_ARTIFACT_IDS)) {
     fail("OpenPose recovery scope drifted from its exact five-cell authority set");
   }
+  const exactOpenPoseRecovery = isExactOrdinals(
+    executionOrdinals, OPENPOSE_RECOVERY_EXECUTION_ORDINALS,
+  );
   if (downloadEvidenceSha256 === CURRENT_DOWNLOAD_EVIDENCE_SHA256
     && JSON.stringify(executionOrdinals) === JSON.stringify(SPARSE_EXECUTION_ORDINALS)
     && (JSON.stringify(remainingArtifactIds) !== JSON.stringify(SPARSE_REMAINING_ARTIFACT_IDS)
@@ -4286,6 +4382,7 @@ export async function runCampaign(args, options = {}) {
       }
       lifetimePlan = authorityLifetimePlan(profile, executionOrdinals, sourceAudits);
       const freeBytes = await operations.diskFreeBytes(scratch);
+      const reviewedPlan = reviewedRecoveryDiskPlan(executionOrdinals);
       diskPlan = estimateJitDiskPlan(
         lifetimePlan,
         freeBytes,
@@ -4293,7 +4390,16 @@ export async function runCampaign(args, options = {}) {
           (subtotal, file) => subtotal + file.bytes, 0,
         ), 0),
         expectedNonModelPaths,
+        downloadEvidenceSha256 === LEGACY_DOWNLOAD_EVIDENCE_SHA256
+          ? LEGACY_REVIEWED_ALL_AT_ONCE_SOURCE_BYTES : reviewedPlan.sourceBytes,
+        reviewedPlan.jitPeakBytes,
+        reviewedPlan.freeFloorBytes,
       );
+      if (exactOpenPoseRecovery) {
+        assertExactOpenPoseRecoveryPreflight({
+          executionOrdinals, remainingArtifactIds, artifactExpectedFiles, lifetimePlan, diskPlan,
+        });
+      }
       if (!diskPlan.admitted) {
         fail(`JIT staging disk admission refused: requires ${diskPlan.peakRequiredAdditionalBytes} bytes at cell ${diskPlan.peakOrdinal}, only ${diskPlan.freeBytes} free`);
       }
@@ -4955,8 +5061,7 @@ export async function runCampaign(args, options = {}) {
 
   if (missingDownloads.length) {
     try {
-      await operations.cleanup(missingStore, guard, "reviewed missing-file store");
-      await assertPathAbsent(missingStore, "reviewed missing-file store");
+      await cleanupMissingFileStore(operations, missingStore, guard, "reviewed missing-file store");
     } catch (error) {
       const message = `reviewed missing-file store cleanup failed: ${errorText(error)}`;
       campaignErrors.push(message);

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -1891,17 +1891,149 @@ test("OpenPose recovery preflight is an exact five-cell byte, peak, floor, and a
   }
 });
 
+test("OpenPose exact selector runs the production preflight before any continuation cell", async () => {
+  async function fixture({ sourceDelta = 0, peakDelta = 0, omitAuthorityFile = false } = {}) {
+    const temporary = await mkdtemp(path.join(tmpdir(), "sc-20739-openpose-preflight-run-"));
+    const runnerTemp = path.join(temporary, "runner-temp");
+    const sceneworks = path.join(temporary, "sceneworks");
+    const inference = path.join(temporary, "inference");
+    const cacheRoot = path.join(temporary, "cache");
+    await Promise.all([runnerTemp, sceneworks, inference, cacheRoot].map((directory) => mkdir(directory)));
+    const output = path.join(runnerTemp, "output");
+    const scratch = path.join(runnerTemp, "scratch");
+    const guard = await validateCampaignPaths({
+      runnerTemp, output, scratch, cacheRoot, repositories: [sceneworks, inference],
+    });
+    await Promise.all([output, scratch].map((directory) => mkdir(directory)));
+    const checked = profile();
+    const { artifactExpectedFiles, downloadEvidenceSha256 } = expectedCurrentArtifactFilesFromEvidenceBytes(
+      checked, await readFile("config/download-pattern-evidence.json"),
+    );
+    if (omitAuthorityFile) artifactExpectedFiles["sdxl-base-q4"] = artifactExpectedFiles["sdxl-base-q4"].slice(1);
+    const authorityBytes = new Map([
+      ["sdxl-base-q4", 6_614_864_978 + sourceDelta - peakDelta],
+      ["sdxl-openpose", 1], ["sdxl-tokenizer-l", 1], ["sdxl-tokenizer-bigg", 1], ["sdxl-vae-fix", 1],
+      ["realvisxl-q4", 1], ["realvisxl-lightning-q4", 14_576_195_183 + peakDelta],
+      ["illustrious-v1-q4", 1], ["illustrious-v2-q4", 1],
+    ]);
+    const events = [];
+    const executedCells = [];
+    const emptyInventory = (root) => ({
+      root, files: 0, bytes: 0, sha256: createHash("sha256").digest("hex"),
+    });
+    const operations = {
+      auditArtifact: async ({ id, artifact }) => {
+        events.push(`audit:${id}`);
+        const files = artifactExpectedFiles[id];
+        const total = authorityBytes.get(id);
+        return {
+          id, ...artifact, complete: true, missingFiles: [],
+          reusedFiles: files.map((file, index) => ({
+            path: file, bytes: index === 0 ? total - (files.length - 1) : 1,
+            sha256: "a".repeat(64),
+          })),
+        };
+      },
+      diskFreeBytes: async () => 256 * 1024 ** 3,
+      directoryInventory: async (root) => emptyInventory(root),
+      cleanup: async (candidate) => { await rm(candidate, { recursive: true, force: true }); },
+      executeCell: async ({ cellDir }) => {
+        const cell = JSON.parse(await readFile(path.join(cellDir, "cell.json"), "utf8"));
+        executedCells.push(cell.id);
+        throw new Error("OpenPose preflight fixture must not execute a continuation cell");
+      },
+      sample: () => {},
+    };
+    const execution = {
+      runId: "openpose-preflight", runAttempt: "1", headSha: "1".repeat(40), headRef: "refs/heads/fixture",
+      workflow: "fixture", runnerName: "fixture-runner", runnerOs: "Windows", runnerArch: "X64",
+    };
+    const importedPrefix = {
+      lineage: { kind: "fixture-openpose-prefix" },
+      outcomes: checked.cells.slice(0, 14).map((cell, index) => ({
+        id: cell.id, status: "passed", receipt: `_imported-prefix/${index + 1}/receipt.json`,
+        error: null, emergencyReceiptError: null, source: "imported-openpose-recovery",
+      })),
+    };
+    try {
+      const result = await runCampaign({}, {
+        prepared: {
+          profile: checked,
+          repositories: { sceneworks: { sha: execution.headSha, clean: true }, inference: { sha: "2".repeat(40), clean: true } },
+          execution, guard, output, scratch, startupErrors: [], gpuIdentity: [],
+          systemMemory: { totalBytes: 128 * 1024 ** 3, availableBytesAtStart: 100 * 1024 ** 3 },
+          sceneworksRoot: sceneworks, artifactExpectedFiles, downloadEvidenceSha256,
+        },
+        prefixSelection: {}, importedPrefix, operations,
+        fault: async (stage) => {
+          if (stage === "preflightSchema") throw new Error("injected preflightSchema");
+        },
+        suppressVerdict: true,
+        executionOrdinals: [15, 16, 17, 18, 19],
+      });
+      return { result, events, executedCells };
+    } finally {
+      await rm(temporary, { recursive: true, force: true });
+    }
+  }
+
+  const valid = await fixture();
+  assert.deepEqual(valid.events, [
+    "audit:sdxl-base-q4", "audit:sdxl-openpose", "audit:sdxl-tokenizer-l", "audit:sdxl-tokenizer-bigg", "audit:sdxl-vae-fix",
+    "audit:realvisxl-q4", "audit:realvisxl-lightning-q4", "audit:illustrious-v1-q4", "audit:illustrious-v2-q4",
+  ]);
+  assert.deepEqual(valid.executedCells, []);
+  assert.match(valid.result.summary.campaignErrors.join("\n"), /injected preflightSchema/);
+
+  for (const [label, options, pattern] of [
+    ["source total", { sourceDelta: 1 }, /OpenPose recovery disk\/JIT plan drifted/],
+    ["staged peak", { peakDelta: 1 }, /OpenPose recovery disk\/JIT plan drifted/],
+    ["authority census", { omitAuthorityFile: true }, /OpenPose recovery authority set drifted/],
+  ]) {
+    const mutated = await fixture(options);
+    assert.deepEqual(mutated.executedCells, [], `${label} must block before any cell executes`);
+    assert.match(mutated.result.summary.campaignErrors.join("\n"), pattern, label);
+  }
+});
+
 test("final missing-file store cleanup tolerates only already-absent ENOENT", async () => {
   const temporary = await mkdtemp(path.join(tmpdir(), "sc-20739-missing-store-cleanup-"));
   try {
-    const missingStore = path.join(temporary, "already-absent");
+    const missingStore = path.join(temporary, "present");
+    await mkdir(missingStore);
+    let removed = false;
     await cleanupMissingFileStore({
-      cleanup: async () => {
-        const error = new Error("already absent");
+      cleanup: async (candidate) => {
+        assert.equal(candidate, missingStore);
+        removed = true;
+        await rm(candidate, { recursive: true });
+      },
+    }, missingStore, {}, "present fixture");
+    assert.equal(removed, true);
+    await assert.rejects(lstat(missingStore), { code: "ENOENT" });
+
+    const racedStore = path.join(temporary, "enoent-race");
+    await mkdir(racedStore);
+    await cleanupMissingFileStore({
+      cleanup: async (candidate) => {
+        await rm(candidate, { recursive: true });
+        const error = new Error("removed concurrently");
         error.code = "ENOENT";
         throw error;
       },
-    }, missingStore, {}, "already absent fixture");
+    }, racedStore, {}, "ENOENT race fixture");
+    await assert.rejects(lstat(racedStore), { code: "ENOENT" });
+
+    const unclearedStore = path.join(temporary, "cleanup-bypassed");
+    await mkdir(unclearedStore);
+    await assert.rejects(
+      cleanupMissingFileStore({ cleanup: async () => {} }, unclearedStore, {}, "absence proof fixture"),
+      /still exists after recursive cleanup/,
+    );
+    assert.equal((await lstat(unclearedStore)).isDirectory(), true);
+
+    const retainedStore = path.join(temporary, "non-enoent");
+    await mkdir(retainedStore);
     await assert.rejects(
       cleanupMissingFileStore({
         cleanup: async () => {
@@ -1909,9 +2041,10 @@ test("final missing-file store cleanup tolerates only already-absent ENOENT", as
           error.code = "EACCES";
           throw error;
         },
-      }, missingStore, {}, "non-ENOENT fixture"),
+      }, retainedStore, {}, "non-ENOENT fixture"),
       /permission denied/,
     );
+    assert.equal((await lstat(retainedStore)).isDirectory(), true);
   } finally {
     await rm(temporary, { recursive: true, force: true });
   }

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -11,9 +11,11 @@ import {
   PROFILE_SCHEMA_PATH,
   RECEIPT_SCHEMA_PATH,
   CACHE_PREFLIGHT_SCHEMA_PATH,
+  assertExactOpenPoseRecoveryPreflight,
   assertExactDownloadedFilePartition,
   authorityLifetimePlan,
   cellSemanticsSha256,
+  cleanupMissingFileStore,
   directoryInventory,
   expectedB646DerivedNamespace,
   expectedArtifactFilesFromEvidence,
@@ -1831,6 +1833,85 @@ test("OpenPose recovery imports only 1 through 14 and replaces exactly the five 
     assert.equal((await readdir(path.join(output, "_imported-prefix"))).includes("15-sdxl-openpose"), false);
     await writeFile(path.join(fixture.candidate, "artifact-metadata.json"), "{}\n");
     await assert.rejects(() => selectOpenPoseRecovery(validRoot, profile()), /metadata|artifact 9500244306/);
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+});
+
+test("OpenPose recovery preflight is an exact five-cell byte, peak, floor, and authority plan", () => {
+  const authorityIds = [
+    "sdxl-base-q4", "sdxl-openpose", "sdxl-tokenizer-l", "sdxl-tokenizer-bigg", "sdxl-vae-fix",
+    "realvisxl-q4", "realvisxl-lightning-q4", "illustrious-v1-q4", "illustrious-v2-q4",
+  ];
+  const artifactExpectedFiles = Object.fromEntries(authorityIds.map((id, index) => [
+    id, Array.from({ length: [20, 1, 1, 1, 1, 19, 20, 19, 19][index] }, (_, file) => `${id}-${file}`),
+  ]));
+  const valid = () => ({
+    executionOrdinals: [15, 16, 17, 18, 19],
+    remainingArtifactIds: [...authorityIds],
+    artifactExpectedFiles,
+    lifetimePlan: authorityIds.map((artifactId) => ({ artifactId })),
+    diskPlan: {
+      reviewedAllAtOnceSourceBytes: 21_191_060_168,
+      logicalSourceBytes: 21_191_060_168,
+      allAtOnceSourceBytes: 21_191_060_168,
+      peakOrdinal: 17,
+      peakArtifactIds: [
+        "sdxl-openpose", "sdxl-tokenizer-l", "sdxl-tokenizer-bigg", "sdxl-vae-fix",
+        "realvisxl-lightning-q4",
+      ],
+      peakStagedBytes: 14_576_195_187,
+      peakSidecarReserveBytes: 0,
+      peakModelAndSidecarBytes: 14_576_195_187,
+      reviewedJitSourcePeakBytes: 14_576_195_187,
+      peakRequiredAdditionalBytes: 106_929_602_242,
+    },
+  });
+  assert.doesNotThrow(() => assertExactOpenPoseRecoveryPreflight(valid()));
+
+  for (const [label, mutate, pattern] of [
+    ["source total", (plan) => { plan.diskPlan.logicalSourceBytes += 1; }, /disk\/JIT plan/],
+    ["staged peak", (plan) => { plan.diskPlan.peakStagedBytes += 1; }, /disk\/JIT plan/],
+    ["JIT floor", (plan) => { plan.diskPlan.peakRequiredAdditionalBytes += 1; }, /disk\/JIT plan/],
+    ["authority set", (plan) => { plan.remainingArtifactIds.pop(); }, /authority set/],
+  ]) {
+    const mutated = valid();
+    mutate(mutated);
+    assert.throws(() => assertExactOpenPoseRecoveryPreflight(mutated), pattern, label);
+    assert.doesNotThrow(() => assertExactOpenPoseRecoveryPreflight(valid()), `${label} restore`);
+  }
+  for (const selector of [
+    [14], [14, 18, 19], Array.from({ length: 19 }, (_, index) => index + 1),
+    [16, 15, 17, 18, 19], [15, 16, 17, 18, 18], [15, 16, 17, 18],
+  ]) {
+    const mutated = valid();
+    mutated.executionOrdinals = selector;
+    assert.throws(() => assertExactOpenPoseRecoveryPreflight(mutated), /exact reviewed/, JSON.stringify(selector));
+    assert.doesNotThrow(() => assertExactOpenPoseRecoveryPreflight(valid()), `${JSON.stringify(selector)} restore`);
+  }
+});
+
+test("final missing-file store cleanup tolerates only already-absent ENOENT", async () => {
+  const temporary = await mkdtemp(path.join(tmpdir(), "sc-20739-missing-store-cleanup-"));
+  try {
+    const missingStore = path.join(temporary, "already-absent");
+    await cleanupMissingFileStore({
+      cleanup: async () => {
+        const error = new Error("already absent");
+        error.code = "ENOENT";
+        throw error;
+      },
+    }, missingStore, {}, "already absent fixture");
+    await assert.rejects(
+      cleanupMissingFileStore({
+        cleanup: async () => {
+          const error = new Error("permission denied");
+          error.code = "EACCES";
+          throw error;
+        },
+      }, missingStore, {}, "non-ENOENT fixture"),
+      /permission denied/,
+    );
   } finally {
     await rm(temporary, { recursive: true, force: true });
   }


### PR DESCRIPTION
Repairs the two pre-render failures from invalid candidate run 32679720253 without changing inference or engine behavior.\n\nLocal acceptance mapping:\n- exact selector [15,16,17,18,19] has a fail-closed recovery plan for source bytes 21,191,060,168, staged peak 14,576,195,187, JIT floor, and exact authority set\n- legacy/full/reordered/duplicated/partial selectors remain rejected or governed by their own exact plans\n- final missing-store cleanup accepts only already-absent ENOENT, still propagates other removal errors, and proves store/staging/derived-cache absence\n- production runCampaign path is covered before any cell can execute\n\nValidation:\n- terminal harness: 29/29 pass; harness check pass\n- artifact inventory: 6/6 pass\n- provisioner Python: 16/16 pass\n- npm run check: pass\n- original implementation full npm run rust:check: pass\n- eight source mutations went RED then restored GREEN: source total, peak, JIT floor, authority, selector vector, preflight-call bypass, cleanup-removal bypass, absence-proof bypass\n- exact inference pin 31e02510 preserved\n\nArtifact 9504924328 remains invalid diagnostic evidence. No workflow or hardware run was dispatched from this branch.