### PR TITLE
feat(web): add Vector Studio and vector-aware Library (sc-22257)

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -185,6 +185,11 @@ const ImageEditor = lazyScreen(
   "ImageEditor",
   "Image Editor",
 );
+const VectorStudio = lazyScreen(
+  () => import("./screens/VectorStudio.jsx"),
+  "VectorStudio",
+  "Vector Studio",
+);
 const QueueScreen = lazyScreen(
   () => import("./screens/QueueScreen.jsx"),
   "QueueScreen",
@@ -253,6 +258,7 @@ export const KEEP_ALIVE_VIEWS = Object.freeze(
     "Keypoints",
     "Editor",
     "ImageEditor",
+    "VectorStudio",
   ]),
 );
 
@@ -292,6 +298,7 @@ export const navSections = [
       { id: "Document", icon: Icon.Wand },
       { id: "Train", icon: Icon.Train },
       { id: "ImageEditor", label: "Image Editor", icon: Icon.ImageEditor },
+      { id: "VectorStudio", label: "Vector Studio", icon: Icon.Wand },
       { id: "Editor", label: "Video Editor", icon: Icon.Editor },
     ],
   },
@@ -339,6 +346,7 @@ export const viewTitles = {
   Train: { title: "Training Studio", blurb: "Build datasets and prepare LoRA training plans." },
   Editor: { title: "Video Editor", blurb: "Cut, sequence and export your timeline." },
   ImageEditor: { title: "Image Editor", blurb: "Crop, upscale and refine a single image on a canvas." },
+  VectorStudio: { title: "Vector Studio", blurb: "Convert a project raster image into a clean SVG." },
   Characters: { title: "Characters", blurb: "Keep the same face across every shot." },
   Presets: { title: "Presets", blurb: "Save and share recurring generation setups." },
   Models: { title: "Models", blurb: "Download, import and manage local checkpoints." },
@@ -1534,7 +1542,7 @@ export function App() {
     return ["auto", ...Array.from(new Set(ids))];
   }, [visibleWorkers]);
   const mediaAssets = useMemo(
-    () => assets.filter((asset) => ["image", "video", "upload", "frame", "render", "document"].includes(asset.type)),
+    () => assets.filter((asset) => ["image", "video", "upload", "frame", "render", "document", "vector"].includes(asset.type)),
     [assets],
   );
 
@@ -2515,6 +2523,10 @@ export function App() {
       }),
     [token, activeProject, requestedGpu, setError, confirmWorkflowEmbeddingBeforeGeneration],
   );
+  const createVectorJob = useMemo(
+    () => makeCreateJob({ definition: CREATE_JOB_DEFINITIONS.vector, token, project: activeProject, requestedGpu, setJobs, setError }),
+    [token, activeProject, requestedGpu, setError],
+  );
 
   // Standalone video upscale (epic 4811 / sc-4816): the net-new `video_upscale` job runs
   // on the generic /api/v1/jobs endpoint (like image_upscale), not the generation video
@@ -2873,6 +2885,13 @@ export function App() {
   function sendAssetRecipeToStudio(asset, options = {}) {
     if (asset?.type === "video") {
       sendAssetRecipeToVideo(asset, options);
+      return;
+    }
+    if (asset?.type === "vector") {
+      setSelectedAssetId(asset.id);
+      closePreview();
+      setActiveView("VectorStudio");
+      setStudioLaunch({ id: crypto.randomUUID(), view: "VectorStudio", assetId: asset.lineage?.sourceAssetId, recipe: asset.recipe });
       return;
     }
     sendAssetRecipeToImage(asset, options);
@@ -3567,6 +3586,7 @@ export function App() {
     createVideoJob,
     createVideoUpscaleJob,
     createImageJob,
+    createVectorJob,
     createAudioJob,
     refinePrompt,
     magicPrompt,
@@ -3713,7 +3733,7 @@ export function App() {
     updateAssetStatus, updateAssetTags, latestImageAssets,
     jobAction, clearCompletedJobs, cancelPendingJobs, prioritizeJobs, clearJob, createVqaJob, createInterleaveJob, createPlaceholderJob,
     projectFilter, setProjectFilter, projects,
-    createVideoJob, createVideoUpscaleJob, createImageJob, createAudioJob, refinePrompt, magicPrompt, imageCaption, imageDescribe, compareFaceLikeness, latestVideoAssets, recentImageAssets,
+    createVideoJob, createVideoUpscaleJob, createImageJob, createVectorJob, createAudioJob, refinePrompt, magicPrompt, imageCaption, imageDescribe, compareFaceLikeness, latestVideoAssets, recentImageAssets,
     recentVideoAssets, recentAudioAssets, studioLaunch,
     editorLaunch, clearEditorLaunch, sendAssetToImageEditor, sendAssetToImageEdit,
     rememberLocalGenerationJob, personTracks, createPersonDetectionJob,
@@ -4080,6 +4100,11 @@ export function App() {
         {keepAliveMounted("ImageEditor") ? (
           <KeepAlivePane active={activeView === "ImageEditor"}>
             <ImageEditor key={activeProject?.id ?? "default"} />
+          </KeepAlivePane>
+        ) : null}
+        {keepAliveMounted("VectorStudio") ? (
+          <KeepAlivePane active={activeView === "VectorStudio"}>
+            <VectorStudio key={activeProject?.id ?? "default"} />
           </KeepAlivePane>
         ) : null}
           </>

--- a/apps/web/src/assetActions.js
+++ b/apps/web/src/assetActions.js
@@ -26,6 +26,7 @@ const MIME_EXTENSIONS = {
   "image/avif": "avif",
   "image/bmp": "bmp",
   "image/tiff": "tiff",
+  "image/svg+xml": "svg",
   "video/mp4": "mp4",
   "video/webm": "webm",
   "video/quicktime": "mov",

--- a/apps/web/src/assetActions.test.js
+++ b/apps/web/src/assetActions.test.js
@@ -64,6 +64,11 @@ describe("suggestedFilename (sc-8727)", () => {
     expect(suggestedFilename(asset)).toBe("shot.jpg");
   });
 
+  it("suggests .svg for a canonical vector source", async () => {
+    const { suggestedFilename } = await importBrowser();
+    expect(suggestedFilename({ displayName: "mark", file: { path: "assets/vector", mimeType: "image/svg+xml" } })).toBe("mark.svg");
+  });
+
   it("falls back to the id, then a generic name, and leaves off an unknown extension", async () => {
     const { suggestedFilename } = await importBrowser();
     expect(suggestedFilename({ id: "asset_9", file: {} })).toBe("asset_9");

--- a/apps/web/src/components/assetMedia.jsx
+++ b/apps/web/src/components/assetMedia.jsx
@@ -54,7 +54,19 @@ function withThumbnailRequest(url) {
 }
 
 export function assetCanRenderAsImage(asset) {
-  return asset?.type === "image" || asset?.file?.mimeType?.startsWith("image/");
+  return !isVectorAsset(asset) && (asset?.type === "image" || asset?.file?.mimeType?.startsWith("image/"));
+}
+
+// The canonical SVG is never rendered by the browser. Vector jobs publish a
+// worker-rasterized PNG preview specifically for every visual UI surface.
+export function isVectorAsset(asset) {
+  return asset?.type === "vector" || asset?.file?.mimeType === "image/svg+xml";
+}
+
+export function vectorPreviewUrl(asset) {
+  if (!isVectorAsset(asset) || !asset?.projectId || !asset?.preview?.path) return "";
+  const path = asset.preview.path.split("/").filter(Boolean).map(encodeURIComponent).join("/");
+  return withMediaTicket(`${API_BASE_URL}/api/v1/projects/${asset.projectId}/files/${path}`);
 }
 
 export function assetCanRenderAsVideo(asset) {
@@ -115,6 +127,7 @@ export function posterUrl(asset) {
 }
 
 export function thumbnailUrl(asset) {
+  if (isVectorAsset(asset)) return vectorPreviewUrl(asset);
   const source = assetCanRenderAsVideo(asset) ? barePosterUrl(asset) : bareAssetUrl(asset);
   return withThumbnailRequest(source);
 }
@@ -222,9 +235,12 @@ export const AssetMedia = React.forwardRef(function AssetMedia({ asset, classNam
   if (!asset) {
     return null;
   }
-  const src = assetUrl(asset);
+  const src = isVectorAsset(asset) ? vectorPreviewUrl(asset) : assetUrl(asset);
   if (!src) {
     return <span className={className}>{asset.type ?? "asset"}</span>;
+  }
+  if (isVectorAsset(asset)) {
+    return <ImageThumb src={src} className={className} />;
   }
   if (assetCanRenderAsVideo(asset)) {
     return (

--- a/apps/web/src/components/assetMedia.test.jsx
+++ b/apps/web/src/components/assetMedia.test.jsx
@@ -1,7 +1,7 @@
 import React, { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { AssetMedia, AssetThumbnail, MissingMedia, assetUrl, posterUrl, thumbnailUrl } from "./assetMedia.jsx";
+import { AssetMedia, AssetThumbnail, MissingMedia, assetCanRenderAsImage, assetUrl, posterUrl, thumbnailUrl } from "./assetMedia.jsx";
 
 const imageAsset = {
   id: "img",
@@ -26,6 +26,12 @@ const audioAsset = {
   origin: "audio_studio",
   file: { path: "assets/line.wav", mimeType: "audio/wav", duration: 3, sampleRate: 24000, channels: 1 },
   projectId: "p1",
+};
+
+const vectorAsset = {
+  id: "vector", type: "vector", projectId: "p1", displayName: "mark.svg",
+  file: { path: "assets/vector.svg", mimeType: "image/svg+xml" },
+  preview: { path: "assets/preview.png", mimeType: "image/png" },
 };
 
 function fireContextMenu(el) {
@@ -93,6 +99,14 @@ describe("bounded thumbnail URLs (sc-14797)", () => {
     expect(new URL(thumbnailUrl(imageAsset)).searchParams.get("thumbnail")).toBe("384");
     expect(new URL(thumbnailUrl(videoAsset)).searchParams.get("thumbnail")).toBe("384");
     expect(new URL(posterUrl(videoAsset)).searchParams.has("thumbnail")).toBe(false);
+  });
+});
+
+describe("vector PNG-only rendering (sc-22257)", () => {
+  it("uses only the worker PNG preview and cannot enter generic image conditioning", () => {
+    expect(assetCanRenderAsImage(vectorAsset)).toBe(false);
+    expect(thumbnailUrl(vectorAsset)).toContain("assets/preview.png");
+    expect(thumbnailUrl(vectorAsset)).not.toContain("vector.svg");
   });
 });
 

--- a/apps/web/src/components/assetPanels.jsx
+++ b/apps/web/src/components/assetPanels.jsx
@@ -11,6 +11,7 @@ import {
   assetCanRenderAsAudio,
   assetCanRenderAsVideo,
   assetUrl,
+  isVectorAsset,
   suppressThumbnailContextMenu,
 } from "./assetMedia.jsx";
 import {
@@ -941,7 +942,7 @@ function FullscreenPreviewComponent({
   // the "and nowhere else" half: no envelope, no button.
   const hasRecordedRecipe = Boolean(
     onUseRecipe &&
-      ["image", "video"].includes(asset.type) &&
+      ["image", "video", "vector"].includes(asset.type) &&
       (asset.generationSet?.recipe || asset.recipe),
   );
   // `asset.type === "image"` rather than the sibling's `["image", "video"]`: this button launches
@@ -1184,10 +1185,10 @@ function FullscreenPreviewComponent({
         items.push({ key: "fit", label: "Fit to View", onSelect: fitToView });
       }
       const submenuItems = [];
-      if (onEditImage) {
+      if (onEditImage && !isVectorAsset(asset)) {
         submenuItems.push({ key: "image-editor", label: "Image Editor", onSelect: () => onEditImage(asset) });
       }
-      if (onEditInStudio) {
+      if (onEditInStudio && !isVectorAsset(asset)) {
         submenuItems.push({ key: "image-studio", label: "Image Studio", onSelect: () => onEditInStudio(asset) });
       }
       const submenu = submenuItems.length ? { label: "Edit in", items: submenuItems } : null;

--- a/apps/web/src/constants.js
+++ b/apps/web/src/constants.js
@@ -23,6 +23,7 @@ export const LIBRARY_ORIGINS = new Set([
   "video_studio",
   "audio_studio",
   "document_studio",
+  "vector_studio",
   "upload",
 ]);
 

--- a/apps/web/src/createJob.js
+++ b/apps/web/src/createJob.js
@@ -49,6 +49,10 @@ export const CREATE_JOB_DEFINITIONS = Object.freeze({
     path: "/api/v1/image/interleave/jobs",
     buildBody: generationBody,
   },
+  vector: {
+    path: "/api/v1/image/vectorize/jobs",
+    buildBody: ([payload], project, requestedGpu) => ({ projectId: project.id, projectName: project.name, requestedGpu, ...payload }),
+  },
 });
 
 // Canonical project-scoped POST-job wrapper. Each definition owns only its route

--- a/apps/web/src/screens/LibraryScreen.jsx
+++ b/apps/web/src/screens/LibraryScreen.jsx
@@ -191,6 +191,7 @@ export function LibraryScreen() {
           <select aria-label="Asset type" onChange={(event) => setTypeFilter(event.target.value)} value={typeFilter}>
             <option value="all">All media</option>
             <option value="image">Images</option>
+            <option value="vector">Vectors</option>
             <option value="video">Videos</option>
             <option value="audio">Audio</option>
             <option value="upload">Uploads</option>

--- a/apps/web/src/screens/VectorStudio.jsx
+++ b/apps/web/src/screens/VectorStudio.jsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { AssetPickerField } from "../components/AssetPicker.jsx";
+import { ModelAvailabilityGate } from "../components/ModelAvailabilityGate.jsx";
+import { WorkerProgressCard } from "../components/WorkerProgressCard.jsx";
+import { assetCanRenderAsImage } from "../components/assetMedia.jsx";
+import { useAppContext } from "../context/AppContext.js";
+import { downloadOffersFor, vectorModelAvailability, vectorModelServesMode } from "../modelEligibility.js";
+import { terminalStatuses } from "../constants.js";
+
+export const VECTOR_DETAIL_PRESETS = Object.freeze({
+  draft: { label: "Draft", maxNewTokens: 2048, maxSvgBytes: 131072, maxWallTimeMs: 60000 },
+  standard: { label: "Standard", maxNewTokens: 4096, maxSvgBytes: 262144, maxWallTimeMs: 120000 },
+  detailed: { label: "Detailed", maxNewTokens: 8192, maxSvgBytes: 524288, maxWallTimeMs: 180000 },
+});
+
+// Strict project-owned raster predicate. This intentionally does not reuse the
+// generic picker category because SVG must never become vector conditioning.
+export function vectorSourceAssets(assets, projectId) {
+  return (assets ?? []).filter((asset) => asset?.projectId === projectId && assetCanRenderAsImage(asset) && !asset.status?.trashed && !asset.status?.rejected);
+}
+
+export function VectorStudio() {
+  const { activeProject, assets = [], jobs = [], models = [], macCapabilities, createVectorJob, createModelDownloadJob, jobAction, setActiveView, studioLaunch } = useAppContext();
+  const [sourceAssetId, setSourceAssetId] = useState("");
+  const [detail, setDetail] = useState("standard");
+  const [prompt, setPrompt] = useState("");
+  const sources = useMemo(() => vectorSourceAssets(assets, activeProject?.id), [assets, activeProject?.id]);
+  useEffect(() => {
+    if (studioLaunch?.view !== "VectorStudio") return;
+    if (sources.some((asset) => asset.id === studioLaunch.assetId)) setSourceAssetId(studioLaunch.assetId);
+    const budget = studioLaunch.recipe?.detailBudget;
+    const matching = Object.entries(VECTOR_DETAIL_PRESETS).find(([, value]) => value.maxNewTokens === budget?.maxNewTokens && value.maxSvgBytes === budget?.maxSvgBytes && value.maxWallTimeMs === budget?.maxWallTimeMs);
+    if (matching) setDetail(matching[0]);
+    if (studioLaunch.recipe?.prompt) setPrompt(studioLaunch.recipe.prompt);
+  }, [studioLaunch, sources]);
+  const vectorModels = models.filter((model) => model.type === "vector");
+  // Select the declaration before provider availability: an installed StarVector
+  // whose provider reports pending_terminal_inference_pin must surface that typed
+  // state, rather than being misclassified as an unsupported mode.
+  const model = vectorModels.find((item) => item.capabilities?.includes("image_to_svg"));
+  const availability = vectorModelAvailability(model, "image_to_svg", macCapabilities);
+  const offers = downloadOffersFor(vectorModels, (item, caps) => vectorModelServesMode(item, "image_to_svg", caps), macCapabilities);
+  const vectorJobs = jobs.filter((job) => job.type === "vector_generate" && !terminalStatuses.has(job.status));
+  const canSubmit = Boolean(sourceAssetId && availability.available && typeof createVectorJob === "function");
+  const submit = async (event) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    await createVectorJob({ mode: "image_to_svg", sourceAssetId, model: model.id, prompt: prompt.trim() || undefined, detailBudget: VECTOR_DETAIL_PRESETS[detail] });
+  };
+  const unavailableCopy = availability.reason === "pending_terminal_inference_pin"
+    ? "StarVector is installed, but this machine is waiting for the terminal inference pin. Conversion will become available automatically when it is claimable."
+    : "Install StarVector-1B from Model Manager to convert project raster images.";
+
+  return (
+    <section className="page-frame vector-studio" aria-labelledby="vector-studio-title">
+      <div className="section-heading"><p className="eyebrow">Advanced</p><h2 id="vector-studio-title">Convert Image</h2><p>Creates canonical SVG plus a safe PNG preview. SVG source is never displayed in the app.</p></div>
+      <ModelAvailabilityGate ready={availability.available} title="StarVector-1B is unavailable" description={unavailableCopy} offers={offers} onDownload={createModelDownloadJob} onOpenModels={() => setActiveView("Models")}>
+        <form className="work-panel" onSubmit={submit}>
+          <AssetPickerField assets={sources} label="Project raster image" onChange={setSourceAssetId} value={sourceAssetId} />
+          <label>Optional guidance<input aria-label="Optional vector guidance" onChange={(event) => setPrompt(event.target.value)} placeholder="Preserve bold silhouettes" value={prompt} /></label>
+          <label>Detail<select aria-label="Vector detail" onChange={(event) => setDetail(event.target.value)} value={detail}>{Object.entries(VECTOR_DETAIL_PRESETS).map(([key, preset]) => <option key={key} value={key}>{preset.label}</option>)}</select></label>
+          <button disabled={!canSubmit} type="submit">Convert to SVG</button>
+        </form>
+      </ModelAvailabilityGate>
+      {vectorJobs.map((job) => <WorkerProgressCard job={job} key={job.id} onCancel={jobAction ? (item) => jobAction(item, "cancel") : undefined} />)}
+    </section>
+  );
+}

--- a/apps/web/src/screens/VectorStudio.test.jsx
+++ b/apps/web/src/screens/VectorStudio.test.jsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { VECTOR_DETAIL_PRESETS, vectorSourceAssets } from "./VectorStudio.jsx";
+
+describe("Vector Studio source boundary", () => {
+  it("admits only active project raster assets and keeps SVG out of conditioning", () => {
+    const assets = [
+      { id: "png", projectId: "p1", type: "image", file: { mimeType: "image/png" }, status: {} },
+      { id: "svg", projectId: "p1", type: "vector", file: { mimeType: "image/svg+xml" }, preview: { path: "preview.png" }, status: {} },
+      { id: "other", projectId: "p2", type: "image", file: { mimeType: "image/png" }, status: {} },
+      { id: "trashed", projectId: "p1", type: "image", file: { mimeType: "image/png" }, status: { trashed: true } },
+    ];
+    expect(vectorSourceAssets(assets, "p1").map((asset) => asset.id)).toEqual(["png"]);
+  });
+
+  it("keeps every selectable detail payload bounded", () => {
+    for (const preset of Object.values(VECTOR_DETAIL_PRESETS)) {
+      expect(preset.maxNewTokens).toBeGreaterThan(0);
+      expect(preset.maxSvgBytes).toBeGreaterThan(0);
+      expect(preset.maxWallTimeMs).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Scope

- adds Advanced Vector Studio with raster-only selection, typed model availability/download state, bounded detail presets, vector job submission, progress/cancel, and replay
- renders vector cards/fullscreen from PNG previews only and exports canonical SVG with a `.svg` suggestion
- adds vector Library filtering while preserving shared grouping/favorite/rating/trash actions
- suppresses Image Editor/Studio actions for vector assets and excludes SVG/vector assets from generic image conditioning

Shortcut: https://app.shortcut.com/trefry/story/22257
Epic: https://app.shortcut.com/trefry/epic/19699

## Local validation

- web lint green
- focused Vitest: 88 passed
- full web suite: 277 files / 4,229 tests passed
- production web build green
- `git diff --check` green

No GPU, model download, or measurement campaign ran.