### PR TITLE
fix(worker): prevent Windows worker-entry stack overflow (SC-22261)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6890,7 +6890,6 @@ name = "sceneworks-rust-worker"
 version = "0.8.7"
 dependencies = [
  "sceneworks-worker",
- "tokio",
 ]
 
 [[package]]

--- a/apps/rust-api/src/main.rs
+++ b/apps/rust-api/src/main.rs
@@ -1,5 +1,4 @@
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // The desktop app launches this same binary a second time as a standalone
     // GPU worker — the Apple-Silicon MLX worker (sc-3289) — by setting
     // SCENEWORKS_WORKER_ONLY=1. The binary already links the mlx-gen engine, so
@@ -25,7 +24,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
     if std::env::var("SCENEWORKS_WORKER_ONLY").is_ok_and(|value| value.trim() == "1") {
-        return sceneworks_rust_api::run_worker().await;
+        return sceneworks_worker::run_on_worker_entry_thread(|| async {
+            sceneworks_rust_api::run_worker()
+                .await
+                .map_err(|error| sceneworks_worker::WorkerError::Engine(error.to_string()))
+        })
+        .map_err(Into::into);
     }
-    sceneworks_rust_api::run().await
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(sceneworks_rust_api::run())
 }

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -867,14 +867,14 @@ fn builtin_starvector_manifests_are_exact_native_image_to_svg_closures() {
             );
             assert_eq!(
                 candidate["productionClosure"]["sha256"],
-                "6a8197ed2285342175833e9c20c4296ce47a3324ada6db5702b35bad6cdcd08a"
+                "b514dd6876ebba96b55e42d5c1814bb3280fbca24def13bfcb300c4d4dc39fb7"
             );
             assert_eq!(
                 candidate["productionClosure"]["entries"]
                     .as_array()
                     .expect("production closure entries")
                     .len(),
-                27
+                28
             );
             assert_eq!(
                 candidate["supportedDevices"]["mlx"],

--- a/apps/rust-worker/Cargo.toml
+++ b/apps/rust-worker/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 
 [dependencies]
 sceneworks-worker = { path = "../../crates/sceneworks-worker" }
-tokio = { version = "1.40", features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/apps/rust-worker/src/main.rs
+++ b/apps/rust-worker/src/main.rs
@@ -1,4 +1,3 @@
-#[tokio::main]
-async fn main() -> Result<(), sceneworks_worker::WorkerError> {
-    sceneworks_worker::run().await
+fn main() -> Result<(), sceneworks_worker::WorkerError> {
+    sceneworks_worker::run_on_worker_entry_thread(sceneworks_worker::run)
 }

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -25387,7 +25387,7 @@
             },
             "productionClosure": {
               "schemaVersion": 1,
-              "sha256": "6a8197ed2285342175833e9c20c4296ce47a3324ada6db5702b35bad6cdcd08a",
+              "sha256": "b514dd6876ebba96b55e42d5c1814bb3280fbca24def13bfcb300c4d4dc39fb7",
               "entries": [
                 {
                   "path": ".github/workflows/starvector-terminal.yml",
@@ -25396,13 +25396,18 @@
                 },
                 {
                   "path": "Cargo.lock",
-                  "byteSize": 248776,
-                  "sha256": "005490160610c5c4eddf915bcba2a52b5bca8ce56fffd3dd2bd8677aa3911221"
+                  "byteSize": 248766,
+                  "sha256": "281ef455f7e030fa815a6060275a3dd155c5b10f538960f962ccde119ec4a2b5"
                 },
                 {
                   "path": "Cargo.toml",
                   "byteSize": 8688,
                   "sha256": "f5a7d810f30aefd8d75adbeee8e07762fb5bd957bb270b4853d6346cc54a96f8"
+                },
+                {
+                  "path": "apps/rust-api/src/main.rs",
+                  "byteSize": 2152,
+                  "sha256": "096a7e0f29c61beaf1ab71a950db365ab4ca202f1a572dde9212fc4683a385ca"
                 },
                 {
                   "path": "crates/sceneworks-worker/Cargo.toml",
@@ -25431,8 +25436,8 @@
                 },
                 {
                   "path": "crates/sceneworks-worker/src/lib.rs",
-                  "byteSize": 144421,
-                  "sha256": "ba3b31838cd243086fc02529b11786f9e22cbc3c8225baf3aa5477afa76a2795"
+                  "byteSize": 146088,
+                  "sha256": "bedf5c216ab6530c1745052703c97a95c40a1d535e1bb749154b5a95e657383e"
                 },
                 {
                   "path": "crates/sceneworks-worker/src/model_jobs.rs",
@@ -25481,8 +25486,8 @@
                 },
                 {
                   "path": "scripts/starvector-production-closure.mjs",
-                  "byteSize": 8166,
-                  "sha256": "8eb7028bddf02ece7575a5a0710d36a5d6b48be39e973057eb2cb70907549e8e"
+                  "byteSize": 8197,
+                  "sha256": "f31baa4b9bc4573476198c47c7d4098a7933edfe8ba830cf2e1b04623a981dc6"
                 },
                 {
                   "path": "scripts/starvector-terminal-assets.mjs",

--- a/crates/sceneworks-worker/src/lib.rs
+++ b/crates/sceneworks-worker/src/lib.rs
@@ -1036,6 +1036,42 @@ fn emit_event(event: &str, payload: Value) {
     emit_event_value(Level::INFO, value);
 }
 
+/// Stack reserved for the outermost worker future.
+///
+/// The worker dispatch future contains every platform-compiled job handler. Windows executable
+/// main threads have a smaller default stack than macOS/Linux, so polling that future directly
+/// from `#[tokio::main]` can overflow before a claimed job reaches its first network transfer.
+/// Keep this explicit rather than relying on a linker-specific `/STACK` flag or Tokio's runtime
+/// worker-thread setting, neither of which changes the stack used by `Runtime::block_on`.
+pub const WORKER_ENTRY_STACK_BYTES: usize = 8 * 1024 * 1024;
+pub const WORKER_ENTRY_THREAD_NAME: &str = "sceneworks-worker-entry";
+
+/// Construct the Tokio runtime and the complete worker future on a named, explicitly sized thread.
+///
+/// `worker` is invoked inside the new thread so its future is never constructed on the process
+/// main thread. Both shipped worker entry binaries use this seam.
+pub fn run_on_worker_entry_thread<F, Fut>(worker: F) -> WorkerResult<()>
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = WorkerResult<()>> + 'static,
+{
+    let worker = std::thread::Builder::new()
+        .name(WORKER_ENTRY_THREAD_NAME.to_owned())
+        .stack_size(WORKER_ENTRY_STACK_BYTES)
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .map_err(WorkerError::Io)?;
+            runtime.block_on(worker())
+        })
+        .map_err(WorkerError::Io)?;
+    match worker.join() {
+        Ok(result) => result,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
 pub async fn run() -> WorkerResult<()> {
     // Install the tracing backbone before anything emits (covers both the
     // standalone `sceneworks-rust-worker` binary and the API's GPU-worker path,

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -125,6 +125,52 @@ include!("tests/segment_assembly.rs");
 // production work dirs and deliberate exceptions enumerated and justified.
 include!("tests/temp_fixture_guard.rs");
 
+#[test]
+fn worker_entry_thread_has_an_explicit_runtime_and_large_stack_contract() {
+    assert!(
+        super::WORKER_ENTRY_STACK_BYTES >= 8 * 1024 * 1024,
+        "worker entry stack must stay at least 8 MiB"
+    );
+    let observed = Arc::new(std::sync::Mutex::new(None));
+    let observed_from_worker = observed.clone();
+    super::run_on_worker_entry_thread(move || async move {
+        tokio::task::yield_now().await;
+        let name = std::thread::current().name().map(str::to_owned);
+        let runtime_is_active = tokio::runtime::Handle::try_current().is_ok();
+        *observed_from_worker.lock().expect("observation lock") = Some((name, runtime_is_active));
+        Ok(())
+    })
+    .expect("worker entry thread completes");
+
+    let observation = observed.lock().expect("observation lock").clone();
+    assert_eq!(
+        observation,
+        Some((Some(super::WORKER_ENTRY_THREAD_NAME.to_owned()), true)),
+        "the worker future must be constructed inside the named runtime thread"
+    );
+}
+
+#[test]
+fn worker_entry_thread_preserves_errors_and_panics() {
+    let error = super::run_on_worker_entry_thread(|| async {
+        Err(super::WorkerError::Engine("worker-entry-error".to_owned()))
+    })
+    .expect_err("worker error must reach the process entrypoint");
+    assert_eq!(error.to_string(), "worker-entry-error");
+
+    let panic = std::panic::catch_unwind(|| {
+        super::run_on_worker_entry_thread(|| async {
+            panic!("worker-entry-panic");
+        })
+    })
+    .expect_err("worker panic must reach the process entrypoint");
+    let message = panic
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| panic.downcast_ref::<String>().map(String::as_str));
+    assert_eq!(message, Some("worker-entry-panic"));
+}
+
 /// sc-19710: the retention driver is opt-in and must never create the managed cache root as a side
 /// effect — an opt-out install growing a `models/resolved` tree just because the worker booted
 /// would be exactly the unrequested state the policy exists to prevent. A store that already

--- a/crates/sceneworks-worker/src/tests.rs
+++ b/crates/sceneworks-worker/src/tests.rs
@@ -127,10 +127,12 @@ include!("tests/temp_fixture_guard.rs");
 
 #[test]
 fn worker_entry_thread_has_an_explicit_runtime_and_large_stack_contract() {
-    assert!(
-        super::WORKER_ENTRY_STACK_BYTES >= 8 * 1024 * 1024,
-        "worker entry stack must stay at least 8 MiB"
-    );
+    const {
+        assert!(
+            super::WORKER_ENTRY_STACK_BYTES >= 8 * 1024 * 1024,
+            "worker entry stack must stay at least 8 MiB"
+        );
+    }
     let observed = Arc::new(std::sync::Mutex::new(None));
     let observed_from_worker = observed.clone();
     super::run_on_worker_entry_thread(move || async move {

--- a/scripts/starvector-production-closure.mjs
+++ b/scripts/starvector-production-closure.mjs
@@ -14,6 +14,7 @@ export const PRODUCTION_CLOSURE_PATHS = Object.freeze([
   ".github/workflows/starvector-terminal.yml",
   "Cargo.lock",
   "Cargo.toml",
+  "apps/rust-api/src/main.rs",
   "crates/sceneworks-worker/Cargo.toml",
   "crates/sceneworks-worker/src/bin/starvector_terminal_lease.rs",
   "crates/sceneworks-worker/src/bin/starvector_terminal_sanitize.rs",

--- a/scripts/starvector-production-closure.test.mjs
+++ b/scripts/starvector-production-closure.test.mjs
@@ -9,6 +9,7 @@ import {
   checkManifestProductionClosure,
   checkProductionClosure,
   closureSha256,
+  PRODUCTION_CLOSURE_PATHS,
   stableJson,
   validateProductionClosureShape,
 } from "./starvector-production-closure.mjs";
@@ -64,6 +65,16 @@ test("shape and tree checks detect every closure mutation", async () => {
 
 test("live manifest seals the exact frozen-tree production closure", async () => {
   const closure = await checkManifestProductionClosure();
-  assert.equal(closure.sha256, "6a8197ed2285342175833e9c20c4296ce47a3324ada6db5702b35bad6cdcd08a");
-  assert.equal(closure.entries.length, 27);
+  assert.equal(closure.sha256, "b514dd6876ebba96b55e42d5c1814bb3280fbca24def13bfcb300c4d4dc39fb7");
+  assert.equal(closure.entries.length, 28);
+});
+
+test("the sealed campaign worker and standalone worker keep the large-stack entry seam", async () => {
+  assert.ok(PRODUCTION_CLOSURE_PATHS.includes("apps/rust-api/src/main.rs"));
+  const [apiMain, workerMain] = await Promise.all([
+    readFile("apps/rust-api/src/main.rs", "utf8"),
+    readFile("apps/rust-worker/src/main.rs", "utf8"),
+  ]);
+  assert.match(apiMain, /SCENEWORKS_WORKER_ONLY[\s\S]+run_on_worker_entry_thread/);
+  assert.match(workerMain, /run_on_worker_entry_thread\(sceneworks_worker::run\)/);
 });

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -804,8 +804,8 @@ def test_starvector_terminal_candidate_schema_is_closed_and_mutation_resistant()
     candidate = model["vector"]["deviceAdmission"]["terminalCandidate"]
     assert candidate["inferenceRevision"] == "c6eb6d8e9545193eac844f6fea2db79e4d14bf2a"
     assert candidate["corpusSha256"] == "757370c4eed38a52a29ac80c258fdedd7e437ab891637bcb1c916aa608bf32b5"
-    assert candidate["productionClosure"]["sha256"] == "6a8197ed2285342175833e9c20c4296ce47a3324ada6db5702b35bad6cdcd08a"
-    assert len(candidate["productionClosure"]["entries"]) == 27
+    assert candidate["productionClosure"]["sha256"] == "b514dd6876ebba96b55e42d5c1814bb3280fbca24def13bfcb300c4d4dc39fb7"
+    assert len(candidate["productionClosure"]["entries"]) == 28
     assert model["vector"]["providers"] == {
         "mlx": {"id": "mlx-starvector-8b", "available": True},
         "candle": {"id": "candle-starvector-8b", "available": True},


### PR DESCRIPTION
## Outcome

- construct and poll both supported worker futures on a named 8 MiB OS thread
- preserve ordinary API Tokio runtime behavior and propagate worker errors/panics
- seal the campaign API entrypoint in the exact terminal production closure

## Validation

- 24 StarVector terminal/closure contract tests passed
- focused worker-entry success/error/panic tests passed
- exact Rust API closure assertion passed
- exact Python manifest audit passed
- cargo check passed for sceneworks-rust-api and sceneworks-rust-worker
- independent adversarial review completed; both findings fixed