### PR TITLE
chore: address final epic code quality comments

### DIFF
--- a/scripts/hash-artifact-inventory.mjs
+++ b/scripts/hash-artifact-inventory.mjs
@@ -132,7 +132,6 @@ export async function listCachedArtifactFiles(root, trustedRoot) {
     for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
       const childRelative = path.join(relative, entry.name);
       const candidate = path.join(absolute, childRelative);
-      const metadata = await lstat(candidate);
       if (entry.isDirectory() && !entry.isSymbolicLink()) {
         const resolved = await realpath(candidate);
         const relation = path.relative(resolvedRoot, resolved);

--- a/scripts/provision_epic_20738_terminal_artifact_test.py
+++ b/scripts/provision_epic_20738_terminal_artifact_test.py
@@ -7,9 +7,8 @@ import stat
 import sys
 import tempfile
 import types
-import unittest
 from pathlib import Path
-from unittest import mock
+from unittest import TestCase, main, mock, skipUnless
 
 
 MODULE_PATH = Path(__file__).with_name("provision-epic-20738-terminal-artifact.py")
@@ -19,7 +18,7 @@ assert SPEC.loader is not None
 SPEC.loader.exec_module(MODULE)
 
 
-class CacheOnlyProvisionTests(unittest.TestCase):
+class CacheOnlyProvisionTests(TestCase):
     REVISION = "a" * 40
     CURRENT_REPOSITORY = "SceneWorks/illustrious-xl-v1-mlx"
     CURRENT_REVISION = "778c3f02b7703b0c2755d0c0447592897193c6b5"
@@ -507,7 +506,7 @@ class CacheOnlyProvisionTests(unittest.TestCase):
                     "commitSha": self.CURRENT_REVISION,
                 }])
 
-    @unittest.skipUnless(os.name == "nt", "Windows extended path spellings are Windows-only")
+    @skipUnless(os.name == "nt", "Windows extended path spellings are Windows-only")
     def test_windows_extended_prefix_normalizes_only_drive_and_unc_paths(self) -> None:
         self.assertEqual(
             MODULE._without_windows_extended_prefix(
@@ -547,4 +546,4 @@ class CacheOnlyProvisionTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    main()


### PR DESCRIPTION
## Summary

- addresses PR #2557 inline comment 3843156074 by consolidating unittest imports and updating the TestCase, skipUnless, and main references
- addresses PR #2557 inline comment 3843159855 by removing only the unused metadata assignment in listCachedArtifactFiles
- preserves behavior and leaves campaign semantics, evidence, and the exact inference pin unchanged

## Validation

- python -m unittest scripts/provision_epic_20738_terminal_artifact_test.py (16/16 passed)
- node --test scripts/hash-artifact-inventory.test.mjs scripts/epic-20738-terminal-cuda-harness.test.mjs (35/35 passed)
- Node syntax checks, Python AST parse, and git diff --check passed