### PR TITLE
Fix terminal cutout lifecycle and shared mask refinement

### DIFF
--- a/apps/web/src/imageJobs.js
+++ b/apps/web/src/imageJobs.js
@@ -28,6 +28,7 @@ export function detailCapableModels(imageModels) {
 // while this dependency is not, and the job would fail at run time with "tile ControlNet weights not
 // found". Look it up in the FULL catalog so the Detail panel can gate the run + offer a one-click install.
 export const TILE_CONTROLNET_MODEL_ID = "controlnet_tile_sdxl";
+export const SAM3_SEGMENT_MODEL_ID = "sam3_person_segment";
 
 export function tileControlNetModel(models) {
   return (models ?? []).find((model) => model.id === TILE_CONTROLNET_MODEL_ID) ?? null;
@@ -37,6 +38,17 @@ export function tileControlNetModel(models) {
 export function tileControlNetInstalled(models) {
   const model = tileControlNetModel(models);
   return Boolean(model) && model.installState !== "missing" && model.installState !== "incomplete";
+}
+
+// SAM3 segmentation is cache-only at job time. Platform capability alone is not
+// readiness: the utility checkpoint must already be complete in Model Manager.
+export function sam3SegmentModel(models) {
+  return (models ?? []).find((model) => model.id === SAM3_SEGMENT_MODEL_ID) ?? null;
+}
+
+export function sam3SegmentInstalled(models) {
+  const model = sam3SegmentModel(models);
+  return Boolean(model) && model.installState === "installed";
 }
 
 // The `POST /api/v1/image/jobs` body for a prompt edit (sc-2435). Reuses the existing

--- a/apps/web/src/screens/ImageEditor.jsx
+++ b/apps/web/src/screens/ImageEditor.jsx
@@ -58,6 +58,9 @@ import {
   tileControlNetInstalled,
   tileControlNetModel,
   TILE_CONTROLNET_MODEL_ID,
+  sam3SegmentInstalled,
+  sam3SegmentModel,
+  SAM3_SEGMENT_MODEL_ID,
   upscaleEngineHasSoftness,
   upscaleFactorsForEngine,
 } from "../imageJobs.js";
@@ -116,6 +119,7 @@ import {
 import {
   applyColorKeyToRgba,
   applyMaskSelectionToRgba,
+  colorKeySelectionMaskRgba,
   documentPointToLayerPoint,
 } from "./imageEditor/colorKeyMath.js";
 import {
@@ -139,6 +143,9 @@ export {
   tileControlNetInstalled,
   tileControlNetModel,
   TILE_CONTROLNET_MODEL_ID,
+  sam3SegmentInstalled,
+  sam3SegmentModel,
+  SAM3_SEGMENT_MODEL_ID,
   upscaleEngineHasSoftness,
   upscaleFactorsForEngine,
 };
@@ -181,6 +188,7 @@ export {
   MASK_PREVIEW_RGBA,
   maskHasContent,
   applyColorKeyToRgba,
+  colorKeySelectionMaskRgba,
   documentPointToLayerPoint,
 };
 
@@ -997,15 +1005,14 @@ function blobToImage(blob) {
   });
 }
 
-function colorKeyCanvasForImage(image, seed, options) {
+function colorKeyMaskCanvasForImage(image, seed, options) {
   const canvas = document.createElement("canvas");
   canvas.width = image.naturalWidth;
   canvas.height = image.naturalHeight;
   const ctx = canvas.getContext("2d");
   ctx.drawImage(image, 0, 0);
   const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-  const cutout = applyColorKeyToRgba(imageData.data, canvas.width, canvas.height, { ...options, ...seed });
-  imageData.data.set(cutout.rgba);
+  imageData.data.set(colorKeySelectionMaskRgba(imageData.data, canvas.width, canvas.height, { ...options, ...seed }));
   ctx.putImageData(imageData, 0, 0);
   return canvas;
 }
@@ -1207,10 +1214,21 @@ export function ImageEditor() {
   // sc-3489), so it is available on a gated Mac — this block is a defensive guard that stays
   // null. The second engine (AuraSR) is dropped on Mac (sc-3668) and gated per-engine below.
   const macUpscaleBlock = macFeatureBlock(macCapabilities, "imageUpscale");
-  // Smart-select runs native SAM3 on MLX (Mac) and Candle (Windows/Linux). Gate it on the
-  // platform-intrinsic `imageSegment` capability, independent of the Mac gating-rollout switch.
-  // When false or still loading, the mask tool shows only the hand brush (graceful degradation).
-  const smartSelectSupported = macCapabilities?.features?.imageSegment?.supported === true;
+  // Smart-select is cache-only at job time: backend capability and a complete
+  // Model-Manager SAM3 install are both required before the UI offers a run.
+  const smartSelectCapabilitySupported = macCapabilities?.features?.imageSegment?.supported === true;
+  const smartSelectModel = sam3SegmentModel(models);
+  const smartSelectInstalled = sam3SegmentInstalled(models);
+  const smartSelectSupported = smartSelectCapabilitySupported && smartSelectInstalled;
+  const [smartSelectDownloadRequested, setSmartSelectDownloadRequested] = useState(false);
+  useEffect(() => {
+    if (smartSelectInstalled) setSmartSelectDownloadRequested(false);
+  }, [smartSelectInstalled]);
+  const requestSmartSelectDownload = useCallback(() => {
+    if (!smartSelectModel || !createModelDownloadJob) return;
+    setSmartSelectDownloadRequested(true);
+    createModelDownloadJob(smartSelectModel);
+  }, [smartSelectModel, createModelDownloadJob]);
 
   // The working document (sc-6117): an ordered raster layer stack composited
   // bottom→top — `{ width, height, source, layers:[Layer], activeLayerId }` (see
@@ -1258,6 +1276,7 @@ export function ImageEditor() {
   // Color-key cutout (sc-22462): selection/preview remain ephemeral until Apply,
   // then the active layer receives one alpha-only bitmap replacement.
   const [colorKeySeed, setColorKeySeed] = useState(null);
+  const [colorKeyLayerId, setColorKeyLayerId] = useState(null);
   const [colorKeyTolerance, setColorKeyTolerance] = useState(12);
   const [colorKeySoftness, setColorKeySoftness] = useState(8);
   const [colorKeyGlobal, setColorKeyGlobal] = useState(false);
@@ -1493,26 +1512,6 @@ export function ImageEditor() {
   useEffect(() => { aiOpRef.current = aiOp; }, [aiOp]);
   useEffect(() => { workingRef.current = working; }, [working]);
 
-  // Preview is an offscreen canvas, never a layer mutation or a history entry.
-  // The stage swaps it in only for the selected active layer, retaining that
-  // layer's normal visibility, opacity, blend mode, and transform.
-  const colorKeyPreview = useMemo(() => {
-    const layer = activeLayerOf(working);
-    if (!layer?.image || !colorKeySeed) return null;
-    try {
-      return {
-        layerId: layer.id,
-        image: colorKeyCanvasForImage(layer.image, colorKeySeed, {
-          tolerance: colorKeyTolerance,
-          softness: colorKeySoftness,
-          global: colorKeyGlobal,
-        }),
-      };
-    } catch {
-      return null;
-    }
-  }, [working, colorKeySeed, colorKeyTolerance, colorKeySoftness, colorKeyGlobal]);
-
   // ── Per-tool hooks (sc-9752, F-052 follow-up) ──────────────────────────────
   // Each tool owns its own state, refs, and handlers. They're called here — before the
   // snapshot/reset/pointer plumbing that reads their refs — and receive the shared,
@@ -1598,7 +1597,9 @@ export function ImageEditor() {
     activeProject,
     requestedGpu,
     runAiOp: runAiOpBridge,
-    stagePointToImage: stagePointToActiveLayerImage,
+    stagePointToImage: stagePointToImageBridge,
+    stagePointToActiveLayerImage,
+    getWorking: () => workingRef.current,
     blobToImage,
     setTool,
   });
@@ -1611,6 +1612,9 @@ export function ImageEditor() {
     maskBaseImage,
     maskOverlay,
     maskSubTool,
+    maskSource,
+    maskTargetLayerId,
+    maskCoordinateSpace,
     selectDraft,
     setMaskMode,
     setMaskBrush,
@@ -1627,15 +1631,73 @@ export function ImageEditor() {
     cancelSelectDrag,
     rasterizeMaskToFile,
     rasterizeMaskToCanvas,
+    installMaskBaseCanvas,
     refineMask,
     resetMaskState,
   } = maskTool;
+
+  const colorKeyActiveLayer = activeLayerOf(working);
+  const colorKeyActiveLayerId = colorKeyActiveLayer?.id ?? null;
+  const colorKeyActiveLayerImage = colorKeyActiveLayer?.image ?? null;
+
+  // Color key is an input to the shared editable mask, not a separate apply
+  // path. Changing Connected/Global/tolerance/softness regenerates the base;
+  // brush/erase and geometric refinements then operate on that same selection.
+  useEffect(() => {
+    if (
+      !colorKeySeed ||
+      !colorKeyActiveLayerImage ||
+      colorKeyActiveLayerId !== colorKeyLayerId ||
+      tool !== "cutout"
+    ) return;
+    try {
+      const mask = colorKeyMaskCanvasForImage(colorKeyActiveLayerImage, colorKeySeed, {
+        tolerance: colorKeyTolerance,
+        softness: colorKeySoftness,
+        global: colorKeyGlobal,
+      });
+      installMaskBaseCanvas(mask, { source: "colorKey", targetLayerId: colorKeyActiveLayerId });
+      setMaskMode(true);
+      setMaskSubTool("brush");
+      setCutoutKeepSelected(false);
+    } catch {
+      clearMask();
+    }
+  }, [
+    tool,
+    colorKeyActiveLayerId,
+    colorKeyActiveLayerImage,
+    colorKeySeed,
+    colorKeyLayerId,
+    colorKeyTolerance,
+    colorKeySoftness,
+    colorKeyGlobal,
+    installMaskBaseCanvas,
+    clearMask,
+    setMaskMode,
+    setMaskSubTool,
+  ]);
+
+  // Do not let an eyedropper seed from one layer regenerate after another
+  // layer becomes active; the hook independently clears its bound mask state.
+  useEffect(() => {
+    if (colorKeyLayerId && working?.activeLayerId !== colorKeyLayerId) {
+      setColorKeySeed(null);
+      setColorKeyLayerId(null);
+    }
+  }, [working?.activeLayerId, colorKeyLayerId]);
 
   // SAM3 cutout preview is an offscreen alpha composition, just like color key:
   // refinement remains editable and no document/history mutation occurs until Apply.
   const maskCutoutPreview = useMemo(() => {
     const layer = activeLayerOf(working);
-    if (tool !== "cutout" || !maskMode || !layer?.image || (!maskHasContent(maskLines) && !maskBaseImage)) return null;
+    if (
+      tool !== "cutout" ||
+      !maskMode ||
+      !layer?.image ||
+      maskTargetLayerId !== layer.id ||
+      (!maskHasContent(maskLines) && !maskBaseImage)
+    ) return null;
     try {
       return {
         layerId: layer.id,
@@ -1644,7 +1706,7 @@ export function ImageEditor() {
     } catch {
       return null;
     }
-  }, [working, tool, maskMode, maskLines, maskBaseImage, rasterizeMaskToCanvas, cutoutKeepSelected]);
+  }, [working, tool, maskMode, maskTargetLayerId, maskLines, maskBaseImage, rasterizeMaskToCanvas, cutoutKeepSelected]);
 
   // Memoize the image-renderable subset (sc-8939): the Image Editor re-renders on every
   // pointermove of a brush stroke / box drag, and re-filtering the full catalog each time
@@ -1708,6 +1770,7 @@ export function ImageEditor() {
     setTool("move");
     setCropRect(null);
     setColorKeySeed(null);
+    setColorKeyLayerId(null);
     // Per-tool state resets are owned by each tool hook now (sc-9752). Each reset mirrors
     // the exact lines it replaced: color → adjust/levels/curves/mode/channel identity;
     // mask → strokes + smart-select base + sub-mode + select gesture latch; boxes →
@@ -2203,6 +2266,8 @@ export function ImageEditor() {
     }
     if (tool === "cutout") {
       setColorKeySeed(null);
+      setColorKeyLayerId(null);
+      clearMask();
       setTool("move");
       return;
     }
@@ -2298,49 +2363,18 @@ export function ImageEditor() {
   // Keep the color-grade hook's bridge pointed at the latest replaceLayerImage (sc-9752).
   replaceLayerImageRef.current = replaceLayerImage;
 
-  // Commit the preview's exact alpha calculation to the active layer. The
-  // checkpoint is deliberately after encode/decode succeeds and immediately
-  // before the one bitmap replacement, so a failed encode has no history entry
-  // and Apply always creates exactly one undoable operation.
-  const applyColorKey = useCallback(async () => {
-    const work = workingRef.current;
-    const layer = activeLayerOf(work);
-    if (!layer?.image || !colorKeySeed) return;
-    const sourceBlob = layer.blob;
-    try {
-      const canvas = colorKeyCanvasForImage(layer.image, colorKeySeed, {
-        tolerance: colorKeyTolerance,
-        softness: colorKeySoftness,
-        global: colorKeyGlobal,
-      });
-      const blob = await canvasToPngBlob(canvas);
-      const { image, objectUrl } = await blobToImage(blob);
-      const current = layerById(workingRef.current, layer.id);
-      if (!current || current.blob !== sourceBlob) {
-        URL.revokeObjectURL(objectUrl);
-        return;
-      }
-      checkpoint();
-      replaceLayerImage(layer.id, image, objectUrl, blob);
-      setEdits((prev) => [
-        ...prev,
-        { op: "colorKey", mode: colorKeyGlobal ? "global" : "connected", tolerance: colorKeyTolerance, softness: colorKeySoftness },
-      ]);
-      setDirty(true);
-      setColorKeySeed(null);
-      setTool("move");
-    } catch (err) {
-      setStatus({ loading: false, error: err.message || "Could not apply the color-key cutout." });
-    }
-  }, [colorKeySeed, colorKeyTolerance, colorKeySoftness, colorKeyGlobal, checkpoint, replaceLayerImage]);
-
-  // Commit the currently refined SAM3 mask to the active layer only. The mask is
+  // Commit the currently refined color-key or SAM3 mask to its originating
+  // active layer only. The mask is
   // converted to an alpha multiplier, so keep/remove choices both preserve an
   // already-transparent source pixel and produce one undoable bitmap replacement.
   const applyMaskCutout = useCallback(async () => {
     const work = workingRef.current;
     const layer = activeLayerOf(work);
-    if (!layer?.image || (!maskHasContent(maskLines) && !maskBaseImage)) return;
+    if (
+      !layer?.image ||
+      maskTargetLayerId !== layer.id ||
+      (!maskHasContent(maskLines) && !maskBaseImage)
+    ) return;
     const sourceBlob = layer.blob;
     try {
       const canvas = maskCutoutCanvasForImage(layer.image, rasterizeMaskToCanvas(), cutoutKeepSelected);
@@ -2353,14 +2387,38 @@ export function ImageEditor() {
       }
       checkpoint();
       replaceLayerImage(layer.id, image, objectUrl, blob);
-      setEdits((prev) => [...prev, { op: "sam3Cutout", mode: cutoutKeepSelected ? "keepSelected" : "removeSelected" }]);
+      const edit = maskSource === "colorKey"
+        ? {
+            op: "colorKey",
+            mode: colorKeyGlobal ? "global" : "connected",
+            tolerance: colorKeyTolerance,
+            softness: colorKeySoftness,
+            refined: true,
+          }
+        : { op: "sam3Cutout", mode: cutoutKeepSelected ? "keepSelected" : "removeSelected" };
+      setEdits((prev) => [...prev, edit]);
       setDirty(true);
       clearMask();
+      setColorKeySeed(null);
+      setColorKeyLayerId(null);
       setTool("move");
     } catch (err) {
-      setStatus({ loading: false, error: err.message || "Could not apply the SAM3 cutout." });
+      setStatus({ loading: false, error: err.message || "Could not apply the selection cutout." });
     }
-  }, [maskLines, maskBaseImage, rasterizeMaskToCanvas, cutoutKeepSelected, checkpoint, replaceLayerImage, clearMask]);
+  }, [
+    maskLines,
+    maskBaseImage,
+    maskTargetLayerId,
+    maskSource,
+    rasterizeMaskToCanvas,
+    cutoutKeepSelected,
+    colorKeyGlobal,
+    colorKeyTolerance,
+    colorKeySoftness,
+    checkpoint,
+    replaceLayerImage,
+    clearMask,
+  ]);
 
   // A document-level AI op (upscale / outpaint / box-keyed edit) flattens the stack
   // into one base layer; warn before discarding a multi-layer stack.
@@ -2752,6 +2810,7 @@ export function ImageEditor() {
       local.y >= layer.image.naturalHeight
     ) return;
     setColorKeySeed({ x: Math.floor(local.x), y: Math.floor(local.y) });
+    setColorKeyLayerId(layer.id);
   }
 
   // ── AI ops on the working image (sc-2432 seam) ────────────────────────────
@@ -2797,9 +2856,10 @@ export function ImageEditor() {
       // stage the flattened document and the result becomes a single new base layer.
       layerSource = "activeLayer",
     }) => {
-      if (!working || aiOp || !activeProject) return;
-      // A composite-source op flattens the stack into one base layer — confirm first.
-      if (layerSource === "composite" && !(await confirmFlatten())) return;
+      if (!working || aiOp || !activeProject) return false;
+      // A composite-source writeback flattens the stack. Read-only consumers such
+      // as Smart Select may stage the composite without changing the document.
+      if (layerSource === "composite" && !onComplete && !(await confirmFlatten())) return false;
       setStatus({ loading: false, error: "" });
       const targetLayerId = activeLayerOf(working)?.id ?? null;
       // Stage the source (and, for a masked edit, the mask) as scratch assets. An
@@ -2815,7 +2875,7 @@ export function ImageEditor() {
       } catch (err) {
         if (scratch) purgeAsset(scratch).catch(() => {});
         setStatus({ loading: false, error: `Could not stage image: ${err.message || err}` });
-        return;
+        return false;
       }
       try {
         const job = await apiFetch(endpoint, token, {
@@ -2841,10 +2901,12 @@ export function ImageEditor() {
           targetLayerId,
         });
         setTool("move");
+        return true;
       } catch (err) {
         purgeAsset(scratch).catch(() => {});
         if (maskScratch) purgeAsset(maskScratch).catch(() => {});
         setStatus({ loading: false, error: `Could not start ${label}: ${err.message || err}` });
+        return false;
       }
     },
     [working, aiOp, activeProject, workingImageToFile, activeLayerToFile, confirmFlatten, importAsset, token, purgeAsset, trackEditorScratchOp],
@@ -3294,7 +3356,7 @@ export function ImageEditor() {
     detail: "Tune detail & structure, then enhance",
     color: "Grade with adjust, levels or curves",
     cutout: maskMode
-      ? (maskSubTool === "select" ? "Drag a box to select an object with SAM3" : "Paint to refine the SAM3 selection")
+      ? (maskSubTool === "select" ? "Drag a box to select an object with SAM3" : "Paint to refine the cutout selection")
       : (colorKeySeed ? "Adjust the key, then apply the alpha cutout" : "Click the background color to preview a cutout"),
     edit: maskMode ? "Paint or box-select the region to edit" : "Describe the edit on the right",
     boxes: "Drag to draw a region, then describe it",
@@ -3335,7 +3397,6 @@ export function ImageEditor() {
     addPaletteColor,
     aiOp,
     applyColorGrade,
-    applyColorKey,
     applyMaskCutout,
     applyCrop,
     assetUrl,
@@ -3399,6 +3460,7 @@ export function ImageEditor() {
     maskLines,
     maskMode,
     maskRefineRadius,
+    maskSource,
     maskSubTool,
     multiRefCapable,
     onTransformSlider,
@@ -3407,6 +3469,7 @@ export function ImageEditor() {
     refineMask,
     removePaletteColor,
     requestEditLoraDownload,
+    requestSmartSelectDownload,
     requestTileControlNetDownload,
     resetActiveColorMode,
     resetActiveLayerTransform,
@@ -3458,6 +3521,9 @@ export function ImageEditor() {
     setUpscaleFactor,
     setUpscaleSoftness,
     showIncompatibleEditLoras,
+    smartSelectCapabilitySupported,
+    smartSelectDownloadRequested,
+    smartSelectModel,
     smartSelectSupported,
     straighten,
     tileControlNet,
@@ -3896,7 +3962,7 @@ export function ImageEditor() {
                     height={layer.image.naturalHeight}
                     image={isActive && maskCutoutPreview?.layerId === layer.id
                       ? maskCutoutPreview.image
-                      : (isActive && colorKeyPreview?.layerId === layer.id ? colorKeyPreview.image : layer.image)}
+                      : layer.image}
                     name="editor-image"
                     opacity={layer.opacity}
                     rotation={t.rotation}
@@ -3975,12 +4041,15 @@ export function ImageEditor() {
               // Isolated layer so the eraser's destination-out clears only the mask
               // overlay, never the image beneath it. The smart-select base (sc-3751)
               // renders first, with the brush strokes (and their erases) composited on top.
-              // The group mirrors the active layer transform: the mask's coordinates
-              // are the staged active bitmap's coordinates, never document coordinates.
+              // Cutout masks are active-bitmap coordinates and mirror its transform;
+              // AI Edit masks remain document coordinates to align with composite
+              // staging and outpaint, including transformed/multi-layer documents.
               <Layer listening={false}>
                 {(() => {
                   const active = activeLayerOf(working);
-                  const t = active?.transform ?? identityTransform();
+                  const t = maskCoordinateSpace === "layer"
+                    ? active?.transform ?? identityTransform()
+                    : identityTransform();
                   return (
                     <Group rotation={t.rotation} scaleX={t.scaleX} scaleY={t.scaleY} x={t.x} y={t.y}>
                       {maskOverlay ? (
@@ -4006,7 +4075,9 @@ export function ImageEditor() {
               // Live smart-select box preview (sc-3751), image-pixel coords like the crop rect.
               <Layer listening={false}>
                 {(() => {
-                  const t = activeLayerOf(working)?.transform ?? identityTransform();
+                  const t = maskCoordinateSpace === "layer"
+                    ? activeLayerOf(working)?.transform ?? identityTransform()
+                    : identityTransform();
                   return (
                     <Group rotation={t.rotation} scaleX={t.scaleX} scaleY={t.scaleY} x={t.x} y={t.y}>
                       <Rect

--- a/apps/web/src/screens/ImageEditor.test.jsx
+++ b/apps/web/src/screens/ImageEditor.test.jsx
@@ -38,6 +38,9 @@ import {
   tileControlNetModel,
   tileControlNetInstalled,
   TILE_CONTROLNET_MODEL_ID,
+  sam3SegmentInstalled,
+  sam3SegmentModel,
+  SAM3_SEGMENT_MODEL_ID,
   rectToBbox,
   bboxToRect,
   isValidHexColor,
@@ -1860,6 +1863,15 @@ describe("reference conditioning (sc-6107)", () => {
 });
 
 describe("inpaint mask", () => {
+  it("requires the SAM3 utility model to be installed, not merely present in the catalog", () => {
+    const missing = { id: SAM3_SEGMENT_MODEL_ID, type: "utility", installState: "missing" };
+    expect(sam3SegmentModel([missing])).toBe(missing);
+    expect(sam3SegmentInstalled([missing])).toBe(false);
+    expect(sam3SegmentInstalled([{ ...missing, installState: "incomplete" }])).toBe(false);
+    expect(sam3SegmentInstalled([{ ...missing, installState: "installed" }])).toBe(true);
+    expect(sam3SegmentInstalled([])).toBe(false);
+  });
+
   it("flags only models tagged image_inpaint as mask-capable", () => {
     expect(modelIsInpaintCapable({ capabilities: ["edit_image", "image_inpaint"] })).toBe(true);
     expect(modelIsInpaintCapable({ capabilities: ["edit_image"] })).toBe(false);

--- a/apps/web/src/screens/imageEditor/ImageEditorToolPanel.jsx
+++ b/apps/web/src/screens/imageEditor/ImageEditorToolPanel.jsx
@@ -41,7 +41,7 @@ function samePanelProps(previous, next) {
 }
 
 export const ImageEditorEditPanel = React.memo(function ImageEditorEditPanel({ scope }) {
-  const { EDIT_OUTPUT_ASPECTS, EditorLoraPanel, FitModeControl, MAX_EDIT_REFERENCES, StudioUpdateBadge, StudioUpdateNotice, aiOp, assetUrl, canMask, clearMask, createLoraDownloadJob, createModelDownloadJob, editAspect, editFitMode, editGuidance, editLora, editLoraDownloadRequested, editLoraInstalled, editLoraRequiredMissing, editLoraSelection, editModel, editModels, editPrompt, editSeed, editorPickerLoras, effectiveFitMode, guidanceDefaultFromModel, imageAssets, maskActive, maskBaseImage, maskBrush, maskErase, maskHasContent, maskLines, maskMode, maskRefineRadius, maskSubTool, multiRefCapable, refAssetIds, refineMask, requestEditLoraDownload, runEdit, selectedEditLoras, selectedEditModel, setEditAspect, setEditFitMode, setEditGuidance, setEditModel, setEditPrompt, setEditSeed, setMaskBrush, setMaskErase, setMaskMode, setMaskRefineRadius, setMaskSubTool, setRefAssetIds, setRefPickerOpen, setShowIncompatibleEditLoras, showIncompatibleEditLoras, smartSelectSupported, updateOptionLabel } = scope;
+  const { EDIT_OUTPUT_ASPECTS, EditorLoraPanel, FitModeControl, MAX_EDIT_REFERENCES, StudioUpdateBadge, StudioUpdateNotice, aiOp, assetUrl, canMask, clearMask, createLoraDownloadJob, createModelDownloadJob, editAspect, editFitMode, editGuidance, editLora, editLoraDownloadRequested, editLoraInstalled, editLoraRequiredMissing, editLoraSelection, editModel, editModels, editPrompt, editSeed, editorPickerLoras, effectiveFitMode, guidanceDefaultFromModel, imageAssets, maskActive, maskBaseImage, maskBrush, maskErase, maskHasContent, maskLines, maskMode, maskRefineRadius, maskSubTool, multiRefCapable, refAssetIds, refineMask, requestEditLoraDownload, requestSmartSelectDownload, runEdit, selectedEditLoras, selectedEditModel, setEditAspect, setEditFitMode, setEditGuidance, setEditModel, setEditPrompt, setEditSeed, setMaskBrush, setMaskErase, setMaskMode, setMaskRefineRadius, setMaskSubTool, setRefAssetIds, setRefPickerOpen, setShowIncompatibleEditLoras, showIncompatibleEditLoras, smartSelectCapabilitySupported, smartSelectDownloadRequested, smartSelectModel, smartSelectSupported, updateOptionLabel } = scope;
   const renderPanel = () => {
     if (editModels.length === 0) {
       return (
@@ -208,6 +208,19 @@ export const ImageEditorEditPanel = React.memo(function ImageEditorEditPanel({ s
                       {aiOp?.label === "smart select" ? "Segmenting…" : "Smart select"}
                     </button>
                   </div>
+                ) : null}
+                {!smartSelectSupported && smartSelectCapabilitySupported && smartSelectModel ? (
+                  <>
+                    <p className="ie-note">SAM3 Smart Select is not installed. The brush remains available, or install SAM3 now.</p>
+                    <button
+                      className="ie-btn block"
+                      disabled={smartSelectDownloadRequested || !requestSmartSelectDownload}
+                      onClick={requestSmartSelectDownload}
+                      type="button"
+                    >
+                      {smartSelectDownloadRequested ? "Installing SAM3…" : "Install SAM3"}
+                    </button>
+                  </>
                 ) : null}
                 {!smartSelectSupported || maskSubTool === "brush" ? (
                   <>
@@ -571,7 +584,7 @@ export const ImageEditorBoxesPanel = React.memo(function ImageEditorBoxesPanel({
 
 export const ImageEditorToolPanel = React.memo(function ImageEditorToolPanel({ panelKey, scope }) {
   renderObserverForTests?.();
-  const { COLOR_ADJUSTMENTS, CROP_RATIOS, CurveEditor, StudioUpdateBadge, StudioUpdateNotice, UPSCALE_ENGINE_DESC, activeGradeIsIdentity, activeLayerOf, actualSize, aiOp, applyColorGrade, applyColorKey, applyCrop, applyMaskCutout, availableUpscaleEngines, cancelCrop, channelStroke, chooseRatio, colorAdjust, colorChannel, colorKeyGlobal, colorKeySeed, colorKeySoftness, colorKeyTolerance, colorMode, createModelDownloadJob, cropRect, curves, cutoutKeepSelected, detailCnScale, detailModel, detailModels, detailStrength, endTransformGesture, fitToView, flipActiveLayer, histogramRef, identityTransform, layerCount, levels, maskBaseImage, maskBrush, maskErase, maskHasContent, maskLines, maskMode, maskRefineRadius, maskSubTool, onTransformSlider, ratioKey, refineMask, requestTileControlNetDownload, resetActiveColorMode, resetActiveLayerTransform, resetAdjust, rotated, runDetail, runUpscale, selectedDetailModel, setActiveTransform, setAdjustValue, setColorChannel, setColorKeyGlobal, setColorKeySeed, setColorKeySoftness, setColorKeyTolerance, setColorMode, setCropDim, setCurves, setCutoutKeepSelected, setDetailCnScale, setDetailModel, setDetailStrength, setLevelsValue, setMaskBrush, setMaskErase, setMaskMode, setMaskRefineRadius, setMaskSubTool, setStraighten, setTool, setUpscaleEngine, setUpscaleFactor, setUpscaleSoftness, smartSelectSupported, straighten, tileControlNet, tileControlNetDownloadRequested, tileControlNetReady, toggleRotate, updateOptionLabel, upscaleEngine, upscaleEngineHasSoftness, upscaleFactor, upscaleFactorsForEngine, upscaleSoftness, working } = scope;
+  const { COLOR_ADJUSTMENTS, CROP_RATIOS, CurveEditor, StudioUpdateBadge, StudioUpdateNotice, UPSCALE_ENGINE_DESC, activeGradeIsIdentity, activeLayerOf, actualSize, aiOp, applyColorGrade, applyCrop, applyMaskCutout, availableUpscaleEngines, cancelCrop, channelStroke, chooseRatio, clearMask, colorAdjust, colorChannel, colorKeyGlobal, colorKeySeed, colorKeySoftness, colorKeyTolerance, colorMode, createModelDownloadJob, cropRect, curves, cutoutKeepSelected, detailCnScale, detailModel, detailModels, detailStrength, endTransformGesture, fitToView, flipActiveLayer, histogramRef, identityTransform, layerCount, levels, maskBaseImage, maskBrush, maskErase, maskHasContent, maskLines, maskMode, maskRefineRadius, maskSource, maskSubTool, onTransformSlider, ratioKey, refineMask, requestSmartSelectDownload, requestTileControlNetDownload, resetActiveColorMode, resetActiveLayerTransform, resetAdjust, rotated, runDetail, runUpscale, selectedDetailModel, setActiveTransform, setAdjustValue, setColorChannel, setColorKeyGlobal, setColorKeySeed, setColorKeySoftness, setColorKeyTolerance, setColorMode, setCropDim, setCurves, setCutoutKeepSelected, setDetailCnScale, setDetailModel, setDetailStrength, setLevelsValue, setMaskBrush, setMaskErase, setMaskMode, setMaskRefineRadius, setMaskSubTool, setStraighten, setTool, setUpscaleEngine, setUpscaleFactor, setUpscaleSoftness, smartSelectCapabilitySupported, smartSelectDownloadRequested, smartSelectModel, smartSelectSupported, straighten, tileControlNet, tileControlNetDownloadRequested, tileControlNetReady, toggleRotate, updateOptionLabel, upscaleEngine, upscaleEngineHasSoftness, upscaleFactor, upscaleFactorsForEngine, upscaleSoftness, working } = scope;
   const renderPanel = (key) => {
     switch (key) {
       case "move":
@@ -1164,106 +1177,112 @@ export const ImageEditorToolPanel = React.memo(function ImageEditorToolPanel({ p
               {smartSelectSupported ? (
                 <>
                   <p className="ie-note">Draw a box around an object on the active layer. SAM3 selection works without choosing an AI Edit model.</p>
-                  <div className="ie-seg two" style={{ width: "100%" }}>
-                    <button
-                      className="ie-seg-btn"
-                      data-active={maskMode && maskSubTool === "select"}
-                      disabled={aiOp?.label === "smart select"}
-                      onClick={() => {
-                        setColorKeySeed(null);
-                        setMaskMode(true);
-                        setMaskSubTool("select");
-                        setMaskErase(false);
-                      }}
-                      type="button"
-                    >
-                      {aiOp?.label === "smart select" ? "Segmenting…" : "Smart select"}
-                    </button>
-                    <button
-                      className="ie-seg-btn"
-                      data-active={maskMode && maskSubTool === "brush"}
-                      onClick={() => {
-                        setMaskMode(true);
-                        setMaskSubTool("brush");
-                      }}
-                      type="button"
-                    >
-                      Refine brush
-                    </button>
-                  </div>
-                  {maskMode && maskSubTool === "select" ? (
-                    <p className="ie-note">Drag a box around an object on the canvas — SAM3 auto-masks it.</p>
-                  ) : null}
-                  {maskMode && maskSubTool === "brush" ? (
-                    <>
-                      <div className="ie-field">
-                        <div className="ie-field-top">
-                          <span className="ie-field-label">Brush size</span>
-                          <span className="ie-field-val">{maskBrush} px</span>
-                        </div>
-                        <input
-                          aria-label="SAM3 refine brush size"
-                          className="ie-range"
-                          max={300}
-                          min={5}
-                          onChange={(event) => setMaskBrush(Number(event.target.value))}
-                          step={1}
-                          type="range"
-                          value={maskBrush}
-                        />
-                      </div>
-                      <button className="ie-btn block" data-active={maskErase} onClick={() => setMaskErase((on) => !on)} type="button">
-                        Eraser
-                      </button>
-                    </>
-                  ) : null}
-                  {maskMode ? (
-                    <>
-                      <div className="ie-field" style={{ marginTop: "10px", marginBottom: "8px" }}>
-                        <div className="ie-field-top">
-                          <span className="ie-field-label">Refine radius</span>
-                          <span className="ie-field-val">{maskRefineRadius}px</span>
-                        </div>
-                        <input
-                          aria-label="SAM3 refine radius"
-                          className="ie-range"
-                          max={40}
-                          min={1}
-                          onChange={(event) => setMaskRefineRadius(Number(event.target.value))}
-                          step={1}
-                          type="range"
-                          value={maskRefineRadius}
-                        />
-                      </div>
-                      <div className="ie-chip-row">
-                        <button className="ie-chip" disabled={!maskHasContent(maskLines) && !maskBaseImage} onClick={() => refineMask("feather")} type="button">Feather</button>
-                        <button className="ie-chip" disabled={!maskHasContent(maskLines) && !maskBaseImage} onClick={() => refineMask("grow")} type="button">Grow</button>
-                        <button className="ie-chip" disabled={!maskHasContent(maskLines) && !maskBaseImage} onClick={() => refineMask("shrink")} type="button">Shrink</button>
-                        <button className="ie-chip" onClick={() => refineMask("invert")} type="button">Invert</button>
-                      </div>
-                    </>
-                  ) : null}
-                  {maskMode && (maskHasContent(maskLines) || maskBaseImage) ? (
-                    <>
-                      <div className="ie-seg two" style={{ marginTop: "10px", width: "100%" }}>
-                        <button className="ie-seg-btn" data-active={cutoutKeepSelected} onClick={() => setCutoutKeepSelected(true)} type="button">Keep selected</button>
-                        <button className="ie-seg-btn" data-active={!cutoutKeepSelected} onClick={() => setCutoutKeepSelected(false)} type="button">Remove selected</button>
-                      </div>
-                      <button className="ie-btn block primary" onClick={applyMaskCutout} style={{ marginTop: "10px" }} type="button">
-                        Apply selection cutout
-                      </button>
-                    </>
-                  ) : null}
+                  <button
+                    className="ie-btn block"
+                    data-active={maskMode && maskSubTool === "select"}
+                    disabled={aiOp?.label === "smart select"}
+                    onClick={() => {
+                      setColorKeySeed(null);
+                      clearMask();
+                      setCutoutKeepSelected(true);
+                      setMaskMode(true);
+                      setMaskSubTool("select");
+                      setMaskErase(false);
+                    }}
+                    type="button"
+                  >
+                    {aiOp?.label === "smart select" ? "Segmenting…" : "Smart select"}
+                  </button>
+                </>
+              ) : smartSelectCapabilitySupported && smartSelectModel ? (
+                <>
+                  <p className="ie-note">SAM3 is supported on this worker but is not installed. Install it in Model Manager to enable Smart Select; color key remains available.</p>
+                  <button
+                    className="ie-btn block"
+                    disabled={smartSelectDownloadRequested || !requestSmartSelectDownload}
+                    onClick={requestSmartSelectDownload}
+                    type="button"
+                  >
+                    {smartSelectDownloadRequested ? "Installing SAM3…" : "Install SAM3"}
+                  </button>
                 </>
               ) : (
                 <p className="ie-note">SAM3 object selection is unavailable on this worker. Color key remains available above; choose a worker with image segmentation support to use Smart Select.</p>
               )}
             </div>
+            {maskMode ? (
+              <div className="ie-section">
+                <div className="ie-sec-title">Refine selection</div>
+                {maskSubTool === "select" ? (
+                  <p className="ie-note">Drag a box around an object on the canvas — SAM3 auto-masks it.</p>
+                ) : (
+                  <>
+                    <div className="ie-field">
+                      <div className="ie-field-top">
+                        <span className="ie-field-label">Brush size</span>
+                        <span className="ie-field-val">{maskBrush} px</span>
+                      </div>
+                      <input
+                        aria-label="Selection refine brush size"
+                        className="ie-range"
+                        max={300}
+                        min={5}
+                        onChange={(event) => setMaskBrush(Number(event.target.value))}
+                        step={1}
+                        type="range"
+                        value={maskBrush}
+                      />
+                    </div>
+                    <button className="ie-btn block" data-active={maskErase} onClick={() => setMaskErase((on) => !on)} type="button">
+                      {maskErase ? "Erase from selection" : "Add to selection"}
+                    </button>
+                  </>
+                )}
+                <button className="ie-btn block" onClick={() => setMaskSubTool("brush")} type="button">
+                  Refine brush
+                </button>
+                <div className="ie-field" style={{ marginTop: "10px", marginBottom: "8px" }}>
+                  <div className="ie-field-top">
+                    <span className="ie-field-label">Refine radius</span>
+                    <span className="ie-field-val">{maskRefineRadius}px</span>
+                  </div>
+                  <input
+                    aria-label="Selection refine radius"
+                    className="ie-range"
+                    max={40}
+                    min={1}
+                    onChange={(event) => setMaskRefineRadius(Number(event.target.value))}
+                    step={1}
+                    type="range"
+                    value={maskRefineRadius}
+                  />
+                </div>
+                <div className="ie-chip-row">
+                  <button className="ie-chip" disabled={!maskHasContent(maskLines) && !maskBaseImage} onClick={() => refineMask("feather")} type="button">Feather</button>
+                  <button className="ie-chip" disabled={!maskHasContent(maskLines) && !maskBaseImage} onClick={() => refineMask("grow")} type="button">Grow</button>
+                  <button className="ie-chip" disabled={!maskHasContent(maskLines) && !maskBaseImage} onClick={() => refineMask("shrink")} type="button">Shrink</button>
+                  <button className="ie-chip" onClick={() => refineMask("invert")} type="button">Invert</button>
+                </div>
+                {maskHasContent(maskLines) || maskBaseImage ? (
+                  <>
+                    <div className="ie-seg two" style={{ marginTop: "10px", width: "100%" }}>
+                      <button className="ie-seg-btn" data-active={cutoutKeepSelected} onClick={() => setCutoutKeepSelected(true)} type="button">Keep selected</button>
+                      <button className="ie-seg-btn" data-active={!cutoutKeepSelected} onClick={() => setCutoutKeepSelected(false)} type="button">Remove selected</button>
+                    </div>
+                    <button className="ie-btn block primary" onClick={applyMaskCutout} style={{ marginTop: "10px" }} type="button">
+                      Apply cutout
+                    </button>
+                  </>
+                ) : null}
+                {maskSource === "colorKey" ? (
+                  <button className="ie-btn block" onClick={() => { setColorKeySeed(null); clearMask(); setMaskMode(false); }} type="button">
+                    Sample another color
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
             <div className="ie-section">
-              <button className="ie-btn block primary" disabled={!colorKeySeed} onClick={applyColorKey} type="button">
-                Apply cutout
-              </button>
-              <button className="ie-btn block" onClick={() => { setColorKeySeed(null); setTool("move"); }} type="button">
+              <button className="ie-btn block" onClick={() => { setColorKeySeed(null); clearMask(); setMaskMode(false); setTool("move"); }} type="button">
                 Cancel
               </button>
             </div>

--- a/apps/web/src/screens/imageEditor/ImageEditorToolPanel.test.jsx
+++ b/apps/web/src/screens/imageEditor/ImageEditorToolPanel.test.jsx
@@ -59,9 +59,10 @@ describe("ImageEditorToolPanel memo boundary", () => {
 });
 
 describe("ImageEditorToolPanel color-key cutout", () => {
-  it("offers connected/global selection, adjustable perceptual edge controls, and one apply action", async () => {
+  it("offers connected/global selection, shared refinement, and one apply action", async () => {
     const setColorKeyGlobal = vi.fn();
-    const applyColorKey = vi.fn();
+    const applyMaskCutout = vi.fn();
+    const refineMask = vi.fn();
     await act(async () => root.render(
       <ImageEditorToolPanel
         panelKey="cutout"
@@ -74,8 +75,26 @@ describe("ImageEditorToolPanel color-key cutout", () => {
           setColorKeySeed: vi.fn(),
           setColorKeySoftness: vi.fn(),
           setColorKeyTolerance: vi.fn(),
-          applyColorKey,
+          applyMaskCutout,
+          clearMask: vi.fn(),
+          cutoutKeepSelected: false,
+          maskBaseImage: {},
+          maskBrush: 40,
+          maskErase: false,
+          maskHasContent: () => false,
+          maskLines: [],
+          maskMode: true,
+          maskRefineRadius: 6,
+          maskSource: "colorKey",
+          maskSubTool: "brush",
+          refineMask,
           setTool: vi.fn(),
+          setCutoutKeepSelected: vi.fn(),
+          setMaskBrush: vi.fn(),
+          setMaskErase: vi.fn(),
+          setMaskMode: vi.fn(),
+          setMaskRefineRadius: vi.fn(),
+          setMaskSubTool: vi.fn(),
         }}
       />,
     ));
@@ -84,13 +103,16 @@ describe("ImageEditorToolPanel color-key cutout", () => {
     await act(async () => {
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Global")
         .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Invert")
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Apply cutout")
         .dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     expect(setColorKeyGlobal).toHaveBeenCalledWith(true);
     expect(container.querySelector("input[aria-label='Color-key tolerance']").value).toBe("12");
     expect(container.querySelector("input[aria-label='Color-key softness']").value).toBe("8");
-    expect(applyColorKey).toHaveBeenCalledTimes(1);
+    expect(refineMask).toHaveBeenCalledWith("invert");
+    expect(applyMaskCutout).toHaveBeenCalledTimes(1);
   });
 
   it("keeps color key actionable when SAM3 is unavailable", async () => {
@@ -106,7 +128,8 @@ describe("ImageEditorToolPanel color-key cutout", () => {
           setColorKeySeed: vi.fn(),
           setColorKeySoftness: vi.fn(),
           setColorKeyTolerance: vi.fn(),
-          applyColorKey: vi.fn(),
+          applyMaskCutout: vi.fn(),
+          clearMask: vi.fn(),
           smartSelectSupported: false,
           setTool: vi.fn(),
         }}
@@ -114,8 +137,43 @@ describe("ImageEditorToolPanel color-key cutout", () => {
     ));
     expect(container.textContent).toContain("SAM3 object selection is unavailable on this worker");
     expect(container.textContent).toContain("Color key remains available above");
-    expect([...container.querySelectorAll("button")].find((button) => button.textContent === "Apply cutout")).toBeTruthy();
+    expect([...container.querySelectorAll("button")].find((button) => button.textContent === "Global")).toBeTruthy();
+    expect(container.querySelector("input[aria-label='Color-key tolerance']")).toBeTruthy();
     expect(container.textContent).not.toContain("Smart select");
+  });
+
+  it("offers an actionable SAM3 install when the worker supports segmentation but the model is missing", async () => {
+    const requestSmartSelectDownload = vi.fn();
+    await act(async () => root.render(
+      <ImageEditorToolPanel
+        panelKey="cutout"
+        scope={{
+          applyMaskCutout: vi.fn(),
+          clearMask: vi.fn(),
+          colorKeyGlobal: false,
+          colorKeySeed: null,
+          colorKeySoftness: 8,
+          colorKeyTolerance: 12,
+          requestSmartSelectDownload,
+          setColorKeyGlobal: vi.fn(),
+          setColorKeySeed: vi.fn(),
+          setColorKeySoftness: vi.fn(),
+          setColorKeyTolerance: vi.fn(),
+          setTool: vi.fn(),
+          smartSelectCapabilitySupported: true,
+          smartSelectDownloadRequested: false,
+          smartSelectModel: { id: "sam3_person_segment", installState: "missing" },
+          smartSelectSupported: false,
+        }}
+      />,
+    ));
+    expect(container.textContent).toContain("supported on this worker but is not installed");
+    await act(async () => {
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Install SAM3")
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(requestSmartSelectDownload).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain("Color key");
   });
 
   it("offers SAM3 keep/remove selection cutouts independently of AI Edit", async () => {
@@ -129,6 +187,7 @@ describe("ImageEditorToolPanel color-key cutout", () => {
         scope={{
           aiOp: null,
           applyMaskCutout,
+          clearMask: vi.fn(),
           colorKeyGlobal: false,
           colorKeySeed: null,
           colorKeySoftness: 8,
@@ -141,6 +200,7 @@ describe("ImageEditorToolPanel color-key cutout", () => {
           maskLines: [],
           maskMode: true,
           maskRefineRadius: 6,
+          maskSource: "smartSelect",
           maskSubTool: "select",
           refineMask: vi.fn(),
           setColorKeyGlobal: vi.fn(),
@@ -163,7 +223,7 @@ describe("ImageEditorToolPanel color-key cutout", () => {
         .dispatchEvent(new MouseEvent("click", { bubbles: true }));
       [...container.querySelectorAll("button")].find((button) => button.textContent === "Remove selected")
         .dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      [...container.querySelectorAll("button")].find((button) => button.textContent === "Apply selection cutout")
+      [...container.querySelectorAll("button")].find((button) => button.textContent === "Apply cutout")
         .dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     expect(setMaskMode).toHaveBeenCalledWith(true);

--- a/apps/web/src/screens/imageEditor/colorKeyMath.js
+++ b/apps/web/src/screens/imageEditor/colorKeyMath.js
@@ -141,6 +141,23 @@ export function applyColorKeyToRgba(rgba, width, height, options) {
   return { rgba: applyAlphaMultipliersInPlace(output, multipliers), multipliers };
 }
 
+// Convert the key into the editor's shared white-selected/black-unselected mask
+// representation. Color key therefore enters the same brush/erase/refinement
+// seam as SAM3 instead of maintaining a separate preview/apply implementation.
+export function colorKeySelectionMaskRgba(rgba, width, height, options) {
+  const multipliers = colorKeyAlphaMultipliers(rgba, width, height, options);
+  const mask = new Uint8ClampedArray(Math.max(0, width * height) * 4);
+  for (let index = 0; index < multipliers.length; index += 1) {
+    const selected = 255 - multipliers[index];
+    const offset = index * 4;
+    mask[offset] = selected;
+    mask[offset + 1] = selected;
+    mask[offset + 2] = selected;
+    mask[offset + 3] = 255;
+  }
+  return mask;
+}
+
 // Convert document coordinates into the active layer's source pixel space. This
 // inverts the same translate/rotate/scale transform used by the canvas compositor.
 export function documentPointToLayerPoint(point, transform = {}) {

--- a/apps/web/src/screens/imageEditor/colorKeyMath.test.js
+++ b/apps/web/src/screens/imageEditor/colorKeyMath.test.js
@@ -4,8 +4,10 @@ import {
   applyColorKeyToRgba,
   applyMaskSelectionToRgba,
   colorKeyAlphaMultipliers,
+  colorKeySelectionMaskRgba,
   documentPointToLayerPoint,
 } from "./colorKeyMath.js";
+import { invertAlpha, maskAlphaFromRgba } from "../../maskRefine.js";
 
 const pixels = (entries) => new Uint8ClampedArray(entries.flatMap(([r, g, b, a = 255]) => [r, g, b, a]));
 
@@ -27,6 +29,27 @@ describe("color-key alpha selection (sc-22462)", () => {
     ]);
     const { rgba } = applyColorKeyToRgba(source, 4, 1, { x: 0, y: 0, tolerance: 6, softness: 0, global: true });
     expect([...rgba.filter((_, index) => index % 4 === 3)]).toEqual([0, 255, 0, 255]);
+  });
+
+  it("turns a global non-contiguous key into the shared mask and applies its refinement", () => {
+    const source = pixels([
+      [30, 180, 90], [30, 80, 220], [30, 180, 90],
+    ]);
+    const maskRgba = colorKeySelectionMaskRgba(source, 3, 1, {
+      x: 0,
+      y: 0,
+      tolerance: 6,
+      softness: 0,
+      global: true,
+    });
+    const keyed = maskAlphaFromRgba(maskRgba);
+    expect([...keyed]).toEqual([255, 0, 255]);
+
+    // Invert is one of the same refinement operations exposed for SAM3. Its
+    // output, not the original key, is what the common alpha seam commits.
+    const refined = invertAlpha(keyed);
+    const result = applyMaskSelectionToRgba(source, refined, false);
+    expect([...result.filter((_, index) => index % 4 === 3)]).toEqual([255, 0, 255]);
   });
 
   it("uses a soft perceptual edge and never resurrects existing transparency", () => {

--- a/apps/web/src/screens/imageEditor/useMaskTool.js
+++ b/apps/web/src/screens/imageEditor/useMaskTool.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   maskAlphaFromRgba,
   writeMaskAlphaToRgba,
@@ -50,11 +50,15 @@ export function useMaskTool({
   requestedGpu,
   runAiOp,
   stagePointToImage,
+  stagePointToActiveLayerImage,
+  getWorking,
   blobToImage,
   setTool,
 }) {
-  const maskWidth = working?.layers?.find((layer) => layer.id === working.activeLayerId)?.image?.naturalWidth ?? working?.width ?? 0;
-  const maskHeight = working?.layers?.find((layer) => layer.id === working.activeLayerId)?.image?.naturalHeight ?? working?.height ?? 0;
+  const activeLayer = working?.layers?.find((layer) => layer.id === working.activeLayerId) ?? null;
+  const maskCoordinateSpace = tool === "cutout" ? "layer" : "document";
+  const maskWidth = maskCoordinateSpace === "layer" ? activeLayer?.image?.naturalWidth ?? 0 : working?.width ?? 0;
+  const maskHeight = maskCoordinateSpace === "layer" ? activeLayer?.image?.naturalHeight ?? 0 : working?.height ?? 0;
   // Inpaint mask (sc-2436): freehand brush strokes in image-pixel coords, rasterized
   // to a mask asset on Run for inpaint-capable models. `maskMode` is the paint sub-mode
   // of the AI Edit tool (Stage panning is suspended while it's on).
@@ -75,10 +79,14 @@ export function useMaskTool({
   const [maskBaseImage, setMaskBaseImage] = useState(null); // HTMLImageElement | null
   const [maskOverlay, setMaskOverlay] = useState(null); // HTMLCanvasElement | null
   const [maskSubTool, setMaskSubTool] = useState("brush"); // "brush" | "select"
+  const [maskSource, setMaskSource] = useState(null); // "colorKey" | "smartSelect" | "brush" | null
+  const [maskTargetLayerId, setMaskTargetLayerId] = useState(null); // cutout selections only
   const [selectDraft, setSelectDraft] = useState(null); // live selection rect during a drag
   const selectDrawingRef = useRef(false);
   const selectStartRef = useRef(null);
   const smartSelectLoaderRef = useRef(null);
+  const pendingSmartSelectRef = useRef(null);
+  const maskContextToolRef = useRef(null);
   if (!smartSelectLoaderRef.current) {
     smartSelectLoaderRef.current = createLatestMaskAssetLoader({ assetUrlFor: assetUrl, blobToImage });
   }
@@ -91,6 +99,7 @@ export function useMaskTool({
   useEffect(
     () => () => {
       smartSelectLoaderRef.current.invalidate();
+      pendingSmartSelectRef.current = null;
     },
     [],
   );
@@ -98,17 +107,48 @@ export function useMaskTool({
   // Leave paint mode when neither AI Edit's inpaint path nor Cutout owns it. SAM3
   // cutout intentionally does not depend on an inpaint-capable edit model.
   useEffect(() => {
-    if (maskMode && !((tool === "edit" && canMask) || tool === "cutout")) setMaskMode(false);
+    if (
+      maskMode &&
+      !pendingSmartSelectRef.current &&
+      !((tool === "edit" && canMask) || tool === "cutout")
+    ) setMaskMode(false);
   }, [tool, canMask, maskMode]);
+
+  // A cutout selection belongs to one source layer. Switching layers invalidates
+  // both an installed mask and a pending SAM3 asset load so neither can be
+  // previewed or committed onto a different layer.
+  useEffect(() => {
+    const activeLayerId = working?.activeLayerId ?? null;
+    const pending = pendingSmartSelectRef.current;
+    if (pending?.targetLayerId && pending.targetLayerId !== activeLayerId) {
+      smartSelectLoaderRef.current.invalidate();
+      pendingSmartSelectRef.current = null;
+    }
+    if (maskTargetLayerId && maskTargetLayerId !== activeLayerId) {
+      replaceMaskLines([]);
+      setMaskMode(false);
+      setMaskBaseImage(null);
+      setMaskOverlay(null);
+      setMaskSource(null);
+      setMaskTargetLayerId(null);
+      maskContextToolRef.current = null;
+      setSelectDraft(null);
+      selectDrawingRef.current = false;
+    }
+  }, [working?.activeLayerId, maskTargetLayerId]);
 
   // Reset the per-bitmap mask state (called by the editor's resetEditorOverlays). Mirrors
   // the exact mask-clearing lines from the inline resetEditorOverlays.
   function resetMaskState() {
     smartSelectLoaderRef.current.invalidate();
+    pendingSmartSelectRef.current = null;
     replaceMaskLines([]);
     setMaskMode(false);
     setMaskBaseImage(null);
     setMaskOverlay(null);
+    setMaskSource(null);
+    setMaskTargetLayerId(null);
+    maskContextToolRef.current = null;
     setMaskSubTool("brush");
     setSelectDraft(null);
     selectDrawingRef.current = false;
@@ -117,15 +157,17 @@ export function useMaskTool({
   // ── Inpaint mask brush (sc-2436) ──────────────────────────────────────────
   function maskPointerDown(event) {
     if (!maskMode || maskSubTool !== "brush" || !working) return;
-    const pt = stagePointToImage(event);
+    const pt = maskCoordinateSpace === "layer" ? stagePointToActiveLayerImage(event) : stagePointToImage(event);
     if (!pt) return;
+    if (maskCoordinateSpace === "layer") setMaskTargetLayerId(working.activeLayerId);
+    if (!maskSource) setMaskSource("brush");
     maskPaintingRef.current = true;
     replaceMaskLines([...maskLinesRef.current, { points: [pt.x, pt.y], size: maskBrush, erase: maskErase }]);
   }
 
   function maskPointerMove(event) {
     if (!maskMode || maskSubTool !== "brush" || !maskPaintingRef.current) return;
-    const pt = stagePointToImage(event);
+    const pt = maskCoordinateSpace === "layer" ? stagePointToActiveLayerImage(event) : stagePointToImage(event);
     if (!pt) return;
     replaceMaskLines(appendMaskStrokePoint(maskLinesRef.current, pt));
   }
@@ -134,19 +176,48 @@ export function useMaskTool({
     maskPaintingRef.current = false;
   }
 
-  function clearMask() {
+  const clearMask = useCallback(() => {
     smartSelectLoaderRef.current.invalidate();
-    replaceMaskLines([]);
+    pendingSmartSelectRef.current = null;
+    maskLinesRef.current = [];
+    setMaskLines([]);
     setMaskBaseImage(null);
     setMaskOverlay(null);
-  }
+    setMaskSource(null);
+    setMaskTargetLayerId(null);
+    maskContextToolRef.current = null;
+  }, []);
+
+  // Document-space AI masks and active-layer cutout masks are intentionally
+  // different coordinate systems. Never carry one across the tool boundary.
+  useEffect(() => {
+    if (maskMode && (tool === "edit" || tool === "cutout")) {
+      if (maskContextToolRef.current && maskContextToolRef.current !== tool) {
+        clearMask();
+        setMaskMode(false);
+        return;
+      }
+      maskContextToolRef.current = tool;
+    }
+    if (tool === "edit" && maskTargetLayerId) {
+      clearMask();
+      setMaskMode(false);
+    } else if (
+      tool === "cutout" &&
+      maskTargetLayerId === null &&
+      (maskBaseImage || maskLinesRef.current.length)
+    ) {
+      clearMask();
+      setMaskMode(false);
+    }
+  }, [tool, maskTargetLayerId, maskMode, maskBaseImage, clearMask]);
 
   // ── Smart-select box (sc-3751) ────────────────────────────────────────────
   // A box-drag sub-mode of the mask tool: drag a selection rect, then on release run the SAM3
   // `image_segment` job over it. Mirrors the sc-6090 box draw, but transient (one rect → one run).
   function selectPointerDown(event) {
     if (!maskMode || maskSubTool !== "select" || !working) return;
-    const pt = stagePointToImage(event);
+    const pt = maskCoordinateSpace === "layer" ? stagePointToActiveLayerImage(event) : stagePointToImage(event);
     if (!pt) return;
     selectDrawingRef.current = true;
     selectStartRef.current = pt;
@@ -155,7 +226,7 @@ export function useMaskTool({
 
   function selectPointerMove(event) {
     if (!selectDrawingRef.current) return;
-    const pt = stagePointToImage(event);
+    const pt = maskCoordinateSpace === "layer" ? stagePointToActiveLayerImage(event) : stagePointToImage(event);
     if (!pt) return;
     setSelectDraft(rectFromPoints(selectStartRef.current, pt));
   }
@@ -241,11 +312,11 @@ export function useMaskTool({
   // Decode a worker mask (white-on-black PNG at working dims) into the editable mask base: a
   // white-on-black canvas for rasterizeMaskToFile + a pink-on-transparent overlay for the preview.
   // Drawn scaled to the working dims defensively (the mask is produced at the working size).
-  function loadMaskBase(image) {
+  const installMaskBaseCanvas = useCallback((maskCanvas, metadata = {}) => {
     const base = document.createElement("canvas");
     base.width = maskWidth;
     base.height = maskHeight;
-    base.getContext("2d").drawImage(image, 0, 0, maskWidth, maskHeight);
+    base.getContext("2d").drawImage(maskCanvas, 0, 0, maskWidth, maskHeight);
     const overlay = document.createElement("canvas");
     overlay.width = maskWidth;
     overlay.height = maskHeight;
@@ -256,23 +327,20 @@ export function useMaskTool({
     octx.putImageData(data, 0, 0);
     setMaskBaseImage(base);
     setMaskOverlay(overlay);
+    replaceMaskLines([]);
+    if (Object.prototype.hasOwnProperty.call(metadata, "source")) setMaskSource(metadata.source);
+    if (Object.prototype.hasOwnProperty.call(metadata, "targetLayerId")) setMaskTargetLayerId(metadata.targetLayerId);
+  }, [maskHeight, maskWidth]);
+
+  function loadMaskBase(image, metadata) {
+    installMaskBaseCanvas(image, metadata);
   }
 
   // Install a refined white-on-black mask canvas as the new mask base (sc-6110): it
   // becomes the base + a fresh pink overlay, and the brush strokes are cleared (they
   // are now baked into the canvas). Mirrors loadMaskBase but from a canvas.
   function applyRefinedMask(maskCanvas) {
-    const overlay = document.createElement("canvas");
-    overlay.width = maskWidth;
-    overlay.height = maskHeight;
-    const octx = overlay.getContext("2d");
-    octx.drawImage(maskCanvas, 0, 0);
-    const data = octx.getImageData(0, 0, overlay.width, overlay.height);
-    tintMaskRgbaInPlace(data.data);
-    octx.putImageData(data, 0, 0);
-    setMaskBaseImage(maskCanvas);
-    setMaskOverlay(overlay);
-    replaceMaskLines([]);
+    installMaskBaseCanvas(maskCanvas);
   }
 
   // Mask refinement (sc-6110): flatten the current mask, run a pure pixel op
@@ -301,13 +369,18 @@ export function useMaskTool({
   // the job, and on completion load the returned binary mask as an editable base under the strokes.
   // It does NOT replace the working image (onComplete owns the result), so the session is unchanged
   // except for the mask layer; the brush/eraser then refines it before Inpaint.
-  function runSmartSelect(rect) {
+  async function runSmartSelect(rect) {
     if (!working || aiOp || !smartSelectSupported) return;
+    const initiatingTool = tool;
+    const targetLayerId = initiatingTool === "cutout" ? working.activeLayerId : null;
+    const targetLayerBlob = targetLayerId ? activeLayer?.blob : null;
     const requestGeneration = smartSelectLoaderRef.current.invalidate();
+    pendingSmartSelectRef.current = { requestGeneration, initiatingTool, targetLayerId, targetLayerBlob };
     const box = rectToSegmentBox(rect);
-    runAiOp({
+    const started = await runAiOp({
       label: "smart select",
       endpoint: "/api/v1/jobs",
+      layerSource: initiatingTool === "cutout" ? "activeLayer" : "composite",
       buildBody: (scratch) =>
         buildSegmentJobBody({
           project: activeProject,
@@ -317,15 +390,33 @@ export function useMaskTool({
           displayName: working?.source?.name,
         }),
       onComplete: async (resultAsset) => {
+        const pending = pendingSmartSelectRef.current;
+        if (!pending || pending.requestGeneration !== requestGeneration) return;
+        const liveWorking = getWorking();
+        if (
+          targetLayerId &&
+          (liveWorking?.activeLayerId !== targetLayerId ||
+            liveWorking?.layers?.find((layer) => layer.id === targetLayerId)?.blob !== targetLayerBlob)
+        ) {
+          smartSelectLoaderRef.current.invalidate();
+          pendingSmartSelectRef.current = null;
+          return;
+        }
         await smartSelectLoaderRef.current.load(resultAsset, requestGeneration, (image) => {
-          loadMaskBase(image);
+          loadMaskBase(image, { source: "smartSelect", targetLayerId });
           // Return to the mask tool so the auto-mask can be refined with the brush/eraser.
-          setTool("edit");
+          setTool(initiatingTool);
           setMaskMode(true);
           setMaskSubTool("brush");
         });
+        if (pendingSmartSelectRef.current?.requestGeneration === requestGeneration) {
+          pendingSmartSelectRef.current = null;
+        }
       },
     });
+    if (!started && pendingSmartSelectRef.current?.requestGeneration === requestGeneration) {
+      pendingSmartSelectRef.current = null;
+    }
   }
 
   return {
@@ -338,6 +429,9 @@ export function useMaskTool({
     maskBaseImage,
     maskOverlay,
     maskSubTool,
+    maskSource,
+    maskTargetLayerId,
+    maskCoordinateSpace,
     selectDraft,
     // Setters used in render
     setMaskMode,
@@ -358,6 +452,8 @@ export function useMaskTool({
     cancelSelectDrag,
     rasterizeMaskToFile,
     rasterizeMaskToCanvas,
+    installMaskBaseCanvas,
+    runSmartSelect,
     refineMask,
     resetMaskState,
   };

--- a/apps/web/src/screens/imageEditor/useMaskTool.test.jsx
+++ b/apps/web/src/screens/imageEditor/useMaskTool.test.jsx
@@ -1,0 +1,195 @@
+import React, { act, useRef, useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { mountRoot, unmountRoot } from "../../testUtils/dom.js";
+import { useMaskTool } from "./useMaskTool.js";
+
+function layer(id, width, height, blob = { id }) {
+  return {
+    id,
+    blob,
+    image: { naturalWidth: width, naturalHeight: height },
+    transform: { x: 14, y: 9, scaleX: 1.5, scaleY: 0.75, rotation: 18 },
+  };
+}
+
+function documentWith(activeLayerId = "a") {
+  return {
+    width: 100,
+    height: 80,
+    activeLayerId,
+    source: { name: "layers.png" },
+    layers: [layer("a", 20, 10), layer("b", 40, 30)],
+  };
+}
+
+describe("useMaskTool coordinate and ownership contracts", () => {
+  let container;
+  let root;
+  let latest;
+  let capturedOp;
+  let setHarnessTool;
+  let originalCreateElement;
+
+  beforeEach(() => {
+    ({ container, root } = mountRoot());
+    originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tagName, options) => {
+      if (tagName !== "canvas") return originalCreateElement(tagName, options);
+      const canvas = {
+        width: 0,
+        height: 0,
+        getContext: () => ({
+          arc: vi.fn(),
+          beginPath: vi.fn(),
+          drawImage: vi.fn(),
+          fill: vi.fn(),
+          fillRect: vi.fn(),
+          getImageData: (_x, _y, width, height) => ({
+            data: new Uint8ClampedArray(width * height * 4),
+          }),
+          lineTo: vi.fn(),
+          moveTo: vi.fn(),
+          putImageData: vi.fn(),
+          stroke: vi.fn(),
+        }),
+        toBlob: (callback) => callback(new Blob(["mask"], { type: "image/png" })),
+      };
+      return canvas;
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: true, blob: async () => new Blob(["mask"]) })));
+    vi.stubGlobal("URL", { ...URL, revokeObjectURL: vi.fn() });
+  });
+
+  afterEach(async () => {
+    await unmountRoot(root, container);
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  function Harness({ canMask = false, initialTool = "cutout", working }) {
+    const [tool, setTool] = useState(initialTool);
+    setHarnessTool = setTool;
+    const workingRef = useRef(working);
+    workingRef.current = working;
+    latest = useMaskTool({
+      working,
+      tool,
+      canMask,
+      smartSelectSupported: true,
+      aiOp: null,
+      activeProject: { id: "project", name: "Project" },
+      requestedGpu: "auto",
+      runAiOp: async (operation) => {
+        capturedOp = operation;
+        setTool("move");
+        return true;
+      },
+      stagePointToImage: () => ({ x: 70, y: 60 }),
+      stagePointToActiveLayerImage: () => ({ x: 3, y: 4 }),
+      getWorking: () => workingRef.current,
+      blobToImage: async () => ({
+        image: { naturalWidth: working.width, naturalHeight: working.height },
+        objectUrl: "blob:mask",
+      }),
+      setTool,
+    });
+    return <div data-tool={tool} />;
+  }
+
+  it("returns a Cutout-launched SAM3 result to Cutout with an editable mask when canMask is false", async () => {
+    const working = documentWith("a");
+    await act(async () => root.render(<Harness working={working} />));
+
+    await act(async () => latest.runSmartSelect({ x: 1, y: 2, width: 12, height: 6 }));
+    expect(capturedOp.layerSource).toBe("activeLayer");
+    expect(container.firstChild.dataset.tool).toBe("move");
+
+    await act(async () => capturedOp.onComplete({ id: "mask-result" }));
+    expect(container.firstChild.dataset.tool).toBe("cutout");
+    expect(latest.maskMode).toBe(true);
+    expect(latest.maskSubTool).toBe("brush");
+    expect(latest.maskBaseImage).toBeTruthy();
+    expect(latest.maskTargetLayerId).toBe("a");
+  });
+
+  it("drops both installed and pending cutout selections when the active layer changes", async () => {
+    const workingA = documentWith("a");
+    await act(async () => root.render(<Harness working={workingA} />));
+    await act(async () => {
+      latest.installMaskBaseCanvas({ width: 20, height: 10 }, { source: "colorKey", targetLayerId: "a" });
+      latest.setMaskMode(true);
+    });
+    expect(latest.maskTargetLayerId).toBe("a");
+
+    await act(async () => root.render(<Harness working={documentWith("b")} />));
+    expect(latest.maskBaseImage).toBeNull();
+    expect(latest.maskTargetLayerId).toBeNull();
+
+    await act(async () => root.render(<Harness working={workingA} />));
+    await act(async () => latest.runSmartSelect({ x: 1, y: 2, width: 12, height: 6 }));
+    const pendingCompletion = capturedOp.onComplete;
+    await act(async () => root.render(<Harness working={documentWith("b")} />));
+    await act(async () => pendingCompletion({ id: "late-mask-result" }));
+    expect(container.firstChild.dataset.tool).toBe("move");
+    expect(latest.maskBaseImage).toBeNull();
+    expect(latest.maskTargetLayerId).toBeNull();
+  });
+
+  it("does not carry an active-layer cutout mask into AI Edit's document coordinate context", async () => {
+    await act(async () => root.render(<Harness canMask working={documentWith("a")} />));
+    await act(async () => {
+      latest.installMaskBaseCanvas({ width: 20, height: 10 }, { source: "colorKey", targetLayerId: "a" });
+      latest.setMaskMode(true);
+    });
+    expect(latest.maskBaseImage).toBeTruthy();
+
+    await act(async () => setHarnessTool("edit"));
+    expect(latest.maskBaseImage).toBeNull();
+    expect(latest.maskTargetLayerId).toBeNull();
+    expect(latest.maskMode).toBe(false);
+    expect(latest.maskCoordinateSpace).toBe("document");
+  });
+
+  it("keeps transformed multilayer AI Edit masks in document coordinates and document dimensions", async () => {
+    const stagePointToImage = vi.fn(() => ({ x: 70, y: 60 }));
+    const stagePointToActiveLayerImage = vi.fn(() => ({ x: 3, y: 4 }));
+    const working = documentWith("a");
+
+    function EditHarness() {
+      const [tool, setTool] = useState("edit");
+      latest = useMaskTool({
+        working,
+        tool,
+        canMask: true,
+        smartSelectSupported: true,
+        aiOp: null,
+        activeProject: { id: "project", name: "Project" },
+        requestedGpu: "auto",
+        runAiOp: async (operation) => {
+          capturedOp = operation;
+          setTool("move");
+          return true;
+        },
+        stagePointToImage,
+        stagePointToActiveLayerImage,
+        getWorking: () => working,
+        blobToImage: async () => ({ image: {}, objectUrl: "blob:mask" }),
+        setTool,
+      });
+      return null;
+    }
+
+    await act(async () => root.render(<EditHarness />));
+    await act(async () => latest.setMaskMode(true));
+    await act(async () => latest.maskPointerDown({}));
+    expect(stagePointToImage).toHaveBeenCalledTimes(1);
+    expect(stagePointToActiveLayerImage).not.toHaveBeenCalled();
+    expect(latest.maskLines[0].points).toEqual([70, 60]);
+    const raster = latest.rasterizeMaskToCanvas();
+    expect([raster.width, raster.height]).toEqual([100, 80]);
+
+    await act(async () => latest.runSmartSelect({ x: 10, y: 8, width: 20, height: 18 }));
+    expect(capturedOp.layerSource).toBe("composite");
+  });
+});


### PR DESCRIPTION
Closes the deterministic findings from terminal review cycle 1 for epic sc-22461.

- restores the initiating Cutout tool after asynchronous SAM3 completion
- routes color key through the shared editable mask and refinement controls
- preserves document-space AI Edit masks while using layer-local Cutout masks
- requires both image-segmentation capability and an installed SAM3 model
- binds pending and installed selections to their source layer/blob

Validation:
- 4 focused test files, 154 tests passed
- full web suite: 278 files, 4,240 tests passed
- ESLint passed
- Vite production build passed
- git diff --check passed

No inference pin, worker routing, backend, model, or GPU changes.