### PR TITLE
SC-21707: keep Windows SDXL promotion atomic without unsafe code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6813,7 +6813,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -117,12 +117,5 @@ candle-gen = { git = "https://github.com/SceneWorks/inference", rev = "26f172e71
 # have a dylib to stage.
 ort = { workspace = true, features = ["cuda"], optional = true }
 
-[target.'cfg(windows)'.dependencies]
-# Cache-only SDXL component publication must replace an existing verified entry in
-# one filesystem operation. `std::fs::rename` cannot replace on Windows, while
-# `MoveFileExW(MOVEFILE_REPLACE_EXISTING)` preserves the same publish-by-rename
-# contract used on Unix (sc-21689).
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
-
 [lints]
 workspace = true

--- a/crates/sceneworks-worker/src/image_jobs/sdxl_imported.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_imported.rs
@@ -509,40 +509,11 @@ fn mirror_cached_sdxl_component_file_with_copy(
 
 fn promote_cached_sdxl_component(staging: &Path, destination: &Path) -> std::io::Result<()> {
     // Readers see either the prior complete component or the newly copied one. The
-    // platform operations below both replace in one call; never unlink the visible
-    // destination before the staged file takes its place.
-    #[cfg(not(windows))]
-    {
-        std::fs::rename(staging, destination)
-    }
-    #[cfg(windows)]
-    {
-        use std::os::windows::ffi::OsStrExt as _;
-        use windows_sys::Win32::Storage::FileSystem::{
-            MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
-        };
-
-        let staging: Vec<u16> = staging.as_os_str().encode_wide().chain(Some(0)).collect();
-        let destination: Vec<u16> = destination
-            .as_os_str()
-            .encode_wide()
-            .chain(Some(0))
-            .collect();
-        // SAFETY: both buffers are owned, NUL-terminated UTF-16 paths and remain
-        // alive for the duration of this synchronous Win32 call.
-        let replaced = unsafe {
-            MoveFileExW(
-                staging.as_ptr(),
-                destination.as_ptr(),
-                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
-            )
-        };
-        if replaced == 0 {
-            Err(std::io::Error::last_os_error())
-        } else {
-            Ok(())
-        }
-    }
+    // tempfile's safe platform implementation atomically replaces an existing
+    // destination on both Unix and Windows. Never unlink the visible destination
+    // before the staged file takes its place.
+    tempfile::TempPath::try_from_path(staging)?.persist(destination)
+        .map_err(|error| error.error)
 }
 
 /// Compare the staged copy with its resolved pinned-HF source without buffering a

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -11197,11 +11197,11 @@ fn cache_only_sdxl_mirror_rejects_unverified_staging_before_publication() {
     );
 }
 
-/// Cross-platform mutation guard for the Windows branch. The executable test
+/// Cross-platform mutation guard for Windows publication. The executable test
 /// below runs on Windows CI; this source contract also fails on every host if
-/// unlink-then-rename is reintroduced where macOS cannot execute that branch.
+/// direct unsafe Win32 calls or unlink-then-rename are reintroduced.
 #[test]
-fn cache_only_sdxl_windows_promotion_contract_never_unlinks_destination() {
+fn cache_only_sdxl_windows_promotion_contract_is_safe_atomic_replace() {
     let source = include_str!("sdxl_imported.rs");
     let promotion = source
         .split("fn promote_cached_sdxl_component")
@@ -11211,8 +11211,16 @@ fn cache_only_sdxl_windows_promotion_contract_never_unlinks_destination() {
         .next()
         .expect("promotion helper body");
 
-    assert!(promotion.contains("MOVEFILE_REPLACE_EXISTING"));
-    assert!(promotion.contains("MoveFileExW"));
+    assert!(promotion.contains("TempPath::try_from_path(staging)"));
+    assert!(promotion.contains(".persist(destination)"));
+    assert!(
+        !source.contains("unsafe"),
+        "SDXL publication must stay within the worker's no-unsafe contract"
+    );
+    assert!(
+        !source.contains("MoveFileExW"),
+        "SDXL publication must use the safe tempfile platform API"
+    );
     assert!(
         !promotion.contains("remove_file(destination)"),
         "Windows publication must never expose an unlink gap"
@@ -11220,8 +11228,8 @@ fn cache_only_sdxl_windows_promotion_contract_never_unlinks_destination() {
 }
 
 /// Windows' standard rename cannot replace an existing destination. This runs
-/// the real Win32 replacement path and prevents the old unlink-then-rename gap
-/// from returning under the platform that needed the fallback.
+/// tempfile's safe platform replacement path and prevents the old
+/// unlink-then-rename gap from returning under the platform that needed it.
 #[cfg(all(windows, feature = "backend-candle"))]
 #[test]
 fn cache_only_sdxl_windows_promotion_replaces_existing_destination() {


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/trefry/story/21707
Final PR failure: https://github.com/SceneWorks/SceneWorks/actions/runs/33165367107/job/98829378589

Fixes the final Windows/Candle compile denial without weakening `unsafe_code = "forbid"` or reintroducing an unlink gap.

- replaces crate-local unsafe `MoveFileExW` with the existing safe `tempfile::TempPath::persist` atomic replace API
- preserves one-operation replace-existing semantics on Windows and Unix
- removes the now-unused direct worker `windows-sys` dependency
- strengthens the source contract to require safe persistence and forbid direct unsafe Win32 use or destination unlink
- retains the Windows runtime replace-existing regression

Validation:
- focused safe atomic source contract: 1/1
- focused SDXL mirror/publication family: 4/4
- full sceneworks-worker tests: 2223 unit tests plus integrations, exit 0
- `RUSTFLAGS=-F unsafe-code` strict all-target/all-feature worker Clippy
- npm run check: 744/744
- fmt, metadata, matrix/tier/pin checks green
- adversarial review cycle 3: MERGE, no P1/P2/P3, confidence 0.99

The exact Windows/Candle workflow remains the authoritative platform receipt.