### PR TITLE
Fix saved quant tier hydration race

### DIFF
--- a/apps/web/src/components/generationStudio.jsx
+++ b/apps/web/src/components/generationStudio.jsx
@@ -48,6 +48,7 @@ export function useQuantTierPicker({
   autoTier = null,
   useGenerationQuality = false,
   reseedOnModelChange = false,
+  preferencesHydrated = true,
 }) {
   const [quantTier, setQuantTier] = useState("");
   const [tierSwitching, setTierSwitching] = useState("");
@@ -56,6 +57,15 @@ export function useQuantTierPicker({
   const availableTiersKey = availableTiers.join(",");
 
   useEffect(() => {
+    // The desktop webview gets a different localStorage origin on every launch. Its durable
+    // per-model tier therefore arrives asynchronously from GET /ui-preferences and is seeded into
+    // lastTierStore by App. If the model catalog wins that startup race, selecting a tier now would
+    // lock in the derived default (usually Q8); seeding the saved sticky later does not otherwise
+    // change any dependency of this effect. Wait for that authoritative seed, then re-run on the
+    // hydration edge so an already-quantized imported checkpoint does not get needlessly folded to
+    // Q8 — including its dense text encoder — merely because catalog loading happened to finish
+    // first.
+    if (!preferencesHydrated) return;
     const modelChanged = modelRef.current !== model;
     modelRef.current = model;
     if (skipReseedRef.current) {
@@ -74,7 +84,7 @@ export function useQuantTierPicker({
     // Install-state is intentionally represented by the stable key; the other values belong
     // to the render which produced it.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [model, availableTiersKey, autoTier]);
+  }, [model, availableTiersKey, autoTier, preferencesHydrated]);
 
   const timerRef = useRef(null);
   useEffect(() => () => clearTimeout(timerRef.current), []);

--- a/apps/web/src/screens/ImageStudio.jsx
+++ b/apps/web/src/screens/ImageStudio.jsx
@@ -1006,6 +1006,7 @@ export function ImageStudio() {
     tierOptions,
     autoTier,
     useGenerationQuality: true,
+    preferencesHydrated,
   });
   const possibleTiers = useMemo(
     () => allPossibleTiers(selectedModel, tierOptions),

--- a/apps/web/src/screens/VideoStudio.jsx
+++ b/apps/web/src/screens/VideoStudio.jsx
@@ -778,6 +778,7 @@ export function VideoStudio() {
     autoTier,
     useGenerationQuality: true,
     reseedOnModelChange: true,
+    preferencesHydrated,
   });
   const availableTierKey = availableTiers.join(",");
   const recipeTierTargetModel = recipeTierRequest

--- a/apps/web/src/screens/generationStudio.shared.test.jsx
+++ b/apps/web/src/screens/generationStudio.shared.test.jsx
@@ -35,6 +35,7 @@ function TierHarness({
   reseedOnModelChange = false,
   useGenerationQuality = false,
   autoTier = null,
+  preferencesHydrated = true,
 }) {
   const state = useQuantTierPicker({
     screen,
@@ -45,6 +46,7 @@ function TierHarness({
     reseedOnModelChange,
     useGenerationQuality,
     autoTier,
+    preferencesHydrated,
   });
   return (
     <div>
@@ -140,6 +142,37 @@ describe("shared generation-studio controls", () => {
       <TierHarness model="video" availableTiers={["q4", "q8", "bf16"]} screen="video" />,
     ));
     expect(container.querySelector("output").textContent).toBe("q4|");
+  });
+
+  it("waits for durable preferences before seeding instead of locking in a catalog-race default", async () => {
+    vi.mocked(readLastTier).mockReturnValue(null);
+    await act(async () => root.render(
+      <TierHarness
+        model="imported-int8"
+        availableTiers={["q4", "q8", "bf16"]}
+        screen="image"
+        useGenerationQuality
+        autoTier="q8"
+        preferencesHydrated={false}
+      />,
+    ));
+    expect(container.querySelector("output").textContent).toBe("|");
+    expect(readLastTier).not.toHaveBeenCalled();
+
+    // App seeds the server's per-model map into lastTierStore before flipping this flag.
+    vi.mocked(readLastTier).mockReturnValue("bf16");
+    await act(async () => root.render(
+      <TierHarness
+        model="imported-int8"
+        availableTiers={["q4", "q8", "bf16"]}
+        screen="image"
+        useGenerationQuality
+        autoTier="q8"
+        preferencesHydrated
+      />,
+    ));
+    expect(container.querySelector("output").textContent).toBe("bf16|");
+    expect(readLastTier).toHaveBeenCalledWith("image", "imported-int8");
   });
 
   it("persists only valid manual selections and rejects unavailable tiers", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes a startup race in the shared generation quant-tier picker. Image and Video Studio now wait for durable UI preferences to hydrate before choosing the initial tier.

Previously, the model catalog could finish first and seed the derived Q8 default. When the saved per-model tier arrived later, no picker dependency changed, so Q8 remained selected for the session. On an already-INT8 imported checkpoint this triggered a redundant load-time Q8 fold of the dense text encoder and increased cold first-image time from about 64 seconds to 136 seconds in the reproduced run.

The regression test reproduces catalog-first startup, then verifies that the hydration edge restores the saved bf16/native choice.

## Related issue

Reported directly; no linked issue.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change or feature that changes existing behavior
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

- Full web lint passed.
- Full web test suite passed: 276 files, 4,218 tests.
- Production Vite build passed.
- Focused shared-picker and quant payload suite passed: 114 tests.
- ImageStudio and VideoStudio suites passed: 188 tests.

- [ ] macOS (Apple Silicon / MLX)
- [ ] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [x] Not platform-specific (web UI, docs, shared crate)

## Checklist

- [x] Rust checks are not applicable; no Rust was changed
- [x] Web lint, test, and build passed
- [ ] I ran npm run check (scaffold checks)
- [x] Documentation is not required for this targeted UI race fix
- [x] All commits are signed off
- [x] My PR is focused on a single logical change