### PR TITLE
feat(calibration): --ltx25-partition splits the canonical campaign across capture hosts (SC-18791)

### DIFF
--- a/docs/memory-calibration-harness.md
+++ b/docs/memory-calibration-harness.md
@@ -220,6 +220,12 @@ the refinement adapter on dev sessions. `--provider <plan-provider-name>` option
 provider block; use it to run the current Krea v1 production point separately from non-promotable v2 candidates.
 `--fixture <fixture-name>` selects every provider block sharing that fixture, which is the intended
 way to execute a multi-rung reference ladder as one reproducible capture.
+`--ltx25-partition <substring[,substring...]>` (valid only with `--model ltx_2_5`) runs the plan rows
+whose names contain any listed substring — a validated non-empty SUBSET of the canonical campaign, so
+the 84-case grid can be split across capture hosts (e.g. `-distilled-` on one Mac, `-dev-` on the
+other) and the per-host evidence bundles merged at ingestion. The checked-in plan remains the sole
+authority: a partition may never select a case outside it, and the full-set equality check still
+applies to unpartitioned runs.
 `--fresh-per-case` overrides scheduling for an oracle capture; `--batch-rungs` forces one target's
 rungs into an experimental batch. Compare the two bundles with the committed larger-of tolerance
 (256 MiB absolute or 5% relative for every phase/metric):

--- a/scripts/memory-calibration-harness.mjs
+++ b/scripts/memory-calibration-harness.mjs
@@ -1615,13 +1615,27 @@ function expectedLtx25LogicalCaseIds() {
   return canonicalLtx25LogicalCaseIds;
 }
 
-function validateCanonicalLtx25Selection(plannedCases) {
+function validateCanonicalLtx25Selection(plannedCases, partitioned = false) {
   const actual = plannedCases.map((planned) => planned.logicalCaseId).sort();
   const expected = expectedLtx25LogicalCaseIds();
-  if (new Set(actual).size !== actual.length || !equal(actual, expected)) {
+  if (new Set(actual).size !== actual.length) {
+    fail("--model ltx_2_5 selected duplicate logical case identities");
+  }
+  if (partitioned) {
+    // A partition may run any non-empty SUBSET of the canonical campaign (so the grid can be
+    // split across capture hosts), but never a case outside it: the repo's checked-in plan
+    // stays the sole authority on what the campaign is.
+    const canonical = new Set(expected);
+    const foreign = actual.filter((id) => !canonical.has(id));
+    if (foreign.length) {
+      fail(`--ltx25-partition selected cases outside the canonical MLX campaign: ${foreign.join(", ")}`);
+    }
+    return;
+  }
+  if (!equal(actual, expected)) {
     fail(
       "--model ltx_2_5 must select the exact canonical MLX campaign declared by "
-        + "config/memory-calibration-plan.json",
+        + "config/memory-calibration-plan.json (pass --ltx25-partition to run a named subset)",
     );
   }
 }
@@ -2011,7 +2025,7 @@ function execute(command, args, input, { env } = {}) {
 export async function runProviderPlan({
   config, providerCommand, sceneWorksRepo, inferenceRepo, resume, backend, model, providerName, fixture,
   onProviderInvocation, onProviderCheckpoint, forceFreshPerCase = false, forceBatchRungs = false,
-  rawLogDir = null, sourcePathPrefix = null, ltx25SnapshotRoot = null,
+  rawLogDir = null, sourcePathPrefix = null, ltx25SnapshotRoot = null, ltx25Partition = null,
   // sc-17774: injectable so the runner's own tests can drive synthetic repositories, which have no
   // inference crate layout to derive a real closure from. Production always uses the default.
   closureDigestFor = null,
@@ -2116,6 +2130,16 @@ export async function runProviderPlan({
   if (model && selectedConfig.providers.length === 0) {
     fail(`provider run selected no plan provider for model ${JSON.stringify(model)}`);
   }
+  if (ltx25Partition != null) {
+    if (model !== "ltx_2_5") fail("--ltx25-partition requires --model ltx_2_5");
+    const needles = String(ltx25Partition).split(",").map((needle) => needle.trim()).filter(Boolean);
+    if (!needles.length) fail("--ltx25-partition must name at least one plan-name substring");
+    selectedConfig.providers = selectedConfig.providers.filter((provider) =>
+      needles.some((needle) => provider.name.includes(needle)));
+    if (!selectedConfig.providers.length) {
+      fail(`--ltx25-partition ${JSON.stringify(ltx25Partition)} selected no ltx_2_5 plan providers`);
+    }
+  }
   if (forceFreshPerCase && forceBatchRungs) fail("cannot force both fresh and batched provider execution");
   const applyExecutionPolicy = (plannedCases) => plannedCases.map((planned) => {
     if (forceFreshPerCase) {
@@ -2150,7 +2174,7 @@ export async function runProviderPlan({
     ? expanded.filter((planned) => planned.backend === selectedBackend)
     : expanded;
   const exactLtx25Selection = model === "ltx_2_5";
-  if (exactLtx25Selection) validateCanonicalLtx25Selection(allSelectedCases);
+  if (exactLtx25Selection) validateCanonicalLtx25Selection(allSelectedCases, ltx25Partition != null);
   if (ltx25SnapshotRoot && !exactLtx25Selection) {
     fail("--ltx25-snapshot-root requires --model ltx_2_5");
   }
@@ -2600,6 +2624,7 @@ async function main() {
   if (command === "run") {
     const model = singleValue("--model");
     const ltx25SnapshotRoot = singleValue("--ltx25-snapshot-root");
+    const ltx25Partition = singleValue("--ltx25-partition");
     const outputPath = value("--output");
     const output = await runProviderPlan({
       config: await readJson(value("--config")),
@@ -2616,6 +2641,7 @@ async function main() {
       rawLogDir: value("--raw-log-dir") ? path.resolve(value("--raw-log-dir")) : null,
       sourcePathPrefix: value("--source-path-prefix"),
       ltx25SnapshotRoot,
+      ltx25Partition,
       onProviderCheckpoint: (checkpoint) => atomicWrite(outputPath, checkpoint),
     });
     return void await atomicWrite(outputPath, output);

--- a/scripts/memory-calibration-harness.test.mjs
+++ b/scripts/memory-calibration-harness.test.mjs
@@ -3743,6 +3743,43 @@ test("--model rejects unknown values and incompatible backend selections", async
   );
 });
 
+test("--ltx25-partition runs a validated subset of the canonical campaign", async () => {
+  const plan = JSON.parse(
+    await readFile(new URL("../config/memory-calibration-plan.json", import.meta.url)),
+  );
+  const cleanRepo = await cleanFixtureRepo();
+  const base = {
+    closureDigestFor: stubClosureDigest,
+    config: plan,
+    providerCommand: ["must-not-run"],
+    sceneWorksRepo: cleanRepo,
+    inferenceRepo: cleanRepo,
+    model: "ltx_2_5",
+    executeProvider: async () => assert.fail("partition selection must fail before provider probe"),
+  };
+  // A real subset passes canonical validation and proceeds to the next requirement
+  // (the snapshot root), instead of failing the full-set equality.
+  await assert.rejects(
+    runProviderPlan({ ...base, ltx25Partition: "-distilled-" }),
+    /requires --ltx25-snapshot-root for per-case artifact binding/,
+  );
+  // The comma form unions substrings and still validates as a subset.
+  await assert.rejects(
+    runProviderPlan({ ...base, ltx25Partition: "-q4-dev-,-q8-dev-" }),
+    /requires --ltx25-snapshot-root for per-case artifact binding/,
+  );
+  // A partition naming nothing in the plan fails closed.
+  await assert.rejects(
+    runProviderPlan({ ...base, ltx25Partition: "no-such-case" }),
+    /selected no ltx_2_5 plan providers/,
+  );
+  // The flag is meaningless outside the LTX-2.5 campaign.
+  await assert.rejects(
+    runProviderPlan({ ...base, model: undefined, backend: "mlx", ltx25Partition: "-distilled-" }),
+    /--ltx25-partition requires --model ltx_2_5/,
+  );
+});
+
 test("the CLI refuses missing or repeated --model values before reading capture inputs", async () => {
   const harness = fileURLToPath(new URL("./memory-calibration-harness.mjs", import.meta.url));
   await assert.rejects(


### PR DESCRIPTION
Fixes the operability gap flagged in the terminal review (F5): `--model ltx_2_5` only accepted the exact full 84-case set, so the campaign could not be split across the two real-weights Macs.

`--ltx25-partition <substring[,substring...]>` runs a validated non-empty SUBSET of the canonical campaign (plan-name substrings, unioned). The checked-in plan stays the sole authority — a partition can never select outside it, duplicates still fail, and unpartitioned runs keep the exact-set equality. Per-host evidence bundles merge at ingestion (resume identity is content-keyed as of #2622).

76/76 harness tests (4 new assertions), check:memory-calibration and check:memory-matrix green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)