### PR TITLE
fix(web): bound background polling and settings persistence [sc-21904]

### DIFF
--- a/apps/web/src/hooks/appGateHooks.test.jsx
+++ b/apps/web/src/hooks/appGateHooks.test.jsx
@@ -104,6 +104,14 @@ class FakeEventSource {
   }
 }
 
+function deferred() {
+  let resolve;
+  const promise = new Promise((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
 async function settle() {
   await act(async () => {
     for (let i = 0; i < 6; i += 1) {
@@ -201,6 +209,50 @@ describe("useAccessGate (sc-9750)", () => {
     // Mint succeeded → ready flips true and the ticket is stored.
     expect(get().api.ready).toBe(true);
     expect(setMediaTicketSpy).toHaveBeenCalledWith("media-1");
+  });
+
+  it("pauses media-ticket refresh while hidden and leaves one timer after visibility churn", async () => {
+    vi.useFakeTimers();
+    try {
+      window.localStorage.setItem("sceneworks-token", "remote-token");
+      apiResponders.set("/api/v1/access", { authRequired: true });
+      apiResponders.set("/api/v1/auth/verify", { ok: true });
+      const pending = deferred();
+      let mints = 0;
+      apiResponders.set("/api/v1/files/ticket", () => {
+        mints += 1;
+        return mints === 1 ? pending.promise : { ticket: `media-${mints}`, expiresInSeconds: 15 };
+      });
+      const mintCalls = () => apiFetch.mock.calls.filter(([path]) => path === "/api/v1/files/ticket").length;
+      const before = mintCalls();
+      mount();
+      await settle();
+      expect(mintCalls()).toBe(before + 1);
+
+      const setVisibility = async (state) => {
+        Object.defineProperty(document, "visibilityState", { configurable: true, value: state });
+        await act(async () => document.dispatchEvent(new Event("visibilitychange")));
+        await settle();
+      };
+      await setVisibility("hidden");
+      await act(async () => vi.advanceTimersByTime(20000));
+      expect(mintCalls()).toBe(before + 1);
+      await setVisibility("visible");
+      await setVisibility("hidden");
+      await setVisibility("visible");
+      expect(mintCalls()).toBe(before + 3);
+
+      pending.resolve({ ticket: "stale", expiresInSeconds: 15 });
+      await settle();
+      await act(async () => vi.advanceTimersByTime(5000));
+      await settle();
+      // The first, hidden in-flight mint is closed, and only the final visible
+      // lifecycle owns a refresh timer.
+      expect(mintCalls()).toBe(before + 4);
+    } finally {
+      Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+      vi.useRealTimers();
+    }
   });
 
   it("still reports ready (degraded) and pushes a notice when the mint fails", async () => {

--- a/apps/web/src/hooks/useAccessGate.js
+++ b/apps/web/src/hooks/useAccessGate.js
@@ -120,7 +120,19 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
   // degrades to placeholders and recovers when a retry lands — and a "media-ticket"
   // notice tells the user why media is broken while the backoff keeps retrying.
   const [mediaTicketFailed, setMediaTicketFailed] = useState(false);
+  // A hidden tab cannot use media URLs, so refreshing their bearer ticket is pure
+  // background churn. Keep the visibility listener separate from the mint effect so
+  // it is registered once for the hook lifetime rather than once per ticket refresh.
+  const [documentVisible, setDocumentVisible] = useState(
+    () => typeof document === "undefined" || document.visibilityState !== "hidden",
+  );
   const ready = authenticated && (mediaReady || mediaTicketFailed);
+
+  useEffect(() => {
+    const onVisibilityChange = () => setDocumentVisible(document.visibilityState !== "hidden");
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, []);
 
   useEffect(() => {
     if (!authenticated || !accessResolved) {
@@ -138,6 +150,9 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
       setMediaTicket("");
       recordStartupMark("media-authorization-settled");
       setMediaReady(true);
+      return undefined;
+    }
+    if (!documentVisible) {
       return undefined;
     }
     let closed = false;
@@ -191,7 +206,7 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
         window.clearTimeout(timer);
       }
     };
-  }, [access.authRequired, accessResolved, authenticated, token, pushNotice, dismissNoticeKind]);
+  }, [access.authRequired, accessResolved, authenticated, documentVisible, token, pushNotice, dismissNoticeKind]);
 
   // Probe whether the deployment requires a password, then release `accessResolved`
   // so an authenticated client (or one not requiring auth) can load its data. Mirrors

--- a/apps/web/src/hooks/useStudioSettings.durable.test.jsx
+++ b/apps/web/src/hooks/useStudioSettings.durable.test.jsx
@@ -71,6 +71,18 @@ describe("advanced studio settings are durable (sc-15425)", () => {
     expect(persistNavigationPreferences).not.toHaveBeenCalled();
   });
 
+  it("persists an absent empty snapshot but skips a cached empty snapshot", async () => {
+    await render(<Harness settings={{}} />);
+    expect(lastSentMap()["ws-1"].image).toEqual({});
+
+    await act(async () => root.unmount());
+    persistNavigationPreferences.mockClear();
+    window.localStorage.setItem("sceneworks-studio-image-ws-1", JSON.stringify({}));
+    root = createRoot(container);
+    await render(<Harness settings={{}} />);
+    expect(persistNavigationPreferences).not.toHaveBeenCalled();
+  });
+
   it("still writes when a cached snapshot changes or readiness resumes", async () => {
     window.localStorage.setItem("sceneworks-studio-image-ws-1", JSON.stringify({ prompt: "old" }));
     await render(<Harness settings={{ prompt: "new" }} />);

--- a/apps/web/src/hooks/useStudioSettings.durable.test.jsx
+++ b/apps/web/src/hooks/useStudioSettings.durable.test.jsx
@@ -62,6 +62,26 @@ describe("advanced studio settings are durable (sc-15425)", () => {
     expect(lastSentMap()["ws-1"].image).toMatchObject({ prompt: "a fox", model: "z_image" });
   });
 
+  it("does not enqueue a durable write when mounting an unchanged cached snapshot", async () => {
+    window.localStorage.setItem(
+      "sceneworks-studio-image-ws-1",
+      JSON.stringify({ prompt: "a fox", model: "z_image" }),
+    );
+    await render(<Harness settings={{ prompt: "a fox", model: "z_image" }} />);
+    expect(persistNavigationPreferences).not.toHaveBeenCalled();
+  });
+
+  it("still writes when a cached snapshot changes or readiness resumes", async () => {
+    window.localStorage.setItem("sceneworks-studio-image-ws-1", JSON.stringify({ prompt: "old" }));
+    await render(<Harness settings={{ prompt: "new" }} />);
+    expect(lastSentMap()["ws-1"].image.prompt).toBe("new");
+
+    persistNavigationPreferences.mockClear();
+    await render(<Harness ready={false} settings={{ prompt: "new" }} />);
+    await render(<Harness ready settings={{ prompt: "new" }} />);
+    expect(lastSentMap()["ws-1"].image.prompt).toBe("new");
+  });
+
   it("restores the cache from the durable copy after a relaunch", async () => {
     await render(<Harness settings={{ prompt: "a fox", model: "z_image" }} />);
     const durable = lastSentMap();

--- a/apps/web/src/hooks/useStudioSettings.js
+++ b/apps/web/src/hooks/useStudioSettings.js
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { persistNavigationPreferences } from "../uiPreferences.js";
 
 // Per-workspace "last used" settings for the Image / Video studios, so leaving a
@@ -148,8 +148,25 @@ function persistToServer(touchedWorkspace) {
 // had read it. Callers pass `preferencesHydrated && <their catalog gate>`.
 export function useStudioSettingsWriter(studio, workspaceId, settings, ready = true) {
   const serialized = JSON.stringify(settings);
+  // A studio normally mounts from the same cache it is about to write. Track that
+  // first settled pass so it does not issue a redundant durable PUT, while retaining
+  // the important ready=false -> true transition as a deliberate first persistence.
+  const scopeRef = useRef("");
+  const initializedRef = useRef(false);
   useEffect(() => {
+    const scope = `${studio}:${workspaceKey(workspaceId)}`;
+    if (scopeRef.current !== scope) {
+      scopeRef.current = scope;
+      initializedRef.current = false;
+    }
     if (!ready) {
+      initializedRef.current = true;
+      return undefined;
+    }
+    const unchangedInitialSnapshot = !initializedRef.current
+      && JSON.stringify(loadStudioSettings(studio, workspaceId)) === serialized;
+    initializedRef.current = true;
+    if (unchangedInitialSnapshot) {
       return undefined;
     }
     writeCache(studio, workspaceId, JSON.parse(serialized));

--- a/apps/web/src/hooks/useStudioSettings.js
+++ b/apps/web/src/hooks/useStudioSettings.js
@@ -44,6 +44,18 @@ export function loadStudioSettings(studio, workspaceId) {
   }
 }
 
+// `loadStudioSettings()` intentionally treats an absent entry like an empty snapshot
+// for callers that just need defaults. The writer additionally needs to know whether
+// an empty snapshot is actually cached: an absent cache must still establish the
+// durable copy on its first ready mount.
+function hasCachedStudioSettings(studio, workspaceId) {
+  try {
+    return window.localStorage.getItem(storageKey(studio, workspaceId)) !== null;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Seed the localStorage cache from the durable server copy on launch (App.jsx, after
  * GET /api/v1/ui-preferences).
@@ -164,6 +176,7 @@ export function useStudioSettingsWriter(studio, workspaceId, settings, ready = t
       return undefined;
     }
     const unchangedInitialSnapshot = !initializedRef.current
+      && hasCachedStudioSettings(studio, workspaceId)
       && JSON.stringify(loadStudioSettings(studio, workspaceId)) === serialized;
     initializedRef.current = true;
     if (unchangedInitialSnapshot) {

--- a/apps/web/src/screens/DatasetCatalogsScreen.jsx
+++ b/apps/web/src/screens/DatasetCatalogsScreen.jsx
@@ -6,6 +6,7 @@ import { RequiredModelsNotice } from "../components/RequiredModelsNotice.jsx";
 import { PERSON_DETECT_MODEL_ID, POSE_DETECT_MODEL_ID } from "../constants.js";
 import { missingRequiredModels } from "../modelEligibility.js";
 import { useAppStatic } from "../context/AppContext.js";
+import { useScreenActive } from "../context/ScreenActiveContext.js";
 import { formatBytes } from "../formatting.js";
 import { isDesktop, tauriInvoke } from "../runtime.js";
 import { persistNavigationPreferences } from "../uiPreferences.js";
@@ -727,6 +728,7 @@ export function DatasetCatalogsScreen() {
   // re-render on every SSE job tick (sc-8855). That is why the required-model notice below is
   // given no `downloadJobs` — it falls back to its local "Queued" state, which needs no live jobs.
   const { token = "", models = [], createModelDownloadJob, setActiveView } = useAppStatic();
+  const screenActive = useScreenActive();
   // The two cache-only preprocessors structured analysis resolves before it can run
   // (catalog_semantic_jobs.rs). Declaration order is display order.
   const missingStructuredModels = useMemo(
@@ -748,6 +750,10 @@ export function DatasetCatalogsScreen() {
   const pollAbortRef = useRef(null);
   const mutationAbortRef = useRef(null);
   const selected = catalogs.find((catalog) => catalog.id === selectedId) ?? null;
+  // Status changes only while a processor is actively making progress. A terminal or
+  // paused catalog has no useful periodic work, and a kept-alive screen must not keep
+  // its poller alive behind another route.
+  const shouldPollSelected = screenActive && selected?.processing?.state === "running";
 
   useEffect(() => {
     const version = selected
@@ -809,7 +815,7 @@ export function DatasetCatalogsScreen() {
   }, [refresh, token]);
 
   useEffect(() => {
-    if (!selectedId) return undefined;
+    if (!selectedId || !shouldPollSelected) return undefined;
     const generation = ++generationRef.current;
     let timer = null;
     let stopped = false;
@@ -830,6 +836,10 @@ export function DatasetCatalogsScreen() {
             : catalog
         )));
         setError("");
+        // Do not arm another timer after the response itself reaches a terminal or
+        // paused state. The render triggered above will also tear this effect down,
+        // but this closes the small interval before that cleanup runs.
+        if (updated.processing?.state !== "running") stopped = true;
       } catch (err) {
         if (isAbortError(err) || stopped || generation !== generationRef.current) return;
         if (err.status === 404) {
@@ -851,7 +861,7 @@ export function DatasetCatalogsScreen() {
       if (timer !== null) window.clearTimeout(timer);
       pollAbortRef.current?.abort();
     };
-  }, [pollEpoch, refresh, selectedId, token]);
+  }, [pollEpoch, refresh, selectedId, shouldPollSelected, token]);
 
   async function chooseFolder(setter) {
     if (!isDesktop) return;

--- a/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
+++ b/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
@@ -377,6 +377,29 @@ describe("DatasetCatalogsScreen", () => {
     expect(requests.filter((item) => item.path.endsWith("/status"))).toHaveLength(0);
   });
 
+  it("clears an already-scheduled poll when the active screen becomes inactive", async () => {
+    await act(async () => root.unmount());
+    vi.useFakeTimers();
+    root = createRoot(container);
+    const renderScreen = async (active) => {
+      await act(async () => {
+        root.render(
+          <ScreenActiveContext.Provider value={active}>
+            <AppContext.Provider value={{ token: "token" }}>
+              <DatasetCatalogsScreen />
+              <ConfirmHost />
+            </AppContext.Provider>
+          </ScreenActiveContext.Provider>,
+        );
+      });
+      await flush();
+    };
+    await renderScreen(true);
+    await renderScreen(false);
+    await act(async () => vi.advanceTimersByTime(9000));
+    expect(requests.filter((item) => item.path.endsWith("/status"))).toHaveLength(0);
+  });
+
   it("stops after a terminal status response", async () => {
     await remountWithFakeTimers();
     const original = fetch.getMockImplementation();

--- a/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
+++ b/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConfirmHost } from "../appConfirm.jsx";
 import { AppContext } from "../context/AppContext.js";
+import { ScreenActiveContext } from "../context/ScreenActiveContext.js";
 import { resetNavigationPreferenceQueueForTests } from "../uiPreferences.js";
 
 const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
@@ -350,6 +351,48 @@ describe("DatasetCatalogsScreen", () => {
       .find((button) => button.textContent.includes("Refresh")).click());
     await flush();
     expect(container.textContent).toContain("8.0 KiB");
+  });
+
+  it("does not poll a paused or inactive selected catalog", async () => {
+    catalogs = [catalog({ processing: { ...catalog().processing, state: "paused" } })];
+    await remountWithFakeTimers();
+    await act(async () => vi.advanceTimersByTime(9000));
+    expect(requests.filter((item) => item.path.endsWith("/status"))).toHaveLength(0);
+
+    catalogs = [catalog()];
+    await act(async () => root.unmount());
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ScreenActiveContext.Provider value={false}>
+          <AppContext.Provider value={{ token: "token" }}>
+            <DatasetCatalogsScreen />
+            <ConfirmHost />
+          </AppContext.Provider>
+        </ScreenActiveContext.Provider>,
+      );
+    });
+    await flush();
+    await act(async () => vi.advanceTimersByTime(9000));
+    expect(requests.filter((item) => item.path.endsWith("/status"))).toHaveLength(0);
+  });
+
+  it("stops after a terminal status response", async () => {
+    await remountWithFakeTimers();
+    const original = fetch.getMockImplementation();
+    let polls = 0;
+    fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/status")) {
+        polls += 1;
+        return response(catalog({ processing: { ...catalog().processing, state: "completed" } }));
+      }
+      return original(url, options);
+    });
+    await act(async () => vi.advanceTimersByTime(3000));
+    await flush();
+    await act(async () => vi.advanceTimersByTime(9000));
+    expect(polls).toBe(1);
   });
 
   it("curates a reproducible primary sample with server paging, facets, saved views, and review overrides", async () => {


### PR DESCRIPTION
## Summary
- stop dataset catalog polling whenever the screen is inactive or processing leaves `running`
- pause media-ticket refresh while hidden and keep a single owned lifecycle timer
- avoid unchanged initial studio-settings persistence while preserving absent, changed, and readiness-transition writes

## Validation
- focused lifecycle/settings tests: 34 passing after the review fix
- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run test` (4,183 passing)
- `npm --prefix apps/web run build`

## Review
One independent adversarial review found the absent-empty snapshot edge case and a missing active-to-inactive timer regression. Both were corrected in the single ordinary fix pass with mutation-checked coverage. The only file overlap with newer feature-head work is semantically disjoint presentation text/tests in `DatasetCatalogsScreen`.

Shortcut: sc-21904