### PR TITLE
[sc-21903] Correct UI drafts, metrics, text, and units

### DIFF
--- a/apps/web/src/App.queue.test.jsx
+++ b/apps/web/src/App.queue.test.jsx
@@ -126,8 +126,8 @@ describe("SceneWorks app shell", () => {
     await settle();
 
     expect(container.textContent).toContain("Fixture GPU 0");
-    expect(container.textContent).toContain("20.0 GB");
-    expect(container.textContent).toContain("4.0 GB / 24.0 GB");
+    expect(container.textContent).toContain("20.0 GiB");
+    expect(container.textContent).toContain("4.0 GiB / 24.0 GiB");
     expect(container.textContent).toContain("12%");
     expect(container.textContent).not.toContain("CPU utility worker");
     expect(container.textContent).not.toContain("Placeholder GPU");
@@ -989,7 +989,7 @@ describe("SceneWorks app shell", () => {
       root.render(withAppContext({ ...queueProps, visibleWorkers: [worker] }, <QueueScreen />));
     });
 
-    expect(container.textContent).toContain("20.0 GB");
+    expect(container.textContent).toContain("20.0 GiB");
     expect(container.textContent).toContain("12%");
 
     await act(async () => {
@@ -1009,9 +1009,9 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    expect(container.textContent).toContain("12.0 GB / 24.0 GB");
+    expect(container.textContent).toContain("12.0 GiB / 24.0 GiB");
     expect(container.textContent).toContain("67%");
-    expect(container.textContent).not.toContain("20.0 GB");
+    expect(container.textContent).not.toContain("20.0 GiB");
   });
 
 });

--- a/apps/web/src/components/CheckpointImportPanel.jsx
+++ b/apps/web/src/components/CheckpointImportPanel.jsx
@@ -120,7 +120,11 @@ export function CheckpointImportPanel({
   const [activeRootId, setActiveRootId] = useState("");
   const [scan, setScan] = useState(null);
   const [pathDraft, setPathDraft] = useState("");
-  const [labelDraft, setLabelDraft] = useState("");
+  // Adding a library and renaming an existing one can be visible at the same
+  // time. Keep their drafts separate so opening/cancelling a rename never
+  // overwrites the name prepared for the next library.
+  const [addLabelDraft, setAddLabelDraft] = useState("");
+  const [renameLabelDraft, setRenameLabelDraft] = useState("");
   const [renaming, setRenaming] = useState("");
 
   // Managed state. `type` is image-only for the same reason the pre-epic form fixed it: the import
@@ -225,9 +229,9 @@ export function CheckpointImportPanel({
     }
     setBusy("approve");
     try {
-      const root = await library.approve(token, { path, label: labelDraft.trim() || undefined });
+      const root = await library.approve(token, { path, label: addLabelDraft.trim() || undefined });
       setPathDraft("");
-      setLabelDraft("");
+      setAddLabelDraft("");
       const next = await loadRoots();
       setMessage({ ...NEUTRAL, tone: "success", text: `Added ${root?.displayLabel ?? path}.` });
       if (root?.rootId) await runScan(root.rootId);
@@ -266,7 +270,7 @@ export function CheckpointImportPanel({
   }
 
   async function renameRoot(rootId) {
-    const label = labelDraft.trim();
+    const label = renameLabelDraft.trim();
     if (!label) {
       setMessage({ ...NEUTRAL, tone: "error", text: "Enter a name for this library." });
       return;
@@ -275,7 +279,7 @@ export function CheckpointImportPanel({
     try {
       await library.update(token, rootId, { label });
       setRenaming("");
-      setLabelDraft("");
+      setRenameLabelDraft("");
       await loadRoots();
       setMessage({ ...NEUTRAL, tone: "success", text: "Library renamed." });
     } catch (error) {
@@ -498,9 +502,9 @@ export function CheckpointImportPanel({
             Name
             <input
               disabled={busy === "approve"}
-              onChange={(event) => setLabelDraft(event.target.value)}
+              onChange={(event) => setAddLabelDraft(event.target.value)}
               placeholder="Optional"
-              value={labelDraft}
+              value={addLabelDraft}
             />
           </label>
           <button disabled={busy === "approve"} onClick={addLibrary} type="button">
@@ -528,7 +532,7 @@ export function CheckpointImportPanel({
                 <button disabled={busy === `relink:${root.rootId}`} onClick={() => relinkRoot(root.rootId)} type="button">
                   Relink library
                 </button>
-                <button onClick={() => { setRenaming(root.rootId); setLabelDraft(root.label ?? ""); }} type="button">
+                <button onClick={() => { setRenaming(root.rootId); setRenameLabelDraft(root.label ?? ""); }} type="button">
                   Rename
                 </button>
                 <button disabled={busy === `forget:${root.rootId}`} onClick={() => forgetRoot(root)} type="button">
@@ -539,12 +543,12 @@ export function CheckpointImportPanel({
                 <div className="checkpoint-root-rename">
                   <label>
                     New name
-                    <input onChange={(event) => setLabelDraft(event.target.value)} value={labelDraft} />
+                    <input onChange={(event) => setRenameLabelDraft(event.target.value)} value={renameLabelDraft} />
                   </label>
                   <button disabled={busy === `rename:${root.rootId}`} onClick={() => renameRoot(root.rootId)} type="button">
                     Save name
                   </button>
-                  <button onClick={() => setRenaming("")} type="button">
+                  <button onClick={() => { setRenaming(""); setRenameLabelDraft(""); }} type="button">
                     Cancel rename
                   </button>
                 </div>

--- a/apps/web/src/components/CheckpointImportPanel.test.jsx
+++ b/apps/web/src/components/CheckpointImportPanel.test.jsx
@@ -223,6 +223,21 @@ describe("CheckpointImportPanel", () => {
     expect(library.remove).toHaveBeenCalledWith("tok", "root-a");
   });
 
+  it("keeps the add-library name draft while a library is renamed", async () => {
+    const library = libraryStub();
+    await render({ library });
+    await type(labelled("Library folder"), "/Volumes/New");
+    await type(labelled("Name"), "New library");
+
+    await click(buttonNamed("Rename"));
+    await type(labelled("New name"), "Renamed existing library");
+    await click(buttonNamed("Save name"));
+    expect(library.update).toHaveBeenLastCalledWith("tok", "root-a", { label: "Renamed existing library" });
+
+    await click(buttonNamed("Add library"));
+    expect(library.approve).toHaveBeenCalledWith("tok", { path: "/Volumes/New", label: "New library" });
+  });
+
   it("uses the desktop bridge folder picker when one is available", async () => {
     const pickFolder = vi.fn(async () => "/Volumes/Picked");
     const library = libraryStub();

--- a/apps/web/src/deviceSummary.js
+++ b/apps/web/src/deviceSummary.js
@@ -20,6 +20,6 @@ export function describeDevice(workers, macCapabilities) {
     return { engine, gpu: "No worker connected" };
   }
   const totalMb = Number(primary.utilization?.memoryTotalMb);
-  const memory = Number.isFinite(totalMb) && totalMb > 0 ? ` · ${(totalMb / 1024).toFixed(0)} GB` : "";
+  const memory = Number.isFinite(totalMb) && totalMb > 0 ? ` · ${(totalMb / 1024).toFixed(0)} GiB` : "";
   return { engine, gpu: `${primary.gpuName ?? `GPU ${primary.gpuId}`}${memory}` };
 }

--- a/apps/web/src/deviceSummary.test.js
+++ b/apps/web/src/deviceSummary.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { describeDevice } from "./deviceSummary.js";
+
+describe("describeDevice", () => {
+  it("labels binary worker memory as GiB", () => {
+    expect(
+      describeDevice([
+        {
+          gpuId: "gpu-0",
+          gpuName: "Fixture GPU",
+          utilization: { memoryTotalMb: 24_576 },
+        },
+      ]),
+    ).toEqual({ engine: "Candle · discrete GPU", gpu: "Fixture GPU · 24 GiB" });
+  });
+});

--- a/apps/web/src/screens/DatasetCatalogsScreen.jsx
+++ b/apps/web/src/screens/DatasetCatalogsScreen.jsx
@@ -513,7 +513,7 @@ function CatalogCuration({ catalogId, token }) {
           <input
             aria-label="Catalog text search"
             onChange={(event) => setQuery((current) => ({ ...current, text: event.target.value }))}
-            placeholder="red dress, full_bodyâ€¦"
+            placeholder="red dress, full_body…"
             value={query.text}
           />
         </label>
@@ -568,7 +568,7 @@ function CatalogCuration({ catalogId, token }) {
       {error ? <p className="notice error" role="alert">{error}</p> : null}
       <div className="catalog-facets" aria-label="Faceted counts">
         {facets.map((facet) => (
-          <span key={facet.field}><strong>{facet.field}</strong>{facet.values?.map((value) => `${value.value} (${count(value.count)})`).join(" Â· ")}</span>
+          <span key={facet.field}><strong>{facet.field}</strong>{facet.values?.map((value) => `${value.value} (${count(value.count)})`).join(" · ")}</span>
         ))}
       </div>
       <form className="catalog-saved-view-form" onSubmit={saveView}>
@@ -697,7 +697,7 @@ function CatalogCuration({ catalogId, token }) {
                 src={withMediaTicket(`${API_BASE_URL}/api/v1/catalogs/${encodeURIComponent(catalogId)}/records/${encodeURIComponent(record.id)}/thumbnail`)}
               />
               <span>{record.metadata?.caption ?? record.id}</span>
-              <small>{record.metadata?.analysis?.medium ?? record.metadata?.medium ?? "Unclassified"}{review ? ` Â· ${review.decision}` : ""}</small>
+              <small>{record.metadata?.analysis?.medium ?? record.metadata?.medium ?? "Unclassified"}{review ? ` · ${review.decision}` : ""}</small>
             </button>
           );
         })}

--- a/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
+++ b/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
@@ -361,6 +361,9 @@ describe("DatasetCatalogsScreen", () => {
     expect(container.textContent).toContain("28 matches");
     expect(container.textContent).toContain("A full-body photograph outdoors");
     expect(container.textContent).toContain("photograph (28)");
+    expect(container.querySelector("input[aria-label='Catalog text search']").placeholder).toBe("red dress, full_body…");
+    expect(container.textContent).toContain("photograph · exclude");
+    expect(container.textContent).not.toMatch(/(?:Ã|Â|â€¦)/);
     const queryRequest = requests.find((item) => item.path.endsWith("/curation/query"));
     expect(queryRequest.body.filters).toEqual(expect.arrayContaining([
       { field: "medium", values: ["photograph"] },

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -113,10 +113,10 @@ function formatTierSize(bytes) {
   }
   const gb = bytes / (1024 * 1024 * 1024);
   if (gb >= 1) {
-    return `${gb.toFixed(1)} GB`;
+    return `${gb.toFixed(1)} GiB`;
   }
   const mb = bytes / (1024 * 1024);
-  return `${mb.toFixed(0)} MB`;
+  return `${mb.toFixed(0)} MiB`;
 }
 
 // Conversion status text, keyed off the catalog's `mlxConversionState`. Turnkey ("ready") models

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -1579,11 +1579,11 @@ describe("ModelManagerScreen quant-tier download panel (sc-8509)", () => {
     expect(labels[0]).toContain("bf16");
     expect(labels[2]).toContain("Q4");
     // Sizes render the ON-DISK footprint (req #1: footprint.diskSizeBytes), not the smaller
-    // compressed downloadSizeBytes. bf16 disk = 24 GB (download 20 GB), q4 disk = 4 GB (download 3 GB).
-    expect(container.textContent).toContain("24.0 GB");
-    expect(container.textContent).toContain("4.0 GB");
-    expect(container.textContent).not.toContain("20.0 GB");
-    expect(container.textContent).not.toContain("3.0 GB");
+    // compressed downloadSizeBytes. bf16 disk = 24 GiB (download 20 GiB), q4 disk = 4 GiB (download 3 GiB).
+    expect(container.textContent).toContain("24.0 GiB");
+    expect(container.textContent).toContain("4.0 GiB");
+    expect(container.textContent).not.toContain("20.0 GiB");
+    expect(container.textContent).not.toContain("3.0 GiB");
     // The installed tier reports installed; the others report not installed.
     const q8Row = rows.find((row) => row.querySelector(".model-tier-label").textContent.includes("Q8"));
     expect(q8Row.querySelector(".status-badge").textContent).toBe("installed");

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -184,9 +184,9 @@ function formatMemory(mb) {
     return "Unknown";
   }
   if (mb >= 1024) {
-    return `${(mb / 1024).toFixed(1)} GB`;
+    return `${(mb / 1024).toFixed(1)} GiB`;
   }
-  return `${Math.round(mb)} MB`;
+  return `${Math.round(mb)} MiB`;
 }
 
 function boundedPercent(value) {

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -62,10 +62,16 @@ function fractionToPercent(fraction) {
   return Math.min(100, Math.max(GPU_LIMIT_MIN_PERCENT, Math.round(fraction * 100)));
 }
 
-// GPU memory telemetry (epic 7819, sc-7825). The worker publishes byte counts; the readout is in GB.
-function bytesToGb(bytes) {
-  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes <= 0) return 0;
+// GPU memory telemetry (epic 7819, sc-7825). The worker publishes byte counts;
+// preserve a reported zero while distinguishing an absent reading from zero.
+function telemetryBytesToGib(bytes) {
+  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes < 0) return null;
   return bytes / (1024 * 1024 * 1024);
+}
+
+function telemetryGibLabel(bytes, digits = 1) {
+  const gib = telemetryBytesToGib(bytes);
+  return gib === null ? "Unavailable" : `${gib.toFixed(digits)} GiB`;
 }
 
 const SCHEME_OPTIONS = [
@@ -574,7 +580,7 @@ export function SettingsScreen({
   const gpuTargetLabel =
     gpuLimitPercent >= 100
       ? "Use all available"
-      : `~${Math.round(unifiedGb * (gpuLimitPercent / 100))} GB of ${unifiedGb} GB (${gpuLimitPercent}%)`;
+      : `~${Math.round(unifiedGb * (gpuLimitPercent / 100))} GiB of ${unifiedGb} GiB (${gpuLimitPercent}%)`;
 
   return (
     <section className="page-frame settings-screen">
@@ -1050,9 +1056,9 @@ export function SettingsScreen({
                 <div className="settings-kv">
                   <span>Unified memory</span>
                   <span>
-                    {unifiedGb} GB
+                    {unifiedGb} GiB
                     {typeof gpu.wiredLimitMb === "number"
-                      ? ` · system cap ${Math.round(gpu.wiredLimitMb / 1024)} GB`
+                      ? ` · system cap ${Math.round(gpu.wiredLimitMb / 1024)} GiB`
                       : ""}
                   </span>
                 </div>
@@ -1098,20 +1104,20 @@ export function SettingsScreen({
                       <div className="settings-kv">
                         <span>Active</span>
                         <span className="settings-mono">
-                          {bytesToGb(gpuTelemetry.activeBytes).toFixed(1)} GB
+                          {telemetryGibLabel(gpuTelemetry.activeBytes)}
                         </span>
                       </div>
                       <div className="settings-kv">
                         <span>Peak</span>
                         <span className="settings-mono">
-                          {bytesToGb(gpuTelemetry.peakBytes).toFixed(1)} GB
+                          {telemetryGibLabel(gpuTelemetry.peakBytes)}
                         </span>
                       </div>
-                      {gpuTelemetry.limitBytes ? (
+                      {gpuTelemetry.limitBytes !== null && gpuTelemetry.limitBytes !== undefined ? (
                         <div className="settings-kv">
                           <span>Limit</span>
                           <span className="settings-mono">
-                            {Math.round(bytesToGb(gpuTelemetry.limitBytes))} GB
+                            {telemetryGibLabel(gpuTelemetry.limitBytes, 0)}
                           </span>
                         </div>
                       ) : null}

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -532,9 +532,11 @@ describe("SettingsScreen GPU memory (desktop macOS)", () => {
   let invoke;
   let SettingsScreen;
   const GIB = 1024 * 1024 * 1024;
+  let telemetry;
 
   beforeEach(async () => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
+    telemetry = { activeBytes: 20 * GIB, peakBytes: 40 * GIB, cacheBytes: 2 * GIB, limitBytes: 64 * GIB };
     invoke = vi.fn(async (command) => {
       switch (command) {
         case "get_app_settings":
@@ -546,7 +548,7 @@ describe("SettingsScreen GPU memory (desktop macOS)", () => {
         case "get_remote_access":
           return null;
         case "get_gpu_telemetry":
-          return { activeBytes: 20 * GIB, peakBytes: 40 * GIB, cacheBytes: 2 * GIB, limitBytes: 64 * GIB };
+          return telemetry;
         case "set_gpu_memory_limit":
           return { gpuMemoryLimitFraction: 0.5 };
         default:
@@ -585,16 +587,27 @@ describe("SettingsScreen GPU memory (desktop macOS)", () => {
     await render();
     expect(invoke).toHaveBeenCalledWith("get_gpu_telemetry", undefined);
     expect(container.textContent).toContain("Live MLX memory");
-    expect(container.textContent).toContain("20.0 GB");
-    expect(container.textContent).toContain("40.0 GB");
-    expect(container.textContent).toContain("64 GB");
+    expect(container.textContent).toContain("20.0 GiB");
+    expect(container.textContent).toContain("40.0 GiB");
+    expect(container.textContent).toContain("64 GiB");
+  });
+
+  it("marks missing telemetry fields unavailable while preserving a reported zero", async () => {
+    telemetry = { activeBytes: 0, limitBytes: 0 };
+    await render();
+    expect(container.textContent).toContain("0.0 GiB");
+    expect(container.textContent).toContain("0 GiB");
+    expect(container.textContent).toContain("Unavailable");
+    const rows = [...container.querySelectorAll(".settings-kv")];
+    expect(rows.find((row) => row.textContent.includes("Active"))?.textContent).toContain("0.0 GiB");
+    expect(rows.find((row) => row.textContent.includes("Peak"))?.textContent).toContain("Unavailable");
   });
 
   it("summarises this machine from the detected GPU and the worker registry", async () => {
     await render();
     expect(container.textContent).toContain("Engine");
     expect(container.textContent).toContain("Unified memory");
-    expect(container.textContent).toContain("128 GB");
+    expect(container.textContent).toContain("128 GiB");
   });
 
   it("applies the GPU memory target live, without restarting the worker", async () => {

--- a/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
+++ b/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
@@ -22,6 +22,14 @@ import { KEEP_ALIVE_VIEWS } from "../App.jsx";
 const datasetOne = { id: "dataset-1", name: "Mira Set", version: 2, characterId: "", items: [] };
 const datasetTwo = { id: "dataset-2", name: "Other Set", version: 1, characterId: "", items: [] };
 
+function deferred() {
+  let resolve;
+  const promise = new Promise((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
 function baseContext(overrides = {}) {
   return {
     activeProject: { id: "project-a", name: "Project A" },
@@ -139,6 +147,29 @@ describe("TrainingStudio dataset draft guard (sc-11970)", () => {
     // Declined → dataset-2 was never loaded; only the original dataset-1 open happened.
     expect(context.loadTrainingDataset).toHaveBeenCalledTimes(1);
     expect(context.loadTrainingDataset).not.toHaveBeenCalledWith("dataset-2");
+  });
+
+  it("does not replace a rename started while dataset refresh is in flight", async () => {
+    const refresh = deferred();
+    const context = baseContext({ refreshTrainingDatasets: vi.fn(() => refresh.promise) });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    const refreshButton = [...container.querySelectorAll("button")].find((button) => button.textContent === "Refresh");
+    await act(async () => {
+      refreshButton.click();
+    });
+    await typeName(container, "Mira Set renamed");
+    await act(async () => {
+      refresh.resolve();
+      await Promise.resolve();
+    });
+
+    expect(nameInput(container).value).toBe("Mira Set renamed");
+    expect(context.loadTrainingDataset).toHaveBeenCalledTimes(1);
   });
 
   it("opens another dataset when the discard prompt is confirmed", async () => {

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -487,6 +487,13 @@ export function TrainingStudio({ mode = "training" } = {}) {
       selectedAssetIds.length !== originalAssetIds.length ||
       selectedAssetIds.some((id, index) => id !== originalAssetIds[index]) ||
       captionsDirty);
+  // Refresh awaits the catalog request. Read the current draft state after that
+  // await so a rename begun while refresh is in flight is never overwritten by
+  // the freshly loaded dataset object.
+  const dirtyRef = useRef(dirty);
+  dirtyRef.current = dirty;
+  const activeDatasetIdRef = useRef(activeDataset?.id ?? "");
+  activeDatasetIdRef.current = activeDataset?.id ?? "";
   const completedParquetImport = useMemo(
     () =>
       jobs.find(
@@ -998,11 +1005,16 @@ export function TrainingStudio({ mode = "training" } = {}) {
   openDatasetRef.current = openDataset;
 
   async function onRefreshDatasets() {
+    const refreshDatasetId = activeDatasetIdRef.current;
     await refreshTrainingDatasets(activeProject?.id);
-    if (!activeDataset?.id || dirty) {
+    if (
+      !refreshDatasetId ||
+      activeDatasetIdRef.current !== refreshDatasetId ||
+      dirtyRef.current
+    ) {
       return;
     }
-    await openDataset(activeDataset.id);
+    await openDataset(refreshDatasetId);
   }
 
   // Permanently delete the OPEN dataset — the backend wipes its on-disk root (images,


### PR DESCRIPTION
## Summary
- isolate add-name and rename drafts across async dataset refreshes
- render missing GPU telemetry as unavailable while preserving legitimate zero
- correct dataset mojibake and binary GiB/MiB labels across advertised UI surfaces

## Story-local acceptance
- Add and rename drafts remain independent: covered including refresh while rename is dirty.
- Missing GPU metrics are unavailable, not zero: partial/absent and genuine-zero cases covered.
- Dataset text and binary units are accurate: catalog literals plus Settings, Queue, device summary, Model Manager and shared formatting covered.

## Validation
- focused 8 files / 192 tests
- npm --prefix apps/web run lint
- npm --prefix apps/web run test (271 files, 4178 tests)
- npm --prefix apps/web run build
- sole adversarial review: PASS

Shortcut: https://app.shortcut.com/trefry/story/21903