### PR TITLE
[sc-21899] Harden workflow replay and insecure-context hashing

### DIFF
--- a/apps/web/src/screens/studioRestore.test.jsx
+++ b/apps/web/src/screens/studioRestore.test.jsx
@@ -12,6 +12,7 @@ vi.mock("../api.js", async (importOriginal) => {
 });
 
 import { AppContext } from "../context/AppContext.js";
+import { recipeFromWorkflowShare } from "../workflowShare.js";
 import { ImageStudio } from "./ImageStudio.jsx";
 import { VideoStudio } from "./VideoStudio.jsx";
 
@@ -610,6 +611,39 @@ describe("reference-tuning declared defaults apply on a fresh late-catalog mount
     expect(snap.ipAdapterScale).toBe(0.33);
     expect(snap.controlnetScale).toBe(0.22);
     expect(snap.trueCfgScale).toBe(1.5);
+  });
+
+  it("replays sanitized shared numeric controls without poisoning the form state", async () => {
+    seedSnapshot("image", {
+      ipAdapterScale: 0.61,
+      controlnetScale: 0.81,
+      trueCfgScale: 4.1,
+    });
+    const recipe = recipeFromWorkflowShare(
+      {
+        mode: "text_to_image",
+        prompt: "shared recipe",
+        advanced: {
+          ipAdapterScale: "bad",
+          controlnetConditioningScale: Infinity,
+          trueCfgScale: "NaN",
+          schedulerShift: "2.5",
+        },
+      },
+      { model: { state: "resolved", catalogId: "z_image_turbo" }, loras: [], styles: [] },
+    );
+
+    await renderSequence(ImageStudio, [
+      imageContext({ studioLaunch: { id: "shared-numeric-replay", view: "Image", recipe } }),
+    ]);
+
+    const snap = readSnapshot("image");
+    // Invalid values were gone before the effect touched the number-backed controls.
+    expect(snap.ipAdapterScale).toBe(0.61);
+    expect(snap.controlnetScale).toBe(0.81);
+    expect(snap.trueCfgScale).toBe(4.1);
+    // Finite values survive in their numeric form, not as serialized strings.
+    expect(snap.schedulerShift).toBe(2.5);
   });
 
   // Issue-2 companion: a saved preset that carries its OWN reference tuning (a character-mode preset

--- a/apps/web/src/training/datasetReadiness.js
+++ b/apps/web/src/training/datasetReadiness.js
@@ -15,10 +15,89 @@
 
 import { datasetItemSelectionKey } from "./datasetHelpers.js";
 
+const SHA256_CONSTANTS = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+function rotateRight(value, bits) {
+  return (value >>> bits) | (value << (32 - bits));
+}
+
+// A small browser-only fallback for HTTP/insecure contexts, where Web Crypto is deliberately not
+// exposed. `captionHash` is a protocol value, so this must be SHA-256 rather than a best-effort
+// non-cryptographic hash; it receives the same UTF-8 bytes as the Web Crypto branch.
+function sha256Fallback(bytes) {
+  const padded = new Uint8Array(Math.ceil((bytes.length + 9) / 64) * 64);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  let bitLength = BigInt(bytes.length) * 8n;
+  for (let index = padded.length - 1; index >= padded.length - 8; index -= 1) {
+    padded[index] = Number(bitLength & 0xffn);
+    bitLength >>= 8n;
+  }
+
+  const hash = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+  ]);
+  const words = new Uint32Array(64);
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    for (let index = 0; index < 16; index += 1) {
+      const wordOffset = offset + index * 4;
+      words[index] =
+        (padded[wordOffset] << 24) |
+        (padded[wordOffset + 1] << 16) |
+        (padded[wordOffset + 2] << 8) |
+        padded[wordOffset + 3];
+    }
+    for (let index = 16; index < 64; index += 1) {
+      const s0 = rotateRight(words[index - 15], 7) ^ rotateRight(words[index - 15], 18) ^ (words[index - 15] >>> 3);
+      const s1 = rotateRight(words[index - 2], 17) ^ rotateRight(words[index - 2], 19) ^ (words[index - 2] >>> 10);
+      words[index] = (words[index - 16] + s0 + words[index - 7] + s1) >>> 0;
+    }
+
+    let [a, b, c, d, e, f, g, h] = hash;
+    for (let index = 0; index < 64; index += 1) {
+      const sum1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25);
+      const choose = (e & f) ^ (~e & g);
+      const temp1 = (h + sum1 + choose + SHA256_CONSTANTS[index] + words[index]) >>> 0;
+      const sum0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22);
+      const majority = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (sum0 + majority) >>> 0;
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+    hash[0] = (hash[0] + a) >>> 0;
+    hash[1] = (hash[1] + b) >>> 0;
+    hash[2] = (hash[2] + c) >>> 0;
+    hash[3] = (hash[3] + d) >>> 0;
+    hash[4] = (hash[4] + e) >>> 0;
+    hash[5] = (hash[5] + f) >>> 0;
+    hash[6] = (hash[6] + g) >>> 0;
+    hash[7] = (hash[7] + h) >>> 0;
+  }
+  return Array.from(hash, (word) => word.toString(16).padStart(8, "0")).join("");
+}
+
 export async function captionHash(caption) {
   const bytes = new TextEncoder().encode(caption ?? "");
-  const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
-  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+  if (globalThis.crypto?.subtle?.digest) {
+    const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
+    return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+  return sha256Fallback(bytes);
 }
 
 // Thumbnail badge per worst-severity (sc-6534 acceptance): ✓ good / ⚠ needs

--- a/apps/web/src/training/datasetReadiness.test.js
+++ b/apps/web/src/training/datasetReadiness.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   aestheticScore,
@@ -46,6 +46,21 @@ describe("captionHash", () => {
     expect(await captionHash("tiny test image")).toBe(
       "d93dcd03ca0197eb0ae2041bfc1b3c3b78399bb19e904c901713bcc85cc39cf7",
     );
+  });
+
+  it("uses the same SHA-256 fallback when crypto.subtle is unavailable", async () => {
+    vi.stubGlobal("crypto", undefined);
+    try {
+      expect(await captionHash("tiny test image")).toBe(
+        "d93dcd03ca0197eb0ae2041bfc1b3c3b78399bb19e904c901713bcc85cc39cf7",
+      );
+      // Locks the UTF-8 input bytes as well as the digest algorithm.
+      expect(await captionHash("snowman ☃")).toBe(
+        "06ab2a8c60adfdefc20e9f26ac58a9151eb716c8c3d34b8cf034ae1a00b0a20a",
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });
 

--- a/apps/web/src/workflowShare.js
+++ b/apps/web/src/workflowShare.js
@@ -381,6 +381,32 @@ function prefillDisposition(key) {
   return ADVANCED_PREFILL[key]?.prefill ?? PREFILL_NONE;
 }
 
+// Shared workflows cross a trust boundary before they reach the number-backed controls in a
+// studio. Keep the list beside the prefill registry: these are the control values that may safely
+// be coerced to a finite number, while every other scalar retains its own meaning and shape.
+const NUMERIC_ADVANCED_PREFILL_KEYS = new Set([
+  "schedulerShift",
+  "steps",
+  "guidanceScale",
+  "ipAdapterScale",
+  "controlnetConditioningScale",
+  "trueCfgScale",
+  "strength",
+  "textStyleGain",
+  "controlScale",
+]);
+
+function sharedRecipeNumber(value) {
+  if (
+    (typeof value !== "number" && typeof value !== "string") ||
+    (typeof value === "string" && value.trim() === "")
+  ) {
+    return null;
+  }
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
 // ---- The adapter --------------------------------------------------------------------------
 
 // The seed of THIS image, as the launch's `replaySeed`.
@@ -424,7 +450,15 @@ export function recipeFromWorkflowShare(
   const rawSettings = {};
   for (const [key, value] of Object.entries(share.advanced ?? {})) {
     if (value !== null && value !== undefined && prefillDisposition(key) !== PREFILL_NONE) {
-      rawSettings[key] = value;
+      if (NUMERIC_ADVANCED_PREFILL_KEYS.has(key)) {
+        const number = sharedRecipeNumber(value);
+        if (number === null) {
+          continue;
+        }
+        rawSettings[key] = number;
+      } else {
+        rawSettings[key] = value;
+      }
     }
   }
   if (!styleIdResolved(report)) {

--- a/apps/web/src/workflowShare.test.js
+++ b/apps/web/src/workflowShare.test.js
@@ -131,6 +131,41 @@ describe("recipeFromWorkflowShare", () => {
     expect(recipe.rawAdapterSettings.sampler).toBe("euler");
   });
 
+  it("drops invalid numeric controls and restores finite values as numbers", () => {
+    const recipe = recipeFromWorkflowShare(
+      share({
+        advanced: {
+          schedulerShift: "2.5",
+          steps: 0,
+          guidanceScale: -1.25,
+          ipAdapterScale: "not a number",
+          controlnetConditioningScale: Infinity,
+          trueCfgScale: "NaN",
+          strength: "",
+          textStyleGain: {},
+          controlScale: [],
+        },
+      }),
+      report(),
+    );
+
+    expect(recipe.rawAdapterSettings).toMatchObject({
+      schedulerShift: 2.5,
+      steps: 0,
+      guidanceScale: -1.25,
+    });
+    for (const key of [
+      "ipAdapterScale",
+      "controlnetConditioningScale",
+      "trueCfgScale",
+      "strength",
+      "textStyleGain",
+      "controlScale",
+    ]) {
+      expect(recipe.rawAdapterSettings).not.toHaveProperty(key);
+    }
+  });
+
   it("always asks for ONE image, whatever batch the shared file came out of", () => {
     // The envelope's seed identifies one image; `count` came from the batch the run requested.
     // Replaying both would reproduce the shared image as the first of a 4-image batch.


### PR DESCRIPTION
## Summary
- normalize shared-recipe numeric replay values before Studio hydration
- drop invalid/non-finite scalars while preserving finite numeric values
- provide a UTF-8 SHA-256 fallback when crypto.subtle is unavailable

## Story-local acceptance
- Invalid shared-recipe numeric scalars are dropped before replay: implemented and covered by workflowShare/studioRestore regressions.
- Valid finite replay values retain their numeric value: implemented and covered for zero, negatives, and numeric strings.
- Caption hashing matches with and without crypto.subtle: covered by ASCII and Unicode known vectors.

## Validation
- npm --prefix apps/web run lint
- npm --prefix apps/web run test (270 files, 4166 tests)
- npm --prefix apps/web run build
- sole fresh adversarial review: PASS

Shortcut: https://app.shortcut.com/trefry/story/21899