### PR TITLE
fix(sc-11045): per-checkpoint dialect disambiguation for the flux2 tree lane

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/checkpoint_plan.rs
+++ b/crates/sceneworks-worker/src/image_jobs/checkpoint_plan.rs
@@ -95,9 +95,10 @@ fn checkpoint_plan_backend_eligible(
 /// loader opens (a single transformer file, a fused checkpoint, a component directory, a ComfyUI
 /// tree), and a plan whose roles could be read two ways must not be silently resolved one of them.
 ///
-/// A family whose dialects disagree refuses rather than guessing. Nothing shipped today declares
-/// two shapes; the refusal exists so that the day one does, it is a planning-time diagnostic and not
-/// a load-time surprise.
+/// A family whose dialects disagree refuses rather than guessing. FLUX.2 deliberately declares both
+/// a ComfyUI tree and a standalone transformer file, so the general plan route refuses until the
+/// persisted plan records a dialect id. A bespoke lane that already knows the exact source shape
+/// validates that shape through `checkpoint_plan_lane_source_shape` instead.
 fn checkpoint_plan_source_shape(
     adapter: &gen_core::CheckpointAdapterRegistration,
     checkpoint_id: &str,
@@ -121,6 +122,41 @@ fn checkpoint_plan_source_shape(
             many.len()
         ))),
     }
+}
+
+/// Validate the exact on-disk shape a bespoke lane opens against the registered adapter.
+///
+/// Unlike [`checkpoint_plan_source_shape`], this does not infer one shape for the whole family: the
+/// caller is the loader for a specific dialect and therefore already knows whether it opens a file,
+/// directory, fused checkpoint, or ComfyUI tree. The adapter remains authoritative — a lane cannot
+/// claim a shape the family never registered — while a second, unrelated dialect does not make the
+/// known lane ambiguous.
+#[cfg(any(
+    test,
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn checkpoint_plan_lane_source_shape(
+    adapter: &gen_core::CheckpointAdapterRegistration,
+    checkpoint_id: &str,
+    expected: gen_core::ImportedModelSource,
+) -> WorkerResult<gen_core::ImportedModelSource> {
+    if adapter
+        .dialects
+        .iter()
+        .any(|dialect| dialect.source == expected)
+    {
+        return Ok(expected);
+    }
+    let mut declared: Vec<gen_core::ImportedModelSource> =
+        adapter.dialects.iter().map(|dialect| dialect.source).collect();
+    declared.sort();
+    declared.dedup();
+    Err(WorkerError::InvalidPayload(format!(
+        "[checkpoint-plan:no-adapter-binding] checkpoint {checkpoint_id:?} ({} family): this \
+         bespoke lane opens {expected:?}, but the registered adapter declares source shapes \
+         {declared:?}",
+        adapter.family
+    )))
 }
 
 /// The persisted checkpoint id a manifest entry is bound to, when it is plan-backed. The same
@@ -1177,6 +1213,29 @@ fn checkpoint_plan_entry_routes_to(entry: &JsonObject, family: &str) -> bool {
         .map_or(true, |declared| declared == family)
 }
 
+/// The importer-stamped structural dialect of one plan-backed manifest entry.
+///
+/// Family identity cannot answer this: FLUX.2 registers both a standalone transformer file and a
+/// ComfyUI tree. Missing and unknown labels fail closed so a sibling family lane cannot claim the
+/// plan by family alone. These are the canonical labels emitted by the catalog and capability facts.
+#[cfg(any(
+    test,
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
+fn checkpoint_plan_entry_source_shape(
+    entry: &JsonObject,
+) -> Option<gen_core::ImportedModelSource> {
+    match entry.get("importSourceShape").and_then(Value::as_str) {
+        Some("transformer_file") => Some(gen_core::ImportedModelSource::TransformerFile),
+        Some("fused_checkpoint") => Some(gen_core::ImportedModelSource::FusedCheckpoint),
+        Some("transformer_directory") => {
+            Some(gen_core::ImportedModelSource::TransformerDirectory)
+        }
+        Some("comfy_ui_tree") => Some(gen_core::ImportedModelSource::ComfyUiTree),
+        _ => None,
+    }
+}
+
 /// Refuse a plan whose family is not the one the asking lane loads.
 ///
 /// Reached only for an entry whose DECLARED family already routes here
@@ -1394,6 +1453,16 @@ pub(crate) fn checkpoint_plan_bespoke_tree(
     if !checkpoint_plan_entry_routes_to(&request.model_manifest_entry, family) {
         return Ok(None);
     }
+    // The entry's importer-stamped dialect is the only source identity a compiled plan carries:
+    // the plan itself records component roles, not a dialect id. A sibling dialect for the same
+    // family must decline here rather than being fed to this ComfyUI-tree loader. The retained plan
+    // route refusal is raised later if no correct sibling lane claims it.
+    let Some(source) = checkpoint_plan_entry_source_shape(&request.model_manifest_entry) else {
+        return Ok(None);
+    };
+    if source != gen_core::ImportedModelSource::ComfyUiTree {
+        return Ok(None);
+    }
     let checkpoint_id = checkpoint_id.to_owned();
     let store = CheckpointPlanStore::open(&settings.data_dir);
     let resolved = store
@@ -1402,7 +1471,7 @@ pub(crate) fn checkpoint_plan_bespoke_tree(
     checkpoint_plan_family_matches(&resolved, &checkpoint_id, family)?;
     let adapter = checkpoint_plan_adapter(family, &checkpoint_id)?;
     checkpoint_plan_backend_eligible(adapter, &checkpoint_id)?;
-    let source = checkpoint_plan_source_shape(adapter, &checkpoint_id)?;
+    let source = checkpoint_plan_lane_source_shape(adapter, &checkpoint_id, source)?;
     let primary = checkpoint_plan_primary(&resolved, source)?;
     let mut consumed = primary.consumed.clone();
     let mut sidecars = Vec::with_capacity(consumed_roles.len());

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -24647,8 +24647,13 @@ fn checkpoint_plan_family_truth_is_read_from_the_registered_adapter() {
 /// FLUX.2 is the live counterexample: its adapter registers a ComfyUI-tree dev loader and a
 /// standalone-transformer Klein loader. The general plan route must continue to refuse because a
 /// compiled plan has no dialect id, while the tree lane can safely select `ComfyUiTree` after
-/// proving that exact shape is registered. This test is backend-portable so the contract is covered
-/// before the Candle-only behavioural test reaches Windows.
+/// proving that exact shape is registered. This test is portable across the MLX and Candle builds
+/// that include the checkpoint-plan implementation, so the contract is covered before the
+/// Candle-only behavioural test reaches Windows.
+#[cfg(any(
+    target_os = "macos",
+    all(not(target_os = "macos"), feature = "backend-candle")
+))]
 #[test]
 fn a_bespoke_lane_accepts_its_registered_shape_on_a_multi_dialect_family() {
     use gen_core::ImportedModelSource::{ComfyUiTree, FusedCheckpoint, TransformerFile};

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -24138,7 +24138,7 @@ fn a_linked_zimage_tree_resolves_all_three_artifacts_from_its_plan() {
             "id": "linked_ztree",
             "catalogScope": "user",
             "family": "z-image",
-            "importSourceShape": "comfyui_tree",
+            "importSourceShape": "comfy_ui_tree",
             "importPlan": { "checkpointId": checkpoint_id }
         }
     }));
@@ -24225,7 +24225,7 @@ fn a_linked_qwen_image_tree_consumes_its_optional_vae_from_the_plan() {
                 "id": format!("linked_{id}"),
                 "catalogScope": "user",
                 "family": "qwen-image",
-                "importSourceShape": "comfyui_tree",
+                "importSourceShape": "comfy_ui_tree",
                 "importPlan": { "checkpointId": checkpoint_id }
             }
         }))
@@ -24329,7 +24329,7 @@ fn a_linked_flux2_tree_loads_the_plans_dit_and_refuses_a_layer_the_lane_would_ig
                 "id": format!("linked_{id}"),
                 "catalogScope": "user",
                 "family": "flux2",
-                "importSourceShape": "comfyui_tree",
+                "importSourceShape": "comfy_ui_tree",
                 "importPlan": { "checkpointId": checkpoint_id }
             }
         }))
@@ -24399,6 +24399,22 @@ fn a_linked_flux2_tree_loads_the_plans_dit_and_refuses_a_layer_the_lane_would_ig
             .expect("the decline is not a refusal")
             .is_none(),
         "the bespoke lane must decline a request the plan route claims"
+    );
+
+    // FLUX.2 also registers a standalone TransformerFile dialect for Klein. A request shape the
+    // general plan route declines must not let this ComfyUI-tree lane claim that sibling dialect by
+    // family alone: it has a different loader and a different resident companion contract.
+    let mut standalone = req.clone();
+    standalone.model = "linked_flux2_klein".to_owned();
+    standalone.model_manifest_entry.insert(
+        "importSourceShape".to_owned(),
+        Value::String("transformer_file".to_owned()),
+    );
+    assert!(
+        flux2_comfyui_candle::prepare_flux2_comfyui_sources(&standalone, &fx.settings)
+            .expect("a sibling dialect declines rather than raising a tree-lane error")
+            .is_none(),
+        "the FLUX.2-dev ComfyUI lane must not claim a plan-backed Klein transformer file"
     );
 }
 
@@ -24623,6 +24639,68 @@ fn checkpoint_plan_family_truth_is_read_from_the_registered_adapter() {
         matches!(refusal, WorkerError::InvalidPayload(_)),
         "backend ineligibility is a typed payload diagnostic, not an engine error"
     );
+}
+
+/// sc-21623 terminal Windows repair: a bespoke lane supplies its exact dialect shape instead of
+/// demanding that the family have only one shape.
+///
+/// FLUX.2 is the live counterexample: its adapter registers a ComfyUI-tree dev loader and a
+/// standalone-transformer Klein loader. The general plan route must continue to refuse because a
+/// compiled plan has no dialect id, while the tree lane can safely select `ComfyUiTree` after
+/// proving that exact shape is registered. This test is backend-portable so the contract is covered
+/// before the Candle-only behavioural test reaches Windows.
+#[test]
+fn a_bespoke_lane_accepts_its_registered_shape_on_a_multi_dialect_family() {
+    use gen_core::ImportedModelSource::{ComfyUiTree, FusedCheckpoint, TransformerFile};
+
+    let adapter = &gen_core::FLUX2_CHECKPOINT_ADAPTER;
+    let id = "linked/root-test/flux2";
+    let ambiguous = checkpoint_plan_source_shape(adapter, id)
+        .expect_err("the general plan route cannot infer one of two dialect shapes");
+    assert!(
+        ambiguous
+            .to_string()
+            .contains("[checkpoint-plan:ambiguous-component]"),
+        "{ambiguous}"
+    );
+    assert_eq!(
+        checkpoint_plan_lane_source_shape(adapter, id, ComfyUiTree).unwrap(),
+        ComfyUiTree,
+        "the ComfyUI lane knows which registered FLUX.2 dialect it opens"
+    );
+    assert_eq!(
+        checkpoint_plan_lane_source_shape(adapter, id, TransformerFile).unwrap(),
+        TransformerFile,
+        "the standalone-file dialect remains independently selectable"
+    );
+    let absent = checkpoint_plan_lane_source_shape(adapter, id, FusedCheckpoint)
+        .expect_err("a bespoke lane cannot invent an unregistered source shape");
+    let message = absent.to_string();
+    assert!(
+        message.contains("[checkpoint-plan:no-adapter-binding]")
+            && message.contains("FusedCheckpoint")
+            && message.contains("ComfyUiTree")
+            && message.contains("TransformerFile"),
+        "{message}"
+    );
+
+    let tree_entry = json!({ "importSourceShape": "comfy_ui_tree" });
+    assert_eq!(
+        checkpoint_plan_entry_source_shape(tree_entry.as_object().unwrap()),
+        Some(ComfyUiTree),
+        "the importer-stamped tree dialect is the lane's per-entry authority"
+    );
+    for sibling_or_invalid in [
+        json!({ "importSourceShape": "transformer_file" }),
+        json!({ "importSourceShape": "comfyui_tree" }),
+        json!({}),
+    ] {
+        assert_ne!(
+            checkpoint_plan_entry_source_shape(sibling_or_invalid.as_object().unwrap()),
+            Some(ComfyUiTree),
+            "a sibling, unknown, or missing entry dialect must not enter the ComfyUI-tree lane"
+        );
+    }
 }
 
 /// The plan is consumed everywhere or refused (sc-20634 review). The inspector emits multi-layer


### PR DESCRIPTION
Terminal-evidence defect 1 (epic sc-11037, story sc-11045): the epic's Klein single-file dialect makes the flux2 family declare TWO source shapes ([TransformerFile, ComfyUiTree]), so `checkpoint_plan_source_shape`'s family-wide lookup refused with `[checkpoint-plan:ambiguous-component]` and redded `image_jobs::tests::a_linked_flux2_tree_loads_the_plans_dit_and_refuses_a_layer_the_lane_would_ignore` at the feature tip.

Fix (ported verbatim from main's sc-21623 repair, commits d8719af6c + 300cc0218, so the feature->main merge stays clean):
- `checkpoint_plan_entry_source_shape` reads the CHECKPOINT ENTRY's importer-stamped `importSourceShape` dialect, failing closed on missing/unknown labels;
- the bespoke ComfyUI-tree lane declines a sibling dialect and validates its exact shape through `checkpoint_plan_lane_source_shape` instead of the family-wide set;
- the general plan route keeps the ambiguity refusal for genuinely undeterminable cases (a compiled plan records roles, not a dialect id).

Tests (run locally under the windows-candle cfg):
- `a_linked_flux2_tree_loads_the_plans_dit_and_refuses_a_layer_the_lane_would_ignore` red -> green, incl. a new Klein transformer_file sibling-decline assertion;
- new `a_bespoke_lane_accepts_its_registered_shape_on_a_multi_dialect_family` proves the OTHER dialect (TransformerFile) resolves independently;
- mutation (lane lookup reverted to family-wide): BOTH tests red.

Gates: cargo test -p sceneworks-worker -p sceneworks-core (all green), clippy --all-targets -D warnings, node scripts/check-candle-build.mjs, cargo fmt --all --check, npm run check (failures identical to base - diff touches only the two Rust files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)