### PR TITLE
test(sc-18791): candle text-LLM roster includes candle-starvector-8b

### DIFF
--- a/crates/sceneworks-worker/src/inference_runtime.rs
+++ b/crates/sceneworks-worker/src/inference_runtime.rs
@@ -507,7 +507,12 @@ mod tests {
             assert!(media_count > 40);
             assert_eq!(
                 text_ids,
-                ["candle-llama", "candle-llava", "candle-starvector-1b"]
+                [
+                    "candle-llama",
+                    "candle-llava",
+                    "candle-starvector-1b",
+                    "candle-starvector-8b",
+                ]
             );
         }
 


### PR DESCRIPTION
The exact-id roster assertion (introduced when the count-pin went stale) was one id short on the candle lane: the linked registry composition appends starvector_8b (candle-llm lib.rs:68) beyond register_text_providers' three. CI on #2674 named it precisely; this adds the fourth id. rust:check:candle green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)