### PR TITLE
[sc-21902] Surface UI failures and classify retries

### DIFF
--- a/apps/web/src/components/DatasetParquetImportDialog.jsx
+++ b/apps/web/src/components/DatasetParquetImportDialog.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 
 import { isDesktop, tauriInvoke } from "../runtime.js";
 import { Modal } from "./Modal.jsx";
+import { errorMessage } from "../errorMessage.js";
 
 const initialSettings = {
   sourcePath: "",
@@ -25,6 +26,7 @@ const captionPresets = {
 export function DatasetParquetImportDialog({ running = false, onClose, onRun }) {
   const [settings, setSettings] = useState(initialSettings);
   const [pickerError, setPickerError] = useState("");
+  const [submitError, setSubmitError] = useState("");
 
   function update(field, value) {
     setSettings((current) => ({ ...current, [field]: value }));
@@ -53,22 +55,27 @@ export function DatasetParquetImportDialog({ running = false, onClose, onRun }) 
   async function submit(event) {
     event.preventDefault();
     if (!settings.sourcePath.trim() || running) return;
-    await onRun({
-      sourcePath: settings.sourcePath.trim(),
-      urlColumn: settings.urlColumn.trim(),
-      captionColumn: settings.captionColumn.trim(),
-      maxItems: Number(settings.maxItems),
-      minEdge: Number(settings.minEdge),
-      concurrency: Number(settings.concurrency),
-      captionIncludes: settings.captionIncludes
-        .split(",")
-        .map((term) => term.trim())
-        .filter(Boolean),
-      captionExcludes: settings.captionExcludes
-        .split(",")
-        .map((term) => term.trim())
-        .filter(Boolean),
-    });
+    setSubmitError("");
+    try {
+      await onRun({
+        sourcePath: settings.sourcePath.trim(),
+        urlColumn: settings.urlColumn.trim(),
+        captionColumn: settings.captionColumn.trim(),
+        maxItems: Number(settings.maxItems),
+        minEdge: Number(settings.minEdge),
+        concurrency: Number(settings.concurrency),
+        captionIncludes: settings.captionIncludes
+          .split(",")
+          .map((term) => term.trim())
+          .filter(Boolean),
+        captionExcludes: settings.captionExcludes
+          .split(",")
+          .map((term) => term.trim())
+          .filter(Boolean),
+      });
+    } catch (error) {
+      setSubmitError(errorMessage(error, "Could not start the Parquet import."));
+    }
   }
 
   return (
@@ -110,6 +117,7 @@ export function DatasetParquetImportDialog({ running = false, onClose, onRun }) 
           </small>
         ) : null}
         {pickerError ? <p className="inline-warning">{pickerError}</p> : null}
+        {submitError ? <p className="inline-warning">{submitError}</p> : null}
 
         <div className="dataset-caption-row">
           <label>

--- a/apps/web/src/components/DatasetParquetImportDialog.test.jsx
+++ b/apps/web/src/components/DatasetParquetImportDialog.test.jsx
@@ -69,4 +69,30 @@ describe("DatasetParquetImportDialog", () => {
       captionExcludes: ["logo", "illustration"],
     });
   });
+
+  it("surfaces a rejected submit without leaving an unhandled promise rejection", async () => {
+    const onRun = vi.fn(() => Promise.reject(undefined));
+    const unhandled = [];
+    const onUnhandled = (event) => {
+      unhandled.push(event.reason);
+      event.preventDefault();
+    };
+    window.addEventListener("unhandledrejection", onUnhandled);
+    root = createRoot(container);
+    act(() => root.render(<DatasetParquetImportDialog onClose={vi.fn()} onRun={onRun} />));
+
+    try {
+      change(fieldByLabel("Parquet file or folder"), "D:\\broken.parquet");
+      await act(async () => {
+        document.body.querySelector('button[type="submit"]').click();
+        await Promise.resolve();
+      });
+
+      expect(onRun).toHaveBeenCalledTimes(1);
+      expect(document.body.textContent).toContain("Could not start the Parquet import.");
+      expect(unhandled).toEqual([]);
+    } finally {
+      window.removeEventListener("unhandledrejection", onUnhandled);
+    }
+  });
 });

--- a/apps/web/src/components/editor/GenerationRail.axes.test.jsx
+++ b/apps/web/src/components/editor/GenerationRail.axes.test.jsx
@@ -1,6 +1,7 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click, setInput } from "../../testUtils/dom.js";
 
 vi.mock("../generationStudio.jsx", () => ({
   LoraPickerSection: () => null,
@@ -101,5 +102,17 @@ describe("GenerationRail catalog axes (sc-15441)", () => {
     render(generationState({ supportsGuidance: false, supportsNegativePrompt: true }));
     expect(container.textContent).not.toContain("Guidance");
     expect(container.textContent).toContain("Negative prompt");
+  });
+
+  it("catches a rejected preset save and shows a safe fallback", async () => {
+    const savePreset = vi.fn(() => Promise.reject({ message: { detail: "not renderable" } }));
+    render(generationState({ savePreset }));
+
+    await click(container.querySelector('button[title="Save current settings as a preset"]'));
+    await act(async () => setInput(container.querySelector('input[placeholder="Preset name"]'), "Rail preset"));
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent === "Save"));
+
+    expect(savePreset).toHaveBeenCalledWith("Rail preset");
+    expect(container.textContent).toContain("Could not save preset.");
   });
 });

--- a/apps/web/src/components/editor/GenerationRail.jsx
+++ b/apps/web/src/components/editor/GenerationRail.jsx
@@ -3,6 +3,7 @@ import { Icon } from "../Icons.jsx";
 import { LoraPickerSection } from "../generationStudio.jsx";
 import { MOTIONS } from "./editorUtils.js";
 import { StudioUpdateBadge, StudioUpdateNotice, updateOptionLabel } from "../StudioUpdateNotice.jsx";
+import { errorMessage } from "../../errorMessage.js";
 
 // The right-hand generation-settings rail (design 2a, epic 12798). Presentational: it
 // renders the controls owned by useEditorGeneration (`gen`) plus the contextual header
@@ -18,13 +19,17 @@ export function GenerationRail({ gen, header, contextActions = [], onGenerate, g
     if (!presetName.trim()) {
       return;
     }
-    const created = await gen.savePreset(presetName);
-    if (created) {
-      setSaveMsg(`Saved “${created.name ?? presetName}”`);
-      setPresetName("");
-      setShowSave(false);
-    } else {
-      setSaveMsg("Could not save preset.");
+    try {
+      const created = await gen.savePreset(presetName);
+      if (created) {
+        setSaveMsg(`Saved “${created.name ?? presetName}”`);
+        setPresetName("");
+        setShowSave(false);
+      } else {
+        setSaveMsg("Could not save preset.");
+      }
+    } catch (error) {
+      setSaveMsg(errorMessage(error, "Could not save preset."));
     }
   }
 

--- a/apps/web/src/components/generationStudio.jsx
+++ b/apps/web/src/components/generationStudio.jsx
@@ -35,6 +35,7 @@ import { StylePicker } from "./StylePicker.jsx";
 import { defaultTierSelection } from "../quantTier.js";
 import { readLastTier, writeLastTier } from "../lastTierStore.js";
 import { readDefaultGenerationQuality } from "../generationQuality.js";
+import { errorMessage } from "../errorMessage.js";
 
 const completedResultFallbackMs = 30000;
 
@@ -797,7 +798,7 @@ export function useSavePreset({
         text: `Saved "${trimmed}" to ${scope === "project" ? "this project" : "all projects"}.`,
       });
     } catch (err) {
-      setPresetSaveMessage({ tone: "error", text: err.message });
+      setPresetSaveMessage({ tone: "error", text: errorMessage(err, "Could not save this preset.") });
     } finally {
       setSavingPreset(false);
     }

--- a/apps/web/src/errorMessage.js
+++ b/apps/web/src/errorMessage.js
@@ -1,0 +1,7 @@
+// UI mutations can reject with values from browser APIs, third-party bridges, or
+// application code. React can render strings but not arbitrary objects, so keep the
+// normalization at the boundary where a rejected value becomes user-facing text.
+export function errorMessage(error, fallback) {
+  const message = error && typeof error === "object" ? error.message : error;
+  return typeof message === "string" && message.trim() ? message : fallback;
+}

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -199,6 +199,16 @@ describe("ImageStudio Save as Preset", () => {
     expect(context.createPreset).not.toHaveBeenCalled();
     expect(container.textContent).toContain("already exists");
   });
+
+  it("normalizes a rejected preset creation into a safe error message", async () => {
+    const context = baseContext({ createPreset: vi.fn(() => Promise.reject({ message: { detail: "not renderable" } })) });
+    await render(context);
+
+    await act(async () => setInput(nameInput(container), "Unavailable preset"));
+    await saveWithScope(container, "This project");
+
+    expect(container.textContent).toContain("Could not save this preset.");
+  });
 });
 
 describe("ImageStudio advanced model defaults", () => {

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -30,6 +30,7 @@ import { ValidationSummary } from "../validation/Validation.jsx";
 import { useAppStatic } from "../context/AppContext.js";
 import { qualityChoices } from "../jobTypes.js";
 import { appConfirm } from "../appConfirm.jsx";
+import { errorMessage } from "../errorMessage.js";
 
 // The Workflow segment a preset editor offers, and how each choice persists.
 //
@@ -639,7 +640,7 @@ export function PresetManagerScreen() {
         setMessage({ tone: "success", text: "Preset created." });
       }
     } catch (err) {
-      setMessage({ tone: "error", text: err.message });
+      setMessage({ tone: "error", text: errorMessage(err, "Could not save this preset.") });
     } finally {
       setSaving(false);
     }
@@ -653,7 +654,7 @@ export function PresetManagerScreen() {
       setSelectedPresetId(duplicated.id);
       setMessage({ tone: "success", text: `Duplicated "${preset.name ?? preset.id}".` });
     } catch (err) {
-      setMessage({ tone: "error", text: err.message });
+      setMessage({ tone: "error", text: errorMessage(err, "Could not duplicate this preset.") });
     } finally {
       setSaving(false);
     }
@@ -674,7 +675,7 @@ export function PresetManagerScreen() {
       }
       setMessage({ tone: "success", text: `Archived "${preset.name ?? preset.id}".` });
     } catch (err) {
-      setMessage({ tone: "error", text: err.message });
+      setMessage({ tone: "error", text: errorMessage(err, "Could not archive this preset.") });
     } finally {
       setSaving(false);
     }

--- a/apps/web/src/screens/PresetManagerScreen.test.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.test.jsx
@@ -230,6 +230,38 @@ describe("PresetManagerScreen", () => {
     );
   });
 
+  it("surfaces rejected create and update saves without unhandled rejections", async () => {
+    const createPreset = vi.fn(() => Promise.reject({ message: { detail: "not renderable" } }));
+    const updatePreset = vi.fn(() => Promise.reject("Preset storage is unavailable."));
+    const unhandled = [];
+    const onUnhandled = (event) => {
+      unhandled.push(event.reason);
+      event.preventDefault();
+    };
+    window.addEventListener("unhandledrejection", onUnhandled);
+
+    try {
+      await render(baseContext({ createPreset, updatePreset }));
+      await clickButton("New preset");
+      await changeField(field(container, "Name"), "Reject me");
+      await clickButton("Create preset");
+      expect(container.textContent).toContain("Could not save this preset.");
+
+      await clickButton("All presets");
+      await act(async () => {
+        [...container.querySelectorAll(".preset-card")]
+          .find((card) => card.textContent.includes("Anime Key Visual"))
+          .querySelector(".secondary-action")
+          .click();
+      });
+      await clickButton("Save preset");
+      expect(container.textContent).toContain("Preset storage is unavailable.");
+      expect(unhandled).toEqual([]);
+    } finally {
+      window.removeEventListener("unhandledrejection", onUnhandled);
+    }
+  });
+
   // sc-10548: PATCH replaces `defaults` wholesale, so anything the editor doesn't render
   // must be carried through explicitly or a rename destroys it.
   it("preserves defaults the editor doesn't render, and still clears ones it does", async () => {

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -3,6 +3,7 @@ import { useAppContext } from "../context/AppContext.js";
 import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
 import { DEFAULT_MAC_CAPABILITIES, macTrainingKernelBlocked } from "../macGating.js";
 import { API_BASE_URL, isAbortError } from "../api.js";
+import { errorMessage } from "../errorMessage.js";
 import { assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
@@ -1457,7 +1458,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
       );
       return job;
     } catch (err) {
-      setDatasetError(err.message);
+      setDatasetError(errorMessage(err, "Could not start the Parquet import."));
       throw err;
     }
   }

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -254,6 +254,26 @@ describe("VideoStudio Save as Preset", () => {
     expect(context.createPreset).not.toHaveBeenCalled();
     expect(container.textContent).toContain("already exists");
   });
+
+  it("shows a string preset-save rejection", async () => {
+    const context = baseContext({ createPreset: vi.fn(() => Promise.reject("Preset service is unavailable.")) });
+    await render(context);
+
+    await act(async () => setInput(nameInput(container), "Unavailable preset"));
+    await saveWithScope(container, "This project");
+
+    expect(container.textContent).toContain("Preset service is unavailable.");
+  });
+
+  it("normalizes an undefined preset-save rejection into a safe error message", async () => {
+    const context = baseContext({ createPreset: vi.fn(() => Promise.reject(undefined)) });
+    await render(context);
+
+    await act(async () => setInput(nameInput(container), "Unavailable preset"));
+    await saveWithScope(container, "This project");
+
+    expect(container.textContent).toContain("Could not save this preset.");
+  });
 });
 
 describe("VideoStudio video_bridge", () => {

--- a/apps/web/src/screens/training/DatasetEditorPanel.jsx
+++ b/apps/web/src/screens/training/DatasetEditorPanel.jsx
@@ -5,6 +5,7 @@ import { CompactSelector } from "../../components/CompactSelector.jsx";
 import { DatasetAddDialog } from "../../components/DatasetAddDialog.jsx";
 import { DatasetCaptionDialog } from "../../components/DatasetCaptionDialog.jsx";
 import { DatasetParquetImportDialog } from "../../components/DatasetParquetImportDialog.jsx";
+import { errorMessage } from "../../errorMessage.js";
 import { Icon } from "../../components/Icons.jsx";
 import { WorkPanel } from "../../components/WorkPanel.jsx";
 import { ValidationSummary } from "../../validation/Validation.jsx";
@@ -115,14 +116,18 @@ export function DatasetEditorPanel({
   const [captionFilter, setCaptionFilter] = React.useState("all");
   const [parquetDialogOpen, setParquetDialogOpen] = React.useState(false);
   const [parquetImporting, setParquetImporting] = React.useState(false);
+  const [parquetError, setParquetError] = React.useState("");
   const parquetImportDisabled = !draftName.trim() || memberAssets.length > 0 || parquetImporting;
 
   async function runParquetImport(settings) {
     if (typeof onImportParquet !== "function" || parquetImporting) return;
     setParquetImporting(true);
+    setParquetError("");
     try {
       await onImportParquet(settings);
       setParquetDialogOpen(false);
+    } catch (error) {
+      setParquetError(errorMessage(error, "Could not start the Parquet import."));
     } finally {
       setParquetImporting(false);
     }
@@ -314,7 +319,10 @@ export function DatasetEditorPanel({
             <button
               className="secondary-action"
               disabled={parquetImportDisabled}
-              onClick={() => setParquetDialogOpen(true)}
+              onClick={() => {
+                setParquetError("");
+                setParquetDialogOpen(true);
+              }}
               title={
                 !draftName.trim()
                   ? "Name the dataset before importing"
@@ -572,11 +580,14 @@ export function DatasetEditorPanel({
         />
       ) : null}
       {parquetDialogOpen ? (
-        <DatasetParquetImportDialog
-          onClose={() => !parquetImporting && setParquetDialogOpen(false)}
-          onRun={runParquetImport}
-          running={parquetImporting}
-        />
+        <>
+          {parquetError ? <p className="inline-warning">{parquetError}</p> : null}
+          <DatasetParquetImportDialog
+            onClose={() => !parquetImporting && setParquetDialogOpen(false)}
+            onRun={runParquetImport}
+            running={parquetImporting}
+          />
+        </>
       ) : null}
     </>
   );

--- a/apps/web/src/screens/training/DatasetEditorPanel.test.jsx
+++ b/apps/web/src/screens/training/DatasetEditorPanel.test.jsx
@@ -147,4 +147,42 @@ describe("DatasetEditorPanel delete affordance", () => {
     // Nothing dataset-scoped to delete, but the panel still renders its draft shell.
     expect(container.querySelector(".dataset-identity-actions")).not.toBeNull();
   });
+
+  it("keeps Parquet-import failures visible and handled at the parent boundary", async () => {
+    const onImportParquet = vi.fn(() => Promise.reject({ message: { detail: "not renderable" } }));
+    const { props } = makeSessions();
+    props.datasetSession.onImportParquet = onImportParquet;
+    const unhandled = [];
+    const onUnhandled = (event) => {
+      unhandled.push(event.reason);
+      event.preventDefault();
+    };
+    window.addEventListener("unhandledrejection", onUnhandled);
+
+    try {
+      await act(async () => root.render(<DatasetEditorPanel {...props} />));
+      await act(async () => {
+        [...container.querySelectorAll("button")].find((button) => button.textContent === "Import Parquet").click();
+      });
+      const input = [...document.body.querySelectorAll("label")]
+        .find((label) => label.textContent.includes("Parquet file or folder"))
+        .querySelector("input");
+      await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(input), "value")?.set;
+        setter.call(input, "D:\\broken.parquet");
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        input.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+      await act(async () => {
+        [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Start import").click();
+        await Promise.resolve();
+      });
+
+      expect(onImportParquet).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain("Could not start the Parquet import.");
+      expect(unhandled).toEqual([]);
+    } finally {
+      window.removeEventListener("unhandledrejection", onUnhandled);
+    }
+  });
 });

--- a/apps/web/src/uiPreferences.js
+++ b/apps/web/src/uiPreferences.js
@@ -65,6 +65,21 @@ let navigationDrainPromise = null;
 let navigationDrainScheduled = false;
 
 const NAVIGATION_WRITE_MAX_ATTEMPTS = 3;
+const NAVIGATION_WRITE_RETRY_BASE_DELAY_MS = 100;
+const NAVIGATION_WRITE_RETRY_MAX_DELAY_MS = 1000;
+
+function navigationWriteRetryDelay(attempt) {
+  return Math.min(
+    NAVIGATION_WRITE_RETRY_MAX_DELAY_MS,
+    NAVIGATION_WRITE_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+  );
+}
+
+function waitForNavigationWriteRetry(attempt) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, navigationWriteRetryDelay(attempt));
+  });
+}
 
 function isAbort(error) {
   return error && typeof error === "object" && error.name === "AbortError";
@@ -90,6 +105,7 @@ async function putNavigationPreferencesWithRetry(patch) {
       if (attempt === NAVIGATION_WRITE_MAX_ATTEMPTS || !shouldRetryNavigationWrite(error)) {
         return;
       }
+      await waitForNavigationWriteRetry(attempt);
     }
   }
 }

--- a/apps/web/src/uiPreferences.js
+++ b/apps/web/src/uiPreferences.js
@@ -64,6 +64,36 @@ let pendingNavigationPatch = null;
 let navigationDrainPromise = null;
 let navigationDrainScheduled = false;
 
+const NAVIGATION_WRITE_MAX_ATTEMPTS = 3;
+
+function isAbort(error) {
+  return error && typeof error === "object" && error.name === "AbortError";
+}
+
+function shouldRetryNavigationWrite(error) {
+  if (isAbort(error)) {
+    return false;
+  }
+  const status = error && typeof error === "object" ? error.status : undefined;
+  if (!Number.isInteger(status)) {
+    return true;
+  }
+  return status === 408 || status === 425 || status === 429 || (status >= 500 && status < 600);
+}
+
+async function putNavigationPreferencesWithRetry(patch) {
+  for (let attempt = 1; attempt <= NAVIGATION_WRITE_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await putUiPreferences(patch);
+      return;
+    } catch (error) {
+      if (attempt === NAVIGATION_WRITE_MAX_ATTEMPTS || !shouldRetryNavigationWrite(error)) {
+        return;
+      }
+    }
+  }
+}
+
 async function drainNavigationPreferences() {
   navigationDrainScheduled = false;
   while (pendingNavigationPatch) {
@@ -71,7 +101,7 @@ async function drainNavigationPreferences() {
     pendingNavigationPatch = null;
     // Read the access token when this request starts, not when the patch was
     // enqueued. A token can be promoted or rotated while an earlier PUT is in flight.
-    await putUiPreferences(patch).catch(() => {});
+    await putNavigationPreferencesWithRetry(patch);
   }
   navigationDrainPromise = null;
 }

--- a/apps/web/src/uiPreferences.test.js
+++ b/apps/web/src/uiPreferences.test.js
@@ -86,33 +86,47 @@ describe("putUiPreferences", () => {
 });
 
 describe("persistNavigationPreferences", () => {
-  it("retries transient network and HTTP failures at the queued-write seam", async () => {
+  it("waits with bounded exponential backoff before retrying transient navigation writes and recovers", async () => {
+    vi.useFakeTimers();
     apiFetch
       .mockRejectedValueOnce(new Error("network unavailable"))
-      .mockRejectedValueOnce(Object.assign(new Error("busy"), { status: 503 }))
+      .mockRejectedValueOnce(Object.assign(new Error("throttled"), { status: 429 }))
       .mockResolvedValueOnce({});
 
-    await persistNavigationPreferences({ activeView: "Library" });
+    try {
+      const persisted = persistNavigationPreferences({ activeView: "Library" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(apiFetch).toHaveBeenCalledTimes(1);
 
-    expect(apiFetch).toHaveBeenCalledTimes(3);
+      await vi.advanceTimersByTimeAsync(99);
+      expect(apiFetch).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(apiFetch).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(199);
+      expect(apiFetch).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(1);
+      await persisted;
+
+      expect(apiFetch).toHaveBeenCalledTimes(3);
+    } finally {
+      await vi.runAllTimersAsync();
+      vi.useRealTimers();
+    }
   });
 
-  it("retries established transient HTTP statuses but not permanent client failures", async () => {
-    for (const status of [408, 425, 429, 500]) {
-      apiFetch.mockReset();
-      apiFetch
-        .mockRejectedValueOnce(Object.assign(new Error(`HTTP ${status}`), { status }))
-        .mockResolvedValueOnce({});
+  it("does not retry a permanent 4xx navigation write", async () => {
+    vi.useFakeTimers();
+    try {
+      apiFetch.mockRejectedValueOnce(Object.assign(new Error("HTTP 400"), { status: 400 }));
 
-      await persistNavigationPreferences({ activeView: `retry-${status}` });
-      expect(apiFetch).toHaveBeenCalledTimes(2);
-    }
-
-    for (const status of [400, 401, 403, 404]) {
-      apiFetch.mockReset();
-      apiFetch.mockRejectedValueOnce(Object.assign(new Error(`HTTP ${status}`), { status }));
-      await persistNavigationPreferences({ activeView: `no-retry-${status}` });
+      const persisted = persistNavigationPreferences({ activeView: "no-retry-400" });
+      await vi.advanceTimersByTimeAsync(1000);
+      await persisted;
       expect(apiFetch).toHaveBeenCalledTimes(1);
+    } finally {
+      await vi.runAllTimersAsync();
+      vi.useRealTimers();
     }
   });
 

--- a/apps/web/src/uiPreferences.test.js
+++ b/apps/web/src/uiPreferences.test.js
@@ -86,6 +86,44 @@ describe("putUiPreferences", () => {
 });
 
 describe("persistNavigationPreferences", () => {
+  it("retries transient network and HTTP failures at the queued-write seam", async () => {
+    apiFetch
+      .mockRejectedValueOnce(new Error("network unavailable"))
+      .mockRejectedValueOnce(Object.assign(new Error("busy"), { status: 503 }))
+      .mockResolvedValueOnce({});
+
+    await persistNavigationPreferences({ activeView: "Library" });
+
+    expect(apiFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries established transient HTTP statuses but not permanent client failures", async () => {
+    for (const status of [408, 425, 429, 500]) {
+      apiFetch.mockReset();
+      apiFetch
+        .mockRejectedValueOnce(Object.assign(new Error(`HTTP ${status}`), { status }))
+        .mockResolvedValueOnce({});
+
+      await persistNavigationPreferences({ activeView: `retry-${status}` });
+      expect(apiFetch).toHaveBeenCalledTimes(2);
+    }
+
+    for (const status of [400, 401, 403, 404]) {
+      apiFetch.mockReset();
+      apiFetch.mockRejectedValueOnce(Object.assign(new Error(`HTTP ${status}`), { status }));
+      await persistNavigationPreferences({ activeView: `no-retry-${status}` });
+      expect(apiFetch).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("does not retry an aborted navigation write", async () => {
+    apiFetch.mockRejectedValueOnce(Object.assign(new Error("aborted"), { name: "AbortError" }));
+
+    await persistNavigationPreferences({ activeView: "Library" });
+
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+  });
+
   it("serializes writes, coalesces the latest intent, and reads the token at request time", async () => {
     const first = deferred();
     const second = deferred();


### PR DESCRIPTION
## Summary
- normalize and visibly handle preset-save and Parquet-import rejection at every live UI boundary
- prevent unhandled async event rejection for editor, studio, and training import flows
- apply bounded delayed exponential retries only to recoverable queued preference writes

## Story-local acceptance
- Preset and Parquet failures are visible without unhandled rejection: covered across manager, Image/Video Studio, editor rail, dialog/panel/training boundaries.
- Preference retries classify recoverable vs permanent failures: timer tests prove delayed bounded retry; abort/permanent 4xx stay one attempt.
- Non-Error rejection values render stably: Error, string, object, and undefined variants covered.

## Validation
- focused 198 tests
- npm --prefix apps/web run lint
- npm --prefix apps/web run test (4184 tests)
- npm --prefix apps/web run build
- sole adversarial review: CHANGES_REQUIRED; all three issues resolved in one mutation-checked fix pass

Shortcut: https://app.shortcut.com/trefry/story/21902