### PR TITLE
perf(web): lazy-load Simple's licences screen off the shell's static graph

### DIFF
--- a/apps/web/src/simple/SimpleShell.jsx
+++ b/apps/web/src/simple/SimpleShell.jsx
@@ -4,6 +4,7 @@ import { Logo } from "../components/Logo.jsx";
 import { ConfirmHost } from "../appConfirm.jsx";
 import { useAppContext } from "../context/AppContext.js";
 import { assetCanRenderAsAudio } from "../components/assetMedia.jsx";
+import { lazyScreen } from "../components/LazyScreen.jsx";
 import { terminalStatuses } from "../constants.js";
 import { breakpointFor, contentMaxWidth } from "./breakpoint.js";
 import { ADVANCED_MODE } from "./uiMode.js";
@@ -29,7 +30,6 @@ import { SimpleAssets } from "./SimpleAssets.jsx";
 import { SimpleModelManager } from "./SimpleModelManager.jsx";
 import { SimpleQueue } from "./SimpleQueue.jsx";
 import { SimpleSettings } from "./SimpleSettings.jsx";
-import { SimpleLicenses } from "./SimpleLicenses.jsx";
 import "./simple.css";
 
 // The Simple UI shell (design handoff "Simple UI for creative studios").
@@ -42,6 +42,15 @@ import "./simple.css";
 //
 // It renders INSIDE App's providers, so every screen reads the same live catalogs, job
 // feed and actions the full workspace does. There is no parallel data layer.
+
+// The bundled licence corpus (apps/desktop/licenses/manifest.json via data/bundledLicenses.js)
+// is ~740 kB raw — the single largest module in the app. Simple reaches it from one Settings
+// sub-screen, so it loads on demand instead of riding in every Simple session's static graph.
+const SimpleLicenses = lazyScreen(
+  () => import("./SimpleLicenses.jsx"),
+  "SimpleLicenses",
+  "Licenses",
+);
 
 export const SIMPLE_SCREENS = [
   {


### PR DESCRIPTION
## What does this PR do?

A local production build fails the bundle budget on `main`:

```
[sceneworks-bundle-report] Bundle budget failed:
- Largest route (Simple UI) rawBytes is 1101852 bytes (budget 1100000 bytes)
```

**Root cause.** `SimpleShell.jsx` statically imported `SimpleLicenses.jsx`, which statically imports `data/bundledLicenses.js` — the licence corpus generated from `apps/desktop/licenses/manifest.json`. At **740,548 raw bytes** that corpus is the largest module in the app, and it was **67% of the Simple UI route's weight**. The shell renders it from a single Settings sub-screen (`screen === "licenses"`), so every Simple session parsed the whole corpus to reach four studios that never touch it.

The bundle-report plugin's `initialExclusions` already fence the corpus out of the *initial* graph; nothing fenced it out of a *route* graph, and the route budget is what finally caught it.

**Fix.** Wrap `SimpleLicenses` in the repo's existing `lazyScreen` boundary — the same retryable `React.lazy` + `Suspense` wrapper `App.jsx` already uses for all 21 advanced route families. One import swap, one declaration; the render site is unchanged. The corpus now loads on demand from Simple and from the advanced Licenses screen alike, and the Simple licences screen renders the identical rows from the identical source.

**Measured** (`apps/web/dist/bundle-report.json`, before → after):

| | before | after |
|---|---|---|
| Simple UI route raw | 1,101,852 (over by 1,852) | **359,949** (−67%) |
| Simple UI route gzip | 230,055 | **107,145** (−53%) |
| largest route | Simple UI | Image Editor (462,379 raw / 143,946 gz) |
| `violations` | 1 | **0** |

Initial and total budgets are unchanged — this only moves a chunk from a route's static graph to its dynamic one. No budget numbers were raised; `bundle-budgets.json` is untouched.

## Related issue

No tracker item — this came out of a local `npm run tauri:build` failure on `main` (`beforeBuildCommand` → `api:build:embedded` → `vite build`), so it blocks any desktop build from current `main`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

- [x] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (web UI, docs, shared crate)

Ran on macOS against this branch:

- `npm --prefix apps/web run lint` — clean
- `npm --prefix apps/web run test` — **270 files / 4150 tests passed**
- `npm --prefix apps/web run build` — green, `bundle-report.json` `violations: []`
- Confirmed `assets/SimpleLicenses-*.js` is emitted as a dynamic chunk (`initial: false`, `routes: []`) and that `bundledLicenses` no longer appears in the Simple UI route's chunk list.

Reproduced the failure first on `main` at `b505160a7` (the emitted report showed the single violation above), then re-ran after the change.

## Checklist

- [x] I ran `npm run rust:check` (if I touched Rust) and it passed — *n/a, no Rust touched*
- [x] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build`
- [ ] I ran `npm run check` (scaffold checks) — **704/705 pass locally; the one failure is environmental, see note below**
- [x] I updated documentation where relevant — *n/a*
- [x] All my commits are signed off
- [x] My PR is focused on a single logical change

### Reviewer note — pre-existing, unrelated

`npm run check` fails one test locally, on `main` as well as on this branch:

```
scripts/epic-20738-terminal-cuda-harness.test.mjs
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'ajv'
```

`ajv` is a declared root `devDependency` that simply is not installed in this checkout (root `npm install` was never run). It is not related to this change — this PR touches one `.jsx` file — and CI installs root deps, so it should be green there. Flagging rather than fixing.
