### PR TITLE
docs: refresh SC-17137 terminal routing guidance

### DIFF
--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -22218,8 +22218,8 @@
         "maxReferenceAssets": 0,
         "maxSourceClipAssets": 0,
         "maxReferenceAudioAssets": 0,
-        // Default-only. sc-19721's pin bump (`75d66db5`) DID make the descriptor reachable, so the
-        // engines.rs drift guard can now compare a curated menu against MiniMax-H3's real
+        // Default-only. The permanent inference pin (`28f0563b`) makes the descriptor reachable, so
+        // the engines.rs drift guard can compare a curated menu against MiniMax-H3's real
         // capabilities — but the provider advertises `samplers: ["default"]` and no scheduler menu
         // of its own, so there is nothing to curate INTO. This stays `["default"]` because that is
         // what the engine offers, not because the descriptor is invisible; a curated menu is
@@ -22240,7 +22240,7 @@
         // peak (sc-17150 activity 19121) — a stage the DEFAULT tier no longer runs. sc-19120's
         // packed q4 conditioning stage measures 14.68 GB end to end (inference
         // `mlx-gen-minimax-h3/src/memory_strategy.rs` + `tests/te_tier_generate_stages.rs`, read
-        // at the pinned `75d66db5`), so 96 over-gated the default tier by ~38 GB at the derivation
+        // at permanent inference pin `28f0563b`), so 96 over-gated the default tier by ~38 GB at the derivation
         // geometry and locked the family off every sub-96 GB Mac for no measured reason.
         //
         // THE DERIVATION — max over the shipped q4 pipeline's stages at the LARGEST geometry this
@@ -22332,11 +22332,11 @@
         //      BELOW this entry's advertised 21:9 pair. So `1536x672` / `672x1536` are ADVERTISED
         //      BUT NOT YET RENDERABLE: the area check passes and the edge check refuses.
         //
-        //      ✅ DISCHARGED BY sc-19721's PIN BUMP. `Cargo.toml` now pins `75d66db5`, which
-        //      carries inference PR #640 (`story/sc-17152-h3-max-size-1536`) — the per-edge ceiling
-        //      is `MAX_CANVAS_EDGE = 2016` on both lanes, comfortably above 1536, so the pinned
-        //      engine accepts the pair and the paragraph above is HISTORY, kept only because it
-        //      explains why the area budget alone never settled the question.
+        //      ✅ DISCHARGED BY THE PERMANENT INFERENCE PIN. `Cargo.toml` pins
+        //      `28f0563baa03640ade1635356d2d54fe8a477f1a`; the pinned provider's per-edge ceiling
+        //      is `MAX_CANVAS_EDGE = 2016` on both lanes, comfortably above 1536, so the engine
+        //      accepts the pair and the paragraph above is HISTORY, kept only because it explains
+        //      why the area budget alone never settled the question.
         //
         //      The tie is enforced, not asserted in prose: `pinned_engine_geometry.rs` reads the
         //      PINNED provider's own `capabilities.max_size` and refuses any advertised resolution

--- a/crates/sceneworks-worker/src/video_jobs/minimax_h3.rs
+++ b/crates/sceneworks-worker/src/video_jobs/minimax_h3.rs
@@ -13,8 +13,9 @@ use sceneworks_core::video_request::{classify_reference_set, ReferenceSetVerdict
 
 // ---------------------------------------------------------------------------
 // MiniMax-H3 / Hailuo 3.0 (epic 17137, sc-19508): a joint audio+video family that emits video AND
-// synchronized stereo audio in ONE denoise pass. MLX runs on macOS; off-Mac Candle dispatch is
-// available for direct/replay execution while user routing remains deliberately disabled.
+// synchronized stereo audio in ONE denoise pass. At the permanent inference pin
+// `28f0563baa03640ade1635356d2d54fe8a477f1a`, MLX and off-Mac Candle both dispatch the live family:
+// Candle user routing covers the base t2va/fl2va partition and the Ref2VA partition.
 //
 // Four facts shape this whole block, and every one of them DEVIATES from the Mochi/Krea template it
 // otherwise mirrors:
@@ -74,9 +75,8 @@ use sceneworks_core::video_request::{classify_reference_set, ReferenceSetVerdict
 /// Adapter id recorded on a real MLX MiniMax-H3 asset.
 #[cfg(target_os = "macos")]
 pub(super) const MINIMAX_H3_ADAPTER: &str = "mlx_minimax_h3";
-/// Adapter id recorded on a real off-Mac Candle MiniMax-H3 asset. It lives with the deliberately
-/// non-user-routed executor rather than the generic Candle route table, so capability-fact parsing
-/// continues to represent only user-reachable Candle lanes.
+/// Adapter id recorded by the live off-Mac Candle MiniMax-H3 provider. The base and Ref2VA Candle
+/// routes are user-routed for their supported native modes; this id names the adapter on those jobs.
 #[cfg(all(not(target_os = "macos"), feature = "backend-candle"))]
 pub(super) const CANDLE_MINIMAX_H3_ADAPTER: &str = "candle_minimax_h3";
 
@@ -143,16 +143,14 @@ pub(super) fn minimax_h3_engine_id(model: &str) -> Option<&'static str> {
 /// Whether the linked inference bundle actually REGISTERS the MiniMax-H3 engine.
 ///
 /// This is the sc-19508 replacement for sc-17159's hard-coded "not in the pinned inference
-/// revision" string, and the reason the whole arm below can be written before sc-18650 moves the
-/// pin. The engine is reached through `media().load(id, spec)` — a **runtime lookup keyed on a
-/// string** — so nothing in this module needs the provider to be importable at compile time. What
-/// it does need is for the id to be PRESENT in the registry, which is exactly what this reads.
+/// revision" string. The engine is reached through `media().load(id, spec)` — a **runtime lookup
+/// keyed on a string** — so nothing in this module needs the provider to be importable at compile
+/// time. What it does need is for the id to be PRESENT in the registry, which is exactly what this
+/// reads; the permanent pin `28f0563baa03640ade1635356d2d54fe8a477f1a` carries that descriptor.
 ///
-/// Deriving it beat asserting it, and sc-19721 is the proof: at `014134e3` the descriptor was
-/// absent and this refusal fired, and when the pin moved to `75d66db5` the descriptor appeared and
-/// the arm went live with **no code change here**. A hard-coded revision string would have gone
-/// stale instead — which is exactly what happened to every prose citation of the old pin around
-/// it.
+/// Deriving it beats asserting it: a mismatched or incomplete linked provider still fails closed,
+/// while the current permanent pin carries the descriptor and reaches the live arm without a
+/// code-side revision switch. A hard-coded revision string would go stale instead.
 ///
 /// The same `media_descriptor(...).is_none()` idiom already gates the not-in-this-bundle branches
 /// of `mlx_fit_gate`, so this is the established way to ask the question.
@@ -504,16 +502,14 @@ pub(super) fn minimax_h3_available(request: &VideoRequest, settings: &Settings) 
 /// say anything else, because at that commit there was no arm to fall through to. Now there is, so
 /// the refusal is derived in three layers, each naming its own cause:
 ///
-/// 1. the engine is not in the linked bundle (today's pin) — READ from the registry, not asserted;
+/// 1. the engine is not in the linked bundle — READ from the registry, not asserted;
 /// 2. the conditioning shape does not match the entry's DiT partition;
 /// 3. the weights are unprovisioned or torn.
 ///
-/// The order is deliberate. Before sc-19721's pin bump every MiniMax-H3 job stopped at (1) with
-/// the same honest reason a user got before; at the current pin (`75d66db5`, the first revision
-/// that registers `mlx_gen_minimax_h3` — see `jobs_store/routing/mlx.rs`) the descriptor is
-/// present, (1) passes with no code change here, and an unprovisioned install stops at (3) with
-/// the resolver's precise error — which is exactly the substitution sc-19508 asked for
-/// ("an unprovisioned install must still fail loudly").
+/// The order is deliberate. At the permanent pin
+/// (`28f0563baa03640ade1635356d2d54fe8a477f1a`) the descriptor is present, so a normal request
+/// reaches the conditioning and load checks; a mismatched provider or unprovisioned install still
+/// stops with the precise fail-loud error required by sc-19508.
 #[cfg(target_os = "macos")]
 pub(super) fn ensure_minimax_h3_renderable(
     request: &VideoRequest,
@@ -1403,9 +1399,8 @@ pub(super) async fn generate_minimax_h3(
 /// With the loader threaded in, a test drives this whole arm against a stub `Generator` and asserts
 /// on the `GenerationRequest` that actually reached the engine — the conditioning, the coerced
 /// frame count, the fps, the seed, and the ABSENCE of the guidance/negative-prompt fields the
-/// checkpoint rejects — with no weights, no GPU, and no registered MiniMax-H3 engine. That last
-/// part is why this seam matters more here than anywhere else: it is the only way any of this arm
-/// is covered before sc-18650 moves the pin.
+/// checkpoint rejects — with no weights or GPU. The seam remains valuable for request-shape
+/// coverage even though the permanent pin registers the MiniMax-H3 provider.
 #[cfg(target_os = "macos")]
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn generate_minimax_h3_using(

--- a/crates/sceneworks-worker/src/video_jobs/mod.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mod.rs
@@ -260,12 +260,10 @@ enum VideoRoute {
 /// ladder for every other mode.
 #[cfg(target_os = "macos")]
 fn resolve_video_route(request: &VideoRequest, settings: &Settings) -> VideoRoute {
-    // MiniMax-H3 readiness is the ONE ladder input that cannot be reached from a test today: it
-    // requires the engine to be REGISTERED in the linked inference bundle, which is false at the
-    // pinned revision (sc-18650 owns the bump). Left inline, the tail arm below would be dead code
-    // no test can distinguish from a deleted one — declaration without reachability, the exact trap
-    // this epic keeps hitting. Threaded in instead, so `resolve_video_route_with` can be driven
-    // with the readiness the pin bump will supply and the arm is covered NOW.
+    // MiniMax-H3 readiness remains the ONE ladder input that needs an injectable seam in tests:
+    // it requires the engine to be REGISTERED in the linked inference bundle. The permanent pin
+    // `28f0563baa03640ade1635356d2d54fe8a477f1a` carries that descriptor; threading readiness in
+    // keeps `resolve_video_route_with` able to distinguish the live tail arm from a deleted one.
     //
     // Evaluated here rather than in the ladder, but NOT eagerly: `minimax_h3_engine_id` is a pure
     // string check, so every other model short-circuits before any filesystem touch and routing
@@ -350,11 +348,11 @@ fn resolve_video_route_with(
         // id, so routing for every pre-existing model stays byte-identical.
         //
         // `minimax_h3_available` folds in three gates that all have to hold before an arm may run:
-        // the engine is actually REGISTERED in the linked inference bundle (false at the current
-        // pin, and the reason this arm is dormant rather than broken), the conditioning shape
-        // agrees with the entry's DiT partition, and both the tier and its shared components
-        // resolve. Any of them failing drops to `Stub`, where `ensure_video_engine_weights` re-runs
-        // the same checks and surfaces the precise reason instead of a procedural fake clip.
+        // the engine is registered in the linked inference bundle (as it is at permanent pin
+        // `28f0563baa03640ade1635356d2d54fe8a477f1a`), the conditioning shape agrees with the
+        // entry's DiT partition, and both the tier and its shared components resolve. Any of them
+        // failing drops to `Stub`, where `ensure_video_engine_weights` re-runs the same checks and
+        // surfaces the precise reason instead of a procedural fake clip.
         VideoRoute::MiniMaxH3(engine_id)
     } else {
         VideoRoute::Stub
@@ -392,9 +390,9 @@ enum CandleVideoRoute {
     Bernini(&'static str),
     /// A candle txt2video engine id → `generate_candle_video` (sc-5097).
     CandleVideo,
-    /// MiniMax-H3's joint audio/video Candle provider. This remains unreachable through the
-    /// scheduler until the separately-owned `candle_video_routed` capability flip, but direct or
-    /// replayed off-Mac jobs must use the real provider rather than procedural stub output.
+    /// MiniMax-H3's joint audio/video Candle provider. Current Candle capabilities route the base
+    /// t2va/fl2va and Ref2VA partitions through this live provider at the permanent inference pin;
+    /// direct or replayed off-Mac jobs therefore use the real provider rather than stub output.
     MiniMaxH3(&'static str),
     /// An in-place ComfyUI Wan2.2 base model (`external_base_*`) → `generate_candle_wan_comfyui`
     /// (epic 10451 Phase 2c, sc-10671). Not an `is_candle_video_engine` id — routed off the forwarded row.

--- a/docs/calibration/sc-18663/minimax-h3-terminal-capture.md
+++ b/docs/calibration/sc-18663/minimax-h3-terminal-capture.md
@@ -1,8 +1,9 @@
 # SC-18663 MiniMax-H3 terminal capture
 
-Run this only after the terminal inference pin bump: the current pinned loaded generator does not
-publish its memory-strategy contract, so this command must fail closed rather than manufacture a
-receipt. It selects the 72 checked-in MiniMax-H3 rows (three tiers, four implemented rungs, two
+Run this against the permanent inference pin `28f0563baa03640ade1635356d2d54fe8a477f1a` and require
+the loaded generator to publish the exact memory-strategy contract for every selected case. The
+harness must fail closed only when that publication is actually missing or mismatched; never
+manufacture a receipt. It selects the 72 checked-in MiniMax-H3 rows (three tiers, four implemented rungs, two
 areas, three legal `17n+5` frame counts) and writes every mutable artifact outside either checkout.
 
 ```bash


### PR DESCRIPTION
## Summary
- correct the SC-18663 terminal capture runbook now that permanent inference pin `28f0563baa03640ade1635356d2d54fe8a477f1a` publishes the MiniMax-H3 memory-strategy contract
- refresh stale Candle MiniMax-H3 comments so they describe the live route and permanent pin rather than the prior dormant state
- address the two documentation findings from SC-17137 SceneWorks feature-end review cycle 1

## Verification
- JSONC/manifest/tier tests: 66 passed
- H3/routing Rust tests: 36 passed
- tier-integrity and memory-matrix freshness checks passed
- rustfmt and `git diff --check` passed
- all 17 inference pin sites resolve to `28f0563baa03640ade1635356d2d54fe8a477f1a`

Documentation/comments only; no behavior, generated artifacts, GPU, or real-weight execution changed.