### PR TITLE
Fix rung4 entrypoint guard so it fires on Windows

### DIFF
--- a/scripts/rung4-contract-prerequisites.mjs
+++ b/scripts/rung4-contract-prerequisites.mjs
@@ -1210,6 +1210,6 @@ function main(argv) {
   );
 }
 
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   main(process.argv.slice(2));
 }


### PR DESCRIPTION
## What changed

One-line fix in `scripts/rung4-contract-prerequisites.mjs`: the CLI entrypoint guard

```js
if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`)
```

is replaced with the pattern already used by `scripts/inference-closure-digest.mjs` and `scripts/generate-memory-matrix.mjs`:

```js
if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url))
```

## Why

On Windows, `process.argv[1]` is a backslash path (`D:\...\rung4-contract-prerequisites.mjs`) while `import.meta.url` is `file:///D:/...`, so the old string comparison never matched. `node scripts/rung4-contract-prerequisites.mjs --repo <inference> --write` exited 0 silently without doing anything, stalling every inference pin bump on the Windows dev box.

## Verification

`node scripts/rung4-contract-prerequisites.mjs --self-test` on Windows now prints `rung4-contract-prerequisites self-test: ok` (previously it produced no output and exited 0).

Both `path` and `fileURLToPath` were already imported in the file, so no other changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)