### PR TITLE
fix(sc-21907): resolve feature-end review blockers

### DIFF
--- a/apps/web/src/screens/DatasetCatalogsScreen.jsx
+++ b/apps/web/src/screens/DatasetCatalogsScreen.jsx
@@ -746,6 +746,10 @@ export function DatasetCatalogsScreen() {
   const [analyzerDraft, setAnalyzerDraft] = useState(DEFAULT_ANALYZER_SETTINGS);
   const [analysisGpu, setAnalysisGpu] = useState("auto");
   const generationRef = useRef(0);
+  // Poll invalidation and mutation ownership are intentionally independent. A hidden
+  // keep-alive screen tears down its poller, but that must not strand an owned mutation's
+  // busy state when the screen becomes active again.
+  const mutationGenerationRef = useRef(0);
   const analyzerDraftVersionRef = useRef("");
   const pollAbortRef = useRef(null);
   const mutationAbortRef = useRef(null);
@@ -768,6 +772,7 @@ export function DatasetCatalogsScreen() {
     generationRef.current += 1;
     pollAbortRef.current?.abort();
     mutationAbortRef.current?.abort();
+    mutationGenerationRef.current += 1;
     setBusy("");
     setSelectedId(id);
     persistNavigationPreferences({ selectedCatalogId: id });
@@ -811,6 +816,7 @@ export function DatasetCatalogsScreen() {
       controller.abort();
       pollAbortRef.current?.abort();
       mutationAbortRef.current?.abort();
+      mutationGenerationRef.current += 1;
     };
   }, [refresh, token]);
 
@@ -874,7 +880,7 @@ export function DatasetCatalogsScreen() {
   }
 
   async function mutate(action, request, success) {
-    const generation = ++generationRef.current;
+    const mutationGeneration = ++mutationGenerationRef.current;
     pollAbortRef.current?.abort();
     mutationAbortRef.current?.abort();
     const controller = new AbortController();
@@ -883,16 +889,16 @@ export function DatasetCatalogsScreen() {
     setError("");
     try {
       const result = await request(controller.signal);
-      if (controller.signal.aborted || generation !== generationRef.current) return;
-      const next = await refresh({ quiet: true, signal: controller.signal, generation });
-      if (controller.signal.aborted || generation !== generationRef.current) return;
+      if (controller.signal.aborted || mutationGeneration !== mutationGenerationRef.current) return;
+      const next = await refresh({ quiet: true, signal: controller.signal });
+      if (controller.signal.aborted || mutationGeneration !== mutationGenerationRef.current) return;
       success?.(result, next);
     } catch (err) {
-      if (!isAbortError(err) && generation === generationRef.current) {
+      if (!isAbortError(err) && mutationGeneration === mutationGenerationRef.current) {
         setError(safeCatalogError(err, action));
       }
     } finally {
-      if (generation === generationRef.current) {
+      if (mutationGeneration === mutationGenerationRef.current) {
         setBusy("");
         setPollEpoch((current) => current + 1);
       }

--- a/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
+++ b/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
@@ -400,6 +400,47 @@ describe("DatasetCatalogsScreen", () => {
     expect(requests.filter((item) => item.path.endsWith("/status"))).toHaveLength(0);
   });
 
+  it("settles a catalog mutation across inactive and active poll lifecycles", async () => {
+    await act(async () => root.unmount());
+    vi.useFakeTimers();
+    root = createRoot(container);
+    const mutation = deferred();
+    const original = fetch.getMockImplementation();
+    fetch.mockImplementation((url, options = {}) => {
+      if (new URL(url).pathname.endsWith("/pause")) return mutation.promise;
+      return original(url, options);
+    });
+    const renderScreen = async (active) => {
+      await act(async () => {
+        root.render(
+          <ScreenActiveContext.Provider value={active}>
+            <AppContext.Provider value={{ token: "token" }}>
+              <DatasetCatalogsScreen />
+              <ConfirmHost />
+            </AppContext.Provider>
+          </ScreenActiveContext.Provider>,
+        );
+      });
+      await flush();
+    };
+    await renderScreen(true);
+
+    const pauseButton = [...container.querySelectorAll("button")].find((button) => button.textContent.includes("Pause"));
+    await act(async () => pauseButton.click());
+    expect(pauseButton.disabled).toBe(true);
+
+    await renderScreen(false);
+    await renderScreen(true);
+    await act(async () => {
+      mutation.resolve(response(catalog()));
+      await Promise.resolve();
+    });
+    await flush();
+
+    const recoveredPauseButton = [...container.querySelectorAll("button")].find((button) => button.textContent.includes("Pause"));
+    expect(recoveredPauseButton.disabled).toBe(false);
+  });
+
   it("stops after a terminal status response", async () => {
     await remountWithFakeTimers();
     const original = fetch.getMockImplementation();

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -236,6 +236,10 @@ const BATCH_RENDER_CAP = 100;
 // ordinary (at-or-under-cap) runs. The worker remains serial; this is client-side
 // backpressure for confirmed large runs only.
 const BATCH_ACTIVE_JOB_LIMIT = BATCH_RENDER_CAP;
+// A styled Cartesian batch can be enormous even though its queue state remains bounded.
+// Yield after this many preflight prompts so the run state commits and Stop can interrupt
+// a clean (no-overage) stream before we ever reach its Cartesian suffix.
+const BATCH_PREFLIGHT_YIELD_INTERVAL = BATCH_RENDER_CAP;
 
 function preferredOption(defaultValue, options) {
   return options.includes(defaultValue) ? defaultValue : options[0] ?? "default";
@@ -2512,24 +2516,6 @@ export function ImageStudio() {
       setBatchConfirmPending(true);
       return;
     }
-    const promptBudgetOverages = batchPromptBudgetOverages(
-      stylePreviewActive && !structuredPromptModel
-        ? (function* composedBatchPrompts() {
-            for (const { prompt: resolvedPrompt } of iterateBatch(batchPrompts, batchVariables)) {
-              const { prompt: cleanPrompt } = parsePromptResolution(resolvedPrompt);
-              yield composeJobPrompt({ promptToSend: cleanPrompt }).composedPrompt;
-            }
-          })()
-        : [],
-      // Preserve the detailed item list for ordinary runs; a high-cardinality stream
-      // needs only the first actionable violation and must not retain them all.
-      batchJobCount > BATCH_RENDER_CAP ? 1 : Infinity,
-    );
-    if (promptBudgetOverages.length) {
-      setBatchError(batchPromptBudgetMessage(promptBudgetOverages));
-      setBatchConfirmPending(false);
-      return;
-    }
     if (dimensionsInvalid || hiresFixTargetInvalid) {
       setBatchError(
         hiresFixTargetMessage ||
@@ -2537,6 +2523,21 @@ export function ImageStudio() {
           "Width and height must each be between 256 and 4096.",
       );
       return;
+    }
+    const styledBatchPrompts = () => (function* composedBatchPrompts() {
+      for (const { prompt: resolvedPrompt } of iterateBatch(batchPrompts, batchVariables)) {
+        const { prompt: cleanPrompt } = parsePromptResolution(resolvedPrompt);
+        yield composeJobPrompt({ promptToSend: cleanPrompt }).composedPrompt;
+      }
+    })();
+    // An ordinary batch remains eager so its warning retains every actionable item.
+    // Only a confirmed high-cardinality product needs the cancelable streaming path below.
+    if (stylePreviewActive && !structuredPromptModel && batchJobCount <= BATCH_RENDER_CAP) {
+      const promptBudgetOverages = batchPromptBudgetOverages(styledBatchPrompts());
+      if (promptBudgetOverages.length) {
+        setBatchError(batchPromptBudgetMessage(promptBudgetOverages));
+        return;
+      }
     }
     setBatchError("");
     setBatchConfirmPending(false);
@@ -2552,6 +2553,37 @@ export function ImageStudio() {
       failed: 0,
       activeJobIds: [],
     });
+    // Validate styled prompts before any job is admitted. This is deliberately a stream:
+    // a high-cardinality all-under-cap Cartesian product used to synchronously exhaust here,
+    // before React could paint the run and make Stop usable. The state above establishes the
+    // cancel owner first; bounded cooperative yields preserve truthful preflight enforcement
+    // without retaining every prompt or letting any job through before validation completes.
+    if (stylePreviewActive && !structuredPromptModel && batchJobCount > BATCH_RENDER_CAP) {
+      let inspected = 0;
+      for (const { prompt: resolvedPrompt } of iterateBatch(batchPrompts, batchVariables)) {
+        if (batchAbortRef.current) {
+          const current = batchRunRef.current;
+          if (current) replaceBatchRun({ ...current, submitting: false });
+          return;
+        }
+        const { prompt: cleanPrompt } = parsePromptResolution(resolvedPrompt);
+        const promptBudgetOverages = batchPromptBudgetOverages(
+          [composeJobPrompt({ promptToSend: cleanPrompt }).composedPrompt],
+          1,
+        );
+        if (promptBudgetOverages.length) {
+          const [{ item: _item, ...budget }] = promptBudgetOverages;
+          replaceBatchRun(null);
+          setBatchError(batchPromptBudgetMessage([{ item: inspected + 1, ...budget }]));
+          return;
+        }
+        inspected += 1;
+        if (batchJobCount > BATCH_RENDER_CAP && inspected % BATCH_PREFLIGHT_YIELD_INTERVAL === 0) {
+          // A macrotask, rather than a microtask, gives the browser an event turn to deliver Stop.
+          await new Promise((resolve) => window.setTimeout(resolve, 0));
+        }
+      }
+    }
     for (const entry of iterateBatch(batchPrompts, batchVariables)) {
       await waitForBatchSlot();
       if (batchAbortRef.current) {

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -283,6 +283,37 @@ describe("Image Studio batch cardinality admission", () => {
     expect(createImageJob).not.toHaveBeenCalled();
   });
 
+  it("makes a no-overage styled Cartesian preflight cancelable before inspecting its full product", async () => {
+    const values = Array.from({ length: 10 }, (_, index) => String(index));
+    const keys = ["a", "b", "c", "d", "e", "f", "g"];
+    window.localStorage.setItem(
+      "sceneworks-studio-image-project_1",
+      JSON.stringify({
+        model: Z_IMAGE.id,
+        count: 1,
+        styleId: "ghibli-style",
+        batchMode: true,
+        batchPromptsText: `under budget ${keys.map((key) => `{{${key}}}`).join(" ")}`,
+        batchVariableValues: Object.fromEntries(keys.map((key) => [key, values])),
+      }),
+    );
+    const createImageJob = vi.fn();
+    await render(baseContext({ createImageJob }));
+
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent.includes("Run batch")));
+    await click(container.querySelector(".batch-confirm .prompt-cta"));
+
+    // The first bounded preflight slice has yielded with the run rendered; the old
+    // synchronous walk could not expose Stop until all ten million prompts were read.
+    await vi.waitFor(() => expect(container.querySelector(".batch-run-progress")?.textContent).toContain("Queued 0/10000000"));
+    expect(container.querySelector(".batch-run-progress button")?.textContent).toBe("Stop");
+    expect(createImageJob).not.toHaveBeenCalled();
+
+    await click(container.querySelector(".batch-run-progress button"));
+    await vi.waitFor(() => expect(container.querySelector(".batch-run-progress")?.textContent).toContain("0/10000000 done"));
+    expect(createImageJob).not.toHaveBeenCalled();
+  });
+
   it("keeps a confirmed run's active queue bounded while preserving its submitted count", async () => {
     const values = Array.from({ length: 101 }, (_, index) => String(index));
     window.localStorage.setItem(

--- a/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
+++ b/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
@@ -172,6 +172,36 @@ describe("TrainingStudio dataset draft guard (sc-11970)", () => {
     expect(context.loadTrainingDataset).toHaveBeenCalledTimes(1);
   });
 
+  it("does not replace an edit made while the refresh reload is pending", async () => {
+    const reload = deferred();
+    let loadCalls = 0;
+    const context = baseContext({
+      refreshTrainingDatasets: vi.fn(async () => {}),
+      loadTrainingDataset: vi.fn(() => {
+        loadCalls += 1;
+        return loadCalls === 1 ? Promise.resolve(datasetOne) : reload.promise;
+      }),
+    });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    const refreshButton = [...container.querySelectorAll("button")].find((button) => button.textContent === "Refresh");
+    await act(async () => {
+      refreshButton.click();
+    });
+    await vi.waitFor(() => expect(context.loadTrainingDataset).toHaveBeenCalledTimes(2));
+    await typeName(container, "Mira Set edited during reload");
+    await act(async () => {
+      reload.resolve(datasetOne);
+      await Promise.resolve();
+    });
+
+    expect(nameInput(container).value).toBe("Mira Set edited during reload");
+  });
+
   it("opens another dataset when the discard prompt is confirmed", async () => {
     appConfirmMock.mockResolvedValue(true);
     const context = baseContext();

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -368,6 +368,10 @@ export function TrainingStudio({ mode = "training" } = {}) {
   // double-click can't fire two DELETEs before `deletingDataset` disables the button.
   const deleteDatasetGuardRef = useRef(false);
   const openDatasetRef = useRef(null);
+  // Every open owns a monotonic generation. A refresh reload is allowed to commit only
+  // if the draft it started from is still current after its second await.
+  const datasetLoadGenerationRef = useRef(0);
+  const datasetDraftRevisionRef = useRef(0);
   const handledParquetImportJobsRef = useRef(new Set());
   const [selectedAssetIds, setSelectedAssetIds] = useState([]);
   // Dataset Doctor readiness report (sc-6534), fetched server-side over the saved
@@ -495,6 +499,9 @@ export function TrainingStudio({ mode = "training" } = {}) {
   dirtyRef.current = dirty;
   const activeDatasetIdRef = useRef(activeDataset?.id ?? "");
   activeDatasetIdRef.current = activeDataset?.id ?? "";
+  useEffect(() => {
+    datasetDraftRevisionRef.current += 1;
+  }, [activeDataset?.id, draftName, selectedAssetIds, associatedCharacterId, captionDraftById]);
   const completedParquetImport = useMemo(
     () =>
       jobs.find(
@@ -967,7 +974,8 @@ export function TrainingStudio({ mode = "training" } = {}) {
     return registerProjectSwitchGuard(() => confirmDiscardUnsavedDraft());
   }, [datasetLibraryMode, registerProjectSwitchGuard]);
 
-  async function openDataset(datasetId) {
+  async function openDataset(datasetId, { preserveCurrentDraft = false } = {}) {
+    const loadGeneration = ++datasetLoadGenerationRef.current;
     // Opening a DIFFERENT dataset re-seeds the whole editor; confirm before discarding an
     // unsaved draft (sc-11970). Re-opening the SAME dataset (internal reloads after a save)
     // never prompts — the ids match and the draft is already persisted.
@@ -976,6 +984,9 @@ export function TrainingStudio({ mode = "training" } = {}) {
       if (!proceed) {
         return;
       }
+    }
+    if (loadGeneration !== datasetLoadGenerationRef.current) {
+      return;
     }
     if (!datasetId) {
       setActiveDataset(null);
@@ -989,7 +1000,21 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setDatasetError("");
     setDatasetMessage("");
     try {
+      const draftRevision = datasetDraftRevisionRef.current;
       const dataset = await loadDataset(datasetId);
+      // A refresh has already checked its first await. Check again at the actual
+      // state commit: a rename, membership/caption edit, or a different open while
+      // this load was pending must win over stale fetched data.
+      if (
+        loadGeneration !== datasetLoadGenerationRef.current ||
+        (preserveCurrentDraft && (
+          activeDatasetIdRef.current !== datasetId ||
+          dirtyRef.current ||
+          datasetDraftRevisionRef.current !== draftRevision
+        ))
+      ) {
+        return null;
+      }
       setActiveDataset(dataset);
       setDraftName(dataset?.name ?? "");
       setSelectedAssetIds(normalizeDatasetAssetIds(dataset, assets));
@@ -1000,7 +1025,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
       setDatasetError(err.message);
       return null;
     } finally {
-      setBusyDatasetId("");
+      if (loadGeneration === datasetLoadGenerationRef.current) setBusyDatasetId("");
     }
   }
   openDatasetRef.current = openDataset;
@@ -1015,7 +1040,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
     ) {
       return;
     }
-    await openDataset(refreshDatasetId);
+    await openDataset(refreshDatasetId, { preserveCurrentDraft: true });
   }
 
   // Permanently delete the OPEN dataset — the backend wipes its on-disk root (images,


### PR DESCRIPTION
## Summary
- make styled high-cardinality preflight cooperative and cancelable before exhaustive traversal
- guard Training Studio refresh commits against edits during the second dataset-load await
- decouple Dataset Catalog polling invalidation from mutation settlement so lifecycle changes cannot strand `busy`

## Feature-end review
This is the single integration batch for Phase 1.8 review cycle 1 at `d8461974c3058f441adda1e69caccc936ffc14c5`. It resolves all three valid blocking findings (E2, E3, E4); cycle 2 will re-review the complete new feature head after merge.

## Validation
- focused Image Studio / Training Studio / Dataset Catalog regressions: 127 passing
- mutation checks: all three guards/bounds demonstrated RED before GREEN
- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run test` (276 files, 4,213 passing)
- `npm --prefix apps/web run build`

Shortcut: sc-21907 / epic 21898