### PR TITLE
[sc-21905] Harden zoom and scrub listener lifecycle

### DIFF
--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -978,6 +978,13 @@ function FullscreenPreviewComponent({
   const compareActive = canCompare && compareMode;
 
   const viewportRef = React.useRef(null);
+  // Compare mode replaces the zoom viewport instead of merely hiding it. Keep the
+  // mounted node in state so the native wheel listener follows that replacement.
+  const [viewportNode, setViewportNode] = React.useState(null);
+  const setViewportRef = React.useCallback((node) => {
+    viewportRef.current = node;
+    setViewportNode(node);
+  }, []);
   const [view, setView] = React.useState(PREVIEW_FIT_VIEW);
   const dragRef = React.useRef(null);
 
@@ -1009,7 +1016,7 @@ function FullscreenPreviewComponent({
   // Wheel-to-zoom anchored at the cursor. Native (non-passive) listener so we can
   // preventDefault the page scroll; React's onWheel is passive in some browsers.
   React.useEffect(() => {
-    const node = viewportRef.current;
+    const node = viewportNode;
     if (!node || isVideo) {
       return undefined;
     }
@@ -1022,7 +1029,7 @@ function FullscreenPreviewComponent({
     };
     node.addEventListener("wheel", onWheel, { passive: false });
     return () => node.removeEventListener("wheel", onWheel);
-  }, [isVideo, displayedAsset?.id]);
+  }, [isVideo, displayedAsset?.id, viewportNode]);
 
   const onPointerDown = (event) => {
     if (view.scale <= PREVIEW_MIN_SCALE) {
@@ -1236,7 +1243,7 @@ function FullscreenPreviewComponent({
             <Icon.ArrowLeft size={18} />
           </button>
           {compareActive ? (
-            <div className="preview-compare" role="group" aria-label="Original and edited image side by side">
+            <div className="preview-compare" key="compare-viewport" role="group" aria-label="Original and edited image side by side">
               <figure className="preview-compare-pane">
                 <AssetMedia asset={sourceAsset} controls={false} />
                 <figcaption>Original</figcaption>
@@ -1251,11 +1258,12 @@ function FullscreenPreviewComponent({
           ) : (
             <div
               className={`preview-zoom-viewport${zoomed ? " zoomed" : ""}`}
+              key="zoom-viewport"
               onPointerDown={onPointerDown}
               onPointerMove={onPointerMove}
               onPointerUp={endDrag}
               onPointerCancel={endDrag}
-              ref={viewportRef}
+              ref={setViewportRef}
             >
               <div
                 className="preview-zoom-inner"

--- a/apps/web/src/components/assetPanels.zoom.test.jsx
+++ b/apps/web/src/components/assetPanels.zoom.test.jsx
@@ -1,0 +1,123 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const actionMocks = vi.hoisted(() => ({
+  assetCanCarryWorkflow: vi.fn(() => true),
+  revealAsset: vi.fn(),
+  saveAssetAs: vi.fn(),
+}));
+
+vi.mock("../assetActions.js", () => ({
+  assetCanCarryWorkflow: actionMocks.assetCanCarryWorkflow,
+  revealAsset: actionMocks.revealAsset,
+  saveAssetAs: actionMocks.saveAssetAs,
+}));
+
+vi.mock("../runtime.js", () => ({
+  isDesktop: true,
+  isPageFullscreen: () => false,
+  setViewerFullscreen: vi.fn(() => Promise.resolve()),
+  tauriInvoke: vi.fn(),
+}));
+
+import { FullscreenPreview } from "./assetPanels.jsx";
+
+const original = {
+  id: "original",
+  displayName: "Original",
+  file: { mimeType: "image/png", path: "original.png" },
+  projectId: "project-1",
+  status: {},
+  type: "image",
+};
+const edited = {
+  ...original,
+  id: "edited",
+  displayName: "Edited",
+  file: { mimeType: "image/png", path: "edited.png" },
+  recipe: { mode: "edit_image" },
+};
+
+let container;
+let root;
+
+async function renderPreview() {
+  root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <FullscreenPreview
+        asset={edited}
+        deleteAsset={() => {}}
+        nextAsset={null}
+        onClose={() => {}}
+        onPreviewAsset={() => {}}
+        previousAsset={null}
+        purgeAsset={() => {}}
+        sourceAsset={original}
+        updateAssetStatus={() => {}}
+      />,
+    );
+  });
+}
+
+function viewport() {
+  return document.body.querySelector(".preview-zoom-viewport");
+}
+
+async function wheel(node) {
+  await act(async () => {
+    node.dispatchEvent(new WheelEvent("wheel", { bubbles: true, cancelable: true, clientX: 10, clientY: 10, deltaY: -1 }));
+  });
+}
+
+beforeEach(() => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (root) {
+    act(() => root.unmount());
+    root = null;
+  }
+  container.remove();
+});
+
+describe("FullscreenPreview zoom viewport lifecycle (sc-21905)", () => {
+  it("rebinds the native wheel listener to the replacement viewport after compare mode", async () => {
+    const addSpy = vi.spyOn(HTMLElement.prototype, "addEventListener");
+    const removeSpy = vi.spyOn(HTMLElement.prototype, "removeEventListener");
+    try {
+      await renderPreview();
+      const firstViewport = viewport();
+
+      await act(async () => {
+        document.body.querySelector(".preview-compare-toggle").click();
+      });
+      expect(viewport()).toBeNull();
+
+      await act(async () => {
+        document.body.querySelector(".preview-compare-toggle").click();
+      });
+      const replacementViewport = viewport();
+      expect(replacementViewport).not.toBe(firstViewport);
+      await wheel(replacementViewport);
+      expect(replacementViewport.classList).toContain("zoomed");
+
+      const wheelAddsOn = (node) =>
+        addSpy.mock.calls.filter(([type], index) => type === "wheel" && addSpy.mock.instances[index] === node);
+      const wheelRemovesOn = (node) =>
+        removeSpy.mock.calls.filter(([type], index) => type === "wheel" && removeSpy.mock.instances[index] === node);
+      const firstWheelAdds = wheelAddsOn(firstViewport);
+      const replacementWheelAdds = wheelAddsOn(replacementViewport);
+      expect(firstWheelAdds).toHaveLength(1);
+      expect(replacementWheelAdds).toHaveLength(1);
+      expect(wheelRemovesOn(firstViewport)).toContainEqual(["wheel", firstWheelAdds[0][1]]);
+    } finally {
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    }
+  });
+});

--- a/apps/web/src/components/editor/Timeline.jsx
+++ b/apps/web/src/components/editor/Timeline.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { Icon } from "../Icons.jsx";
 import { trackItems } from "../../timeline.js";
 import {
@@ -81,6 +81,7 @@ export function Timeline({
   onSelectMarker,
 }) {
   const laneRef = useRef(null);
+  const rulerDragRef = useRef(null);
   const tracks = timeline?.tracks ?? [];
   const overlayTrack = tracks.find((t) => t.id === OVERLAY_TRACK_ID || t.kind === "overlay") ?? null;
   const mainTrack = tracks.find((t) => t.id === MAIN_TRACK_ID || t.kind === "video") ?? null;
@@ -122,11 +123,26 @@ export function Timeline({
     }
   }
 
+  const stopRulerDrag = useCallback(() => {
+    const drag = rulerDragRef.current;
+    if (!drag) {
+      return;
+    }
+    window.removeEventListener("mousemove", drag.onMove);
+    window.removeEventListener("mouseup", drag.onUp);
+    rulerDragRef.current = null;
+  }, []);
+
+  // The drag outlives the ruler element, so its window listeners must also be
+  // owned by the component rather than only by its mouseup handler.
+  useEffect(() => stopRulerDrag, [stopRulerDrag]);
+
   function handleRulerMouseDown(event) {
     const el = laneRef.current;
     if (!el || duration <= 0) {
       return;
     }
+    stopRulerDrag();
     const rect = el.getBoundingClientRect();
     const toSeconds = (clientX) => {
       const ratio = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width));
@@ -134,10 +150,8 @@ export function Timeline({
     };
     onScrub?.(toSeconds(event.clientX));
     const onMove = (moveEvent) => onScrub?.(toSeconds(moveEvent.clientX));
-    const onUp = () => {
-      window.removeEventListener("mousemove", onMove);
-      window.removeEventListener("mouseup", onUp);
-    };
+    const onUp = () => stopRulerDrag();
+    rulerDragRef.current = { onMove, onUp };
     window.addEventListener("mousemove", onMove);
     window.addEventListener("mouseup", onUp);
   }

--- a/apps/web/src/components/editor/Timeline.test.jsx
+++ b/apps/web/src/components/editor/Timeline.test.jsx
@@ -1,0 +1,105 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Timeline } from "./Timeline.jsx";
+
+let container;
+let root;
+
+function renderTimeline(onScrub = vi.fn(), zoom = 1) {
+  if (!root) {
+    root = createRoot(container);
+  }
+  act(() => {
+    root.render(
+      <Timeline
+        assetsById={{}}
+        duration={10}
+        onAddAudioTrack={() => {}}
+        onScrub={onScrub}
+        onSelectGap={() => {}}
+        onSelectItem={() => {}}
+        onSelectKey={() => {}}
+        onToggleMute={() => {}}
+        onToggleSnap={() => {}}
+        onToggleSolo={() => {}}
+        onToggleVisible={() => {}}
+        onZoomIn={() => {}}
+        onZoomOut={() => {}}
+        playheadSeconds={0}
+        snap={false}
+        timeline={{ tracks: [] }}
+        zoom={zoom}
+      />,
+    );
+  });
+  return onScrub;
+}
+
+function ruler() {
+  return container.querySelector(".ve-ruler");
+}
+
+function lane() {
+  return container.querySelector(".ve-lanes");
+}
+
+async function mouseDown(node, clientX) {
+  await act(async () => {
+    node.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX }));
+  });
+}
+
+beforeEach(() => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (root) {
+    act(() => root.unmount());
+    root = null;
+  }
+  container.remove();
+});
+
+describe("Timeline ruler drag lifecycle (sc-21905)", () => {
+  it("removes the exact window listeners when unmounted during a ruler drag", async () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    try {
+      renderTimeline();
+      vi.spyOn(lane(), "getBoundingClientRect").mockReturnValue({ left: 0, width: 100 });
+      await mouseDown(ruler(), 50);
+
+      const mousemoveAdd = addSpy.mock.calls.find(([type]) => type === "mousemove");
+      const mouseupAdd = addSpy.mock.calls.find(([type]) => type === "mouseup");
+      expect(mousemoveAdd).toBeDefined();
+      expect(mouseupAdd).toBeDefined();
+
+      act(() => root.unmount());
+      root = null;
+      expect(removeSpy).toHaveBeenCalledWith("mousemove", mousemoveAdd[1]);
+      expect(removeSpy).toHaveBeenCalledWith("mouseup", mouseupAdd[1]);
+    } finally {
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    }
+  });
+
+  it("reads the current lane geometry at the start of each new scrub", async () => {
+    const onScrub = renderTimeline();
+    let rect = { left: 0, width: 100 };
+    vi.spyOn(lane(), "getBoundingClientRect").mockImplementation(() => rect);
+
+    await mouseDown(ruler(), 60);
+    await act(async () => window.dispatchEvent(new MouseEvent("mouseup")));
+    rect = { left: 20, width: 200 };
+    renderTimeline(onScrub, 2);
+    await mouseDown(ruler(), 120);
+
+    expect(onScrub).toHaveBeenNthCalledWith(1, 6);
+    expect(onScrub).toHaveBeenNthCalledWith(2, 5);
+  });
+});


### PR DESCRIPTION
## Summary
- remount and rebind the compare-mode zoom viewport wheel listener
- centrally own and clean exact ruler drag window listener identities
- read current lane geometry for every new post-zoom scrub

## Story-local acceptance
- Wheel zoom survives compare viewport replacement: remount/rebind interaction covered.
- Mid-drag unmount removes every window listener: exact add/remove identity covered before mouseup.
- New scrub after zoom uses current geometry: changed-rect interaction covered.

## Validation
- focused 3 lifecycle interactions
- npm --prefix apps/web run lint
- npm --prefix apps/web run test (273 files, 4179 tests)
- npm --prefix apps/web run build
- sole adversarial review: PASS

Shortcut: https://app.shortcut.com/trefry/story/21905