### PR TITLE
docs: align H3 contract tests with permanent pin

### DIFF
--- a/apps/web/src/minimaxH3CatalogCopy.test.jsx
+++ b/apps/web/src/minimaxH3CatalogCopy.test.jsx
@@ -436,9 +436,9 @@ describe("MiniMax-H3 prompt guide (sc-17162)", () => {
     // pin predated it, so this file asserted the caveat was cited against the PIN BUMP (sc-18650)
     // rather than against the PR.
     //
-    // sc-19721 is that pin bump: `Cargo.toml` now pins `75d66db5`, which carries #640, and the
-    // engine's own `max_size` is `MAX_CANVAS_EDGE = 2016` on both lanes. The refusal is gone, so the
-    // caveat is a false claim and is deleted rather than re-pointed at a third event.
+    // The permanent inference pin `28f0563baa03640ade1635356d2d54fe8a477f1a` carries the provider
+    // geometry with `MAX_CANVAS_EDGE = 2016` on both lanes. The refusal is gone, so the caveat is a
+    // false claim and is deleted rather than re-pointed at a third event.
     //
     // What keeps this from being a vacuous absence check is that the real guard lives where it can
     // read the engine: `pinned_engine_geometry.rs` asserts every advertised MiniMax-H3 resolution's

--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -10032,16 +10032,12 @@ fn run_minimax_h3(request: &Value) -> Result<Value, String> {
     ) {
         return Err("MiniMax-H3 admission rejected an exact-fit calibrated budget".to_owned());
     }
-    // THE EXACT-FIT ACCEPT ABOVE IS NOT SELF-VALIDATING, and on this provider that is not
-    // hypothetical. `Generator::memory_strategy_safety_check` has a TRAIT DEFAULT
-    // (`gen-core/src/generator.rs:58-72`) that, for a generator publishing no contract, accepts ANY
-    // resident selection unconditionally — budget ignored. At the pinned revision
-    // `mlx-gen-minimax-h3`'s generator overrides neither `memory_strategy_contract` nor
-    // `memory_strategy_safety_check`, so a resident capture reaching this line on the default would
-    // record an "exact fit accepted" that tested nothing at all. The contract identity check after
-    // load already fails closed on that path; this is the second, independent guard, and it is the
-    // one that stays meaningful if a future provider publishes a contract but regresses the check:
-    // the same loaded generator must REJECT a zero budget, or its accept is not evidence.
+    // THE EXACT-FIT ACCEPT ABOVE IS NOT SELF-VALIDATING. The permanent pin publishes the
+    // MiniMax-H3 `memory_strategy_contract` and overrides `memory_strategy_safety_check`, so this
+    // loaded generator's accept is checked against the provider contract rather than a trait
+    // default. The contract identity check after load is the first guard; this independent probe
+    // stays meaningful if a future provider publishes a contract but regresses the check: the same
+    // loaded generator must REJECT a zero budget, or its accept is not evidence.
     let mut unknown_budget = exact_fit.clone();
     unknown_budget.budget.total_bytes = 0;
     if !matches!(
@@ -14142,19 +14138,12 @@ mod minimax_tests {
         );
     }
 
-    /// **The campaign blocker, pinned in code.** At the current inference pin the MiniMax-H3 MLX
-    /// generator overrides neither `memory_strategy_contract` nor `memory_strategy_safety_check`,
-    /// so a LOADED generator publishes no contract and inherits a trait default that accepts ANY
-    /// resident selection with the budget ignored. `run_minimax_h3` therefore cannot emit a record
-    /// at this pin: it fails closed immediately after load.
-    ///
-    /// This test asserts the registry half — the contract registration exists and is real — while
-    /// the generator half is what the pending pin bump must fix. When the bump lands, the arm's
-    /// post-load contract comparison and its zero-budget re-probe start passing and NOTHING else in
-    /// this arm needs to change; if instead the bump publishes a contract while regressing the
-    /// check, the zero-budget re-probe is what still catches it.
+    /// **The provider contract, pinned in code.** At the permanent inference pin the MiniMax-H3
+    /// provider publishes `memory_strategy_contract` and its admission check is non-vacuous in both
+    /// directions. The registry contract and loaded-provider checks must continue to agree; a future
+    /// contract/check drift fails here rather than producing evidence.
     #[test]
-    fn the_registry_contract_exists_even_though_the_loaded_generator_half_is_pending_a_pin_bump() {
+    fn the_minimax_h3_memory_strategy_contract_enforces_non_vacuous_admission() {
         let registry = mlx_gen_minimax_h3::provider_registry().unwrap();
         let contract = registry
             .memory_strategy_contract(
@@ -14168,8 +14157,8 @@ mod minimax_tests {
             contract.calibration.as_ref().unwrap().fingerprint,
             MINIMAX_CALIBRATION_FINGERPRINT
         );
-        // The registered admission check is non-vacuous in BOTH directions, weights-free — which is
-        // exactly the property the loaded generator does not yet inherit.
+        // The registered admission check is non-vacuous in BOTH directions, weights-free — the
+        // same property the loaded generator must enforce at the permanent pin.
         let spec = weights_free_spec(Some(Quant::Q4), LoadShape::EagerMaterialization);
         let selection = planned_selection(&minimal_request(MINIMAX_PROVIDER)).unwrap();
         let calibration = contract.calibration.as_ref().unwrap();

--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -15917,13 +15917,12 @@ fn minimax_h3_never_degrades_to_a_fake_video() {
 
 /// The `VideoRoute::MiniMaxH3` tail arm is REACHED once the engine is ready (sc-19508).
 ///
-/// Without this the arm would be untestable dead code until sc-18650 lands: `minimax_h3_available`
-/// requires the engine to be REGISTERED, which is false at the pinned revision, so every MiniMax job
-/// falls to `Stub` and deleting the arm entirely would be green in every other test. Declaration is
-/// not reachability — this drives the real ladder with the readiness the pin bump will supply.
+/// Without this the arm would be untestable: `minimax_h3_available` requires the engine to be
+/// REGISTERED, and the permanent pin supplies that provider. Declaration is not reachability —
+/// this drives the real ladder with the readiness seam so the live arm cannot be deleted unnoticed.
 ///
-/// The `false` half is equally load-bearing: it pins today's behavior (Stub, where the fail-loud
-/// gate runs) so the arm cannot be made unconditionally live by mistake.
+/// The false half remains load-bearing for the separate readiness seam: it proves that an unavailable
+/// provider still falls to `Stub`, while the true half proves the registered Candle/MLX route arm.
 #[cfg(target_os = "macos")]
 #[test]
 fn minimax_h3_reaches_its_own_route_arm_once_the_engine_is_ready() {


### PR DESCRIPTION
## Summary
- remove the remaining stale pre-pin MiniMax-H3 contract and routing commentary found by SC-17137 feature-end review cycle 2
- rename the MLX contract test so it describes the permanent-pin behavior rather than a pending pin bump
- correct the web catalog test comment to the permanent inference pin `28f0563baa03640ade1635356d2d54fe8a477f1a`

## Verification
- Candle H3 route test passed
- rustfmt and `git diff --check` passed
- all 17 inference pin sites resolve to `28f0563baa03640ade1635356d2d54fe8a477f1a`
- repo-wide stale-pin/blocker search reviewed; remaining `75d66db5` occurrences are historical receipts/attribution

Comments and test naming only; assertions and runtime behavior are unchanged. MLX-only and web dependency surfaces are covered by CI on their supported hosts.