### PR TITLE
fix(ci): recognize signal-terminated source workers (SC-22261)

### DIFF
--- a/scripts/starvector-terminal-source-install.mjs
+++ b/scripts/starvector-terminal-source-install.mjs
@@ -18,6 +18,7 @@ const IDENTITIES = [
 const TERMINAL = new Set(["completed", "failed", "canceled"]);
 const die = (message) => { throw new Error(`starvector terminal source install: ${message}`); };
 const delay = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+const childIsRunning = (child) => child.exitCode === null && child.signalCode === null;
 
 export function sourceInstallRequests() {
   return [
@@ -62,7 +63,7 @@ async function responseJson(response, context) {
 
 async function waitHealthy(url, children) {
   for (let attempt = 0; attempt < 180; attempt += 1) {
-    if (children.some((child) => child.exitCode !== null)) die("source-built API or worker exited during startup");
+    if (children.some((child) => !childIsRunning(child))) die("source-built API or worker exited during startup");
     try {
       const response = await fetch(new URL("/api/v1/health", url));
       const body = await response.json();
@@ -81,7 +82,7 @@ async function installModel(url, request, children) {
   }), `Model Manager install ${request.modelId}`);
   if (typeof created?.id !== "string" || !created.id) die(`Model Manager install ${request.modelId} returned no job id`);
   for (let attempt = 0; attempt < 10800; attempt += 1) {
-    if (children.some((child) => child.exitCode !== null)) die(`source-built API or worker exited while installing ${request.modelId}`);
+    if (children.some((child) => !childIsRunning(child))) die(`source-built API or worker exited while installing ${request.modelId}`);
     const job = await responseJson(await fetch(new URL(`/api/v1/jobs/${created.id}`, url)), `Model Manager job ${created.id}`);
     if (TERMINAL.has(job.status)) {
       if (job.status !== "completed") die(`${request.modelId} ended ${job.status}: ${job.error ?? job.message ?? "no error detail"}`);
@@ -92,10 +93,74 @@ async function installModel(url, request, children) {
   die(`timed out waiting for Model Manager install ${request.modelId}`);
 }
 
-async function stop(children) {
-  for (const child of [...children].reverse()) if (child.exitCode === null) child.kill("SIGTERM");
-  for (let attempt = 0; attempt < 100 && children.some((child) => child.exitCode === null); attempt += 1) await delay(100);
-  if (children.some((child) => child.exitCode === null)) die("source-built API or worker did not stop");
+export function windowsTaskkillArguments(pid) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) die("cannot terminate a Windows child without a valid process id");
+  return ["/PID", String(pid), "/T", "/F"];
+}
+
+async function runWindowsTaskkill(pid, timeoutMs) {
+  await new Promise((resolve) => {
+    const killer = spawn("taskkill.exe", windowsTaskkillArguments(pid), { stdio: "inherit", windowsHide: true });
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      try { killer.kill("SIGKILL"); } catch { /* the helper may already have exited */ }
+      finish();
+    }, timeoutMs);
+    killer.once("error", finish);
+    killer.once("exit", finish);
+  });
+}
+
+async function waitForChildExit(child, timeoutMs) {
+  if (!childIsRunning(child)) return true;
+  return new Promise((resolve) => {
+    let timer;
+    const finish = (exited) => {
+      clearTimeout(timer);
+      child.removeListener("exit", onExit);
+      resolve(exited);
+    };
+    const onExit = () => finish(true);
+    child.once("exit", onExit);
+    timer = setTimeout(() => finish(false), timeoutMs);
+    if (!childIsRunning(child)) finish(true);
+  });
+}
+
+export async function stopSourceChildren(children, {
+  platform = process.platform,
+  taskkill = runWindowsTaskkill,
+  timeoutMs = 10000,
+} = {}) {
+  const graceful = [...children].reverse().filter(childIsRunning);
+  const gracefulExits = graceful.map((child) => waitForChildExit(child, timeoutMs));
+  for (const child of graceful) {
+    try { child.kill("SIGTERM"); } catch { /* escalate below */ }
+  }
+  await Promise.all(gracefulExits);
+
+  const stubborn = [...children].reverse().filter(childIsRunning);
+  const forcedExits = stubborn.map((child) => waitForChildExit(child, timeoutMs));
+  if (platform === "win32") {
+    await Promise.all(stubborn.map((child) => Promise.race([
+      taskkill(child.pid, timeoutMs),
+      delay(timeoutMs),
+    ])));
+  }
+  else {
+    for (const child of stubborn) {
+      try { child.kill("SIGKILL"); } catch { /* report the live child below */ }
+    }
+  }
+  await Promise.all(forcedExits);
+  const livePids = children.filter(childIsRunning).map((child) => child.pid ?? "unknown");
+  if (livePids.length > 0) die(`source-built API or worker did not stop (pids: ${livePids.join(", ")})`);
 }
 
 export async function installSourceClosure({ root, stateRoot, url }) {
@@ -115,7 +180,7 @@ export async function installSourceClosure({ root, stateRoot, url }) {
     const record = { schema_version: 1, preparation_only: true, model_execution: false, campaign_evidence: false, data_dir: dataDir, hf_home: hfHome, prompt_revision: PROMPT_REVISION, jobs, health, completed_at: new Date().toISOString() };
     await writeFile(path.join(stateRoot, "source-closure.json"), `${JSON.stringify(record, null, 2)}\n`);
     return record;
-  } finally { await stop(children); }
+  } finally { await stopSourceChildren(children); }
 }
 
 if (isExecutedModule(import.meta.url)) {

--- a/scripts/starvector-terminal-source-install.test.mjs
+++ b/scripts/starvector-terminal-source-install.test.mjs
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 import { pathToFileURL } from "node:url";
 import { isExecutedModule } from "./starvector-terminal-cli.mjs";
-import { sourceInstallEnvironment, sourceInstallRequests } from "./starvector-terminal-source-install.mjs";
+import { sourceInstallEnvironment, sourceInstallRequests, stopSourceChildren, windowsTaskkillArguments } from "./starvector-terminal-source-install.mjs";
 
 test("terminal CLIs compare platform paths through canonical file URLs", () => {
   const executable = path.resolve("scripts/starvector-terminal-source-install.mjs");
@@ -34,6 +35,70 @@ test("source preparation clears terminal/offline inheritance and isolates both p
   assert.equal(env.HF_HUB_CACHE, path.join(hfHome, "hub"));
   assert.equal(env.SCENEWORKS_GPU_ID, "cpu");
   for (const name of ["HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE", "SCENEWORKS_TERMINAL_CAMPAIGN", "SCENEWORKS_TERMINAL_NO_JOB_DOWNLOADS"]) assert.equal(env[name], undefined);
+});
+
+test("source preparation escalates stubborn Windows children through taskkill", async () => {
+  const signals = [];
+  const child = Object.assign(new EventEmitter(), {
+    exitCode: null,
+    signalCode: null,
+    pid: 4242,
+    kill(signal) { signals.push(signal); return true; },
+  });
+  const taskkill = async (pid) => {
+    assert.equal(pid, 4242);
+    child.signalCode = "SIGKILL";
+    child.emit("exit", null, "SIGKILL");
+  };
+  await stopSourceChildren([child], { platform: "win32", taskkill, timeoutMs: 1 });
+  assert.deepEqual(signals, ["SIGTERM"]);
+  assert.deepEqual(windowsTaskkillArguments(4242), ["/PID", "4242", "/T", "/F"]);
+});
+
+test("source preparation escalates stubborn POSIX children through SIGKILL", async () => {
+  const signals = [];
+  const child = Object.assign(new EventEmitter(), {
+    exitCode: null,
+    signalCode: null,
+    pid: 4243,
+    kill(signal) {
+      signals.push(signal);
+      if (signal === "SIGKILL") {
+        this.signalCode = signal;
+        this.emit("exit", null, signal);
+      }
+      return true;
+    },
+  });
+  await stopSourceChildren([child], { platform: "linux", timeoutMs: 1 });
+  assert.deepEqual(signals, ["SIGTERM", "SIGKILL"]);
+});
+
+test("source preparation recognizes signal-terminated children as stopped", async () => {
+  const child = {
+    exitCode: null,
+    signalCode: "SIGTERM",
+    pid: 4244,
+    kill() { assert.fail("a signal-terminated child must not be killed again"); },
+  };
+  await stopSourceChildren([child], { timeoutMs: 1 });
+});
+
+test("source preparation remains bounded when taskkill itself hangs", async () => {
+  const child = Object.assign(new EventEmitter(), {
+    exitCode: null,
+    signalCode: null,
+    pid: 4245,
+    kill() { return true; },
+  });
+  await assert.rejects(
+    stopSourceChildren([child], {
+      platform: "win32",
+      taskkill: async () => new Promise(() => {}),
+      timeoutMs: 1,
+    }),
+    /did not stop \(pids: 4245\)/,
+  );
 });
 
 test("source workflow is preparation-only on both real-weight hosts", async () => {


### PR DESCRIPTION
## Outcome
- recognize Node children terminated by signal as stopped
- await exit events before bounded escalation
- use exact-PID taskkill tree termination on genuinely stuck Windows children
- keep taskkill itself bounded

## Evidence
- source run 33306476862 completed all three Model Manager installs on Windows and wrote the complete closure record before teardown falsely failed
- focused terminal and closure tests: 27/27 passed
- isolated memory-watchdog suite: 34/34 passed
- repository suite: changed terminal tests passed; two unrelated timing tests failed under concurrent load and passed in isolation
- independent adversarial review: no remaining findings

SC-22261