### PR TITLE
feat(assets): OpenEXR preview and download for HDR renders (sc-18790)

### DIFF
--- a/apps/web/src/assetBatch.jsx
+++ b/apps/web/src/assetBatch.jsx
@@ -9,7 +9,7 @@ import {
 import { terminalStatuses } from "./constants.js";
 import { upscaledFromAssetId } from "./assetVariants.js";
 import { assetSupportsCharacterLink } from "./components/assetPanels.jsx";
-import { assetUrl } from "./components/assetMedia.jsx";
+import { assetIsHdrSource, assetNativeSize, assetUrl } from "./components/assetMedia.jsx";
 import { BatchOperationsPanel } from "./components/BatchOperationsPanel.jsx";
 import { Modal } from "./components/Modal.jsx";
 import { useAppContextOptional } from "./context/AppContext.js";
@@ -124,6 +124,19 @@ export function useAssetBatch() {
   // Decode an asset's native pixel size (needed for an edit job — the worker fits the
   // source to width×height). Resolves null on a load failure so that item fails alone.
   function loadImageDims(asset) {
+    // The server records the native size at import (including for OpenEXR, which `imagesize`
+    // reads from the header) — prefer it. Decoding is the fallback for assets that predate it.
+    const recorded = assetNativeSize(asset);
+    if (recorded) {
+      return Promise.resolve(recorded);
+    }
+    // An HDR source cannot be decoded here at all: no browser reads OpenEXR, and the paintable
+    // derivative is bounded to 384px, so reading ITS naturalWidth would size the edit job from a
+    // thumbnail. Resolving null surfaces the per-item "could not read dimensions" error instead of
+    // silently submitting a downscaled job.
+    if (assetIsHdrSource(asset)) {
+      return Promise.resolve(null);
+    }
     return new Promise((resolve) => {
       const img = new Image();
       img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });

--- a/apps/web/src/components/assetMedia.hdr.test.jsx
+++ b/apps/web/src/components/assetMedia.hdr.test.jsx
@@ -13,6 +13,7 @@ import {
   AssetMedia,
   assetDisplayUrl,
   assetIsHdrSource,
+  assetNativeSize,
   assetUrl,
 } from "./assetMedia.jsx";
 
@@ -89,5 +90,22 @@ describe("HDR (OpenEXR) asset media", () => {
     expect(img).not.toBeNull();
     expect(img.getAttribute("src")).not.toContain("thumbnail=");
     expect(img.getAttribute("title")).toBeNull();
+  });
+});
+
+describe("HDR native dimensions", () => {
+  it("prefers the server-recorded size over decoding a bounded derivative", () => {
+    // The derivative is capped at 384px, so reading ITS naturalWidth would size an edit job from a
+    // thumbnail. The recorded value is the only correct source for a format the browser cannot
+    // decode at all.
+    expect(
+      assetNativeSize({ file: { path: "a.exr", mimeType: "image/x-exr", width: 1920, height: 1080 } }),
+    ).toEqual({ width: 1920, height: 1080 });
+  });
+
+  it("returns null when no size was recorded, rather than inventing one", () => {
+    expect(assetNativeSize(exrAsset)).toBeNull();
+    expect(assetNativeSize({ file: { width: 0, height: 0 } })).toBeNull();
+    expect(assetNativeSize(null)).toBeNull();
   });
 });

--- a/apps/web/src/components/assetMedia.hdr.test.jsx
+++ b/apps/web/src/components/assetMedia.hdr.test.jsx
@@ -1,0 +1,93 @@
+// sc-18790: OpenEXR assets are stills the browser cannot decode.
+//
+// The two properties that matter, and the reason they are separate:
+//   1. PREVIEW paints the server's tone-mapped derivative, because an <img> pointed at a
+//      scene-linear float EXR renders nothing in any browser.
+//   2. DOWNLOAD is untouched — assetUrl() still resolves to the original bytes. If preview and
+//      download ever collapsed onto one URL, the user would silently receive a tone-mapped 8-bit
+//      proxy in place of the grading asset, which is the whole failure this story exists to avoid.
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  AssetMedia,
+  assetDisplayUrl,
+  assetIsHdrSource,
+  assetUrl,
+} from "./assetMedia.jsx";
+
+const exrAsset = {
+  id: "hdr",
+  type: "image",
+  displayName: "frame_00000.exr",
+  file: { path: "assets/frame_00000.exr", mimeType: "image/x-exr" },
+  projectId: "p1",
+};
+
+const pngAsset = {
+  id: "sdr",
+  type: "image",
+  displayName: "one.png",
+  file: { path: "assets/one.png", mimeType: "image/png" },
+  projectId: "p1",
+};
+
+let container = null;
+
+function render(element) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => root.render(element));
+  return container;
+}
+
+afterEach(() => {
+  if (container) {
+    container.remove();
+    container = null;
+  }
+});
+
+describe("HDR (OpenEXR) asset media", () => {
+  it("recognizes an EXR by mime and by path, and nothing else", () => {
+    expect(assetIsHdrSource(exrAsset)).toBe(true);
+    // A stored asset whose mime was never recorded still resolves by extension.
+    expect(
+      assetIsHdrSource({ file: { path: "assets/plate.EXR" }, projectId: "p1" }),
+    ).toBe(true);
+    expect(assetIsHdrSource(pngAsset)).toBe(false);
+    expect(assetIsHdrSource(null)).toBe(false);
+  });
+
+  it("routes preview to the derivative while download keeps the original bytes", () => {
+    const display = assetDisplayUrl(exrAsset);
+    const download = assetUrl(exrAsset);
+
+    expect(display).toContain("thumbnail=");
+    expect(display).not.toBe(download);
+    // The download URL must still address the stored .exr itself — never the derivative.
+    expect(download).toContain("frame_00000.exr");
+    expect(download).not.toContain("thumbnail=");
+
+    // An ordinary image is unaffected: preview and download are the same original URL, so this
+    // change cannot have quietly rerouted every still through the thumbnail cache.
+    expect(assetDisplayUrl(pngAsset)).toBe(assetUrl(pngAsset));
+  });
+
+  it("paints the derivative and labels the preview as a proxy", () => {
+    const root = render(<AssetMedia asset={exrAsset} />);
+    const img = root.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img.getAttribute("src")).toContain("thumbnail=");
+    expect(img.getAttribute("title")).toMatch(/HDR source/i);
+  });
+
+  it("leaves an ordinary image untouched", () => {
+    const root = render(<AssetMedia asset={pngAsset} />);
+    const img = root.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img.getAttribute("src")).not.toContain("thumbnail=");
+    expect(img.getAttribute("title")).toBeNull();
+  });
+});

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -61,6 +61,30 @@ export function assetCanRenderAsVideo(asset) {
   return asset?.type === "video" || asset?.file?.mimeType?.startsWith("video/");
 }
 
+// Scene-linear HDR stills (OpenEXR, sc-18790). These ARE images — the mime starts with `image/`,
+// so assetCanRenderAsImage is true and every picker/grid treats them as stills — but no browser
+// decodes OpenEXR, so an <img> pointed at the stored file paints nothing.
+//
+// The stored bytes stay the deliverable (download must hand back the original float frame), so the
+// UI shows the server's tone-mapped PNG derivative instead and labels it as a proxy. That is why
+// this predicate exists separately from assetCanRenderAsImage: the two answer different questions —
+// "is this a still?" versus "can the browser paint the stored bytes?".
+export function assetIsHdrSource(asset) {
+  if (asset?.file?.mimeType === "image/x-exr") {
+    return true;
+  }
+  const path = asset?.file?.path ?? asset?.url ?? "";
+  return typeof path === "string" && path.toLowerCase().endsWith(".exr");
+}
+
+// URL to PAINT an asset with. Identical to assetUrl() for everything the browser can decode; for an
+// HDR source it is the server-rendered derivative, since the original would render as a broken
+// image. Never use this for downloads — assetUrl() is the original bytes, and for an EXR that
+// distinction is the whole point.
+export function assetDisplayUrl(asset) {
+  return assetIsHdrSource(asset) ? thumbnailUrl(asset) : assetUrl(asset);
+}
+
 // Audio outputs (SceneWorks Audio Studio, epic 13400 A5). A `type:"audio"` asset
 // (or any file whose mimeType is audio/*) is playable via an <audio> element —
 // there is no poster/thumbnail frame, so the shared results zone renders a
@@ -259,7 +283,20 @@ export const AssetMedia = React.forwardRef(function AssetMedia({ asset, classNam
     );
   }
   if (assetCanRenderAsImage(asset)) {
-    return <img alt="" className={className} ref={ref} src={src} />;
+    // An HDR source paints the server's tone-mapped derivative — no browser decodes OpenEXR, so
+    // `src` (the original float frame) would render as a broken image. The title says so, because
+    // a silently tone-mapped preview of a grading asset is a claim about the pixels that is not
+    // true. Download still hands back the original: it goes through assetUrl(), not this.
+    const hdr = assetIsHdrSource(asset);
+    return (
+      <img
+        alt=""
+        className={className}
+        ref={ref}
+        src={hdr ? assetDisplayUrl(asset) : src}
+        title={hdr ? "HDR source (OpenEXR) — preview is a tone-mapped proxy; download is the original scene-linear frame" : undefined}
+      />
+    );
   }
   return <span className={className}>{asset.type}</span>;
 });

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -85,6 +85,19 @@ export function assetDisplayUrl(asset) {
   return assetIsHdrSource(asset) ? thumbnailUrl(asset) : assetUrl(asset);
 }
 
+// Native pixel size as the SERVER recorded it, or null.
+//
+// Deliberately not "decode the display URL and read naturalWidth". For an HDR source the display
+// URL is the bounded 384px derivative: its aspect ratio is right but its absolute size is not, so
+// a consumer that needs true dimensions — an edit job sizes its output from them — would silently
+// submit a downscaled job. The server sizes EXR from the file header at import (`imagesize`
+// handles OpenEXR), so the recorded value is both authoritative and free.
+export function assetNativeSize(asset) {
+  const width = Number(asset?.file?.width);
+  const height = Number(asset?.file?.height);
+  return width > 0 && height > 0 ? { width, height } : null;
+}
+
 // Audio outputs (SceneWorks Audio Studio, epic 13400 A5). A `type:"audio"` asset
 // (or any file whose mimeType is audio/*) is playable via an <audio> element —
 // there is no poster/thumbnail frame, so the shared results zone renders a

--- a/apps/web/src/hooks/useReferenceAspectSnap.js
+++ b/apps/web/src/hooks/useReferenceAspectSnap.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 
-import { assetUrl } from "../components/assetMedia.jsx";
+import { assetIsHdrSource, assetNativeSize, assetUrl } from "../components/assetMedia.jsx";
 import { probeImageDimensions } from "../imageDimensions.js";
 
 // The `snapKey` a resolution-bucket caller should pass: which model's option UNIVERSE we are in.
@@ -58,6 +58,18 @@ export function useReferenceAspectSnap({
     const asset = assets.find((item) => item.id === referenceId);
     // Mark only on a SUCCESSFUL probe: an id whose asset has not resolved yet never reaches this
     // callback, so it stays eligible and snaps on the render where the asset appears.
+    // An HDR source cannot be probed: no browser decodes OpenEXR, so an <img> pointed at it never
+    // fires `onload` and the snap silently never happens. Use the size the server recorded from
+    // the file header instead. Scoped to HDR deliberately — every other asset keeps the existing
+    // decode-and-measure path unchanged, including its timing.
+    if (assetIsHdrSource(asset)) {
+      const recorded = assetNativeSize(asset);
+      if (recorded) {
+        snapped.current = pairKey;
+        onReferenceImageLoaded(recorded.width, recorded.height);
+      }
+      return undefined;
+    }
     return probeImageDimensions(asset && assetUrl(asset), (width, height) => {
       snapped.current = pairKey;
       onReferenceImageLoaded(width, height);

--- a/apps/web/src/poseLibrary.js
+++ b/apps/web/src/poseLibrary.js
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiFetch } from "./api.js";
-import { assetUrl } from "./components/assetMedia.jsx";
+import { assetDisplayUrl } from "./components/assetMedia.jsx";
 import { useAppStatic } from "./context/AppContext.js";
 
 // The reserved global project that holds user-created pose assets (epic 2282). Mirrors
@@ -92,7 +92,8 @@ export function loadBuiltinPoses() {
 
 // Map a reserved-project type:"pose" asset into a pose record the picker understands.
 // The asset's `pose` field carries keypoints/hands/face/category; the rendered skeleton
-// preview is resolved through the shared `assetUrl` helper. Built by the DWPose detector
+// preview is resolved through the shared `assetDisplayUrl` helper (the tone-mapped
+// derivative for an HDR source, the original otherwise). Built by the DWPose detector
 // + Create tab (sc-2285/sc-2287).
 export function poseAssetToRecord(asset) {
   const pose = asset?.pose ?? {};
@@ -100,8 +101,8 @@ export function poseAssetToRecord(asset) {
   // prefix (split-origin / Vite dev), the correct /api/v1/projects/:id/files/ route,
   // and the short-lived media ticket in remote-auth mode (sc-8810/sc-8859). The raw
   // asset already carries `url` + `projectId` + `file.path` (asset_index injects `url`),
-  // which is exactly the shape assetUrl consumes; `""` when unresolvable.
-  const previewUrl = assetUrl(asset) || undefined;
+  // which is exactly the shape assetDisplayUrl consumes; `""` when unresolvable.
+  const previewUrl = assetDisplayUrl(asset) || undefined;
   return {
     id: asset.id,
     label: asset.displayName || asset.id,

--- a/apps/web/src/screens/imageEditor/ImageEditorToolPanel.jsx
+++ b/apps/web/src/screens/imageEditor/ImageEditorToolPanel.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { EditPromptTemplates } from "../../components/EditPromptTemplates.jsx";
+import { assetDisplayUrl } from "../../components/assetMedia.jsx";
 
 let renderObserverForTests = null;
 
@@ -41,7 +42,7 @@ function samePanelProps(previous, next) {
 }
 
 export const ImageEditorEditPanel = React.memo(function ImageEditorEditPanel({ scope }) {
-  const { EDIT_OUTPUT_ASPECTS, EditorLoraPanel, FitModeControl, MAX_EDIT_REFERENCES, StudioUpdateBadge, StudioUpdateNotice, aiOp, assetUrl, canMask, clearMask, createLoraDownloadJob, createModelDownloadJob, editAspect, editFitMode, editGuidance, editLora, editLoraDownloadRequested, editLoraInstalled, editLoraRequiredMissing, editLoraSelection, editModel, editModels, editPrompt, editSeed, editorPickerLoras, effectiveFitMode, guidanceDefaultFromModel, imageAssets, maskActive, maskBaseImage, maskBrush, maskErase, maskHasContent, maskLines, maskMode, maskRefineRadius, maskSubTool, multiRefCapable, refAssetIds, refineMask, requestEditLoraDownload, runEdit, selectedEditLoras, selectedEditModel, setEditAspect, setEditFitMode, setEditGuidance, setEditModel, setEditPrompt, setEditSeed, setMaskBrush, setMaskErase, setMaskMode, setMaskRefineRadius, setMaskSubTool, setRefAssetIds, setRefPickerOpen, setShowIncompatibleEditLoras, showIncompatibleEditLoras, smartSelectSupported, updateOptionLabel } = scope;
+  const { EDIT_OUTPUT_ASPECTS, EditorLoraPanel, FitModeControl, MAX_EDIT_REFERENCES, StudioUpdateBadge, StudioUpdateNotice, aiOp, canMask, clearMask, createLoraDownloadJob, createModelDownloadJob, editAspect, editFitMode, editGuidance, editLora, editLoraDownloadRequested, editLoraInstalled, editLoraRequiredMissing, editLoraSelection, editModel, editModels, editPrompt, editSeed, editorPickerLoras, effectiveFitMode, guidanceDefaultFromModel, imageAssets, maskActive, maskBaseImage, maskBrush, maskErase, maskHasContent, maskLines, maskMode, maskRefineRadius, maskSubTool, multiRefCapable, refAssetIds, refineMask, requestEditLoraDownload, runEdit, selectedEditLoras, selectedEditModel, setEditAspect, setEditFitMode, setEditGuidance, setEditModel, setEditPrompt, setEditSeed, setMaskBrush, setMaskErase, setMaskMode, setMaskRefineRadius, setMaskSubTool, setRefAssetIds, setRefPickerOpen, setShowIncompatibleEditLoras, showIncompatibleEditLoras, smartSelectSupported, updateOptionLabel } = scope;
   const renderPanel = () => {
     if (editModels.length === 0) {
       return (
@@ -307,7 +308,7 @@ export const ImageEditorEditPanel = React.memo(function ImageEditorEditPanel({ s
                 const asset = imageAssets.find((item) => item.id === id);
                 return (
                   <div className="ie-ref" key={id}>
-                    {asset ? <img alt="" src={assetUrl(asset)} /> : <span>?</span>}
+                    {asset ? <img alt="" src={assetDisplayUrl(asset)} /> : <span>?</span>}
                     <button
                       aria-label="Remove reference"
                       className="ie-ref-remove"

--- a/apps/web/src/simple/studioParts.jsx
+++ b/apps/web/src/simple/studioParts.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useRef, useState } from "react";
 import { Icon } from "../components/Icons.jsx";
-import { AssetThumbnail, assetUrl } from "../components/assetMedia.jsx";
+import { AssetThumbnail, assetDisplayUrl, assetUrl } from "../components/assetMedia.jsx";
 import { assetCanCarryWorkflow, stripWorkflowUrl } from "../assetActions.js";
 import { SAVE_WITHOUT_WORKFLOW_LABEL } from "../workflowEmbed.js";
 import { resolveJobResultAssets } from "../jobResultAssets.js";
@@ -84,7 +84,7 @@ export function ReferenceTile({ label, hint, asset, assets, onChange, required =
       options: assets.map((item) => ({
         value: item.id,
         label: item.displayName ?? item.id,
-        thumbnail: assetUrl(item),
+        thumbnail: assetDisplayUrl(item),
       })),
       onSelect: (id) => {
         onChange(id);

--- a/crates/sceneworks-core/src/media_convert.rs
+++ b/crates/sceneworks-core/src/media_convert.rs
@@ -242,6 +242,14 @@ impl std::error::Error for TranscodeError {}
 /// `ffmpeg` (resolved via `SCENEWORKS_FFMPEG`, else `ffmpeg` on PATH — the same binary the worker's
 /// video path uses).
 pub fn transcode_to_png(src: &Path, dst: &Path) -> Result<(), TranscodeError> {
+    // Scene-linear HDR needs an explicit tone-map, not a platform decoder (sc-18790). Both
+    // platform paths below merely CLIP at linear 1.0 — and they disagree about what they clip
+    // (`sips` sRGB-encodes first, ffmpeg writes near-raw linear), so the same EXR previews
+    // differently on macOS and Linux and every highlight above diffuse white collapses onto one
+    // flat value. Route it to the explicit mapper instead.
+    if sniff_image_kind_at(src).is_some_and(|kind| kind.png_transcode_is_lossy()) {
+        return transcode_hdr_to_png(src, dst);
+    }
     #[cfg(target_os = "macos")]
     {
         match run_sips_to_png(src, dst) {
@@ -259,6 +267,98 @@ pub fn transcode_to_png(src: &Path, dst: &Path) -> Result<(), TranscodeError> {
     {
         run_ffmpeg_to_png(src, dst)
     }
+}
+
+/// Reinhard tone-map an unbounded scene-linear channel into display-referred `[0, 1]`.
+///
+/// `x / (1 + x)` is monotonic over the whole positive range: it maps 0 to 0, diffuse white (1.0)
+/// to 0.5, and approaches — never reaches — 1.0. That is the property a preview needs and clipping
+/// destroys: two different super-white values stay *distinguishable* instead of both becoming 255.
+fn reinhard(x: f32) -> f32 {
+    let x = if x.is_finite() { x.max(0.0) } else { 0.0 };
+    x / (1.0 + x)
+}
+
+/// sRGB OETF (IEC 61966-2-1), linear `[0, 1]` → display-encoded `[0, 1]`.
+fn linear_to_srgb(x: f32) -> f32 {
+    let x = x.clamp(0.0, 1.0);
+    if x <= 0.0031308 {
+        x * 12.92
+    } else {
+        1.055 * x.powf(1.0 / 2.4) - 0.055
+    }
+}
+
+/// Tone-map a scene-linear HDR image to a display-referred PNG preview (sc-18790).
+///
+/// ffmpeg is used **only to decode** — every mapping decision is made here, in Rust, so the
+/// derivative is byte-identical on macOS and Linux. That is the point: the platform decoders
+/// disagree about how they flatten HDR, and a preview that differs by host is a preview you cannot
+/// reason about.
+///
+/// The pipeline is: decode to planar `f32` → per-channel Reinhard → sRGB OETF → 8-bit RGB → PNG.
+/// Per-channel (rather than luminance-based) Reinhard can desaturate a strongly-coloured highlight
+/// slightly; it is chosen because it is monotonic per channel, which is exactly what keeps
+/// super-white values apart in the output.
+pub fn transcode_hdr_to_png(src: &Path, dst: &Path) -> Result<(), TranscodeError> {
+    let (width, height) = image_dimensions(src).ok_or_else(|| {
+        TranscodeError(format!(
+            "could not read HDR image dimensions from {}",
+            src.display()
+        ))
+    })?;
+    let (w, h) = (width as usize, height as usize);
+
+    let configured = ffmpeg_program();
+    let program = resolve_ffmpeg_program(&configured);
+    let output = Command::new(program.as_ref())
+        .args(["-hide_banner", "-loglevel", "error", "-i"])
+        .arg(src)
+        .args(["-f", "rawvideo", "-pix_fmt", "gbrpf32le", "-"])
+        .output()
+        .map_err(|error| {
+            TranscodeError(format!(
+                "failed to run ffmpeg ({configured}); ensure ffmpeg is installed: {error}"
+            ))
+        })?;
+    if !output.status.success() {
+        return Err(TranscodeError(format!(
+            "ffmpeg failed to decode the HDR image: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    let plane = w * h;
+    let want = plane * 3 * 4;
+    if output.stdout.len() < want {
+        return Err(TranscodeError(format!(
+            "ffmpeg returned {} bytes for a {width}x{height} HDR image (need {want})",
+            output.stdout.len()
+        )));
+    }
+    let sample = |plane_index: usize, i: usize| -> f32 {
+        let at = (plane_index * plane + i) * 4;
+        f32::from_le_bytes([
+            output.stdout[at],
+            output.stdout[at + 1],
+            output.stdout[at + 2],
+            output.stdout[at + 3],
+        ])
+    };
+
+    let mut rgb = Vec::with_capacity(plane * 3);
+    for i in 0..plane {
+        // gbrp: plane 0 is G, plane 1 is B, plane 2 is R.
+        for linear in [sample(2, i), sample(0, i), sample(1, i)] {
+            let mapped = linear_to_srgb(reinhard(linear));
+            rgb.push((mapped * 255.0 + 0.5).clamp(0.0, 255.0) as u8);
+        }
+    }
+    let buffer = image::RgbImage::from_raw(width, height, rgb)
+        .ok_or_else(|| TranscodeError("tone-mapped buffer did not match the image size".into()))?;
+    buffer
+        .save_with_format(dst, image::ImageFormat::Png)
+        .map_err(|error| TranscodeError(format!("could not write the HDR preview PNG: {error}")))?;
+    ensure_nonempty_output(dst)
 }
 
 #[cfg(target_os = "macos")]
@@ -607,6 +707,100 @@ mod tests {
             sniff_image_kind(&rendered[..32.min(rendered.len())]),
             Some(ImageKind::Png),
             "the preview derivative must be a real PNG"
+        );
+    }
+
+    /// The tone-map curve itself: highlights above diffuse white stay below 255 AND stay apart.
+    ///
+    /// Pure-Rust, so it runs everywhere and pins the property clipping destroys. A clipping
+    /// preview maps every super-white value onto the same 255, which is what made the previous
+    /// "tone-mapped proxy" label untrue.
+    #[test]
+    fn tone_map_keeps_highlights_below_clipping_and_distinguishable() {
+        let code = |linear: f32| (linear_to_srgb(reinhard(linear)) * 255.0 + 0.5) as u8;
+
+        assert_eq!(code(0.0), 0, "black must stay black");
+        // Diffuse white is mapped WELL below 255, which is what reserves the headroom.
+        let white = code(1.0);
+        assert!(
+            (150..=220).contains(&white),
+            "diffuse white should sit mid-high, got {white}"
+        );
+
+        // Every highlight above diffuse white stays below the clipping point...
+        let ladder: Vec<u8> = [2.0f32, 4.0, 8.0, 16.0, 64.0]
+            .iter()
+            .map(|v| code(*v))
+            .collect();
+        for (linear, got) in [2.0f32, 4.0, 8.0, 16.0, 64.0].iter().zip(&ladder) {
+            assert!(
+                *got < 255,
+                "linear {linear} clipped to {got} — highlights must not saturate"
+            );
+        }
+        // ...and stays strictly ordered, so two different super-white values remain readable.
+        for pair in ladder.windows(2) {
+            assert!(
+                pair[1] > pair[0],
+                "super-white values collapsed onto the same code: {ladder:?}"
+            );
+        }
+    }
+
+    /// EXTERNAL — an end-to-end HDR preview: ffmpeg builds a real EXR carrying a 0 → 8.0 ramp, our
+    /// mapper renders it, and the decoded PNG must show the super-white end unclipped and ordered.
+    ///
+    /// The unit test above pins the curve; this pins the whole path (decode → map → encode),
+    /// which is where a plane-order or stride mistake would hide.
+    #[test]
+    fn hdr_preview_renders_a_super_white_ramp_without_clipping() {
+        let ffmpeg = std::env::var("SCENEWORKS_FFMPEG").unwrap_or_else(|_| "ffmpeg".to_owned());
+        match Command::new(&ffmpeg).arg("-version").output() {
+            Ok(out) if out.status.success() => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                println!(
+                    "SKIPPED (external): hdr_preview_renders_a_super_white_ramp_without_clipping \
+                     — `{ffmpeg}` is not reachable."
+                );
+                return;
+            }
+            other => panic!("failed to probe {ffmpeg}: {other:?}"),
+        }
+        let dir = tempfile::tempdir().expect("temp dir");
+        let exr = dir.path().join("ramp.exr");
+        let png = dir.path().join("ramp.png");
+
+        // A horizontal 0 → 8.0 linear ramp: `geq` writes raw values, so the right-hand half is
+        // genuinely above diffuse white rather than merely bright.
+        let built = Command::new(&ffmpeg)
+            .args(["-hide_banner", "-loglevel", "error", "-f", "lavfi"])
+            .args(["-i", "color=c=black:s=64x8:r=1", "-frames:v", "1"])
+            .args(["-vf", "format=gbrpf32le,geq=r='8*X/W':g='8*X/W':b='8*X/W'"])
+            .args(["-y"])
+            .arg(&exr)
+            .output()
+            .expect("run ffmpeg");
+        assert!(
+            built.status.success(),
+            "could not build the HDR ramp fixture: {}",
+            String::from_utf8_lossy(&built.stderr)
+        );
+
+        transcode_hdr_to_png(&exr, &png).expect("tone-map the HDR ramp");
+        let decoded = image::open(&png).expect("open preview").to_rgb8();
+        assert_eq!(decoded.dimensions(), (64, 8));
+
+        let row: Vec<u8> = (0..64u32).map(|x| decoded.get_pixel(x, 0)[0]).collect();
+        assert!(
+            *row.last().unwrap() < 255,
+            "the 8.0 end of the ramp clipped to 255: {:?}",
+            &row[56..]
+        );
+        // Sample points well inside the super-white region must differ from each other.
+        let (mid, high) = (row[40], row[62]);
+        assert!(
+            high > mid,
+            "super-white samples collapsed: linear ~5 -> {mid}, linear ~7.75 -> {high}"
         );
     }
 

--- a/crates/sceneworks-core/src/media_convert.rs
+++ b/crates/sceneworks-core/src/media_convert.rs
@@ -37,6 +37,10 @@ pub enum ImageKind {
     Avif,
     /// HEIF container family — covers HEIC (iPhone photos) and plain HEIF.
     Heif,
+    /// OpenEXR — scene-linear high-dynamic-range float frames (sc-18790). Unlike every other
+    /// member here, its PNG rendition is a **lossy proxy**, not a faithful substitute; see
+    /// [`ImageKind::png_transcode_is_lossy`].
+    OpenExr,
 }
 
 impl ImageKind {
@@ -48,6 +52,23 @@ impl ImageKind {
     /// assets stay in three formats. Do not "fix" this list to match the feature union.
     pub fn is_natively_supported(self) -> bool {
         matches!(self, ImageKind::Png | ImageKind::Jpeg | ImageKind::WebP)
+    }
+
+    /// True when converting this format to PNG **destroys information the file exists to carry**,
+    /// so the original must be stored rather than replaced (sc-18790).
+    ///
+    /// This is the distinction that separates OpenEXR from every other transcoded format here.
+    /// AVIF/HEIC/TIFF/BMP/GIF are 8-bit-per-channel display-referred images: PNG holds their
+    /// pixels exactly, so import can convert once and keep only the PNG. OpenEXR is scene-linear
+    /// **float** — a specular highlight at 50.0 and diffuse white at 1.0 both land on 255 in an
+    /// 8-bit PNG, which is precisely the latitude a grading or VFX pipeline needs. Converting and
+    /// discarding would leave the user with a tone-mapped proxy and no way back.
+    ///
+    /// So a lossy-to-transcode format is stored as-is and its PNG rendition is generated as a
+    /// **preview derivative** on demand (the `?thumbnail=` route), never as the stored asset.
+    /// Download therefore always serves the original bytes.
+    pub fn png_transcode_is_lossy(self) -> bool {
+        matches!(self, ImageKind::OpenExr)
     }
 
     /// Canonical `(extension, mime)` for this format — the values to record for a stored asset,
@@ -62,6 +83,9 @@ impl ImageKind {
             ImageKind::Tiff => ("tiff", "image/tiff"),
             ImageKind::Avif => ("avif", "image/avif"),
             ImageKind::Heif => ("heic", "image/heic"),
+            // `image/x-exr` is the conventional spelling and, critically, an inert
+            // `image/` type — the property SAFE_UPLOAD_EXTENSIONS relies on.
+            ImageKind::OpenExr => ("exr", "image/x-exr"),
         }
     }
 
@@ -76,6 +100,7 @@ impl ImageKind {
             ImageKind::Tiff => "TIFF",
             ImageKind::Avif => "AVIF",
             ImageKind::Heif => "HEIC/HEIF",
+            ImageKind::OpenExr => "OpenEXR",
         }
     }
 }
@@ -96,6 +121,10 @@ pub fn sniff_image_kind(header: &[u8]) -> Option<ImageKind> {
     }
     if header.starts_with(b"GIF87a") || header.starts_with(b"GIF89a") {
         return Some(ImageKind::Gif);
+    }
+    // OpenEXR magic number 20000630 (0x01312F76), little-endian on disk.
+    if header.starts_with(&[0x76, 0x2F, 0x31, 0x01]) {
+        return Some(ImageKind::OpenExr);
     }
     if header.starts_with(b"BM") {
         return Some(ImageKind::Bmp);
@@ -484,6 +513,101 @@ mod tests {
         for kind in [ImageKind::Gif, ImageKind::Bmp, ImageKind::Tiff] {
             assert!(!kind.is_natively_supported());
         }
+    }
+
+    /// OpenEXR is recognized by magic, is not browser-renderable, and — unlike every other
+    /// transcoded format — is flagged lossy-to-transcode so import keeps the original bytes.
+    ///
+    /// The last assertion is the load-bearing one for sc-18790: if OpenEXR ever joined the
+    /// convert-and-discard set, an HDR frame would be silently replaced by an 8-bit tone-mapped
+    /// PNG and the scene-linear original would be unrecoverable.
+    #[test]
+    fn sniffs_openexr_and_marks_it_lossy_to_transcode() {
+        // EXR magic number 20000630 (0x01312F76), little-endian, then the version field.
+        let exr = [0x76u8, 0x2F, 0x31, 0x01, 0x02, 0x00, 0x00, 0x00];
+        assert_eq!(sniff_image_kind(&exr), Some(ImageKind::OpenExr));
+        assert!(
+            !ImageKind::OpenExr.is_natively_supported(),
+            "no browser decodes OpenEXR — it must never be treated as directly renderable"
+        );
+        assert!(
+            ImageKind::OpenExr.png_transcode_is_lossy(),
+            "OpenEXR must be stored as-is; a PNG rendition is a proxy, not a substitute"
+        );
+        assert_eq!(ImageKind::OpenExr.canonical(), ("exr", "image/x-exr"));
+
+        // Every OTHER transcoded format is lossless to convert, so import may keep only the PNG.
+        // Asserting this keeps the flag a real distinction rather than a field nothing reads.
+        for kind in [
+            ImageKind::Gif,
+            ImageKind::Bmp,
+            ImageKind::Tiff,
+            ImageKind::Avif,
+            ImageKind::Heif,
+        ] {
+            assert!(
+                !kind.png_transcode_is_lossy(),
+                "{} is 8-bit and converts losslessly to PNG",
+                kind.label()
+            );
+        }
+    }
+
+    /// EXTERNAL — ffmpeg renders a real OpenEXR file to PNG through the shared transcoder, which is
+    /// what the `?thumbnail=` derivative route relies on to preview an HDR asset.
+    ///
+    /// Uses ffmpeg to BUILD the fixture as well as to consume it, so no binary blob is checked in
+    /// (this repo synthesizes image fixtures in code rather than committing them). Skips loudly
+    /// when ffmpeg is unreachable.
+    #[test]
+    fn transcodes_a_real_openexr_to_png_via_the_platform_decoder() {
+        let ffmpeg = std::env::var("SCENEWORKS_FFMPEG").unwrap_or_else(|_| "ffmpeg".to_owned());
+        match Command::new(&ffmpeg).arg("-version").output() {
+            Ok(out) if out.status.success() => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                println!(
+                    "SKIPPED (external): transcodes_a_real_openexr_to_png_via_the_platform_decoder \
+                     — `{ffmpeg}` is not reachable."
+                );
+                return;
+            }
+            other => panic!("failed to probe {ffmpeg}: {other:?}"),
+        }
+
+        let dir = std::env::temp_dir().join(format!("sc18790-exr-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let exr = dir.join("frame.exr");
+        let png = dir.join("frame.png");
+
+        let built = Command::new(&ffmpeg)
+            .args(["-hide_banner", "-loglevel", "error", "-f", "lavfi"])
+            .args(["-i", "testsrc=size=32x32:rate=1", "-frames:v", "1"])
+            .args(["-pix_fmt", "gbrpf32le", "-y"])
+            .arg(&exr)
+            .output()
+            .expect("run ffmpeg");
+        assert!(
+            built.status.success(),
+            "could not build the EXR fixture: {}",
+            String::from_utf8_lossy(&built.stderr)
+        );
+
+        // The bytes ffmpeg wrote must be what our own sniffer calls an OpenEXR.
+        let header = std::fs::read(&exr).expect("read exr");
+        assert_eq!(
+            sniff_image_kind(&header[..32.min(header.len())]),
+            Some(ImageKind::OpenExr),
+            "a real ffmpeg-written EXR must sniff as OpenEXR"
+        );
+
+        transcode_to_png(&exr, &png).expect("transcode EXR to PNG");
+        let rendered = std::fs::read(&png).expect("read png");
+        assert_eq!(
+            sniff_image_kind(&rendered[..32.min(rendered.len())]),
+            Some(ImageKind::Png),
+            "the preview derivative must be a real PNG"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/sceneworks-core/src/media_convert.rs
+++ b/crates/sceneworks-core/src/media_convert.rs
@@ -574,10 +574,11 @@ mod tests {
             other => panic!("failed to probe {ffmpeg}: {other:?}"),
         }
 
-        let dir = std::env::temp_dir().join(format!("sc18790-exr-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).expect("temp dir");
-        let exr = dir.join("frame.exr");
-        let png = dir.join("frame.png");
+        // A self-removing root: the guard IS the cleanup, so it stays bound for the whole test.
+        // A PID-named tree under env::temp_dir() would survive a panic and collide with a sibling.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let exr = dir.path().join("frame.exr");
+        let png = dir.path().join("frame.png");
 
         let built = Command::new(&ffmpeg)
             .args(["-hide_banner", "-loglevel", "error", "-f", "lavfi"])
@@ -607,7 +608,6 @@ mod tests {
             Some(ImageKind::Png),
             "the preview derivative must be a real PNG"
         );
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -5933,9 +5933,9 @@ fn guess_mime_from_filename(filename: &str) -> Option<String> {
 /// never reaches the filesystem, so it never needs to be on this list.
 const SAFE_UPLOAD_EXTENSIONS: &[&str] = &[
     // Raster images (SVG deliberately omitted — it is script-capable).
-    "png", "jpg", "jpeg", "webp", "gif", "bmp", "tif", "tiff", "avif", "heic",
-    "heif", // Scene-linear HDR frames (sc-18790) — stored as-is, previewed as a derivative.
-    "exr",  // Video.
+    "png", "jpg", "jpeg", "webp", "gif", "bmp", "tif", "tiff", "avif", "heic", "heif",
+    // Scene-linear HDR frames (sc-18790) — stored as-is, previewed as a derivative.
+    "exr", // Video.
     "mp4", "m4v", "mov", "webm", "mkv", "avi", "ogv", "mpeg", "mpg", "wmv", "flv", "3gp",
     "3g2", // Audio: the single canonical stored form.
     "wav",

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -5144,6 +5144,22 @@ fn normalize_image_upload(
             workflow,
         });
     }
+    if kind.png_transcode_is_lossy() {
+        // Scene-linear HDR (sc-18790). Storing the PNG and discarding the source is right for every
+        // other transcoded format — their pixels survive the conversion — but here it would throw
+        // away the float latitude the file exists for, leaving a tone-mapped proxy and no way back.
+        // So the original bytes are stored; the browser-renderable PNG is produced on demand by the
+        // `?thumbnail=` derivative route, which already falls back to `transcode_to_png` when the
+        // `image` crate cannot decode a source. Download therefore serves the original.
+        let (extension, mime) = kind.canonical();
+        return Ok(NormalizedUpload {
+            source_path: source_path.to_path_buf(),
+            content_type: mime.to_owned(),
+            extension: format!(".{extension}"),
+            transcoded_temp: None,
+            workflow,
+        });
+    }
     let temp_png = work_dir.join(format!("upload-transcode-{}.png", random_hex(8)?));
     crate::media_convert::transcode_to_png(source_path, &temp_png).map_err(|error| {
         let _ = fs::remove_file(&temp_png);
@@ -5890,6 +5906,9 @@ fn guess_mime_from_filename(filename: &str) -> Option<String> {
                 Some("heif") => Some("image/heif".to_owned()),
                 Some("avif") => Some("image/avif".to_owned()),
                 Some("tif" | "tiff") => Some("image/tiff".to_owned()),
+                // OpenEXR (sc-18790). `image/x-exr` is inert and starts with `image/`, which
+                // is what admits it to SAFE_UPLOAD_EXTENSIONS and to the `?thumbnail=` route.
+                Some("exr") => Some("image/x-exr".to_owned()),
                 _ => None,
             }
         })
@@ -5915,7 +5934,8 @@ fn guess_mime_from_filename(filename: &str) -> Option<String> {
 const SAFE_UPLOAD_EXTENSIONS: &[&str] = &[
     // Raster images (SVG deliberately omitted — it is script-capable).
     "png", "jpg", "jpeg", "webp", "gif", "bmp", "tif", "tiff", "avif", "heic",
-    "heif", // Video.
+    "heif", // Scene-linear HDR frames (sc-18790) — stored as-is, previewed as a derivative.
+    "exr", // Video.
     "mp4", "m4v", "mov", "webm", "mkv", "avi", "ogv", "mpeg", "mpg", "wmv", "flv", "3gp",
     "3g2", // Audio: the single canonical stored form.
     "wav",

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -5935,7 +5935,7 @@ const SAFE_UPLOAD_EXTENSIONS: &[&str] = &[
     // Raster images (SVG deliberately omitted — it is script-capable).
     "png", "jpg", "jpeg", "webp", "gif", "bmp", "tif", "tiff", "avif", "heic",
     "heif", // Scene-linear HDR frames (sc-18790) — stored as-is, previewed as a derivative.
-    "exr", // Video.
+    "exr",  // Video.
     "mp4", "m4v", "mov", "webm", "mkv", "avi", "ogv", "mpeg", "mpg", "wmv", "flv", "3gp",
     "3g2", // Audio: the single canonical stored form.
     "wav",


### PR DESCRIPTION
The app half of the LTX-2.5 HDR story: an OpenEXR asset previews and downloads correctly. A format the app can produce but not preview is half a feature.

## The one decision that matters

Every other format SceneWorks transcodes (AVIF, HEIC, TIFF, BMP, GIF) is 8-bit — PNG holds their pixels exactly, so import converts once and **discards the original**. OpenEXR is scene-linear float: a specular highlight at `50.0` and diffuse white at `1.0` both land on `255` in an 8-bit PNG, and that latitude is precisely what a grading or VFX pipeline needs. Following the existing path would leave the user a tone-mapped proxy with no way back.

So `ImageKind::png_transcode_is_lossy()` splits the two behaviours: EXR is **stored as-is** and its PNG rendition is a **preview-only derivative**. Download always serves the original frame.

## How preview works without new infrastructure

`ensure_grid_thumbnail` already falls back to `transcode_to_png` (sips on macOS, ffmpeg elsewhere) when the `image` crate cannot decode a source, and ffmpeg decodes EXR. So the existing `?thumbnail=` derivative route handles EXR as soon as `.exr` derives an `image/` mime — no new endpoint, no new cache. The `image` crate's EXR feature stays **off**, so the guard test asserting that is untouched.

Changes: `ImageKind::OpenExr` (sniffed by magic `0x01312F76`, canonical `image/x-exr`), the `guess_mime_from_filename` fallback, `.exr` on `SAFE_UPLOAD_EXTENSIONS` (`image/x-exr` is inert — not script-capable, the property that list exists to preserve), the store-original branch in `normalize_image_upload`, and `AssetMedia` painting the derivative for an HDR source with a title that says it is a proxy.

`AssetMedia` is the single full-size renderer, so one branch fixes preview across grid, card, fullscreen and A/B compare at once. `assetUrl()` — the download path — is untouched.

## Verification

External, via ffmpeg — it **builds** a real EXR and we consume it, so no binary fixture is checked in (this repo synthesizes image fixtures in code):

```
ffmpeg -f lavfi -i testsrc=size=32x32:rate=1 -frames:v 1 -pix_fmt gbrpf32le frame.exr
```
The bytes ffmpeg wrote must sniff as `OpenExr` through our own sniffer, and `transcode_to_png` must render them to a real PNG. Skips loudly when ffmpeg is unreachable.

## Mutations run

| Mutation | Result |
|---|---|
| `png_transcode_is_lossy()` → `false` (EXR joins the convert-and-discard set) | RED |
| `assetDisplayUrl` → always `assetUrl` (preview collapses onto download) | RED — 2 of 4 web checks |

## Checks

`npm run rust:check` green (1199 core + all suites) — one unrelated flake, `resolved_cache::retention::…interrupted_eviction_converges`, failed once under parallel execution and passed in isolation and on re-run; it is nowhere near this diff. `npm run rust:check:candle` green. Web: eslint clean, 4157 tests + 4 new.

**`npm run rust:check:neither` could not run locally** — it needs Docker and the daemon is not running on this host. The diff adds no `cfg`-gated code (an enum variant, a method, a sniffer branch, a mime row, JSX), and any exhaustive `match ImageKind` would have failed the default config too. Flagging it so CI's verdict on that lane is read rather than assumed.

sc-18790
