### PR TITLE
fix(sc-21534): heartbeat the source-guard verify; hash the closure once per load

### DIFF
--- a/crates/sceneworks-core/src/model_artifacts.rs
+++ b/crates/sceneworks-core/src/model_artifacts.rs
@@ -725,6 +725,18 @@ impl ModelArtifactResolver {
         artifact: &Arc<ResolvedModelArtifact>,
     ) -> Result<ActiveArtifactLease, ArtifactContractError> {
         artifact.validate()?;
+        self.acquire_runtime_lease_prevalidated(artifact)
+    }
+
+    /// [`Self::acquire_runtime_lease`] minus the full-content `validate()`, for the ONE caller
+    /// that has just proven the artifact itself: `ResolvedCacheStore::acquire_complete` validates
+    /// at full strength under the entry's artifact+metadata locks immediately before leasing, in
+    /// the same call — so a second full hash here re-read the whole bundle without closing any
+    /// window (sc-21534). Every other caller must use [`Self::acquire_runtime_lease`].
+    pub(crate) fn acquire_runtime_lease_prevalidated(
+        &self,
+        artifact: &Arc<ResolvedModelArtifact>,
+    ) -> Result<ActiveArtifactLease, ArtifactContractError> {
         let cache_key = artifact.cache_key()?;
         self.lease_registry.acquire(&cache_key);
         Ok(ActiveArtifactLease {

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -252,7 +252,7 @@ pub enum ResolvedCacheEntryState {
     Complete,
     Corrupt,
     /// Summary-only state for an entry with a durable eviction tombstone whose removal has not
-    /// finished yet. Never persisted into the metadata journal; `validate_metadata_shape` rejects
+    /// finished yet. Never persisted into the metadata journal; `validate_metadata_shape_with` rejects
     /// it there.
     Evicting,
 }
@@ -773,7 +773,16 @@ impl ResolvedCacheStore {
         if let Some(mut metadata) = existing {
             match metadata.state {
                 ResolvedCacheEntryState::Complete => {
-                    validate_complete_metadata(self, &metadata)?;
+                    // Paths and sizes only (sc-21534): "already complete" is a read verdict that
+                    // skips materialization; the load boundary still re-hashes before use. A
+                    // same-size alteration is therefore refused at load (falling back to the
+                    // source tier) rather than re-materialized here — the same posture as the
+                    // local-tier scan.
+                    validate_complete_metadata_inner(
+                        self,
+                        &metadata,
+                        ContentVerification::PathsAndSizesOnly,
+                    )?;
                     return Ok(ReservationOutcome::AlreadyComplete(Box::new(metadata)));
                 }
                 ResolvedCacheEntryState::Materializing => {
@@ -868,7 +877,14 @@ impl ResolvedCacheStore {
             JournalRead::Valid { metadata, .. }
                 if metadata.state == ResolvedCacheEntryState::Complete =>
             {
-                validate_complete_metadata(self, &metadata)?;
+                // Paths and sizes only (sc-21534): this is a read — callers use it to decide
+                // whether materialization can be skipped, and the load boundary
+                // ([`Self::acquire_complete`]) still re-hashes before any bytes reach a runtime.
+                validate_complete_metadata_inner(
+                    self,
+                    &metadata,
+                    ContentVerification::PathsAndSizesOnly,
+                )?;
                 Some(*metadata)
             }
             _ => None,
@@ -877,9 +893,10 @@ impl ResolvedCacheStore {
         Ok(result)
     }
 
-    /// Full runtime listing: complete entries are re-hashed, and any entry that fails validation
-    /// fails the whole listing. Recovery, staging cleanup and byte accounting depend on that
-    /// strictness, so it is the internal default.
+    /// Full runtime listing: complete entries are validated on identity, shape, confinement, file
+    /// presence and sizes (not content — see [`EntryListing`]), and any entry that fails fails the
+    /// whole listing. Recovery, staging cleanup and byte accounting depend on that fail-fast
+    /// semantics, so it is the internal default.
     pub fn enumerate(&self) -> Result<Vec<ResolvedCacheEntrySummary>, ResolvedCacheError> {
         self.list(EntryListing::Runtime)
     }
@@ -1028,22 +1045,20 @@ impl ResolvedCacheStore {
             }
             _ => return Ok(None),
         };
-        // FULL STRENGTH, deliberately: this is the load boundary. The scan
-        // ([`Self::valid_local_artifacts`]) and the retention sweep both validate on paths and
-        // sizes only, and this re-hash under the entry's locks is precisely what makes that safe —
-        // it is the check that must refuse an altered bundle before any bytes reach a runtime.
-        //
-        // The boundary is defended three times over, so do not read a green suite as licence to
-        // relax any one of them: this call, `acquire_runtime_lease`'s own
-        // `ResolvedModelArtifact::validate` just below, and the full-strength
-        // `write_metadata_unlocked` that stamps usage all re-hash the closure. The *property* is
-        // pinned by
-        // `the_local_tier_scan_skips_content_hashing_while_the_lease_boundary_still_refuses_altered_bytes`;
-        // because of the redundancy that test stays green if only one of the three is downgraded.
+        // FULL STRENGTH, deliberately — and exactly ONCE (sc-21534): this is the load boundary.
+        // The scan ([`Self::valid_local_artifacts`]), the listings, and the retention sweep all
+        // validate on paths and sizes only, and this re-hash under the entry's locks is precisely
+        // what makes that safe — it is the ONE check that must refuse an altered bundle before any
+        // bytes reach a runtime. The lease acquisition and the usage stamp below run under these
+        // same locks in this same call, so re-hashing there added no window this check does not
+        // already close; it only multiplied the cost (4 full hashes of a 33 GB bundle = the Krea
+        // bf16 4.5-minute verify that outlasted the stale-worker sweep). The property is pinned by
+        // `the_local_tier_scan_skips_content_hashing_while_the_lease_boundary_still_refuses_altered_bytes`
+        // and the single-pass cost by `the_load_boundary_hashes_the_closure_exactly_once`.
         validate_complete_metadata(self, &metadata)?;
         let artifact = Arc::new(metadata.artifact.clone());
         let runtime_lease = resolver
-            .acquire_runtime_lease(&artifact)
+            .acquire_runtime_lease_prevalidated(&artifact)
             .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
         let lease_id = random_id()?;
         let now = now_seconds()?;
@@ -1085,10 +1100,26 @@ impl ResolvedCacheStore {
                 }) => {
                     let mut changed = false;
                     if had_invalid_slot {
-                        metadata.recovery_status = RecoveryStatus::RecoveredFromOlderSlot;
-                        metadata.artifact_pinned = true;
-                        metadata.refresh_effective_pin();
-                        changed = true;
+                        // FULL STRENGTH before the pin (sc-21534, same defense as the receipt
+                        // resurrection below): this branch re-pins a Complete entry recovered
+                        // from its older journal slot, and the listings — including this
+                        // method's opening `enumerate()` — no longer hash content. A
+                        // content-altered bundle pinned here would be refused at every load yet
+                        // never evicted — a permanent disk leak — so prove the bytes first. On
+                        // failure, record the observation and leave the entry UNPINNED and
+                        // unhealed: the load boundary refuses it regardless, and staying
+                        // unpinned is what lets retention reclaim it (after proving the source
+                        // holds a complete second copy) so the next use re-materializes clean.
+                        if metadata.state == ResolvedCacheEntryState::Complete
+                            && validate_complete_metadata(self, &metadata).is_err()
+                        {
+                            self.write_corrupt_marker(&digest)?;
+                        } else {
+                            metadata.recovery_status = RecoveryStatus::RecoveredFromOlderSlot;
+                            metadata.artifact_pinned = true;
+                            metadata.refresh_effective_pin();
+                            changed = true;
+                        }
                     }
                     let materializing_session_is_stale =
                         if metadata.state == ResolvedCacheEntryState::Materializing {
@@ -1133,6 +1164,10 @@ impl ResolvedCacheStore {
                     }
                 }
                 Err(_) => {
+                    // FULL STRENGTH kept here (sc-21534): unlike the listings, this path
+                    // resurrects an entry from its receipt and PINS it. A content-corrupt bundle
+                    // resurrected pinned would be refused at every load yet never evicted, so the
+                    // rare invalid-tombstone recovery proves the bytes before it re-pins them.
                     let receipt = self.read_complete_receipt(&digest).and_then(|metadata| {
                         validate_complete_metadata(self, &metadata)?;
                         Ok(metadata)
@@ -1446,7 +1481,13 @@ impl ResolvedCacheStore {
         digest: &str,
         metadata: &ResolvedCacheMetadata,
     ) -> Result<(), ResolvedCacheError> {
-        validate_metadata_shape(metadata, digest)?;
+        // Shape only (sc-21534): a journal write records a state or usage transition; it never
+        // changes bundle bytes, and re-hashing the closure here charged a full-bundle SHA-256 to
+        // every usage stamp and pin flip. Every boundary that STAMPS `Complete` content proves it
+        // itself immediately before writing (`record_complete` / `publish_staged` / `recover`'s
+        // receipt path run a full `artifact.validate()`), and the load boundary
+        // (`acquire_complete`) re-hashes before any bytes reach a runtime.
+        validate_metadata_shape_with(metadata, digest, ContentVerification::PathsAndSizesOnly)?;
         let generation = match self.read_metadata_unlocked(digest) {
             Ok(JournalRead::Valid { .. }) => {
                 highest_generation(&self.inner.root.join("entries").join(digest))?
@@ -2164,13 +2205,6 @@ fn validate_candidate(candidate: &PromotionCandidate) -> Result<(), ResolvedCach
     Ok(())
 }
 
-fn validate_metadata_shape(
-    metadata: &ResolvedCacheMetadata,
-    digest: &str,
-) -> Result<(), ResolvedCacheError> {
-    validate_metadata_shape_with(metadata, digest, ContentVerification::RehashEveryFile)
-}
-
 fn validate_metadata_shape_with(
     metadata: &ResolvedCacheMetadata,
     digest: &str,
@@ -2244,7 +2278,12 @@ fn validate_complete_metadata(
 }
 
 /// How a whole-store listing treats complete entries. `Runtime` is the strict internal listing
-/// (recovery, staging cleanup, byte accounting); `Inspect` is the read-only status listing.
+/// (recovery, staging cleanup, byte accounting); `Inspect` is the read-only status listing. Both
+/// validate on paths and sizes only (sc-21534: recovery re-hashed every complete entry in the
+/// cache at startup, the same whole-cache cost sc-19712 F-3 removed from job submission; byte
+/// accounting needs sizes, and every caller that ACTS on a summary re-proves it under fresh
+/// locks). They differ in failure semantics: a `Runtime` listing fails on the first invalid
+/// entry, an `Inspect` listing degrades that entry to `Corrupt` and keeps going.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum EntryListing {
     Runtime,
@@ -2254,8 +2293,7 @@ enum EntryListing {
 impl EntryListing {
     fn verification(self) -> ContentVerification {
         match self {
-            Self::Runtime => ContentVerification::RehashEveryFile,
-            Self::Inspect => ContentVerification::PathsAndSizesOnly,
+            Self::Runtime | Self::Inspect => ContentVerification::PathsAndSizesOnly,
         }
     }
 }
@@ -2275,8 +2313,10 @@ enum ContentVerification {
     ///
     /// This mode is safe on a read path only because it is never the last word: the load boundary
     /// ([`ResolvedCacheStore::acquire_complete`]) re-verifies at [`Self::RehashEveryFile`] under
-    /// the entry's locks before any bytes reach a runtime, and every journal write validates at
-    /// full strength. Do not weaken that boundary — it is what this mode leans on.
+    /// the entry's locks before any bytes reach a runtime, and every boundary that stamps
+    /// `Complete` content (`record_complete`, `publish_staged`, `recover`'s receipt resurrection)
+    /// proves the bytes itself immediately before writing. Do not weaken the load boundary — it
+    /// is what this mode leans on.
     PathsAndSizesOnly,
 }
 
@@ -2286,7 +2326,10 @@ fn validate_complete_metadata_inner(
     verification: ContentVerification,
 ) -> Result<(), ResolvedCacheError> {
     let digest = cache_key_digest(&metadata.cache_key)?;
-    validate_metadata_shape_with(metadata, &digest, verification)?;
+    // Shape only here: the mode-specific content check is the `match verification` below, so
+    // passing `verification` through would hash the whole closure TWICE per full-strength call
+    // (sc-21534 — half of the 4x-per-load multiple behind the Krea bf16 4.5-minute verify).
+    validate_metadata_shape_with(metadata, &digest, ContentVerification::PathsAndSizesOnly)?;
     if metadata.state != ResolvedCacheEntryState::Complete
         || metadata.reservation_id.is_some()
         || metadata.reservation_owner.is_some()

--- a/crates/sceneworks-core/src/resolved_cache/retention_tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/retention_tests.rs
@@ -1510,8 +1510,10 @@ fn the_retention_scan_judges_on_paths_and_sizes_rather_than_rehashing_the_cache(
 /// The split exists because journal reads are on hot, user-facing surfaces — the catalog GET, the
 /// Settings storage status, every pin read — and re-hashing a whole bundle to decide which slot to
 /// read puts the bundle's byte count behind each of them while proving nothing a reader may act
-/// on. Safety is unchanged where it matters: content that no longer matches its recorded hash is
-/// still refused before it can reach a runtime, and every write validates at full strength.
+/// on. sc-21534 extended the cheap mode to every read surface (`lookup_complete`, `enumerate`,
+/// the reservation short-circuit): they now see a same-size-altered entry as complete, and the
+/// ONE place that refuses it is the load boundary, `acquire_complete`, before any bytes reach a
+/// runtime.
 #[test]
 fn journal_reads_skip_content_hashing_while_the_load_path_still_refuses_altered_bytes() {
     let scratch = TempDir::new().unwrap();
@@ -1533,8 +1535,17 @@ fn journal_reads_skip_content_hashing_while_the_load_path_still_refuses_altered_
     assert_eq!(inspected[0].cache_key, candidate.cache_key);
     assert_eq!(inspected[0].state, ResolvedCacheEntryState::Complete);
     assert!(store.effective_pin(&candidate.cache_key).is_ok());
+    // sc-21534: the point lookup and the runtime listing are reads too — they must offer the
+    // entry without paying a content hash, exactly like the scan and the status listing.
+    assert!(store
+        .lookup_complete(&candidate.cache_key)
+        .unwrap()
+        .is_some());
+    assert_eq!(store.enumerate().unwrap().len(), 1);
 
     // The load path is unmoved: altered bytes are refused before an artifact reaches a runtime.
-    assert!(store.lookup_complete(&candidate.cache_key).is_err());
-    assert!(store.enumerate().is_err());
+    let resolver = resolver(&library, ActiveArtifactLeaseRegistry::default());
+    assert!(store
+        .acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
+        .is_err());
 }

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -233,6 +233,67 @@ fn the_local_tier_scan_skips_content_hashing_while_the_lease_boundary_still_refu
     );
 }
 
+/// sc-21534 — one `acquire_complete` call re-reads each closure file exactly ONCE.
+///
+/// The load boundary is the single full-strength check that keeps every cheap paths-and-sizes
+/// read safe, but before this pin it hashed the closure FOUR times per load: twice inside
+/// `validate_complete_metadata` (the shape check duplicated the content check), once more in
+/// `acquire_runtime_lease`, and once more in the usage-stamp journal write — all under the same
+/// locks in the same call, so the extras closed no window. On a 33 GB bundle that multiple turned
+/// one ~70 s verify into the ~4.5-minute pass that outlasted the API's 90 s stale-worker sweep.
+/// Stated as an operation count, like
+/// `the_availability_decision_never_re_reads_the_artifact_it_admits`: a duration cannot see this
+/// on a small fixture.
+#[test]
+fn the_load_boundary_hashes_the_closure_exactly_once() {
+    let scratch = TempDir::new().unwrap();
+    let source = scratch.path().join("source");
+    let data = scratch.path().join("data");
+    std::fs::create_dir(&source).unwrap();
+    let store = ResolvedCacheStore::open(&data).unwrap();
+    let candidate = hub_layout_candidate(&source, REVISION_A);
+    let materializer = ResolvedCacheMaterializer::new(store.clone());
+    let published = match materializer
+        .materialize(
+            &candidate,
+            &source,
+            "fixture:model",
+            &MaterializationCancellation::default(),
+        )
+        .unwrap()
+    {
+        MaterializationOutcome::Published(metadata) => *metadata,
+        other => panic!("fixture bundle was not published: {other:?}"),
+    };
+    let hashed_files = published
+        .artifact
+        .closure
+        .members
+        .iter()
+        .flat_map(|member| member.files.iter())
+        .filter(|file| file.sha256.is_some())
+        .count() as u64;
+    assert!(
+        hashed_files >= 1,
+        "the fixture must record content digests or the count below is vacuous"
+    );
+
+    let registry = ActiveArtifactLeaseRegistry::default();
+    let resolver = resolver(&source, registry.clone());
+    let (lease, hashes) = crate::model_artifacts::observe_content_hashes(|| {
+        store.acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
+    });
+    assert!(
+        lease.unwrap().is_some(),
+        "the boundary must still issue the lease it is charging one hash pass for"
+    );
+    assert_eq!(
+        hashes, hashed_files,
+        "acquiring a complete entry must hash each closure file exactly once — the shape check, \
+         the runtime lease, and the usage stamp must all reuse the one full-strength verdict"
+    );
+}
+
 /// A submission's availability read must not park behind the sweep's expensive verification
 /// (sc-19712, the coupled residue).
 ///
@@ -684,9 +745,10 @@ fn reservation_is_exclusive_unrelated_keys_progress_and_drop_interrupts() {
     assert_eq!(active.reservation_owner.as_deref(), Some("image:model-a"));
     let mut traversing = active.clone();
     traversing.session_id = Some("../../outside".to_owned());
-    assert!(validate_metadata_shape(
+    assert!(validate_metadata_shape_with(
         &traversing,
-        &cache_key_digest(&candidate_a.cache_key).unwrap()
+        &cache_key_digest(&candidate_a.cache_key).unwrap(),
+        ContentVerification::PathsAndSizesOnly
     )
     .is_err());
     assert!(matches!(
@@ -1070,6 +1132,87 @@ fn pin_owners_aggregate_exactly() {
     assert!(store
         .set_model_pin(&candidate.cache_key, "\n", true)
         .is_err());
+}
+
+/// sc-21534 — the older-slot recovery must not PIN a content-altered bundle.
+///
+/// The listings (including `recover()`'s opening `enumerate()`) validate on paths and sizes only,
+/// so this branch is the last reader before an entry recovered from its older journal slot gets
+/// re-pinned. A same-size alteration pinned here would be refused at every load yet never
+/// evicted — a permanent disk leak — so the branch must prove the bytes at full strength first
+/// and, on failure, leave the entry UNPINNED: still refused at the load boundary, but evictable,
+/// so retention can reclaim it and the next use re-materializes clean.
+#[test]
+fn older_slot_recovery_refuses_to_pin_altered_bytes() {
+    let scratch = TempDir::new().unwrap();
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let source = scratch.path().join("source");
+    std::fs::create_dir(&source).unwrap();
+    // Materialize through the real promotion path: it enriches the recorded closure with content
+    // digests post-copy, which is what lets the full-strength check see the alteration below (the
+    // `source_candidate` shortcut records no digests, so it cannot exercise this branch).
+    let candidate = hub_layout_candidate(&source, REVISION_A);
+    let materializer = ResolvedCacheMaterializer::new(store.clone());
+    match materializer
+        .materialize(
+            &candidate,
+            &source,
+            "fixture:model",
+            &MaterializationCancellation::default(),
+        )
+        .unwrap()
+    {
+        MaterializationOutcome::Published(_) => {}
+        other => panic!("fixture bundle was not published: {other:?}"),
+    }
+    // Unpin twice so BOTH journal slots record `artifact_pinned: false` — otherwise the older
+    // slot the recovery falls back to still carries the materialization-era pin, and the assert
+    // below could not tell an inherited pin from the recovery-added one under test.
+    store.set_artifact_pin(&candidate.cache_key, false).unwrap();
+    store.set_artifact_pin(&candidate.cache_key, false).unwrap();
+    let entry = store.entry_path(&candidate.cache_key).unwrap();
+    let newest = [entry.join("metadata.0.json"), entry.join("metadata.1.json")]
+        .into_iter()
+        .max_by_key(|path| {
+            read_journal(path)
+                .map(|value| value.generation)
+                .unwrap_or(0)
+        })
+        .unwrap();
+    std::fs::write(newest, b"corrupt").unwrap();
+    // Same length, different bytes: paths-and-sizes reads cannot see it, only the full-strength
+    // check this branch must run before pinning can.
+    let bundle_file = store
+        .bundle_path(&candidate.cache_key)
+        .unwrap()
+        .join(&candidate.artifact.closure.members[0].destination)
+        .join("weights.bin");
+    assert_eq!(std::fs::read(&bundle_file).unwrap(), b"model-weights");
+    std::fs::write(&bundle_file, b"MODEL-WEIGHTS").unwrap();
+
+    let recovered = store.recover().unwrap();
+    assert_eq!(recovered.len(), 1);
+    let metadata = recovered[0].metadata.as_ref().unwrap();
+    assert!(
+        !metadata.effective_pin,
+        "an older-slot recovery of altered bytes must never pin the entry — pinned it would be \
+         refused at every load yet blocked from eviction forever"
+    );
+    assert_ne!(
+        metadata.recovery_status,
+        RecoveryStatus::RecoveredFromOlderSlot,
+        "the recovery must not claim it recovered content it could not verify"
+    );
+
+    // The unpinned entry is still refused where it matters: the load boundary.
+    let registry = ActiveArtifactLeaseRegistry::default();
+    let resolver = resolver(&source, registry.clone());
+    assert!(
+        store
+            .acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
+            .is_err(),
+        "altered bytes stay refused at the load boundary"
+    );
 }
 
 #[test]

--- a/crates/sceneworks-worker/src/architecture_tests.rs
+++ b/crates/sceneworks-worker/src/architecture_tests.rs
@@ -468,3 +468,45 @@ fn real_image_job_modules_import_the_json_macro_they_invoke() {
         );
     }
 }
+
+/// sc-21534 — the pre-loader source guard (sc-19708) can re-verify a multi-GB resolved bundle,
+/// which outlasts the API's 90s stale-worker timeout. `run_utility_job` must therefore await the
+/// guard's blocking task through the `heartbeat_while_blocking` keepalive (whose behavior is
+/// pinned by `heartbeat_while_blocking_keeps_worker_live_through_a_long_pass`), never bare —
+/// a bare `.await` is exactly how the Krea bf16 lost-heartbeat incident swept a healthy worker.
+/// Source-structure assertion in the same style as the dispatch-matrix test above: behavior lives
+/// in the wrapper's own test; this pins the WIRING at the one admission call site.
+#[test]
+fn the_source_guard_await_is_wrapped_in_the_heartbeat_keepalive() {
+    let code = code_without_comments_or_literals(WORKER);
+    let function = code
+        .split_once("async fn run_utility_job(")
+        .expect("worker must declare run_utility_job")
+        .1;
+    let after_guard_spawn = function
+        .split_once("RuntimeSourceGuard::begin(")
+        .expect("run_utility_job must admit every job through the source guard")
+        .1;
+    let between_guard_and_dispatch = after_guard_spawn
+        .split_once("match job.job_type {")
+        .expect("the guard must run before the job-type dispatch")
+        .0;
+    let after_wrapper = between_guard_and_dispatch
+        .split_once("heartbeat_while_blocking(")
+        .expect(
+            "the source-guard blocking task must be awaited via heartbeat_while_blocking, not \
+             bare — a guard pass longer than the stale-worker timeout would get the worker swept \
+             mid-verify",
+        )
+        .1;
+    // The wrapper must be wrapping THE GUARD's handle, not some other blocking task that later
+    // lands in the same window while the guard goes back to a bare await.
+    assert!(
+        after_wrapper
+            .split_once(')')
+            .expect("the keepalive call must close its argument list")
+            .0
+            .contains("guard_task"),
+        "heartbeat_while_blocking must receive the source guard's own JoinHandle (guard_task)"
+    );
+}

--- a/crates/sceneworks-worker/src/external_library_runtime.rs
+++ b/crates/sceneworks-worker/src/external_library_runtime.rs
@@ -630,6 +630,18 @@ fn lease_local_artifact(
     // and must leave the entry alone.
     store
         .acquire_complete(cache_key, &resolver, repository)
+        .map_err(|error| {
+            // sc-21534: the load boundary is now the ONE surface that detects a content-altered
+            // bundle (every listing and lookup judges on paths and sizes), and its refusal names
+            // the mismatched file. Falling back to the source tier is the right recovery, but
+            // swallowing the verdict would leave no trace of WHY the local bytes were refused.
+            tracing::warn!(
+                cache_key,
+                repository,
+                error = %error,
+                "resolved-cache entry refused at the load boundary; serving from the source tier"
+            );
+        })
         .ok()
         .flatten()
 }

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -1865,20 +1865,25 @@ async fn run_utility_job(
         let guard_job_type = job.job_type.clone();
         let guard_payload = job.payload.clone();
         let guard_settings = settings.clone();
-        let source_guard = tokio::task::spawn_blocking(move || {
+        let guard_task = tokio::task::spawn_blocking(move || {
             external_library_runtime::RuntimeSourceGuard::begin(
                 &guard_job_type,
                 &guard_payload,
                 &guard_settings,
             )
-        })
+        });
+        // The guard's admission pass can re-verify a multi-GB resolved bundle, which outlasts the
+        // API's stale-worker timeout — the sc-13856 hazard at a new call site. Awaiting the handle
+        // bare let the sweep mark a still-healthy worker offline mid-verification (the Krea bf16
+        // 90s lost-heartbeat incident), so the wait must pump heartbeats on the progress interval.
+        let source_guard = progress::heartbeat_while_blocking(
+            api,
+            settings,
+            &job.id,
+            "model source guard",
+            guard_task,
+        )
         .await
-        .map_err(|error| {
-            (
-                "Model source unavailable.",
-                WorkerError::Io(std::io::Error::other(error.to_string())),
-            )
-        })?
         .map_err(|error| ("Model source unavailable.", error))?;
         let dispatch_result = match job.job_type {
             JobType::Placeholder => run_placeholder_job(api, settings, &job, &shutdown)


### PR DESCRIPTION
[sc-21534](https://app.shortcut.com/trefry/story/21534)

## Incident

Krea 2 bf16 generation: the sc-19708 pre-loader source guard re-verified the 33 GB resolved bundle for ~4.5 min with no heartbeat; the API's 90 s stale-worker sweep marked the worker offline, interrupted the job, and subsequent jobs failed `mlx_unavailable`. Model-agnostic — every resolved-cache model pays this; Krea bf16 is just the biggest bundle.

## Defect 1 — heartbeat gap (worker)

`run_utility_job` awaited the source guard's `spawn_blocking` handle bare instead of using `heartbeat_while_blocking`, which was built for exactly this hazard (sc-13856 / #1690). The await now pumps heartbeats on the progress interval; the wiring is pinned by a source-structure test (behavior is pinned by the existing `heartbeat_while_blocking_keeps_worker_live_through_a_long_pass`).

## Defect 2 — redundant full-bundle hashing (core)

One `acquire_complete` call hashed the full closure **four** times (duplicate content check inside `validate_complete_metadata`, a second full validate in `acquire_runtime_lease`, a third in the usage-stamp journal write) — all under the same locks in the same call, closing no window the first hash doesn't already close. `lookup_complete`, `reserve`'s AlreadyComplete arm, and the Runtime listing (`enumerate`, used by startup `recover`) also hashed at full strength on read paths.

Now:
- The load boundary performs exactly **one** full-strength hash before any bytes reach a runtime (new pin: `the_load_boundary_hashes_the_closure_exactly_once`).
- Every read surface judges on paths and sizes, matching the sc-19712 F-3 posture.
- Journal writes are shape-only; each boundary that stamps Complete content (`record_complete`, `publish_staged`, `recover`'s receipt path) proves the bytes itself immediately before writing.
- `recover()`'s two re-pinning paths keep/gain a full-strength check so a content-altered bundle is never pinned; the older-slot path leaves it unpinned so retention can reclaim it (new pin: `older_slot_recovery_refuses_to_pin_altered_bytes`).
- The worker now logs the load boundary's refusal before falling back to the source tier (previously the only content-alteration verdict in the system was silently discarded via `.ok()`).

The altered-bytes property still holds and is still pinned: `the_local_tier_scan_skips_content_hashing_while_the_lease_boundary_still_refuses_altered_bytes` and the updated `journal_reads_skip_content_hashing_while_the_load_path_still_refuses_altered_bytes`.

## Verification

- `cargo test -p sceneworks-core --lib` (1182) and `-p sceneworks-worker --lib` (1906) green.
- Mutation checks: load-boundary downgrade → 3 tests red; redundant lease hash restored → count test red; keepalive wrapper removed → architecture test red; recovery guard removed → recovery test red. Each restored + `touch`ed.
- `npm run rust:check`, `rust:check:candle`, `rust:check:neither` all green on the final tree.
- Adversarial review: one major finding (older-slot recovery could pin altered bytes) fixed; two minors fixed (tightened architecture test, refusal logging); one minor declined — `heartbeat_while_blocking`'s transport-failure error is reported under the "Model source unavailable." message, cosmetic misattribution consistent with the wrapper's other call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)