### PR TITLE
fix(sc-21715): make the calibration status tally partition the evidence bundle

### DIFF
--- a/crates/sceneworks-core/src/memory_calibration.rs
+++ b/crates/sceneworks-core/src/memory_calibration.rs
@@ -3307,9 +3307,28 @@ mod tests {
             runtime_complete_count > 0,
             "the bundle must carry runtime-complete records"
         );
+        // sc-21715: the partition runs over ALL FOUR `RecordStatus` variants, not over the two
+        // certifying ones. This used to read `records.len() == complete + runtime_complete` — the
+        // same identity `summary.calibrationRunsByStatus` published as a two-key tally, and true
+        // only while the corpus had never carried a `gated` or `negative_complete` receipt.
+        // Admitting one (the sc-11045 five-rung capture is exactly such a receipt) would have
+        // reddened this line with nothing actually wrong. Both certifying populations must still
+        // be non-empty — asserted above; what the partition asserts is that no record falls
+        // outside the four, so a fifth variant cannot be added without landing here.
+        let gated_count = bundle
+            .records
+            .iter()
+            .filter(|record| record.status == RecordStatus::Gated)
+            .count();
+        let negative_complete_count = bundle
+            .records
+            .iter()
+            .filter(|record| record.status == RecordStatus::NegativeComplete)
+            .count();
         assert_eq!(
             bundle.records.len(),
-            complete_count + runtime_complete_count
+            complete_count + runtime_complete_count + gated_count + negative_complete_count,
+            "every record must carry one of the four RecordStatus variants"
         );
         // Same partition posture for the load shapes: both exist, and together they are the whole
         // bundle — a record with any third shape (or none) breaks the identity.

--- a/docs/generated/memory-matrix.json
+++ b/docs/generated/memory-matrix.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 8,
+  "schemaVersion": 9,
   "generatedFrom": {
     "sceneWorksRevision": "source-tree:472bd21e0d25e49779c443e71893bf9b75e4b91912668d728bc6f4417c0fd0a2",
     "inferenceRevision": "624fed20c1969b851b60265e3b9dac951068c1f5",
@@ -193,7 +193,9 @@
     "calibrationRuns": 108,
     "calibrationRunsByStatus": {
       "complete": 85,
-      "runtimeComplete": 23
+      "runtimeComplete": 23,
+      "gated": 0,
+      "negativeComplete": 0
     },
     "currentCalibrationRuns": 0,
     "memoryContractReconciliation": {

--- a/docs/generated/memory-matrix.md
+++ b/docs/generated/memory-matrix.md
@@ -10,8 +10,11 @@
 - Elided coordinates: 8350 (Implemented/unverified 3999, Missing 4351)
 - MLX staged-residency static coverage: image 47/53, video 9/10
 - Full models: 0
+- Calibration records in the evidence bundle: 108
 - Full complete calibration records: 85
 - Base-only runtime-complete calibration records: 23
+- Gated calibration records (captured, certifying nothing): 0
+- Negative-complete calibration records: 0
 
 sc-18099: `cells` is a SUBSET. A coordinate is published when it is PLANNED (an entry in config/memory-calibration-plan.json targets it), MEASURED (memoryCharacterization is not `unmeasured`), BOUND to a calibration record in docs/generated/memory-calibration-evidence.json, or CITES evidence of its own (historical, current-environment, strategy-parameter, or structural). Every elided coordinate is therefore unplanned, unmeasured, unbound and uncited; its `state` and its per-rung population are counted in `summary.elidedByState` and `coverage`, never dropped. The counts on this page, `summary`, and the per-(entry, backend, rung) `coverage` census in the JSON artifact are all derived from every resolved coordinate, published or not, and `models[].axes` publishes the axes those coordinates span so an unmeasured lane stays distinguishable from an absent one.
 

--- a/docs/krea-candle-memory-ladder-sc-11045.md
+++ b/docs/krea-candle-memory-ladder-sc-11045.md
@@ -25,7 +25,10 @@ and regenerating gives:
 
 - `summary.currentCalibrationRuns`: **0 → 0** (unchanged).
 - `summary.calibrationRunsByStatus`: `{complete: 85, runtimeComplete: 23}` (unchanged — the five are
-  counted in neither bucket).
+  counted in neither bucket). sc-21715 has since made this tally PARTITION the bundle, so the same
+  ingest today reads `{complete: 85, runtimeComplete: 23, gated: 5, negativeComplete: 0}` — the five
+  are named rather than uncounted, and neither certifying bucket moves, which is the claim this
+  bullet was making.
 - `npm run report:stale-lanes`: `9 stale, 0 current` (unchanged); `candle:krea_2_turbo` still ranked
   #8 at `1/1` bindings, **`0/0` records**, `status=stale`.
 
@@ -34,13 +37,16 @@ to stand on. Stamping the shipped bindings to this revision would assert a promo
 does not support, which is the "launder a stale measurement into a current one" failure the
 calibration runbook refuses by design. **§7d is deliberately not performed here.**
 
-One further reason to keep these records out of the admission bundle: they would be the first
-`gated` records ever to enter it, and that surfaces a latent inconsistency in the generator —
-`summary.calibrationRuns` is `records.length` (113) while
+One further reason to keep these records out of the admission bundle at the time: they would have
+been the first `gated` records ever to enter it, and that surfaced a latent inconsistency in the
+generator — `summary.calibrationRuns` was `records.length` (113) while
 `"the published summary re-derives from the evidence bundle and the closure ledger (sc-17774)"`
-recomputes it as `complete + runtimeComplete` (108). The two agreed only because every record in the
-bundle had always been complete. That is a real defect in its own right, but it is not this story's
-to fix, and forcing it open is not a precondition for publishing a gated oracle.
+recomputed it as `complete + runtimeComplete` (108). The two agreed only because every record in the
+bundle had always been complete. That was a real defect in its own right, not this story's to fix,
+and forcing it open was never a precondition for publishing a gated oracle. It was filed as sc-21715
+and fixed there: the tally now partitions the bundle over every admitted status, so admitting these
+five is no longer blocked by it. Promotion still is — for the reasons above, which are about
+evidence, not about counting.
 
 ## Capture provenance
 

--- a/packages/schemas/memory-matrix.schema.json
+++ b/packages/schemas/memory-matrix.schema.json
@@ -494,8 +494,8 @@
   ],
   "properties": {
     "schemaVersion": {
-      "description": "2 (SC-15812): backend-scoped story ownership. 3 (sc-16268): removed per-cell evidenceRevision. 4 (SC-15969): added rung-4 survey rows. 5 (SC-16060): split implementation and memory-characterization claims. 6 (SC-15823): adds Runtime verified so base-only runtime activation cannot masquerade as Full Verified, and publishes complete/runtime-complete calibration counts. 7 (sc-18099): `cells` is the planned-or-evidenced SUBSET of the catalog cross-product rather than the cross-product itself; `coverage`, `models[].axes` and `manifestScopes` added and required; `summary` gained publishedCells/elidedCells/elidedByState/publicationPredicate; `modelSlices` entries may be empty; `rung4SurveyRows` absorbed the family-level summary/blockStacks/findings that `cells[].rung4Survey` no longer carries; `cells[].evidence` replaced declaredCalibration/loadability with a `manifestScope` key into `manifestScopes`; `calibrationRuns[].record` is a projection of the evidence-bundle row. 8 (sc-18815): the model universe is MODALITY-AWARE rather than `type === \"image\"`. `summary.imageModels` was REMOVED and replaced by `catalogEntries` + `catalogEntriesByModality` \u2014 not additive, because a reader indexing `imageModels` now gets `undefined` rather than a wrong number, which is the point; `models[]` gained required `modality` and `resolvedRoutes` and its count moved 53 -> 63; `models[].backends` and `owningModelStories` may be EMPTY (an entry the routing catalog routes nowhere); `cells[].owningModelStory` may be `null` (video cells have no per-entry owner); `cells[].rung4Survey` gained a required `surveyed` discriminator and its three verdict fields became nullable; `rung4SurveyRows[].familyStory` may be a family NAME rather than a story id; `summary` gained `unroutedEntries`, `videoMlxStagedStaticCoverage`(+`Denominator`) and `rung4Survey.pendingFamilyBackends`.",
-      "const": 8
+      "description": "2 (SC-15812): backend-scoped story ownership. 3 (sc-16268): removed per-cell evidenceRevision. 4 (SC-15969): added rung-4 survey rows. 5 (SC-16060): split implementation and memory-characterization claims. 6 (SC-15823): adds Runtime verified so base-only runtime activation cannot masquerade as Full Verified, and publishes complete/runtime-complete calibration counts. 7 (sc-18099): `cells` is the planned-or-evidenced SUBSET of the catalog cross-product rather than the cross-product itself; `coverage`, `models[].axes` and `manifestScopes` added and required; `summary` gained publishedCells/elidedCells/elidedByState/publicationPredicate; `modelSlices` entries may be empty; `rung4SurveyRows` absorbed the family-level summary/blockStacks/findings that `cells[].rung4Survey` no longer carries; `cells[].evidence` replaced declaredCalibration/loadability with a `manifestScope` key into `manifestScopes`; `calibrationRuns[].record` is a projection of the evidence-bundle row. 8 (sc-18815): the model universe is MODALITY-AWARE rather than `type === \"image\"`. `summary.imageModels` was REMOVED and replaced by `catalogEntries` + `catalogEntriesByModality` \u2014 not additive, because a reader indexing `imageModels` now gets `undefined` rather than a wrong number, which is the point; `models[]` gained required `modality` and `resolvedRoutes` and its count moved 53 -> 63; `models[].backends` and `owningModelStories` may be EMPTY (an entry the routing catalog routes nowhere); `cells[].owningModelStory` may be `null` (video cells have no per-entry owner); `cells[].rung4Survey` gained a required `surveyed` discriminator and its three verdict fields became nullable; `rung4SurveyRows[].familyStory` may be a family NAME rather than a story id; `summary` gained `unroutedEntries`, `videoMlxStagedStaticCoverage`(+`Denominator`) and `rung4Survey.pendingFamilyBackends`. 9 (sc-21715): `summary.calibrationRunsByStatus` PARTITIONS the evidence bundle rather than counting two of its statuses — it gained required `gated` and `negativeComplete` keys, so its values sum to `summary.calibrationRuns` (which has always counted every record, whatever its status) by construction. A version-8 reader that took `complete + runtimeComplete` as the bundle size is wrong the moment a non-certifying receipt is admitted.",
+      "const": 9
     },
     "generatedFrom": {
       "type": "object"
@@ -550,6 +550,7 @@
         "videoMlxStagedStaticCoverage",
         "videoMlxStagedStaticCoverageDenominator",
         "fullModels",
+        "calibrationRuns",
         "calibrationRunsByStatus",
         "rung4Survey"
       ],
@@ -617,13 +618,21 @@
           "type": "string",
           "minLength": 1
         },
+        "calibrationRuns": {
+          "description": "sc-21715. EVERY record in docs/generated/memory-calibration-evidence.json, whatever its status — not the certifying subset. It answers \"how many receipts exist\"; the top-level `calibrationRuns.length` answers \"how many bound to a published coordinate\", and `calibrationRunsByStatus` splits this total by what each receipt certifies. The three are deliberately different numbers: a `gated` capture and an out-of-matrix receipt each move some of them and not others, and collapsing them would hide exactly that.",
+          "type": "integer",
+          "minimum": 0
+        },
         "calibrationRunsByStatus": {
+          "description": "sc-21715. A PARTITION of the evidence bundle by record status: one key per member of the bundle schema's `$defs.record.properties.status` enum, so the values sum to `calibrationRuns`. Until version 9 this held only the two certifying statuses, which equalled the bundle size only while the corpus contained nothing else.",
           "type": "object",
           "additionalProperties": false,
-          "required": ["complete", "runtimeComplete"],
+          "required": ["complete", "runtimeComplete", "gated", "negativeComplete"],
           "properties": {
             "complete": { "type": "integer", "minimum": 0 },
-            "runtimeComplete": { "type": "integer", "minimum": 0 }
+            "runtimeComplete": { "type": "integer", "minimum": 0 },
+            "gated": { "type": "integer", "minimum": 0 },
+            "negativeComplete": { "type": "integer", "minimum": 0 }
           }
         },
         "rung4Survey": {

--- a/scripts/generate-memory-matrix.mjs
+++ b/scripts/generate-memory-matrix.mjs
@@ -12,6 +12,7 @@ import { canonicalSourceText, semanticSourceBody } from "./lib/source-revision.m
 import { routedLanes } from "./check-tier-integrity.mjs";
 import {
   evidenceSemantics,
+  RECORD_STATUSES,
   validateBundle as validateCalibrationBundle,
 } from "./memory-calibration-harness.mjs";
 import {
@@ -828,6 +829,14 @@ function isTemporalVideoCell(cell, modality) {
     (Array.isArray(envelope.fps) && envelope.fps.length > 0) ||
     Number.isFinite(envelope.defaultFps)
   );
+}
+
+// sc-21715. The matrix spells keys in camelCase and the bundle spells statuses in snake_case, so the
+// tally's key set is a pure function of `RECORD_STATUSES` rather than a second list that can drift
+// from it. Deliberately NOT exported: the sc-17774 test re-derives these keys itself, and a shared
+// helper would let a wrong mapping agree with itself on both sides.
+function calibrationStatusKey(status) {
+  return status.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
 }
 
 export function calibrationBinding(
@@ -5020,6 +5029,30 @@ export async function buildMatrix({ sourceOverrides = {}, cellFilter = null, pub
     );
   const mlxStagedModels = stagedByModality("image");
   const mlxStagedVideoModels = stagedByModality("video");
+  // sc-21715. The status tally PARTITIONS the bundle: one key per member of `RECORD_STATUSES`, which
+  // is read from the bundle schema, so a status added there appears here rather than falling outside
+  // every published count. Before this it was a hand-written pair (`complete`, `runtimeComplete`) and
+  // `summary.calibrationRuns` was `records.length`, which are the same number only while the corpus
+  // happens to hold nothing else — true for all 108 shipped records and false the moment a `gated`
+  // capture is admitted (the sc-11045 five-rung is exactly that, held outside the bundle for this
+  // reason). The two counts disagreed silently; now the parts sum to the whole by construction and
+  // the assertion below fails generation if they ever do not.
+  const calibrationRunsByStatus = Object.fromEntries(
+    RECORD_STATUSES.map((status) => [
+      calibrationStatusKey(status),
+      calibrationBundle.records.filter((record) => record.status === status).length,
+    ]),
+  );
+  const talliedCalibrationRuns = Object.values(calibrationRunsByStatus).reduce(
+    (total, count) => total + count,
+    0,
+  );
+  if (talliedCalibrationRuns !== calibrationBundle.records.length) {
+    throw new Error(
+      `calibrationRunsByStatus does not partition the bundle: tallied ${talliedCalibrationRuns} of ` +
+        `${calibrationBundle.records.length} records`,
+    );
+  }
   const matrix = {
     // 2 (SC-15812): `models[].owningFamilyStory`/`owningModelStory` were both RENAMED (now plural)
     // and RETYPED (integer -> backend->id object). A reader written against 1 gets `undefined` for
@@ -5069,7 +5102,13 @@ export async function buildMatrix({ sourceOverrides = {}, cellFilter = null, pub
     // `videoMlxStagedStaticCoverage`(+Denominator) and `rung4Survey.pendingFamilyBackends`. A
     // version-7 reader that took `owningModelStory` as an integer, or `imageModels` as the entry
     // count, is wrong on both — hence a version, not an additive bump.
-    schemaVersion: 8,
+    //
+    // 9 (sc-21715): `summary.calibrationRunsByStatus` PARTITIONS the bundle instead of counting two
+    // of its statuses. It gained required `gated` and `negativeComplete` keys, so its values now sum
+    // to `summary.calibrationRuns` (which has always counted every record) by construction. A
+    // version-8 reader that took `complete + runtimeComplete` as the bundle size is wrong as soon as
+    // a non-certifying receipt is admitted — the disagreement this version exists to end.
+    schemaVersion: 9,
     generatedFrom: {
       sceneWorksRevision,
       inferenceRevision: pin,
@@ -5195,13 +5234,13 @@ export async function buildMatrix({ sourceOverrides = {}, cellFilter = null, pub
         .map(([id, entry]) => ({ id, ...entry }))
         .sort((left, right) => left.id.localeCompare(right.id)),
       fullModels: 0,
+      // sc-21715: EVERY record in the evidence bundle, whatever its status — not the certifying
+      // subset. It answers "how many receipts exist", and `matrix.calibrationRuns.length` answers
+      // "how many bound to a published coordinate"; `calibrationRunsByStatus` splits this total into
+      // what each receipt certifies. A `gated` or `negative_complete` receipt is therefore counted
+      // here and named there, never invisible in both.
       calibrationRuns: calibrationBundle.records.length,
-      calibrationRunsByStatus: {
-        complete: calibrationBundle.records.filter((record) => record.status === "complete").length,
-        runtimeComplete: calibrationBundle.records.filter(
-          (record) => record.status === "runtime_complete",
-        ).length,
-      },
+      calibrationRunsByStatus,
       currentCalibrationRuns: cells.reduce(
         (count, cell) => count + cell.evidence.currentEnvironmentVerification.length,
         0,
@@ -5325,8 +5364,13 @@ export function renderMarkdown(matrix) {
     })`,
     `- MLX staged-residency static coverage: image ${matrix.summary.mlxStagedStaticCoverage}/${matrix.summary.mlxStagedStaticCoverageDenominator}, video ${matrix.summary.videoMlxStagedStaticCoverage}/${matrix.summary.videoMlxStagedStaticCoverageDenominator}`,
     `- Full models: ${matrix.summary.fullModels}`,
+    `- Calibration records in the evidence bundle: ${matrix.summary.calibrationRuns}`,
     `- Full complete calibration records: ${matrix.summary.calibrationRunsByStatus.complete}`,
     `- Base-only runtime-complete calibration records: ${matrix.summary.calibrationRunsByStatus.runtimeComplete}`,
+    // sc-21715: rendered even at zero. A gated capture that certifies nothing is still a capture that
+    // happened, and a line that only appears once the count moves cannot be read as "none yet".
+    `- Gated calibration records (captured, certifying nothing): ${matrix.summary.calibrationRunsByStatus.gated}`,
+    `- Negative-complete calibration records: ${matrix.summary.calibrationRunsByStatus.negativeComplete}`,
     "",
     `sc-18099: \`cells\` is a SUBSET. ${matrix.summary.publicationPredicate} The counts on this page, \`summary\`, and the per-(entry, backend, rung) \`coverage\` census in the JSON artifact are all derived from every resolved coordinate, published or not, and \`models[].axes\` publishes the axes those coordinates span so an unmeasured lane stays distinguishable from an absent one.`,
     "",

--- a/scripts/generate-memory-matrix.test.mjs
+++ b/scripts/generate-memory-matrix.test.mjs
@@ -62,7 +62,7 @@ import {
   stagedResidencyIsAvailable,
   strategyStatus,
 } from "./generate-memory-matrix.mjs";
-import { logicalCaseId, recordId } from "./memory-calibration-harness.mjs";
+import { logicalCaseId, RECORD_STATUSES, recordId } from "./memory-calibration-harness.mjs";
 import { recordsNeedingDigest } from "./backfill-closure-digests.mjs";
 import { stripJsoncComments } from "./lib/jsonc.mjs";
 import { stripInertLines } from "./lib/source-revision.mjs";
@@ -478,7 +478,7 @@ test("provenance is stamped once on the document, never per row", async () => {
   // sc-16268: the per-row copy was one constant repeated ~7,360 times, which turned every
   // fingerprint rotation into a ~14,700-line rewrite of a file that can only be regenerated.
   const matrix = await buildMatrix({ publish: false });
-  assert.equal(matrix.schemaVersion, 8);
+  assert.equal(matrix.schemaVersion, 9);
   assert.match(matrix.generatedFrom.sceneWorksRevision, /^source-tree:[0-9a-f]{64}$/);
   assert.ok(matrix.cells.length > 1000);
   assert.equal(
@@ -4960,13 +4960,29 @@ test("the published summary re-derives from the evidence bundle and the closure 
     await readFile(new URL("config/inference-provider-closures.json", root)),
   );
 
-  const tally = { complete: 0, runtimeComplete: 0 };
+  // sc-21715. Recomputed over EVERY status the bundle schema admits, not over a transcribed pair.
+  // This assertion used to read `complete + runtimeComplete` and agreed with the writer's
+  // `records.length` only because the corpus had never held anything else; the first `gated` receipt
+  // — the sc-11045 five-rung, kept outside the bundle for exactly this reason — made the two
+  // disagree. The keys are derived here rather than imported from the generator so a wrong
+  // snake_case -> camelCase mapping cannot agree with itself on both sides.
+  const statusKey = (status) => status.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+  const tally = Object.fromEntries(RECORD_STATUSES.map((status) => [statusKey(status), 0]));
   for (const record of evidence.records) {
-    if (record.status === "complete") tally.complete += 1;
-    if (record.status === "runtime_complete") tally.runtimeComplete += 1;
+    assert.ok(
+      Object.hasOwn(tally, statusKey(record.status)),
+      `${record.id}: status ${record.status} is outside the schema's status enum`,
+    );
+    tally[statusKey(record.status)] += 1;
   }
   assert.deepEqual(matrix.summary.calibrationRunsByStatus, tally);
-  assert.equal(matrix.summary.calibrationRuns, tally.complete + tally.runtimeComplete);
+  // The whole is the bundle, and the parts partition it. Asserting BOTH is the point: either alone
+  // is satisfied by a writer that drops a non-certifying receipt from one of the two numbers.
+  assert.equal(matrix.summary.calibrationRuns, evidence.records.length);
+  assert.equal(
+    Object.values(tally).reduce((total, count) => total + count, 0),
+    matrix.summary.calibrationRuns,
+  );
 
   // `binding.eligible` is the generator's own coordinate match; everything else here is recomputed.
   const eligibleByRecord = new Map(
@@ -5322,6 +5338,78 @@ test("MiniMax-H3 has one legal measured-spanning grid per implemented tier/rung 
     /declares engaged rungs/,
     "the generator must reject an impossible declared engaged rung before terminal capture",
   );
+});
+
+test("a gated receipt keeps the summary and its recomputation in agreement (sc-21715)", async () => {
+  // The regression this story owns. `summary.calibrationRuns` counts the BUNDLE and
+  // `calibrationRunsByStatus` partitions it; before sc-21715 the tally named only the two certifying
+  // statuses, so the first non-certifying receipt made the writer say N while the sc-17774
+  // recomputation said N-1. Synthetic rather than the shipped sc-11045 five-rung capture, so the
+  // proof does not depend on that evidence file still being in the tree — and so it survives the
+  // capture being promoted.
+  const bundle = JSON.parse(
+    await readFile(new URL("../docs/generated/memory-calibration-evidence.json", import.meta.url), "utf8"),
+  );
+  const donor = bundle.records.find(
+    (record) => record.status === "complete" && record.sourceProvenance === undefined,
+  );
+  assert.ok(donor, "the shipped bundle must carry a plain complete record to re-status");
+  // `status` is deliberately OUTSIDE `recordId`'s identity, so flipping it alone would collide with
+  // the donor's id. Perturb `hardware`, which is in the identity and which `calibrationBinding` never
+  // reads: the clone keeps the donor's coordinate and still binds.
+  const gated = JSON.parse(JSON.stringify(donor));
+  gated.status = "gated";
+  gated.hardware = { ...gated.hardware, osVersion: `${gated.hardware.osVersion}-sc21715` };
+  gated.logicalCaseId = logicalCaseId(gated);
+  gated.id = recordId(gated);
+  assert.notEqual(gated.id, donor.id, "the synthetic receipt must be a distinct record");
+
+  const withGated = JSON.parse(JSON.stringify(bundle));
+  withGated.records.push(gated);
+  const matrix = await buildMatrix({
+    publish: false,
+    sourceOverrides: { calibrationEvidence: JSON.stringify(withGated) },
+  });
+  const baseline = await buildMatrix({ publish: false });
+  assert.equal(
+    baseline.summary.calibrationRunsByStatus.gated,
+    0,
+    "the shipped corpus must still be gated-free, or this proves nothing about the first one",
+  );
+
+  // Exactly the two assertions the sc-17774 test makes, against a corpus that now holds a receipt
+  // certifying nothing.
+  const statusKey = (status) => status.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+  const tally = Object.fromEntries(RECORD_STATUSES.map((status) => [statusKey(status), 0]));
+  for (const record of withGated.records) tally[statusKey(record.status)] += 1;
+  assert.deepEqual(matrix.summary.calibrationRunsByStatus, tally);
+  assert.equal(matrix.summary.calibrationRuns, withGated.records.length);
+  assert.equal(
+    Object.values(tally).reduce((total, count) => total + count, 0),
+    matrix.summary.calibrationRuns,
+  );
+
+  // ...and the receipt is NAMED, not merely counted. `gated` moves by one while both certifying
+  // buckets stand still, so the extra record can never be read as a new certifying run — which a
+  // fix that only corrected the total would have left indistinguishable.
+  assert.equal(matrix.summary.calibrationRunsByStatus.gated, 1);
+  assert.equal(
+    matrix.summary.calibrationRunsByStatus.complete,
+    baseline.summary.calibrationRunsByStatus.complete,
+  );
+  assert.equal(
+    matrix.summary.calibrationRunsByStatus.runtimeComplete,
+    baseline.summary.calibrationRunsByStatus.runtimeComplete,
+  );
+
+  // The receipt binds to a coordinate and certifies nothing there: that ineligibility is what keeps
+  // `currentCalibrationRuns` from moving, and it is the property the counts above must not obscure.
+  const bound = matrix.calibrationRuns.find((run) => run.record.id === gated.id);
+  assert.ok(bound, "a gated receipt still binds to its coordinate");
+  assert.equal(bound.semantics, "gated");
+  assert.equal(bound.binding.eligible, false);
+  assert.ok(bound.binding.reasons.includes("record-not-complete"));
+  assert.equal(matrix.summary.currentCalibrationRuns, baseline.summary.currentCalibrationRuns);
 });
 
 test("an out-of-matrix family's RECEIPT is unbound rather than fatal (sc-18663)", async () => {

--- a/scripts/generate-memory-matrix.test.mjs
+++ b/scripts/generate-memory-matrix.test.mjs
@@ -3770,6 +3770,32 @@ test("a survey edit rotates the source fingerprint", async () => {
   assert.equal(edited.generatedFrom.sources.rung4Survey.path, SOURCE_PATHS.rung4Survey);
 });
 
+test("the published status tally's key set is the bundle schema's status enum (sc-21715)", async () => {
+  // The generator derives `summary.calibrationRunsByStatus` from `RECORD_STATUSES`, so a status
+  // added to the bundle schema appears in the object automatically — but the matrix schema pins the
+  // key set with `additionalProperties: false` and a fixed `required`, so the artifact would then
+  // fail validation with an opaque "additional properties not allowed". Connecting the two is what
+  // turns that into a legible failure here, the same way the rung-4 vocabularies are connected
+  // below. Both `required` and `properties` are checked: either alone would let a key be admitted
+  // and not demanded, or demanded and not admitted.
+  const schema = JSON.parse(
+    await readFile(new URL("../packages/schemas/memory-matrix.schema.json", import.meta.url), "utf8"),
+  );
+  const tally = schema.properties.summary.properties.calibrationRunsByStatus;
+  const expected = RECORD_STATUSES.map((status) =>
+    status.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase()),
+  );
+  assert.deepEqual([...tally.required].sort(), [...expected].sort());
+  assert.deepEqual(Object.keys(tally.properties).sort(), [...expected].sort());
+  assert.equal(tally.additionalProperties, false);
+  // ...and the artifact carries exactly that key set, so the schema and the writer cannot agree
+  // with each other while the shipped document holds something else.
+  const matrix = JSON.parse(
+    await readFile(new URL("../docs/generated/memory-matrix.json", import.meta.url), "utf8"),
+  );
+  assert.deepEqual(Object.keys(matrix.summary.calibrationRunsByStatus).sort(), [...expected].sort());
+});
+
 test("the survey vocabulary, the generator's enums and the published schema agree", async () => {
   // Three copies of the same vocabulary — the survey file documents it, the generator validates
   // against it, the schema constrains the artifact. Nothing connected them, so a value added to one
@@ -5407,8 +5433,16 @@ test("a gated receipt keeps the summary and its recomputation in agreement (sc-2
   const bound = matrix.calibrationRuns.find((run) => run.record.id === gated.id);
   assert.ok(bound, "a gated receipt still binds to its coordinate");
   assert.equal(bound.semantics, "gated");
+  // The donor binds ELIGIBLY, and the clone differs from it only in `status` (plus the `hardware`
+  // perturbation that rotates the id). Pinning the donor's empty reason set and the clone's exact
+  // one-reason set is what makes `gated` the cause: an already-ineligible donor would satisfy
+  // `eligible === false` while proving nothing, which is the drift a `.includes()` cannot see.
+  const donorBound = matrix.calibrationRuns.find((run) => run.record.id === donor.id);
+  assert.ok(donorBound, "the donor must still bind");
+  assert.deepEqual(donorBound.binding.reasons, []);
+  assert.equal(donorBound.binding.eligible, true);
   assert.equal(bound.binding.eligible, false);
-  assert.ok(bound.binding.reasons.includes("record-not-complete"));
+  assert.deepEqual(bound.binding.reasons, ["record-not-complete"]);
   assert.equal(matrix.summary.currentCalibrationRuns, baseline.summary.currentCalibrationRuns);
 });
 

--- a/scripts/memory-calibration-harness.mjs
+++ b/scripts/memory-calibration-harness.mjs
@@ -726,7 +726,9 @@ export function validateRecord(record) {
   object(record, "record");
   text(record.id, "record.id");
   text(record.logicalCaseId, `${record.id}.logicalCaseId`);
-  if (!["complete", "runtime_complete", "gated", "negative_complete"].includes(record.status)) {
+  // sc-21715: read from the schema (`RECORD_STATUSES`) rather than transcribed, so this check and
+  // every downstream tally admit exactly the same set.
+  if (!RECORD_STATUSES.includes(record.status)) {
     fail(`${record.id}: invalid status`);
   }
   if (!["authoritative", "candidate", "fixture"].includes(record.evidenceScope)) {

--- a/scripts/memory-calibration-harness.mjs
+++ b/scripts/memory-calibration-harness.mjs
@@ -18,6 +18,10 @@ export const HARNESS_VERSION = "sceneworks-memory-v5";
 // sc-18864 bumped the RECORD SHAPE (per-phase `deviceBytes`/`wiredBytes` removed) without changing
 // the measuring instrument, so the bundle schema version moves and the harness version does not.
 export const SCHEMA_VERSION = 5;
+// sc-21715: the record-status universe, READ from the bundle schema rather than transcribed here, so
+// a status added there cannot leave a downstream tally silently partial. Every consumer that
+// partitions a bundle by status (`summary.calibrationRunsByStatus`) derives its keys from this list.
+export const RECORD_STATUSES = Object.freeze([...CALIBRATION_SCHEMA.$defs.record.properties.status.enum]);
 export const REQUIRED_SCENARIOS = [
   "exact_fit", "unknown_budget", "stale_evidence", "warm_repeat",
   "cancel", "error", "loadability", "overlay",

--- a/tests/test_memory_matrix.py
+++ b/tests/test_memory_matrix.py
@@ -306,26 +306,38 @@ def test_calibration_evidence_is_schema_valid_and_matrix_ingested():
     assert all(re.fullmatch(r"imc-[0-9a-f]{20}", record_id) for record_id in evidence_ids)
     evidence_by_id = {record["id"]: record for record in calibration["records"]}
     records_by_status = Counter(record["status"] for record in calibration["records"])
-    # The bundle carries exactly two statuses. A third would slip straight past every partition below,
-    # which is the defect this owns — not the size of either population. Those sizes have only ever
-    # grown (complete 33 -> 50 -> 52 -> 65 -> 70 across sc-16915 / SC-18237 / SC-18353 / SC-19753;
-    # runtime_complete 15 -> 19 at SC-18218), and renewing the pair each time re-froze the corpus
-    # without ever asserting a property. Both populations must be non-empty and must partition the
-    # bundle exactly; everything downstream is then derived from `records_by_status` rather than from a
-    # second transcription of it, so the matrix and the bundle cannot disagree.
-    assert set(records_by_status) == {"complete", "runtime_complete"}
-    assert all(count > 0 for count in records_by_status.values())
+    # Population SIZES are never pinned here: they have only ever grown (complete 33 -> 50 -> 52 -> 65
+    # -> 70 across sc-16915 / SC-18237 / SC-18353 / SC-19753; runtime_complete 15 -> 19 at SC-18218)
+    # and renewing the pair each time re-froze the corpus without ever asserting a property.
+    # Everything downstream is derived from `records_by_status` rather than from a second
+    # transcription of it, so the matrix and the bundle cannot disagree.
+    #
+    # sc-21715: this used to read `set(records_by_status) == {"complete", "runtime_complete"}`,
+    # because a third status DID slip past every partition below — `calibrationRunsByStatus` named
+    # only those two while `summary.calibrationRuns` counted the whole bundle. The tally now
+    # partitions the bundle over the schema's full status enum, so the corpus no longer has to be
+    # held two-status to keep the derived counts honest. What must still hold is that no record
+    # carries a status the schema does not admit, and that both certifying populations are non-empty.
+    record_statuses = calibration_schema["$defs"]["record"]["properties"]["status"]["enum"]
+    assert set(records_by_status) <= set(record_statuses)
+    assert records_by_status["complete"] > 0
+    assert records_by_status["runtime_complete"] > 0
     assert len(evidence_ids) == len(calibration["records"]) == sum(
         records_by_status.values()
     )
     assert {run["record"]["id"] for run in matrix["calibrationRuns"]} == evidence_ids
     runs_by_status = Counter(run["record"]["status"] for run in matrix["calibrationRuns"])
     assert runs_by_status == records_by_status
-    assert matrix["summary"]["calibrationRuns"] == sum(runs_by_status.values())
+    assert matrix["summary"]["calibrationRuns"] == len(calibration["records"])
+    # A key per admitted status, zeros included, summing to the total above — derived from the enum
+    # so a status added to the schema reds here instead of quietly falling outside the tally.
     assert matrix["summary"]["calibrationRunsByStatus"] == {
-        "complete": records_by_status["complete"],
-        "runtimeComplete": records_by_status["runtime_complete"],
+        re.sub(r"_([a-z])", lambda m: m.group(1).upper(), status): records_by_status[status]
+        for status in record_statuses
     }
+    assert sum(matrix["summary"]["calibrationRunsByStatus"].values()) == matrix["summary"][
+        "calibrationRuns"
+    ]
 
     # `current` vs `historical` is decided against the shipped inference pin plus exact audited
     # compatibility. SC-15833 certifies the Candle FLUX.2 closure across an exact window -- captured


### PR DESCRIPTION
Closes [sc-21715](https://app.shortcut.com/trefry/story/21715) (epic [21713](https://app.shortcut.com/trefry/epic/21713)).

## The defect

`summary.calibrationRuns` is `calibrationBundle.records.length`, while the sc-17774 summary test recomputed the same number as `complete + runtimeComplete`. Both read 108 today — and only because every record the bundle has ever held was `complete` or `runtime_complete`. The bundle schema admits four statuses. Reproduced before changing anything: ingesting the five `gated` records of the sc-11045 five-rung capture (held outside the bundle for exactly this reason) gives writer 113, test 108.

## The semantic, decided

`summary.calibrationRuns` counts **every record in the bundle, whatever its status**. It answers "how many receipts exist"; the top-level `calibrationRuns[]` array answers "how many bound to a published coordinate" (it skips out-of-matrix receipts, sc-18663); `calibrationRunsByStatus` splits the total by what each receipt certifies. Documented at the field in both the generator and `packages/schemas/memory-matrix.schema.json`.

`calibrationRunsByStatus` is now a **partition** rather than a hand-written pair: one key per member of the bundle schema's status enum (`complete`, `runtimeComplete`, `gated`, `negativeComplete`), derived from that enum via a new `RECORD_STATUSES` export so it cannot drift from it. Generation throws if the parts do not sum to the whole.

Matrix `schemaVersion` 8 -> 9: two new required keys under `summary.calibrationRunsByStatus`, and `summary.calibrationRuns` documented and required for the first time. No other consumer reads either — the Rust `include_str!` of the matrix takes only `models[]`.

## The two-status assumption elsewhere

The same corpus identity survived in `sceneworks-core`'s `packaged_bundle_uses_the_current_schema_...` (`records.len() == complete + runtime_complete`) and in `tests/test_memory_matrix.py` (`set(records_by_status) == {"complete", "runtime_complete"}`). Both are now partitions over the full status set, so admitting a gated receipt no longer reds a lane with nothing actually wrong. Every other `["complete", "runtime_complete"]` site in the repo is a certifying-subset **predicate** — correct as written, deliberately left alone.

## Tests

- new: a synthetic `gated` receipt is ingested and writer + recomputation still agree; `gated` moves by one while both certifying buckets stand still; the receipt still binds, ineligibly, with the donor's empty reason set and the clone's exact `["record-not-complete"]` pinned so `gated` is provably the cause.
- new: the matrix schema's tally key set (required, properties, and the shipped artifact's keys) is tied to the bundle schema's status enum.
- changed: the sc-17774 test recomputes over the full enum, asserts the total against `records.length`, and asserts the partition sums to it. Keys derived locally rather than imported, so a wrong mapping cannot agree with itself on both sides.

Mutation-checked, each run: non-exhaustive tally -> generator's partition guard fires; `calibrationRuns` counting only certifying records -> 108 != 109; committed artifact losing its `gated` key -> sc-17774 deep-equal reds; schema `required` losing `negativeComplete` -> key-set test reds; `gated` made eligible in `calibrationBinding` -> regression test reds; the old Rust identity with a gated record present -> 109 vs 108.

## Verification

- `node --test scripts/generate-memory-matrix.test.mjs` 125/125
- `node --test scripts/memory-calibration-harness.test.mjs` 62/62
- `python -m pytest tests/test_memory_matrix.py -q` 9 passed
- `cargo test -p sceneworks-core --lib memory_calibration::` 18 passed; `cargo clippy -p sceneworks-core --all-targets` clean; `cargo fmt --all -- --check` clean
- `npm run check:memory-matrix` clean (committed artifacts match the committed generator)
- `npm run check` repo-wide: only the 42 pre-existing Windows failures in `memory-calibration-watchdog` / `run-ltx-safety-canary` / `epic-20738-terminal-cuda-harness` (`socket.AF_UNIX`, `/bin/sh` ENOENT, POSIX file modes)

`docs/krea-candle-memory-ladder-sc-11045.md`'s deferred-defect note now points here and records the post-fix ingest numbers, re-measured: `{complete: 85, runtimeComplete: 23, gated: 5, negativeComplete: 0}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)