### PR TITLE
fix(worker): clear final Windows Candle regressions

### DIFF
--- a/crates/sceneworks-worker/src/image_jobs/sdxl_imported.rs
+++ b/crates/sceneworks-worker/src/image_jobs/sdxl_imported.rs
@@ -485,7 +485,10 @@ fn mirror_cached_sdxl_component_file_with_copy(
     // incapable of becoming a later task's live write target.
     let staging = destination_dir.join(format!("{file}.{}.partial", Uuid::new_v4().simple()));
     copy_source(&cached, &staging)
-        .and_then(|_| std::fs::File::open(&staging))
+        // Windows' FlushFileBuffers requires a write-capable handle. File::open is
+        // read-only there and returns AccessDenied from sync_all even though the
+        // copy itself succeeded.
+        .and_then(|_| std::fs::OpenOptions::new().write(true).open(&staging))
         .and_then(|file| file.sync_all())
         .and_then(|_| {
             sdxl_component_files_match(&cached, &staging).and_then(|matches| {

--- a/crates/sceneworks-worker/src/image_jobs/tests.rs
+++ b/crates/sceneworks-worker/src/image_jobs/tests.rs
@@ -163,9 +163,12 @@ fn every_specialized_text_encoder_engine_rejects_an_unresolved_selection_before_
         "z_image_turbo_control",
         "z_image_control",
         "flux2_klein_9b",
+        #[cfg(target_os = "macos")]
         "flux2_klein_9b_edit",
+        #[cfg(target_os = "macos")]
         "flux2_klein_9b_kv_edit",
         "flux2_dev",
+        #[cfg(target_os = "macos")]
         "flux2_dev_edit",
         "flux2_dev_control",
     ] {

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -3719,7 +3719,14 @@ mod tests {
             .as_mut()
             .and_then(|contract| contract.calibration.as_mut())
             .expect("Krea provider calibration")
-            .fingerprint = "krea-turbo-cuda-phase-curves-mutated".into();
+            .fingerprint = "krea-turbo-cuda-phase-curves-v2".into();
+        assert!(
+            wrong_contract
+                .provider_contract
+                .as_ref()
+                .is_some_and(|contract| contract.conformance_errors().is_empty()),
+            "the mutation must remain a valid contract so it isolates identity mismatch"
+        );
         assert_eq!(
             run(Some(&wrong_contract)),
             Some(KreaTurboFit::Unverified {


### PR DESCRIPTION
## Summary
- open SDXL staging files with write access before `sync_all` so Windows `FlushFileBuffers` succeeds
- keep MLX-only FLUX.2 edit route IDs out of the cross-platform Candle behavior inventory while retaining Candle base-route coverage
- mutate Krea calibration to a valid distinct fingerprint so the mismatch test isolates identity

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- focused specialized text-encoder behavior test
- three cache-only SDXL mirror tests
- linked/managed SDXL route-shape test
- independent adversarial review: MERGE, confidence 0.98

## Tracker
- SC-21707