### PR TITLE
ci(windows): bound candle acceptance at sixty minutes

### DIFF
--- a/.github/workflows/windows-candle.yml
+++ b/.github/workflows/windows-candle.yml
@@ -334,19 +334,23 @@ jobs:
     # default (sc-10420). This lane is the SOLE self-hosted cuda box and
     # serializes main-push runs (github.sha concurrency), so a wedge here holds
     # that box and starves every queued PR/main run on it until the cap fires
-    # (sc-13603). Well above the healthy ~11-14 min build+test+clippy — a cold
-    # candle-kernels (nvcc) rebuild still fits comfortably.
+    # (sc-13603). The ordinary lane now carries the exhaustive worker suite,
+    # sidecar build, memory-adapter checks, Clippy, and fresh capability dump.
+    # SC-21707 measured a healthy warm PR run at 39m19s, then an exact-main push
+    # reached capability verification only after 44m19s and was killed by the old
+    # 45m cap. Sixty minutes keeps the runner bounded while preserving enough
+    # variance headroom to finish every required gate on a slower CUDA runner.
     #
     # Provisioning now keys the 240m budget on its OWN input rather than on the five-rung
     # conjunction (sc-18677): a provision-only dispatch is a supported mode, and H3's
     # component set is 144.051 GB (210.332 GB once transformer_ref joins in sc-17149) against
     # Krea q4's ~14 GB, so it is the branch that most
     # needs the long budget. Krea's two dispatch shapes keep their exact previous values --
-    # five-rung + provision 240, five-rung alone 120, everything else 45.
+    # five-rung + provision 240, five-rung alone 120, everything else 60.
     # The LTX Eros acceptance capture (sc-18902, from main) keeps its own six-hour ceiling.
     # The strictly serial 19-cell epic-20738 terminal campaign gets a job-level twelve-hour
     # ceiling; no individual step receives a timeout above GitHub's 360-minute step limit.
-    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && inputs.run_ltx_eros_acceptance && 360 || github.event_name == 'workflow_dispatch' && inputs.run_epic_20738_terminal_cuda && 720 || github.event_name == 'workflow_dispatch' && inputs.provision_snapshot && 240 || github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && 120 || 45 }}
+    timeout-minutes: ${{ github.event_name == 'workflow_dispatch' && inputs.run_ltx_eros_acceptance && 360 || github.event_name == 'workflow_dispatch' && inputs.run_epic_20738_terminal_cuda && 720 || github.event_name == 'workflow_dispatch' && inputs.provision_snapshot && 240 || github.event_name == 'workflow_dispatch' && inputs.run_five_rung_reference && 120 || 60 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Refuse combined manual measurement profiles

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -380,18 +380,18 @@ test("windows-candle rebuilds the exact Krea snapshot path from the generalized 
   assert.match(workflow, /if \(\$isKrea -and \$env:KREA_ROOT_OVERRIDE\) \{/);
 });
 
-// sc-18677/sc-20974: the provisioning and terminal timeout arms are load-bearing. Pin the whole
-// expression the way the macOS twin above pins its lane's -- otherwise either a revert to the
-// ordinary 45m cap or the terminal campaign's observed 360m cutoff passes every other test here.
-test("windows-candle keeps the terminal, provisioning, and five-rung timeout budgets", async () => {
+// sc-18677/sc-20974/sc-21707: every timeout arm is load-bearing. Pin the whole expression the way
+// the macOS twin above pins its lane's -- otherwise either a revert to the ordinary 45m cap or the
+// terminal campaign's observed 360m cutoff passes every other test here.
+test("windows-candle keeps the ordinary, terminal, provisioning, and five-rung timeout budgets", async () => {
   const workflow = await source(".github/workflows/windows-candle.yml");
   const runbook = await source("docs/epic-20738-terminal-cuda.md");
   const timeoutContract =
-    /timeout-minutes: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.run_ltx_eros_acceptance && 360 \|\| github\.event_name == 'workflow_dispatch' && inputs\.run_epic_20738_terminal_cuda && 720 \|\| github\.event_name == 'workflow_dispatch' && inputs\.provision_snapshot && 240 \|\| github\.event_name == 'workflow_dispatch' && inputs\.run_five_rung_reference && 120 \|\| 45 \}\}/;
+    /timeout-minutes: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.run_ltx_eros_acceptance && 360 \|\| github\.event_name == 'workflow_dispatch' && inputs\.run_epic_20738_terminal_cuda && 720 \|\| github\.event_name == 'workflow_dispatch' && inputs\.provision_snapshot && 240 \|\| github\.event_name == 'workflow_dispatch' && inputs\.run_five_rung_reference && 120 \|\| 60 \}\}/;
   assert.match(
     workflow,
     // The LTX Eros arm (SC-18902, from main) keeps six hours, while the strictly serial
-    // 19-cell terminal campaign gets twelve. Provisioning, five-rung, and default stay fixed.
+    // 19-cell terminal campaign gets twelve. Provisioning, five-rung, and the 60m default stay fixed.
     timeoutContract,
   );
   assert.match(
@@ -402,9 +402,11 @@ test("windows-candle keeps the terminal, provisioning, and five-rung timeout bud
 
   const terminalArm =
     "github.event_name == 'workflow_dispatch' && inputs.run_epic_20738_terminal_cuda && 720";
+  const ordinaryArm = "inputs.run_five_rung_reference && 120 || 60";
   for (const [name, mutated] of [
     ["terminal timeout regressed to 360", workflow.replace(terminalArm, terminalArm.replace("720", "360"))],
     ["terminal timeout arm removed", workflow.replace(` || ${terminalArm}`, "")],
+    ["ordinary timeout regressed to 45", workflow.replace(ordinaryArm, ordinaryArm.replace("60", "45"))],
   ]) {
     assert.notEqual(mutated, workflow, `${name} mutation must modify the workflow fixture`);
     assert.throws(


### PR DESCRIPTION
## Summary
- raise only the ordinary Windows Candle job timeout from 45 to 60 minutes
- preserve all coverage, ordering, runner/concurrency behavior, and special 120/240/360/720-minute dispatch budgets
- pin the 60-minute fallback with a discriminating regression mutation

## Evidence
- post-merge run 33188951645 reached capability verification only after 44m19s of successful required work and was cancelled at the 45m cap
- full worker suite: 1,911 passed / 0 failed; sidecar, adapter, and Clippy passed
- `node --test scripts/platform-review-contracts.test.mjs`: 74/74 passed
- `actionlint .github/workflows/windows-candle.yml`: passed
- independent adversarial review: MERGE, confidence 0.98, no findings

## Tracker
- SC-21707