### PR TITLE
fix(web): bound prompt expansion and mask work [sc-21906]

### DIFF
--- a/apps/web/src/batchOps.js
+++ b/apps/web/src/batchOps.js
@@ -144,9 +144,17 @@ export function summarizeBatchProgress(items, jobs, observedJobs) {
 // before posting, so enqueueing can be slow. An item with no jobId and no `error` is
 // therefore PENDING submission (NOT failed); `error: true` marks a submission that threw.
 // `active` = queued + running (jobs that Cancel can still stop).
-export function summarizeBatchRun(items, jobs, observedJobs) {
-  const summary = { total: items?.length ?? 0, pending: 0, queued: 0, running: 0, completed: 0, failed: 0 };
-  for (const item of items ?? []) {
+export function summarizeBatchRun(items, jobs, observedJobs, total = items?.length ?? 0) {
+  const listedItems = items ?? [];
+  const summary = {
+    total: Math.max(total, listedItems.length),
+    pending: Math.max(total - listedItems.length, 0),
+    queued: 0,
+    running: 0,
+    completed: 0,
+    failed: 0,
+  };
+  for (const item of listedItems) {
     if (item.error) {
       summary.failed += 1;
       continue;

--- a/apps/web/src/batchOps.js
+++ b/apps/web/src/batchOps.js
@@ -139,31 +139,46 @@ export function summarizeBatchProgress(items, jobs, observedJobs) {
   return summary;
 }
 
-// Progress for a prompt-batch run (sc-9980). Unlike summarizeBatchProgress, this fan-out
-// enqueues incrementally — a structured-caption model auto-expands each resolved prompt
-// before posting, so enqueueing can be slow. An item with no jobId and no `error` is
-// therefore PENDING submission (NOT failed); `error: true` marks a submission that threw.
-// `active` = queued + running (jobs that Cancel can still stop).
-export function summarizeBatchRun(items, jobs, observedJobs, total = items?.length ?? 0) {
-  const listedItems = items ?? [];
+// Move terminal active jobs into the bounded prompt-batch totals. The active-id list is
+// deliberately small (the Studio applies backpressure before it grows without bound), while
+// completed and failed are scalar counters. Returns the original run when nothing settled.
+export function settlePromptBatchRun(run, jobs, observedJobs) {
+  if (!run?.activeJobIds?.length) return run;
+  let completed = run.completed ?? 0;
+  let failed = run.failed ?? 0;
+  const activeJobIds = [];
+  for (const jobId of run.activeJobIds) {
+    const status = batchItemStatus(jobId, jobs, observedJobs);
+    if (status === "completed") {
+      completed += 1;
+      observedJobs?.delete(jobId);
+    } else if (status === "failed") {
+      failed += 1;
+      observedJobs?.delete(jobId);
+    } else {
+      activeJobIds.push(jobId);
+    }
+  }
+  if (activeJobIds.length === run.activeJobIds.length) return run;
+  return { ...run, completed, failed, activeJobIds };
+}
+
+// Progress for a prompt-batch run (sc-9980). It holds scalar totals plus only the bounded
+// currently-active job ids, never one entry per resolved prompt. `submitted` includes posts
+// that failed before returning a job id; `pending` is the not-yet-submitted suffix.
+export function summarizeBatchRun(run, jobs, observedJobs) {
+  const total = Math.max(run?.total ?? 0, 0);
+  const submitted = Math.min(Math.max(run?.submitted ?? 0, 0), total);
   const summary = {
-    total: Math.max(total, listedItems.length),
-    pending: Math.max(total - listedItems.length, 0),
+    total,
+    pending: total - submitted,
     queued: 0,
     running: 0,
-    completed: 0,
-    failed: 0,
+    completed: run?.completed ?? 0,
+    failed: run?.failed ?? 0,
   };
-  for (const item of listedItems) {
-    if (item.error) {
-      summary.failed += 1;
-      continue;
-    }
-    if (!item.jobId) {
-      summary.pending += 1;
-      continue;
-    }
-    summary[batchItemStatus(item.jobId, jobs, observedJobs)] += 1;
+  for (const jobId of run?.activeJobIds ?? []) {
+    summary[batchItemStatus(jobId, jobs, observedJobs)] += 1;
   }
   summary.done = summary.completed + summary.failed;
   summary.active = summary.queued + summary.running;

--- a/apps/web/src/batchOps.test.js
+++ b/apps/web/src/batchOps.test.js
@@ -172,6 +172,11 @@ describe("batch ops (sc-6112)", () => {
 });
 
 describe("summarizeBatchRun (sc-9980)", () => {
+  it("counts an unstreamed suffix as pending when the run total is known", () => {
+    const summary = summarizeBatchRun([{ jobId: "j1" }], [{ id: "j1", status: "queued" }], undefined, 4);
+    expect(summary).toMatchObject({ total: 4, pending: 3, queued: 1, failed: 0, done: 0, allDone: false });
+  });
+
   it("counts not-yet-submitted items as pending, not failed", () => {
     const summary = summarizeBatchRun(
       [{ jobId: "j1" }, { jobId: null }, { jobId: null }],

--- a/apps/web/src/batchOps.test.js
+++ b/apps/web/src/batchOps.test.js
@@ -8,6 +8,7 @@ import {
   batchItemStatusForItem,
   batchItemResultAsset,
   summarizeBatchProgress,
+  settlePromptBatchRun,
   summarizeBatchRun,
 } from "./batchOps.js";
 
@@ -173,22 +174,26 @@ describe("batch ops (sc-6112)", () => {
 
 describe("summarizeBatchRun (sc-9980)", () => {
   it("counts an unstreamed suffix as pending when the run total is known", () => {
-    const summary = summarizeBatchRun([{ jobId: "j1" }], [{ id: "j1", status: "queued" }], undefined, 4);
+    const summary = summarizeBatchRun(
+      { total: 4, submitted: 1, completed: 0, failed: 0, activeJobIds: ["j1"] },
+      [{ id: "j1", status: "queued" }],
+    );
     expect(summary).toMatchObject({ total: 4, pending: 3, queued: 1, failed: 0, done: 0, allDone: false });
   });
 
-  it("counts not-yet-submitted items as pending, not failed", () => {
+  it("counts not-yet-submitted prompts as pending, not failed", () => {
     const summary = summarizeBatchRun(
-      [{ jobId: "j1" }, { jobId: null }, { jobId: null }],
+      { total: 3, submitted: 1, completed: 0, failed: 0, activeJobIds: ["j1"] },
       [{ id: "j1", status: "queued" }],
     );
     expect(summary).toMatchObject({ total: 3, pending: 2, queued: 1, failed: 0, done: 0, allDone: false });
   });
 
-  it("marks a thrown submission as failed via the error flag", () => {
-    const summary = summarizeBatchRun([{ jobId: null, error: true }, { jobId: "j1" }], [
-      { id: "j1", status: "completed" },
-    ]);
+  it("counts a failed submission without retaining its prompt", () => {
+    const summary = summarizeBatchRun(
+      { total: 2, submitted: 2, completed: 0, failed: 1, activeJobIds: ["j1"] },
+      [{ id: "j1", status: "completed" }],
+    );
     expect(summary).toMatchObject({ total: 2, failed: 1, completed: 1, pending: 0, done: 2 });
   });
 
@@ -197,9 +202,26 @@ describe("summarizeBatchRun (sc-9980)", () => {
       { id: "j1", status: "completed" },
       { id: "j2", status: "running" },
     ];
-    const mid = summarizeBatchRun([{ jobId: "j1" }, { jobId: "j2" }], jobs);
+    const mid = summarizeBatchRun(
+      { total: 2, submitted: 2, completed: 0, failed: 0, activeJobIds: ["j1", "j2"] },
+      jobs,
+    );
     expect(mid).toMatchObject({ completed: 1, running: 1, active: 1, allDone: false });
-    const doneAll = summarizeBatchRun([{ jobId: "j1" }], [{ id: "j1", status: "completed" }]);
+    const doneAll = summarizeBatchRun(
+      { total: 1, submitted: 1, completed: 0, failed: 0, activeJobIds: ["j1"] },
+      [{ id: "j1", status: "completed" }],
+    );
     expect(doneAll).toMatchObject({ done: 1, active: 0, allDone: true });
+  });
+
+  it("settles terminal jobs into scalar totals and drops their ids", () => {
+    const observed = new Map([["j1", "observed"]]);
+    const settled = settlePromptBatchRun(
+      { total: 3, submitted: 3, completed: 0, failed: 1, activeJobIds: ["j1", "j2"] },
+      [{ id: "j1", status: "completed" }, { id: "j2", status: "running" }],
+      observed,
+    );
+    expect(settled).toEqual({ total: 3, submitted: 3, completed: 1, failed: 1, activeJobIds: ["j2"] });
+    expect(observed.has("j1")).toBe(false);
   });
 });

--- a/apps/web/src/imageStudioValidation.js
+++ b/apps/web/src/imageStudioValidation.js
@@ -14,10 +14,14 @@ import { promptBudget } from "./styleComposer.js";
 import { issue } from "./validation/issues.js";
 
 export function batchPromptBudgetOverages(composedPrompts = []) {
-  return composedPrompts.flatMap((prompt, index) => {
+  const overages = [];
+  let index = 0;
+  for (const prompt of composedPrompts) {
     const budget = promptBudget(prompt);
-    return budget.over ? [{ item: index + 1, ...budget }] : [];
-  });
+    if (budget.over) overages.push({ item: index + 1, ...budget });
+    index += 1;
+  }
+  return overages;
 }
 
 export function batchPromptBudgetMessage(overages = []) {

--- a/apps/web/src/imageStudioValidation.js
+++ b/apps/web/src/imageStudioValidation.js
@@ -13,12 +13,17 @@ import { MAX_IMAGE_DIMENSION, MIN_IMAGE_DIMENSION } from "./resolutionOverride.j
 import { promptBudget } from "./styleComposer.js";
 import { issue } from "./validation/issues.js";
 
-export function batchPromptBudgetOverages(composedPrompts = []) {
+// `limit` lets a streaming caller stop after the first actionable violation instead
+// of retaining an entry for every member of a very large batch.
+export function batchPromptBudgetOverages(composedPrompts = [], limit = Infinity) {
   const overages = [];
   let index = 0;
   for (const prompt of composedPrompts) {
     const budget = promptBudget(prompt);
-    if (budget.over) overages.push({ item: index + 1, ...budget });
+    if (budget.over) {
+      overages.push({ item: index + 1, ...budget });
+      if (overages.length >= limit) break;
+    }
     index += 1;
   }
   return overages;

--- a/apps/web/src/imageStudioValidation.test.js
+++ b/apps/web/src/imageStudioValidation.test.js
@@ -332,6 +332,17 @@ describe("imageBatchValidation", () => {
     );
   });
 
+  it("stops a streaming budget preflight after the first actionable overage", () => {
+    function* prompts() {
+      yield "x".repeat(PROMPT_MAX_CHARS + 1);
+      throw new Error("the preflight must not retain or inspect later violations");
+    }
+
+    expect(batchPromptBudgetOverages(prompts(), 1)).toEqual([
+      { item: 1, length: 4001, max: 4000, remaining: -1, over: true },
+    ]);
+  });
+
   it("catches a batch item whose short raw prompt only exceeds the cap after style composition", () => {
     const rawPrompt = "a fox";
     const composedPrompt = composeStyledPrompt({

--- a/apps/web/src/promptBatch.js
+++ b/apps/web/src/promptBatch.js
@@ -124,17 +124,6 @@ function linePlan(prompt, variableMap) {
   return { tokens, named, linked, axes };
 }
 
-// Cartesian product of the axis sizes as index tuples. `[]` axes → `[[]]` (one empty
-// combination), so a line with no axes still yields exactly one render. The last axis
-// varies fastest, matching the documented ordering.
-function axisCombos(axes) {
-  return axes.reduce(
-    (combos, axis) =>
-      combos.flatMap((combo) => Array.from({ length: axis.size }, (_, i) => [...combo, i])),
-    [[]],
-  );
-}
-
 // Resolve one line for a combination (an index per axis). Named tokens with no axis
 // (unfilled) stay literal; the returned `values` map carries the chosen named values.
 function resolveLine(plan, combo) {
@@ -217,19 +206,32 @@ export function resolvePrompt(template, valueMap) {
   });
 }
 
-// Expand a batch to its concrete prompts. Each prompt line fans out over its own axes
-// (named cross-product × inline occurrences × linked groups zipped). Each entry carries
-// the resolved `prompt` plus the `values` map of the named bindings that produced it.
-export function expandBatch(prompts, variables) {
+// Yield a batch's concrete prompts one at a time. The last axis varies fastest, matching
+// the documented ordering, but this never builds the full Cartesian product in memory.
+export function* iterateBatch(prompts, variables) {
   const variableMap = buildVariableMap(variables);
-  const out = [];
   for (const prompt of promptList(prompts)) {
     const plan = linePlan(prompt, variableMap);
-    for (const combo of axisCombos(plan.axes)) {
-      out.push(resolveLine(plan, combo));
+    const combo = Array(plan.axes.length).fill(0);
+    // An axis-free line still has one empty combination.
+    for (;;) {
+      yield resolveLine(plan, combo);
+      let axis = plan.axes.length - 1;
+      while (axis >= 0) {
+        combo[axis] += 1;
+        if (combo[axis] < plan.axes[axis].size) break;
+        combo[axis] = 0;
+        axis -= 1;
+      }
+      if (axis < 0) break;
     }
   }
-  return out;
+}
+
+// Expand a batch to its concrete prompts. This compatibility helper intentionally
+// materializes the iterable; high-cardinality callers should consume iterateBatch().
+export function expandBatch(prompts, variables) {
+  return [...iterateBatch(prompts, variables)];
 }
 
 // The first resolved prompt (line 1, first choice of every axis) — for a live preview

--- a/apps/web/src/promptBatch.test.js
+++ b/apps/web/src/promptBatch.test.js
@@ -5,6 +5,7 @@ import {
   expandBatch,
   extractKeys,
   firstResolvedPrompt,
+  iterateBatch,
   linkedGroupIssues,
   missingKeys,
   parsePromptResolution,
@@ -142,6 +143,31 @@ describe("expandBatch", () => {
 
   it("returns nothing for an all-blank prompt list", () => {
     expect(expandBatch(["", "   "], [{ key: "x", values: ["a"] }])).toEqual([]);
+  });
+});
+
+describe("iterateBatch", () => {
+  it("preserves expandBatch ordering while yielding one entry at a time", () => {
+    const prompts = ["{{name}}/{{hair}}", "{{name}} alone"];
+    const variables = [
+      { key: "name", values: ["Alice", "Bob"] },
+      { key: "hair", values: ["red", "blue"] },
+    ];
+    expect([...iterateBatch(prompts, variables)]).toEqual(expandBatch(prompts, variables));
+  });
+
+  it("can take a first result from an enormous Cartesian space without materializing it", () => {
+    const values = Array.from({ length: 1000 }, (_, index) => String(index));
+    const iterator = iterateBatch(["{{a}}/{{b}}/{{c}}"], [
+      { key: "a", values },
+      { key: "b", values },
+      { key: "c", values },
+    ]);
+
+    expect(iterator.next()).toEqual({
+      done: false,
+      value: { prompt: "0/0/0", values: { a: "0", b: "0", c: "0" } },
+    });
   });
 });
 

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -31,7 +31,7 @@ import {
 } from "../resolutionOverride.js";
 import { pidDecodeHeadsUp } from "../pidDecodeNotice.js";
 import { promptEnhancementAvailable } from "../promptEnhancement.js";
-import { batchItemStatus, summarizeBatchRun } from "../batchOps.js";
+import { batchItemStatus, settlePromptBatchRun, summarizeBatchRun } from "../batchOps.js";
 import {
   DEFAULT_SCENE_PROMPT,
   promptHintFor,
@@ -232,6 +232,10 @@ const REFERENCE_TUNING_PRESET_KEYS = [
 // Above this many resolved images a batch run needs explicit confirmation, so a stray
 // value or an over-eager cross-product can't silently queue a huge job (sc-9957).
 const BATCH_RENDER_CAP = 100;
+// Keep high-cardinality batch state bounded without changing the eager behavior of
+// ordinary (at-or-under-cap) runs. The worker remains serial; this is client-side
+// backpressure for confirmed large runs only.
+const BATCH_ACTIVE_JOB_LIMIT = BATCH_RENDER_CAP;
 
 function preferredOption(defaultValue, options) {
   return options.includes(defaultValue) ? defaultValue : options[0] ?? "default";
@@ -456,6 +460,8 @@ export function ImageStudio() {
     handleLoadBatch, handleDeleteBatch, handleImportBatch, handleNewBatch,
   } = useBatchPromptState({ saved, createPromptBatch, updatePromptBatch, deletePromptBatch });
   const batchObservedJobsRef = useRef(new Map());
+  const batchRunRef = useRef(batchRun);
+  const batchSlotWaitersRef = useRef([]);
   const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
   const [model, setModel] = useState(saved.model ?? imageModels[0]?.id ?? "z_image_turbo");
   const [textEncoderSelection, setTextEncoderSelection] = useState({
@@ -2464,6 +2470,24 @@ export function ImageStudio() {
       resolutionOverride: opts.resolution ?? null,
     });
 
+  function replaceBatchRun(next) {
+    batchRunRef.current = next;
+    setBatchRun(next);
+  }
+
+  function releaseBatchSlotWaiters() {
+    const waiters = batchSlotWaitersRef.current.splice(0);
+    for (const resolve of waiters) resolve();
+  }
+
+  async function waitForBatchSlot() {
+    while (!batchAbortRef.current) {
+      const activeJobIds = batchRunRef.current?.activeJobIds ?? [];
+      if (activeJobIds.length < BATCH_ACTIVE_JOB_LIMIT) return;
+      await new Promise((resolve) => batchSlotWaitersRef.current.push(resolve));
+    }
+  }
+
   // Fan out one image job per resolved prompt (mirrors the asset batch, sc-6112): each
   // posts independently so the worker runs them serially with its between-image cache
   // release, and progress/cancel read the live jobs feed.
@@ -2497,6 +2521,9 @@ export function ImageStudio() {
             }
           })()
         : [],
+      // Preserve the detailed item list for ordinary runs; a high-cardinality stream
+      // needs only the first actionable violation and must not retain them all.
+      batchJobCount > BATCH_RENDER_CAP ? 1 : Infinity,
     );
     if (promptBudgetOverages.length) {
       setBatchError(batchPromptBudgetMessage(promptBudgetOverages));
@@ -2515,20 +2542,24 @@ export function ImageStudio() {
     setBatchConfirmPending(false);
     batchAbortRef.current = false;
     batchObservedJobsRef.current.clear();
-    // Keep only the submitted prefix while streaming. `total` represents the unvisited
-    // suffix as pending, so a confirmed large batch never starts with a full item list.
-    const items = [];
-    setBatchRun({ submitting: true, total: batchJobCount, items: [] });
+    // Keep scalar totals plus a bounded in-flight id set. Once the set reaches the normal
+    // batch cap, wait for a terminal job before posting the next resolved prompt.
+    replaceBatchRun({
+      submitting: true,
+      total: batchJobCount,
+      submitted: 0,
+      completed: 0,
+      failed: 0,
+      activeJobIds: [],
+    });
     for (const entry of iterateBatch(batchPrompts, batchVariables)) {
+      await waitForBatchSlot();
       if (batchAbortRef.current) {
         break;
       }
       // Strip a leading [WxH] directive (sc-10063): the model gets the clean prompt, the job
       // gets that per-prompt resolution.
       const { prompt: cleanPrompt, resolution } = parsePromptResolution(entry.prompt);
-      const item = { prompt: cleanPrompt, jobId: null, error: false };
-      items.push(item);
-      setBatchRun({ submitting: true, total: batchJobCount, items });
       try {
         let request;
         if (structuredPromptModel) {
@@ -2536,6 +2567,7 @@ export function ImageStudio() {
           // resolved prompt into a JSON caption first (sc-9980) — N sequential refine calls.
           // A prompt that fails to expand fails only that item; the rest continue.
           const expanded = await onMagicExpand(cleanPrompt);
+          if (batchAbortRef.current) break;
           if (!validateCaption(expanded).ok) {
             throw new Error("Auto-generated caption was invalid.");
           }
@@ -2550,31 +2582,39 @@ export function ImageStudio() {
           request = buildBatchJobRequest(cleanPrompt, { resolution });
         }
         const job = await createImageJob(request);
-        Object.assign(item, { jobId: job?.id ?? null, error: !job?.id });
+        const current = batchRunRef.current;
+        if (!current) break;
+        replaceBatchRun(
+          job?.id
+            ? { ...current, submitted: current.submitted + 1, activeJobIds: [...current.activeJobIds, job.id] }
+            : { ...current, submitted: current.submitted + 1, failed: current.failed + 1 },
+        );
+        if (batchAbortRef.current && job?.id) jobAction(job, "cancel");
       } catch {
-        item.error = true;
+        const current = batchRunRef.current;
+        if (!current) break;
+        replaceBatchRun({ ...current, submitted: current.submitted + 1, failed: current.failed + 1 });
       }
-      setBatchRun({ submitting: true, total: batchJobCount, items });
     }
-    setBatchRun({ submitting: false, total: batchJobCount, items });
+    const current = batchRunRef.current;
+    if (current) replaceBatchRun({ ...current, submitting: false });
   }
 
   // Stop the enqueue loop (if still running) and cancel every still-pending job in the run;
   // completed/failed items are left as-is.
   function cancelBatchRun() {
     batchAbortRef.current = true;
-    if (!batchRun) {
+    releaseBatchSlotWaiters();
+    const current = batchRunRef.current;
+    if (!current) {
       return;
     }
-    for (const item of batchRun.items) {
-      if (!item.jobId) {
-        continue;
-      }
-      const status = batchItemStatus(item.jobId, jobs, batchObservedJobsRef.current);
+    for (const jobId of current.activeJobIds) {
+      const status = batchItemStatus(jobId, jobs, batchObservedJobsRef.current);
       if (status !== "queued" && status !== "running") {
         continue;
       }
-      const job = jobs.find((entry) => entry.id === item.jobId);
+      const job = jobs.find((entry) => entry.id === jobId);
       if (job) {
         jobAction(job, "cancel");
       }
@@ -2582,11 +2622,12 @@ export function ImageStudio() {
   }
 
   const batchRunProgress = batchRun
-    ? summarizeBatchRun(batchRun.items, jobs, batchObservedJobsRef.current, batchRun.total)
+    ? summarizeBatchRun(batchRun, jobs, batchObservedJobsRef.current)
     : null;
   useEffect(() => {
-    if (!batchRun) return;
-    const batchJobIds = new Set(batchRun.items.map((item) => item.jobId).filter(Boolean));
+    const current = batchRunRef.current;
+    if (!current) return;
+    const batchJobIds = new Set(current.activeJobIds);
     for (const job of jobs) {
       if (batchJobIds.has(job.id)) {
         const status =
@@ -2598,7 +2639,13 @@ export function ImageStudio() {
         batchObservedJobsRef.current.set(job.id, status);
       }
     }
-  }, [batchRun, jobs]);
+    const settled = settlePromptBatchRun(current, jobs, batchObservedJobsRef.current);
+    if (settled !== current) {
+      batchRunRef.current = settled;
+      setBatchRun(settled);
+      releaseBatchSlotWaiters();
+    }
+  }, [batchRun, jobs, setBatchRun]);
   const batchMissingKeys = missingKeys(batchPrompts, batchVariables);
   const batchGroupIssues = linkedGroupIssues(batchPrompts);
   // Prompt lines whose leading [WxH] directive (sc-10063) breaks the SELECTED model's geometry — the
@@ -2850,7 +2897,7 @@ export function ImageStudio() {
                         Cancel remaining
                       </button>
                     ) : (
-                      <button className="batch-btn ghost" onClick={() => setBatchRun(null)} type="button">
+                      <button className="batch-btn ghost" onClick={() => replaceBatchRun(null)} type="button">
                         Clear
                       </button>
                     )}

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -23,7 +23,7 @@ import { StudioUpdateBadge, StudioUpdateNotice, updateOptionLabel } from "../com
 import StructuredPromptBuilder from "../components/StructuredPromptBuilder.jsx";
 import ReferenceCaptionPicker from "../components/ReferenceCaptionPicker.jsx";
 import BatchPromptPanel from "../components/BatchPromptPanel.jsx";
-import { expandBatch, linkedGroupIssues, missingKeys, parsePromptResolution } from "../promptBatch.js";
+import { iterateBatch, linkedGroupIssues, missingKeys, parsePromptResolution } from "../promptBatch.js";
 import {
   dimensionConstraintMessage,
   evaluateModelDimensions,
@@ -2479,16 +2479,23 @@ export function ImageStudio() {
       setBatchError("Waiting for engine capabilities before using the restored decoder.");
       return;
     }
-    const resolved = expandBatch(batchPrompts, batchVariables);
-    if (!resolved.length) {
+    // batchJobCount is cardinality(), so admission happens before any Cartesian expansion.
+    if (!batchJobCount) {
+      return;
+    }
+    // Soft cap: a large run must be confirmed once, showing the exact image count.
+    if (!confirmed && batchTotal > BATCH_RENDER_CAP) {
+      setBatchConfirmPending(true);
       return;
     }
     const promptBudgetOverages = batchPromptBudgetOverages(
       stylePreviewActive && !structuredPromptModel
-        ? resolved.map(({ prompt: resolvedPrompt }) => {
-            const { prompt: cleanPrompt } = parsePromptResolution(resolvedPrompt);
-            return composeJobPrompt({ promptToSend: cleanPrompt }).composedPrompt;
-          })
+        ? (function* composedBatchPrompts() {
+            for (const { prompt: resolvedPrompt } of iterateBatch(batchPrompts, batchVariables)) {
+              const { prompt: cleanPrompt } = parsePromptResolution(resolvedPrompt);
+              yield composeJobPrompt({ promptToSend: cleanPrompt }).composedPrompt;
+            }
+          })()
         : [],
     );
     if (promptBudgetOverages.length) {
@@ -2505,27 +2512,23 @@ export function ImageStudio() {
       return;
     }
     setBatchError("");
-    // Soft cap: a large run must be confirmed once, showing the exact image count.
-    if (!confirmed && resolved.length * batchImagesPerPrompt > BATCH_RENDER_CAP) {
-      setBatchConfirmPending(true);
-      return;
-    }
     setBatchConfirmPending(false);
     batchAbortRef.current = false;
     batchObservedJobsRef.current.clear();
-    // Items carry `error` so not-yet-submitted rows read as pending, not failed, while a
-    // (possibly slow, structured) enqueue is in flight. Updated after each post so progress
-    // ticks up live.
-    const items = resolved.map((entry) => ({ prompt: entry.prompt, jobId: null, error: false }));
-    setBatchRun({ submitting: true, items: items.map((item) => ({ ...item })) });
-    for (let i = 0; i < resolved.length; i += 1) {
+    // Keep only the submitted prefix while streaming. `total` represents the unvisited
+    // suffix as pending, so a confirmed large batch never starts with a full item list.
+    const items = [];
+    setBatchRun({ submitting: true, total: batchJobCount, items: [] });
+    for (const entry of iterateBatch(batchPrompts, batchVariables)) {
       if (batchAbortRef.current) {
         break;
       }
-      const entry = resolved[i];
       // Strip a leading [WxH] directive (sc-10063): the model gets the clean prompt, the job
       // gets that per-prompt resolution.
       const { prompt: cleanPrompt, resolution } = parsePromptResolution(entry.prompt);
+      const item = { prompt: cleanPrompt, jobId: null, error: false };
+      items.push(item);
+      setBatchRun({ submitting: true, total: batchJobCount, items });
       try {
         let request;
         if (structuredPromptModel) {
@@ -2547,13 +2550,13 @@ export function ImageStudio() {
           request = buildBatchJobRequest(cleanPrompt, { resolution });
         }
         const job = await createImageJob(request);
-        items[i] = { prompt: cleanPrompt, jobId: job?.id ?? null, error: !job?.id };
+        Object.assign(item, { jobId: job?.id ?? null, error: !job?.id });
       } catch {
-        items[i] = { prompt: cleanPrompt, jobId: null, error: true };
+        item.error = true;
       }
-      setBatchRun({ submitting: true, items: items.map((item) => ({ ...item })) });
+      setBatchRun({ submitting: true, total: batchJobCount, items });
     }
-    setBatchRun({ submitting: false, items });
+    setBatchRun({ submitting: false, total: batchJobCount, items });
   }
 
   // Stop the enqueue loop (if still running) and cancel every still-pending job in the run;
@@ -2579,7 +2582,7 @@ export function ImageStudio() {
   }
 
   const batchRunProgress = batchRun
-    ? summarizeBatchRun(batchRun.items, jobs, batchObservedJobsRef.current)
+    ? summarizeBatchRun(batchRun.items, jobs, batchObservedJobsRef.current, batchRun.total)
     : null;
   useEffect(() => {
     if (!batchRun) return;

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -201,6 +201,54 @@ describe("ImageStudio Save as Preset", () => {
   });
 });
 
+describe("Image Studio batch cardinality admission", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  it("confirms an enormous batch from cardinality without materializing its combinations", async () => {
+    const values = Array.from({ length: 10 }, (_, index) => String(index));
+    const keys = ["a", "b", "c", "d", "e", "f", "g"];
+    window.localStorage.setItem(
+      "sceneworks-studio-image-project_1",
+      JSON.stringify({
+        model: Z_IMAGE.id,
+        batchMode: true,
+        batchPromptsText: keys.map((key) => `{{${key}}}`).join(" "),
+        batchVariableValues: Object.fromEntries(keys.map((key) => [key, values])),
+      }),
+    );
+    const createImageJob = vi.fn();
+    await render(baseContext({ createImageJob }));
+
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent.includes("Run batch")));
+
+    expect(container.querySelector(".batch-confirm")?.textContent).toContain("Queue 40000000 images");
+    expect(createImageJob).not.toHaveBeenCalled();
+  });
+});
+
 describe("ImageStudio advanced model defaults", () => {
   let container;
   let root;

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -247,6 +247,56 @@ describe("Image Studio batch cardinality admission", () => {
     expect(container.querySelector(".batch-confirm")?.textContent).toContain("Queue 40000000 images");
     expect(createImageJob).not.toHaveBeenCalled();
   });
+
+  it("stops styled high-cardinality preflight at the first actionable budget violation", async () => {
+    const values = Array.from({ length: 10 }, (_, index) => String(index));
+    const keys = ["a", "b", "c", "d", "e", "f", "g"];
+    window.localStorage.setItem(
+      "sceneworks-studio-image-project_1",
+      JSON.stringify({
+        model: Z_IMAGE.id,
+        count: 1,
+        styleId: "ghibli-style",
+        batchMode: true,
+        batchPromptsText: `${"x".repeat(3600)} ${keys.map((key) => `{{${key}}}`).join(" ")}`,
+        batchVariableValues: Object.fromEntries(keys.map((key) => [key, values])),
+      }),
+    );
+    const createImageJob = vi.fn();
+    await render(baseContext({ createImageJob }));
+
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent.includes("Run batch")));
+    expect(container.querySelector(".batch-confirm")?.textContent).toContain("Queue 10000000 images");
+    await click(container.querySelector(".batch-confirm .prompt-cta"));
+
+    expect(container.querySelector(".batch-warning")?.textContent).toContain("Batch prompt 1");
+    expect(createImageJob).not.toHaveBeenCalled();
+  });
+
+  it("keeps a confirmed run's active queue bounded while preserving its submitted count", async () => {
+    const values = Array.from({ length: 101 }, (_, index) => String(index));
+    window.localStorage.setItem(
+      "sceneworks-studio-image-project_1",
+      JSON.stringify({
+        model: Z_IMAGE.id,
+        count: 1,
+        batchMode: true,
+        batchPromptsText: "{{value}}",
+        batchVariableValues: { value: values },
+      }),
+    );
+    let sequence = 0;
+    const createImageJob = vi.fn(async () => ({ id: `batch-${sequence++}` }));
+    await render(baseContext({ createImageJob }));
+
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent.includes("Run batch")));
+    await click(container.querySelector(".batch-confirm .prompt-cta"));
+    await vi.waitFor(() => expect(createImageJob).toHaveBeenCalledTimes(100));
+
+    expect(container.querySelector(".batch-run-progress")?.textContent).toContain("Queued 100/101");
+    await click([...container.querySelectorAll(".batch-run-progress button")].find((button) => button.textContent === "Stop"));
+    await vi.waitFor(() => expect(container.querySelector(".batch-run-progress")?.textContent).toContain("0/101 done"));
+  });
 });
 
 describe("ImageStudio advanced model defaults", () => {

--- a/apps/web/src/screens/imageEditor/maskAssetLoader.js
+++ b/apps/web/src/screens/imageEditor/maskAssetLoader.js
@@ -1,0 +1,40 @@
+// Keeps only the newest smart-select mask asset load eligible to commit. Starting a new
+// selection invalidates older job completions and aborts an asset fetch already in flight.
+export function createLatestMaskAssetLoader({ fetchImpl = fetch, assetUrlFor, blobToImage }) {
+  let generation = 0;
+  let controller = null;
+
+  function invalidate() {
+    generation += 1;
+    controller?.abort();
+    controller = null;
+    return generation;
+  }
+
+  async function load(asset, requestGeneration, onLoad) {
+    if (requestGeneration !== generation) return false;
+    controller?.abort();
+    const activeController = new AbortController();
+    controller = activeController;
+    try {
+      const response = await fetchImpl(assetUrlFor(asset), { signal: activeController.signal });
+      if (!response.ok) throw new Error(`Failed to load mask (${response.status})`);
+      const decoded = await blobToImage(await response.blob());
+      if (requestGeneration !== generation || activeController.signal.aborted) {
+        URL.revokeObjectURL(decoded.objectUrl);
+        return false;
+      }
+      onLoad(decoded.image);
+      URL.revokeObjectURL(decoded.objectUrl);
+      return true;
+    } catch (error) {
+      // A superseded request is expected cancellation, not an editor error.
+      if (requestGeneration !== generation || activeController.signal.aborted) return false;
+      throw error;
+    } finally {
+      if (controller === activeController) controller = null;
+    }
+  }
+
+  return { invalidate, load };
+}

--- a/apps/web/src/screens/imageEditor/maskAssetLoader.test.js
+++ b/apps/web/src/screens/imageEditor/maskAssetLoader.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createLatestMaskAssetLoader } from "./maskAssetLoader.js";
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("createLatestMaskAssetLoader", () => {
+  it("aborts a superseded asset fetch and commits only the latest mask", async () => {
+    const firstFetch = deferred();
+    const secondFetch = deferred();
+    const fetchImpl = vi.fn()
+      .mockReturnValueOnce(firstFetch.promise)
+      .mockReturnValueOnce(secondFetch.promise);
+    const blobToImage = vi.fn(async (blob) => ({ image: { id: blob.id }, objectUrl: `blob:${blob.id}` }));
+    const loader = createLatestMaskAssetLoader({
+      fetchImpl,
+      assetUrlFor: (asset) => asset.url,
+      blobToImage,
+    });
+    const revokeObjectURL = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const committed = [];
+
+    const firstGeneration = loader.invalidate();
+    const firstLoad = loader.load({ url: "old" }, firstGeneration, (image) => committed.push(image.id));
+    const firstSignal = fetchImpl.mock.calls[0][1].signal;
+
+    const secondGeneration = loader.invalidate();
+    expect(firstSignal.aborted).toBe(true);
+    const secondLoad = loader.load({ url: "new" }, secondGeneration, (image) => committed.push(image.id));
+
+    firstFetch.resolve({ ok: true, blob: async () => ({ id: "old" }) });
+    secondFetch.resolve({ ok: true, blob: async () => ({ id: "new" }) });
+
+    await expect(firstLoad).resolves.toBe(false);
+    await expect(secondLoad).resolves.toBe(true);
+    expect(committed).toEqual(["new"]);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:old");
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:new");
+    revokeObjectURL.mockRestore();
+  });
+});

--- a/apps/web/src/screens/imageEditor/maskStroke.js
+++ b/apps/web/src/screens/imageEditor/maskStroke.js
@@ -1,0 +1,9 @@
+// Append a point to the active mask stroke without cloning its growing point buffer on
+// every pointer event. The caller creates a new outer stroke list to notify React; the
+// current stroke remains private to the active gesture.
+export function appendMaskStrokePoint(lines, point) {
+  const line = lines.at(-1);
+  if (!line) return lines;
+  line.points.push(point.x, point.y);
+  return [...lines];
+}

--- a/apps/web/src/screens/imageEditor/maskStroke.test.js
+++ b/apps/web/src/screens/imageEditor/maskStroke.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { appendMaskStrokePoint } from "./maskStroke.js";
+
+describe("appendMaskStrokePoint", () => {
+  it("keeps the active point buffer and only copies the outer stroke list", () => {
+    const points = [1, 2];
+    const lines = [{ points, size: 64, erase: false }];
+
+    const next = appendMaskStrokePoint(lines, { x: 3, y: 4 });
+
+    expect(next).not.toBe(lines);
+    expect(next[0]).toBe(lines[0]);
+    expect(next[0].points).toBe(points);
+    expect(points).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/apps/web/src/screens/imageEditor/useMaskTool.js
+++ b/apps/web/src/screens/imageEditor/useMaskTool.js
@@ -15,6 +15,8 @@ import {
   tintMaskRgbaInPlace,
   maskHasContent,
 } from "./maskShared.js";
+import { appendMaskStrokePoint } from "./maskStroke.js";
+import { createLatestMaskAssetLoader } from "./maskAssetLoader.js";
 
 // Inpaint-mask brush + smart-select tool (sc-2436 / sc-3751 / sc-6110) extracted from
 // ImageEditor.jsx (sc-9752, F-052 follow-up). Owns the brush-stroke + smart-select-base
@@ -54,6 +56,7 @@ export function useMaskTool({
   // to a mask asset on Run for inpaint-capable models. `maskMode` is the paint sub-mode
   // of the AI Edit tool (Stage panning is suspended while it's on).
   const [maskLines, setMaskLines] = useState([]); // [{ points:[x,y,…], size, erase }]
+  const maskLinesRef = useRef([]);
   const [maskMode, setMaskMode] = useState(false);
   const [maskBrush, setMaskBrush] = useState(64);
   const [maskErase, setMaskErase] = useState(false);
@@ -72,6 +75,22 @@ export function useMaskTool({
   const [selectDraft, setSelectDraft] = useState(null); // live selection rect during a drag
   const selectDrawingRef = useRef(false);
   const selectStartRef = useRef(null);
+  const smartSelectLoaderRef = useRef(null);
+  if (!smartSelectLoaderRef.current) {
+    smartSelectLoaderRef.current = createLatestMaskAssetLoader({ assetUrlFor: assetUrl, blobToImage });
+  }
+
+  function replaceMaskLines(next) {
+    maskLinesRef.current = next;
+    setMaskLines(next);
+  }
+
+  useEffect(
+    () => () => {
+      smartSelectLoaderRef.current.invalidate();
+    },
+    [],
+  );
 
   // Leave paint mode (restoring Stage panning) when the edit tool is closed or the
   // model can't inpaint — otherwise the canvas would stay in a paint state with no UI.
@@ -82,7 +101,8 @@ export function useMaskTool({
   // Reset the per-bitmap mask state (called by the editor's resetEditorOverlays). Mirrors
   // the exact mask-clearing lines from the inline resetEditorOverlays.
   function resetMaskState() {
-    setMaskLines([]);
+    smartSelectLoaderRef.current.invalidate();
+    replaceMaskLines([]);
     setMaskMode(false);
     setMaskBaseImage(null);
     setMaskOverlay(null);
@@ -97,18 +117,14 @@ export function useMaskTool({
     const pt = stagePointToImage(event);
     if (!pt) return;
     maskPaintingRef.current = true;
-    setMaskLines((prev) => [...prev, { points: [pt.x, pt.y], size: maskBrush, erase: maskErase }]);
+    replaceMaskLines([...maskLinesRef.current, { points: [pt.x, pt.y], size: maskBrush, erase: maskErase }]);
   }
 
   function maskPointerMove(event) {
     if (!maskMode || maskSubTool !== "brush" || !maskPaintingRef.current) return;
     const pt = stagePointToImage(event);
     if (!pt) return;
-    setMaskLines((prev) => {
-      if (!prev.length) return prev;
-      const last = prev[prev.length - 1];
-      return [...prev.slice(0, -1), { ...last, points: [...last.points, pt.x, pt.y] }];
-    });
+    replaceMaskLines(appendMaskStrokePoint(maskLinesRef.current, pt));
   }
 
   function maskPointerUp() {
@@ -116,7 +132,8 @@ export function useMaskTool({
   }
 
   function clearMask() {
-    setMaskLines([]);
+    smartSelectLoaderRef.current.invalidate();
+    replaceMaskLines([]);
     setMaskBaseImage(null);
     setMaskOverlay(null);
   }
@@ -252,7 +269,7 @@ export function useMaskTool({
     octx.putImageData(data, 0, 0);
     setMaskBaseImage(maskCanvas);
     setMaskOverlay(overlay);
-    setMaskLines([]);
+    replaceMaskLines([]);
   }
 
   // Mask refinement (sc-6110): flatten the current mask, run a pure pixel op
@@ -283,6 +300,7 @@ export function useMaskTool({
   // except for the mask layer; the brush/eraser then refines it before Inpaint.
   function runSmartSelect(rect) {
     if (!working || aiOp || !canMask) return;
+    const requestGeneration = smartSelectLoaderRef.current.invalidate();
     const box = rectToSegmentBox(rect);
     runAiOp({
       label: "smart select",
@@ -296,15 +314,13 @@ export function useMaskTool({
           displayName: working?.source?.name,
         }),
       onComplete: async (resultAsset) => {
-        const res = await fetch(assetUrl(resultAsset));
-        if (!res.ok) throw new Error(`Failed to load mask (${res.status})`);
-        const { image, objectUrl } = await blobToImage(await res.blob());
-        loadMaskBase(image);
-        URL.revokeObjectURL(objectUrl); // the pixels are copied into the base/overlay canvases
-        // Return to the mask tool so the auto-mask can be refined with the brush/eraser.
-        setTool("edit");
-        setMaskMode(true);
-        setMaskSubTool("brush");
+        await smartSelectLoaderRef.current.load(resultAsset, requestGeneration, (image) => {
+          loadMaskBase(image);
+          // Return to the mask tool so the auto-mask can be refined with the brush/eraser.
+          setTool("edit");
+          setMaskMode(true);
+          setMaskSubTool("brush");
+        });
       },
     });
   }


### PR DESCRIPTION
## Summary
- admit prompt batches by cardinality and preserve ordered generation through lazy iteration
- keep confirmed high-cardinality style preflight and queue/progress state bounded with backpressure
- avoid per-move mask point-array copies and abort superseded mask asset loads with latest-only commits

## Validation
- focused batch/Image Studio/mask tests: 219 passing after the review fix
- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run test` (4,190 passing)
- `npm --prefix apps/web run build`

## Review
One independent adversarial review found two post-confirmation O(cardinality) retention paths. The single ordinary fix pass now stops style preflight at the first violation and retains only scalar totals plus at most 100 active queue IDs; both bounds were mutation-checked. A merge-tree check against the current feature head is clean; the only shared file is a semantically separate Image Studio test block.

Shortcut: sc-21906