### PR TITLE
Show model initialization before catalog is ready

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -22,7 +22,7 @@ import { AccessGate } from "./components/AccessGate.jsx";
 import { Logo } from "./components/Logo.jsx";
 import { StatusDot } from "./components/StatusDot.jsx";
 import { FullscreenPreview, assetSeed } from "./components/assetPanels.jsx";
-import { fallbackModels, isLibraryAsset, terminalStatuses } from "./constants.js";
+import { isLibraryAsset, terminalStatuses } from "./constants.js";
 import { isEditorJob } from "./jobTypes.js";
 import { LibraryScreen } from "./screens/LibraryScreen.jsx";
 import { editModelForAsset, workflowModelType } from "./presetUtils.js";
@@ -52,7 +52,7 @@ import { useJobEvents } from "./hooks/useJobEvents.js";
 import { AppStaticContext, AppLiveContext } from "./context/AppContext.js";
 import { ScreenActiveContext } from "./context/ScreenActiveContext.js";
 import { DEFAULT_MAC_CAPABILITIES } from "./macGating.js";
-import { generationModelsForType, videoModelUsable } from "./modelEligibility.js";
+import { generationModelsForType } from "./modelEligibility.js";
 import { isAccentId } from "./accents.js";
 import { writeDefaultGenerationQuality } from "./generationQuality.js";
 import { persistNavigationPreferences, putUiPreferences } from "./uiPreferences.js";
@@ -574,6 +574,11 @@ export function App() {
   const [macCapabilitiesAuthoritative, setMacCapabilitiesAuthoritative] = useState(false);
   const [macCapabilitiesError, setMacCapabilitiesError] = useState("");
   const [macCapabilitiesLoading, setMacCapabilitiesLoading] = useState(false);
+  // The generation pickers must not treat the hand-authored fallback catalog as proof that a
+  // model is present on this machine. Until GET /models completes its install/availability sweep,
+  // keep the studios in an explicit initializing state instead (the request may legitimately take
+  // tens of seconds on a cold start). A settled refresh keeps the last authoritative catalog live.
+  const [modelCatalogStatus, setModelCatalogStatus] = useState("idle");
   const [trainingTargets, setTrainingTargets] = useState({ schemaVersion: 1, targets: [] });
   const [trainingPresets, setTrainingPresets] = useState({ schemaVersion: 1, presets: [] });
   const [trainingTargetsError, setTrainingTargetsError] = useState("");
@@ -1002,6 +1007,7 @@ export function App() {
   // restoring stale platform facts after a newer request has started.
   const macCapabilitiesRequestRef = useRef(0);
   const refreshModelsRef = useRef(null);
+  const modelCatalogRequestRef = useRef(0);
   const refreshModelAndLorasRef = useRef(null);
   const refreshTrainingTargetsRef = useRef(null);
   const refreshTrainingPresetsRef = useRef(null);
@@ -1353,20 +1359,13 @@ export function App() {
   // loaders are sc-10668+), so they must not be offered as a generation target.
   // Manifest models never set `usable`, so they are unaffected.
   const imageModels = useMemo(() => {
-    const items = generationModelsForType(models, "image");
-    return items.length || models.length ? items : fallbackModels.filter((model) => model.type === "image");
+    return generationModelsForType(models, "image");
   }, [models]);
-  const videoModels = useMemo(() => {
-    const items = generationModelsForType(models, "video");
-    return items.length || models.length
-      ? items
-      : fallbackModels.filter((model) => videoModelUsable(model, macCapabilities));
-  }, [models, macCapabilities]);
-  // Audio models (epic 13400) — same live-catalog-then-fallback split as image/video, consumed by
-  // the Audio Studio (C0/C1). Per-mode eligibility comes from audioModelServesMode.
+  const videoModels = useMemo(() => generationModelsForType(models, "video"), [models]);
+  // Audio models (epic 13400) are resolved from the authoritative live catalog and consumed by
+  // Audio Studio (C0/C1). Per-mode eligibility comes from audioModelServesMode.
   const audioModels = useMemo(() => {
-    const items = generationModelsForType(models, "audio");
-    return items.length || models.length ? items : fallbackModels.filter((model) => model.type === "audio");
+    return generationModelsForType(models, "audio");
   }, [models]);
   const selectedAsset = useMemo(
     () => assets.find((asset) => asset.id === selectedAssetId) ?? assets[0] ?? null,
@@ -2048,13 +2047,28 @@ export function App() {
   }
 
   async function refreshModels({ signal } = {}) {
+    const requestId = ++modelCatalogRequestRef.current;
+    // Do not blank an already-authoritative catalog during an SSE/manual refresh. This state is
+    // specifically the cold-start boundary where no availability answer exists yet.
+    setModelCatalogStatus((current) => (current === "ready" ? current : "loading"));
     try {
       const items = await apiFetch("/api/v1/models", token, { signal });
+      if (requestId !== modelCatalogRequestRef.current) {
+        return refreshFailure("stale");
+      }
       setModels(items);
+      setModelCatalogStatus("ready");
       domainErrors.models("");
       return refreshSuccess(items);
     } catch (err) {
-      if (isAbortError(err)) return refreshFailure("aborted", err);
+      if (requestId !== modelCatalogRequestRef.current) {
+        return refreshFailure("stale", err);
+      }
+      if (isAbortError(err)) {
+        setModelCatalogStatus((current) => (current === "loading" ? "idle" : current));
+        return refreshFailure("aborted", err);
+      }
+      setModelCatalogStatus((current) => (current === "loading" ? "error" : current));
       domainErrors.models(err.message);
       return refreshFailure("error", err);
     }
@@ -3582,6 +3596,7 @@ export function App() {
     videoModels,
     audioModels,
     models,
+    modelCatalogStatus,
     // Mac UI gating (sc-3486)
     macCapabilities,
     macCapabilitiesAuthoritative,
@@ -3702,7 +3717,7 @@ export function App() {
     recentVideoAssets, recentAudioAssets, studioLaunch,
     editorLaunch, clearEditorLaunch, sendAssetToImageEditor, sendAssetToImageEdit,
     rememberLocalGenerationJob, personTracks, createPersonDetectionJob,
-    createPersonTrackJob, saveTrackCorrections, imageModels, videoModels, audioModels, models, macCapabilities,
+    createPersonTrackJob, saveTrackCorrections, imageModels, videoModels, audioModels, models, modelCatalogStatus, macCapabilities,
     macCapabilitiesAuthoritative, macCapabilitiesError, macCapabilitiesLoading,
     refreshMacCapabilities,
     loras, deleteLora, updateLora, fetchLoraEmbeddedTags, deleteModel, deleteModelVariant, createModelDownloadJob, createLoraDownloadJob, createModelConvertJob,

--- a/apps/web/src/App.replacePerson.test.jsx
+++ b/apps/web/src/App.replacePerson.test.jsx
@@ -29,6 +29,17 @@ describe("SceneWorks app shell", () => {
       if (path.endsWith("/projects")) {
         return Promise.resolve(response([{ id: "project-default", name: "Default Project" }]));
       }
+      if (path.endsWith("/models")) {
+        return Promise.resolve(response([{
+          id: "ltx_2_3",
+          name: "LTX-2.3",
+          type: "video",
+          capabilities: ["replace_person", "image_to_video", "text_to_video"],
+          installState: "installed",
+          defaults: { duration: 4, fps: 24, resolution: "1280x720", quality: "balanced" },
+          limits: { durations: [4], fps: [24], resolutions: ["1280x720"] },
+        }]));
+      }
       return Promise.resolve(response([]));
     });
   });

--- a/apps/web/src/App.routeHydration.test.jsx
+++ b/apps/web/src/App.routeHydration.test.jsx
@@ -144,6 +144,33 @@ describe("route-owned App hydration (sc-14783)", () => {
     expect(FakeEventSource.instances).toHaveLength(1);
   });
 
+  it("shows model initialization instead of unverified fallback rows", async () => {
+    const models = deferred();
+    installFetch({
+      "/api/v1/models": () => models.promise,
+    });
+    await renderApp();
+
+    await navigate("Image");
+    expect(container.textContent).toContain("Initializing models");
+    expect(container.textContent).not.toContain("Z-Image-Turbo");
+    expect(container.querySelector('[aria-label="Initializing models"]')).toBeTruthy();
+
+    await act(async () => {
+      models.resolve(response([{
+        id: "krea_2_turbo",
+        name: "Krea 2 Turbo",
+        type: "image",
+        capabilities: ["text_to_image"],
+        installState: "installed",
+      }]));
+    });
+    await settle();
+
+    expect(container.textContent).not.toContain("Initializing models");
+    expect(container.textContent).toContain("Krea 2 Turbo");
+  });
+
   it("hydrates and renders character training datasets on first Characters navigation", async () => {
     installFetch({
       "/api/v1/projects/project-a/characters": () =>

--- a/apps/web/src/components/ModelAvailabilityGate.jsx
+++ b/apps/web/src/components/ModelAvailabilityGate.jsx
@@ -9,6 +9,8 @@ import { terminalStatuses } from "../constants.js";
 //
 // Props:
 //   ready          — when true, render `children` (the Studio body) unchanged.
+//   initializing   — availability is not authoritative yet; render an indeterminate startup state
+//                    instead of download offers derived from an empty or fallback catalog.
 //   title/description — gate copy.
 //   eyebrow        — the kicker above the title. Defaults to the Studio wording ("No supported
 //                    model installed", i.e. none of a whole family qualifies); a screen gated on
@@ -26,6 +28,7 @@ function offerSizeText(model) {
 
 export function ModelAvailabilityGate({
   ready,
+  initializing = false,
   title,
   description,
   eyebrow = "No supported model installed",
@@ -39,6 +42,26 @@ export function ModelAvailabilityGate({
 }) {
   if (ready) {
     return children;
+  }
+  if (initializing) {
+    return (
+      <section className="model-availability-gate" aria-live="polite">
+        <div className="model-availability-gate-card">
+          <div className="section-heading">
+            <p className="eyebrow">Starting local catalog</p>
+            <h2>Initializing models…</h2>
+          </div>
+          <p>Checking which models are installed and available on this machine.</p>
+          <div
+            aria-label="Initializing models"
+            className="catalog-progress catalog-progress--indeterminate"
+            role="progressbar"
+          >
+            <span />
+          </div>
+        </div>
+      </section>
+    );
   }
   const activeJobFor = (model) =>
     downloadJobs.find((job) => job.payload?.modelId === model.id && !terminalStatuses.has(job.status));

--- a/apps/web/src/components/ModelAvailabilityGate.test.jsx
+++ b/apps/web/src/components/ModelAvailabilityGate.test.jsx
@@ -37,6 +37,22 @@ describe("ModelAvailabilityGate", () => {
     expect(container.querySelector(".model-availability-gate")).toBeNull();
   });
 
+  it("shows initialization progress without advertising download offers", async () => {
+    await renderGate({
+      ready: false,
+      initializing: true,
+      title: "Image Studio needs a model",
+      offers: [{ id: "fallback-only", name: "Unverified fallback" }],
+      children: <div className="studio-body">Studio</div>,
+    });
+
+    expect(container.textContent).toContain("Initializing models");
+    expect(container.textContent).toContain("Checking which models are installed");
+    expect(container.textContent).not.toContain("Unverified fallback");
+    expect(container.querySelector('[role="progressbar"]')).toBeTruthy();
+    expect(container.querySelector(".studio-body")).toBeNull();
+  });
+
   it("offers recommended models for download when gated and queues on click", async () => {
     const onDownload = vi.fn();
     await renderGate({

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -914,17 +914,13 @@ const seededFallbackModels = [
       resolutions: ["1536x672", "672x1536", "1344x768", "768x1344", "1024x768", "768x1024", "768x768", "576x320", "320x576"],
     },
     ui: {
-      // Licence-required attribution (MiniMax H3 Community License §IV.2, sc-17227). It must be in
-      // the MIRROR too: the generation surfaces render whichever catalog is in hand, and the
-      // fallback one is what they get before /api/v1/models lands — a licence obligation that is
-      // discharged only once the network answers is not discharged (sc-17161).
+      // Licence-required attribution (MiniMax H3 Community License §IV.2, sc-17227). Keep it in
+      // the hand-authored mirror as a parity invariant even though generation surfaces now wait for
+      // the authoritative /api/v1/models response before offering a model (sc-17161).
       attribution: "Powered by MiniMax H3",
-      // sc-17162 — the withheld-component disclosure has to survive into the MIRROR for the same
-      // reason the attribution does. `ModelManagerScreen` renders `ui.description` from whichever
-      // catalog is in hand, so a description that only warns about H3-Context-IR / H3-Regenerate-2K
-      // / dense attention once /api/v1/models answers leaves the pre-network card advertising a
-      // model that does more than these weights do. Condensed against the manifest's prose, but it
-      // carries the same four load-bearing claims, and
+      // sc-17162 — keep the withheld-component disclosure in the MIRROR as well so its descriptive
+      // metadata stays in lockstep with the generated manifest. Condensed against the manifest's
+      // prose, but it carries the same four load-bearing claims, and
       // `minimaxH3CatalogCopy.test.js` pins the mirror to the manifest claim-by-claim.
       description: "MiniMax-H3 joint video + synchronized stereo audio, with first/last-frame conditioning. No guidance scale and no negative prompt. Open weights, not the hosted Hailuo product: H3-Context-IR and H3-Regenerate-2K are unreleased, so prompt adherence differs from the API and 2K is not reachable from these weights; sparse-attention inference is unreleased too, so attention runs dense and the shortest clip at 1344x768 is about a two-hour render. Fourteen fixed lengths between 5.17s and 14.38s — 15s is refused rather than shortened — and no still-image mode.",
       durationHint: "Fourteen clip lengths only, 5.17s-14.38s at 24fps, and 15s is refused rather than shortened to 14.38s. Cost is canvas-driven — 5.17s at 576x320 is ~14 minutes, the same clip at 1344x768 is ~2 hours.",

--- a/apps/web/src/screens/AudioStudio.jsx
+++ b/apps/web/src/screens/AudioStudio.jsx
@@ -205,6 +205,7 @@ export function AudioStudio() {
     assets = [],
     audioModels = [],
     models = [],
+    modelCatalogStatus = "ready",
     jobs = [],
     audioLocalJobs = [],
     recentAudioAssets = [],
@@ -778,6 +779,7 @@ export function AudioStudio() {
   return (
     <ModelAvailabilityGate
       ready={modelReady}
+      initializing={modelCatalogStatus === "idle" || modelCatalogStatus === "loading"}
       title="Audio Studio needs an audio model"
       description="Download a recommended audio model to start generating speech, music and sound."
       offers={modelOffers}

--- a/apps/web/src/screens/CharacterStudio.jsx
+++ b/apps/web/src/screens/CharacterStudio.jsx
@@ -158,6 +158,7 @@ export function CharacterStudio() {
     purgeAsset,
     imageModels,
     models = [],
+    modelCatalogStatus = "ready",
     jobs = [],
     latestImageAssets,
     loras,
@@ -830,6 +831,7 @@ export function CharacterStudio() {
             >
               <ModelAvailabilityGate
                 ready={angleModels.length > 0}
+                initializing={modelCatalogStatus === "idle" || modelCatalogStatus === "loading"}
                 title="Angle Set needs an angle-capable model"
                 description="Generating character angle sets needs a model like InstantID (RealVisXL). Download one to get started."
                 offers={angleOffers}
@@ -874,6 +876,7 @@ export function CharacterStudio() {
             >
               <ModelAvailabilityGate
                 ready={poseModels.length > 0}
+                initializing={modelCatalogStatus === "idle" || modelCatalogStatus === "loading"}
                 title="Pose Library needs a pose-capable model"
                 description="Generating character poses needs a model like InstantID (RealVisXL). Download one to get started."
                 offers={poseOffers}

--- a/apps/web/src/screens/DocumentStudio.jsx
+++ b/apps/web/src/screens/DocumentStudio.jsx
@@ -157,6 +157,7 @@ export function DocumentStudio() {
     jobAction,
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
     models = [],
+    modelCatalogStatus = "ready",
     rememberLocalGenerationJob,
     setActiveView,
     requestedGpu,
@@ -370,6 +371,7 @@ export function DocumentStudio() {
   return (
     <ModelAvailabilityGate
       ready={modelReady}
+      initializing={modelCatalogStatus === "idle" || modelCatalogStatus === "loading"}
       title="Document Studio needs an interleave-capable model"
       description="Interleaved text-image documents need a model like SenseNova-U1. Download one to get started."
       offers={modelOffers}

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -302,6 +302,7 @@ export function ImageStudio() {
     gpuOptions,
     imageModels,
     models = [],
+    modelCatalogStatus = "ready",
     jobs = [],
     importAsset,
     latestImageAssets,
@@ -2749,6 +2750,7 @@ export function ImageStudio() {
   return (
     <ModelAvailabilityGate
       ready={modelReady}
+      initializing={modelCatalogStatus === "idle" || modelCatalogStatus === "loading"}
       title="Image Studio needs an image model"
       description="Download a recommended image model to start generating."
       offers={modelOffers}

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -330,6 +330,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setActiveView,
     studioLaunch,
     models = [],
+    modelCatalogStatus = "ready",
     createModelDownloadJob,
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
     registerProjectSwitchGuard,
@@ -1763,6 +1764,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
   return (
     <ModelAvailabilityGate
       ready={trainingReady}
+      initializing={modelCatalogStatus === "idle" || modelCatalogStatus === "loading"}
       title="Training needs a trainable base model"
       description="LoRA training needs a downloaded base model (e.g. Z-Image-Turbo or SDXL). Download one to get started."
       offers={trainingOffers}

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -226,6 +226,7 @@ export function VideoStudio() {
     updateAssetStatus,
     videoModels,
     models = [],
+    modelCatalogStatus = "ready",
     macCapabilities = DEFAULT_MAC_CAPABILITIES,
     preferencesHydrated,
   } = useAppContext();
@@ -1909,6 +1910,7 @@ export function VideoStudio() {
   return (
     <ModelAvailabilityGate
       ready={modelReady}
+      initializing={modelCatalogStatus === "idle" || modelCatalogStatus === "loading"}
       title="Video Studio needs a video model"
       description="Download a recommended video model to start generating."
       offers={modelOffers}


### PR DESCRIPTION
## Summary

- stop using the static fallback catalog as startup evidence that generation models are available
- show an indeterminate model-initialization state until the authoritative catalog request settles
- preserve the last authoritative catalog during later refreshes and ignore stale catalog responses
- apply the shared initialization gate across model-backed studios

## Validation

- `npm test` — 270 files, 4,158 tests passed
- `npm run lint -- --quiet`
- `npm run build`