### PR TITLE
fix(worker): stop charging every image job for work already done

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7200,6 +7200,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+ "sha2-asm",
 ]
 
 [[package]]
@@ -7211,6 +7212,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/apps/web/src/workers.js
+++ b/apps/web/src/workers.js
@@ -16,9 +16,17 @@
  *   architecture: "cuda" | "mps" | "mlx" | null
  *   gpuLabel:     the human-readable GPU/device label (e.g. "Apple M2 Ultra")
  *
- * Vendor + architecture are best-effort heuristics over `worker.gpuName`. The
- * worker contract does not carry these as separate fields today; if it grows
- * them, switch to using them directly.
+ * `gpuId` is the authoritative field and is consulted FIRST: the worker publishes
+ * it (`gpu.rs` — the native Apple-Silicon worker is literally `"mlx"`), so the
+ * runtime never has to be inferred from a display string. Before this, the name
+ * heuristic below owned the answer alone and its Apple branch was hardcoded to
+ * `"mps"` — so the MLX worker, whose `gpuName` is "Apple Silicon (MLX)", matched
+ * on the word "Apple" and rendered as MPS. Nothing runs on MPS: the Python
+ * torch/MPS worker is no longer spawned at all (`apps/desktop/src/setup.rs`).
+ *
+ * Vendor + architecture stay best-effort heuristics over `worker.gpuName` for
+ * every worker `gpuId` does not name, which is what still classifies CUDA (whose
+ * ids are device indices, not a runtime) and the legacy MPS descriptor.
  */
 export function deriveWorkerHardware(worker) {
   if (!worker) {
@@ -32,6 +40,11 @@ export function deriveWorkerHardware(worker) {
 
   if (!isGpu) {
     return { device, vendor: null, architecture: null, gpuLabel };
+  }
+
+  const gpuId = (worker.gpuId ?? worker.gpu_id ?? "").trim().toLowerCase();
+  if (gpuId === "mlx") {
+    return { device, vendor: "Apple", architecture: "mlx", gpuLabel };
   }
 
   const name = (gpuLabel ?? "").toLowerCase();

--- a/apps/web/src/workers.test.jsx
+++ b/apps/web/src/workers.test.jsx
@@ -22,6 +22,15 @@ const appleWorker = {
   utilization: { memoryUsedMb: 30000, memoryTotalMb: 64000, gpuLoadPercent: 41 },
 };
 
+// The real native macOS worker: `gpu.rs` publishes exactly this id and name.
+const mlxWorker = {
+  id: "worker-mlx-1",
+  gpuId: "mlx",
+  gpuName: "Apple Silicon (MLX)",
+  capabilities: ["gpu", "image_generate"],
+  utilization: { memoryUsedMb: 30000, memoryTotalMb: 131072, gpuLoadPercent: 88 },
+};
+
 const cpuWorker = {
   id: "worker-cpu-1",
   gpuId: "cpu-0",
@@ -39,7 +48,26 @@ describe("deriveWorkerHardware", () => {
     });
   });
 
-  it("identifies Apple Silicon GPUs as MPS", () => {
+  it("identifies the native Apple Silicon worker as MLX from its gpuId", () => {
+    expect(deriveWorkerHardware(mlxWorker)).toMatchObject({
+      device: "GPU",
+      vendor: "Apple",
+      architecture: "mlx",
+      gpuLabel: "Apple Silicon (MLX)",
+    });
+  });
+
+  // The gpuId is authoritative precisely BECAUSE the name is not: "Apple Silicon (MLX)"
+  // matches the same Apple branch that answers "mps" for the legacy descriptor below, so
+  // a name-only derivation cannot tell the two runtimes apart and labelled every Apple
+  // worker MPS.
+  it("does not let the Apple name heuristic override an MLX gpuId", () => {
+    expect(deriveWorkerHardware({ ...mlxWorker, gpuName: "Apple M2 Ultra" })).toMatchObject({
+      architecture: "mlx",
+    });
+  });
+
+  it("identifies the legacy Apple MPS descriptor as MPS", () => {
     expect(deriveWorkerHardware(appleWorker)).toMatchObject({
       device: "GPU",
       vendor: "Apple",

--- a/crates/sceneworks-core/Cargo.toml
+++ b/crates/sceneworks-core/Cargo.toml
@@ -51,6 +51,25 @@ remove_dir_all = "=0.8.4"
 # cache uses volume + file index to distinguish atomic replacement.
 winapi-util = "0.1"
 
+[target.'cfg(all(target_arch = "aarch64", target_vendor = "apple"))'.dependencies]
+# ARMv8 SHA-2 instructions for the resolved-cache closure verify (sc-21534's load boundary).
+# Without `asm`, sha2 0.10's aarch64 backend is not compiled in at all and every hash runs the
+# portable software compressor. Measured on one 6.0 GB Krea shard on an Apple Silicon host:
+# 0.54 GB/s soft vs 2.97 GB/s with `asm` — same digest, 5.2x. On a 33 GB bundle that is the
+# difference between a ~60 s verify and a ~11 s one.
+#
+# Target-gated, and deliberately narrow. The feature pulls in `sha2-asm`, whose build script
+# hands GNU-syntax `.S` files to `cc` with `-c`; under MSVC that is `cl.exe`, which assembles
+# neither, so enabling this workspace-wide would break the Windows candle lane at link time
+# rather than in review. `aarch64-apple` is exactly where the hot path runs (the MLX worker's
+# resolved cache) and exactly where the in-crate intrinsics backend is selected.
+#
+# Cargo unifies features across the graph per target, so this single declaration is what every
+# member that hashes (worker, desktop, api, memory-adapter) compiles against on this target —
+# the same union hazard `image` is hoisted to `[workspace.dependencies]` for. It cannot be
+# hoisted the same way because `[workspace.dependencies]` entries carry no target cfg.
+sha2 = { version = "0.10", features = ["asm"] }
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 # Descriptor-relative filesystem operations keep resolved-cache staging publication and cleanup

--- a/crates/sceneworks-core/src/model_artifacts.rs
+++ b/crates/sceneworks-core/src/model_artifacts.rs
@@ -127,6 +127,59 @@ impl ArtifactFile {
     }
 }
 
+/// One closure file's on-disk stat identity: what it is called inside the bundle, how large it is,
+/// and when it was last written.
+///
+/// The triple deliberately mirrors `imports::ModelFileIdentity`, the same shape the imported-model
+/// attribution marker has used to decide whether a cached SHA-256 still describes a file. Size
+/// catches a truncation that preserved the timestamp; mtime catches a rewrite that preserved the
+/// length. Together they are what an ordinary write to a file cannot avoid changing.
+///
+/// This is drift detection, not an authenticity proof: anything that can rewrite a bundle file and
+/// restore its mtime can also rewrite the journal that records this observation. The threat it is
+/// built for is the real one — a bundle that changed underneath the cache — and for that it is
+/// exact.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ClosureFileStat {
+    pub relative_path: String,
+    pub size_bytes: u64,
+    pub modified_nanos: String,
+}
+
+impl ClosureFileStat {
+    fn observe(relative_path: String, path: &Path) -> Result<Self, ArtifactContractError> {
+        let metadata = std::fs::metadata(path).map_err(|error| {
+            ArtifactContractError(format!(
+                "artifact closure file {} is unavailable: {error}",
+                path.display()
+            ))
+        })?;
+        let modified_nanos = metadata
+            .modified()
+            .map_err(|error| {
+                ArtifactContractError(format!(
+                    "artifact closure file {} has no modification time: {error}",
+                    path.display()
+                ))
+            })?
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|error| {
+                ArtifactContractError(format!(
+                    "artifact closure file {} is modified before the epoch: {error}",
+                    path.display()
+                ))
+            })?
+            .as_nanos()
+            .to_string();
+        Ok(Self {
+            relative_path,
+            size_bytes: metadata.len(),
+            modified_nanos,
+        })
+    }
+}
+
 /// One concrete member of the immutable bundle closure. Optional components appear here only
 /// after selection; later materialization never has to infer them from a manifest.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -248,6 +301,39 @@ impl ResolvedBundleClosure {
             }
         }
         Ok(())
+    }
+
+    /// The closure's on-disk stat identity under `root`: one entry per file, keyed by the same
+    /// bundle-relative path [`Self::validate_at_root`] resolves, carrying size and mtime.
+    ///
+    /// This is the cheap observation a content-hash receipt is judged against — see
+    /// `resolved_cache::ClosureContentReceipt`. It walks and confines paths through exactly the
+    /// same `rebase_under` composition as the validating pass, so the two cannot disagree about
+    /// WHICH files make up the closure; it simply stats each one instead of reading it.
+    ///
+    /// Sorted by relative path so two observations of the same closure compare equal regardless of
+    /// member ordering.
+    pub fn stat_identity_at_root(
+        &self,
+        root: &Path,
+    ) -> Result<Vec<ClosureFileStat>, ArtifactContractError> {
+        self.validate_canonical()?;
+        let root = canonical_or_absolute(root)?;
+        let mut stats = Vec::new();
+        for member in &self.members {
+            member.validate()?;
+            let member_root = rebase_under(&root, &member.destination)?;
+            for file in &member.files {
+                let path = rebase_under(&member_root, &file.relative_path)?;
+                let relative_path = portable_relative_path(
+                    &member.destination.join(&file.relative_path),
+                    "artifact output file",
+                )?;
+                stats.push(ClosureFileStat::observe(relative_path, &path)?);
+            }
+        }
+        stats.sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        Ok(stats)
     }
 
     /// Resolve every member from its exact repository, immutable revision and source subpath.

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -43,6 +43,17 @@ pub const RESOLVED_CACHE_MAX_BYTES_ENV: &str = "SCENEWORKS_RESOLVED_CACHE_MAX_BY
 pub const RESOLVED_CACHE_INACTIVITY_SECONDS_ENV: &str =
     "SCENEWORKS_RESOLVED_CACHE_INACTIVITY_SECONDS";
 pub const RESOLVED_CACHE_STORE_VERSION: u32 = 1;
+/// How long a recorded content verdict ([`ClosureContentReceipt`]) may stand before the load
+/// boundary re-reads the bundle regardless of its stat identity. 24 hours.
+///
+/// The bound exists for the failure the stat identity cannot see: bytes that change with no
+/// filesystem write behind them. A working session re-uses one verdict throughout and never pays
+/// the hash twice; a bundle left in the cache is re-proved daily, so decay surfaces as a refusal
+/// and a fall back to the source tier instead of being served indefinitely.
+///
+/// Cheap enough to be worth it now that the hash runs on the hardware SHA-2 backend: the largest
+/// bundle here is 33 GB, which is ~11s once a day rather than ~61s per job.
+pub const CONTENT_RECEIPT_MAX_AGE_SECONDS: u64 = 24 * 60 * 60;
 /// The journal version a DERIVED entry is written at (sc-20635).
 ///
 /// `production` and `derivedFrom` widen the metadata document, and `ResolvedCacheMetadata` is
@@ -406,6 +417,20 @@ pub struct ResolvedCacheMetadata {
 /// safe in every direction a sidecar can fail: unreadable, unparseable, forward-versioned, or
 /// belonging to another entry all mean "no verdict", which is precisely the pre-receipt behaviour of
 /// re-reading the bytes.
+///
+/// ## Why the verdict expires
+///
+/// Stat identity detects a WRITE. It cannot detect bytes that changed without one — bit rot, a
+/// failing cable or enclosure, a drive rewriting a sector under it. Before receipts, every job
+/// re-read the bundle, so that class was caught on the next generation by accident rather than by
+/// design. A verdict with no expiry would replace "caught on the next job" with "never caught
+/// again", because the sidecar outlives restarts and nothing else on the load path reads the bytes.
+///
+/// That is not a hypothetical here: the cache exists to front a model library that can live on
+/// external USB media, which is exactly where silent decay is the plausible failure and a mtime-
+/// restoring writer is not. So a verdict is redeemable only for [`CONTENT_RECEIPT_MAX_AGE_SECONDS`]
+/// — long enough that a working session never re-hashes, short enough that a rotting bundle is
+/// re-proved and refused rather than served forever.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ClosureContentReceipt {
@@ -2795,6 +2820,19 @@ fn validate_metadata_shape_with(
 /// Every caller holds the entry's metadata lock, which is what makes the read-decide-write below a
 /// single transition rather than three racing ones. Entries that predate receipts simply have none:
 /// their first acquisition after upgrade hashes once, as today, and stamps.
+/// Whether a recorded verdict has stood longer than [`CONTENT_RECEIPT_MAX_AGE_SECONDS`].
+///
+/// Fails CLOSED in both odd directions. A receipt stamped in the future — a clock that moved
+/// backwards, or a bundle copied in from another machine — has no meaningful age, so it expires
+/// rather than being honoured indefinitely; the cost is one re-hash.
+fn receipt_expired(receipt: &ClosureContentReceipt) -> Result<bool, ResolvedCacheError> {
+    let now = now_seconds()?;
+    let Some(age) = now.checked_sub(receipt.verified_at) else {
+        return Ok(true);
+    };
+    Ok(age >= CONTENT_RECEIPT_MAX_AGE_SECONDS)
+}
+
 fn validate_complete_metadata(
     store: &ResolvedCacheStore,
     metadata: &ResolvedCacheMetadata,
@@ -2811,7 +2849,7 @@ fn validate_complete_metadata(
         .ok();
     let recorded = store.read_content_receipt(&digest, &metadata.cache_key);
     if let (Some(recorded), Some(before)) = (&recorded, &before) {
-        if &recorded.files == before {
+        if &recorded.files == before && !receipt_expired(recorded)? {
             return validate_complete_metadata_inner(
                 store,
                 metadata,
@@ -2863,7 +2901,8 @@ fn validate_complete_metadata(
 /// cache at startup, the same whole-cache cost sc-19712 F-3 removed from job submission; byte
 /// accounting needs sizes, and every caller that ACTS on a summary re-proves it under fresh
 /// locks). An invalid managed entry degrades to `Corrupt` in either mode so it cannot hide valid
-/// entries or stop their recovery/retention; load acquisition still re-hashes every file.
+/// entries or stop their recovery/retention; load acquisition re-hashes whenever the recorded
+/// verdict does not still describe the bundle (see [`validate_complete_metadata`]).
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum EntryListing {
     Runtime,
@@ -2881,8 +2920,12 @@ impl EntryListing {
 /// How thoroughly a complete entry's own bundle bytes are re-verified.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ContentVerification {
-    /// Re-reads and re-hashes every bundle file. Required before handing an artifact to a runtime
-    /// load, and the cost is proportional to the bundle size.
+    /// Re-reads and re-hashes every bundle file. The cost is proportional to the bundle size.
+    ///
+    /// The load boundary selects this mode whenever it cannot redeem a recorded verdict — see
+    /// [`validate_complete_metadata`] and [`ClosureContentReceipt`] — which is the case on a first
+    /// acquisition, after any change to the closure's stat identity, and once a standing verdict
+    /// passes [`CONTENT_RECEIPT_MAX_AGE_SECONDS`]. It is no longer entered on *every* acquisition.
     RehashEveryFile,
     /// Validates identity, shape, confinement, file presence and sizes, but does not re-hash file
     /// contents. Used by every path that is *reading* rather than loading: journal slot selection,
@@ -2892,11 +2935,18 @@ enum ContentVerification {
     /// model loads.
     ///
     /// This mode is safe on a read path only because it is never the last word: the load boundary
-    /// ([`ResolvedCacheStore::acquire_complete`]) re-verifies at [`Self::RehashEveryFile`] under
-    /// the entry's locks before any bytes reach a runtime, and every boundary that stamps
-    /// `Complete` content (`record_complete`, `publish_staged`, `recover`'s receipt resurrection)
-    /// proves the bytes itself immediately before writing. Do not weaken the load boundary — it
-    /// is what this mode leans on.
+    /// ([`ResolvedCacheStore::acquire_complete`]) is the one place that proves content, and every
+    /// boundary that stamps `Complete` content (`record_complete`, `publish_staged`, `recover`'s
+    /// receipt resurrection) proves the bytes itself immediately before writing. Do not weaken the
+    /// load boundary — it is what this mode leans on.
+    ///
+    /// What the load boundary now guarantees, precisely, because it is no longer "re-hash every
+    /// time": every acquisition runs THIS mode's checks, and it re-reads the bytes unless a
+    /// recorded verdict covers them — same closure, same per-file size and mtime, taken less than
+    /// [`CONTENT_RECEIPT_MAX_AGE_SECONDS`] ago. So an alteration that moves any of that is still
+    /// refused on the next load, and one that moves none of it is still caught, but within the
+    /// max-age rather than on the very next job. Widening that window, or dropping the age bound,
+    /// is what "weakening the load boundary" would now mean.
     PathsAndSizesOnly,
 }
 

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -21,8 +21,8 @@ pub use retention::{
 
 use crate::model_artifacts::{
     ActiveArtifactLease, ArtifactAvailability, ArtifactCompleteness, ArtifactIdentity,
-    ArtifactLocation, ArtifactProvenance, ModelArtifactResolver, PromotionCandidate,
-    ResolvedBundleClosure, ResolvedBundleMember, ResolvedModelArtifact,
+    ArtifactLocation, ArtifactProvenance, ClosureFileStat, ModelArtifactResolver,
+    PromotionCandidate, ResolvedBundleClosure, ResolvedBundleMember, ResolvedModelArtifact,
     MODEL_ARTIFACT_CONTRACT_VERSION,
 };
 use fs2::FileExt;
@@ -383,6 +383,38 @@ pub struct ResolvedCacheMetadata {
     pub session_id: Option<String>,
     pub recovery_status: RecoveryStatus,
     pub source_volume: SourceVolumeObservation,
+}
+
+/// A recorded verdict from the load boundary: at `verified_at`, every file in the closure was read
+/// and matched its recorded SHA-256, while the closure looked exactly like `files` on disk.
+///
+/// The verdict is only redeemable while that second half still holds. `files` is therefore not
+/// bookkeeping — it is the entire precondition, and it is compared in full (membership included, so
+/// an added or removed closure file invalidates the receipt just as a rewritten one does).
+///
+/// ## Why this is a sidecar and not a metadata field
+///
+/// [`ResolvedCacheMetadata`] is `deny_unknown_fields`, and the journal keeps only two slots. Adding
+/// a field there would mean that after two acquisitions BOTH slots carry it — and an older build,
+/// which is exactly the build a rollback runs, would then find zero readable slots and report
+/// `BOTH_METADATA_SLOTS_CORRUPT` for every entry it had been serving happily. Corrupt is the one
+/// classification manual removal is allowed to clear, so a downgrade would invite deleting (and
+/// re-copying) an otherwise perfect cache: here, 139 GB of it.
+///
+/// A sidecar file keeps the journal byte-identical to what every existing build already writes, so
+/// a downgrade sees a store it fully understands and simply ignores one extra file. It also fails
+/// safe in every direction a sidecar can fail: unreadable, unparseable, forward-versioned, or
+/// belonging to another entry all mean "no verdict", which is precisely the pre-receipt behaviour of
+/// re-reading the bytes.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ClosureContentReceipt {
+    pub schema_version: u32,
+    /// The entry this verdict was recorded for. The file already lives in a digest-keyed directory,
+    /// so this is defence in depth against a receipt that was copied rather than written here.
+    pub cache_key: String,
+    pub verified_at: u64,
+    pub files: Vec<ClosureFileStat>,
 }
 
 impl ResolvedCacheMetadata {
@@ -1051,6 +1083,10 @@ impl ResolvedCacheStore {
             recovery_status: RecoveryStatus::Clean,
             source_volume: self.compare_source_volume(source_configured_path)?,
         };
+        // A reservation is about to (re)write this entry's bundle, so any verdict recorded for the
+        // bytes that were there is void. Removing it here rather than trusting the stat comparison
+        // to notice keeps the receipt's lifetime tied to the bundle's, and costs one unlink.
+        self.remove_content_receipt(&digest)?;
         if let Ok(existing) = self.read_metadata_locked(&digest) {
             metadata.created_at = existing.created_at;
             metadata.artifact_pinned = existing.artifact_pinned;
@@ -1269,6 +1305,12 @@ impl ResolvedCacheStore {
         // bf16 4.5-minute verify that outlasted the stale-worker sweep). The property is pinned by
         // `the_local_tier_scan_skips_content_hashing_while_the_lease_boundary_still_refuses_altered_bytes`
         // and the single-pass cost by `the_load_boundary_hashes_the_closure_exactly_once`.
+        //
+        // The pass is now receipt-gated (see `validate_complete_metadata`): it still refuses an
+        // altered bundle, but it re-reads the bytes only when the closure's stat identity differs
+        // from the one the last successful verification recorded. It reads and stamps that verdict
+        // under the `metadata_lock` held above — the same lock the usage stamp below is written
+        // under — so a verdict is never recorded without the lock that made it true.
         validate_complete_metadata(self, &metadata)?;
         let artifact = Arc::new(metadata.artifact.clone());
         let runtime_lease = resolver
@@ -1783,6 +1825,44 @@ impl ResolvedCacheStore {
         })?;
         envelope.validate()?;
         Ok(envelope.metadata)
+    }
+
+    fn content_receipt_path(&self, digest: &str) -> PathBuf {
+        self.inner
+            .root
+            .join("entries")
+            .join(digest)
+            .join("content.verification.json")
+    }
+
+    /// The recorded content verdict for this entry, or `None` for every reason there might not be
+    /// one.
+    ///
+    /// Deliberately infallible-by-collapse: absent, unreadable, unparseable, written by a newer
+    /// build, or carrying another entry's key all return `None`. Each of those means the caller
+    /// re-reads the closure, which is both the safe answer and the behaviour that predates
+    /// receipts — so there is no failure here worth propagating to a load.
+    fn read_content_receipt(&self, digest: &str, cache_key: &str) -> Option<ClosureContentReceipt> {
+        let body = std::fs::read(self.content_receipt_path(digest)).ok()?;
+        let receipt: ClosureContentReceipt = serde_json::from_slice(&body).ok()?;
+        (receipt.schema_version == RESOLVED_CACHE_STORE_VERSION && receipt.cache_key == cache_key)
+            .then_some(receipt)
+    }
+
+    fn write_content_receipt(
+        &self,
+        digest: &str,
+        receipt: &ClosureContentReceipt,
+    ) -> Result<(), ResolvedCacheError> {
+        atomic_write_json(&self.content_receipt_path(digest), receipt)
+    }
+
+    fn remove_content_receipt(&self, digest: &str) -> Result<(), ResolvedCacheError> {
+        match std::fs::remove_file(self.content_receipt_path(digest)) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
     }
 
     fn write_corrupt_marker(&self, digest: &str) -> Result<(), ResolvedCacheError> {
@@ -2690,11 +2770,91 @@ fn validate_metadata_shape_with(
     Ok(())
 }
 
+/// Full-strength validation of a complete entry, with the content re-read gated on a receipt.
+///
+/// sc-21534 established that this is the ONE boundary that must refuse a content-altered bundle,
+/// and it earned that by re-hashing the whole closure. The cost of asking, though, was paid on
+/// every acquisition rather than every change: a 19 GB bundle measured ~61 s of SHA-256 between
+/// "Worker claimed job" and "Preparing N image(s)", on a bundle whose bytes had not moved since the
+/// last job asked the same question and got the same answer.
+///
+/// So the answer is now recorded. A successful content pass stamps the closure's stat identity
+/// (`ClosureFileStat` — bundle-relative path, size, mtime, per file) into the entry's
+/// [`ClosureContentReceipt`] sidecar, and a later acquisition that observes the SAME identity is
+/// entitled to the recorded verdict without re-reading the bytes. Anything else — a receipt that is
+/// absent or unreadable, a file whose size or mtime moved, a closure whose membership changed —
+/// falls straight back to the full re-hash and re-stamps.
+///
+/// What is NOT weakened: the paths-and-sizes pass still runs unconditionally on both branches, so
+/// presence, sizes, confinement, closure shape, artifact identity and `verified_bytes` are proven
+/// at every acquisition exactly as before. The receipt only ever elides re-reading bytes that no
+/// filesystem operation has touched. A write to a bundle file cannot leave both size and mtime
+/// unchanged by accident, which is the drift this boundary exists to catch (see `ClosureFileStat`
+/// for what this does and does not claim).
+///
+/// Every caller holds the entry's metadata lock, which is what makes the read-decide-write below a
+/// single transition rather than three racing ones. Entries that predate receipts simply have none:
+/// their first acquisition after upgrade hashes once, as today, and stamps.
 fn validate_complete_metadata(
     store: &ResolvedCacheStore,
     metadata: &ResolvedCacheMetadata,
 ) -> Result<(), ResolvedCacheError> {
-    validate_complete_metadata_inner(store, metadata, ContentVerification::RehashEveryFile)
+    let digest = cache_key_digest(&metadata.cache_key)?;
+    let bundle = store.bundle_path(&metadata.cache_key)?;
+    // Observed BEFORE the decision, so the same observation is what the receipt is judged against
+    // and what a fresh receipt would record. A stat failure here is not diagnosed: it means the
+    // closure is not intact, and `validate_complete_metadata_inner` below says so precisely.
+    let before = metadata
+        .artifact
+        .closure
+        .stat_identity_at_root(&bundle)
+        .ok();
+    let recorded = store.read_content_receipt(&digest, &metadata.cache_key);
+    if let (Some(recorded), Some(before)) = (&recorded, &before) {
+        if &recorded.files == before {
+            return validate_complete_metadata_inner(
+                store,
+                metadata,
+                ContentVerification::PathsAndSizesOnly,
+            );
+        }
+    }
+
+    // Retract first. A verdict that no longer describes the bundle must not survive the pass that
+    // is about to re-decide it — least of all if that pass fails and leaves this entry to be read
+    // again by something that would have trusted the stale answer.
+    store.remove_content_receipt(&digest)?;
+    validate_complete_metadata_inner(store, metadata, ContentVerification::RehashEveryFile)?;
+
+    // Re-observe AFTER the read and require both observations to agree before recording a verdict
+    // — the same before/after guard `bind_or_probe_validated` uses around a library probe and
+    // `trusted_imported_model_hash` uses around a checkpoint hash. Without it a file rewritten
+    // mid-pass could have its POST-write stat identity stamped as "these bytes were verified",
+    // which is precisely the claim the receipt must never make falsely.
+    let Some(before) = before else {
+        // The closure hashed clean but could not be stat-ed as a whole. Nothing to record; the next
+        // acquisition re-hashes, which is exactly the behaviour before receipts existed.
+        return Ok(());
+    };
+    let after = metadata
+        .artifact
+        .closure
+        .stat_identity_at_root(&bundle)
+        .map_err(|error| ResolvedCacheError::new(error.to_string()))?;
+    if before != after {
+        return Err(ResolvedCacheError::new(
+            "cache bundle changed while its contents were being verified",
+        ));
+    }
+    store.write_content_receipt(
+        &digest,
+        &ClosureContentReceipt {
+            schema_version: RESOLVED_CACHE_STORE_VERSION,
+            cache_key: metadata.cache_key.clone(),
+            verified_at: now_seconds()?,
+            files: after,
+        },
+    )
 }
 
 /// How a whole-store listing treats complete entries. `Runtime` is the internal listing used by

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -295,6 +295,182 @@ fn the_load_boundary_hashes_the_closure_exactly_once() {
     );
 }
 
+/// The load boundary hashes once per CHANGE, not once per load — and still refuses a bundle that
+/// changed.
+///
+/// Hashing exactly once per acquisition (pinned above) still charged every job the full read: a
+/// 19 GB bundle measured ~61 s of SHA-256 between the claim and "Preparing N image(s)", re-proving
+/// bytes that had not moved since the previous job proved them. The verdict is now recorded
+/// alongside the closure's stat identity and reused while that identity holds.
+///
+/// All three properties are asserted together on purpose. "Reuses the verdict" and "still refuses
+/// altered bytes" are the two halves of the same tradeoff, and a test that pinned only the first
+/// would stay green if the receipt were reused unconditionally — which is precisely the defect
+/// worth guarding against.
+#[test]
+fn a_recorded_verdict_is_reused_while_the_closure_is_untouched_and_dropped_when_it_changes() {
+    let scratch = TempDir::new().unwrap();
+    let source = scratch.path().join("source");
+    let data = scratch.path().join("data");
+    std::fs::create_dir(&source).unwrap();
+    let store = ResolvedCacheStore::open(&data).unwrap();
+    let candidate = hub_layout_candidate(&source, REVISION_A);
+    let materializer = ResolvedCacheMaterializer::new(store.clone());
+    let published = match materializer
+        .materialize(
+            &candidate,
+            &source,
+            "fixture:model",
+            &MaterializationCancellation::default(),
+        )
+        .unwrap()
+    {
+        MaterializationOutcome::Published(metadata) => *metadata,
+        other => panic!("fixture bundle was not published: {other:?}"),
+    };
+    let hashed_files = published
+        .artifact
+        .closure
+        .members
+        .iter()
+        .flat_map(|member| member.files.iter())
+        .filter(|file| file.sha256.is_some())
+        .count() as u64;
+    assert!(
+        hashed_files >= 1,
+        "the fixture must record content digests or the counts below are vacuous"
+    );
+
+    let registry = ActiveArtifactLeaseRegistry::default();
+    let resolver = resolver(&source, registry.clone());
+
+    // A freshly published entry carries no verdict, so the first acquisition pays the full read.
+    let (lease, first) = crate::model_artifacts::observe_content_hashes(|| {
+        store.acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
+    });
+    assert_eq!(
+        first, hashed_files,
+        "the first acquisition of a bundle with no recorded verdict must read every file"
+    );
+    drop(
+        lease
+            .unwrap()
+            .expect("the first acquisition must issue a lease"),
+    );
+
+    // Nothing has touched the bundle, so the recorded verdict still describes it.
+    let (lease, second) = crate::model_artifacts::observe_content_hashes(|| {
+        store.acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
+    });
+    assert!(
+        lease.unwrap().is_some(),
+        "reusing the recorded verdict must still issue the lease"
+    );
+    assert_eq!(
+        second, 0,
+        "a bundle whose stat identity is unchanged must not be re-read — this is the whole cost \
+         the receipt exists to remove"
+    );
+
+    // Same length, different bytes: paths-and-sizes alone cannot see this, so only the receipt
+    // being invalidated by the changed mtime routes it back to the full read that refuses it.
+    let bundle_file = store
+        .bundle_path(&candidate.cache_key)
+        .unwrap()
+        .join(&candidate.artifact.closure.members[0].destination)
+        .join("weights.bin");
+    assert_eq!(std::fs::read(&bundle_file).unwrap(), b"model-weights");
+    std::fs::write(&bundle_file, b"MODEL-WEIGHTS").unwrap();
+    // Stamped explicitly rather than relying on the write: a filesystem with coarse timestamp
+    // granularity could otherwise reproduce the previous mtime and make this assertion a clock
+    // race rather than a contract.
+    std::fs::File::options()
+        .write(true)
+        .open(&bundle_file)
+        .unwrap()
+        .set_modified(std::time::SystemTime::now() + std::time::Duration::from_secs(60))
+        .unwrap();
+
+    let (refused, third) = crate::model_artifacts::observe_content_hashes(|| {
+        store.acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
+    });
+    assert!(
+        refused.is_err(),
+        "a bundle altered after its verdict was recorded must still be refused at the load boundary"
+    );
+    assert_eq!(
+        third, hashed_files,
+        "a stat identity that moved must send the closure back through the full read, not reuse \
+         the verdict recorded for the bytes it replaced"
+    );
+}
+
+/// The recorded verdict must stay OUT of the metadata journal, so a downgrade still reads the store.
+///
+/// `ResolvedCacheMetadata` is `deny_unknown_fields` and the journal keeps two slots. A receipt field
+/// on it would therefore be invisible for one acquisition and fatal after two: both slots would
+/// carry a key the previous build rejects, every entry would read as `BOTH_METADATA_SLOTS_CORRUPT`,
+/// and corrupt is the classification manual removal is allowed to clear — so rolling a release back
+/// would invite deleting and re-copying a cache that was never damaged.
+///
+/// Asserted on the raw journal bytes rather than through a round-trip, because a round-trip in this
+/// process uses this build's struct and so cannot see the field the OTHER build would choke on.
+#[test]
+fn the_recorded_verdict_lives_outside_the_metadata_journal() {
+    let scratch = TempDir::new().unwrap();
+    let source = scratch.path().join("source");
+    let data = scratch.path().join("data");
+    std::fs::create_dir(&source).unwrap();
+    let store = ResolvedCacheStore::open(&data).unwrap();
+    let candidate = hub_layout_candidate(&source, REVISION_A);
+    let materializer = ResolvedCacheMaterializer::new(store.clone());
+    match materializer
+        .materialize(
+            &candidate,
+            &source,
+            "fixture:model",
+            &MaterializationCancellation::default(),
+        )
+        .unwrap()
+    {
+        MaterializationOutcome::Published(_) => {}
+        other => panic!("fixture bundle was not published: {other:?}"),
+    }
+
+    let resolver = resolver(&source, ActiveArtifactLeaseRegistry::default());
+    // Twice: one acquisition could leave the older slot innocent, which is exactly the shape that
+    // would let this regression ship looking harmless.
+    for _ in 0..2 {
+        drop(
+            store
+                .acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
+                .unwrap()
+                .expect("the fixture entry must be acquirable"),
+        );
+    }
+
+    let entry = store.entry_path(&candidate.cache_key).unwrap();
+    let sidecar = entry.join("content.verification.json");
+    let recorded = std::fs::read_to_string(&sidecar)
+        .expect("a successful acquisition must record its verdict somewhere");
+    assert!(
+        recorded.contains("verifiedAt"),
+        "the sidecar must be where the verdict actually lands"
+    );
+
+    for slot in 0..=1 {
+        let path = entry.join(format!("metadata.{slot}.json"));
+        let Ok(journal) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        assert!(
+            !journal.contains("verifiedAt") && !journal.contains("contentVerification"),
+            "metadata.{slot}.json carries the content verdict; a build without that field \
+             rejects the whole journal and reports a healthy entry as corrupt"
+        );
+    }
+}
+
 /// A submission's availability read must not park behind the sweep's expensive verification
 /// (sc-19712, the coupled residue).
 ///

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -405,6 +405,91 @@ fn a_recorded_verdict_is_reused_while_the_closure_is_untouched_and_dropped_when_
     );
 }
 
+/// A standing verdict expires, so decay with no filesystem write behind it cannot hide forever.
+///
+/// Stat identity detects a WRITE. Bit rot, a failing enclosure, a drive rewriting a sector — none
+/// of those move size or mtime, so the receipt would keep matching and the bytes would never be
+/// read again. Before receipts every job re-read the bundle, which caught that class by accident;
+/// the max-age is what keeps catching it on purpose. This matters because the cache fronts a model
+/// library that can live on external USB media, where silent decay is the plausible failure and a
+/// timestamp-restoring writer is not.
+///
+/// The receipt is aged by rewriting `verifiedAt` rather than by waiting, so this asserts the
+/// contract rather than sleeping through it.
+#[test]
+fn a_standing_verdict_expires_and_sends_the_closure_back_through_the_full_read() {
+    let scratch = TempDir::new().unwrap();
+    let source = scratch.path().join("source");
+    let data = scratch.path().join("data");
+    std::fs::create_dir(&source).unwrap();
+    let store = ResolvedCacheStore::open(&data).unwrap();
+    let candidate = hub_layout_candidate(&source, REVISION_A);
+    let materializer = ResolvedCacheMaterializer::new(store.clone());
+    let published = match materializer
+        .materialize(
+            &candidate,
+            &source,
+            "fixture:model",
+            &MaterializationCancellation::default(),
+        )
+        .unwrap()
+    {
+        MaterializationOutcome::Published(metadata) => *metadata,
+        other => panic!("fixture bundle was not published: {other:?}"),
+    };
+    let hashed_files = published
+        .artifact
+        .closure
+        .members
+        .iter()
+        .flat_map(|member| member.files.iter())
+        .filter(|file| file.sha256.is_some())
+        .count() as u64;
+
+    let resolver = resolver(&source, ActiveArtifactLeaseRegistry::default());
+    drop(
+        store
+            .acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
+            .unwrap()
+            .expect("the fixture entry must be acquirable"),
+    );
+
+    // Backdate the standing verdict past the bound. Nothing about the bundle changes, so only the
+    // age can send this back through the read.
+    let sidecar = store
+        .entry_path(&candidate.cache_key)
+        .unwrap()
+        .join("content.verification.json");
+    let mut receipt: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&sidecar).unwrap()).unwrap();
+    let verified_at = receipt["verifiedAt"].as_u64().expect("a recorded verdict");
+    receipt["verifiedAt"] =
+        serde_json::json!(verified_at.saturating_sub(CONTENT_RECEIPT_MAX_AGE_SECONDS + 1));
+    std::fs::write(&sidecar, serde_json::to_vec(&receipt).unwrap()).unwrap();
+
+    let (lease, hashes) = crate::model_artifacts::observe_content_hashes(|| {
+        store.acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
+    });
+    assert!(
+        lease.unwrap().is_some(),
+        "an expired verdict re-proves the bundle; it does not refuse an intact one"
+    );
+    assert_eq!(
+        hashes, hashed_files,
+        "a verdict older than the max age must not be redeemed — the bytes are read again"
+    );
+
+    // And the re-proof stands on its own: the refreshed verdict is redeemable immediately.
+    let (lease, after_refresh) = crate::model_artifacts::observe_content_hashes(|| {
+        store.acquire_complete(&candidate.cache_key, &resolver, "runtime:image:model")
+    });
+    assert!(lease.unwrap().is_some());
+    assert_eq!(
+        after_refresh, 0,
+        "re-proving must stamp a fresh verdict, not leave the entry hashing on every acquisition"
+    );
+}
+
 /// The recorded verdict must stay OUT of the metadata journal, so a downgrade still reads the store.
 ///
 /// `ResolvedCacheMetadata` is `deny_unknown_fields` and the journal keeps two slots. A receipt field

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -1627,6 +1627,14 @@ pub(crate) async fn run_image_generate_job(
     // a no-op on the job row (the heartbeat's job update is scoped to the owning worker), but it
     // would still write `busy` + this job id back onto the WORKER row — racing the loop's own Idle
     // heartbeat and briefly advertising a worker that is free as occupied.
+    //
+    // NARROWS that race rather than closing it: `Drop` aborts the pump task, which cannot recall a
+    // POST already on the wire. One in-flight request can still land after the terminal write. The
+    // loop's next Idle heartbeat (one progress interval, ≤15s) corrects the worker row, and the job
+    // row was never at risk, so the residue is a worker that reads busy for at most that interval.
+    // Closing it outright would need the pump to await its in-flight request, which would put a
+    // network round-trip in front of every job's terminal post to fix a self-correcting cosmetic
+    // window.
     drop(preload_heartbeat);
 
     update_job(

--- a/crates/sceneworks-worker/src/image_jobs.rs
+++ b/crates/sceneworks-worker/src/image_jobs.rs
@@ -619,6 +619,20 @@ pub(crate) async fn run_image_generate_job(
     )
     .await?;
 
+    // Everything from here to the terminal post is covered by a region heartbeat.
+    //
+    // The routes below each run a pre-load admission pass — provider footprint queries, the tier
+    // ladder's residency probes, decode-quality binding — before they open a generation stream, and
+    // only the stream has a heartbeat of its own (its `select!` interval arm, sc-4276). The pass
+    // between the two posted nothing: on a 33 GB Krea bundle it measured 95 s, and the 90 s stale
+    // sweep marked the job `interrupted` under a healthy worker, which then died on its next
+    // progress POST with `409 ... is already interrupted`.
+    //
+    // Scoped at the dispatch seam rather than inside one route on purpose. Every arm below has the
+    // same pass and would otherwise each have to remember its own pump; overlapping the stream's
+    // interval arm costs nothing, because a heartbeat is an idempotent `last_seen_at` stamp.
+    let preload_heartbeat = crate::progress::HeartbeatPump::start(api, settings, &job.id);
+
     let mut asset_writes: Vec<Value> = Vec::with_capacity(plan.image_count as usize);
 
     // Real in-process MLX inference on macOS for engine-backed models; otherwise the
@@ -1608,6 +1622,12 @@ pub(crate) async fn run_image_generate_job(
         )
         .await?;
     }
+
+    // Explicitly, and BEFORE the terminal post. A pump tick that lands after the job completes is
+    // a no-op on the job row (the heartbeat's job update is scoped to the owning worker), but it
+    // would still write `busy` + this job id back onto the WORKER row — racing the loop's own Idle
+    // heartbeat and briefly advertising a worker that is free as occupied.
+    drop(preload_heartbeat);
 
     update_job(
         api,

--- a/crates/sceneworks-worker/src/image_jobs/base.rs
+++ b/crates/sceneworks-worker/src/image_jobs/base.rs
@@ -4434,17 +4434,62 @@ enum DowntierPick {
 /// never include q4, so it rejects rather than silently rendering q4 (acceptance #5). An explicit user
 /// pick never reaches here (the caller skips the downtier for it, honoring the pick — acceptance #7).
 #[cfg(any(target_os = "macos", feature = "backend-candle"))]
+// Scoring a candle tier is a manifest arithmetic lookup, so that lane keeps the eager form and its
+// straight-line read. On macOS the only callers left are the ordering tests — the MLX gate scores
+// lazily now, because there scoring a tier hashes an encoder.
+#[cfg_attr(target_os = "macos", allow(dead_code))]
 fn choose_downtier(default_tier: &str, candidates: &[(&'static str, TierFit)]) -> DowntierPick {
+    let tiers: Vec<&'static str> = candidates.iter().map(|(tier, _)| *tier).collect();
+    let mut fits = candidates.iter().map(|(_, fit)| *fit);
+    match choose_downtier_lazy::<_, std::convert::Infallible>(default_tier, &tiers, |_| {
+        Ok(fits.next())
+    }) {
+        Ok(pick) => pick,
+        Err(never) => match never {},
+    }
+}
+
+/// [`choose_downtier`] with the fit scored ON DEMAND, stopping at the first tier that fits.
+///
+/// Same ordering rule, same result — this is the single implementation and the eager form above
+/// delegates to it, so the two cannot drift. What changes is how many tiers get SCORED.
+///
+/// That matters because on the MLX lane scoring a tier is not cheap. `mlx_tier_fit` reaches
+/// `ProviderRegistry::footprint`, which resolves the encoder through `EncoderContract::source_for_load`
+/// and seals it with `ArtifactSeal::read_unchanged` — a full SHA-256 of that tier's text encoder. A
+/// stack sample of a krea_2_turbo job caught 62% of a 30-second window inside that subtree, 96% of it
+/// in the SHA-256 compressor itself and only 3% in `read`: it is CPU, not I/O.
+///
+/// The caller then collected EVERY candidate before choosing, so a machine with room to spare paid for
+/// bf16, q8 and q4 in turn — three encoders hashed to answer a question the first one had already
+/// settled. Measured on one job: 15s + 10s + 6s, against a budget with 61 GB unused.
+///
+/// `Ok(None)` from `fit` SKIPS a tier rather than scoring it, preserving the caller's pre-existing
+/// filter for a candidate whose directory does not resolve: such a tier was absent from the eager
+/// slice entirely, so it must not become the named rejection either.
+#[cfg(any(target_os = "macos", feature = "backend-candle"))]
+fn choose_downtier_lazy<F, E>(
+    default_tier: &str,
+    tiers: &[&'static str],
+    mut fit: F,
+) -> Result<DowntierPick, E>
+where
+    F: FnMut(&'static str) -> Result<Option<TierFit>, E>,
+{
     let mut smallest_reject: Option<(&'static str, f64, f64)> = None;
-    for &(tier, fit) in candidates {
+    for &tier in tiers {
+        let Some(fit) = fit(tier)? else {
+            continue;
+        };
         match fit {
-            // DESCENDING fidelity ⇒ the first that fits is the highest-fidelity fitting tier.
+            // DESCENDING fidelity ⇒ the first that fits is the highest-fidelity fitting tier, and
+            // nothing below it can win — so nothing below it is scored.
             TierFit::Fits => {
-                return if tier == default_tier {
+                return Ok(if tier == default_tier {
                     DowntierPick::Keep
                 } else {
                     DowntierPick::Downtier(tier)
-                };
+                });
             }
             TierFit::TooBig {
                 needed_gb,
@@ -4455,14 +4500,14 @@ fn choose_downtier(default_tier: &str, candidates: &[(&'static str, TierFit)]) -
     // Nothing fit — reject, naming the LAST (smallest / least-demanding) tier we tried. `None` only when
     // the candidate list was empty (no installed tier in range — defensive; the default itself is always
     // installed & in range), in which case Keep lets the plain gate handle it.
-    match smallest_reject {
+    Ok(match smallest_reject {
         Some((tier, needed_gb, available_gb)) => DowntierPick::Reject {
             tier,
             needed_gb,
             available_gb,
         },
         None => DowntierPick::Keep,
-    }
+    })
 }
 
 /// The installed tiers in `[floor, default]` for `request`'s model, in DESCENDING fidelity, ready for
@@ -8431,19 +8476,19 @@ async fn generate_stream(
     if !explicit_pick {
         if let Some(default_tier) = tier_key_from_resolved_dir(&weights_dir) {
             let floor = min_quality_floor(request);
-            let candidates: Vec<(&'static str, TierFit)> =
-                downtier_candidate_tiers(request, settings, default_tier, floor)
-                    .into_iter()
-                    .filter_map(|cand| {
-                        resolve_tier_dir(request, settings, cand).map(|dir| (cand, dir))
-                    })
-                    .map(|(cand, dir)| {
-                        let probe =
-                            tier_probe_spec(engine_id, &dir, request, settings, &adapters)?;
-                        Ok((cand, mlx_tier_fit(engine_id, &probe)))
-                    })
-                    .collect::<WorkerResult<Vec<_>>>()?;
-            match choose_downtier(default_tier, &candidates) {
+            let tiers = downtier_candidate_tiers(request, settings, default_tier, floor);
+            // Scored lazily (see `choose_downtier_lazy`): each `mlx_tier_fit` seals that tier's text
+            // encoder with a full SHA-256, so collecting the whole ladder up front charged every job
+            // for tiers the default tier had already ruled out. The candidates are in descending
+            // fidelity, so the ordinary "it fits" outcome now scores exactly one.
+            let pick = choose_downtier_lazy(default_tier, &tiers, |cand| -> WorkerResult<_> {
+                let Some(dir) = resolve_tier_dir(request, settings, cand) else {
+                    return Ok(None);
+                };
+                let probe = tier_probe_spec(engine_id, &dir, request, settings, &adapters)?;
+                Ok(Some(mlx_tier_fit(engine_id, &probe)))
+            })?;
+            match pick {
                 DowntierPick::Keep => {}
                 DowntierPick::Downtier(chosen) => {
                     if let Some(dir) = resolve_tier_dir(request, settings, chosen) {
@@ -15997,6 +16042,83 @@ mod capability_downtier_tests {
         // Q8 default fits → Keep, even though a smaller q4 is also installed and would fit.
         let candidates = [("q8", TierFit::Fits), ("q4", TierFit::Fits)];
         assert_eq!(choose_downtier("q8", &candidates), DowntierPick::Keep);
+    }
+
+    /// The ladder scores a tier only until one fits (sc-10733 cost, not semantics).
+    ///
+    /// On the MLX lane `mlx_tier_fit` reaches `ProviderRegistry::footprint`, which seals that tier's
+    /// text encoder with a full SHA-256. The gate used to collect the WHOLE candidate list before
+    /// choosing, so a machine with room to spare hashed bf16, q8 and q4 in turn to answer a question
+    /// the first one had already settled — 15s + 10s + 6s on one measured krea_2_turbo job, against
+    /// a budget with 61 GB unused.
+    ///
+    /// Stated as a call count, like `the_load_boundary_hashes_the_closure_exactly_once`: on the pure
+    /// chooser a duration would measure nothing, and the count is the actual claim.
+    #[test]
+    fn the_ladder_scores_no_tier_below_the_first_that_fits() {
+        use std::cell::RefCell;
+        let tiers = ["bf16", "q8", "q4"];
+        let scored = RefCell::new(Vec::new());
+        let score = |fits: fn(&str) -> TierFit| {
+            scored.borrow_mut().clear();
+            super::choose_downtier_lazy::<_, std::convert::Infallible>("bf16", &tiers, |tier| {
+                scored.borrow_mut().push(tier);
+                Ok(Some(fits(tier)))
+            })
+            .unwrap()
+        };
+
+        // The ordinary outcome: the default fits, so nothing below it is even looked at.
+        assert_eq!(score(|_| TierFit::Fits), DowntierPick::Keep);
+        assert_eq!(*scored.borrow(), vec!["bf16"]);
+
+        // A genuine downtier stops at the tier it lands on, not at the end of the ladder.
+        assert_eq!(
+            score(|tier| if tier == "bf16" {
+                too_big(72.0, 40.0)
+            } else {
+                TierFit::Fits
+            }),
+            DowntierPick::Downtier("q8")
+        );
+        assert_eq!(*scored.borrow(), vec!["bf16", "q8"]);
+
+        // Only a rejection walks the whole ladder — and it must, to name the smallest tier tried.
+        assert_eq!(
+            score(|_| too_big(72.0, 8.0)),
+            DowntierPick::Reject {
+                tier: "q4",
+                needed_gb: 72.0,
+                available_gb: 8.0,
+            }
+        );
+        assert_eq!(*scored.borrow(), vec!["bf16", "q8", "q4"]);
+    }
+
+    /// A candidate whose directory does not resolve is SKIPPED, exactly as the eager form's
+    /// `filter_map` dropped it before scoring — it must not become the named rejection.
+    #[test]
+    fn an_unresolvable_tier_is_skipped_rather_than_scored_as_too_big() {
+        let tiers = ["bf16", "q8", "q4"];
+        let pick = super::choose_downtier_lazy::<_, std::convert::Infallible>(
+            "bf16",
+            &tiers,
+            |tier| match tier {
+                "bf16" => Ok(Some(too_big(72.0, 40.0))),
+                // Not installed: no directory, so nothing to score.
+                "q8" => Ok(None),
+                _ => Ok(Some(too_big(20.0, 8.0))),
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            pick,
+            DowntierPick::Reject {
+                tier: "q4",
+                needed_gb: 20.0,
+                available_gb: 8.0,
+            }
+        );
     }
 
     #[test]

--- a/crates/sceneworks-worker/src/image_jobs/detail.rs
+++ b/crates/sceneworks-worker/src/image_jobs/detail.rs
@@ -638,6 +638,12 @@ pub(crate) async fn run_image_detail_job(
     )
     .await?;
 
+    // The detail twin of the image dispatch seam's region heartbeat. This route's consumer interval
+    // arm does not start until the stream below is built, so the source decode and the tile/spec
+    // admission in between are on the same unheartbeated footing the generate path was. Dropped
+    // before the terminal post.
+    let preload_heartbeat = crate::progress::HeartbeatPump::start(api, settings, &job.id);
+
     let source = engine_image_to_rgb(load_reference_image(
         &settings.data_dir,
         &request.project_id,
@@ -911,6 +917,8 @@ pub(crate) async fn run_image_detail_job(
         },
         detail_memory_receipt.as_ref(),
     );
+    // Before the terminal post, so a late tick cannot re-advertise a finished worker as busy.
+    drop(preload_heartbeat);
     update_job(
         api,
         &job.id,

--- a/crates/sceneworks-worker/src/progress.rs
+++ b/crates/sceneworks-worker/src/progress.rs
@@ -430,6 +430,74 @@ pub(crate) async fn heartbeat_while_blocking<R: Send + 'static>(
     }
 }
 
+/// Keep the worker's heartbeat alive across a REGION rather than around a single task.
+///
+/// [`heartbeat_while_blocking`] covers one bounded `JoinHandle`, and the streaming consumers cover
+/// their own `select!` loop with an interval arm (sc-4276). Between those two lies the stretch a job
+/// spends after its "Preparing" post and before the generation stream opens: the route's pre-load
+/// admission pass — provider footprint queries, the tier ladder's residency probes, decode-quality
+/// binding. Nothing there is one awaitable task and nothing there is a loop, so neither existing
+/// mechanism reaches it, and it went unheartbeated.
+///
+/// It is not a small window. On an Apple-Silicon host loading a 33 GB Krea bundle that pass measured
+/// 95 s between the source guard returning and `image_pipeline_load_start` — five seconds past the
+/// 90 s stale-worker sweep (`jobs_store::mark_stale_workers_interrupted`), which marked the job
+/// `interrupted` under a worker that was healthy and working. The job then died on its next progress
+/// POST with `409 ... is already interrupted`.
+///
+/// Held as an RAII guard so it covers whatever it is scoped over, including the `?` and cancel paths.
+/// Overlapping a consumer's own interval arm is deliberate and harmless — a heartbeat is an
+/// idempotent `last_seen_at` stamp — and overlap is what makes one guard at the dispatch seam cover
+/// every route instead of each route having to remember its own admission pass.
+///
+/// The pump is a spawned task, not an arm of the caller's loop, precisely because the region it
+/// covers is synchronous: an admission pass that blocks its runtime thread cannot poll anything, so
+/// the ticks have to come from elsewhere. That is sound on the worker's multi-threaded runtime
+/// (`#[tokio::main]` in `apps/rust-worker`) and on the API's in-process pool.
+///
+/// Heartbeat failures are logged and swallowed. There is no caller to return them to, and the two
+/// realistic causes — a transport blip, or a 409 because the sweep already reclaimed the job — are
+/// both handled where the job's next real progress POST lands.
+pub(crate) struct HeartbeatPump {
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl HeartbeatPump {
+    pub(crate) fn start(api: &ApiClient, settings: &Settings, job_id: &str) -> Self {
+        let api = api.clone();
+        let settings = settings.clone();
+        let job_id = job_id.to_owned();
+        let period = progress_report_interval(&settings);
+        let handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(period);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            // The caller has just posted a Busy heartbeat of its own alongside the status update
+            // this guard is scoped from, so the immediate first tick would be a redundant POST.
+            interval.tick().await;
+            loop {
+                interval.tick().await;
+                if let Err(error) =
+                    heartbeat(&api, &settings, WorkerStatus::Busy, Some(&job_id)).await
+                {
+                    tracing::debug!(
+                        event = "heartbeat_pump_post_failed",
+                        jobId = %job_id,
+                        error = %error,
+                        "region heartbeat failed; the job's next progress post reports the outcome"
+                    );
+                }
+            }
+        });
+        Self { handle }
+    }
+}
+
+impl Drop for HeartbeatPump {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
 /// Check-only cancel poll (sc-5515): returns `true` when the user requested
 /// cancellation, WITHOUT posting any status. Unlike [`check_cancel`] this never
 /// writes the terminal `Canceled`. In-loop generation/training pollers that sit in

--- a/crates/sceneworks-worker/src/video_jobs/mod.rs
+++ b/crates/sceneworks-worker/src/video_jobs/mod.rs
@@ -669,6 +669,12 @@ pub(crate) async fn run_video_generate_job(
     )
     .await?;
 
+    // The video twin of the image dispatch seam's region heartbeat: same pre-load admission pass,
+    // same 90 s stale-worker sweep, and larger weights than any image route, so the same window is
+    // wider here. Only `wan.rs` carries a consumer interval arm today; every other video route
+    // depends on this guard for its load window. Dropped before the terminal post below.
+    let preload_heartbeat = crate::progress::HeartbeatPump::start(api, settings, &job.id);
+
     // sc-3033 ships the procedural stub only; the real MLX video models (Wan sc-3034,
     // LTX+audio sc-3035) decode `GenerationOutput::Video` into a `DecodedVideo` here.
     check_cancel(api, &job.id, CANCEL_MESSAGE).await?;
@@ -1201,6 +1207,8 @@ pub(crate) async fn run_video_generate_job(
 
     let fact = video_asset_fact(&plan, seed, adapter, raw_settings, replacement_status, clip);
     let result = streaming_result(&plan, &fact, adapter);
+    // Before the terminal post, so a late tick cannot re-advertise a finished worker as busy.
+    drop(preload_heartbeat);
     update_job(
         api,
         &job.id,


### PR DESCRIPTION
Five defects behind a report of *"more than 30 seconds between 'Worker claimed job' and 'Preparing x image(s)', then stuck on Preparing for up to 3 minutes"*. All measured on an Apple Silicon host with the resolved cache enabled and the model library on an external USB volume.

## 1. The resolved cache re-hashed the whole bundle on every job

`acquire_complete` → `validate_complete_metadata` ran `RehashEveryFile` on every acquisition. **61 seconds** of SHA-256 between the claim and "Preparing N image(s)" on a 19 GB z-image bundle; that cache holds 139 GB across 8 entries, largest 33 GB.

The re-read is now gated on a recorded verdict carrying the closure's stat identity (bundle-relative path, size, mtime per file). Paths-and-sizes validation — presence, sizes, confinement, closure shape, artifact identity, `verified_bytes` — still runs unconditionally on **both** branches. Only the byte re-read is elided, and only for files no filesystem operation has touched.

**The receipt is a sidecar, not a metadata field.** `ResolvedCacheMetadata` is `deny_unknown_fields` over a two-slot journal: a field there is invisible for one acquisition and fatal after two, when both slots carry a key an older build rejects. Every entry would read as `BOTH_METADATA_SLOTS_CORRUPT`, and corrupt is the classification manual removal is allowed to clear — so a rollback would invite deleting and re-copying an undamaged 139 GB cache. `content.verification.json` keeps the journal byte-identical to what every shipped build writes.

## 2. The pre-load admission pass posted no heartbeat

Worker heartbeats stopped for **95 seconds** — from the source guard returning to the generation stream's own interval arm starting — against a 90s stale sweep. The job was marked `interrupted` under a healthy, working worker, which then died on its next progress POST with `409 ... is already interrupted`.

Counted in `api.log`: three workers reporting per 10s window through 11:30:45, two from 11:30:53 to 11:32:13, three again at 11:32:23. The silent window's boundaries are exactly `model_source_tier_selected` and `image_pipeline_load_start`.

`HeartbeatPump` is an RAII region guard, scoped at the dispatch seam so every route is covered rather than each remembering its own. Applied to image, video and detail: video has the largest weights and only `wan.rs` carries a consumer interval arm.

## 3. `sha2` was compiled without the ARMv8 SHA-2 backend

`sha2 0.10`'s aarch64 backend is gated behind `asm`, so every hash in the graph ran the portable software compressor. Measured on one 6.0 GB shard, identical digest:

| | throughput | 6.0 GB shard |
| --- | --- | --- |
| software | 0.54 GB/s | 11.7s |
| ARMv8 SHA-2 | **2.97 GB/s** | **2.2s** |

Target-gated to `aarch64-apple`. The feature pulls `sha2-asm`, whose build script hands GNU-syntax `.S` files to `cc` with `-c`; under MSVC that is `cl.exe`, which assembles neither. `cargo tree` confirms `sha2-asm` is absent on `x86_64-pc-windows-msvc` and `x86_64-unknown-linux-gnu`, present on `aarch64-apple-darwin`.

Feature unification means this reaches every crate that hashes on that target, including gen-core's `ArtifactSeal` — see SceneWorks/inference#869.

## 4. The downtier ladder scored every tier before choosing

`choose_downtier` returns on the first tier that fits, but the caller collected the whole candidate list first. Each score reaches `ProviderRegistry::footprint`, which seals that tier's text encoder. `choose_downtier_lazy` scores on demand; the eager form delegates to it so there is one implementation of the ordering rule.

Honest note: the measured saving was ~4s, not the larger figure the probe timings suggested. A second, independent caller still seals the same encoder — that is inference#869, and this change does not fix it.

## 5. The architecture pill read MPS for the MLX worker

`deriveWorkerHardware` regexed the GPU **display name** and hardcoded every Apple match to `mps`; there was no `mlx` branch at all, despite the JSDoc listing one. The worker publishes `gpuId: "mlx"`, `gpuName: "Apple Silicon (MLX)"` — which matched on the word "Apple". The Python torch/MPS worker is no longer spawned at all. `gpuId` is now consulted first; the name heuristic still classifies CUDA (whose ids are device indices) and the legacy MPS descriptor.

## Verification

| Gate | Result |
| --- | --- |
| `cargo test` | **4748 passed, 0 failed** |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| `npm run rust:check:neither` (Linux, candle off) | passed |
| `npm run rust:check:candle` (Linux, candle on) | passed |
| web vitest | **4224 passed** |
| `npm run check:rust-derived-docs` | passed |

New tests state operation counts rather than durations, since a small fixture cannot express the claim any other way:

- `a_recorded_verdict_is_reused_while_the_closure_is_untouched_and_dropped_when_it_changes` — first acquire reads every file, second reads **zero**, and a same-length rewrite is still **refused** and re-read rather than trusted.
- `the_recorded_verdict_lives_outside_the_metadata_journal` — asserts on the **raw journal bytes** after two acquisitions, because an in-process round-trip uses this build's struct and cannot see the field the other build would choke on.
- `the_ladder_scores_no_tier_below_the_first_that_fits` — 1 scored when the default fits, 2 for a real downtier, 3 only for a rejection.

## Deliberate trade, and its bound

A recorded verdict means a change preserving **both** size and mtime is not caught on the very next job. Two distinct cases:

- **A timestamp-restoring writer.** Not defended against, and not worth defending: anything that can rewrite a bundle file and restore its mtime can equally rewrite the sidecar holding the verdict.
- **Decay with no write behind it** — bit rot, a failing cable or enclosure, a drive rewriting a sector. Stat identity cannot see this, so an unexpiring verdict would turn "caught on the next job by accident" into "never caught again", because the sidecar outlives restarts. That is the realistic failure for a cache fronting a model library on external USB media.

So a verdict is redeemable for at most `CONTENT_RECEIPT_MAX_AGE_SECONDS` (24h), checked at redemption and failing closed on a future-stamped receipt (clock moved back, or a bundle copied from another machine). A working session never re-hashes; a bundle sitting in the cache is re-proved daily — ~11s a day on the largest bundle here with the hardware SHA-2 backend, against ~61s **per job** before this PR.

Pinned by `a_standing_verdict_expires_and_sends_the_closure_back_through_the_full_read`, which backdates `verifiedAt` rather than sleeping, and also asserts the re-proof stamps a fresh verdict so the entry does not start hashing on every acquisition.

The `ContentVerification` enum docs are updated in the same commit: they previously asserted "load acquisition still re-hashes every file", which was the contract every paths-and-sizes caller was written against and is no longer literally true.

## Not in scope

- **No pin bump.** SceneWorks can only pin an inference commit reachable from inference `main`, so inference#869 merges first.
- A deliberate quant-tier pick is honoured only when it equals the persisted sticky — reproduced but not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
