### PR TITLE
fix(sc-20739): align Illustrious OpenPose capability matrix

### DIFF
--- a/config/backend-capabilities/matrix.json
+++ b/config/backend-capabilities/matrix.json
@@ -22,12 +22,12 @@
     "descriptorMlxRuntime": "9f0330602a75cf386cedea98b87b757ef98dd9b18c0d31a70e75ef1f268baaef",
     "descriptorPreviewFacts": "2e63c9948b01672335b15e1a77c300c6ecbbc6c94d419e1157614a569f03d8be",
     "exceptionRegister": "6645ec832bfe4a49f266f9475f70748af1a3deb99660d780dcdb74e195b15984",
-    "manifest": "080b46370f19784456318568258adb7b38125cd872dc1135ff297524080a7a34",
+    "manifest": "9cffb0d4762da659ecf12a02e2a92876b15dc9bb048ba6b62afbe6fe9225b13d",
     "modelImportDefaults": "958ce5647f0ab3bb489cb1338974f511bd852fc577051d48cb5e9b5ec4512ab4",
     "routerCandle": "d55ed85e9d208c42848f22c1e245caca1015d196e002e7bb891642b32b5c2bf6",
     "routerCatalog": "0a08189104df04729dddc8a94c210876e243afd0b03812ce6c072b3a9efe453c",
     "routerGaps": "885a73b08cd2d598d656adb15d69a2ea0a78faa0437fc3ba0e25d5f5245efcb2",
-    "routerMlx": "d9bc69db199a5efe378db62d558ab134a0ee1c82da8561dbb1d0d641bd0f57cb",
+    "routerMlx": "a9d4618464115f939befbdb052e1739b8ab6060c39820508ce9c2b4f32df677f",
     "scheduler": "7adf257c047f8fd15dff086add27a928d5e09ceed29c1371ab3058de254d0748",
     "trainingCatalog": "ba87e0cb93ab872fd2a430f2ac4aeaedf8c65d6869b37b7ff7df4071309289e0",
     "webAudioStudio": "9b0e0c85ee0117b122e1f7968198f37bcf864c1efcbd405fa45570e63b6f9b16",
@@ -53,7 +53,7 @@
     "workerImageMageFinetuned": "9cba14a96d3900768a1306752af6ec6d07fbf68d604449f9611c8ad08d091f1b",
     "workerImagePulid": "7809ccd7ef6059a09b976ec7f00ff3d1a95f120050b9f343a9aabc4b0ebac199",
     "workerImagePulidCandle": "e03c33082e5e8c1762a166769ada64cc4942abc5c06a8c6990a5a8914ea205c2",
-    "workerImageQwenEditCandle": "13d893e31e031ca1fadafa1b93f284ef669f7154d4d3fdf954838fb00884ae2c",
+    "workerImageQwenEditCandle": "68676c54a15f92e0d7e79343bd32cd3bf8e6f86613be1dec06c3cf568ab41142",
     "workerImageSdxlImported": "63e5f2891be1f3e8ea1dc77ef3837254ab188ccc63fdaf608de2d37499332efd",
     "workerTrainingDispatch": "479520bfabe44f79ff1e18617c442fadead941e2a8dac973b26ee1e54100c447",
     "workerUtilityDispatch": "017142f8ac644fa2d275e35b94827af4f60644340956dfb84576d7e940737f0d",
@@ -1762,8 +1762,8 @@
       "conditioningShape": [
         {
           "capability": "control",
-          "mlx": false,
-          "candle": false
+          "mlx": true,
+          "candle": true
         },
         {
           "capability": "mask",
@@ -1876,8 +1876,8 @@
       "conditioningShape": [
         {
           "capability": "control",
-          "mlx": false,
-          "candle": false
+          "mlx": true,
+          "candle": true
         },
         {
           "capability": "mask",

--- a/crates/sceneworks-core/src/jobs_store/routing/matrix.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/matrix.rs
@@ -1305,10 +1305,14 @@ fn bespoke_image_lane_support(
                         | ("conditioning", "reference")
                 )
         }
-        // Staged until the final accepted inference pin and descriptor dump. The route is wired,
-        // but the checked-in semantic matrix/exceptions deliberately remain pin-keyed to the
-        // current provider facts and must not be advanced from source inference alone.
-        CandleImageLane::SdxlControl => false,
+        // The terminal CUDA campaign accepted this exact five-model route. Keep the semantic
+        // supplement tied to the production route table rather than the shared `sdxl` descriptor:
+        // the latter is intentionally broader than the product's OpenPose admission boundary.
+        CandleImageLane::SdxlControl => {
+            super::candle::is_sdxl_control_model(model)
+                && category == "conditioning"
+                && capability == "control"
+        }
         CandleImageLane::QwenEdit => {
             matches!(
                 model,
@@ -1863,15 +1867,6 @@ fn conditioning_cell(
     let (job_type, payload) = conditioning_payload(model, shape, mlx_facts, candle_facts)?;
     let job = probe_job(job_type, &model.id, payload)?;
     let supports = |facts: &RuntimeDescriptorFacts| {
-        // The shared `sdxl` runtime descriptor advertises ControlNet for every route alias, and the
-        // scheduler deliberately owns unsupported Illustrious control payloads only to reject them.
-        // Neither fact is product support: cells 18-19 remained terminal-evidence-only, so their
-        // exact model ids must stay false on both backends despite the shared descriptor/claim.
-        if shape == "control"
-            && matches!(model.id.as_str(), "illustrious_xl_v1" | "illustrious_xl_v2")
-        {
-            return false;
-        }
         let descriptors = native_generator_descriptors(facts, &model.id);
         descriptors
             .into_iter()
@@ -3594,8 +3589,9 @@ mod tests {
         );
 
         // Mutate the actual Candle runtime snapshot and feed it through the production derivation;
-        // this is deliberately not a copied matrix fixture. Removing a native fact must restore
-        // precisely its MLX-only parity obligation and make the checked-in matrix mismatch.
+        // this is deliberately not a copied matrix fixture. The accepted SDXL OpenPose product
+        // route is now an independent authority, so losing the shared descriptor's conditioning
+        // annotation must not revoke any of the exact five claims or recreate a residual gap.
         let mut missing_candle_control: Value = serde_json::from_str(CANDLE_RUNTIME_FACTS).unwrap();
         let generators = missing_candle_control["snapshot"]["generator_capabilities"]
             .as_array_mut()
@@ -3610,7 +3606,13 @@ mod tests {
             &serde_json::to_string(&missing_candle_control).unwrap(),
         )
         .expect("mutated production facts still derive a matrix");
-        for model in ["realvisxl", "realvisxl_lightning", "sdxl"] {
+        for model in [
+            "sdxl",
+            "realvisxl",
+            "realvisxl_lightning",
+            "illustrious_xl_v1",
+            "illustrious_xl_v2",
+        ] {
             let cell = mutated
                 .models
                 .iter()
@@ -3621,18 +3623,13 @@ mod tests {
                         .find(|cell| cell.capability == "control")
                 })
                 .unwrap_or_else(|| panic!("mutated derivation emits {model}/control"));
-            assert_eq!((cell.mlx, cell.candle), (Some(true), Some(false)));
-            assert_eq!(
-                cell.parity_obligation
-                    .as_ref()
-                    .map(|obligation| obligation.work_item.as_str()),
-                Some("epic-8588")
-            );
+            assert_eq!((cell.mlx, cell.candle), (Some(true), Some(true)));
+            assert!(cell.parity_obligation.is_none());
         }
         let checked_in: BackendCapabilityMatrix = serde_json::from_str(CHECKED_IN).unwrap();
         assert!(
-            checked_in_matrix_matches_live(checked_in, mutated).is_err(),
-            "removing Candle SDXL control must break the checked-in matrix/residual relationship"
+            checked_in_matrix_matches_live(checked_in, mutated).is_ok(),
+            "the route-backed exact five must survive descriptor-only capture drift"
         );
 
         let mut missing_scail_multi_reference: Value =
@@ -4129,7 +4126,7 @@ mod tests {
     }
 
     #[test]
-    fn sc18481_strict_pose_control_uses_only_real_base_model_lanes() {
+    fn sc20739_strict_pose_control_uses_only_real_product_lanes() {
         let matrix = backend_capability_matrix().unwrap();
         for model in [
             "z_image_turbo",
@@ -4154,20 +4151,59 @@ mod tests {
             assert!(control.parity_obligation.is_none());
         }
 
-        for model in ["illustrious_xl_v1", "illustrious_xl_v2"] {
+        let exact_sdxl_openpose_models = [
+            "sdxl",
+            "realvisxl",
+            "realvisxl_lightning",
+            "illustrious_xl_v1",
+            "illustrious_xl_v2",
+        ];
+        for model in exact_sdxl_openpose_models {
             let row = matrix.models.iter().find(|row| row.id == model).unwrap();
             let control = row
                 .conditioning_shape
                 .iter()
                 .find(|cell| cell.capability == "control")
-                .expect("shared descriptor axis remains represented");
+                .expect("promoted OpenPose model must expose the control axis");
             assert_eq!(
                 (control.mlx, control.candle),
-                (Some(false), Some(false)),
-                "{model} terminal evidence must not become a product control claim"
+                (Some(true), Some(true)),
+                "{model} must preserve the accepted cross-backend OpenPose claim"
             );
             assert!(control.parity_obligation.is_none());
         }
+
+        assert_eq!(
+            super::super::candle::SDXL_CONTROL_MODELS,
+            exact_sdxl_openpose_models.as_slice(),
+            "the generic SDXL OpenPose model allowlist must remain the accepted exact five"
+        );
+        let manifest: ManifestRoot =
+            serde_json::from_str(&strip_jsonc_comments(MANIFEST)).expect("manifest parses");
+        let actual_sdxl_openpose_models: BTreeSet<_> = manifest
+            .models
+            .iter()
+            .filter_map(|model| {
+                let job = probe_job(
+                    JobType::ImageGenerate,
+                    &model.id,
+                    json!({
+                        "mode": "text_to_image",
+                        "prompt": "probe",
+                        "advanced": { "poses": [{}] }
+                    }),
+                )
+                .expect("control probe is structurally valid");
+                (super::super::candle::image_job_candle_lane(&job)
+                    == Some(super::super::candle::CandleImageLane::SdxlControl))
+                .then_some(model.id.as_str())
+            })
+            .collect();
+        assert_eq!(
+            actual_sdxl_openpose_models,
+            exact_sdxl_openpose_models.into_iter().collect(),
+            "the generic SDXL OpenPose route must not broaden beyond the accepted exact five"
+        );
 
         // These edit models consume the pose image as an ordinary reference; they do not own the
         // strict control lane and must not inherit the base-model supplement above.


### PR DESCRIPTION
Shortcut: sc-20739
Epic: 20738

Closes the C3 terminal-review blocker where the semantic capability matrix contradicted the already-promoted exact-five SDXL OpenPose product contract.

## Change

- Removes the stale Illustrious terminal-only false override from matrix derivation.
- Derives Candle SDXL OpenPose support from the production exact-five route.
- Regenerates `config/backend-capabilities/matrix.json`.
- Updates the obsolete descriptor-drift expectation and adds a focused exact-five regression guard.

The semantic JSON diff is exactly four booleans:

- `illustrious_xl_v1/conditioningShape/control`: MLX `false -> true`, Candle `false -> true`
- `illustrious_xl_v2/conditioningShape/control`: MLX `false -> true`, Candle `false -> true`

Regeneration also refreshed three provenance-only capture hashes (`manifest`, `routerMlx`, and `workerImageQwenEditCandle`). No other capability semantic changed; residual, Krea, CFG++, and TrueV2 surfaces remain unchanged and fail closed where previously required.

## Terminal evidence and pin

The accepted terminal campaign remains applicable: run 32686177202, artifact 9507015524. This change does not touch campaign inputs, worker execution, harness logic, workflow logic, evidence, GPU behavior, weights, or measurement code.

The inference pin remains exactly `31e02510ad6e9e1a3c3d205058576329d724c60d` across Cargo manifests and lockfile.

## Validation

- `cargo test -p sceneworks-core jobs_store::routing::matrix::tests:: -- --nocapture` — 37/37 PASS
- Focused sc-20739 exact-five test — PASS
- Checked-in/live matrix derivation — PASS
- Matrix regeneration byte-idempotence — PASS
- `cargo clippy -p sceneworks-core --all-targets -- -D warnings` — PASS
- `cargo fmt --all -- --check` — PASS
- Platform/engine web-source contracts — 76/76 PASS
- `git diff --check` — PASS
- Restored RED mutations: force Illustrious v1 control false; broaden the SDXL allowlist with Krea

## Exceptional review gate

The user explicitly authorized one exceptional fix plus a fourth independent terminal verification cycle after the normal three-cycle cap. This PR must not merge until that independent C4 review returns PASS.