### PR TITLE
fix(web): complete UI review remediation [sc-21898]

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,9 +4,9 @@
   "version": "0.8.7",
   "type": "module",
   "scripts": {
-    "dev": "vite --host 0.0.0.0",
+    "dev": "vite --host 127.0.0.1",
     "build": "vite build",
-    "preview": "vite preview --host 0.0.0.0",
+    "preview": "vite preview --host 127.0.0.1",
     "lint": "eslint src",
     "test": "vitest run --environment jsdom",
     "gen:styles": "node scripts/generate-styles.mjs",

--- a/apps/web/scripts/vite-safe-dev-smoke.mjs
+++ b/apps/web/scripts/vite-safe-dev-smoke.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createServer } from "vite";
+
+const webRoot = fileURLToPath(new URL("..", import.meta.url));
+const repoRoot = path.resolve(webRoot, "../..");
+
+function vitePath(file) {
+  return path.resolve(file).replaceAll("\\", "/");
+}
+
+function fsUrl(file) {
+  return `/@fs/${encodeURI(vitePath(file))}`;
+}
+
+const server = await createServer({
+  configFile: path.join(webRoot, "vite.config.js"),
+  root: webRoot,
+  // Exercise the exposure boundary in the explicit LAN posture. Port zero
+  // keeps this smoke test safe for concurrent runs.
+  server: { host: "0.0.0.0", port: 0 },
+});
+
+try {
+  assert.deepEqual(server.config.server.fs.allow, [
+    vitePath(webRoot),
+    vitePath(path.join(repoRoot, "apps", "desktop", "licenses")),
+  ]);
+  await server.transformRequest("/src/data/bundledLicenses.js");
+  await server.listen();
+  const address = server.httpServer.address();
+  const origin = `http://127.0.0.1:${address.port}`;
+  const configPath = vitePath(path.join(repoRoot, "config", "manifests", "builtin.styles.jsonc"));
+  const deniedPaths = [
+    fsUrl(configPath),
+    fsUrl(path.join(repoRoot, "crates", "sceneworks-worker", "Cargo.toml")),
+    fsUrl(path.join(repoRoot, "documents", "style.txt")),
+    `/@fs/${configPath.replace("config", "con%66ig")}`,
+    `/@fs/${configPath.replace("/config/", "/documents/../config/")}`,
+  ];
+
+  for (const requestPath of deniedPaths) {
+    const response = await fetch(`${origin}${requestPath}`);
+    assert.equal(response.ok, false, `${requestPath} must not be readable through /@fs`);
+  }
+} finally {
+  await server.close();
+}

--- a/apps/web/src/App.queue.test.jsx
+++ b/apps/web/src/App.queue.test.jsx
@@ -126,8 +126,8 @@ describe("SceneWorks app shell", () => {
     await settle();
 
     expect(container.textContent).toContain("Fixture GPU 0");
-    expect(container.textContent).toContain("20.0 GB");
-    expect(container.textContent).toContain("4.0 GB / 24.0 GB");
+    expect(container.textContent).toContain("20.0 GiB");
+    expect(container.textContent).toContain("4.0 GiB / 24.0 GiB");
     expect(container.textContent).toContain("12%");
     expect(container.textContent).not.toContain("CPU utility worker");
     expect(container.textContent).not.toContain("Placeholder GPU");
@@ -989,7 +989,7 @@ describe("SceneWorks app shell", () => {
       root.render(withAppContext({ ...queueProps, visibleWorkers: [worker] }, <QueueScreen />));
     });
 
-    expect(container.textContent).toContain("20.0 GB");
+    expect(container.textContent).toContain("20.0 GiB");
     expect(container.textContent).toContain("12%");
 
     await act(async () => {
@@ -1009,9 +1009,9 @@ describe("SceneWorks app shell", () => {
       );
     });
 
-    expect(container.textContent).toContain("12.0 GB / 24.0 GB");
+    expect(container.textContent).toContain("12.0 GiB / 24.0 GiB");
     expect(container.textContent).toContain("67%");
-    expect(container.textContent).not.toContain("20.0 GB");
+    expect(container.textContent).not.toContain("20.0 GiB");
   });
 
 });

--- a/apps/web/src/assetBatch.jsx
+++ b/apps/web/src/assetBatch.jsx
@@ -55,6 +55,10 @@ export function useAssetBatch() {
   // Bulk Discard / Move-to-character on the current selection. `bulkAction` gates the
   // buttons while a fan-out is in flight; `moveOpen` reveals the inline character picker.
   const [bulkAction, setBulkAction] = useState(null);
+  // A failed move must remain visible until the user clears the selection or dismisses it;
+  // a later successful move must never rewrite that truthful outcome as total success.
+  const [moveOutcome, setMoveOutcome] = useState(null);
+  const selectionEpochsRef = useRef(new Map());
   // When a discard selection contains folded upscales, hold the pending choice here:
   // { targets: Asset[] (the selection snapshot), sources: Asset[] (their source originals) }.
   // Non-null drives the DiscardUpscaledDialog; the user picks both / upscaled-only / cancel.
@@ -106,6 +110,7 @@ export function useAssetBatch() {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
+      selectionEpochsRef.current.set(id, (selectionEpochsRef.current.get(id) ?? 0) + 1);
       return next;
     });
   // Add every id in `ids` to the selection (union — never drops an existing pick), so a
@@ -113,12 +118,18 @@ export function useAssetBatch() {
   const selectAll = (ids) =>
     setSelectedAssetIds((prev) => {
       const next = new Set(prev);
-      for (const id of ids) next.add(id);
+      for (const id of ids) {
+        if (!next.has(id)) {
+          next.add(id);
+          selectionEpochsRef.current.set(id, (selectionEpochsRef.current.get(id) ?? 0) + 1);
+        }
+      }
       return next;
     });
   const clearSelection = () => {
     setSelectedAssetIds(new Set());
     setMoveOpen(false);
+    setMoveOutcome(null);
   };
 
   // Decode an asset's native pixel size (needed for an edit job — the worker fits the
@@ -242,20 +253,36 @@ export function useAssetBatch() {
     if (!moveCharacterId || !movableSelected.length || bulkAction) return;
     const toLibrary = moveCharacterId === LIBRARY_MOVE_TARGET;
     if (toLibrary ? !moveAssetToLibrary : !moveAssetToCharacter) return;
+    // Snapshot both targets and their selection epochs. Results can arrive in any order;
+    // only remove targets that have not been reselected while the fan-out was in flight.
+    const targets = movableSelected;
+    const targetEpochs = new Map(targets.map((asset) => [asset.id, selectionEpochsRef.current.get(asset.id) ?? 0]));
     setBulkAction("move");
     try {
-      for (const asset of movableSelected) {
-        try {
-          if (toLibrary) {
-            await moveAssetToLibrary(asset);
-          } else {
-            await moveAssetToCharacter(asset, moveCharacterId);
-          }
-        } catch {
-          // One asset failing (e.g. already moved) shouldn't abort the rest.
+      const outcomes = await Promise.allSettled(
+        targets.map((asset) => (toLibrary ? moveAssetToLibrary(asset) : moveAssetToCharacter(asset, moveCharacterId))),
+      );
+      const successfulIds = new Set();
+      const failures = [];
+      outcomes.forEach((outcome, index) => {
+        if (outcome.status === "fulfilled") {
+          successfulIds.add(targets[index].id);
+        } else {
+          const reason = outcome.reason;
+          failures.push({ asset: targets[index], message: reason?.message ?? String(reason || "Could not move this asset.") });
         }
+      });
+      setSelectedAssetIds((current) => {
+        const next = new Set(current);
+        for (const id of successfulIds) {
+          if (selectionEpochsRef.current.get(id) === targetEpochs.get(id)) next.delete(id);
+        }
+        return next;
+      });
+      setMoveOpen(false);
+      if (failures.length) {
+        setMoveOutcome({ succeeded: successfulIds.size, failures });
       }
-      clearSelection();
     } finally {
       setBulkAction(null);
     }
@@ -278,6 +305,8 @@ export function useAssetBatch() {
     runBatch,
     closeBatch,
     bulkAction,
+    moveOutcome,
+    dismissMoveOutcome: () => setMoveOutcome(null),
     discardSelected,
     discardPrompt,
     resolveDiscardPrompt,
@@ -305,6 +334,8 @@ export function AssetSelectionBar({ batch, showDiscard = true, allowLibraryTarge
     availableCharacters,
     setBatchOpen,
     bulkAction,
+    moveOutcome,
+    dismissMoveOutcome,
     discardSelected,
     discardPrompt,
     resolveDiscardPrompt,
@@ -375,6 +406,17 @@ export function AssetSelectionBar({ batch, showDiscard = true, allowLibraryTarge
       <button onClick={clearSelection} type="button">
         Clear
       </button>
+      {moveOutcome ? (
+        <div className="batch-move-outcome" role="alert">
+          <span>
+            Moved {moveOutcome.succeeded}; {moveOutcome.failures.length} failed. Failed assets remain selected.
+            {moveOutcome.failures[0]?.message ? ` ${moveOutcome.failures[0].message}` : ""}
+          </span>
+          <button aria-label="Dismiss move result" onClick={dismissMoveOutcome} type="button">
+            Dismiss
+          </button>
+        </div>
+      ) : null}
       {moveOpen && moveTargets.length ? (
         <div className="batch-move-picker">
           <select

--- a/apps/web/src/assetBatch.jsx
+++ b/apps/web/src/assetBatch.jsx
@@ -21,6 +21,15 @@ import { DEFAULT_MAC_CAPABILITIES, macUpscaleEngineBlocked } from "./macGating.j
 // collide with a real character id.
 export const LIBRARY_MOVE_TARGET = "__sceneworks_library__";
 
+function moveFailureMessage(reason) {
+  const message = reason && typeof reason === "object" ? reason.message : reason;
+  if (typeof message === "string" && message) return message;
+  if (typeof message === "number" || typeof message === "boolean" || typeof message === "bigint" || typeof message === "symbol") {
+    return String(message);
+  }
+  return "Could not move this asset.";
+}
+
 // Shared multi-asset batch selection (sc-6112) — selection state, the upscale/detail/edit
 // fan-out, and the bulk Discard / Move-to-character actions. Lifted out of LibraryScreen so
 // the Assets page and the Character Assets page drive the identical toolbar from one source.
@@ -58,6 +67,7 @@ export function useAssetBatch() {
   // A failed move must remain visible until the user clears the selection or dismisses it;
   // a later successful move must never rewrite that truthful outcome as total success.
   const [moveOutcome, setMoveOutcome] = useState(null);
+  const moveOutcomeEpochRef = useRef(0);
   const selectionEpochsRef = useRef(new Map());
   // When a discard selection contains folded upscales, hold the pending choice here:
   // { targets: Asset[] (the selection snapshot), sources: Asset[] (their source originals) }.
@@ -129,6 +139,7 @@ export function useAssetBatch() {
   const clearSelection = () => {
     setSelectedAssetIds(new Set());
     setMoveOpen(false);
+    moveOutcomeEpochRef.current += 1;
     setMoveOutcome(null);
   };
 
@@ -257,6 +268,7 @@ export function useAssetBatch() {
     // only remove targets that have not been reselected while the fan-out was in flight.
     const targets = movableSelected;
     const targetEpochs = new Map(targets.map((asset) => [asset.id, selectionEpochsRef.current.get(asset.id) ?? 0]));
+    const moveOutcomeEpoch = moveOutcomeEpochRef.current;
     setBulkAction("move");
     try {
       const outcomes = await Promise.allSettled(
@@ -268,8 +280,7 @@ export function useAssetBatch() {
         if (outcome.status === "fulfilled") {
           successfulIds.add(targets[index].id);
         } else {
-          const reason = outcome.reason;
-          failures.push({ asset: targets[index], message: reason?.message ?? String(reason || "Could not move this asset.") });
+          failures.push({ asset: targets[index], message: moveFailureMessage(outcome.reason) });
         }
       });
       setSelectedAssetIds((current) => {
@@ -280,7 +291,7 @@ export function useAssetBatch() {
         return next;
       });
       setMoveOpen(false);
-      if (failures.length) {
+      if (failures.length && moveOutcomeEpochRef.current === moveOutcomeEpoch) {
         setMoveOutcome({ succeeded: successfulIds.size, failures });
       }
     } finally {
@@ -306,7 +317,10 @@ export function useAssetBatch() {
     closeBatch,
     bulkAction,
     moveOutcome,
-    dismissMoveOutcome: () => setMoveOutcome(null),
+    dismissMoveOutcome: () => {
+      moveOutcomeEpochRef.current += 1;
+      setMoveOutcome(null);
+    },
     discardSelected,
     discardPrompt,
     resolveDiscardPrompt,
@@ -360,7 +374,26 @@ export function AssetSelectionBar({ batch, showDiscard = true, allowLibraryTarge
     />
   ) : null;
 
-  if (selectedAssetIds.size === 0) return discardDialog;
+  const moveOutcomeAlert = moveOutcome ? (
+    <div className="batch-move-outcome" role="alert">
+      <span>
+        Moved {moveOutcome.succeeded}; {moveOutcome.failures.length} failed. Failed assets remain selected.
+        {moveOutcome.failures[0]?.message ? ` ${moveOutcome.failures[0].message}` : ""}
+      </span>
+      <button aria-label="Dismiss move result" onClick={dismissMoveOutcome} type="button">
+        Dismiss
+      </button>
+    </div>
+  ) : null;
+
+  if (selectedAssetIds.size === 0) {
+    return (
+      <>
+        {moveOutcomeAlert}
+        {discardDialog}
+      </>
+    );
+  }
 
   // Move destinations: the Main Library (optional) followed by every non-archived character.
   const moveTargets = [
@@ -406,17 +439,7 @@ export function AssetSelectionBar({ batch, showDiscard = true, allowLibraryTarge
       <button onClick={clearSelection} type="button">
         Clear
       </button>
-      {moveOutcome ? (
-        <div className="batch-move-outcome" role="alert">
-          <span>
-            Moved {moveOutcome.succeeded}; {moveOutcome.failures.length} failed. Failed assets remain selected.
-            {moveOutcome.failures[0]?.message ? ` ${moveOutcome.failures[0].message}` : ""}
-          </span>
-          <button aria-label="Dismiss move result" onClick={dismissMoveOutcome} type="button">
-            Dismiss
-          </button>
-        </div>
-      ) : null}
+      {moveOutcomeAlert}
       {moveOpen && moveTargets.length ? (
         <div className="batch-move-picker">
           <select

--- a/apps/web/src/assetBatch.split.test.jsx
+++ b/apps/web/src/assetBatch.split.test.jsx
@@ -33,6 +33,16 @@ function AssetBatchProbe({ onReady }) {
   return null;
 }
 
+function AssetBatchToolbarProbe({ onReady }) {
+  const batch = useAssetBatch();
+  React.useEffect(() => {
+    batch.toggleSelect("a1");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  onReady(batch);
+  return <AssetSelectionBar batch={batch} />;
+}
+
 function render(ui) {
   const container = document.createElement("div");
   document.body.appendChild(container);
@@ -126,6 +136,16 @@ describe("useAssetBatch truthful bulk move outcomes (sc-21901)", () => {
     return () => latest;
   }
 
+  function mountToolbar(overrides = {}) {
+    let latest;
+    harness = render(
+      <AppContext.Provider value={{ assets, characters, imageModels: [], jobs: [], ...overrides }}>
+        <AssetBatchToolbarProbe onReady={(batch) => { latest = batch; }} />
+      </AppContext.Provider>,
+    );
+    return () => latest;
+  }
+
   it("keeps failed and newly selected assets actionable after mixed character-move outcomes", async () => {
     const first = deferred();
     const second = deferred();
@@ -167,6 +187,72 @@ describe("useAssetBatch truthful bulk move outcomes (sc-21901)", () => {
 
     expect(batch().selectedAssetList.map((asset) => asset.id)).toEqual(["a2"]);
     expect(batch().moveOutcome).toMatchObject({ succeeded: 1, failures: [{ asset: { id: "a2" }, message: "library is read-only" }] });
+  });
+
+  it("keeps a deferred mixed move failure visible after concurrent deselection empties the selection", async () => {
+    const first = deferred();
+    const second = deferred();
+    const moveAssetToCharacter = vi.fn((asset) => (asset.id === "a1" ? first.promise : second.promise));
+    const batch = mountToolbar({ moveAssetToCharacter });
+    await act(async () => {
+      batch().toggleSelect("a2");
+      batch().setMoveCharacterId("c1");
+    });
+
+    let moving;
+    act(() => {
+      moving = batch().moveSelectedToCharacter();
+    });
+    await act(async () => {
+      batch().toggleSelect("a1");
+      batch().toggleSelect("a2");
+      first.resolve({ id: "a1" });
+      second.reject(new Error("destination unavailable"));
+      await moving;
+    });
+
+    expect(document.body.querySelector('[role="alert"]').textContent).toContain("Moved 1; 1 failed. Failed assets remain selected. destination unavailable");
+  });
+
+  it("does not restore an in-flight move result after an explicit clear", async () => {
+    const first = deferred();
+    const second = deferred();
+    const moveAssetToCharacter = vi.fn((asset) => (asset.id === "a1" ? first.promise : second.promise));
+    const batch = mount({ moveAssetToCharacter });
+    await act(async () => {
+      batch().toggleSelect("a2");
+      batch().setMoveCharacterId("c1");
+    });
+
+    let moving;
+    act(() => {
+      moving = batch().moveSelectedToCharacter();
+      batch().clearSelection();
+    });
+    await act(async () => {
+      first.resolve({ id: "a1" });
+      second.reject(new Error("destination unavailable"));
+      await moving;
+    });
+
+    expect(batch().moveOutcome).toBeNull();
+  });
+
+  it("normalizes object-valued rejection messages into a stable move failure", async () => {
+    const moveAssetToCharacter = vi.fn(async (asset) => {
+      if (asset.id === "a2") throw { message: { code: "destination_unavailable" } };
+      return { id: asset.id };
+    });
+    const batch = mount({ moveAssetToCharacter });
+    await act(async () => {
+      batch().toggleSelect("a2");
+      batch().setMoveCharacterId("c1");
+    });
+    await act(async () => {
+      await batch().moveSelectedToCharacter();
+    });
+
+    expect(batch().moveOutcome).toMatchObject({ failures: [{ asset: { id: "a2" }, message: "Could not move this asset." }] });
   });
 
   it("renders a partial move outcome as an alert", () => {

--- a/apps/web/src/assetBatch.split.test.jsx
+++ b/apps/web/src/assetBatch.split.test.jsx
@@ -1,6 +1,6 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AssetSelectionBar, useAssetBatch } from "./assetBatch.jsx";
 import { AppStaticContext, AppLiveContext, AppContext } from "./context/AppContext.js";
 
@@ -13,8 +13,9 @@ import { AppStaticContext, AppLiveContext, AppContext } from "./context/AppConte
 // degrades to inert defaults when rendered with no provider at all.
 
 const assets = [
-  { id: "a1", kind: "image", file: { path: "a1.png" } },
-  { id: "a2", kind: "image", file: { path: "a2.png" } },
+  { id: "a1", kind: "image", type: "image", file: { path: "a1.png" } },
+  { id: "a2", kind: "image", type: "image", file: { path: "a2.png" } },
+  { id: "a3", kind: "image", type: "image", file: { path: "a3.png" } },
 ];
 const characters = [
   { id: "c1", name: "Ada", archived: false },
@@ -46,6 +47,10 @@ function render(ui) {
     },
   };
 }
+
+beforeEach(() => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+});
 
 describe("useAssetBatch under the split context providers (sc-9751)", () => {
   let harness;
@@ -90,6 +95,89 @@ describe("useAssetBatch under the split context providers (sc-9751)", () => {
     );
     expect(latest.selectedAssetList.map((a) => a.id)).toEqual(["a1"]);
     expect(latest.availableCharacters.map((c) => c.id)).toEqual(["c1"]);
+  });
+});
+
+describe("useAssetBatch truthful bulk move outcomes (sc-21901)", () => {
+  let harness;
+
+  afterEach(() => {
+    harness?.cleanup();
+    harness = null;
+  });
+
+  function deferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((nextResolve, nextReject) => {
+      resolve = nextResolve;
+      reject = nextReject;
+    });
+    return { promise, resolve, reject };
+  }
+
+  function mount(overrides = {}) {
+    let latest;
+    harness = render(
+      <AppContext.Provider value={{ assets, characters, imageModels: [], jobs: [], ...overrides }}>
+        <AssetBatchProbe onReady={(batch) => { latest = batch; }} />
+      </AppContext.Provider>,
+    );
+    return () => latest;
+  }
+
+  it("keeps failed and newly selected assets actionable after mixed character-move outcomes", async () => {
+    const first = deferred();
+    const second = deferred();
+    const moveAssetToCharacter = vi.fn((asset) => (asset.id === "a1" ? first.promise : second.promise));
+    const batch = mount({ moveAssetToCharacter });
+    await act(async () => {
+      batch().toggleSelect("a2");
+      batch().setMoveCharacterId("c1");
+    });
+
+    const moving = batch().moveSelectedToCharacter();
+    await act(async () => {
+      batch().toggleSelect("a3");
+      second.reject("destination unavailable");
+      first.resolve({ id: "a1" });
+      await moving;
+    });
+
+    expect(batch().selectedAssetList.map((asset) => asset.id).sort()).toEqual(["a2", "a3"]);
+    expect(batch().moveOutcome).toMatchObject({ succeeded: 1, failures: [{ asset: { id: "a2" }, message: "destination unavailable" }] });
+  });
+
+  it("reports a mixed Library move without treating it as total success", async () => {
+    const first = deferred();
+    const second = deferred();
+    const moveAssetToLibrary = vi.fn((asset) => (asset.id === "a1" ? first.promise : second.promise));
+    const batch = mount({ moveAssetToLibrary });
+    await act(async () => {
+      batch().toggleSelect("a2");
+      batch().setMoveCharacterId("__sceneworks_library__");
+    });
+
+    const moving = batch().moveSelectedToCharacter();
+    await act(async () => {
+      first.resolve({ id: "a1" });
+      second.reject(new Error("library is read-only"));
+      await moving;
+    });
+
+    expect(batch().selectedAssetList.map((asset) => asset.id)).toEqual(["a2"]);
+    expect(batch().moveOutcome).toMatchObject({ succeeded: 1, failures: [{ asset: { id: "a2" }, message: "library is read-only" }] });
+  });
+
+  it("renders a partial move outcome as an alert", () => {
+    const fakeBatch = {
+      selectedAssetIds: new Set(["a2"]), eligibleSelected: [], movableSelected: [], availableCharacters: [], setBatchOpen() {},
+      bulkAction: null, discardSelected() {}, discardPrompt: null, resolveDiscardPrompt() {}, cancelDiscard() {},
+      moveOpen: false, setMoveOpen() {}, moveCharacterId: "", setMoveCharacterId() {}, moveSelectedToCharacter() {}, clearSelection() {},
+      moveOutcome: { succeeded: 1, failures: [{ asset: { id: "a2" }, message: "library is read-only" }] }, dismissMoveOutcome() {},
+    };
+    harness = render(<AssetSelectionBar batch={fakeBatch} />);
+    expect(document.body.querySelector('[role="alert"]').textContent).toContain("Moved 1; 1 failed. Failed assets remain selected. library is read-only");
   });
 });
 

--- a/apps/web/src/batchOps.js
+++ b/apps/web/src/batchOps.js
@@ -144,9 +144,17 @@ export function summarizeBatchProgress(items, jobs, observedJobs) {
 // before posting, so enqueueing can be slow. An item with no jobId and no `error` is
 // therefore PENDING submission (NOT failed); `error: true` marks a submission that threw.
 // `active` = queued + running (jobs that Cancel can still stop).
-export function summarizeBatchRun(items, jobs, observedJobs) {
-  const summary = { total: items?.length ?? 0, pending: 0, queued: 0, running: 0, completed: 0, failed: 0 };
-  for (const item of items ?? []) {
+export function summarizeBatchRun(items, jobs, observedJobs, total = items?.length ?? 0) {
+  const listedItems = items ?? [];
+  const summary = {
+    total: Math.max(total, listedItems.length),
+    pending: Math.max(total - listedItems.length, 0),
+    queued: 0,
+    running: 0,
+    completed: 0,
+    failed: 0,
+  };
+  for (const item of listedItems) {
     if (item.error) {
       summary.failed += 1;
       continue;

--- a/apps/web/src/batchOps.js
+++ b/apps/web/src/batchOps.js
@@ -139,31 +139,46 @@ export function summarizeBatchProgress(items, jobs, observedJobs) {
   return summary;
 }
 
-// Progress for a prompt-batch run (sc-9980). Unlike summarizeBatchProgress, this fan-out
-// enqueues incrementally — a structured-caption model auto-expands each resolved prompt
-// before posting, so enqueueing can be slow. An item with no jobId and no `error` is
-// therefore PENDING submission (NOT failed); `error: true` marks a submission that threw.
-// `active` = queued + running (jobs that Cancel can still stop).
-export function summarizeBatchRun(items, jobs, observedJobs, total = items?.length ?? 0) {
-  const listedItems = items ?? [];
+// Move terminal active jobs into the bounded prompt-batch totals. The active-id list is
+// deliberately small (the Studio applies backpressure before it grows without bound), while
+// completed and failed are scalar counters. Returns the original run when nothing settled.
+export function settlePromptBatchRun(run, jobs, observedJobs) {
+  if (!run?.activeJobIds?.length) return run;
+  let completed = run.completed ?? 0;
+  let failed = run.failed ?? 0;
+  const activeJobIds = [];
+  for (const jobId of run.activeJobIds) {
+    const status = batchItemStatus(jobId, jobs, observedJobs);
+    if (status === "completed") {
+      completed += 1;
+      observedJobs?.delete(jobId);
+    } else if (status === "failed") {
+      failed += 1;
+      observedJobs?.delete(jobId);
+    } else {
+      activeJobIds.push(jobId);
+    }
+  }
+  if (activeJobIds.length === run.activeJobIds.length) return run;
+  return { ...run, completed, failed, activeJobIds };
+}
+
+// Progress for a prompt-batch run (sc-9980). It holds scalar totals plus only the bounded
+// currently-active job ids, never one entry per resolved prompt. `submitted` includes posts
+// that failed before returning a job id; `pending` is the not-yet-submitted suffix.
+export function summarizeBatchRun(run, jobs, observedJobs) {
+  const total = Math.max(run?.total ?? 0, 0);
+  const submitted = Math.min(Math.max(run?.submitted ?? 0, 0), total);
   const summary = {
-    total: Math.max(total, listedItems.length),
-    pending: Math.max(total - listedItems.length, 0),
+    total,
+    pending: total - submitted,
     queued: 0,
     running: 0,
-    completed: 0,
-    failed: 0,
+    completed: run?.completed ?? 0,
+    failed: run?.failed ?? 0,
   };
-  for (const item of listedItems) {
-    if (item.error) {
-      summary.failed += 1;
-      continue;
-    }
-    if (!item.jobId) {
-      summary.pending += 1;
-      continue;
-    }
-    summary[batchItemStatus(item.jobId, jobs, observedJobs)] += 1;
+  for (const jobId of run?.activeJobIds ?? []) {
+    summary[batchItemStatus(jobId, jobs, observedJobs)] += 1;
   }
   summary.done = summary.completed + summary.failed;
   summary.active = summary.queued + summary.running;

--- a/apps/web/src/batchOps.test.js
+++ b/apps/web/src/batchOps.test.js
@@ -172,6 +172,11 @@ describe("batch ops (sc-6112)", () => {
 });
 
 describe("summarizeBatchRun (sc-9980)", () => {
+  it("counts an unstreamed suffix as pending when the run total is known", () => {
+    const summary = summarizeBatchRun([{ jobId: "j1" }], [{ id: "j1", status: "queued" }], undefined, 4);
+    expect(summary).toMatchObject({ total: 4, pending: 3, queued: 1, failed: 0, done: 0, allDone: false });
+  });
+
   it("counts not-yet-submitted items as pending, not failed", () => {
     const summary = summarizeBatchRun(
       [{ jobId: "j1" }, { jobId: null }, { jobId: null }],

--- a/apps/web/src/batchOps.test.js
+++ b/apps/web/src/batchOps.test.js
@@ -8,6 +8,7 @@ import {
   batchItemStatusForItem,
   batchItemResultAsset,
   summarizeBatchProgress,
+  settlePromptBatchRun,
   summarizeBatchRun,
 } from "./batchOps.js";
 
@@ -173,22 +174,26 @@ describe("batch ops (sc-6112)", () => {
 
 describe("summarizeBatchRun (sc-9980)", () => {
   it("counts an unstreamed suffix as pending when the run total is known", () => {
-    const summary = summarizeBatchRun([{ jobId: "j1" }], [{ id: "j1", status: "queued" }], undefined, 4);
+    const summary = summarizeBatchRun(
+      { total: 4, submitted: 1, completed: 0, failed: 0, activeJobIds: ["j1"] },
+      [{ id: "j1", status: "queued" }],
+    );
     expect(summary).toMatchObject({ total: 4, pending: 3, queued: 1, failed: 0, done: 0, allDone: false });
   });
 
-  it("counts not-yet-submitted items as pending, not failed", () => {
+  it("counts not-yet-submitted prompts as pending, not failed", () => {
     const summary = summarizeBatchRun(
-      [{ jobId: "j1" }, { jobId: null }, { jobId: null }],
+      { total: 3, submitted: 1, completed: 0, failed: 0, activeJobIds: ["j1"] },
       [{ id: "j1", status: "queued" }],
     );
     expect(summary).toMatchObject({ total: 3, pending: 2, queued: 1, failed: 0, done: 0, allDone: false });
   });
 
-  it("marks a thrown submission as failed via the error flag", () => {
-    const summary = summarizeBatchRun([{ jobId: null, error: true }, { jobId: "j1" }], [
-      { id: "j1", status: "completed" },
-    ]);
+  it("counts a failed submission without retaining its prompt", () => {
+    const summary = summarizeBatchRun(
+      { total: 2, submitted: 2, completed: 0, failed: 1, activeJobIds: ["j1"] },
+      [{ id: "j1", status: "completed" }],
+    );
     expect(summary).toMatchObject({ total: 2, failed: 1, completed: 1, pending: 0, done: 2 });
   });
 
@@ -197,9 +202,26 @@ describe("summarizeBatchRun (sc-9980)", () => {
       { id: "j1", status: "completed" },
       { id: "j2", status: "running" },
     ];
-    const mid = summarizeBatchRun([{ jobId: "j1" }, { jobId: "j2" }], jobs);
+    const mid = summarizeBatchRun(
+      { total: 2, submitted: 2, completed: 0, failed: 0, activeJobIds: ["j1", "j2"] },
+      jobs,
+    );
     expect(mid).toMatchObject({ completed: 1, running: 1, active: 1, allDone: false });
-    const doneAll = summarizeBatchRun([{ jobId: "j1" }], [{ id: "j1", status: "completed" }]);
+    const doneAll = summarizeBatchRun(
+      { total: 1, submitted: 1, completed: 0, failed: 0, activeJobIds: ["j1"] },
+      [{ id: "j1", status: "completed" }],
+    );
     expect(doneAll).toMatchObject({ done: 1, active: 0, allDone: true });
+  });
+
+  it("settles terminal jobs into scalar totals and drops their ids", () => {
+    const observed = new Map([["j1", "observed"]]);
+    const settled = settlePromptBatchRun(
+      { total: 3, submitted: 3, completed: 0, failed: 1, activeJobIds: ["j1", "j2"] },
+      [{ id: "j1", status: "completed" }, { id: "j2", status: "running" }],
+      observed,
+    );
+    expect(settled).toEqual({ total: 3, submitted: 3, completed: 1, failed: 1, activeJobIds: ["j2"] });
+    expect(observed.has("j1")).toBe(false);
   });
 });

--- a/apps/web/src/components/AssetPicker.jsx
+++ b/apps/web/src/components/AssetPicker.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   AssetThumbnail,
   assetCanRenderAsAudio,
@@ -422,6 +422,8 @@ function MediaSourcePickerModal({
   const [tab, setTab] = useState("assets");
   const [query, setQuery] = useState("");
   const [selectedIds, setSelectedIds] = useState(() => normalizeSelection(initialSelectedIds, assets, multiple));
+  const selectedIdsRef = useRef(normalizeSelection(initialSelectedIds, assets, multiple));
+  const selectionVersionRef = useRef(0);
   const [characterId, setCharacterId] = useState(characters[0]?.id ?? "");
   const [dragActive, setDragActive] = useState(false);
   const [uploading, setUploading] = useState(false);
@@ -429,8 +431,19 @@ function MediaSourcePickerModal({
   const mediaLabel = mediaKind === "video" ? "video" : "image";
 
   useEffect(() => {
-    setSelectedIds((ids) => normalizeSelection(ids, assets, multiple));
+    setSelectedIds((ids) => {
+      const nextIds = normalizeSelection(ids, assets, multiple);
+      selectedIdsRef.current = nextIds;
+      return nextIds;
+    });
   }, [assets, multiple]);
+
+  function updateSelectedIds(updater) {
+    const nextIds = updater(selectedIdsRef.current);
+    selectedIdsRef.current = nextIds;
+    setSelectedIds(nextIds);
+    return nextIds;
+  }
 
   useEffect(() => {
     if (characterId && characters.some((character) => character.id === characterId)) {
@@ -482,6 +495,7 @@ function MediaSourcePickerModal({
     }
     setUploading(true);
     setUploadError("");
+    const selectionVersion = selectionVersionRef.current;
     try {
       const outcomes = await Promise.allSettled(
         (multiple ? selectedFiles : selectedFiles.slice(0, 1)).map((file) =>
@@ -492,9 +506,17 @@ function MediaSourcePickerModal({
         .filter((outcome) => outcome.status === "fulfilled" && outcome.value?.id && assetMatchesMediaKind(outcome.value, mediaKind))
         .map((outcome) => outcome.value.id);
       const failureCount = outcomes.length - importedIds.length;
-      const nextIds = multiple ? [...new Set([...selectedIds, ...importedIds])] : importedIds.slice(0, 1);
+      // Uploads settle later than card clicks. Merge into the latest selection rather than
+      // the render-time `selectedIds` captured when the upload began. A manual single-select
+      // made while the import was pending wins over the import's automatic selection.
+      const nextIds = updateSelectedIds((currentIds) =>
+        multiple
+          ? [...new Set([...currentIds, ...importedIds])]
+          : selectionVersion === selectionVersionRef.current
+            ? importedIds.slice(0, 1)
+            : currentIds,
+      );
       if (failureCount) {
-        setSelectedIds(nextIds);
         setUploadError(
           importedIds.length
             ? `Imported ${importedIds.length} ${mediaLabel}${importedIds.length === 1 ? "" : "s"}; ${failureCount} failed.`
@@ -526,7 +548,8 @@ function MediaSourcePickerModal({
 
   function renderAssetGrid(emptyLabel) {
     function toggleAsset(asset) {
-      setSelectedIds((ids) => {
+      selectionVersionRef.current += 1;
+      updateSelectedIds((ids) => {
         if (multiple) {
           return ids.includes(asset.id) ? ids.filter((id) => id !== asset.id) : [...ids, asset.id];
         }
@@ -599,7 +622,7 @@ function MediaSourcePickerModal({
           onFiles={handleUpload}
         />
       ) : null}
-      {tab === "upload" && uploadError ? <p className="inline-warning">{uploadError}</p> : null}
+      {uploadError ? <p className="inline-warning">{uploadError}</p> : null}
 
       {tab === "character" ? (
         <div className="dataset-add-character">
@@ -710,6 +733,8 @@ export function AssetPickerModal({
   const [category, setCategory] = useState("all");
   const [query, setQuery] = useState("");
   const [selectedIds, setSelectedIds] = useState(() => normalizeSelection(initialSelectedIds, assets, multiple));
+  const selectedIdsRef = useRef(normalizeSelection(initialSelectedIds, assets, multiple));
+  const selectionVersionRef = useRef(0);
   const [dragActive, setDragActive] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState("");
@@ -717,8 +742,19 @@ export function AssetPickerModal({
   const mediaLabel = mediaKind ?? "file";
 
   useEffect(() => {
-    setSelectedIds((ids) => normalizeSelection(ids, assets, multiple));
+    setSelectedIds((ids) => {
+      const nextIds = normalizeSelection(ids, assets, multiple);
+      selectedIdsRef.current = nextIds;
+      return nextIds;
+    });
   }, [assets, multiple]);
+
+  function updateSelectedIds(updater) {
+    const nextIds = updater(selectedIdsRef.current);
+    selectedIdsRef.current = nextIds;
+    setSelectedIds(nextIds);
+    return nextIds;
+  }
 
   // Mirrors MediaSourcePickerModal's upload path: import each file with `select: false` (a
   // field-scoped picker must not hijack the app-wide Library selection), keep only imports of
@@ -734,6 +770,7 @@ export function AssetPickerModal({
     }
     setUploading(true);
     setUploadError("");
+    const selectionVersion = selectionVersionRef.current;
     try {
       const outcomes = await Promise.allSettled(
         (multiple ? selectedFiles : selectedFiles.slice(0, 1)).map((file) =>
@@ -749,9 +786,14 @@ export function AssetPickerModal({
         )
         .map((outcome) => outcome.value.id);
       const failureCount = outcomes.length - importedIds.length;
-      const nextIds = multiple ? [...new Set([...selectedIds, ...importedIds])] : importedIds.slice(0, 1);
+      const nextIds = updateSelectedIds((currentIds) =>
+        multiple
+          ? [...new Set([...currentIds, ...importedIds])]
+          : selectionVersion === selectionVersionRef.current
+            ? importedIds.slice(0, 1)
+            : currentIds,
+      );
       if (failureCount) {
-        setSelectedIds(nextIds);
         setUploadError(
           importedIds.length
             ? `Imported ${importedIds.length} ${mediaLabel} file${importedIds.length === 1 ? "" : "s"}; ${failureCount} failed.`
@@ -790,7 +832,8 @@ export function AssetPickerModal({
   }, [assets, activeCategory, query, searchIndex]);
 
   function toggleAsset(asset) {
-    setSelectedIds((ids) => {
+    selectionVersionRef.current += 1;
+    updateSelectedIds((ids) => {
       if (multiple) {
         return ids.includes(asset.id) ? ids.filter((id) => id !== asset.id) : [...ids, asset.id];
       }

--- a/apps/web/src/components/AssetPicker.test.jsx
+++ b/apps/web/src/components/AssetPicker.test.jsx
@@ -368,6 +368,55 @@ describe("VideoSourcePickerField video-only sources", () => {
     await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Use Selection"));
     expect(onChange).toHaveBeenCalledWith(["plain-image", "uploaded-image-1"]);
   });
+
+  it("keeps a selection made while a source-image upload is pending", async () => {
+    let resolveFirst;
+    let rejectSecond;
+    const importAsset = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }))
+      .mockImplementationOnce(() => new Promise((_, reject) => { rejectSecond = reject; }));
+    const onChange = vi.fn();
+    await act(async () => {
+      root.render(
+        <ImageEditSourcePickerField
+          assets={assets}
+          characters={characters}
+          importAsset={importAsset}
+          label="Reference images"
+          multiple
+          onChange={onChange}
+          projectId="p1"
+          values={[]}
+        />,
+      );
+    });
+
+    await click(container.querySelector('button[aria-haspopup="dialog"]'));
+    await click(tab("File Upload"));
+    const input = document.body.querySelector('input[type="file"]');
+    const files = [
+      new File(["upload"], "upload-1.png", { type: "image/png" }),
+      new File(["upload"], "upload-2.png", { type: "image/png" }),
+    ];
+    Object.defineProperty(input, "files", { configurable: true, value: files });
+    await act(async () => input.dispatchEvent(new Event("change", { bubbles: true })));
+
+    // Switch back and select a pre-existing card before the deferred importer settles.
+    await click(tab("Assets"));
+    await click(document.body.querySelector('.asset-picker-grid [role="option"]'));
+    await act(async () => {
+      // Settle out of order: a partial failure must not overwrite the concurrent pick
+      // or masquerade as a complete success.
+      rejectSecond(new Error("upload-2 failed"));
+      resolveFirst({ id: "uploaded-late", type: "image", projectId: "p1" });
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Imported 1 image; 1 failed.");
+    await click([...document.body.querySelectorAll("button")].find((button) => button.textContent === "Use Selection"));
+    expect(onChange).toHaveBeenCalledWith(["plain-image", "uploaded-late"]);
+  });
 });
 
 // sc-17137 review, item 2. `AssetPickerModal` grew an upload/dropzone import path so a picker
@@ -479,6 +528,21 @@ describe("AssetPickerField audio import (VideoStudio reference audio)", () => {
     expect(importAsset).toHaveBeenCalledWith(file, { select: false, throwOnError: true });
     expect(onChange).toHaveBeenCalledWith(["voice-1", "uploaded-audio"]);
     expect(document.body.querySelector('[role="dialog"]')).toBeFalsy();
+  });
+
+  it("keeps a selection made while an asset-picker upload is pending", async () => {
+    let resolveImport;
+    const importAsset = vi.fn(() => new Promise((resolve) => { resolveImport = resolve; }));
+    const onChange = vi.fn();
+    const input = await openPicker({ importAsset, onChange, values: [] });
+    const file = new File(["audio"], "take.wav", { type: "audio/wav" });
+
+    Object.defineProperty(input, "files", { configurable: true, value: [file] });
+    await act(async () => input.dispatchEvent(new Event("change", { bubbles: true })));
+    await click(document.body.querySelector('.asset-picker-grid [role="option"]'));
+    await act(async () => resolveImport(importedAudioAsset("uploaded-late")));
+
+    expect(onChange).toHaveBeenCalledWith(["voice-1", "uploaded-late"]);
   });
 
   it("imports a DROPPED audio file through the same path", async () => {

--- a/apps/web/src/components/CheckpointImportPanel.jsx
+++ b/apps/web/src/components/CheckpointImportPanel.jsx
@@ -120,7 +120,11 @@ export function CheckpointImportPanel({
   const [activeRootId, setActiveRootId] = useState("");
   const [scan, setScan] = useState(null);
   const [pathDraft, setPathDraft] = useState("");
-  const [labelDraft, setLabelDraft] = useState("");
+  // Adding a library and renaming an existing one can be visible at the same
+  // time. Keep their drafts separate so opening/cancelling a rename never
+  // overwrites the name prepared for the next library.
+  const [addLabelDraft, setAddLabelDraft] = useState("");
+  const [renameLabelDraft, setRenameLabelDraft] = useState("");
   const [renaming, setRenaming] = useState("");
 
   // Managed state. `type` is image-only for the same reason the pre-epic form fixed it: the import
@@ -225,9 +229,9 @@ export function CheckpointImportPanel({
     }
     setBusy("approve");
     try {
-      const root = await library.approve(token, { path, label: labelDraft.trim() || undefined });
+      const root = await library.approve(token, { path, label: addLabelDraft.trim() || undefined });
       setPathDraft("");
-      setLabelDraft("");
+      setAddLabelDraft("");
       const next = await loadRoots();
       setMessage({ ...NEUTRAL, tone: "success", text: `Added ${root?.displayLabel ?? path}.` });
       if (root?.rootId) await runScan(root.rootId);
@@ -266,7 +270,7 @@ export function CheckpointImportPanel({
   }
 
   async function renameRoot(rootId) {
-    const label = labelDraft.trim();
+    const label = renameLabelDraft.trim();
     if (!label) {
       setMessage({ ...NEUTRAL, tone: "error", text: "Enter a name for this library." });
       return;
@@ -275,7 +279,7 @@ export function CheckpointImportPanel({
     try {
       await library.update(token, rootId, { label });
       setRenaming("");
-      setLabelDraft("");
+      setRenameLabelDraft("");
       await loadRoots();
       setMessage({ ...NEUTRAL, tone: "success", text: "Library renamed." });
     } catch (error) {
@@ -498,9 +502,9 @@ export function CheckpointImportPanel({
             Name
             <input
               disabled={busy === "approve"}
-              onChange={(event) => setLabelDraft(event.target.value)}
+              onChange={(event) => setAddLabelDraft(event.target.value)}
               placeholder="Optional"
-              value={labelDraft}
+              value={addLabelDraft}
             />
           </label>
           <button disabled={busy === "approve"} onClick={addLibrary} type="button">
@@ -528,7 +532,7 @@ export function CheckpointImportPanel({
                 <button disabled={busy === `relink:${root.rootId}`} onClick={() => relinkRoot(root.rootId)} type="button">
                   Relink library
                 </button>
-                <button onClick={() => { setRenaming(root.rootId); setLabelDraft(root.label ?? ""); }} type="button">
+                <button onClick={() => { setRenaming(root.rootId); setRenameLabelDraft(root.label ?? ""); }} type="button">
                   Rename
                 </button>
                 <button disabled={busy === `forget:${root.rootId}`} onClick={() => forgetRoot(root)} type="button">
@@ -539,12 +543,12 @@ export function CheckpointImportPanel({
                 <div className="checkpoint-root-rename">
                   <label>
                     New name
-                    <input onChange={(event) => setLabelDraft(event.target.value)} value={labelDraft} />
+                    <input onChange={(event) => setRenameLabelDraft(event.target.value)} value={renameLabelDraft} />
                   </label>
                   <button disabled={busy === `rename:${root.rootId}`} onClick={() => renameRoot(root.rootId)} type="button">
                     Save name
                   </button>
-                  <button onClick={() => setRenaming("")} type="button">
+                  <button onClick={() => { setRenaming(""); setRenameLabelDraft(""); }} type="button">
                     Cancel rename
                   </button>
                 </div>

--- a/apps/web/src/components/CheckpointImportPanel.test.jsx
+++ b/apps/web/src/components/CheckpointImportPanel.test.jsx
@@ -223,6 +223,21 @@ describe("CheckpointImportPanel", () => {
     expect(library.remove).toHaveBeenCalledWith("tok", "root-a");
   });
 
+  it("keeps the add-library name draft while a library is renamed", async () => {
+    const library = libraryStub();
+    await render({ library });
+    await type(labelled("Library folder"), "/Volumes/New");
+    await type(labelled("Name"), "New library");
+
+    await click(buttonNamed("Rename"));
+    await type(labelled("New name"), "Renamed existing library");
+    await click(buttonNamed("Save name"));
+    expect(library.update).toHaveBeenLastCalledWith("tok", "root-a", { label: "Renamed existing library" });
+
+    await click(buttonNamed("Add library"));
+    expect(library.approve).toHaveBeenCalledWith("tok", { path: "/Volumes/New", label: "New library" });
+  });
+
   it("uses the desktop bridge folder picker when one is available", async () => {
     const pickFolder = vi.fn(async () => "/Volumes/Picked");
     const library = libraryStub();

--- a/apps/web/src/components/DatasetParquetImportDialog.jsx
+++ b/apps/web/src/components/DatasetParquetImportDialog.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 
 import { isDesktop, tauriInvoke } from "../runtime.js";
 import { Modal } from "./Modal.jsx";
+import { errorMessage } from "../errorMessage.js";
 
 const initialSettings = {
   sourcePath: "",
@@ -25,6 +26,7 @@ const captionPresets = {
 export function DatasetParquetImportDialog({ running = false, onClose, onRun }) {
   const [settings, setSettings] = useState(initialSettings);
   const [pickerError, setPickerError] = useState("");
+  const [submitError, setSubmitError] = useState("");
 
   function update(field, value) {
     setSettings((current) => ({ ...current, [field]: value }));
@@ -53,22 +55,27 @@ export function DatasetParquetImportDialog({ running = false, onClose, onRun }) 
   async function submit(event) {
     event.preventDefault();
     if (!settings.sourcePath.trim() || running) return;
-    await onRun({
-      sourcePath: settings.sourcePath.trim(),
-      urlColumn: settings.urlColumn.trim(),
-      captionColumn: settings.captionColumn.trim(),
-      maxItems: Number(settings.maxItems),
-      minEdge: Number(settings.minEdge),
-      concurrency: Number(settings.concurrency),
-      captionIncludes: settings.captionIncludes
-        .split(",")
-        .map((term) => term.trim())
-        .filter(Boolean),
-      captionExcludes: settings.captionExcludes
-        .split(",")
-        .map((term) => term.trim())
-        .filter(Boolean),
-    });
+    setSubmitError("");
+    try {
+      await onRun({
+        sourcePath: settings.sourcePath.trim(),
+        urlColumn: settings.urlColumn.trim(),
+        captionColumn: settings.captionColumn.trim(),
+        maxItems: Number(settings.maxItems),
+        minEdge: Number(settings.minEdge),
+        concurrency: Number(settings.concurrency),
+        captionIncludes: settings.captionIncludes
+          .split(",")
+          .map((term) => term.trim())
+          .filter(Boolean),
+        captionExcludes: settings.captionExcludes
+          .split(",")
+          .map((term) => term.trim())
+          .filter(Boolean),
+      });
+    } catch (error) {
+      setSubmitError(errorMessage(error, "Could not start the Parquet import."));
+    }
   }
 
   return (
@@ -110,6 +117,7 @@ export function DatasetParquetImportDialog({ running = false, onClose, onRun }) 
           </small>
         ) : null}
         {pickerError ? <p className="inline-warning">{pickerError}</p> : null}
+        {submitError ? <p className="inline-warning">{submitError}</p> : null}
 
         <div className="dataset-caption-row">
           <label>

--- a/apps/web/src/components/DatasetParquetImportDialog.test.jsx
+++ b/apps/web/src/components/DatasetParquetImportDialog.test.jsx
@@ -69,4 +69,30 @@ describe("DatasetParquetImportDialog", () => {
       captionExcludes: ["logo", "illustration"],
     });
   });
+
+  it("surfaces a rejected submit without leaving an unhandled promise rejection", async () => {
+    const onRun = vi.fn(() => Promise.reject(undefined));
+    const unhandled = [];
+    const onUnhandled = (event) => {
+      unhandled.push(event.reason);
+      event.preventDefault();
+    };
+    window.addEventListener("unhandledrejection", onUnhandled);
+    root = createRoot(container);
+    act(() => root.render(<DatasetParquetImportDialog onClose={vi.fn()} onRun={onRun} />));
+
+    try {
+      change(fieldByLabel("Parquet file or folder"), "D:\\broken.parquet");
+      await act(async () => {
+        document.body.querySelector('button[type="submit"]').click();
+        await Promise.resolve();
+      });
+
+      expect(onRun).toHaveBeenCalledTimes(1);
+      expect(document.body.textContent).toContain("Could not start the Parquet import.");
+      expect(unhandled).toEqual([]);
+    } finally {
+      window.removeEventListener("unhandledrejection", onUnhandled);
+    }
+  });
 });

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -978,6 +978,13 @@ function FullscreenPreviewComponent({
   const compareActive = canCompare && compareMode;
 
   const viewportRef = React.useRef(null);
+  // Compare mode replaces the zoom viewport instead of merely hiding it. Keep the
+  // mounted node in state so the native wheel listener follows that replacement.
+  const [viewportNode, setViewportNode] = React.useState(null);
+  const setViewportRef = React.useCallback((node) => {
+    viewportRef.current = node;
+    setViewportNode(node);
+  }, []);
   const [view, setView] = React.useState(PREVIEW_FIT_VIEW);
   const dragRef = React.useRef(null);
 
@@ -1009,7 +1016,7 @@ function FullscreenPreviewComponent({
   // Wheel-to-zoom anchored at the cursor. Native (non-passive) listener so we can
   // preventDefault the page scroll; React's onWheel is passive in some browsers.
   React.useEffect(() => {
-    const node = viewportRef.current;
+    const node = viewportNode;
     if (!node || isVideo) {
       return undefined;
     }
@@ -1022,7 +1029,7 @@ function FullscreenPreviewComponent({
     };
     node.addEventListener("wheel", onWheel, { passive: false });
     return () => node.removeEventListener("wheel", onWheel);
-  }, [isVideo, displayedAsset?.id]);
+  }, [isVideo, displayedAsset?.id, viewportNode]);
 
   const onPointerDown = (event) => {
     if (view.scale <= PREVIEW_MIN_SCALE) {
@@ -1236,7 +1243,7 @@ function FullscreenPreviewComponent({
             <Icon.ArrowLeft size={18} />
           </button>
           {compareActive ? (
-            <div className="preview-compare" role="group" aria-label="Original and edited image side by side">
+            <div className="preview-compare" key="compare-viewport" role="group" aria-label="Original and edited image side by side">
               <figure className="preview-compare-pane">
                 <AssetMedia asset={sourceAsset} controls={false} />
                 <figcaption>Original</figcaption>
@@ -1251,11 +1258,12 @@ function FullscreenPreviewComponent({
           ) : (
             <div
               className={`preview-zoom-viewport${zoomed ? " zoomed" : ""}`}
+              key="zoom-viewport"
               onPointerDown={onPointerDown}
               onPointerMove={onPointerMove}
               onPointerUp={endDrag}
               onPointerCancel={endDrag}
-              ref={viewportRef}
+              ref={setViewportRef}
             >
               <div
                 className="preview-zoom-inner"

--- a/apps/web/src/components/assetPanels.zoom.test.jsx
+++ b/apps/web/src/components/assetPanels.zoom.test.jsx
@@ -1,0 +1,123 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const actionMocks = vi.hoisted(() => ({
+  assetCanCarryWorkflow: vi.fn(() => true),
+  revealAsset: vi.fn(),
+  saveAssetAs: vi.fn(),
+}));
+
+vi.mock("../assetActions.js", () => ({
+  assetCanCarryWorkflow: actionMocks.assetCanCarryWorkflow,
+  revealAsset: actionMocks.revealAsset,
+  saveAssetAs: actionMocks.saveAssetAs,
+}));
+
+vi.mock("../runtime.js", () => ({
+  isDesktop: true,
+  isPageFullscreen: () => false,
+  setViewerFullscreen: vi.fn(() => Promise.resolve()),
+  tauriInvoke: vi.fn(),
+}));
+
+import { FullscreenPreview } from "./assetPanels.jsx";
+
+const original = {
+  id: "original",
+  displayName: "Original",
+  file: { mimeType: "image/png", path: "original.png" },
+  projectId: "project-1",
+  status: {},
+  type: "image",
+};
+const edited = {
+  ...original,
+  id: "edited",
+  displayName: "Edited",
+  file: { mimeType: "image/png", path: "edited.png" },
+  recipe: { mode: "edit_image" },
+};
+
+let container;
+let root;
+
+async function renderPreview() {
+  root = createRoot(container);
+  await act(async () => {
+    root.render(
+      <FullscreenPreview
+        asset={edited}
+        deleteAsset={() => {}}
+        nextAsset={null}
+        onClose={() => {}}
+        onPreviewAsset={() => {}}
+        previousAsset={null}
+        purgeAsset={() => {}}
+        sourceAsset={original}
+        updateAssetStatus={() => {}}
+      />,
+    );
+  });
+}
+
+function viewport() {
+  return document.body.querySelector(".preview-zoom-viewport");
+}
+
+async function wheel(node) {
+  await act(async () => {
+    node.dispatchEvent(new WheelEvent("wheel", { bubbles: true, cancelable: true, clientX: 10, clientY: 10, deltaY: -1 }));
+  });
+}
+
+beforeEach(() => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (root) {
+    act(() => root.unmount());
+    root = null;
+  }
+  container.remove();
+});
+
+describe("FullscreenPreview zoom viewport lifecycle (sc-21905)", () => {
+  it("rebinds the native wheel listener to the replacement viewport after compare mode", async () => {
+    const addSpy = vi.spyOn(HTMLElement.prototype, "addEventListener");
+    const removeSpy = vi.spyOn(HTMLElement.prototype, "removeEventListener");
+    try {
+      await renderPreview();
+      const firstViewport = viewport();
+
+      await act(async () => {
+        document.body.querySelector(".preview-compare-toggle").click();
+      });
+      expect(viewport()).toBeNull();
+
+      await act(async () => {
+        document.body.querySelector(".preview-compare-toggle").click();
+      });
+      const replacementViewport = viewport();
+      expect(replacementViewport).not.toBe(firstViewport);
+      await wheel(replacementViewport);
+      expect(replacementViewport.classList).toContain("zoomed");
+
+      const wheelAddsOn = (node) =>
+        addSpy.mock.calls.filter(([type], index) => type === "wheel" && addSpy.mock.instances[index] === node);
+      const wheelRemovesOn = (node) =>
+        removeSpy.mock.calls.filter(([type], index) => type === "wheel" && removeSpy.mock.instances[index] === node);
+      const firstWheelAdds = wheelAddsOn(firstViewport);
+      const replacementWheelAdds = wheelAddsOn(replacementViewport);
+      expect(firstWheelAdds).toHaveLength(1);
+      expect(replacementWheelAdds).toHaveLength(1);
+      expect(wheelRemovesOn(firstViewport)).toContainEqual(["wheel", firstWheelAdds[0][1]]);
+    } finally {
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    }
+  });
+});

--- a/apps/web/src/components/editor/GenerationRail.axes.test.jsx
+++ b/apps/web/src/components/editor/GenerationRail.axes.test.jsx
@@ -1,6 +1,7 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { click, setInput } from "../../testUtils/dom.js";
 
 vi.mock("../generationStudio.jsx", () => ({
   LoraPickerSection: () => null,
@@ -101,5 +102,17 @@ describe("GenerationRail catalog axes (sc-15441)", () => {
     render(generationState({ supportsGuidance: false, supportsNegativePrompt: true }));
     expect(container.textContent).not.toContain("Guidance");
     expect(container.textContent).toContain("Negative prompt");
+  });
+
+  it("catches a rejected preset save and shows a safe fallback", async () => {
+    const savePreset = vi.fn(() => Promise.reject({ message: { detail: "not renderable" } }));
+    render(generationState({ savePreset }));
+
+    await click(container.querySelector('button[title="Save current settings as a preset"]'));
+    await act(async () => setInput(container.querySelector('input[placeholder="Preset name"]'), "Rail preset"));
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent === "Save"));
+
+    expect(savePreset).toHaveBeenCalledWith("Rail preset");
+    expect(container.textContent).toContain("Could not save preset.");
   });
 });

--- a/apps/web/src/components/editor/GenerationRail.jsx
+++ b/apps/web/src/components/editor/GenerationRail.jsx
@@ -3,6 +3,7 @@ import { Icon } from "../Icons.jsx";
 import { LoraPickerSection } from "../generationStudio.jsx";
 import { MOTIONS } from "./editorUtils.js";
 import { StudioUpdateBadge, StudioUpdateNotice, updateOptionLabel } from "../StudioUpdateNotice.jsx";
+import { errorMessage } from "../../errorMessage.js";
 
 // The right-hand generation-settings rail (design 2a, epic 12798). Presentational: it
 // renders the controls owned by useEditorGeneration (`gen`) plus the contextual header
@@ -18,13 +19,17 @@ export function GenerationRail({ gen, header, contextActions = [], onGenerate, g
     if (!presetName.trim()) {
       return;
     }
-    const created = await gen.savePreset(presetName);
-    if (created) {
-      setSaveMsg(`Saved “${created.name ?? presetName}”`);
-      setPresetName("");
-      setShowSave(false);
-    } else {
-      setSaveMsg("Could not save preset.");
+    try {
+      const created = await gen.savePreset(presetName);
+      if (created) {
+        setSaveMsg(`Saved “${created.name ?? presetName}”`);
+        setPresetName("");
+        setShowSave(false);
+      } else {
+        setSaveMsg("Could not save preset.");
+      }
+    } catch (error) {
+      setSaveMsg(errorMessage(error, "Could not save preset."));
     }
   }
 

--- a/apps/web/src/components/editor/Timeline.jsx
+++ b/apps/web/src/components/editor/Timeline.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { Icon } from "../Icons.jsx";
 import { trackItems } from "../../timeline.js";
 import {
@@ -81,6 +81,7 @@ export function Timeline({
   onSelectMarker,
 }) {
   const laneRef = useRef(null);
+  const rulerDragRef = useRef(null);
   const tracks = timeline?.tracks ?? [];
   const overlayTrack = tracks.find((t) => t.id === OVERLAY_TRACK_ID || t.kind === "overlay") ?? null;
   const mainTrack = tracks.find((t) => t.id === MAIN_TRACK_ID || t.kind === "video") ?? null;
@@ -122,11 +123,26 @@ export function Timeline({
     }
   }
 
+  const stopRulerDrag = useCallback(() => {
+    const drag = rulerDragRef.current;
+    if (!drag) {
+      return;
+    }
+    window.removeEventListener("mousemove", drag.onMove);
+    window.removeEventListener("mouseup", drag.onUp);
+    rulerDragRef.current = null;
+  }, []);
+
+  // The drag outlives the ruler element, so its window listeners must also be
+  // owned by the component rather than only by its mouseup handler.
+  useEffect(() => stopRulerDrag, [stopRulerDrag]);
+
   function handleRulerMouseDown(event) {
     const el = laneRef.current;
     if (!el || duration <= 0) {
       return;
     }
+    stopRulerDrag();
     const rect = el.getBoundingClientRect();
     const toSeconds = (clientX) => {
       const ratio = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width));
@@ -134,10 +150,8 @@ export function Timeline({
     };
     onScrub?.(toSeconds(event.clientX));
     const onMove = (moveEvent) => onScrub?.(toSeconds(moveEvent.clientX));
-    const onUp = () => {
-      window.removeEventListener("mousemove", onMove);
-      window.removeEventListener("mouseup", onUp);
-    };
+    const onUp = () => stopRulerDrag();
+    rulerDragRef.current = { onMove, onUp };
     window.addEventListener("mousemove", onMove);
     window.addEventListener("mouseup", onUp);
   }

--- a/apps/web/src/components/editor/Timeline.test.jsx
+++ b/apps/web/src/components/editor/Timeline.test.jsx
@@ -1,0 +1,105 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Timeline } from "./Timeline.jsx";
+
+let container;
+let root;
+
+function renderTimeline(onScrub = vi.fn(), zoom = 1) {
+  if (!root) {
+    root = createRoot(container);
+  }
+  act(() => {
+    root.render(
+      <Timeline
+        assetsById={{}}
+        duration={10}
+        onAddAudioTrack={() => {}}
+        onScrub={onScrub}
+        onSelectGap={() => {}}
+        onSelectItem={() => {}}
+        onSelectKey={() => {}}
+        onToggleMute={() => {}}
+        onToggleSnap={() => {}}
+        onToggleSolo={() => {}}
+        onToggleVisible={() => {}}
+        onZoomIn={() => {}}
+        onZoomOut={() => {}}
+        playheadSeconds={0}
+        snap={false}
+        timeline={{ tracks: [] }}
+        zoom={zoom}
+      />,
+    );
+  });
+  return onScrub;
+}
+
+function ruler() {
+  return container.querySelector(".ve-ruler");
+}
+
+function lane() {
+  return container.querySelector(".ve-lanes");
+}
+
+async function mouseDown(node, clientX) {
+  await act(async () => {
+    node.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientX }));
+  });
+}
+
+beforeEach(() => {
+  global.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  if (root) {
+    act(() => root.unmount());
+    root = null;
+  }
+  container.remove();
+});
+
+describe("Timeline ruler drag lifecycle (sc-21905)", () => {
+  it("removes the exact window listeners when unmounted during a ruler drag", async () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    try {
+      renderTimeline();
+      vi.spyOn(lane(), "getBoundingClientRect").mockReturnValue({ left: 0, width: 100 });
+      await mouseDown(ruler(), 50);
+
+      const mousemoveAdd = addSpy.mock.calls.find(([type]) => type === "mousemove");
+      const mouseupAdd = addSpy.mock.calls.find(([type]) => type === "mouseup");
+      expect(mousemoveAdd).toBeDefined();
+      expect(mouseupAdd).toBeDefined();
+
+      act(() => root.unmount());
+      root = null;
+      expect(removeSpy).toHaveBeenCalledWith("mousemove", mousemoveAdd[1]);
+      expect(removeSpy).toHaveBeenCalledWith("mouseup", mouseupAdd[1]);
+    } finally {
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    }
+  });
+
+  it("reads the current lane geometry at the start of each new scrub", async () => {
+    const onScrub = renderTimeline();
+    let rect = { left: 0, width: 100 };
+    vi.spyOn(lane(), "getBoundingClientRect").mockImplementation(() => rect);
+
+    await mouseDown(ruler(), 60);
+    await act(async () => window.dispatchEvent(new MouseEvent("mouseup")));
+    rect = { left: 20, width: 200 };
+    renderTimeline(onScrub, 2);
+    await mouseDown(ruler(), 120);
+
+    expect(onScrub).toHaveBeenNthCalledWith(1, 6);
+    expect(onScrub).toHaveBeenNthCalledWith(2, 5);
+  });
+});

--- a/apps/web/src/components/generationStudio.jsx
+++ b/apps/web/src/components/generationStudio.jsx
@@ -35,6 +35,7 @@ import { StylePicker } from "./StylePicker.jsx";
 import { defaultTierSelection } from "../quantTier.js";
 import { readLastTier, writeLastTier } from "../lastTierStore.js";
 import { readDefaultGenerationQuality } from "../generationQuality.js";
+import { errorMessage } from "../errorMessage.js";
 
 const completedResultFallbackMs = 30000;
 
@@ -797,7 +798,7 @@ export function useSavePreset({
         text: `Saved "${trimmed}" to ${scope === "project" ? "this project" : "all projects"}.`,
       });
     } catch (err) {
-      setPresetSaveMessage({ tone: "error", text: err.message });
+      setPresetSaveMessage({ tone: "error", text: errorMessage(err, "Could not save this preset.") });
     } finally {
       setSavingPreset(false);
     }

--- a/apps/web/src/data/previewSupportCatalog.test.js
+++ b/apps/web/src/data/previewSupportCatalog.test.js
@@ -12,9 +12,8 @@ import {
   PREVIEW_SUPPORT_GENERATOR,
 } from "./previewSupportDerivation.js";
 import previewSupport from "./previewSupport.json";
-// Raw source text (Vite `?raw`) so the guard derives from the same bytes the generator reads. Both
-// live outside the web root — see the server.fs.allow entries in vite.config.js (mirrors the
-// style.txt / builtin.styles.jsonc pair).
+// Raw source text (Vite `?raw`) so the guard derives from the same bytes the generator reads. These
+// test-only inputs are not included in the dev server's /@fs allow-list.
 import enginesSource from "../../../../crates/sceneworks-worker/src/engines.rs?raw";
 import qwenEditCandleSource from "../../../../crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs?raw";
 import pulidMlxSource from "../../../../crates/sceneworks-worker/src/image_jobs/pulid.rs?raw";

--- a/apps/web/src/data/previewSupportCatalog.test.js
+++ b/apps/web/src/data/previewSupportCatalog.test.js
@@ -1,3 +1,6 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -12,49 +15,55 @@ import {
   PREVIEW_SUPPORT_GENERATOR,
 } from "./previewSupportDerivation.js";
 import previewSupport from "./previewSupport.json";
-// Raw source text (Vite `?raw`) so the guard derives from the same bytes the generator reads. These
-// test-only inputs are not included in the dev server's /@fs allow-list.
-import enginesSource from "../../../../crates/sceneworks-worker/src/engines.rs?raw";
-import qwenEditCandleSource from "../../../../crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs?raw";
-import pulidMlxSource from "../../../../crates/sceneworks-worker/src/image_jobs/pulid.rs?raw";
-import pulidCandleSource from "../../../../crates/sceneworks-worker/src/image_jobs/pulid_candle.rs?raw";
-import previewSupportManifestRaw from "../../../../config/manifests/builtin.preview-support.jsonc?raw";
+function readRepositoryFile(relativePath) {
+  return readFileSync(resolve(process.cwd(), "../..", relativePath), "utf8");
+}
+
+function readCapabilityFacts(relativeDirectory) {
+  const directory = resolve(process.cwd(), "../..", relativeDirectory);
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /^capabilities\..+\.json$/.test(entry.name))
+    .map((entry) => ({ name: entry.name, facts: JSON.parse(readFileSync(`${directory}/${entry.name}`, "utf8")) }))
+    .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+}
+
+// This drift guard reads the generator's exact repository inputs in its
+// non-listening Node test process, never via a Vite server's /@fs endpoint.
+const enginesSource = readRepositoryFile("crates/sceneworks-worker/src/engines.rs");
+const qwenEditCandleSource = readRepositoryFile(
+  "crates/sceneworks-worker/src/image_jobs/qwen_edit_candle.rs",
+);
+const pulidMlxSource = readRepositoryFile("crates/sceneworks-worker/src/image_jobs/pulid.rs");
+const pulidCandleSource = readRepositoryFile("crates/sceneworks-worker/src/image_jobs/pulid_candle.rs");
+const previewSupportManifestRaw = readRepositoryFile(
+  "config/manifests/builtin.preview-support.jsonc",
+);
 // The inference pin itself. `verifyEngineCapabilityFacts` in scripts/bump-inference.mjs compares the
 // facts files against it, but that script runs only when someone bumps THROUGH it — CI never invokes
 // it. So a pin edited by hand would leave the whole catalog advertising the PREVIOUS revision's
 // truth with nothing red. `check-license-coverage.mjs` had already learned this (it compares
 // `audit.inferenceRevision` to the live pin set AND runs in the parity lane); this is the same
 // assertion for the same class of artifact, on a guard that runs on every PR.
-import workerCargoToml from "../../../../crates/sceneworks-worker/Cargo.toml?raw";
+const workerCargoToml = readRepositoryFile("crates/sceneworks-worker/Cargo.toml");
 // The DECLARED backend set (sc-17119). Every other input below is discovered from the facts
 // directory, and a directory listing cannot see a file that was never written — which is why
 // `capabilities.mlx.json` was absent for four consecutive pins with the whole suite green.
-import factsDeclarationSource from "../../../../crates/sceneworks-worker/src/engine_capability_facts.rs?raw";
+const factsDeclarationSource = readRepositoryFile(
+  "crates/sceneworks-worker/src/engine_capability_facts.rs",
+);
 import { fallbackModels } from "../constants.js";
 
 // DISCOVERED, never listed. The generator globs this directory so a newly dumped backend is picked
 // up with no edit; a guard that hardcodes `capabilities.candle.json` would then fail the moment the
 // macOS lane lands `capabilities.mlx.json` — i.e. it would punish exactly the follow-up the design
 // is waiting on. Everything below is derived per-backend from whatever is on disk.
-const factsModules = import.meta.glob(
-  "../../../../config/engine-capabilities/capabilities.*.json",
-  { eager: true, query: "?raw", import: "default" },
-);
-const factsEntries = Object.entries(factsModules)
-  .map(([path, raw]) => ({ name: path.slice(path.lastIndexOf("/") + 1), facts: JSON.parse(raw) }))
-  .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+const factsEntries = readCapabilityFacts("config/engine-capabilities/");
 const factsFiles = factsEntries.map((entry) => entry.facts);
 
 // The AUDIO registry's dumps (sc-17593), one directory down. The glob above is single-level, so the
 // two sets cannot bleed into each other — which matters because they share backend names ("candle"
 // is the audio backend on every platform) while their engine-id namespaces are independent.
-const audioFactsModules = import.meta.glob(
-  "../../../../config/engine-capabilities/audio/capabilities.*.json",
-  { eager: true, query: "?raw", import: "default" },
-);
-const audioFactsEntries = Object.entries(audioFactsModules)
-  .map(([path, raw]) => ({ name: path.slice(path.lastIndexOf("/") + 1), facts: JSON.parse(raw) }))
-  .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));
+const audioFactsEntries = readCapabilityFacts("config/engine-capabilities/audio/");
 const audioFactsFiles = audioFactsEntries.map((entry) => entry.facts);
 
 const rows = parseEngineModelTable(enginesSource);

--- a/apps/web/src/data/styleCatalog.test.js
+++ b/apps/web/src/data/styleCatalog.test.js
@@ -4,12 +4,12 @@ import { parseStyleCatalog, PROMPT_TEMPLATE } from "./parseStyleCatalog.js";
 import { catalogToStylesManifest } from "./styleManifest.js";
 import styles from "./styles.json";
 // Raw source text (Vite `?raw`) so the test derives from the same bytes the
-// generator reads. documents/style.txt lives outside the web root — see the
-// server.fs.allow entry in vite.config.js (mirrors the license-corpus import).
+// generator reads. This test-only import is never placed on the dev server's
+// /@fs allow-list.
 import styleSource from "../../../../documents/style.txt?raw";
 // sc-13134: the backend/MCP catalog. Read as ?raw + JSON.parse so the drift guard derives
-// from the exact committed bytes. config/ is under the workspace root (searchForWorkspaceRoot
-// in vite.config.js), so vite's server.fs.allow permits it like documents/.
+// from the exact committed bytes. Like style.txt, this test-only input is not
+// readable from the dev server's /@fs endpoint.
 import stylesManifestRaw from "../../../../config/manifests/builtin.styles.jsonc?raw";
 
 // Guards sc-13127: styles.json must stay a mechanical derivation of

--- a/apps/web/src/data/styleCatalog.test.js
+++ b/apps/web/src/data/styleCatalog.test.js
@@ -1,16 +1,24 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { parseStyleCatalog, PROMPT_TEMPLATE } from "./parseStyleCatalog.js";
 import { catalogToStylesManifest } from "./styleManifest.js";
 import styles from "./styles.json";
-// Raw source text (Vite `?raw`) so the test derives from the same bytes the
-// generator reads. This test-only import is never placed on the dev server's
-// /@fs allow-list.
-import styleSource from "../../../../documents/style.txt?raw";
+// Read the exact generator inputs directly in this non-listening test process.
+// They are intentionally never put on a Vite server's /@fs allow-list.
+const styleSource = readFileSync(
+  resolve(process.cwd(), "../..", "documents/style.txt"),
+  "utf8",
+);
 // sc-13134: the backend/MCP catalog. Read as ?raw + JSON.parse so the drift guard derives
 // from the exact committed bytes. Like style.txt, this test-only input is not
 // readable from the dev server's /@fs endpoint.
-import stylesManifestRaw from "../../../../config/manifests/builtin.styles.jsonc?raw";
+const stylesManifestRaw = readFileSync(
+  resolve(process.cwd(), "../..", "config/manifests/builtin.styles.jsonc"),
+  "utf8",
+);
 
 // Guards sc-13127: styles.json must stay a mechanical derivation of
 // documents/style.txt — never hand-edited. If style.txt changes, re-run

--- a/apps/web/src/deviceSummary.js
+++ b/apps/web/src/deviceSummary.js
@@ -20,6 +20,6 @@ export function describeDevice(workers, macCapabilities) {
     return { engine, gpu: "No worker connected" };
   }
   const totalMb = Number(primary.utilization?.memoryTotalMb);
-  const memory = Number.isFinite(totalMb) && totalMb > 0 ? ` · ${(totalMb / 1024).toFixed(0)} GB` : "";
+  const memory = Number.isFinite(totalMb) && totalMb > 0 ? ` · ${(totalMb / 1024).toFixed(0)} GiB` : "";
   return { engine, gpu: `${primary.gpuName ?? `GPU ${primary.gpuId}`}${memory}` };
 }

--- a/apps/web/src/deviceSummary.test.js
+++ b/apps/web/src/deviceSummary.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { describeDevice } from "./deviceSummary.js";
+
+describe("describeDevice", () => {
+  it("labels binary worker memory as GiB", () => {
+    expect(
+      describeDevice([
+        {
+          gpuId: "gpu-0",
+          gpuName: "Fixture GPU",
+          utilization: { memoryTotalMb: 24_576 },
+        },
+      ]),
+    ).toEqual({ engine: "Candle · discrete GPU", gpu: "Fixture GPU · 24 GiB" });
+  });
+});

--- a/apps/web/src/errorMessage.js
+++ b/apps/web/src/errorMessage.js
@@ -1,0 +1,7 @@
+// UI mutations can reject with values from browser APIs, third-party bridges, or
+// application code. React can render strings but not arbitrary objects, so keep the
+// normalization at the boundary where a rejected value becomes user-facing text.
+export function errorMessage(error, fallback) {
+  const message = error && typeof error === "object" ? error.message : error;
+  return typeof message === "string" && message.trim() ? message : fallback;
+}

--- a/apps/web/src/hooks/appGateHooks.test.jsx
+++ b/apps/web/src/hooks/appGateHooks.test.jsx
@@ -104,6 +104,14 @@ class FakeEventSource {
   }
 }
 
+function deferred() {
+  let resolve;
+  const promise = new Promise((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
 async function settle() {
   await act(async () => {
     for (let i = 0; i < 6; i += 1) {
@@ -201,6 +209,50 @@ describe("useAccessGate (sc-9750)", () => {
     // Mint succeeded → ready flips true and the ticket is stored.
     expect(get().api.ready).toBe(true);
     expect(setMediaTicketSpy).toHaveBeenCalledWith("media-1");
+  });
+
+  it("pauses media-ticket refresh while hidden and leaves one timer after visibility churn", async () => {
+    vi.useFakeTimers();
+    try {
+      window.localStorage.setItem("sceneworks-token", "remote-token");
+      apiResponders.set("/api/v1/access", { authRequired: true });
+      apiResponders.set("/api/v1/auth/verify", { ok: true });
+      const pending = deferred();
+      let mints = 0;
+      apiResponders.set("/api/v1/files/ticket", () => {
+        mints += 1;
+        return mints === 1 ? pending.promise : { ticket: `media-${mints}`, expiresInSeconds: 15 };
+      });
+      const mintCalls = () => apiFetch.mock.calls.filter(([path]) => path === "/api/v1/files/ticket").length;
+      const before = mintCalls();
+      mount();
+      await settle();
+      expect(mintCalls()).toBe(before + 1);
+
+      const setVisibility = async (state) => {
+        Object.defineProperty(document, "visibilityState", { configurable: true, value: state });
+        await act(async () => document.dispatchEvent(new Event("visibilitychange")));
+        await settle();
+      };
+      await setVisibility("hidden");
+      await act(async () => vi.advanceTimersByTime(20000));
+      expect(mintCalls()).toBe(before + 1);
+      await setVisibility("visible");
+      await setVisibility("hidden");
+      await setVisibility("visible");
+      expect(mintCalls()).toBe(before + 3);
+
+      pending.resolve({ ticket: "stale", expiresInSeconds: 15 });
+      await settle();
+      await act(async () => vi.advanceTimersByTime(5000));
+      await settle();
+      // The first, hidden in-flight mint is closed, and only the final visible
+      // lifecycle owns a refresh timer.
+      expect(mintCalls()).toBe(before + 4);
+    } finally {
+      Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+      vi.useRealTimers();
+    }
   });
 
   it("still reports ready (degraded) and pushes a notice when the mint fails", async () => {

--- a/apps/web/src/hooks/useAccessGate.js
+++ b/apps/web/src/hooks/useAccessGate.js
@@ -120,7 +120,19 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
   // degrades to placeholders and recovers when a retry lands — and a "media-ticket"
   // notice tells the user why media is broken while the backoff keeps retrying.
   const [mediaTicketFailed, setMediaTicketFailed] = useState(false);
+  // A hidden tab cannot use media URLs, so refreshing their bearer ticket is pure
+  // background churn. Keep the visibility listener separate from the mint effect so
+  // it is registered once for the hook lifetime rather than once per ticket refresh.
+  const [documentVisible, setDocumentVisible] = useState(
+    () => typeof document === "undefined" || document.visibilityState !== "hidden",
+  );
   const ready = authenticated && (mediaReady || mediaTicketFailed);
+
+  useEffect(() => {
+    const onVisibilityChange = () => setDocumentVisible(document.visibilityState !== "hidden");
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, []);
 
   useEffect(() => {
     if (!authenticated || !accessResolved) {
@@ -138,6 +150,9 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
       setMediaTicket("");
       recordStartupMark("media-authorization-settled");
       setMediaReady(true);
+      return undefined;
+    }
+    if (!documentVisible) {
       return undefined;
     }
     let closed = false;
@@ -191,7 +206,7 @@ export function useAccessGate({ setError, pushNotice, dismissNoticeKind }) {
         window.clearTimeout(timer);
       }
     };
-  }, [access.authRequired, accessResolved, authenticated, token, pushNotice, dismissNoticeKind]);
+  }, [access.authRequired, accessResolved, authenticated, documentVisible, token, pushNotice, dismissNoticeKind]);
 
   // Probe whether the deployment requires a password, then release `accessResolved`
   // so an authenticated client (or one not requiring auth) can load its data. Mirrors

--- a/apps/web/src/hooks/useStudioSettings.durable.test.jsx
+++ b/apps/web/src/hooks/useStudioSettings.durable.test.jsx
@@ -71,6 +71,18 @@ describe("advanced studio settings are durable (sc-15425)", () => {
     expect(persistNavigationPreferences).not.toHaveBeenCalled();
   });
 
+  it("persists an absent empty snapshot but skips a cached empty snapshot", async () => {
+    await render(<Harness settings={{}} />);
+    expect(lastSentMap()["ws-1"].image).toEqual({});
+
+    await act(async () => root.unmount());
+    persistNavigationPreferences.mockClear();
+    window.localStorage.setItem("sceneworks-studio-image-ws-1", JSON.stringify({}));
+    root = createRoot(container);
+    await render(<Harness settings={{}} />);
+    expect(persistNavigationPreferences).not.toHaveBeenCalled();
+  });
+
   it("still writes when a cached snapshot changes or readiness resumes", async () => {
     window.localStorage.setItem("sceneworks-studio-image-ws-1", JSON.stringify({ prompt: "old" }));
     await render(<Harness settings={{ prompt: "new" }} />);

--- a/apps/web/src/hooks/useStudioSettings.durable.test.jsx
+++ b/apps/web/src/hooks/useStudioSettings.durable.test.jsx
@@ -62,6 +62,26 @@ describe("advanced studio settings are durable (sc-15425)", () => {
     expect(lastSentMap()["ws-1"].image).toMatchObject({ prompt: "a fox", model: "z_image" });
   });
 
+  it("does not enqueue a durable write when mounting an unchanged cached snapshot", async () => {
+    window.localStorage.setItem(
+      "sceneworks-studio-image-ws-1",
+      JSON.stringify({ prompt: "a fox", model: "z_image" }),
+    );
+    await render(<Harness settings={{ prompt: "a fox", model: "z_image" }} />);
+    expect(persistNavigationPreferences).not.toHaveBeenCalled();
+  });
+
+  it("still writes when a cached snapshot changes or readiness resumes", async () => {
+    window.localStorage.setItem("sceneworks-studio-image-ws-1", JSON.stringify({ prompt: "old" }));
+    await render(<Harness settings={{ prompt: "new" }} />);
+    expect(lastSentMap()["ws-1"].image.prompt).toBe("new");
+
+    persistNavigationPreferences.mockClear();
+    await render(<Harness ready={false} settings={{ prompt: "new" }} />);
+    await render(<Harness ready settings={{ prompt: "new" }} />);
+    expect(lastSentMap()["ws-1"].image.prompt).toBe("new");
+  });
+
   it("restores the cache from the durable copy after a relaunch", async () => {
     await render(<Harness settings={{ prompt: "a fox", model: "z_image" }} />);
     const durable = lastSentMap();

--- a/apps/web/src/hooks/useStudioSettings.js
+++ b/apps/web/src/hooks/useStudioSettings.js
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { persistNavigationPreferences } from "../uiPreferences.js";
 
 // Per-workspace "last used" settings for the Image / Video studios, so leaving a
@@ -148,8 +148,25 @@ function persistToServer(touchedWorkspace) {
 // had read it. Callers pass `preferencesHydrated && <their catalog gate>`.
 export function useStudioSettingsWriter(studio, workspaceId, settings, ready = true) {
   const serialized = JSON.stringify(settings);
+  // A studio normally mounts from the same cache it is about to write. Track that
+  // first settled pass so it does not issue a redundant durable PUT, while retaining
+  // the important ready=false -> true transition as a deliberate first persistence.
+  const scopeRef = useRef("");
+  const initializedRef = useRef(false);
   useEffect(() => {
+    const scope = `${studio}:${workspaceKey(workspaceId)}`;
+    if (scopeRef.current !== scope) {
+      scopeRef.current = scope;
+      initializedRef.current = false;
+    }
     if (!ready) {
+      initializedRef.current = true;
+      return undefined;
+    }
+    const unchangedInitialSnapshot = !initializedRef.current
+      && JSON.stringify(loadStudioSettings(studio, workspaceId)) === serialized;
+    initializedRef.current = true;
+    if (unchangedInitialSnapshot) {
       return undefined;
     }
     writeCache(studio, workspaceId, JSON.parse(serialized));

--- a/apps/web/src/hooks/useStudioSettings.js
+++ b/apps/web/src/hooks/useStudioSettings.js
@@ -44,6 +44,18 @@ export function loadStudioSettings(studio, workspaceId) {
   }
 }
 
+// `loadStudioSettings()` intentionally treats an absent entry like an empty snapshot
+// for callers that just need defaults. The writer additionally needs to know whether
+// an empty snapshot is actually cached: an absent cache must still establish the
+// durable copy on its first ready mount.
+function hasCachedStudioSettings(studio, workspaceId) {
+  try {
+    return window.localStorage.getItem(storageKey(studio, workspaceId)) !== null;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Seed the localStorage cache from the durable server copy on launch (App.jsx, after
  * GET /api/v1/ui-preferences).
@@ -164,6 +176,7 @@ export function useStudioSettingsWriter(studio, workspaceId, settings, ready = t
       return undefined;
     }
     const unchangedInitialSnapshot = !initializedRef.current
+      && hasCachedStudioSettings(studio, workspaceId)
       && JSON.stringify(loadStudioSettings(studio, workspaceId)) === serialized;
     initializedRef.current = true;
     if (unchangedInitialSnapshot) {

--- a/apps/web/src/ideogramCaption.test.js
+++ b/apps/web/src/ideogramCaption.test.js
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { describe, expect, it } from "vitest";
 import {
   BBOX_MAX,
@@ -25,7 +28,10 @@ import {
   verifyCaption,
   verifyRaw,
 } from "./ideogramCaption.js";
-import styleInjectionFixturesRaw from "../../../documents/ideogram-style-injection.fixtures.json?raw";
+const styleInjectionFixturesRaw = readFileSync(
+  resolve(process.cwd(), "../..", "documents/ideogram-style-injection.fixtures.json"),
+  "utf8",
+);
 
 // The validated reference render's caption, byte-identical to the engine's
 // `mlx-gen-ideogram/tests/common/mod.rs` CAPTION_JSON — which is itself

--- a/apps/web/src/imageStudioValidation.js
+++ b/apps/web/src/imageStudioValidation.js
@@ -14,10 +14,14 @@ import { promptBudget } from "./styleComposer.js";
 import { issue } from "./validation/issues.js";
 
 export function batchPromptBudgetOverages(composedPrompts = []) {
-  return composedPrompts.flatMap((prompt, index) => {
+  const overages = [];
+  let index = 0;
+  for (const prompt of composedPrompts) {
     const budget = promptBudget(prompt);
-    return budget.over ? [{ item: index + 1, ...budget }] : [];
-  });
+    if (budget.over) overages.push({ item: index + 1, ...budget });
+    index += 1;
+  }
+  return overages;
 }
 
 export function batchPromptBudgetMessage(overages = []) {

--- a/apps/web/src/imageStudioValidation.js
+++ b/apps/web/src/imageStudioValidation.js
@@ -13,12 +13,17 @@ import { MAX_IMAGE_DIMENSION, MIN_IMAGE_DIMENSION } from "./resolutionOverride.j
 import { promptBudget } from "./styleComposer.js";
 import { issue } from "./validation/issues.js";
 
-export function batchPromptBudgetOverages(composedPrompts = []) {
+// `limit` lets a streaming caller stop after the first actionable violation instead
+// of retaining an entry for every member of a very large batch.
+export function batchPromptBudgetOverages(composedPrompts = [], limit = Infinity) {
   const overages = [];
   let index = 0;
   for (const prompt of composedPrompts) {
     const budget = promptBudget(prompt);
-    if (budget.over) overages.push({ item: index + 1, ...budget });
+    if (budget.over) {
+      overages.push({ item: index + 1, ...budget });
+      if (overages.length >= limit) break;
+    }
     index += 1;
   }
   return overages;

--- a/apps/web/src/imageStudioValidation.test.js
+++ b/apps/web/src/imageStudioValidation.test.js
@@ -332,6 +332,17 @@ describe("imageBatchValidation", () => {
     );
   });
 
+  it("stops a streaming budget preflight after the first actionable overage", () => {
+    function* prompts() {
+      yield "x".repeat(PROMPT_MAX_CHARS + 1);
+      throw new Error("the preflight must not retain or inspect later violations");
+    }
+
+    expect(batchPromptBudgetOverages(prompts(), 1)).toEqual([
+      { item: 1, length: 4001, max: 4000, remaining: -1, over: true },
+    ]);
+  });
+
   it("catches a batch item whose short raw prompt only exceeds the cap after style composition", () => {
     const rawPrompt = "a fox";
     const composedPrompt = composeStyledPrompt({

--- a/apps/web/src/promptBatch.js
+++ b/apps/web/src/promptBatch.js
@@ -124,17 +124,6 @@ function linePlan(prompt, variableMap) {
   return { tokens, named, linked, axes };
 }
 
-// Cartesian product of the axis sizes as index tuples. `[]` axes → `[[]]` (one empty
-// combination), so a line with no axes still yields exactly one render. The last axis
-// varies fastest, matching the documented ordering.
-function axisCombos(axes) {
-  return axes.reduce(
-    (combos, axis) =>
-      combos.flatMap((combo) => Array.from({ length: axis.size }, (_, i) => [...combo, i])),
-    [[]],
-  );
-}
-
 // Resolve one line for a combination (an index per axis). Named tokens with no axis
 // (unfilled) stay literal; the returned `values` map carries the chosen named values.
 function resolveLine(plan, combo) {
@@ -217,19 +206,32 @@ export function resolvePrompt(template, valueMap) {
   });
 }
 
-// Expand a batch to its concrete prompts. Each prompt line fans out over its own axes
-// (named cross-product × inline occurrences × linked groups zipped). Each entry carries
-// the resolved `prompt` plus the `values` map of the named bindings that produced it.
-export function expandBatch(prompts, variables) {
+// Yield a batch's concrete prompts one at a time. The last axis varies fastest, matching
+// the documented ordering, but this never builds the full Cartesian product in memory.
+export function* iterateBatch(prompts, variables) {
   const variableMap = buildVariableMap(variables);
-  const out = [];
   for (const prompt of promptList(prompts)) {
     const plan = linePlan(prompt, variableMap);
-    for (const combo of axisCombos(plan.axes)) {
-      out.push(resolveLine(plan, combo));
+    const combo = Array(plan.axes.length).fill(0);
+    // An axis-free line still has one empty combination.
+    for (;;) {
+      yield resolveLine(plan, combo);
+      let axis = plan.axes.length - 1;
+      while (axis >= 0) {
+        combo[axis] += 1;
+        if (combo[axis] < plan.axes[axis].size) break;
+        combo[axis] = 0;
+        axis -= 1;
+      }
+      if (axis < 0) break;
     }
   }
-  return out;
+}
+
+// Expand a batch to its concrete prompts. This compatibility helper intentionally
+// materializes the iterable; high-cardinality callers should consume iterateBatch().
+export function expandBatch(prompts, variables) {
+  return [...iterateBatch(prompts, variables)];
 }
 
 // The first resolved prompt (line 1, first choice of every axis) — for a live preview

--- a/apps/web/src/promptBatch.test.js
+++ b/apps/web/src/promptBatch.test.js
@@ -5,6 +5,7 @@ import {
   expandBatch,
   extractKeys,
   firstResolvedPrompt,
+  iterateBatch,
   linkedGroupIssues,
   missingKeys,
   parsePromptResolution,
@@ -142,6 +143,31 @@ describe("expandBatch", () => {
 
   it("returns nothing for an all-blank prompt list", () => {
     expect(expandBatch(["", "   "], [{ key: "x", values: ["a"] }])).toEqual([]);
+  });
+});
+
+describe("iterateBatch", () => {
+  it("preserves expandBatch ordering while yielding one entry at a time", () => {
+    const prompts = ["{{name}}/{{hair}}", "{{name}} alone"];
+    const variables = [
+      { key: "name", values: ["Alice", "Bob"] },
+      { key: "hair", values: ["red", "blue"] },
+    ];
+    expect([...iterateBatch(prompts, variables)]).toEqual(expandBatch(prompts, variables));
+  });
+
+  it("can take a first result from an enormous Cartesian space without materializing it", () => {
+    const values = Array.from({ length: 1000 }, (_, index) => String(index));
+    const iterator = iterateBatch(["{{a}}/{{b}}/{{c}}"], [
+      { key: "a", values },
+      { key: "b", values },
+      { key: "c", values },
+    ]);
+
+    expect(iterator.next()).toEqual({
+      done: false,
+      value: { prompt: "0/0/0", values: { a: "0", b: "0", c: "0" } },
+    });
   });
 });
 

--- a/apps/web/src/screens/DatasetCatalogsScreen.jsx
+++ b/apps/web/src/screens/DatasetCatalogsScreen.jsx
@@ -6,6 +6,7 @@ import { RequiredModelsNotice } from "../components/RequiredModelsNotice.jsx";
 import { PERSON_DETECT_MODEL_ID, POSE_DETECT_MODEL_ID } from "../constants.js";
 import { missingRequiredModels } from "../modelEligibility.js";
 import { useAppStatic } from "../context/AppContext.js";
+import { useScreenActive } from "../context/ScreenActiveContext.js";
 import { formatBytes } from "../formatting.js";
 import { isDesktop, tauriInvoke } from "../runtime.js";
 import { persistNavigationPreferences } from "../uiPreferences.js";
@@ -727,6 +728,7 @@ export function DatasetCatalogsScreen() {
   // re-render on every SSE job tick (sc-8855). That is why the required-model notice below is
   // given no `downloadJobs` — it falls back to its local "Queued" state, which needs no live jobs.
   const { token = "", models = [], createModelDownloadJob, setActiveView } = useAppStatic();
+  const screenActive = useScreenActive();
   // The two cache-only preprocessors structured analysis resolves before it can run
   // (catalog_semantic_jobs.rs). Declaration order is display order.
   const missingStructuredModels = useMemo(
@@ -748,6 +750,10 @@ export function DatasetCatalogsScreen() {
   const pollAbortRef = useRef(null);
   const mutationAbortRef = useRef(null);
   const selected = catalogs.find((catalog) => catalog.id === selectedId) ?? null;
+  // Status changes only while a processor is actively making progress. A terminal or
+  // paused catalog has no useful periodic work, and a kept-alive screen must not keep
+  // its poller alive behind another route.
+  const shouldPollSelected = screenActive && selected?.processing?.state === "running";
 
   useEffect(() => {
     const version = selected
@@ -809,7 +815,7 @@ export function DatasetCatalogsScreen() {
   }, [refresh, token]);
 
   useEffect(() => {
-    if (!selectedId) return undefined;
+    if (!selectedId || !shouldPollSelected) return undefined;
     const generation = ++generationRef.current;
     let timer = null;
     let stopped = false;
@@ -830,6 +836,10 @@ export function DatasetCatalogsScreen() {
             : catalog
         )));
         setError("");
+        // Do not arm another timer after the response itself reaches a terminal or
+        // paused state. The render triggered above will also tear this effect down,
+        // but this closes the small interval before that cleanup runs.
+        if (updated.processing?.state !== "running") stopped = true;
       } catch (err) {
         if (isAbortError(err) || stopped || generation !== generationRef.current) return;
         if (err.status === 404) {
@@ -851,7 +861,7 @@ export function DatasetCatalogsScreen() {
       if (timer !== null) window.clearTimeout(timer);
       pollAbortRef.current?.abort();
     };
-  }, [pollEpoch, refresh, selectedId, token]);
+  }, [pollEpoch, refresh, selectedId, shouldPollSelected, token]);
 
   async function chooseFolder(setter) {
     if (!isDesktop) return;

--- a/apps/web/src/screens/DatasetCatalogsScreen.jsx
+++ b/apps/web/src/screens/DatasetCatalogsScreen.jsx
@@ -513,7 +513,7 @@ function CatalogCuration({ catalogId, token }) {
           <input
             aria-label="Catalog text search"
             onChange={(event) => setQuery((current) => ({ ...current, text: event.target.value }))}
-            placeholder="red dress, full_bodyâ€¦"
+            placeholder="red dress, full_body…"
             value={query.text}
           />
         </label>
@@ -568,7 +568,7 @@ function CatalogCuration({ catalogId, token }) {
       {error ? <p className="notice error" role="alert">{error}</p> : null}
       <div className="catalog-facets" aria-label="Faceted counts">
         {facets.map((facet) => (
-          <span key={facet.field}><strong>{facet.field}</strong>{facet.values?.map((value) => `${value.value} (${count(value.count)})`).join(" Â· ")}</span>
+          <span key={facet.field}><strong>{facet.field}</strong>{facet.values?.map((value) => `${value.value} (${count(value.count)})`).join(" · ")}</span>
         ))}
       </div>
       <form className="catalog-saved-view-form" onSubmit={saveView}>
@@ -697,7 +697,7 @@ function CatalogCuration({ catalogId, token }) {
                 src={withMediaTicket(`${API_BASE_URL}/api/v1/catalogs/${encodeURIComponent(catalogId)}/records/${encodeURIComponent(record.id)}/thumbnail`)}
               />
               <span>{record.metadata?.caption ?? record.id}</span>
-              <small>{record.metadata?.analysis?.medium ?? record.metadata?.medium ?? "Unclassified"}{review ? ` Â· ${review.decision}` : ""}</small>
+              <small>{record.metadata?.analysis?.medium ?? record.metadata?.medium ?? "Unclassified"}{review ? ` · ${review.decision}` : ""}</small>
             </button>
           );
         })}

--- a/apps/web/src/screens/DatasetCatalogsScreen.jsx
+++ b/apps/web/src/screens/DatasetCatalogsScreen.jsx
@@ -746,6 +746,10 @@ export function DatasetCatalogsScreen() {
   const [analyzerDraft, setAnalyzerDraft] = useState(DEFAULT_ANALYZER_SETTINGS);
   const [analysisGpu, setAnalysisGpu] = useState("auto");
   const generationRef = useRef(0);
+  // Poll invalidation and mutation ownership are intentionally independent. A hidden
+  // keep-alive screen tears down its poller, but that must not strand an owned mutation's
+  // busy state when the screen becomes active again.
+  const mutationGenerationRef = useRef(0);
   const analyzerDraftVersionRef = useRef("");
   const pollAbortRef = useRef(null);
   const mutationAbortRef = useRef(null);
@@ -768,6 +772,7 @@ export function DatasetCatalogsScreen() {
     generationRef.current += 1;
     pollAbortRef.current?.abort();
     mutationAbortRef.current?.abort();
+    mutationGenerationRef.current += 1;
     setBusy("");
     setSelectedId(id);
     persistNavigationPreferences({ selectedCatalogId: id });
@@ -811,6 +816,7 @@ export function DatasetCatalogsScreen() {
       controller.abort();
       pollAbortRef.current?.abort();
       mutationAbortRef.current?.abort();
+      mutationGenerationRef.current += 1;
     };
   }, [refresh, token]);
 
@@ -874,7 +880,7 @@ export function DatasetCatalogsScreen() {
   }
 
   async function mutate(action, request, success) {
-    const generation = ++generationRef.current;
+    const mutationGeneration = ++mutationGenerationRef.current;
     pollAbortRef.current?.abort();
     mutationAbortRef.current?.abort();
     const controller = new AbortController();
@@ -883,16 +889,16 @@ export function DatasetCatalogsScreen() {
     setError("");
     try {
       const result = await request(controller.signal);
-      if (controller.signal.aborted || generation !== generationRef.current) return;
-      const next = await refresh({ quiet: true, signal: controller.signal, generation });
-      if (controller.signal.aborted || generation !== generationRef.current) return;
+      if (controller.signal.aborted || mutationGeneration !== mutationGenerationRef.current) return;
+      const next = await refresh({ quiet: true, signal: controller.signal });
+      if (controller.signal.aborted || mutationGeneration !== mutationGenerationRef.current) return;
       success?.(result, next);
     } catch (err) {
-      if (!isAbortError(err) && generation === generationRef.current) {
+      if (!isAbortError(err) && mutationGeneration === mutationGenerationRef.current) {
         setError(safeCatalogError(err, action));
       }
     } finally {
-      if (generation === generationRef.current) {
+      if (mutationGeneration === mutationGenerationRef.current) {
         setBusy("");
         setPollEpoch((current) => current + 1);
       }

--- a/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
+++ b/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
@@ -400,6 +400,47 @@ describe("DatasetCatalogsScreen", () => {
     expect(requests.filter((item) => item.path.endsWith("/status"))).toHaveLength(0);
   });
 
+  it("settles a catalog mutation across inactive and active poll lifecycles", async () => {
+    await act(async () => root.unmount());
+    vi.useFakeTimers();
+    root = createRoot(container);
+    const mutation = deferred();
+    const original = fetch.getMockImplementation();
+    fetch.mockImplementation((url, options = {}) => {
+      if (new URL(url).pathname.endsWith("/pause")) return mutation.promise;
+      return original(url, options);
+    });
+    const renderScreen = async (active) => {
+      await act(async () => {
+        root.render(
+          <ScreenActiveContext.Provider value={active}>
+            <AppContext.Provider value={{ token: "token" }}>
+              <DatasetCatalogsScreen />
+              <ConfirmHost />
+            </AppContext.Provider>
+          </ScreenActiveContext.Provider>,
+        );
+      });
+      await flush();
+    };
+    await renderScreen(true);
+
+    const pauseButton = [...container.querySelectorAll("button")].find((button) => button.textContent.includes("Pause"));
+    await act(async () => pauseButton.click());
+    expect(pauseButton.disabled).toBe(true);
+
+    await renderScreen(false);
+    await renderScreen(true);
+    await act(async () => {
+      mutation.resolve(response(catalog()));
+      await Promise.resolve();
+    });
+    await flush();
+
+    const recoveredPauseButton = [...container.querySelectorAll("button")].find((button) => button.textContent.includes("Pause"));
+    expect(recoveredPauseButton.disabled).toBe(false);
+  });
+
   it("stops after a terminal status response", async () => {
     await remountWithFakeTimers();
     const original = fetch.getMockImplementation();

--- a/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
+++ b/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
@@ -361,6 +361,9 @@ describe("DatasetCatalogsScreen", () => {
     expect(container.textContent).toContain("28 matches");
     expect(container.textContent).toContain("A full-body photograph outdoors");
     expect(container.textContent).toContain("photograph (28)");
+    expect(container.querySelector("input[aria-label='Catalog text search']").placeholder).toBe("red dress, full_body…");
+    expect(container.textContent).toContain("photograph · exclude");
+    expect(container.textContent).not.toMatch(/(?:Ã|Â|â€¦)/);
     const queryRequest = requests.find((item) => item.path.endsWith("/curation/query"));
     expect(queryRequest.body.filters).toEqual(expect.arrayContaining([
       { field: "medium", values: ["photograph"] },

--- a/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
+++ b/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
@@ -377,6 +377,29 @@ describe("DatasetCatalogsScreen", () => {
     expect(requests.filter((item) => item.path.endsWith("/status"))).toHaveLength(0);
   });
 
+  it("clears an already-scheduled poll when the active screen becomes inactive", async () => {
+    await act(async () => root.unmount());
+    vi.useFakeTimers();
+    root = createRoot(container);
+    const renderScreen = async (active) => {
+      await act(async () => {
+        root.render(
+          <ScreenActiveContext.Provider value={active}>
+            <AppContext.Provider value={{ token: "token" }}>
+              <DatasetCatalogsScreen />
+              <ConfirmHost />
+            </AppContext.Provider>
+          </ScreenActiveContext.Provider>,
+        );
+      });
+      await flush();
+    };
+    await renderScreen(true);
+    await renderScreen(false);
+    await act(async () => vi.advanceTimersByTime(9000));
+    expect(requests.filter((item) => item.path.endsWith("/status"))).toHaveLength(0);
+  });
+
   it("stops after a terminal status response", async () => {
     await remountWithFakeTimers();
     const original = fetch.getMockImplementation();

--- a/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
+++ b/apps/web/src/screens/DatasetCatalogsScreen.test.jsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConfirmHost } from "../appConfirm.jsx";
 import { AppContext } from "../context/AppContext.js";
+import { ScreenActiveContext } from "../context/ScreenActiveContext.js";
 import { resetNavigationPreferenceQueueForTests } from "../uiPreferences.js";
 
 const { invoke } = vi.hoisted(() => ({ invoke: vi.fn() }));
@@ -350,6 +351,48 @@ describe("DatasetCatalogsScreen", () => {
       .find((button) => button.textContent.includes("Refresh")).click());
     await flush();
     expect(container.textContent).toContain("8.0 KiB");
+  });
+
+  it("does not poll a paused or inactive selected catalog", async () => {
+    catalogs = [catalog({ processing: { ...catalog().processing, state: "paused" } })];
+    await remountWithFakeTimers();
+    await act(async () => vi.advanceTimersByTime(9000));
+    expect(requests.filter((item) => item.path.endsWith("/status"))).toHaveLength(0);
+
+    catalogs = [catalog()];
+    await act(async () => root.unmount());
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <ScreenActiveContext.Provider value={false}>
+          <AppContext.Provider value={{ token: "token" }}>
+            <DatasetCatalogsScreen />
+            <ConfirmHost />
+          </AppContext.Provider>
+        </ScreenActiveContext.Provider>,
+      );
+    });
+    await flush();
+    await act(async () => vi.advanceTimersByTime(9000));
+    expect(requests.filter((item) => item.path.endsWith("/status"))).toHaveLength(0);
+  });
+
+  it("stops after a terminal status response", async () => {
+    await remountWithFakeTimers();
+    const original = fetch.getMockImplementation();
+    let polls = 0;
+    fetch.mockImplementation((url, options = {}) => {
+      const path = new URL(url).pathname;
+      if (path.endsWith("/status")) {
+        polls += 1;
+        return response(catalog({ processing: { ...catalog().processing, state: "completed" } }));
+      }
+      return original(url, options);
+    });
+    await act(async () => vi.advanceTimersByTime(3000));
+    await flush();
+    await act(async () => vi.advanceTimersByTime(9000));
+    expect(polls).toBe(1);
   });
 
   it("curates a reproducible primary sample with server paging, facets, saved views, and review overrides", async () => {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -31,7 +31,7 @@ import {
 } from "../resolutionOverride.js";
 import { pidDecodeHeadsUp } from "../pidDecodeNotice.js";
 import { promptEnhancementAvailable } from "../promptEnhancement.js";
-import { batchItemStatus, summarizeBatchRun } from "../batchOps.js";
+import { batchItemStatus, settlePromptBatchRun, summarizeBatchRun } from "../batchOps.js";
 import {
   DEFAULT_SCENE_PROMPT,
   promptHintFor,
@@ -232,6 +232,10 @@ const REFERENCE_TUNING_PRESET_KEYS = [
 // Above this many resolved images a batch run needs explicit confirmation, so a stray
 // value or an over-eager cross-product can't silently queue a huge job (sc-9957).
 const BATCH_RENDER_CAP = 100;
+// Keep high-cardinality batch state bounded without changing the eager behavior of
+// ordinary (at-or-under-cap) runs. The worker remains serial; this is client-side
+// backpressure for confirmed large runs only.
+const BATCH_ACTIVE_JOB_LIMIT = BATCH_RENDER_CAP;
 
 function preferredOption(defaultValue, options) {
   return options.includes(defaultValue) ? defaultValue : options[0] ?? "default";
@@ -456,6 +460,8 @@ export function ImageStudio() {
     handleLoadBatch, handleDeleteBatch, handleImportBatch, handleNewBatch,
   } = useBatchPromptState({ saved, createPromptBatch, updatePromptBatch, deletePromptBatch });
   const batchObservedJobsRef = useRef(new Map());
+  const batchRunRef = useRef(batchRun);
+  const batchSlotWaitersRef = useRef([]);
   const [advancedOpen, setAdvancedOpen] = useState(saved.advancedOpen ?? false);
   const [model, setModel] = useState(saved.model ?? imageModels[0]?.id ?? "z_image_turbo");
   const [textEncoderSelection, setTextEncoderSelection] = useState({
@@ -2464,6 +2470,24 @@ export function ImageStudio() {
       resolutionOverride: opts.resolution ?? null,
     });
 
+  function replaceBatchRun(next) {
+    batchRunRef.current = next;
+    setBatchRun(next);
+  }
+
+  function releaseBatchSlotWaiters() {
+    const waiters = batchSlotWaitersRef.current.splice(0);
+    for (const resolve of waiters) resolve();
+  }
+
+  async function waitForBatchSlot() {
+    while (!batchAbortRef.current) {
+      const activeJobIds = batchRunRef.current?.activeJobIds ?? [];
+      if (activeJobIds.length < BATCH_ACTIVE_JOB_LIMIT) return;
+      await new Promise((resolve) => batchSlotWaitersRef.current.push(resolve));
+    }
+  }
+
   // Fan out one image job per resolved prompt (mirrors the asset batch, sc-6112): each
   // posts independently so the worker runs them serially with its between-image cache
   // release, and progress/cancel read the live jobs feed.
@@ -2497,6 +2521,9 @@ export function ImageStudio() {
             }
           })()
         : [],
+      // Preserve the detailed item list for ordinary runs; a high-cardinality stream
+      // needs only the first actionable violation and must not retain them all.
+      batchJobCount > BATCH_RENDER_CAP ? 1 : Infinity,
     );
     if (promptBudgetOverages.length) {
       setBatchError(batchPromptBudgetMessage(promptBudgetOverages));
@@ -2515,20 +2542,24 @@ export function ImageStudio() {
     setBatchConfirmPending(false);
     batchAbortRef.current = false;
     batchObservedJobsRef.current.clear();
-    // Keep only the submitted prefix while streaming. `total` represents the unvisited
-    // suffix as pending, so a confirmed large batch never starts with a full item list.
-    const items = [];
-    setBatchRun({ submitting: true, total: batchJobCount, items: [] });
+    // Keep scalar totals plus a bounded in-flight id set. Once the set reaches the normal
+    // batch cap, wait for a terminal job before posting the next resolved prompt.
+    replaceBatchRun({
+      submitting: true,
+      total: batchJobCount,
+      submitted: 0,
+      completed: 0,
+      failed: 0,
+      activeJobIds: [],
+    });
     for (const entry of iterateBatch(batchPrompts, batchVariables)) {
+      await waitForBatchSlot();
       if (batchAbortRef.current) {
         break;
       }
       // Strip a leading [WxH] directive (sc-10063): the model gets the clean prompt, the job
       // gets that per-prompt resolution.
       const { prompt: cleanPrompt, resolution } = parsePromptResolution(entry.prompt);
-      const item = { prompt: cleanPrompt, jobId: null, error: false };
-      items.push(item);
-      setBatchRun({ submitting: true, total: batchJobCount, items });
       try {
         let request;
         if (structuredPromptModel) {
@@ -2536,6 +2567,7 @@ export function ImageStudio() {
           // resolved prompt into a JSON caption first (sc-9980) — N sequential refine calls.
           // A prompt that fails to expand fails only that item; the rest continue.
           const expanded = await onMagicExpand(cleanPrompt);
+          if (batchAbortRef.current) break;
           if (!validateCaption(expanded).ok) {
             throw new Error("Auto-generated caption was invalid.");
           }
@@ -2550,31 +2582,39 @@ export function ImageStudio() {
           request = buildBatchJobRequest(cleanPrompt, { resolution });
         }
         const job = await createImageJob(request);
-        Object.assign(item, { jobId: job?.id ?? null, error: !job?.id });
+        const current = batchRunRef.current;
+        if (!current) break;
+        replaceBatchRun(
+          job?.id
+            ? { ...current, submitted: current.submitted + 1, activeJobIds: [...current.activeJobIds, job.id] }
+            : { ...current, submitted: current.submitted + 1, failed: current.failed + 1 },
+        );
+        if (batchAbortRef.current && job?.id) jobAction(job, "cancel");
       } catch {
-        item.error = true;
+        const current = batchRunRef.current;
+        if (!current) break;
+        replaceBatchRun({ ...current, submitted: current.submitted + 1, failed: current.failed + 1 });
       }
-      setBatchRun({ submitting: true, total: batchJobCount, items });
     }
-    setBatchRun({ submitting: false, total: batchJobCount, items });
+    const current = batchRunRef.current;
+    if (current) replaceBatchRun({ ...current, submitting: false });
   }
 
   // Stop the enqueue loop (if still running) and cancel every still-pending job in the run;
   // completed/failed items are left as-is.
   function cancelBatchRun() {
     batchAbortRef.current = true;
-    if (!batchRun) {
+    releaseBatchSlotWaiters();
+    const current = batchRunRef.current;
+    if (!current) {
       return;
     }
-    for (const item of batchRun.items) {
-      if (!item.jobId) {
-        continue;
-      }
-      const status = batchItemStatus(item.jobId, jobs, batchObservedJobsRef.current);
+    for (const jobId of current.activeJobIds) {
+      const status = batchItemStatus(jobId, jobs, batchObservedJobsRef.current);
       if (status !== "queued" && status !== "running") {
         continue;
       }
-      const job = jobs.find((entry) => entry.id === item.jobId);
+      const job = jobs.find((entry) => entry.id === jobId);
       if (job) {
         jobAction(job, "cancel");
       }
@@ -2582,11 +2622,12 @@ export function ImageStudio() {
   }
 
   const batchRunProgress = batchRun
-    ? summarizeBatchRun(batchRun.items, jobs, batchObservedJobsRef.current, batchRun.total)
+    ? summarizeBatchRun(batchRun, jobs, batchObservedJobsRef.current)
     : null;
   useEffect(() => {
-    if (!batchRun) return;
-    const batchJobIds = new Set(batchRun.items.map((item) => item.jobId).filter(Boolean));
+    const current = batchRunRef.current;
+    if (!current) return;
+    const batchJobIds = new Set(current.activeJobIds);
     for (const job of jobs) {
       if (batchJobIds.has(job.id)) {
         const status =
@@ -2598,7 +2639,13 @@ export function ImageStudio() {
         batchObservedJobsRef.current.set(job.id, status);
       }
     }
-  }, [batchRun, jobs]);
+    const settled = settlePromptBatchRun(current, jobs, batchObservedJobsRef.current);
+    if (settled !== current) {
+      batchRunRef.current = settled;
+      setBatchRun(settled);
+      releaseBatchSlotWaiters();
+    }
+  }, [batchRun, jobs, setBatchRun]);
   const batchMissingKeys = missingKeys(batchPrompts, batchVariables);
   const batchGroupIssues = linkedGroupIssues(batchPrompts);
   // Prompt lines whose leading [WxH] directive (sc-10063) breaks the SELECTED model's geometry — the
@@ -2850,7 +2897,7 @@ export function ImageStudio() {
                         Cancel remaining
                       </button>
                     ) : (
-                      <button className="batch-btn ghost" onClick={() => setBatchRun(null)} type="button">
+                      <button className="batch-btn ghost" onClick={() => replaceBatchRun(null)} type="button">
                         Clear
                       </button>
                     )}

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -236,6 +236,10 @@ const BATCH_RENDER_CAP = 100;
 // ordinary (at-or-under-cap) runs. The worker remains serial; this is client-side
 // backpressure for confirmed large runs only.
 const BATCH_ACTIVE_JOB_LIMIT = BATCH_RENDER_CAP;
+// A styled Cartesian batch can be enormous even though its queue state remains bounded.
+// Yield after this many preflight prompts so the run state commits and Stop can interrupt
+// a clean (no-overage) stream before we ever reach its Cartesian suffix.
+const BATCH_PREFLIGHT_YIELD_INTERVAL = BATCH_RENDER_CAP;
 
 function preferredOption(defaultValue, options) {
   return options.includes(defaultValue) ? defaultValue : options[0] ?? "default";
@@ -2512,24 +2516,6 @@ export function ImageStudio() {
       setBatchConfirmPending(true);
       return;
     }
-    const promptBudgetOverages = batchPromptBudgetOverages(
-      stylePreviewActive && !structuredPromptModel
-        ? (function* composedBatchPrompts() {
-            for (const { prompt: resolvedPrompt } of iterateBatch(batchPrompts, batchVariables)) {
-              const { prompt: cleanPrompt } = parsePromptResolution(resolvedPrompt);
-              yield composeJobPrompt({ promptToSend: cleanPrompt }).composedPrompt;
-            }
-          })()
-        : [],
-      // Preserve the detailed item list for ordinary runs; a high-cardinality stream
-      // needs only the first actionable violation and must not retain them all.
-      batchJobCount > BATCH_RENDER_CAP ? 1 : Infinity,
-    );
-    if (promptBudgetOverages.length) {
-      setBatchError(batchPromptBudgetMessage(promptBudgetOverages));
-      setBatchConfirmPending(false);
-      return;
-    }
     if (dimensionsInvalid || hiresFixTargetInvalid) {
       setBatchError(
         hiresFixTargetMessage ||
@@ -2537,6 +2523,21 @@ export function ImageStudio() {
           "Width and height must each be between 256 and 4096.",
       );
       return;
+    }
+    const styledBatchPrompts = () => (function* composedBatchPrompts() {
+      for (const { prompt: resolvedPrompt } of iterateBatch(batchPrompts, batchVariables)) {
+        const { prompt: cleanPrompt } = parsePromptResolution(resolvedPrompt);
+        yield composeJobPrompt({ promptToSend: cleanPrompt }).composedPrompt;
+      }
+    })();
+    // An ordinary batch remains eager so its warning retains every actionable item.
+    // Only a confirmed high-cardinality product needs the cancelable streaming path below.
+    if (stylePreviewActive && !structuredPromptModel && batchJobCount <= BATCH_RENDER_CAP) {
+      const promptBudgetOverages = batchPromptBudgetOverages(styledBatchPrompts());
+      if (promptBudgetOverages.length) {
+        setBatchError(batchPromptBudgetMessage(promptBudgetOverages));
+        return;
+      }
     }
     setBatchError("");
     setBatchConfirmPending(false);
@@ -2552,6 +2553,37 @@ export function ImageStudio() {
       failed: 0,
       activeJobIds: [],
     });
+    // Validate styled prompts before any job is admitted. This is deliberately a stream:
+    // a high-cardinality all-under-cap Cartesian product used to synchronously exhaust here,
+    // before React could paint the run and make Stop usable. The state above establishes the
+    // cancel owner first; bounded cooperative yields preserve truthful preflight enforcement
+    // without retaining every prompt or letting any job through before validation completes.
+    if (stylePreviewActive && !structuredPromptModel && batchJobCount > BATCH_RENDER_CAP) {
+      let inspected = 0;
+      for (const { prompt: resolvedPrompt } of iterateBatch(batchPrompts, batchVariables)) {
+        if (batchAbortRef.current) {
+          const current = batchRunRef.current;
+          if (current) replaceBatchRun({ ...current, submitting: false });
+          return;
+        }
+        const { prompt: cleanPrompt } = parsePromptResolution(resolvedPrompt);
+        const promptBudgetOverages = batchPromptBudgetOverages(
+          [composeJobPrompt({ promptToSend: cleanPrompt }).composedPrompt],
+          1,
+        );
+        if (promptBudgetOverages.length) {
+          const [{ item: _item, ...budget }] = promptBudgetOverages;
+          replaceBatchRun(null);
+          setBatchError(batchPromptBudgetMessage([{ item: inspected + 1, ...budget }]));
+          return;
+        }
+        inspected += 1;
+        if (batchJobCount > BATCH_RENDER_CAP && inspected % BATCH_PREFLIGHT_YIELD_INTERVAL === 0) {
+          // A macrotask, rather than a microtask, gives the browser an event turn to deliver Stop.
+          await new Promise((resolve) => window.setTimeout(resolve, 0));
+        }
+      }
+    }
     for (const entry of iterateBatch(batchPrompts, batchVariables)) {
       await waitForBatchSlot();
       if (batchAbortRef.current) {

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -23,7 +23,7 @@ import { StudioUpdateBadge, StudioUpdateNotice, updateOptionLabel } from "../com
 import StructuredPromptBuilder from "../components/StructuredPromptBuilder.jsx";
 import ReferenceCaptionPicker from "../components/ReferenceCaptionPicker.jsx";
 import BatchPromptPanel from "../components/BatchPromptPanel.jsx";
-import { expandBatch, linkedGroupIssues, missingKeys, parsePromptResolution } from "../promptBatch.js";
+import { iterateBatch, linkedGroupIssues, missingKeys, parsePromptResolution } from "../promptBatch.js";
 import {
   dimensionConstraintMessage,
   evaluateModelDimensions,
@@ -2479,16 +2479,23 @@ export function ImageStudio() {
       setBatchError("Waiting for engine capabilities before using the restored decoder.");
       return;
     }
-    const resolved = expandBatch(batchPrompts, batchVariables);
-    if (!resolved.length) {
+    // batchJobCount is cardinality(), so admission happens before any Cartesian expansion.
+    if (!batchJobCount) {
+      return;
+    }
+    // Soft cap: a large run must be confirmed once, showing the exact image count.
+    if (!confirmed && batchTotal > BATCH_RENDER_CAP) {
+      setBatchConfirmPending(true);
       return;
     }
     const promptBudgetOverages = batchPromptBudgetOverages(
       stylePreviewActive && !structuredPromptModel
-        ? resolved.map(({ prompt: resolvedPrompt }) => {
-            const { prompt: cleanPrompt } = parsePromptResolution(resolvedPrompt);
-            return composeJobPrompt({ promptToSend: cleanPrompt }).composedPrompt;
-          })
+        ? (function* composedBatchPrompts() {
+            for (const { prompt: resolvedPrompt } of iterateBatch(batchPrompts, batchVariables)) {
+              const { prompt: cleanPrompt } = parsePromptResolution(resolvedPrompt);
+              yield composeJobPrompt({ promptToSend: cleanPrompt }).composedPrompt;
+            }
+          })()
         : [],
     );
     if (promptBudgetOverages.length) {
@@ -2505,27 +2512,23 @@ export function ImageStudio() {
       return;
     }
     setBatchError("");
-    // Soft cap: a large run must be confirmed once, showing the exact image count.
-    if (!confirmed && resolved.length * batchImagesPerPrompt > BATCH_RENDER_CAP) {
-      setBatchConfirmPending(true);
-      return;
-    }
     setBatchConfirmPending(false);
     batchAbortRef.current = false;
     batchObservedJobsRef.current.clear();
-    // Items carry `error` so not-yet-submitted rows read as pending, not failed, while a
-    // (possibly slow, structured) enqueue is in flight. Updated after each post so progress
-    // ticks up live.
-    const items = resolved.map((entry) => ({ prompt: entry.prompt, jobId: null, error: false }));
-    setBatchRun({ submitting: true, items: items.map((item) => ({ ...item })) });
-    for (let i = 0; i < resolved.length; i += 1) {
+    // Keep only the submitted prefix while streaming. `total` represents the unvisited
+    // suffix as pending, so a confirmed large batch never starts with a full item list.
+    const items = [];
+    setBatchRun({ submitting: true, total: batchJobCount, items: [] });
+    for (const entry of iterateBatch(batchPrompts, batchVariables)) {
       if (batchAbortRef.current) {
         break;
       }
-      const entry = resolved[i];
       // Strip a leading [WxH] directive (sc-10063): the model gets the clean prompt, the job
       // gets that per-prompt resolution.
       const { prompt: cleanPrompt, resolution } = parsePromptResolution(entry.prompt);
+      const item = { prompt: cleanPrompt, jobId: null, error: false };
+      items.push(item);
+      setBatchRun({ submitting: true, total: batchJobCount, items });
       try {
         let request;
         if (structuredPromptModel) {
@@ -2547,13 +2550,13 @@ export function ImageStudio() {
           request = buildBatchJobRequest(cleanPrompt, { resolution });
         }
         const job = await createImageJob(request);
-        items[i] = { prompt: cleanPrompt, jobId: job?.id ?? null, error: !job?.id };
+        Object.assign(item, { jobId: job?.id ?? null, error: !job?.id });
       } catch {
-        items[i] = { prompt: cleanPrompt, jobId: null, error: true };
+        item.error = true;
       }
-      setBatchRun({ submitting: true, items: items.map((item) => ({ ...item })) });
+      setBatchRun({ submitting: true, total: batchJobCount, items });
     }
-    setBatchRun({ submitting: false, items });
+    setBatchRun({ submitting: false, total: batchJobCount, items });
   }
 
   // Stop the enqueue loop (if still running) and cancel every still-pending job in the run;
@@ -2579,7 +2582,7 @@ export function ImageStudio() {
   }
 
   const batchRunProgress = batchRun
-    ? summarizeBatchRun(batchRun.items, jobs, batchObservedJobsRef.current)
+    ? summarizeBatchRun(batchRun.items, jobs, batchObservedJobsRef.current, batchRun.total)
     : null;
   useEffect(() => {
     if (!batchRun) return;

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -283,6 +283,37 @@ describe("Image Studio batch cardinality admission", () => {
     expect(createImageJob).not.toHaveBeenCalled();
   });
 
+  it("makes a no-overage styled Cartesian preflight cancelable before inspecting its full product", async () => {
+    const values = Array.from({ length: 10 }, (_, index) => String(index));
+    const keys = ["a", "b", "c", "d", "e", "f", "g"];
+    window.localStorage.setItem(
+      "sceneworks-studio-image-project_1",
+      JSON.stringify({
+        model: Z_IMAGE.id,
+        count: 1,
+        styleId: "ghibli-style",
+        batchMode: true,
+        batchPromptsText: `under budget ${keys.map((key) => `{{${key}}}`).join(" ")}`,
+        batchVariableValues: Object.fromEntries(keys.map((key) => [key, values])),
+      }),
+    );
+    const createImageJob = vi.fn();
+    await render(baseContext({ createImageJob }));
+
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent.includes("Run batch")));
+    await click(container.querySelector(".batch-confirm .prompt-cta"));
+
+    // The first bounded preflight slice has yielded with the run rendered; the old
+    // synchronous walk could not expose Stop until all ten million prompts were read.
+    await vi.waitFor(() => expect(container.querySelector(".batch-run-progress")?.textContent).toContain("Queued 0/10000000"));
+    expect(container.querySelector(".batch-run-progress button")?.textContent).toBe("Stop");
+    expect(createImageJob).not.toHaveBeenCalled();
+
+    await click(container.querySelector(".batch-run-progress button"));
+    await vi.waitFor(() => expect(container.querySelector(".batch-run-progress")?.textContent).toContain("0/10000000 done"));
+    expect(createImageJob).not.toHaveBeenCalled();
+  });
+
   it("keeps a confirmed run's active queue bounded while preserving its submitted count", async () => {
     const values = Array.from({ length: 101 }, (_, index) => String(index));
     window.localStorage.setItem(

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -199,6 +199,16 @@ describe("ImageStudio Save as Preset", () => {
     expect(context.createPreset).not.toHaveBeenCalled();
     expect(container.textContent).toContain("already exists");
   });
+
+  it("normalizes a rejected preset creation into a safe error message", async () => {
+    const context = baseContext({ createPreset: vi.fn(() => Promise.reject({ message: { detail: "not renderable" } })) });
+    await render(context);
+
+    await act(async () => setInput(nameInput(container), "Unavailable preset"));
+    await saveWithScope(container, "This project");
+
+    expect(container.textContent).toContain("Could not save this preset.");
+  });
 });
 
 describe("ImageStudio advanced model defaults", () => {

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -201,6 +201,54 @@ describe("ImageStudio Save as Preset", () => {
   });
 });
 
+describe("Image Studio batch cardinality admission", () => {
+  let container;
+  let root;
+
+  beforeEach(() => {
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+    ({ container, root } = mountRoot());
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.clearAllMocks();
+  });
+
+  async function render(context) {
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={context}>
+          <ImageStudio />
+        </AppContext.Provider>,
+      );
+    });
+    await act(async () => {});
+  }
+
+  it("confirms an enormous batch from cardinality without materializing its combinations", async () => {
+    const values = Array.from({ length: 10 }, (_, index) => String(index));
+    const keys = ["a", "b", "c", "d", "e", "f", "g"];
+    window.localStorage.setItem(
+      "sceneworks-studio-image-project_1",
+      JSON.stringify({
+        model: Z_IMAGE.id,
+        batchMode: true,
+        batchPromptsText: keys.map((key) => `{{${key}}}`).join(" "),
+        batchVariableValues: Object.fromEntries(keys.map((key) => [key, values])),
+      }),
+    );
+    const createImageJob = vi.fn();
+    await render(baseContext({ createImageJob }));
+
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent.includes("Run batch")));
+
+    expect(container.querySelector(".batch-confirm")?.textContent).toContain("Queue 40000000 images");
+    expect(createImageJob).not.toHaveBeenCalled();
+  });
+});
+
 describe("ImageStudio advanced model defaults", () => {
   let container;
   let root;

--- a/apps/web/src/screens/ImageStudio.test.jsx
+++ b/apps/web/src/screens/ImageStudio.test.jsx
@@ -247,6 +247,56 @@ describe("Image Studio batch cardinality admission", () => {
     expect(container.querySelector(".batch-confirm")?.textContent).toContain("Queue 40000000 images");
     expect(createImageJob).not.toHaveBeenCalled();
   });
+
+  it("stops styled high-cardinality preflight at the first actionable budget violation", async () => {
+    const values = Array.from({ length: 10 }, (_, index) => String(index));
+    const keys = ["a", "b", "c", "d", "e", "f", "g"];
+    window.localStorage.setItem(
+      "sceneworks-studio-image-project_1",
+      JSON.stringify({
+        model: Z_IMAGE.id,
+        count: 1,
+        styleId: "ghibli-style",
+        batchMode: true,
+        batchPromptsText: `${"x".repeat(3600)} ${keys.map((key) => `{{${key}}}`).join(" ")}`,
+        batchVariableValues: Object.fromEntries(keys.map((key) => [key, values])),
+      }),
+    );
+    const createImageJob = vi.fn();
+    await render(baseContext({ createImageJob }));
+
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent.includes("Run batch")));
+    expect(container.querySelector(".batch-confirm")?.textContent).toContain("Queue 10000000 images");
+    await click(container.querySelector(".batch-confirm .prompt-cta"));
+
+    expect(container.querySelector(".batch-warning")?.textContent).toContain("Batch prompt 1");
+    expect(createImageJob).not.toHaveBeenCalled();
+  });
+
+  it("keeps a confirmed run's active queue bounded while preserving its submitted count", async () => {
+    const values = Array.from({ length: 101 }, (_, index) => String(index));
+    window.localStorage.setItem(
+      "sceneworks-studio-image-project_1",
+      JSON.stringify({
+        model: Z_IMAGE.id,
+        count: 1,
+        batchMode: true,
+        batchPromptsText: "{{value}}",
+        batchVariableValues: { value: values },
+      }),
+    );
+    let sequence = 0;
+    const createImageJob = vi.fn(async () => ({ id: `batch-${sequence++}` }));
+    await render(baseContext({ createImageJob }));
+
+    await click([...container.querySelectorAll("button")].find((button) => button.textContent.includes("Run batch")));
+    await click(container.querySelector(".batch-confirm .prompt-cta"));
+    await vi.waitFor(() => expect(createImageJob).toHaveBeenCalledTimes(100));
+
+    expect(container.querySelector(".batch-run-progress")?.textContent).toContain("Queued 100/101");
+    await click([...container.querySelectorAll(".batch-run-progress button")].find((button) => button.textContent === "Stop"));
+    await vi.waitFor(() => expect(container.querySelector(".batch-run-progress")?.textContent).toContain("0/101 done"));
+  });
 });
 
 describe("ImageStudio advanced model defaults", () => {

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -113,10 +113,10 @@ function formatTierSize(bytes) {
   }
   const gb = bytes / (1024 * 1024 * 1024);
   if (gb >= 1) {
-    return `${gb.toFixed(1)} GB`;
+    return `${gb.toFixed(1)} GiB`;
   }
   const mb = bytes / (1024 * 1024);
-  return `${mb.toFixed(0)} MB`;
+  return `${mb.toFixed(0)} MiB`;
 }
 
 // Conversion status text, keyed off the catalog's `mlxConversionState`. Turnkey ("ready") models

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -1579,11 +1579,11 @@ describe("ModelManagerScreen quant-tier download panel (sc-8509)", () => {
     expect(labels[0]).toContain("bf16");
     expect(labels[2]).toContain("Q4");
     // Sizes render the ON-DISK footprint (req #1: footprint.diskSizeBytes), not the smaller
-    // compressed downloadSizeBytes. bf16 disk = 24 GB (download 20 GB), q4 disk = 4 GB (download 3 GB).
-    expect(container.textContent).toContain("24.0 GB");
-    expect(container.textContent).toContain("4.0 GB");
-    expect(container.textContent).not.toContain("20.0 GB");
-    expect(container.textContent).not.toContain("3.0 GB");
+    // compressed downloadSizeBytes. bf16 disk = 24 GiB (download 20 GiB), q4 disk = 4 GiB (download 3 GiB).
+    expect(container.textContent).toContain("24.0 GiB");
+    expect(container.textContent).toContain("4.0 GiB");
+    expect(container.textContent).not.toContain("20.0 GiB");
+    expect(container.textContent).not.toContain("3.0 GiB");
     // The installed tier reports installed; the others report not installed.
     const q8Row = rows.find((row) => row.querySelector(".model-tier-label").textContent.includes("Q8"));
     expect(q8Row.querySelector(".status-badge").textContent).toBe("installed");

--- a/apps/web/src/screens/PresetManagerScreen.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.jsx
@@ -30,6 +30,7 @@ import { ValidationSummary } from "../validation/Validation.jsx";
 import { useAppStatic } from "../context/AppContext.js";
 import { qualityChoices } from "../jobTypes.js";
 import { appConfirm } from "../appConfirm.jsx";
+import { errorMessage } from "../errorMessage.js";
 
 // The Workflow segment a preset editor offers, and how each choice persists.
 //
@@ -639,7 +640,7 @@ export function PresetManagerScreen() {
         setMessage({ tone: "success", text: "Preset created." });
       }
     } catch (err) {
-      setMessage({ tone: "error", text: err.message });
+      setMessage({ tone: "error", text: errorMessage(err, "Could not save this preset.") });
     } finally {
       setSaving(false);
     }
@@ -653,7 +654,7 @@ export function PresetManagerScreen() {
       setSelectedPresetId(duplicated.id);
       setMessage({ tone: "success", text: `Duplicated "${preset.name ?? preset.id}".` });
     } catch (err) {
-      setMessage({ tone: "error", text: err.message });
+      setMessage({ tone: "error", text: errorMessage(err, "Could not duplicate this preset.") });
     } finally {
       setSaving(false);
     }
@@ -674,7 +675,7 @@ export function PresetManagerScreen() {
       }
       setMessage({ tone: "success", text: `Archived "${preset.name ?? preset.id}".` });
     } catch (err) {
-      setMessage({ tone: "error", text: err.message });
+      setMessage({ tone: "error", text: errorMessage(err, "Could not archive this preset.") });
     } finally {
       setSaving(false);
     }

--- a/apps/web/src/screens/PresetManagerScreen.test.jsx
+++ b/apps/web/src/screens/PresetManagerScreen.test.jsx
@@ -230,6 +230,38 @@ describe("PresetManagerScreen", () => {
     );
   });
 
+  it("surfaces rejected create and update saves without unhandled rejections", async () => {
+    const createPreset = vi.fn(() => Promise.reject({ message: { detail: "not renderable" } }));
+    const updatePreset = vi.fn(() => Promise.reject("Preset storage is unavailable."));
+    const unhandled = [];
+    const onUnhandled = (event) => {
+      unhandled.push(event.reason);
+      event.preventDefault();
+    };
+    window.addEventListener("unhandledrejection", onUnhandled);
+
+    try {
+      await render(baseContext({ createPreset, updatePreset }));
+      await clickButton("New preset");
+      await changeField(field(container, "Name"), "Reject me");
+      await clickButton("Create preset");
+      expect(container.textContent).toContain("Could not save this preset.");
+
+      await clickButton("All presets");
+      await act(async () => {
+        [...container.querySelectorAll(".preset-card")]
+          .find((card) => card.textContent.includes("Anime Key Visual"))
+          .querySelector(".secondary-action")
+          .click();
+      });
+      await clickButton("Save preset");
+      expect(container.textContent).toContain("Preset storage is unavailable.");
+      expect(unhandled).toEqual([]);
+    } finally {
+      window.removeEventListener("unhandledrejection", onUnhandled);
+    }
+  });
+
   // sc-10548: PATCH replaces `defaults` wholesale, so anything the editor doesn't render
   // must be carried through explicitly or a rename destroys it.
   it("preserves defaults the editor doesn't render, and still clears ones it does", async () => {

--- a/apps/web/src/screens/QueueScreen.jsx
+++ b/apps/web/src/screens/QueueScreen.jsx
@@ -184,9 +184,9 @@ function formatMemory(mb) {
     return "Unknown";
   }
   if (mb >= 1024) {
-    return `${(mb / 1024).toFixed(1)} GB`;
+    return `${(mb / 1024).toFixed(1)} GiB`;
   }
-  return `${Math.round(mb)} MB`;
+  return `${Math.round(mb)} MiB`;
 }
 
 function boundedPercent(value) {

--- a/apps/web/src/screens/SettingsScreen.jsx
+++ b/apps/web/src/screens/SettingsScreen.jsx
@@ -62,10 +62,16 @@ function fractionToPercent(fraction) {
   return Math.min(100, Math.max(GPU_LIMIT_MIN_PERCENT, Math.round(fraction * 100)));
 }
 
-// GPU memory telemetry (epic 7819, sc-7825). The worker publishes byte counts; the readout is in GB.
-function bytesToGb(bytes) {
-  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes <= 0) return 0;
+// GPU memory telemetry (epic 7819, sc-7825). The worker publishes byte counts;
+// preserve a reported zero while distinguishing an absent reading from zero.
+function telemetryBytesToGib(bytes) {
+  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes < 0) return null;
   return bytes / (1024 * 1024 * 1024);
+}
+
+function telemetryGibLabel(bytes, digits = 1) {
+  const gib = telemetryBytesToGib(bytes);
+  return gib === null ? "Unavailable" : `${gib.toFixed(digits)} GiB`;
 }
 
 const SCHEME_OPTIONS = [
@@ -574,7 +580,7 @@ export function SettingsScreen({
   const gpuTargetLabel =
     gpuLimitPercent >= 100
       ? "Use all available"
-      : `~${Math.round(unifiedGb * (gpuLimitPercent / 100))} GB of ${unifiedGb} GB (${gpuLimitPercent}%)`;
+      : `~${Math.round(unifiedGb * (gpuLimitPercent / 100))} GiB of ${unifiedGb} GiB (${gpuLimitPercent}%)`;
 
   return (
     <section className="page-frame settings-screen">
@@ -1050,9 +1056,9 @@ export function SettingsScreen({
                 <div className="settings-kv">
                   <span>Unified memory</span>
                   <span>
-                    {unifiedGb} GB
+                    {unifiedGb} GiB
                     {typeof gpu.wiredLimitMb === "number"
-                      ? ` · system cap ${Math.round(gpu.wiredLimitMb / 1024)} GB`
+                      ? ` · system cap ${Math.round(gpu.wiredLimitMb / 1024)} GiB`
                       : ""}
                   </span>
                 </div>
@@ -1098,20 +1104,20 @@ export function SettingsScreen({
                       <div className="settings-kv">
                         <span>Active</span>
                         <span className="settings-mono">
-                          {bytesToGb(gpuTelemetry.activeBytes).toFixed(1)} GB
+                          {telemetryGibLabel(gpuTelemetry.activeBytes)}
                         </span>
                       </div>
                       <div className="settings-kv">
                         <span>Peak</span>
                         <span className="settings-mono">
-                          {bytesToGb(gpuTelemetry.peakBytes).toFixed(1)} GB
+                          {telemetryGibLabel(gpuTelemetry.peakBytes)}
                         </span>
                       </div>
-                      {gpuTelemetry.limitBytes ? (
+                      {gpuTelemetry.limitBytes !== null && gpuTelemetry.limitBytes !== undefined ? (
                         <div className="settings-kv">
                           <span>Limit</span>
                           <span className="settings-mono">
-                            {Math.round(bytesToGb(gpuTelemetry.limitBytes))} GB
+                            {telemetryGibLabel(gpuTelemetry.limitBytes, 0)}
                           </span>
                         </div>
                       ) : null}

--- a/apps/web/src/screens/SettingsScreen.test.jsx
+++ b/apps/web/src/screens/SettingsScreen.test.jsx
@@ -532,9 +532,11 @@ describe("SettingsScreen GPU memory (desktop macOS)", () => {
   let invoke;
   let SettingsScreen;
   const GIB = 1024 * 1024 * 1024;
+  let telemetry;
 
   beforeEach(async () => {
     global.IS_REACT_ACT_ENVIRONMENT = true;
+    telemetry = { activeBytes: 20 * GIB, peakBytes: 40 * GIB, cacheBytes: 2 * GIB, limitBytes: 64 * GIB };
     invoke = vi.fn(async (command) => {
       switch (command) {
         case "get_app_settings":
@@ -546,7 +548,7 @@ describe("SettingsScreen GPU memory (desktop macOS)", () => {
         case "get_remote_access":
           return null;
         case "get_gpu_telemetry":
-          return { activeBytes: 20 * GIB, peakBytes: 40 * GIB, cacheBytes: 2 * GIB, limitBytes: 64 * GIB };
+          return telemetry;
         case "set_gpu_memory_limit":
           return { gpuMemoryLimitFraction: 0.5 };
         default:
@@ -585,16 +587,27 @@ describe("SettingsScreen GPU memory (desktop macOS)", () => {
     await render();
     expect(invoke).toHaveBeenCalledWith("get_gpu_telemetry", undefined);
     expect(container.textContent).toContain("Live MLX memory");
-    expect(container.textContent).toContain("20.0 GB");
-    expect(container.textContent).toContain("40.0 GB");
-    expect(container.textContent).toContain("64 GB");
+    expect(container.textContent).toContain("20.0 GiB");
+    expect(container.textContent).toContain("40.0 GiB");
+    expect(container.textContent).toContain("64 GiB");
+  });
+
+  it("marks missing telemetry fields unavailable while preserving a reported zero", async () => {
+    telemetry = { activeBytes: 0, limitBytes: 0 };
+    await render();
+    expect(container.textContent).toContain("0.0 GiB");
+    expect(container.textContent).toContain("0 GiB");
+    expect(container.textContent).toContain("Unavailable");
+    const rows = [...container.querySelectorAll(".settings-kv")];
+    expect(rows.find((row) => row.textContent.includes("Active"))?.textContent).toContain("0.0 GiB");
+    expect(rows.find((row) => row.textContent.includes("Peak"))?.textContent).toContain("Unavailable");
   });
 
   it("summarises this machine from the detected GPU and the worker registry", async () => {
     await render();
     expect(container.textContent).toContain("Engine");
     expect(container.textContent).toContain("Unified memory");
-    expect(container.textContent).toContain("128 GB");
+    expect(container.textContent).toContain("128 GiB");
   });
 
   it("applies the GPU memory target live, without restarting the worker", async () => {

--- a/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
+++ b/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
@@ -172,6 +172,36 @@ describe("TrainingStudio dataset draft guard (sc-11970)", () => {
     expect(context.loadTrainingDataset).toHaveBeenCalledTimes(1);
   });
 
+  it("does not replace an edit made while the refresh reload is pending", async () => {
+    const reload = deferred();
+    let loadCalls = 0;
+    const context = baseContext({
+      refreshTrainingDatasets: vi.fn(async () => {}),
+      loadTrainingDataset: vi.fn(() => {
+        loadCalls += 1;
+        return loadCalls === 1 ? Promise.resolve(datasetOne) : reload.promise;
+      }),
+    });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    const refreshButton = [...container.querySelectorAll("button")].find((button) => button.textContent === "Refresh");
+    await act(async () => {
+      refreshButton.click();
+    });
+    await vi.waitFor(() => expect(context.loadTrainingDataset).toHaveBeenCalledTimes(2));
+    await typeName(container, "Mira Set edited during reload");
+    await act(async () => {
+      reload.resolve(datasetOne);
+      await Promise.resolve();
+    });
+
+    expect(nameInput(container).value).toBe("Mira Set edited during reload");
+  });
+
   it("opens another dataset when the discard prompt is confirmed", async () => {
     appConfirmMock.mockResolvedValue(true);
     const context = baseContext();

--- a/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
+++ b/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
@@ -149,6 +149,54 @@ describe("TrainingStudio dataset draft guard (sc-11970)", () => {
     expect(context.loadTrainingDataset).not.toHaveBeenCalledWith("dataset-2");
   });
 
+  it("clears the refresh owner when a different dataset open is declined", async () => {
+    const reload = deferred();
+    let loadCalls = 0;
+    appConfirmMock.mockResolvedValue(false);
+    const context = baseContext({
+      refreshTrainingDatasets: vi.fn(async () => {}),
+      loadTrainingDataset: vi.fn(() => {
+        loadCalls += 1;
+        return loadCalls === 1 ? Promise.resolve(datasetOne) : reload.promise;
+      }),
+    });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    const refreshButton = [...container.querySelectorAll("button")].find((button) => button.textContent === "Refresh");
+    await act(async () => {
+      refreshButton.click();
+    });
+    await vi.waitFor(() => expect(context.loadTrainingDataset).toHaveBeenCalledTimes(2));
+
+    await typeName(container, "Mira Set edited while refresh reloads");
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{
+          ...context,
+          studioLaunch: { id: "launch-2", view: "LibraryDataSets", datasetId: "dataset-2" },
+        }}>{<TrainingDataSetsLibrary />}</AppContext.Provider>,
+      );
+    });
+    await vi.waitFor(() => expect(appConfirmMock).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      reload.resolve(datasetOne);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      container.querySelector(".compact-selector-pill").click();
+    });
+    const datasetOneOption = [...container.querySelectorAll(".compact-selector-item")]
+      .find((button) => button.textContent.includes("Mira Set"));
+    expect(datasetOneOption.disabled).toBe(false);
+    expect(datasetOneOption.textContent).not.toContain("Opening…");
+  });
+
   it("does not replace a rename started while dataset refresh is in flight", async () => {
     const refresh = deferred();
     const context = baseContext({ refreshTrainingDatasets: vi.fn(() => refresh.promise) });

--- a/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
+++ b/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
@@ -202,6 +202,145 @@ describe("TrainingStudio dataset draft guard (sc-11970)", () => {
     expect(nameInput(container).value).toBe("Mira Set edited during reload");
   });
 
+  it("does not replace a rename made while a completed Parquet import refreshes", async () => {
+    const refresh = deferred();
+    const refreshTrainingDatasets = vi.fn(() => refresh.promise);
+    const context = baseContext({ refreshTrainingDatasets });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{
+          ...context,
+          jobs: [{
+            id: "job-parquet",
+            type: "dataset_parquet_import",
+            status: "completed",
+            payload: { datasetId: "dataset-1" },
+            result: { importedItemCount: 1 },
+          }],
+        }}>{<TrainingDataSetsLibrary />}</AppContext.Provider>,
+      );
+    });
+    await vi.waitFor(() => expect(refreshTrainingDatasets).toHaveBeenCalledTimes(1));
+
+    await typeName(container, "Mira Set renamed during import refresh");
+    await act(async () => {
+      refresh.resolve();
+      await Promise.resolve();
+    });
+
+    expect(nameInput(container).value).toBe("Mira Set renamed during import refresh");
+    expect(context.loadTrainingDataset).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not replace a rename made while a completed Parquet import reloads", async () => {
+    const reload = deferred();
+    let loadCalls = 0;
+    const context = baseContext({
+      refreshTrainingDatasets: vi.fn(async () => {}),
+      loadTrainingDataset: vi.fn(() => {
+        loadCalls += 1;
+        return loadCalls === 1 ? Promise.resolve(datasetOne) : reload.promise;
+      }),
+    });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{
+          ...context,
+          jobs: [{
+            id: "job-parquet",
+            type: "dataset_parquet_import",
+            status: "completed",
+            payload: { datasetId: "dataset-1" },
+            result: { importedItemCount: 1 },
+          }],
+        }}>{<TrainingDataSetsLibrary />}</AppContext.Provider>,
+      );
+    });
+    await vi.waitFor(() => expect(context.loadTrainingDataset).toHaveBeenCalledTimes(2));
+
+    await typeName(container, "Mira Set renamed during import reload");
+    await act(async () => {
+      reload.resolve(datasetOne);
+      await Promise.resolve();
+    });
+
+    expect(nameInput(container).value).toBe("Mira Set renamed during import reload");
+  });
+
+  it("does not commit a completed Parquet import reload after the effect is superseded", async () => {
+    const firstReload = deferred();
+    const secondRefresh = deferred();
+    let refreshCalls = 0;
+    let loadCalls = 0;
+    const reloadedDataset = {
+      ...datasetOne,
+      version: 3,
+      items: [{ id: "parquet-item", path: "images/parquet.jpg", displayName: "parquet.jpg" }],
+    };
+    const context = baseContext({
+      refreshTrainingDatasets: vi.fn(() => {
+        refreshCalls += 1;
+        return refreshCalls === 1 ? Promise.resolve() : secondRefresh.promise;
+      }),
+      loadTrainingDataset: vi.fn(() => {
+        loadCalls += 1;
+        return loadCalls === 1 ? Promise.resolve(datasetOne) : firstReload.promise;
+      }),
+    });
+    const completedJob = (importedItemCount) => ({
+      id: "job-parquet",
+      type: "dataset_parquet_import",
+      status: "completed",
+      payload: { datasetId: "dataset-1" },
+      result: { importedItemCount },
+    });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{ ...context, jobs: [completedJob(1)] }}>
+          {<TrainingDataSetsLibrary />}
+        </AppContext.Provider>,
+      );
+    });
+    await vi.waitFor(() => expect(context.loadTrainingDataset).toHaveBeenCalledTimes(2));
+
+    // Updating the completion supersedes the first effect while its nested dataset load
+    // is still pending. Keep the replacement effect in its refresh await, so only the
+    // stale nested load could commit this fetched item.
+    await act(async () => {
+      root.render(
+        <AppContext.Provider value={{ ...context, jobs: [completedJob(2)] }}>
+          {<TrainingDataSetsLibrary />}
+        </AppContext.Provider>,
+      );
+    });
+    await vi.waitFor(() => expect(context.refreshTrainingDatasets).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      firstReload.resolve(reloadedDataset);
+      await Promise.resolve();
+    });
+
+    expect(container.querySelectorAll(".training-caption-card")).toHaveLength(0);
+    expect(container.textContent).not.toContain("Parquet import completed");
+  });
+
   it("opens another dataset when the discard prompt is confirmed", async () => {
     appConfirmMock.mockResolvedValue(true);
     const context = baseContext();

--- a/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
+++ b/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
@@ -22,6 +22,14 @@ import { KEEP_ALIVE_VIEWS } from "../App.jsx";
 const datasetOne = { id: "dataset-1", name: "Mira Set", version: 2, characterId: "", items: [] };
 const datasetTwo = { id: "dataset-2", name: "Other Set", version: 1, characterId: "", items: [] };
 
+function deferred() {
+  let resolve;
+  const promise = new Promise((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
 function baseContext(overrides = {}) {
   return {
     activeProject: { id: "project-a", name: "Project A" },
@@ -139,6 +147,29 @@ describe("TrainingStudio dataset draft guard (sc-11970)", () => {
     // Declined → dataset-2 was never loaded; only the original dataset-1 open happened.
     expect(context.loadTrainingDataset).toHaveBeenCalledTimes(1);
     expect(context.loadTrainingDataset).not.toHaveBeenCalledWith("dataset-2");
+  });
+
+  it("does not replace a rename started while dataset refresh is in flight", async () => {
+    const refresh = deferred();
+    const context = baseContext({ refreshTrainingDatasets: vi.fn(() => refresh.promise) });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<AppContext.Provider value={context}>{<TrainingDataSetsLibrary />}</AppContext.Provider>);
+    });
+    await settle();
+
+    const refreshButton = [...container.querySelectorAll("button")].find((button) => button.textContent === "Refresh");
+    await act(async () => {
+      refreshButton.click();
+    });
+    await typeName(container, "Mira Set renamed");
+    await act(async () => {
+      refresh.resolve();
+      await Promise.resolve();
+    });
+
+    expect(nameInput(container).value).toBe("Mira Set renamed");
+    expect(context.loadTrainingDataset).toHaveBeenCalledTimes(1);
   });
 
   it("opens another dataset when the discard prompt is confirmed", async () => {

--- a/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
+++ b/apps/web/src/screens/TrainingStudio.datasetGuard.test.jsx
@@ -339,6 +339,15 @@ describe("TrainingStudio dataset draft guard (sc-11970)", () => {
 
     expect(container.querySelectorAll(".training-caption-card")).toHaveLength(0);
     expect(container.textContent).not.toContain("Parquet import completed");
+
+    // The replacement effect is intentionally still awaiting here. Unmount before
+    // settling it so this regression leaves no background promise between tests.
+    await act(async () => {
+      root.unmount();
+      root = null;
+      secondRefresh.resolve();
+      await Promise.resolve();
+    });
   });
 
   it("opens another dataset when the discard prompt is confirmed", async () => {

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -3,6 +3,7 @@ import { useAppContext } from "../context/AppContext.js";
 import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
 import { DEFAULT_MAC_CAPABILITIES, macTrainingKernelBlocked } from "../macGating.js";
 import { API_BASE_URL, isAbortError } from "../api.js";
+import { errorMessage } from "../errorMessage.js";
 import { assetCanRenderAsImage } from "../components/assetMedia.jsx";
 import { Icon } from "../components/Icons.jsx";
 import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
@@ -1457,7 +1458,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
       );
       return job;
     } catch (err) {
-      setDatasetError(err.message);
+      setDatasetError(errorMessage(err, "Could not start the Parquet import."));
       throw err;
     }
   }

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -978,19 +978,18 @@ export function TrainingStudio({ mode = "training" } = {}) {
     datasetId,
     { preserveCurrentDraft = false, expectedDraftRevision, canCommit } = {},
   ) {
-    const loadGeneration = ++datasetLoadGenerationRef.current;
     // Opening a DIFFERENT dataset re-seeds the whole editor; confirm before discarding an
     // unsaved draft (sc-11970). Re-opening the SAME dataset (internal reloads after a save)
-    // never prompts — the ids match and the draft is already persisted.
+    // never prompts — the ids match and the draft is already persisted. A declined request
+    // must not take load ownership: an already-pending reload still owns busyDatasetId and
+    // must be able to clear it when it settles.
     if (datasetId && datasetId !== activeDataset?.id) {
       const proceed = await confirmDiscardUnsavedDraft();
       if (!proceed) {
         return;
       }
     }
-    if (loadGeneration !== datasetLoadGenerationRef.current) {
-      return;
-    }
+    const loadGeneration = ++datasetLoadGenerationRef.current;
     if (!datasetId) {
       setActiveDataset(null);
       setDraftName("");

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -974,7 +974,10 @@ export function TrainingStudio({ mode = "training" } = {}) {
     return registerProjectSwitchGuard(() => confirmDiscardUnsavedDraft());
   }, [datasetLibraryMode, registerProjectSwitchGuard]);
 
-  async function openDataset(datasetId, { preserveCurrentDraft = false } = {}) {
+  async function openDataset(
+    datasetId,
+    { preserveCurrentDraft = false, expectedDraftRevision, canCommit } = {},
+  ) {
     const loadGeneration = ++datasetLoadGenerationRef.current;
     // Opening a DIFFERENT dataset re-seeds the whole editor; confirm before discarding an
     // unsaved draft (sc-11970). Re-opening the SAME dataset (internal reloads after a save)
@@ -1000,13 +1003,14 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setDatasetError("");
     setDatasetMessage("");
     try {
-      const draftRevision = datasetDraftRevisionRef.current;
+      const draftRevision = expectedDraftRevision ?? datasetDraftRevisionRef.current;
       const dataset = await loadDataset(datasetId);
       // A refresh has already checked its first await. Check again at the actual
       // state commit: a rename, membership/caption edit, or a different open while
       // this load was pending must win over stale fetched data.
       if (
         loadGeneration !== datasetLoadGenerationRef.current ||
+        (canCommit && !canCommit()) ||
         (preserveCurrentDraft && (
           activeDatasetIdRef.current !== datasetId ||
           dirtyRef.current ||
@@ -1103,14 +1107,25 @@ export function TrainingStudio({ mode = "training" } = {}) {
     }
     const jobId = completedParquetImportId;
     const datasetId = activeDataset.id;
+    const draftRevision = datasetDraftRevisionRef.current;
     const handledJobs = handledParquetImportJobsRef.current;
     handledJobs.add(jobId);
     let canceled = false;
     let settled = false;
+    const canCommit = () => (
+      !canceled &&
+      activeDatasetIdRef.current === datasetId &&
+      datasetDraftRevisionRef.current === draftRevision
+    );
     void (async () => {
       try {
         await refreshTrainingDatasets(activeProject?.id);
-        const dataset = await openDatasetRef.current?.(datasetId);
+        if (!canCommit()) return;
+        const dataset = await openDatasetRef.current?.(datasetId, {
+          preserveCurrentDraft: true,
+          expectedDraftRevision: draftRevision,
+          canCommit,
+        });
         if (canceled || !dataset) return;
         const imported = completedParquetImportCount;
         setDatasetMessage(

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -487,6 +487,13 @@ export function TrainingStudio({ mode = "training" } = {}) {
       selectedAssetIds.length !== originalAssetIds.length ||
       selectedAssetIds.some((id, index) => id !== originalAssetIds[index]) ||
       captionsDirty);
+  // Refresh awaits the catalog request. Read the current draft state after that
+  // await so a rename begun while refresh is in flight is never overwritten by
+  // the freshly loaded dataset object.
+  const dirtyRef = useRef(dirty);
+  dirtyRef.current = dirty;
+  const activeDatasetIdRef = useRef(activeDataset?.id ?? "");
+  activeDatasetIdRef.current = activeDataset?.id ?? "";
   const completedParquetImport = useMemo(
     () =>
       jobs.find(
@@ -998,11 +1005,16 @@ export function TrainingStudio({ mode = "training" } = {}) {
   openDatasetRef.current = openDataset;
 
   async function onRefreshDatasets() {
+    const refreshDatasetId = activeDatasetIdRef.current;
     await refreshTrainingDatasets(activeProject?.id);
-    if (!activeDataset?.id || dirty) {
+    if (
+      !refreshDatasetId ||
+      activeDatasetIdRef.current !== refreshDatasetId ||
+      dirtyRef.current
+    ) {
       return;
     }
-    await openDataset(activeDataset.id);
+    await openDataset(refreshDatasetId);
   }
 
   // Permanently delete the OPEN dataset — the backend wipes its on-disk root (images,

--- a/apps/web/src/screens/TrainingStudio.jsx
+++ b/apps/web/src/screens/TrainingStudio.jsx
@@ -368,6 +368,10 @@ export function TrainingStudio({ mode = "training" } = {}) {
   // double-click can't fire two DELETEs before `deletingDataset` disables the button.
   const deleteDatasetGuardRef = useRef(false);
   const openDatasetRef = useRef(null);
+  // Every open owns a monotonic generation. A refresh reload is allowed to commit only
+  // if the draft it started from is still current after its second await.
+  const datasetLoadGenerationRef = useRef(0);
+  const datasetDraftRevisionRef = useRef(0);
   const handledParquetImportJobsRef = useRef(new Set());
   const [selectedAssetIds, setSelectedAssetIds] = useState([]);
   // Dataset Doctor readiness report (sc-6534), fetched server-side over the saved
@@ -495,6 +499,9 @@ export function TrainingStudio({ mode = "training" } = {}) {
   dirtyRef.current = dirty;
   const activeDatasetIdRef = useRef(activeDataset?.id ?? "");
   activeDatasetIdRef.current = activeDataset?.id ?? "";
+  useEffect(() => {
+    datasetDraftRevisionRef.current += 1;
+  }, [activeDataset?.id, draftName, selectedAssetIds, associatedCharacterId, captionDraftById]);
   const completedParquetImport = useMemo(
     () =>
       jobs.find(
@@ -967,7 +974,8 @@ export function TrainingStudio({ mode = "training" } = {}) {
     return registerProjectSwitchGuard(() => confirmDiscardUnsavedDraft());
   }, [datasetLibraryMode, registerProjectSwitchGuard]);
 
-  async function openDataset(datasetId) {
+  async function openDataset(datasetId, { preserveCurrentDraft = false } = {}) {
+    const loadGeneration = ++datasetLoadGenerationRef.current;
     // Opening a DIFFERENT dataset re-seeds the whole editor; confirm before discarding an
     // unsaved draft (sc-11970). Re-opening the SAME dataset (internal reloads after a save)
     // never prompts — the ids match and the draft is already persisted.
@@ -976,6 +984,9 @@ export function TrainingStudio({ mode = "training" } = {}) {
       if (!proceed) {
         return;
       }
+    }
+    if (loadGeneration !== datasetLoadGenerationRef.current) {
+      return;
     }
     if (!datasetId) {
       setActiveDataset(null);
@@ -989,7 +1000,21 @@ export function TrainingStudio({ mode = "training" } = {}) {
     setDatasetError("");
     setDatasetMessage("");
     try {
+      const draftRevision = datasetDraftRevisionRef.current;
       const dataset = await loadDataset(datasetId);
+      // A refresh has already checked its first await. Check again at the actual
+      // state commit: a rename, membership/caption edit, or a different open while
+      // this load was pending must win over stale fetched data.
+      if (
+        loadGeneration !== datasetLoadGenerationRef.current ||
+        (preserveCurrentDraft && (
+          activeDatasetIdRef.current !== datasetId ||
+          dirtyRef.current ||
+          datasetDraftRevisionRef.current !== draftRevision
+        ))
+      ) {
+        return null;
+      }
       setActiveDataset(dataset);
       setDraftName(dataset?.name ?? "");
       setSelectedAssetIds(normalizeDatasetAssetIds(dataset, assets));
@@ -1000,7 +1025,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
       setDatasetError(err.message);
       return null;
     } finally {
-      setBusyDatasetId("");
+      if (loadGeneration === datasetLoadGenerationRef.current) setBusyDatasetId("");
     }
   }
   openDatasetRef.current = openDataset;
@@ -1015,7 +1040,7 @@ export function TrainingStudio({ mode = "training" } = {}) {
     ) {
       return;
     }
-    await openDataset(refreshDatasetId);
+    await openDataset(refreshDatasetId, { preserveCurrentDraft: true });
   }
 
   // Permanently delete the OPEN dataset — the backend wipes its on-disk root (images,

--- a/apps/web/src/screens/VideoStudio.test.jsx
+++ b/apps/web/src/screens/VideoStudio.test.jsx
@@ -254,6 +254,26 @@ describe("VideoStudio Save as Preset", () => {
     expect(context.createPreset).not.toHaveBeenCalled();
     expect(container.textContent).toContain("already exists");
   });
+
+  it("shows a string preset-save rejection", async () => {
+    const context = baseContext({ createPreset: vi.fn(() => Promise.reject("Preset service is unavailable.")) });
+    await render(context);
+
+    await act(async () => setInput(nameInput(container), "Unavailable preset"));
+    await saveWithScope(container, "This project");
+
+    expect(container.textContent).toContain("Preset service is unavailable.");
+  });
+
+  it("normalizes an undefined preset-save rejection into a safe error message", async () => {
+    const context = baseContext({ createPreset: vi.fn(() => Promise.reject(undefined)) });
+    await render(context);
+
+    await act(async () => setInput(nameInput(container), "Unavailable preset"));
+    await saveWithScope(container, "This project");
+
+    expect(container.textContent).toContain("Could not save this preset.");
+  });
 });
 
 describe("VideoStudio video_bridge", () => {

--- a/apps/web/src/screens/imageEditor/maskAssetLoader.js
+++ b/apps/web/src/screens/imageEditor/maskAssetLoader.js
@@ -1,0 +1,40 @@
+// Keeps only the newest smart-select mask asset load eligible to commit. Starting a new
+// selection invalidates older job completions and aborts an asset fetch already in flight.
+export function createLatestMaskAssetLoader({ fetchImpl = fetch, assetUrlFor, blobToImage }) {
+  let generation = 0;
+  let controller = null;
+
+  function invalidate() {
+    generation += 1;
+    controller?.abort();
+    controller = null;
+    return generation;
+  }
+
+  async function load(asset, requestGeneration, onLoad) {
+    if (requestGeneration !== generation) return false;
+    controller?.abort();
+    const activeController = new AbortController();
+    controller = activeController;
+    try {
+      const response = await fetchImpl(assetUrlFor(asset), { signal: activeController.signal });
+      if (!response.ok) throw new Error(`Failed to load mask (${response.status})`);
+      const decoded = await blobToImage(await response.blob());
+      if (requestGeneration !== generation || activeController.signal.aborted) {
+        URL.revokeObjectURL(decoded.objectUrl);
+        return false;
+      }
+      onLoad(decoded.image);
+      URL.revokeObjectURL(decoded.objectUrl);
+      return true;
+    } catch (error) {
+      // A superseded request is expected cancellation, not an editor error.
+      if (requestGeneration !== generation || activeController.signal.aborted) return false;
+      throw error;
+    } finally {
+      if (controller === activeController) controller = null;
+    }
+  }
+
+  return { invalidate, load };
+}

--- a/apps/web/src/screens/imageEditor/maskAssetLoader.test.js
+++ b/apps/web/src/screens/imageEditor/maskAssetLoader.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createLatestMaskAssetLoader } from "./maskAssetLoader.js";
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("createLatestMaskAssetLoader", () => {
+  it("aborts a superseded asset fetch and commits only the latest mask", async () => {
+    const firstFetch = deferred();
+    const secondFetch = deferred();
+    const fetchImpl = vi.fn()
+      .mockReturnValueOnce(firstFetch.promise)
+      .mockReturnValueOnce(secondFetch.promise);
+    const blobToImage = vi.fn(async (blob) => ({ image: { id: blob.id }, objectUrl: `blob:${blob.id}` }));
+    const loader = createLatestMaskAssetLoader({
+      fetchImpl,
+      assetUrlFor: (asset) => asset.url,
+      blobToImage,
+    });
+    const revokeObjectURL = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const committed = [];
+
+    const firstGeneration = loader.invalidate();
+    const firstLoad = loader.load({ url: "old" }, firstGeneration, (image) => committed.push(image.id));
+    const firstSignal = fetchImpl.mock.calls[0][1].signal;
+
+    const secondGeneration = loader.invalidate();
+    expect(firstSignal.aborted).toBe(true);
+    const secondLoad = loader.load({ url: "new" }, secondGeneration, (image) => committed.push(image.id));
+
+    firstFetch.resolve({ ok: true, blob: async () => ({ id: "old" }) });
+    secondFetch.resolve({ ok: true, blob: async () => ({ id: "new" }) });
+
+    await expect(firstLoad).resolves.toBe(false);
+    await expect(secondLoad).resolves.toBe(true);
+    expect(committed).toEqual(["new"]);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:old");
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:new");
+    revokeObjectURL.mockRestore();
+  });
+});

--- a/apps/web/src/screens/imageEditor/maskStroke.js
+++ b/apps/web/src/screens/imageEditor/maskStroke.js
@@ -1,0 +1,9 @@
+// Append a point to the active mask stroke without cloning its growing point buffer on
+// every pointer event. The caller creates a new outer stroke list to notify React; the
+// current stroke remains private to the active gesture.
+export function appendMaskStrokePoint(lines, point) {
+  const line = lines.at(-1);
+  if (!line) return lines;
+  line.points.push(point.x, point.y);
+  return [...lines];
+}

--- a/apps/web/src/screens/imageEditor/maskStroke.test.js
+++ b/apps/web/src/screens/imageEditor/maskStroke.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { appendMaskStrokePoint } from "./maskStroke.js";
+
+describe("appendMaskStrokePoint", () => {
+  it("keeps the active point buffer and only copies the outer stroke list", () => {
+    const points = [1, 2];
+    const lines = [{ points, size: 64, erase: false }];
+
+    const next = appendMaskStrokePoint(lines, { x: 3, y: 4 });
+
+    expect(next).not.toBe(lines);
+    expect(next[0]).toBe(lines[0]);
+    expect(next[0].points).toBe(points);
+    expect(points).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/apps/web/src/screens/imageEditor/useMaskTool.js
+++ b/apps/web/src/screens/imageEditor/useMaskTool.js
@@ -15,6 +15,8 @@ import {
   tintMaskRgbaInPlace,
   maskHasContent,
 } from "./maskShared.js";
+import { appendMaskStrokePoint } from "./maskStroke.js";
+import { createLatestMaskAssetLoader } from "./maskAssetLoader.js";
 
 // Inpaint-mask brush + smart-select tool (sc-2436 / sc-3751 / sc-6110) extracted from
 // ImageEditor.jsx (sc-9752, F-052 follow-up). Owns the brush-stroke + smart-select-base
@@ -54,6 +56,7 @@ export function useMaskTool({
   // to a mask asset on Run for inpaint-capable models. `maskMode` is the paint sub-mode
   // of the AI Edit tool (Stage panning is suspended while it's on).
   const [maskLines, setMaskLines] = useState([]); // [{ points:[x,y,…], size, erase }]
+  const maskLinesRef = useRef([]);
   const [maskMode, setMaskMode] = useState(false);
   const [maskBrush, setMaskBrush] = useState(64);
   const [maskErase, setMaskErase] = useState(false);
@@ -72,6 +75,22 @@ export function useMaskTool({
   const [selectDraft, setSelectDraft] = useState(null); // live selection rect during a drag
   const selectDrawingRef = useRef(false);
   const selectStartRef = useRef(null);
+  const smartSelectLoaderRef = useRef(null);
+  if (!smartSelectLoaderRef.current) {
+    smartSelectLoaderRef.current = createLatestMaskAssetLoader({ assetUrlFor: assetUrl, blobToImage });
+  }
+
+  function replaceMaskLines(next) {
+    maskLinesRef.current = next;
+    setMaskLines(next);
+  }
+
+  useEffect(
+    () => () => {
+      smartSelectLoaderRef.current.invalidate();
+    },
+    [],
+  );
 
   // Leave paint mode (restoring Stage panning) when the edit tool is closed or the
   // model can't inpaint — otherwise the canvas would stay in a paint state with no UI.
@@ -82,7 +101,8 @@ export function useMaskTool({
   // Reset the per-bitmap mask state (called by the editor's resetEditorOverlays). Mirrors
   // the exact mask-clearing lines from the inline resetEditorOverlays.
   function resetMaskState() {
-    setMaskLines([]);
+    smartSelectLoaderRef.current.invalidate();
+    replaceMaskLines([]);
     setMaskMode(false);
     setMaskBaseImage(null);
     setMaskOverlay(null);
@@ -97,18 +117,14 @@ export function useMaskTool({
     const pt = stagePointToImage(event);
     if (!pt) return;
     maskPaintingRef.current = true;
-    setMaskLines((prev) => [...prev, { points: [pt.x, pt.y], size: maskBrush, erase: maskErase }]);
+    replaceMaskLines([...maskLinesRef.current, { points: [pt.x, pt.y], size: maskBrush, erase: maskErase }]);
   }
 
   function maskPointerMove(event) {
     if (!maskMode || maskSubTool !== "brush" || !maskPaintingRef.current) return;
     const pt = stagePointToImage(event);
     if (!pt) return;
-    setMaskLines((prev) => {
-      if (!prev.length) return prev;
-      const last = prev[prev.length - 1];
-      return [...prev.slice(0, -1), { ...last, points: [...last.points, pt.x, pt.y] }];
-    });
+    replaceMaskLines(appendMaskStrokePoint(maskLinesRef.current, pt));
   }
 
   function maskPointerUp() {
@@ -116,7 +132,8 @@ export function useMaskTool({
   }
 
   function clearMask() {
-    setMaskLines([]);
+    smartSelectLoaderRef.current.invalidate();
+    replaceMaskLines([]);
     setMaskBaseImage(null);
     setMaskOverlay(null);
   }
@@ -252,7 +269,7 @@ export function useMaskTool({
     octx.putImageData(data, 0, 0);
     setMaskBaseImage(maskCanvas);
     setMaskOverlay(overlay);
-    setMaskLines([]);
+    replaceMaskLines([]);
   }
 
   // Mask refinement (sc-6110): flatten the current mask, run a pure pixel op
@@ -283,6 +300,7 @@ export function useMaskTool({
   // except for the mask layer; the brush/eraser then refines it before Inpaint.
   function runSmartSelect(rect) {
     if (!working || aiOp || !canMask) return;
+    const requestGeneration = smartSelectLoaderRef.current.invalidate();
     const box = rectToSegmentBox(rect);
     runAiOp({
       label: "smart select",
@@ -296,15 +314,13 @@ export function useMaskTool({
           displayName: working?.source?.name,
         }),
       onComplete: async (resultAsset) => {
-        const res = await fetch(assetUrl(resultAsset));
-        if (!res.ok) throw new Error(`Failed to load mask (${res.status})`);
-        const { image, objectUrl } = await blobToImage(await res.blob());
-        loadMaskBase(image);
-        URL.revokeObjectURL(objectUrl); // the pixels are copied into the base/overlay canvases
-        // Return to the mask tool so the auto-mask can be refined with the brush/eraser.
-        setTool("edit");
-        setMaskMode(true);
-        setMaskSubTool("brush");
+        await smartSelectLoaderRef.current.load(resultAsset, requestGeneration, (image) => {
+          loadMaskBase(image);
+          // Return to the mask tool so the auto-mask can be refined with the brush/eraser.
+          setTool("edit");
+          setMaskMode(true);
+          setMaskSubTool("brush");
+        });
       },
     });
   }

--- a/apps/web/src/screens/studioRestore.test.jsx
+++ b/apps/web/src/screens/studioRestore.test.jsx
@@ -12,6 +12,7 @@ vi.mock("../api.js", async (importOriginal) => {
 });
 
 import { AppContext } from "../context/AppContext.js";
+import { recipeFromWorkflowShare } from "../workflowShare.js";
 import { ImageStudio } from "./ImageStudio.jsx";
 import { VideoStudio } from "./VideoStudio.jsx";
 
@@ -610,6 +611,39 @@ describe("reference-tuning declared defaults apply on a fresh late-catalog mount
     expect(snap.ipAdapterScale).toBe(0.33);
     expect(snap.controlnetScale).toBe(0.22);
     expect(snap.trueCfgScale).toBe(1.5);
+  });
+
+  it("replays sanitized shared numeric controls without poisoning the form state", async () => {
+    seedSnapshot("image", {
+      ipAdapterScale: 0.61,
+      controlnetScale: 0.81,
+      trueCfgScale: 4.1,
+    });
+    const recipe = recipeFromWorkflowShare(
+      {
+        mode: "text_to_image",
+        prompt: "shared recipe",
+        advanced: {
+          ipAdapterScale: "bad",
+          controlnetConditioningScale: Infinity,
+          trueCfgScale: "NaN",
+          schedulerShift: "2.5",
+        },
+      },
+      { model: { state: "resolved", catalogId: "z_image_turbo" }, loras: [], styles: [] },
+    );
+
+    await renderSequence(ImageStudio, [
+      imageContext({ studioLaunch: { id: "shared-numeric-replay", view: "Image", recipe } }),
+    ]);
+
+    const snap = readSnapshot("image");
+    // Invalid values were gone before the effect touched the number-backed controls.
+    expect(snap.ipAdapterScale).toBe(0.61);
+    expect(snap.controlnetScale).toBe(0.81);
+    expect(snap.trueCfgScale).toBe(4.1);
+    // Finite values survive in their numeric form, not as serialized strings.
+    expect(snap.schedulerShift).toBe(2.5);
   });
 
   // Issue-2 companion: a saved preset that carries its OWN reference tuning (a character-mode preset

--- a/apps/web/src/screens/training/DatasetEditorPanel.jsx
+++ b/apps/web/src/screens/training/DatasetEditorPanel.jsx
@@ -5,6 +5,7 @@ import { CompactSelector } from "../../components/CompactSelector.jsx";
 import { DatasetAddDialog } from "../../components/DatasetAddDialog.jsx";
 import { DatasetCaptionDialog } from "../../components/DatasetCaptionDialog.jsx";
 import { DatasetParquetImportDialog } from "../../components/DatasetParquetImportDialog.jsx";
+import { errorMessage } from "../../errorMessage.js";
 import { Icon } from "../../components/Icons.jsx";
 import { WorkPanel } from "../../components/WorkPanel.jsx";
 import { ValidationSummary } from "../../validation/Validation.jsx";
@@ -115,14 +116,18 @@ export function DatasetEditorPanel({
   const [captionFilter, setCaptionFilter] = React.useState("all");
   const [parquetDialogOpen, setParquetDialogOpen] = React.useState(false);
   const [parquetImporting, setParquetImporting] = React.useState(false);
+  const [parquetError, setParquetError] = React.useState("");
   const parquetImportDisabled = !draftName.trim() || memberAssets.length > 0 || parquetImporting;
 
   async function runParquetImport(settings) {
     if (typeof onImportParquet !== "function" || parquetImporting) return;
     setParquetImporting(true);
+    setParquetError("");
     try {
       await onImportParquet(settings);
       setParquetDialogOpen(false);
+    } catch (error) {
+      setParquetError(errorMessage(error, "Could not start the Parquet import."));
     } finally {
       setParquetImporting(false);
     }
@@ -314,7 +319,10 @@ export function DatasetEditorPanel({
             <button
               className="secondary-action"
               disabled={parquetImportDisabled}
-              onClick={() => setParquetDialogOpen(true)}
+              onClick={() => {
+                setParquetError("");
+                setParquetDialogOpen(true);
+              }}
               title={
                 !draftName.trim()
                   ? "Name the dataset before importing"
@@ -572,11 +580,14 @@ export function DatasetEditorPanel({
         />
       ) : null}
       {parquetDialogOpen ? (
-        <DatasetParquetImportDialog
-          onClose={() => !parquetImporting && setParquetDialogOpen(false)}
-          onRun={runParquetImport}
-          running={parquetImporting}
-        />
+        <>
+          {parquetError ? <p className="inline-warning">{parquetError}</p> : null}
+          <DatasetParquetImportDialog
+            onClose={() => !parquetImporting && setParquetDialogOpen(false)}
+            onRun={runParquetImport}
+            running={parquetImporting}
+          />
+        </>
       ) : null}
     </>
   );

--- a/apps/web/src/screens/training/DatasetEditorPanel.test.jsx
+++ b/apps/web/src/screens/training/DatasetEditorPanel.test.jsx
@@ -147,4 +147,42 @@ describe("DatasetEditorPanel delete affordance", () => {
     // Nothing dataset-scoped to delete, but the panel still renders its draft shell.
     expect(container.querySelector(".dataset-identity-actions")).not.toBeNull();
   });
+
+  it("keeps Parquet-import failures visible and handled at the parent boundary", async () => {
+    const onImportParquet = vi.fn(() => Promise.reject({ message: { detail: "not renderable" } }));
+    const { props } = makeSessions();
+    props.datasetSession.onImportParquet = onImportParquet;
+    const unhandled = [];
+    const onUnhandled = (event) => {
+      unhandled.push(event.reason);
+      event.preventDefault();
+    };
+    window.addEventListener("unhandledrejection", onUnhandled);
+
+    try {
+      await act(async () => root.render(<DatasetEditorPanel {...props} />));
+      await act(async () => {
+        [...container.querySelectorAll("button")].find((button) => button.textContent === "Import Parquet").click();
+      });
+      const input = [...document.body.querySelectorAll("label")]
+        .find((label) => label.textContent.includes("Parquet file or folder"))
+        .querySelector("input");
+      await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(input), "value")?.set;
+        setter.call(input, "D:\\broken.parquet");
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        input.dispatchEvent(new Event("change", { bubbles: true }));
+      });
+      await act(async () => {
+        [...document.body.querySelectorAll("button")].find((button) => button.textContent === "Start import").click();
+        await Promise.resolve();
+      });
+
+      expect(onImportParquet).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain("Could not start the Parquet import.");
+      expect(unhandled).toEqual([]);
+    } finally {
+      window.removeEventListener("unhandledrejection", onUnhandled);
+    }
+  });
 });

--- a/apps/web/src/styleComposer.test.js
+++ b/apps/web/src/styleComposer.test.js
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -9,10 +12,12 @@ import {
 } from "./styleComposer.js";
 // sc-13134 cross-language golden fixtures. The SAME file drives the Rust port's parity test
 // (crates/sceneworks-core/src/style_composer.rs), so a headless/MCP server-side fold and this
-// client composer stay byte-identical. Imported as ?raw by Vitest only; documents/ is not on the
-// dev server's /@fs allow-list.
-// and JSON.parsed so both languages read the exact same bytes.
-import composerFixturesRaw from "../../../documents/style-composer.fixtures.json?raw";
+// client composer stay byte-identical. This non-listening test reads the exact
+// file directly, without putting documents/ on a Vite server's /@fs allow-list.
+const composerFixturesRaw = readFileSync(
+  resolve(process.cwd(), "../..", "documents/style-composer.fixtures.json"),
+  "utf8",
+);
 
 // sc-13129: the style composer wraps an already-preset-folded userPrompt in a Subject/Style
 // template — the user's prose leads, the catalog style trails it — splicing around any directive

--- a/apps/web/src/styleComposer.test.js
+++ b/apps/web/src/styleComposer.test.js
@@ -9,7 +9,8 @@ import {
 } from "./styleComposer.js";
 // sc-13134 cross-language golden fixtures. The SAME file drives the Rust port's parity test
 // (crates/sceneworks-core/src/style_composer.rs), so a headless/MCP server-side fold and this
-// client composer stay byte-identical. Imported as ?raw (documents/ is on vite's server.fs.allow)
+// client composer stay byte-identical. Imported as ?raw by Vitest only; documents/ is not on the
+// dev server's /@fs allow-list.
 // and JSON.parsed so both languages read the exact same bytes.
 import composerFixturesRaw from "../../../documents/style-composer.fixtures.json?raw";
 

--- a/apps/web/src/training/datasetReadiness.js
+++ b/apps/web/src/training/datasetReadiness.js
@@ -15,10 +15,89 @@
 
 import { datasetItemSelectionKey } from "./datasetHelpers.js";
 
+const SHA256_CONSTANTS = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+];
+
+function rotateRight(value, bits) {
+  return (value >>> bits) | (value << (32 - bits));
+}
+
+// A small browser-only fallback for HTTP/insecure contexts, where Web Crypto is deliberately not
+// exposed. `captionHash` is a protocol value, so this must be SHA-256 rather than a best-effort
+// non-cryptographic hash; it receives the same UTF-8 bytes as the Web Crypto branch.
+function sha256Fallback(bytes) {
+  const padded = new Uint8Array(Math.ceil((bytes.length + 9) / 64) * 64);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  let bitLength = BigInt(bytes.length) * 8n;
+  for (let index = padded.length - 1; index >= padded.length - 8; index -= 1) {
+    padded[index] = Number(bitLength & 0xffn);
+    bitLength >>= 8n;
+  }
+
+  const hash = new Uint32Array([
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+  ]);
+  const words = new Uint32Array(64);
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    for (let index = 0; index < 16; index += 1) {
+      const wordOffset = offset + index * 4;
+      words[index] =
+        (padded[wordOffset] << 24) |
+        (padded[wordOffset + 1] << 16) |
+        (padded[wordOffset + 2] << 8) |
+        padded[wordOffset + 3];
+    }
+    for (let index = 16; index < 64; index += 1) {
+      const s0 = rotateRight(words[index - 15], 7) ^ rotateRight(words[index - 15], 18) ^ (words[index - 15] >>> 3);
+      const s1 = rotateRight(words[index - 2], 17) ^ rotateRight(words[index - 2], 19) ^ (words[index - 2] >>> 10);
+      words[index] = (words[index - 16] + s0 + words[index - 7] + s1) >>> 0;
+    }
+
+    let [a, b, c, d, e, f, g, h] = hash;
+    for (let index = 0; index < 64; index += 1) {
+      const sum1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25);
+      const choose = (e & f) ^ (~e & g);
+      const temp1 = (h + sum1 + choose + SHA256_CONSTANTS[index] + words[index]) >>> 0;
+      const sum0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22);
+      const majority = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (sum0 + majority) >>> 0;
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+    hash[0] = (hash[0] + a) >>> 0;
+    hash[1] = (hash[1] + b) >>> 0;
+    hash[2] = (hash[2] + c) >>> 0;
+    hash[3] = (hash[3] + d) >>> 0;
+    hash[4] = (hash[4] + e) >>> 0;
+    hash[5] = (hash[5] + f) >>> 0;
+    hash[6] = (hash[6] + g) >>> 0;
+    hash[7] = (hash[7] + h) >>> 0;
+  }
+  return Array.from(hash, (word) => word.toString(16).padStart(8, "0")).join("");
+}
+
 export async function captionHash(caption) {
   const bytes = new TextEncoder().encode(caption ?? "");
-  const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
-  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+  if (globalThis.crypto?.subtle?.digest) {
+    const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
+    return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+  return sha256Fallback(bytes);
 }
 
 // Thumbnail badge per worst-severity (sc-6534 acceptance): ✓ good / ⚠ needs

--- a/apps/web/src/training/datasetReadiness.test.js
+++ b/apps/web/src/training/datasetReadiness.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   aestheticScore,
@@ -46,6 +46,21 @@ describe("captionHash", () => {
     expect(await captionHash("tiny test image")).toBe(
       "d93dcd03ca0197eb0ae2041bfc1b3c3b78399bb19e904c901713bcc85cc39cf7",
     );
+  });
+
+  it("uses the same SHA-256 fallback when crypto.subtle is unavailable", async () => {
+    vi.stubGlobal("crypto", undefined);
+    try {
+      expect(await captionHash("tiny test image")).toBe(
+        "d93dcd03ca0197eb0ae2041bfc1b3c3b78399bb19e904c901713bcc85cc39cf7",
+      );
+      // Locks the UTF-8 input bytes as well as the digest algorithm.
+      expect(await captionHash("snowman ☃")).toBe(
+        "06ab2a8c60adfdefc20e9f26ac58a9151eb716c8c3d34b8cf034ae1a00b0a20a",
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });
 

--- a/apps/web/src/uiPreferences.js
+++ b/apps/web/src/uiPreferences.js
@@ -65,6 +65,21 @@ let navigationDrainPromise = null;
 let navigationDrainScheduled = false;
 
 const NAVIGATION_WRITE_MAX_ATTEMPTS = 3;
+const NAVIGATION_WRITE_RETRY_BASE_DELAY_MS = 100;
+const NAVIGATION_WRITE_RETRY_MAX_DELAY_MS = 1000;
+
+function navigationWriteRetryDelay(attempt) {
+  return Math.min(
+    NAVIGATION_WRITE_RETRY_MAX_DELAY_MS,
+    NAVIGATION_WRITE_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1),
+  );
+}
+
+function waitForNavigationWriteRetry(attempt) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, navigationWriteRetryDelay(attempt));
+  });
+}
 
 function isAbort(error) {
   return error && typeof error === "object" && error.name === "AbortError";
@@ -90,6 +105,7 @@ async function putNavigationPreferencesWithRetry(patch) {
       if (attempt === NAVIGATION_WRITE_MAX_ATTEMPTS || !shouldRetryNavigationWrite(error)) {
         return;
       }
+      await waitForNavigationWriteRetry(attempt);
     }
   }
 }

--- a/apps/web/src/uiPreferences.js
+++ b/apps/web/src/uiPreferences.js
@@ -64,6 +64,36 @@ let pendingNavigationPatch = null;
 let navigationDrainPromise = null;
 let navigationDrainScheduled = false;
 
+const NAVIGATION_WRITE_MAX_ATTEMPTS = 3;
+
+function isAbort(error) {
+  return error && typeof error === "object" && error.name === "AbortError";
+}
+
+function shouldRetryNavigationWrite(error) {
+  if (isAbort(error)) {
+    return false;
+  }
+  const status = error && typeof error === "object" ? error.status : undefined;
+  if (!Number.isInteger(status)) {
+    return true;
+  }
+  return status === 408 || status === 425 || status === 429 || (status >= 500 && status < 600);
+}
+
+async function putNavigationPreferencesWithRetry(patch) {
+  for (let attempt = 1; attempt <= NAVIGATION_WRITE_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await putUiPreferences(patch);
+      return;
+    } catch (error) {
+      if (attempt === NAVIGATION_WRITE_MAX_ATTEMPTS || !shouldRetryNavigationWrite(error)) {
+        return;
+      }
+    }
+  }
+}
+
 async function drainNavigationPreferences() {
   navigationDrainScheduled = false;
   while (pendingNavigationPatch) {
@@ -71,7 +101,7 @@ async function drainNavigationPreferences() {
     pendingNavigationPatch = null;
     // Read the access token when this request starts, not when the patch was
     // enqueued. A token can be promoted or rotated while an earlier PUT is in flight.
-    await putUiPreferences(patch).catch(() => {});
+    await putNavigationPreferencesWithRetry(patch);
   }
   navigationDrainPromise = null;
 }

--- a/apps/web/src/uiPreferences.test.js
+++ b/apps/web/src/uiPreferences.test.js
@@ -86,33 +86,47 @@ describe("putUiPreferences", () => {
 });
 
 describe("persistNavigationPreferences", () => {
-  it("retries transient network and HTTP failures at the queued-write seam", async () => {
+  it("waits with bounded exponential backoff before retrying transient navigation writes and recovers", async () => {
+    vi.useFakeTimers();
     apiFetch
       .mockRejectedValueOnce(new Error("network unavailable"))
-      .mockRejectedValueOnce(Object.assign(new Error("busy"), { status: 503 }))
+      .mockRejectedValueOnce(Object.assign(new Error("throttled"), { status: 429 }))
       .mockResolvedValueOnce({});
 
-    await persistNavigationPreferences({ activeView: "Library" });
+    try {
+      const persisted = persistNavigationPreferences({ activeView: "Library" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(apiFetch).toHaveBeenCalledTimes(1);
 
-    expect(apiFetch).toHaveBeenCalledTimes(3);
+      await vi.advanceTimersByTimeAsync(99);
+      expect(apiFetch).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(apiFetch).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(199);
+      expect(apiFetch).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(1);
+      await persisted;
+
+      expect(apiFetch).toHaveBeenCalledTimes(3);
+    } finally {
+      await vi.runAllTimersAsync();
+      vi.useRealTimers();
+    }
   });
 
-  it("retries established transient HTTP statuses but not permanent client failures", async () => {
-    for (const status of [408, 425, 429, 500]) {
-      apiFetch.mockReset();
-      apiFetch
-        .mockRejectedValueOnce(Object.assign(new Error(`HTTP ${status}`), { status }))
-        .mockResolvedValueOnce({});
+  it("does not retry a permanent 4xx navigation write", async () => {
+    vi.useFakeTimers();
+    try {
+      apiFetch.mockRejectedValueOnce(Object.assign(new Error("HTTP 400"), { status: 400 }));
 
-      await persistNavigationPreferences({ activeView: `retry-${status}` });
-      expect(apiFetch).toHaveBeenCalledTimes(2);
-    }
-
-    for (const status of [400, 401, 403, 404]) {
-      apiFetch.mockReset();
-      apiFetch.mockRejectedValueOnce(Object.assign(new Error(`HTTP ${status}`), { status }));
-      await persistNavigationPreferences({ activeView: `no-retry-${status}` });
+      const persisted = persistNavigationPreferences({ activeView: "no-retry-400" });
+      await vi.advanceTimersByTimeAsync(1000);
+      await persisted;
       expect(apiFetch).toHaveBeenCalledTimes(1);
+    } finally {
+      await vi.runAllTimersAsync();
+      vi.useRealTimers();
     }
   });
 

--- a/apps/web/src/uiPreferences.test.js
+++ b/apps/web/src/uiPreferences.test.js
@@ -86,6 +86,44 @@ describe("putUiPreferences", () => {
 });
 
 describe("persistNavigationPreferences", () => {
+  it("retries transient network and HTTP failures at the queued-write seam", async () => {
+    apiFetch
+      .mockRejectedValueOnce(new Error("network unavailable"))
+      .mockRejectedValueOnce(Object.assign(new Error("busy"), { status: 503 }))
+      .mockResolvedValueOnce({});
+
+    await persistNavigationPreferences({ activeView: "Library" });
+
+    expect(apiFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries established transient HTTP statuses but not permanent client failures", async () => {
+    for (const status of [408, 425, 429, 500]) {
+      apiFetch.mockReset();
+      apiFetch
+        .mockRejectedValueOnce(Object.assign(new Error(`HTTP ${status}`), { status }))
+        .mockResolvedValueOnce({});
+
+      await persistNavigationPreferences({ activeView: `retry-${status}` });
+      expect(apiFetch).toHaveBeenCalledTimes(2);
+    }
+
+    for (const status of [400, 401, 403, 404]) {
+      apiFetch.mockReset();
+      apiFetch.mockRejectedValueOnce(Object.assign(new Error(`HTTP ${status}`), { status }));
+      await persistNavigationPreferences({ activeView: `no-retry-${status}` });
+      expect(apiFetch).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("does not retry an aborted navigation write", async () => {
+    apiFetch.mockRejectedValueOnce(Object.assign(new Error("aborted"), { name: "AbortError" }));
+
+    await persistNavigationPreferences({ activeView: "Library" });
+
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+  });
+
   it("serializes writes, coalesces the latest intent, and reads the token at request time", async () => {
     const first = deferred();
     const second = deferred();

--- a/apps/web/src/workflowShare.js
+++ b/apps/web/src/workflowShare.js
@@ -381,6 +381,32 @@ function prefillDisposition(key) {
   return ADVANCED_PREFILL[key]?.prefill ?? PREFILL_NONE;
 }
 
+// Shared workflows cross a trust boundary before they reach the number-backed controls in a
+// studio. Keep the list beside the prefill registry: these are the control values that may safely
+// be coerced to a finite number, while every other scalar retains its own meaning and shape.
+const NUMERIC_ADVANCED_PREFILL_KEYS = new Set([
+  "schedulerShift",
+  "steps",
+  "guidanceScale",
+  "ipAdapterScale",
+  "controlnetConditioningScale",
+  "trueCfgScale",
+  "strength",
+  "textStyleGain",
+  "controlScale",
+]);
+
+function sharedRecipeNumber(value) {
+  if (
+    (typeof value !== "number" && typeof value !== "string") ||
+    (typeof value === "string" && value.trim() === "")
+  ) {
+    return null;
+  }
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
 // ---- The adapter --------------------------------------------------------------------------
 
 // The seed of THIS image, as the launch's `replaySeed`.
@@ -424,7 +450,15 @@ export function recipeFromWorkflowShare(
   const rawSettings = {};
   for (const [key, value] of Object.entries(share.advanced ?? {})) {
     if (value !== null && value !== undefined && prefillDisposition(key) !== PREFILL_NONE) {
-      rawSettings[key] = value;
+      if (NUMERIC_ADVANCED_PREFILL_KEYS.has(key)) {
+        const number = sharedRecipeNumber(value);
+        if (number === null) {
+          continue;
+        }
+        rawSettings[key] = number;
+      } else {
+        rawSettings[key] = value;
+      }
     }
   }
   if (!styleIdResolved(report)) {

--- a/apps/web/src/workflowShare.test.js
+++ b/apps/web/src/workflowShare.test.js
@@ -131,6 +131,41 @@ describe("recipeFromWorkflowShare", () => {
     expect(recipe.rawAdapterSettings.sampler).toBe("euler");
   });
 
+  it("drops invalid numeric controls and restores finite values as numbers", () => {
+    const recipe = recipeFromWorkflowShare(
+      share({
+        advanced: {
+          schedulerShift: "2.5",
+          steps: 0,
+          guidanceScale: -1.25,
+          ipAdapterScale: "not a number",
+          controlnetConditioningScale: Infinity,
+          trueCfgScale: "NaN",
+          strength: "",
+          textStyleGain: {},
+          controlScale: [],
+        },
+      }),
+      report(),
+    );
+
+    expect(recipe.rawAdapterSettings).toMatchObject({
+      schedulerShift: 2.5,
+      steps: 0,
+      guidanceScale: -1.25,
+    });
+    for (const key of [
+      "ipAdapterScale",
+      "controlnetConditioningScale",
+      "trueCfgScale",
+      "strength",
+      "textStyleGain",
+      "controlScale",
+    ]) {
+      expect(recipe.rawAdapterSettings).not.toHaveProperty(key);
+    }
+  });
+
   it("always asks for ONE image, whatever batch the shared file came out of", () => {
     // The envelope's seed identifies one image; `count` came from the batch the run requested.
     // Replaying both would reproduce the shared image as the first of a 4-image batch.

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { defineConfig, searchForWorkspaceRoot } from "vite";
+import { defineConfig } from "vite";
 
 import precompressPlugin from "./vite-plugin-precompress.js";
 import bundleReportPlugin from "./vite-plugin-bundle-report.js";
@@ -25,23 +25,13 @@ const bundleBudgets = JSON.parse(
 // loader would deny it unless it's on server.fs.allow. (The production embedded
 // build resolves these via rollup and isn't gated by this.)
 const licensesDir = fileURLToPath(new URL("../desktop/licenses", import.meta.url));
-
-// The style-catalog drift-guard test (src/data/styleCatalog.test.js) imports the
-// authored documents/style.txt as ?raw to re-derive styles.json. That dir is at
-// the repo root, outside the web project root, so allow it like licensesDir.
+const webRoot = fileURLToPath(new URL(".", import.meta.url));
 const documentsDir = fileURLToPath(new URL("../../documents", import.meta.url));
-
-// The same drift-guard test also imports the backend Style manifest
-// (config/manifests/builtin.styles.jsonc, sc-13134) as ?raw to assert it stays a
-// mechanical derivation of style.txt. config/ is at the repo root, outside the web
-// project root, so allow it like documentsDir.
 const configDir = fileURLToPath(new URL("../../config", import.meta.url));
-
-// The live-preview-support drift guard (src/data/previewSupportCatalog.test.js, sc-16965) imports
-// crates/sceneworks-worker/src/engines.rs as ?raw to re-parse the MODEL_TABLE join the generator
-// reads — the same "derive from the committed bytes" shape as documents/style.txt above. crates/ is
-// at the repo root, outside the web project root, so allow it like documentsDir.
 const cratesDir = fileURLToPath(new URL("../../crates", import.meta.url));
+const testOnlyFsAllow = process.env.VITEST
+  ? [documentsDir, configDir, cratesDir]
+  : [];
 
 export default defineConfig({
   // Generate the pre-paint /theme-init.js from src/accents.js at dev/build time
@@ -71,14 +61,16 @@ export default defineConfig({
       "Cache-Control": "no-store",
     },
     fs: {
-      // Keep the default workspace-root allowance and add the desktop license
-      // corpus the Licenses screen imports from.
+      // Do not use Vite's default workspace-root allowance: a LAN-opted dev
+      // server must not turn the checkout into an /@fs/ download surface. The
+      // web root and production license corpus are the only exposed roots.
+      // Vitest's in-memory module loader needs its raw drift-guard inputs. It
+      // identifies itself with VITEST and never listens for HTTP requests, so
+      // a developer cannot enable those paths with a Vite --mode argument.
       allow: [
-        searchForWorkspaceRoot(process.cwd()),
+        webRoot,
         licensesDir,
-        documentsDir,
-        configDir,
-        cratesDir,
+        ...testOnlyFsAllow,
       ],
     },
   },

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -26,12 +26,6 @@ const bundleBudgets = JSON.parse(
 // build resolves these via rollup and isn't gated by this.)
 const licensesDir = fileURLToPath(new URL("../desktop/licenses", import.meta.url));
 const webRoot = fileURLToPath(new URL(".", import.meta.url));
-const documentsDir = fileURLToPath(new URL("../../documents", import.meta.url));
-const configDir = fileURLToPath(new URL("../../config", import.meta.url));
-const cratesDir = fileURLToPath(new URL("../../crates", import.meta.url));
-const testOnlyFsAllow = process.env.VITEST
-  ? [documentsDir, configDir, cratesDir]
-  : [];
 
 export default defineConfig({
   // Generate the pre-paint /theme-init.js from src/accents.js at dev/build time
@@ -64,13 +58,11 @@ export default defineConfig({
       // Do not use Vite's default workspace-root allowance: a LAN-opted dev
       // server must not turn the checkout into an /@fs/ download surface. The
       // web root and production license corpus are the only exposed roots.
-      // Vitest's in-memory module loader needs its raw drift-guard inputs. It
-      // identifies itself with VITEST and never listens for HTTP requests, so
-      // a developer cannot enable those paths with a Vite --mode argument.
+      // Drift guards read their repository inputs directly with Node rather
+      // than widening the configuration shared by every Vite server.
       allow: [
         webRoot,
         licensesDir,
-        ...testOnlyFsAllow,
       ],
     },
   },

--- a/apps/web/vite.config.test.js
+++ b/apps/web/vite.config.test.js
@@ -14,8 +14,7 @@ describe("Vite safe development boundary", () => {
   });
 
   it("rejects sensitive /@fs reads from a LAN-bound Vite process", () => {
-    const env = { ...process.env };
-    delete env.VITEST;
+    const env = { ...process.env, VITEST: "1" };
     const result = spawnSync(process.execPath, ["scripts/vite-safe-dev-smoke.mjs"], {
       cwd: webRoot,
       encoding: "utf8",

--- a/apps/web/vite.config.test.js
+++ b/apps/web/vite.config.test.js
@@ -1,0 +1,27 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const webRoot = process.cwd();
+const packageJson = JSON.parse(readFileSync(path.join(webRoot, "package.json"), "utf8"));
+
+describe("Vite safe development boundary", () => {
+  it("binds npm dev and preview to loopback unless --host explicitly overrides them", () => {
+    expect(packageJson.scripts.dev).toBe("vite --host 127.0.0.1");
+    expect(packageJson.scripts.preview).toBe("vite preview --host 127.0.0.1");
+  });
+
+  it("rejects sensitive /@fs reads from a LAN-bound Vite process", () => {
+    const env = { ...process.env };
+    delete env.VITEST;
+    const result = spawnSync(process.execPath, ["scripts/vite-safe-dev-smoke.mjs"], {
+      cwd: webRoot,
+      encoding: "utf8",
+      env,
+    });
+
+    expect(result.status, result.stderr || result.stdout).toBe(0);
+  });
+});


### PR DESCRIPTION
## Epic

[Shortcut epic 21898 — Code Review 2026-08-26 UI](https://app.shortcut.com/trefry/epic/21898)

Completes the independently verified UI remediation scope:

- E1 — normalize imported and external values before typed UI state
- E2 — preserve concurrent user state and report complete, partial, and failed async outcomes truthfully
- E3 — stop pollers, refreshers, persistence effects, and DOM listeners outside their lifecycle
- E4 — bound combinatorial and pointer-driven work and keep long work cancelable
- E5 — display accurate labels, units, metrics, and messages
- E6 — keep Vite loopback-only by default and deny repository `/@fs` reads in LAN mode
- E7 — behavior-level regression coverage for all 21 included findings

## Integrated story PRs

- #2621 — workflow replay and insecure-context hashing
- #2624 — Vite development exposure
- #2623 — truthful asynchronous asset operations
- #2626 — mutation failures and retry classification
- #2625 — draft isolation, metrics, text, and units
- #2628 — inactive background work cleanup
- #2627 — remount-safe zoom and scrub listeners
- #2629 — bounded prompt expansion and mask work
- #2630, #2631, #2633 — terminal integration race/cancellation fixes

## Terminal evidence

Exact feature head: `994ed9cd0c016954e4506c4514b1a1ead1a43cfe`

- `npm --prefix apps/web run lint`: pass
- `npm --prefix apps/web run test`: 276 files, 4,217 tests pass
- `npm --prefix apps/web run build`: pass
- live Vite default bind: `::1` loopback
- LAN `/@fs` smoke: config, crates, documents, encoded, and traversal variants denied
- independent feature-end review: PASS; all E1–E7 and all five integrated blockers verified
- changed behavior-test surface: 33 files / 959 tests pass
- `git diff --check`: pass
- current `main` is an ancestor of the feature head with zero main-only commits; synchronization is a no-op

Inference, pin changes, Rust backend work, and measurement campaigns are out of scope for this UI epic. No migrations or known limitations.