### PR TITLE
SC-22261: use available Windows terminal shell

### DIFF
--- a/.github/workflows/starvector-terminal-provision.yml
+++ b/.github/workflows/starvector-terminal-provision.yml
@@ -171,13 +171,13 @@ jobs:
           name: ${{ inputs.inference_preflight_artifact }}
           path: ${{ runner.temp }}\starvector-preflight
       - name: Publish exact inference, preflight, and model closure
-        shell: pwsh
+        shell: powershell
         run: |
           node scripts/starvector-terminal-provision.mjs checkout "$env:GITHUB_WORKSPACE\inference-source" "$env:STARVECTOR_TERMINAL_ROOT\inference" $env:STARVECTOR_INFERENCE_REVISION
           node scripts/starvector-terminal-provision.mjs preflight "$env:RUNNER_TEMP\starvector-preflight" "$env:STARVECTOR_TERMINAL_ROOT\inference-preflight" $env:STARVECTOR_INFERENCE_REVISION
           node scripts/starvector-terminal-provision.mjs weights $env:STARVECTOR_TERMINAL_ROOT $env:STARVECTOR_APP_DATA_SOURCE $env:STARVECTOR_HF_HOME_SOURCE $env:STARVECTOR_PROMPT_PROVIDER $env:STARVECTOR_PROMPT_MODEL $env:STARVECTOR_PROMPT_REVISION
       - name: Provision pinned metric runtime and official checkpoints
-        shell: pwsh
+        shell: powershell
         run: |
           if (-not (Test-Path "$env:STARVECTOR_TERMINAL_ROOT\metrics\Scripts\python.exe")) { py -3.11 -m venv "$env:STARVECTOR_TERMINAL_ROOT\metrics" }
           & "$env:STARVECTOR_TERMINAL_ROOT\metrics\Scripts\python.exe" -m pip install --disable-pip-version-check numpy==2.2.6 scikit-image==0.25.2 lpips==0.1.4 torch==2.7.0 torchvision==0.22.0 Pillow==11.3.0 open-clip-torch==3.1.0
@@ -186,7 +186,7 @@ jobs:
           node scripts/starvector-terminal-provision.mjs download https://huggingface.co/laion/CLIP-ViT-B-32-laion2B-s34B-b79K/resolve/1a25a446712ba5ee05982a381eed697ef9b435cf/open_clip_pytorch_model.bin "$env:STARVECTOR_TERMINAL_ROOT\metrics\checkpoints\open_clip_pytorch_model.bin" 1bd3c7172de5b207ceac554f5ab5266166f3b9baccc9af5989bc801016d080ad
           node scripts/starvector-terminal-provision.mjs metrics "$env:GITHUB_WORKSPACE\sceneworks" "$env:STARVECTOR_TERMINAL_ROOT\metrics" "$env:STARVECTOR_TERMINAL_ROOT\metrics\Scripts\python.exe" $env:STARVECTOR_CLIP_REVISION
       - name: Materialize the exact pinned 120-row corpus
-        shell: pwsh
+        shell: powershell
         run: |
           New-Item -ItemType Directory -Force "$env:RUNNER_TEMP\starvector-parquet" | Out-Null
           node scripts/starvector-terminal-provision.mjs download https://huggingface.co/datasets/starvector/svg-stack-simple/resolve/1d2a96a17cc0c4c1f337b7631adc8c5885bc72ea/data/test-00000-of-00001.parquet "$env:RUNNER_TEMP\starvector-parquet\source-0.parquet" ed6b73f3c92277e81b244c6ab3071d0831c4820178aed072182246bab402b004
@@ -199,7 +199,7 @@ jobs:
           }
       - name: Read-only readiness validation
         if: ${{ always() }}
-        shell: pwsh
+        shell: powershell
         run: node scripts/starvector-terminal-readiness.mjs "$env:GITHUB_WORKSPACE\sceneworks" release/starvector-terminal-campaign-v1.json "$env:STARVECTOR_TERMINAL_ROOT\inference" "$env:STARVECTOR_TERMINAL_ROOT\weights" "$env:STARVECTOR_TERMINAL_ROOT\metrics" "$env:STARVECTOR_TERMINAL_ROOT\metrics\Scripts\python.exe" "$env:STARVECTOR_TERMINAL_ROOT\corpora\starvector-terminal-v1" "$env:RUNNER_TEMP\starvector-terminal-provision\windows.json"
       - name: Upload Windows provisioning readiness even on failure
         if: ${{ always() }}

--- a/.github/workflows/starvector-terminal-readiness.yml
+++ b/.github/workflows/starvector-terminal-readiness.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Validate Windows terminal host without executing models
-        shell: pwsh
+        shell: powershell
         run: |
           node scripts/starvector-terminal-readiness.mjs $env:GITHUB_WORKSPACE release/starvector-terminal-campaign-v1.json $env:STARVECTOR_TERMINAL_INFERENCE_ROOT $env:STARVECTOR_TERMINAL_WEIGHTS_ROOT $env:STARVECTOR_TERMINAL_METRICS_ROOT $env:STARVECTOR_TERMINAL_METRICS_PYTHON $env:STARVECTOR_TERMINAL_CORPUS_ASSETS_ROOT "$env:RUNNER_TEMP\\starvector-terminal-readiness\\windows.json"
       - name: Upload Windows readiness report even on failure

--- a/.github/workflows/starvector-terminal-source.yml
+++ b/.github/workflows/starvector-terminal-source.yml
@@ -41,10 +41,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build the current-tree product service
-        shell: pwsh
+        shell: powershell
         run: cargo build --locked -p sceneworks-rust-api
       - name: Install exact closure through Model Manager
-        shell: pwsh
+        shell: powershell
         run: node scripts/starvector-terminal-source-install.mjs $env:GITHUB_WORKSPACE $env:STARVECTOR_SOURCE_ROOT $env:STARVECTOR_SOURCE_API_URL
       - name: Upload source-closure record even on failure
         if: ${{ always() }}

--- a/.github/workflows/starvector-terminal.yml
+++ b/.github/workflows/starvector-terminal.yml
@@ -128,7 +128,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run production vector_generate route for CUDA 1B
-        shell: pwsh
+        shell: powershell
         run: |
           cargo build --release --locked -p sceneworks-worker --bin starvector_terminal_lease --bin starvector_terminal_sanitize
           $env:STARVECTOR_TERMINAL_CASE_BUNDLE = "$env:RUNNER_TEMP\\starvector-terminal\\cuda-1b\\case-bundle.json"
@@ -145,7 +145,7 @@ jobs:
           if-no-files-found: warn
       - name: Stop CUDA 1B source-built service
         if: ${{ always() }}
-        shell: pwsh
+        shell: powershell
         run: node scripts/starvector-terminal-product-service.mjs stop "$env:RUNNER_TEMP\starvector-terminal\cuda-1b"
 
   cuda-8b:
@@ -168,7 +168,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run production vector_generate route and shared hostile/prompt suites for CUDA 8B
-        shell: pwsh
+        shell: powershell
         run: |
           cargo build --release --locked -p sceneworks-worker --bin starvector_terminal_lease --bin starvector_terminal_sanitize
           $env:STARVECTOR_TERMINAL_CASE_BUNDLE = "$env:RUNNER_TEMP\\starvector-terminal\\cuda-8b\\case-bundle.json"
@@ -185,7 +185,7 @@ jobs:
           if-no-files-found: warn
       - name: Stop CUDA 8B source-built service
         if: ${{ always() }}
-        shell: pwsh
+        shell: powershell
         run: node scripts/starvector-terminal-product-service.mjs stop "$env:RUNNER_TEMP\starvector-terminal\cuda-8b"
 
   seal-receipt:

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -867,7 +867,7 @@ fn builtin_starvector_manifests_are_exact_native_image_to_svg_closures() {
             );
             assert_eq!(
                 candidate["productionClosure"]["sha256"],
-                "006e321aa15fae04c1faf4d891f5b4e6bf187686a7c99a2bdb8d5089a125cf48"
+                "6a8197ed2285342175833e9c20c4296ce47a3324ada6db5702b35bad6cdcd08a"
             );
             assert_eq!(
                 candidate["productionClosure"]["entries"]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -25387,12 +25387,12 @@
             },
             "productionClosure": {
               "schemaVersion": 1,
-              "sha256": "006e321aa15fae04c1faf4d891f5b4e6bf187686a7c99a2bdb8d5089a125cf48",
+              "sha256": "6a8197ed2285342175833e9c20c4296ce47a3324ada6db5702b35bad6cdcd08a",
               "entries": [
                 {
                   "path": ".github/workflows/starvector-terminal.yml",
-                  "byteSize": 16029,
-                  "sha256": "e8d74b88a446e30441605b037a426ae2e68b416b1b35b1ca518b976158fa01df"
+                  "byteSize": 16053,
+                  "sha256": "36a59f5032557b9a60baabb38c85f6aa9d9d3a623001e6cd881f95419b4a4547"
                 },
                 {
                   "path": "Cargo.lock",

--- a/scripts/starvector-production-closure.test.mjs
+++ b/scripts/starvector-production-closure.test.mjs
@@ -64,6 +64,6 @@ test("shape and tree checks detect every closure mutation", async () => {
 
 test("live manifest seals the exact frozen-tree production closure", async () => {
   const closure = await checkManifestProductionClosure();
-  assert.equal(closure.sha256, "006e321aa15fae04c1faf4d891f5b4e6bf187686a7c99a2bdb8d5089a125cf48");
+  assert.equal(closure.sha256, "6a8197ed2285342175833e9c20c4296ce47a3324ada6db5702b35bad6cdcd08a");
   assert.equal(closure.entries.length, 27);
 });

--- a/scripts/starvector-terminal-source-install.test.mjs
+++ b/scripts/starvector-terminal-source-install.test.mjs
@@ -44,6 +44,17 @@ test("source workflow is preparation-only on both real-weight hosts", async () =
   assert.doesNotMatch(workflow, /starvector-terminal-(?:producer|campaign|route)\.mjs|vector_generate|campaign_run_id/i);
 });
 
+test("Windows terminal workflows use the in-box PowerShell host", async () => {
+  const workflows = await Promise.all([
+    "source",
+    "provision",
+    "readiness",
+    "",
+  ].map((suffix) => readFile(new URL(`../.github/workflows/starvector-terminal${suffix ? `-${suffix}` : ""}.yml`, import.meta.url), "utf8")));
+  for (const workflow of workflows) assert.doesNotMatch(workflow, /shell: pwsh/);
+  assert.equal(workflows.reduce((count, workflow) => count + (workflow.match(/shell: powershell/g) ?? []).length, 0), 11);
+});
+
 test("existing default-branch workflow bridges every pre-merge terminal operation", async () => {
   const bridge = await readFile(new URL("../.github/workflows/server-candle-linux.yml", import.meta.url), "utf8");
   for (const operation of ["source", "provision", "readiness", "campaign"]) {

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -804,7 +804,7 @@ def test_starvector_terminal_candidate_schema_is_closed_and_mutation_resistant()
     candidate = model["vector"]["deviceAdmission"]["terminalCandidate"]
     assert candidate["inferenceRevision"] == "c6eb6d8e9545193eac844f6fea2db79e4d14bf2a"
     assert candidate["corpusSha256"] == "757370c4eed38a52a29ac80c258fdedd7e437ab891637bcb1c916aa608bf32b5"
-    assert candidate["productionClosure"]["sha256"] == "006e321aa15fae04c1faf4d891f5b4e6bf187686a7c99a2bdb8d5089a125cf48"
+    assert candidate["productionClosure"]["sha256"] == "6a8197ed2285342175833e9c20c4296ce47a3324ada6db5702b35bad6cdcd08a"
     assert len(candidate["productionClosure"]["entries"]) == 27
     assert model["vector"]["providers"] == {
         "mlx": {"id": "mlx-starvector-8b", "available": True},


### PR DESCRIPTION
## Summary
- use the in-box Windows PowerShell host across StarVector terminal source, provision, readiness, and campaign workflows
- preserve the existing PowerShell scripts without requiring optional PowerShell 7
- add a regression test forbidding `pwsh` in the terminal workflow set

## Evidence
- source closure run 33302128650 failed before model installation with `pwsh: command not found` on the Windows CUDA runner
- `node --test scripts/starvector-terminal-source-install.test.mjs scripts/starvector-terminal-provision.test.mjs scripts/starvector-terminal-workflow.test.mjs` (19/19)
- actionlint clean aside from explicitly ignored repository custom runner labels
- no terminal campaign was dispatched