### PR TITLE
fix(web): retain dataset reload ownership on decline [sc-21907]

### DIFF
--- a/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
+++ b/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
@@ -149,6 +149,54 @@ describe("TrainingStudio dataset draft guard (sc-11970)", () => {
     expect(context.loadTrainingDataset).not.toHaveBeenCalledWith("dataset-2");
   });
 
+  it("clears the refresh owner when a different dataset open is declined", async () => {
+    const reload = deferred();
+    let loadCalls = 0;
+    appConfirmMock.mockResolvedValue(false);
+    const context = baseContext({
+      refreshTrainingDatasets: vi.fn(async () => {}),
+      loadTrainingDataset: vi.fn(() => {
+        loadCalls += 1;
+        return loadCalls === 1 ? Promise.resolve(datasetOne) : reload.promise;
+      }),
+    });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    const refreshButton = [...container.querySelectorAll("button")].find((button) => button.textContent === "Refresh");
+    await act(async () => {
+      refreshButton.click();
+    });
+    await vi.waitFor(() => expect(context.loadTrainingDataset).toHaveBeenCalledTimes(2));
+
+    await typeName(container, "Mira Set edited while refresh reloads");
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{
+          ...context,
+          studioLaunch: { id: "launch-2", view: "LibraryDataSets", datasetId: "dataset-2" },
+        }}>{<TrainingDataSetsLibrary />}</AppContext.Provider>,
+      );
+    });
+    await vi.waitFor(() => expect(appConfirmMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      reload.resolve(datasetOne);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      container.querySelector(".compact-selector-pill").click();
+    });
+    const datasetOneOption = [...container.querySelectorAll(".compact-selector-item")]
+      .find((button) => button.textContent.includes("Mira Set"));
+    expect(datasetOneOption.disabled).toBe(false);
+    expect(datasetOneOption.textContent).not.toContain("Opening…");
+  });
+
   it("does not replace a rename started while dataset refresh is in flight", async () => {
     const refresh = deferred();
     const context = baseContext({ refreshTrainingDatasets: vi.fn(() => refresh.promise) });

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -978,19 +978,18 @@ export function TrainingStudio({ mode = "training" } = {}) {
     datasetId,
     { preserveCurrentDraft = false, expectedDraftRevision, canCommit } = {},
   ) {
-    const loadGeneration = ++datasetLoadGenerationRef.current;
     // Opening a DIFFERENT dataset re-seeds the whole editor; confirm before discarding an
     // unsaved draft (sc-11970). Re-opening the SAME dataset (internal reloads after a save)
-    // never prompts — the ids match and the draft is already persisted.
+    // never prompts — the ids match and the draft is already persisted. A declined request
+    // must not take load ownership: an already-pending reload still owns busyDatasetId and
+    // must be able to clear it when it settles.
     if (datasetId && datasetId !== activeDataset?.id) {
       const proceed = await confirmDiscardUnsavedDraft();
       if (!proceed) {
         return;
       }
     }
-    if (loadGeneration !== datasetLoadGenerationRef.current) {
-      return;
-    }
+    const loadGeneration = ++datasetLoadGenerationRef.current;
     if (!datasetId) {
       setActiveDataset(null);
       setDraftName("");


### PR DESCRIPTION
## Summary
- move Training Studio dataset-load ownership acquisition after discard confirmation
- preserve a pending refresh reload when a cross-dataset switch is declined
- add behavior-level coverage proving busy state and the “Opening…” label clear truthfully

## Epic requirements
- E2: async outcomes retain the correct owner across declined navigation
- E5: the dataset selector no longer presents a stale “Opening…” state
- E7: regression is mutation-checked and covered in the full web suite

## Validation
- focused Training Studio guards: 12/12
- mutation: pre-confirm generation ownership leaves option disabled (RED); restored ordering (GREEN)
- mutation: pre-confirm ownership leaves “Opening…” visible (RED); restored ordering (GREEN)
- `npm --prefix apps/web run lint`
- `npm --prefix apps/web run test`: 276 files, 4217/4217
- `npm --prefix apps/web run build`
- `git diff --check`

Terminal integration batch for [sc-21907](https://app.shortcut.com/trefry/story/21907) in epic [sc-21898](https://app.shortcut.com/trefry/epic/21898). This is the user-authorized fourth terminal-review exception.