### PR TITLE
fix(sc-21907): guard completed import reloads

### DIFF
--- a/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
+++ b/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
@@ -202,6 +202,145 @@ describe("TrainingStudio dataset draft guard (sc-11970)", () => {
     expect(nameInput(container).value).toBe("Mira Set edited during reload");
   });
 
+  it("does not replace a rename made while a completed Parquet import refreshes", async () => {
+    const refresh = deferred();
+    const refreshTrainingDatasets = vi.fn(() => refresh.promise);
+    const context = baseContext({ refreshTrainingDatasets });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{
+          ...context,
+          jobs: [{
+            id: "job-parquet",
+            type: "dataset_parquet_import",
+            status: "completed",
+            payload: { datasetId: "dataset-1" },
+            result: { importedItemCount: 1 },
+          }],
+        }}>{<TrainingDataSetsLibrary />}</AppContext.Provider>,
+      );
+    });
+    await vi.waitFor(() => expect(refreshTrainingDatasets).toHaveBeenCalledTimes(1));
+
+    await typeName(container, "Mira Set renamed during import refresh");
+    await act(async () => {
+      refresh.resolve();
+      await Promise.resolve();
+    });
+
+    expect(nameInput(container).value).toBe("Mira Set renamed during import refresh");
+    expect(context.loadTrainingDataset).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not replace a rename made while a completed Parquet import reloads", async () => {
+    const reload = deferred();
+    let loadCalls = 0;
+    const context = baseContext({
+      refreshTrainingDatasets: vi.fn(async () => {}),
+      loadTrainingDataset: vi.fn(() => {
+        loadCalls += 1;
+        return loadCalls === 1 ? Promise.resolve(datasetOne) : reload.promise;
+      }),
+    });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{
+          ...context,
+          jobs: [{
+            id: "job-parquet",
+            type: "dataset_parquet_import",
+            status: "completed",
+            payload: { datasetId: "dataset-1" },
+            result: { importedItemCount: 1 },
+          }],
+        }}>{<TrainingDataSetsLibrary />}</AppContext.Provider>,
+      );
+    });
+    await vi.waitFor(() => expect(context.loadTrainingDataset).toHaveBeenCalledTimes(2));
+
+    await typeName(container, "Mira Set renamed during import reload");
+    await act(async () => {
+      reload.resolve(datasetOne);
+      await Promise.resolve();
+    });
+
+    expect(nameInput(container).value).toBe("Mira Set renamed during import reload");
+  });
+
+  it("does not commit a completed Parquet import reload after the effect is superseded", async () => {
+    const firstReload = deferred();
+    const secondRefresh = deferred();
+    let refreshCalls = 0;
+    let loadCalls = 0;
+    const reloadedDataset = {
+      ...datasetOne,
+      version: 3,
+      items: [{ id: "parquet-item", path: "images/parquet.jpg", displayName: "parquet.jpg" }],
+    };
+    const context = baseContext({
+      refreshTrainingDatasets: vi.fn(() => {
+        refreshCalls += 1;
+        return refreshCalls === 1 ? Promise.resolve() : secondRefresh.promise;
+      }),
+      loadTrainingDataset: vi.fn(() => {
+        loadCalls += 1;
+        return loadCalls === 1 ? Promise.resolve(datasetOne) : firstReload.promise;
+      }),
+    });
+    const completedJob = (importedItemCount) => ({
+      id: "job-parquet",
+      type: "dataset_parquet_import",
+      status: "completed",
+      payload: { datasetId: "dataset-1" },
+      result: { importedItemCount },
+    });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{ ...context, jobs: [completedJob(1)] }}>
+          {<TrainingDataSetsLibrary />}
+        </AppContext.Provider>,
+      );
+    });
+    await vi.waitFor(() => expect(context.loadTrainingDataset).toHaveBeenCalledTimes(2));
+
+    // Updating the completion supersedes the first effect while its nested dataset load
+    // is still pending. Keep the replacement effect in its refresh await, so only the
+    // stale nested load could commit this fetched item.
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{ ...context, jobs: [completedJob(2)] }}>
+          {<TrainingDataSetsLibrary />}
+        </AppContext.Provider>,
+      );
+    });
+    await vi.waitFor(() => expect(context.refreshTrainingDatasets).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      firstReload.resolve(reloadedDataset);
+      await Promise.resolve();
+    });
+
+    expect(container.querySelectorAll(".training-caption-card")).toHaveLength(0);
+    expect(container.textContent).not.toContain("Parquet import completed");
+  });
+
   it("opens another dataset when the discard prompt is confirmed", async () => {
     appConfirmMock.mockResolvedValue(true);
     const context = baseContext();

--- a/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
+++ b/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
@@ -339,6 +339,15 @@ describe("TrainingStudio dataset draft guard (sc-11970)", () => {
 
     expect(container.querySelectorAll(".training-caption-card")).toHaveLength(0);
     expect(container.textContent).not.toContain("Parquet import completed");
+
+    // The replacement effect is intentionally still awaiting here. Unmount before
+    // settling it so this regression leaves no background promise between tests.
+    await act(async () => {
+      root.unmount();
+      root = null;
+      secondRefresh.resolve();
+      await Promise.resolve();
+    });
   });
 
   it("opens another dataset when the discard prompt is confirmed", async () => {

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -974,7 +974,10 @@ export function TrainingStudio({ mode = "training" } = {}) {
     return registerProjectSwitchGuard(() => confirmDiscardUnsavedDraft());
   }, [datasetLibraryMode, registerProjectSwitchGuard]);
 
-  async function openDataset(datasetId, { preserveCurrentDraft = false } = {}) {
+  async function openDataset(
+    datasetId,
+    { preserveCurrentDraft = false, expectedDraftRevision, canCommit } = {},
+  ) {
     const loadGeneration = ++datasetLoadGenerationRef.current;
     // Opening a DIFFERENT dataset re-seeds the whole editor; confirm before discarding an
     // unsaved draft (sc-11970). Re-opening the SAME dataset (internal reloads after a save)
@@ -1000,13 +1003,14 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setDatasetError("");
     setDatasetMessage("");
     try {
-      const draftRevision = datasetDraftRevisionRef.current;
+      const draftRevision = expectedDraftRevision ?? datasetDraftRevisionRef.current;
       const dataset = await loadDataset(datasetId);
       // A refresh has already checked its first await. Check again at the actual
       // state commit: a rename, membership/caption edit, or a different open while
       // this load was pending must win over stale fetched data.
       if (
         loadGeneration !== datasetLoadGenerationRef.current ||
+        (canCommit && !canCommit()) ||
         (preserveCurrentDraft && (
           activeDatasetIdRef.current !== datasetId ||
           dirtyRef.current ||
@@ -1103,14 +1107,25 @@ export function TrainingStudio({ mode = "training" } = {}) {
     }
     const jobId = completedParquetImportId;
     const datasetId = activeDataset.id;
+    const draftRevision = datasetDraftRevisionRef.current;
     const handledJobs = handledParquetImportJobsRef.current;
     handledJobs.add(jobId);
     let canceled = false;
     let settled = false;
+    const canCommit = () => (
+      !canceled &&
+      activeDatasetIdRef.current === datasetId &&
+      datasetDraftRevisionRef.current === draftRevision
+    );
     void (async () => {
       try {
         await refreshTrainingDatasets(activeProject?.id);
-        const dataset = await openDatasetRef.current?.(datasetId);
+        if (!canCommit()) return;
+        const dataset = await openDatasetRef.current?.(datasetId, {
+          preserveCurrentDraft: true,
+          expectedDraftRevision: draftRevision,
+          canCommit,
+        });
         if (canceled || !dataset) return;
         const imported = completedParquetImportCount;
         setDatasetMessage(


### PR DESCRIPTION
## Summary
- preserve concurrent Training Studio edits throughout completed-Parquet-import refresh and nested dataset load
- prevent cleaned-up or superseded completed-import effects from committing stale fetched state
- settle deferred replacement refreshes in the concurrency regression so the exact default fork-pool suite exits cleanly

## Feature-end review
This is the single integration batch for Phase 1.8 review cycle 2 at `d51e2af2c102ef945607433df79c2ce8d5c90be9`. Cycle 2 verified all prior blockers resolved and identified this remaining E2/E3 race. After merge, cycle 3 is the final permitted complete-head review.

## Validation
- focused Training Studio guards + LazyScreen under default fork pool: 13 passing
- preservation and final-cancellation predicates mutation-checked RED/GREEN
- `npm --prefix apps/web run lint`
- exact `npm --prefix apps/web run test` (276 files, 4,216 passing, exit 0)
- `npm --prefix apps/web run build`

Shortcut: sc-21907 / epic 21898