### PR TITLE
fix(cuda): canonicalize harness roots (sc-21517)

### DIFF
--- a/scripts/epic-20738-terminal-cuda-harness.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.mjs
@@ -1109,9 +1109,10 @@ async function nearestExistingParent(candidate) {
   }
 }
 
-async function assertNewConfinedDirectory(candidate, runnerTemp, repositories, label) {
+async function assertNewConfinedDirectory(
+  candidate, runnerTemp, repositories, label, lexicalRunnerTemp = runnerTemp,
+) {
   const target = assertOutsideRepository(candidate, repositories, label);
-  if (!isWithin(runnerTemp, target)) fail(`${label} must be a descendant of the resolved RUNNER_TEMP`);
   try {
     await lstat(target);
     fail(`${label} must not already exist`);
@@ -1120,13 +1121,20 @@ async function assertNewConfinedDirectory(candidate, runnerTemp, repositories, l
   }
   const parent = await nearestExistingParent(target);
   if (!isWithin(runnerTemp, parent.resolved, { allowEqual: true })) {
+    if (!isWithin(path.resolve(lexicalRunnerTemp), target)) {
+      fail(`${label} must be a descendant of the resolved RUNNER_TEMP`);
+    }
     fail(`${label} traverses a symlink or reparse point outside RUNNER_TEMP`);
   }
   const throughResolvedParent = path.resolve(parent.resolved, path.relative(parent.lexical, target));
   if (!isWithin(runnerTemp, throughResolvedParent)) {
+    if (!isWithin(runnerTemp, target)) {
+      fail(`${label} must be a descendant of the resolved RUNNER_TEMP`);
+    }
     fail(`${label} resolves outside RUNNER_TEMP`);
   }
-  return target;
+  assertOutsideRepository(throughResolvedParent, repositories, label);
+  return { target, resolved: throughResolvedParent };
 }
 
 export async function validateTrustedCacheRoot(candidate, repositories, runnerTemp) {
@@ -1139,9 +1147,7 @@ export async function validateTrustedCacheRoot(candidate, repositories, runnerTe
     fail("trusted cache root must be an existing ordinary directory, not a symlink/reparse point");
   }
   const resolved = await realpath(target);
-  if (comparable(resolved) !== comparable(target)) {
-    fail("trusted cache root traverses a symlink or reparse point");
-  }
+  assertOutsideRepository(resolved, repositories, "trusted cache root");
   if (isWithin(resolved, runnerTemp, { allowEqual: true })
     || isWithin(runnerTemp, resolved, { allowEqual: true })) {
     fail("trusted cache root and RUNNER_TEMP must be separate trees");
@@ -1160,20 +1166,21 @@ export async function validateCampaignPaths({
   const resolvedCacheRoot = await validateTrustedCacheRoot(
     cacheRoot, resolvedRepositories, resolvedRunnerTemp,
   );
-  const resolvedOutput = await assertNewConfinedDirectory(
-    output, resolvedRunnerTemp, resolvedRepositories, "output",
+  const outputPaths = await assertNewConfinedDirectory(
+    output, resolvedRunnerTemp, resolvedRepositories, "output", runnerTemp,
   );
-  const resolvedScratch = await assertNewConfinedDirectory(
-    scratch, resolvedRunnerTemp, resolvedRepositories, "scratch",
+  const scratchPaths = await assertNewConfinedDirectory(
+    scratch, resolvedRunnerTemp, resolvedRepositories, "scratch", runnerTemp,
   );
-  if (comparable(resolvedOutput) === comparable(resolvedScratch)
-    || isWithin(resolvedOutput, resolvedScratch) || isWithin(resolvedScratch, resolvedOutput)) {
+  if (comparable(outputPaths.resolved) === comparable(scratchPaths.resolved)
+    || isWithin(outputPaths.resolved, scratchPaths.resolved)
+    || isWithin(scratchPaths.resolved, outputPaths.resolved)) {
     fail("output and scratch must be distinct, non-nested RUNNER_TEMP descendants");
   }
   return {
     runnerTemp: resolvedRunnerTemp,
-    output: resolvedOutput,
-    scratch: resolvedScratch,
+    output: outputPaths.resolved,
+    scratch: scratchPaths.resolved,
     cacheRoot: resolvedCacheRoot,
     repositories: resolvedRepositories,
   };
@@ -1181,20 +1188,18 @@ export async function validateCampaignPaths({
 
 async function assertExistingConfinedTree(candidate, guard, label) {
   const target = assertOutsideRepository(candidate, guard.repositories, label);
-  if (!isWithin(guard.runnerTemp, target)) fail(`${label} escaped RUNNER_TEMP before cleanup`);
   const metadata = await lstat(target);
   if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
     fail(`${label} is not a controller-owned ordinary directory before cleanup`);
   }
   const resolved = await realpath(target);
-  if (comparable(resolved) !== comparable(target)) {
-    fail(`${label} was replaced by a symlink or reparse point before cleanup`);
-  }
-  const parent = await realpath(path.dirname(target));
+  assertOutsideRepository(resolved, guard.repositories, label);
+  if (!isWithin(guard.runnerTemp, resolved)) fail(`${label} escaped RUNNER_TEMP before cleanup`);
+  const parent = await realpath(path.dirname(resolved));
   if (!isWithin(guard.runnerTemp, parent, { allowEqual: true })) {
     fail(`${label} parent escaped RUNNER_TEMP before cleanup`);
   }
-  return target;
+  return resolved;
 }
 
 export async function safeRemoveTree(candidate, guard, label = "cleanup target") {
@@ -1233,12 +1238,12 @@ async function sha256File(file) {
 }
 
 export async function hashedFiles(root, { exclude = new Set() } = {}) {
-  const absolute = path.resolve(root);
-  const rootMetadata = await lstat(absolute);
-  if (!rootMetadata.isDirectory() || rootMetadata.isSymbolicLink()
-    || comparable(await realpath(absolute)) !== comparable(absolute)) {
-    fail(`evidence root is not an ordinary non-reparse directory: ${absolute}`);
+  const requested = path.resolve(root);
+  const rootMetadata = await lstat(requested);
+  if (!rootMetadata.isDirectory() || rootMetadata.isSymbolicLink()) {
+    fail(`evidence root is not an ordinary non-reparse directory: ${requested}`);
   }
+  const absolute = await realpath(requested);
   const files = [];
   async function visit(directory) {
     const entries = await readdir(directory, { withFileTypes: true });
@@ -1646,10 +1651,10 @@ function legacyRecoveryProfile(currentProfile) {
 async function ordinaryTreeFiles(root) {
   const absolute = path.resolve(root);
   const metadata = await lstat(absolute);
-  if (!metadata.isDirectory() || metadata.isSymbolicLink()
-    || comparable(await realpath(absolute)) !== comparable(absolute)) {
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
     fail(`imported prefix root must be an ordinary confined directory: ${absolute}`);
   }
+  const resolvedRoot = await realpath(absolute);
   const files = [];
   async function visit(directory) {
     for (const entry of await readdir(directory, { withFileTypes: true })) {
@@ -1659,11 +1664,11 @@ async function ordinaryTreeFiles(root) {
         fail(`imported prefix contains a symlink/reparse point: ${candidate}`);
       }
       const resolved = await realpath(candidate);
-      if (!isWithin(absolute, resolved)) {
+      if (!isWithin(resolvedRoot, resolved)) {
         fail(`imported prefix entry escaped its candidate root: ${candidate}`);
       }
-      if (entry.isDirectory()) await visit(resolved);
-      else if (entry.isFile()) files.push(resolved);
+      if (entry.isDirectory()) await visit(candidate);
+      else if (entry.isFile()) files.push(candidate);
       else fail(`imported prefix contains a non-regular entry: ${candidate}`);
     }
   }

--- a/scripts/epic-20738-terminal-cuda-harness.test.mjs
+++ b/scripts/epic-20738-terminal-cuda-harness.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { cp, lstat, mkdtemp, mkdir, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import {
+  cp, lstat, mkdtemp, mkdir, readdir, readFile, realpath, rm, symlink, writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -2477,7 +2479,7 @@ test("campaign paths are fresh non-nested RUNNER_TEMP descendants and cleanup re
     const guard = await validateCampaignPaths({
       runnerTemp, output, scratch, cacheRoot, repositories,
     });
-    assert.equal(guard.output, output);
+    assert.equal(guard.output, path.join(await realpath(runnerTemp), "output"));
     await mkdir(scratch);
     await safeRemoveTree(scratch, guard, "fixture scratch");
 
@@ -2521,6 +2523,67 @@ test("campaign paths are fresh non-nested RUNNER_TEMP descendants and cleanup re
       }
       throw error;
     }
+    const benignParentLink = path.join(temporary, "benign-cache-parent-link");
+    const repositoryParentLink = path.join(temporary, "repository-cache-parent-link");
+    const runnerParentLink = path.join(temporary, "runner-parent-link");
+    const benignCacheRoot = path.join(benignParentLink, "cache");
+    const repositoryCacheRoot = path.join(repositoryParentLink, "cache");
+    await Promise.all([
+      mkdir(path.join(outside, "cache")),
+      mkdir(path.join(sceneworks, "cache")),
+      symlink(outside, benignParentLink, process.platform === "win32" ? "junction" : "dir"),
+      symlink(sceneworks, repositoryParentLink, process.platform === "win32" ? "junction" : "dir"),
+      symlink(runnerTemp, runnerParentLink, process.platform === "win32" ? "junction" : "dir"),
+    ]);
+    const aliasedGuard = await validateCampaignPaths({
+      runnerTemp,
+      output: path.join(runnerTemp, "aliased-cache-output"),
+      scratch: path.join(runnerTemp, "aliased-cache-scratch"),
+      cacheRoot: benignCacheRoot,
+      repositories,
+    });
+    assert.equal(aliasedGuard.cacheRoot, await realpath(benignCacheRoot));
+    // Mutation check: removing the canonical repository confinement check must make this reject fail.
+    await assert.rejects(
+      validateCampaignPaths({
+        runnerTemp,
+        output: path.join(runnerTemp, "repository-cache-output"),
+        scratch: path.join(runnerTemp, "repository-cache-scratch"),
+        cacheRoot: repositoryCacheRoot,
+        repositories,
+      }),
+      /trusted cache root must be outside repository/,
+    );
+    await assert.rejects(
+      validateCampaignPaths({
+        runnerTemp,
+        output: path.join(runnerTemp, "canonical-collision"),
+        scratch: path.join(runnerParentLink, "canonical-collision"),
+        cacheRoot,
+        repositories,
+      }),
+      /output and scratch must be distinct, non-nested/,
+    );
+    const retargetableGuard = await validateCampaignPaths({
+      runnerTemp: runnerParentLink,
+      output: path.join(runnerParentLink, "retarget-output"),
+      scratch: path.join(runnerParentLink, "retarget-scratch"),
+      cacheRoot,
+      repositories,
+    });
+    assert.equal(retargetableGuard.output, path.join(await realpath(runnerTemp), "retarget-output"));
+    assert.equal(retargetableGuard.scratch, path.join(await realpath(runnerTemp), "retarget-scratch"));
+    await rm(runnerParentLink);
+    await symlink(outside, runnerParentLink, process.platform === "win32" ? "junction" : "dir");
+    await Promise.all([
+      mkdir(retargetableGuard.output),
+      mkdir(retargetableGuard.scratch),
+      mkdir(path.join(outside, "retarget-scratch")),
+    ]);
+    await writeFile(path.join(outside, "retarget-scratch", "keep.txt"), "keep", "utf8");
+    await safeRemoveTree(retargetableGuard.scratch, retargetableGuard, "retargeted scratch");
+    await assert.rejects(lstat(retargetableGuard.scratch), { code: "ENOENT" });
+    assert.equal(await readFile(path.join(outside, "retarget-scratch", "keep.txt"), "utf8"), "keep");
     await assert.rejects(
       validateCampaignPaths({
         runnerTemp,


### PR DESCRIPTION
## What does this PR do?

Canonicalizes CUDA harness campaign, cache, evidence, and imported-prefix roots before confinement and use. Benign parent aliases such as macOS `/var -> /private/var` now work, while canonical repository/RUNNER_TEMP escapes, direct symlink/reparse roots, canonical output/scratch collisions, and pre-cleanup replacements remain rejected.

The harness returns canonical output and scratch destinations so a validated parent alias cannot be retargeted between validation and creation or recursive cleanup.

## Related story

[SC-21517](https://app.shortcut.com/trefry/story/21517/cuda-harness-symlink-guard-reds-12-tests-on-any-macos-dev-machine)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## Acceptance mapping

- Native macOS default `TMPDIR`: focused harness changed from 18/30 with the reported 12 false failures to 30/30.
- Benign parent alias: regression accepts and returns the canonical cache/output/scratch destinations.
- Canonical escape: regression rejects a cache alias resolving into a protected repository.
- Guard strength: unchanged direct reparse and cleanup-replacement cases pass; a new retarget-after-validation case preserves the replacement tree.
- Mutation check: temporarily removing `assertOutsideRepository(resolved, repositories, "trusted cache root")` makes the escape assertion fail with `Missing expected rejection`.

## How was this tested?

- [x] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (Node harness logic)

Commands, with no `TMPDIR` or `RUNNER_TEMP` override:

- `node --test scripts/epic-20738-terminal-cuda-harness.test.mjs` — 30/30
- `npm run check` — 734/734
- Independent adversarial review plus repair review — PASS, high confidence

## Checklist

- [x] I ran `npm run rust:check` if I touched Rust (not applicable; no Rust changed)
- [x] I ran the web checks if I touched the web app (not applicable; no web code changed)
- [x] I ran `npm run check` (scaffold checks)
- [x] I updated documentation where relevant (not applicable; behavior is pinned in tests)
- [x] All commits are signed off
- [x] My PR is focused on a single logical change
