### PR TITLE
Image Editor transparent cutouts: color key and SAM3

### DIFF
--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Stage, Layer, Image as KonvaImage, Line, Rect, Transformer } from "react-konva";
+import { Stage, Layer, Group, Image as KonvaImage, Line, Rect, Transformer } from "react-konva";
 import { apiFetch, inspectWorkflowFile, isAbortError } from "../api.js";
 import { terminalStatuses } from "../jobTypes.js";
 import { useAppContext } from "../context/AppContext.js";
@@ -72,6 +72,7 @@ import {
 import { useColorGradeTool } from "./imageEditor/useColorGradeTool.js";
 import { useBoxesTool } from "./imageEditor/useBoxesTool.js";
 import { useMaskTool } from "./imageEditor/useMaskTool.js";
+import { maskAlphaFromRgba } from "../maskRefine.js";
 import {
   COLOR_ADJUSTMENTS,
   IDENTITY_COLOR_ADJUST,
@@ -114,6 +115,7 @@ import {
 } from "./imageEditor/maskShared.js";
 import {
   applyColorKeyToRgba,
+  applyMaskSelectionToRgba,
   documentPointToLayerPoint,
 } from "./imageEditor/colorKeyMath.js";
 import {
@@ -1008,6 +1010,19 @@ function colorKeyCanvasForImage(image, seed, options) {
   return canvas;
 }
 
+function maskCutoutCanvasForImage(image, maskCanvas, keepSelected) {
+  const canvas = document.createElement("canvas");
+  canvas.width = image.naturalWidth;
+  canvas.height = image.naturalHeight;
+  const ctx = canvas.getContext("2d");
+  ctx.drawImage(image, 0, 0);
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const mask = maskCanvas.getContext("2d").getImageData(0, 0, canvas.width, canvas.height);
+  imageData.data.set(applyMaskSelectionToRgba(imageData.data, maskAlphaFromRgba(mask.data), keepSelected));
+  ctx.putImageData(imageData, 0, 0);
+  return canvas;
+}
+
 function canvasToPngBlob(canvas) {
   return new Promise((resolve, reject) => {
     canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error("Could not encode the cutout."))), "image/png");
@@ -1246,6 +1261,7 @@ export function ImageEditor() {
   const [colorKeyTolerance, setColorKeyTolerance] = useState(12);
   const [colorKeySoftness, setColorKeySoftness] = useState(8);
   const [colorKeyGlobal, setColorKeyGlobal] = useState(false);
+  const [cutoutKeepSelected, setCutoutKeepSelected] = useState(true);
   const [ratioKey, setRatioKey] = useState("free");
   const [rotated, setRotated] = useState(false);
   const [cropRect, setCropRect] = useState(null); // image-pixel coords, or null
@@ -1577,11 +1593,12 @@ export function ImageEditor() {
     working,
     tool,
     canMask,
+    smartSelectSupported,
     aiOp,
     activeProject,
     requestedGpu,
     runAiOp: runAiOpBridge,
-    stagePointToImage: stagePointToImageBridge,
+    stagePointToImage: stagePointToActiveLayerImage,
     blobToImage,
     setTool,
   });
@@ -1609,9 +1626,25 @@ export function ImageEditor() {
     selectPointerUp,
     cancelSelectDrag,
     rasterizeMaskToFile,
+    rasterizeMaskToCanvas,
     refineMask,
     resetMaskState,
   } = maskTool;
+
+  // SAM3 cutout preview is an offscreen alpha composition, just like color key:
+  // refinement remains editable and no document/history mutation occurs until Apply.
+  const maskCutoutPreview = useMemo(() => {
+    const layer = activeLayerOf(working);
+    if (tool !== "cutout" || !maskMode || !layer?.image || (!maskHasContent(maskLines) && !maskBaseImage)) return null;
+    try {
+      return {
+        layerId: layer.id,
+        image: maskCutoutCanvasForImage(layer.image, rasterizeMaskToCanvas(), cutoutKeepSelected),
+      };
+    } catch {
+      return null;
+    }
+  }, [working, tool, maskMode, maskLines, maskBaseImage, rasterizeMaskToCanvas, cutoutKeepSelected]);
 
   // Memoize the image-renderable subset (sc-8939): the Image Editor re-renders on every
   // pointermove of a brush stroke / box drag, and re-filtering the full catalog each time
@@ -2301,6 +2334,34 @@ export function ImageEditor() {
     }
   }, [colorKeySeed, colorKeyTolerance, colorKeySoftness, colorKeyGlobal, checkpoint, replaceLayerImage]);
 
+  // Commit the currently refined SAM3 mask to the active layer only. The mask is
+  // converted to an alpha multiplier, so keep/remove choices both preserve an
+  // already-transparent source pixel and produce one undoable bitmap replacement.
+  const applyMaskCutout = useCallback(async () => {
+    const work = workingRef.current;
+    const layer = activeLayerOf(work);
+    if (!layer?.image || (!maskHasContent(maskLines) && !maskBaseImage)) return;
+    const sourceBlob = layer.blob;
+    try {
+      const canvas = maskCutoutCanvasForImage(layer.image, rasterizeMaskToCanvas(), cutoutKeepSelected);
+      const blob = await canvasToPngBlob(canvas);
+      const { image, objectUrl } = await blobToImage(blob);
+      const current = layerById(workingRef.current, layer.id);
+      if (!current || current.blob !== sourceBlob) {
+        URL.revokeObjectURL(objectUrl);
+        return;
+      }
+      checkpoint();
+      replaceLayerImage(layer.id, image, objectUrl, blob);
+      setEdits((prev) => [...prev, { op: "sam3Cutout", mode: cutoutKeepSelected ? "keepSelected" : "removeSelected" }]);
+      setDirty(true);
+      clearMask();
+      setTool("move");
+    } catch (err) {
+      setStatus({ loading: false, error: err.message || "Could not apply the SAM3 cutout." });
+    }
+  }, [maskLines, maskBaseImage, rasterizeMaskToCanvas, cutoutKeepSelected, checkpoint, replaceLayerImage, clearMask]);
+
   // A document-level AI op (upscale / outpaint / box-keyed edit) flattens the stack
   // into one base layer; warn before discarding a multi-layer stack.
   const confirmFlatten = useCallback(() => {
@@ -2656,12 +2717,29 @@ export function ImageEditor() {
   }
   stagePointToImageRef.current = stagePointToImage;
 
+  // SAM3 receives a scratch image of the active layer, not the composited
+  // document. Convert the visible-stage drag through that layer's transform so
+  // the worker box and the editable mask use the bitmap's own pixel coordinates.
+  function stagePointToActiveLayerImage(event) {
+    const point = stagePointToImage(event);
+    const layer = activeLayerOf(workingRef.current);
+    if (!point || !layer?.image) return null;
+    const local = documentPointToLayerPoint(point, layer.transform);
+    if (!local) return null;
+    return {
+      x: clamp(local.x, 0, layer.image.naturalWidth),
+      y: clamp(local.y, 0, layer.image.naturalHeight),
+    };
+  }
+
   // The canvas reports document coordinates, while each layer can be translated,
   // rotated, or scaled. Invert the active layer transform before sampling its
   // source bitmap so the eyedropper and the eventual alpha write address the
   // same pixels.
   function colorKeyPointerDown(event) {
-    if (tool !== "cutout") return;
+    // When cutout is in SAM3 mask mode the canvas gesture belongs to the brush/
+    // selection box, not to the color-key eyedropper.
+    if (tool !== "cutout" || maskMode) return;
     const layer = activeLayerOf(workingRef.current);
     const point = stagePointToImage(event);
     if (!layer?.image || !point) return;
@@ -3215,7 +3293,9 @@ export function ImageEditor() {
     upscale: "Pick an engine and factor, then run",
     detail: "Tune detail & structure, then enhance",
     color: "Grade with adjust, levels or curves",
-    cutout: colorKeySeed ? "Adjust the key, then apply the alpha cutout" : "Click the background color to preview a cutout",
+    cutout: maskMode
+      ? (maskSubTool === "select" ? "Drag a box to select an object with SAM3" : "Paint to refine the SAM3 selection")
+      : (colorKeySeed ? "Adjust the key, then apply the alpha cutout" : "Click the background color to preview a cutout"),
     edit: maskMode ? "Paint or box-select the region to edit" : "Describe the edit on the right",
     boxes: "Drag to draw a region, then describe it",
   }[tool];
@@ -3256,6 +3336,7 @@ export function ImageEditor() {
     aiOp,
     applyColorGrade,
     applyColorKey,
+    applyMaskCutout,
     applyCrop,
     assetUrl,
     availableUpscaleEngines,
@@ -3280,6 +3361,7 @@ export function ImageEditor() {
     createLoraDownloadJob,
     createModelDownloadJob,
     cropRect,
+    cutoutKeepSelected,
     curves,
     deleteBox,
     detailCnScale,
@@ -3350,6 +3432,7 @@ export function ImageEditor() {
     setColorMode,
     setCropDim,
     setCurves,
+    setCutoutKeepSelected,
     setDetailCnScale,
     setDetailModel,
     setDetailStrength,
@@ -3811,7 +3894,9 @@ export function ImageEditor() {
                     key={layer.id}
                     globalCompositeOperation={layer.blendMode}
                     height={layer.image.naturalHeight}
-                    image={isActive && colorKeyPreview?.layerId === layer.id ? colorKeyPreview.image : layer.image}
+                    image={isActive && maskCutoutPreview?.layerId === layer.id
+                      ? maskCutoutPreview.image
+                      : (isActive && colorKeyPreview?.layerId === layer.id ? colorKeyPreview.image : layer.image)}
                     name="editor-image"
                     opacity={layer.opacity}
                     rotation={t.rotation}
@@ -3886,40 +3971,57 @@ export function ImageEditor() {
                 </>
               ) : null}
             </Layer>
-            {canMask && (maskLines.length || maskOverlay) ? (
+            {maskMode && (maskLines.length || maskOverlay) ? (
               // Isolated layer so the eraser's destination-out clears only the mask
               // overlay, never the image beneath it. The smart-select base (sc-3751)
               // renders first, with the brush strokes (and their erases) composited on top.
+              // The group mirrors the active layer transform: the mask's coordinates
+              // are the staged active bitmap's coordinates, never document coordinates.
               <Layer listening={false}>
-                {maskOverlay ? (
-                  <KonvaImage height={working.height} image={maskOverlay} width={working.width} x={0} y={0} />
-                ) : null}
-                {maskLines.map((line, index) => (
-                  <Line
-                    globalCompositeOperation={line.erase ? "destination-out" : "source-over"}
-                    key={index}
-                    lineCap="round"
-                    lineJoin="round"
-                    points={line.points}
-                    stroke="rgba(255,40,120,0.5)"
-                    strokeWidth={line.size}
-                  />
-                ))}
+                {(() => {
+                  const active = activeLayerOf(working);
+                  const t = active?.transform ?? identityTransform();
+                  return (
+                    <Group rotation={t.rotation} scaleX={t.scaleX} scaleY={t.scaleY} x={t.x} y={t.y}>
+                      {maskOverlay ? (
+                        <KonvaImage height={maskOverlay.height} image={maskOverlay} width={maskOverlay.width} x={0} y={0} />
+                      ) : null}
+                      {maskLines.map((line, index) => (
+                        <Line
+                          globalCompositeOperation={line.erase ? "destination-out" : "source-over"}
+                          key={index}
+                          lineCap="round"
+                          lineJoin="round"
+                          points={line.points}
+                          stroke="rgba(255,40,120,0.5)"
+                          strokeWidth={line.size}
+                        />
+                      ))}
+                    </Group>
+                  );
+                })()}
               </Layer>
             ) : null}
-            {tool === "edit" && maskMode && maskSubTool === "select" && selectDraft ? (
+            {(tool === "edit" || tool === "cutout") && maskMode && maskSubTool === "select" && selectDraft ? (
               // Live smart-select box preview (sc-3751), image-pixel coords like the crop rect.
               <Layer listening={false}>
-                <Rect
-                  dash={[8, 6]}
-                  fill="rgba(255,40,120,0.12)"
-                  height={selectDraft.height}
-                  stroke="rgba(255,40,120,0.9)"
-                  strokeWidth={2 / view.scale}
-                  width={selectDraft.width}
-                  x={selectDraft.x}
-                  y={selectDraft.y}
-                />
+                {(() => {
+                  const t = activeLayerOf(working)?.transform ?? identityTransform();
+                  return (
+                    <Group rotation={t.rotation} scaleX={t.scaleX} scaleY={t.scaleY} x={t.x} y={t.y}>
+                      <Rect
+                        dash={[8, 6]}
+                        fill="rgba(255,40,120,0.12)"
+                        height={selectDraft.height}
+                        stroke="rgba(255,40,120,0.9)"
+                        strokeWidth={2 / view.scale}
+                        width={selectDraft.width}
+                        x={selectDraft.x}
+                        y={selectDraft.y}
+                      />
+                    </Group>
+                  );
+                })()}
               </Layer>
             ) : null}
             {tool === "boxes" ? (

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -113,6 +113,10 @@ import {
   maskHasContent,
 } from "./imageEditor/maskShared.js";
 import {
+  applyColorKeyToRgba,
+  documentPointToLayerPoint,
+} from "./imageEditor/colorKeyMath.js";
+import {
   ImageEditorToolPanel,
   useStableImageEditorToolPanelScope,
 } from "./imageEditor/ImageEditorToolPanel.jsx";
@@ -174,6 +178,8 @@ export {
   tintMaskRgbaInPlace,
   MASK_PREVIEW_RGBA,
   maskHasContent,
+  applyColorKeyToRgba,
+  documentPointToLayerPoint,
 };
 
 const MIN_SCALE = 0.05;
@@ -196,7 +202,7 @@ export function readStoredEditorLayout() {
 }
 
 // Tool identity for the rail / accordion headers / inspector header (epic 10243).
-export const EDITOR_TOOL_ORDER = ["move", "transform", "crop", "upscale", "detail", "color", "edit", "boxes"];
+export const EDITOR_TOOL_ORDER = ["move", "transform", "crop", "upscale", "detail", "color", "cutout", "edit", "boxes"];
 export const EDITOR_TOOL_META = {
   move: { label: "Move", desc: "Pan and inspect the canvas" },
   transform: { label: "Transform", desc: "Move, scale & rotate the layer" },
@@ -204,6 +210,7 @@ export const EDITOR_TOOL_META = {
   upscale: { label: "Upscale", desc: "Increase resolution with AI" },
   detail: { label: "Detail", desc: "Refine texture with tile ControlNet" },
   color: { label: "Color grade", desc: "Adjust tone, levels & curves" },
+  cutout: { label: "Cutout", desc: "Remove a color-keyed background" },
   edit: { label: "AI Edit", desc: "Prompt-driven edit & inpaint" },
   boxes: { label: "Boxes", desc: "Region layout & color-keyed edit" },
 };
@@ -237,6 +244,10 @@ export const EDITOR_TOOL_ICONS = {
   ]),
   color: strokeSvg({ key: "color" }, [
     <circle key="a" cx="12" cy="12" r="9" />, <path key="b" d="M12 3a9 9 0 0 1 0 18z" fill="currentColor" stroke="none" />,
+  ]),
+  cutout: strokeSvg({ key: "cutout" }, [
+    <path key="a" d="M4 5h16v14H4z" />, <path key="b" d="M7 15l3-4 2 2 2-3 3 5" />,
+    <circle key="c" cx="9" cy="9" r="1.2" />,
   ]),
   edit: strokeSvg({ key: "edit" }, [
     <path key="a" d="M15 4l5 5" />, <path key="b" d="M4 20l4-1 10-10-3-3L5 16z" />,
@@ -984,6 +995,25 @@ function blobToImage(blob) {
   });
 }
 
+function colorKeyCanvasForImage(image, seed, options) {
+  const canvas = document.createElement("canvas");
+  canvas.width = image.naturalWidth;
+  canvas.height = image.naturalHeight;
+  const ctx = canvas.getContext("2d");
+  ctx.drawImage(image, 0, 0);
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const cutout = applyColorKeyToRgba(imageData.data, canvas.width, canvas.height, { ...options, ...seed });
+  imageData.data.set(cutout.rgba);
+  ctx.putImageData(imageData, 0, 0);
+  return canvas;
+}
+
+function canvasToPngBlob(canvas) {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error("Could not encode the cutout."))), "image/png");
+  });
+}
+
 // Decode an editor source and, only when it exceeds the conservative WebKit
 // canvas ceiling, rasterize it directly into a bounded surface before any Konva
 // or export canvas is allocated. The caller owns the returned object URL.
@@ -1210,6 +1240,12 @@ export function ImageEditor() {
 
   // Crop tool (sc-2430): client-side, rasterized into a new working image on Apply.
   const [tool, setTool] = useState("move");
+  // Color-key cutout (sc-22462): selection/preview remain ephemeral until Apply,
+  // then the active layer receives one alpha-only bitmap replacement.
+  const [colorKeySeed, setColorKeySeed] = useState(null);
+  const [colorKeyTolerance, setColorKeyTolerance] = useState(12);
+  const [colorKeySoftness, setColorKeySoftness] = useState(8);
+  const [colorKeyGlobal, setColorKeyGlobal] = useState(false);
   const [ratioKey, setRatioKey] = useState("free");
   const [rotated, setRotated] = useState(false);
   const [cropRect, setCropRect] = useState(null); // image-pixel coords, or null
@@ -1441,6 +1477,26 @@ export function ImageEditor() {
   useEffect(() => { aiOpRef.current = aiOp; }, [aiOp]);
   useEffect(() => { workingRef.current = working; }, [working]);
 
+  // Preview is an offscreen canvas, never a layer mutation or a history entry.
+  // The stage swaps it in only for the selected active layer, retaining that
+  // layer's normal visibility, opacity, blend mode, and transform.
+  const colorKeyPreview = useMemo(() => {
+    const layer = activeLayerOf(working);
+    if (!layer?.image || !colorKeySeed) return null;
+    try {
+      return {
+        layerId: layer.id,
+        image: colorKeyCanvasForImage(layer.image, colorKeySeed, {
+          tolerance: colorKeyTolerance,
+          softness: colorKeySoftness,
+          global: colorKeyGlobal,
+        }),
+      };
+    } catch {
+      return null;
+    }
+  }, [working, colorKeySeed, colorKeyTolerance, colorKeySoftness, colorKeyGlobal]);
+
   // ── Per-tool hooks (sc-9752, F-052 follow-up) ──────────────────────────────
   // Each tool owns its own state, refs, and handlers. They're called here — before the
   // snapshot/reset/pointer plumbing that reads their refs — and receive the shared,
@@ -1618,6 +1674,7 @@ export function ImageEditor() {
   const resetEditorOverlays = useCallback(() => {
     setTool("move");
     setCropRect(null);
+    setColorKeySeed(null);
     // Per-tool state resets are owned by each tool hook now (sc-9752). Each reset mirrors
     // the exact lines it replaced: color → adjust/levels/curves/mode/channel identity;
     // mask → strokes + smart-select base + sub-mode + select gesture latch; boxes →
@@ -2111,6 +2168,11 @@ export function ImageEditor() {
       cancelCrop();
       return;
     }
+    if (tool === "cutout") {
+      setColorKeySeed(null);
+      setTool("move");
+      return;
+    }
     if (selectedBoxId) {
       setSelectedBoxId(null);
       return;
@@ -2202,6 +2264,42 @@ export function ImageEditor() {
   }, []);
   // Keep the color-grade hook's bridge pointed at the latest replaceLayerImage (sc-9752).
   replaceLayerImageRef.current = replaceLayerImage;
+
+  // Commit the preview's exact alpha calculation to the active layer. The
+  // checkpoint is deliberately after encode/decode succeeds and immediately
+  // before the one bitmap replacement, so a failed encode has no history entry
+  // and Apply always creates exactly one undoable operation.
+  const applyColorKey = useCallback(async () => {
+    const work = workingRef.current;
+    const layer = activeLayerOf(work);
+    if (!layer?.image || !colorKeySeed) return;
+    const sourceBlob = layer.blob;
+    try {
+      const canvas = colorKeyCanvasForImage(layer.image, colorKeySeed, {
+        tolerance: colorKeyTolerance,
+        softness: colorKeySoftness,
+        global: colorKeyGlobal,
+      });
+      const blob = await canvasToPngBlob(canvas);
+      const { image, objectUrl } = await blobToImage(blob);
+      const current = layerById(workingRef.current, layer.id);
+      if (!current || current.blob !== sourceBlob) {
+        URL.revokeObjectURL(objectUrl);
+        return;
+      }
+      checkpoint();
+      replaceLayerImage(layer.id, image, objectUrl, blob);
+      setEdits((prev) => [
+        ...prev,
+        { op: "colorKey", mode: colorKeyGlobal ? "global" : "connected", tolerance: colorKeyTolerance, softness: colorKeySoftness },
+      ]);
+      setDirty(true);
+      setColorKeySeed(null);
+      setTool("move");
+    } catch (err) {
+      setStatus({ loading: false, error: err.message || "Could not apply the color-key cutout." });
+    }
+  }, [colorKeySeed, colorKeyTolerance, colorKeySoftness, colorKeyGlobal, checkpoint, replaceLayerImage]);
 
   // A document-level AI op (upscale / outpaint / box-keyed edit) flattens the stack
   // into one base layer; warn before discarding a multi-layer stack.
@@ -2527,6 +2625,7 @@ export function ImageEditor() {
   // The stage's pointer events drive both the mask brush (edit tool) and box
   // drawing (boxes tool); each handler no-ops unless its tool/mode is active.
   function handleStagePointerDown(event) {
+    colorKeyPointerDown(event);
     maskPointerDown(event);
     selectPointerDown(event);
     boxPointerDown(event);
@@ -2556,6 +2655,26 @@ export function ImageEditor() {
     };
   }
   stagePointToImageRef.current = stagePointToImage;
+
+  // The canvas reports document coordinates, while each layer can be translated,
+  // rotated, or scaled. Invert the active layer transform before sampling its
+  // source bitmap so the eyedropper and the eventual alpha write address the
+  // same pixels.
+  function colorKeyPointerDown(event) {
+    if (tool !== "cutout") return;
+    const layer = activeLayerOf(workingRef.current);
+    const point = stagePointToImage(event);
+    if (!layer?.image || !point) return;
+    const local = documentPointToLayerPoint(point, layer.transform);
+    if (
+      !local ||
+      local.x < 0 ||
+      local.y < 0 ||
+      local.x >= layer.image.naturalWidth ||
+      local.y >= layer.image.naturalHeight
+    ) return;
+    setColorKeySeed({ x: Math.floor(local.x), y: Math.floor(local.y) });
+  }
 
   // ── AI ops on the working image (sc-2432 seam) ────────────────────────────
   // Flatten the composited document to a PNG File. `filename` overrides the name
@@ -3077,6 +3196,7 @@ export function ImageEditor() {
     else if (key === "transform") startTransform();
     else if (key === "crop") startCrop();
     else if (key === "color") startColorGrade();
+    else if (key === "cutout") setTool("cutout");
     else if (key === "boxes") selectBoxTool();
     else setTool(key);
   }
@@ -3095,6 +3215,7 @@ export function ImageEditor() {
     upscale: "Pick an engine and factor, then run",
     detail: "Tune detail & structure, then enhance",
     color: "Grade with adjust, levels or curves",
+    cutout: colorKeySeed ? "Adjust the key, then apply the alpha cutout" : "Click the background color to preview a cutout",
     edit: maskMode ? "Paint or box-select the region to edit" : "Describe the edit on the right",
     boxes: "Drag to draw a region, then describe it",
   }[tool];
@@ -3134,6 +3255,7 @@ export function ImageEditor() {
     addPaletteColor,
     aiOp,
     applyColorGrade,
+    applyColorKey,
     applyCrop,
     assetUrl,
     availableUpscaleEngines,
@@ -3149,6 +3271,10 @@ export function ImageEditor() {
     clearMask,
     colorAdjust,
     colorChannel,
+    colorKeyGlobal,
+    colorKeySeed,
+    colorKeySoftness,
+    colorKeyTolerance,
     colorMode,
     composedPrompt,
     createLoraDownloadJob,
@@ -3217,6 +3343,10 @@ export function ImageEditor() {
     setActiveTransform,
     setAdjustValue,
     setColorChannel,
+    setColorKeyGlobal,
+    setColorKeySeed,
+    setColorKeySoftness,
+    setColorKeyTolerance,
     setColorMode,
     setCropDim,
     setCurves,
@@ -3648,7 +3778,7 @@ export function ImageEditor() {
         ) : null}
         {working && stageSize.width > 0 && stageSize.height > 0 ? (
           <Stage
-            draggable={tool !== "crop" && tool !== "boxes" && tool !== "transform" && !maskMode}
+            draggable={tool !== "crop" && tool !== "boxes" && tool !== "transform" && tool !== "cutout" && !maskMode}
             height={stageSize.height}
             onDragEnd={(event) => {
               if (event.target !== event.target.getStage()) return;
@@ -3669,16 +3799,6 @@ export function ImageEditor() {
             y={view.y}
           >
             <Layer>
-              <Rect
-                fill="#ffffff"
-                height={working.height}
-                name="editor-bg"
-                shadowBlur={12}
-                shadowColor="rgba(0,0,0,0.35)"
-                width={working.width}
-                x={0}
-                y={0}
-              />
               {/* Editor layers (sc-6117): one <KonvaImage> per raster layer, bottom→top,
                   honoring per-layer visibility / opacity / blend / transform. The ACTIVE
                   layer carries the color-grade filter + the cached node ref (the live
@@ -3691,7 +3811,7 @@ export function ImageEditor() {
                     key={layer.id}
                     globalCompositeOperation={layer.blendMode}
                     height={layer.image.naturalHeight}
-                    image={layer.image}
+                    image={isActive && colorKeyPreview?.layerId === layer.id ? colorKeyPreview.image : layer.image}
                     name="editor-image"
                     opacity={layer.opacity}
                     rotation={t.rotation}

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -703,6 +703,12 @@ describe("editor download plan", () => {
     });
   });
 
+  it("treats an alpha-only active-layer replacement as an edited PNG export", () => {
+    const cutoutBlob = { id: "color-key-alpha", size: 4096 };
+    const cutout = doc({ installedBlob: original.blob }, { blob: cutoutBlob });
+    expect(plan(cutout)).toMatchObject({ mode: "raster", carriesWorkflow: false, hadWorkflow: true });
+  });
+
   // The AC's headline case: open a generated image, change nothing, Download. Before this story
   // that produced a re-encode with the recipe gone and nothing said about it.
   it("never re-rasterizes an unmodified generated image", () => {

--- a/apps/web/src/screens/imageEditor/ImageEditorToolPanel.jsx
+++ b/apps/web/src/screens/imageEditor/ImageEditorToolPanel.jsx
@@ -571,7 +571,7 @@ export const ImageEditorBoxesPanel = React.memo(function ImageEditorBoxesPanel({
 
 export const ImageEditorToolPanel = React.memo(function ImageEditorToolPanel({ panelKey, scope }) {
   renderObserverForTests?.();
-  const { COLOR_ADJUSTMENTS, CROP_RATIOS, CurveEditor, StudioUpdateBadge, StudioUpdateNotice, UPSCALE_ENGINE_DESC, activeGradeIsIdentity, activeLayerOf, actualSize, aiOp, applyColorGrade, applyCrop, availableUpscaleEngines, cancelCrop, channelStroke, chooseRatio, colorAdjust, colorChannel, colorMode, createModelDownloadJob, cropRect, curves, detailCnScale, detailModel, detailModels, detailStrength, endTransformGesture, fitToView, flipActiveLayer, histogramRef, identityTransform, layerCount, levels, onTransformSlider, ratioKey, requestTileControlNetDownload, resetActiveColorMode, resetActiveLayerTransform, resetAdjust, rotated, runDetail, runUpscale, selectedDetailModel, setActiveTransform, setAdjustValue, setColorChannel, setColorMode, setCropDim, setCurves, setDetailCnScale, setDetailModel, setDetailStrength, setLevelsValue, setStraighten, setTool, setUpscaleEngine, setUpscaleFactor, setUpscaleSoftness, straighten, tileControlNet, tileControlNetDownloadRequested, tileControlNetReady, toggleRotate, updateOptionLabel, upscaleEngine, upscaleEngineHasSoftness, upscaleFactor, upscaleFactorsForEngine, upscaleSoftness, working } = scope;
+  const { COLOR_ADJUSTMENTS, CROP_RATIOS, CurveEditor, StudioUpdateBadge, StudioUpdateNotice, UPSCALE_ENGINE_DESC, activeGradeIsIdentity, activeLayerOf, actualSize, aiOp, applyColorGrade, applyColorKey, applyCrop, availableUpscaleEngines, cancelCrop, channelStroke, chooseRatio, colorAdjust, colorChannel, colorKeyGlobal, colorKeySeed, colorKeySoftness, colorKeyTolerance, colorMode, createModelDownloadJob, cropRect, curves, detailCnScale, detailModel, detailModels, detailStrength, endTransformGesture, fitToView, flipActiveLayer, histogramRef, identityTransform, layerCount, levels, onTransformSlider, ratioKey, requestTileControlNetDownload, resetActiveColorMode, resetActiveLayerTransform, resetAdjust, rotated, runDetail, runUpscale, selectedDetailModel, setActiveTransform, setAdjustValue, setColorChannel, setColorKeyGlobal, setColorKeySeed, setColorKeySoftness, setColorKeyTolerance, setColorMode, setCropDim, setCurves, setDetailCnScale, setDetailModel, setDetailStrength, setLevelsValue, setStraighten, setTool, setUpscaleEngine, setUpscaleFactor, setUpscaleSoftness, straighten, tileControlNet, tileControlNetDownloadRequested, tileControlNetReady, toggleRotate, updateOptionLabel, upscaleEngine, upscaleEngineHasSoftness, upscaleFactor, upscaleFactorsForEngine, upscaleSoftness, working } = scope;
   const renderPanel = (key) => {
     switch (key) {
       case "move":
@@ -1091,6 +1091,80 @@ export const ImageEditorToolPanel = React.memo(function ImageEditorToolPanel({ p
                 type="button"
               >
                 Apply grade
+              </button>
+            </div>
+          </>
+        );
+      case "cutout":
+        return (
+          <>
+            <div className="ie-section">
+              <div className="ie-sec-title">Color key</div>
+              <p className="ie-note">
+                Click a background pixel on the active layer. The checkerboard shows the alpha preview without changing the image until you apply it.
+              </p>
+              <div className="ie-readout">
+                <span className="ie-readout-k">Sample</span>
+                <span className="ie-readout-v">
+                  {colorKeySeed ? `${colorKeySeed.x}, ${colorKeySeed.y}` : "Click canvas"}
+                </span>
+              </div>
+            </div>
+            <div className="ie-section">
+              <div className="ie-sec-title">Selection</div>
+              <div className="ie-seg two" style={{ width: "100%" }}>
+                <button className="ie-seg-btn" data-active={!colorKeyGlobal} onClick={() => setColorKeyGlobal(false)} type="button">
+                  Connected
+                </button>
+                <button className="ie-seg-btn" data-active={colorKeyGlobal} onClick={() => setColorKeyGlobal(true)} type="button">
+                  Global
+                </button>
+              </div>
+              <p className="ie-note">
+                Connected preserves separate same-color subject areas. Global removes every matching pixel on this layer.
+              </p>
+            </div>
+            <div className="ie-section">
+              <div className="ie-field">
+                <div className="ie-field-top">
+                  <span className="ie-field-label">Tolerance</span>
+                  <span className="ie-field-val">{colorKeyTolerance}</span>
+                </div>
+                <input
+                  aria-label="Color-key tolerance"
+                  className="ie-range"
+                  max={100}
+                  min={0}
+                  onChange={(event) => setColorKeyTolerance(Number(event.target.value))}
+                  step={1}
+                  type="range"
+                  value={colorKeyTolerance}
+                />
+              </div>
+              <div className="ie-field">
+                <div className="ie-field-top">
+                  <span className="ie-field-label">Softness</span>
+                  <span className="ie-field-val">{colorKeySoftness}</span>
+                </div>
+                <input
+                  aria-label="Color-key softness"
+                  className="ie-range"
+                  max={100}
+                  min={0}
+                  onChange={(event) => setColorKeySoftness(Number(event.target.value))}
+                  step={1}
+                  type="range"
+                  value={colorKeySoftness}
+                />
+              </div>
+              <p className="ie-note">Matching uses perceptual color distance; softness feathers the alpha edge.</p>
+            </div>
+            <div className="ie-section">
+              <button className="ie-btn block primary" disabled={!colorKeySeed} onClick={applyColorKey} type="button">
+                Apply cutout
+              </button>
+              <button className="ie-btn block" onClick={() => { setColorKeySeed(null); setTool("move"); }} type="button">
+                Cancel
               </button>
             </div>
           </>

--- a/apps/web/src/screens/imageEditor/ImageEditorToolPanel.jsx
+++ b/apps/web/src/screens/imageEditor/ImageEditorToolPanel.jsx
@@ -571,7 +571,7 @@ export const ImageEditorBoxesPanel = React.memo(function ImageEditorBoxesPanel({
 
 export const ImageEditorToolPanel = React.memo(function ImageEditorToolPanel({ panelKey, scope }) {
   renderObserverForTests?.();
-  const { COLOR_ADJUSTMENTS, CROP_RATIOS, CurveEditor, StudioUpdateBadge, StudioUpdateNotice, UPSCALE_ENGINE_DESC, activeGradeIsIdentity, activeLayerOf, actualSize, aiOp, applyColorGrade, applyColorKey, applyCrop, availableUpscaleEngines, cancelCrop, channelStroke, chooseRatio, colorAdjust, colorChannel, colorKeyGlobal, colorKeySeed, colorKeySoftness, colorKeyTolerance, colorMode, createModelDownloadJob, cropRect, curves, detailCnScale, detailModel, detailModels, detailStrength, endTransformGesture, fitToView, flipActiveLayer, histogramRef, identityTransform, layerCount, levels, onTransformSlider, ratioKey, requestTileControlNetDownload, resetActiveColorMode, resetActiveLayerTransform, resetAdjust, rotated, runDetail, runUpscale, selectedDetailModel, setActiveTransform, setAdjustValue, setColorChannel, setColorKeyGlobal, setColorKeySeed, setColorKeySoftness, setColorKeyTolerance, setColorMode, setCropDim, setCurves, setDetailCnScale, setDetailModel, setDetailStrength, setLevelsValue, setStraighten, setTool, setUpscaleEngine, setUpscaleFactor, setUpscaleSoftness, straighten, tileControlNet, tileControlNetDownloadRequested, tileControlNetReady, toggleRotate, updateOptionLabel, upscaleEngine, upscaleEngineHasSoftness, upscaleFactor, upscaleFactorsForEngine, upscaleSoftness, working } = scope;
+  const { COLOR_ADJUSTMENTS, CROP_RATIOS, CurveEditor, StudioUpdateBadge, StudioUpdateNotice, UPSCALE_ENGINE_DESC, activeGradeIsIdentity, activeLayerOf, actualSize, aiOp, applyColorGrade, applyColorKey, applyCrop, applyMaskCutout, availableUpscaleEngines, cancelCrop, channelStroke, chooseRatio, colorAdjust, colorChannel, colorKeyGlobal, colorKeySeed, colorKeySoftness, colorKeyTolerance, colorMode, createModelDownloadJob, cropRect, curves, cutoutKeepSelected, detailCnScale, detailModel, detailModels, detailStrength, endTransformGesture, fitToView, flipActiveLayer, histogramRef, identityTransform, layerCount, levels, maskBaseImage, maskBrush, maskErase, maskHasContent, maskLines, maskMode, maskRefineRadius, maskSubTool, onTransformSlider, ratioKey, refineMask, requestTileControlNetDownload, resetActiveColorMode, resetActiveLayerTransform, resetAdjust, rotated, runDetail, runUpscale, selectedDetailModel, setActiveTransform, setAdjustValue, setColorChannel, setColorKeyGlobal, setColorKeySeed, setColorKeySoftness, setColorKeyTolerance, setColorMode, setCropDim, setCurves, setCutoutKeepSelected, setDetailCnScale, setDetailModel, setDetailStrength, setLevelsValue, setMaskBrush, setMaskErase, setMaskMode, setMaskRefineRadius, setMaskSubTool, setStraighten, setTool, setUpscaleEngine, setUpscaleFactor, setUpscaleSoftness, smartSelectSupported, straighten, tileControlNet, tileControlNetDownloadRequested, tileControlNetReady, toggleRotate, updateOptionLabel, upscaleEngine, upscaleEngineHasSoftness, upscaleFactor, upscaleFactorsForEngine, upscaleSoftness, working } = scope;
   const renderPanel = (key) => {
     switch (key) {
       case "move":
@@ -1158,6 +1158,106 @@ export const ImageEditorToolPanel = React.memo(function ImageEditorToolPanel({ p
                 />
               </div>
               <p className="ie-note">Matching uses perceptual color distance; softness feathers the alpha edge.</p>
+            </div>
+            <div className="ie-section">
+              <div className="ie-sec-title">SAM3 object selection</div>
+              {smartSelectSupported ? (
+                <>
+                  <p className="ie-note">Draw a box around an object on the active layer. SAM3 selection works without choosing an AI Edit model.</p>
+                  <div className="ie-seg two" style={{ width: "100%" }}>
+                    <button
+                      className="ie-seg-btn"
+                      data-active={maskMode && maskSubTool === "select"}
+                      disabled={aiOp?.label === "smart select"}
+                      onClick={() => {
+                        setColorKeySeed(null);
+                        setMaskMode(true);
+                        setMaskSubTool("select");
+                        setMaskErase(false);
+                      }}
+                      type="button"
+                    >
+                      {aiOp?.label === "smart select" ? "Segmenting…" : "Smart select"}
+                    </button>
+                    <button
+                      className="ie-seg-btn"
+                      data-active={maskMode && maskSubTool === "brush"}
+                      onClick={() => {
+                        setMaskMode(true);
+                        setMaskSubTool("brush");
+                      }}
+                      type="button"
+                    >
+                      Refine brush
+                    </button>
+                  </div>
+                  {maskMode && maskSubTool === "select" ? (
+                    <p className="ie-note">Drag a box around an object on the canvas — SAM3 auto-masks it.</p>
+                  ) : null}
+                  {maskMode && maskSubTool === "brush" ? (
+                    <>
+                      <div className="ie-field">
+                        <div className="ie-field-top">
+                          <span className="ie-field-label">Brush size</span>
+                          <span className="ie-field-val">{maskBrush} px</span>
+                        </div>
+                        <input
+                          aria-label="SAM3 refine brush size"
+                          className="ie-range"
+                          max={300}
+                          min={5}
+                          onChange={(event) => setMaskBrush(Number(event.target.value))}
+                          step={1}
+                          type="range"
+                          value={maskBrush}
+                        />
+                      </div>
+                      <button className="ie-btn block" data-active={maskErase} onClick={() => setMaskErase((on) => !on)} type="button">
+                        Eraser
+                      </button>
+                    </>
+                  ) : null}
+                  {maskMode ? (
+                    <>
+                      <div className="ie-field" style={{ marginTop: "10px", marginBottom: "8px" }}>
+                        <div className="ie-field-top">
+                          <span className="ie-field-label">Refine radius</span>
+                          <span className="ie-field-val">{maskRefineRadius}px</span>
+                        </div>
+                        <input
+                          aria-label="SAM3 refine radius"
+                          className="ie-range"
+                          max={40}
+                          min={1}
+                          onChange={(event) => setMaskRefineRadius(Number(event.target.value))}
+                          step={1}
+                          type="range"
+                          value={maskRefineRadius}
+                        />
+                      </div>
+                      <div className="ie-chip-row">
+                        <button className="ie-chip" disabled={!maskHasContent(maskLines) && !maskBaseImage} onClick={() => refineMask("feather")} type="button">Feather</button>
+                        <button className="ie-chip" disabled={!maskHasContent(maskLines) && !maskBaseImage} onClick={() => refineMask("grow")} type="button">Grow</button>
+                        <button className="ie-chip" disabled={!maskHasContent(maskLines) && !maskBaseImage} onClick={() => refineMask("shrink")} type="button">Shrink</button>
+                        <button className="ie-chip" onClick={() => refineMask("invert")} type="button">Invert</button>
+                      </div>
+                    </>
+                  ) : null}
+                  {maskMode && (maskHasContent(maskLines) || maskBaseImage) ? (
+                    <>
+                      <div className="ie-seg two" style={{ marginTop: "10px", width: "100%" }}>
+                        <button className="ie-seg-btn" data-active={cutoutKeepSelected} onClick={() => setCutoutKeepSelected(true)} type="button">Keep selected</button>
+                        <button className="ie-seg-btn" data-active={!cutoutKeepSelected} onClick={() => setCutoutKeepSelected(false)} type="button">Remove selected</button>
+                      </div>
+                      <button className="ie-btn block primary" onClick={applyMaskCutout} style={{ marginTop: "10px" }} type="button">
+                        Apply selection cutout
+                      </button>
+                    </>
+                  ) : null}
+                </>
+              ) : (
+                <p className="ie-note">SAM3 object selection is unavailable on this worker. Color key remains available above; choose a worker with image segmentation support to use Smart Select.</p>
+              )}
             </div>
             <div className="ie-section">
               <button className="ie-btn block primary" disabled={!colorKeySeed} onClick={applyColorKey} type="button">

--- a/apps/web/src/screens/imageEditor/ImageEditorToolPanel.test.jsx
+++ b/apps/web/src/screens/imageEditor/ImageEditorToolPanel.test.jsx
@@ -58,6 +58,42 @@ describe("ImageEditorToolPanel memo boundary", () => {
   });
 });
 
+describe("ImageEditorToolPanel color-key cutout", () => {
+  it("offers connected/global selection, adjustable perceptual edge controls, and one apply action", async () => {
+    const setColorKeyGlobal = vi.fn();
+    const applyColorKey = vi.fn();
+    await act(async () => root.render(
+      <ImageEditorToolPanel
+        panelKey="cutout"
+        scope={{
+          colorKeyGlobal: false,
+          colorKeySeed: { x: 7, y: 9 },
+          colorKeySoftness: 8,
+          colorKeyTolerance: 12,
+          setColorKeyGlobal,
+          setColorKeySeed: vi.fn(),
+          setColorKeySoftness: vi.fn(),
+          setColorKeyTolerance: vi.fn(),
+          applyColorKey,
+          setTool: vi.fn(),
+        }}
+      />,
+    ));
+    expect(container.textContent).toContain("Click a background pixel on the active layer");
+    expect(container.textContent).toContain("Connected preserves separate same-color subject areas");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Global")
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Apply cutout")
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(setColorKeyGlobal).toHaveBeenCalledWith(true);
+    expect(container.querySelector("input[aria-label='Color-key tolerance']").value).toBe("12");
+    expect(container.querySelector("input[aria-label='Color-key softness']").value).toBe("8");
+    expect(applyColorKey).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("ImageEditorEditPanel quick edit instructions", () => {
   const model = { id: "z_image_edit", name: "Z-Image-Edit" };
 

--- a/apps/web/src/screens/imageEditor/ImageEditorToolPanel.test.jsx
+++ b/apps/web/src/screens/imageEditor/ImageEditorToolPanel.test.jsx
@@ -92,6 +92,85 @@ describe("ImageEditorToolPanel color-key cutout", () => {
     expect(container.querySelector("input[aria-label='Color-key softness']").value).toBe("8");
     expect(applyColorKey).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps color key actionable when SAM3 is unavailable", async () => {
+    await act(async () => root.render(
+      <ImageEditorToolPanel
+        panelKey="cutout"
+        scope={{
+          colorKeyGlobal: false,
+          colorKeySeed: { x: 7, y: 9 },
+          colorKeySoftness: 8,
+          colorKeyTolerance: 12,
+          setColorKeyGlobal: vi.fn(),
+          setColorKeySeed: vi.fn(),
+          setColorKeySoftness: vi.fn(),
+          setColorKeyTolerance: vi.fn(),
+          applyColorKey: vi.fn(),
+          smartSelectSupported: false,
+          setTool: vi.fn(),
+        }}
+      />,
+    ));
+    expect(container.textContent).toContain("SAM3 object selection is unavailable on this worker");
+    expect(container.textContent).toContain("Color key remains available above");
+    expect([...container.querySelectorAll("button")].find((button) => button.textContent === "Apply cutout")).toBeTruthy();
+    expect(container.textContent).not.toContain("Smart select");
+  });
+
+  it("offers SAM3 keep/remove selection cutouts independently of AI Edit", async () => {
+    const setMaskMode = vi.fn();
+    const setMaskSubTool = vi.fn();
+    const setCutoutKeepSelected = vi.fn();
+    const applyMaskCutout = vi.fn();
+    await act(async () => root.render(
+      <ImageEditorToolPanel
+        panelKey="cutout"
+        scope={{
+          aiOp: null,
+          applyMaskCutout,
+          colorKeyGlobal: false,
+          colorKeySeed: null,
+          colorKeySoftness: 8,
+          colorKeyTolerance: 12,
+          cutoutKeepSelected: true,
+          maskBaseImage: {},
+          maskBrush: 40,
+          maskErase: false,
+          maskHasContent: () => false,
+          maskLines: [],
+          maskMode: true,
+          maskRefineRadius: 6,
+          maskSubTool: "select",
+          refineMask: vi.fn(),
+          setColorKeyGlobal: vi.fn(),
+          setColorKeySeed: vi.fn(),
+          setColorKeySoftness: vi.fn(),
+          setColorKeyTolerance: vi.fn(),
+          setCutoutKeepSelected,
+          setMaskBrush: vi.fn(),
+          setMaskErase: vi.fn(),
+          setMaskMode,
+          setMaskRefineRadius: vi.fn(),
+          setMaskSubTool,
+          smartSelectSupported: true,
+        }}
+      />,
+    ));
+    expect(container.textContent).toContain("works without choosing an AI Edit model");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Smart select")
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Remove selected")
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Apply selection cutout")
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(setMaskMode).toHaveBeenCalledWith(true);
+    expect(setMaskSubTool).toHaveBeenCalledWith("select");
+    expect(setCutoutKeepSelected).toHaveBeenCalledWith(false);
+    expect(applyMaskCutout).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("ImageEditorEditPanel quick edit instructions", () => {

--- a/apps/web/src/screens/imageEditor/colorKeyMath.js
+++ b/apps/web/src/screens/imageEditor/colorKeyMath.js
@@ -1,0 +1,145 @@
+// Color-key selection is intentionally canvas-free: the editor uses the same
+// selection both for the live preview and the one committed alpha write. Keeping
+// it here makes the connected/global semantics testable without Konva or a DOM.
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function srgbToLinear(channel) {
+  const value = channel / 255;
+  return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+}
+
+// Oklab is a compact perceptual space. Euclidean distances here track visible
+// colour changes much more faithfully than raw RGB channel deltas.
+export function rgbaToOklab(r, g, b) {
+  const linearR = srgbToLinear(r);
+  const linearG = srgbToLinear(g);
+  const linearB = srgbToLinear(b);
+  const l = Math.cbrt(0.4122214708 * linearR + 0.5363325363 * linearG + 0.0514459929 * linearB);
+  const m = Math.cbrt(0.2119034982 * linearR + 0.6806995451 * linearG + 0.1073969566 * linearB);
+  const s = Math.cbrt(0.0883024619 * linearR + 0.2817188376 * linearG + 0.6299787005 * linearB);
+  return [
+    0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+    1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+    0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+  ];
+}
+
+export function oklabDistance(a, b) {
+  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+}
+
+// UI values are 0..100. Oklab's useful RGB-gamut distance is roughly 0..0.5,
+// so map that compactly while retaining room for a visibly soft edge.
+export function colorKeyDistanceLimit(value) {
+  return (clamp(Number(value) || 0, 0, 100) / 100) * 0.5;
+}
+
+function alphaMultiplier(distance, tolerance, softness) {
+  if (distance <= tolerance) return 0;
+  if (softness <= 0 || distance >= tolerance + softness) return 255;
+  return Math.round(((distance - tolerance) / softness) * 255);
+}
+
+// Return an alpha multiplier for every source pixel. In connected mode the
+// matching region is 4-neighbour connected to the eyedropped pixel; equal-colour
+// islands on the subject remain untouched. Global mode deliberately visits every
+// matching pixel instead.
+export function colorKeyAlphaMultipliers(
+  rgba,
+  width,
+  height,
+  { x, y, tolerance = 12, softness = 8, global = false } = {},
+) {
+  const pixelCount = Math.max(0, width * height);
+  const multipliers = new Uint8ClampedArray(pixelCount);
+  multipliers.fill(255);
+  if (!rgba || !pixelCount) return multipliers;
+
+  const seedX = clamp(Math.floor(x), 0, width - 1);
+  const seedY = clamp(Math.floor(y), 0, height - 1);
+  const seedOffset = (seedY * width + seedX) * 4;
+  const target = rgbaToOklab(rgba[seedOffset], rgba[seedOffset + 1], rgba[seedOffset + 2]);
+  const threshold = colorKeyDistanceLimit(tolerance);
+  const feather = colorKeyDistanceLimit(softness);
+  const limit = threshold + feather;
+  const distances = new Float32Array(pixelCount);
+  const matches = new Uint8Array(pixelCount);
+
+  for (let index = 0; index < pixelCount; index += 1) {
+    const offset = index * 4;
+    const distance = oklabDistance(target, rgbaToOklab(rgba[offset], rgba[offset + 1], rgba[offset + 2]));
+    distances[index] = distance;
+    if (distance <= limit) matches[index] = 1;
+  }
+
+  const visit = (index) => {
+    multipliers[index] = alphaMultiplier(distances[index], threshold, feather);
+  };
+  if (global) {
+    for (let index = 0; index < pixelCount; index += 1) if (matches[index]) visit(index);
+    return multipliers;
+  }
+
+  const start = seedY * width + seedX;
+  if (!matches[start]) return multipliers;
+  const seen = new Uint8Array(pixelCount);
+  const queue = [start];
+  seen[start] = 1;
+  for (let cursor = 0; cursor < queue.length; cursor += 1) {
+    const index = queue[cursor];
+    visit(index);
+    const px = index % width;
+    const py = Math.floor(index / width);
+    const neighbors = [index - 1, index + 1, index - width, index + width];
+    for (const next of neighbors) {
+      if (
+        next < 0 ||
+        next >= pixelCount ||
+        (next === index - 1 && px === 0) ||
+        (next === index + 1 && px === width - 1) ||
+        (next === index - width && py === 0) ||
+        (next === index + width && py === height - 1) ||
+        seen[next] ||
+        !matches[next]
+      ) continue;
+      seen[next] = 1;
+      queue.push(next);
+    }
+  }
+  return multipliers;
+}
+
+// Shared apply-as-alpha seam: callers supply a non-destructive alpha multiplier
+// (255 = preserve, 0 = fully cut out). This composes with existing source alpha,
+// so a later selection tool such as SAM3 cannot accidentally resurrect pixels.
+export function applyAlphaMultipliersInPlace(rgba, multipliers) {
+  const count = Math.min(Math.floor(rgba.length / 4), multipliers.length);
+  for (let index = 0; index < count; index += 1) {
+    const alphaOffset = index * 4 + 3;
+    rgba[alphaOffset] = Math.round((rgba[alphaOffset] * multipliers[index]) / 255);
+  }
+  return rgba;
+}
+
+export function applyColorKeyToRgba(rgba, width, height, options) {
+  const output = new Uint8ClampedArray(rgba);
+  const multipliers = colorKeyAlphaMultipliers(output, width, height, options);
+  return { rgba: applyAlphaMultipliersInPlace(output, multipliers), multipliers };
+}
+
+// Convert document coordinates into the active layer's source pixel space. This
+// inverts the same translate/rotate/scale transform used by the canvas compositor.
+export function documentPointToLayerPoint(point, transform = {}) {
+  const x = point.x - (transform.x || 0);
+  const y = point.y - (transform.y || 0);
+  const angle = -((transform.rotation || 0) * Math.PI) / 180;
+  const rotatedX = x * Math.cos(angle) - y * Math.sin(angle);
+  const rotatedY = x * Math.sin(angle) + y * Math.cos(angle);
+  const scaleX = transform.scaleX ?? 1;
+  const scaleY = transform.scaleY ?? 1;
+  if (!scaleX || !scaleY) return null;
+  return { x: rotatedX / scaleX, y: rotatedY / scaleY };
+}

--- a/apps/web/src/screens/imageEditor/colorKeyMath.js
+++ b/apps/web/src/screens/imageEditor/colorKeyMath.js
@@ -124,6 +124,17 @@ export function applyAlphaMultipliersInPlace(rgba, multipliers) {
   return rgba;
 }
 
+// Apply the editable SAM3 mask as alpha to a source bitmap. `keepSelected` uses
+// the white selection directly; remove-selected reverses it. Both paths use the
+// same alpha-multiplier seam as color key so existing transparency is preserved.
+export function applyMaskSelectionToRgba(rgba, maskAlpha, keepSelected) {
+  const multipliers = new Uint8ClampedArray(maskAlpha.length);
+  for (let index = 0; index < maskAlpha.length; index += 1) {
+    multipliers[index] = keepSelected ? maskAlpha[index] : 255 - maskAlpha[index];
+  }
+  return applyAlphaMultipliersInPlace(new Uint8ClampedArray(rgba), multipliers);
+}
+
 export function applyColorKeyToRgba(rgba, width, height, options) {
   const output = new Uint8ClampedArray(rgba);
   const multipliers = colorKeyAlphaMultipliers(output, width, height, options);

--- a/apps/web/src/screens/imageEditor/colorKeyMath.test.js
+++ b/apps/web/src/screens/imageEditor/colorKeyMath.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyAlphaMultipliersInPlace,
+  applyColorKeyToRgba,
+  colorKeyAlphaMultipliers,
+  documentPointToLayerPoint,
+} from "./colorKeyMath.js";
+
+const pixels = (entries) => new Uint8ClampedArray(entries.flatMap(([r, g, b, a = 255]) => [r, g, b, a]));
+
+describe("color-key alpha selection (sc-22462)", () => {
+  it("removes only the 4-connected perceptual match by default", () => {
+    // blue subject pixel at index 3 separates the identically green island at index 4.
+    const source = pixels([
+      [30, 180, 90], [31, 181, 91], [30, 180, 90], [30, 80, 220], [30, 180, 90],
+    ]);
+    const { rgba } = applyColorKeyToRgba(source, 5, 1, { x: 0, y: 0, tolerance: 6, softness: 0 });
+    expect([...rgba.filter((_, index) => index % 4 === 3)]).toEqual([0, 0, 0, 255, 255]);
+    // RGB remains intact; cutout is alpha-only.
+    expect([...rgba.slice(0, 3)]).toEqual([30, 180, 90]);
+  });
+
+  it("global mode removes disconnected matches but leaves a distinguishable subject pixel", () => {
+    const source = pixels([
+      [30, 180, 90], [30, 80, 220], [30, 180, 90], [100, 130, 130],
+    ]);
+    const { rgba } = applyColorKeyToRgba(source, 4, 1, { x: 0, y: 0, tolerance: 6, softness: 0, global: true });
+    expect([...rgba.filter((_, index) => index % 4 === 3)]).toEqual([0, 255, 0, 255]);
+  });
+
+  it("uses a soft perceptual edge and never resurrects existing transparency", () => {
+    const source = pixels([[20, 170, 90, 80], [28, 176, 96, 200], [90, 80, 220, 255]]);
+    const multipliers = colorKeyAlphaMultipliers(source, 3, 1, { x: 0, y: 0, tolerance: 2, softness: 20 });
+    expect(multipliers[0]).toBe(0);
+    expect(multipliers[1]).toBeGreaterThan(0);
+    expect(multipliers[1]).toBeLessThan(255);
+    const result = applyAlphaMultipliersInPlace(new Uint8ClampedArray(source), multipliers);
+    expect(result[3]).toBe(0);
+    expect(result[7]).toBeLessThan(200);
+    expect(result[11]).toBe(255);
+  });
+
+  it("maps an eyedropper click through the active layer transform", () => {
+    const point = documentPointToLayerPoint({ x: 15, y: 25 }, { x: 10, y: 20, scaleX: 2, scaleY: 1, rotation: 0 });
+    expect(point).toEqual({ x: 2.5, y: 5 });
+    const rotated = documentPointToLayerPoint({ x: 10, y: 13 }, { x: 10, y: 10, rotation: 90, scaleX: 1, scaleY: 1 });
+    expect(rotated.x).toBeCloseTo(3);
+    expect(rotated.y).toBeCloseTo(0);
+  });
+});

--- a/apps/web/src/screens/imageEditor/colorKeyMath.test.js
+++ b/apps/web/src/screens/imageEditor/colorKeyMath.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyAlphaMultipliersInPlace,
   applyColorKeyToRgba,
+  applyMaskSelectionToRgba,
   colorKeyAlphaMultipliers,
   documentPointToLayerPoint,
 } from "./colorKeyMath.js";
@@ -38,6 +39,18 @@ describe("color-key alpha selection (sc-22462)", () => {
     expect(result[3]).toBe(0);
     expect(result[7]).toBeLessThan(200);
     expect(result[11]).toBe(255);
+  });
+
+  it("applies a SAM3 selection as keep-selected or remove-selected alpha without resurrecting transparency", () => {
+    const source = pixels([[1, 2, 3, 255], [4, 5, 6, 120], [7, 8, 9, 0]]);
+    // First and last pixels are selected. The already-transparent last source pixel
+    // remains transparent in both modes, proving selection alpha is composed.
+    const mask = new Uint8ClampedArray([255, 0, 255]);
+    const kept = applyMaskSelectionToRgba(source, mask, true);
+    const removed = applyMaskSelectionToRgba(source, mask, false);
+    expect([...kept.filter((_, index) => index % 4 === 3)]).toEqual([255, 0, 0]);
+    expect([...removed.filter((_, index) => index % 4 === 3)]).toEqual([0, 120, 0]);
+    expect([...kept.slice(0, 3)]).toEqual([1, 2, 3]);
   });
 
   it("maps an eyedropper click through the active layer transform", () => {

--- a/apps/web/src/screens/imageEditor/useMaskTool.js
+++ b/apps/web/src/screens/imageEditor/useMaskTool.js
@@ -44,6 +44,7 @@ export function useMaskTool({
   working,
   tool,
   canMask,
+  smartSelectSupported,
   aiOp,
   activeProject,
   requestedGpu,
@@ -52,6 +53,8 @@ export function useMaskTool({
   blobToImage,
   setTool,
 }) {
+  const maskWidth = working?.layers?.find((layer) => layer.id === working.activeLayerId)?.image?.naturalWidth ?? working?.width ?? 0;
+  const maskHeight = working?.layers?.find((layer) => layer.id === working.activeLayerId)?.image?.naturalHeight ?? working?.height ?? 0;
   // Inpaint mask (sc-2436): freehand brush strokes in image-pixel coords, rasterized
   // to a mask asset on Run for inpaint-capable models. `maskMode` is the paint sub-mode
   // of the AI Edit tool (Stage panning is suspended while it's on).
@@ -92,10 +95,10 @@ export function useMaskTool({
     [],
   );
 
-  // Leave paint mode (restoring Stage panning) when the edit tool is closed or the
-  // model can't inpaint — otherwise the canvas would stay in a paint state with no UI.
+  // Leave paint mode when neither AI Edit's inpaint path nor Cutout owns it. SAM3
+  // cutout intentionally does not depend on an inpaint-capable edit model.
   useEffect(() => {
-    if (maskMode && (tool !== "edit" || !canMask)) setMaskMode(false);
+    if (maskMode && !((tool === "edit" && canMask) || tool === "cutout")) setMaskMode(false);
   }, [tool, canMask, maskMode]);
 
   // Reset the per-bitmap mask state (called by the editor's resetEditorOverlays). Mirrors
@@ -164,7 +167,7 @@ export function useMaskTool({
     setSelectDraft(null);
     // Discard a click / sub-minimum smudge; otherwise run segmentation over the box.
     if (!draft || draft.width < MIN_BOX_PX || draft.height < MIN_BOX_PX) return;
-    const rect = clampRectToCanvas(draft, working.width, working.height);
+    const rect = clampRectToCanvas(draft, maskWidth, maskHeight);
     runSmartSelect(rect);
   }
 
@@ -186,8 +189,8 @@ export function useMaskTool({
   // refine ops (sc-6110). White = edit region; erased holes flatten to black (=keep).
   function rasterizeMaskToCanvas() {
     const scratch = document.createElement("canvas");
-    scratch.width = working.width;
-    scratch.height = working.height;
+    scratch.width = maskWidth;
+    scratch.height = maskHeight;
     const sctx = scratch.getContext("2d");
     // Smart-select base first (sc-3751): the white-on-black SAM3 mask underlays the brush strokes,
     // so paint strokes add to it and erase strokes (destination-out) carve it back. Its opaque
@@ -214,8 +217,8 @@ export function useMaskTool({
     }
     // Flatten onto black so erased/holes read as black (= keep).
     const out = document.createElement("canvas");
-    out.width = working.width;
-    out.height = working.height;
+    out.width = maskWidth;
+    out.height = maskHeight;
     const octx = out.getContext("2d");
     octx.fillStyle = "#000000";
     octx.fillRect(0, 0, out.width, out.height);
@@ -240,12 +243,12 @@ export function useMaskTool({
   // Drawn scaled to the working dims defensively (the mask is produced at the working size).
   function loadMaskBase(image) {
     const base = document.createElement("canvas");
-    base.width = working.width;
-    base.height = working.height;
-    base.getContext("2d").drawImage(image, 0, 0, working.width, working.height);
+    base.width = maskWidth;
+    base.height = maskHeight;
+    base.getContext("2d").drawImage(image, 0, 0, maskWidth, maskHeight);
     const overlay = document.createElement("canvas");
-    overlay.width = working.width;
-    overlay.height = working.height;
+    overlay.width = maskWidth;
+    overlay.height = maskHeight;
     const octx = overlay.getContext("2d");
     octx.drawImage(base, 0, 0);
     const data = octx.getImageData(0, 0, overlay.width, overlay.height);
@@ -260,8 +263,8 @@ export function useMaskTool({
   // are now baked into the canvas). Mirrors loadMaskBase but from a canvas.
   function applyRefinedMask(maskCanvas) {
     const overlay = document.createElement("canvas");
-    overlay.width = working.width;
-    overlay.height = working.height;
+    overlay.width = maskWidth;
+    overlay.height = maskHeight;
     const octx = overlay.getContext("2d");
     octx.drawImage(maskCanvas, 0, 0);
     const data = octx.getImageData(0, 0, overlay.width, overlay.height);
@@ -299,7 +302,7 @@ export function useMaskTool({
   // It does NOT replace the working image (onComplete owns the result), so the session is unchanged
   // except for the mask layer; the brush/eraser then refines it before Inpaint.
   function runSmartSelect(rect) {
-    if (!working || aiOp || !canMask) return;
+    if (!working || aiOp || !smartSelectSupported) return;
     const requestGeneration = smartSelectLoaderRef.current.invalidate();
     const box = rectToSegmentBox(rect);
     runAiOp({
@@ -354,6 +357,7 @@ export function useMaskTool({
     selectPointerUp,
     cancelSelectDrag,
     rasterizeMaskToFile,
+    rasterizeMaskToCanvas,
     refineMask,
     resetMaskState,
   };


### PR DESCRIPTION
## Summary

Implements the two user-facing feature slices for epic 22461 in one cumulative SceneWorks batch.

- sc-22462: dedicated non-AI color-key cutout with Oklab matching, connected/global modes, tolerance, softness, transformed-layer sampling, preview, active-layer alpha application, and undo/redo
- sc-22464: SAM3 box selection in the Cutout workflow, independent of inpaint model selection, with shared refinement and keep-selected/remove-selected alpha application
- Preserves existing AI Edit inpaint behavior and leaves the MLX/Candle image_segment backend, model, checkpoint, and inference pin unchanged

## Validation

- Focused web tests: 153 passed on the final combined tree
- Full web suite: 277 files, 4233 tests passed
- Web ESLint passed
- Production Vite build passed
- mac_capabilities_master_switch_and_infra_features passed
- native_candle_utility_capabilities_dispatch_supported_shapes_only passed
- checked_in_matrix_matches_all_authoritative_sources passed
- git diff --check passed

Shortcut epic: https://app.shortcut.com/trefry/epic/22461