### PR TITLE
feat(vector): add safe SVG fixture pipeline (sc-22251)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "as-slice"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +1908,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,7 +2077,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2276,7 +2294,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2284,6 +2302,15 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "exr"
@@ -2403,6 +2430,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "float8"
@@ -3879,6 +3912,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
 name = "language-tokenizer"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4796,7 +4840,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4930,7 +4974,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5052,7 +5096,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5419,7 +5463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5606,6 +5650,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5625,7 +5675,7 @@ checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -5855,6 +5905,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quick-xml"
@@ -6294,6 +6353,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+]
+
+[[package]]
 name = "rfd"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6315,6 +6388,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -6375,6 +6457,12 @@ dependencies = [
  "serde_json",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "runtime-catalog"
@@ -6505,7 +6593,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6562,7 +6650,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6827,8 +6915,10 @@ dependencies = [
  "ort",
  "parquet",
  "pmetal-mlx-rs",
+ "quick-xml 0.37.5",
  "quote",
  "reqwest 0.12.28",
+ "resvg",
  "runtime-cuda",
  "runtime-macos",
  "rusqlite",
@@ -7316,6 +7406,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7346,7 +7445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7458,6 +7557,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7513,6 +7621,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
 
 [[package]]
 name = "swift-rs"
@@ -8007,7 +8125,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8132,6 +8250,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.17.16",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -8569,7 +8713,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8814,6 +8958,28 @@ dependencies = [
  "serde",
  "unic-ucd-ident",
  "url",
+]
+
+[[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -9251,7 +9417,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9962,6 +10128,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5675,7 +5675,7 @@ checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.41.0",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -5905,15 +5905,6 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
-name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quick-xml"
@@ -6915,7 +6906,7 @@ dependencies = [
  "ort",
  "parquet",
  "pmetal-mlx-rs",
- "quick-xml 0.37.5",
+ "quick-xml",
  "quote",
  "reqwest 0.12.28",
  "resvg",

--- a/apps/rust-api/src/dto.rs
+++ b/apps/rust-api/src/dto.rs
@@ -793,6 +793,18 @@ pub(crate) struct ImageJobRequest {
     pub(crate) advanced: JsonObject,
 }
 
+/// The deliberately narrow, fixture-only image-to-SVG intake used by the Vector Studio walking
+/// skeleton. Production raster/provider routing is a later story; keeping this input typed and
+/// separate prevents an arbitrary SVG from entering the generic raw-job route.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ImageToSvgJobRequest {
+    pub(crate) project_id: String,
+    #[serde(default)]
+    pub(crate) project_name: Option<String>,
+    pub(crate) fixture_svg: String,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct VqaJobRequest {

--- a/apps/rust-api/src/generation.rs
+++ b/apps/rust-api/src/generation.rs
@@ -271,6 +271,36 @@ pub(crate) async fn create_image_job(
     Ok((StatusCode::CREATED, Json(public_job_snapshot(job))))
 }
 
+/// Create the CPU-only fixture vectorization job. The worker owns SVG parsing, sanitization,
+/// canonicalization, preview rasterization, and publication; this route only validates the typed
+/// envelope and prevents accidental use of the raw generic queue API.
+pub(crate) async fn create_image_to_svg_job(
+    State(state): State<AppState>,
+    ApiJson(payload): ApiJson<ImageToSvgJobRequest>,
+) -> Result<(StatusCode, Json<JobSnapshot>), ApiError> {
+    if payload.project_id.trim().is_empty() {
+        return Err(ApiError::bad_request("projectId is required"));
+    }
+    if payload.fixture_svg.trim().is_empty() {
+        return Err(ApiError::bad_request("fixtureSvg is required"));
+    }
+    let mut job_payload = to_json_object(&payload)?;
+    // The job type describes the CPU vector capability; the operation is an explicit payload
+    // mode so later StarVector/provider work can extend `vector_generate` without inventing a
+    // second job class.
+    job_payload.insert("mode".to_owned(), Value::String("image_to_svg".to_owned()));
+    let job = create_generation_job(
+        state,
+        JobType::VectorGenerate,
+        Some(payload.project_id),
+        payload.project_name,
+        job_payload,
+        "cpu".to_owned(),
+    )
+    .await?;
+    Ok((StatusCode::CREATED, Json(public_job_snapshot(job))))
+}
+
 /// Refuse every imported request shape that the selected backend cannot execute. The exact stamped
 /// source shape and operation select one provider registration; family identity alone never admits
 /// a request. Builtins retain their id-keyed routing and are out of this family gate.
@@ -1197,6 +1227,7 @@ pub(crate) fn contract_number(value: f32) -> Value {
 pub(crate) fn typed_generation_route(job_type: &JobType) -> Option<&'static str> {
     match job_type {
         JobType::ImageGenerate | JobType::ImageEdit => Some("/api/v1/image/jobs"),
+        JobType::VectorGenerate => Some("/api/v1/image/vectorize/jobs"),
         JobType::VideoGenerate
         | JobType::VideoExtend
         | JobType::VideoBridge

--- a/apps/rust-api/src/lib.rs
+++ b/apps/rust-api/src/lib.rs
@@ -152,8 +152,9 @@ use training::{
 };
 mod generation;
 use generation::{
-    create_audio_job, create_image_job, create_interleave_job, create_video_job, create_vqa_job,
-    parse_recipe_preset_resolution, typed_generation_route, JobCatalogSnapshot,
+    create_audio_job, create_image_job, create_image_to_svg_job, create_interleave_job,
+    create_video_job, create_vqa_job, parse_recipe_preset_resolution, typed_generation_route,
+    JobCatalogSnapshot,
 };
 #[cfg(test)]
 use generation::{validate_interleave_job, validate_vqa_job};
@@ -184,12 +185,12 @@ use dto::{
     DatasetFaceRecordsBody, DatasetImageFixBody, DatasetParquetImportJobRequest,
     DatasetRepointBody, DatasetUpscaleJobRequest, DirectoriesResponse, EventsQuery,
     FaceLikenessCompareRequest, FrameExtractRequest, HealthResponse, HostCapabilitiesResponse,
-    ImageJobRequest, InterleaveJobRequest, JobsQuery, LoraCatalogItemQuery, LoraImportRequest,
-    LoraUpdateRequest, LorasQuery, MetricsQuery, ModelConvertRequest, ModelDownloadRequest,
-    ModelImportRequest, ModelImportSourceV1, OwnershipModeV1, PersonDetectionJobRequest,
-    PersonTrackCorrectionsRequest, PersonTrackJobRequest, ProjectCreateRequest, PromptBatchesQuery,
-    PromptRefineRequest, QualityAckBody, ReadinessQuery, RecipePresetsQuery,
-    SavedVoiceCreateRequest, StartupReadinessResponse, TimelineCreateRequest,
+    ImageJobRequest, ImageToSvgJobRequest, InterleaveJobRequest, JobsQuery, LoraCatalogItemQuery,
+    LoraImportRequest, LoraUpdateRequest, LorasQuery, MetricsQuery, ModelConvertRequest,
+    ModelDownloadRequest, ModelImportRequest, ModelImportSourceV1, OwnershipModeV1,
+    PersonDetectionJobRequest, PersonTrackCorrectionsRequest, PersonTrackJobRequest,
+    ProjectCreateRequest, PromptBatchesQuery, PromptRefineRequest, QualityAckBody, ReadinessQuery,
+    RecipePresetsQuery, SavedVoiceCreateRequest, StartupReadinessResponse, TimelineCreateRequest,
     TimelineExportRequest, TimelineSaveRequest, TrainingCaptionJobRequest, VerifyResponse,
     VideoJobRequest, VqaJobRequest,
 };
@@ -1706,6 +1707,10 @@ fn create_app_with_state_mode(
             post(save_person_track_corrections),
         )
         .route("/api/v1/image/jobs", post(create_image_job))
+        .route(
+            "/api/v1/image/vectorize/jobs",
+            post(create_image_to_svg_job),
+        )
         .route("/api/v1/image/vqa/jobs", post(create_vqa_job))
         .route("/api/v1/image/interleave/jobs", post(create_interleave_job))
         .route("/api/v1/video/jobs", post(create_video_job))
@@ -2108,6 +2113,16 @@ async fn get_project_file(
     // One fixed representation prevents unbounded cache variants. Derivatives
     // are generated on first use, so assets written before this route existed
     // backfill without a migration.
+    let force_download = project_file
+        .content_type
+        .eq_ignore_ascii_case("image/svg+xml");
+    if force_download && query.thumbnail.is_some() {
+        // Do not let the generic thumbnail branch become a second inline SVG preview route. Vector
+        // sidecars point at the worker-rendered PNG instead.
+        return Err(ApiError::bad_request(
+            "SVG thumbnails are not supported; use the vector PNG preview",
+        ));
+    }
     let (served_path, content_type) = if let Some(size) = query.thumbnail {
         if size != GRID_THUMBNAIL_SIZE {
             return Err(ApiError::bad_request(format!(
@@ -2208,6 +2223,12 @@ async fn get_project_file(
                 )
                     .into_response();
                 response.headers_mut().extend(base_headers);
+                if force_download {
+                    response.headers_mut().insert(
+                        header::CONTENT_DISPOSITION,
+                        HeaderValue::from_static("attachment"),
+                    );
+                }
                 response.headers_mut().insert(
                     header::CONTENT_LENGTH,
                     HeaderValue::from_str(&len.to_string())
@@ -2242,6 +2263,14 @@ async fn get_project_file(
     )
         .into_response();
     response.headers_mut().extend(base_headers);
+    if force_download {
+        // Raw SVG is active document syntax. It is available only as a download; clients must use
+        // the worker-produced PNG preview path recorded on a vector sidecar for inline display.
+        response.headers_mut().insert(
+            header::CONTENT_DISPOSITION,
+            HeaderValue::from_static("attachment"),
+        );
+    }
     Ok(response)
 }
 

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -251,6 +251,9 @@ async fn generic_jobs_route_rejects_generation_types_with_their_typed_route() {
         ("video_extend", "/api/v1/video/jobs"),
         ("video_bridge", "/api/v1/video/jobs"),
         ("person_replace", "/api/v1/video/jobs"),
+        // Vector Studio is a typed `vector_generate` capability. `image_to_svg` is a payload
+        // mode owned by its dedicated fixture route, never a generic job type.
+        ("vector_generate", "/api/v1/image/vectorize/jobs"),
         // Audio Studio (sc-13404): the audio route injects the model's manifest entry too, so an
         // `audio_generate` job enqueued raw through the generic route must be rejected the same way.
         ("audio_generate", "/api/v1/audio/jobs"),
@@ -278,6 +281,33 @@ async fn generic_jobs_route_rejects_generation_types_with_their_typed_route() {
             "{job_type}: error must name {typed_route}, got {body}"
         );
     }
+}
+
+#[tokio::test]
+async fn fixture_vector_route_uses_vector_generate_with_image_to_svg_mode() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+
+    let (status, created) = request(
+        app,
+        "POST",
+        "/api/v1/image/vectorize/jobs",
+        json!({
+            "projectId": "project-1",
+            "projectName": "Fixture",
+            "fixtureSvg": "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"/>",
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(created["type"], "vector_generate");
+    assert_eq!(created["requestedGpu"], "cpu");
+    assert_eq!(created["payload"]["mode"], "image_to_svg");
+    assert_eq!(
+        created["payload"]["fixtureSvg"],
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"/>"
+    );
 }
 
 /// The other half of the guard: the job types the generic route legitimately serves keep

--- a/apps/rust-api/src/tests/media.rs
+++ b/apps/rust-api/src/tests/media.rs
@@ -81,6 +81,70 @@ async fn project_file_route_serves_files_and_rejects_traversal() {
 }
 
 #[tokio::test]
+async fn vector_source_is_attachment_only_while_its_preview_is_inline_png() {
+    let temp_dir = tempfile::tempdir().expect("temp dir creates");
+    let app = create_app(test_settings(&temp_dir)).expect("app creates");
+    let (_, created) = request(
+        app.clone(),
+        "POST",
+        "/api/v1/projects",
+        json!({ "name": "Vector files" }),
+    )
+    .await;
+    let project_id = created["id"].as_str().expect("project id");
+    let root = std::path::PathBuf::from(created["path"].as_str().expect("project path"))
+        .join("assets/images/vector");
+    std::fs::create_dir_all(&root).expect("vector parent creates");
+    std::fs::write(
+        root.join("vector.svg"),
+        b"<svg xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"1\" height=\"1\"/></svg>",
+    )
+    .expect("svg fixture writes");
+    std::fs::write(root.join("preview.png"), PNG_32X32).expect("preview fixture writes");
+
+    let (status, headers, _) = request_raw(
+        app.clone(),
+        "GET",
+        &format!("/api/v1/projects/{project_id}/files/assets/images/vector/vector.svg"),
+        Body::empty(),
+        &[],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(headers["content-type"], "image/svg+xml");
+    assert_eq!(headers["content-disposition"], "attachment");
+    assert_eq!(headers["x-content-type-options"], "nosniff");
+
+    let (status, error) = request(
+        app.clone(),
+        "GET",
+        &format!(
+            "/api/v1/projects/{project_id}/files/assets/images/vector/vector.svg?thumbnail=320"
+        ),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        error["detail"],
+        "SVG thumbnails are not supported; use the vector PNG preview"
+    );
+
+    let (status, headers, bytes) = request_raw(
+        app,
+        "GET",
+        &format!("/api/v1/projects/{project_id}/files/assets/images/vector/preview.png"),
+        Body::empty(),
+        &[],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(headers["content-type"], "image/png");
+    assert!(headers.get("content-disposition").is_none());
+    assert_eq!(bytes, PNG_32X32);
+}
+
+#[tokio::test]
 async fn project_file_route_backfills_and_reuses_bounded_thumbnails() {
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
     let settings = test_settings(&temp_dir);

--- a/apps/web/src/jobTypes.js
+++ b/apps/web/src/jobTypes.js
@@ -30,6 +30,7 @@ export const GPU_REQUIRED_JOB_TYPES = new Set([
 
 // Utility job types that run on any worker (no GPU required).
 export const NON_GPU_JOB_TYPES = new Set([
+  "vector_generate",
   "dataset_parquet_import",
   "model_download",
   "model_import",

--- a/crates/sceneworks-core/src/contracts.rs
+++ b/crates/sceneworks-core/src/contracts.rs
@@ -214,6 +214,10 @@ string_enum! {
         ImageEdit => "image_edit",
         ImageVqa => "image_vqa",
         ImageInterleave => "image_interleave",
+        // CPU-only vector generation walking skeleton (epic 19699, sc-22251).
+        // The worker sanitizes and canonicalizes the supplied SVG before it ever reaches the
+        // project tree, then publishes the SVG and its native PNG preview as one pair.
+        VectorGenerate => "vector_generate",
         VideoGenerate => "video_generate",
         VideoExtend => "video_extend",
         VideoBridge => "video_bridge",
@@ -527,6 +531,7 @@ string_enum! {
         Upload => "upload",
         Frame => "frame",
         Render => "render",
+        Vector => "vector",
         // An interleaved text-image document (SenseNova-U1). The asset's `file`
         // points to an InterleavedDocument JSON in assets/documents/; the images it
         // references are ordinary `image` assets. See sc-1576.

--- a/crates/sceneworks-core/src/jobs_store.rs
+++ b/crates/sceneworks-core/src/jobs_store.rs
@@ -98,6 +98,7 @@ pub const JOB_STATUSES: &[&str] = &[
     "interrupted",
 ];
 pub const NON_GPU_JOB_TYPES: &[&str] = &[
+    "vector_generate",
     "model_download",
     "model_import",
     "model_convert",

--- a/crates/sceneworks-core/src/jobs_store/routing/gaps.rs
+++ b/crates/sceneworks-core/src/jobs_store/routing/gaps.rs
@@ -438,7 +438,8 @@ pub fn mac_rust_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         // sc-4415: face_likeness_compare runs the same native SCRFD+ArcFace stack to score two existing
         // assets on demand — a native Rust/MLX job, not a native-flow gap. Gated by the worker's
         // capability advertisement, so it queues rather than enforce-fails here.
-        | JobType::FaceLikenessCompare => Ok(()),
+        | JobType::FaceLikenessCompare
+        | JobType::VectorGenerate => Ok(()),
 
         // Forward-compat: an unrecognized job type isn't a known native-flow gap, so don't
         // enforce-fail it (it would otherwise break a newer job type this build doesn't model).
@@ -707,6 +708,7 @@ pub fn candle_supported(job: &JobSnapshot) -> Result<(), UnsupportedReason> {
         // too (audio is candle-native on every platform); it routes by the `audio_generate` capability
         // advertisement rather than enforce-failing here.
         | JobType::AudioGenerate
+        | JobType::VectorGenerate
         | JobType::Unknown(_) => Ok(()),
     }
 }

--- a/crates/sceneworks-core/src/project_store.rs
+++ b/crates/sceneworks-core/src/project_store.rs
@@ -854,6 +854,19 @@ impl ProjectStore {
             .map(str::to_owned)
             .or(guessed_mime)
             .unwrap_or_else(|| "application/octet-stream".to_owned());
+        // SVG is active document syntax, not a generic upload format. Vector assets may enter
+        // only through the worker-owned `vector_generate` sanitizer/rasterizer boundary, which
+        // writes a canonical SVG plus a bounded PNG preview together (sc-22251).
+        if content_type.eq_ignore_ascii_case("image/svg+xml")
+            || Path::new(&upload.filename)
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("svg"))
+        {
+            return Err(ProjectStoreError::BadRequest(
+                "SVG uploads are not supported; use Vector Studio".to_owned(),
+            ));
+        }
         if !content_type.starts_with("image/") {
             return Err(ProjectStoreError::BadRequest(
                 "Only image dataset uploads are supported".to_owned(),
@@ -1920,6 +1933,19 @@ impl ProjectStore {
             .map(str::to_owned)
             .or(guessed_mime)
             .unwrap_or_else(|| "application/octet-stream".to_owned());
+        // SVG is active document syntax, not a generic upload format. Vector assets may enter
+        // only through the worker-owned `vector_generate` sanitizer/rasterizer boundary, which
+        // writes a canonical SVG plus a bounded PNG preview together (sc-22251).
+        if content_type.eq_ignore_ascii_case("image/svg+xml")
+            || Path::new(&upload.filename)
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("svg"))
+        {
+            return Err(ProjectStoreError::BadRequest(
+                "SVG uploads are not supported; use Vector Studio".to_owned(),
+            ));
+        }
         if !content_type.starts_with("image/")
             && !content_type.starts_with("video/")
             && !content_type.starts_with("audio/")
@@ -4879,6 +4905,16 @@ fn build_generated_asset_sidecar(
             object.insert("extra".to_owned(), extra.clone());
         }
     }
+    // SVG is never a browser-previewable media type. The worker supplies a separately stored,
+    // bounded PNG fact after sanitizing/rasterizing the SVG; keep it on the vector sidecar rather
+    // than asking clients to infer a sibling filename or to fetch the active source document.
+    if media_type == "vector" {
+        if let Some(preview) = fact.get("preview") {
+            if let Some(object) = asset.as_object_mut() {
+                object.insert("preview".to_owned(), preview.clone());
+            }
+        }
+    }
     asset
 }
 
@@ -6846,6 +6882,39 @@ mod tests {
             json!(false)
         );
         assert_eq!(asset["lineage"]["jobId"], json!("job-1"));
+    }
+
+    #[test]
+    fn build_generated_vector_sidecar_keeps_svg_source_and_png_preview_distinct() {
+        let fact = json!({
+            "assetId": "asset_vector",
+            "type": "vector",
+            "mediaPath": "assets/images/genset_v/asset_vector/vector.svg",
+            "mimeType": "image/svg+xml",
+            "width": 12,
+            "height": 8,
+            "createdAt": "2026-08-29T00:00:00Z",
+            "mode": "image_to_svg",
+            "model": "fixture_svg",
+            "adapter": "fixture_svg",
+            "prompt": "",
+            "negativePrompt": "",
+            "count": 1,
+            "normalizedWidth": 12,
+            "normalizedHeight": 8,
+            "preview": {
+                "path": "assets/images/genset_v/asset_vector/preview.png",
+                "mimeType": "image/png",
+                "width": 12,
+                "height": 8,
+            },
+        });
+        let asset = build_generated_asset_sidecar("project-1", "job-1", "genset_v", &fact);
+        assert_eq!(asset["type"], "vector");
+        assert_eq!(asset["file"]["path"], fact["mediaPath"]);
+        assert_eq!(asset["file"]["mimeType"], "image/svg+xml");
+        assert_eq!(asset["preview"]["mimeType"], "image/png");
+        assert_ne!(asset["file"]["path"], asset["preview"]["path"]);
     }
 
     /// sc-4408: a scored generation's `rawAdapterSettings.faceLikeness` block (attached worker-side by
@@ -11652,6 +11721,46 @@ mod tests {
         assert!(is_safe_upload_extension("mp4"));
         assert!(!is_safe_upload_extension("svg"));
         assert!(!is_safe_upload_extension("html"));
+    }
+
+    #[test]
+    fn import_asset_refuses_svg_even_when_the_client_claims_png() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let store = ProjectStore::new(temp_dir.path().join("data"), "test-version");
+        let project = store.create_project("No raw SVG").expect("project creates");
+        let source = temp_dir.path().join("untrusted.svg");
+        std::fs::write(
+            &source,
+            b"<svg xmlns=\"http://www.w3.org/2000/svg\"><script/></svg>",
+        )
+        .expect("fixture writes");
+
+        let error = store
+            .import_asset(
+                &project.id,
+                UploadAsset {
+                    filename: "untrusted.svg".to_owned(),
+                    // The filename check must still win when the client lies about the MIME type.
+                    content_type: Some("image/png".to_owned()),
+                    source_path: source,
+                    source_asset_id: None,
+                    provenance: None,
+                },
+            )
+            .expect_err("generic SVG import is forbidden");
+        assert!(matches!(error, ProjectStoreError::BadRequest(_)));
+        assert!(store
+            .list_assets(&project.id, false, false, AssetScope::All)
+            .expect("list")
+            .is_empty());
+        assert!(
+            !Path::new(&project.path)
+                .join("assets/uploads")
+                .read_dir()
+                .expect("upload dir")
+                .any(|entry| entry.is_ok()),
+            "rejected SVG leaves neither asset nor sidecar"
+        );
     }
 
     /// sc-8872 (F-070): end-to-end — a `video/mp4` upload named `evil.html` is stored with a `.mp4`

--- a/crates/sceneworks-worker/ARCHITECTURE.md
+++ b/crates/sceneworks-worker/ARCHITECTURE.md
@@ -79,6 +79,7 @@ conditional/partial.
 | `image_edit` | ⚠️ MLX / candle, eligible edit models only | `run_utility_job` → `run_image_generate_job`; `job_is_mlx_eligible`; `image_job_is_candle_eligible` |
 | `image_vqa` | ⚠️ MLX / candle, SenseNova-U1 only | `run_utility_job` → `run_vqa_job`; `understanding_job_is_mlx_eligible` |
 | `image_interleave` | ⚠️ MLX / candle, SenseNova-U1 only | `run_utility_job` → `run_interleave_job`; `understanding_job_is_mlx_eligible` |
+| `vector_generate` | ✅ CPU utility, fixture-backed `image_to_svg` only | `run_utility_job` → `run_image_to_svg_job`; `vector_jobs::run_image_to_svg_job` |
 | `video_generate` | ⚠️ MLX / candle, eligible models and modes only | `run_utility_job` → `run_video_generate_job`; `video_job_is_mlx_eligible`; `video_job_is_candle_eligible` |
 | `video_extend` | ⚠️ MLX LTX/Wan eligible paths; candle Wan-VACE eligible path | `run_utility_job` → `run_video_generate_job`; `video_job_is_mlx_eligible`; `video_job_is_candle_eligible` |
 | `video_bridge` | ⚠️ MLX LTX/Wan eligible paths; candle Wan-VACE eligible path | `run_utility_job` → `run_video_generate_job`; `video_job_is_mlx_eligible`; `video_job_is_candle_eligible` |

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -21,7 +21,7 @@ glob = "0.3"
 # cross-platform (the image-job pipeline + its tests run everywhere; only real MLX inference
 # is macOS-gated). Feature set is the workspace union (sc-15052) — it always effectively was.
 image = { workspace = true }
-quick-xml = "0.37"
+quick-xml = "0.41"
 resvg = { version = "0.45", default-features = false }
 # CPU raster for DWPose skeleton rendering (epic 3018, sc-3028): filled polygons
 # (rotated-ellipse limbs), circles (joints/points), for the Z-Image strict-pose

--- a/crates/sceneworks-worker/Cargo.toml
+++ b/crates/sceneworks-worker/Cargo.toml
@@ -21,6 +21,8 @@ glob = "0.3"
 # cross-platform (the image-job pipeline + its tests run everywhere; only real MLX inference
 # is macOS-gated). Feature set is the workspace union (sc-15052) — it always effectively was.
 image = { workspace = true }
+quick-xml = "0.37"
+resvg = { version = "0.45", default-features = false }
 # CPU raster for DWPose skeleton rendering (epic 3018, sc-3028): filled polygons
 # (rotated-ellipse limbs), circles (joints/points), for the Z-Image strict-pose
 # ControlNet. Pure-Rust + cross-platform (the renderer + its tests run everywhere;

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -235,6 +235,8 @@ use media_jobs::*;
 mod image_decode;
 mod image_jobs;
 use image_jobs::*;
+mod vector_jobs;
+use vector_jobs::*;
 // Ideogram 4 mandatory JSON-caption conditioning + placeholder detect-and-recover (epic 4725,
 // sc-6501). Pure prompt-guard + post-render heuristic, compiled cross-platform so its unit tests run
 // on the Linux parity lane. sc-6610: its functions are called only from the macOS MLX generate path
@@ -2044,6 +2046,9 @@ async fn run_utility_job(
             JobType::ImageEdit => run_image_generate_job(api, settings, &job)
                 .await
                 .map_err(|error| ("Image edit failed.", error)),
+            JobType::VectorGenerate => run_image_to_svg_job(api, settings, &job)
+                .await
+                .map_err(|error| ("Image vectorization failed.", error)),
             // Native MLX tile-ControlNet detail refine (epic 3041, sc-3060), served in-process
             // by the engine on the macOS Apple-Silicon GPU worker. Off macOS the capability is
             // never advertised, so this arm is unreachable there and the job remains queued.

--- a/crates/sceneworks-worker/src/vector_jobs.rs
+++ b/crates/sceneworks-worker/src/vector_jobs.rs
@@ -1,0 +1,496 @@
+//! CPU-only vector walking skeleton (sc-22251).
+//!
+//! The fixture input is hostile by default: it is parsed into a deliberately small inert SVG
+//! subset, canonicalized before persistence, rendered through resvg (which has no network/resource
+//! loader), and published as an SVG+PNG directory rename. The API indexes the returned fact only
+//! after both files exist, so a malformed SVG never gains a visible asset or sidecar.
+
+use std::path::{Path, PathBuf};
+
+use quick_xml::events::Event;
+use quick_xml::Reader;
+use resvg::usvg;
+use serde_json::json;
+
+use super::*;
+
+const MAX_SVG_BYTES: usize = 256 * 1024;
+const MAX_SVG_DEPTH: usize = 32;
+const MAX_SVG_ELEMENTS: usize = 2_000;
+const MAX_PREVIEW_DIMENSION: u32 = 2_048;
+const SVG_NAMESPACE: &str = "http://www.w3.org/2000/svg";
+
+pub(crate) async fn run_image_to_svg_job(
+    api: &ApiClient,
+    settings: &Settings,
+    job: &JobSnapshot,
+) -> WorkerResult<()> {
+    if job.payload.get("mode").and_then(serde_json::Value::as_str) != Some("image_to_svg") {
+        return Err(WorkerError::InvalidPayload(
+            "vector_generate only supports the image_to_svg mode".to_owned(),
+        ));
+    }
+    let fixture = required_payload_string(&job.payload, "fixtureSvg")?;
+    let canonical = sanitize_svg(fixture)?;
+    let project_id = required_payload_string(&job.payload, "projectId")?;
+    let project = ProjectStore::new(settings.data_dir.clone(), "worker").get_project(project_id)?;
+    let project_path = PathBuf::from(project.path);
+
+    heartbeat(api, settings, WorkerStatus::Busy, Some(&job.id)).await?;
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Preparing,
+            ProgressStage::Preparing,
+            0.15,
+            "Sanitizing fixture SVG.",
+            None,
+            None,
+            None,
+        ),
+    )
+    .await?;
+    check_cancel(api, &job.id, "Vectorization canceled before publication.").await?;
+
+    let created_at = now_rfc3339();
+    let asset_id = fresh_asset_id();
+    let generation_set_id = format!("genset_{}", uuid::Uuid::new_v4().simple());
+    let base = project_path
+        .join("assets")
+        .join("images")
+        .join(&generation_set_id);
+    let staging = base.join(format!(".{asset_id}.tmp"));
+    let published = base.join(&asset_id);
+    let svg_path = staging.join("vector.svg");
+    let preview_path = staging.join("preview.png");
+
+    let publish_result: WorkerResult<()> = async {
+        tokio::fs::create_dir_all(&staging).await?;
+        tokio::fs::write(&svg_path, canonical.svg.as_bytes()).await?;
+        render_preview(
+            &canonical.svg,
+            canonical.width,
+            canonical.height,
+            &preview_path,
+        )
+        .await?;
+        check_cancel(api, &job.id, "Vectorization canceled before publication.").await?;
+        tokio::fs::rename(&staging, &published).await?;
+        Ok(())
+    }
+    .await;
+    if publish_result.is_err() {
+        let _ = tokio::fs::remove_dir_all(&staging).await;
+    }
+    publish_result?;
+
+    let media_path = format!("assets/images/{generation_set_id}/{asset_id}/vector.svg");
+    let preview_path = format!("assets/images/{generation_set_id}/{asset_id}/preview.png");
+    let fact = json!({
+        "assetId": asset_id,
+        "type": "vector",
+        "mediaPath": media_path,
+        "mimeType": "image/svg+xml",
+        "width": canonical.width,
+        "height": canonical.height,
+        "createdAt": created_at,
+        "mode": "image_to_svg",
+        "model": "fixture_svg",
+        "adapter": "fixture_svg",
+        "prompt": "",
+        "negativePrompt": "",
+        "count": 1,
+        "normalizedWidth": canonical.width,
+        "normalizedHeight": canonical.height,
+        "preview": { "path": preview_path, "mimeType": "image/png", "width": canonical.width, "height": canonical.height },
+    });
+    let result = json!({
+        "generationSetId": generation_set_id,
+        "expectedCount": 1,
+        "adapter": "fixture_svg",
+        "model": "fixture_svg",
+        "generationSet": {
+            "id": generation_set_id,
+            "mode": "image_to_svg",
+            "model": "fixture_svg",
+            "prompt": "",
+            "negativePrompt": "",
+            "count": 1,
+            "createdAt": created_at,
+        },
+        "assetWrites": [fact],
+    })
+    .as_object()
+    .cloned()
+    .expect("vector result is an object");
+    update_job(
+        api,
+        &job.id,
+        progress_payload(
+            JobStatus::Completed,
+            ProgressStage::Completed,
+            1.0,
+            "Fixture SVG stored with a PNG preview.",
+            None,
+            Some(result),
+            None,
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+struct CanonicalSvg {
+    svg: String,
+    width: u32,
+    height: u32,
+}
+
+fn sanitize_svg(input: &str) -> WorkerResult<CanonicalSvg> {
+    if input.len() > MAX_SVG_BYTES {
+        return Err(WorkerError::InvalidPayload(
+            "fixtureSvg exceeds the 256 KiB SVG budget".to_owned(),
+        ));
+    }
+    let mut reader = Reader::from_reader(input.as_bytes());
+    reader.config_mut().trim_text(true);
+    let mut buffer = Vec::new();
+    let mut output = String::from("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+    let mut stack = Vec::new();
+    let mut elements = 0usize;
+    let mut dimensions = None;
+    let mut root_seen = false;
+    loop {
+        match reader.read_event_into(&mut buffer) {
+            Ok(Event::Start(event)) => {
+                let (name, mut attrs) = canonical_element(&reader, &event)?;
+                if stack.is_empty() && (root_seen || name != "svg") {
+                    return Err(WorkerError::InvalidPayload(
+                        "fixtureSvg root must be <svg>".to_owned(),
+                    ));
+                }
+                if stack.len() >= MAX_SVG_DEPTH {
+                    return Err(WorkerError::InvalidPayload(
+                        "fixtureSvg exceeds the element nesting budget".to_owned(),
+                    ));
+                }
+                elements += 1;
+                if elements > MAX_SVG_ELEMENTS {
+                    return Err(WorkerError::InvalidPayload(
+                        "fixtureSvg exceeds the element budget".to_owned(),
+                    ));
+                }
+                if stack.is_empty() {
+                    root_seen = true;
+                    if !attrs
+                        .iter()
+                        .any(|(key, value)| key == "xmlns" && value == SVG_NAMESPACE)
+                    {
+                        attrs.push(("xmlns".to_owned(), SVG_NAMESPACE.to_owned()));
+                        attrs.sort_unstable();
+                    }
+                    dimensions = Some(svg_dimensions(&attrs)?);
+                }
+                write_start(&mut output, &name, &attrs, false);
+                stack.push(name);
+            }
+            Ok(Event::Empty(event)) => {
+                let (name, attrs) = canonical_element(&reader, &event)?;
+                if stack.is_empty() || name == "svg" {
+                    return Err(WorkerError::InvalidPayload(
+                        "fixtureSvg has an invalid empty root".to_owned(),
+                    ));
+                }
+                elements += 1;
+                if elements > MAX_SVG_ELEMENTS {
+                    return Err(WorkerError::InvalidPayload(
+                        "fixtureSvg exceeds the element budget".to_owned(),
+                    ));
+                }
+                write_start(&mut output, &name, &attrs, true);
+            }
+            Ok(Event::End(event)) => {
+                let name = std::str::from_utf8(event.name().as_ref())
+                    .map_err(|_| {
+                        WorkerError::InvalidPayload("fixtureSvg tag is not UTF-8".to_owned())
+                    })?
+                    .to_owned();
+                if stack.pop().as_deref() != Some(name.as_str()) {
+                    return Err(WorkerError::InvalidPayload(
+                        "fixtureSvg has mismatched tags".to_owned(),
+                    ));
+                }
+                output.push_str("</");
+                output.push_str(&name);
+                output.push('>');
+            }
+            Ok(Event::Text(text)) => {
+                let bytes: &[u8] = text.as_ref();
+                if !bytes.iter().all(u8::is_ascii_whitespace) {
+                    return Err(WorkerError::InvalidPayload(
+                        "fixtureSvg text nodes are not supported".to_owned(),
+                    ));
+                }
+            }
+            Ok(Event::Comment(_)) | Ok(Event::Decl(_)) => {}
+            Ok(Event::Eof) => break,
+            Ok(Event::CData(_)) | Ok(Event::DocType(_)) | Ok(Event::PI(_)) => {
+                return Err(WorkerError::InvalidPayload(
+                    "fixtureSvg contains a disallowed XML construct".to_owned(),
+                ));
+            }
+            Err(error) => {
+                return Err(WorkerError::InvalidPayload(format!(
+                    "fixtureSvg is malformed: {error}"
+                )))
+            }
+        }
+        buffer.clear();
+    }
+    if !stack.is_empty() || dimensions.is_none() {
+        return Err(WorkerError::InvalidPayload(
+            "fixtureSvg is incomplete".to_owned(),
+        ));
+    }
+    // A second parse through the renderer proves the canonical subset is renderable before any
+    // write. usvg does not load network resources, and our whitelist already removed every URL.
+    usvg::Tree::from_str(&output, &usvg::Options::default()).map_err(|error| {
+        WorkerError::InvalidPayload(format!("fixtureSvg cannot be rendered: {error}"))
+    })?;
+    let (width, height) = dimensions.expect("validated above");
+    Ok(CanonicalSvg {
+        svg: output,
+        width,
+        height,
+    })
+}
+
+fn canonical_element(
+    reader: &Reader<&[u8]>,
+    event: &quick_xml::events::BytesStart<'_>,
+) -> WorkerResult<(String, Vec<(String, String)>)> {
+    let name = std::str::from_utf8(event.name().as_ref())
+        .map_err(|_| WorkerError::InvalidPayload("fixtureSvg tag is not UTF-8".to_owned()))?
+        .to_owned();
+    if !matches!(
+        name.as_str(),
+        "svg" | "g" | "path" | "rect" | "circle" | "ellipse" | "line" | "polyline" | "polygon"
+    ) {
+        return Err(WorkerError::InvalidPayload(format!(
+            "fixtureSvg element <{name}> is not allowed"
+        )));
+    }
+    let mut attrs = Vec::new();
+    for attribute in event.attributes().with_checks(true) {
+        let attribute = attribute.map_err(|error| {
+            WorkerError::InvalidPayload(format!("fixtureSvg attribute is malformed: {error}"))
+        })?;
+        let key = std::str::from_utf8(attribute.key.as_ref())
+            .map_err(|_| {
+                WorkerError::InvalidPayload("fixtureSvg attribute is not UTF-8".to_owned())
+            })?
+            .to_owned();
+        let value = attribute
+            .decode_and_unescape_value(reader.decoder())
+            .map_err(|error| {
+                WorkerError::InvalidPayload(format!("fixtureSvg attribute is invalid: {error}"))
+            })?
+            .into_owned();
+        // The root namespace is the one URL-looking value admitted by this inert subset; it names
+        // SVG syntax and is never dereferenced. Every actual resource-bearing URL is rejected.
+        let namespace_ok = key == "xmlns" && value == SVG_NAMESPACE;
+        if !allowed_attribute(&name, &key)
+            || (key == "xmlns" && !namespace_ok)
+            || (!namespace_ok && unsafe_attribute_value(&value))
+        {
+            return Err(WorkerError::InvalidPayload(format!(
+                "fixtureSvg attribute {key} is not allowed"
+            )));
+        }
+        attrs.push((key, value));
+    }
+    attrs.sort_unstable();
+    Ok((name, attrs))
+}
+
+fn allowed_attribute(element: &str, attribute: &str) -> bool {
+    let common = matches!(
+        attribute,
+        "fill"
+            | "fill-opacity"
+            | "stroke"
+            | "stroke-opacity"
+            | "stroke-width"
+            | "stroke-linecap"
+            | "stroke-linejoin"
+            | "opacity"
+            | "transform"
+    );
+    common
+        || match element {
+            "svg" => matches!(attribute, "xmlns" | "width" | "height" | "viewBox"),
+            "path" => attribute == "d",
+            "rect" => matches!(attribute, "x" | "y" | "width" | "height" | "rx" | "ry"),
+            "circle" => matches!(attribute, "cx" | "cy" | "r"),
+            "ellipse" => matches!(attribute, "cx" | "cy" | "rx" | "ry"),
+            "line" => matches!(attribute, "x1" | "x2" | "y1" | "y2"),
+            "polyline" | "polygon" => attribute == "points",
+            "g" => false,
+            _ => false,
+        }
+}
+
+fn unsafe_attribute_value(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    lower.contains("url(")
+        || lower.contains("javascript:")
+        || lower.contains("data:")
+        || lower.contains("http:")
+        || lower.contains("https:")
+        || lower.contains("//")
+}
+
+fn svg_dimensions(attrs: &[(String, String)]) -> WorkerResult<(u32, u32)> {
+    let named = |name: &str| {
+        attrs
+            .iter()
+            .find(|(key, _)| key == name)
+            .map(|(_, value)| value.as_str())
+    };
+    let viewbox = named("viewBox").map(parse_viewbox).transpose()?;
+    let width = named("width")
+        .map(parse_dimension)
+        .transpose()?
+        .or_else(|| viewbox.map(|pair| pair.0))
+        .unwrap_or(512);
+    let height = named("height")
+        .map(parse_dimension)
+        .transpose()?
+        .or_else(|| viewbox.map(|pair| pair.1))
+        .unwrap_or(512);
+    if width == 0 || height == 0 || width > MAX_PREVIEW_DIMENSION || height > MAX_PREVIEW_DIMENSION
+    {
+        return Err(WorkerError::InvalidPayload(format!(
+            "fixtureSvg dimensions must be 1..={MAX_PREVIEW_DIMENSION}"
+        )));
+    }
+    Ok((width, height))
+}
+
+fn parse_dimension(value: &str) -> WorkerResult<u32> {
+    let parsed = value
+        .parse::<f64>()
+        .ok()
+        .filter(|value| value.is_finite() && *value > 0.0)
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "fixtureSvg dimensions must be finite positive numbers".to_owned(),
+            )
+        })?;
+    Ok(parsed.ceil() as u32)
+}
+
+fn parse_viewbox(value: &str) -> WorkerResult<(u32, u32)> {
+    let numbers = value
+        .split(|character: char| character.is_ascii_whitespace() || character == ',')
+        .filter(|value| !value.is_empty())
+        .map(|value| value.parse::<f64>().ok().filter(|value| value.is_finite()))
+        .collect::<Option<Vec<_>>>()
+        .filter(|values| values.len() == 4 && values[2] > 0.0 && values[3] > 0.0)
+        .ok_or_else(|| {
+            WorkerError::InvalidPayload(
+                "fixtureSvg viewBox must contain four finite numbers".to_owned(),
+            )
+        })?;
+    Ok((numbers[2].ceil() as u32, numbers[3].ceil() as u32))
+}
+
+fn write_start(output: &mut String, name: &str, attrs: &[(String, String)], empty: bool) {
+    output.push('<');
+    output.push_str(name);
+    for (key, value) in attrs {
+        output.push(' ');
+        output.push_str(key);
+        output.push_str("=\"");
+        for character in value.chars() {
+            match character {
+                '&' => output.push_str("&amp;"),
+                '<' => output.push_str("&lt;"),
+                '"' => output.push_str("&quot;"),
+                _ => output.push(character),
+            }
+        }
+        output.push('"');
+    }
+    output.push_str(if empty { "/>" } else { ">" });
+}
+
+async fn render_preview(svg: &str, width: u32, height: u32, path: &Path) -> WorkerResult<()> {
+    let svg = svg.to_owned();
+    let path = path.to_owned();
+    tokio::task::spawn_blocking(move || {
+        let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).map_err(|error| {
+            WorkerError::InvalidPayload(format!("fixtureSvg cannot be rendered: {error}"))
+        })?;
+        let mut pixmap = resvg::tiny_skia::Pixmap::new(width, height).ok_or_else(|| {
+            WorkerError::InvalidPayload("fixtureSvg preview dimensions are invalid".to_owned())
+        })?;
+        // resvg draws only the already-sanitized inert geometry into a fixed-size PNG.
+        resvg::render(
+            &tree,
+            resvg::tiny_skia::Transform::identity(),
+            &mut pixmap.as_mut(),
+        );
+        pixmap
+            .save_png(path)
+            .map_err(|error| WorkerError::Io(std::io::Error::other(error)))
+    })
+    .await
+    .map_err(|error| task_join_error("SVG preview render", error))??;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalizes_inert_svg_and_rejects_active_or_over_budget_input() {
+        let valid = sanitize_svg("<svg height=\"8\" width=\"12\" xmlns=\"http://www.w3.org/2000/svg\"><rect height=\"4\" width=\"3\"/></svg>")
+            .expect("valid inert fixture");
+        assert_eq!((valid.width, valid.height), (12, 8));
+        assert!(
+            valid.svg.contains("height=\"8\" width=\"12\""),
+            "attributes are canonicalized"
+        );
+        for malicious in [
+            "<svg><script>alert(1)</script></svg>",
+            "<svg><rect fill=\"url(https://example.invalid/a)\"/></svg>",
+            "<svg><rect onclick=\"alert(1)\"/></svg>",
+            "<svg xmlns=\"https://example.invalid/not-svg\"/>",
+        ] {
+            assert!(sanitize_svg(malicious).is_err(), "{malicious}");
+        }
+        assert!(sanitize_svg(&format!("<svg>{}</svg>", " ".repeat(MAX_SVG_BYTES))).is_err());
+    }
+
+    #[tokio::test]
+    async fn renders_a_bounded_png_preview_from_the_canonical_svg() {
+        let canonical = sanitize_svg(
+            "<svg width=\"12\" height=\"8\" xmlns=\"http://www.w3.org/2000/svg\"><rect width=\"12\" height=\"8\" fill=\"#ff0000\"/></svg>",
+        )
+        .expect("valid fixture");
+        let temp = tempfile::tempdir().expect("temp dir");
+        let path = temp.path().join("preview.png");
+        render_preview(&canonical.svg, canonical.width, canonical.height, &path)
+            .await
+            .expect("preview writes");
+        let preview = image::open(&path).expect("preview decodes").to_rgba8();
+        assert_eq!(preview.dimensions(), (12, 8));
+        assert!(
+            preview.get_pixel(0, 0)[0] > 200,
+            "preview rendered the red rectangle"
+        );
+    }
+}

--- a/crates/sceneworks-worker/src/vector_jobs.rs
+++ b/crates/sceneworks-worker/src/vector_jobs.rs
@@ -8,7 +8,7 @@
 use std::path::{Path, PathBuf};
 
 use quick_xml::events::Event;
-use quick_xml::Reader;
+use quick_xml::{Reader, XmlVersion};
 use resvg::usvg;
 use serde_json::json;
 
@@ -235,7 +235,10 @@ fn sanitize_svg(input: &str) -> WorkerResult<CanonicalSvg> {
             }
             Ok(Event::Comment(_)) | Ok(Event::Decl(_)) => {}
             Ok(Event::Eof) => break,
-            Ok(Event::CData(_)) | Ok(Event::DocType(_)) | Ok(Event::PI(_)) => {
+            Ok(Event::CData(_))
+            | Ok(Event::DocType(_))
+            | Ok(Event::PI(_))
+            | Ok(Event::GeneralRef(_)) => {
                 return Err(WorkerError::InvalidPayload(
                     "fixtureSvg contains a disallowed XML construct".to_owned(),
                 ));
@@ -292,7 +295,7 @@ fn canonical_element(
             })?
             .to_owned();
         let value = attribute
-            .decode_and_unescape_value(reader.decoder())
+            .decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())
             .map_err(|error| {
                 WorkerError::InvalidPayload(format!("fixtureSvg attribute is invalid: {error}"))
             })?


### PR DESCRIPTION
## Outcome
- add a typed vector_generate walking-skeleton route for image_to_svg
- canonicalize bounded inert SVG and publish SVG plus raster preview atomically
- record vector lifecycle and provenance while keeping raw SVG attachment-only

## Acceptance criteria
- Fixture-generated SVG is canonicalized and dangerous active content is rejected before publication.
- Canonical SVG and PNG preview publish as one atomic vector asset pair with replay/provenance metadata.
- Raw SVG remains attachment-only; generic image upload and thumbnail paths reject SVG.

## Validation
- npm run check (746/746)
- env -u HF_HOME CARGO_TARGET_DIR=/Users/michael/.codex/cargo-targets/epic-19699-sc-22251-integration npm run rust:check
- npm run rust:check:neither
- npm run rust:check:candle

The route is deliberately fixture-only at this walking-skeleton stage; native StarVector providers are delivered by the dependent inference slices.