### PR TITLE
test: isolate MiniMax-H3 resolver fixtures (SC-18650)

### DIFF
--- a/crates/sceneworks-worker/src/video_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/video_jobs/tests.rs
@@ -16051,6 +16051,11 @@ fn candle_minimax_h3_tier_selection_defaults_q4_and_preserves_explicit_precision
 fn candle_minimax_h3_resolves_exact_installed_roots_for_every_tier() {
     use crate::video_jobs::minimax_h3::resolve_candle_minimax_h3_load;
 
+    let _env = crate::test_env::EnvVars::set(&[
+        ("HF_HUB_CACHE", ""),
+        ("HUGGINGFACE_HUB_CACHE", ""),
+        ("HF_HOME", ""),
+    ]);
     const UPSTREAM: &str = "MiniMaxAI/MiniMax-H3";
     const REHOST: &str = "SceneWorks/minimax-h3-mlx";
     const REVISION: &str = "1111111111111111111111111111111111111111";
@@ -16160,6 +16165,11 @@ fn candle_minimax_h3_resolves_exact_installed_roots_for_every_tier() {
 fn candle_minimax_h3_ref_resolves_hosted_partition_and_rejects_torn_tiers() {
     use crate::video_jobs::minimax_h3::resolve_candle_minimax_h3_load;
 
+    let _env = crate::test_env::EnvVars::set(&[
+        ("HF_HUB_CACHE", ""),
+        ("HUGGINGFACE_HUB_CACHE", ""),
+        ("HF_HOME", ""),
+    ]);
     const UPSTREAM: &str = "MiniMaxAI/MiniMax-H3";
     const REHOST: &str = "SceneWorks/minimax-h3-mlx";
     const REVISION: &str = "2222222222222222222222222222222222222222";


### PR DESCRIPTION
## Summary

Fixes the Windows Candle worker failure discovered on final MiniMax-H3 PR #2597.

The two MiniMax-H3 resolver tests built synthetic Hugging Face snapshots but inherited `HF_HUB_CACHE`, `HUGGINGFACE_HUB_CACHE`, or `HF_HOME` from the self-hosted runner. Real snapshots therefore won resolution and made the deterministic fixtures fail. Both tests now clear those variables through the existing serialized/restoring `EnvVars` guard.

Production resolver behavior is unchanged.

## Validation

- Both exact failing backend-candle tests pass with all three ambient variables deliberately contaminated.
- Shared-process filtered Candle H3 resolver run: 4 passed, 0 failed.
- Candle clippy with `-D warnings`: pass.
- `cargo fmt --all -- --check`: pass.
- `git diff --check`: pass.
- Independent review: PASS.
- No GPU, real weights, or calibration run.