### PR TITLE
[sc-21900] Restrict Vite development exposure

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,9 +4,9 @@
   "version": "0.8.7",
   "type": "module",
   "scripts": {
-    "dev": "vite --host 0.0.0.0",
+    "dev": "vite --host 127.0.0.1",
     "build": "vite build",
-    "preview": "vite preview --host 0.0.0.0",
+    "preview": "vite preview --host 127.0.0.1",
     "lint": "eslint src",
     "test": "vitest run --environment jsdom",
     "gen:styles": "node scripts/generate-styles.mjs",

--- a/apps/web/scripts/vite-safe-dev-smoke.mjs
+++ b/apps/web/scripts/vite-safe-dev-smoke.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createServer } from "vite";
+
+const webRoot = fileURLToPath(new URL("..", import.meta.url));
+const repoRoot = path.resolve(webRoot, "../..");
+
+function vitePath(file) {
+  return path.resolve(file).replaceAll("\\", "/");
+}
+
+function fsUrl(file) {
+  return `/@fs/${encodeURI(vitePath(file))}`;
+}
+
+const server = await createServer({
+  configFile: path.join(webRoot, "vite.config.js"),
+  root: webRoot,
+  // Exercise the exposure boundary in the explicit LAN posture. Port zero
+  // keeps this smoke test safe for concurrent runs.
+  server: { host: "0.0.0.0", port: 0 },
+});
+
+try {
+  assert.deepEqual(server.config.server.fs.allow, [
+    vitePath(webRoot),
+    vitePath(path.join(repoRoot, "apps", "desktop", "licenses")),
+  ]);
+  await server.transformRequest("/src/data/bundledLicenses.js");
+  await server.listen();
+  const address = server.httpServer.address();
+  const origin = `http://127.0.0.1:${address.port}`;
+  const configPath = vitePath(path.join(repoRoot, "config", "manifests", "builtin.styles.jsonc"));
+  const deniedPaths = [
+    fsUrl(configPath),
+    fsUrl(path.join(repoRoot, "crates", "sceneworks-worker", "Cargo.toml")),
+    fsUrl(path.join(repoRoot, "documents", "style.txt")),
+    `/@fs/${configPath.replace("config", "con%66ig")}`,
+    `/@fs/${configPath.replace("/config/", "/documents/../config/")}`,
+  ];
+
+  for (const requestPath of deniedPaths) {
+    const response = await fetch(`${origin}${requestPath}`);
+    assert.equal(response.ok, false, `${requestPath} must not be readable through /@fs`);
+  }
+} finally {
+  await server.close();
+}

--- a/apps/web/src/data/previewSupportCatalog.test.js
+++ b/apps/web/src/data/previewSupportCatalog.test.js
@@ -12,9 +12,8 @@ import {
   PREVIEW_SUPPORT_GENERATOR,
 } from "./previewSupportDerivation.js";
 import previewSupport from "./previewSupport.json";
-// Raw source text (Vite `?raw`) so the guard derives from the same bytes the generator reads. Both
-// live outside the web root — see the server.fs.allow entries in vite.config.js (mirrors the
-// style.txt / builtin.styles.jsonc pair).
+// Raw source text (Vite `?raw`) so the guard derives from the same bytes the generator reads. These
+// test-only inputs are not included in the dev server's /@fs allow-list.
 import enginesSource from "../../../../crates/sceneworks-worker/src/engines.rs?raw";
 import qwenEditCandleSource from "../../../../crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs?raw";
 import pulidMlxSource from "../../../../crates/sceneworks-worker/src/image_jobs/pulid.rs?raw";

--- a/apps/web/src/data/previewSupportCatalog.test.js
+++ b/apps/web/src/data/previewSupportCatalog.test.js
@@ -1,3 +1,6 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -12,49 +15,55 @@ import {
   PREVIEW_SUPPORT_GENERATOR,
 } from "./previewSupportDerivation.js";
 import previewSupport from "./previewSupport.json";
-// Raw source text (Vite `?raw`) so the guard derives from the same bytes the generator reads. These
-// test-only inputs are not included in the dev server's /@fs allow-list.
-import enginesSource from "../../../../crates/sceneworks-worker/src/engines.rs?raw";
-import qwenEditCandleSource from "../../../../crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs?raw";
-import pulidMlxSource from "../../../../crates/sceneworks-worker/src/image_jobs/pulid.rs?raw";
-import pulidCandleSource from "../../../../crates/sceneworks-worker/src/image_jobs/pulid_candle.rs?raw";
-import previewSupportManifestRaw from "../../../../config/manifests/builtin.preview-support.jsonc?raw";
+function readRepositoryFile(relativePath) {
+  return readFileSync(resolve(process.cwd(), "../..", relativePath), "utf8");
+}
+
+function readCapabilityFacts(relativeDirectory) {
+  const directory = resolve(process.cwd(), "../..", relativeDirectory);
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /^capabilities\..+\.json$/.test(entry.name))
+    .map((entry) => ({ name: entry.name, facts: JSON.parse(readFileSync(`${directory}/${entry.name}`, "utf8")) }))
+    .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+}
+
+// This drift guard reads the generator's exact repository inputs in its
+// non-listening Node test process, never via a Vite server's /@fs endpoint.
+const enginesSource = readRepositoryFile("crates/sceneworks-worker/src/engines.rs");
+const qwenEditCandleSource = readRepositoryFile(
+  "crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs",
+);
+const pulidMlxSource = readRepositoryFile("crates/sceneworks-worker/src/image_jobs/pulid.rs");
+const pulidCandleSource = readRepositoryFile("crates/sceneworks-worker/src/image_jobs/pulid_candle.rs");
+const previewSupportManifestRaw = readRepositoryFile(
+  "config/manifests/builtin.preview-support.jsonc",
+);
 // The inference pin itself. `verifyEngineCapabilityFacts` in scripts/bump-inference.mjs compares the
 // facts files against it, but that script runs only when someone bumps THROUGH it — CI never invokes
 // it. So a pin edited by hand would leave the whole catalog advertising the PREVIOUS revision's
 // truth with nothing red. `check-license-coverage.mjs` had already learned this (it compares
 // `audit.inferenceRevision` to the live pin set AND runs in the parity lane); this is the same
 // assertion for the same class of artifact, on a guard that runs on every PR.
-import workerCargoToml from "../../../../crates/sceneworks-worker/Cargo.toml?raw";
+const workerCargoToml = readRepositoryFile("crates/sceneworks-worker/Cargo.toml");
 // The DECLARED backend set (sc-17119). Every other input below is discovered from the facts
 // directory, and a directory listing cannot see a file that was never written — which is why
 // `capabilities.mlx.json` was absent for four consecutive pins with the whole suite green.
-import factsDeclarationSource from "../../../../crates/sceneworks-worker/src/engine_capability_facts.rs?raw";
+const factsDeclarationSource = readRepositoryFile(
+  "crates/sceneworks-worker/src/engine_capability_facts.rs",
+);
 import { fallbackModels } from "../constants.js";
 
 // DISCOVERED, never listed. The generator globs this directory so a newly dumped backend is picked
 // up with no edit; a guard that hardcodes `capabilities.candle.json` would then fail the moment the
 // macOS lane lands `capabilities.mlx.json` — i.e. it would punish exactly the follow-up the design
 // is waiting on. Everything below is derived per-backend from whatever is on disk.
-const factsModules = import.meta.glob(
-  "../../../../config/engine-capabilities/capabilities.*.json",
-  { eager: true, query: "?raw", import: "default" },
-);
-const factsEntries = Object.entries(factsModules)
-  .map(([path, raw]) => ({ name: path.slice(path.lastIndexOf("/") + 1), facts: JSON.parse(raw) }))
-  .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+const factsEntries = readCapabilityFacts("config/engine-capabilities/");
 const factsFiles = factsEntries.map((entry) => entry.facts);
 
 // The AUDIO registry's dumps (sc-17593), one directory down. The glob above is single-level, so the
 // two sets cannot bleed into each other — which matters because they share backend names ("candle"
 // is the audio backend on every platform) while their engine-id namespaces are independent.
-const audioFactsModules = import.meta.glob(
-  "../../../../config/engine-capabilities/audio/capabilities.*.json",
-  { eager: true, query: "?raw", import: "default" },
-);
-const audioFactsEntries = Object.entries(audioFactsModules)
-  .map(([path, raw]) => ({ name: path.slice(path.lastIndexOf("/") + 1), facts: JSON.parse(raw) }))
-  .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+const audioFactsEntries = readCapabilityFacts("config/engine-capabilities/audio/");
 const audioFactsFiles = audioFactsEntries.map((entry) => entry.facts);
 
 const rows = parseEngineModelTable(enginesSource);

--- a/apps/web/src/data/styleCatalog.test.js
+++ b/apps/web/src/data/styleCatalog.test.js
@@ -4,12 +4,12 @@ import { parseStyleCatalog, PROMPT_TEMPLATE } from "./parseStyleCatalog.js";
 import { catalogToStylesManifest } from "./styleManifest.js";
 import styles from "./styles.json";
 // Raw source text (Vite `?raw`) so the test derives from the same bytes the
-// generator reads. documents/style.txt lives outside the web root — see the
-// server.fs.allow entry in vite.config.js (mirrors the license-corpus import).
+// generator reads. This test-only import is never placed on the dev server's
+// /@fs allow-list.
 import styleSource from "../../../../documents/style.txt?raw";
 // sc-13134: the backend/MCP catalog. Read as ?raw + JSON.parse so the drift guard derives
-// from the exact committed bytes. config/ is under the workspace root (searchForWorkspaceRoot
-// in vite.config.js), so vite's server.fs.allow permits it like documents/.
+// from the exact committed bytes. Like style.txt, this test-only input is not
+// readable from the dev server's /@fs endpoint.
 import stylesManifestRaw from "../../../../config/manifests/builtin.styles.jsonc?raw";
 
 // Guards sc-13127: styles.json must stay a mechanical derivation of

--- a/apps/web/src/data/styleCatalog.test.js
+++ b/apps/web/src/data/styleCatalog.test.js
@@ -1,16 +1,24 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { parseStyleCatalog, PROMPT_TEMPLATE } from "./parseStyleCatalog.js";
 import { catalogToStylesManifest } from "./styleManifest.js";
 import styles from "./styles.json";
-// Raw source text (Vite `?raw`) so the test derives from the same bytes the
-// generator reads. This test-only import is never placed on the dev server's
-// /@fs allow-list.
-import styleSource from "../../../../documents/style.txt?raw";
+// Read the exact generator inputs directly in this non-listening test process.
+// They are intentionally never put on a Vite server's /@fs allow-list.
+const styleSource = readFileSync(
+  resolve(process.cwd(), "../..", "documents/style.txt"),
+  "utf8",
+);
 // sc-13134: the backend/MCP catalog. Read as ?raw + JSON.parse so the drift guard derives
 // from the exact committed bytes. Like style.txt, this test-only input is not
 // readable from the dev server's /@fs endpoint.
-import stylesManifestRaw from "../../../../config/manifests/builtin.styles.jsonc?raw";
+const stylesManifestRaw = readFileSync(
+  resolve(process.cwd(), "../..", "config/manifests/builtin.styles.jsonc"),
+  "utf8",
+);
 
 // Guards sc-13127: styles.json must stay a mechanical derivation of
 // documents/style.txt — never hand-edited. If style.txt changes, re-run

--- a/apps/web/src/ideogramCaption.test.js
+++ b/apps/web/src/ideogramCaption.test.js
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { describe, expect, it } from "vitest";
 import {
   BBOX_MAX,
@@ -25,7 +28,10 @@ import {
   verifyCaption,
   verifyRaw,
 } from "./ideogramCaption.js";
-import styleInjectionFixturesRaw from "../../../documents/ideogram-style-injection.fixtures.json?raw";
+const styleInjectionFixturesRaw = readFileSync(
+  resolve(process.cwd(), "../..", "documents/ideogram-style-injection.fixtures.json"),
+  "utf8",
+);
 
 // The validated reference render's caption, byte-identical to the engine's
 // `mlx-gen-ideogram/tests/common/mod.rs` CAPTION_JSON — which is itself

--- a/apps/web/src/styleComposer.test.js
+++ b/apps/web/src/styleComposer.test.js
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -9,10 +12,12 @@ import {
 } from "./styleComposer.js";
 // sc-13134 cross-language golden fixtures. The SAME file drives the Rust port's parity test
 // (crates/sceneworks-core/src/style_composer.rs), so a headless/MCP server-side fold and this
-// client composer stay byte-identical. Imported as ?raw by Vitest only; documents/ is not on the
-// dev server's /@fs allow-list.
-// and JSON.parsed so both languages read the exact same bytes.
-import composerFixturesRaw from "../../../documents/style-composer.fixtures.json?raw";
+// client composer stay byte-identical. This non-listening test reads the exact
+// file directly, without putting documents/ on a Vite server's /@fs allow-list.
+const composerFixturesRaw = readFileSync(
+  resolve(process.cwd(), "../..", "documents/style-composer.fixtures.json"),
+  "utf8",
+);
 
 // sc-13129: the style composer wraps an already-preset-folded userPrompt in a Subject/Style
 // template — the user's prose leads, the catalog style trails it — splicing around any directive

--- a/apps/web/src/styleComposer.test.js
+++ b/apps/web/src/styleComposer.test.js
@@ -9,7 +9,8 @@ import {
 } from "./styleComposer.js";
 // sc-13134 cross-language golden fixtures. The SAME file drives the Rust port's parity test
 // (crates/sceneworks-core/src/style_composer.rs), so a headless/MCP server-side fold and this
-// client composer stay byte-identical. Imported as ?raw (documents/ is on vite's server.fs.allow)
+// client composer stay byte-identical. Imported as ?raw by Vitest only; documents/ is not on the
+// dev server's /@fs allow-list.
 // and JSON.parsed so both languages read the exact same bytes.
 import composerFixturesRaw from "../../../documents/style-composer.fixtures.json?raw";
 

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { defineConfig, searchForWorkspaceRoot } from "vite";
+import { defineConfig } from "vite";
 
 import precompressPlugin from "./vite-plugin-precompress.js";
 import bundleReportPlugin from "./vite-plugin-bundle-report.js";
@@ -25,23 +25,13 @@ const bundleBudgets = JSON.parse(
 // loader would deny it unless it's on server.fs.allow. (The production embedded
 // build resolves these via rollup and isn't gated by this.)
 const licensesDir = fileURLToPath(new URL("../desktop/licenses", import.meta.url));
-
-// The style-catalog drift-guard test (src/data/styleCatalog.test.js) imports the
-// authored documents/style.txt as ?raw to re-derive styles.json. That dir is at
-// the repo root, outside the web project root, so allow it like licensesDir.
+const webRoot = fileURLToPath(new URL(".", import.meta.url));
 const documentsDir = fileURLToPath(new URL("../../documents", import.meta.url));
-
-// The same drift-guard test also imports the backend Style manifest
-// (config/manifests/builtin.styles.jsonc, sc-13134) as ?raw to assert it stays a
-// mechanical derivation of style.txt. config/ is at the repo root, outside the web
-// project root, so allow it like documentsDir.
 const configDir = fileURLToPath(new URL("../../config", import.meta.url));
-
-// The live-preview-support drift guard (src/data/previewSupportCatalog.test.js, sc-16965) imports
-// crates/sceneworks-worker/src/engines.rs as ?raw to re-parse the MODEL_TABLE join the generator
-// reads — the same "derive from the committed bytes" shape as documents/style.txt above. crates/ is
-// at the repo root, outside the web project root, so allow it like documentsDir.
 const cratesDir = fileURLToPath(new URL("../../crates", import.meta.url));
+const testOnlyFsAllow = process.env.VITEST
+  ? [documentsDir, configDir, cratesDir]
+  : [];
 
 export default defineConfig({
   // Generate the pre-paint /theme-init.js from src/accents.js at dev/build time
@@ -71,14 +61,16 @@ export default defineConfig({
       "Cache-Control": "no-store",
     },
     fs: {
-      // Keep the default workspace-root allowance and add the desktop license
-      // corpus the Licenses screen imports from.
+      // Do not use Vite's default workspace-root allowance: a LAN-opted dev
+      // server must not turn the checkout into an /@fs/ download surface. The
+      // web root and production license corpus are the only exposed roots.
+      // Vitest's in-memory module loader needs its raw drift-guard inputs. It
+      // identifies itself with VITEST and never listens for HTTP requests, so
+      // a developer cannot enable those paths with a Vite --mode argument.
       allow: [
-        searchForWorkspaceRoot(process.cwd()),
+        webRoot,
         licensesDir,
-        documentsDir,
-        configDir,
-        cratesDir,
+        ...testOnlyFsAllow,
       ],
     },
   },

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -26,12 +26,6 @@ const bundleBudgets = JSON.parse(
 // build resolves these via rollup and isn't gated by this.)
 const licensesDir = fileURLToPath(new URL("../desktop/licenses", import.meta.url));
 const webRoot = fileURLToPath(new URL(".", import.meta.url));
-const documentsDir = fileURLToPath(new URL("../../documents", import.meta.url));
-const configDir = fileURLToPath(new URL("../../config", import.meta.url));
-const cratesDir = fileURLToPath(new URL("../../crates", import.meta.url));
-const testOnlyFsAllow = process.env.VITEST
-  ? [documentsDir, configDir, cratesDir]
-  : [];
 
 export default defineConfig({
   // Generate the pre-paint /theme-init.js from src/accents.js at dev/build time
@@ -64,13 +58,11 @@ export default defineConfig({
       // Do not use Vite's default workspace-root allowance: a LAN-opted dev
       // server must not turn the checkout into an /@fs/ download surface. The
       // web root and production license corpus are the only exposed roots.
-      // Vitest's in-memory module loader needs its raw drift-guard inputs. It
-      // identifies itself with VITEST and never listens for HTTP requests, so
-      // a developer cannot enable those paths with a Vite --mode argument.
+      // Drift guards read their repository inputs directly with Node rather
+      // than widening the configuration shared by every Vite server.
       allow: [
         webRoot,
         licensesDir,
-        ...testOnlyFsAllow,
       ],
     },
   },

--- a/apps/web/vite.config.test.js
+++ b/apps/web/vite.config.test.js
@@ -14,8 +14,7 @@ describe("Vite safe development boundary", () => {
   });
 
   it("rejects sensitive /@fs reads from a LAN-bound Vite process", () => {
-    const env = { ...process.env };
-    delete env.VITEST;
+    const env = { ...process.env, VITEST: "1" };
     const result = spawnSync(process.execPath, ["scripts/vite-safe-dev-smoke.mjs"], {
       cwd: webRoot,
       encoding: "utf8",

--- a/apps/web/vite.config.test.js
+++ b/apps/web/vite.config.test.js
@@ -1,0 +1,27 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const webRoot = process.cwd();
+const packageJson = JSON.parse(readFileSync(path.join(webRoot, "package.json"), "utf8"));
+
+describe("Vite safe development boundary", () => {
+  it("binds npm dev and preview to loopback unless --host explicitly overrides them", () => {
+    expect(packageJson.scripts.dev).toBe("vite --host 127.0.0.1");
+    expect(packageJson.scripts.preview).toBe("vite preview --host 127.0.0.1");
+  });
+
+  it("rejects sensitive /@fs reads from a LAN-bound Vite process", () => {
+    const env = { ...process.env };
+    delete env.VITEST;
+    const result = spawnSync(process.execPath, ["scripts/vite-safe-dev-smoke.mjs"], {
+      cwd: webRoot,
+      encoding: "utf8",
+      env,
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- make Vite dev/preview loopback-only by default with explicit LAN host override
- restrict every listening Vite server to the web root and required license corpus
- isolate test-only repository reads from the dev-server /@fs allowlist

## Story-local acceptance
- Dev and preview bind to loopback by default: behavior-level script assertions cover both.
- LAN mode denies config/, crates/, and documents/ through /@fs: live clean-process smoke covers direct, encoded, traversal, and hostile VITEST=1 cases with known existing files.
- Production build and license imports continue: focused license suites and production build are green.

## Validation
- hostile VITEST=1 LAN Vite smoke
- focused 5 files / 210 tests
- npm --prefix apps/web run lint
- npm --prefix apps/web run test (271 files, 4168 tests)
- npm --prefix apps/web run build
- sole adversarial review: CHANGES_REQUIRED; issue resolved in one mutation-checked fix pass

Shortcut: https://app.shortcut.com/trefry/story/21900