### PR TITLE
fix: keep StarVector measurement revision as provenance (SC-22261)

### DIFF
--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -867,7 +867,7 @@ fn builtin_starvector_manifests_are_exact_native_image_to_svg_closures() {
             );
             assert_eq!(
                 candidate["productionClosure"]["sha256"],
-                "b514dd6876ebba96b55e42d5c1814bb3280fbca24def13bfcb300c4d4dc39fb7"
+                "96fef4f4d319e16ccc4ea23f7379f325dc0aa53cbba7c3b6b8a116670b21c2bc"
             );
             assert_eq!(
                 candidate["productionClosure"]["entries"]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -25387,7 +25387,7 @@
             },
             "productionClosure": {
               "schemaVersion": 1,
-              "sha256": "b514dd6876ebba96b55e42d5c1814bb3280fbca24def13bfcb300c4d4dc39fb7",
+              "sha256": "96fef4f4d319e16ccc4ea23f7379f325dc0aa53cbba7c3b6b8a116670b21c2bc",
               "entries": [
                 {
                   "path": ".github/workflows/starvector-terminal.yml",
@@ -25456,8 +25456,8 @@
                 },
                 {
                   "path": "crates/sceneworks-worker/src/vector_admission.rs",
-                  "byteSize": 34652,
-                  "sha256": "8cdac81ed1e9ebedf589cb868a84fa04ef5e58edd0656ebd02a5a44cb5c7acb7"
+                  "byteSize": 35504,
+                  "sha256": "c17ab85876aeb027932fa378ff123a42cb3f4f0e24ee0c454aa49cf3be17734c"
                 },
                 {
                   "path": "crates/sceneworks-worker/src/vector_jobs.rs",

--- a/crates/sceneworks-worker/src/vector_admission.rs
+++ b/crates/sceneworks-worker/src/vector_admission.rs
@@ -454,11 +454,12 @@ fn validate_terminal_candidate(
             ))
         };
     };
-    if !is_lower_hex(inference_revision, 40)
-        || inference_revision != crate::catalog_semantic_jobs::INFERENCE_RUNTIME_REVISION
-    {
+    // Capture provenance remains mandatory and machine-readable, but it is not an evidence-currency
+    // term. A later inference pin alone cannot invalidate this measured terminal candidate; the
+    // corpus, immutable model identity, provider identities, and production closure below own that.
+    if !is_lower_hex(inference_revision, 40) {
         return Err(TerminalCandidateError::Invalid(
-            "terminal inferenceRevision does not match the linked inference runtime",
+            "terminal inferenceRevision is malformed",
         ));
     }
     let Some(corpus_sha256) = candidate.get("corpusSha256").and_then(Value::as_str) else {
@@ -830,13 +831,31 @@ mod tests {
     }
 
     #[test]
+    fn eight_b_candidate_inference_revision_is_provenance_not_currency() {
+        let mut model = complete_eight_b_model();
+        model["vector"]["deviceAdmission"]["terminalCandidate"]["inferenceRevision"] =
+            json!("0".repeat(40));
+
+        for (backend, total_bytes) in [
+            (VectorBackend::Mlx, 137_438_953_472),
+            (VectorBackend::Candle, 51_539_607_552),
+        ] {
+            assert_eq!(
+                vector_admission_refusal(&model, backend, Some(&facts(backend, total_bytes))),
+                None,
+                "a well-formed capture revision must not invalidate unchanged terminal evidence"
+            );
+        }
+    }
+
+    #[test]
     fn eight_b_candidate_identity_and_closure_mutations_fail_closed() {
         let exact = complete_eight_b_model();
         let mlx = facts(VectorBackend::Mlx, 137_438_953_472);
         for mutate in [
             |value: &mut Value| {
                 value["vector"]["deviceAdmission"]["terminalCandidate"]["inferenceRevision"] =
-                    json!("0".repeat(40));
+                    json!("main");
             },
             |value: &mut Value| {
                 value["vector"]["deviceAdmission"]["terminalCandidate"]["model"]["repository"] =

--- a/scripts/starvector-production-closure.test.mjs
+++ b/scripts/starvector-production-closure.test.mjs
@@ -65,7 +65,7 @@ test("shape and tree checks detect every closure mutation", async () => {
 
 test("live manifest seals the exact frozen-tree production closure", async () => {
   const closure = await checkManifestProductionClosure();
-  assert.equal(closure.sha256, "b514dd6876ebba96b55e42d5c1814bb3280fbca24def13bfcb300c4d4dc39fb7");
+  assert.equal(closure.sha256, "96fef4f4d319e16ccc4ea23f7379f325dc0aa53cbba7c3b6b8a116670b21c2bc");
   assert.equal(closure.entries.length, 28);
 });
 

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -804,7 +804,7 @@ def test_starvector_terminal_candidate_schema_is_closed_and_mutation_resistant()
     candidate = model["vector"]["deviceAdmission"]["terminalCandidate"]
     assert candidate["inferenceRevision"] == "c6eb6d8e9545193eac844f6fea2db79e4d14bf2a"
     assert candidate["corpusSha256"] == "757370c4eed38a52a29ac80c258fdedd7e437ab891637bcb1c916aa608bf32b5"
-    assert candidate["productionClosure"]["sha256"] == "b514dd6876ebba96b55e42d5c1814bb3280fbca24def13bfcb300c4d4dc39fb7"
+    assert candidate["productionClosure"]["sha256"] == "96fef4f4d319e16ccc4ea23f7379f325dc0aa53cbba7c3b6b8a116670b21c2bc"
     assert len(candidate["productionClosure"]["entries"]) == 28
     assert model["vector"]["providers"] == {
         "mlx": {"id": "mlx-starvector-8b", "available": True},


### PR DESCRIPTION
## Summary
- stop rejecting a measured StarVector 8B terminal candidate solely because its recorded inference revision differs from the currently linked inference pin
- retain the recorded revision as a required well-formed provenance SHA
- deterministically reseal the measured production source closure and synchronize all exact aggregate assertions

## Policy
Pin changes alone do not invalidate measurements. Contract, model, provider, production-closure, corpus, and measured-device changes remain fail-closed.

## Validation
- cargo test -p sceneworks-worker vector_admission::tests --lib
- cargo test -p sceneworks-rust-api --lib tests::jobs::builtin_starvector_manifests_are_exact_native_image_to_svg_closures -- --exact
- exact Python manifest audit
- node scripts/starvector-production-closure.mjs check-manifest
- node --test scripts/starvector-production-closure.test.mjs
- cargo fmt --all -- --check
- cargo clippy -p sceneworks-worker --lib -- -D warnings
- independent adversarial review: no findings after closure reseal and assertion synchronization

No measurement or campaign evidence was regenerated.