### PR TITLE
fix(epic): feature-end review round 1 — linked-entry exposure, mixed execution label, pin case bypass (sc-11045)

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -2969,13 +2969,34 @@ pub(crate) fn normalize_model_import_source(
 /// A managed variant is a pinned FETCH of specific upstream bytes, so the ownership modes that do
 /// not fetch — a linked library reference, a local copy, an upload, a bare URL — cannot claim one.
 fn resolve_managed_variant_pin(payload: &mut ModelImportRequest) -> Result<(), ApiError> {
-    let Some(variant) = payload
-        .model_id
-        .as_deref()
-        .map(str::trim)
-        .and_then(sceneworks_core::managed_checkpoint_variants::managed_nvfp4_variant)
-    else {
-        return Ok(());
+    use sceneworks_core::managed_checkpoint_variants::{
+        match_managed_nvfp4_variant_id, ManagedVariantIdMatch,
+    };
+    // Case-INSENSITIVELY, because a managed variant's id is its install-directory name and its
+    // checkpoint identity, and `safe_download_dir` preserves whatever case the request supplied
+    // while NTFS and a default APFS volume do not. An exact-match lookup therefore missed
+    // `"NVFP4-Krea-2-Turbo"` — no registered repo, revision, file or checksum was applied — while
+    // the distinct-id collision check saw a new id and the filesystem saw the curated variant's own
+    // directory. Arbitrary bytes then landed under the curated identity with nothing verified.
+    //
+    // A near miss is REFUSED, never normalized to the canonical id. Rewriting it would install
+    // something the request did not name, which is the same class of silent substitution this
+    // function exists to refuse everywhere else; the diagnostic names the canonical id so a client
+    // bug is one edit away from correct.
+    let variant = match match_managed_nvfp4_variant_id(payload.model_id.as_deref().unwrap_or("")) {
+        ManagedVariantIdMatch::Unregistered => return Ok(()),
+        ManagedVariantIdMatch::Exact(variant) => variant,
+        ManagedVariantIdMatch::NearMiss(variant) => {
+            return Err(ApiError::bad_request(format!(
+                "Model id '{}' differs only in case from the managed NVFP4 variant '{}', which \
+                 shares its install directory and checkpoint identity on this platform. Import it \
+                 under the exact id '{}', or choose a model id that is not a case variant of a \
+                 managed variant.",
+                payload.model_id.as_deref().unwrap_or("").trim(),
+                variant.variant_id,
+                variant.variant_id
+            )));
+        }
     };
     let claim = |detail: &str| {
         Err(ApiError::bad_request(format!(

--- a/apps/rust-api/src/tests/checkpoint_library.rs
+++ b/apps/rust-api/src/tests/checkpoint_library.rs
@@ -664,12 +664,18 @@ async fn a_managed_variant_import_cannot_be_talked_out_of_its_pin() {
     assert_eq!(job["payload"]["files"], json!([file]));
 
     // 2. A DIFFERENT checksum under the variant's identity is refused, not silently rewritten.
+    //    Posted under KREA_VARIANT_ID — the id whose repo/revision these are — so the CHECKSUM
+    //    branch is what fires; under KLEIN's id the repo comparison refused it first and this case
+    //    proved nothing about checksums.
+    //
+    //    Failing mutation: delete the `expected_sha256` comparison branch in
+    //    `resolve_managed_variant_pin`.
     let (status, body) = request(
         app.clone(),
         "POST",
         "/api/v1/models/import",
         json!({
-            "modelId": KLEIN_VARIANT_ID,
+            "modelId": KREA_VARIANT_ID,
             "source": {"kind": "huggingFace", "repo": repo, "revision": revision},
             "expectedSha256": "0".repeat(64),
             "type": "image"
@@ -677,13 +683,44 @@ async fn a_managed_variant_import_cannot_be_talked_out_of_its_pin() {
     )
     .await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
+    assert!(
+        body.to_string().contains("asserts checksum"),
+        "the checksum branch is what must refuse this: {body:?}"
+    );
+
+    // The KLEIN variant is equally pinned — proved through its OWN pin, so the loop below can stay
+    // on one variant without leaving the second registration untested.
+    let klein = listed["variants"][1]["pinnedArtifact"].clone();
+    let (status, body) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/models/import",
+        json!({
+            "modelId": KLEIN_VARIANT_ID,
+            "source": {"kind": "huggingFace", "repo": klein["repo"], "revision": klein["revision"]},
+            "expectedSha256": "0".repeat(64),
+            "type": "image"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body:?}");
+    assert!(body.to_string().contains("asserts checksum"), "{body:?}");
 
     // 3. So is a substituted repo, revision, or file — and any ownership mode that does not fetch
     //    the pinned bytes at all.
+    //
+    // Each hostile body is posted against the variant its pin belongs to. Posting KREA's repo under
+    // KLEIN's id (the original shape of this loop) made the very first check — the repo comparison —
+    // fire for all three Hugging Face rows, so the revision and file branches were never reached
+    // and only one of the four was actually under test.
+    //
+    // Failing mutations, one per row: delete the corresponding `claim(...)` branch in
+    // `resolve_managed_variant_pin` (repo / revision / file / non-fetching source) — that row alone
+    // turns green-to-red.
     for hostile in [
         json!({"kind": "huggingFace", "repo": "attacker/lookalike"}),
         json!({"kind": "huggingFace", "repo": repo, "revision": "a".repeat(40)}),
-        json!({"kind": "huggingFace", "repo": repo, "files": ["other.safetensors"]}),
+        json!({"kind": "huggingFace", "repo": repo, "revision": revision, "files": ["other.safetensors"]}),
         json!({"kind": "url", "url": "https://example.com/model.safetensors"}),
     ] {
         let (status, body) = request(
@@ -691,7 +728,8 @@ async fn a_managed_variant_import_cannot_be_talked_out_of_its_pin() {
             "POST",
             "/api/v1/models/import",
             json!({
-                "modelId": KLEIN_VARIANT_ID,
+                // KREA_VARIANT_ID, because `repo`/`revision` above were read from `variants[0]`.
+                "modelId": KREA_VARIANT_ID,
                 "source": hostile.clone(),
                 "type": "image"
             }),
@@ -703,4 +741,88 @@ async fn a_managed_variant_import_cannot_be_talked_out_of_its_pin() {
             "{hostile} must not install under a managed variant's identity: {body:?}"
         );
     }
+}
+
+/// A managed variant's id is its install DIRECTORY name and its checkpoint identity, and the
+/// directory resolver preserves case while NTFS and a default APFS volume do not. So a case-variant
+/// id — `"NVFP4-Krea-2-Turbo"` — used to miss the registry entirely: no repo, revision, file or
+/// checksum was pinned, `expectedSha256` could be omitted outright, the distinct-id collision check
+/// saw a brand-new id, and the bytes landed in the curated variant's own directory under the
+/// curated variant's own identity.
+///
+/// It is REFUSED rather than normalized: rewriting the id would install something the request did
+/// not name. The exact id still works, so this is a near-miss guard and not a blanket ban.
+///
+/// Failing mutation: make the lookup case-SENSITIVE again — replace the
+/// `match_managed_nvfp4_variant_id` call in `resolve_managed_variant_pin` with the old
+/// `.map(str::trim).and_then(managed_nvfp4_variant)`. Every case row below then returns 201 with no
+/// `expectedSha256` on the queued job.
+#[tokio::test]
+async fn a_case_variant_of_a_managed_variant_id_cannot_dodge_the_pin() {
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    seed_manifests(&temp_dir.path().join("config"));
+    let settings = test_settings(&temp_dir);
+    std::fs::create_dir_all(&settings.data_dir).expect("data dir creates");
+    let app = create_app(settings).expect("app creates");
+
+    for cased in [
+        "NVFP4-Krea-2-Turbo",
+        "NVFP4-KREA-2-TURBO",
+        "nvfp4-Krea-2-turbo",
+        "NVFP4-flux2-Klein-9B-True-V2",
+    ] {
+        let (status, body) = request(
+            app.clone(),
+            "POST",
+            "/api/v1/models/import",
+            json!({
+                "modelId": cased,
+                // The hostile shape the blocker described: an arbitrary source and NO checksum,
+                // which the worker's `if let Some(..)` verification treats as nothing to verify.
+                "sourceUrl": "https://example.com/anything.safetensors",
+                "type": "image"
+            }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "{cased} must not install under a managed variant's identity: {body:?}"
+        );
+        assert!(
+            body.to_string().contains("differs only in case"),
+            "{cased} must be refused as a case near-miss, not by some later check: {body:?}"
+        );
+    }
+
+    // The EXACT id is unaffected: it still resolves and is still pinned.
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/models/import",
+        json!({ "modelId": KREA_VARIANT_ID, "type": "image" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{job:?}");
+    assert!(
+        job["payload"]["expectedSha256"]
+            .as_str()
+            .is_some_and(|sha| sha.len() == 64),
+        "the exact id still gets the registration's digest: {job:?}"
+    );
+
+    // And an ordinary id that merely SHARES a prefix is not a near miss at all.
+    let (status, job) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/models/import",
+        json!({
+            "modelId": "nvfp4-krea-2-turbo-mine",
+            "sourceUrl": "https://example.com/anything.safetensors",
+            "type": "image"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "{job:?}");
 }

--- a/apps/web/src/formatting.js
+++ b/apps/web/src/formatting.js
@@ -95,9 +95,26 @@ const EXECUTION_REPRESENTATION_LABELS = {
   "dense-fallback": "dense fallback",
 };
 
+// A load that ran PART of a codec packed and part dense carries `mixed:<packed>/<dense>` instead of
+// either pure label (sc-11045). "native (packed)" for such a run is untrue about the dense majority
+// whenever the engine's shipping policy is mixed — which the pinned engine documents for this leg —
+// so the mix is rendered with its counts rather than collapsed to whichever arm happens to be
+// non-empty. A bare `mixed` with no counts still renders honestly.
+const MIXED_PREFIX = "mixed";
+
 export function executionRepresentationLabel(representation) {
   const key = representation && String(representation).trim();
   if (!key) return "not measured";
+  if (key === MIXED_PREFIX) return "mixed";
+  if (key.startsWith(`${MIXED_PREFIX}:`)) {
+    const [packed, dense] = key.slice(MIXED_PREFIX.length + 1).split("/");
+    const packedCount = Number(packed);
+    const denseCount = Number(dense);
+    if (Number.isFinite(packedCount) && Number.isFinite(denseCount)) {
+      return `mixed (${packedCount} packed / ${denseCount} dense)`;
+    }
+    return "mixed";
+  }
   return EXECUTION_REPRESENTATION_LABELS[key] ?? key;
 }
 

--- a/apps/web/src/formatting.test.js
+++ b/apps/web/src/formatting.test.js
@@ -99,4 +99,26 @@ describe("source codec vs execution representation", () => {
     expect(weightFactsLabel({ quantLabel: "q4" })).toBe("—");
     expect(weightFactsLabel(undefined)).toBe("—");
   });
+
+  // sc-11045: a run that executed PART of the codec packed and part dense is neither "native
+  // (packed)" nor "dense fallback". The pinned engine's shipping policy for this leg is mixed, so
+  // rendering the any-collapse said "native (packed)" about a load whose majority was dense.
+  //
+  // Failing mutation: restore the any-collapse in
+  // `CheckpointWeightFactsV1::representation_label` (Rust) — the metrics row then carries
+  // "native-packed" and the first expectation below is red.
+  it("renders a mixed execution with its counts rather than collapsing to either arm", () => {
+    expect(
+      weightFactsLabel({ sourceCodec: "nvfp4-v1", executionRepresentation: "mixed:68/95" }),
+    ).toBe("nvfp4-v1 · mixed (68 packed / 95 dense)");
+    expect(executionRepresentationLabel("mixed:68/95")).toBe("mixed (68 packed / 95 dense)");
+    expect(executionRepresentationLabel("mixed:68/95")).not.toMatch(/native/i);
+    // A bare or unparseable mix still says "mixed" rather than guessing an arm.
+    expect(executionRepresentationLabel("mixed")).toBe("mixed");
+    expect(executionRepresentationLabel("mixed:x/y")).toBe("mixed");
+    // The pure arms and the unmeasured arm are untouched.
+    expect(executionRepresentationLabel("native-packed")).toBe("native (packed)");
+    expect(executionRepresentationLabel("dense-fallback")).toBe("dense fallback");
+    expect(executionRepresentationLabel(undefined)).toBe("not measured");
+  });
 });

--- a/crates/sceneworks-core/src/base_weights.rs
+++ b/crates/sceneworks-core/src/base_weights.rs
@@ -691,13 +691,38 @@ fn metadata_declares_nvfp4(entries: &serde_json::Map<String, Value>) -> bool {
     let Some(layers) = parsed.get("layers").and_then(Value::as_object) else {
         return false;
     };
-    !layers.is_empty()
-        && layers.values().all(|layer| {
-            layer
-                .get("format")
-                .and_then(Value::as_str)
-                .is_some_and(|format| format.eq_ignore_ascii_case("nvfp4"))
-        })
+    !layers.is_empty() && layers.values().all(nvfp4_layer_descriptor_is_decodable)
+}
+
+/// The block size `nvfp4-v1` decodes: 16 E2M1 values per FP8 block scale.
+///
+/// Not a tunable. It is baked into [`has_nvfp4_triplets`]'s shape arithmetic (`cols / 16` blocks
+/// per row, rounded to the 128×4 swizzle) and into the codec on the engine side.
+const NVFP4_GROUP_SIZE: u64 = 16;
+
+/// One `_quantization_metadata.layers` entry: `nvfp4` format, and a group size this build decodes.
+///
+/// The group size used to be READ by nobody. A converter emitting `group_size: 32` (the MXFP4 block
+/// size, and a plausible future NVFP4 variant) declared `format: "nvfp4"` and passed — and then the
+/// shape checks below, which assume 16, would either reject the file for the wrong reason or, where
+/// the arithmetic happened to line up, admit it and hand the codec blocks it decodes at the wrong
+/// stride. A declared size this build does not implement is refused explicitly (sc-11045 review).
+///
+/// An ABSENT `group_size` is accepted: the pinned Krea 2 artifact's descriptors carry one, but the
+/// field is optional in the converter's schema and its absence means "the codec default", which is
+/// 16. Only a size that is present and different is a refusal.
+fn nvfp4_layer_descriptor_is_decodable(layer: &Value) -> bool {
+    if !layer
+        .get("format")
+        .and_then(Value::as_str)
+        .is_some_and(|format| format.eq_ignore_ascii_case("nvfp4"))
+    {
+        return false;
+    }
+    match layer.get("group_size") {
+        None | Some(Value::Null) => true,
+        Some(value) => value.as_u64() == Some(NVFP4_GROUP_SIZE),
+    }
 }
 
 fn tensor_header<'a>(
@@ -776,8 +801,11 @@ fn has_nvfp4_triplets(entries: &serde_json::Map<String, Value>) -> bool {
         let block_values = block_shape
             .iter()
             .try_fold(1u64, |product, dim| product.checked_mul(*dim));
+        // `NVFP4_GROUP_SIZE` values per block scale — the same 16 the layer descriptor is validated
+        // against in `nvfp4_layer_descriptor_is_decodable`, so the two cannot drift apart.
         let expected_blocks = round_up_u64(*rows, 128).and_then(|scale_rows| {
-            round_up_u64(cols / 16, 4).and_then(|scale_cols| scale_rows.checked_mul(scale_cols))
+            round_up_u64(cols / NVFP4_GROUP_SIZE, 4)
+                .and_then(|scale_cols| scale_rows.checked_mul(scale_cols))
         });
         if !matches!((block_values, expected_blocks), (Some(actual), Some(expected)) if actual == expected)
             || !matches!(
@@ -1495,6 +1523,69 @@ mod tests {
         assert_eq!(verdict.quant, QuantFormat::Fp8InlineScale);
         // And the import gate must not admit it under the krea_2 NVFP4 arm either.
         assert!(import_supported(&verdict).is_err());
+    }
+
+    /// The declared `group_size` is CHECKED against the 16 this build decodes (sc-11045 review).
+    ///
+    /// The descriptor carries it and nothing read it. `nvfp4-v1` is a 16-value block codec, and the
+    /// triplet proof below hard-codes that stride (`cols / 16` block scales per row, padded to the
+    /// 128x4 swizzle). A converter emitting `group_size: 32` — the MXFP4 block size, and the most
+    /// plausible shape a future NVFP4 variant takes — declared `format: "nvfp4"` and passed the
+    /// declaration check unread, leaving only the shape arithmetic between it and the codec.
+    ///
+    /// An ABSENT size still means "the codec default", so it is accepted; only a present-and-wrong
+    /// one is refused.
+    ///
+    /// Failing mutation (run): drop the `group_size` arm from
+    /// `nvfp4_layer_descriptor_is_decodable` (return `true` after the format check). Every
+    /// mis-sized row below then classifies as `Nvfp4`.
+    #[test]
+    fn a_declared_group_size_this_build_does_not_decode_is_not_nvfp4() {
+        // Re-declare the layer map with a chosen `group_size`, everything else identical to the
+        // fixture the two passing tests above use.
+        let with_group_size = |group_size: Option<Value>| {
+            let Value::Object(mut map) = quantization_metadata_nvfp4_header(
+                "model.diffusion_model.txtfusion.projector.weight",
+                6,
+                false,
+                &["nvfp4"],
+            ) else {
+                unreachable!("the fixture builds an object")
+            };
+            let mut declared = serde_json::Map::new();
+            for index in 0..6 {
+                let mut layer = serde_json::Map::new();
+                layer.insert("format".to_owned(), json!("nvfp4"));
+                if let Some(group_size) = group_size.clone() {
+                    layer.insert("group_size".to_owned(), group_size);
+                }
+                declared.insert(format!("blocks.{index}.attn.wq"), Value::Object(layer));
+            }
+            map.insert(
+                "__metadata__".to_owned(),
+                json!({
+                    "format": "pt",
+                    "_quantization_metadata":
+                        serde_json::to_string(&json!({"layers": declared})).unwrap(),
+                }),
+            );
+            recognized(classify_base_header(&Value::Object(map))).quant
+        };
+
+        // The size this build decodes, and its absence (the codec default), both classify NVFP4.
+        assert_eq!(with_group_size(Some(json!(16))), QuantFormat::Nvfp4);
+        assert_eq!(with_group_size(None), QuantFormat::Nvfp4);
+        assert_eq!(with_group_size(Some(Value::Null)), QuantFormat::Nvfp4);
+
+        // Anything else is refused, and the file drops back to what its tensor surface says it is
+        // rather than being handed to a codec that would decode it at the wrong stride.
+        for group_size in [json!(32), json!(8), json!(64), json!(0), json!("16")] {
+            assert_eq!(
+                with_group_size(Some(group_size.clone())),
+                QuantFormat::Fp8InlineScale,
+                "group_size {group_size} is not one this build decodes as nvfp4-v1"
+            );
+        }
     }
 
     /// A descriptor that annotates something with no proven triplet under it keeps the WHOLE file

--- a/crates/sceneworks-core/src/checkpoint_weight_facts.rs
+++ b/crates/sceneworks-core/src/checkpoint_weight_facts.rs
@@ -398,7 +398,8 @@ impl fmt::Display for MaterializationUnavailable {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "camelCase")]
 pub enum MaterializationFact {
-    /// Measured rows, sorted by `(codec_id, representation)`.
+    /// Measured rows, sorted by `(codec_id, representation)`. Never empty — see
+    /// [`CheckpointWeightFactsError::EmptyReportedMaterialization`].
     #[serde(rename = "reported")]
     Reported {
         rows: Vec<MaterializedCodecFact>,
@@ -436,6 +437,13 @@ pub enum CheckpointWeightFactsError {
         codec_id: String,
         tensor_count: usize,
     },
+    /// A `Reported` materialization carries no rows at all. "Measured, and it materialized nothing"
+    /// is not a thing a load can be; the honest statement for a load nobody measured is
+    /// [`MaterializationFact::Unavailable`], and an empty `Reported` was silently equivalent to a
+    /// measured DENSE run — [`CheckpointWeightFactsV1::executes_natively`] answered `Some(false)`
+    /// and the label rendered "dense fallback" — which is the fabricated-measurement mirror of the
+    /// lie this module exists to prevent (sc-11045 review).
+    EmptyReportedMaterialization,
     /// The payload declares a `schemaVersion` this build cannot read. A future version may add
     /// fields whose absence changes what the rest of the payload MEANS, so decoding it as v1 and
     /// dropping them would produce a confidently-wrong fact set — exactly the class this module
@@ -485,6 +493,11 @@ impl fmt::Display for CheckpointWeightFactsError {
                  labelled `{}`, but this host declares no native execution for that codec — a \
                  non-native host runs the declared dense fallback and its receipt must say so",
                 ExecutionRepresentation::NativePacked
+            ),
+            Self::EmptyReportedMaterialization => write!(
+                f,
+                "checkpoint weight facts: a `reported` materialization carries no rows; a load \
+                 nobody measured is `unavailable`, not a measurement of nothing"
             ),
             Self::UnsupportedSchemaVersion { version } => write!(
                 f,
@@ -602,6 +615,9 @@ impl CheckpointWeightFactsV1 {
             }
         }
         if let MaterializationFact::Reported { rows, .. } = &materialization {
+            if rows.is_empty() {
+                return Err(CheckpointWeightFactsError::EmptyReportedMaterialization);
+            }
             let mut seen: BTreeSet<(&str, ExecutionRepresentation)> = BTreeSet::new();
             for row in rows {
                 if !is_codec_id(&row.codec_id) {
@@ -734,14 +750,102 @@ impl CheckpointWeightFactsV1 {
         }
     }
 
+    /// **How much** of this codec ran packed and how much took the dense fallback, as a single
+    /// summary. `None` when nothing measured the load.
+    ///
+    /// This is the fact [`Self::executes_natively`] deliberately loses. That predicate is
+    /// `any`-shaped — the right shape for "may this run be called native at all" — but a receipt
+    /// that reports BOTH a non-empty `native-packed` row and a non-empty `dense-fallback` row
+    /// describes a genuinely mixed load, and collapsing it to `true` rendered as "native (packed)"
+    /// on a user-facing surface. That is untrue about the majority of the tensors whenever the
+    /// engine's shipping policy is mixed, and the pinned engine documents exactly such a policy for
+    /// this leg (a minority of projections executing the packed W4A4 operand, the remainder
+    /// decoded to dense W4A16).
+    ///
+    /// Zero-count rows assert nothing (the same boundary [`Self::try_new`] draws when it lets an
+    /// empty native row skip the capability check), so they never make a load "mixed".
+    pub fn execution_mix(&self, codec_id: &str) -> Option<ExecutionMix> {
+        let MaterializationFact::Reported { rows, .. } = &self.materialization else {
+            return None;
+        };
+        let tensors = |representation| {
+            rows.iter()
+                .filter(|row| row.codec_id == codec_id && row.representation == representation)
+                .map(|row| row.tensor_count)
+                .sum::<usize>()
+        };
+        let native_tensors = tensors(ExecutionRepresentation::NativePacked);
+        let dense_tensors = tensors(ExecutionRepresentation::DenseFallback);
+        Some(match (native_tensors, dense_tensors) {
+            (0, _) => ExecutionMix::DenseFallback,
+            (_, 0) => ExecutionMix::NativePacked,
+            (native_tensors, dense_tensors) => ExecutionMix::Mixed {
+                native_tensors,
+                dense_tensors,
+            },
+        })
+    }
+
     /// The single representation label to render for a codec, or `None` when unknown. Never
     /// synthesized from the capability — a host that *could* run packed may still have taken the
     /// dense path for a reason only the receipt knows.
-    pub fn representation_label(&self, codec_id: &str) -> Option<&'static str> {
-        match self.executes_natively(codec_id)? {
-            true => Some(ExecutionRepresentation::NativePacked.label()),
-            false => Some(ExecutionRepresentation::DenseFallback.label()),
+    ///
+    /// A mixed load renders as [`ExecutionMix::Mixed`]'s counted label rather than as either pure
+    /// arm; see [`Self::execution_mix`].
+    pub fn representation_label(&self, codec_id: &str) -> Option<String> {
+        Some(self.execution_mix(codec_id)?.label())
+    }
+}
+
+/// The `"mixed"` summary kind, and the separator its counted form uses.
+///
+/// **Not an [`ExecutionRepresentation`].** The two engine wire strings label individual measured
+/// ROWS and are shared verbatim across the repo boundary; this is a SceneWorks-side summary OVER
+/// those rows, and it is spelled differently on purpose so a reader (and
+/// [`ExecutionRepresentation::from_label`]) cannot mistake one vocabulary for the other.
+pub const MIXED_EXECUTION_LABEL: &str = "mixed";
+
+/// What a codec's measured rows add up to, across representations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExecutionMix {
+    /// Every measured tensor of this codec executed in its stored packing.
+    NativePacked,
+    /// No measured tensor of this codec executed packed.
+    DenseFallback,
+    /// Both, with the tensor counts that make the split legible.
+    Mixed {
+        native_tensors: usize,
+        dense_tensors: usize,
+    },
+}
+
+impl ExecutionMix {
+    /// The value a telemetry column carries and a client renders.
+    ///
+    /// The two pure arms are the engine's own row labels, unchanged — every existing consumer and
+    /// every persisted row keeps reading exactly what it read before. The mixed arm is
+    /// `"mixed:<packed>/<dense>"`: a distinct value (so a query can separate mixed runs from either
+    /// pure one) that also carries the counts, so a surface can say *how* mixed without a second
+    /// column.
+    pub fn label(self) -> String {
+        match self {
+            Self::NativePacked => ExecutionRepresentation::NativePacked.label().to_owned(),
+            Self::DenseFallback => ExecutionRepresentation::DenseFallback.label().to_owned(),
+            Self::Mixed {
+                native_tensors,
+                dense_tensors,
+            } => format!("{MIXED_EXECUTION_LABEL}:{native_tensors}/{dense_tensors}"),
         }
+    }
+
+    /// Whether any measured tensor executed in its stored packing — the `any` question, asked
+    /// explicitly rather than by collapsing the mix.
+    pub fn has_native(self) -> bool {
+        matches!(self, Self::NativePacked | Self::Mixed { .. })
+    }
+
+    pub fn is_mixed(self) -> bool {
+        matches!(self, Self::Mixed { .. })
     }
 }
 
@@ -812,7 +916,7 @@ mod tests {
         assert!(facts.declares(NVFP4_CODEC_ID));
         assert_eq!(facts.executes_natively(NVFP4_CODEC_ID), Some(true));
         assert_eq!(
-            facts.representation_label(NVFP4_CODEC_ID),
+            facts.representation_label(NVFP4_CODEC_ID).as_deref(),
             Some("native-packed")
         );
         assert!(facts.capability().executes_natively(NVFP4_CODEC_ID));
@@ -836,7 +940,7 @@ mod tests {
         .expect("a capable host that ran dense reports dense");
         assert_eq!(facts.executes_natively(NVFP4_CODEC_ID), Some(false));
         assert_eq!(
-            facts.representation_label(NVFP4_CODEC_ID),
+            facts.representation_label(NVFP4_CODEC_ID).as_deref(),
             Some("dense-fallback")
         );
     }
@@ -1130,6 +1234,65 @@ mod tests {
         assert_eq!(error, CheckpointWeightFactsError::EmptySourceInventory);
     }
 
+    /// An empty `reported` receipt is refused — it is a FABRICATED measurement (sc-11045 review).
+    ///
+    /// It used to be accepted, and it was silently equivalent to a measured dense run:
+    /// `executes_natively` answered `Some(false)` and the label rendered "dense fallback" for a
+    /// load nobody measured. That is the same class of untruth as labelling a dense run native,
+    /// only pointing the other way — and it is exactly the reading the explicit `Unavailable` arm
+    /// exists to keep separate.
+    ///
+    /// Failing mutation (run): delete the `if rows.is_empty()` guard in `try_new`. The
+    /// construction succeeds and the two assertions after it read "measured dense".
+    #[test]
+    fn an_empty_reported_materialization_is_refused_on_both_paths() {
+        let error = CheckpointWeightFactsV1::try_new(
+            None,
+            sm_120(),
+            nvfp4_source(),
+            MaterializationFact::Reported {
+                rows: Vec::new(),
+                complete: true,
+            },
+        )
+        .expect_err("a measurement of nothing is not a measurement");
+        assert_eq!(
+            error,
+            CheckpointWeightFactsError::EmptyReportedMaterialization
+        );
+        assert!(error.to_string().contains("unavailable"));
+
+        // The deserializer runs the same validation, so a hand-edited sidecar cannot smuggle one
+        // back in either.
+        let valid = CheckpointWeightFactsV1::try_new(
+            None,
+            sm_120(),
+            nvfp4_source(),
+            reported(vec![row(ExecutionRepresentation::NativePacked, 588, 1)]),
+        )
+        .expect("valid");
+        let json = serde_json::to_string(&valid).expect("serializes");
+        let mut value: serde_json::Value = serde_json::from_str(&json).expect("json");
+        value["materialization"]["rows"] = serde_json::json!([]);
+        let error = serde_json::from_value::<CheckpointWeightFactsV1>(value)
+            .expect_err("an emptied receipt is refused on the way back in");
+        assert!(
+            error.to_string().contains("no rows"),
+            "unexpected error: {error}"
+        );
+
+        // The honest statement for the same situation still constructs.
+        CheckpointWeightFactsV1::try_new(
+            None,
+            sm_120(),
+            nvfp4_source(),
+            MaterializationFact::Unavailable {
+                reason: MaterializationUnavailable::NoRuntimeReceipt,
+            },
+        )
+        .expect("`unavailable` is how a load nobody measured is stated");
+    }
+
     #[test]
     fn duplicate_rows_are_refused_on_both_sides() {
         let duplicate_source = CheckpointWeightFactsV1::try_new(
@@ -1168,6 +1331,154 @@ mod tests {
                 representation: ExecutionRepresentation::DenseFallback,
             }
         );
+    }
+
+    /// A receipt reporting BOTH a non-empty packed row and a non-empty dense row describes a MIXED
+    /// load, and it must render as one (sc-11045, epic 11037, major 2-SW).
+    ///
+    /// `executes_natively` is `any`-shaped, so a mixed receipt collapsed to `Some(true)` and the
+    /// single label became `"native-packed"` → "native (packed)". The pinned engine documents a
+    /// mixed shipping policy for this leg (a minority of projections on the packed W4A4 operand,
+    /// the rest decoded to dense W4A16), so that reading was untrue about the MAJORITY of the
+    /// tensors on the very hosts the label is most likely to be read on.
+    ///
+    /// Failing mutation (run): restore the `any` collapse — make `representation_label` go back to
+    /// `match self.executes_natively(codec_id)? { true => native, false => dense }`. The counted
+    /// label below becomes `"native-packed"`.
+    #[test]
+    fn a_receipt_with_both_representations_reports_mixed_with_counts() {
+        // The engine README's shipping policy for this leg, as a receipt: 68 of 163 packed.
+        let facts = CheckpointWeightFactsV1::try_new(
+            None,
+            sm_120(),
+            nvfp4_source(),
+            reported(vec![
+                row(ExecutionRepresentation::NativePacked, 68, 2_400_000_000),
+                row(ExecutionRepresentation::DenseFallback, 95, 9_100_000_000),
+            ]),
+        )
+        .expect("a capable host may report a mixed load");
+
+        assert_eq!(
+            facts.execution_mix(NVFP4_CODEC_ID),
+            Some(ExecutionMix::Mixed {
+                native_tensors: 68,
+                dense_tensors: 95,
+            })
+        );
+        assert_eq!(
+            facts.representation_label(NVFP4_CODEC_ID).as_deref(),
+            Some("mixed:68/95"),
+            "a mixed load must not render as either pure representation"
+        );
+        assert!(facts
+            .execution_mix(NVFP4_CODEC_ID)
+            .expect("measured")
+            .is_mixed());
+        // The `any` predicate is untouched — it still answers the question it asks.
+        assert_eq!(facts.executes_natively(NVFP4_CODEC_ID), Some(true));
+        assert_eq!(facts.resident_bytes(), Some(11_500_000_000));
+    }
+
+    /// The pure arms keep the engine's own wire strings, byte for byte, and the tri-state
+    /// "not measured" arm is untouched.
+    #[test]
+    fn the_pure_and_unmeasured_arms_are_unchanged_by_the_mixed_state() {
+        let pure = |representation, tensor_count| {
+            CheckpointWeightFactsV1::try_new(
+                None,
+                sm_120(),
+                nvfp4_source(),
+                reported(vec![row(representation, tensor_count, 1)]),
+            )
+            .expect("valid")
+        };
+
+        let native = pure(ExecutionRepresentation::NativePacked, 588);
+        assert_eq!(
+            native.execution_mix(NVFP4_CODEC_ID),
+            Some(ExecutionMix::NativePacked)
+        );
+        assert_eq!(
+            native.representation_label(NVFP4_CODEC_ID).as_deref(),
+            Some("native-packed")
+        );
+
+        let dense = pure(ExecutionRepresentation::DenseFallback, 588);
+        assert_eq!(
+            dense.execution_mix(NVFP4_CODEC_ID),
+            Some(ExecutionMix::DenseFallback)
+        );
+        assert_eq!(
+            dense.representation_label(NVFP4_CODEC_ID).as_deref(),
+            Some("dense-fallback")
+        );
+
+        // A zero-count row asserts nothing, so it never makes a load "mixed".
+        let empty_native = CheckpointWeightFactsV1::try_new(
+            None,
+            NativeExecutionCapabilityFact::dense_only(),
+            nvfp4_source(),
+            reported(vec![
+                row(ExecutionRepresentation::NativePacked, 0, 0),
+                row(ExecutionRepresentation::DenseFallback, 588, 1),
+            ]),
+        )
+        .expect("an empty native row claims nothing");
+        assert_eq!(
+            empty_native.execution_mix(NVFP4_CODEC_ID),
+            Some(ExecutionMix::DenseFallback)
+        );
+        assert_eq!(
+            empty_native.representation_label(NVFP4_CODEC_ID).as_deref(),
+            Some("dense-fallback")
+        );
+
+        // Unmeasured stays tri-state `None` — never "mixed", never either pure arm.
+        let unmeasured = CheckpointWeightFactsV1::declared_source(
+            None,
+            sm_120(),
+            NVFP4_CODEC_ID,
+            MaterializationUnavailable::NoRuntimeReceipt,
+        )
+        .expect("valid");
+        assert_eq!(unmeasured.execution_mix(NVFP4_CODEC_ID), None);
+        assert_eq!(unmeasured.representation_label(NVFP4_CODEC_ID), None);
+
+        // And a codec the receipt reported nothing for is dense-by-measurement, as before: the
+        // rows exist, none of them are this codec's native rows.
+        assert_eq!(
+            native.execution_mix(DENSE_BF16_CODEC_ID),
+            Some(ExecutionMix::DenseFallback)
+        );
+    }
+
+    /// The mixed label is a SUMMARY, in a vocabulary the engine's row labels do not share.
+    #[test]
+    fn the_mixed_label_is_not_an_execution_representation() {
+        assert_eq!(MIXED_EXECUTION_LABEL, "mixed");
+        for label in ["mixed", "mixed:68/95"] {
+            assert_eq!(
+                ExecutionRepresentation::from_label(label),
+                None,
+                "{label} must not parse as a measured row's representation"
+            );
+        }
+        assert_eq!(
+            ExecutionMix::Mixed {
+                native_tensors: 1,
+                dense_tensors: 2,
+            }
+            .label(),
+            "mixed:1/2"
+        );
+        assert!(ExecutionMix::NativePacked.has_native());
+        assert!(ExecutionMix::Mixed {
+            native_tensors: 1,
+            dense_tensors: 2,
+        }
+        .has_native());
+        assert!(!ExecutionMix::DenseFallback.has_native());
     }
 
     #[test]

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -707,6 +707,20 @@ impl JobsStore {
         // not error — it would silently write `j_type` into `source_codec`. That is why
         // `purge_terminal_jobs_completed_before` names every column on both sides instead of
         // relying on `*`; keep it that way.
+        //
+        // `image_count` is here for the same reason and was MISSED (sc-11045 review): it was
+        // back-filled onto `generation_metrics` (epic 10402) but never onto the history mirror, so
+        // a database materialized before epic 10402 has a history table without it — and both
+        // pieces of named SQL below reference `image_count` on that table by name. Every retention
+        // sweep and every Generation Stats read on such an install fails with "no such column"
+        // rather than degrading. Naming the columns is what makes the mapping order-independent; it
+        // is also what makes a MISSING column a hard error instead of a silent shift.
+        ensure_column(
+            &transaction,
+            "generation_metrics_history",
+            "image_count",
+            "integer",
+        )?;
         ensure_column(
             &transaction,
             "generation_metrics_history",

--- a/crates/sceneworks-core/src/managed_checkpoint_variants.rs
+++ b/crates/sceneworks-core/src/managed_checkpoint_variants.rs
@@ -7,6 +7,7 @@
 //! | verb | owner |
 //! | --- | --- |
 //! | install | [`ManagedIngest`] — staging, checksum, one atomic rename, `compile_managed` |
+//! | confirm | [`ManagedCheckpointVariantV1::confirm_installed`] — called post-commit by the worker's model-import job for an install id this registry knows |
 //! | remove | [`CheckpointPlanStore::remove_managed`] |
 //! | identity | [`ImportPlanV1::semantic_digest`](crate::checkpoint_import::ImportPlanV1::semantic_digest) |
 //! | format | the engine's registered `nvfp4-v1` codec, via the header classification in [`crate::base_weights`] |
@@ -386,6 +387,11 @@ impl ManagedCheckpointVariantV1 {
     /// as "how much will this download", and without a consumer it could drift arbitrarily far
     /// from the pinned artifact with nothing red. Checked here rather than at finalize because
     /// this is the one verb that compares a committed install against the registration as a whole.
+    ///
+    /// **Called in production**, post-commit, by the worker's model-import job (sc-11045): once
+    /// `ManagedIngest::finalize` has committed, an install id this registry knows is confirmed
+    /// against its registration and a mismatch fails the job. An import with no registration —
+    /// every ordinary user import — never reaches it.
     pub fn confirm_installed(&self, install: &ManagedInstallV1) -> Result<(), ManagedVariantError> {
         self.validate()?;
         if install.install_id != self.variant_id {
@@ -491,8 +497,57 @@ pub fn managed_nvfp4_variants() -> &'static [ManagedCheckpointVariantV1] {
 /// There is no sibling that maps a model, family, backend, or host capability onto a variant, and
 /// adding one would be the auto-selection this epic forbids (E2 / SC#5). A caller that wants NVFP4
 /// states which artifact it means.
+///
+/// **Exact, byte-for-byte.** A caller deciding what to do about a merely case-different id must go
+/// through [`match_managed_nvfp4_variant_id`], which reports the near miss instead of resolving it.
 pub fn managed_nvfp4_variant(variant_id: &str) -> Option<&'static ManagedCheckpointVariantV1> {
     managed_nvfp4_variants()
         .iter()
         .find(|variant| variant.variant_id == variant_id)
+}
+
+/// How a caller-supplied model id relates to the registry.
+///
+/// The third arm is the one that matters. A managed variant's id IS its install-directory name and
+/// its checkpoint identity, and the directory resolver preserves case while the two filesystems
+/// SceneWorks ships on (NTFS, APFS as configured) do not — so `"NVFP4-Krea-2-Turbo"` and
+/// `"nvfp4-krea-2-turbo"` are one directory and one identity there while an exact-match registry
+/// lookup sees only the second. That gap let a case-different id miss the pin enforcement entirely
+/// (no registered repo, revision, file or checksum), pass the distinct-id collision check, and then
+/// install arbitrary bytes into the curated variant's own directory under its own identity.
+///
+/// [`ManagedVariantIdMatch::NearMiss`] closes it, and the caller closes it by REFUSING rather than by
+/// normalizing. Silently rewriting the id to the canonical spelling would make a request install
+/// something other than what it asked for, which is exactly the "convenience is not a guarantee"
+/// rule this registry is built on; a near miss is a client bug or an attempt, and both deserve a
+/// diagnostic naming the canonical id.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ManagedVariantIdMatch {
+    /// The id is not a managed variant at all. An ordinary import.
+    Unregistered,
+    /// The id names a registered variant exactly.
+    Exact(&'static ManagedCheckpointVariantV1),
+    /// The id differs from a registered variant only by ASCII case — the same install directory and
+    /// the same checkpoint identity on a case-insensitive filesystem, under an id the registry
+    /// cannot key on.
+    NearMiss(&'static ManagedCheckpointVariantV1),
+}
+
+/// Classify a caller-supplied model id against the registry, case-insensitively.
+///
+/// Surrounding whitespace is trimmed first, as it always was — a padded id already resolved to the
+/// registration and was already pinned, so it is `Exact`. Only the CASE difference is the near miss.
+pub fn match_managed_nvfp4_variant_id(model_id: &str) -> ManagedVariantIdMatch {
+    let candidate = model_id.trim();
+    let Some(variant) = managed_nvfp4_variants()
+        .iter()
+        .find(|variant| variant.variant_id.eq_ignore_ascii_case(candidate))
+    else {
+        return ManagedVariantIdMatch::Unregistered;
+    };
+    if variant.variant_id == candidate {
+        ManagedVariantIdMatch::Exact(variant)
+    } else {
+        ManagedVariantIdMatch::NearMiss(variant)
+    }
 }

--- a/crates/sceneworks-core/tests/jobs_store.rs
+++ b/crates/sceneworks-core/tests/jobs_store.rs
@@ -786,18 +786,44 @@ fn generation_metrics_separate_source_codec_from_execution_representation() {
 /// holding `j_status`, and `j_type` holding whatever landed there — unparseable, so Generation
 /// Stats breaks for every install that predates this change. Naming both branches' columns is what
 /// this pins.
+///
+/// Driven at TWO ages of database (sc-11045 review). The older one predates `image_count` as well:
+/// that column was back-filled onto `generation_metrics` by epic 10402 but never onto the history
+/// mirror, while both pieces of named SQL reference it on that table BY NAME — so on an install
+/// old enough to have a history table without it, every retention sweep and every Generation Stats
+/// read failed outright with "no such column". A test that always seeds `image_count` cannot see
+/// that; this one seeds a schema without it.
 #[test]
 fn generation_metrics_history_survives_a_pre_migration_schema() {
-    let db = temp_db("gen-metrics-upgrade");
+    for (label, with_image_count) in [
+        ("gen-metrics-upgrade", true),
+        ("gen-metrics-upgrade-pre-image-count", false),
+    ] {
+        generation_metrics_history_upgrade_case(label, with_image_count);
+    }
+}
+
+/// One age of pre-migration database. `with_image_count: false` is the epic-10402-era shape.
+///
+/// Failing mutation (run): delete the `ensure_column(…, "generation_metrics_history",
+/// "image_count", …)` call in `initialize`. The second case then fails on the retention sweep with
+/// `no such column: image_count`.
+fn generation_metrics_history_upgrade_case(label: &str, with_image_count: bool) {
+    let db = temp_db(label);
     let path = db.path();
 
     // Build the schema as it shipped BEFORE sc-21484: `generation_metrics` without the two
     // columns, and a history mirror materialized from that older shape. Written by hand rather
     // than by an older `initialize()` because the point is the physical column ORDER, and only a
     // literal `create table` fixes it.
+    let image_count_column = if with_image_count {
+        "image_count integer,"
+    } else {
+        ""
+    };
     let connection = Connection::open(&path).expect("db opens");
     connection
-        .execute_batch(
+        .execute_batch(&format!(
             "
             create table generation_metrics (
               job_id text primary key,
@@ -808,7 +834,7 @@ fn generation_metrics_history_survives_a_pre_migration_schema() {
               scheduler text,
               scheduler_shift real,
               steps integer,
-              image_count integer,
+              {image_count_column}
               guidance_scale real,
               true_cfg_scale real,
               guidance_method text,
@@ -831,8 +857,8 @@ fn generation_metrics_history_survives_a_pre_migration_schema() {
             create table generation_metrics_history as
               select m.*, 'x' as j_type, 'x' as j_status, 'x' as j_project_id, 'x' as j_created_at
                 from generation_metrics m where 0;
-            ",
-        )
+            "
+        ))
         .expect("pre-migration schema seeds");
     drop(connection);
 
@@ -862,6 +888,14 @@ fn generation_metrics_history_survives_a_pre_migration_schema() {
         "an upgraded history mirror must have the new columns appended after the identity \
          columns, or this test proves nothing: {columns:?}"
     );
+    // The older shape's `image_count` is back-filled too, and it lands in the appended block — the
+    // exact position the named SQL is indifferent to and a positional one would not be.
+    if !with_image_count {
+        assert!(
+            index("image_count") > index("j_created_at"),
+            "{label}: an epic-10402-era mirror gets image_count appended: {columns:?}"
+        );
+    }
 
     connection
         .execute(
@@ -883,6 +917,7 @@ fn generation_metrics_history_survives_a_pre_migration_schema() {
                 quant_label: Some("nvfp4".to_owned()),
                 source_codec: Some("nvfp4-v1".to_owned()),
                 execution_representation: Some("dense-fallback".to_owned()),
+                image_count: Some(3),
                 total_ms: Some(4321),
                 ..Default::default()
             },
@@ -916,6 +951,11 @@ fn generation_metrics_history_survives_a_pre_migration_schema() {
     assert_eq!(row.metrics.model.as_deref(), Some("kreamania-v7"));
     assert_eq!(row.metrics.quant_label.as_deref(), Some("nvfp4"));
     assert_eq!(row.metrics.total_ms, Some(4321));
+    assert_eq!(
+        row.metrics.image_count,
+        Some(3),
+        "{label}: the back-filled image_count carries through the sweep and the union"
+    );
 
     // And the type filter — which reads `stats.j_type` — still finds it.
     assert_eq!(

--- a/crates/sceneworks-core/tests/managed_checkpoint_variants.rs
+++ b/crates/sceneworks-core/tests/managed_checkpoint_variants.rs
@@ -509,6 +509,53 @@ fn nothing_maps_a_model_onto_a_variant() {
     }
 }
 
+/// A case-different id is a NEAR MISS, reported as one, and never silently resolved.
+///
+/// It cannot be `Unregistered` — on NTFS and a default APFS volume it is the same install directory
+/// and the same checkpoint identity as the registration, so treating it as an ordinary import is
+/// precisely the pin bypass. It also must not be `Exact`: resolving it would install the pinned
+/// bytes under an id the request did not name.
+///
+/// Failing mutation: make the `find` in `match_managed_nvfp4_variant_id` compare with `==` instead
+/// of `eq_ignore_ascii_case` — every case row below becomes `Unregistered`.
+#[test]
+fn a_case_variant_id_is_reported_as_a_near_miss() {
+    use sceneworks_core::managed_checkpoint_variants::{
+        match_managed_nvfp4_variant_id, ManagedVariantIdMatch,
+    };
+
+    for exact in [KREA_VARIANT, KLEIN_VARIANT] {
+        assert_eq!(
+            match_managed_nvfp4_variant_id(exact),
+            ManagedVariantIdMatch::Exact(registered(exact)),
+            "the exact id still resolves"
+        );
+        // A padded id resolved (and was pinned) before this change and still does.
+        assert_eq!(
+            match_managed_nvfp4_variant_id(&format!("  {exact} ")),
+            ManagedVariantIdMatch::Exact(registered(exact))
+        );
+        assert_eq!(
+            match_managed_nvfp4_variant_id(&exact.to_ascii_uppercase()),
+            ManagedVariantIdMatch::NearMiss(registered(exact)),
+            "an upper-cased id is a near miss, not a stranger and not the registration"
+        );
+    }
+
+    assert_eq!(
+        match_managed_nvfp4_variant_id("NVFP4-Krea-2-Turbo"),
+        ManagedVariantIdMatch::NearMiss(registered(KREA_VARIANT))
+    );
+    // A genuinely different id is untouched — this is a near-miss guard, not a prefix ban.
+    for stranger in ["nvfp4-krea-2-turbo-mine", "krea_2_turbo", "nvfp4", ""] {
+        assert_eq!(
+            match_managed_nvfp4_variant_id(stranger),
+            ManagedVariantIdMatch::Unregistered,
+            "{stranger:?} is an ordinary import"
+        );
+    }
+}
+
 /// A generation request against an installed Krea variant is admitted ONLY when it names `nvfp4`.
 ///
 /// The legacy MLX bit count is refused rather than coerced, and so is any other named tier: an
@@ -712,9 +759,20 @@ fn changing_the_pinned_provenance_is_refused() {
     let error = resized
         .confirm_installed(&install)
         .expect_err("a variant that mis-states its download size must not confirm");
+    // The SIZE branch's OWN wording. `"not the pinned"` is emitted by the digest branch too, so an
+    // assertion on it did not distinguish which check refused — it matched a substring this case
+    // does not own. The two assertions below are specific to the size comparison.
     assert!(
-        error.reason().contains("not the pinned"),
+        error
+            .reason()
+            .contains("the registered size is what a client is told it will download"),
         "unexpected size-mismatch reason: {error}"
+    );
+    assert!(
+        error
+            .reason()
+            .contains(&format!("committed {} bytes", variant.size_bytes)),
+        "the size refusal must report the OBSERVED size: {error}"
     );
     // ...and the honest registration still confirms, so the check is a comparison and not a
     // blanket refusal.

--- a/crates/sceneworks-worker/src/checkpoint_weight_facts_host.rs
+++ b/crates/sceneworks-worker/src/checkpoint_weight_facts_host.rs
@@ -181,7 +181,9 @@ pub(crate) fn insert_facts_into_raw_settings(
 ///
 /// Both halves are `None` without facts. The second is `None` whenever the load was not measured,
 /// and that stays `None`: an absent representation means "not measured", which the stats surface
-/// renders as unknown rather than as dense.
+/// renders as unknown rather than as dense. A load that ran PART of the codec packed and part dense
+/// carries the distinct `"mixed:<packed>/<dense>"` value rather than either pure label — see
+/// [`sceneworks_core::checkpoint_weight_facts::ExecutionMix`].
 /// Gated to the lanes that build image metrics at all: `image_jobs/base.rs` is included only where
 /// a media backend is linked, so on the "neither" build (no MLX, no candle) there is no metrics
 /// producer to call this and an ungated definition would be a dead-code error on that PR lane.
@@ -201,9 +203,7 @@ pub(crate) fn facts_metrics_pair(
     };
     (
         Some(entry.codec_id.clone()),
-        facts
-            .representation_label(&entry.codec_id)
-            .map(str::to_owned),
+        facts.representation_label(&entry.codec_id),
     )
 }
 

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -22591,6 +22591,7 @@ fn checkpoint_plan_route_refuses_before_load_with_typed_diagnostics() {
     let compiled = fx.compile("kreamania.safetensors", &krea_native_entries());
     let edit = fx.plan_backed_request(
         &compiled,
+        None,
         json!({ "mode": "edit_image", "sourceAssetId": "asset-1" }),
     );
     let declined = prepare_checkpoint_plan_sources(&edit, &fx.settings).unwrap();
@@ -23480,6 +23481,208 @@ fn a_quantized_plan_is_gated_on_the_providers_advertised_tiers_not_on_its_layer_
             message.contains("[checkpoint-plan:unsupported-operation]"),
             "{label}: and it must carry the typed code: {message}"
         );
+    }
+}
+
+/// A single-file Krea NVFP4 transformer: the `_quantization_metadata` layer map plus one complete
+/// packed triplet (`U8` weight / `F8_E4M3` blocked scale / scalar `F32` second scale) per
+/// projection, over the `krea_2` family marker.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn write_krea_nvfp4_safetensors(path: &Path) {
+    let layers = 6;
+    let mut declared = serde_json::Map::new();
+    for index in 0..layers {
+        declared.insert(
+            format!("blocks.{index}.attn.wq"),
+            json!({"format": "nvfp4", "group_size": 16}),
+        );
+    }
+    let mut header = serde_json::Map::new();
+    header.insert(
+        "__metadata__".to_owned(),
+        json!({
+            "format": "pt",
+            "_quantization_metadata": serde_json::to_string(&json!({"layers": declared})).unwrap(),
+        }),
+    );
+    let mut entries: Vec<(String, &'static str, Vec<u64>)> = vec![(
+        "model.diffusion_model.txtfusion.projector.weight".to_owned(),
+        "BF16",
+        vec![128, 128],
+    )];
+    for index in 0..layers {
+        let base = format!("blocks.{index}.attn.wq");
+        entries.push((format!("{base}.weight"), "U8", vec![128, 32]));
+        entries.push((format!("{base}.weight_scale"), "F8_E4M3", vec![128, 4]));
+        entries.push((format!("{base}.weight_scale_2"), "F32", vec![]));
+    }
+    let mut offset = 0_u64;
+    for (name, dtype, shape) in &entries {
+        let width = match *dtype {
+            "F32" => 4,
+            "BF16" | "F16" => 2,
+            _ => 1,
+        };
+        let bytes = shape.iter().product::<u64>().max(1) * width;
+        header.insert(
+            name.clone(),
+            json!({"dtype": dtype, "shape": shape, "data_offsets": [offset, offset + bytes]}),
+        );
+        offset += bytes;
+    }
+    let encoded = serde_json::to_vec(&Value::Object(header)).unwrap();
+    let mut bytes = (encoded.len() as u64).to_le_bytes().to_vec();
+    bytes.extend(encoded);
+    bytes.resize(bytes.len() + offset as usize, 0x5a);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, bytes).unwrap();
+}
+
+/// Feature-end review (sc-11045, epic 11037, major 6) — the DISPATCH half of linked NVFP4 exposure.
+///
+/// A LINKED copy of a packed NVFP4 checkpoint must be refused a `q4` tier exactly as a managed copy
+/// is. `imported_model_quant` gates on `krea_imported_native_nvfp4`, which reads
+/// `imported_entry_source_codec` off the manifest entry — and until sc-11045 that answered `None`
+/// for every linked entry, because only the managed import branch stamped `importQuantFormat`. The
+/// guard was therefore off for linked copies, and `Quant::Q4` (or `mlxQuantize: 4`) could be handed
+/// to packed E2M1 bytes.
+///
+/// The entry is NOT hand-written: it is what `model_jobs::linked_checkpoint_manifest_entry`
+/// produces for this compile, with the classification the production job reads off the same file.
+///
+/// Failing mutation (run): pass `None` for `classification` — i.e. drop the stamping — and the
+/// `q4`/`mlxQuantize` rows stop being refused as native NVFP4.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+#[test]
+fn a_linked_packed_nvfp4_checkpoint_cannot_be_dispatched_at_a_q4_tier() {
+    let fx = CheckpointPlanFixture::new("linked-nvfp4-dispatch", true);
+    let relative = "kreamania_nvfp4.safetensors";
+    let file = fx.library_dir.join(relative);
+    write_krea_nvfp4_safetensors(&file);
+    let compiled = fx
+        .store
+        .compile_linked(&fx.root_id, relative)
+        .expect("the packed linked checkpoint compiles");
+
+    let classification = crate::model_jobs::base_weight_manifest_classification(&file);
+    assert_eq!(
+        classification,
+        Some(("transformer_file", "nvfp4")),
+        "fixture check: the file's own header proves it is packed NVFP4"
+    );
+
+    let queued: JsonObject = json!({
+        "id": "linked_kreamania_nvfp4",
+        "type": "image",
+        "catalogScope": "user",
+        "source": {
+            "provider": "linked-library",
+            "rootId": fx.root_id,
+            "relativePath": relative,
+        },
+    })
+    .as_object()
+    .unwrap()
+    .clone();
+    let entry = crate::model_jobs::linked_checkpoint_manifest_entry(
+        queued.clone(),
+        &compiled,
+        classification,
+    );
+
+    let descriptor = crate::inference_runtime::imported_model_descriptor(
+        "krea_2",
+        gen_core::ImportedModelSource::TransformerFile,
+        gen_core::ImportedModelOperation::Generate,
+    )
+    .expect("fixture check: this backend binds krea_2 transformer-file generation");
+
+    let request_with = |advanced: Value| {
+        request(json!({
+            "projectId": "p",
+            "model": "linked_kreamania_nvfp4",
+            "prompt": "a fox",
+            "count": 1,
+            "advanced": advanced,
+            "modelManifestEntry": Value::Object(entry.clone()),
+        }))
+    };
+
+    for advanced in [
+        json!({ "quantTier": "q4" }),
+        json!({ "quantTier": "q8" }),
+        json!({ "quant": "q4" }),
+        json!({ "quantTier": "bf16" }),
+        json!({ "mlxQuantize": 4 }),
+    ] {
+        let error = imported_model_quant(&request_with(advanced.clone()), &descriptor, "Linked")
+            .expect_err("packed NVFP4 bytes accept no other tier");
+        let WorkerError::InvalidPayload(message) = error else {
+            panic!("{advanced}: expected a typed payload refusal, got {error:?}");
+        };
+        assert!(
+            message.contains("stored as native NVFP4"),
+            "{advanced}: the refusal must come from the NATIVE-NVFP4 guard, not from the \
+             provider's advertised-tier check: {message}"
+        );
+    }
+
+    // The NEGATIVE CONTROL, and the named mutation made permanent: the SAME compile, the SAME
+    // request, stamped with NO classification is exactly what an unstamped linked entry was before
+    // sc-11045 — and the native guard does not fire for it. Without this the assertions above are
+    // satisfied by any refusal at all, and the mutation ("pass `None` for classification") could
+    // only be run by hand on a lane that executes candle/MLX tests.
+    let unstamped =
+        crate::model_jobs::linked_checkpoint_manifest_entry(queued.clone(), &compiled, None);
+    assert_eq!(
+        sceneworks_core::jobs_store::imported_entry_source_codec(&unstamped),
+        None,
+        "the pre-sc-11045 shape: the same packed bytes, with no source codec anywhere"
+    );
+    let unstamped_request = request(json!({
+        "projectId": "p",
+        "model": "linked_kreamania_nvfp4",
+        "prompt": "a fox",
+        "count": 1,
+        "advanced": { "quantTier": "q4" },
+        "modelManifestEntry": Value::Object(unstamped),
+    }));
+    let unguarded = imported_model_quant(&unstamped_request, &descriptor, "Linked");
+    let message = match unguarded {
+        Ok(_) => String::new(),
+        Err(WorkerError::InvalidPayload(message)) => message,
+        Err(other) => panic!("unexpected error shape: {other:?}"),
+    };
+    assert!(
+        !message.contains("stored as native NVFP4"),
+        "SANITY: without the stamp the native guard cannot fire — so the rows above are measuring \
+         the stamp, not some unrelated refusal: {message}"
+    );
+
+    // The checkpoint's own tier is what it accepts, and an unspecified tier resolves to it too —
+    // so this is a guard, not a blanket refusal. Only where the registered provider advertises the
+    // packed tier at all: MLX has no NVFP4 consumer, so on that lane every tier including its own
+    // is refused, and asserting acceptance there would measure the registry rather than the guard.
+    if descriptor
+        .capabilities
+        .supported_quants
+        .contains(&gen_core::Quant::Nvfp4)
+    {
+        for advanced in [json!({ "quantTier": "nvfp4" }), json!({})] {
+            let (quant, bits) =
+                imported_model_quant(&request_with(advanced.clone()), &descriptor, "Linked")
+                    .unwrap_or_else(|error| {
+                        panic!("{advanced} must resolve to the packed tier: {error}")
+                    });
+            assert_eq!(quant, Some(gen_core::Quant::Nvfp4), "{advanced}");
+            assert_eq!(bits, None, "{advanced}: a packed tier is never a bit count");
+        }
     }
 }
 
@@ -24906,7 +25109,7 @@ fn an_approved_root_becomes_a_selectable_plan_backed_model_through_the_import_st
         "SANITY: the queued entry is not yet plan-backed"
     );
 
-    let entry = crate::model_jobs::linked_checkpoint_manifest_entry(queued, &compiled);
+    let entry = crate::model_jobs::linked_checkpoint_manifest_entry(queued, &compiled, None);
     assert_eq!(
         sceneworks_core::jobs_store::checkpoint_plan_checkpoint_id(&entry),
         Some(compiled.checkpoint_id.as_str()),
@@ -24982,6 +25185,7 @@ fn relinking_a_moved_library_restores_the_route_without_touching_the_manifest_en
             .unwrap()
             .clone(),
         &compiled,
+        None,
     );
     let mut payload = json!({
         "projectId": "p",
@@ -25117,7 +25321,7 @@ fn the_linked_import_stamp_carries_the_plan_identity_and_no_install_path() {
         "SANITY: the queued entry is not yet plan-backed"
     );
 
-    let entry = crate::model_jobs::linked_checkpoint_manifest_entry(queued, &compiled);
+    let entry = crate::model_jobs::linked_checkpoint_manifest_entry(queued, &compiled, None);
     assert_eq!(
         sceneworks_core::jobs_store::checkpoint_plan_checkpoint_id(&entry),
         Some(checkpoint_id),

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -22591,7 +22591,6 @@ fn checkpoint_plan_route_refuses_before_load_with_typed_diagnostics() {
     let compiled = fx.compile("kreamania.safetensors", &krea_native_entries());
     let edit = fx.plan_backed_request(
         &compiled,
-        None,
         json!({ "mode": "edit_image", "sourceAssetId": "asset-1" }),
     );
     let declined = prepare_checkpoint_plan_sources(&edit, &fx.settings).unwrap();

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -4650,6 +4650,34 @@ async fn stable_model_file_sha256(
     Ok((hash, after))
 }
 
+/// The `(importSourceShape, importQuantFormat)` pair a single checkpoint file's safetensors header
+/// proves, or `None` when it proves nothing a manifest entry may claim (sc-11045, epic 11037).
+///
+/// The managed import branch derives the same pair inline, because it can do more: it holds staged
+/// bytes it is about to install, so it REFUSES an unsupported triple and a bare `mage-flow` file
+/// outright. A linked import has already compiled a verified plan over the user's own file and must
+/// not retroactively refuse it, so an unrecognized header stamps nothing here rather than failing
+/// the job. What must not differ is the PAIR — two copies of one rule disagreeing about what a
+/// checkpoint is stored as is the sc-13542 resolver-drift class, and
+/// `linked_classification_tests::the_linked_classifier_matches_the_managed_branchs_mapping` pins
+/// them together.
+///
+/// A component that is not a whole model (a text encoder, a VAE) yields `None`: it is not
+/// registerable as an imported model at all, so it has no source shape to advertise.
+pub(crate) fn base_weight_manifest_classification(
+    path: &Path,
+) -> Option<(&'static str, &'static str)> {
+    let BaseWeightDetection::Recognized(verdict) = detect_base_weight_file(path).ok()? else {
+        return None;
+    };
+    let source = match verdict.component {
+        ComponentRole::Transformer => "transformer_file",
+        ComponentRole::Checkpoint => "fused_checkpoint",
+        ComponentRole::TextEncoder | ComponentRole::Vae => return None,
+    };
+    Some((source, verdict.quant.as_str()))
+}
+
 /// The manifest entry a compiled linked checkpoint becomes (epic 20398, sc-20635).
 ///
 /// This is the stamp that makes a linked checkpoint REACHABLE. `importPlan.checkpointId` is the
@@ -4662,9 +4690,28 @@ async fn stable_model_file_sha256(
 /// A plan-backed entry carries NO `paths.model`. The plan-driven route resolves the plan's own
 /// layers through the plan store; writing an install path here would both be a lie (nothing was
 /// installed) and hand the entry to a bespoke lane as well, breaking the single-claim invariant.
+///
+/// # The header classification rides too (sc-11045, epic 11037)
+///
+/// `classification` is the `(importSourceShape, importQuantFormat)` pair
+/// [`base_weight_manifest_classification`] proved from the linked file's own safetensors header —
+/// the SAME detector the managed branch runs, over the same bytes.
+///
+/// It was managed-only, and that made a LINKED copy of an NVFP4 checkpoint invisible to every E8
+/// surface even though the bytes are identical: `imported_entry_source_codec` answered `None`, so
+/// admission's native claim was false, the catalog emitted no `runtimeQuantTiers` (the provider
+/// surface early-returns without an `importSourceShape`), the asset receipt and the
+/// `generation_metrics` row carried no source codec, and — worst — the worker's dispatch guard
+/// `krea_imported_native_nvfp4` was false, so `imported_model_quant` would happily hand `Quant::Q4`
+/// to packed E2M1 bytes. E8 is a property of the CHECKPOINT, not of who owns the copy, so the
+/// classification is stamped in both ownership modes.
+///
+/// `None` stamps nothing. A header that proves no base-weight verdict is not a reason to invent
+/// one, and an absent key is what every consumer already handles.
 pub(crate) fn linked_checkpoint_manifest_entry(
     mut entry: JsonObject,
     compiled: &sceneworks_core::checkpoint_plan_store::CompiledCheckpointV1,
+    classification: Option<(&str, &str)>,
 ) -> JsonObject {
     entry
         .entry("family")
@@ -4677,6 +4724,16 @@ pub(crate) fn linked_checkpoint_manifest_entry(
             "semanticDigest": compiled.record.plan.semantic_digest,
         }),
     );
+    if let Some((source_shape, quant_format)) = classification {
+        entry.insert(
+            "importSourceShape".to_owned(),
+            Value::String(source_shape.to_owned()),
+        );
+        entry.insert(
+            "importQuantFormat".to_owned(),
+            Value::String(quant_format.to_owned()),
+        );
+    }
     // A linked checkpoint is referenced in place; nothing was copied into an app-owned install
     // directory, so any inherited install path would name a directory that does not exist.
     if let Some(paths) = entry.get_mut("paths").and_then(Value::as_object_mut) {
@@ -4723,6 +4780,18 @@ async fn run_linked_checkpoint_import_job(
     .await?;
     let store =
         sceneworks_core::checkpoint_plan_store::CheckpointPlanStore::open(&settings.data_dir);
+    // The absolute path of the linked file, resolved through the APPROVED root — the same
+    // confinement `compile_linked` applies, never a path built from the payload. It is what the
+    // header classification below reads; a root that no longer resolves simply yields no
+    // classification (the compile below produces the typed refusal for that case).
+    let linked_file = store
+        .resolve_root(root_id)
+        .ok()
+        .zip(
+            sceneworks_core::checkpoint_plan_store::portable_relative_path_parts(relative_path)
+                .ok(),
+        )
+        .map(|(root, parts)| root.join(parts));
     let root_id = root_id.to_owned();
     let relative_path = relative_path.to_owned();
     // Full-content compile streams every byte through SHA-256, so it runs off the async runtime.
@@ -4759,7 +4828,18 @@ async fn run_linked_checkpoint_import_job(
         .and_then(Value::as_object)
         .cloned()
     {
-        let manifest_entry = linked_checkpoint_manifest_entry(manifest_entry, &compiled);
+        // The SAME header classification the managed branch runs, over the user's own file. Reading
+        // a safetensors header is a bounded seek-and-parse, but it is still blocking I/O.
+        let classification = match linked_file {
+            Some(path) => {
+                tokio::task::spawn_blocking(move || base_weight_manifest_classification(&path))
+                    .await
+                    .unwrap_or(None)
+            }
+            None => None,
+        };
+        let manifest_entry =
+            linked_checkpoint_manifest_entry(manifest_entry, &compiled, classification);
         let manifest_path = model_manifest_target(settings, &job.payload)?;
         upsert_manifest_entry(&manifest_path, "models", manifest_entry).await?;
     }
@@ -5305,6 +5385,35 @@ pub(crate) async fn run_model_import_job(
         crate::paths::normalize_existing_or_absolute(&install.install_path).ok(),
         Some(target_dir.clone())
     );
+    // A CURATED managed NVFP4 variant confirms against its registration (sc-11045, epic 11037).
+    //
+    // `ManagedCheckpointVariantV1::confirm_installed` compares the committed install id, checkpoint
+    // id, path, digest and — the reason it exists — the registered `size_bytes` against the file on
+    // disk. It had no production caller at all, which made the registered size the decorative
+    // number its own doc comment says it must not be: it is what a client renders as "how much will
+    // this download", and nothing compared it to anything.
+    //
+    // Post-commit rather than at finalize: this is the one verb that checks a COMMITTED install
+    // against the registration as a whole, and the digest verification inside `finalize` has
+    // already refused substituted bytes by the time it runs. A failure here is a registration
+    // defect (a stale or invented size), so it fails the job with the diagnostic rather than
+    // recording a curated identity the registry does not actually describe. Non-variant imports —
+    // every ordinary user import — have no registration and skip it entirely.
+    if let Some(variant) =
+        sceneworks_core::managed_checkpoint_variants::managed_nvfp4_variant(&install.install_id)
+    {
+        if let Err(error) = variant.confirm_installed(&install) {
+            return fail_job(
+                api,
+                &job.id,
+                "Model import failed.",
+                Some(format!(
+                    "The installed bytes do not match the managed variant's registration: {error}"
+                )),
+            )
+            .await;
+        }
+    }
     if !install.duplicate_checkpoint_ids().is_empty() {
         // Reported, never acted on: a user may legitimately keep both a linked library copy and a
         // managed one, so neither is deleted and the import still succeeds (AC2).
@@ -7853,6 +7962,310 @@ mod co_requisite_tests {
                 "{model_id}: the error must name the missing `vocoder` component + its repo BEFORE engine \
                  load, got: {message}"
             );
+        }
+    }
+}
+
+/// The linked half of E8: a LINKED copy of an NVFP4 checkpoint is exposed exactly as a managed one
+/// (sc-11045, epic 11037).
+///
+/// Ungated on purpose. The stamp and the resolvers that read it are platform-independent — the
+/// backend-specific dispatch half lives in `image_jobs::tests` — and this is the layer where "the
+/// same bytes, owned differently, are the same checkpoint" is decided.
+#[cfg(test)]
+mod linked_classification_tests {
+    use super::*;
+    use sceneworks_core::checkpoint_weight_facts::NVFP4_CODEC_ID;
+    use std::path::PathBuf;
+
+    fn write_header_file(
+        path: &Path,
+        metadata: Value,
+        entries: &[(String, &'static str, Vec<u64>)],
+    ) {
+        let mut header = serde_json::Map::new();
+        header.insert("__metadata__".to_owned(), metadata);
+        let mut offset = 0_u64;
+        for (name, dtype, shape) in entries {
+            let width = match *dtype {
+                "F32" => 4,
+                "BF16" | "F16" => 2,
+                _ => 1,
+            };
+            let bytes = shape.iter().product::<u64>().max(1) * width;
+            header.insert(
+                name.clone(),
+                json!({"dtype": dtype, "shape": shape, "data_offsets": [offset, offset + bytes]}),
+            );
+            offset += bytes;
+        }
+        let encoded = serde_json::to_vec(&Value::Object(header)).unwrap();
+        let mut bytes = (encoded.len() as u64).to_le_bytes().to_vec();
+        bytes.extend(encoded);
+        bytes.resize(bytes.len() + offset as usize, 0x5a);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, bytes).unwrap();
+    }
+
+    /// A single-file NVFP4 transformer whose header carries everything the classifier proves: the
+    /// `_quantization_metadata` layer map, and one complete packed triplet per projection.
+    fn write_nvfp4_transformer(path: &Path) {
+        let layers = 6;
+        let mut declared = serde_json::Map::new();
+        for index in 0..layers {
+            declared.insert(
+                format!("blocks.{index}.attn.wq"),
+                json!({"format": "nvfp4", "group_size": 16}),
+            );
+        }
+        let mut entries: Vec<(String, &'static str, Vec<u64>)> = vec![(
+            "model.diffusion_model.txtfusion.projector.weight".to_owned(),
+            "BF16",
+            vec![128, 128],
+        )];
+        for index in 0..layers {
+            let base = format!("blocks.{index}.attn.wq");
+            entries.push((format!("{base}.weight"), "U8", vec![128, 32]));
+            entries.push((format!("{base}.weight_scale"), "F8_E4M3", vec![128, 4]));
+            entries.push((format!("{base}.weight_scale_2"), "F32", vec![]));
+        }
+        write_header_file(
+            path,
+            json!({
+                "format": "pt",
+                "_quantization_metadata": serde_json::to_string(&json!({"layers": declared}))
+                    .unwrap(),
+            }),
+            &entries,
+        );
+    }
+
+    /// The same family surface, stored DENSE — the control row.
+    fn write_dense_transformer(path: &Path) {
+        write_header_file(
+            path,
+            json!({ "format": "pt" }),
+            &[
+                (
+                    "model.diffusion_model.txtfusion.projector.weight".to_owned(),
+                    "BF16",
+                    vec![128, 128],
+                ),
+                (
+                    "model.diffusion_model.blocks.0.attn.wq.weight".to_owned(),
+                    "BF16",
+                    vec![128, 128],
+                ),
+                (
+                    "model.diffusion_model.first.weight".to_owned(),
+                    "BF16",
+                    vec![128, 128],
+                ),
+            ],
+        )
+    }
+
+    struct LinkedFixture {
+        _data: tempfile::TempDir,
+        _library: tempfile::TempDir,
+        store: CheckpointPlanStore,
+        library_dir: PathBuf,
+        root_id: String,
+    }
+
+    fn linked_fixture(label: &str) -> LinkedFixture {
+        let data = tempfile::Builder::new()
+            .prefix(&format!("linked-e8-{label}-data-{}-", std::process::id()))
+            .tempdir()
+            .unwrap();
+        let library = tempfile::Builder::new()
+            .prefix(&format!("linked-e8-{label}-lib-{}-", std::process::id()))
+            .tempdir()
+            .unwrap();
+        let library_dir = std::fs::canonicalize(library.path()).unwrap();
+        let store = CheckpointPlanStore::open(data.path());
+        let root_id = store.approve_root(&library_dir).unwrap().root_id;
+        LinkedFixture {
+            _data: data,
+            _library: library,
+            store,
+            library_dir,
+            root_id,
+        }
+    }
+
+    /// The queued entry the API hands the worker, before any stamp.
+    fn queued_entry(root_id: &str, relative_path: &str) -> JsonObject {
+        json!({
+            "id": "linked_kreamania_nvfp4",
+            "name": "kreamania nvfp4",
+            "type": "image",
+            "catalogScope": "user",
+            "source": {
+                "provider": "linked-library",
+                "rootId": root_id,
+                "relativePath": relative_path,
+            },
+        })
+        .as_object()
+        .unwrap()
+        .clone()
+    }
+
+    /// A LINKED NVFP4 checkpoint resolves to the `nvfp4-v1` SOURCE CODEC, exactly as a managed copy
+    /// of the identical bytes does.
+    ///
+    /// This is the one fact every E8 surface reads: admission's native claim, the catalog's
+    /// `runtimeQuantTiers`, the telemetry `source_codec`, the asset receipt's facts object, and the
+    /// worker's dispatch guard. Before the stamp it answered `None` for a linked entry, so all five
+    /// were silently absent for a checkpoint that is stored packed.
+    ///
+    /// Failing mutation (run): delete the `if let Some((source_shape, quant_format)) =
+    /// classification` block in `linked_checkpoint_manifest_entry`.
+    #[test]
+    fn a_linked_nvfp4_checkpoint_is_stamped_and_resolves_to_the_nvfp4_source_codec() {
+        let fx = linked_fixture("codec");
+        let relative = "kreamania_nvfp4.safetensors";
+        let file = fx.library_dir.join(relative);
+        write_nvfp4_transformer(&file);
+        let compiled = fx.store.compile_linked(&fx.root_id, relative).unwrap();
+
+        let classification = base_weight_manifest_classification(&file);
+        assert_eq!(
+            classification,
+            Some(("transformer_file", "nvfp4")),
+            "the header proves a packed single-file transformer"
+        );
+
+        let entry = linked_checkpoint_manifest_entry(
+            queued_entry(&fx.root_id, relative),
+            &compiled,
+            classification,
+        );
+
+        assert_eq!(
+            entry.get("importQuantFormat").and_then(Value::as_str),
+            Some("nvfp4")
+        );
+        assert_eq!(
+            entry.get("importSourceShape").and_then(Value::as_str),
+            Some("transformer_file"),
+            "without a source shape the catalog's provider surface early-returns and emits no \
+             runtimeQuantTiers at all"
+        );
+        assert_eq!(
+            sceneworks_core::jobs_store::imported_entry_source_codec(&entry),
+            Some(NVFP4_CODEC_ID),
+            "the linked entry answers the SAME source-codec question a managed one does"
+        );
+        // The linked invariants sc-20635 established are untouched.
+        assert_eq!(
+            sceneworks_core::jobs_store::checkpoint_plan_checkpoint_id(&entry),
+            Some(compiled.checkpoint_id.as_str())
+        );
+        assert!(
+            sceneworks_core::jobs_store::imported_entry_loadable_path(&entry).is_none(),
+            "a linked entry still owns no installed bytes, so no bespoke lane can claim it"
+        );
+    }
+
+    /// A DENSE linked checkpoint is stamped with its own classification and never with NVFP4 —
+    /// the stamp is a reading of the header, not a constant.
+    #[test]
+    fn a_linked_dense_checkpoint_is_not_stamped_nvfp4() {
+        let fx = linked_fixture("dense");
+        let relative = "kreamania_dense.safetensors";
+        let file = fx.library_dir.join(relative);
+        write_dense_transformer(&file);
+        let compiled = fx.store.compile_linked(&fx.root_id, relative).unwrap();
+
+        let classification = base_weight_manifest_classification(&file);
+        assert_eq!(classification, Some(("transformer_file", "bf16")));
+        let entry = linked_checkpoint_manifest_entry(
+            queued_entry(&fx.root_id, relative),
+            &compiled,
+            classification,
+        );
+        assert_eq!(
+            sceneworks_core::jobs_store::imported_entry_source_codec(&entry),
+            Some("dense-bf16-v1")
+        );
+    }
+
+    /// A header that proves nothing stamps nothing — an absent key, never an invented one.
+    ///
+    /// Two halves, because the plan store refuses to COMPILE a file it cannot assign a component
+    /// role and a family, so the unclassifiable file never reaches the stamp in production. The
+    /// reachable shape is a file that compiles while the base-weight detector still declines it, so
+    /// the classifier's `None` and the stamp's handling of `None` are pinned separately.
+    #[test]
+    fn an_unclassifiable_linked_file_stamps_neither_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let mystery = dir.path().join("mystery.safetensors");
+        write_header_file(
+            &mystery,
+            json!({ "format": "pt" }),
+            &[("some.random.weight".to_owned(), "F32", vec![4, 4])],
+        );
+        assert_eq!(
+            base_weight_manifest_classification(&mystery),
+            None,
+            "a header with no base-weight evidence proves no classification"
+        );
+
+        let fx = linked_fixture("unknown");
+        let relative = "kreamania_dense.safetensors";
+        write_dense_transformer(&fx.library_dir.join(relative));
+        let compiled = fx.store.compile_linked(&fx.root_id, relative).unwrap();
+        let entry =
+            linked_checkpoint_manifest_entry(queued_entry(&fx.root_id, relative), &compiled, None);
+        assert!(entry.get("importQuantFormat").is_none());
+        assert!(entry.get("importSourceShape").is_none());
+        assert_eq!(
+            sceneworks_core::jobs_store::imported_entry_source_codec(&entry),
+            None
+        );
+        // ...and the plan stamp is unaffected, so an unclassified linked entry is still selectable.
+        assert_eq!(
+            sceneworks_core::jobs_store::checkpoint_plan_checkpoint_id(&entry),
+            Some(compiled.checkpoint_id.as_str())
+        );
+    }
+
+    /// The linked classifier and the managed branch's inline mapping answer the same pair for one
+    /// file. Two copies of one rule that can disagree about what a checkpoint is stored as is the
+    /// sc-13542 resolver-drift class; this is the witness that they do not.
+    ///
+    /// The managed mapping is restated here from `run_model_import_job` (it is inlined inside a
+    /// `fail_job`-returning `match` and cannot be called from a test), so this compares the two
+    /// TRANSCRIPTIONS. A future edit to either that changes the pair turns it red.
+    #[test]
+    fn the_linked_classifier_matches_the_managed_branchs_mapping() {
+        let dir = tempfile::tempdir().unwrap();
+        for (label, write) in [
+            ("nvfp4", write_nvfp4_transformer as fn(&Path)),
+            ("dense", write_dense_transformer as fn(&Path)),
+        ] {
+            let file = dir.path().join(format!("{label}.safetensors"));
+            write(&file);
+            let detection = detect_base_weight_file(&file).expect("the header parses");
+            let managed = match detection {
+                BaseWeightDetection::Recognized(verdict) => {
+                    let source = match verdict.component {
+                        ComponentRole::Transformer => Some("transformer_file"),
+                        ComponentRole::Checkpoint => Some("fused_checkpoint"),
+                        ComponentRole::TextEncoder | ComponentRole::Vae => None,
+                    };
+                    source.map(|source| (source, verdict.quant.as_str()))
+                }
+                BaseWeightDetection::Unrecognized { .. } => None,
+            };
+            assert_eq!(
+                base_weight_manifest_classification(&file),
+                managed,
+                "{label}: the linked and managed classifications must not drift"
+            );
+            assert!(managed.is_some(), "{label}: fixture check — it classifies");
         }
     }
 }

--- a/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
+++ b/crates/sceneworks-worker/src/tests/lora_and_downloads.rs
@@ -2118,9 +2118,17 @@ struct ManagedImportFixture {
     source: PathBuf,
     install_dir: PathBuf,
     manifest_path: PathBuf,
+    model_id: String,
 }
 
 async fn managed_import_fixture(base_url: String) -> ManagedImportFixture {
+    managed_import_fixture_with_id(base_url, "managed_krea").await
+}
+
+async fn managed_import_fixture_with_id(
+    base_url: String,
+    model_id: &str,
+) -> ManagedImportFixture {
     let temp = tempdir().expect("tempdir creates");
     let mut settings = test_settings(base_url.clone(), None);
     settings.api_url = base_url;
@@ -2133,13 +2141,17 @@ async fn managed_import_fixture(base_url: String) -> ManagedImportFixture {
         .expect("manifest writes");
     let source = settings.data_dir.join("models/incoming/kreamania.safetensors");
     write_krea_native_safetensors(&source, 0x5a);
-    let install_dir = settings.data_dir.join("models/imports/managed_krea");
+    let install_dir = settings
+        .data_dir
+        .join("models/imports")
+        .join(model_id);
     ManagedImportFixture {
         _temp: temp,
         settings,
         source,
         install_dir,
         manifest_path,
+        model_id: model_id.to_owned(),
     }
 }
 
@@ -2148,7 +2160,7 @@ impl ManagedImportFixture {
         let mut job_json = job_snapshot_json("job-1", false);
         job_json["type"] = json!("model_import");
         job_json["payload"] = json!({
-            "modelId": "managed_krea",
+            "modelId": self.model_id,
             "modelName": "Managed Krea",
             "sourcePath": self.source.to_str().expect("utf-8 source"),
             "targetDir": self.install_dir.to_str().expect("utf-8 target"),
@@ -2164,11 +2176,14 @@ impl ManagedImportFixture {
                 "credentialHost": "civitai.com"
             },
             "manifestEntry": {
-                "id": "managed_krea",
+                "id": self.model_id,
                 "name": "Managed Krea",
                 "type": "image",
                 "family": "krea_2",
-                "source": { "provider": "civitai", "path": "models/imports/managed_krea" },
+                "source": {
+                    "provider": "civitai",
+                    "path": format!("models/imports/{}", self.model_id),
+                },
             },
         });
         serde_json::from_value(job_json).expect("job deserializes")
@@ -2183,7 +2198,7 @@ impl ManagedImportFixture {
             .get("models")?
             .as_array()?
             .iter()
-            .find(|entry| entry.get("id").and_then(Value::as_str) == Some("managed_krea"))
+            .find(|entry| entry.get("id").and_then(Value::as_str) == Some(self.model_id.as_str()))
             .cloned()
     }
 
@@ -2202,13 +2217,18 @@ impl ManagedImportFixture {
         let store = sceneworks_core::checkpoint_plan_store::CheckpointPlanStore::open(
             &self.settings.data_dir,
         );
-        assert!(store.record("managed/managed_krea").is_err(), "{context}");
+        assert!(
+            store
+                .record(&format!("managed/{}", self.model_id))
+                .is_err(),
+            "{context}"
+        );
         assert_eq!(
             store.inventory().map(|inventory| inventory.records.len()),
             Ok(0),
             "{context}"
         );
-        let staging = store.staging_root().join("managed_krea");
+        let staging = store.staging_root().join(&self.model_id);
         assert!(!staging.exists(), "{context}: staging survived");
         assert!(
             self.source.is_file(),
@@ -2320,6 +2340,71 @@ async fn managed_model_import_commits_atomically_and_stamps_the_plan_binding() {
 
     // Nothing is left staged.
     assert!(!store.staging_root().join("managed_krea").exists());
+}
+
+/// sc-11045 (minor f): an install committed under a REGISTERED managed variant's id is confirmed
+/// against that registration, and a mismatch fails the job.
+///
+/// `ManagedCheckpointVariantV1::confirm_installed` — including the `size_bytes` comparison its own
+/// doc comment calls the reason the field is not decorative — had no production caller at all. The
+/// registered size is what a client renders as "how much will this download"; with nothing reading
+/// it, it could drift arbitrarily far from the pinned artifact with nothing red anywhere.
+///
+/// The fixture's bytes are a few hundred, not the pinned 7.6 GB, so both the digest and the size
+/// disagree with the registration. The import's OWN integrity check passes (the job declares the
+/// digest of the bytes it is actually importing), so the refusal below can only come from the
+/// registration confirmation.
+///
+/// Failing mutation (run): delete the `if let Some(variant) = managed_nvfp4_variant(...)` block
+/// after the commit in `run_model_import_job`. The job then completes and records a curated
+/// variant's identity over bytes the registration does not describe.
+#[tokio::test]
+async fn an_install_under_a_registered_variant_id_is_confirmed_against_its_registration() {
+    let _env = isolate_hf_cache();
+    let (base_url, posts) = spawn_tree_stub_with_files(vec![("model.safetensors", 8)]).await;
+    let variant_id = "nvfp4-krea-2-turbo";
+    assert!(
+        sceneworks_core::managed_checkpoint_variants::managed_nvfp4_variant(variant_id).is_some(),
+        "fixture check: the id under test is a registered variant"
+    );
+    let fixture = managed_import_fixture_with_id(base_url, variant_id).await;
+    // The digest of the bytes actually being imported, so the ingest's own verification PASSES and
+    // the only thing left to refuse is the registration mismatch.
+    let expected = sha256_hex(&fixture.source);
+    let api = ApiClient::new(&fixture.settings);
+    let client = reqwest::Client::new();
+
+    super::model_jobs::run_model_import_job(
+        &api,
+        &fixture.settings,
+        &client,
+        &fixture.job(Some(&expected)),
+    )
+    .await
+    .expect("a registration mismatch fails the job rather than erroring the worker");
+
+    let posts = posts.lock().expect("posts lock");
+    let failure = posts
+        .iter()
+        .find(|post| post.get("status").and_then(Value::as_str) == Some("failed"))
+        .unwrap_or_else(|| panic!("expected a failed progress post, got {posts:?}"));
+    let detail = failure
+        .get("error")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("a failed import must carry an error detail: {failure:?}"));
+    assert!(
+        detail.contains("managed variant's registration"),
+        "the failure must name the registration confirmation, got {detail:?}"
+    );
+    assert!(
+        detail.contains("[managed-variant]"),
+        "and carry the registry's typed diagnostic, got {detail:?}"
+    );
+    // The manifest never records the curated identity over bytes the registration does not describe.
+    assert!(
+        fixture.manifest_entry().is_none(),
+        "a refused confirmation must not leave a manifest entry: {detail:?}"
+    );
 }
 
 /// AC1: a hash-mismatched ingest leaves no runnable partial install — no install directory, no


### PR DESCRIPTION
The epic's one strict feature-end review, closed in a single PR against the feature branch. Pin unchanged (1caa686); no `Cargo.lock` change.

## Blocker 5 — managed-variant pin case bypass

`resolve_managed_variant_pin` looked the registry up case-SENSITIVELY (trim only) while `safe_download_dir` preserves case. On Windows/macOS that made `POST /api/v1/models/import` with `modelId: "NVFP4-Krea-2-Turbo"`, an arbitrary `sourceUrl` and no `expectedSha256` miss pin enforcement entirely, pass the distinct-id collision check, and install unverified bytes into the curated variant's own directory under its own checkpoint identity.

**Design choice: refuse, do not normalize.** `match_managed_nvfp4_variant_id` now reports `Exact` / `NearMiss` / `Unregistered`, and a near miss is a 400 naming the canonical id. Rewriting the id to the canonical spelling would install something the request did not name — the same silent substitution this function refuses everywhere else. A padded id still resolves (it always did, and it was always pinned); only the case difference is the near miss.

## Major 6 — linked NVFP4 entries had zero E8 exposure

Only the managed import branch stamped `importQuantFormat` / `importSourceShape`, so a LINKED copy of identical packed bytes answered `None` from `imported_entry_source_codec`: no native admission, no `runtimeQuantTiers` (the provider surface early-returns without a source shape), no telemetry `source_codec`, no asset-receipt facts — and `krea_imported_native_nvfp4` false, so `imported_model_quant` could hand `Quant::Q4` to packed E2M1 bytes.

`run_linked_checkpoint_import_job` now runs the same base-weight header classification over the linked file (resolved through the approved root) and `linked_checkpoint_manifest_entry` stamps both keys. E8 is a property of the checkpoint, not of who owns the copy.

## Major 2-SW — the `any` collapse rendered a MIXED load as "native (packed)"

`executes_natively` is `any`-shaped, so a receipt with both a non-empty `native-packed` row and a non-empty `dense-fallback` row rendered as native — untrue about the majority of tensors whenever the engine's shipping policy is mixed, which the pinned engine documents for this leg (68/163 packed + 95/163 W4A16-dense).

New explicit `ExecutionMix` third state: telemetry carries the distinct `mixed:<packed>/<dense>`, the web label renders `nvfp4-v1 · mixed (68 packed / 95 dense)`. The pure arms keep the engine's wire strings byte for byte and the tri-state "not measured" arm is untouched. This is what makes the parallel inference-side W4A16→dense-fallback demotion VISIBLE instead of flipping the whole label to dense.

## Minors

- **(a)** `image_count` was never `ensure_column`ed onto `generation_metrics_history` while both pieces of named SQL reference it by name — every retention sweep and Generation Stats read failed with "no such column" on a pre-epic-10402 install. Back-filled; the pre-migration test now drives two ages of database, one WITHOUT `image_count`.
- **(b)** The hostile-import loop posted KLEIN's id against KREA's pin, so the repo check fired for all three HF rows and the revision/file branches were never reached. Ids and pins are paired; the checksum case moved to the id whose pin it contradicts.
- **(c)** The size-mismatch assertion matched `"not the pinned"`, which the digest branch also emits. It now matches the size branch's own wording plus the observed byte count.
- **(d)** An empty `Reported { rows: [], complete: true }` was a fabricated "measured dense" (`executes_natively` → `Some(false)`). Refused on construction and on deserialize.
- **(e)** The declared NVFP4 `group_size` was read by nobody while the triplet proof hard-codes a stride of 16. A present-and-different size is now refused; absent still means the codec default.
- **(f)** `confirm_installed` — including the `size_bytes` check its own doc calls the reason the field is not decorative — had no production caller. Wired into the worker's managed-install post-commit step for an install id the registry knows; ordinary imports never reach it.

## Mutations run red then restored

| # | Mutation | Test that went red |
|---|---|---|
| 1 | case-SENSITIVE registry lookup | `a_case_variant_id_is_reported_as_a_near_miss` |
| 2 | drop the classification stamping | `a_linked_nvfp4_checkpoint_is_stamped_…`, `a_linked_dense_checkpoint_is_not_stamped_nvfp4` |
| 3 | restore the any-collapse in `representation_label` | `a_receipt_with_both_representations_reports_mixed_with_counts` |
| 3b | drop the mixed handling in `executionRepresentationLabel` | `renders a mixed execution with its counts…` (vitest) |
| 4 | delete the `image_count` `ensure_column` | `generation_metrics_history_survives_a_pre_migration_schema` |
| 5a | disable the revision claim branch | `a_managed_variant_import_cannot_be_talked_out_of_its_pin` |
| 5b | disable the file claim branch | same |
| 5c | disable the checksum claim branch | same |
| 6 | delete the `observed != size_bytes` branch | `changing_the_pinned_provenance_is_refused` |
| 7 | delete the empty-rows guard in `try_new` | `an_empty_reported_materialization_is_refused_on_both_paths` |
| 8 | drop the `group_size` arm | `a_declared_group_size_this_build_does_not_decode_is_not_nvfp4` |
| 9 | delete the `confirm_installed` wiring | `an_install_under_a_registered_variant_id_is_confirmed_against_its_registration` |

The candle/MLX-gated dispatch test cannot RUN on this host (no lane `cargo test`s the candle cfg on Windows), so its named mutation — "pass `None` for `classification`" — is built into the test as a permanent negative control rather than left as a manual step: the same compile, stamped with `None`, is asserted NOT to trip the native guard.

## Gates

- `cargo test -p sceneworks-core -p sceneworks-worker -p sceneworks-rust-api` — green (PowerShell)
- `cargo clippy --all-targets -- -D warnings` on those three — clean
- `cargo fmt --all`
- `node scripts/check-candle-build.mjs` — OK, incl. test targets under `-D warnings` (MSVC 14.44 vcvars)
- `npm run rust:check:neither` — clean
- `npm run check` — 85 failures, byte-identical to the stashed baseline at the feature branch head (pre-existing Windows script-harness class)
- `npx vitest run --environment jsdom` — 270 files / 4155 tests passed (Git Bash; junction removed afterwards)

No memory-matrix `SOURCE_PATHS` file was touched, so no regeneration was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)