### PR TITLE
feat(memory): anchor + analytic derivation admits LTX-2.5 on MLX from 3 anchors (sc-22507)

### DIFF
--- a/config/memory-anchors.json
+++ b/config/memory-anchors.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": 1,
+  "anchors": [
+    {
+      "id": "ltx_2_5:mlx:bf16:sc-18797-ltx-2-5-mlx-ladder-v1:imc-9c4c5fe8356bcc4f139f",
+      "modelId": "ltx_2_5",
+      "modelFamily": "ltx-video",
+      "backend": "mlx",
+      "tier": "bf16",
+      "mode": "text_to_video",
+      "overlay": null,
+      "referenceCount": 0,
+      "loadShape": "eager_materialization",
+      "source": {
+        "path": "docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json",
+        "sha256": "6038f39e21feaa5fcde9490c7a0791a2906bff6695386f734c013569de77b725",
+        "recordId": "imc-9c4c5fe8356bcc4f139f",
+        "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1"
+      },
+      "geometry": {
+        "width": 704,
+        "height": 1280,
+        "frames": 449,
+        "fps": 30
+      },
+      "phaseActivePeakBytes": {
+        "conditioning": 45472780950,
+        "denoise": 64442151098,
+        "decode": 79539453812
+      },
+      "overallAllocatorEnvelopeBytes": 92135650144
+    },
+    {
+      "id": "ltx_2_5:mlx:q4:sc-18797-ltx-2-5-mlx-ladder-v1:imc-50fbdda27ed3159a6ca1",
+      "modelId": "ltx_2_5",
+      "modelFamily": "ltx-video",
+      "backend": "mlx",
+      "tier": "q4",
+      "mode": "text_to_video",
+      "overlay": null,
+      "referenceCount": 0,
+      "loadShape": "eager_materialization",
+      "source": {
+        "path": "docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json",
+        "sha256": "6038f39e21feaa5fcde9490c7a0791a2906bff6695386f734c013569de77b725",
+        "recordId": "imc-50fbdda27ed3159a6ca1",
+        "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1"
+      },
+      "geometry": {
+        "width": 768,
+        "height": 512,
+        "frames": 145,
+        "fps": 24
+      },
+      "phaseActivePeakBytes": {
+        "conditioning": 13166818976,
+        "denoise": 23765841366,
+        "decode": 60013908200
+      },
+      "overallAllocatorEnvelopeBytes": 62401296566
+    },
+    {
+      "id": "ltx_2_5:mlx:q8:sc-18797-ltx-2-5-mlx-ladder-v1:imc-7f8186376a9a3143ebee",
+      "modelId": "ltx_2_5",
+      "modelFamily": "ltx-video",
+      "backend": "mlx",
+      "tier": "q8",
+      "mode": "text_to_video",
+      "overlay": null,
+      "referenceCount": 0,
+      "loadShape": "eager_materialization",
+      "source": {
+        "path": "docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json",
+        "sha256": "6038f39e21feaa5fcde9490c7a0791a2906bff6695386f734c013569de77b725",
+        "recordId": "imc-7f8186376a9a3143ebee",
+        "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1"
+      },
+      "geometry": {
+        "width": 1280,
+        "height": 704,
+        "frames": 145,
+        "fps": 24
+      },
+      "phaseActivePeakBytes": {
+        "conditioning": 23406395552,
+        "denoise": 35925328080,
+        "decode": 64847765684
+      },
+      "overallAllocatorEnvelopeBytes": 69260977594
+    }
+  ]
+}

--- a/config/memory-anchors.json
+++ b/config/memory-anchors.json
@@ -2,15 +2,23 @@
   "schemaVersion": 1,
   "anchors": [
     {
-      "id": "ltx_2_5:mlx:bf16:sc-18797-ltx-2-5-mlx-ladder-v1:imc-9c4c5fe8356bcc4f139f",
+      "id": "ltx_2_5:mlx:bf16:dev:diffvae:sc-18797-ltx-2-5-mlx-ladder-v1:imc-9c4c5fe8356bcc4f139f",
       "modelId": "ltx_2_5",
       "modelFamily": "ltx-video",
+      "route": "ltx_2_5",
+      "provider": "ltx_2_5",
       "backend": "mlx",
       "tier": "bf16",
+      "transformerVariant": "dev",
+      "decoder": "diffvae",
       "mode": "text_to_video",
       "overlay": null,
       "referenceCount": 0,
       "loadShape": "eager_materialization",
+      "measuredRegime": {
+        "decodeTiled": false,
+        "transformerWindowed": false
+      },
       "source": {
         "path": "docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json",
         "sha256": "6038f39e21feaa5fcde9490c7a0791a2906bff6695386f734c013569de77b725",
@@ -31,15 +39,97 @@
       "overallAllocatorEnvelopeBytes": 92135650144
     },
     {
-      "id": "ltx_2_5:mlx:q4:sc-18797-ltx-2-5-mlx-ladder-v1:imc-50fbdda27ed3159a6ca1",
+      "id": "ltx_2_5:mlx:bf16:distilled:conv:sc-18797-ltx-2-5-mlx-ladder-v1:imc-4e1b3a02a6ced3434824",
       "modelId": "ltx_2_5",
       "modelFamily": "ltx-video",
+      "route": "ltx_2_5",
+      "provider": "ltx_2_5",
+      "backend": "mlx",
+      "tier": "bf16",
+      "transformerVariant": "distilled",
+      "decoder": "conv",
+      "mode": "text_to_video",
+      "overlay": null,
+      "referenceCount": 0,
+      "loadShape": "deferred_materialization",
+      "measuredRegime": {
+        "decodeTiled": true,
+        "transformerWindowed": true
+      },
+      "source": {
+        "path": "docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json",
+        "sha256": "6038f39e21feaa5fcde9490c7a0791a2906bff6695386f734c013569de77b725",
+        "recordId": "imc-4e1b3a02a6ced3434824",
+        "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1"
+      },
+      "geometry": {
+        "width": 1280,
+        "height": 704,
+        "frames": 145,
+        "fps": 24
+      },
+      "phaseActivePeakBytes": {
+        "conditioning": 11725368252,
+        "denoise": 8148677508,
+        "decode": 8229179000
+      },
+      "overallAllocatorEnvelopeBytes": 12389051376
+    },
+    {
+      "id": "ltx_2_5:mlx:bf16:distilled:diffvae:sc-18797-ltx-2-5-mlx-ladder-v1:imc-6f2b28a41967fd486b50",
+      "modelId": "ltx_2_5",
+      "modelFamily": "ltx-video",
+      "route": "ltx_2_5",
+      "provider": "ltx_2_5",
+      "backend": "mlx",
+      "tier": "bf16",
+      "transformerVariant": "distilled",
+      "decoder": "diffvae",
+      "mode": "text_to_video",
+      "overlay": null,
+      "referenceCount": 0,
+      "loadShape": "deferred_materialization",
+      "measuredRegime": {
+        "decodeTiled": false,
+        "transformerWindowed": true
+      },
+      "source": {
+        "path": "docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json",
+        "sha256": "6038f39e21feaa5fcde9490c7a0791a2906bff6695386f734c013569de77b725",
+        "recordId": "imc-6f2b28a41967fd486b50",
+        "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1"
+      },
+      "geometry": {
+        "width": 1280,
+        "height": 704,
+        "frames": 145,
+        "fps": 24
+      },
+      "phaseActivePeakBytes": {
+        "conditioning": 11725838268,
+        "denoise": 8149147524,
+        "decode": 66125852164
+      },
+      "overallAllocatorEnvelopeBytes": 66789535288
+    },
+    {
+      "id": "ltx_2_5:mlx:q4:dev:diffvae:sc-18797-ltx-2-5-mlx-ladder-v1:imc-50fbdda27ed3159a6ca1",
+      "modelId": "ltx_2_5",
+      "modelFamily": "ltx-video",
+      "route": "ltx_2_5",
+      "provider": "ltx_2_5",
       "backend": "mlx",
       "tier": "q4",
+      "transformerVariant": "dev",
+      "decoder": "diffvae",
       "mode": "text_to_video",
       "overlay": null,
       "referenceCount": 0,
       "loadShape": "eager_materialization",
+      "measuredRegime": {
+        "decodeTiled": false,
+        "transformerWindowed": false
+      },
       "source": {
         "path": "docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json",
         "sha256": "6038f39e21feaa5fcde9490c7a0791a2906bff6695386f734c013569de77b725",
@@ -60,15 +150,60 @@
       "overallAllocatorEnvelopeBytes": 62401296566
     },
     {
-      "id": "ltx_2_5:mlx:q8:sc-18797-ltx-2-5-mlx-ladder-v1:imc-7f8186376a9a3143ebee",
+      "id": "ltx_2_5:mlx:q8:dev:conv:sc-18797-ltx-2-5-mlx-ladder-v1:imc-beaa0f2aacf0832ea28a",
       "modelId": "ltx_2_5",
       "modelFamily": "ltx-video",
+      "route": "ltx_2_5",
+      "provider": "ltx_2_5",
       "backend": "mlx",
       "tier": "q8",
+      "transformerVariant": "dev",
+      "decoder": "conv",
       "mode": "text_to_video",
       "overlay": null,
       "referenceCount": 0,
       "loadShape": "eager_materialization",
+      "measuredRegime": {
+        "decodeTiled": true,
+        "transformerWindowed": false
+      },
+      "source": {
+        "path": "docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json",
+        "sha256": "6038f39e21feaa5fcde9490c7a0791a2906bff6695386f734c013569de77b725",
+        "recordId": "imc-beaa0f2aacf0832ea28a",
+        "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1"
+      },
+      "geometry": {
+        "width": 704,
+        "height": 1280,
+        "frames": 145,
+        "fps": 24
+      },
+      "phaseActivePeakBytes": {
+        "conditioning": 23405449760,
+        "denoise": 35924382288,
+        "decode": 8257474680
+      },
+      "overallAllocatorEnvelopeBytes": 40337594198
+    },
+    {
+      "id": "ltx_2_5:mlx:q8:dev:diffvae:sc-18797-ltx-2-5-mlx-ladder-v1:imc-7f8186376a9a3143ebee",
+      "modelId": "ltx_2_5",
+      "modelFamily": "ltx-video",
+      "route": "ltx_2_5",
+      "provider": "ltx_2_5",
+      "backend": "mlx",
+      "tier": "q8",
+      "transformerVariant": "dev",
+      "decoder": "diffvae",
+      "mode": "text_to_video",
+      "overlay": null,
+      "referenceCount": 0,
+      "loadShape": "eager_materialization",
+      "measuredRegime": {
+        "decodeTiled": false,
+        "transformerWindowed": false
+      },
       "source": {
         "path": "docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json",
         "sha256": "6038f39e21feaa5fcde9490c7a0791a2906bff6695386f734c013569de77b725",

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod lora_family;
 pub mod lora_url;
 pub mod managed_checkpoint_variants;
 pub mod media_convert;
+pub mod memory_anchor;
 pub mod memory_calibration;
 pub mod minimax_h3_turbo;
 pub mod mlx_tier_completeness;

--- a/crates/sceneworks-core/src/memory_anchor.rs
+++ b/crates/sceneworks-core/src/memory_anchor.rs
@@ -1,0 +1,785 @@
+//! Measured memory anchors and the analytic peak derivation built on them (sc-22507, epic 22505).
+//!
+//! One anchor per `(model, quant tier, backend lane)` carries the measured per-phase peak
+//! decomposition of a single retained calibration render. Everything else is derived analytically:
+//! activation terms scale linearly in latent tokens (`area x latent frames`), decode scales in
+//! output voxels, attention transients are bounded by the declared rung parameters, and bounded
+//! regimes (tiled decode, windowed transformer residency, deferred materialization) substitute
+//! architecture-bounded terms for the anchored ones. This replaces grid measurement: a request at
+//! a `(geometry, frames)` cell that was never measured is admitted from the derived estimate.
+//!
+//! The store is checked in at `config/memory-anchors.json` and is validated against the immutable
+//! retained evidence it was extracted from (`PACKAGED_MEMORY_ANCHOR_SOURCES`): every anchor's
+//! source file must hash to the recorded digest and the anchor's phase bytes must equal the source
+//! record's measured values byte-for-byte, so the store cannot drift from the corpus it cites.
+//!
+//! Like `video_memory_curves`, this module deliberately has no `gen-core` dependency; worker lanes
+//! translate their own backend/rung/load-shape types at the edge.
+
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const MEMORY_ANCHOR_SCHEMA_VERSION: u32 = 1;
+
+/// The checked-in anchor store.
+pub const PACKAGED_MEMORY_ANCHORS: &str = include_str!("../../../config/memory-anchors.json");
+
+/// Immutable retained evidence the anchors were extracted from. Every anchor's `source.path` must
+/// name one of these files, whose bytes are compiled in so the handshake cannot be bypassed by
+/// editing the file on disk.
+const PACKAGED_MEMORY_ANCHOR_SOURCES: &[(&str, &str)] = &[(
+    "docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json",
+    include_str!("../../../docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json"),
+)];
+
+// ---------------------------------------------------------------------------------------------
+// Architecture facts (LTX-2.5 pipeline geometry).
+// ---------------------------------------------------------------------------------------------
+
+/// LTX's video VAE is x32 spatial: one latent token per 32x32 output patch. Mirrors the constant
+/// the MLX calibration adapter derives its regressors from
+/// (`crates/sceneworks-memory-adapter/src/bin/mlx.rs`).
+pub const LTX_LATENT_PATCH_EDGE_PX: u64 = 32;
+
+/// LTX's video VAE is x8 causal temporal: `latent_frames = 1 + ceil((frames - 1) / 8)`. Same
+/// source as [`LTX_LATENT_PATCH_EDGE_PX`]; the engine's frame lattice is `frames = 1 + 8k`.
+pub const LTX_TEMPORAL_SCALE: u64 = 8;
+
+// ---------------------------------------------------------------------------------------------
+// Derivation coefficients. Each names the architecture term it prices; each uncertainty a
+// coefficient cannot pin exactly is covered by [`ANCHOR_ALLOCATOR_ENVELOPE_MARGIN`], and the
+// corpus validation test (`derivation_brackets_every_retained_corpus_peak`) is the falsifier.
+// ---------------------------------------------------------------------------------------------
+
+/// Conditioning-phase bytes per latent token: the packed video latent plus the Gemma text
+/// cross-attention context held in fp32 workspace (4096 f32 lanes x 8 concurrently live per-token
+/// tensors). Retained-corpus slopes across tiers/load shapes sit at 110-131 KiB/token.
+pub const COND_PER_TOKEN_BYTES: i128 = 131_072;
+
+/// Conditioning-phase bound under deferred materialization: only the projected text embeddings and
+/// latent init are resident (the transformer stays unmaterialized), which the retained captures
+/// show as geometry-independent (11.73 GB active / 12.02 GB allocator at every measured geometry).
+/// Bound set above the allocator figure.
+pub const COND_DEFERRED_BOUND_BYTES: u64 = 12_900_000_000;
+
+/// Denoise-phase bytes per latent token: the DiT forward's live activation set (residual stream,
+/// attention chunk workspace under the declared `attentionChunkSize`, MLP intermediates) at fp32.
+/// Retained-corpus slopes sit at 306-330 KiB/token across all three tiers and both load shapes.
+pub const DENOISE_PER_TOKEN_BYTES: i128 = 335_872;
+
+/// Denoise-phase intercept under `bounded_transformer_residency` (window size 1): one resident
+/// AvDiT block of the declared 48 plus the bounded attention workspace, replacing the full
+/// transformer residency the anchor was measured with. The per-token activation slope is
+/// unchanged by windowing ([`DENOISE_PER_TOKEN_BYTES`]).
+pub const DENOISE_WINDOWED_BASE_BYTES: u64 = 2_650_000_000;
+
+/// Decode-phase bytes per output voxel in the single-pass conv-VAE regime: concurrently live
+/// pixel-space working copies (four fp32 RGB-equivalent planes). Retained-corpus slopes span
+/// 30-63 B/voxel; the spread is covered by [`ANCHOR_ALLOCATOR_ENVELOPE_MARGIN`].
+pub const DECODE_PER_VOXEL_BYTES: i128 = 48;
+
+/// Decode-phase bound under `bounded_decode` (declared `decodeTileEdge`/`decodeOverlap`): decoder
+/// weights plus tile-bounded workspace, independent of output geometry. Retained tiled captures
+/// peak at 8.26 GB across tiers; bound set above them.
+pub const DECODE_TILED_BOUND_BYTES: u64 = 9_000_000_000;
+
+/// Multiplicative margin applied to every derived phase peak. It covers, jointly: the MLX
+/// allocator envelope above the phase active peak (observed up to 15.9% in the retained corpus —
+/// cache retention across phase transitions), and the residual spread of the per-token /
+/// per-voxel coefficients around the architecture-derived values above (observed under 4%).
+pub const ANCHOR_ALLOCATOR_ENVELOPE_MARGIN: f64 = 0.17;
+
+/// Validation-only tightness budget: the corpus validation test refuses a derived bound more than
+/// this fraction above the measured allocator envelope, so the margins above stay falsifiable
+/// instead of quietly widening into a vacuous always-passes bound.
+pub const ANCHOR_VALIDATION_TIGHTNESS_BUDGET: f64 = 0.25;
+
+// ---------------------------------------------------------------------------------------------
+// Store schema.
+// ---------------------------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MemoryAnchorStore {
+    pub schema_version: u32,
+    pub anchors: Vec<MemoryAnchor>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnchorBackend {
+    Mlx,
+    Candle,
+}
+
+impl AnchorBackend {
+    pub const fn as_key(self) -> &'static str {
+        match self {
+            Self::Mlx => "mlx",
+            Self::Candle => "candle",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnchorLoadShape {
+    EagerMaterialization,
+    DeferredMaterialization,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AnchorSource {
+    /// Repo-relative path of the retained evidence file; must be a compiled-in source.
+    pub path: String,
+    /// SHA-256 of that file's bytes at extraction time.
+    pub sha256: String,
+    /// The calibration record inside it this anchor was extracted from.
+    pub record_id: String,
+    pub calibration_fingerprint: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AnchorGeometry {
+    pub width: u32,
+    pub height: u32,
+    pub frames: u32,
+    pub fps: u32,
+}
+
+/// The measured per-phase ACTIVE peak decomposition of the anchor render.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AnchorPhaseBytes {
+    pub conditioning: u64,
+    pub denoise: u64,
+    pub decode: u64,
+}
+
+/// One measured anchor: identity plus the peak decomposition of exactly one retained render.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MemoryAnchor {
+    pub id: String,
+    pub model_id: String,
+    pub model_family: String,
+    pub backend: AnchorBackend,
+    /// Plan tier key: `q4` / `q8` / `bf16` / ...
+    pub tier: String,
+    pub mode: String,
+    /// The anchor was measured overlay-free; a future overlay anchor is a new row, never a reuse.
+    pub overlay: Option<String>,
+    pub reference_count: u32,
+    /// Materialization shape the anchor render ran under. The derivation reaches the OTHER shape
+    /// analytically (see [`COND_DEFERRED_BOUND_BYTES`]), so this stays informational identity.
+    pub load_shape: AnchorLoadShape,
+    pub source: AnchorSource,
+    pub geometry: AnchorGeometry,
+    pub phase_active_peak_bytes: AnchorPhaseBytes,
+    /// The measured overall allocator envelope of the anchor render (active + reclaimable).
+    pub overall_allocator_envelope_bytes: u64,
+}
+
+/// Strict parse plus the invariants serde cannot express. No partial store is usable.
+pub fn load_memory_anchors(raw: &str) -> Result<MemoryAnchorStore, String> {
+    let store: MemoryAnchorStore = serde_json::from_str(raw)
+        .map_err(|error| format!("memory anchors do not parse: {error}"))?;
+    if store.schema_version != MEMORY_ANCHOR_SCHEMA_VERSION {
+        return Err(format!(
+            "memory anchor schema version {} is not the supported {MEMORY_ANCHOR_SCHEMA_VERSION}",
+            store.schema_version
+        ));
+    }
+    let mut identities = BTreeMap::new();
+    for anchor in &store.anchors {
+        let identity = (anchor.model_id.clone(), anchor.tier.clone(), anchor.backend);
+        if let Some(previous) = identities.insert(identity, &anchor.id) {
+            return Err(format!(
+                "duplicate memory anchor for ({}, {}, {}): {} and {} — exactly one anchor per \
+                 (model, tier, backend lane) is the schema invariant",
+                anchor.model_id,
+                anchor.tier,
+                anchor.backend.as_key(),
+                previous,
+                anchor.id
+            ));
+        }
+        validate_anchor(anchor)?;
+    }
+    Ok(store)
+}
+
+/// One anchor's extraction handshake against the compiled-in retained evidence.
+fn validate_anchor(anchor: &MemoryAnchor) -> Result<(), String> {
+    if anchor.geometry.width == 0 || anchor.geometry.height == 0 || anchor.geometry.frames == 0 {
+        return Err(format!(
+            "memory anchor {} has a degenerate geometry",
+            anchor.id
+        ));
+    }
+    if anchor.phase_active_peak_bytes.conditioning == 0
+        || anchor.phase_active_peak_bytes.denoise == 0
+        || anchor.phase_active_peak_bytes.decode == 0
+        || anchor.overall_allocator_envelope_bytes == 0
+    {
+        return Err(format!("memory anchor {} has a zero phase peak", anchor.id));
+    }
+    let Some((_, source_raw)) = PACKAGED_MEMORY_ANCHOR_SOURCES
+        .iter()
+        .find(|(path, _)| *path == anchor.source.path)
+    else {
+        return Err(format!(
+            "memory anchor {} cites source {} which is not a compiled retained-evidence file",
+            anchor.id, anchor.source.path
+        ));
+    };
+    let digest = format!("{:x}", Sha256::digest(source_raw.as_bytes()));
+    if digest != anchor.source.sha256 {
+        return Err(format!(
+            "memory anchor {} source digest mismatch for {}: recorded {} actual {digest}",
+            anchor.id, anchor.source.path, anchor.source.sha256
+        ));
+    }
+    let source: serde_json::Value = serde_json::from_str(source_raw).map_err(|error| {
+        format!(
+            "retained evidence {} does not parse: {error}",
+            anchor.source.path
+        )
+    })?;
+    let records = source
+        .get("records")
+        .and_then(|records| records.as_array())
+        .ok_or_else(|| format!("retained evidence {} has no records", anchor.source.path))?;
+    let record = records
+        .iter()
+        .find(|record| {
+            record.get("id").and_then(|id| id.as_str()) == Some(anchor.source.record_id.as_str())
+        })
+        .ok_or_else(|| {
+            format!(
+                "memory anchor {} cites record {} absent from {}",
+                anchor.id, anchor.source.record_id, anchor.source.path
+            )
+        })?;
+    let target = record.get("target").unwrap_or(&serde_json::Value::Null);
+    let str_at = |value: &serde_json::Value, key: &str| {
+        value
+            .get(key)
+            .and_then(|value| value.as_str())
+            .map(str::to_owned)
+    };
+    if str_at(target, "modelId").as_deref() != Some(anchor.model_id.as_str())
+        || str_at(target, "tier").as_deref() != Some(anchor.tier.as_str())
+        || str_at(record, "backend").as_deref() != Some(anchor.backend.as_key())
+        || str_at(target, "mode").as_deref() != Some(anchor.mode.as_str())
+        || str_at(record, "calibrationFingerprint").as_deref()
+            != Some(anchor.source.calibration_fingerprint.as_str())
+    {
+        return Err(format!(
+            "memory anchor {} identity disagrees with its source record {}",
+            anchor.id, anchor.source.record_id
+        ));
+    }
+    let geometry = target.get("geometry").unwrap_or(&serde_json::Value::Null);
+    let u64_at = |value: &serde_json::Value, key: &str| value.get(key).and_then(|v| v.as_u64());
+    if u64_at(geometry, "width") != Some(u64::from(anchor.geometry.width))
+        || u64_at(geometry, "height") != Some(u64::from(anchor.geometry.height))
+        || u64_at(geometry, "frames") != Some(u64::from(anchor.geometry.frames))
+    {
+        return Err(format!(
+            "memory anchor {} geometry disagrees with its source record {}",
+            anchor.id, anchor.source.record_id
+        ));
+    }
+    let mut measured = BTreeMap::new();
+    if let Some(measurements) = record
+        .get("diagnostics")
+        .and_then(|diagnostics| diagnostics.get("measurements"))
+        .and_then(|measurements| measurements.as_array())
+    {
+        for entry in measurements {
+            if let (Some(name), Some(value)) = (
+                entry.get("name").and_then(|name| name.as_str()),
+                entry.get("value").and_then(|value| value.as_u64()),
+            ) {
+                measured.insert(name.to_owned(), value);
+            }
+        }
+    }
+    let envelope = record
+        .get("observedMemory")
+        .and_then(|memory| memory.get("overall"))
+        .and_then(|overall| overall.get("allocatorBytes"))
+        .and_then(|bytes| bytes.as_u64());
+    if measured.get("conditioningActivePeak").copied()
+        != Some(anchor.phase_active_peak_bytes.conditioning)
+        || measured.get("denoiseActivePeak").copied()
+            != Some(anchor.phase_active_peak_bytes.denoise)
+        || measured.get("decodeActivePeak").copied() != Some(anchor.phase_active_peak_bytes.decode)
+        || envelope != Some(anchor.overall_allocator_envelope_bytes)
+    {
+        return Err(format!(
+            "memory anchor {} peak bytes disagree with its source record {} — the store may not \
+             drift from the retained evidence it cites",
+            anchor.id, anchor.source.record_id
+        ));
+    }
+    Ok(())
+}
+
+/// The packaged store, parsed and validated once. `None` is fail-open: callers keep their
+/// pre-existing floor.
+pub fn packaged_memory_anchors() -> Option<&'static MemoryAnchorStore> {
+    static PACKAGED: OnceLock<Option<MemoryAnchorStore>> = OnceLock::new();
+    PACKAGED
+        .get_or_init(|| load_memory_anchors(PACKAGED_MEMORY_ANCHORS).ok())
+        .as_ref()
+}
+
+impl MemoryAnchorStore {
+    /// The unique anchor for one `(model, backend lane, tier)` coordinate.
+    pub fn anchor_for(
+        &self,
+        model_id: &str,
+        backend: AnchorBackend,
+        tier: &str,
+    ) -> Option<&MemoryAnchor> {
+        self.anchors.iter().find(|anchor| {
+            anchor.model_id == model_id && anchor.backend == backend && anchor.tier == tier
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Derivation.
+// ---------------------------------------------------------------------------------------------
+
+/// The workload axes the derivation prices. Geometry is the requested output; the three regime
+/// flags translate the engaged rung composition and materialization shape of the candidate being
+/// graded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AnchorDeriveRequest {
+    pub width: u32,
+    pub height: u32,
+    pub frames: u32,
+    /// `bounded_decode` engaged: decode is tile-bounded ([`DECODE_TILED_BOUND_BYTES`]).
+    pub decode_tiled: bool,
+    /// `bounded_transformer_residency` engaged: denoise holds one window instead of the full
+    /// transformer ([`DENOISE_WINDOWED_BASE_BYTES`]).
+    pub transformer_windowed: bool,
+    /// Deferred materialization: conditioning holds no transformer weights
+    /// ([`COND_DEFERRED_BOUND_BYTES`]).
+    pub deferred_materialization: bool,
+}
+
+/// Margin-widened per-phase peak estimates. The admission peak is the max over phases; the shared
+/// selector's backend estimate margin still rides on top, exactly as it does for fitted curves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AnchorDerivedPhases {
+    pub conditioning: u64,
+    pub denoise: u64,
+    pub decode: u64,
+}
+
+impl AnchorDerivedPhases {
+    pub const fn peak_bytes(self) -> u64 {
+        let mut peak = self.conditioning;
+        if self.denoise > peak {
+            peak = self.denoise;
+        }
+        if self.decode > peak {
+            peak = self.decode;
+        }
+        peak
+    }
+}
+
+/// Latent token count: spatial patches x latent temporal depth (ceil mappings so an off-lattice
+/// request rounds up, never down).
+fn latent_tokens(width: u32, height: u32, frames: u32) -> i128 {
+    let patches_w = (u64::from(width)).div_ceil(LTX_LATENT_PATCH_EDGE_PX);
+    let patches_h = (u64::from(height)).div_ceil(LTX_LATENT_PATCH_EDGE_PX);
+    let latent_frames = 1 + (u64::from(frames) - 1).div_ceil(LTX_TEMPORAL_SCALE);
+    i128::from(patches_w) * i128::from(patches_h) * i128::from(latent_frames)
+}
+
+fn voxels(width: u32, height: u32, frames: u32) -> i128 {
+    i128::from(width) * i128::from(height) * i128::from(frames)
+}
+
+/// Widen one derived phase estimate by [`ANCHOR_ALLOCATOR_ENVELOPE_MARGIN`] in integer bytes.
+fn widened(bytes: i128) -> Option<u64> {
+    let bytes = u64::try_from(bytes.max(0)).ok()?;
+    let widened = (bytes as f64 * (1.0 + ANCHOR_ALLOCATOR_ENVELOPE_MARGIN)).ceil();
+    (widened.is_finite() && widened < u64::MAX as f64).then_some(widened as u64)
+}
+
+impl MemoryAnchor {
+    /// Derive the per-phase peak estimate for one requested video workload from this anchor.
+    ///
+    /// * conditioning: anchored intercept + [`COND_PER_TOKEN_BYTES`] per latent token, or the
+    ///   deferred-materialization bound.
+    /// * denoise: anchored intercept + [`DENOISE_PER_TOKEN_BYTES`] per latent token (attention
+    ///   transient bounded by the declared chunk parameter, so no super-linear term), or the
+    ///   windowed-residency intercept plus the same slope.
+    /// * decode: anchored intercept + [`DECODE_PER_VOXEL_BYTES`] per output voxel, or the
+    ///   tile-bounded constant.
+    ///
+    /// Returns `None` on degenerate geometry; every estimate is widened by
+    /// [`ANCHOR_ALLOCATOR_ENVELOPE_MARGIN`].
+    pub fn derive_video_phase_peaks(
+        &self,
+        request: AnchorDeriveRequest,
+    ) -> Option<AnchorDerivedPhases> {
+        if request.width == 0 || request.height == 0 || request.frames == 0 {
+            return None;
+        }
+        let anchor_tokens = latent_tokens(
+            self.geometry.width,
+            self.geometry.height,
+            self.geometry.frames,
+        );
+        let anchor_voxels = voxels(
+            self.geometry.width,
+            self.geometry.height,
+            self.geometry.frames,
+        );
+        let tokens = latent_tokens(request.width, request.height, request.frames);
+        let voxels = voxels(request.width, request.height, request.frames);
+
+        let conditioning = if request.deferred_materialization {
+            i128::from(COND_DEFERRED_BOUND_BYTES)
+        } else {
+            i128::from(self.phase_active_peak_bytes.conditioning)
+                + COND_PER_TOKEN_BYTES * (tokens - anchor_tokens)
+        };
+        let denoise = if request.transformer_windowed {
+            i128::from(DENOISE_WINDOWED_BASE_BYTES) + DENOISE_PER_TOKEN_BYTES * tokens
+        } else {
+            i128::from(self.phase_active_peak_bytes.denoise)
+                + DENOISE_PER_TOKEN_BYTES * (tokens - anchor_tokens)
+        };
+        let decode = if request.decode_tiled {
+            i128::from(DECODE_TILED_BOUND_BYTES)
+        } else {
+            i128::from(self.phase_active_peak_bytes.decode)
+                + DECODE_PER_VOXEL_BYTES * (voxels - anchor_voxels)
+        };
+        Some(AnchorDerivedPhases {
+            conditioning: widened(conditioning)?,
+            denoise: widened(denoise)?,
+            decode: widened(decode)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LTX25_CORPUS_PATH: &str = "docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json";
+
+    fn corpus_raw() -> &'static str {
+        PACKAGED_MEMORY_ANCHOR_SOURCES
+            .iter()
+            .find(|(path, _)| *path == LTX25_CORPUS_PATH)
+            .map(|(_, raw)| *raw)
+            .expect("the LTX-2.5 MLX retained corpus is compiled in")
+    }
+
+    struct CorpusRecord {
+        id: String,
+        tier: String,
+        width: u32,
+        height: u32,
+        frames: u32,
+        decode_tiled: bool,
+        transformer_windowed: bool,
+        deferred: bool,
+        conditioning_active: u64,
+        denoise_active: u64,
+        decode_active: u64,
+        overall_envelope: u64,
+    }
+
+    /// Every retained, runtime-complete LTX-2.5 MLX measured record — the validation corpus.
+    fn retained_corpus() -> Vec<CorpusRecord> {
+        let source: serde_json::Value =
+            serde_json::from_str(corpus_raw()).expect("retained corpus parses");
+        let records = source["records"].as_array().expect("corpus records");
+        records
+            .iter()
+            .filter(|record| {
+                record["target"]["modelId"].as_str() == Some("ltx_2_5")
+                    && record["backend"].as_str() == Some("mlx")
+                    && record["status"].as_str() == Some("runtime_complete")
+            })
+            .map(|record| {
+                let geometry = &record["target"]["geometry"];
+                let engaged: Vec<&str> = record["strategy"]["engagedRungs"]
+                    .as_array()
+                    .expect("engaged rungs")
+                    .iter()
+                    .filter_map(|value| value.as_str())
+                    .collect();
+                let measured: std::collections::BTreeMap<&str, u64> = record["diagnostics"]
+                    ["measurements"]
+                    .as_array()
+                    .expect("measurements")
+                    .iter()
+                    .filter_map(|entry| Some((entry["name"].as_str()?, entry["value"].as_u64()?)))
+                    .collect();
+                CorpusRecord {
+                    id: record["id"].as_str().expect("record id").to_owned(),
+                    tier: record["target"]["tier"].as_str().expect("tier").to_owned(),
+                    width: geometry["width"].as_u64().expect("width") as u32,
+                    height: geometry["height"].as_u64().expect("height") as u32,
+                    frames: geometry["frames"].as_u64().expect("frames") as u32,
+                    decode_tiled: engaged.contains(&"bounded_decode"),
+                    transformer_windowed: engaged.contains(&"bounded_transformer_residency"),
+                    deferred: record["loadShape"].as_str() == Some("deferred_materialization"),
+                    conditioning_active: measured["conditioningActivePeak"],
+                    denoise_active: measured["denoiseActivePeak"],
+                    decode_active: measured["decodeActivePeak"],
+                    overall_envelope: record["observedMemory"]["overall"]["allocatorBytes"]
+                        .as_u64()
+                        .expect("overall envelope"),
+                }
+            })
+            .collect()
+    }
+
+    fn store() -> &'static MemoryAnchorStore {
+        packaged_memory_anchors().expect("the packaged anchor store loads")
+    }
+
+    // -------------------------------------------------------------------------------------
+    // AC 1 (store half): LTX-2.5 MLX q4/q8/bf16 each carry exactly one anchor.
+    // -------------------------------------------------------------------------------------
+
+    #[test]
+    fn ltx25_mlx_carries_exactly_one_anchor_per_tier() {
+        for tier in ["q4", "q8", "bf16"] {
+            let matching = store()
+                .anchors
+                .iter()
+                .filter(|anchor| {
+                    anchor.model_id == "ltx_2_5"
+                        && anchor.backend == AnchorBackend::Mlx
+                        && anchor.tier == tier
+                })
+                .count();
+            assert_eq!(matching, 1, "tier {tier} must carry exactly one anchor");
+            let anchor = store()
+                .anchor_for("ltx_2_5", AnchorBackend::Mlx, tier)
+                .expect("lookup resolves the tier's anchor");
+            assert_eq!(anchor.tier, tier);
+            assert_eq!(anchor.source.path, LTX25_CORPUS_PATH);
+        }
+    }
+
+    #[test]
+    fn a_duplicate_anchor_identity_is_rejected() {
+        let mut doctored: serde_json::Value =
+            serde_json::from_str(PACKAGED_MEMORY_ANCHORS).expect("packaged store parses");
+        let clone = doctored["anchors"][0].clone();
+        doctored["anchors"]
+            .as_array_mut()
+            .expect("anchors")
+            .push(clone);
+        let error = load_memory_anchors(&doctored.to_string())
+            .expect_err("a duplicated (model, tier, backend) must be rejected");
+        assert!(error.contains("duplicate memory anchor"), "{error}");
+    }
+
+    #[test]
+    fn an_anchor_that_drifts_from_its_source_record_is_rejected() {
+        let mut doctored: serde_json::Value =
+            serde_json::from_str(PACKAGED_MEMORY_ANCHORS).expect("packaged store parses");
+        let peak = doctored["anchors"][0]["phaseActivePeakBytes"]["conditioning"]
+            .as_u64()
+            .expect("conditioning peak");
+        doctored["anchors"][0]["phaseActivePeakBytes"]["conditioning"] =
+            serde_json::json!(peak + 1);
+        let error = load_memory_anchors(&doctored.to_string())
+            .expect_err("a store whose bytes drift from the retained evidence must be rejected");
+        assert!(error.contains("disagree"), "{error}");
+    }
+
+    #[test]
+    fn a_stale_source_digest_or_foreign_source_path_is_rejected() {
+        let mut doctored: serde_json::Value =
+            serde_json::from_str(PACKAGED_MEMORY_ANCHORS).expect("packaged store parses");
+        doctored["anchors"][0]["source"]["sha256"] = serde_json::json!("0".repeat(64));
+        let error = load_memory_anchors(&doctored.to_string()).expect_err("digest must bind");
+        assert!(error.contains("digest mismatch"), "{error}");
+
+        let mut foreign: serde_json::Value =
+            serde_json::from_str(PACKAGED_MEMORY_ANCHORS).expect("packaged store parses");
+        foreign["anchors"][0]["source"]["path"] = serde_json::json!("docs/nowhere.json");
+        let error = load_memory_anchors(&foreign.to_string()).expect_err("path must be compiled");
+        assert!(
+            error.contains("not a compiled retained-evidence file"),
+            "{error}"
+        );
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Derivation properties.
+    // -------------------------------------------------------------------------------------
+
+    fn plain_request(width: u32, height: u32, frames: u32) -> AnchorDeriveRequest {
+        AnchorDeriveRequest {
+            width,
+            height,
+            frames,
+            decode_tiled: false,
+            transformer_windowed: false,
+            deferred_materialization: false,
+        }
+    }
+
+    #[test]
+    fn derivation_at_the_anchor_geometry_reproduces_the_anchor_peaks_plus_margin() {
+        let anchor = store()
+            .anchor_for("ltx_2_5", AnchorBackend::Mlx, "q8")
+            .expect("q8 anchor");
+        let derived = anchor
+            .derive_video_phase_peaks(plain_request(
+                anchor.geometry.width,
+                anchor.geometry.height,
+                anchor.geometry.frames,
+            ))
+            .expect("derivable at the anchor's own geometry");
+        let expect = |measured: u64| {
+            ((measured as f64) * (1.0 + ANCHOR_ALLOCATOR_ENVELOPE_MARGIN)).ceil() as u64
+        };
+        assert_eq!(
+            derived.conditioning,
+            expect(anchor.phase_active_peak_bytes.conditioning)
+        );
+        assert_eq!(
+            derived.denoise,
+            expect(anchor.phase_active_peak_bytes.denoise)
+        );
+        assert_eq!(
+            derived.decode,
+            expect(anchor.phase_active_peak_bytes.decode)
+        );
+    }
+
+    #[test]
+    fn derived_peaks_grow_with_frames_and_area_in_the_plain_regime() {
+        let anchor = store()
+            .anchor_for("ltx_2_5", AnchorBackend::Mlx, "q4")
+            .expect("q4 anchor");
+        let small = anchor
+            .derive_video_phase_peaks(plain_request(768, 512, 89))
+            .expect("small derivable");
+        let longer = anchor
+            .derive_video_phase_peaks(plain_request(768, 512, 145))
+            .expect("longer derivable");
+        let larger = anchor
+            .derive_video_phase_peaks(plain_request(1280, 704, 89))
+            .expect("larger derivable");
+        assert!(longer.peak_bytes() > small.peak_bytes());
+        assert!(larger.peak_bytes() > small.peak_bytes());
+    }
+
+    #[test]
+    fn degenerate_geometry_is_not_derivable() {
+        let anchor = store()
+            .anchor_for("ltx_2_5", AnchorBackend::Mlx, "q4")
+            .expect("q4 anchor");
+        assert!(anchor
+            .derive_video_phase_peaks(plain_request(0, 512, 89))
+            .is_none());
+        assert!(anchor
+            .derive_video_phase_peaks(plain_request(768, 0, 89))
+            .is_none());
+        assert!(anchor
+            .derive_video_phase_peaks(plain_request(768, 512, 0))
+            .is_none());
+    }
+
+    // -------------------------------------------------------------------------------------
+    // AC 2: the derivation reproduces every retained LTX-2.5 MLX measured peak within the
+    // per-term justified margins (epic acceptance test 2, v1).
+    // -------------------------------------------------------------------------------------
+
+    #[test]
+    fn derivation_brackets_every_retained_corpus_peak() {
+        let corpus = retained_corpus();
+        // Shape, not a frozen count: every anchored tier must be exercised by the corpus, and
+        // both bounded regimes must appear, or this test silently stops asking its question.
+        for tier in ["q4", "q8", "bf16"] {
+            assert!(
+                corpus.iter().any(|record| record.tier == tier),
+                "the retained corpus must cover tier {tier}"
+            );
+        }
+        assert!(corpus.iter().any(|record| record.decode_tiled));
+        assert!(corpus.iter().any(|record| record.transformer_windowed));
+        assert!(corpus.iter().any(|record| record.deferred));
+
+        for record in corpus {
+            let anchor = store()
+                .anchor_for("ltx_2_5", AnchorBackend::Mlx, &record.tier)
+                .unwrap_or_else(|| panic!("tier {} carries an anchor", record.tier));
+            let derived = anchor
+                .derive_video_phase_peaks(AnchorDeriveRequest {
+                    width: record.width,
+                    height: record.height,
+                    frames: record.frames,
+                    decode_tiled: record.decode_tiled,
+                    transformer_windowed: record.transformer_windowed,
+                    deferred_materialization: record.deferred,
+                })
+                .unwrap_or_else(|| panic!("record {} is derivable", record.id));
+
+            // Per-phase safety: the margin-widened derived phase covers the measured active peak.
+            for (phase, derived_bytes, measured_bytes) in [
+                (
+                    "conditioning",
+                    derived.conditioning,
+                    record.conditioning_active,
+                ),
+                ("denoise", derived.denoise, record.denoise_active),
+                ("decode", derived.decode, record.decode_active),
+            ] {
+                assert!(
+                    derived_bytes >= measured_bytes,
+                    "record {} phase {phase}: derived {derived_bytes} under measured \
+                     {measured_bytes}",
+                    record.id
+                );
+            }
+
+            // Overall bracket: at or above the measured allocator envelope, and within the
+            // validation tightness budget so the margins stay falsifiable.
+            let upper = derived.peak_bytes();
+            assert!(
+                upper >= record.overall_envelope,
+                "record {}: derived admission bound {upper} under the measured allocator \
+                 envelope {}",
+                record.id,
+                record.overall_envelope
+            );
+            let tight_cap = ((record.overall_envelope as f64)
+                * (1.0 + ANCHOR_VALIDATION_TIGHTNESS_BUDGET))
+                .ceil() as u64;
+            assert!(
+                upper <= tight_cap,
+                "record {}: derived admission bound {upper} exceeds the tightness cap \
+                 {tight_cap} over envelope {}",
+                record.id,
+                record.overall_envelope
+            );
+        }
+    }
+}

--- a/crates/sceneworks-core/src/memory_anchor.rs
+++ b/crates/sceneworks-core/src/memory_anchor.rs
@@ -15,12 +15,34 @@
 //!
 //! Like `video_memory_curves`, this module deliberately has no `gen-core` dependency; worker lanes
 //! translate their own backend/rung/load-shape types at the edge.
+//!
+//! # Validated domain
+//!
+//! An anchor's identity cell is `(model, tier, backend lane, transformer variant, decoder)` — the
+//! same pipeline axes the fitted curves key on. A request whose variant/decoder differ from the
+//! anchor's is NOT derivable: the retained corpus contains no dev-vs-distilled pair at a common
+//! regime, so the variant effect is unmeasurable from this evidence and must not be assumed away.
+//!
+//! An anchor's own measured REGIME is equally load-bearing. A phase that reuses the anchor's
+//! measured intercept requires the anchor to have been measured in that phase's unbounded regime;
+//! a phase priced by an architecture bound ([`COND_DEFERRED_BOUND_BYTES`],
+//! [`DENOISE_WINDOWED_BASE_BYTES`], [`decode_tiled_bound_bytes`]) does not touch the anchor at all.
+//! `derive_video_phase_peaks` enforces exactly that and returns `None` (fail open to the caller's
+//! floor) otherwise — a deferred-measured conditioning intercept applied to an eager request would
+//! under-estimate by the entire transformer residency.
+//!
+//! The retained LTX-2.5 MLX corpus measures frames at 145 and 449 only (fps 24 and 30). The frames
+//! term is therefore validated downward from f449 to f145 on `bf16 dev/diffvae` and nowhere else;
+//! every other cell's independent evidence varies AREA at f145. Frame extrapolation above f449 is
+//! architecture-justified (latent frames are affine in frames), not corpus-validated.
 
 use std::collections::BTreeMap;
 use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+
+use crate::memory_calibration::{Ltx25Decoder, Ltx25TransformerVariant};
 
 pub const MEMORY_ANCHOR_SCHEMA_VERSION: u32 = 1;
 
@@ -49,47 +71,93 @@ pub const LTX_LATENT_PATCH_EDGE_PX: u64 = 32;
 pub const LTX_TEMPORAL_SCALE: u64 = 8;
 
 // ---------------------------------------------------------------------------------------------
-// Derivation coefficients. Each names the architecture term it prices; each uncertainty a
-// coefficient cannot pin exactly is covered by [`ANCHOR_ALLOCATOR_ENVELOPE_MARGIN`], and the
-// corpus validation test (`derivation_brackets_every_retained_corpus_peak`) is the falsifier.
+// Derivation coefficients.
+//
+// E3 requires per-term-justified margins, so the two kinds of uncertainty are kept apart:
+//
+// * COEFFICIENT uncertainty lives INSIDE each coefficient. Every slope below is set at or above
+//   the highest slope the retained corpus measures WITHIN one identity cell and regime (pairs that
+//   differ only in geometry), so no coefficient sits mid-spread and none of them leans on the
+//   margin to stay above the trend.
+// * The MLX ALLOCATOR envelope above a phase's ACTIVE peak is the one remaining unmodelled term,
+//   and it is the only thing [`ANCHOR_ALLOCATOR_ENVELOPE_MARGIN`] is asked to cover.
+//
+// Every bound constant also names the TIER it was measured on and why that tier upper-bounds the
+// others. The corpus validation test (`derivation_brackets_every_retained_corpus_peak`) is the
+// falsifier for all of it.
 // ---------------------------------------------------------------------------------------------
 
 /// Conditioning-phase bytes per latent token: the packed video latent plus the Gemma text
 /// cross-attention context held in fp32 workspace (4096 f32 lanes x 8 concurrently live per-token
-/// tensors). Retained-corpus slopes across tiers/load shapes sit at 110-131 KiB/token.
+/// tensors). Within-cell retained slopes: 109,944 B/token (`q8 dev/diffvae`) and 130,884 B/token
+/// (`bf16 dev/diffvae`). Set at 128 KiB/token, above the highest measured slope.
 pub const COND_PER_TOKEN_BYTES: i128 = 131_072;
 
 /// Conditioning-phase bound under deferred materialization: only the projected text embeddings and
 /// latent init are resident (the transformer stays unmaterialized), which the retained captures
-/// show as geometry-independent (11.73 GB active / 12.02 GB allocator at every measured geometry).
-/// Bound set above the allocator figure.
+/// show as geometry-independent (11.73 GB active / 12.02 GB allocator at 57.0M and 130.7M output
+/// voxels alike). Bound set above the allocator figure.
+///
+/// TIER PROVENANCE: measured on `bf16 distilled` captures only. It upper-bounds q8/q4 because in
+/// this regime the transformer weights are not resident at all — what is held is the projected text
+/// embedding and latent-init workspace in fp32, which weight quantization does not shrink.
 pub const COND_DEFERRED_BOUND_BYTES: u64 = 12_900_000_000;
 
 /// Denoise-phase bytes per latent token: the DiT forward's live activation set (residual stream,
 /// attention chunk workspace under the declared `attentionChunkSize`, MLP intermediates) at fp32.
-/// Retained-corpus slopes sit at 306-330 KiB/token across all three tiers and both load shapes.
+/// Within-cell retained slopes: 306,560 (`q8 dev/diffvae`), 328,805 and 329,431 B/token
+/// (`bf16 distilled/diffvae`, `bf16 dev/diffvae`). Set at 328 KiB/token, above the highest.
 pub const DENOISE_PER_TOKEN_BYTES: i128 = 335_872;
 
 /// Denoise-phase intercept under `bounded_transformer_residency` (window size 1): one resident
 /// AvDiT block of the declared 48 plus the bounded attention workspace, replacing the full
-/// transformer residency the anchor was measured with. The per-token activation slope is
+/// transformer residency an unwindowed anchor was measured with. The per-token activation slope is
 /// unchanged by windowing ([`DENOISE_PER_TOKEN_BYTES`]).
+///
+/// TIER PROVENANCE: measured on `bf16 distilled` windowed captures only (implied intercept 2.65 GB
+/// at both measured token counts). bf16 is the WIDEST tier — one resident AvDiT block is strictly
+/// larger at bf16 than at q8/q4 — so this upper-bounds the quantized tiers.
 pub const DENOISE_WINDOWED_BASE_BYTES: u64 = 2_650_000_000;
 
-/// Decode-phase bytes per output voxel in the single-pass conv-VAE regime: concurrently live
-/// pixel-space working copies (four fp32 RGB-equivalent planes). Retained-corpus slopes span
-/// 30-63 B/voxel; the spread is covered by [`ANCHOR_ALLOCATOR_ENVELOPE_MARGIN`].
-pub const DECODE_PER_VOXEL_BYTES: i128 = 48;
+/// Decode-phase bytes per output voxel in the single-pass DIFFVAE regime: concurrently live
+/// pixel-space working copies. Every non-tiled decode record in the retained corpus is a diffvae
+/// record — single-pass conv decode is UNMEASURED, and the identity/regime guards in
+/// [`MemoryAnchor::derive_video_phase_peaks`] keep it out of this law rather than pricing it here.
+///
+/// Within-cell retained slopes: 30.57 (`q8 dev/diffvae`), 48.92 (`bf16 dev/diffvae`), 62.81 and
+/// 62.87 B/voxel (`bf16 distilled/diffvae`). Set at 63 B/voxel — the observed UPPER slope — so the
+/// bound cannot cross below the measured trend at large output geometries.
+pub const DECODE_PER_VOXEL_BYTES: i128 = 63;
 
-/// Decode-phase bound under `bounded_decode` (declared `decodeTileEdge`/`decodeOverlap`): decoder
-/// weights plus tile-bounded workspace, independent of output geometry. Retained tiled captures
-/// peak at 8.26 GB across tiers; bound set above them.
-pub const DECODE_TILED_BOUND_BYTES: u64 = 9_000_000_000;
+/// Tile-bounded decode WORKSPACE under `bounded_decode` (declared `decodeTileEdge`/`decodeOverlap`):
+/// decoder weights plus the tile-sized activation working set, which the declared tile parameters
+/// make geometry-independent by construction of the tiling.
+///
+/// Measured on the two retained tiled captures — `bf16 distilled/conv` 8.23 GB and `q8 dev/conv`
+/// 8.26 GB. Both sit at the SAME 130.7M output voxels, so the geometry-independence of this term
+/// rests on the tiling contract, not on two measured points; subtracting
+/// [`DECODE_TILED_PER_VOXEL_BYTES`] at that geometry leaves an implied workspace of 6.66-6.69 GB
+/// and this constant is set above it. bf16 is the widest tier for the decoder weights, so it
+/// upper-bounds q8/q4.
+pub const DECODE_TILE_WORKSPACE_BYTES: i128 = 7_000_000_000;
 
-/// Multiplicative margin applied to every derived phase peak. It covers, jointly: the MLX
-/// allocator envelope above the phase active peak (observed up to 15.9% in the retained corpus —
-/// cache retention across phase transitions), and the residual spread of the per-token /
-/// per-voxel coefficients around the architecture-derived values above (observed under 4%).
+/// Tiling bounds the decode WORKSPACE, not the OUTPUT: a tiled decode still materializes the whole
+/// output clip, so the tiled decode estimate cannot be a flat constant. This term is
+/// architecture-determined rather than fitted — `width x height x frames x 3 RGB channels x 4 bytes`
+/// of fp32 pixel space, the widest element the decode path materializes before delivery.
+pub const DECODE_TILED_PER_VOXEL_BYTES: i128 = 12;
+
+/// Tile-bounded decode estimate at one output geometry: the geometry-independent workspace plus the
+/// output clip the tiling does not bound.
+pub const fn decode_tiled_bound_bytes(voxels: i128) -> i128 {
+    DECODE_TILE_WORKSPACE_BYTES + DECODE_TILED_PER_VOXEL_BYTES * voxels
+}
+
+/// Multiplicative margin applied to every derived phase peak. It covers exactly ONE term: the MLX
+/// allocator envelope that sits above a phase's ACTIVE peak (cache retention across phase
+/// transitions), observed at up to 15.84% over the binding active phase across the retained corpus.
+/// Coefficient uncertainty is NOT covered here — it is priced inside the coefficients above, each
+/// of which is set at or above the highest measured within-cell slope.
 pub const ANCHOR_ALLOCATOR_ENVELOPE_MARGIN: f64 = 0.17;
 
 /// Validation-only tightness budget: the corpus validation test refuses a derived bound more than
@@ -161,6 +229,19 @@ pub struct AnchorPhaseBytes {
     pub decode: u64,
 }
 
+/// The bounded rungs the anchor render itself engaged, taken from the source record's
+/// `strategy.engagedRungs`. A phase whose derivation reuses the anchor's measured intercept
+/// requires the anchor to have run that phase UNBOUNDED; see
+/// [`MemoryAnchor::derive_video_phase_peaks`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AnchorMeasuredRegime {
+    /// `bounded_decode` was engaged for the anchor render.
+    pub decode_tiled: bool,
+    /// `bounded_transformer_residency` was engaged for the anchor render.
+    pub transformer_windowed: bool,
+}
+
 /// One measured anchor: identity plus the peak decomposition of exactly one retained render.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -168,21 +249,52 @@ pub struct MemoryAnchor {
     pub id: String,
     pub model_id: String,
     pub model_family: String,
+    /// Resolved engine id. The retained LTX-2.5 corpus carries no `target.route`, so this binds
+    /// against `target.provider` exactly as `video_memory_curves::source_route` does.
+    pub route: String,
+    /// Provider descriptor id the anchor render was measured against. The measurement pins one
+    /// artifact repository/revision, so a different provider answering for the same catalog model
+    /// must not inherit it.
+    pub provider: String,
     pub backend: AnchorBackend,
     /// Plan tier key: `q4` / `q8` / `bf16` / ...
     pub tier: String,
+    /// LTX-2.5 pipeline identity — the same axes the fitted curves key on. The corpus has no
+    /// dev-vs-distilled pair at a common regime, so a request on the other variant/decoder is not
+    /// derivable from this anchor.
+    pub transformer_variant: Ltx25TransformerVariant,
+    pub decoder: Ltx25Decoder,
     pub mode: String,
     /// The anchor was measured overlay-free; a future overlay anchor is a new row, never a reuse.
     pub overlay: Option<String>,
     pub reference_count: u32,
-    /// Materialization shape the anchor render ran under. The derivation reaches the OTHER shape
-    /// analytically (see [`COND_DEFERRED_BOUND_BYTES`]), so this stays informational identity.
+    /// Materialization shape the anchor render ran under. This is LOAD-BEARING, not informational:
+    /// a deferred-measured conditioning intercept does not price an eager request (the transformer
+    /// residency is missing from it entirely), so the derivation refuses that combination.
     pub load_shape: AnchorLoadShape,
+    /// The bounded rungs the anchor render itself engaged, for the same reason.
+    pub measured_regime: AnchorMeasuredRegime,
     pub source: AnchorSource,
     pub geometry: AnchorGeometry,
     pub phase_active_peak_bytes: AnchorPhaseBytes,
     /// The measured overall allocator envelope of the anchor render (active + reclaimable).
     pub overall_allocator_envelope_bytes: u64,
+}
+
+/// Store-key spelling of the LTX-2.5 transformer variant, matching the retained evidence.
+pub const fn transformer_variant_key(variant: Ltx25TransformerVariant) -> &'static str {
+    match variant {
+        Ltx25TransformerVariant::Distilled => "distilled",
+        Ltx25TransformerVariant::Dev => "dev",
+    }
+}
+
+/// Store-key spelling of the LTX-2.5 decoder, matching the retained evidence.
+pub const fn decoder_key(decoder: Ltx25Decoder) -> &'static str {
+    match decoder {
+        Ltx25Decoder::Conv => "conv",
+        Ltx25Decoder::DiffVae => "diffvae",
+    }
 }
 
 /// Strict parse plus the invariants serde cannot express. No partial store is usable.
@@ -197,14 +309,23 @@ pub fn load_memory_anchors(raw: &str) -> Result<MemoryAnchorStore, String> {
     }
     let mut identities = BTreeMap::new();
     for anchor in &store.anchors {
-        let identity = (anchor.model_id.clone(), anchor.tier.clone(), anchor.backend);
+        let identity = (
+            anchor.model_id.clone(),
+            anchor.tier.clone(),
+            anchor.backend,
+            transformer_variant_key(anchor.transformer_variant),
+            decoder_key(anchor.decoder),
+        );
         if let Some(previous) = identities.insert(identity, &anchor.id) {
             return Err(format!(
-                "duplicate memory anchor for ({}, {}, {}): {} and {} — exactly one anchor per \
-                 (model, tier, backend lane) is the schema invariant",
+                "duplicate memory anchor for ({}, {}, {}, {}, {}): {} and {} — exactly one anchor \
+                 per (model, tier, backend lane, transformer variant, decoder) is the schema \
+                 invariant",
                 anchor.model_id,
                 anchor.tier,
                 anchor.backend.as_key(),
+                transformer_variant_key(anchor.transformer_variant),
+                decoder_key(anchor.decoder),
                 previous,
                 anchor.id
             ));
@@ -273,15 +394,49 @@ fn validate_anchor(anchor: &MemoryAnchor) -> Result<(), String> {
             .and_then(|value| value.as_str())
             .map(str::to_owned)
     };
+    // `target.route` is absent from the LTX-2.5 seed; `video_memory_curves::source_route` treats
+    // `target.provider` as the route spelling in exactly that case, and so does this.
+    let record_route = str_at(target, "route").or_else(|| str_at(target, "provider"));
     if str_at(target, "modelId").as_deref() != Some(anchor.model_id.as_str())
         || str_at(target, "tier").as_deref() != Some(anchor.tier.as_str())
         || str_at(record, "backend").as_deref() != Some(anchor.backend.as_key())
         || str_at(target, "mode").as_deref() != Some(anchor.mode.as_str())
+        || str_at(target, "provider").as_deref() != Some(anchor.provider.as_str())
+        || record_route.as_deref() != Some(anchor.route.as_str())
+        || str_at(target, "transformerVariant").as_deref()
+            != Some(transformer_variant_key(anchor.transformer_variant))
+        || str_at(target, "decoder").as_deref() != Some(decoder_key(anchor.decoder))
         || str_at(record, "calibrationFingerprint").as_deref()
             != Some(anchor.source.calibration_fingerprint.as_str())
     {
         return Err(format!(
             "memory anchor {} identity disagrees with its source record {}",
+            anchor.id, anchor.source.record_id
+        ));
+    }
+    let load_shape_key = match anchor.load_shape {
+        AnchorLoadShape::EagerMaterialization => "eager_materialization",
+        AnchorLoadShape::DeferredMaterialization => "deferred_materialization",
+    };
+    if str_at(record, "loadShape").as_deref() != Some(load_shape_key) {
+        return Err(format!(
+            "memory anchor {} load shape disagrees with its source record {}",
+            anchor.id, anchor.source.record_id
+        ));
+    }
+    let engaged: Vec<&str> = record
+        .get("strategy")
+        .and_then(|strategy| strategy.get("engagedRungs"))
+        .and_then(|rungs| rungs.as_array())
+        .map(|rungs| rungs.iter().filter_map(|rung| rung.as_str()).collect())
+        .unwrap_or_default();
+    if anchor.measured_regime.decode_tiled != engaged.contains(&"bounded_decode")
+        || anchor.measured_regime.transformer_windowed
+            != engaged.contains(&"bounded_transformer_residency")
+    {
+        return Err(format!(
+            "memory anchor {} measured regime disagrees with the engaged rungs of its source \
+             record {}",
             anchor.id, anchor.source.record_id
         ));
     }
@@ -316,6 +471,15 @@ fn validate_anchor(anchor: &MemoryAnchor) -> Result<(), String> {
         .and_then(|memory| memory.get("overall"))
         .and_then(|overall| overall.get("allocatorBytes"))
         .and_then(|bytes| bytes.as_u64());
+    // Output rate is evidence identity, not decoration: bind it to the measured `outputFps` rather
+    // than leaving a serialized field nothing checks.
+    if measured.get("outputFps").copied() != Some(u64::from(anchor.geometry.fps)) {
+        return Err(format!(
+            "memory anchor {} fps {} disagrees with the outputFps measurement of its source \
+             record {}",
+            anchor.id, anchor.geometry.fps, anchor.source.record_id
+        ));
+    }
     if measured.get("conditioningActivePeak").copied()
         != Some(anchor.phase_active_peak_bytes.conditioning)
         || measured.get("denoiseActivePeak").copied()
@@ -342,15 +506,24 @@ pub fn packaged_memory_anchors() -> Option<&'static MemoryAnchorStore> {
 }
 
 impl MemoryAnchorStore {
-    /// The unique anchor for one `(model, backend lane, tier)` coordinate.
+    /// The unique anchor for one `(model, backend lane, tier, transformer variant, decoder)`
+    /// coordinate. The pipeline axes are part of the key, not a post-filter: the corpus measures no
+    /// dev-vs-distilled pair at a common regime, so one variant's anchor may not price the other's
+    /// render.
     pub fn anchor_for(
         &self,
         model_id: &str,
         backend: AnchorBackend,
         tier: &str,
+        transformer_variant: Ltx25TransformerVariant,
+        decoder: Ltx25Decoder,
     ) -> Option<&MemoryAnchor> {
         self.anchors.iter().find(|anchor| {
-            anchor.model_id == model_id && anchor.backend == backend && anchor.tier == tier
+            anchor.model_id == model_id
+                && anchor.backend == backend
+                && anchor.tier == tier
+                && anchor.transformer_variant == transformer_variant
+                && anchor.decoder == decoder
         })
     }
 }
@@ -367,7 +540,7 @@ pub struct AnchorDeriveRequest {
     pub width: u32,
     pub height: u32,
     pub frames: u32,
-    /// `bounded_decode` engaged: decode is tile-bounded ([`DECODE_TILED_BOUND_BYTES`]).
+    /// `bounded_decode` engaged: decode is tile-bounded ([`decode_tiled_bound_bytes`]).
     pub decode_tiled: bool,
     /// `bounded_transformer_residency` engaged: denoise holds one window instead of the full
     /// transformer ([`DENOISE_WINDOWED_BASE_BYTES`]).
@@ -404,7 +577,9 @@ impl AnchorDerivedPhases {
 fn latent_tokens(width: u32, height: u32, frames: u32) -> i128 {
     let patches_w = (u64::from(width)).div_ceil(LTX_LATENT_PATCH_EDGE_PX);
     let patches_h = (u64::from(height)).div_ceil(LTX_LATENT_PATCH_EDGE_PX);
-    let latent_frames = 1 + (u64::from(frames) - 1).div_ceil(LTX_TEMPORAL_SCALE);
+    let latent_frames = 1 + u64::from(frames)
+        .saturating_sub(1)
+        .div_ceil(LTX_TEMPORAL_SCALE);
     i128::from(patches_w) * i128::from(patches_h) * i128::from(latent_frames)
 }
 
@@ -413,8 +588,15 @@ fn voxels(width: u32, height: u32, frames: u32) -> i128 {
 }
 
 /// Widen one derived phase estimate by [`ANCHOR_ALLOCATOR_ENVELOPE_MARGIN`] in integer bytes.
+///
+/// A non-positive pre-margin value is NOT clamped to zero: an extrapolation that ran below the
+/// anchor far enough to go negative has left the law's domain, and a 0-byte peak would admit
+/// anything. `None` fails open to the caller's floor instead.
 fn widened(bytes: i128) -> Option<u64> {
-    let bytes = u64::try_from(bytes.max(0)).ok()?;
+    if bytes <= 0 {
+        return None;
+    }
+    let bytes = u64::try_from(bytes).ok()?;
     let widened = (bytes as f64 * (1.0 + ANCHOR_ALLOCATOR_ENVELOPE_MARGIN)).ceil();
     (widened.is_finite() && widened < u64::MAX as f64).then_some(widened as u64)
 }
@@ -428,15 +610,30 @@ impl MemoryAnchor {
     ///   transient bounded by the declared chunk parameter, so no super-linear term), or the
     ///   windowed-residency intercept plus the same slope.
     /// * decode: anchored intercept + [`DECODE_PER_VOXEL_BYTES`] per output voxel, or the
-    ///   tile-bounded constant.
+    ///   tile-bounded estimate ([`decode_tiled_bound_bytes`]).
     ///
-    /// Returns `None` on degenerate geometry; every estimate is widened by
+    /// REGIME GUARD: a phase priced from the anchor's own measured intercept requires the anchor to
+    /// have been measured in that phase's UNBOUNDED regime. A deferred-materialization anchor
+    /// carries no transformer residency in its conditioning peak; a windowed anchor carries one
+    /// AvDiT block instead of 48 in its denoise peak; a tiled anchor carries a tile workspace
+    /// instead of the full decode working set. Reusing any of those for an unbounded request would
+    /// under-estimate by the whole omitted residency, so the derivation refuses instead.
+    ///
+    /// Returns `None` on degenerate geometry, on a regime the anchor cannot price, and on any
+    /// extrapolation that runs non-positive; every estimate is widened by
     /// [`ANCHOR_ALLOCATOR_ENVELOPE_MARGIN`].
     pub fn derive_video_phase_peaks(
         &self,
         request: AnchorDeriveRequest,
     ) -> Option<AnchorDerivedPhases> {
         if request.width == 0 || request.height == 0 || request.frames == 0 {
+            return None;
+        }
+        let anchor_deferred = self.load_shape == AnchorLoadShape::DeferredMaterialization;
+        if (!request.deferred_materialization && anchor_deferred)
+            || (!request.transformer_windowed && self.measured_regime.transformer_windowed)
+            || (!request.decode_tiled && self.measured_regime.decode_tiled)
+        {
             return None;
         }
         let anchor_tokens = latent_tokens(
@@ -465,7 +662,7 @@ impl MemoryAnchor {
                 + DENOISE_PER_TOKEN_BYTES * (tokens - anchor_tokens)
         };
         let decode = if request.decode_tiled {
-            i128::from(DECODE_TILED_BOUND_BYTES)
+            decode_tiled_bound_bytes(voxels)
         } else {
             i128::from(self.phase_active_peak_bytes.decode)
                 + DECODE_PER_VOXEL_BYTES * (voxels - anchor_voxels)
@@ -495,6 +692,8 @@ mod tests {
     struct CorpusRecord {
         id: String,
         tier: String,
+        transformer_variant: Ltx25TransformerVariant,
+        decoder: Ltx25Decoder,
         width: u32,
         height: u32,
         frames: u32,
@@ -537,6 +736,16 @@ mod tests {
                 CorpusRecord {
                     id: record["id"].as_str().expect("record id").to_owned(),
                     tier: record["target"]["tier"].as_str().expect("tier").to_owned(),
+                    transformer_variant: match record["target"]["transformerVariant"].as_str() {
+                        Some("dev") => Ltx25TransformerVariant::Dev,
+                        Some("distilled") => Ltx25TransformerVariant::Distilled,
+                        other => panic!("unknown transformer variant {other:?}"),
+                    },
+                    decoder: match record["target"]["decoder"].as_str() {
+                        Some("conv") => Ltx25Decoder::Conv,
+                        Some("diffvae") => Ltx25Decoder::DiffVae,
+                        other => panic!("unknown decoder {other:?}"),
+                    },
                     width: geometry["width"].as_u64().expect("width") as u32,
                     height: geometry["height"].as_u64().expect("height") as u32,
                     frames: geometry["frames"].as_u64().expect("frames") as u32,
@@ -559,28 +768,216 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------------------
-    // AC 1 (store half): LTX-2.5 MLX q4/q8/bf16 each carry exactly one anchor.
+    // AC 1 (store half): every LTX-2.5 MLX (tier, transformer variant, decoder) cell the
+    // retained corpus measures carries exactly one anchor, and no cell it does not measure
+    // carries any.
     // -------------------------------------------------------------------------------------
 
     #[test]
-    fn ltx25_mlx_carries_exactly_one_anchor_per_tier() {
-        for tier in ["q4", "q8", "bf16"] {
+    fn ltx25_mlx_carries_exactly_one_anchor_per_measured_pipeline_cell() {
+        let corpus = retained_corpus();
+        let measured: std::collections::BTreeSet<(String, &str, &str)> = corpus
+            .iter()
+            .map(|record| {
+                (
+                    record.tier.clone(),
+                    transformer_variant_key(record.transformer_variant),
+                    decoder_key(record.decoder),
+                )
+            })
+            .collect();
+        // Shape, not a frozen count: the corpus spans more than one variant and more than one
+        // decoder, so this test cannot silently degenerate into a single-cell assertion.
+        assert!(
+            measured
+                .iter()
+                .map(|(_, variant, _)| *variant)
+                .collect::<std::collections::BTreeSet<_>>()
+                .len()
+                > 1,
+            "the retained corpus must span more than one transformer variant"
+        );
+        assert!(
+            measured
+                .iter()
+                .map(|(_, _, decoder)| *decoder)
+                .collect::<std::collections::BTreeSet<_>>()
+                .len()
+                > 1,
+            "the retained corpus must span more than one decoder"
+        );
+
+        for (tier, variant_key, decoder_key_str) in &measured {
             let matching = store()
                 .anchors
                 .iter()
                 .filter(|anchor| {
                     anchor.model_id == "ltx_2_5"
                         && anchor.backend == AnchorBackend::Mlx
-                        && anchor.tier == tier
+                        && anchor.tier == *tier
+                        && transformer_variant_key(anchor.transformer_variant) == *variant_key
+                        && decoder_key(anchor.decoder) == *decoder_key_str
                 })
                 .count();
-            assert_eq!(matching, 1, "tier {tier} must carry exactly one anchor");
-            let anchor = store()
-                .anchor_for("ltx_2_5", AnchorBackend::Mlx, tier)
-                .expect("lookup resolves the tier's anchor");
-            assert_eq!(anchor.tier, tier);
+            assert_eq!(
+                matching, 1,
+                "cell ({tier}, {variant_key}, {decoder_key_str}) must carry exactly one anchor"
+            );
+        }
+        assert_eq!(
+            store()
+                .anchors
+                .iter()
+                .filter(
+                    |anchor| anchor.model_id == "ltx_2_5" && anchor.backend == AnchorBackend::Mlx
+                )
+                .count(),
+            measured.len(),
+            "the store must not carry an anchor for a pipeline cell the corpus never measured"
+        );
+        for anchor in &store().anchors {
             assert_eq!(anchor.source.path, LTX25_CORPUS_PATH);
         }
+    }
+
+    /// The pipeline cell is part of the lookup key, not a post-filter: the corpus contains no
+    /// dev-vs-distilled pair at a common regime, so the variant effect is unmeasurable and one
+    /// variant's anchor must never resolve for the other's request.
+    #[test]
+    fn a_foreign_pipeline_cell_resolves_no_anchor() {
+        // Measured at q8: dev/diffvae and dev/conv. Never measured at q8: either distilled combo.
+        assert!(store()
+            .anchor_for(
+                "ltx_2_5",
+                AnchorBackend::Mlx,
+                "q8",
+                Ltx25TransformerVariant::Dev,
+                Ltx25Decoder::DiffVae
+            )
+            .is_some());
+        assert!(store()
+            .anchor_for(
+                "ltx_2_5",
+                AnchorBackend::Mlx,
+                "q8",
+                Ltx25TransformerVariant::Distilled,
+                Ltx25Decoder::Conv
+            )
+            .is_none());
+        // Measured at q4: dev/diffvae only.
+        assert!(store()
+            .anchor_for(
+                "ltx_2_5",
+                AnchorBackend::Mlx,
+                "q4",
+                Ltx25TransformerVariant::Dev,
+                Ltx25Decoder::Conv
+            )
+            .is_none());
+    }
+
+    /// An anchor measured in a BOUNDED regime carries a truncated intercept for that phase. It may
+    /// not price the unbounded request that would reuse it.
+    #[test]
+    fn an_anchor_measured_in_a_bounded_regime_refuses_the_unbounded_request() {
+        let bounded = store()
+            .anchor_for(
+                "ltx_2_5",
+                AnchorBackend::Mlx,
+                "bf16",
+                Ltx25TransformerVariant::Distilled,
+                Ltx25Decoder::Conv,
+            )
+            .expect("the bf16 distilled/conv anchor exists");
+        assert_eq!(bounded.load_shape, AnchorLoadShape::DeferredMaterialization);
+        assert!(bounded.measured_regime.decode_tiled);
+        assert!(bounded.measured_regime.transformer_windowed);
+
+        let matching = AnchorDeriveRequest {
+            width: bounded.geometry.width,
+            height: bounded.geometry.height,
+            frames: bounded.geometry.frames,
+            decode_tiled: true,
+            transformer_windowed: true,
+            deferred_materialization: true,
+        };
+        assert!(bounded.derive_video_phase_peaks(matching).is_some());
+        for (label, request) in [
+            (
+                "eager request against a deferred anchor",
+                AnchorDeriveRequest {
+                    deferred_materialization: false,
+                    ..matching
+                },
+            ),
+            (
+                "unwindowed request against a windowed anchor",
+                AnchorDeriveRequest {
+                    transformer_windowed: false,
+                    ..matching
+                },
+            ),
+            (
+                "single-pass request against a tiled anchor",
+                AnchorDeriveRequest {
+                    decode_tiled: false,
+                    ..matching
+                },
+            ),
+        ] {
+            assert!(
+                bounded.derive_video_phase_peaks(request).is_none(),
+                "{label} must fall open to the caller's floor"
+            );
+        }
+    }
+
+    /// The store schema may not be doctored into a regime it was not measured in — the handshake
+    /// binds `loadShape` and `measuredRegime` to the source record.
+    #[test]
+    fn a_doctored_load_shape_or_measured_regime_is_rejected() {
+        let mut doctored: serde_json::Value =
+            serde_json::from_str(PACKAGED_MEMORY_ANCHORS).expect("packaged store parses");
+        doctored["anchors"][0]["loadShape"] = serde_json::json!("deferred_materialization");
+        let error =
+            load_memory_anchors(&doctored.to_string()).expect_err("load shape must bind to source");
+        assert!(error.contains("load shape disagrees"), "{error}");
+
+        let mut doctored: serde_json::Value =
+            serde_json::from_str(PACKAGED_MEMORY_ANCHORS).expect("packaged store parses");
+        doctored["anchors"][0]["measuredRegime"]["decodeTiled"] = serde_json::json!(true);
+        let error = load_memory_anchors(&doctored.to_string())
+            .expect_err("measured regime must bind to the engaged rungs");
+        assert!(error.contains("measured regime disagrees"), "{error}");
+    }
+
+    /// Identity fields that were previously stored-and-unchecked are bound to the source record.
+    #[test]
+    fn a_doctored_pipeline_identity_provider_route_or_fps_is_rejected() {
+        for (field, value) in [
+            ("transformerVariant", serde_json::json!("distilled")),
+            ("decoder", serde_json::json!("conv")),
+            ("provider", serde_json::json!("someone_else")),
+            ("route", serde_json::json!("ltx_2_5_other")),
+        ] {
+            let mut doctored: serde_json::Value =
+                serde_json::from_str(PACKAGED_MEMORY_ANCHORS).expect("packaged store parses");
+            doctored["anchors"][0][field] = value;
+            let error = load_memory_anchors(&doctored.to_string())
+                .err()
+                .unwrap_or_else(|| panic!("{field} must bind to the source record"));
+            assert!(error.contains("identity disagrees"), "{field}: {error}");
+        }
+
+        let mut doctored: serde_json::Value =
+            serde_json::from_str(PACKAGED_MEMORY_ANCHORS).expect("packaged store parses");
+        let fps = doctored["anchors"][0]["geometry"]["fps"]
+            .as_u64()
+            .expect("fps");
+        doctored["anchors"][0]["geometry"]["fps"] = serde_json::json!(fps + 1);
+        let error = load_memory_anchors(&doctored.to_string())
+            .expect_err("fps must bind to the outputFps measurement");
+        assert!(error.contains("disagrees with the outputFps"), "{error}");
     }
 
     #[test]
@@ -647,8 +1044,14 @@ mod tests {
     #[test]
     fn derivation_at_the_anchor_geometry_reproduces_the_anchor_peaks_plus_margin() {
         let anchor = store()
-            .anchor_for("ltx_2_5", AnchorBackend::Mlx, "q8")
-            .expect("q8 anchor");
+            .anchor_for(
+                "ltx_2_5",
+                AnchorBackend::Mlx,
+                "q8",
+                Ltx25TransformerVariant::Dev,
+                Ltx25Decoder::DiffVae,
+            )
+            .expect("q8 dev/diffvae anchor");
         let derived = anchor
             .derive_video_phase_peaks(plain_request(
                 anchor.geometry.width,
@@ -676,8 +1079,14 @@ mod tests {
     #[test]
     fn derived_peaks_grow_with_frames_and_area_in_the_plain_regime() {
         let anchor = store()
-            .anchor_for("ltx_2_5", AnchorBackend::Mlx, "q4")
-            .expect("q4 anchor");
+            .anchor_for(
+                "ltx_2_5",
+                AnchorBackend::Mlx,
+                "q4",
+                Ltx25TransformerVariant::Dev,
+                Ltx25Decoder::DiffVae,
+            )
+            .expect("q4 dev/diffvae anchor");
         let small = anchor
             .derive_video_phase_peaks(plain_request(768, 512, 89))
             .expect("small derivable");
@@ -691,11 +1100,110 @@ mod tests {
         assert!(larger.peak_bytes() > small.peak_bytes());
     }
 
+    /// E3: coefficient uncertainty is priced INSIDE the coefficients, not inside the allocator
+    /// margin. Every per-unit constant must be at or above the highest slope the retained corpus
+    /// measures within one identity cell and regime — a coefficient sitting mid-spread would cross
+    /// below the measured trend at large geometry, where nothing else would catch it.
+    ///
+    /// The corpus validation test cannot ask this question: its records all sit near the anchors,
+    /// so a mid-spread coefficient still brackets them.
+    #[test]
+    fn every_per_unit_coefficient_bounds_the_highest_measured_within_cell_slope() {
+        let corpus = retained_corpus();
+        let mut cond_slopes: Vec<f64> = Vec::new();
+        let mut denoise_slopes: Vec<f64> = Vec::new();
+        let mut decode_slopes: Vec<f64> = Vec::new();
+        for (index, left) in corpus.iter().enumerate() {
+            for right in &corpus[index + 1..] {
+                // Only a pair that differs in GEOMETRY ALONE measures a slope.
+                if left.tier != right.tier
+                    || left.transformer_variant != right.transformer_variant
+                    || left.decoder != right.decoder
+                    || left.decode_tiled != right.decode_tiled
+                    || left.transformer_windowed != right.transformer_windowed
+                    || left.deferred != right.deferred
+                {
+                    continue;
+                }
+                let left_tokens = latent_tokens(left.width, left.height, left.frames);
+                let right_tokens = latent_tokens(right.width, right.height, right.frames);
+                if left_tokens != right_tokens {
+                    let delta = (right_tokens - left_tokens) as f64;
+                    // Both intercept-priced phases; a bounded phase has no anchor slope to fit.
+                    if !left.deferred {
+                        cond_slopes.push(
+                            (right.conditioning_active as f64 - left.conditioning_active as f64)
+                                / delta,
+                        );
+                    }
+                    denoise_slopes
+                        .push((right.denoise_active as f64 - left.denoise_active as f64) / delta);
+                }
+                let left_voxels = voxels(left.width, left.height, left.frames);
+                let right_voxels = voxels(right.width, right.height, right.frames);
+                if left_voxels != right_voxels && !left.decode_tiled {
+                    decode_slopes.push(
+                        (right.decode_active as f64 - left.decode_active as f64)
+                            / (right_voxels - left_voxels) as f64,
+                    );
+                }
+            }
+        }
+        // Shape: the corpus must actually measure each slope, or this test asks nothing.
+        assert!(!cond_slopes.is_empty(), "no measured conditioning slope");
+        assert!(!denoise_slopes.is_empty(), "no measured denoise slope");
+        assert!(!decode_slopes.is_empty(), "no measured decode slope");
+
+        let highest = |slopes: &[f64]| slopes.iter().cloned().fold(f64::MIN, f64::max);
+        for (name, coefficient, slopes) in [
+            ("conditioning", COND_PER_TOKEN_BYTES as f64, &cond_slopes),
+            ("denoise", DENOISE_PER_TOKEN_BYTES as f64, &denoise_slopes),
+            ("decode", DECODE_PER_VOXEL_BYTES as f64, &decode_slopes),
+        ] {
+            let observed = highest(slopes);
+            assert!(
+                coefficient >= observed,
+                "{name} coefficient {coefficient} sits below the highest measured within-cell \
+                 slope {observed}: coefficient uncertainty must be priced in the coefficient, not \
+                 in the allocator margin"
+            );
+        }
+    }
+
+    /// The frames term is affine in `frames`, and `frames == 0` must not underflow the latent
+    /// frame count on its way there.
+    #[test]
+    fn latent_tokens_does_not_underflow_at_zero_frames() {
+        assert_eq!(latent_tokens(640, 640, 0), latent_tokens(640, 640, 1));
+    }
+
+    /// An extrapolation driven non-positive has left the law's domain. Clamping it to zero would
+    /// mint a 0-byte peak that admits ANYTHING, so widening refuses instead and the caller keeps
+    /// its floor.
+    ///
+    /// No packaged anchor can currently be driven negative by geometry alone — the smallest
+    /// derivable request still leaves every phase positive — so this asks the question of
+    /// `widened` directly rather than pretending a reachable geometry exercises it. It is the
+    /// guard that keeps a future anchor with a smaller intercept, or a larger coefficient, from
+    /// silently minting a zero.
+    #[test]
+    fn a_non_positive_phase_estimate_is_refused_rather_than_clamped_to_zero() {
+        assert_eq!(widened(-1), None);
+        assert_eq!(widened(0), None);
+        assert_eq!(widened(1_000_000), Some(1_170_000));
+    }
+
     #[test]
     fn degenerate_geometry_is_not_derivable() {
         let anchor = store()
-            .anchor_for("ltx_2_5", AnchorBackend::Mlx, "q4")
-            .expect("q4 anchor");
+            .anchor_for(
+                "ltx_2_5",
+                AnchorBackend::Mlx,
+                "q4",
+                Ltx25TransformerVariant::Dev,
+                Ltx25Decoder::DiffVae,
+            )
+            .expect("q4 dev/diffvae anchor");
         assert!(anchor
             .derive_video_phase_peaks(plain_request(0, 512, 89))
             .is_none());
@@ -727,10 +1235,23 @@ mod tests {
         assert!(corpus.iter().any(|record| record.transformer_windowed));
         assert!(corpus.iter().any(|record| record.deferred));
 
-        for record in corpus {
+        for record in &corpus {
             let anchor = store()
-                .anchor_for("ltx_2_5", AnchorBackend::Mlx, &record.tier)
-                .unwrap_or_else(|| panic!("tier {} carries an anchor", record.tier));
+                .anchor_for(
+                    "ltx_2_5",
+                    AnchorBackend::Mlx,
+                    &record.tier,
+                    record.transformer_variant,
+                    record.decoder,
+                )
+                .unwrap_or_else(|| {
+                    panic!(
+                        "cell ({}, {}, {}) carries an anchor",
+                        record.tier,
+                        transformer_variant_key(record.transformer_variant),
+                        decoder_key(record.decoder)
+                    )
+                });
             let derived = anchor
                 .derive_video_phase_peaks(AnchorDeriveRequest {
                     width: record.width,
@@ -780,6 +1301,55 @@ mod tests {
                 record.id,
                 record.overall_envelope
             );
+        }
+
+        // The tiled decode estimate must GROW with output voxels. The corpus has both of its
+        // tiled captures at the same 130.7M output voxels, so this is the assertion that keeps a
+        // geometry-blind flat constant from coming back: a flat bound would silently
+        // under-admit a large tiled render whose output clip alone runs to gigabytes.
+        let tiled_at = |voxels: i128| decode_tiled_bound_bytes(voxels);
+        assert!(
+            tiled_at(931_000_000) > tiled_at(130_662_400),
+            "the tiled decode bound must grow with output voxels"
+        );
+        assert!(
+            tiled_at(931_000_000) - tiled_at(130_662_400)
+                >= DECODE_TILED_PER_VOXEL_BYTES * (931_000_000 - 130_662_400),
+            "the tiled decode bound must grow at least at the output-clip rate"
+        );
+
+        // Corpus-support shape (informative, never a hard fail on the frozen corpus): the frames
+        // and token terms are only validated where a cell carries a record that DIFFERS from its
+        // anchor in latent token count. Where it does not — q4 today — the derivation's
+        // extrapolation for that tier is unexercised, and this annotation is what makes the gap
+        // visible instead of implied.
+        for tier in ["q4", "q8", "bf16"] {
+            let independent = corpus.iter().any(|record| {
+                let Some(anchor) = store().anchor_for(
+                    "ltx_2_5",
+                    AnchorBackend::Mlx,
+                    &record.tier,
+                    record.transformer_variant,
+                    record.decoder,
+                ) else {
+                    return false;
+                };
+                record.tier == tier
+                    && record.id != anchor.source.record_id
+                    && latent_tokens(record.width, record.height, record.frames)
+                        != latent_tokens(
+                            anchor.geometry.width,
+                            anchor.geometry.height,
+                            anchor.geometry.frames,
+                        )
+            });
+            if !independent {
+                eprintln!(
+                    "corpus support gap: tier {tier} has no retained record that differs from its \
+                     anchor in latent token count, so its token/frames extrapolation is validated \
+                     by zero independent cells"
+                );
+            }
         }
     }
 }

--- a/crates/sceneworks-worker/src/memory_strategy.rs
+++ b/crates/sceneworks-worker/src/memory_strategy.rs
@@ -264,6 +264,13 @@ pub enum CandidateBasis {
     /// Synthesized estimate extrapolated from a measured cell's per-phase peaks (sc-18096). The
     /// caller must have already honored the binding-phase constraint before submitting it.
     EstimateFittedCurve,
+    /// Synthesized estimate derived analytically from one measured memory anchor (sc-22507,
+    /// epic 22505): activation terms linear in latent tokens, decode in voxels, bounded regimes
+    /// substituted from declared rung parameters. Unlike [`Self::EstimateFittedCurve`] it is not
+    /// hull-restricted — admitting a never-measured `(geometry, frames)` cell is its purpose —
+    /// and like [`Self::EstimateFloor`] the per-cell binding-phase constraint does not apply:
+    /// the anchor measured all three phases and the derivation prices each per phase.
+    EstimateAnchorDerived,
     /// Synthesized estimate from the weights + headroom floor — no measured cell in its
     /// extrapolation basis, so the binding-phase constraint does not apply (see the scope
     /// sentence on the constraint's doc).
@@ -272,7 +279,10 @@ pub enum CandidateBasis {
 
 impl CandidateBasis {
     pub const fn is_estimate(self) -> bool {
-        matches!(self, Self::EstimateFittedCurve | Self::EstimateFloor)
+        matches!(
+            self,
+            Self::EstimateFittedCurve | Self::EstimateAnchorDerived | Self::EstimateFloor
+        )
     }
 
     /// Stable label for tracing/telemetry.
@@ -280,6 +290,7 @@ impl CandidateBasis {
         match self {
             Self::Measured => "measured",
             Self::EstimateFittedCurve => "fitted_curve",
+            Self::EstimateAnchorDerived => "anchor_derived",
             Self::EstimateFloor => "floor",
         }
     }

--- a/crates/sceneworks-worker/src/video_admission.rs
+++ b/crates/sceneworks-worker/src/video_admission.rs
@@ -889,6 +889,10 @@ pub(crate) struct LadderVideoSelector<'a> {
     /// The shared backend-neutral fitted-curve container. `None` is a normal fail-open state: every
     /// rung retains its pre-existing weights-plus-headroom floor candidate.
     curves: Option<&'a VideoMemoryCurveBundle>,
+    /// Measured memory anchors (sc-22507, epic 22505). When the fitted curves miss, a matching
+    /// anchor derives a per-phase estimate for the requested geometry analytically — including a
+    /// `(geometry, frames)` cell that was never measured. `None` fails open to the floor.
+    anchors: Option<&'a sceneworks_core::memory_anchor::MemoryAnchorStore>,
     /// Backend bundle resolver for the provider's load-bearing decode working set. Tests default to
     /// `None` so focused curve/floor fixtures do not accidentally inherit a real provider profile.
     decode_profile: VideoDecodeProfileResolver,
@@ -955,6 +959,7 @@ impl<'a> LadderVideoSelector<'a> {
             budget,
             headroom_bytes,
             curves,
+            anchors: sceneworks_core::memory_anchor::packaged_memory_anchors(),
             decode_profile: no_video_decode_profile,
             attributable_resident_bytes,
             accounting_error: None,
@@ -962,6 +967,17 @@ impl<'a> LadderVideoSelector<'a> {
             selections: Vec::new(),
             resident_floors: Vec::new(),
         }
+    }
+
+    /// Replace the packaged anchor store (tests only): focused floor/curve fixtures must be able
+    /// to prove the anchor path carried — or did not carry — a selection.
+    #[cfg(test)]
+    fn with_anchor_store(
+        mut self,
+        anchors: Option<&'a sceneworks_core::memory_anchor::MemoryAnchorStore>,
+    ) -> Self {
+        self.anchors = anchors;
+        self
     }
 
     fn with_profiles(
@@ -1156,6 +1172,59 @@ fn curve_decode_pass(decode_pass: VideoDecodePass) -> VideoCurveDecodePass {
     }
 }
 
+/// Derive per-phase peaks from the measured memory anchor for this `(model, tier, lane)`
+/// coordinate (sc-22507, epic 22505), for the exact regime of the candidate being graded.
+///
+/// Deliberately NOT hull-restricted: the whole point of the anchor + analytic derivation is that
+/// a request at a `(geometry, frames)` never measured is priced from the anchor plus architecture
+/// facts instead of falling to the phase-blind floor. Identity stays strict — model, family,
+/// lane, tier, mode, overlay-free, reference-free — and the anchor store itself is validated
+/// against the retained evidence it was extracted from at load.
+fn anchor_derived_phase_peaks<'a>(
+    selector: &LadderVideoSelector<'a>,
+    geometry: VideoAdmissionGeometry,
+    engaged: &[MemoryStrategy],
+) -> Option<(PhasePeaks, &'a str)> {
+    use sceneworks_core::memory_anchor::{AnchorBackend, AnchorDeriveRequest};
+
+    let store = selector.anchors?;
+    let identity = &selector.identity;
+    // The anchors were measured overlay-free with zero references; a differently-conditioned
+    // surface must not borrow them.
+    if identity.overlay.is_some() || identity.reference_count != 0 {
+        return None;
+    }
+    let backend = match identity.lane {
+        VideoLane::Mlx => AnchorBackend::Mlx,
+        VideoLane::Candle => AnchorBackend::Candle,
+    };
+    let anchor = store.anchor_for(
+        identity.model_id,
+        backend,
+        crate::mlx_fit_gate::plan_tier_key(identity.tier),
+    )?;
+    if anchor.model_family != identity.model_family || anchor.mode != identity.mode {
+        return None;
+    }
+    let derived = anchor.derive_video_phase_peaks(AnchorDeriveRequest {
+        width: geometry.width,
+        height: geometry.height,
+        frames: geometry.estimate_frames(),
+        decode_tiled: engaged.contains(&MemoryStrategy::BoundedDecode),
+        transformer_windowed: engaged.contains(&MemoryStrategy::BoundedTransformerResidency),
+        deferred_materialization: selector.contract.load_shape
+            == gen_core::LoadShape::DeferredMaterialization,
+    })?;
+    Some((
+        PhasePeaks {
+            conditioning_bytes: derived.conditioning,
+            denoise_bytes: derived.denoise,
+            decode_bytes: derived.decode,
+        },
+        anchor.id.as_str(),
+    ))
+}
+
 /// Prefer the exact fitted per-phase curve for this cell; otherwise preserve the established
 /// weights-plus-headroom floor byte-for-byte. The lookup itself owns every fail-closed identity and
 /// geometry check, including lane/closure/load-shape/mode and the measured area-by-voxel hull.
@@ -1226,6 +1295,19 @@ fn fitted_or_floor_phase_peaks<'a>(
             CandidateBasis::EstimateFittedCurve,
             evaluation.closure_digest,
             Some(evaluation.curve_id),
+            None,
+        );
+    }
+    // Anchor + analytic derivation (sc-22507): between the exact fitted curve and the
+    // phase-blind floor. A never-measured (geometry, frames) cell is priced from the one
+    // measured anchor for this (model, tier, lane); the shared selector then applies its
+    // ordinary backend estimate margin, exactly as it does for fitted-curve candidates.
+    if let Some((derived, anchor_id)) = anchor_derived_phase_peaks(selector, geometry, engaged) {
+        return (
+            derived,
+            CandidateBasis::EstimateAnchorDerived,
+            selector.identity.expected_closure_digest,
+            Some(anchor_id),
             None,
         );
     }
@@ -1508,7 +1590,39 @@ pub(crate) fn packaged_video_evidence_covers_request(
         sceneworks_core::video_memory_curves::packaged_video_memory_curves(),
         contract,
         request,
+    ) || anchor_evidence_covers_request(
+        sceneworks_core::memory_anchor::packaged_memory_anchors(),
+        request,
     )
+}
+
+/// Whether the packaged anchor store carries the measured anchor this request's `(model, tier,
+/// lane)` coordinate derives from (sc-22507). Coverage is identity-only — no geometry hull — so
+/// a never-measured `(geometry, frames)` request still reaches the ladder and its anchor-derived
+/// candidate instead of bypassing the gate.
+fn anchor_evidence_covers_request(
+    anchors: Option<&sceneworks_core::memory_anchor::MemoryAnchorStore>,
+    request: &VideoAdmissionInputs<'_>,
+) -> bool {
+    let Some(anchors) = anchors else {
+        return false;
+    };
+    if request.overlay.is_some() || request.reference_count != 0 {
+        return false;
+    }
+    let backend = match request.lane {
+        VideoLane::Mlx => sceneworks_core::memory_anchor::AnchorBackend::Mlx,
+        VideoLane::Candle => sceneworks_core::memory_anchor::AnchorBackend::Candle,
+    };
+    anchors
+        .anchor_for(
+            request.model_id,
+            backend,
+            crate::mlx_fit_gate::plan_tier_key(request.tier),
+        )
+        .is_some_and(|anchor| {
+            anchor.model_family == request.model_family && anchor.mode == request.mode
+        })
 }
 
 /// Test seam for exact fixture contracts/curves. Production always calls

--- a/crates/sceneworks-worker/src/video_admission.rs
+++ b/crates/sceneworks-worker/src/video_admission.rs
@@ -1172,14 +1172,40 @@ fn curve_decode_pass(decode_pass: VideoDecodePass) -> VideoCurveDecodePass {
     }
 }
 
-/// Derive per-phase peaks from the measured memory anchor for this `(model, tier, lane)`
-/// coordinate (sc-22507, epic 22505), for the exact regime of the candidate being graded.
+/// Whether the anchor's evidence is CURRENT for the contract being admitted.
+///
+/// The fitted-curve path demotes to the floor when the contract carries no calibration identity,
+/// when the calibration ABI moved, or when the fingerprint no longer names the measured closure.
+/// The anchor path must demote on exactly the same events: a pin bump or ABI change that stales the
+/// evidence cannot be allowed to leave the anchor derivation live while the fitted curve falls.
+///
+/// The fingerprint compared here is the calibration campaign's, which is what the anchor's source
+/// record carries. sc-22511 re-keys currency on the model's own loader closure; this helper is the
+/// single seam that changes when it does. Do not grow a second currency notion beside it.
+fn anchor_currency_matches(
+    selector: &LadderVideoSelector<'_>,
+    anchor: &sceneworks_core::memory_anchor::MemoryAnchor,
+) -> bool {
+    selector
+        .contract
+        .calibration
+        .as_ref()
+        .is_some_and(|calibration| {
+            calibration.abi == selector.identity.calibration_abi
+                && calibration.fingerprint == anchor.source.calibration_fingerprint
+        })
+}
+
+/// Derive per-phase peaks from the measured memory anchor for this
+/// `(model, tier, lane, transformer variant, decoder)` coordinate (sc-22507, epic 22505), for the
+/// exact regime of the candidate being graded.
 ///
 /// Deliberately NOT hull-restricted: the whole point of the anchor + analytic derivation is that
 /// a request at a `(geometry, frames)` never measured is priced from the anchor plus architecture
-/// facts instead of falling to the phase-blind floor. Identity stays strict — model, family,
-/// lane, tier, mode, overlay-free, reference-free — and the anchor store itself is validated
-/// against the retained evidence it was extracted from at load.
+/// facts instead of falling to the phase-blind floor. Identity stays strict — model, family, route,
+/// provider, lane, tier, pipeline variant/decoder, mode, overlay-free, reference-free, and current
+/// calibration — and the anchor store itself is validated against the retained evidence it was
+/// extracted from at load.
 fn anchor_derived_phase_peaks<'a>(
     selector: &LadderVideoSelector<'a>,
     geometry: VideoAdmissionGeometry,
@@ -1198,14 +1224,31 @@ fn anchor_derived_phase_peaks<'a>(
         VideoLane::Mlx => AnchorBackend::Mlx,
         VideoLane::Candle => AnchorBackend::Candle,
     };
+    // The pipeline cell is part of the lookup key, exactly as it is for the fitted curve: the
+    // retained corpus has no dev-vs-distilled pair at a common regime, so a request on another
+    // variant/decoder has no measured basis here and must fall to the floor.
     let anchor = store.anchor_for(
         identity.model_id,
         backend,
         crate::mlx_fit_gate::plan_tier_key(identity.tier),
+        identity.transformer_variant?,
+        identity.decoder?,
     )?;
-    if anchor.model_family != identity.model_family || anchor.mode != identity.mode {
+    if anchor.model_family != identity.model_family
+        || anchor.mode != identity.mode
+        || anchor.route != identity.route
+        || anchor.provider != selector.contract.provider_id
+        || !anchor_currency_matches(selector, anchor)
+    {
         return None;
     }
+    // `decode_tiled` is keyed on the ENGAGED RUNG, not on `geometry.decode_pass`, because the rung
+    // is what actually bounds the decoder's working set: the rung is the selected memory strategy
+    // the provider will execute, while `decode_pass` describes how the caller intends to walk the
+    // clip. A `VideoDecodePass::Tiled` request without the rung is therefore priced by the
+    // single-pass voxel law — an over-estimate, and the safe direction. The fitted path keys on
+    // both because its curves are measured per `(rung, decode_pass)` cell; the anchor derivation
+    // has one law per regime and only the rung selects between them.
     let derived = anchor.derive_video_phase_peaks(AnchorDeriveRequest {
         width: geometry.width,
         height: geometry.height,
@@ -1592,16 +1635,22 @@ pub(crate) fn packaged_video_evidence_covers_request(
         request,
     ) || anchor_evidence_covers_request(
         sceneworks_core::memory_anchor::packaged_memory_anchors(),
+        contract,
         request,
     )
 }
 
-/// Whether the packaged anchor store carries the measured anchor this request's `(model, tier,
-/// lane)` coordinate derives from (sc-22507). Coverage is identity-only — no geometry hull — so
-/// a never-measured `(geometry, frames)` request still reaches the ladder and its anchor-derived
-/// candidate instead of bypassing the gate.
+/// Whether the packaged anchor store carries the measured anchor this request's
+/// `(model, tier, lane, transformer variant, decoder)` coordinate derives from (sc-22507).
+/// Coverage is identity-only — no geometry hull — so a never-measured `(geometry, frames)` request
+/// still reaches the ladder and its anchor-derived candidate instead of bypassing the gate.
+///
+/// This mirrors [`anchor_derived_phase_peaks`]'s identity and currency guards exactly. A gate that
+/// admitted a request the derivation then refuses would only push it to the floor, but a gate that
+/// stayed open across a staled calibration would state the wrong thing about the evidence.
 fn anchor_evidence_covers_request(
     anchors: Option<&sceneworks_core::memory_anchor::MemoryAnchorStore>,
+    contract: &MemoryProviderContract,
     request: &VideoAdmissionInputs<'_>,
 ) -> bool {
     let Some(anchors) = anchors else {
@@ -1610,6 +1659,10 @@ fn anchor_evidence_covers_request(
     if request.overlay.is_some() || request.reference_count != 0 {
         return false;
     }
+    let (Some(transformer_variant), Some(decoder)) = (request.transformer_variant, request.decoder)
+    else {
+        return false;
+    };
     let backend = match request.lane {
         VideoLane::Mlx => sceneworks_core::memory_anchor::AnchorBackend::Mlx,
         VideoLane::Candle => sceneworks_core::memory_anchor::AnchorBackend::Candle,
@@ -1619,9 +1672,18 @@ fn anchor_evidence_covers_request(
             request.model_id,
             backend,
             crate::mlx_fit_gate::plan_tier_key(request.tier),
+            transformer_variant,
+            decoder,
         )
         .is_some_and(|anchor| {
-            anchor.model_family == request.model_family && anchor.mode == request.mode
+            anchor.model_family == request.model_family
+                && anchor.mode == request.mode
+                && anchor.route == request.route
+                && anchor.provider == contract.provider_id
+                && contract.calibration.as_ref().is_some_and(|calibration| {
+                    calibration.abi == gen_core::MEMORY_CALIBRATION_ABI
+                        && calibration.fingerprint == anchor.source.calibration_fingerprint
+                })
         })
 }
 

--- a/crates/sceneworks-worker/src/video_admission/tests.rs
+++ b/crates/sceneworks-worker/src/video_admission/tests.rs
@@ -2835,3 +2835,199 @@ fn same_rung_cap_binding_carries_cap_peak_but_actual_request_geometry() {
     );
     assert!(outcome.refusal.is_none());
 }
+
+// --------------------------------------------------------------------------------------------
+// sc-22507 (epic 22505): anchor + analytic derivation. One measured anchor per
+// (model, tier, lane) prices a never-measured (geometry, frames) cell; the selector admits from
+// the derived estimate when it fits.
+// --------------------------------------------------------------------------------------------
+
+/// A conformant LTX-2.5 contract on the MLX lane whose identity matches the packaged anchors.
+fn ltx25_fixture_contract(rungs: &[MemoryStrategy]) -> MemoryProviderContract {
+    let mut contract = fixture_contract(20, 4, rungs);
+    contract.provider_id = "ltx_2_5".to_owned();
+    assert!(contract.conformance_errors().is_empty());
+    contract
+}
+
+fn ltx25_identity(expected_closure_digest: &str) -> VideoRequestIdentity<'_> {
+    VideoRequestIdentity {
+        model_id: "ltx_2_5",
+        model_family: "ltx-video",
+        route: "ltx_2_5",
+        mode: "text_to_video",
+        reference_count: 0,
+        reference_shape: "none",
+        fps: 25,
+        overlay: None,
+        lane: VideoLane::Mlx,
+        tier: tier(),
+        transformer_variant: Some(Ltx25TransformerVariant::Distilled),
+        decoder: Some(Ltx25Decoder::Conv),
+        calibration_abi: gen_core::MEMORY_CALIBRATION_ABI,
+        expected_closure_digest,
+    }
+}
+
+/// The geometry deliberately absent from the retained corpus: 640x640 was measured only at
+/// f145, and no record at any geometry was measured at 89 frames.
+fn ltx25_unmeasured_geometry() -> VideoAdmissionGeometry {
+    VideoAdmissionGeometry {
+        width: 640,
+        height: 640,
+        frames: 89,
+        decode_pass_frames: 89,
+        batch: 1,
+        decode_pass: VideoDecodePass::SinglePass,
+        role: VideoGeometryRole::Requested,
+    }
+}
+
+fn ltx25_expected_derived_peaks() -> sceneworks_core::memory_anchor::AnchorDerivedPhases {
+    let anchor = sceneworks_core::memory_anchor::packaged_memory_anchors()
+        .expect("packaged anchors load")
+        .anchor_for(
+            "ltx_2_5",
+            sceneworks_core::memory_anchor::AnchorBackend::Mlx,
+            "q8",
+        )
+        .expect("the q8 MLX anchor exists");
+    anchor
+        .derive_video_phase_peaks(sceneworks_core::memory_anchor::AnchorDeriveRequest {
+            width: 640,
+            height: 640,
+            frames: 89,
+            decode_tiled: false,
+            transformer_windowed: false,
+            deferred_materialization: false,
+        })
+        .expect("the unmeasured geometry is derivable")
+}
+
+#[test]
+fn an_unmeasured_ltx25_geometry_is_admitted_from_the_anchor_derived_estimate() {
+    let contract = ltx25_fixture_contract(&[]);
+    let expected = ltx25_expected_derived_peaks();
+
+    let mut selector = LadderVideoSelector::new(
+        ltx25_identity(crate::mlx_fit_gate::UNCALIBRATED_CLOSURE),
+        &contract,
+        budget(128.0),
+        18 * GIB,
+        0,
+    );
+    let verdict = selector.select(ltx25_unmeasured_geometry());
+    let VideoRungSelection::Selected { rung, .. } = verdict else {
+        panic!("expected an anchor-derived selection, got {verdict:?}");
+    };
+    assert_eq!(rung, StrategyRung::Resident);
+    assert_eq!(selector.selections.len(), 1);
+    // The selected candidate carries the anchor derivation, not the weights+headroom floor: the
+    // raw predicted peak is exactly the core derivation's max phase, and the evidence revision
+    // names the anchor it came from.
+    assert_eq!(
+        selector.selections[0].predicted_peak_bytes,
+        expected.peak_bytes()
+    );
+    assert_eq!(
+        selector.selections[0].evidence_revision,
+        "ltx_2_5:mlx:q8:sc-18797-ltx-2-5-mlx-ladder-v1:imc-7f8186376a9a3143ebee"
+    );
+
+    // Differential control: the SAME request without an anchor store falls back to the
+    // phase-blind floor — a different peak and the floor's evidence label — proving the anchor
+    // path, not the floor, carried the admission above.
+    let mut floored = LadderVideoSelector::new(
+        ltx25_identity(crate::mlx_fit_gate::UNCALIBRATED_CLOSURE),
+        &contract,
+        budget(128.0),
+        18 * GIB,
+        0,
+    )
+    .with_anchor_store(None);
+    let floor_verdict = floored.select(ltx25_unmeasured_geometry());
+    assert!(matches!(floor_verdict, VideoRungSelection::Selected { .. }));
+    assert_ne!(
+        floored.selections[0].predicted_peak_bytes,
+        expected.peak_bytes()
+    );
+    assert_eq!(
+        floored.selections[0].evidence_revision,
+        "video-estimate-floor-v1"
+    );
+}
+
+#[test]
+fn the_production_funnel_admits_an_unmeasured_ltx25_geometry_from_the_anchor() {
+    // The production entry point requires packaged request evidence before probing. LTX-2.5 has
+    // no fitted curve, so this passes only because the packaged anchor store covers the request;
+    // the admitted context must then carry the anchor-derived peak end-to-end.
+    let generator = fixture_generator(Some(ltx25_fixture_contract(&[])));
+    let expected = ltx25_expected_derived_peaks();
+    let mut request = inputs(89, budget(128.0), 18 * GIB);
+    request.model_id = "ltx_2_5";
+    request.route = "ltx_2_5";
+    request.width = 640;
+    request.height = 640;
+    request.fps = 25;
+    let outcome = admit_video_generation(&generator, request);
+    assert!(outcome.refusal.is_none(), "{:?}", outcome.refusal);
+    let context = outcome
+        .context
+        .expect("the anchor-covered request must reach the ladder and select");
+    assert_eq!(context.selection.strategy, MemoryStrategy::Resident);
+    assert_eq!(context.predicted_peak_bytes, expected.peak_bytes());
+    assert_eq!(
+        context.evidence_revision,
+        "ltx_2_5:mlx:q8:sc-18797-ltx-2-5-mlx-ladder-v1:imc-7f8186376a9a3143ebee"
+    );
+
+    // Control: the identical request under a model id with no anchor (and no fitted curve) is
+    // not covered by packaged evidence, so the production gate stays failed open.
+    let mut uncovered = inputs(89, budget(128.0), 18 * GIB);
+    uncovered.model_id = "ltx_2_5_nonexistent";
+    uncovered.route = "ltx_2_5";
+    uncovered.width = 640;
+    uncovered.height = 640;
+    uncovered.fps = 25;
+    assert_eq!(
+        admit_video_generation(&generator, uncovered),
+        VideoAdmissionOutcome::default(),
+        "no packaged evidence must keep the historical fail-open behavior"
+    );
+}
+
+#[test]
+fn the_anchor_derived_estimate_admits_when_it_fits_and_refuses_when_it_does_not() {
+    let contract = ltx25_fixture_contract(&[]);
+    let expected = ltx25_expected_derived_peaks();
+    let widened_gb =
+        crate::memory_strategy::peak_bytes_to_gb(crate::memory_strategy::widened_peak_bytes(
+            expected.peak_bytes(),
+            crate::ladder_margin_policy::MLX_ESTIMATE_MARGIN,
+        ));
+
+    let mut fits = LadderVideoSelector::new(
+        ltx25_identity(crate::mlx_fit_gate::UNCALIBRATED_CLOSURE),
+        &contract,
+        budget(widened_gb + 0.5),
+        18 * GIB,
+        0,
+    );
+    assert!(matches!(
+        fits.select(ltx25_unmeasured_geometry()),
+        VideoRungSelection::Selected { .. }
+    ));
+
+    let mut refused = LadderVideoSelector::new(
+        ltx25_identity(crate::mlx_fit_gate::UNCALIBRATED_CLOSURE),
+        &contract,
+        budget(widened_gb - 0.5),
+        18 * GIB,
+        0,
+    );
+    assert!(matches!(
+        refused.select(ltx25_unmeasured_geometry()),
+        VideoRungSelection::Reject { .. }
+    ));
+}

--- a/crates/sceneworks-worker/src/video_admission/tests.rs
+++ b/crates/sceneworks-worker/src/video_admission/tests.rs
@@ -2842,14 +2842,26 @@ fn same_rung_cap_binding_carries_cap_peak_but_actual_request_geometry() {
 // the derived estimate when it fits.
 // --------------------------------------------------------------------------------------------
 
+/// The calibration campaign the packaged LTX-2.5 anchors were extracted from. The anchor path
+/// requires the contract to still name it, exactly as the fitted path requires its own fingerprint.
+const LTX25_ANCHOR_FINGERPRINT: &str = "sc-18797-ltx-2-5-mlx-ladder-v1";
+
 /// A conformant LTX-2.5 contract on the MLX lane whose identity matches the packaged anchors.
 fn ltx25_fixture_contract(rungs: &[MemoryStrategy]) -> MemoryProviderContract {
     let mut contract = fixture_contract(20, 4, rungs);
     contract.provider_id = "ltx_2_5".to_owned();
+    contract.calibration = Some(MemoryCalibrationIdentity {
+        abi: gen_core::MEMORY_CALIBRATION_ABI,
+        fingerprint: LTX25_ANCHOR_FINGERPRINT.to_owned(),
+        load_shape: LoadShape::EagerMaterialization,
+    });
     assert!(contract.conformance_errors().is_empty());
     contract
 }
 
+/// The pipeline cell the packaged `q8` anchor was measured on. The corpus measures no
+/// `q8 distilled/*` cell at all, so `distilled` here is not an alternative — it is the
+/// unmeasured-cell control below.
 fn ltx25_identity(expected_closure_digest: &str) -> VideoRequestIdentity<'_> {
     VideoRequestIdentity {
         model_id: "ltx_2_5",
@@ -2862,8 +2874,8 @@ fn ltx25_identity(expected_closure_digest: &str) -> VideoRequestIdentity<'_> {
         overlay: None,
         lane: VideoLane::Mlx,
         tier: tier(),
-        transformer_variant: Some(Ltx25TransformerVariant::Distilled),
-        decoder: Some(Ltx25Decoder::Conv),
+        transformer_variant: Some(Ltx25TransformerVariant::Dev),
+        decoder: Some(Ltx25Decoder::DiffVae),
         calibration_abi: gen_core::MEMORY_CALIBRATION_ABI,
         expected_closure_digest,
     }
@@ -2890,8 +2902,10 @@ fn ltx25_expected_derived_peaks() -> sceneworks_core::memory_anchor::AnchorDeriv
             "ltx_2_5",
             sceneworks_core::memory_anchor::AnchorBackend::Mlx,
             "q8",
+            Ltx25TransformerVariant::Dev,
+            Ltx25Decoder::DiffVae,
         )
-        .expect("the q8 MLX anchor exists");
+        .expect("the q8 dev/diffvae MLX anchor exists");
     anchor
         .derive_video_phase_peaks(sceneworks_core::memory_anchor::AnchorDeriveRequest {
             width: 640,
@@ -2931,7 +2945,7 @@ fn an_unmeasured_ltx25_geometry_is_admitted_from_the_anchor_derived_estimate() {
     );
     assert_eq!(
         selector.selections[0].evidence_revision,
-        "ltx_2_5:mlx:q8:sc-18797-ltx-2-5-mlx-ladder-v1:imc-7f8186376a9a3143ebee"
+        "ltx_2_5:mlx:q8:dev:diffvae:sc-18797-ltx-2-5-mlx-ladder-v1:imc-7f8186376a9a3143ebee"
     );
 
     // Differential control: the SAME request without an anchor store falls back to the
@@ -2967,6 +2981,8 @@ fn the_production_funnel_admits_an_unmeasured_ltx25_geometry_from_the_anchor() {
     let mut request = inputs(89, budget(128.0), 18 * GIB);
     request.model_id = "ltx_2_5";
     request.route = "ltx_2_5";
+    request.transformer_variant = Some(Ltx25TransformerVariant::Dev);
+    request.decoder = Some(Ltx25Decoder::DiffVae);
     request.width = 640;
     request.height = 640;
     request.fps = 25;
@@ -2979,7 +2995,7 @@ fn the_production_funnel_admits_an_unmeasured_ltx25_geometry_from_the_anchor() {
     assert_eq!(context.predicted_peak_bytes, expected.peak_bytes());
     assert_eq!(
         context.evidence_revision,
-        "ltx_2_5:mlx:q8:sc-18797-ltx-2-5-mlx-ladder-v1:imc-7f8186376a9a3143ebee"
+        "ltx_2_5:mlx:q8:dev:diffvae:sc-18797-ltx-2-5-mlx-ladder-v1:imc-7f8186376a9a3143ebee"
     );
 
     // Control: the identical request under a model id with no anchor (and no fitted curve) is
@@ -2987,6 +3003,8 @@ fn the_production_funnel_admits_an_unmeasured_ltx25_geometry_from_the_anchor() {
     let mut uncovered = inputs(89, budget(128.0), 18 * GIB);
     uncovered.model_id = "ltx_2_5_nonexistent";
     uncovered.route = "ltx_2_5";
+    uncovered.transformer_variant = Some(Ltx25TransformerVariant::Dev);
+    uncovered.decoder = Some(Ltx25Decoder::DiffVae);
     uncovered.width = 640;
     uncovered.height = 640;
     uncovered.fps = 25;
@@ -3030,4 +3048,146 @@ fn the_anchor_derived_estimate_admits_when_it_fits_and_refuses_when_it_does_not(
         refused.select(ltx25_unmeasured_geometry()),
         VideoRungSelection::Reject { .. }
     ));
+}
+
+/// The retained corpus measures no `q8 distilled/conv` cell. A request on that pipeline must fall
+/// to the phase-blind floor rather than borrowing the `q8 dev/diffvae` anchor's measurements.
+#[test]
+fn an_unmeasured_pipeline_cell_falls_to_the_estimate_floor() {
+    let contract = ltx25_fixture_contract(&[]);
+    let mut identity = ltx25_identity(crate::mlx_fit_gate::UNCALIBRATED_CLOSURE);
+    identity.transformer_variant = Some(Ltx25TransformerVariant::Distilled);
+    identity.decoder = Some(Ltx25Decoder::Conv);
+
+    let mut selector = LadderVideoSelector::new(identity, &contract, budget(128.0), 18 * GIB, 0);
+    assert!(matches!(
+        selector.select(ltx25_unmeasured_geometry()),
+        VideoRungSelection::Selected { .. }
+    ));
+    assert_eq!(
+        selector.selections[0].evidence_revision, "video-estimate-floor-v1",
+        "a pipeline cell the corpus never measured must not be priced from another cell's anchor"
+    );
+    assert_ne!(
+        selector.selections[0].predicted_peak_bytes,
+        ltx25_expected_derived_peaks().peak_bytes()
+    );
+}
+
+/// Every identity/currency axis the anchor derivation binds, exercised one mutation at a time.
+///
+/// `anchor_derived_phase_peaks` is called directly here because a foreign provider id or a moved
+/// calibration ABI also makes the CONTRACT undecidable to the shared selector, which would mask the
+/// anchor guard behind an unrelated (and equally safe) demotion. The end-to-end control below then
+/// proves one of these axes really does land on the phase-blind floor through `select`.
+#[test]
+fn a_foreign_identity_or_staled_calibration_does_not_reach_the_anchor_derivation() {
+    let baseline_contract = ltx25_fixture_contract(&[]);
+    let derived = |identity: VideoRequestIdentity<'_>, contract: &MemoryProviderContract| {
+        let selector = LadderVideoSelector::new(identity, contract, budget(128.0), 18 * GIB, 0);
+        anchor_derived_phase_peaks(&selector, ltx25_unmeasured_geometry(), &[])
+            .map(|(_, anchor_id)| anchor_id.to_owned())
+    };
+
+    assert_eq!(
+        derived(
+            ltx25_identity(crate::mlx_fit_gate::UNCALIBRATED_CLOSURE),
+            &baseline_contract
+        )
+        .as_deref(),
+        Some("ltx_2_5:mlx:q8:dev:diffvae:sc-18797-ltx-2-5-mlx-ladder-v1:imc-7f8186376a9a3143ebee"),
+        "the conformant baseline must reach the anchor, or every mutation below proves nothing"
+    );
+
+    // Identity axes: family, mode, route, and pipeline cell.
+    for (label, mutate) in [
+        (
+            "foreign family",
+            (|identity: &mut VideoRequestIdentity<'static>| identity.model_family = "ltx-video-x")
+                as fn(&mut VideoRequestIdentity<'static>),
+        ),
+        ("foreign mode", |identity| identity.mode = "image_to_video"),
+        ("foreign route", |identity| identity.route = "ltx_2_5_eros"),
+        ("unmeasured variant", |identity| {
+            identity.transformer_variant = Some(Ltx25TransformerVariant::Distilled)
+        }),
+        ("unmeasured decoder", |identity| {
+            identity.decoder = Some(Ltx25Decoder::Conv)
+        }),
+        ("absent pipeline identity", |identity| {
+            identity.transformer_variant = None
+        }),
+        ("moved calibration ABI", |identity| {
+            identity.calibration_abi = gen_core::MEMORY_CALIBRATION_ABI + 1
+        }),
+    ] {
+        let mut identity = ltx25_identity(crate::mlx_fit_gate::UNCALIBRATED_CLOSURE);
+        mutate(&mut identity);
+        assert_eq!(
+            derived(identity, &baseline_contract),
+            None,
+            "{label} must not reach the anchor derivation"
+        );
+    }
+
+    // Contract axes: the provider that produced the measurement, and calibration currency.
+    let mut foreign_provider = ltx25_fixture_contract(&[]);
+    foreign_provider.provider_id = "ltx_2_5_community_rehost".to_owned();
+
+    let mut absent_calibration = ltx25_fixture_contract(&[]);
+    absent_calibration.calibration = None;
+
+    let mut foreign_fingerprint = ltx25_fixture_contract(&[]);
+    foreign_fingerprint.calibration = Some(MemoryCalibrationIdentity {
+        abi: gen_core::MEMORY_CALIBRATION_ABI,
+        fingerprint: "sc-99999-some-later-campaign-v1".to_owned(),
+        load_shape: LoadShape::EagerMaterialization,
+    });
+
+    for (label, contract) in [
+        ("foreign provider", &foreign_provider),
+        ("no calibration identity", &absent_calibration),
+        ("staled calibration fingerprint", &foreign_fingerprint),
+    ] {
+        assert_eq!(
+            derived(
+                ltx25_identity(crate::mlx_fit_gate::UNCALIBRATED_CLOSURE),
+                contract
+            ),
+            None,
+            "{label} must not reach the anchor derivation"
+        );
+    }
+
+    // End-to-end control: a staled fingerprint really does land on the phase-blind floor, and the
+    // production evidence gate stops claiming coverage for it.
+    let mut selector = LadderVideoSelector::new(
+        ltx25_identity(crate::mlx_fit_gate::UNCALIBRATED_CLOSURE),
+        &foreign_fingerprint,
+        budget(128.0),
+        18 * GIB,
+        0,
+    );
+    assert!(matches!(
+        selector.select(ltx25_unmeasured_geometry()),
+        VideoRungSelection::Selected { .. }
+    ));
+    assert_eq!(
+        selector.selections[0].evidence_revision, "video-estimate-floor-v1",
+        "a staled calibration fingerprint must demote the anchor derivation to the floor"
+    );
+
+    let generator = fixture_generator(Some(foreign_fingerprint));
+    let mut request = inputs(89, budget(128.0), 18 * GIB);
+    request.model_id = "ltx_2_5";
+    request.route = "ltx_2_5";
+    request.transformer_variant = Some(Ltx25TransformerVariant::Dev);
+    request.decoder = Some(Ltx25Decoder::DiffVae);
+    request.width = 640;
+    request.height = 640;
+    request.fps = 25;
+    assert!(
+        !packaged_video_evidence_covers_request(&generator, &request),
+        "a staled calibration fingerprint must not keep the anchor evidence gate open"
+    );
 }

--- a/docker/rust.Dockerfile
+++ b/docker/rust.Dockerfile
@@ -95,6 +95,7 @@ COPY config ./config
 COPY docs/generated/memory-calibration-evidence.json ./docs/generated/
 COPY docs/generated/video-memory-curves.json ./docs/generated/
 COPY docs/generated/ltx-mlx-*.json ./docs/generated/
+COPY docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json ./docs/calibration/sc-18791/
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
@@ -222,6 +223,7 @@ COPY config ./config
 COPY docs/generated/memory-calibration-evidence.json ./docs/generated/
 COPY docs/generated/video-memory-curves.json ./docs/generated/
 COPY docs/generated/ltx-mlx-*.json ./docs/generated/
+COPY docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json ./docs/calibration/sc-18791/
 
 # nvcc compiles every candle provider's CUDA kernels here (compiling needs no GPU).
 # The general Candle kernels retain compute_80 PTX, but the GGUF/MoE kernels in

--- a/docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json
+++ b/docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json
@@ -1,0 +1,4494 @@
+{
+  "harnessVersion": "sceneworks-memory-v5",
+  "records": [
+    {
+      "artifact": {
+        "inventorySha256": "25e83a8566c322782a39ad67f84ae5bd9bcfa628f5a404ee42d650b54e9b4373",
+        "repository": "SceneWorks/ltx-2.5-mlx",
+        "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+        "variant": "q4"
+      },
+      "backend": "mlx",
+      "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1",
+      "capturedAt": "2026-08-30T10:26:48Z",
+      "derivation": {
+        "justification": "Exact physical MLX provider response, artifact inventory, and selected/reference outputs are preserved as immutable capture receipts.",
+        "lifecycle": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-edd25b7371841406eacb"
+          ]
+        },
+        "loadability": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-edd25b7371841406eacb"
+          ]
+        },
+        "memory": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-edd25b7371841406eacb"
+          ]
+        },
+        "negativeMutation": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-edd25b7371841406eacb"
+          ]
+        },
+        "overlay": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-edd25b7371841406eacb"
+          ]
+        },
+        "quality": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-edd25b7371841406eacb"
+          ]
+        }
+      },
+      "diagnostics": {
+        "adapter": "memory-mlx-adapter:ltx-2.5-full-pipeline",
+        "blockers": [
+          "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningActivePeak",
+            "unit": "bytes",
+            "value": 13166818976
+          },
+          {
+            "name": "denoiseActivePeak",
+            "unit": "bytes",
+            "value": 23765824982
+          },
+          {
+            "name": "decodeActivePeak",
+            "unit": "bytes",
+            "value": 60013920904
+          },
+          {
+            "name": "overallAllocatorEnvelope",
+            "unit": "bytes",
+            "value": 62416251478
+          },
+          {
+            "name": "predictedOverallCeiling",
+            "unit": "bytes",
+            "value": 63015223296
+          },
+          {
+            "name": "renderedFrames",
+            "unit": "count",
+            "value": 145
+          },
+          {
+            "name": "outputFps",
+            "unit": "count",
+            "value": 24
+          },
+          {
+            "name": "devVariant",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "diffusionDecoder",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "negativeMutationMaximumErrorPer255",
+            "unit": "count",
+            "value": 192
+          },
+          {
+            "name": "negativeMutationMeanErrorPer255",
+            "unit": "count",
+            "value": 66
+          },
+          {
+            "name": "negativeMutationRootMeanSquareErrorPer255",
+            "unit": "count",
+            "value": 68
+          },
+          {
+            "name": "audioMutationMaximumAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationMeanAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationRootMeanSquareErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "ltx-2-5-mlx-q4-dev-diffvae-512x768-f145-fps24-seed18755",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-17b5e196f5563098afb3",
+      "loadShape": "eager_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/ltx-2.5-mlx@081658ce6886cacba20817ce0359bbefef706ff2:q4",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-129a92fcfb87a6dad613",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 13166818976,
+          "allocatorBytes": 15569149550,
+          "reclaimableBytes": 2402330574
+        },
+        "decode": {
+          "activeBytes": 60013920904,
+          "allocatorBytes": 60013920904,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 23765824982,
+          "allocatorBytes": 23765824982,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 60013920904,
+          "allocatorBytes": 62416251478,
+          "reclaimableBytes": 2402330574
+        }
+      },
+      "predictedPeakBytes": {
+        "conditioning": 13891534848,
+        "decode": 63015223296,
+        "denoise": 24964497408,
+        "overall": 63015223296
+      },
+      "quality": {
+        "audio": {
+          "channels": 2,
+          "maximumAbsoluteError": 0,
+          "maximumAbsoluteErrorThreshold": 0.011764705882352941,
+          "meanAbsoluteError": 0,
+          "meanAbsoluteErrorThreshold": 0.00392156862745098,
+          "referencePcmSha256": "a34019e07a87ea9223dc0450929217d595679a6487affc5a87146f553408d741",
+          "result": "passed",
+          "rootMeanSquareError": 0,
+          "rootMeanSquareErrorThreshold": 0.0058823529411764705,
+          "sampleCount": 576960,
+          "sampleRateHz": 48000,
+          "selectedPcmSha256": "a34019e07a87ea9223dc0450929217d595679a6487affc5a87146f553408d741"
+        },
+        "contract": "identical public artifact revision, transformer variant, decoder, prompt, seed, geometry, cadence, tier, required adapter recipe, and loaded provider; every video pixel and interleaved PCM sample in the measured render versus warm full-pipeline repeat",
+        "identicalInputs": true,
+        "maximumError": 0,
+        "maximumErrorThreshold": 0.011764705882352941,
+        "meanError": 0,
+        "meanErrorThreshold": 0.00392156862745098,
+        "result": "passed",
+        "rootMeanSquareError": 0,
+        "rootMeanSquareErrorThreshold": 0.0058823529411764705
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "scenarios": [
+        {
+          "effectiveBudgetBytes": 63015223296,
+          "name": "exact_fit",
+          "predictedBytes": 63015223296,
+          "result": "passed"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "the loaded provider rejected a zero/unknown budget",
+          "result": "passed"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "the loaded provider rejected a mutated calibration fingerprint",
+          "result": "passed"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "an identical-input full-pipeline request completed on the same loaded provider",
+          "result": "passed"
+        },
+        {
+          "name": "cancel",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "result": "passed"
+        },
+        {
+          "name": "overlay",
+          "reason": "target.overlay is none; transformerVariant and decoder are typed base-recipe axes, including dev's mandatory refinement adapter",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "runtime_complete",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency",
+          "bounded_attention"
+        ],
+        "parameters": {
+          "attentionChunkSize": 16777216
+        },
+        "rung": "bounded_attention"
+      },
+      "sweep": {
+        "axes": [
+          {
+            "parameter": "attentionChunkSize",
+            "testedValues": [
+              16777216
+            ]
+          }
+        ],
+        "cases": [
+          {
+            "parameters": {
+              "attentionChunkSize": 16777216
+            },
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": true
+      },
+      "target": {
+        "decoder": "diffvae",
+        "geometry": {
+          "batch": 1,
+          "frames": 145,
+          "height": 768,
+          "width": 512
+        },
+        "mode": "text_to_video",
+        "modelId": "ltx_2_5",
+        "overlay": "none",
+        "provider": "ltx_2_5",
+        "tier": "q4",
+        "transformerVariant": "dev"
+      }
+    },
+    {
+      "artifact": {
+        "inventorySha256": "3f8527f80689bde77e4ab9852fd1e920d574b917430a32d81851981a1c7495f9",
+        "repository": "SceneWorks/ltx-2.5-mlx",
+        "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+        "variant": "bf16"
+      },
+      "backend": "mlx",
+      "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1",
+      "capturedAt": "2026-08-30T08:57:53Z",
+      "derivation": {
+        "justification": "Exact physical MLX provider response, artifact inventory, and selected/reference outputs are preserved as immutable capture receipts.",
+        "lifecycle": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-066918dbd60d57d62068"
+          ]
+        },
+        "loadability": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-066918dbd60d57d62068"
+          ]
+        },
+        "memory": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-066918dbd60d57d62068"
+          ]
+        },
+        "negativeMutation": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-066918dbd60d57d62068"
+          ]
+        },
+        "overlay": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-066918dbd60d57d62068"
+          ]
+        },
+        "quality": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-066918dbd60d57d62068"
+          ]
+        }
+      },
+      "diagnostics": {
+        "adapter": "memory-mlx-adapter:ltx-2.5-full-pipeline",
+        "blockers": [
+          "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningActivePeak",
+            "unit": "bytes",
+            "value": 11725838268
+          },
+          {
+            "name": "denoiseActivePeak",
+            "unit": "bytes",
+            "value": 5050490756
+          },
+          {
+            "name": "decodeActivePeak",
+            "unit": "bytes",
+            "value": 61500024208
+          },
+          {
+            "name": "overallAllocatorEnvelope",
+            "unit": "bytes",
+            "value": 61796394436
+          },
+          {
+            "name": "predictedOverallCeiling",
+            "unit": "bytes",
+            "value": 64625836032
+          },
+          {
+            "name": "renderedFrames",
+            "unit": "count",
+            "value": 145
+          },
+          {
+            "name": "outputFps",
+            "unit": "count",
+            "value": 24
+          },
+          {
+            "name": "devVariant",
+            "unit": "count",
+            "value": 0
+          },
+          {
+            "name": "diffusionDecoder",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "negativeMutationMaximumErrorPer255",
+            "unit": "count",
+            "value": 192
+          },
+          {
+            "name": "negativeMutationMeanErrorPer255",
+            "unit": "count",
+            "value": 70
+          },
+          {
+            "name": "negativeMutationRootMeanSquareErrorPer255",
+            "unit": "count",
+            "value": 75
+          },
+          {
+            "name": "audioMutationMaximumAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationMeanAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationRootMeanSquareErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "ltx-2-5-mlx-bf16-distilled-diffvae-768x512-f145-fps24-seed18755",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-1cc36cce12c1a65bb2a1",
+      "loadShape": "deferred_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/ltx-2.5-mlx@081658ce6886cacba20817ce0359bbefef706ff2:bf16",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-009d054ef7394144a6b4",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 11725838268,
+          "allocatorBytes": 12022208496,
+          "reclaimableBytes": 296370228
+        },
+        "decode": {
+          "activeBytes": 61500024208,
+          "allocatorBytes": 61500024208,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 5050490756,
+          "allocatorBytes": 5050490756,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 61500024208,
+          "allocatorBytes": 61796394436,
+          "reclaimableBytes": 296370228
+        }
+      },
+      "predictedPeakBytes": {
+        "conditioning": 12348030976,
+        "decode": 64625836032,
+        "denoise": 5368709120,
+        "overall": 64625836032
+      },
+      "quality": {
+        "audio": {
+          "channels": 2,
+          "maximumAbsoluteError": 0,
+          "maximumAbsoluteErrorThreshold": 0.011764705882352941,
+          "meanAbsoluteError": 0,
+          "meanAbsoluteErrorThreshold": 0.00392156862745098,
+          "referencePcmSha256": "841782930856bda986d6ae611208aea185eaef1d40df19dd07eb8b075be25e71",
+          "result": "passed",
+          "rootMeanSquareError": 0,
+          "rootMeanSquareErrorThreshold": 0.0058823529411764705,
+          "sampleCount": 576960,
+          "sampleRateHz": 48000,
+          "selectedPcmSha256": "841782930856bda986d6ae611208aea185eaef1d40df19dd07eb8b075be25e71"
+        },
+        "contract": "identical public artifact revision, transformer variant, decoder, prompt, seed, geometry, cadence, tier, required adapter recipe, and loaded provider; every video pixel and interleaved PCM sample in the measured render versus warm full-pipeline repeat",
+        "identicalInputs": true,
+        "maximumError": 0,
+        "maximumErrorThreshold": 0.011764705882352941,
+        "meanError": 0,
+        "meanErrorThreshold": 0.00392156862745098,
+        "result": "passed",
+        "rootMeanSquareError": 0,
+        "rootMeanSquareErrorThreshold": 0.0058823529411764705
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "scenarios": [
+        {
+          "effectiveBudgetBytes": 64625836032,
+          "name": "exact_fit",
+          "predictedBytes": 64625836032,
+          "result": "passed"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "the loaded provider rejected a zero/unknown budget",
+          "result": "passed"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "the loaded provider rejected a mutated calibration fingerprint",
+          "result": "passed"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "an identical-input full-pipeline request completed on the same loaded provider",
+          "result": "passed"
+        },
+        {
+          "name": "cancel",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "result": "passed"
+        },
+        {
+          "name": "overlay",
+          "reason": "target.overlay is none; transformerVariant and decoder are typed base-recipe axes, including dev's mandatory refinement adapter",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "runtime_complete",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency",
+          "bounded_attention",
+          "bounded_transformer_residency"
+        ],
+        "parameters": {
+          "attentionChunkSize": 16777216,
+          "transformerWindowComponent": "dit",
+          "transformerWindowSize": 1
+        },
+        "rung": "bounded_transformer_residency"
+      },
+      "sweep": {
+        "axes": [
+          {
+            "parameter": "attentionChunkSize",
+            "testedValues": [
+              16777216
+            ]
+          },
+          {
+            "parameter": "transformerWindowSize",
+            "testedValues": [
+              1
+            ]
+          }
+        ],
+        "cases": [
+          {
+            "parameters": {
+              "attentionChunkSize": 16777216,
+              "transformerWindowComponent": "dit",
+              "transformerWindowSize": 1
+            },
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": true
+      },
+      "target": {
+        "decoder": "diffvae",
+        "geometry": {
+          "batch": 1,
+          "frames": 145,
+          "height": 512,
+          "width": 768
+        },
+        "mode": "text_to_video",
+        "modelId": "ltx_2_5",
+        "overlay": "none",
+        "provider": "ltx_2_5",
+        "tier": "bf16",
+        "transformerVariant": "distilled"
+      }
+    },
+    {
+      "artifact": {
+        "inventorySha256": "48b7b1ab3329d060760934994b7f0f2579845c3cc332779b44d009369283a344",
+        "repository": "SceneWorks/ltx-2.5-mlx",
+        "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+        "variant": "q8"
+      },
+      "backend": "mlx",
+      "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1",
+      "capturedAt": "2026-08-30T08:52:44Z",
+      "derivation": {
+        "justification": "Exact physical MLX provider response, artifact inventory, and selected/reference outputs are preserved as immutable capture receipts.",
+        "lifecycle": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-9b3c435b3ea728b6af6f"
+          ]
+        },
+        "loadability": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-9b3c435b3ea728b6af6f"
+          ]
+        },
+        "memory": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-9b3c435b3ea728b6af6f"
+          ]
+        },
+        "negativeMutation": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-9b3c435b3ea728b6af6f"
+          ]
+        },
+        "overlay": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-9b3c435b3ea728b6af6f"
+          ]
+        },
+        "quality": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-9b3c435b3ea728b6af6f"
+          ]
+        }
+      },
+      "diagnostics": {
+        "adapter": "memory-mlx-adapter:ltx-2.5-full-pipeline",
+        "blockers": [
+          "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningActivePeak",
+            "unit": "bytes",
+            "value": 22403703038
+          },
+          {
+            "name": "denoiseActivePeak",
+            "unit": "bytes",
+            "value": 33129499766
+          },
+          {
+            "name": "decodeActivePeak",
+            "unit": "bytes",
+            "value": 62669145328
+          },
+          {
+            "name": "overallAllocatorEnvelope",
+            "unit": "bytes",
+            "value": 65146621120
+          },
+          {
+            "name": "predictedOverallCeiling",
+            "unit": "bytes",
+            "value": 65833795584
+          },
+          {
+            "name": "renderedFrames",
+            "unit": "count",
+            "value": 145
+          },
+          {
+            "name": "outputFps",
+            "unit": "count",
+            "value": 24
+          },
+          {
+            "name": "devVariant",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "diffusionDecoder",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "negativeMutationMaximumErrorPer255",
+            "unit": "count",
+            "value": 192
+          },
+          {
+            "name": "negativeMutationMeanErrorPer255",
+            "unit": "count",
+            "value": 66
+          },
+          {
+            "name": "negativeMutationRootMeanSquareErrorPer255",
+            "unit": "count",
+            "value": 68
+          },
+          {
+            "name": "audioMutationMaximumAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationMeanAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationRootMeanSquareErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "ltx-2-5-mlx-q8-dev-diffvae-640x640-f145-fps24-seed18755",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-1fc07e8cd38354ea1ccc",
+      "loadShape": "eager_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/ltx-2.5-mlx@081658ce6886cacba20817ce0359bbefef706ff2:q8",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-008e4480bb6c768ee018",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 22403703038,
+          "allocatorBytes": 24881178830,
+          "reclaimableBytes": 2477475792
+        },
+        "decode": {
+          "activeBytes": 62669145328,
+          "allocatorBytes": 62669145328,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 33129499766,
+          "allocatorBytes": 33129499766,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 62669145328,
+          "allocatorBytes": 65146621120,
+          "reclaimableBytes": 2477475792
+        }
+      },
+      "predictedPeakBytes": {
+        "conditioning": 23555211264,
+        "decode": 65833795584,
+        "denoise": 34829500416,
+        "overall": 65833795584
+      },
+      "quality": {
+        "audio": {
+          "channels": 2,
+          "maximumAbsoluteError": 0,
+          "maximumAbsoluteErrorThreshold": 0.011764705882352941,
+          "meanAbsoluteError": 0,
+          "meanAbsoluteErrorThreshold": 0.00392156862745098,
+          "referencePcmSha256": "d7c6dfd42dfc750610909ba4ef5b32ab8d1b079e374bb267df88cc96eb43308e",
+          "result": "passed",
+          "rootMeanSquareError": 0,
+          "rootMeanSquareErrorThreshold": 0.0058823529411764705,
+          "sampleCount": 576960,
+          "sampleRateHz": 48000,
+          "selectedPcmSha256": "d7c6dfd42dfc750610909ba4ef5b32ab8d1b079e374bb267df88cc96eb43308e"
+        },
+        "contract": "identical public artifact revision, transformer variant, decoder, prompt, seed, geometry, cadence, tier, required adapter recipe, and loaded provider; every video pixel and interleaved PCM sample in the measured render versus warm full-pipeline repeat",
+        "identicalInputs": true,
+        "maximumError": 0,
+        "maximumErrorThreshold": 0.011764705882352941,
+        "meanError": 0,
+        "meanErrorThreshold": 0.00392156862745098,
+        "result": "passed",
+        "rootMeanSquareError": 0,
+        "rootMeanSquareErrorThreshold": 0.0058823529411764705
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "scenarios": [
+        {
+          "effectiveBudgetBytes": 65833795584,
+          "name": "exact_fit",
+          "predictedBytes": 65833795584,
+          "result": "passed"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "the loaded provider rejected a zero/unknown budget",
+          "result": "passed"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "the loaded provider rejected a mutated calibration fingerprint",
+          "result": "passed"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "an identical-input full-pipeline request completed on the same loaded provider",
+          "result": "passed"
+        },
+        {
+          "name": "cancel",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "result": "passed"
+        },
+        {
+          "name": "overlay",
+          "reason": "target.overlay is none; transformerVariant and decoder are typed base-recipe axes, including dev's mandatory refinement adapter",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "runtime_complete",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency",
+          "bounded_attention"
+        ],
+        "parameters": {
+          "attentionChunkSize": 16777216
+        },
+        "rung": "bounded_attention"
+      },
+      "sweep": {
+        "axes": [
+          {
+            "parameter": "attentionChunkSize",
+            "testedValues": [
+              16777216
+            ]
+          }
+        ],
+        "cases": [
+          {
+            "parameters": {
+              "attentionChunkSize": 16777216
+            },
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": true
+      },
+      "target": {
+        "decoder": "diffvae",
+        "geometry": {
+          "batch": 1,
+          "frames": 145,
+          "height": 640,
+          "width": 640
+        },
+        "mode": "text_to_video",
+        "modelId": "ltx_2_5",
+        "overlay": "none",
+        "provider": "ltx_2_5",
+        "tier": "q8",
+        "transformerVariant": "dev"
+      }
+    },
+    {
+      "artifact": {
+        "inventorySha256": "87951a915b40d82f4a2ef422aa9631d1af3da7507d5521880141f53da90ad1c0",
+        "repository": "SceneWorks/ltx-2.5-mlx",
+        "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+        "variant": "bf16"
+      },
+      "backend": "mlx",
+      "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1",
+      "capturedAt": "2026-08-30T11:03:51Z",
+      "derivation": {
+        "justification": "Exact physical MLX provider response, artifact inventory, and selected/reference outputs are preserved as immutable capture receipts.",
+        "lifecycle": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-5c40c3d6e78d271b7464"
+          ]
+        },
+        "loadability": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-5c40c3d6e78d271b7464"
+          ]
+        },
+        "memory": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-5c40c3d6e78d271b7464"
+          ]
+        },
+        "negativeMutation": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-5c40c3d6e78d271b7464"
+          ]
+        },
+        "overlay": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-5c40c3d6e78d271b7464"
+          ]
+        },
+        "quality": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-5c40c3d6e78d271b7464"
+          ]
+        }
+      },
+      "diagnostics": {
+        "adapter": "memory-mlx-adapter:ltx-2.5-full-pipeline",
+        "blockers": [
+          "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningActivePeak",
+            "unit": "bytes",
+            "value": 41096010476
+          },
+          {
+            "name": "denoiseActivePeak",
+            "unit": "bytes",
+            "value": 53425993490
+          },
+          {
+            "name": "decodeActivePeak",
+            "unit": "bytes",
+            "value": 66138435076
+          },
+          {
+            "name": "overallAllocatorEnvelope",
+            "unit": "bytes",
+            "value": 71698413440
+          },
+          {
+            "name": "predictedOverallCeiling",
+            "unit": "bytes",
+            "value": 69457674240
+          },
+          {
+            "name": "renderedFrames",
+            "unit": "count",
+            "value": 145
+          },
+          {
+            "name": "outputFps",
+            "unit": "count",
+            "value": 24
+          },
+          {
+            "name": "devVariant",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "diffusionDecoder",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "negativeMutationMaximumErrorPer255",
+            "unit": "count",
+            "value": 192
+          },
+          {
+            "name": "negativeMutationMeanErrorPer255",
+            "unit": "count",
+            "value": 64
+          },
+          {
+            "name": "negativeMutationRootMeanSquareErrorPer255",
+            "unit": "count",
+            "value": 65
+          },
+          {
+            "name": "audioMutationMaximumAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationMeanAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationRootMeanSquareErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "ltx-2-5-mlx-bf16-dev-diffvae-1280x704-f145-fps24-seed18755",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-4779c6464c56f7c2a894",
+      "loadShape": "eager_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/ltx-2.5-mlx@081658ce6886cacba20817ce0359bbefef706ff2:bf16",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-162f2859821a1fb54be0",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 41096010476,
+          "allocatorBytes": 46655988840,
+          "reclaimableBytes": 5559978364
+        },
+        "decode": {
+          "activeBytes": 66138435076,
+          "allocatorBytes": 66138435076,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 53425993490,
+          "allocatorBytes": 53425993490,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 66138435076,
+          "allocatorBytes": 71698413440,
+          "reclaimableBytes": 5559978364
+        }
+      },
+      "predictedPeakBytes": {
+        "conditioning": 43150999552,
+        "decode": 69457674240,
+        "denoise": 56103010304,
+        "overall": 69457674240
+      },
+      "quality": {
+        "audio": {
+          "channels": 2,
+          "maximumAbsoluteError": 0,
+          "maximumAbsoluteErrorThreshold": 0.011764705882352941,
+          "meanAbsoluteError": 0,
+          "meanAbsoluteErrorThreshold": 0.00392156862745098,
+          "referencePcmSha256": "6d84d460727a4e11be83a348bba6c1fa1fb750fb8f186e0cec1fd3cb8d92bd6e",
+          "result": "passed",
+          "rootMeanSquareError": 0,
+          "rootMeanSquareErrorThreshold": 0.0058823529411764705,
+          "sampleCount": 576960,
+          "sampleRateHz": 48000,
+          "selectedPcmSha256": "6d84d460727a4e11be83a348bba6c1fa1fb750fb8f186e0cec1fd3cb8d92bd6e"
+        },
+        "contract": "identical public artifact revision, transformer variant, decoder, prompt, seed, geometry, cadence, tier, required adapter recipe, and loaded provider; every video pixel and interleaved PCM sample in the measured render versus warm full-pipeline repeat",
+        "identicalInputs": true,
+        "maximumError": 0,
+        "maximumErrorThreshold": 0.011764705882352941,
+        "meanError": 0,
+        "meanErrorThreshold": 0.00392156862745098,
+        "result": "passed",
+        "rootMeanSquareError": 0,
+        "rootMeanSquareErrorThreshold": 0.0058823529411764705
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "scenarios": [
+        {
+          "effectiveBudgetBytes": 69457674240,
+          "name": "exact_fit",
+          "predictedBytes": 69457674240,
+          "result": "passed"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "the loaded provider rejected a zero/unknown budget",
+          "result": "passed"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "the loaded provider rejected a mutated calibration fingerprint",
+          "result": "passed"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "an identical-input full-pipeline request completed on the same loaded provider",
+          "result": "passed"
+        },
+        {
+          "name": "cancel",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "result": "passed"
+        },
+        {
+          "name": "overlay",
+          "reason": "target.overlay is none; transformerVariant and decoder are typed base-recipe axes, including dev's mandatory refinement adapter",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "runtime_complete",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency",
+          "bounded_attention"
+        ],
+        "parameters": {
+          "attentionChunkSize": 16777216
+        },
+        "rung": "bounded_attention"
+      },
+      "sweep": {
+        "axes": [
+          {
+            "parameter": "attentionChunkSize",
+            "testedValues": [
+              16777216
+            ]
+          }
+        ],
+        "cases": [
+          {
+            "parameters": {
+              "attentionChunkSize": 16777216
+            },
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": true
+      },
+      "target": {
+        "decoder": "diffvae",
+        "geometry": {
+          "batch": 1,
+          "frames": 145,
+          "height": 704,
+          "width": 1280
+        },
+        "mode": "text_to_video",
+        "modelId": "ltx_2_5",
+        "overlay": "none",
+        "provider": "ltx_2_5",
+        "tier": "bf16",
+        "transformerVariant": "dev"
+      }
+    },
+    {
+      "artifact": {
+        "inventorySha256": "3f8527f80689bde77e4ab9852fd1e920d574b917430a32d81851981a1c7495f9",
+        "repository": "SceneWorks/ltx-2.5-mlx",
+        "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+        "variant": "bf16"
+      },
+      "backend": "mlx",
+      "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1",
+      "capturedAt": "2026-08-30T10:14:54Z",
+      "derivation": {
+        "justification": "Exact physical MLX provider response, artifact inventory, and selected/reference outputs are preserved as immutable capture receipts.",
+        "lifecycle": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-16bc57b45346ead4f1e5"
+          ]
+        },
+        "loadability": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-16bc57b45346ead4f1e5"
+          ]
+        },
+        "memory": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-16bc57b45346ead4f1e5"
+          ]
+        },
+        "negativeMutation": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-16bc57b45346ead4f1e5"
+          ]
+        },
+        "overlay": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-16bc57b45346ead4f1e5"
+          ]
+        },
+        "quality": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-16bc57b45346ead4f1e5"
+          ]
+        }
+      },
+      "diagnostics": {
+        "adapter": "memory-mlx-adapter:ltx-2.5-full-pipeline",
+        "blockers": [
+          "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningActivePeak",
+            "unit": "bytes",
+            "value": 11725838268
+          },
+          {
+            "name": "denoiseActivePeak",
+            "unit": "bytes",
+            "value": 5050490756
+          },
+          {
+            "name": "decodeActivePeak",
+            "unit": "bytes",
+            "value": 61495573424
+          },
+          {
+            "name": "overallAllocatorEnvelope",
+            "unit": "bytes",
+            "value": 61791419336
+          },
+          {
+            "name": "predictedOverallCeiling",
+            "unit": "bytes",
+            "value": 64625836032
+          },
+          {
+            "name": "renderedFrames",
+            "unit": "count",
+            "value": 145
+          },
+          {
+            "name": "outputFps",
+            "unit": "count",
+            "value": 24
+          },
+          {
+            "name": "devVariant",
+            "unit": "count",
+            "value": 0
+          },
+          {
+            "name": "diffusionDecoder",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "negativeMutationMaximumErrorPer255",
+            "unit": "count",
+            "value": 192
+          },
+          {
+            "name": "negativeMutationMeanErrorPer255",
+            "unit": "count",
+            "value": 72
+          },
+          {
+            "name": "negativeMutationRootMeanSquareErrorPer255",
+            "unit": "count",
+            "value": 78
+          },
+          {
+            "name": "audioMutationMaximumAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationMeanAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationRootMeanSquareErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "ltx-2-5-mlx-bf16-distilled-diffvae-512x768-f145-fps24-seed18755",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-4b567516325bd6326687",
+      "loadShape": "deferred_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/ltx-2.5-mlx@081658ce6886cacba20817ce0359bbefef706ff2:bf16",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-0f735ff1108cec3a46fc",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 11725838268,
+          "allocatorBytes": 12021684180,
+          "reclaimableBytes": 295845912
+        },
+        "decode": {
+          "activeBytes": 61495573424,
+          "allocatorBytes": 61495573424,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 5050490756,
+          "allocatorBytes": 5050490756,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 61495573424,
+          "allocatorBytes": 61791419336,
+          "reclaimableBytes": 295845912
+        }
+      },
+      "predictedPeakBytes": {
+        "conditioning": 12348030976,
+        "decode": 64625836032,
+        "denoise": 5368709120,
+        "overall": 64625836032
+      },
+      "quality": {
+        "audio": {
+          "channels": 2,
+          "maximumAbsoluteError": 0,
+          "maximumAbsoluteErrorThreshold": 0.011764705882352941,
+          "meanAbsoluteError": 0,
+          "meanAbsoluteErrorThreshold": 0.00392156862745098,
+          "referencePcmSha256": "ecdc04d3b49e97cc50b3c382b15248bc6f52f5479ed4a680a8e7975f0f50c8b1",
+          "result": "passed",
+          "rootMeanSquareError": 0,
+          "rootMeanSquareErrorThreshold": 0.0058823529411764705,
+          "sampleCount": 576960,
+          "sampleRateHz": 48000,
+          "selectedPcmSha256": "ecdc04d3b49e97cc50b3c382b15248bc6f52f5479ed4a680a8e7975f0f50c8b1"
+        },
+        "contract": "identical public artifact revision, transformer variant, decoder, prompt, seed, geometry, cadence, tier, required adapter recipe, and loaded provider; every video pixel and interleaved PCM sample in the measured render versus warm full-pipeline repeat",
+        "identicalInputs": true,
+        "maximumError": 0,
+        "maximumErrorThreshold": 0.011764705882352941,
+        "meanError": 0,
+        "meanErrorThreshold": 0.00392156862745098,
+        "result": "passed",
+        "rootMeanSquareError": 0,
+        "rootMeanSquareErrorThreshold": 0.0058823529411764705
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "scenarios": [
+        {
+          "effectiveBudgetBytes": 64625836032,
+          "name": "exact_fit",
+          "predictedBytes": 64625836032,
+          "result": "passed"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "the loaded provider rejected a zero/unknown budget",
+          "result": "passed"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "the loaded provider rejected a mutated calibration fingerprint",
+          "result": "passed"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "an identical-input full-pipeline request completed on the same loaded provider",
+          "result": "passed"
+        },
+        {
+          "name": "cancel",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "result": "passed"
+        },
+        {
+          "name": "overlay",
+          "reason": "target.overlay is none; transformerVariant and decoder are typed base-recipe axes, including dev's mandatory refinement adapter",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "runtime_complete",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency",
+          "bounded_attention",
+          "bounded_transformer_residency"
+        ],
+        "parameters": {
+          "attentionChunkSize": 16777216,
+          "transformerWindowComponent": "dit",
+          "transformerWindowSize": 1
+        },
+        "rung": "bounded_transformer_residency"
+      },
+      "sweep": {
+        "axes": [
+          {
+            "parameter": "attentionChunkSize",
+            "testedValues": [
+              16777216
+            ]
+          },
+          {
+            "parameter": "transformerWindowSize",
+            "testedValues": [
+              1
+            ]
+          }
+        ],
+        "cases": [
+          {
+            "parameters": {
+              "attentionChunkSize": 16777216,
+              "transformerWindowComponent": "dit",
+              "transformerWindowSize": 1
+            },
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": true
+      },
+      "target": {
+        "decoder": "diffvae",
+        "geometry": {
+          "batch": 1,
+          "frames": 145,
+          "height": 768,
+          "width": 512
+        },
+        "mode": "text_to_video",
+        "modelId": "ltx_2_5",
+        "overlay": "none",
+        "provider": "ltx_2_5",
+        "tier": "bf16",
+        "transformerVariant": "distilled"
+      }
+    },
+    {
+      "artifact": {
+        "inventorySha256": "3f8527f80689bde77e4ab9852fd1e920d574b917430a32d81851981a1c7495f9",
+        "repository": "SceneWorks/ltx-2.5-mlx",
+        "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+        "variant": "bf16"
+      },
+      "backend": "mlx",
+      "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1",
+      "capturedAt": "2026-08-30T09:21:26Z",
+      "derivation": {
+        "justification": "Exact physical MLX provider response, artifact inventory, and selected/reference outputs are preserved as immutable capture receipts.",
+        "lifecycle": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-d3771f3076da6c07291d"
+          ]
+        },
+        "loadability": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-d3771f3076da6c07291d"
+          ]
+        },
+        "memory": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-d3771f3076da6c07291d"
+          ]
+        },
+        "negativeMutation": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-d3771f3076da6c07291d"
+          ]
+        },
+        "overlay": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-d3771f3076da6c07291d"
+          ]
+        },
+        "quality": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-d3771f3076da6c07291d"
+          ]
+        }
+      },
+      "diagnostics": {
+        "adapter": "memory-mlx-adapter:ltx-2.5-full-pipeline",
+        "blockers": [
+          "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningActivePeak",
+            "unit": "bytes",
+            "value": 11725368252
+          },
+          {
+            "name": "denoiseActivePeak",
+            "unit": "bytes",
+            "value": 8148677508
+          },
+          {
+            "name": "decodeActivePeak",
+            "unit": "bytes",
+            "value": 8229179000
+          },
+          {
+            "name": "overallAllocatorEnvelope",
+            "unit": "bytes",
+            "value": 12389051376
+          },
+          {
+            "name": "predictedOverallCeiling",
+            "unit": "bytes",
+            "value": 12348030976
+          },
+          {
+            "name": "renderedFrames",
+            "unit": "count",
+            "value": 145
+          },
+          {
+            "name": "outputFps",
+            "unit": "count",
+            "value": 24
+          },
+          {
+            "name": "devVariant",
+            "unit": "count",
+            "value": 0
+          },
+          {
+            "name": "diffusionDecoder",
+            "unit": "count",
+            "value": 0
+          },
+          {
+            "name": "negativeMutationMaximumErrorPer255",
+            "unit": "count",
+            "value": 192
+          },
+          {
+            "name": "negativeMutationMeanErrorPer255",
+            "unit": "count",
+            "value": 65
+          },
+          {
+            "name": "negativeMutationRootMeanSquareErrorPer255",
+            "unit": "count",
+            "value": 66
+          },
+          {
+            "name": "audioMutationMaximumAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationMeanAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationRootMeanSquareErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "ltx-2-5-mlx-bf16-distilled-conv-1280x704-f145-fps24-seed18755",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-4e1b3a02a6ced3434824",
+      "loadShape": "deferred_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/ltx-2.5-mlx@081658ce6886cacba20817ce0359bbefef706ff2:bf16",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-0aa8a44af9552a3fc9d7",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 11725368252,
+          "allocatorBytes": 12389051376,
+          "reclaimableBytes": 663683124
+        },
+        "decode": {
+          "activeBytes": 8229179000,
+          "allocatorBytes": 8229179000,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 8148677508,
+          "allocatorBytes": 8148677508,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 11725368252,
+          "allocatorBytes": 12389051376,
+          "reclaimableBytes": 663683124
+        }
+      },
+      "predictedPeakBytes": {
+        "conditioning": 12348030976,
+        "decode": 8657043456,
+        "denoise": 8589934592,
+        "overall": 12348030976
+      },
+      "quality": {
+        "audio": {
+          "channels": 2,
+          "maximumAbsoluteError": 0,
+          "maximumAbsoluteErrorThreshold": 0.011764705882352941,
+          "meanAbsoluteError": 0,
+          "meanAbsoluteErrorThreshold": 0.00392156862745098,
+          "referencePcmSha256": "70807dfe13798a6b1d0c05afcd66d62b4ef5953440b863e27e84a9b9f7b998d1",
+          "result": "passed",
+          "rootMeanSquareError": 0,
+          "rootMeanSquareErrorThreshold": 0.0058823529411764705,
+          "sampleCount": 576960,
+          "sampleRateHz": 48000,
+          "selectedPcmSha256": "70807dfe13798a6b1d0c05afcd66d62b4ef5953440b863e27e84a9b9f7b998d1"
+        },
+        "contract": "identical public artifact revision, transformer variant, decoder, prompt, seed, geometry, cadence, tier, required adapter recipe, and loaded provider; every video pixel and interleaved PCM sample in the measured render versus warm full-pipeline repeat",
+        "identicalInputs": true,
+        "maximumError": 0,
+        "maximumErrorThreshold": 0.011764705882352941,
+        "meanError": 0,
+        "meanErrorThreshold": 0.00392156862745098,
+        "result": "passed",
+        "rootMeanSquareError": 0,
+        "rootMeanSquareErrorThreshold": 0.0058823529411764705
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "scenarios": [
+        {
+          "effectiveBudgetBytes": 12348030976,
+          "name": "exact_fit",
+          "predictedBytes": 12348030976,
+          "result": "passed"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "the loaded provider rejected a zero/unknown budget",
+          "result": "passed"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "the loaded provider rejected a mutated calibration fingerprint",
+          "result": "passed"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "an identical-input full-pipeline request completed on the same loaded provider",
+          "result": "passed"
+        },
+        {
+          "name": "cancel",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "result": "passed"
+        },
+        {
+          "name": "overlay",
+          "reason": "target.overlay is none; transformerVariant and decoder are typed base-recipe axes, including dev's mandatory refinement adapter",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "runtime_complete",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency",
+          "bounded_decode",
+          "bounded_attention",
+          "bounded_transformer_residency"
+        ],
+        "parameters": {
+          "attentionChunkSize": 16777216,
+          "decodeOverlap": 64,
+          "decodeTileEdge": 192,
+          "transformerWindowComponent": "dit",
+          "transformerWindowSize": 1
+        },
+        "rung": "bounded_transformer_residency"
+      },
+      "sweep": {
+        "axes": [
+          {
+            "parameter": "attentionChunkSize",
+            "testedValues": [
+              16777216
+            ]
+          },
+          {
+            "parameter": "decodeOverlap",
+            "testedValues": [
+              64
+            ]
+          },
+          {
+            "parameter": "decodeTileEdge",
+            "testedValues": [
+              192
+            ]
+          },
+          {
+            "parameter": "transformerWindowSize",
+            "testedValues": [
+              1
+            ]
+          }
+        ],
+        "cases": [
+          {
+            "parameters": {
+              "attentionChunkSize": 16777216,
+              "decodeOverlap": 64,
+              "decodeTileEdge": 192,
+              "transformerWindowComponent": "dit",
+              "transformerWindowSize": 1
+            },
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": true
+      },
+      "target": {
+        "decoder": "conv",
+        "geometry": {
+          "batch": 1,
+          "frames": 145,
+          "height": 704,
+          "width": 1280
+        },
+        "mode": "text_to_video",
+        "modelId": "ltx_2_5",
+        "overlay": "none",
+        "provider": "ltx_2_5",
+        "tier": "bf16",
+        "transformerVariant": "distilled"
+      }
+    },
+    {
+      "artifact": {
+        "inventorySha256": "25e83a8566c322782a39ad67f84ae5bd9bcfa628f5a404ee42d650b54e9b4373",
+        "repository": "SceneWorks/ltx-2.5-mlx",
+        "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+        "variant": "q4"
+      },
+      "backend": "mlx",
+      "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1",
+      "capturedAt": "2026-08-30T09:10:32Z",
+      "derivation": {
+        "justification": "Exact physical MLX provider response, artifact inventory, and selected/reference outputs are preserved as immutable capture receipts.",
+        "lifecycle": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-6d9bed097065478533a6"
+          ]
+        },
+        "loadability": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-6d9bed097065478533a6"
+          ]
+        },
+        "memory": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-6d9bed097065478533a6"
+          ]
+        },
+        "negativeMutation": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-6d9bed097065478533a6"
+          ]
+        },
+        "overlay": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-6d9bed097065478533a6"
+          ]
+        },
+        "quality": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-6d9bed097065478533a6"
+          ]
+        }
+      },
+      "diagnostics": {
+        "adapter": "memory-mlx-adapter:ltx-2.5-full-pipeline",
+        "blockers": [
+          "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningActivePeak",
+            "unit": "bytes",
+            "value": 13166818976
+          },
+          {
+            "name": "denoiseActivePeak",
+            "unit": "bytes",
+            "value": 23765841366
+          },
+          {
+            "name": "decodeActivePeak",
+            "unit": "bytes",
+            "value": 60013908200
+          },
+          {
+            "name": "overallAllocatorEnvelope",
+            "unit": "bytes",
+            "value": 62401296566
+          },
+          {
+            "name": "predictedOverallCeiling",
+            "unit": "bytes",
+            "value": 63015223296
+          },
+          {
+            "name": "renderedFrames",
+            "unit": "count",
+            "value": 145
+          },
+          {
+            "name": "outputFps",
+            "unit": "count",
+            "value": 24
+          },
+          {
+            "name": "devVariant",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "diffusionDecoder",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "negativeMutationMaximumErrorPer255",
+            "unit": "count",
+            "value": 192
+          },
+          {
+            "name": "negativeMutationMeanErrorPer255",
+            "unit": "count",
+            "value": 69
+          },
+          {
+            "name": "negativeMutationRootMeanSquareErrorPer255",
+            "unit": "count",
+            "value": 73
+          },
+          {
+            "name": "audioMutationMaximumAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationMeanAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationRootMeanSquareErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "ltx-2-5-mlx-q4-dev-diffvae-768x512-f145-fps24-seed18755",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-50fbdda27ed3159a6ca1",
+      "loadShape": "eager_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/ltx-2.5-mlx@081658ce6886cacba20817ce0359bbefef706ff2:q4",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-09c5fbd207e9048193be",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 13166818976,
+          "allocatorBytes": 15554207342,
+          "reclaimableBytes": 2387388366
+        },
+        "decode": {
+          "activeBytes": 60013908200,
+          "allocatorBytes": 60013908200,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 23765841366,
+          "allocatorBytes": 23765841366,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 60013908200,
+          "allocatorBytes": 62401296566,
+          "reclaimableBytes": 2387388366
+        }
+      },
+      "predictedPeakBytes": {
+        "conditioning": 13891534848,
+        "decode": 63015223296,
+        "denoise": 24964497408,
+        "overall": 63015223296
+      },
+      "quality": {
+        "audio": {
+          "channels": 2,
+          "maximumAbsoluteError": 0,
+          "maximumAbsoluteErrorThreshold": 0.011764705882352941,
+          "meanAbsoluteError": 0,
+          "meanAbsoluteErrorThreshold": 0.00392156862745098,
+          "referencePcmSha256": "cff88ce39b8c7e876fd76e9d8ca38781804dc13d82f64319433dd93cb5971b3f",
+          "result": "passed",
+          "rootMeanSquareError": 0,
+          "rootMeanSquareErrorThreshold": 0.0058823529411764705,
+          "sampleCount": 576960,
+          "sampleRateHz": 48000,
+          "selectedPcmSha256": "cff88ce39b8c7e876fd76e9d8ca38781804dc13d82f64319433dd93cb5971b3f"
+        },
+        "contract": "identical public artifact revision, transformer variant, decoder, prompt, seed, geometry, cadence, tier, required adapter recipe, and loaded provider; every video pixel and interleaved PCM sample in the measured render versus warm full-pipeline repeat",
+        "identicalInputs": true,
+        "maximumError": 0,
+        "maximumErrorThreshold": 0.011764705882352941,
+        "meanError": 0,
+        "meanErrorThreshold": 0.00392156862745098,
+        "result": "passed",
+        "rootMeanSquareError": 0,
+        "rootMeanSquareErrorThreshold": 0.0058823529411764705
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "scenarios": [
+        {
+          "effectiveBudgetBytes": 63015223296,
+          "name": "exact_fit",
+          "predictedBytes": 63015223296,
+          "result": "passed"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "the loaded provider rejected a zero/unknown budget",
+          "result": "passed"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "the loaded provider rejected a mutated calibration fingerprint",
+          "result": "passed"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "an identical-input full-pipeline request completed on the same loaded provider",
+          "result": "passed"
+        },
+        {
+          "name": "cancel",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "result": "passed"
+        },
+        {
+          "name": "overlay",
+          "reason": "target.overlay is none; transformerVariant and decoder are typed base-recipe axes, including dev's mandatory refinement adapter",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "runtime_complete",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency",
+          "bounded_attention"
+        ],
+        "parameters": {
+          "attentionChunkSize": 16777216
+        },
+        "rung": "bounded_attention"
+      },
+      "sweep": {
+        "axes": [
+          {
+            "parameter": "attentionChunkSize",
+            "testedValues": [
+              16777216
+            ]
+          }
+        ],
+        "cases": [
+          {
+            "parameters": {
+              "attentionChunkSize": 16777216
+            },
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": true
+      },
+      "target": {
+        "decoder": "diffvae",
+        "geometry": {
+          "batch": 1,
+          "frames": 145,
+          "height": 512,
+          "width": 768
+        },
+        "mode": "text_to_video",
+        "modelId": "ltx_2_5",
+        "overlay": "none",
+        "provider": "ltx_2_5",
+        "tier": "q4",
+        "transformerVariant": "dev"
+      }
+    },
+    {
+      "artifact": {
+        "inventorySha256": "3f8527f80689bde77e4ab9852fd1e920d574b917430a32d81851981a1c7495f9",
+        "repository": "SceneWorks/ltx-2.5-mlx",
+        "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+        "variant": "bf16"
+      },
+      "backend": "mlx",
+      "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1",
+      "capturedAt": "2026-08-30T10:09:29Z",
+      "derivation": {
+        "justification": "Exact physical MLX provider response, artifact inventory, and selected/reference outputs are preserved as immutable capture receipts.",
+        "lifecycle": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-2afb6cff5cfc0141926e"
+          ]
+        },
+        "loadability": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-2afb6cff5cfc0141926e"
+          ]
+        },
+        "memory": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-2afb6cff5cfc0141926e"
+          ]
+        },
+        "negativeMutation": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-2afb6cff5cfc0141926e"
+          ]
+        },
+        "overlay": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-2afb6cff5cfc0141926e"
+          ]
+        },
+        "quality": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-2afb6cff5cfc0141926e"
+          ]
+        }
+      },
+      "diagnostics": {
+        "adapter": "memory-mlx-adapter:ltx-2.5-full-pipeline",
+        "blockers": [
+          "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningActivePeak",
+            "unit": "bytes",
+            "value": 11725838268
+          },
+          {
+            "name": "denoiseActivePeak",
+            "unit": "bytes",
+            "value": 8149147524
+          },
+          {
+            "name": "decodeActivePeak",
+            "unit": "bytes",
+            "value": 66125852164
+          },
+          {
+            "name": "overallAllocatorEnvelope",
+            "unit": "bytes",
+            "value": 66789535288
+          },
+          {
+            "name": "predictedOverallCeiling",
+            "unit": "bytes",
+            "value": 69457674240
+          },
+          {
+            "name": "renderedFrames",
+            "unit": "count",
+            "value": 145
+          },
+          {
+            "name": "outputFps",
+            "unit": "count",
+            "value": 24
+          },
+          {
+            "name": "devVariant",
+            "unit": "count",
+            "value": 0
+          },
+          {
+            "name": "diffusionDecoder",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "negativeMutationMaximumErrorPer255",
+            "unit": "count",
+            "value": 192
+          },
+          {
+            "name": "negativeMutationMeanErrorPer255",
+            "unit": "count",
+            "value": 65
+          },
+          {
+            "name": "negativeMutationRootMeanSquareErrorPer255",
+            "unit": "count",
+            "value": 66
+          },
+          {
+            "name": "audioMutationMaximumAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationMeanAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationRootMeanSquareErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "ltx-2-5-mlx-bf16-distilled-diffvae-1280x704-f145-fps24-seed18755",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-6f2b28a41967fd486b50",
+      "loadShape": "deferred_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/ltx-2.5-mlx@081658ce6886cacba20817ce0359bbefef706ff2:bf16",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-0e6b290e797d5d954937",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 11725838268,
+          "allocatorBytes": 12389521392,
+          "reclaimableBytes": 663683124
+        },
+        "decode": {
+          "activeBytes": 66125852164,
+          "allocatorBytes": 66125852164,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 8149147524,
+          "allocatorBytes": 8149147524,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 66125852164,
+          "allocatorBytes": 66789535288,
+          "reclaimableBytes": 663683124
+        }
+      },
+      "predictedPeakBytes": {
+        "conditioning": 12348030976,
+        "decode": 69457674240,
+        "denoise": 8589934592,
+        "overall": 69457674240
+      },
+      "quality": {
+        "audio": {
+          "channels": 2,
+          "maximumAbsoluteError": 0,
+          "maximumAbsoluteErrorThreshold": 0.011764705882352941,
+          "meanAbsoluteError": 0,
+          "meanAbsoluteErrorThreshold": 0.00392156862745098,
+          "referencePcmSha256": "70807dfe13798a6b1d0c05afcd66d62b4ef5953440b863e27e84a9b9f7b998d1",
+          "result": "passed",
+          "rootMeanSquareError": 0,
+          "rootMeanSquareErrorThreshold": 0.0058823529411764705,
+          "sampleCount": 576960,
+          "sampleRateHz": 48000,
+          "selectedPcmSha256": "70807dfe13798a6b1d0c05afcd66d62b4ef5953440b863e27e84a9b9f7b998d1"
+        },
+        "contract": "identical public artifact revision, transformer variant, decoder, prompt, seed, geometry, cadence, tier, required adapter recipe, and loaded provider; every video pixel and interleaved PCM sample in the measured render versus warm full-pipeline repeat",
+        "identicalInputs": true,
+        "maximumError": 0,
+        "maximumErrorThreshold": 0.011764705882352941,
+        "meanError": 0,
+        "meanErrorThreshold": 0.00392156862745098,
+        "result": "passed",
+        "rootMeanSquareError": 0,
+        "rootMeanSquareErrorThreshold": 0.0058823529411764705
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "scenarios": [
+        {
+          "effectiveBudgetBytes": 69457674240,
+          "name": "exact_fit",
+          "predictedBytes": 69457674240,
+          "result": "passed"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "the loaded provider rejected a zero/unknown budget",
+          "result": "passed"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "the loaded provider rejected a mutated calibration fingerprint",
+          "result": "passed"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "an identical-input full-pipeline request completed on the same loaded provider",
+          "result": "passed"
+        },
+        {
+          "name": "cancel",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "result": "passed"
+        },
+        {
+          "name": "overlay",
+          "reason": "target.overlay is none; transformerVariant and decoder are typed base-recipe axes, including dev's mandatory refinement adapter",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "runtime_complete",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency",
+          "bounded_attention",
+          "bounded_transformer_residency"
+        ],
+        "parameters": {
+          "attentionChunkSize": 16777216,
+          "transformerWindowComponent": "dit",
+          "transformerWindowSize": 1
+        },
+        "rung": "bounded_transformer_residency"
+      },
+      "sweep": {
+        "axes": [
+          {
+            "parameter": "attentionChunkSize",
+            "testedValues": [
+              16777216
+            ]
+          },
+          {
+            "parameter": "transformerWindowSize",
+            "testedValues": [
+              1
+            ]
+          }
+        ],
+        "cases": [
+          {
+            "parameters": {
+              "attentionChunkSize": 16777216,
+              "transformerWindowComponent": "dit",
+              "transformerWindowSize": 1
+            },
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": true
+      },
+      "target": {
+        "decoder": "diffvae",
+        "geometry": {
+          "batch": 1,
+          "frames": 145,
+          "height": 704,
+          "width": 1280
+        },
+        "mode": "text_to_video",
+        "modelId": "ltx_2_5",
+        "overlay": "none",
+        "provider": "ltx_2_5",
+        "tier": "bf16",
+        "transformerVariant": "distilled"
+      }
+    },
+    {
+      "artifact": {
+        "inventorySha256": "48b7b1ab3329d060760934994b7f0f2579845c3cc332779b44d009369283a344",
+        "repository": "SceneWorks/ltx-2.5-mlx",
+        "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+        "variant": "q8"
+      },
+      "backend": "mlx",
+      "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1",
+      "capturedAt": "2026-08-30T11:43:09Z",
+      "derivation": {
+        "justification": "Exact physical MLX provider response, artifact inventory, and selected/reference outputs are preserved as immutable capture receipts.",
+        "lifecycle": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-2e42791598cf2e7dd409"
+          ]
+        },
+        "loadability": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-2e42791598cf2e7dd409"
+          ]
+        },
+        "memory": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-2e42791598cf2e7dd409"
+          ]
+        },
+        "negativeMutation": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-2e42791598cf2e7dd409"
+          ]
+        },
+        "overlay": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-2e42791598cf2e7dd409"
+          ]
+        },
+        "quality": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-2e42791598cf2e7dd409"
+          ]
+        }
+      },
+      "diagnostics": {
+        "adapter": "memory-mlx-adapter:ltx-2.5-full-pipeline",
+        "blockers": [
+          "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningActivePeak",
+            "unit": "bytes",
+            "value": 23406395552
+          },
+          {
+            "name": "denoiseActivePeak",
+            "unit": "bytes",
+            "value": 35925328080
+          },
+          {
+            "name": "decodeActivePeak",
+            "unit": "bytes",
+            "value": 64847765684
+          },
+          {
+            "name": "overallAllocatorEnvelope",
+            "unit": "bytes",
+            "value": 69260977594
+          },
+          {
+            "name": "predictedOverallCeiling",
+            "unit": "bytes",
+            "value": 68115496960
+          },
+          {
+            "name": "renderedFrames",
+            "unit": "count",
+            "value": 145
+          },
+          {
+            "name": "outputFps",
+            "unit": "count",
+            "value": 24
+          },
+          {
+            "name": "devVariant",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "diffusionDecoder",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "negativeMutationMaximumErrorPer255",
+            "unit": "count",
+            "value": 192
+          },
+          {
+            "name": "negativeMutationMeanErrorPer255",
+            "unit": "count",
+            "value": 65
+          },
+          {
+            "name": "negativeMutationRootMeanSquareErrorPer255",
+            "unit": "count",
+            "value": 66
+          },
+          {
+            "name": "audioMutationMaximumAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationMeanAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationRootMeanSquareErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "ltx-2-5-mlx-q8-dev-diffvae-1280x704-f145-fps24-seed18755",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-7f8186376a9a3143ebee",
+      "loadShape": "eager_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/ltx-2.5-mlx@081658ce6886cacba20817ce0359bbefef706ff2:q8",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-2296fd978fd1a2702547",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 23406395552,
+          "allocatorBytes": 27819607462,
+          "reclaimableBytes": 4413211910
+        },
+        "decode": {
+          "activeBytes": 64847765684,
+          "allocatorBytes": 64847765684,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 35925328080,
+          "allocatorBytes": 35925328080,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 64847765684,
+          "allocatorBytes": 69260977594,
+          "reclaimableBytes": 4413211910
+        }
+      },
+      "predictedPeakBytes": {
+        "conditioning": 24628953088,
+        "decode": 68115496960,
+        "denoise": 37782290432,
+        "overall": 68115496960
+      },
+      "quality": {
+        "audio": {
+          "channels": 2,
+          "maximumAbsoluteError": 0,
+          "maximumAbsoluteErrorThreshold": 0.011764705882352941,
+          "meanAbsoluteError": 0,
+          "meanAbsoluteErrorThreshold": 0.00392156862745098,
+          "referencePcmSha256": "9d1cc71bfb5d18125e49b479f56c7b0b0d282f710d02e17cdfad31fb0c1667d2",
+          "result": "passed",
+          "rootMeanSquareError": 0,
+          "rootMeanSquareErrorThreshold": 0.0058823529411764705,
+          "sampleCount": 576960,
+          "sampleRateHz": 48000,
+          "selectedPcmSha256": "9d1cc71bfb5d18125e49b479f56c7b0b0d282f710d02e17cdfad31fb0c1667d2"
+        },
+        "contract": "identical public artifact revision, transformer variant, decoder, prompt, seed, geometry, cadence, tier, required adapter recipe, and loaded provider; every video pixel and interleaved PCM sample in the measured render versus warm full-pipeline repeat",
+        "identicalInputs": true,
+        "maximumError": 0,
+        "maximumErrorThreshold": 0.011764705882352941,
+        "meanError": 0,
+        "meanErrorThreshold": 0.00392156862745098,
+        "result": "passed",
+        "rootMeanSquareError": 0,
+        "rootMeanSquareErrorThreshold": 0.0058823529411764705
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "scenarios": [
+        {
+          "effectiveBudgetBytes": 68115496960,
+          "name": "exact_fit",
+          "predictedBytes": 68115496960,
+          "result": "passed"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "the loaded provider rejected a zero/unknown budget",
+          "result": "passed"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "the loaded provider rejected a mutated calibration fingerprint",
+          "result": "passed"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "an identical-input full-pipeline request completed on the same loaded provider",
+          "result": "passed"
+        },
+        {
+          "name": "cancel",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "result": "passed"
+        },
+        {
+          "name": "overlay",
+          "reason": "target.overlay is none; transformerVariant and decoder are typed base-recipe axes, including dev's mandatory refinement adapter",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "runtime_complete",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency",
+          "bounded_attention"
+        ],
+        "parameters": {
+          "attentionChunkSize": 16777216
+        },
+        "rung": "bounded_attention"
+      },
+      "sweep": {
+        "axes": [
+          {
+            "parameter": "attentionChunkSize",
+            "testedValues": [
+              16777216
+            ]
+          }
+        ],
+        "cases": [
+          {
+            "parameters": {
+              "attentionChunkSize": 16777216
+            },
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": true
+      },
+      "target": {
+        "decoder": "diffvae",
+        "geometry": {
+          "batch": 1,
+          "frames": 145,
+          "height": 704,
+          "width": 1280
+        },
+        "mode": "text_to_video",
+        "modelId": "ltx_2_5",
+        "overlay": "none",
+        "provider": "ltx_2_5",
+        "tier": "q8",
+        "transformerVariant": "dev"
+      }
+    },
+    {
+      "artifact": {
+        "inventorySha256": "87951a915b40d82f4a2ef422aa9631d1af3da7507d5521880141f53da90ad1c0",
+        "repository": "SceneWorks/ltx-2.5-mlx",
+        "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+        "variant": "bf16"
+      },
+      "backend": "mlx",
+      "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1",
+      "capturedAt": "2026-08-30T16:42:04Z",
+      "derivation": {
+        "justification": "Exact physical MLX provider response, artifact inventory, and selected/reference outputs are preserved as immutable capture receipts.",
+        "lifecycle": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-bd34b9dca451d372772f"
+          ]
+        },
+        "loadability": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-bd34b9dca451d372772f"
+          ]
+        },
+        "memory": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-bd34b9dca451d372772f"
+          ]
+        },
+        "negativeMutation": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-bd34b9dca451d372772f"
+          ]
+        },
+        "overlay": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-bd34b9dca451d372772f"
+          ]
+        },
+        "quality": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-bd34b9dca451d372772f"
+          ]
+        }
+      },
+      "diagnostics": {
+        "adapter": "memory-mlx-adapter:ltx-2.5-full-pipeline",
+        "blockers": [
+          "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningActivePeak",
+            "unit": "bytes",
+            "value": 45472780950
+          },
+          {
+            "name": "denoiseActivePeak",
+            "unit": "bytes",
+            "value": 64442151098
+          },
+          {
+            "name": "decodeActivePeak",
+            "unit": "bytes",
+            "value": 79539453812
+          },
+          {
+            "name": "overallAllocatorEnvelope",
+            "unit": "bytes",
+            "value": 92135650144
+          },
+          {
+            "name": "predictedOverallCeiling",
+            "unit": "bytes",
+            "value": 83550535680
+          },
+          {
+            "name": "renderedFrames",
+            "unit": "count",
+            "value": 449
+          },
+          {
+            "name": "outputFps",
+            "unit": "count",
+            "value": 30
+          },
+          {
+            "name": "devVariant",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "diffusionDecoder",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "negativeMutationMaximumErrorPer255",
+            "unit": "count",
+            "value": 192
+          },
+          {
+            "name": "negativeMutationMeanErrorPer255",
+            "unit": "count",
+            "value": 65
+          },
+          {
+            "name": "negativeMutationRootMeanSquareErrorPer255",
+            "unit": "count",
+            "value": 65
+          },
+          {
+            "name": "audioMutationMaximumAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationMeanAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationRootMeanSquareErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "ltx-2-5-mlx-bf16-dev-diffvae-704x1280-f449-fps30-seed18755",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-9c4c5fe8356bcc4f139f",
+      "loadShape": "eager_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/ltx-2.5-mlx@081658ce6886cacba20817ce0359bbefef706ff2:bf16",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-276d4cbe31eda3e1126a",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 45472780950,
+          "allocatorBytes": 58068977282,
+          "reclaimableBytes": 12596196332
+        },
+        "decode": {
+          "activeBytes": 79539453812,
+          "allocatorBytes": 79539453812,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 64442151098,
+          "allocatorBytes": 64442151098,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 79539453812,
+          "allocatorBytes": 92135650144,
+          "reclaimableBytes": 12596196332
+        }
+      },
+      "predictedPeakBytes": {
+        "conditioning": 47781511168,
+        "decode": 83550535680,
+        "denoise": 67712843776,
+        "overall": 83550535680
+      },
+      "quality": {
+        "audio": {
+          "channels": 2,
+          "maximumAbsoluteError": 0,
+          "maximumAbsoluteErrorThreshold": 0.011764705882352941,
+          "meanAbsoluteError": 0,
+          "meanAbsoluteErrorThreshold": 0.00392156862745098,
+          "referencePcmSha256": "19346d4ce22ce9eba792abf5f67d12a892f018e6fc8017af6f720b5e5e237413",
+          "result": "passed",
+          "rootMeanSquareError": 0,
+          "rootMeanSquareErrorThreshold": 0.0058823529411764705,
+          "sampleCount": 1433280,
+          "sampleRateHz": 48000,
+          "selectedPcmSha256": "19346d4ce22ce9eba792abf5f67d12a892f018e6fc8017af6f720b5e5e237413"
+        },
+        "contract": "identical public artifact revision, transformer variant, decoder, prompt, seed, geometry, cadence, tier, required adapter recipe, and loaded provider; every video pixel and interleaved PCM sample in the measured render versus warm full-pipeline repeat",
+        "identicalInputs": true,
+        "maximumError": 0,
+        "maximumErrorThreshold": 0.011764705882352941,
+        "meanError": 0,
+        "meanErrorThreshold": 0.00392156862745098,
+        "result": "passed",
+        "rootMeanSquareError": 0,
+        "rootMeanSquareErrorThreshold": 0.0058823529411764705
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "scenarios": [
+        {
+          "effectiveBudgetBytes": 83550535680,
+          "name": "exact_fit",
+          "predictedBytes": 83550535680,
+          "result": "passed"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "the loaded provider rejected a zero/unknown budget",
+          "result": "passed"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "the loaded provider rejected a mutated calibration fingerprint",
+          "result": "passed"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "an identical-input full-pipeline request completed on the same loaded provider",
+          "result": "passed"
+        },
+        {
+          "name": "cancel",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "result": "passed"
+        },
+        {
+          "name": "overlay",
+          "reason": "target.overlay is none; transformerVariant and decoder are typed base-recipe axes, including dev's mandatory refinement adapter",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "runtime_complete",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency",
+          "bounded_attention"
+        ],
+        "parameters": {
+          "attentionChunkSize": 16777216
+        },
+        "rung": "bounded_attention"
+      },
+      "sweep": {
+        "axes": [
+          {
+            "parameter": "attentionChunkSize",
+            "testedValues": [
+              16777216
+            ]
+          }
+        ],
+        "cases": [
+          {
+            "parameters": {
+              "attentionChunkSize": 16777216
+            },
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": true
+      },
+      "target": {
+        "decoder": "diffvae",
+        "geometry": {
+          "batch": 1,
+          "frames": 449,
+          "height": 1280,
+          "width": 704
+        },
+        "mode": "text_to_video",
+        "modelId": "ltx_2_5",
+        "overlay": "none",
+        "provider": "ltx_2_5",
+        "tier": "bf16",
+        "transformerVariant": "dev"
+      }
+    },
+    {
+      "artifact": {
+        "inventorySha256": "48b7b1ab3329d060760934994b7f0f2579845c3cc332779b44d009369283a344",
+        "repository": "SceneWorks/ltx-2.5-mlx",
+        "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+        "variant": "q8"
+      },
+      "backend": "mlx",
+      "calibrationFingerprint": "sc-18797-ltx-2-5-mlx-ladder-v1",
+      "capturedAt": "2026-08-30T09:54:42Z",
+      "derivation": {
+        "justification": "Exact physical MLX provider response, artifact inventory, and selected/reference outputs are preserved as immutable capture receipts.",
+        "lifecycle": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-086b24915f2f599b29ee"
+          ]
+        },
+        "loadability": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-086b24915f2f599b29ee"
+          ]
+        },
+        "memory": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-086b24915f2f599b29ee"
+          ]
+        },
+        "negativeMutation": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-086b24915f2f599b29ee"
+          ]
+        },
+        "overlay": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-086b24915f2f599b29ee"
+          ]
+        },
+        "quality": {
+          "kind": "direct",
+          "sourceSessionIds": [
+            "ims-086b24915f2f599b29ee"
+          ]
+        }
+      },
+      "diagnostics": {
+        "adapter": "memory-mlx-adapter:ltx-2.5-full-pipeline",
+        "blockers": [
+          "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency"
+        ],
+        "execution": "executed",
+        "measurements": [
+          {
+            "name": "conditioningActivePeak",
+            "unit": "bytes",
+            "value": 23405449760
+          },
+          {
+            "name": "denoiseActivePeak",
+            "unit": "bytes",
+            "value": 35924382288
+          },
+          {
+            "name": "decodeActivePeak",
+            "unit": "bytes",
+            "value": 8257474680
+          },
+          {
+            "name": "overallAllocatorEnvelope",
+            "unit": "bytes",
+            "value": 40337594198
+          },
+          {
+            "name": "predictedOverallCeiling",
+            "unit": "bytes",
+            "value": 37782290432
+          },
+          {
+            "name": "renderedFrames",
+            "unit": "count",
+            "value": 145
+          },
+          {
+            "name": "outputFps",
+            "unit": "count",
+            "value": 24
+          },
+          {
+            "name": "devVariant",
+            "unit": "count",
+            "value": 1
+          },
+          {
+            "name": "diffusionDecoder",
+            "unit": "count",
+            "value": 0
+          },
+          {
+            "name": "negativeMutationMaximumErrorPer255",
+            "unit": "count",
+            "value": 192
+          },
+          {
+            "name": "negativeMutationMeanErrorPer255",
+            "unit": "count",
+            "value": 65
+          },
+          {
+            "name": "negativeMutationRootMeanSquareErrorPer255",
+            "unit": "count",
+            "value": 65
+          },
+          {
+            "name": "audioMutationMaximumAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationMeanAbsoluteErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          },
+          {
+            "name": "audioMutationRootMeanSquareErrorMicrounits",
+            "unit": "count",
+            "value": 250000
+          }
+        ]
+      },
+      "evidenceScope": "authoritative",
+      "fixture": "ltx-2-5-mlx-q8-dev-conv-704x1280-f145-fps24-seed18755",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "harnessVersion": "sceneworks-memory-v5",
+      "id": "imc-beaa0f2aacf0832ea28a",
+      "loadShape": "eager_materialization",
+      "loadability": {
+        "resolvedPathFingerprint": "SceneWorks/ltx-2.5-mlx@081658ce6886cacba20817ce0359bbefef706ff2:q8",
+        "result": "passed"
+      },
+      "logicalCaseId": "implan-0e420041065a9b1c9149",
+      "negativeMutation": null,
+      "observedMemory": {
+        "conditioning": {
+          "activeBytes": 23405449760,
+          "allocatorBytes": 27818661670,
+          "reclaimableBytes": 4413211910
+        },
+        "decode": {
+          "activeBytes": 8257474680,
+          "allocatorBytes": 8257474680,
+          "reclaimableBytes": 0
+        },
+        "denoise": {
+          "activeBytes": 35924382288,
+          "allocatorBytes": 35924382288,
+          "reclaimableBytes": 0
+        },
+        "overall": {
+          "activeBytes": 35924382288,
+          "allocatorBytes": 40337594198,
+          "reclaimableBytes": 4413211910
+        }
+      },
+      "predictedPeakBytes": {
+        "conditioning": 24628953088,
+        "decode": 8724152320,
+        "denoise": 37782290432,
+        "overall": 37782290432
+      },
+      "quality": {
+        "audio": {
+          "channels": 2,
+          "maximumAbsoluteError": 0,
+          "maximumAbsoluteErrorThreshold": 0.011764705882352941,
+          "meanAbsoluteError": 0,
+          "meanAbsoluteErrorThreshold": 0.00392156862745098,
+          "referencePcmSha256": "aa459c7800557982843072f65a689fec7c4557551a24ee4682547991a39fd0d1",
+          "result": "passed",
+          "rootMeanSquareError": 0,
+          "rootMeanSquareErrorThreshold": 0.0058823529411764705,
+          "sampleCount": 576960,
+          "sampleRateHz": 48000,
+          "selectedPcmSha256": "aa459c7800557982843072f65a689fec7c4557551a24ee4682547991a39fd0d1"
+        },
+        "contract": "identical public artifact revision, transformer variant, decoder, prompt, seed, geometry, cadence, tier, required adapter recipe, and loaded provider; every video pixel and interleaved PCM sample in the measured render versus warm full-pipeline repeat",
+        "identicalInputs": true,
+        "maximumError": 0,
+        "maximumErrorThreshold": 0.011764705882352941,
+        "meanError": 0,
+        "meanErrorThreshold": 0.00392156862745098,
+        "result": "passed",
+        "rootMeanSquareError": 0,
+        "rootMeanSquareErrorThreshold": 0.0058823529411764705
+      },
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "scenarios": [
+        {
+          "effectiveBudgetBytes": 37782290432,
+          "name": "exact_fit",
+          "predictedBytes": 37782290432,
+          "result": "passed"
+        },
+        {
+          "name": "unknown_budget",
+          "reason": "the loaded provider rejected a zero/unknown budget",
+          "result": "passed"
+        },
+        {
+          "name": "stale_evidence",
+          "reason": "the loaded provider rejected a mutated calibration fingerprint",
+          "result": "passed"
+        },
+        {
+          "name": "warm_repeat",
+          "reason": "an identical-input full-pipeline request completed on the same loaded provider",
+          "result": "passed"
+        },
+        {
+          "name": "cancel",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "error",
+          "reason": "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity render per fresh process; cancellation and injected-error lifecycle cases remain explicitly unexecuted here and are not used as calibration currency",
+          "result": "not_run"
+        },
+        {
+          "name": "loadability",
+          "result": "passed"
+        },
+        {
+          "name": "overlay",
+          "reason": "target.overlay is none; transformerVariant and decoder are typed base-recipe axes, including dev's mandatory refinement adapter",
+          "result": "not_applicable"
+        }
+      ],
+      "status": "runtime_complete",
+      "strategy": {
+        "engagedRungs": [
+          "resident",
+          "staged_residency",
+          "bounded_decode",
+          "bounded_attention"
+        ],
+        "parameters": {
+          "attentionChunkSize": 16777216,
+          "decodeOverlap": 64,
+          "decodeTileEdge": 192
+        },
+        "rung": "bounded_attention"
+      },
+      "sweep": {
+        "axes": [
+          {
+            "parameter": "attentionChunkSize",
+            "testedValues": [
+              16777216
+            ]
+          },
+          {
+            "parameter": "decodeOverlap",
+            "testedValues": [
+              64
+            ]
+          },
+          {
+            "parameter": "decodeTileEdge",
+            "testedValues": [
+              192
+            ]
+          }
+        ],
+        "cases": [
+          {
+            "parameters": {
+              "attentionChunkSize": 16777216,
+              "decodeOverlap": 64,
+              "decodeTileEdge": 192
+            },
+            "result": "passed"
+          }
+        ],
+        "rangeVerified": true
+      },
+      "target": {
+        "decoder": "conv",
+        "geometry": {
+          "batch": 1,
+          "frames": 145,
+          "height": 1280,
+          "width": 704
+        },
+        "mode": "text_to_video",
+        "modelId": "ltx_2_5",
+        "overlay": "none",
+        "provider": "ltx_2_5",
+        "tier": "q8",
+        "transformerVariant": "dev"
+      }
+    }
+  ],
+  "schemaVersion": 6,
+  "sourceSessions": [
+    {
+      "capturedAt": "2026-08-30T08:57:53Z",
+      "claims": [
+        "memory",
+        "quality",
+        "negative_mutation",
+        "lifecycle",
+        "loadability",
+        "overlay"
+      ],
+      "command": "[\"/Users/michael/.codex/worktrees/epic18755/sc18791-final-mlx-target-e4d37922/release/memory-mlx-adapter\"]",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "id": "ims-066918dbd60d57d62068",
+      "inputs": [
+        {
+          "bytes": 72780882680,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/distilled/bf16",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "base",
+          "sha256": "3f8527f80689bde77e4ab9852fd1e920d574b917430a32d81851981a1c7495f9",
+          "variant": "bf16"
+        },
+        {
+          "bytes": 23951748129,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/enhancer",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "enhancer",
+          "sha256": "8c91bd63a7d481eeb0115e71a0ce5df375cc8dc009357bb3284df15c6e135119",
+          "variant": "enhancer"
+        }
+      ],
+      "kind": "physical_mlx",
+      "outputs": [
+        {
+          "bytes": 2187,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/ims-066918dbd60d57d62068.request.json",
+          "role": "request",
+          "sha256": "2a00f55cb3791ce2a2e44e0f855ec0ad1e865829cb3f44299ff949a61983c183"
+        },
+        {
+          "bytes": 173359165,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-009d054ef7394144a6b4-selected_av-768x512-f145-2a98e9bde228c71a37f07b06fbec68b92d753a49c4e2a30302fe0d26e3680e36.avbin",
+          "role": "selected_av",
+          "sha256": "2a98e9bde228c71a37f07b06fbec68b92d753a49c4e2a30302fe0d26e3680e36"
+        },
+        {
+          "bytes": 173359165,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-009d054ef7394144a6b4-reference_av-768x512-f145-2a98e9bde228c71a37f07b06fbec68b92d753a49c4e2a30302fe0d26e3680e36.avbin",
+          "role": "reference_av",
+          "sha256": "2a98e9bde228c71a37f07b06fbec68b92d753a49c4e2a30302fe0d26e3680e36"
+        }
+      ],
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "result": "passed",
+      "sourcePath": "docs/calibration/sc-18791/e4d37922-b971699f/ims-066918dbd60d57d62068.log",
+      "stdoutSha256": "eb84261b987c8eb93ac8e97cb3c90d6096e85439420d82cf07523998aaeb5354",
+      "target": {
+        "decoder": "diffvae",
+        "mode": "text_to_video",
+        "overlay": "none",
+        "rung": "bounded_transformer_residency",
+        "tier": "bf16",
+        "transformerVariant": "distilled"
+      }
+    },
+    {
+      "capturedAt": "2026-08-30T09:54:42Z",
+      "claims": [
+        "memory",
+        "quality",
+        "negative_mutation",
+        "lifecycle",
+        "loadability",
+        "overlay"
+      ],
+      "command": "[\"/Users/michael/.codex/worktrees/epic18755/sc18791-final-mlx-target-e4d37922/release/memory-mlx-adapter\"]",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "id": "ims-086b24915f2f599b29ee",
+      "inputs": [
+        {
+          "bytes": 41836075248,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/dev/q8",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "base",
+          "sha256": "48b7b1ab3329d060760934994b7f0f2579845c3cc332779b44d009369283a344",
+          "variant": "q8"
+        },
+        {
+          "bytes": 23951748129,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/enhancer",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "enhancer",
+          "sha256": "8c91bd63a7d481eeb0115e71a0ce5df375cc8dc009357bb3284df15c6e135119",
+          "variant": "enhancer"
+        },
+        {
+          "bytes": 8899889568,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/distilled_lora/ltx-2.5-22b-distilled-lora-450-bf16.safetensors",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "adapter",
+          "sha256": "86370bbf79a9eb4edaa158907e2b48a5188fe4c5dc8ce30c7eb8f2f131a9bbf5",
+          "variant": "dev_refinement_lora"
+        }
+      ],
+      "kind": "physical_mlx",
+      "outputs": [
+        {
+          "bytes": 2116,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/ims-086b24915f2f599b29ee.request.json",
+          "role": "request",
+          "sha256": "3367a6fa4a47297b6cc3228116b03fffe0285541d7f56905bdc776f23db25ca1"
+        },
+        {
+          "bytes": 394297405,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-0e420041065a9b1c9149-selected_av-704x1280-f145-71bf6c0ac84548abb7c340fd735d6af21ea1ba7c3da0d5e408a232d56faebea8.avbin",
+          "role": "selected_av",
+          "sha256": "71bf6c0ac84548abb7c340fd735d6af21ea1ba7c3da0d5e408a232d56faebea8"
+        },
+        {
+          "bytes": 394297405,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-0e420041065a9b1c9149-reference_av-704x1280-f145-71bf6c0ac84548abb7c340fd735d6af21ea1ba7c3da0d5e408a232d56faebea8.avbin",
+          "role": "reference_av",
+          "sha256": "71bf6c0ac84548abb7c340fd735d6af21ea1ba7c3da0d5e408a232d56faebea8"
+        }
+      ],
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "result": "passed",
+      "sourcePath": "docs/calibration/sc-18791/e4d37922-b971699f/ims-086b24915f2f599b29ee.log",
+      "stdoutSha256": "6dc3408439fad11d550090a2a8da534a40cce7edace2dd70154e286af4891c07",
+      "target": {
+        "decoder": "conv",
+        "mode": "text_to_video",
+        "overlay": "none",
+        "rung": "bounded_attention",
+        "tier": "q8",
+        "transformerVariant": "dev"
+      }
+    },
+    {
+      "capturedAt": "2026-08-30T10:14:54Z",
+      "claims": [
+        "memory",
+        "quality",
+        "negative_mutation",
+        "lifecycle",
+        "loadability",
+        "overlay"
+      ],
+      "command": "[\"/Users/michael/.codex/worktrees/epic18755/sc18791-final-mlx-target-e4d37922/release/memory-mlx-adapter\"]",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "id": "ims-16bc57b45346ead4f1e5",
+      "inputs": [
+        {
+          "bytes": 72780882680,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/distilled/bf16",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "base",
+          "sha256": "3f8527f80689bde77e4ab9852fd1e920d574b917430a32d81851981a1c7495f9",
+          "variant": "bf16"
+        },
+        {
+          "bytes": 23951748129,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/enhancer",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "enhancer",
+          "sha256": "8c91bd63a7d481eeb0115e71a0ce5df375cc8dc009357bb3284df15c6e135119",
+          "variant": "enhancer"
+        }
+      ],
+      "kind": "physical_mlx",
+      "outputs": [
+        {
+          "bytes": 2187,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/ims-16bc57b45346ead4f1e5.request.json",
+          "role": "request",
+          "sha256": "f89b15c97173799f5745760a19689666ccc2917bc92ec27e5108e0d4003817e5"
+        },
+        {
+          "bytes": 173359165,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-0f735ff1108cec3a46fc-selected_av-512x768-f145-79aa5b1a2b940462f467a256942bc049ed81afa77802c28ab4ab3365cd7d5e4a.avbin",
+          "role": "selected_av",
+          "sha256": "79aa5b1a2b940462f467a256942bc049ed81afa77802c28ab4ab3365cd7d5e4a"
+        },
+        {
+          "bytes": 173359165,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-0f735ff1108cec3a46fc-reference_av-512x768-f145-79aa5b1a2b940462f467a256942bc049ed81afa77802c28ab4ab3365cd7d5e4a.avbin",
+          "role": "reference_av",
+          "sha256": "79aa5b1a2b940462f467a256942bc049ed81afa77802c28ab4ab3365cd7d5e4a"
+        }
+      ],
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "result": "passed",
+      "sourcePath": "docs/calibration/sc-18791/e4d37922-b971699f/ims-16bc57b45346ead4f1e5.log",
+      "stdoutSha256": "8752b9b95fa2e6775cc6aa009a923949768a54dbc6f5de6a8f65d6a02d04e4f7",
+      "target": {
+        "decoder": "diffvae",
+        "mode": "text_to_video",
+        "overlay": "none",
+        "rung": "bounded_transformer_residency",
+        "tier": "bf16",
+        "transformerVariant": "distilled"
+      }
+    },
+    {
+      "capturedAt": "2026-08-30T10:09:29Z",
+      "claims": [
+        "memory",
+        "quality",
+        "negative_mutation",
+        "lifecycle",
+        "loadability",
+        "overlay"
+      ],
+      "command": "[\"/Users/michael/.codex/worktrees/epic18755/sc18791-final-mlx-target-e4d37922/release/memory-mlx-adapter\"]",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "id": "ims-2afb6cff5cfc0141926e",
+      "inputs": [
+        {
+          "bytes": 72780882680,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/distilled/bf16",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "base",
+          "sha256": "3f8527f80689bde77e4ab9852fd1e920d574b917430a32d81851981a1c7495f9",
+          "variant": "bf16"
+        },
+        {
+          "bytes": 23951748129,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/enhancer",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "enhancer",
+          "sha256": "8c91bd63a7d481eeb0115e71a0ce5df375cc8dc009357bb3284df15c6e135119",
+          "variant": "enhancer"
+        }
+      ],
+      "kind": "physical_mlx",
+      "outputs": [
+        {
+          "bytes": 2189,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/ims-2afb6cff5cfc0141926e.request.json",
+          "role": "request",
+          "sha256": "cb6ffc039d96147fc016a28b959ada2f184fa7a378d54510e61e01ded47793c8"
+        },
+        {
+          "bytes": 394297405,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-0e6b290e797d5d954937-selected_av-1280x704-f145-2dcc3d83e120ab03b70cfed921e87854136ad34103117db83ab74d3f46289dd9.avbin",
+          "role": "selected_av",
+          "sha256": "2dcc3d83e120ab03b70cfed921e87854136ad34103117db83ab74d3f46289dd9"
+        },
+        {
+          "bytes": 394297405,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-0e6b290e797d5d954937-reference_av-1280x704-f145-2dcc3d83e120ab03b70cfed921e87854136ad34103117db83ab74d3f46289dd9.avbin",
+          "role": "reference_av",
+          "sha256": "2dcc3d83e120ab03b70cfed921e87854136ad34103117db83ab74d3f46289dd9"
+        }
+      ],
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "result": "passed",
+      "sourcePath": "docs/calibration/sc-18791/e4d37922-b971699f/ims-2afb6cff5cfc0141926e.log",
+      "stdoutSha256": "2baac51b1277450c61379a89b83cb52330c42d7996c113eaf3f80b380af49db8",
+      "target": {
+        "decoder": "diffvae",
+        "mode": "text_to_video",
+        "overlay": "none",
+        "rung": "bounded_transformer_residency",
+        "tier": "bf16",
+        "transformerVariant": "distilled"
+      }
+    },
+    {
+      "capturedAt": "2026-08-30T11:43:09Z",
+      "claims": [
+        "memory",
+        "quality",
+        "negative_mutation",
+        "lifecycle",
+        "loadability",
+        "overlay"
+      ],
+      "command": "[\"/Users/michael/.codex/worktrees/epic18755/sc18791-final-mlx-target-e4d37922/release/memory-mlx-adapter\"]",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "id": "ims-2e42791598cf2e7dd409",
+      "inputs": [
+        {
+          "bytes": 41836075248,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/dev/q8",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "base",
+          "sha256": "48b7b1ab3329d060760934994b7f0f2579845c3cc332779b44d009369283a344",
+          "variant": "q8"
+        },
+        {
+          "bytes": 23951748129,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/enhancer",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "enhancer",
+          "sha256": "8c91bd63a7d481eeb0115e71a0ce5df375cc8dc009357bb3284df15c6e135119",
+          "variant": "enhancer"
+        },
+        {
+          "bytes": 8899889568,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/distilled_lora/ltx-2.5-22b-distilled-lora-450-bf16.safetensors",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "adapter",
+          "sha256": "86370bbf79a9eb4edaa158907e2b48a5188fe4c5dc8ce30c7eb8f2f131a9bbf5",
+          "variant": "dev_refinement_lora"
+        }
+      ],
+      "kind": "physical_mlx",
+      "outputs": [
+        {
+          "bytes": 2036,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/ims-2e42791598cf2e7dd409.request.json",
+          "role": "request",
+          "sha256": "81fc72b72906556a09e2373d4805e520dc08a632060e7cb7a1f102ddc4b397f4"
+        },
+        {
+          "bytes": 394297405,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-2296fd978fd1a2702547-selected_av-1280x704-f145-8db1967b5069ab98b4e407f8797dfb71bf0474ce2269da7423bef9f46a65c55e.avbin",
+          "role": "selected_av",
+          "sha256": "8db1967b5069ab98b4e407f8797dfb71bf0474ce2269da7423bef9f46a65c55e"
+        },
+        {
+          "bytes": 394297405,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-2296fd978fd1a2702547-reference_av-1280x704-f145-8db1967b5069ab98b4e407f8797dfb71bf0474ce2269da7423bef9f46a65c55e.avbin",
+          "role": "reference_av",
+          "sha256": "8db1967b5069ab98b4e407f8797dfb71bf0474ce2269da7423bef9f46a65c55e"
+        }
+      ],
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "result": "passed",
+      "sourcePath": "docs/calibration/sc-18791/e4d37922-b971699f/ims-2e42791598cf2e7dd409.log",
+      "stdoutSha256": "41aaea09c75efc09e3e3ae051b832a97cbbcd8d960d645e1b2327a70c7f6fe22",
+      "target": {
+        "decoder": "diffvae",
+        "mode": "text_to_video",
+        "overlay": "none",
+        "rung": "bounded_attention",
+        "tier": "q8",
+        "transformerVariant": "dev"
+      }
+    },
+    {
+      "capturedAt": "2026-08-30T11:03:51Z",
+      "claims": [
+        "memory",
+        "quality",
+        "negative_mutation",
+        "lifecycle",
+        "loadability",
+        "overlay"
+      ],
+      "command": "[\"/Users/michael/.codex/worktrees/epic18755/sc18791-final-mlx-target-e4d37922/release/memory-mlx-adapter\"]",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "id": "ims-5c40c3d6e78d271b7464",
+      "inputs": [
+        {
+          "bytes": 72780883052,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/dev/bf16",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "base",
+          "sha256": "87951a915b40d82f4a2ef422aa9631d1af3da7507d5521880141f53da90ad1c0",
+          "variant": "bf16"
+        },
+        {
+          "bytes": 23951748129,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/enhancer",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "enhancer",
+          "sha256": "8c91bd63a7d481eeb0115e71a0ce5df375cc8dc009357bb3284df15c6e135119",
+          "variant": "enhancer"
+        },
+        {
+          "bytes": 8899889568,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/distilled_lora/ltx-2.5-22b-distilled-lora-450-bf16.safetensors",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "adapter",
+          "sha256": "86370bbf79a9eb4edaa158907e2b48a5188fe4c5dc8ce30c7eb8f2f131a9bbf5",
+          "variant": "dev_refinement_lora"
+        }
+      ],
+      "kind": "physical_mlx",
+      "outputs": [
+        {
+          "bytes": 2040,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/ims-5c40c3d6e78d271b7464.request.json",
+          "role": "request",
+          "sha256": "d1ccc429feb47e1692044d5f3afd2ac55d9102921770a4a6a3c2bbb6eb6731bc"
+        },
+        {
+          "bytes": 394297405,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-162f2859821a1fb54be0-selected_av-1280x704-f145-6dac46fb75945353788fa2a0ffcc34d5a9211f796574866fcb0e3d9a7a2600ee.avbin",
+          "role": "selected_av",
+          "sha256": "6dac46fb75945353788fa2a0ffcc34d5a9211f796574866fcb0e3d9a7a2600ee"
+        },
+        {
+          "bytes": 394297405,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-162f2859821a1fb54be0-reference_av-1280x704-f145-6dac46fb75945353788fa2a0ffcc34d5a9211f796574866fcb0e3d9a7a2600ee.avbin",
+          "role": "reference_av",
+          "sha256": "6dac46fb75945353788fa2a0ffcc34d5a9211f796574866fcb0e3d9a7a2600ee"
+        }
+      ],
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "result": "passed",
+      "sourcePath": "docs/calibration/sc-18791/e4d37922-b971699f/ims-5c40c3d6e78d271b7464.log",
+      "stdoutSha256": "d944633cad6d4a45b124860873997dccf385d1ab5eeb2cd25578f13ad68a81fb",
+      "target": {
+        "decoder": "diffvae",
+        "mode": "text_to_video",
+        "overlay": "none",
+        "rung": "bounded_attention",
+        "tier": "bf16",
+        "transformerVariant": "dev"
+      }
+    },
+    {
+      "capturedAt": "2026-08-30T09:10:32Z",
+      "claims": [
+        "memory",
+        "quality",
+        "negative_mutation",
+        "lifecycle",
+        "loadability",
+        "overlay"
+      ],
+      "command": "[\"/Users/michael/.codex/worktrees/epic18755/sc18791-final-mlx-target-e4d37922/release/memory-mlx-adapter\"]",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "id": "ims-6d9bed097065478533a6",
+      "inputs": [
+        {
+          "bytes": 41000527273,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/dev/q4",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "base",
+          "sha256": "25e83a8566c322782a39ad67f84ae5bd9bcfa628f5a404ee42d650b54e9b4373",
+          "variant": "q4"
+        },
+        {
+          "bytes": 23951748129,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/enhancer",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "enhancer",
+          "sha256": "8c91bd63a7d481eeb0115e71a0ce5df375cc8dc009357bb3284df15c6e135119",
+          "variant": "enhancer"
+        },
+        {
+          "bytes": 8899889568,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/distilled_lora/ltx-2.5-22b-distilled-lora-450-bf16.safetensors",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "adapter",
+          "sha256": "86370bbf79a9eb4edaa158907e2b48a5188fe4c5dc8ce30c7eb8f2f131a9bbf5",
+          "variant": "dev_refinement_lora"
+        }
+      ],
+      "kind": "physical_mlx",
+      "outputs": [
+        {
+          "bytes": 2034,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/ims-6d9bed097065478533a6.request.json",
+          "role": "request",
+          "sha256": "56ad8c8e83dffa54de11d943bc18998e8ddf6c00974f211c26eba1957de8d503"
+        },
+        {
+          "bytes": 173359165,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-09c5fbd207e9048193be-selected_av-768x512-f145-1dbb06c4742463ccdab48afed33f64ab22b8bb348ee1e80ec4d7965448c8dcbc.avbin",
+          "role": "selected_av",
+          "sha256": "1dbb06c4742463ccdab48afed33f64ab22b8bb348ee1e80ec4d7965448c8dcbc"
+        },
+        {
+          "bytes": 173359165,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-09c5fbd207e9048193be-reference_av-768x512-f145-1dbb06c4742463ccdab48afed33f64ab22b8bb348ee1e80ec4d7965448c8dcbc.avbin",
+          "role": "reference_av",
+          "sha256": "1dbb06c4742463ccdab48afed33f64ab22b8bb348ee1e80ec4d7965448c8dcbc"
+        }
+      ],
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "result": "passed",
+      "sourcePath": "docs/calibration/sc-18791/e4d37922-b971699f/ims-6d9bed097065478533a6.log",
+      "stdoutSha256": "01cbc26cc29171979fb74da76240b367a87813fb9973b16ddba456ce3e45afd0",
+      "target": {
+        "decoder": "diffvae",
+        "mode": "text_to_video",
+        "overlay": "none",
+        "rung": "bounded_attention",
+        "tier": "q4",
+        "transformerVariant": "dev"
+      }
+    },
+    {
+      "capturedAt": "2026-08-30T08:52:44Z",
+      "claims": [
+        "memory",
+        "quality",
+        "negative_mutation",
+        "lifecycle",
+        "loadability",
+        "overlay"
+      ],
+      "command": "[\"/Users/michael/.codex/worktrees/epic18755/sc18791-final-mlx-target-e4d37922/release/memory-mlx-adapter\"]",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "id": "ims-9b3c435b3ea728b6af6f",
+      "inputs": [
+        {
+          "bytes": 41836075248,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/dev/q8",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "base",
+          "sha256": "48b7b1ab3329d060760934994b7f0f2579845c3cc332779b44d009369283a344",
+          "variant": "q8"
+        },
+        {
+          "bytes": 23951748129,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/enhancer",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "enhancer",
+          "sha256": "8c91bd63a7d481eeb0115e71a0ce5df375cc8dc009357bb3284df15c6e135119",
+          "variant": "enhancer"
+        },
+        {
+          "bytes": 8899889568,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/distilled_lora/ltx-2.5-22b-distilled-lora-450-bf16.safetensors",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "adapter",
+          "sha256": "86370bbf79a9eb4edaa158907e2b48a5188fe4c5dc8ce30c7eb8f2f131a9bbf5",
+          "variant": "dev_refinement_lora"
+        }
+      ],
+      "kind": "physical_mlx",
+      "outputs": [
+        {
+          "bytes": 2034,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/ims-9b3c435b3ea728b6af6f.request.json",
+          "role": "request",
+          "sha256": "e681179164d864132ed2b305f72418f6d64af89425075653394c43d1cec3c2e9"
+        },
+        {
+          "bytes": 180486205,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-008e4480bb6c768ee018-selected_av-640x640-f145-e58e7f8adf81cf724b8334b1598237aa52720162e092cc0dc0155874bd1c0936.avbin",
+          "role": "selected_av",
+          "sha256": "e58e7f8adf81cf724b8334b1598237aa52720162e092cc0dc0155874bd1c0936"
+        },
+        {
+          "bytes": 180486205,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-008e4480bb6c768ee018-reference_av-640x640-f145-e58e7f8adf81cf724b8334b1598237aa52720162e092cc0dc0155874bd1c0936.avbin",
+          "role": "reference_av",
+          "sha256": "e58e7f8adf81cf724b8334b1598237aa52720162e092cc0dc0155874bd1c0936"
+        }
+      ],
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "result": "passed",
+      "sourcePath": "docs/calibration/sc-18791/e4d37922-b971699f/ims-9b3c435b3ea728b6af6f.log",
+      "stdoutSha256": "8fd7db62a3d64fbcc4dc594ef4489bdc746eba29ac5130b00c319fdfec614bc7",
+      "target": {
+        "decoder": "diffvae",
+        "mode": "text_to_video",
+        "overlay": "none",
+        "rung": "bounded_attention",
+        "tier": "q8",
+        "transformerVariant": "dev"
+      }
+    },
+    {
+      "capturedAt": "2026-08-30T16:42:04Z",
+      "claims": [
+        "memory",
+        "quality",
+        "negative_mutation",
+        "lifecycle",
+        "loadability",
+        "overlay"
+      ],
+      "command": "[\"/Users/michael/.codex/worktrees/epic18755/sc18791-final-mlx-target-e4d37922/release/memory-mlx-adapter\"]",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "id": "ims-bd34b9dca451d372772f",
+      "inputs": [
+        {
+          "bytes": 72780883052,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/dev/bf16",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "base",
+          "sha256": "87951a915b40d82f4a2ef422aa9631d1af3da7507d5521880141f53da90ad1c0",
+          "variant": "bf16"
+        },
+        {
+          "bytes": 23951748129,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/enhancer",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "enhancer",
+          "sha256": "8c91bd63a7d481eeb0115e71a0ce5df375cc8dc009357bb3284df15c6e135119",
+          "variant": "enhancer"
+        },
+        {
+          "bytes": 8899889568,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/distilled_lora/ltx-2.5-22b-distilled-lora-450-bf16.safetensors",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "adapter",
+          "sha256": "86370bbf79a9eb4edaa158907e2b48a5188fe4c5dc8ce30c7eb8f2f131a9bbf5",
+          "variant": "dev_refinement_lora"
+        }
+      ],
+      "kind": "physical_mlx",
+      "outputs": [
+        {
+          "bytes": 2040,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/ims-bd34b9dca451d372772f.request.json",
+          "role": "request",
+          "sha256": "79fc775b1861cfbfb88c6293c29912a67deebd7d72db8fa908794670b4a61bdb"
+        },
+        {
+          "bytes": 1219548989,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-276d4cbe31eda3e1126a-selected_av-704x1280-f449-0cd16275bb462840f9c20a365fdc495abf60dc4c005c99777da121b45fffce0a.avbin",
+          "role": "selected_av",
+          "sha256": "0cd16275bb462840f9c20a365fdc495abf60dc4c005c99777da121b45fffce0a"
+        },
+        {
+          "bytes": 1219548989,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-276d4cbe31eda3e1126a-reference_av-704x1280-f449-0cd16275bb462840f9c20a365fdc495abf60dc4c005c99777da121b45fffce0a.avbin",
+          "role": "reference_av",
+          "sha256": "0cd16275bb462840f9c20a365fdc495abf60dc4c005c99777da121b45fffce0a"
+        }
+      ],
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "result": "passed",
+      "sourcePath": "docs/calibration/sc-18791/e4d37922-b971699f/ims-bd34b9dca451d372772f.log",
+      "stdoutSha256": "78c0ac9b497c8f2fac94ae5b64c6af2571acb8ff002a2eeae0c482a90d537641",
+      "target": {
+        "decoder": "diffvae",
+        "mode": "text_to_video",
+        "overlay": "none",
+        "rung": "bounded_attention",
+        "tier": "bf16",
+        "transformerVariant": "dev"
+      }
+    },
+    {
+      "capturedAt": "2026-08-30T09:21:26Z",
+      "claims": [
+        "memory",
+        "quality",
+        "negative_mutation",
+        "lifecycle",
+        "loadability",
+        "overlay"
+      ],
+      "command": "[\"/Users/michael/.codex/worktrees/epic18755/sc18791-final-mlx-target-e4d37922/release/memory-mlx-adapter\"]",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "id": "ims-d3771f3076da6c07291d",
+      "inputs": [
+        {
+          "bytes": 72780882680,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/distilled/bf16",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "base",
+          "sha256": "3f8527f80689bde77e4ab9852fd1e920d574b917430a32d81851981a1c7495f9",
+          "variant": "bf16"
+        },
+        {
+          "bytes": 23951748129,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/enhancer",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "enhancer",
+          "sha256": "8c91bd63a7d481eeb0115e71a0ce5df375cc8dc009357bb3284df15c6e135119",
+          "variant": "enhancer"
+        }
+      ],
+      "kind": "physical_mlx",
+      "outputs": [
+        {
+          "bytes": 2269,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/ims-d3771f3076da6c07291d.request.json",
+          "role": "request",
+          "sha256": "77d754858a23a52931abf83bcb1016dd2b308768048864c54df92b10b7ca889f"
+        },
+        {
+          "bytes": 394297405,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-0aa8a44af9552a3fc9d7-selected_av-1280x704-f145-82aaa066e5bd4a6458e161f4871a72a097b58da91e8def02885a56ff69f06776.avbin",
+          "role": "selected_av",
+          "sha256": "82aaa066e5bd4a6458e161f4871a72a097b58da91e8def02885a56ff69f06776"
+        },
+        {
+          "bytes": 394297405,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-0aa8a44af9552a3fc9d7-reference_av-1280x704-f145-82aaa066e5bd4a6458e161f4871a72a097b58da91e8def02885a56ff69f06776.avbin",
+          "role": "reference_av",
+          "sha256": "82aaa066e5bd4a6458e161f4871a72a097b58da91e8def02885a56ff69f06776"
+        }
+      ],
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "result": "passed",
+      "sourcePath": "docs/calibration/sc-18791/e4d37922-b971699f/ims-d3771f3076da6c07291d.log",
+      "stdoutSha256": "f0e71b363cb6eb07ee049257e6db5bb882bceebd35a58e2d3a12ff2ca90842c3",
+      "target": {
+        "decoder": "conv",
+        "mode": "text_to_video",
+        "overlay": "none",
+        "rung": "bounded_transformer_residency",
+        "tier": "bf16",
+        "transformerVariant": "distilled"
+      }
+    },
+    {
+      "capturedAt": "2026-08-30T10:26:48Z",
+      "claims": [
+        "memory",
+        "quality",
+        "negative_mutation",
+        "lifecycle",
+        "loadability",
+        "overlay"
+      ],
+      "command": "[\"/Users/michael/.codex/worktrees/epic18755/sc18791-final-mlx-target-e4d37922/release/memory-mlx-adapter\"]",
+      "hardware": {
+        "chip": "Apple M5 Max",
+        "memoryBytes": 137438953472,
+        "metalDevice": "Apple M5 Max",
+        "mlxMemoryLimitBytes": 130567005798,
+        "model": "Mac17,6",
+        "osVersion": "26.5.2",
+        "probe": "sysctl + sw_vers + system_profiler + mlx_rs::memory::get_memory_limit; wired=mlx_default_memory_limit/1.5",
+        "wiredLimitBytes": 87044670532
+      },
+      "id": "ims-edd25b7371841406eacb",
+      "inputs": [
+        {
+          "bytes": 41000527273,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/dev/q4",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "base",
+          "sha256": "25e83a8566c322782a39ad67f84ae5bd9bcfa628f5a404ee42d650b54e9b4373",
+          "variant": "q4"
+        },
+        {
+          "bytes": 23951748129,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/enhancer",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "enhancer",
+          "sha256": "8c91bd63a7d481eeb0115e71a0ce5df375cc8dc009357bb3284df15c6e135119",
+          "variant": "enhancer"
+        },
+        {
+          "bytes": 8899889568,
+          "path": "/Users/michael/ModelStaging/sc18783-hf-cache/models--SceneWorks--ltx-2.5-mlx/snapshots/081658ce6886cacba20817ce0359bbefef706ff2/distilled_lora/ltx-2.5-22b-distilled-lora-450-bf16.safetensors",
+          "repository": "SceneWorks/ltx-2.5-mlx",
+          "resolvedRevision": "081658ce6886cacba20817ce0359bbefef706ff2",
+          "role": "adapter",
+          "sha256": "86370bbf79a9eb4edaa158907e2b48a5188fe4c5dc8ce30c7eb8f2f131a9bbf5",
+          "variant": "dev_refinement_lora"
+        }
+      ],
+      "kind": "physical_mlx",
+      "outputs": [
+        {
+          "bytes": 2034,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/ims-edd25b7371841406eacb.request.json",
+          "role": "request",
+          "sha256": "6345de7452794dc1bd7293fb64d7f3de7ff43040d0418d400b166190a6bbb6b2"
+        },
+        {
+          "bytes": 173359165,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-129a92fcfb87a6dad613-selected_av-512x768-f145-a1c6c8ec55df72909c942889e996cbab78195db41e3c4e3c1456915964aefe9e.avbin",
+          "role": "selected_av",
+          "sha256": "a1c6c8ec55df72909c942889e996cbab78195db41e3c4e3c1456915964aefe9e"
+        },
+        {
+          "bytes": 173359165,
+          "path": "docs/calibration/sc-18791/e4d37922-b971699f/implan-129a92fcfb87a6dad613-reference_av-512x768-f145-a1c6c8ec55df72909c942889e996cbab78195db41e3c4e3c1456915964aefe9e.avbin",
+          "role": "reference_av",
+          "sha256": "a1c6c8ec55df72909c942889e996cbab78195db41e3c4e3c1456915964aefe9e"
+        }
+      ],
+      "repositories": {
+        "inference": {
+          "closureDigest": "ce3e25d7e34f63a69d9ac4a3eac97706a32704c0504b819f239a442593af8652",
+          "dirty": false,
+          "revision": "e4d37922a49f4c2d9b4ddd7e5ac0ffa5c9899ed7"
+        },
+        "sceneWorks": {
+          "dirty": false,
+          "matrixSourceRevision": "source-tree:ea23415aedce8e69c81187dfdfb1de24b390a2b1c31fafadc12eca2b66821b91",
+          "revision": "b971699faa98d8af9d263fcc5d07db20c83b0af5"
+        }
+      },
+      "result": "passed",
+      "sourcePath": "docs/calibration/sc-18791/e4d37922-b971699f/ims-edd25b7371841406eacb.log",
+      "stdoutSha256": "f419aeab91ca21a3fbd448a4a789915ae35fe0aaa9be76ea2d5b368d97deb809",
+      "target": {
+        "decoder": "diffvae",
+        "mode": "text_to_video",
+        "overlay": "none",
+        "rung": "bounded_attention",
+        "tier": "q4",
+        "transformerVariant": "dev"
+      }
+    }
+  ]
+}

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -1053,15 +1053,17 @@ test("Rust Docker dependency layers include every memory-strategy adapter target
 
 test("Rust Docker builders copy every production generated embed from sceneworks-core", async () => {
   const coreSources = await Promise.all(
-    ["memory_calibration.rs", "video_memory_curves.rs"].map((file) =>
-      source(`crates/sceneworks-core/src/${file}`),
+    ["memory_calibration.rs", "video_memory_curves.rs", "memory_anchor.rs"].map(
+      (file) => source(`crates/sceneworks-core/src/${file}`),
     ),
   );
   const generatedEmbeds = new Set(
     [
       ...coreSources
         .join("\n")
-        .matchAll(/include_str!\("\.\.\/\.\.\/\.\.\/(docs\/generated\/[^"\n]+)"\)/g),
+        .matchAll(
+          /include_str!\("\.\.\/\.\.\/\.\.\/(docs\/(?:generated|calibration)\/[^"\n]+)"\)/g,
+        ),
     ].map((match) => match[1]),
   );
   assert(generatedEmbeds.has("docs/generated/memory-calibration-evidence.json"));
@@ -1070,12 +1072,16 @@ test("Rust Docker builders copy every production generated embed from sceneworks
     [...generatedEmbeds].some((path) => path.startsWith("docs/generated/ltx-mlx-")),
     "the promoted video-memory curve must compile at least one immutable LTX evidence source",
   );
+  assert(
+    generatedEmbeds.has("docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json"),
+    "the memory-anchor store must compile its retained LTX-2.5 evidence source (sc-22507)",
+  );
 
   const dockerfile = await source("docker/rust.Dockerfile");
   for (const path of generatedEmbeds) {
     const copy = path.startsWith("docs/generated/ltx-mlx-")
       ? "COPY docs/generated/ltx-mlx-*.json ./docs/generated/"
-      : `COPY ${path} ./docs/generated/`;
+      : `COPY ${path} ./${path.slice(0, path.lastIndexOf("/") + 1)}`;
     assert.equal(
       dockerfile.split(copy).length - 1,
       2,


### PR DESCRIPTION
Walking skeleton for epic sc-22505: one measured anchor per (model, tier, backend lane) plus an analytic derivation replaces grid-measurement-based admission, delivered end-to-end for LTX-2.5 on the MLX lane.

## What this adds

**Anchor store** — `config/memory-anchors.json` (schema v1), embedded by the new `crates/sceneworks-core/src/memory_anchor.rs`. One anchor per (model, tier, backend lane): identity + source provenance + anchor geometry + the measured per-phase active-peak decomposition (conditioning / denoise / decode) + the overall allocator envelope. The loader enforces the one-anchor-per-coordinate invariant and validates every anchor byte-for-byte against the compiled retained evidence it cites (path must be a compiled source, file digest must match, and the anchor's peaks/geometry/identity must equal the cited record's) — the store cannot drift from the corpus.

**Retained corpus** — `docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json` (11 runtime-complete LTX-2.5 MLX records from the sc-18791 campaign, captured 2026-08-30 under fingerprint `sc-18797-ltx-2-5-mlx-ladder-v1`). This file existed only on the unmerged `story/sc-18791-mlx-campaign-launcher` / `evidence/sc-18791-mac2` branches (byte-identical on both); it is restored here at its original path because it is the retained measured evidence the epic's anchors and validation corpus are defined over. No new renders were taken.

**The 3 anchors** (largest untiled/unwindowed eager record per tier):
- q4 → `imc-50fbdda27ed3159a6ca1` (768x512 f145)
- q8 → `imc-7f8186376a9a3143ebee` (1280x704 f145)
- bf16 → `imc-9c4c5fe8356bcc4f139f` (704x1280 f449)

**Derivation** (`MemoryAnchor::derive_video_phase_peaks`) — per-phase, anchored affine laws per epic E2:
- latent tokens = ceil(w/32)·ceil(h/32)·(1 + ceil((f-1)/8)) (LTX x32 spatial / x8 causal temporal facts, mirrored from the MLX adapter);
- conditioning and denoise scale linearly in tokens from the anchor's intercept (attention transient is bounded by the declared `attentionChunkSize`, so there is no super-linear term);
- decode scales linearly in output voxels;
- bounded regimes substitute architecture-bounded terms: `bounded_decode` → tile-bounded decode constant, `bounded_transformer_residency` (window 1 of 48 blocks) → windowed denoise intercept + the same token slope, deferred materialization → text-embedding-only conditioning bound.
Every coefficient is a named constant with a doc comment stating the term it prices and the uncertainty its margin covers; `ANCHOR_ALLOCATOR_ENVELOPE_MARGIN` (17%) covers the observed MLX allocator envelope over active peaks (≤15.9% in the corpus) plus coefficient spread.

**Selector wiring** — in `fitted_or_floor_phase_peaks` (video lane), candidate priority is now fitted curve → **anchor-derived** → floor, with a new `CandidateBasis::EstimateAnchorDerived` graded behind the ordinary MLX estimate margin exactly like fitted-curve estimates. The anchor path is deliberately NOT hull-restricted — pricing never-measured (geometry, frames) cells is its purpose — which supersedes the exact-cell/convex-hull machinery for this model. `packaged_video_evidence_covers_request` now also counts anchor coverage, so a production LTX-2.5 request reaches the ladder instead of bypassing the gate for lack of a fitted curve. Old machinery is untouched otherwise (later stories own its removal).

## Scope vs story AC

1. *"LTX-2.5 MLX q4/q8/bf16 each carry exactly one anchor; a render at a (geometry, frame count) never measured is admitted from a derived estimate when it fits, shown by a selector test."* — Done. `ltx25_mlx_carries_exactly_one_anchor_per_tier` pins the store; `an_unmeasured_ltx25_geometry_is_admitted_from_the_anchor_derived_estimate` admits 640x640 f89 (a cell absent from the corpus) with the anchor's peak and provenance id, with a no-anchor differential control; `the_anchor_derived_estimate_admits_when_it_fits_and_refuses_when_it_does_not` walks the budget window; `the_production_funnel_admits_an_unmeasured_ltx25_geometry_from_the_anchor` proves the production entry point end-to-end.
2. *"The derivation reproduces the retained LTX-2.5 measured corpus peaks within per-term justified margins."* — Done. `derivation_brackets_every_retained_corpus_peak` runs the derivation against all 11 retained records in their exact regimes and asserts, per record: every derived phase ≥ its measured active peak, and measured allocator envelope ≤ derived admission bound ≤ envelope × 1.25 (`ANCHOR_VALIDATION_TIGHTNESS_BUDGET`, keeping the margins falsifiable). Observed bound/envelope ratios span 1.010–1.218.

## Tests

- sceneworks-core: 8 new tests (store invariants, tamper/duplicate/digest rejection, derivation identity/monotonicity/degeneracy, corpus validation).
- sceneworks-worker: 3 new tests (selector admission at an unmeasured cell + differential, fits/refuses budget window, production funnel end-to-end + uncovered-model control).
- Docker: both Rust builders now COPY the corpus file; the `platform-review-contracts` embed guard scans `memory_anchor.rs` and the new path shape (76/76 pass).

Every new assertion was mutation-checked (one mutation at a time, restored after): store byte tamper → RED; denoise slope zeroed → RED; allocator margin zeroed → RED (lower bracket); margin inflated to 100% → RED (tightness cap); tiled decode bound shrunk → RED; anchor path disabled in the selector → RED; `EstimateAnchorDerived` dropped from `is_estimate` → RED (budget-window test); anchor coverage dropped from the production gate → RED (funnel test).

## Verification

- `cargo test -p sceneworks-core --lib` (1273 passed) and `cargo test -p sceneworks-worker --lib` (2036 passed) green.
- `npm run rust:check` (macOS), `npm run rust:check:candle`, `npm run rust:check:neither` — all exit 0 (run to files, exit codes checked directly).
- `node --test scripts/platform-review-contracts.test.mjs` — 76 pass.

Part of epic sc-22505 (targets `feature/sc-22505-memory-anchor-teardown`). sc-22507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review response (2026-09-01) — scope change: 3 anchors → 6, one per measured pipeline cell

The adversarial review found the derivation pricing renders it had no measured basis for. Every item is resolved; two changed the shape of the store.

**Identity is now the pipeline cell.** `MemoryAnchor` gains `transformerVariant`, `decoder`, `provider`, and `route`, each bound to the source record at load (route resolves via `target.route` or `target.provider`, mirroring `video_memory_curves::source_route`). The store key and `anchor_for` are `(model, tier, lane, transformer variant, decoder)`. All three original anchors were measured `dev`/`diffvae` while the corpus spans four combos — the AC selector test was demonstrating a dev/diffvae anchor pricing a distilled/conv render.

Rather than restricting the validation corpus to the anchor's cell (which would have dropped tiled, windowed and deferred coverage entirely — every such record is `distilled` or `conv`), the store now carries **one anchor per measured cell, six in total**:

| tier | variant | decoder | anchor record | regime |
|---|---|---|---|---|
| q4 | dev | diffvae | `imc-50fbdda27ed3159a6ca1` | eager, unbounded |
| q8 | dev | diffvae | `imc-7f8186376a9a3143ebee` | eager, unbounded |
| q8 | dev | conv | `imc-beaa0f2aacf0832ea28a` | eager, tiled decode |
| bf16 | dev | diffvae | `imc-9c4c5fe8356bcc4f139f` | eager, unbounded |
| bf16 | distilled | diffvae | `imc-6f2b28a41967fd486b50` | deferred, windowed |
| bf16 | distilled | conv | `imc-4e1b3a02a6ced3434824` | deferred, windowed, tiled |

All 11 retained records stay in the validation corpus, each priced by its own cell's anchor. No new renders; the anchor for each cell is its largest measured output geometry, so every corpus extrapolation runs downward.

**The anchor's own measured regime is load-bearing.** `loadShape` was documented as informational, but the conditioning and denoise intercepts depend on it — a deferred-measured intercept applied to an eager request under-estimates by the entire transformer residency. Anchors now carry `measuredRegime` (bounded decode / windowed residency) bound to the source record's `engagedRungs`, and `derive_video_phase_peaks` returns `None` for any request whose phase would reuse an intercept measured in a bounded regime.

**Tiled decode is no longer geometry-blind.** `DECODE_TILED_BOUND_BYTES` was a flat 9 GB whose geometry-independence was validated at exactly one output geometry (both tiled captures sit at 130.7M voxels). Tiling bounds the workspace, not the output clip, so it is now `DECODE_TILE_WORKSPACE_BYTES + DECODE_TILED_PER_VOXEL_BYTES * voxels` (7 GB workspace + RGB fp32 output), which grows without bound in geometry.

**Margins are per-term (closes the AC2 scope gap).** Coefficient uncertainty moved out of the blanket multiplier and into the coefficients themselves: `DECODE_PER_VOXEL_BYTES` 48 → 63, the observed upper within-cell slope (48 sat mid-spread and crossed below the measured trend at ~1.85e9 voxels). `ANCHOR_ALLOCATOR_ENVELOPE_MARGIN` (0.17) is now justified by one term only — the allocator envelope over the binding active phase, observed at up to 15.84%. Each bound constant states the tier it was measured on and why that tier upper-bounds the others. The "single-pass conv-VAE" mislabel is corrected to diffvae (every non-tiled decode record is diffvae; single-pass conv is unmeasured and the regime guard keeps it out).

**Calibration currency.** `anchor_currency_matches` requires the contract to carry a calibration identity whose ABI matches the request and whose fingerprint names the anchor's campaign; `anchor_evidence_covers_request` mirrors it. A pin bump or ABI change now demotes the anchor derivation exactly as it demotes the fitted curve. sc-22511 re-keys currency on the model's own loader closure — that helper is the single seam it changes; no new currency scheme was invented here.

**Numerics and hygiene.** `widened` returns `None` rather than clamping a non-positive extrapolation to a 0-byte peak that would admit anything. `latent_tokens` uses `saturating_sub(1)` at `frames == 0`. `geometry.fps` is validated against the `outputFps` measurement instead of being serialized and ignored. A comment at the decode branch states why `decode_tiled` keys on the engaged rung rather than `geometry.decode_pass`.

### New falsifiers

- `every_per_unit_coefficient_bounds_the_highest_measured_within_cell_slope` — computes within-cell slopes from the corpus and asserts each coefficient is at or above the highest. The bracket test cannot ask this: its records sit too near the anchors for a mid-spread coefficient to show.
- `derivation_brackets_every_retained_corpus_peak` now asserts the tiled bound grows with voxels, and annotates (never fails) the tiers whose token/frames extrapolation is validated by zero independent cells — q4 today, where both records share the anchor's geometry.
- `an_anchor_measured_in_a_bounded_regime_refuses_the_unbounded_request`, `a_foreign_pipeline_cell_resolves_no_anchor`, `a_doctored_load_shape_or_measured_regime_is_rejected`, `a_doctored_pipeline_identity_provider_route_or_fps_is_rejected`, `a_non_positive_phase_estimate_is_refused_rather_than_clamped_to_zero`, `latent_tokens_does_not_underflow_at_zero_frames`.
- Worker: `an_unmeasured_pipeline_cell_falls_to_the_estimate_floor` (q8 distilled/conv → `video-estimate-floor-v1`) and `a_foreign_identity_or_staled_calibration_does_not_reach_the_anchor_derivation` (family, mode, route, variant, decoder, absent pipeline identity, moved ABI, foreign provider, absent/staled calibration — plus an end-to-end control proving a staled fingerprint really lands on the floor and closes the evidence gate).

The module doc now records the validated domain: frames measured at 145 and 449 only, the frames term validated downward from f449 to f145 on `bf16 dev/diffvae` and nowhere else.

### Mutation verification

Every new or changed assertion, one mutation at a time, `touch` between runs, restored after — all RED:

| assertion | mutation | result |
|---|---|---|
| `every_per_unit_coefficient_bounds_…` | `DECODE_PER_VOXEL_BYTES` 63 → 48 | RED |
| `derivation_brackets_every_retained_corpus_peak` | `DECODE_TILED_PER_VOXEL_BYTES` 12 → 0 (flat bound) | RED |
| `a_non_positive_phase_estimate_is_refused_…` | restore `bytes.max(0)` in `widened` | RED |
| `latent_tokens_does_not_underflow_at_zero_frames` | restore `(frames - 1)` | RED |
| `an_anchor_measured_in_a_bounded_regime_refuses_…` | delete the regime guard in `derive_video_phase_peaks` | RED |
| `a_foreign_pipeline_cell_resolves_no_anchor` | drop variant/decoder from `anchor_for` | RED |
| `an_unmeasured_pipeline_cell_falls_to_the_estimate_floor` | same | RED |
| `a_doctored_load_shape_or_measured_regime_is_rejected` | delete the `loadShape` check | RED |
| `a_doctored_load_shape_or_measured_regime_is_rejected` | neuter the `engagedRungs` check | RED |
| `a_doctored_pipeline_identity_provider_route_or_fps_is_rejected` | delete provider/route/variant/decoder from the identity check | RED |
| `a_doctored_pipeline_identity_provider_route_or_fps_is_rejected` | neuter the `outputFps` check | RED |
| `ltx25_mlx_carries_exactly_one_anchor_per_measured_pipeline_cell` | delete the q8 dev/conv anchor from the store | RED |
| `a_foreign_identity_or_staled_calibration_…` | drop `anchor.provider != contract.provider_id` | RED |
| `a_foreign_identity_or_staled_calibration_…` | drop `anchor_currency_matches` | RED |
| `a_foreign_identity_or_staled_calibration_…` | drop `anchor.route != identity.route` | RED |
| `a_foreign_identity_or_staled_calibration_…` | drop the calibration clause from `anchor_evidence_covers_request` | RED |

### Verification

`npm run rust:check`, `npm run rust:check:candle`, `npm run rust:check:neither` — all exit 0 (redirected to files, exit codes read directly, not through a pipe).
