### PR TITLE
evidence(sc-11045): candle krea_2_turbo five-rung capture (epic 11037)

### DIFF
--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -754,11 +754,19 @@ runs `assess-reuse` and **asserts the verdict is `unable_to_amortize`** before c
 ```bash
 gh workflow run windows-candle.yml --ref main \
   -f run_five_rung_reference=true \
-  -f provision_krea_snapshot=false \
+  -f provision_snapshot=false \
   -f inference_revision=<exact adapter INFERENCE_PIN> \
-  -f krea_repository=SceneWorks/krea-2-turbo-mlx \
-  -f krea_revision=<exact 40-hex artifact revision>
+  -f provision_repository=SceneWorks/krea-2-turbo-mlx \
+  -f provision_revision=<exact 40-hex artifact revision>
 ```
+
+🔴 **These are the post-sc-18677 input names.** Provisioning was generalized away from the
+hardcoded Krea reference and the inputs were **renamed, not duplicated**:
+`provision_krea_snapshot` → `provision_snapshot`, `krea_repository` → `provision_repository`,
+`krea_revision` → `provision_revision` (windows-candle.yml, `workflow_dispatch` header). The old
+spellings are silently ignored rather than rejected, and because an omitted `workflow_dispatch`
+input takes its **default**, a dispatch using them still runs — against whatever the defaults say.
+Verified against the real dispatch in sc-11045 (run 33000590976).
 
 Captures fixture `fresh-five-rung-krea-q4-1024-seed16402-step2` **twice** — once `--fresh-per-case`,
 once `--batch-rungs` — schema-checks both and runs `compare-reuse` between them.

--- a/docs/generated/krea-candle-five-rung-sc-11045.json
+++ b/docs/generated/krea-candle-five-rung-sc-11045.json
@@ -1,0 +1,948 @@
+{
+  "harnessVersion": "sceneworks-memory-v5",
+  "records": [
+    {
+      "artifact": {
+        "repository": "SceneWorks/krea-2-turbo-mlx",
+        "resolvedRevision": "d009674080cc1bccf2b629d834c34bf5eccdb723",
+        "variant": "q4"
+      },
+      "backend": "candle",
+      "calibrationFingerprint": "krea-turbo-cuda-phase-curves-v1",
+      "capturedAt": "2026-08-26T19:08:54Z",
+      "diagnostics": {
+        "adapter": "memory-candle-adapter:krea_2_turbo-five-rung-reference",
+        "blockers": [
+          "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningDevicePeakDelta",
+            "unit": "bytes",
+            "value": 3828350976
+          },
+          {
+            "name": "denoiseDevicePeakDelta",
+            "unit": "bytes",
+            "value": 14800650240
+          },
+          {
+            "name": "decodeDevicePeakDelta",
+            "unit": "bytes",
+            "value": 9199157248
+          },
+          {
+            "name": "overallDevicePeakDelta",
+            "unit": "bytes",
+            "value": 14800650240
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "fresh-five-rung-krea-q4-1024-seed16402-step2",
+      "hardware": {
+        "computeCapability": "12.0",
+        "deviceId": "0",
+        "driverVersion": "596.36",
+        "memoryBytes": 102641958912,
+        "name": "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition",
+        "probe": "C:\\WINDOWS\\System32\\nvidia-smi.exe selected through CUDA_VISIBLE_DEVICES",
+        "runtimeVersion": "12.9"
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-25e4d186c7016141e988",
+      "loadShape": "deferred_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/krea-2-turbo-mlx@d009674080cc1bccf2b629d834c34bf5eccdb723:q4",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-9ef4646a8b33df0b8fea",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 3828350976,
+          "allocatorBytes": 3828350976,
+          "reclaimableBytes": 0
+        },
+        "decode": {
+          "activeBytes": 9199157248,
+          "allocatorBytes": 9199157248,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 14800650240,
+          "allocatorBytes": 14800650240,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 14800650240,
+          "allocatorBytes": 14800650240,
+          "reclaimableBytes": 0
+        }
+      },
+      "predictedPeakBytes": null,
+      "quality": {
+        "result": "not_run"
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "60d4cc2d8214902f7c3c43a21002626070115dc67bc81e7b004522b46eadf370",
+          "dirty": false,
+          "revision": "3cd86ba2165f35db7c4fceecbeb7fbd12bca1c0c"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:bcbbd4d93afaf5612cf72fb1b26e415ad0374406fc7ded9ba056522fe58f57fa",
+          "revision": "769363b7bd7d0e8d73a82e48f521aa5dadcb9d5a"
+        }
+      },
+      "scenarios": [
+        {
+          "name": "exact_fit",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "cancel",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "overlay",
+          "reason": "the calibration target declares overlay \"none\"; the Candle Krea base-only text-to-image path executes no overlay, so this record has no second resident network to measure",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "gated",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency",
+          "bounded_decode"
+        ],
+        "parameters": {
+          "decodeOverlap": 128,
+          "decodeTileEdge": 512
+        },
+        "rung": "bounded_decode"
+      },
+      "sweep": {
+        "axes": [
+          {
+            "parameter": "decodeOverlap",
+            "testedValues": [
+              128
+            ]
+          },
+          {
+            "parameter": "decodeTileEdge",
+            "testedValues": [
+              512
+            ]
+          }
+        ],
+        "cases": [
+          {
+            "parameters": {
+              "decodeOverlap": 128,
+              "decodeTileEdge": 512
+            },
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": false
+      },
+      "target": {
+        "geometry": {
+          "batch": 1,
+          "frames": 1,
+          "height": 1024,
+          "width": 1024
+        },
+        "mode": "text_to_image",
+        "modelId": "krea_2_turbo",
+        "overlay": "none",
+        "provider": "krea_2_turbo",
+        "tier": "q4"
+      }
+    },
+    {
+      "artifact": {
+        "repository": "SceneWorks/krea-2-turbo-mlx",
+        "resolvedRevision": "d009674080cc1bccf2b629d834c34bf5eccdb723",
+        "variant": "q4"
+      },
+      "backend": "candle",
+      "calibrationFingerprint": "krea-turbo-cuda-phase-curves-v1",
+      "capturedAt": "2026-08-26T19:07:37Z",
+      "diagnostics": {
+        "adapter": "memory-candle-adapter:krea_2_turbo-five-rung-reference",
+        "blockers": [
+          "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningDevicePeakDelta",
+            "unit": "bytes",
+            "value": 3828350976
+          },
+          {
+            "name": "denoiseDevicePeakDelta",
+            "unit": "bytes",
+            "value": 11310989312
+          },
+          {
+            "name": "decodeDevicePeakDelta",
+            "unit": "bytes",
+            "value": 9232711680
+          },
+          {
+            "name": "overallDevicePeakDelta",
+            "unit": "bytes",
+            "value": 11310989312
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "fresh-five-rung-krea-q4-1024-seed16402-step2",
+      "hardware": {
+        "computeCapability": "12.0",
+        "deviceId": "0",
+        "driverVersion": "596.36",
+        "memoryBytes": 102641958912,
+        "name": "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition",
+        "probe": "C:\\WINDOWS\\System32\\nvidia-smi.exe selected through CUDA_VISIBLE_DEVICES",
+        "runtimeVersion": "12.9"
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-3fc9bf23d8b351edaa57",
+      "loadShape": "deferred_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/krea-2-turbo-mlx@d009674080cc1bccf2b629d834c34bf5eccdb723:q4",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-718ab07b96c67ce5aef0",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 3828350976,
+          "allocatorBytes": 3828350976,
+          "reclaimableBytes": 0
+        },
+        "decode": {
+          "activeBytes": 9232711680,
+          "allocatorBytes": 9232711680,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 11310989312,
+          "allocatorBytes": 11310989312,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 11310989312,
+          "allocatorBytes": 11310989312,
+          "reclaimableBytes": 0
+        }
+      },
+      "predictedPeakBytes": null,
+      "quality": {
+        "result": "not_run"
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "60d4cc2d8214902f7c3c43a21002626070115dc67bc81e7b004522b46eadf370",
+          "dirty": false,
+          "revision": "3cd86ba2165f35db7c4fceecbeb7fbd12bca1c0c"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:bcbbd4d93afaf5612cf72fb1b26e415ad0374406fc7ded9ba056522fe58f57fa",
+          "revision": "769363b7bd7d0e8d73a82e48f521aa5dadcb9d5a"
+        }
+      },
+      "scenarios": [
+        {
+          "name": "exact_fit",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "cancel",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "overlay",
+          "reason": "the calibration target declares overlay \"none\"; the Candle Krea base-only text-to-image path executes no overlay, so this record has no second resident network to measure",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "gated",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency",
+          "bounded_decode",
+          "bounded_attention"
+        ],
+        "parameters": {
+          "attentionChunkSize": 134217728,
+          "decodeOverlap": 128,
+          "decodeTileEdge": 512
+        },
+        "rung": "bounded_attention"
+      },
+      "sweep": {
+        "axes": [
+          {
+            "parameter": "attentionChunkSize",
+            "testedValues": [
+              134217728
+            ]
+          },
+          {
+            "parameter": "decodeOverlap",
+            "testedValues": [
+              128
+            ]
+          },
+          {
+            "parameter": "decodeTileEdge",
+            "testedValues": [
+              512
+            ]
+          }
+        ],
+        "cases": [
+          {
+            "parameters": {
+              "attentionChunkSize": 134217728,
+              "decodeOverlap": 128,
+              "decodeTileEdge": 512
+            },
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": false
+      },
+      "target": {
+        "geometry": {
+          "batch": 1,
+          "frames": 1,
+          "height": 1024,
+          "width": 1024
+        },
+        "mode": "text_to_image",
+        "modelId": "krea_2_turbo",
+        "overlay": "none",
+        "provider": "krea_2_turbo",
+        "tier": "q4"
+      }
+    },
+    {
+      "artifact": {
+        "repository": "SceneWorks/krea-2-turbo-mlx",
+        "resolvedRevision": "d009674080cc1bccf2b629d834c34bf5eccdb723",
+        "variant": "q4"
+      },
+      "backend": "candle",
+      "calibrationFingerprint": "krea-turbo-cuda-phase-curves-v1",
+      "capturedAt": "2026-08-26T19:09:32Z",
+      "diagnostics": {
+        "adapter": "memory-candle-adapter:krea_2_turbo-five-rung-reference",
+        "blockers": [
+          "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningDevicePeakDelta",
+            "unit": "bytes",
+            "value": 12720275456
+          },
+          {
+            "name": "denoiseDevicePeakDelta",
+            "unit": "bytes",
+            "value": 17921212416
+          },
+          {
+            "name": "decodeDevicePeakDelta",
+            "unit": "bytes",
+            "value": 25171066880
+          },
+          {
+            "name": "overallDevicePeakDelta",
+            "unit": "bytes",
+            "value": 25171066880
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "fresh-five-rung-krea-q4-1024-seed16402-step2",
+      "hardware": {
+        "computeCapability": "12.0",
+        "deviceId": "0",
+        "driverVersion": "596.36",
+        "memoryBytes": 102641958912,
+        "name": "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition",
+        "probe": "C:\\WINDOWS\\System32\\nvidia-smi.exe selected through CUDA_VISIBLE_DEVICES",
+        "runtimeVersion": "12.9"
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-509754af068769903e2a",
+      "loadShape": "deferred_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/krea-2-turbo-mlx@d009674080cc1bccf2b629d834c34bf5eccdb723:q4",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-f32f19edb19130c8a967",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 12720275456,
+          "allocatorBytes": 12720275456,
+          "reclaimableBytes": 0
+        },
+        "decode": {
+          "activeBytes": 25171066880,
+          "allocatorBytes": 25171066880,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 17921212416,
+          "allocatorBytes": 17921212416,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 25171066880,
+          "allocatorBytes": 25171066880,
+          "reclaimableBytes": 0
+        }
+      },
+      "predictedPeakBytes": null,
+      "quality": {
+        "result": "not_run"
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "60d4cc2d8214902f7c3c43a21002626070115dc67bc81e7b004522b46eadf370",
+          "dirty": false,
+          "revision": "3cd86ba2165f35db7c4fceecbeb7fbd12bca1c0c"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:bcbbd4d93afaf5612cf72fb1b26e415ad0374406fc7ded9ba056522fe58f57fa",
+          "revision": "769363b7bd7d0e8d73a82e48f521aa5dadcb9d5a"
+        }
+      },
+      "scenarios": [
+        {
+          "name": "exact_fit",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "cancel",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "overlay",
+          "reason": "the calibration target declares overlay \"none\"; the Candle Krea base-only text-to-image path executes no overlay, so this record has no second resident network to measure",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "gated",
+      "strategy": {
+        "engagedRungs": [
+          "resident"
+        ],
+        "parameters": {},
+        "rung": "resident"
+      },
+      "sweep": {
+        "axes": [],
+        "cases": [
+          {
+            "parameters": {},
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": false
+      },
+      "target": {
+        "geometry": {
+          "batch": 1,
+          "frames": 1,
+          "height": 1024,
+          "width": 1024
+        },
+        "mode": "text_to_image",
+        "modelId": "krea_2_turbo",
+        "overlay": "none",
+        "provider": "krea_2_turbo",
+        "tier": "q4"
+      }
+    },
+    {
+      "artifact": {
+        "repository": "SceneWorks/krea-2-turbo-mlx",
+        "resolvedRevision": "d009674080cc1bccf2b629d834c34bf5eccdb723",
+        "variant": "q4"
+      },
+      "backend": "candle",
+      "calibrationFingerprint": "krea-turbo-cuda-phase-curves-v1",
+      "capturedAt": "2026-08-26T19:08:15Z",
+      "diagnostics": {
+        "adapter": "memory-candle-adapter:krea_2_turbo-five-rung-reference",
+        "blockers": [
+          "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningDevicePeakDelta",
+            "unit": "bytes",
+            "value": 3828350976
+          },
+          {
+            "name": "denoiseDevicePeakDelta",
+            "unit": "bytes",
+            "value": 15102640128
+          },
+          {
+            "name": "decodeDevicePeakDelta",
+            "unit": "bytes",
+            "value": 22352494592
+          },
+          {
+            "name": "overallDevicePeakDelta",
+            "unit": "bytes",
+            "value": 22352494592
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "fresh-five-rung-krea-q4-1024-seed16402-step2",
+      "hardware": {
+        "computeCapability": "12.0",
+        "deviceId": "0",
+        "driverVersion": "596.36",
+        "memoryBytes": 102641958912,
+        "name": "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition",
+        "probe": "C:\\WINDOWS\\System32\\nvidia-smi.exe selected through CUDA_VISIBLE_DEVICES",
+        "runtimeVersion": "12.9"
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-7f1a63e5459300aed47c",
+      "loadShape": "deferred_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/krea-2-turbo-mlx@d009674080cc1bccf2b629d834c34bf5eccdb723:q4",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-803421beb6e919475ffe",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 3828350976,
+          "allocatorBytes": 3828350976,
+          "reclaimableBytes": 0
+        },
+        "decode": {
+          "activeBytes": 22352494592,
+          "allocatorBytes": 22352494592,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 15102640128,
+          "allocatorBytes": 15102640128,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 22352494592,
+          "allocatorBytes": 22352494592,
+          "reclaimableBytes": 0
+        }
+      },
+      "predictedPeakBytes": null,
+      "quality": {
+        "result": "not_run"
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "60d4cc2d8214902f7c3c43a21002626070115dc67bc81e7b004522b46eadf370",
+          "dirty": false,
+          "revision": "3cd86ba2165f35db7c4fceecbeb7fbd12bca1c0c"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:bcbbd4d93afaf5612cf72fb1b26e415ad0374406fc7ded9ba056522fe58f57fa",
+          "revision": "769363b7bd7d0e8d73a82e48f521aa5dadcb9d5a"
+        }
+      },
+      "scenarios": [
+        {
+          "name": "exact_fit",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "cancel",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "overlay",
+          "reason": "the calibration target declares overlay \"none\"; the Candle Krea base-only text-to-image path executes no overlay, so this record has no second resident network to measure",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "gated",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency"
+        ],
+        "parameters": {},
+        "rung": "staged_residency"
+      },
+      "sweep": {
+        "axes": [],
+        "cases": [
+          {
+            "parameters": {},
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": false
+      },
+      "target": {
+        "geometry": {
+          "batch": 1,
+          "frames": 1,
+          "height": 1024,
+          "width": 1024
+        },
+        "mode": "text_to_image",
+        "modelId": "krea_2_turbo",
+        "overlay": "none",
+        "provider": "krea_2_turbo",
+        "tier": "q4"
+      }
+    },
+    {
+      "artifact": {
+        "repository": "SceneWorks/krea-2-turbo-mlx",
+        "resolvedRevision": "d009674080cc1bccf2b629d834c34bf5eccdb723",
+        "variant": "q4"
+      },
+      "backend": "candle",
+      "calibrationFingerprint": "krea-turbo-cuda-phase-curves-v1",
+      "capturedAt": "2026-08-26T19:07:00Z",
+      "diagnostics": {
+        "adapter": "memory-candle-adapter:krea_2_turbo-five-rung-reference",
+        "blockers": [
+          "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningDevicePeakDelta",
+            "unit": "bytes",
+            "value": 3828350976
+          },
+          {
+            "name": "denoiseDevicePeakDelta",
+            "unit": "bytes",
+            "value": 3996123136
+          },
+          {
+            "name": "decodeDevicePeakDelta",
+            "unit": "bytes",
+            "value": 3830448128
+          },
+          {
+            "name": "overallDevicePeakDelta",
+            "unit": "bytes",
+            "value": 3996123136
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "fresh-five-rung-krea-q4-1024-seed16402-step2",
+      "hardware": {
+        "computeCapability": "12.0",
+        "deviceId": "0",
+        "driverVersion": "596.36",
+        "memoryBytes": 102641958912,
+        "name": "NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition",
+        "probe": "C:\\WINDOWS\\System32\\nvidia-smi.exe selected through CUDA_VISIBLE_DEVICES",
+        "runtimeVersion": "12.9"
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-89d319fe2aed72ae01bb",
+      "loadShape": "deferred_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/krea-2-turbo-mlx@d009674080cc1bccf2b629d834c34bf5eccdb723:q4",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-3f4f842abc170557f267",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 3828350976,
+          "allocatorBytes": 3828350976,
+          "reclaimableBytes": 0
+        },
+        "decode": {
+          "activeBytes": 3830448128,
+          "allocatorBytes": 3830448128,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 3996123136,
+          "allocatorBytes": 3996123136,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 3996123136,
+          "allocatorBytes": 3996123136,
+          "reclaimableBytes": 0
+        }
+      },
+      "predictedPeakBytes": null,
+      "quality": {
+        "result": "not_run"
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "60d4cc2d8214902f7c3c43a21002626070115dc67bc81e7b004522b46eadf370",
+          "dirty": false,
+          "revision": "3cd86ba2165f35db7c4fceecbeb7fbd12bca1c0c"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:bcbbd4d93afaf5612cf72fb1b26e415ad0374406fc7ded9ba056522fe58f57fa",
+          "revision": "769363b7bd7d0e8d73a82e48f521aa5dadcb9d5a"
+        }
+      },
+      "scenarios": [
+        {
+          "name": "exact_fit",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "cancel",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "reason": "five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it intentionally remains gated because this run does not repeat the full promotion-quality, negative-mutation, and lifecycle scenario suite",
+          "result": "not_run"
+        },
+        {
+          "name": "overlay",
+          "reason": "the calibration target declares overlay \"none\"; the Candle Krea base-only text-to-image path executes no overlay, so this record has no second resident network to measure",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "gated",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency",
+          "bounded_decode",
+          "bounded_attention",
+          "bounded_transformer_residency"
+        ],
+        "parameters": {
+          "attentionChunkSize": 134217728,
+          "decodeOverlap": 128,
+          "decodeTileEdge": 512,
+          "transformerWindowSize": 1
+        },
+        "rung": "bounded_transformer_residency"
+      },
+      "sweep": {
+        "axes": [
+          {
+            "parameter": "attentionChunkSize",
+            "testedValues": [
+              134217728
+            ]
+          },
+          {
+            "parameter": "decodeOverlap",
+            "testedValues": [
+              128
+            ]
+          },
+          {
+            "parameter": "decodeTileEdge",
+            "testedValues": [
+              512
+            ]
+          },
+          {
+            "parameter": "transformerWindowSize",
+            "testedValues": [
+              1
+            ]
+          }
+        ],
+        "cases": [
+          {
+            "parameters": {
+              "attentionChunkSize": 134217728,
+              "decodeOverlap": 128,
+              "decodeTileEdge": 512,
+              "transformerWindowSize": 1
+            },
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": false
+      },
+      "target": {
+        "geometry": {
+          "batch": 1,
+          "frames": 1,
+          "height": 1024,
+          "width": 1024
+        },
+        "mode": "text_to_image",
+        "modelId": "krea_2_turbo",
+        "overlay": "none",
+        "provider": "krea_2_turbo",
+        "tier": "q4"
+      }
+    }
+  ],
+  "schemaVersion": 5,
+  "sourceSessions": []
+}

--- a/docs/krea-candle-memory-ladder-sc-11045.md
+++ b/docs/krea-candle-memory-ladder-sc-11045.md
@@ -1,0 +1,102 @@
+# Krea 2 Turbo Candle/CUDA five-rung memory ladder (SC-11045)
+
+This record separates implementation/loadability evidence from calibration. It **does not promote any
+Krea Candle cell to Verified**, and it does not move any shipped calibration binding. The capture is
+published separately at `docs/generated/krea-candle-five-rung-sc-11045.json`, outside the runtime
+admission bundle, following the SC-15817 precedent.
+
+## Why this capture certifies nothing
+
+Every record carries `status: "gated"` by the harness's own declaration. Each one states the reason
+in `diagnostics.blockers`:
+
+> five-rung oracle capture measures exact per-rung memory and strategy identity for SC-16059; it
+> intentionally remains gated because this run does not repeat the full promotion-quality,
+> negative-mutation, and lifecycle scenario suite
+
+That is a design property of the fixture, not a failure of this run — the step exited `success`, the
+adapter reports `diagnostics.execution: "executed"`, and every rung carries real device deltas from a
+real probe. But `scripts/generate-memory-matrix.mjs` promotes only records whose `status` is
+`complete` or `runtime_complete` (see its `record-not-complete` reason and the
+`currentEnvironmentVerification` filter), so these five are excluded from promotion by construction.
+
+Measured, not assumed — ingesting these records into `docs/generated/memory-calibration-evidence.json`
+and regenerating gives:
+
+- `summary.currentCalibrationRuns`: **0 → 0** (unchanged).
+- `summary.calibrationRunsByStatus`: `{complete: 85, runtimeComplete: 23}` (unchanged — the five are
+  counted in neither bucket).
+- `npm run report:stale-lanes`: `9 stale, 0 current` (unchanged); `candle:krea_2_turbo` still ranked
+  #8 at `1/1` bindings, **`0/0` records**, `status=stale`.
+
+So the lane does not move even on the record half, and the §7d binding half has no certifying record
+to stand on. Stamping the shipped bindings to this revision would assert a promotion the evidence
+does not support, which is the "launder a stale measurement into a current one" failure the
+calibration runbook refuses by design. **§7d is deliberately not performed here.**
+
+One further reason to keep these records out of the admission bundle: they would be the first
+`gated` records ever to enter it, and that surfaces a latent inconsistency in the generator —
+`summary.calibrationRuns` is `records.length` (113) while
+`"the published summary re-derives from the evidence bundle and the closure ledger (sc-17774)"`
+recomputes it as `complete + runtimeComplete` (108). The two agreed only because every record in the
+bundle had always been complete. That is a real defect in its own right, but it is not this story's
+to fix, and forcing it open is not a precondition for publishing a gated oracle.
+
+## Capture provenance
+
+Captured by the guarded `windows-candle.yml` dispatch
+([run 33000590976](https://github.com/SceneWorks/SceneWorks/actions/runs/33000590976), conclusion
+`success`) — the documented route; local capture is refused by the pinned `VramProbe` idle gate
+because GPU 1 hosts the desktop.
+
+- Fixture: `fresh-five-rung-krea-q4-1024-seed16402-step2`, `--fresh-per-case`.
+- Artifact: `SceneWorks/krea-2-turbo-mlx@d009674080cc1bccf2b629d834c34bf5eccdb723`, variant `q4`.
+- SceneWorks `769363b7bd7d0e8d73a82e48f521aa5dadcb9d5a`, inference
+  `3cd86ba2165f35db7c4fceecbeb7fbd12bca1c0c`, both worktrees clean.
+- Provider closure digest `60d4cc2d8214…` — this is the lane's **live** digest, so the capture is at
+  the current closure; only the gated status keeps it from certifying.
+- Contract fingerprint `krea-turbo-cuda-phase-curves-v1`; load shape `deferred_materialization`;
+  target `krea_2_turbo` q4 `text_to_image` at 1024x1024, batch 1.
+- Device: NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition, compute capability 12.0,
+  102,641,958,912 bytes, CUDA 12.9, driver 596.36, GPU 0 selected through `CUDA_VISIBLE_DEVICES`.
+
+## The five rungs
+
+Observed overall device peak delta, one fresh process per rung:
+
+| Rung | Parameters | Observed peak (bytes) | GiB |
+| --- | --- | ---: | ---: |
+| Resident | none | 25,171,066,880 | 23.44 |
+| Staged residency | none | 22,352,494,592 | 20.82 |
+| Bounded decode | tile 512, overlap 128 | 14,800,650,240 | 13.78 |
+| Bounded attention | tile 512, overlap 128, score budget 134,217,728 | 11,310,989,312 | 10.53 |
+| Bounded transformer residency | prior parameters, block window 1 | 3,996,123,136 | 3.72 |
+
+The ladder is strictly monotone across all five rungs — high-water **23.44 GiB** at `resident` down
+to a **3.72 GiB** floor at full bounding, a 6.3x span.
+
+Per-phase deltas confirm where the peak lives. At `bounded_decode` the phases are conditioning
+3.57 GiB, denoise 13.78 GiB, decode 8.57 GiB — **denoise attention is the peak, not VAE decode**,
+matching the Wan finding. The exception is `resident`, whose decode phase (23.44 GiB) dominates
+because nothing is bounding it; that is exactly the rung the ladder exists to retire.
+
+## Reuse comparison
+
+The workflow also captured the same fixture with `--batch-rungs` and ran `compare-reuse` between the
+two passes. Verdict: **`unable_to_amortize`** — one of the two verdicts the lane accepts.
+
+Batched rungs track the fresh ones closely at the bounded end (`bounded_decode` 13.88 vs 13.78 GiB,
+`bounded_attention` 10.35 vs 10.53 GiB, `resident` identical at 23.44 GiB) but diverge where a
+carried-over allocator state changes the phase shape — `staged_residency` reads 22.69 vs 20.82 GiB
+with conditioning jumping 3.57 → 11.44 GiB, and `bounded_transformer_residency` reads 4.79 vs
+3.72 GiB. Sharing one process across rungs does not recover the load cost and distorts the very
+phase boundaries the ladder measures, so `--fresh-per-case` remains the authoritative shape. The
+comparison and batched bundles are retained on the run artifact
+(`sc-16059-candle-reuse-33000590976`); only the authoritative fresh capture is committed.
+
+## What would make this lane current
+
+A certifying capture — one that also runs the promotion-quality, negative-mutation, and lifecycle
+scenario suite so the records land `complete` rather than `gated` — followed by the binding half in
+§7d of the calibration runbook. Until then `candle:krea_2_turbo` keeps serving its measured numbers
+behind the widened 2.00% margin, which is a signal and not a gate.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "generate:memory-matrix": "node scripts/generate-memory-matrix.mjs",
     "generate:manifest-memory-declarations": "node scripts/generate-manifest-memory-declarations.mjs",
     "check:memory-matrix": "node scripts/generate-memory-matrix.mjs --check",
-    "check:memory-calibration": "node scripts/memory-calibration-harness.mjs check --input docs/generated/memory-calibration-evidence.json && node scripts/memory-calibration-harness.mjs check --input docs/generated/ltx-mlx-video-sc-18808.json && node scripts/memory-calibration-harness.mjs check --input docs/generated/ltx-mlx-geometry-sweep-sc-18810.json && node scripts/memory-calibration-harness.mjs check --input docs/generated/qwen-candle-five-rung-sc-15817.json",
+    "check:memory-calibration": "node scripts/memory-calibration-harness.mjs check --input docs/generated/memory-calibration-evidence.json && node scripts/memory-calibration-harness.mjs check --input docs/generated/ltx-mlx-video-sc-18808.json && node scripts/memory-calibration-harness.mjs check --input docs/generated/ltx-mlx-geometry-sweep-sc-18810.json && node scripts/memory-calibration-harness.mjs check --input docs/generated/qwen-candle-five-rung-sc-15817.json && node scripts/memory-calibration-harness.mjs check --input docs/generated/krea-candle-five-rung-sc-11045.json",
     "report:stale-lanes": "node scripts/stale-lane-report.mjs",
     "check:rust-derived-docs": "npm run check:memory-matrix && npm run check:tier-integrity",
     "generate:tier-integrity": "node scripts/check-tier-integrity.mjs",


### PR DESCRIPTION
Lands the last evidence item of epic 11037's terminal phase: the `candle:krea_2_turbo`
five-rung calibration capture, taken on real q4 weights through the guarded
`windows-candle.yml` dispatch.

**Capture:** [run 33000590976](https://github.com/SceneWorks/SceneWorks/actions/runs/33000590976), conclusion `success`.
Fixture `fresh-five-rung-krea-q4-1024-seed16402-step2`, `--fresh-per-case`, artifact
`SceneWorks/krea-2-turbo-mlx@d009674080cc…` variant `q4`, on an RTX PRO 6000 Blackwell
(cc 12.0, CUDA 12.9, driver 596.36). This is the documented route — a local capture is
refused by the pinned `VramProbe` idle gate because GPU 1 hosts the desktop.

### The ladder

| Rung | Parameters | Observed peak | GiB |
| --- | --- | ---: | ---: |
| Resident | none | 25,171,066,880 | 23.44 |
| Staged residency | none | 22,352,494,592 | 20.82 |
| Bounded decode | tile 512, overlap 128 | 14,800,650,240 | 13.78 |
| Bounded attention | + score budget 134,217,728 | 11,310,989,312 | 10.53 |
| Bounded transformer residency | + block window 1 | 3,996,123,136 | 3.72 |

Strictly monotone across all five rungs, a 6.3x span. Per-phase deltas put the peak in
**denoise attention, not VAE decode**, at every bounded rung. `compare-reuse` against a
`--batch-rungs` pass returns `unable_to_amortize`.

### 🔴 Scope call: this capture certifies nothing, so §7d is not performed

Every record is `status: "gated"` **by the harness's own declaration** — the fixture does
not repeat the promotion-quality, negative-mutation and lifecycle scenario suite, and each
record says so in `diagnostics.blockers`. The generator promotes only `complete` /
`runtime_complete` records.

I measured this rather than assuming it. Ingesting the five into
`memory-calibration-evidence.json` and regenerating gives:

- `summary.currentCalibrationRuns`: **0 → 0**
- `summary.calibrationRunsByStatus`: `{complete: 85, runtimeComplete: 23}` — unchanged; the
  five land in neither bucket
- `report:stale-lanes`: `9 stale, 0 current` — unchanged; `candle:krea_2_turbo` still ranked
  #8 at `1/1` bindings, **`0/0` records**, `status=stale`

The lane does not move even on the record half, so the §7d binding half has nothing
certifying to stand on. Stamping the shipped bindings to this revision would assert a
promotion the evidence does not support. Correspondingly, **no §9 pin relaxations are
needed** — `tests/test_memory_matrix.py` is `9 passed` unchanged, which is itself
confirmation that nothing was promoted.

So the capture is published to `docs/generated/krea-candle-five-rung-sc-11045.json`,
**outside the runtime admission bundle**, following the SC-15817 precedent
(`docs/generated/qwen-candle-five-rung-sc-15817.json`), and wired into
`check:memory-calibration`.

### Latent defect found, not fixed here

These would be the first `gated` records ever in the admission bundle, and that exposes an
inconsistency in the generator: `summary.calibrationRuns` is `records.length` (113) while
the sc-17774 summary test recomputes it as `complete + runtimeComplete` (108). The two
agreed only because every record in that bundle had always been complete. Real defect,
but not this story's, and not a precondition for publishing a gated oracle. Flagged for a
follow-up.

### Also

Corrects `calibration-runbook.md` §6b, which still documented the pre-sc-18677 dispatch
input names (`provision_krea_snapshot` / `krea_repository` / `krea_revision`). They were
renamed, not duplicated — and since an omitted `workflow_dispatch` input takes its
**default**, the stale spelling runs against defaults instead of failing loudly.

### Verification

- `npm run check:memory-calibration` — exit 0 (now covering the new file)
- `npm run check:memory-matrix` (`--check`) — exit 0; regeneration is byte-identical, as
  expected for an out-of-bundle capture
- `node --test scripts/generate-memory-matrix.test.mjs scripts/memory-calibration-harness.test.mjs` — 185 pass, 0 fail
- `python -m pytest -q tests/test_memory_matrix.py` — 9 passed (the parity-lane suite §9 warns about)

No pin bumps; no dismantled gate re-enabled; nothing else ran on the GPUs during the capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
