### PR TITLE
chore: derive the 20738 harness inference rev from the live pin

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -1191,8 +1191,10 @@ jobs:
       # source-reviewed fixed cache root is censused from checked-in immutable download evidence
       # before transfer: there is no cache input,
       # snapshot/glob/ref-main fallback, matrix, child workflow, per-cell dispatch, or secret weight
-      # path. Exact archived 19-PASS artifact 9500244306 is revalidated under the final pinned
-      # 31e02510 provenance. Its authentic PASS cells 1-14 are imported while only the five OpenPose
+      # path. Exact archived 19-PASS artifact 9500244306 is revalidated under the capture-time
+      # inference provenance the artifact itself records -- never a second copy of the repository
+      # pin, which no `npm run bump:inference` would ever advance. Its authentic PASS cells 1-14
+      # are imported while only the five OpenPose
       # cells 15-19 are replaced with same-seed causal-control receipts after their complete source/disk
       # plan passes and network is forced
       # offline. Authorities are copied just in time, retained only through their exact last consumer,
@@ -1276,10 +1278,16 @@ jobs:
           New-Item -ItemType Directory -Path $evidence -Force | Out-Null
           gh run download $runId --name $artifactName --dir $evidence
           if ($LASTEXITCODE -ne 0) { throw "failed to download audited 19-PASS OpenPose recovery artifact $artifactId" }
+          # The archived campaign names its own inference revision; the artifact digest asserted
+          # above already pins that value, so read it back out of the evidence instead of carrying
+          # a second copy of the repository pin here.
+          $summary = Get-Content -LiteralPath (Join-Path $evidence 'campaign-summary.json') -Raw | ConvertFrom-Json
+          $inferenceSha = [string]$summary.repositories.inference.sha
+          if ($inferenceSha -notmatch '^[0-9a-f]{40}$') { throw 'archived 19-PASS campaign summary does not record an exact inference revision' }
           $metadata = [ordered]@{
             artifactId = $artifactId; artifactName = $artifactName; artifactSize = $artifactSize; artifactDigest = $artifactDigest
             runId = $runId; runAttempt = $runAttempt; headSha = $headSha
-            inferenceSha = '31e02510ad6e9e1a3c3d205058576329d724c60d'
+            inferenceSha = $inferenceSha
             profile = 'epic-20738-candle-cuda-terminal-v1'
             cellSemanticsSha256 = '2fcd20e4909f0bd0ba6c78c6a85247267c354735f77f4ed4912d47941a8512c1'
             artifactSemanticsSha256 = '1e98392f71b1ad3d10d4bf18a6f23a497f5ffe588127ac59c54e53d392e6e255'

--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -54,7 +54,6 @@ const EXPECTED_ARTIFACT_SEMANTICS_SHA256 = "1e98392f71b1ad3d10d4bf18a6f23a497f5f
 const LEGACY_RECOVERY_ARTIFACT_SEMANTICS_SHA256 = "5b9ef60c18ab15caeca7ff0411b199618f0aa22cc051a70607aa7a0f7c6cd932";
 const LEGACY_ARTIFACT_SEMANTICS_SHA256 = "f2bb7a77b83ce11cc32c3a1f9639534a67a149bc464a9730fb5c0988b4a03f9e";
 const LEGACY_SCENEWORKS_HEAD = "8886a9e69f26beec05688c81b414859bd102f6d0";
-const FROZEN_INFERENCE_PIN = "31e02510ad6e9e1a3c3d205058576329d724c60d";
 const HISTORICAL_INFERENCE_PIN = "b646a6f89ba9f6b07efe53dd583d8a42e21e9871";
 const LTX_CURRENT_REVISION = "01df27d308466533aa09d251e3aebdcc627d07eb";
 const LTX_APPROVED_PARENT_REVISION = "254989c3ca7ee691187647f350b112c0c448789d";
@@ -1045,6 +1044,34 @@ export function inferencePins(cargoToml) {
   const pins = [...cargoToml.matchAll(/git\s*=\s*"https:\/\/github\.com\/SceneWorks\/inference(?:\.git)?"[^}\n]*?rev\s*=\s*"([0-9a-f]{40})"/g)]
     .map((match) => match[1]);
   return [...new Set(pins)];
+}
+
+// Every SceneWorks manifest that carries a `SceneWorks/inference` git pin. `scripts/bump-inference.mjs`
+// rewrites exactly these three, so they are the repository's single inference-revision source.
+export const INFERENCE_PIN_MANIFESTS = [
+  "Cargo.toml",
+  "crates/sceneworks-worker/Cargo.toml",
+  "crates/sceneworks-memory-adapter/Cargo.toml",
+];
+
+// Derive the live inference revision from the checked-out manifests instead of restating it as a
+// harness constant. A second copy of the pin is a copy no `npm run bump:inference` touches, so it
+// goes stale silently and reds this controller for a reason that has nothing to do with the epic.
+export async function liveInferencePin(root = "") {
+  const perManifest = new Map();
+  for (const manifest of INFERENCE_PIN_MANIFESTS) {
+    const found = inferencePins(await readFile(path.join(root, manifest), "utf8"));
+    if (found.length !== 1) {
+      fail(`${manifest} must declare exactly one SceneWorks/inference revision; got ${found.join(",") || "none"}`);
+    }
+    perManifest.set(manifest, found[0]);
+  }
+  const distinct = new Set(perManifest.values());
+  if (distinct.size !== 1) {
+    fail(`SceneWorks manifests disagree on the inference revision: ${
+      [...perManifest].map(([manifest, pin]) => `${manifest}=${pin}`).join(", ")}`);
+  }
+  return [...distinct][0];
 }
 
 function assertOutsideRepository(candidate, repositories, label) {
@@ -2930,7 +2957,11 @@ function validateOpenPoseRecoveryMetadata(metadata) {
     || metadata.runId !== OPENPOSE_RECOVERY_RUN_ID
     || metadata.runAttempt !== OPENPOSE_RECOVERY_RUN_ATTEMPT
     || metadata.headSha !== OPENPOSE_RECOVERY_SCENEWORKS_HEAD
-    || metadata.inferenceSha !== FROZEN_INFERENCE_PIN
+    // The capture revision belongs to the archived artifact, not to this repository: the artifact's
+    // own `sha256:` digest is already asserted above, so it pins the recorded revision far more
+    // tightly than a harness constant could. Require only the exact 40-hex shape here and bind the
+    // value by agreement with the artifact's own campaign summary and per-cell receipts below.
+    || !SHA40.test(metadata.inferenceSha)
     || metadata.profile !== PROFILE_NAME
     || metadata.cellSemanticsSha256 !== EXPECTED_CELL_SEMANTICS_SHA256
     || metadata.artifactSemanticsSha256 !== EXPECTED_ARTIFACT_SEMANTICS_SHA256) {
@@ -2942,7 +2973,7 @@ function validateOpenPoseRecoverySummary(summary, currentProfile, metadata) {
   if (summary?.schemaVersion !== 1 || summary.profile !== PROFILE_NAME
     || summary.repositories?.sceneworks?.sha !== metadata.headSha
     || summary.repositories?.sceneworks?.clean !== true
-    || summary.repositories?.inference?.sha !== FROZEN_INFERENCE_PIN
+    || summary.repositories?.inference?.sha !== metadata.inferenceSha
     || summary.repositories?.inference?.clean !== true
     || summary.execution?.runId !== metadata.runId
     || summary.execution?.runAttempt !== metadata.runAttempt
@@ -3009,7 +3040,7 @@ export async function selectOpenPoseRecovery(prefixCandidates, currentProfile) {
         ? { headSha: RECOVERY_SCENEWORKS_HEAD, runId: RECOVERY_RUN_ID, runAttempt: RECOVERY_RUN_ATTEMPT }
         : ordinal <= 13
           ? { headSha: SPARSE_RECOVERY_SCENEWORKS_HEAD, runId: SPARSE_RECOVERY_RUN_ID, runAttempt: SPARSE_RECOVERY_RUN_ATTEMPT }
-          : { ...metadata, inferenceSha: FROZEN_INFERENCE_PIN };
+          : metadata;
     validateRecoveryReceiptProvenance(receipt, cell, provenance, `OpenPose recovery imported receipt ${ordinalName}`);
     if (ordinal <= IMPORTED_PREFIX_CELLS) {
       validateTrustedLegacyImportedReceiptDocument(receipt);
@@ -4141,9 +4172,9 @@ export async function runCampaign(args, options = {}) {
     const inference = repositoryIdentity(args.inference, "inference");
     if (sceneworks.sha !== args.sceneworksRevision) fail("SceneWorks HEAD does not match --sceneworks-revision");
     if (inference.sha !== args.inferenceRevision) fail("inference HEAD does not match --inference-revision");
-    const pins = inferencePins(await readFile(path.join(sceneworks.root, "Cargo.toml"), "utf8"));
-    if (pins.length !== 1 || pins[0] !== inference.sha) {
-      fail(`SceneWorks must have exactly one inference revision and it must equal checked-out inference HEAD; got ${pins.join(",")}`);
+    const pin = await liveInferencePin(sceneworks.root);
+    if (pin !== inference.sha) {
+      fail(`SceneWorks pins inference ${pin} but the checked-out inference HEAD is ${inference.sha}`);
     }
     const manifest = JSON.parse(stripJsoncComments(await readFile(
       path.join(sceneworks.root, "config/manifests/builtin.models.jsonc"), "utf8",
@@ -5228,17 +5259,14 @@ async function main() {
       offlineBeforeCells: false,
     });
     const profile = validateProfile(loadProfile(profilePath));
-    const pins = inferencePins(await readFile("Cargo.toml", "utf8"));
-    if (pins.length !== 1 || pins[0] !== FROZEN_INFERENCE_PIN) {
-      fail("terminal SceneWorks manifests do not bind the corrected frozen inference pin");
-    }
+    const pin = await liveInferencePin();
     const manifest = JSON.parse(stripJsoncComments(await readFile("config/manifests/builtin.models.jsonc", "utf8")));
     validateManifestAuthorities(profile, manifest);
     const downloadEvidenceBytes = await readFile(DOWNLOAD_EVIDENCE_PATH, "utf8");
     const { artifactExpectedFiles: expected } =
       expectedCurrentArtifactFilesFromEvidenceBytes(profile, downloadEvidenceBytes);
     if (Object.keys(expected).length !== 23) fail("terminal exact filename census is incomplete");
-    process.stdout.write(`${PROFILE_NAME}: exactly 19 serialized cells and immutable authorities OK\n`);
+    process.stdout.write(`${PROFILE_NAME}: exactly 19 serialized cells and immutable authorities OK (inference pin ${pin})\n`);
     return;
   }
   if (command === "run") {

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -23,6 +23,8 @@ import {
   expectedLoadSpecQuantBits,
   estimateJitDiskPlan,
   inferencePins,
+  INFERENCE_PIN_MANIFESTS,
+  liveInferencePin,
   hashedFiles,
   installSidecarObstructions,
   inspectDerivedSidecarRoot,
@@ -878,6 +880,65 @@ test("raw nvidia-smi and one exact inference pin fixtures parse deterministicall
   assert.deepEqual(inferencePins(`dep = { git = "https://github.com/SceneWorks/inference", rev = "${"a".repeat(40)}" }`), ["a".repeat(40)]);
 });
 
+async function writePinManifests(root, pins) {
+  for (const [index, manifest] of INFERENCE_PIN_MANIFESTS.entries()) {
+    const file = path.join(root, manifest);
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(
+      file,
+      [
+        "[dependencies]",
+        `gen-core = { git = "https://github.com/SceneWorks/inference", rev = "${pins[index]}" }`,
+        // Same-shape pins on other repositories must not be mistaken for the inference revision.
+        'mlx-rs = { package = "pmetal-mlx-rs", git = "https://github.com/michaeltrefry/mlx-rs", rev = "bd8f0e3c757195b17b2c34fae3073ab826fb7bc1" }',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+  }
+}
+
+test("the terminal inference revision is derived from the live manifests, never restated", async () => {
+  // The three manifests `scripts/bump-inference.mjs` rewrites are the only inference-pin source.
+  const bump = await readFile("scripts/bump-inference.mjs", "utf8");
+  for (const manifest of INFERENCE_PIN_MANIFESTS) {
+    assert.match(bump, new RegExp(manifest.replace(/[/.]/g, "\\$&")), `${manifest} is a bump-inference target`);
+  }
+
+  // The controller and the dispatch workflow must not carry a second copy of any inference pin.
+  const controller = await readFile("scripts/epic-20738-terminal-cuda-harness.mjs", "utf8");
+  assert.doesNotMatch(controller, /FROZEN_INFERENCE_PIN/);
+  const workflow = await readFile(".github/workflows/windows-candle.yml", "utf8");
+  assert.doesNotMatch(workflow, /inferenceSha = '[0-9a-f]{40}'/);
+  assert.match(workflow, /campaign-summary\.json[\s\S]*?\$summary\.repositories\.inference\.sha[\s\S]*?inferenceSha = \$inferenceSha/);
+
+  // The live checkout agrees with itself, and the derived value is what the manifests actually say.
+  const live = await liveInferencePin();
+  assert.match(live, /^[0-9a-f]{40}$/);
+  for (const manifest of INFERENCE_PIN_MANIFESTS) {
+    assert.deepEqual(inferencePins(await readFile(manifest, "utf8")), [live], manifest);
+  }
+
+  const temporary = await mkdtemp(path.join(tmpdir(), "sc-21393-live-pin-"));
+  try {
+    const agreed = path.join(temporary, "agreed");
+    const pin = "c".repeat(40);
+    await writePinManifests(agreed, [pin, pin, pin]);
+    assert.equal(await liveInferencePin(agreed), pin, "an arbitrary agreed revision parses, not a literal");
+
+    const drifted = path.join(temporary, "drifted");
+    await writePinManifests(drifted, [pin, pin, "d".repeat(40)]);
+    await assert.rejects(liveInferencePin(drifted), /manifests disagree on the inference revision/);
+
+    const missing = path.join(temporary, "missing");
+    await writePinManifests(missing, [pin, pin, pin]);
+    await writeFile(path.join(missing, INFERENCE_PIN_MANIFESTS[1]), "[dependencies]\n", "utf8");
+    await assert.rejects(liveInferencePin(missing), /must declare exactly one SceneWorks\/inference revision/);
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+});
+
 test("Draft 2020-12 schemas validate the profile and close adversarial receipt drift", async () => {
   assert.doesNotThrow(() => validateDocumentWithSchema(PROFILE_SCHEMA_PATH, PROFILE_PATH));
   const temporary = await mkdtemp(path.join(tmpdir(), "sc-20945-schema-"));
@@ -1673,6 +1734,8 @@ async function writePass18RecoveryCandidate(root) {
   return { candidate, evidence, metadata, summary };
 }
 
+const OPENPOSE_FIXTURE_INFERENCE_SHA = "e7c1a9d0".repeat(5);
+
 async function writeOpenPoseRecoveryCandidate(root) {
   const pass18Root = path.join(path.dirname(root), `${path.basename(root)}-pass18-source`);
   await mkdir(pass18Root);
@@ -1692,7 +1755,10 @@ async function writeOpenPoseRecoveryCandidate(root) {
     runId: "32664618999",
     runAttempt: "1",
     headSha: "7d7a3efa3088204311e3be01330f35702774feb6",
-    inferenceSha: "31e02510ad6e9e1a3c3d205058576329d724c60d",
+    // Deliberately not the revision the real 9500244306 artifact was captured at: the controller
+    // must accept whatever exact revision the evidence itself records, so a fixture revision that
+    // matches no repository constant proves the frozen-pin comparison is gone for good.
+    inferenceSha: OPENPOSE_FIXTURE_INFERENCE_SHA,
     profile: PROFILE_NAME,
     cellSemanticsSha256: "2fcd20e4909f0bd0ba6c78c6a85247267c354735f77f4ed4912d47941a8512c1",
     artifactSemanticsSha256: "1e98392f71b1ad3d10d4bf18a6f23a497f5ffe588127ac59c54e53d392e6e255",
@@ -1799,7 +1865,7 @@ test("18-PASS recovery imports authentic PASS ordinals and keeps failed LTX cell
       ["historical-pin", async (candidate) => {
         const file = path.join(candidate, "artifact-metadata.json");
         const value = JSON.parse(await readFile(file));
-        value.inferenceSha = "31e02510ad6e9e1a3c3d205058576329d724c60d";
+        value.inferenceSha = "b".repeat(40);
         await writeFile(file, JSON.stringify(value));
       }, /artifact 9498929065/],
     ]) {
@@ -1831,6 +1897,37 @@ test("OpenPose recovery imports only 1 through 14 and replaces exactly the five 
     assert.equal(imported.outcomes.length, 14);
     assert.deepEqual(imported.lineage.executionOrdinals, [15, 16, 17, 18, 19]);
     assert.equal((await readdir(path.join(output, "_imported-prefix"))).includes("15-sdxl-openpose"), false);
+
+    // The capture revision is no longer compared against a harness constant, so it has to be bound
+    // by internal agreement instead: metadata, campaign summary, and per-cell receipt must all name
+    // the same exact 40-hex revision, and any one of them drifting has to reject the artifact.
+    for (const [label, mutate, pattern] of [
+      ["shapeless metadata revision", async (candidate) => {
+        const file = path.join(candidate, "artifact-metadata.json");
+        const value = JSON.parse(await readFile(file));
+        value.inferenceSha = "refs/heads/main";
+        await writeFile(file, JSON.stringify(value));
+      }, /artifact 9500244306/],
+      ["summary revision drift", async (candidate) => {
+        const file = path.join(candidate, "evidence", "campaign-summary.json");
+        const value = JSON.parse(await readFile(file));
+        value.repositories.inference.sha = "9".repeat(40);
+        await writeFile(file, JSON.stringify(value));
+      }, /19-PASS evidence|audited 19-PASS final run/],
+      ["receipt revision drift", async (candidate) => {
+        const file = path.join(candidate, "evidence", "14-ltx-2-3-q8", "receipt.json");
+        const value = JSON.parse(await readFile(file));
+        value.repositories.inference.sha = "9".repeat(40);
+        await writeFile(file, JSON.stringify(value));
+      }, /imported receipt 14-ltx-2-3-q8/],
+    ]) {
+      const root = path.join(temporary, label.replace(/\s+/g, "-"));
+      await mkdir(root);
+      await cp(fixture.candidate, path.join(root, "9500244306"), { recursive: true });
+      await mutate(path.join(root, "9500244306"));
+      await assert.rejects(selectOpenPoseRecovery(root, profile()), pattern, label);
+    }
+
     await writeFile(path.join(fixture.candidate, "artifact-metadata.json"), "{}\n");
     await assert.rejects(() => selectOpenPoseRecovery(validRoot, profile()), /metadata|artifact 9500244306/);
   } finally {
@@ -3995,7 +4092,9 @@ test("schemas, clean Node dependencies, and workflow preserve the opt-in single-
   assert.match(terminalBlock, /9500244306[\s\S]*?17134718[\s\S]*?9af191547befc7833f82f4d9057fff8abfe09b21eada2be2b4f252d73ae30818/);
   assert.match(terminalBlock, /\$artifact\.expired[\s\S]*?\$artifact\.size_in_bytes[\s\S]*?\$artifact\.digest/);
   assert.match(terminalBlock, /gh run download \$runId --name \$artifactName --dir \$evidence/);
-  assert.match(terminalBlock, /7d7a3efa3088204311e3be01330f35702774feb6[\s\S]*?31e02510ad6e9e1a3c3d205058576329d724c60d/);
+  assert.match(terminalBlock, /7d7a3efa3088204311e3be01330f35702774feb6[\s\S]*?inferenceSha = \$inferenceSha/);
+  assert.match(terminalBlock, /\$summary\.repositories\.inference\.sha[\s\S]*?\$inferenceSha -notmatch '\^\[0-9a-f\]\{40\}\$'/);
+  assert.doesNotMatch(terminalBlock, /inferenceSha = '[0-9a-f]{40}'/);
   assert.doesNotMatch(terminalBlock, /snapshot_download/);
   assert.match(terminalBlock, /python -m venv \$venv/);
   assert.match(terminalBlock, /pip install[^\n]*'huggingface_hub==0\.36\.0'/);


### PR DESCRIPTION
Michael's decision: the repo has exactly ONE inference pin source. `scripts/epic-20738-terminal-cuda-harness.mjs` carried `FROZEN_INFERENCE_PIN` and `.github/workflows/windows-candle.yml` mirrored the same rev into the recovery artifact metadata — two copies no `npm run bump:inference` touches. Both were already stale, so `harness.mjs check` failed on `main` today.

New `liveInferencePin()` derives the rev from the three manifests bump-inference rewrites (root `Cargo.toml`, `crates/sceneworks-worker`, `crates/sceneworks-memory-adapter`) and rejects any disagreement between them; `check` now stamps the derived rev on stdout and the campaign summary already stamps the checked-out inference HEAD it asserts against.

The archived 19-PASS artifact's capture rev is now bound by internal agreement inside the evidence (metadata ↔ campaign summary ↔ per-cell receipts, exact 40-hex) instead of a repo constant — the artifact's asserted `sha256:` digest already pins that value. The workflow reads it back out of `campaign-summary.json`.

Tests: 30/30 in the harness suite (3 new guards each mutation-proven individually), 723/723 in `npm run check`. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)