### PR TITLE
[sc-21901] Preserve truthful async asset state

### DIFF
--- a/apps/web/src/assetBatch.jsx
+++ b/apps/web/src/assetBatch.jsx
@@ -55,6 +55,10 @@ export function useAssetBatch() {
   // Bulk Discard / Move-to-character on the current selection. `bulkAction` gates the
   // buttons while a fan-out is in flight; `moveOpen` reveals the inline character picker.
   const [bulkAction, setBulkAction] = useState(null);
+  // A failed move must remain visible until the user clears the selection or dismisses it;
+  // a later successful move must never rewrite that truthful outcome as total success.
+  const [moveOutcome, setMoveOutcome] = useState(null);
+  const selectionEpochsRef = useRef(new Map());
   // When a discard selection contains folded upscales, hold the pending choice here:
   // { targets: Asset[] (the selection snapshot), sources: Asset[] (their source originals) }.
   // Non-null drives the DiscardUpscaledDialog; the user picks both / upscaled-only / cancel.
@@ -106,6 +110,7 @@ export function useAssetBatch() {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
+      selectionEpochsRef.current.set(id, (selectionEpochsRef.current.get(id) ?? 0) + 1);
       return next;
     });
   // Add every id in `ids` to the selection (union — never drops an existing pick), so a
@@ -113,12 +118,18 @@ export function useAssetBatch() {
   const selectAll = (ids) =>
     setSelectedAssetIds((prev) => {
       const next = new Set(prev);
-      for (const id of ids) next.add(id);
+      for (const id of ids) {
+        if (!next.has(id)) {
+          next.add(id);
+          selectionEpochsRef.current.set(id, (selectionEpochsRef.current.get(id) ?? 0) + 1);
+        }
+      }
       return next;
     });
   const clearSelection = () => {
     setSelectedAssetIds(new Set());
     setMoveOpen(false);
+    setMoveOutcome(null);
   };
 
   // Decode an asset's native pixel size (needed for an edit job — the worker fits the
@@ -242,20 +253,36 @@ export function useAssetBatch() {
     if (!moveCharacterId || !movableSelected.length || bulkAction) return;
     const toLibrary = moveCharacterId === LIBRARY_MOVE_TARGET;
     if (toLibrary ? !moveAssetToLibrary : !moveAssetToCharacter) return;
+    // Snapshot both targets and their selection epochs. Results can arrive in any order;
+    // only remove targets that have not been reselected while the fan-out was in flight.
+    const targets = movableSelected;
+    const targetEpochs = new Map(targets.map((asset) => [asset.id, selectionEpochsRef.current.get(asset.id) ?? 0]));
     setBulkAction("move");
     try {
-      for (const asset of movableSelected) {
-        try {
-          if (toLibrary) {
-            await moveAssetToLibrary(asset);
-          } else {
-            await moveAssetToCharacter(asset, moveCharacterId);
-          }
-        } catch {
-          // One asset failing (e.g. already moved) shouldn't abort the rest.
+      const outcomes = await Promise.allSettled(
+        targets.map((asset) => (toLibrary ? moveAssetToLibrary(asset) : moveAssetToCharacter(asset, moveCharacterId))),
+      );
+      const successfulIds = new Set();
+      const failures = [];
+      outcomes.forEach((outcome, index) => {
+        if (outcome.status === "fulfilled") {
+          successfulIds.add(targets[index].id);
+        } else {
+          const reason = outcome.reason;
+          failures.push({ asset: targets[index], message: reason?.message ?? String(reason || "Could not move this asset.") });
         }
+      });
+      setSelectedAssetIds((current) => {
+        const next = new Set(current);
+        for (const id of successfulIds) {
+          if (selectionEpochsRef.current.get(id) === targetEpochs.get(id)) next.delete(id);
+        }
+        return next;
+      });
+      setMoveOpen(false);
+      if (failures.length) {
+        setMoveOutcome({ succeeded: successfulIds.size, failures });
       }
-      clearSelection();
     } finally {
       setBulkAction(null);
     }
@@ -278,6 +305,8 @@ export function useAssetBatch() {
     runBatch,
     closeBatch,
     bulkAction,
+    moveOutcome,
+    dismissMoveOutcome: () => setMoveOutcome(null),
     discardSelected,
     discardPrompt,
     resolveDiscardPrompt,
@@ -305,6 +334,8 @@ export function AssetSelectionBar({ batch, showDiscard = true, allowLibraryTarge
     availableCharacters,
     setBatchOpen,
     bulkAction,
+    moveOutcome,
+    dismissMoveOutcome,
     discardSelected,
     discardPrompt,
     resolveDiscardPrompt,
@@ -375,6 +406,17 @@ export function AssetSelectionBar({ batch, showDiscard = true, allowLibraryTarge
       <button onClick={clearSelection} type="button">
         Clear
       </button>
+      {moveOutcome ? (
+        <div className="batch-move-outcome" role="alert">
+          <span>
+            Moved {moveOutcome.succeeded}; {moveOutcome.failures.length} failed. Failed assets remain selected.
+            {moveOutcome.failures[0]?.message ? ` ${moveOutcome.failures[0].message}` : ""}
+          </span>
+          <button aria-label="Dismiss move result" onClick={dismissMoveOutcome} type="button">
+            Dismiss
+          </button>
+        </div>
+      ) : null}
       {moveOpen && moveTargets.length ? (
         <div className="batch-move-picker">
           <select

--- a/apps/web/src/assetBatch.jsx
+++ b/apps/web/src/assetBatch.jsx
@@ -21,6 +21,15 @@ import { DEFAULT_MAC_CAPABILITIES, macUpscaleEngineBlocked } from "./macGating.j
 // collide with a real character id.
 export const LIBRARY_MOVE_TARGET = "__sceneworks_library__";
 
+function moveFailureMessage(reason) {
+  const message = reason && typeof reason === "object" ? reason.message : reason;
+  if (typeof message === "string" && message) return message;
+  if (typeof message === "number" || typeof message === "boolean" || typeof message === "bigint" || typeof message === "symbol") {
+    return String(message);
+  }
+  return "Could not move this asset.";
+}
+
 // Shared multi-asset batch selection (sc-6112) — selection state, the upscale/detail/edit
 // fan-out, and the bulk Discard / Move-to-character actions. Lifted out of LibraryScreen so
 // the Assets page and the Character Assets page drive the identical toolbar from one source.
@@ -58,6 +67,7 @@ export function useAssetBatch() {
   // A failed move must remain visible until the user clears the selection or dismisses it;
   // a later successful move must never rewrite that truthful outcome as total success.
   const [moveOutcome, setMoveOutcome] = useState(null);
+  const moveOutcomeEpochRef = useRef(0);
   const selectionEpochsRef = useRef(new Map());
   // When a discard selection contains folded upscales, hold the pending choice here:
   // { targets: Asset[] (the selection snapshot), sources: Asset[] (their source originals) }.
@@ -129,6 +139,7 @@ export function useAssetBatch() {
   const clearSelection = () => {
     setSelectedAssetIds(new Set());
     setMoveOpen(false);
+    moveOutcomeEpochRef.current += 1;
     setMoveOutcome(null);
   };
 
@@ -257,6 +268,7 @@ export function useAssetBatch() {
     // only remove targets that have not been reselected while the fan-out was in flight.
     const targets = movableSelected;
     const targetEpochs = new Map(targets.map((asset) => [asset.id, selectionEpochsRef.current.get(asset.id) ?? 0]));
+    const moveOutcomeEpoch = moveOutcomeEpochRef.current;
     setBulkAction("move");
     try {
       const outcomes = await Promise.allSettled(
@@ -268,8 +280,7 @@ export function useAssetBatch() {
         if (outcome.status === "fulfilled") {
           successfulIds.add(targets[index].id);
         } else {
-          const reason = outcome.reason;
-          failures.push({ asset: targets[index], message: reason?.message ?? String(reason || "Could not move this asset.") });
+          failures.push({ asset: targets[index], message: moveFailureMessage(outcome.reason) });
         }
       });
       setSelectedAssetIds((current) => {
@@ -280,7 +291,7 @@ export function useAssetBatch() {
         return next;
       });
       setMoveOpen(false);
-      if (failures.length) {
+      if (failures.length && moveOutcomeEpochRef.current === moveOutcomeEpoch) {
         setMoveOutcome({ succeeded: successfulIds.size, failures });
       }
     } finally {
@@ -306,7 +317,10 @@ export function useAssetBatch() {
     closeBatch,
     bulkAction,
     moveOutcome,
-    dismissMoveOutcome: () => setMoveOutcome(null),
+    dismissMoveOutcome: () => {
+      moveOutcomeEpochRef.current += 1;
+      setMoveOutcome(null);
+    },
     discardSelected,
     discardPrompt,
     resolveDiscardPrompt,
@@ -360,7 +374,26 @@ export function AssetSelectionBar({ batch, showDiscard = true, allowLibraryTarge
     />
   ) : null;
 
-  if (selectedAssetIds.size === 0) return discardDialog;
+  const moveOutcomeAlert = moveOutcome ? (
+    <div className="batch-move-outcome" role="alert">
+      <span>
+        Moved {moveOutcome.succeeded}; {moveOutcome.failures.length} failed. Failed assets remain selected.
+        {moveOutcome.failures[0]?.message ? ` ${moveOutcome.failures[0].message}` : ""}
+      </span>
+      <button aria-label="Dismiss move result" onClick={dismissMoveOutcome} type="button">
+        Dismiss
+      </button>
+    </div>
+  ) : null;
+
+  if (selectedAssetIds.size === 0) {
+    return (
+      <>
+        {moveOutcomeAlert}
+        {discardDialog}
+      </>
+    );
+  }
 
   // Move destinations: the Main Library (optional) followed by every non-archived character.
   const moveTargets = [
@@ -406,17 +439,7 @@ export function AssetSelectionBar({ batch, showDiscard = true, allowLibraryTarge
       <button onClick={clearSelection} type="button">
         Clear
       </button>
-      {moveOutcome ? (
-        <div className="batch-move-outcome" role="alert">
-          <span>
-            Moved {moveOutcome.succeeded}; {moveOutcome.failures.length} failed. Failed assets remain selected.
-            {moveOutcome.failures[0]?.message ? ` ${moveOutcome.failures[0].message}` : ""}
-          </span>
-          <button aria-label="Dismiss move result" onClick={dismissMoveOutcome} type="button">
-            Dismiss
-          </button>
-        </div>
-      ) : null}
+      {moveOutcomeAlert}
       {moveOpen && moveTargets.length ? (
         <div className="batch-move-picker">
           <select

--- a/apps/web/src/assetBatch.split.test.jsx
+++ b/apps/web/src/assetBatch.split.test.jsx
@@ -33,6 +33,16 @@ function AssetBatchProbe({ onReady }) {
   return null;
 }
 
+function AssetBatchToolbarProbe({ onReady }) {
+  const batch = useAssetBatch();
+  React.useEffect(() => {
+    batch.toggleSelect("a1");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  onReady(batch);
+  return <AssetSelectionBar batch={batch} />;
+}
+
 function render(ui) {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -126,6 +136,16 @@ describe("useAssetBatch truthful bulk move outcomes (sc-21901)", () => {
     return () => latest;
   }
 
+  function mountToolbar(overrides = {}) {
+    let latest;
+    harness = render(
+      <AppContext.Provider value={{ assets, characters, imageModels: [], jobs: [], ...overrides }}>
+        <AssetBatchToolbarProbe onReady={(batch) => { latest = batch; }} />
+      </AppContext.Provider>,
+    );
+    return () => latest;
+  }
+
   it("keeps failed and newly selected assets actionable after mixed character-move outcomes", async () => {
     const first = deferred();
     const second = deferred();
@@ -167,6 +187,72 @@ describe("useAssetBatch truthful bulk move outcomes (sc-21901)", () => {
 
     expect(batch().selectedAssetList.map((asset) => asset.id)).toEqual(["a2"]);
     expect(batch().moveOutcome).toMatchObject({ succeeded: 1, failures: [{ asset: { id: "a2" }, message: "library is read-only" }] });
+  });
+
+  it("keeps a deferred mixed move failure visible after concurrent deselection empties the selection", async () => {
+    const first = deferred();
+    const second = deferred();
+    const moveAssetToCharacter = vi.fn((asset) => (asset.id === "a1" ? first.promise : second.promise));
+    const batch = mountToolbar({ moveAssetToCharacter });
+    await act(async () => {
+      batch().toggleSelect("a2");
+      batch().setMoveCharacterId("c1");
+    });
+
+    let moving;
+    act(() => {
+      moving = batch().moveSelectedToCharacter();
+    });
+    await act(async () => {
+      batch().toggleSelect("a1");
+      batch().toggleSelect("a2");
+      first.resolve({ id: "a1" });
+      second.reject(new Error("destination unavailable"));
+      await moving;
+    });
+
+    expect(document.body.querySelector('[role="alert"]').textContent).toContain("Moved 1; 1 failed. Failed assets remain selected. destination unavailable");
+  });
+
+  it("does not restore an in-flight move result after an explicit clear", async () => {
+    const first = deferred();
+    const second = deferred();
+    const moveAssetToCharacter = vi.fn((asset) => (asset.id === "a1" ? first.promise : second.promise));
+    const batch = mount({ moveAssetToCharacter });
+    await act(async () => {
+      batch().toggleSelect("a2");
+      batch().setMoveCharacterId("c1");
+    });
+
+    let moving;
+    act(() => {
+      moving = batch().moveSelectedToCharacter();
+      batch().clearSelection();
+    });
+    await act(async () => {
+      first.resolve({ id: "a1" });
+      second.reject(new Error("destination unavailable"));
+      await moving;
+    });
+
+    expect(batch().moveOutcome).toBeNull();
+  });
+
+  it("normalizes object-valued rejection messages into a stable move failure", async () => {
+    const moveAssetToCharacter = vi.fn(async (asset) => {
+      if (asset.id === "a2") throw { message: { code: "destination_unavailable" } };
+      return { id: asset.id };
+    });
+    const batch = mount({ moveAssetToCharacter });
+    await act(async () => {
+      batch().toggleSelect("a2");
+      batch().setMoveCharacterId("c1");
+    });
+    await act(async () => {
+      await batch().moveSelectedToCharacter();
+    });
+
+    expect(batch().moveOutcome).toMatchObject({ failures: [{ asset: { id: "a2" }, message: "Could not move this asset." }] });
   });
 
   it("renders a partial move outcome as an alert", () => {

--- a/apps/web/src/assetBatch.split.test.jsx
+++ b/apps/web/src/assetBatch.split.test.jsx
@@ -1,6 +1,6 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AssetSelectionBar, useAssetBatch } from "./assetBatch.jsx";
 import { AppStaticContext, AppLiveContext, AppContext } from "./context/AppContext.js";
 
@@ -13,8 +13,9 @@ import { AppStaticContext, AppLiveContext, AppContext } from "./context/AppConte
 // degrades to inert defaults when rendered with no provider at all.
 
 const assets = [
-  { id: "a1", kind: "image", file: { path: "a1.png" } },
-  { id: "a2", kind: "image", file: { path: "a2.png" } },
+  { id: "a1", kind: "image", type: "image", file: { path: "a1.png" } },
+  { id: "a2", kind: "image", type: "image", file: { path: "a2.png" } },
+  { id: "a3", kind: "image", type: "image", file: { path: "a3.png" } },
 ];
 const characters = [
   { id: "c1", name: "Ada", archived: false },
@@ -46,6 +47,10 @@ function render(ui) {
     },
   };
 }
+
+beforeEach(() => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+});
 
 describe("useAssetBatch under the split context providers (sc-9751)", () => {
   let harness;
@@ -90,6 +95,89 @@ describe("useAssetBatch under the split context providers (sc-9751)", () => {
     );
     expect(latest.selectedAssetList.map((a) => a.id)).toEqual(["a1"]);
     expect(latest.availableCharacters.map((c) => c.id)).toEqual(["c1"]);
+  });
+});
+
+describe("useAssetBatch truthful bulk move outcomes (sc-21901)", () => {
+  let harness;
+
+  afterEach(() => {
+    harness?.cleanup();
+    harness = null;
+  });
+
+  function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((nextResolve, nextReject) => {
+      resolve = nextResolve;
+      reject = nextReject;
+    });
+    return { promise, resolve, reject };
+  }
+
+  function mount(overrides = {}) {
+    let latest;
+    harness = render(
+      <AppContext.Provider value={{ assets, characters, imageModels: [], jobs: [], ...overrides }}>
+        <AssetBatchProbe onReady={(batch) => { latest = batch; }} />
+      </AppContext.Provider>,
+    );
+    return () => latest;
+  }
+
+  it("keeps failed and newly selected assets actionable after mixed character-move outcomes", async () => {
+    const first = deferred();
+    const second = deferred();
+    const moveAssetToCharacter = vi.fn((asset) => (asset.id === "a1" ? first.promise : second.promise));
+    const batch = mount({ moveAssetToCharacter });
+    await act(async () => {
+      batch().toggleSelect("a2");
+      batch().setMoveCharacterId("c1");
+    });
+
+    const moving = batch().moveSelectedToCharacter();
+    await act(async () => {
+      batch().toggleSelect("a3");
+      second.reject("destination unavailable");
+      first.resolve({ id: "a1" });
+      await moving;
+    });
+
+    expect(batch().selectedAssetList.map((asset) => asset.id).sort()).toEqual(["a2", "a3"]);
+    expect(batch().moveOutcome).toMatchObject({ succeeded: 1, failures: [{ asset: { id: "a2" }, message: "destination unavailable" }] });
+  });
+
+  it("reports a mixed Library move without treating it as total success", async () => {
+    const first = deferred();
+    const second = deferred();
+    const moveAssetToLibrary = vi.fn((asset) => (asset.id === "a1" ? first.promise : second.promise));
+    const batch = mount({ moveAssetToLibrary });
+    await act(async () => {
+      batch().toggleSelect("a2");
+      batch().setMoveCharacterId("__sceneworks_library__");
+    });
+
+    const moving = batch().moveSelectedToCharacter();
+    await act(async () => {
+      first.resolve({ id: "a1" });
+      second.reject(new Error("library is read-only"));
+      await moving;
+    });
+
+    expect(batch().selectedAssetList.map((asset) => asset.id)).toEqual(["a2"]);
+    expect(batch().moveOutcome).toMatchObject({ succeeded: 1, failures: [{ asset: { id: "a2" }, message: "library is read-only" }] });
+  });
+
+  it("renders a partial move outcome as an alert", () => {
+    const fakeBatch = {
+      selectedAssetIds: new Set(["a2"]), eligibleSelected: [], movableSelected: [], availableCharacters: [], setBatchOpen() {},
+      bulkAction: null, discardSelected() {}, discardPrompt: null, resolveDiscardPrompt() {}, cancelDiscard() {},
+      moveOpen: false, setMoveOpen() {}, moveCharacterId: "", setMoveCharacterId() {}, moveSelectedToCharacter() {}, clearSelection() {},
+      moveOutcome: { succeeded: 1, failures: [{ asset: { id: "a2" }, message: "library is read-only" }] }, dismissMoveOutcome() {},
+    };
+    harness = render(<AssetSelectionBar batch={fakeBatch} />);
+    expect(document.body.querySelector('[role="alert"]').textContent).toContain("Moved 1; 1 failed. Failed assets remain selected. library is read-only");
   });
 });
 

--- a/apps/web/src/components/AssetPicker.jsx
+++ b/apps/web/src/components/AssetPicker.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   AssetThumbnail,
   assetCanRenderAsAudio,
@@ -422,6 +422,8 @@ function MediaSourcePickerModal({
   const [tab, setTab] = useState("assets");
   const [query, setQuery] = useState("");
   const [selectedIds, setSelectedIds] = useState(() => normalizeSelection(initialSelectedIds, assets, multiple));
+  const selectedIdsRef = useRef(normalizeSelection(initialSelectedIds, assets, multiple));
+  const selectionVersionRef = useRef(0);
   const [characterId, setCharacterId] = useState(characters[0]?.id ?? "");
   const [dragActive, setDragActive] = useState(false);
   const [uploading, setUploading] = useState(false);
@@ -429,8 +431,19 @@ function MediaSourcePickerModal({
   const mediaLabel = mediaKind === "video" ? "video" : "image";
 
   useEffect(() => {
-    setSelectedIds((ids) => normalizeSelection(ids, assets, multiple));
+    setSelectedIds((ids) => {
+      const nextIds = normalizeSelection(ids, assets, multiple);
+      selectedIdsRef.current = nextIds;
+      return nextIds;
+    });
   }, [assets, multiple]);
+
+  function updateSelectedIds(updater) {
+    const nextIds = updater(selectedIdsRef.current);
+    selectedIdsRef.current = nextIds;
+    setSelectedIds(nextIds);
+    return nextIds;
+  }
 
   useEffect(() => {
     if (characterId && characters.some((character) => character.id === characterId)) {
@@ -482,6 +495,7 @@ function MediaSourcePickerModal({
     }
     setUploading(true);
     setUploadError("");
+    const selectionVersion = selectionVersionRef.current;
     try {
       const outcomes = await Promise.allSettled(
         (multiple ? selectedFiles : selectedFiles.slice(0, 1)).map((file) =>
@@ -492,9 +506,17 @@ function MediaSourcePickerModal({
         .filter((outcome) => outcome.status === "fulfilled" && outcome.value?.id && assetMatchesMediaKind(outcome.value, mediaKind))
         .map((outcome) => outcome.value.id);
       const failureCount = outcomes.length - importedIds.length;
-      const nextIds = multiple ? [...new Set([...selectedIds, ...importedIds])] : importedIds.slice(0, 1);
+      // Uploads settle later than card clicks. Merge into the latest selection rather than
+      // the render-time `selectedIds` captured when the upload began. A manual single-select
+      // made while the import was pending wins over the import's automatic selection.
+      const nextIds = updateSelectedIds((currentIds) =>
+        multiple
+          ? [...new Set([...currentIds, ...importedIds])]
+          : selectionVersion === selectionVersionRef.current
+            ? importedIds.slice(0, 1)
+            : currentIds,
+      );
       if (failureCount) {
-        setSelectedIds(nextIds);
         setUploadError(
           importedIds.length
             ? `Imported ${importedIds.length} ${mediaLabel}${importedIds.length === 1 ? "" : "s"}; ${failureCount} failed.`
@@ -526,7 +548,8 @@ function MediaSourcePickerModal({
 
   function renderAssetGrid(emptyLabel) {
     function toggleAsset(asset) {
-      setSelectedIds((ids) => {
+      selectionVersionRef.current += 1;
+      updateSelectedIds((ids) => {
         if (multiple) {
           return ids.includes(asset.id) ? ids.filter((id) => id !== asset.id) : [...ids, asset.id];
         }
@@ -599,7 +622,7 @@ function MediaSourcePickerModal({
           onFiles={handleUpload}
         />
       ) : null}
-      {tab === "upload" && uploadError ? <p className="inline-warning">{uploadError}</p> : null}
+      {uploadError ? <p className="inline-warning">{uploadError}</p> : null}
 
       {tab === "character" ? (
         <div className="dataset-add-character">
@@ -710,6 +733,8 @@ export function AssetPickerModal({
   const [category, setCategory] = useState("all");
   const [query, setQuery] = useState("");
   const [selectedIds, setSelectedIds] = useState(() => normalizeSelection(initialSelectedIds, assets, multiple));
+  const selectedIdsRef = useRef(normalizeSelection(initialSelectedIds, assets, multiple));
+  const selectionVersionRef = useRef(0);
   const [dragActive, setDragActive] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState("");
@@ -717,8 +742,19 @@ export function AssetPickerModal({
   const mediaLabel = mediaKind ?? "file";
 
   useEffect(() => {
-    setSelectedIds((ids) => normalizeSelection(ids, assets, multiple));
+    setSelectedIds((ids) => {
+      const nextIds = normalizeSelection(ids, assets, multiple);
+      selectedIdsRef.current = nextIds;
+      return nextIds;
+    });
   }, [assets, multiple]);
+
+  function updateSelectedIds(updater) {
+    const nextIds = updater(selectedIdsRef.current);
+    selectedIdsRef.current = nextIds;
+    setSelectedIds(nextIds);
+    return nextIds;
+  }
 
   // Mirrors MediaSourcePickerModal's upload path: import each file with `select: false` (a
   // field-scoped picker must not hijack the app-wide Library selection), keep only imports of
@@ -734,6 +770,7 @@ export function AssetPickerModal({
     }
     setUploading(true);
     setUploadError("");
+    const selectionVersion = selectionVersionRef.current;
     try {
       const outcomes = await Promise.allSettled(
         (multiple ? selectedFiles : selectedFiles.slice(0, 1)).map((file) =>
@@ -749,9 +786,14 @@ export function AssetPickerModal({
         )
         .map((outcome) => outcome.value.id);
       const failureCount = outcomes.length - importedIds.length;
-      const nextIds = multiple ? [...new Set([...selectedIds, ...importedIds])] : importedIds.slice(0, 1);
+      const nextIds = updateSelectedIds((currentIds) =>
+        multiple
+          ? [...new Set([...currentIds, ...importedIds])]
+          : selectionVersion === selectionVersionRef.current
+            ? importedIds.slice(0, 1)
+            : currentIds,
+      );
       if (failureCount) {
-        setSelectedIds(nextIds);
         setUploadError(
           importedIds.length
             ? `Imported ${importedIds.length} ${mediaLabel} file${importedIds.length === 1 ? "" : "s"}; ${failureCount} failed.`
@@ -790,7 +832,8 @@ export function AssetPickerModal({
   }, [assets, activeCategory, query, searchIndex]);
 
   function toggleAsset(asset) {
-    setSelectedIds((ids) => {
+    selectionVersionRef.current += 1;
+    updateSelectedIds((ids) => {
       if (multiple) {
         return ids.includes(asset.id) ? ids.filter((id) => id !== asset.id) : [...ids, asset.id];
       }

--- a/apps/web/src/components/AssetPicker.test.jsx
+++ b/apps/web/src/components/AssetPicker.test.jsx
@@ -368,6 +368,55 @@ describe("VideoSourcePickerField video-only sources", () => {
     await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Use Selection"));
     expect(onChange).toHaveBeenCalledWith(["plain-image", "uploaded-image-1"]);
   });
+
+  it("keeps a selection made while a source-image upload is pending", async () => {
+    let resolveFirst;
+    let rejectSecond;
+    const importAsset = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }))
+      .mockImplementationOnce(() => new Promise((_, reject) => { rejectSecond = reject; }));
+    const onChange = vi.fn();
+    await act(async () => {
+      root.render(
+        <ImageEditSourcePickerField
+          assets={assets}
+          characters={characters}
+          importAsset={importAsset}
+          label="Reference images"
+          multiple
+          onChange={onChange}
+          projectId="p1"
+          values={[]}
+        />,
+      );
+    });
+
+    await click(container.querySelector('button[aria-haspopup="dialog"]'));
+    await click(tab("File Upload"));
+    const input = document.body.querySelector('input[type="file"]');
+    const files = [
+      new File(["upload"], "upload-1.png", { type: "image/png" }),
+      new File(["upload"], "upload-2.png", { type: "image/png" }),
+    ];
+    Object.defineProperty(input, "files", { configurable: true, value: files });
+    await act(async () => input.dispatchEvent(new Event("change", { bubbles: true })));
+
+    // Switch back and select a pre-existing card before the deferred importer settles.
+    await click(tab("Assets"));
+    await click(document.body.querySelector('.asset-picker-grid [role="option"]'));
+    await act(async () => {
+      // Settle out of order: a partial failure must not overwrite the concurrent pick
+      // or masquerade as a complete success.
+      rejectSecond(new Error("upload-2 failed"));
+      resolveFirst({ id: "uploaded-late", type: "image", projectId: "p1" });
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Imported 1 image; 1 failed.");
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Use Selection"));
+    expect(onChange).toHaveBeenCalledWith(["plain-image", "uploaded-late"]);
+  });
 });
 
 // sc-17137 review, item 2. `AssetPickerModal` grew an upload/dropzone import path so a picker
@@ -479,6 +528,21 @@ describe("AssetPickerField audio import (VideoStudio reference audio)", () => {
     expect(importAsset).toHaveBeenCalledWith(file, { select: false, throwOnError: true });
     expect(onChange).toHaveBeenCalledWith(["voice-1", "uploaded-audio"]);
     expect(document.body.querySelector('[role="dialog"]')).toBeFalsy();
+  });
+
+  it("keeps a selection made while an asset-picker upload is pending", async () => {
+    let resolveImport;
+    const importAsset = vi.fn(() => new Promise((resolve) => { resolveImport = resolve; }));
+    const onChange = vi.fn();
+    const input = await openPicker({ importAsset, onChange, values: [] });
+    const file = new File(["audio"], "take.wav", { type: "audio/wav" });
+
+    Object.defineProperty(input, "files", { configurable: true, value: [file] });
+    await act(async () => input.dispatchEvent(new Event("change", { bubbles: true })));
+    await click(document.body.querySelector('.asset-picker-grid [role="option"]'));
+    await act(async () => resolveImport(importedAudioAsset("uploaded-late")));
+
+    expect(onChange).toHaveBeenCalledWith(["voice-1", "uploaded-late"]);
   });
 
   it("imports a DROPPED audio file through the same path", async () => {


### PR DESCRIPTION
## Summary
- preserve selections changed while either asset-picker upload is in flight
- retain failed and concurrently selected assets after Library/Character batch moves
- report mixed outcomes visibly with stable non-Error normalization

## Story-local acceptance
- Concurrent upload selections survive completion: covered in both picker flows with deferred promises.
- Batch moves distinguish success/failure and leave failures actionable: covered for Library and Character variants.
- Partial failure is visibly reported: covered even when concurrent deselection leaves no selection; rejection objects normalize to safe text.

## Validation
- focused asset-picker and asset-batch regressions
- npm --prefix apps/web run lint
- npm --prefix apps/web run test (270 files, 4174 tests)
- npm --prefix apps/web run build
- sole adversarial review: CHANGES_REQUIRED; both issues resolved in one mutation-checked fix pass

Shortcut: https://app.shortcut.com/trefry/story/21901