### PR TITLE
Per-term margins replace blanket estimate widening (sc-22508)

### DIFF
--- a/crates/sceneworks-worker/src/candle_memory_strategy.rs
+++ b/crates/sceneworks-worker/src/candle_memory_strategy.rs
@@ -7,7 +7,7 @@
 //! ESTIMATE-floor candidate —
 //! manifest `vramGbByTier`/`sequentialPeakGb` rows plus the standard headroom, never a promised
 //! unmeasured saving — graded by the shared selector behind the candle estimate margin
-//! (`crate::ladder_margin_policy::CANDLE_ESTIMATE_MARGIN`; CUDA OOM is a recoverable `Err`, so the
+//! (`crate::ladder_margin_policy::CANDLE_RECAPTURE_SPREAD`; CUDA OOM is a recoverable `Err`, so the
 //! margin is looser than MLX's). Any eligible measured candidate at the same rung supersedes the
 //! estimate, so measured-current admission is byte-for-byte unchanged; an UNCERTIFIED artifact
 //! gets no floors at all (the manifest rows describe the certified bytes, not an imported
@@ -1938,6 +1938,11 @@ fn evaluate_shared_image_inner(
                 evidence,
                 closure_digest,
                 basis: *basis,
+                // sc-22508: the candle floors here are manifest `sequentialPeakGb`/`vramGbByTier`
+                // rows, not a weights+headroom split this lane can decompose, so no activation term
+                // is declared and the selector charges the backend's whole-peak accounting residual
+                // (`CANDLE_RECAPTURE_SPREAD`). Declaring a split is sc-22509's anchor work.
+                unmodeled_activation_bytes: None,
             },
         )
         .collect::<Vec<_>>();
@@ -2928,7 +2933,7 @@ mod tests {
                 ((tier_resident_gb(tier) * BYTES_PER_GIB).ceil() as u64)
                     .max(facts.base_bytes.saturating_add(headroom_bytes)),
             );
-            let free_gb = staged_gb * (1.0 + crate::ladder_margin_policy::CANDLE_ESTIMATE_MARGIN)
+            let free_gb = staged_gb * (1.0 + crate::ladder_margin_policy::CANDLE_RECAPTURE_SPREAD)
                 + crate::vram_gate::HEADROOM_GB
                 + 0.5;
             assert!(
@@ -4242,7 +4247,7 @@ mod tests {
         // a margin re-derivation would silently move the window again.
         let staged_floor_gb = STAGED_ROW_GB + crate::vram_gate::HEADROOM_GB;
         let widened_staged_gb =
-            staged_floor_gb * (1.0 + crate::ladder_margin_policy::CANDLE_ESTIMATE_MARGIN);
+            staged_floor_gb * (1.0 + crate::ladder_margin_policy::CANDLE_RECAPTURE_SPREAD);
         let free_gb = widened_staged_gb + SELECTOR_RESERVE_GB + 0.3;
         assert!(
             free_gb - SELECTOR_RESERVE_GB < RESIDENT_PEAK_GB,
@@ -5169,7 +5174,7 @@ mod tests {
         // does not — recomputed from the policy margin, never a frozen literal.
         let staged_row_floor_gb = 2.5 + crate::vram_gate::HEADROOM_GB;
         let free_gb = staged_row_floor_gb
-            * (1.0 + crate::ladder_margin_policy::CANDLE_ESTIMATE_MARGIN)
+            * (1.0 + crate::ladder_margin_policy::CANDLE_RECAPTURE_SPREAD)
             + crate::vram_gate::HEADROOM_GB
             + 0.3;
         assert!(

--- a/crates/sceneworks-worker/src/krea_control_fit.rs
+++ b/crates/sceneworks-worker/src/krea_control_fit.rs
@@ -713,6 +713,7 @@ fn fit_ladder_for_tier(
             evidence,
             closure_digest: measured_closure_digest,
             basis: crate::memory_strategy::CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         })
         .collect::<Vec<_>>();
     // A floor is a declaration under the LIVE closure — nothing there for currency to invalidate.
@@ -721,6 +722,9 @@ fn fit_ladder_for_tier(
         evidence,
         closure_digest: &live_closure_digest,
         basis: crate::memory_strategy::CandidateBasis::EstimateFloor,
+        // sc-22508: this control-lane floor is a manifest-row declaration, not a weights+headroom
+        // split, so it declares no activation term and takes the candle whole-peak residual.
+        unmodeled_activation_bytes: None,
     }));
     match crate::memory_strategy::select_strategy(
         request,
@@ -1179,7 +1183,7 @@ mod tests {
         // CONSTANT and could never fire); the outcome it pinned was a BestEffort fallback.
         // sc-18095 (epic 18093) turns that currency into a signal: a control ladder whose provider
         // closure moved keeps serving its measured rows, graded at the candle stale-measured
-        // margin (`crate::ladder_margin_policy::CANDLE_STALE_MEASURED_MARGIN`, 2%), instead of
+        // margin (`crate::ladder_margin_policy::CANDLE_RECAPTURE_SPREAD`, 2%), instead of
         // being demoted. Both digest sides are still read rather than frozen: `expected` is the
         // live digest for `candle:krea_2_turbo_control` from the packaged closure table, and the
         // candidate carries `candle.control.inferenceClosureDigest` from the manifest. This test
@@ -1667,7 +1671,7 @@ mod tests {
         let sequential = 30.0;
         let staged_floor = sequential - HEADROOM_GB;
         let resident_floor = peak - HEADROOM_GB;
-        let margin = crate::ladder_margin_policy::CANDLE_ESTIMATE_MARGIN;
+        let margin = crate::ladder_margin_policy::CANDLE_RECAPTURE_SPREAD;
         // An effective budget between the WIDENED staged floor and the resident floor: a rung
         // priced on the staged row admits here; one clamped to the resident row cannot. Recomputed
         // from the policy margin, never a frozen literal.

--- a/crates/sceneworks-worker/src/ladder_e2e_sc18101.rs
+++ b/crates/sceneworks-worker/src/ladder_e2e_sc18101.rs
@@ -48,18 +48,17 @@ use crate::mlx_fit_gate::{MlxRequestInputs, MlxRequestPlan};
 // ---------------------------------------------------------------------------------------------
 // The margins, taken FROM the policy rather than restated (sc-18101 review #4).
 //
-// Every margin-shaped literal in this file is derived from these two constants: the arithmetic
-// (`1.0 + …`) and the tracing substrings (`estimate_margin={…}`) alike. Editing a policy constant
-// therefore changes what these scenarios assert, instead of leaving them asserting a margin nobody
-// ships. `margin_substrings_match_the_emitted_tracing` pins the one step the compiler cannot check:
-// that `{}`-formatting a constant reproduces the token `tracing` actually writes.
+// sc-22508 retired the blanket per-backend margins. What the selector now emits is a NAMED term
+// plus the bytes it charged, so these scenarios assert the term and the arithmetic
+// (`widened == raw + allowance_bytes`) instead of a single fraction.
+// `margin_substrings_match_the_emitted_tracing` pins the one step the compiler cannot check: that
+// `{}`-formatting a constant reproduces the token `tracing` actually writes.
 //
 // BASELINE-CHECKOUT PATCH: `crate::ladder_margin_policy` does not exist before sc-18094, so a
-// pre-epic checkout replaces exactly these two lines with `= 0.10;` and `= 0.05;`. Nothing else in
-// this file differs there.
+// pre-epic checkout replaces exactly this line with `= 0.05;`. Nothing else in this file differs
+// there.
 // ---------------------------------------------------------------------------------------------
-const ESTIMATE_MARGIN: f64 = crate::ladder_margin_policy::MLX_ESTIMATE_MARGIN;
-const STALE_MARGIN: f64 = crate::ladder_margin_policy::MLX_STALE_MEASURED_MARGIN;
+const STALE_MARGIN: f64 = crate::ladder_margin_policy::MLX_RECAPTURE_SPREAD;
 
 /// Where renders, selection logs, and the machine-readable evidence rows are written. Stable and
 /// outside the repo so a run's artifacts survive a `git clean` and can be diffed across commits.
@@ -472,21 +471,26 @@ fn c1_unmeasured_cell_engages_a_deep_rung_and_renders() {
         ),
         "criterion 1 requires the SELECTION to be estimate-scoped:\n{log}"
     );
-    let estimate_margin_field = format!("estimate_margin={ESTIMATE_MARGIN}");
+    // sc-22508: the image lane's estimate candidates are weights+headroom FLOORS, so the allowance
+    // the selector charges must be the headroom term — named in the event, not a blanket fraction.
+    let allowance_term_field = format!(
+        "allowance_term={}",
+        crate::ladder_margin_policy::AdmissionTerm::AllocatorEnvelopeOverActivation.as_key()
+    );
     assert!(
-        log.contains(&estimate_margin_field),
-        "criterion 1 requires the applied MLX estimate margin ({ESTIMATE_MARGIN}) in the logs:\n{log}"
+        log.contains(&allowance_term_field),
+        "criterion 1 requires the per-term allowance ({allowance_term_field}) in the logs:\n{log}"
     );
 
     // The admitted ceiling is the WIDENED peak, not `context.predicted_peak_bytes`.
     //
     // `mlx_fit_gate.rs:2404-2417` deliberately puts the estimate's RAW peak on the run context: the
-    // context carries the rung's incremental working-set demand, while the margin lives in the
+    // context carries the rung's incremental working-set demand, while the allowance lives in the
     // admission arithmetic (`memory_strategy::select_strategy` grades against
-    // `raw * (1 + estimate_margin)` and the refusal message quotes that widened number). Comparing
+    // `raw + allowance_bytes` and the refusal message quotes that widened number). Comparing
     // the observed peak against the raw context value would be checking the prediction WITHOUT its
-    // margin — a stricter test than the policy promises, and not the one the story specifies. Both
-    // numbers are recorded; the assertion is against the widened one.
+    // allowance — a stricter test than the policy promises, and not the one the story specifies.
+    // Both numbers are recorded; the assertion is against the widened one.
     let raw_peak_bytes = field_in_line(
         &log,
         "memory-strategy selection uses an estimate-backed candidate at the widened peak",
@@ -499,10 +503,16 @@ fn c1_unmeasured_cell_engages_a_deep_rung_and_renders() {
         "widened_peak_bytes=",
     )
     .expect("the selection event carries widened_peak_bytes");
+    let allowance_bytes = field_in_line(
+        &log,
+        "memory-strategy selection uses an estimate-backed candidate at the widened peak",
+        "allowance_bytes=",
+    )
+    .expect("the selection event carries allowance_bytes");
     assert_eq!(
         admitted_ceiling_bytes,
-        (raw_peak_bytes as f64 * (1.0 + ESTIMATE_MARGIN)).ceil() as u64,
-        "the admitted ceiling must be the raw estimate times the MLX estimate margin"
+        raw_peak_bytes + allowance_bytes,
+        "the admitted ceiling must be the raw estimate plus exactly the named per-term allowance"
     );
 
     let render_memory = evaluation.memory;
@@ -566,7 +576,8 @@ fn c1_unmeasured_cell_engages_a_deep_rung_and_renders() {
         "rawEstimateGib": gib(raw_peak_bytes),
         "admittedCeilingBytes": admitted_ceiling_bytes,
         "admittedCeilingGib": gib(admitted_ceiling_bytes),
-        "estimateMargin": ESTIMATE_MARGIN,
+        "allowanceTerm": crate::ladder_margin_policy::AdmissionTerm::AllocatorEnvelopeOverActivation.as_key(),
+        "allowanceFraction": crate::ladder_margin_policy::FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE,
         "contextPredictedPeakGib": gib(evaluation.context.predicted_peak_bytes),
         "observedPeakBytes": observed_peak_bytes,
         "observedPeakGib": gib(observed_peak_bytes),
@@ -952,7 +963,7 @@ fn c3_current_lane_enforces_exact_static_boundary() {
     );
     assert!(
         !log.contains("stale-closure")
-            && !log.contains("stale_margin=")
+            && !log.contains("allowance_term=same_cell_recapture_spread")
             && !log.contains("widened peak"),
         "criterion 3 requires current evidence to be graded at the raw peak without stale \
          widening:\n{log}"
@@ -1196,7 +1207,8 @@ fn c5_fitted_curve_estimate_is_synthesized_and_admitted() {
         "fittedRawPeakBytes": raw,
         "fittedRawPeakGib": gib(raw),
         "firstWidenedPeakBytes": widened,
-        "estimateMargin": ESTIMATE_MARGIN,
+        "allowanceTerm": crate::ladder_margin_policy::AdmissionTerm::AllocatorEnvelopeOverActivation.as_key(),
+        "allowanceFraction": crate::ladder_margin_policy::FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE,
         "tierDir": tier_dir.display().to_string(),
     }));
 }
@@ -1365,36 +1377,35 @@ fn load_shape_population_is_typed_and_manifest_derived() {
 /// The one margin coupling the compiler cannot check: that `{}`-formatting a policy constant
 /// reproduces the exact token `tracing` writes into the event.
 ///
-/// The scenarios above grep for `estimate_margin={ESTIMATE_MARGIN}`. `tracing` records an `f64`
-/// field with `Display`, so a rounded substring would never match the corpus-derived policy token,
-/// and a substring built from a literal would silently stop matching if the policy moved. Building
-/// it from the constant with `{}` is correct only as long as both sides agree, which is what this
-/// asserts.
+/// The scenarios above grep for `allowance_term=…` and for `{STALE_MARGIN}`. `tracing` records an
+/// `f64` field with `Display`, so a rounded substring would never match the corpus-derived policy
+/// token, and a substring built from a literal would silently stop matching if the policy moved.
+/// Building it from the constant with `{}` is correct only as long as both sides agree, which is
+/// what this asserts.
 #[test]
 fn margin_substrings_match_the_emitted_tracing() {
     use std::fmt::Write as _;
 
     // Reproduce exactly how `tracing`'s field formatter renders the value the gate passes it.
     let mut rendered = String::new();
-    write!(rendered, "{ESTIMATE_MARGIN}").expect("f64 formats");
-    assert_eq!(
-        rendered, "0.5040734033902377",
-        "MLX estimate margin token drifted"
-    );
-    rendered.clear();
     write!(rendered, "{STALE_MARGIN}").expect("f64 formats");
     assert_eq!(
-        rendered, "0.2520367016951188",
-        "MLX stale-measured margin token drifted"
+        rendered, "0.1260183508475594",
+        "MLX same-cell recapture spread token drifted"
     );
 
-    // And the constants really are the policy's, not a local copy that happens to agree.
-    assert_eq!(
-        ESTIMATE_MARGIN,
-        crate::ladder_margin_policy::MLX_ESTIMATE_MARGIN
-    );
+    // And the constant really is the policy's, not a local copy that happens to agree.
     assert_eq!(
         STALE_MARGIN,
-        crate::ladder_margin_policy::MLX_STALE_MEASURED_MARGIN
+        crate::ladder_margin_policy::MLX_RECAPTURE_SPREAD
+    );
+    // The term keys the scenarios grep for are the policy's own, not restated literals.
+    assert_eq!(
+        crate::ladder_margin_policy::AdmissionTerm::AllocatorEnvelopeOverActivation.as_key(),
+        "allocator_envelope_over_activation"
+    );
+    assert_eq!(
+        crate::ladder_margin_policy::AdmissionTerm::SameCellRecaptureSpread.as_key(),
+        "same_cell_recapture_spread"
     );
 }

--- a/crates/sceneworks-worker/src/ladder_margin_policy.rs
+++ b/crates/sceneworks-worker/src/ladder_margin_policy.rs
@@ -24,11 +24,13 @@
 //!   `scripts/derive-ladder-margins.mjs` reports the max binding-phase spread across the corpus's
 //!   repeat pairs, and the epic-18093 "x2 safety" and "x2 estimate widening" multipliers that sat
 //!   on top of it — neither of which named a term — are gone.
-//! * [`AdmissionTerm::AllocatorEnvelopeOverActivation`] — the MLX allocator envelope that sits
-//!   above a floor's modelled ACTIVATION bytes. It is proportionate ONLY to that activation
-//!   (headroom) term. The weights half of a floor is counted bytes off the manifest that the
-//!   allocator holds exactly once, so charging it a percentage was the single largest piece of the
-//!   retired blanket margin.
+//! * [`AdmissionTerm::AllocatorEnvelopeOverActivation`] — the allocator envelope that sits above a
+//!   floor's modelled ACTIVATION bytes. It is proportionate ONLY to that activation (headroom)
+//!   term. The weights half of a floor is counted bytes off the manifest that the allocator holds
+//!   exactly once, so charging it a percentage was the single largest piece of the retired blanket
+//!   margin. The fraction is per-backend ([`FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE`] on MLX,
+//!   [`CANDLE_FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE`] on candle) because the envelope is a property of
+//!   the allocator, not of the term's name.
 //!
 //! The margin constants are pinned against the derivation by
 //! `scripts/derive-ladder-margins.test.mjs`, so corpus growth that widens the measured spread reds
@@ -56,14 +58,22 @@ pub const MLX_RECAPTURE_SPREAD: f64 = 0.1260183508475594;
 /// reclaimable slack), so the residual is small and bounded by the accounting, not by variance.
 pub const CANDLE_RECAPTURE_SPREAD: f64 = 0.02;
 
-/// Allowance on the ACTIVATION (headroom) term of a weights+headroom floor, as a fraction of THAT
-/// TERM — not of the floor.
+/// Allowance on the ACTIVATION (headroom) term of an MLX weights+headroom floor, as a fraction of
+/// THAT TERM — not of the floor.
 ///
 /// UNCERTAINTY COVERED: the MLX allocator envelope that sits above the modelled active bytes
 /// (cache retention across phase transitions), measured at up to 15.84% over the binding active
-/// phase across the retained corpus and bounded at 17% — the SAME term, from the same measurement,
-/// that `sceneworks_core::memory_anchor::ANCHOR_ALLOCATOR_ENVELOPE_MARGIN` prices for a derived
-/// peak. A floor's weights are allocated once and counted exactly, so they carry none of it.
+/// phase across the retained corpus and bounded at 17% — the same envelope, from the same
+/// measurement, that `sceneworks_core::memory_anchor::ANCHOR_ALLOCATOR_ENVELOPE_MARGIN` prices for
+/// a derived peak. A floor's weights are allocated once and counted exactly, so they carry none of
+/// it.
+///
+/// DIFFERENT BASE, same constant — state it rather than let the shared number imply otherwise.
+/// `memory_anchor::widened` multiplies a WHOLE derived phase estimate (its weights included) by
+/// this fraction, while this constant multiplies a floor's ACTIVATION term alone. The two are equal
+/// because the envelope was measured once, not because they are charged against the same quantity;
+/// the equality pin below is a pin on the measurement, not on the base. Whether the anchor side
+/// should narrow its base to activation is carried to the feature-end review, NOT decided here.
 ///
 /// NOT COVERED, deliberately: whether one flat headroom number is the right ACTIVE model for this
 /// geometry at all. That residual is unmeasured, and epic 22505 E6 makes runtime catching its
@@ -71,6 +81,23 @@ pub const CANDLE_RECAPTURE_SPREAD: f64 = 0.02;
 /// blanket 50.41% was that standing multiple, priced against the whole peak and named after
 /// nothing.
 pub const FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE: f64 = 0.17;
+
+/// The candle lane's counterpart to [`FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE`], charged against the
+/// SAME term (a floor's activation bytes) but named separately because the uncertainty is a
+/// different physical thing and must not silently inherit an MLX allocator measurement.
+///
+/// UNCERTAINTY COVERED: candle has no allocator-pool envelope to measure — its evidence is
+/// deterministic live-allocation counting, and `scripts/derive-ladder-margins.mjs` records that 10
+/// of the corpus's candle records report observed == predicted to the byte with no record showing
+/// reclaimable slack. What remains above a candle floor's modelled activation is that accounting
+/// residual, which is exactly the quantity [`CANDLE_RECAPTURE_SPREAD`] documents; this constant is
+/// defined as that value rather than restating a second number the corpus does not separately
+/// measure.
+///
+/// It is deliberately NOT 17%: the 17% figure is a measurement of the MLX allocator's retention
+/// across phase transitions, a mechanism candle's counted allocations do not have. Borrowing it
+/// would be picking a margin by magnitude, which is what E3 retires.
+pub const CANDLE_FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE: f64 = CANDLE_RECAPTURE_SPREAD;
 
 /// Constraint inherited by the estimate-admission follow-ups (sc-18096/18097), pinned here
 /// because the allowances above cannot carry it: estimate-backed admission MUST NOT admit a
@@ -185,6 +212,16 @@ const fn recapture_spread(backend: MemoryBackend) -> f64 {
     }
 }
 
+/// Allocator envelope over a declared floor's ACTIVATION term, for one backend. Matched
+/// exhaustively for the same reason as [`recapture_spread`]: a new backend must name its own
+/// envelope rather than inherit one measured on somebody else's allocator.
+const fn floor_envelope_allowance(backend: MemoryBackend) -> f64 {
+    match backend {
+        MemoryBackend::Candle => CANDLE_FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE,
+        MemoryBackend::Mlx => FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE,
+    }
+}
+
 /// The one allowance the selector adds on top of a candidate's peak.
 ///
 /// The undeclared-floor arm is the only approximation left, and it is stated rather than hidden: a
@@ -217,7 +254,7 @@ pub fn admission_allowance(subject: AdmissionSubject) -> AdmissionAllowance {
             if subject.unmodeled_activation_bytes.is_some() {
                 AdmissionAllowance {
                     term: AdmissionTerm::AllocatorEnvelopeOverActivation,
-                    fraction: FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE,
+                    fraction: floor_envelope_allowance(subject.backend),
                 }
             } else {
                 spread
@@ -236,6 +273,13 @@ const _: () = {
     // The fatal-OOM lane is never charged less than the recoverable one for the SAME term.
     assert!(MLX_RECAPTURE_SPREAD >= CANDLE_RECAPTURE_SPREAD);
     assert!(FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE > 0.0 && FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE < 1.0);
+    assert!(
+        CANDLE_FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE > 0.0
+            && CANDLE_FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE < 1.0
+    );
+    // Same ordering rule as the recapture term: the fatal-OOM lane is never charged less than the
+    // recoverable one for the SAME term.
+    assert!(FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE >= CANDLE_FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE);
     assert!(ESTIMATE_ADMISSION_REQUIRES_MEASURED_BINDING_PHASE);
     assert!(RESIDUAL_BOUNDED_MAX_OVER_PHASES_EXEMPT_FROM_BINDING_PHASE_PIN);
 };
@@ -253,11 +297,42 @@ mod tests {
         assert_eq!(MLX_RECAPTURE_SPREAD, 0.1260183508475594);
         assert_eq!(CANDLE_RECAPTURE_SPREAD, 0.02);
         assert_eq!(FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE, 0.17);
-        // Same term, same measurement, one number: the anchor derivation prices this exact
-        // envelope for a derived peak, and a floor must not price it differently.
+        assert_eq!(
+            CANDLE_FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE,
+            CANDLE_RECAPTURE_SPREAD
+        );
+        // One measurement, one number: the anchor derivation prices this same measured envelope,
+        // and a floor must not price the envelope differently.
+        //
+        // The BASE differs, deliberately and on the record: `memory_anchor::widened` multiplies a
+        // whole derived phase estimate (weights included) by this fraction, while the floor
+        // allowance multiplies the activation term alone. This equality therefore pins the shared
+        // measurement, NOT a shared base. Narrowing the anchor side's base is a live question for
+        // the epic 22505 feature-end review and is out of scope here.
         assert_eq!(
             FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE,
             sceneworks_core::memory_anchor::ANCHOR_ALLOCATOR_ENVELOPE_MARGIN
+        );
+    }
+
+    /// The floor envelope is a property of the ALLOCATOR, so the two lanes must not share one
+    /// fraction. A candle floor that inherited the MLX allocator's 17% would be charged 8.5x its
+    /// own measured accounting residual on a term candle counts exactly.
+    #[test]
+    fn each_backend_prices_its_own_floor_envelope() {
+        let headroom = 18_000_000_000_u64;
+        let mlx = admission_allowance(subject(CandidateBasis::EstimateFloor, Some(headroom)));
+        let candle = admission_allowance(AdmissionSubject {
+            backend: MemoryBackend::Candle,
+            ..subject(CandidateBasis::EstimateFloor, Some(headroom))
+        });
+        assert_eq!(mlx.term, AdmissionTerm::AllocatorEnvelopeOverActivation);
+        assert_eq!(candle.term, AdmissionTerm::AllocatorEnvelopeOverActivation);
+        assert_eq!(mlx.fraction, FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE);
+        assert_eq!(candle.fraction, CANDLE_FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE);
+        assert!(
+            candle.bytes(60_000_000_000, headroom) < mlx.bytes(60_000_000_000, headroom),
+            "the recoverable lane must not be charged the fatal lane's allocator envelope"
         );
     }
 

--- a/crates/sceneworks-worker/src/ladder_margin_policy.rs
+++ b/crates/sceneworks-worker/src/ladder_margin_policy.rs
@@ -1,87 +1,79 @@
-//! Ladder margin policy derived from repeat-capture variance (sc-18094, epic 18093).
+//! Per-term admission allowances (sc-22508, epic 22505).
 //!
-//! Epic 18093 retires "measurement currency as a gate". Instead of invalidating evidence whose
-//! closure digest went stale, the selector keeps it eligible behind a widened margin (sc-18095,
-//! applied in `crate::memory_strategy::select_strategy`), and will admit estimate-backed rungs
-//! nobody has measured behind a wider one still (sc-18096/18097). This module owns ONLY the margin
-//! constants those consumers read; it changes no selector behavior by itself.
+//! Epic 18093 shipped ONE multiplicative margin per backend per currency — `peak * 1.5041` on the
+//! MLX estimate path, `peak * 1.2520` on the MLX stale path — applied to the whole predicted peak
+//! regardless of which part of that peak was actually uncertain. On a 60 GB derived peak the MLX
+//! estimate margin alone added 30 GB of pad, which is what kept a request that truly fits a 128 GB
+//! host out of rungs it fits on. Epic 22505 E3 retires that shape: **an allowance is priced against
+//! the specific term whose value is uncertain, never against the whole peak just because the whole
+//! peak is what the selector happens to hold.**
 //!
-//! Every value here is pinned to a committed derivation —
-//! `scripts/derive-ladder-margins.mjs`, run against
-//! `docs/generated/memory-calibration-evidence.json` (89 records as derived) — and
-//! `scripts/derive-ladder-margins.test.mjs` fails if a constant and the derivation output ever
-//! disagree, so evidence growth that pushes observed variance past a floor reds CI instead of
-//! silently under-margining. Derivation summary as of the 89-record corpus:
+//! There are exactly three terms, and each names the uncertainty it covers:
 //!
-//! * mlx: 22 repeat groups (85 pairs) sharing the full evidence key
-//!   (route/backend/tier/rung/parameters/geometry). Max binding-relevant capture-to-capture
-//!   spread on a phase peak: 12.6018% (the historical versus SC-19753 Z-Image q4 bounded-
-//!   transformer-residency conditioning peak). Doubled as a safety term: 25.2037%, so variance
-//!   now overrides the 5% floor. The binding/non-binding split is a SAME-CELL argument only;
-//!   the max CAN-BIND per-phase spread (any phase, accounting flips excluded) is 17.1369%, whose
-//!   fully widened 68.55% estimate term still exceeds the shipped 50.4073% estimate margin — see
-//!   [`ESTIMATE_ADMISSION_REQUIRES_MEASURED_BINDING_PHASE`].
-//! * candle: 15 records, all unique keys, ZERO repeat pairs. Per the sc-18094 rule the hard
-//!   floor is the whole margin; no variance number is invented.
+//! * [`AdmissionTerm::FullyPriced`] — nothing is left for the selector to add. Two bases reach it.
+//!   A MEASURED cell under the live closure is the measurement. An
+//!   [`CandidateBasis::EstimateAnchorDerived`] peak already carries both of its uncertainties
+//!   inside the derivation (`sceneworks_core::memory_anchor`): coefficient uncertainty is priced
+//!   INSIDE each coefficient (every slope sits at or above the highest measured within-cell slope)
+//!   and the MLX allocator envelope above a phase's active peak is priced by
+//!   `ANCHOR_ALLOCATOR_ENVELOPE_MARGIN`. Re-widening it here would double-charge terms the
+//!   derivation already paid for.
+//! * [`AdmissionTerm::SameCellRecaptureSpread`] — capture-to-capture spread of the SAME cell's
+//!   binding phase. This one IS proportionate to the whole peak, because the quantity that moves
+//!   between two captures of one cell is the peak itself. Derived, not invented:
+//!   `scripts/derive-ladder-margins.mjs` reports the max binding-phase spread across the corpus's
+//!   repeat pairs, and the epic-18093 "x2 safety" and "x2 estimate widening" multipliers that sat
+//!   on top of it — neither of which named a term — are gone.
+//! * [`AdmissionTerm::AllocatorEnvelopeOverActivation`] — the MLX allocator envelope that sits
+//!   above a floor's modelled ACTIVATION bytes. It is proportionate ONLY to that activation
+//!   (headroom) term. The weights half of a floor is counted bytes off the manifest that the
+//!   allocator holds exactly once, so charging it a percentage was the single largest piece of the
+//!   retired blanket margin.
 //!
-//! A margin is a fraction: a candidate fits a budget when
-//! `peak_bytes * (1.0 + margin) <= budget_bytes`.
+//! The margin constants are pinned against the derivation by
+//! `scripts/derive-ladder-margins.test.mjs`, so corpus growth that widens the measured spread reds
+//! CI instead of silently under-charging.
 
-/// Hard floor for MLX margins, applied when repeat-capture variance is thin. The 89-record corpus's
-/// 25.2037% variance term currently exceeds it; it remains the minimum for a future thinner corpus.
-/// Why 5%:
+use gen_core::MemoryBackend;
+
+use crate::memory_strategy::CandidateBasis;
+
+/// Same-cell capture-to-capture spread on the MLX lane: the max binding-phase spread over the
+/// corpus's repeat pairs (`scripts/derive-ladder-margins.mjs`, `recaptureSpread`).
 ///
-/// 1. An MLX allocator overshoot aborts the whole worker process via the default MLX error
-///    handler (no recoverable `Err` exists on that lane), so the margin must cover variance not
-///    yet sampled, not just the 12.60% max observed across 85 pairs in the current corpus.
-/// 2. The evidence corpus itself demonstrates ~5% envelope headroom: across all 74 MLX records
-///    the shipped predictor's envelope gap `(predicted - observed) / predicted` spans
-///    4.76%..5.58% — computed and printed by `scripts/derive-ladder-margins.mjs`
-///    (`predictorEnvelopeGapRange`) and pinned in `scripts/derive-ladder-margins.test.mjs`, not
-///    asserted from prose. A 5% floor keeps stale/estimate admission no more aggressive than
-///    the gap the calibrated pipeline already carries on every measured cell. (The epic
-///    15448-era ~5-6% cold-allocator settle observations are not restated anywhere in `docs/`,
-///    so the floor is anchored to the evidence file rather than to unverifiable history.)
-pub const LADDER_MARGIN_HARD_FLOOR_MLX: f64 = 0.05;
+/// UNCERTAINTY COVERED: re-running one measured cell lands on a different peak. Nothing else. The
+/// epic-18093 constant doubled this number as "protection against the next capture landing outside
+/// the sampled range" and then doubled it AGAIN for estimates; neither doubling named a term, and a
+/// margin that cannot name its term is what E3 retires. The failure posture for what the sampled
+/// range does not cover is runtime catching (E6), not a standing 4x pad on every admission.
+pub const MLX_RECAPTURE_SPREAD: f64 = 0.1260183508475594;
 
-/// Hard floor for candle margins — and, with zero candle repeat pairs in the corpus, the whole
-/// candle margin. Looser than MLX because the failure mode is cheaper and the accounting is
-/// tighter: a CUDA/candle allocation failure is a recoverable `Err` that fails the job while the
-/// worker survives, and candle evidence is deterministic live-allocation counting (10 of 15
-/// records report observed == predicted to the byte, none show reclaimable slack).
-pub const LADDER_MARGIN_HARD_FLOOR_CANDLE: f64 = 0.02;
-
-/// Margin applied to MEASURED evidence whose closure digest is stale (sc-18095), MLX lane.
-/// Derived: `max(LADDER_MARGIN_HARD_FLOOR_MLX, 2 x 12.6018% observed max binding spread)`;
-/// variance binds at 25.2037%. Stale admission is SAME-CELL admission (the cell being admitted is
-/// the cell that was measured), which is exactly the scope where the derivation's non-binding
-/// exclusion is sound: a phase far below the measured envelope cannot become the envelope within
-/// the admitted spread bounds.
-pub const MLX_STALE_MEASURED_MARGIN: f64 = 0.2520367016951188;
-
-/// Margin applied to ESTIMATE-BACKED unmeasured candidates (sc-18096/18097), MLX lane. Double
-/// the stale-measured margin: an estimate carries model extrapolation error on top of the
-/// capture variance a re-measured cell would show.
+/// Same-cell spread on the candle lane. The corpus has ZERO candle repeat pairs, so no spread is
+/// measurable and none is invented; this is the documented accounting-residual floor instead.
 ///
-/// SCOPE: this margin absorbs re-capture variance only for candidates whose predicted BINDING
-/// PHASE matches the measured cell's. The corpus demonstrates a 17.1369% per-phase re-capture
-/// spread (denoise) whose fully widened 68.55% derivation term exceeds this margin; admission that
-/// extrapolates the binding phase is forbidden by
-/// [`ESTIMATE_ADMISSION_REQUIRES_MEASURED_BINDING_PHASE`] instead.
-pub const MLX_ESTIMATE_MARGIN: f64 = 0.5040734033902377;
+/// UNCERTAINTY COVERED: candle evidence is deterministic live-allocation counting rather than an
+/// allocator-pool envelope (10 of 16 records report observed == predicted to the byte, none show
+/// reclaimable slack), so the residual is small and bounded by the accounting, not by variance.
+pub const CANDLE_RECAPTURE_SPREAD: f64 = 0.02;
 
-/// Margin applied to MEASURED evidence whose closure digest is stale (sc-18095), candle lane.
-/// Equal to `LADDER_MARGIN_HARD_FLOOR_CANDLE`: the corpus has no candle repeat pairs, so the
-/// documented hard floor is the whole margin.
-pub const CANDLE_STALE_MEASURED_MARGIN: f64 = 0.02;
-
-/// Margin applied to ESTIMATE-BACKED unmeasured candidates (sc-18096/18097), candle lane.
-/// Double the candle stale-measured margin, same widening rationale as
-/// [`MLX_ESTIMATE_MARGIN`].
-pub const CANDLE_ESTIMATE_MARGIN: f64 = 0.04;
+/// Allowance on the ACTIVATION (headroom) term of a weights+headroom floor, as a fraction of THAT
+/// TERM — not of the floor.
+///
+/// UNCERTAINTY COVERED: the MLX allocator envelope that sits above the modelled active bytes
+/// (cache retention across phase transitions), measured at up to 15.84% over the binding active
+/// phase across the retained corpus and bounded at 17% — the SAME term, from the same measurement,
+/// that `sceneworks_core::memory_anchor::ANCHOR_ALLOCATOR_ENVELOPE_MARGIN` prices for a derived
+/// peak. A floor's weights are allocated once and counted exactly, so they carry none of it.
+///
+/// NOT COVERED, deliberately: whether one flat headroom number is the right ACTIVE model for this
+/// geometry at all. That residual is unmeasured, and epic 22505 E6 makes runtime catching its
+/// failure posture rather than a standing multiple of an already-modelled allowance. The retired
+/// blanket 50.41% was that standing multiple, priced against the whole peak and named after
+/// nothing.
+pub const FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE: f64 = 0.17;
 
 /// Constraint inherited by the estimate-admission follow-ups (sc-18096/18097), pinned here
-/// because the margins above cannot carry it: estimate-backed admission MUST NOT admit a
+/// because the allowances above cannot carry it: estimate-backed admission MUST NOT admit a
 /// candidate whose predicted binding phase differs from the measured cell's binding phase
 /// without per-phase variance re-derivation for that phase.
 ///
@@ -89,20 +81,17 @@ pub const CANDLE_ESTIMATE_MARGIN: f64 = 0.04;
 /// cross-fingerprint same-key re-capture spread on a phase peak (denoise/activeBytes,
 /// imc-5ea462dfe3101260a9b1 vs imc-da3533c476605929f10d). That phase was non-binding in its
 /// measured cell (a 16 GB text-encoder conditioning peak dominated at 1024 squared), so it cannot
-/// flip a same-cell admission; but an estimate
-/// extrapolating to a different rung (bounded conditioning) or larger geometry (MLX activation
-/// transients scale linearly in area) can make denoise carry the request peak — the fatal-OOM
-/// direction on MLX. Folding that spread into the estimate margin per the derivation rule
-/// (x2 safety, floor, x2 widening) yields 68.55% — unusable — so the risk is carried by this
-/// rule instead. `scripts/derive-ladder-margins.test.mjs` pins this constant against the
-/// script's mirror export and asserts its fully widened 68.55% term still exceeds
-/// [`MLX_ESTIMATE_MARGIN`], i.e. the constraint stays load-bearing.
+/// flip a same-cell admission; but an estimate extrapolating to a different rung (bounded
+/// conditioning) or larger geometry (MLX activation transients scale linearly in area) can make
+/// denoise carry the request peak — the fatal-OOM direction on MLX. That spread belongs to a phase
+/// the candidate's own term does not cover, so pricing it as a fraction of the peak would be
+/// exactly the untethered widening E3 retires; the risk is carried by this rule instead.
 ///
 /// SCOPE: this constraint governs estimate candidates extrapolated from a measured cell
 /// (fitted per-phase curves). Candidates with no measured cell in their extrapolation basis —
 /// the weights + headroom floor path of epic 18093 R1 — have no measured binding phase to
 /// match and are NOT gated by this constraint; their risk is carried by the headroom floor and
-/// the estimate margin, not this rule.
+/// its own allowance, not this rule.
 pub const ESTIMATE_ADMISSION_REQUIRES_MEASURED_BINDING_PHASE: bool = true;
 
 /// Ratified exemption for a prediction that evaluates **every phase independently**, adds that
@@ -117,19 +106,136 @@ pub const ESTIMATE_ADMISSION_REQUIRES_MEASURED_BINDING_PHASE: bool = true;
 /// backend estimate margin remains applied after the max-over-phases envelope.
 pub const RESIDUAL_BOUNDED_MAX_OVER_PHASES_EXEMPT_FROM_BINDING_PHASE_PIN: bool = true;
 
+/// The named uncertainty one admission allowance covers, and — decisively — the term it is
+/// proportionate to. See the module header for what each one covers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AdmissionTerm {
+    /// Nothing unpriced; the allowance is zero bytes.
+    FullyPriced,
+    /// Proportionate to the whole peak, because a re-capture moves the peak itself.
+    SameCellRecaptureSpread,
+    /// Proportionate to the floor's modelled activation (headroom) term ONLY, never to its
+    /// counted weights.
+    AllocatorEnvelopeOverActivation,
+}
+
+impl AdmissionTerm {
+    /// Stable label for tracing/telemetry, so an admission event names the uncertainty it paid for.
+    pub const fn as_key(self) -> &'static str {
+        match self {
+            Self::FullyPriced => "fully_priced",
+            Self::SameCellRecaptureSpread => "same_cell_recapture_spread",
+            Self::AllocatorEnvelopeOverActivation => "allocator_envelope_over_activation",
+        }
+    }
+}
+
+/// One priced allowance: a named term and a fraction OF THAT TERM's bytes.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AdmissionAllowance {
+    pub term: AdmissionTerm,
+    /// Fraction of the term's own bytes. It equals a fraction of the peak only for
+    /// [`AdmissionTerm::SameCellRecaptureSpread`], whose term IS the peak.
+    pub fraction: f64,
+}
+
+impl AdmissionAllowance {
+    /// Nothing left to charge.
+    pub const NONE: Self = Self {
+        term: AdmissionTerm::FullyPriced,
+        fraction: 0.0,
+    };
+
+    /// The bytes this allowance adds, given the peak it grades and the candidate's declared
+    /// unmodeled-activation headroom.
+    ///
+    /// Rounded UP in integer bytes, so an admitted ceiling is never under the exact product and
+    /// the GiB conversion stays a single downstream step.
+    pub fn bytes(self, peak_bytes: u64, term_bytes: u64) -> u64 {
+        let base = match self.term {
+            AdmissionTerm::FullyPriced => return 0,
+            AdmissionTerm::SameCellRecaptureSpread => peak_bytes,
+            AdmissionTerm::AllocatorEnvelopeOverActivation => term_bytes,
+        };
+        (base as f64 * self.fraction)
+            .ceil()
+            .clamp(0.0, u64::MAX as f64) as u64
+    }
+}
+
+/// Everything the policy needs to name a candidate's remaining uncertainty.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AdmissionSubject {
+    pub backend: MemoryBackend,
+    pub basis: CandidateBasis,
+    /// The candidate's evidence was measured under a closure digest that has since moved.
+    pub closure_is_stale: bool,
+    /// The portion of the peak that is a flat, phase-blind activation ALLOWANCE rather than counted
+    /// weights, declared by the site that built the floor. `None` where the basis does not
+    /// decompose its peak.
+    pub unmodeled_activation_bytes: Option<u64>,
+}
+
+/// Same-cell recapture spread for one backend. Matched exhaustively so a new backend cannot compile
+/// without choosing a value.
+const fn recapture_spread(backend: MemoryBackend) -> f64 {
+    match backend {
+        MemoryBackend::Candle => CANDLE_RECAPTURE_SPREAD,
+        MemoryBackend::Mlx => MLX_RECAPTURE_SPREAD,
+    }
+}
+
+/// The one allowance the selector adds on top of a candidate's peak.
+///
+/// The undeclared-floor arm is the only approximation left, and it is stated rather than hidden: a
+/// floor that does not publish its weights/headroom split cannot have the headroom term charged, so
+/// it falls back to the backend's whole-peak accounting residual. Runtime catching owns what that
+/// does not cover (E6); the fix for a lane that wants better is to declare the split, not to widen
+/// the number.
+pub fn admission_allowance(subject: AdmissionSubject) -> AdmissionAllowance {
+    let spread = AdmissionAllowance {
+        term: AdmissionTerm::SameCellRecaptureSpread,
+        fraction: recapture_spread(subject.backend),
+    };
+    match subject.basis {
+        // A measurement under the live closure is the measurement. A moved closure leaves exactly
+        // the same-cell recapture question open — the cell being admitted IS the cell measured.
+        CandidateBasis::Measured => {
+            if subject.closure_is_stale {
+                spread
+            } else {
+                AdmissionAllowance::NONE
+            }
+        }
+        // The fitted per-phase laws already carry each phase's max fit/held-out residual, so what
+        // remains is the recapture spread of the cell the curve was fitted through.
+        CandidateBasis::EstimateFittedCurve => spread,
+        // Coefficient uncertainty is inside the coefficients and the allocator envelope is inside
+        // `ANCHOR_ALLOCATOR_ENVELOPE_MARGIN`. Nothing is left for the selector to add.
+        CandidateBasis::EstimateAnchorDerived => AdmissionAllowance::NONE,
+        CandidateBasis::EstimateFloor => {
+            if subject.unmodeled_activation_bytes.is_some() {
+                AdmissionAllowance {
+                    term: AdmissionTerm::AllocatorEnvelopeOverActivation,
+                    fraction: FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE,
+                }
+            } else {
+                spread
+            }
+        }
+    }
+}
+
 /// Structural invariants of the policy, enforced at COMPILE TIME (a violating edit fails
-/// `cargo build`, not just a test lane), independent of the current corpus: margins never dip
-/// under their backend's floor, estimates are strictly wider than stale-measured, the
-/// fatal-OOM backend (MLX) is never less conservative than the recoverable one (candle), and
-/// the estimate-admission binding-phase constraint stays declared (it may only be retired
-/// together with a per-phase variance re-derivation — see its doc).
+/// `cargo build`, not just a test lane), independent of the current corpus.
 const _: () = {
-    assert!(MLX_STALE_MEASURED_MARGIN >= LADDER_MARGIN_HARD_FLOOR_MLX);
-    assert!(CANDLE_STALE_MEASURED_MARGIN >= LADDER_MARGIN_HARD_FLOOR_CANDLE);
-    assert!(MLX_ESTIMATE_MARGIN > MLX_STALE_MEASURED_MARGIN);
-    assert!(CANDLE_ESTIMATE_MARGIN > CANDLE_STALE_MEASURED_MARGIN);
-    assert!(MLX_STALE_MEASURED_MARGIN >= CANDLE_STALE_MEASURED_MARGIN);
-    assert!(MLX_ESTIMATE_MARGIN >= CANDLE_ESTIMATE_MARGIN);
+    // Every spread is a real, bounded fraction of its own term. An allowance at or above 1.0 on the
+    // recapture term would be a blanket doubling wearing a term's name.
+    assert!(MLX_RECAPTURE_SPREAD > 0.0 && MLX_RECAPTURE_SPREAD < 1.0);
+    assert!(CANDLE_RECAPTURE_SPREAD > 0.0 && CANDLE_RECAPTURE_SPREAD < 1.0);
+    // The fatal-OOM lane is never charged less than the recoverable one for the SAME term.
+    assert!(MLX_RECAPTURE_SPREAD >= CANDLE_RECAPTURE_SPREAD);
+    assert!(FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE > 0.0 && FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE < 1.0);
     assert!(ESTIMATE_ADMISSION_REQUIRES_MEASURED_BINDING_PHASE);
     assert!(RESIDUAL_BOUNDED_MAX_OVER_PHASES_EXEMPT_FROM_BINDING_PHASE_PIN);
 };
@@ -143,15 +249,97 @@ mod tests {
     /// coupling to the derivation; this pin makes a drive-by constant edit red in `rust:check`
     /// too, without waiting for the node lane.
     #[test]
-    fn constants_match_the_sc_18094_derivation() {
-        assert_eq!(LADDER_MARGIN_HARD_FLOOR_MLX, 0.05);
-        assert_eq!(LADDER_MARGIN_HARD_FLOOR_CANDLE, 0.02);
-        assert_eq!(MLX_STALE_MEASURED_MARGIN, 0.2520367016951188);
-        assert_eq!(MLX_ESTIMATE_MARGIN, 0.5040734033902377);
-        assert_eq!(CANDLE_STALE_MEASURED_MARGIN, 0.02);
-        assert_eq!(CANDLE_ESTIMATE_MARGIN, 0.04);
-        // ESTIMATE_ADMISSION_REQUIRES_MEASURED_BINDING_PHASE is pinned in the compile-time
-        // invariants block above (clippy forbids constant assertions in a runtime test) and
-        // against the script's mirror export by scripts/derive-ladder-margins.test.mjs.
+    fn constants_match_the_sc_22508_derivation() {
+        assert_eq!(MLX_RECAPTURE_SPREAD, 0.1260183508475594);
+        assert_eq!(CANDLE_RECAPTURE_SPREAD, 0.02);
+        assert_eq!(FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE, 0.17);
+        // Same term, same measurement, one number: the anchor derivation prices this exact
+        // envelope for a derived peak, and a floor must not price it differently.
+        assert_eq!(
+            FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE,
+            sceneworks_core::memory_anchor::ANCHOR_ALLOCATOR_ENVELOPE_MARGIN
+        );
+    }
+
+    fn subject(basis: CandidateBasis, headroom: Option<u64>) -> AdmissionSubject {
+        AdmissionSubject {
+            backend: MemoryBackend::Mlx,
+            basis,
+            closure_is_stale: false,
+            unmodeled_activation_bytes: headroom,
+        }
+    }
+
+    /// E3, stated as arithmetic: the floor's allowance tracks its HEADROOM term and is blind to its
+    /// weights. Two floors with the same headroom and wildly different weights must be charged the
+    /// same bytes — which no fraction-of-the-peak margin can do.
+    #[test]
+    fn the_floor_allowance_is_proportionate_to_headroom_not_to_the_peak() {
+        let headroom = 18_000_000_000_u64;
+        let allowance = admission_allowance(subject(CandidateBasis::EstimateFloor, Some(headroom)));
+        assert_eq!(
+            allowance.term,
+            AdmissionTerm::AllocatorEnvelopeOverActivation
+        );
+
+        let expected = (headroom as f64 * FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE).ceil() as u64;
+        let small_weights = allowance.bytes(20_000_000_000 + headroom, headroom);
+        let huge_weights = allowance.bytes(200_000_000_000 + headroom, headroom);
+        assert_eq!(small_weights, expected);
+        assert_eq!(huge_weights, expected);
+
+        // And it does track the term: double the headroom, double the allowance.
+        assert_eq!(
+            allowance.bytes(20_000_000_000 + 2 * headroom, 2 * headroom),
+            ((2 * headroom) as f64 * FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE).ceil() as u64
+        );
+    }
+
+    /// The recapture term is the one allowance that IS a fraction of the peak, and its doc says so
+    /// because the quantity that moves between captures is the peak. Pin that it is the measured
+    /// spread alone — not the retired x2/x4 widenings.
+    #[test]
+    fn the_recapture_allowance_is_the_measured_spread_with_no_blanket_widening() {
+        let stale = AdmissionSubject {
+            closure_is_stale: true,
+            ..subject(CandidateBasis::Measured, None)
+        };
+        let allowance = admission_allowance(stale);
+        assert_eq!(allowance.term, AdmissionTerm::SameCellRecaptureSpread);
+        assert_eq!(allowance.fraction, MLX_RECAPTURE_SPREAD);
+        assert_eq!(
+            allowance.bytes(100_000_000_000, 0),
+            (100_000_000_000.0 * MLX_RECAPTURE_SPREAD).ceil() as u64
+        );
+    }
+
+    /// The anchor derivation prices its own two terms, so the selector adds nothing. This is the
+    /// bullet that lets a 60 GB derived peak reach the rungs it fits.
+    #[test]
+    fn an_anchor_derived_peak_carries_no_selector_allowance() {
+        let allowance = admission_allowance(subject(CandidateBasis::EstimateAnchorDerived, None));
+        assert_eq!(allowance.term, AdmissionTerm::FullyPriced);
+        assert_eq!(allowance.bytes(60 * 1024 * 1024 * 1024, 0), 0);
+    }
+
+    /// A current measurement is the measurement; an undeclared floor states its approximation by
+    /// falling back to the whole-peak accounting residual rather than to a wider invented number.
+    #[test]
+    fn current_measurements_and_undeclared_floors_take_their_documented_arms() {
+        assert_eq!(
+            admission_allowance(subject(CandidateBasis::Measured, None)).term,
+            AdmissionTerm::FullyPriced
+        );
+        let undeclared = admission_allowance(subject(CandidateBasis::EstimateFloor, None));
+        assert_eq!(undeclared.term, AdmissionTerm::SameCellRecaptureSpread);
+        assert_eq!(undeclared.fraction, MLX_RECAPTURE_SPREAD);
+        assert_eq!(
+            admission_allowance(AdmissionSubject {
+                backend: MemoryBackend::Candle,
+                ..subject(CandidateBasis::EstimateFloor, None)
+            })
+            .fraction,
+            CANDLE_RECAPTURE_SPREAD
+        );
     }
 }

--- a/crates/sceneworks-worker/src/memory_strategy.rs
+++ b/crates/sceneworks-worker/src/memory_strategy.rs
@@ -2869,10 +2869,28 @@ mod tests {
         let expected_widened_bytes =
             (raw_peak_bytes as f64 * (1.0 + CANDLE_RECAPTURE_SPREAD)).ceil();
         assert_eq!(needed_gb, expected_widened_bytes / BYTES_PER_GIB);
-        // The candle estimate margin is strictly wider than the candle stale margin — pinned at
-        // COMPILE TIME by `ladder_margin_policy`'s invariant block — so grading an estimate with
-        // the stale margin would have produced a smaller needed_gb: this equality pins the
-        // ESTIMATE margin specifically.
+        // sc-22508 DELETED the claim that used to stand here — "the candle estimate margin is
+        // strictly wider than the candle stale margin, so this equality pins the ESTIMATE margin
+        // specifically". There is no longer an estimate margin distinct from a stale one: an
+        // undeclared floor and a stale measurement now resolve to the SAME
+        // `CANDLE_RECAPTURE_SPREAD`, and the equality above therefore discriminates nothing about
+        // WHICH allowance was charged.
+        //
+        // Assert the term instead — that is the axis that still carries information. This
+        // candidate declares no activation split, so the policy must charge it the whole-peak
+        // recapture spread; a wiring that reached the activation-envelope arm without a declared
+        // term would sail past the numeric equality above and fail here.
+        assert_eq!(
+            crate::ladder_margin_policy::admission_allowance(AdmissionSubject {
+                backend: MemoryBackend::Candle,
+                basis: CandidateBasis::EstimateFloor,
+                closure_is_stale: false,
+                unmodeled_activation_bytes: None,
+            })
+            .term
+            .as_key(),
+            "same_cell_recapture_spread"
+        );
     }
 
     /// Mutation check demanded by the story: prove the estimate widening is APPLIED. This

--- a/crates/sceneworks-worker/src/memory_strategy.rs
+++ b/crates/sceneworks-worker/src/memory_strategy.rs
@@ -26,10 +26,7 @@ use gen_core::{
 };
 use sceneworks_core::memory_calibration::StrategyRung;
 
-use crate::ladder_margin_policy::{
-    CANDLE_ESTIMATE_MARGIN, CANDLE_STALE_MEASURED_MARGIN, MLX_ESTIMATE_MARGIN,
-    MLX_STALE_MEASURED_MARGIN,
-};
+use crate::ladder_margin_policy::{admission_allowance, AdmissionSubject};
 
 /// Bridge a calibration receipt's persisted materialization shape to the gen-core contract type.
 /// The two enums are the same axis; `sceneworks-core` keeps its own spelling because it
@@ -312,6 +309,31 @@ pub struct Candidate<'a> {
     /// Whether the peak is a measurement or a synthesized estimate (sc-18096). Like
     /// `closure_digest`, this lives on `Candidate` because `MemoryEvidence` is pinned gen-core.
     pub basis: CandidateBasis,
+    /// The portion of `evidence.predicted_peak_bytes` that is a flat, phase-blind activation
+    /// ALLOWANCE rather than counted weight bytes (sc-22508).
+    ///
+    /// Declared by whoever builds a weights+headroom floor, because only that site knows the split.
+    /// It is the term
+    /// [`crate::ladder_margin_policy::AdmissionTerm::AllocatorEnvelopeOverActivation`] is charged
+    /// against — the whole reason the selector no longer multiplies a floor's counted weights by a
+    /// percentage. `None` on every basis that does not decompose its peak.
+    pub unmodeled_activation_bytes: Option<u64>,
+}
+
+impl Candidate<'_> {
+    /// How this candidate's remaining uncertainty is named, given how its currency graded.
+    fn admission_subject(
+        &self,
+        backend: MemoryBackend,
+        currency: CandidateCurrency,
+    ) -> AdmissionSubject {
+        AdmissionSubject {
+            backend,
+            basis: self.basis,
+            closure_is_stale: currency == CandidateCurrency::StaleClosure,
+            unmodeled_activation_bytes: self.unmodeled_activation_bytes,
+        }
+    }
 }
 
 const BYTES_PER_GIB: f64 = 1024.0 * 1024.0 * 1024.0;
@@ -345,43 +367,58 @@ impl CandidateCurrency {
     }
 }
 
-/// The stale-measured margin for one backend (sc-18094 derivation, consumed here by sc-18095).
+/// The ceiling one candidate is graded at: its canonical peak plus the ONE named per-term allowance
+/// [`crate::ladder_margin_policy::admission_allowance`] prices for it (sc-22508).
 ///
-/// Matched on the canonical [`MemoryBackend`] family so a new backend cannot compile without
-/// choosing a margin.
-const fn stale_measured_margin(backend: MemoryBackend) -> f64 {
-    match backend {
-        MemoryBackend::Candle => CANDLE_STALE_MEASURED_MARGIN,
-        MemoryBackend::Mlx => MLX_STALE_MEASURED_MARGIN,
-    }
+/// Before sc-22508 this was `peak * (1 + backend_margin)` with the margin chosen from the backend
+/// and the currency alone — one number stretched over every uncertainty any candidate could have.
+/// Now the allowance names its uncertainty and is charged against the term that carries it, so a
+/// floor's counted weights and an anchor derivation's already-priced coefficients are not padded
+/// a second time.
+///
+/// The addition happens in integer bytes with a ceil inside the allowance, so the admitted ceiling
+/// is never under the exact product and the GiB conversion stays a single downstream step.
+pub(crate) fn admitted_peak_bytes(subject: AdmissionSubject, peak_bytes: u64) -> u64 {
+    let allowance = admission_allowance(subject);
+    peak_bytes.saturating_add(
+        allowance.bytes(peak_bytes, subject.unmodeled_activation_bytes.unwrap_or(0)),
+    )
 }
 
-/// The estimate margin for one backend (sc-18094 derivation, consumed here by sc-18096). Same
-/// exhaustive-match rationale as [`stale_measured_margin`].
-pub(crate) const fn estimate_margin(backend: MemoryBackend) -> f64 {
-    match backend {
-        MemoryBackend::Candle => CANDLE_ESTIMATE_MARGIN,
-        MemoryBackend::Mlx => MLX_ESTIMATE_MARGIN,
-    }
+/// The selector's own stale-measured grading (sc-18095), exported so the MLX gate's evidence-path
+/// budget pre-check grades a stale candidate at the SAME admitted ceiling `select_strategy` will
+/// (sc-18096). The pre-check runs against each candidate's captured foreign reserve, which the
+/// selector's uniform budget cannot carry, so the two must share this one policy function rather
+/// than each deriving an allowance.
+pub(crate) fn stale_admitted_peak_bytes(backend: MemoryBackend, peak_bytes: u64) -> u64 {
+    admitted_peak_bytes(
+        AdmissionSubject {
+            backend,
+            basis: CandidateBasis::Measured,
+            closure_is_stale: true,
+            unmodeled_activation_bytes: None,
+        },
+        peak_bytes,
+    )
 }
 
-/// Widen a stale-closure or estimate candidate's canonical byte ceiling by its policy margin
-/// (sc-18095/sc-18096). The widening happens in integer bytes with a ceil, so the admitted ceiling
-/// is never under the exact `peak * (1 + margin)` product and the GiB conversion stays a single
-/// downstream step.
-pub(crate) fn widened_peak_bytes(peak_bytes: u64, margin: f64) -> u64 {
-    (peak_bytes as f64 * (1.0 + margin))
-        .ceil()
-        .clamp(0.0, u64::MAX as f64) as u64
-}
-
-/// The selector's own stale-measured widening (sc-18095), exported so the MLX gate's
-/// evidence-path budget pre-check grades a stale candidate at the SAME admitted ceiling
-/// `select_strategy` will (sc-18096). The pre-check runs against each candidate's captured
-/// foreign reserve, which the selector's uniform budget cannot carry, so the two must share this
-/// one policy function rather than each deriving a margin.
-pub(crate) fn stale_widened_peak_bytes(backend: MemoryBackend, peak_bytes: u64) -> u64 {
-    widened_peak_bytes(peak_bytes, stale_measured_margin(backend))
+/// The admitted ceiling of a weights+headroom FLOOR whose split is declared (sc-22508), exported
+/// for the video lane's refusal-artifact guard so it compares against the same number
+/// `select_strategy` graded the floor candidate at.
+pub(crate) fn floor_admitted_peak_bytes(
+    backend: MemoryBackend,
+    peak_bytes: u64,
+    unmodeled_activation_bytes: Option<u64>,
+) -> u64 {
+    admitted_peak_bytes(
+        AdmissionSubject {
+            backend,
+            basis: CandidateBasis::EstimateFloor,
+            closure_is_stale: false,
+            unmodeled_activation_bytes,
+        },
+        peak_bytes,
+    )
 }
 
 /// Worker-owned live budget. Headroom is removed once from the live/reclaimable pool and once from
@@ -576,8 +613,7 @@ pub fn select_strategy(
     let available_bytes = (available_gb * BYTES_PER_GIB)
         .ceil()
         .clamp(0.0, u64::MAX as f64) as u64;
-    let stale_margin = stale_measured_margin(contract.backend.backend_kind());
-    let estimate_margin = estimate_margin(contract.backend.backend_kind());
+    let backend_kind = contract.backend.backend_kind();
     let mut deepest = None;
     let mut first_unknown = None;
     for strategy in MemoryStrategy::ALL {
@@ -616,17 +652,12 @@ pub fn select_strategy(
                     );
                 }
                 Ok(currency) => {
-                    let admitted_peak_bytes = match currency {
-                        CandidateCurrency::Current => candidate.evidence.predicted_peak_bytes,
-                        CandidateCurrency::StaleClosure => widened_peak_bytes(
-                            candidate.evidence.predicted_peak_bytes,
-                            stale_margin,
-                        ),
-                        CandidateCurrency::Estimate => widened_peak_bytes(
-                            candidate.evidence.predicted_peak_bytes,
-                            estimate_margin,
-                        ),
-                    };
+                    // sc-22508: ONE per-term allowance, named by the policy from this candidate's
+                    // basis and currency, charged against the term that carries the uncertainty.
+                    let subject = candidate.admission_subject(backend_kind, currency);
+                    let allowance = crate::ladder_margin_policy::admission_allowance(subject);
+                    let admitted_peak_bytes =
+                        admitted_peak_bytes(subject, candidate.evidence.predicted_peak_bytes);
                     if currency == CandidateCurrency::StaleClosure {
                         // sc-18095: record the admission and the widened peak so a later OOM under
                         // this selection is attributable to stale-closure evidence.
@@ -636,7 +667,10 @@ pub fn select_strategy(
                             ?strategy,
                             raw_peak_bytes = candidate.evidence.predicted_peak_bytes,
                             widened_peak_bytes = admitted_peak_bytes,
-                            stale_margin,
+                            allowance_term = allowance.term.as_key(),
+                            allowance_fraction = allowance.fraction,
+                            allowance_bytes = admitted_peak_bytes
+                                .saturating_sub(candidate.evidence.predicted_peak_bytes),
                             candidate_closure_digest = candidate.closure_digest,
                             expected_closure_digest = request.expected_closure_digest,
                             "stale-closure memory-strategy candidate admitted with widened margin"
@@ -653,7 +687,9 @@ pub fn select_strategy(
                             basis = candidate.basis.as_key(),
                             raw_peak_bytes = candidate.evidence.predicted_peak_bytes,
                             widened_peak_bytes = admitted_peak_bytes,
-                            estimate_margin,
+                            allowance_term = allowance.term.as_key(),
+                            allowance_fraction = allowance.fraction,
+                            allowance_bytes = admitted_peak_bytes.saturating_sub(candidate.evidence.predicted_peak_bytes),
                             "estimate-backed memory-strategy candidate admitted with widened margin"
                         );
                     }
@@ -722,6 +758,9 @@ pub fn select_strategy(
             )
         {
             let needed_gb = peak_bytes_to_gb(*admitted_peak_bytes);
+            let allowance = crate::ladder_margin_policy::admission_allowance(
+                candidate.admission_subject(backend_kind, *currency),
+            );
             if *currency == CandidateCurrency::StaleClosure {
                 tracing::warn!(
                     route = request.resolved_route,
@@ -729,7 +768,10 @@ pub fn select_strategy(
                     ?strategy,
                     raw_peak_bytes = candidate.evidence.predicted_peak_bytes,
                     widened_peak_bytes = *admitted_peak_bytes,
-                    stale_margin,
+                    allowance_term = allowance.term.as_key(),
+                    allowance_fraction = allowance.fraction,
+                    allowance_bytes = (*admitted_peak_bytes)
+                        .saturating_sub(candidate.evidence.predicted_peak_bytes),
                     "memory-strategy selection uses stale-closure evidence at the widened peak"
                 );
             }
@@ -741,7 +783,9 @@ pub fn select_strategy(
                     basis = candidate.basis.as_key(),
                     raw_peak_bytes = candidate.evidence.predicted_peak_bytes,
                     widened_peak_bytes = *admitted_peak_bytes,
-                    estimate_margin,
+                    allowance_term = allowance.term.as_key(),
+                    allowance_fraction = allowance.fraction,
+                    allowance_bytes = (*admitted_peak_bytes).saturating_sub(candidate.evidence.predicted_peak_bytes),
                     "memory-strategy selection uses an estimate-backed candidate at the widened peak"
                 );
             }
@@ -776,6 +820,10 @@ pub fn select_strategy(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ladder_margin_policy::{
+        AdmissionTerm, CANDLE_RECAPTURE_SPREAD, FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE,
+        MLX_RECAPTURE_SPREAD,
+    };
     use gen_core::{
         LoadShape, MemoryBackendRealization, MemoryBudget, MemoryCacheState,
         MemoryCalibrationIdentity, MemoryConformanceState, MemoryEvidenceDimensions,
@@ -968,6 +1016,7 @@ mod tests {
             evidence: &source_only_change,
             closure_digest: INF,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
 
         assert!(matches!(
@@ -1005,6 +1054,7 @@ mod tests {
             evidence: &exact,
             closure_digest: INF,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
 
         assert!(matches!(
@@ -1045,6 +1095,7 @@ mod tests {
                 evidence: &staged,
                 closure_digest: INF,
                 basis: CandidateBasis::Measured,
+                unmodeled_activation_bytes: None,
             },
             Candidate {
                 selection: MemorySelection {
@@ -1055,6 +1106,7 @@ mod tests {
                 evidence: &resident,
                 closure_digest: INF,
                 basis: CandidateBasis::Measured,
+                unmodeled_activation_bytes: None,
             },
         ];
         let mut provider = contract();
@@ -1116,6 +1168,7 @@ mod tests {
             evidence: &staged,
             closure_digest: INF,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
         assert_eq!(
             select_strategy(
@@ -1153,6 +1206,7 @@ mod tests {
             evidence: &staged,
             closure_digest: INF,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
         assert_eq!(
             select_strategy(
@@ -1192,6 +1246,7 @@ mod tests {
             evidence: &staged,
             closure_digest: INF,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
         assert_eq!(
             select_strategy(
@@ -1223,6 +1278,7 @@ mod tests {
             evidence: &captured,
             closure_digest: INF,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
         let mut changed_contract = contract();
         changed_contract.additional_prerequisites.push((
@@ -1309,6 +1365,7 @@ mod tests {
                 evidence: &excluded_staged,
                 closure_digest: INF,
                 basis: CandidateBasis::Measured,
+                unmodeled_activation_bytes: None,
             },
             Candidate {
                 selection: MemorySelection {
@@ -1319,6 +1376,7 @@ mod tests {
                 evidence: &bounded_decode,
                 closure_digest: INF,
                 basis: CandidateBasis::Measured,
+                unmodeled_activation_bytes: None,
             },
         ];
         assert!(matches!(
@@ -1361,6 +1419,7 @@ mod tests {
                 evidence: &resident,
                 closure_digest: INF,
                 basis: CandidateBasis::Measured,
+                unmodeled_activation_bytes: None,
             },
             Candidate {
                 selection: MemorySelection {
@@ -1371,6 +1430,7 @@ mod tests {
                 evidence: &staged,
                 closure_digest: INF,
                 basis: CandidateBasis::Measured,
+                unmodeled_activation_bytes: None,
             },
         ];
         let mut provider = contract();
@@ -1434,6 +1494,7 @@ mod tests {
             evidence: &staged,
             closure_digest: INF,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
         let mut scope = request();
         scope.mode = "character_image";
@@ -1500,6 +1561,7 @@ mod tests {
             evidence: &staged,
             closure_digest: INF,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
         let budget = Some(Budget {
             available_gb: 8.0,
@@ -1523,6 +1585,7 @@ mod tests {
                     evidence: &staged,
                     closure_digest: INF,
                     basis: CandidateBasis::Measured,
+                    unmodeled_activation_bytes: None,
                 }],
             ),
             Selection::Selected {
@@ -1547,6 +1610,7 @@ mod tests {
             evidence: &staged,
             closure_digest: INF,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
         let budget = Some(Budget {
             available_gb: 8.0,
@@ -1575,6 +1639,7 @@ mod tests {
                     evidence: &wrong_backend,
                     closure_digest: INF,
                     basis: CandidateBasis::Measured,
+                    unmodeled_activation_bytes: None,
                 }],
             ),
             Selection::Unverified {
@@ -1622,6 +1687,7 @@ mod tests {
             evidence: &high,
             closure_digest: INF,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
         let low_candidate = Candidate {
             evidence: &low,
@@ -1634,6 +1700,7 @@ mod tests {
             evidence: &high,
             closure_digest: INF,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
         let budget = Some(Budget {
             available_gb: 8.0,
@@ -1672,6 +1739,7 @@ mod tests {
                     evidence: &tied_high,
                     closure_digest: INF,
                     basis: CandidateBasis::Measured,
+                    unmodeled_activation_bytes: None,
                 },
             ],
         );
@@ -2000,6 +2068,7 @@ mod tests {
                 evidence: record,
                 closure_digest: INF,
                 basis: CandidateBasis::Measured,
+                unmodeled_activation_bytes: None,
             })
             .collect::<Vec<_>>();
         let provider = contract();
@@ -2137,6 +2206,7 @@ mod tests {
             evidence: &record,
             closure_digest: INF,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         }];
         let select = |provider: &MemoryProviderContract| {
             select_strategy(
@@ -2248,6 +2318,7 @@ mod tests {
                     evidence: record,
                     closure_digest: INF,
                     basis: CandidateBasis::Measured,
+                    unmodeled_activation_bytes: None,
                 })
                 .collect::<Vec<_>>();
 
@@ -2327,6 +2398,7 @@ mod tests {
                     evidence: &staged,
                     closure_digest: INF,
                     basis: CandidateBasis::Measured,
+                    unmodeled_activation_bytes: None,
                 }],
             ),
             Selection::Selected {
@@ -2365,6 +2437,7 @@ mod tests {
                 evidence: &staged,
                 closure_digest: STALE_CLOSURE,
                 basis: CandidateBasis::Measured,
+                unmodeled_activation_bytes: None,
             }],
         );
         let Selection::Selected { needed_gb, .. } = result else {
@@ -2375,7 +2448,7 @@ mod tests {
             "the admitted peak must be WIDENED past the raw measurement, got {needed_gb}"
         );
         let expected_widened_bytes =
-            (raw_peak_bytes as f64 * (1.0 + CANDLE_STALE_MEASURED_MARGIN)).ceil();
+            (raw_peak_bytes as f64 * (1.0 + CANDLE_RECAPTURE_SPREAD)).ceil();
         assert_eq!(needed_gb, expected_widened_bytes / BYTES_PER_GIB);
     }
 
@@ -2408,6 +2481,7 @@ mod tests {
                 evidence: record,
                 closure_digest: STALE_CLOSURE,
                 basis: CandidateBasis::Measured,
+                unmodeled_activation_bytes: None,
             })
             .collect::<Vec<_>>();
         let selection = select_strategy(
@@ -2468,6 +2542,7 @@ mod tests {
                 evidence: &staged,
                 closure_digest: STALE_CLOSURE,
                 basis: CandidateBasis::Measured,
+                unmodeled_activation_bytes: None,
             }],
         );
         let Selection::Reject { needed_gb, .. } = result else {
@@ -2505,12 +2580,14 @@ mod tests {
             evidence: &current,
             closure_digest: INF,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
         let stale_candidate = Candidate {
             selection,
             evidence: &stale,
             closure_digest: STALE_CLOSURE,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
         let budget = Some(Budget {
             available_gb: 10.0,
@@ -2572,6 +2649,7 @@ mod tests {
                     evidence: &captured,
                     closure_digest: STALE_CLOSURE,
                     basis: CandidateBasis::Measured,
+                    unmodeled_activation_bytes: None,
                 }],
             ),
             Selection::Unverified {
@@ -2598,6 +2676,7 @@ mod tests {
                     evidence: &wrong_backend,
                     closure_digest: STALE_CLOSURE,
                     basis: CandidateBasis::Measured,
+                    unmodeled_activation_bytes: None,
                 }],
             ),
             Selection::Unverified {
@@ -2634,6 +2713,7 @@ mod tests {
             evidence: &staged,
             closure_digest: STALE_CLOSURE,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
         let budget = |available_gb| {
             Some(Budget {
@@ -2656,8 +2736,7 @@ mod tests {
         else {
             panic!("the MLX-widened peak fits a 13 GiB budget");
         };
-        let expected_widened_bytes =
-            (raw_peak_bytes as f64 * (1.0 + MLX_STALE_MEASURED_MARGIN)).ceil();
+        let expected_widened_bytes = (raw_peak_bytes as f64 * (1.0 + MLX_RECAPTURE_SPREAD)).ceil();
         assert_eq!(needed_gb, expected_widened_bytes / BYTES_PER_GIB);
     }
 
@@ -2716,13 +2795,14 @@ mod tests {
                     evidence: &staged,
                     closure_digest: STALE_CLOSURE,
                     basis: CandidateBasis::Measured,
+                    unmodeled_activation_bytes: None,
                 }],
             )
         });
         assert!(matches!(result, Selection::Selected { .. }), "{result:?}");
         let output = String::from_utf8(capture.0.lock().unwrap().clone()).unwrap();
         let widened_peak_bytes =
-            (raw_peak_bytes as f64 * (1.0 + CANDLE_STALE_MEASURED_MARGIN)).ceil() as u64;
+            (raw_peak_bytes as f64 * (1.0 + CANDLE_RECAPTURE_SPREAD)).ceil() as u64;
         assert!(
             output.contains("stale-closure memory-strategy candidate admitted with widened margin"),
             "admission event missing from trace output: {output}"
@@ -2780,13 +2860,14 @@ mod tests {
                 evidence: &staged,
                 closure_digest: INF,
                 basis: CandidateBasis::EstimateFloor,
+                unmodeled_activation_bytes: None,
             }],
         );
         let Selection::Selected { needed_gb, .. } = result else {
             panic!("an implemented rung's estimate candidate must be selectable: {result:?}");
         };
         let expected_widened_bytes =
-            (raw_peak_bytes as f64 * (1.0 + CANDLE_ESTIMATE_MARGIN)).ceil();
+            (raw_peak_bytes as f64 * (1.0 + CANDLE_RECAPTURE_SPREAD)).ceil();
         assert_eq!(needed_gb, expected_widened_bytes / BYTES_PER_GIB);
         // The candle estimate margin is strictly wider than the candle stale margin — pinned at
         // COMPILE TIME by `ladder_margin_policy`'s invariant block — so grading an estimate with
@@ -2822,6 +2903,7 @@ mod tests {
                 evidence: &staged,
                 closure_digest: INF,
                 basis: CandidateBasis::EstimateFloor,
+                unmodeled_activation_bytes: None,
             }],
         );
         let Selection::Reject { needed_gb, .. } = result else {
@@ -2859,12 +2941,14 @@ mod tests {
             evidence: &measured,
             closure_digest: INF,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
         let estimate_candidate = Candidate {
             selection,
             evidence: &estimate,
             closure_digest: INF,
             basis: CandidateBasis::EstimateFloor,
+            unmodeled_activation_bytes: None,
         };
         let budget = Some(Budget {
             available_gb: 10.0,
@@ -2897,6 +2981,7 @@ mod tests {
             evidence: &measured,
             closure_digest: STALE_CLOSURE,
             basis: CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         };
         let result = select_strategy(
             request(),
@@ -2907,8 +2992,7 @@ mod tests {
         let Selection::Selected { needed_gb, .. } = result else {
             panic!("the stale measurement must stay selectable: {result:?}");
         };
-        let expected_widened_bytes =
-            (8.0 * BYTES_PER_GIB * (1.0 + CANDLE_STALE_MEASURED_MARGIN)).ceil();
+        let expected_widened_bytes = (8.0 * BYTES_PER_GIB * (1.0 + CANDLE_RECAPTURE_SPREAD)).ceil();
         assert_eq!(
             needed_gb,
             expected_widened_bytes / BYTES_PER_GIB,
@@ -2934,6 +3018,160 @@ mod tests {
                 Selection::Reject { .. }
             ),
             "an estimate must not overrule the measured refusal at its own rung"
+        );
+    }
+
+    /// sc-22508 AC: **a 60 GB anchor-derived peak admits at every rung it truly fits on a 128 GB
+    /// budget.** Under the retired blanket policy that peak was graded at `60 * 1.5041 = 90.2 GB`,
+    /// so the whole 90.2..128 band of hosts that genuinely fit the render refused it. The anchor
+    /// derivation prices its own terms, so the selector now grades it AT its peak.
+    ///
+    /// The test walks the ladder rung by rung rather than checking one budget, because "admits at
+    /// every rung it truly fits" is a claim about the whole ladder: each rung's derived peak must
+    /// be admitted on a host that holds exactly that peak, and every rung deeper than the request
+    /// must too.
+    #[test]
+    fn a_sixty_gb_anchor_derived_peak_admits_at_every_rung_it_fits_on_a_128_gb_host() {
+        let provider = contract();
+        // Rung peaks in GB, resident..bounded-transformer. The resident rung IS the AC's 60 GB.
+        let peaks_gb = [60.0_f64, 48.0, 36.0, 24.0, 12.0];
+        let evidences = MemoryStrategy::ALL
+            .into_iter()
+            .zip(peaks_gb)
+            .map(|(strategy, gb)| {
+                let mut record = estimate_evidence(strategy, &provider);
+                record.key.parameters = cumulative_params(strategy);
+                record.predicted_peak_bytes = (gb * BYTES_PER_GIB) as u64;
+                record
+            })
+            .collect::<Vec<_>>();
+        let candidates = MemoryStrategy::ALL
+            .into_iter()
+            .zip(&evidences)
+            .map(|(strategy, record)| Candidate {
+                selection: MemorySelection {
+                    strategy,
+                    parameters: cumulative_params(strategy),
+                    tier: tier(),
+                },
+                evidence: record,
+                closure_digest: INF,
+                basis: CandidateBasis::EstimateAnchorDerived,
+                unmodeled_activation_bytes: None,
+            })
+            .collect::<Vec<_>>();
+
+        // A 128 GB host. `available_gb` is what a real budget leaves after the OS and other
+        // residents; sweeping it across the ladder is what makes the claim "every rung it fits".
+        for (index, strategy) in MemoryStrategy::ALL.into_iter().enumerate() {
+            // Exactly the bytes this rung's derived peak needs, and not one byte more: the raw
+            // peak IS the admitted ceiling, so equality must fit.
+            let available_gb = peaks_gb[index];
+            let selection = select_strategy(
+                request(),
+                &provider,
+                Some(Budget {
+                    available_gb,
+                    reclaimable_gb: 0.0,
+                    total_gb: 128.0,
+                    reserved_headroom_gb: 0.0,
+                }),
+                &candidates,
+            );
+            match selection {
+                Selection::Selected {
+                    selection: chosen,
+                    needed_gb,
+                    ..
+                } => {
+                    assert_eq!(
+                        chosen.strategy, strategy,
+                        "a host holding exactly the {strategy:?} derived peak must select that \
+                         rung, not a deeper one"
+                    );
+                    assert!(
+                        (needed_gb - available_gb).abs() < 1e-9,
+                        "the admitted need must be the derived peak itself ({available_gb}), not a \
+                         widened one: {needed_gb}"
+                    );
+                }
+                other => panic!("{strategy:?} at exactly its derived peak must admit: {other:?}"),
+            }
+        }
+
+        // The retired blanket margin is the mutation this test exists to catch: grading the 60 GB
+        // resident peak at `60 * 1.5041` would need 90.24 GB, so a 128 GB host with 60 GB free
+        // would have dropped to a deeper rung. Pin that the band really is closed.
+        let blanket_widened_gb = 60.0 * (1.0 + 0.5040734033902377);
+        assert!(
+            blanket_widened_gb > 60.0 && blanket_widened_gb < 128.0,
+            "the retired margin really did sit inside the 128 GB host's band"
+        );
+        assert_eq!(
+            admitted_peak_bytes(
+                candidates[0].admission_subject(MemoryBackend::Mlx, CandidateCurrency::Estimate),
+                evidences[0].predicted_peak_bytes,
+            ),
+            evidences[0].predicted_peak_bytes,
+            "an anchor-derived candidate is graded at its peak, with no selector allowance"
+        );
+    }
+
+    /// sc-22508 E3, at the selector seam: a FLOOR's allowance is charged against its declared
+    /// headroom term, so two floors with identical headroom and wildly different counted weights
+    /// receive the same allowance in bytes. No fraction-of-the-peak margin can satisfy this.
+    #[test]
+    fn a_floors_allowance_tracks_its_headroom_term_not_its_counted_weights() {
+        let provider = contract();
+        let headroom_bytes = (6.0 * BYTES_PER_GIB) as u64;
+        let small = (10.0 * BYTES_PER_GIB) as u64 + headroom_bytes;
+        let large = (100.0 * BYTES_PER_GIB) as u64 + headroom_bytes;
+
+        let mut small_record = estimate_evidence(MemoryStrategy::Resident, &provider);
+        small_record.predicted_peak_bytes = small;
+        let mut large_record = estimate_evidence(MemoryStrategy::Resident, &provider);
+        large_record.predicted_peak_bytes = large;
+
+        fn floor_of<'a>(record: &'a MemoryEvidence, headroom_bytes: u64) -> Candidate<'a> {
+            Candidate {
+                selection: MemorySelection {
+                    strategy: MemoryStrategy::Resident,
+                    parameters: cumulative_params(MemoryStrategy::Resident),
+                    tier: tier(),
+                },
+                evidence: record,
+                closure_digest: INF,
+                basis: CandidateBasis::EstimateFloor,
+                unmodeled_activation_bytes: Some(headroom_bytes),
+            }
+        }
+        let subject = |candidate: &Candidate<'_>| {
+            candidate.admission_subject(MemoryBackend::Mlx, CandidateCurrency::Estimate)
+        };
+
+        let small_candidate = floor_of(&small_record, headroom_bytes);
+        let large_candidate = floor_of(&large_record, headroom_bytes);
+        let small_allowance = admitted_peak_bytes(subject(&small_candidate), small) - small;
+        let large_allowance = admitted_peak_bytes(subject(&large_candidate), large) - large;
+
+        assert_eq!(
+            crate::ladder_margin_policy::admission_allowance(subject(&small_candidate)).term,
+            AdmissionTerm::AllocatorEnvelopeOverActivation
+        );
+        assert_eq!(
+            small_allowance,
+            (headroom_bytes as f64 * FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE).ceil() as u64
+        );
+        assert_eq!(
+            small_allowance, large_allowance,
+            "a 10x larger weights term must not buy a larger allowance — the allowance belongs to \
+             the headroom, which is identical here"
+        );
+        // A whole-peak margin would have charged the big floor ~10x more; state that directly so
+        // reintroducing one cannot pass.
+        assert!(
+            large_allowance * 2 < large,
+            "the allowance must stay a term-sized number, not a fraction of a 106 GiB peak"
         );
     }
 
@@ -2965,6 +3203,7 @@ mod tests {
                 evidence: record,
                 closure_digest: INF,
                 basis: CandidateBasis::EstimateFloor,
+                unmodeled_activation_bytes: None,
             })
             .collect::<Vec<_>>();
         let selection = select_strategy(
@@ -3048,13 +3287,14 @@ mod tests {
                     evidence: &staged,
                     closure_digest: INF,
                     basis: CandidateBasis::EstimateFittedCurve,
+                    unmodeled_activation_bytes: None,
                 }],
             )
         });
         assert!(matches!(result, Selection::Selected { .. }), "{result:?}");
         let output = String::from_utf8(capture.0.lock().unwrap().clone()).unwrap();
         let widened_peak_bytes =
-            (raw_peak_bytes as f64 * (1.0 + CANDLE_ESTIMATE_MARGIN)).ceil() as u64;
+            (raw_peak_bytes as f64 * (1.0 + CANDLE_RECAPTURE_SPREAD)).ceil() as u64;
         assert!(
             output
                 .contains("estimate-backed memory-strategy candidate admitted with widened margin"),

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -1177,13 +1177,14 @@ struct VerifiedGeometryAlternative {
 /// closure-current binding, but a DIFFERENT geometry — the cell the request itself could not be
 /// admitted on.
 ///
-/// Closure-current is a deliberate restriction, not an oversight: `MLX_ESTIMATE_MARGIN` was
-/// derived to cover extrapolation error on top of same-closure re-capture variance
-/// (`crates/sceneworks-worker/src/ladder_margin_policy.rs`). A stale-closure record already carries
-/// its own corpus-derived drift allowance on the MEASURED path; stacking that drift under an
-/// extrapolation would spend the estimate margin twice, and no derivation covers the sum — so a
-/// stale record may keep serving its own cell behind the stale margin (sc-18095) but may not seed
-/// an extrapolated estimate.
+/// Closure-current is a deliberate restriction, not an oversight: a fitted-curve estimate is
+/// charged exactly ONE allowance — `AdmissionTerm::SameCellRecaptureSpread`, the measured
+/// capture-to-capture spread of the cell the curve was fitted through
+/// (`crates/sceneworks-worker/src/ladder_margin_policy.rs`). A stale-closure record carries that
+/// same recapture term on the MEASURED path for its own cell. Seeding an extrapolation from one
+/// would stack closure drift under the extrapolation while still paying for a single recapture,
+/// and no derivation covers the sum — so a stale record may keep serving its own cell (sc-18095)
+/// but may not seed an extrapolated estimate.
 ///
 /// Everything the extrapolation, the binding-phase constraint, and the loaded-provider identity
 /// gate need is captured here, so the synthesis step never re-reads the bundle.
@@ -2095,6 +2096,11 @@ struct SynthesizedEstimate {
     selection: MemorySelection,
     evidence: MemoryEvidence,
     basis: crate::memory_strategy::CandidateBasis,
+    /// The ACTIVATION slice of `evidence.predicted_peak_bytes`, declared by the arm that built the
+    /// peak (sc-22508). `Some` only on the weights+headroom floor arm, which composes the peak here
+    /// as `estimate_floor_weights_bytes + generic_headroom_bytes` and therefore knows the split;
+    /// the fitted-curve arm scales a measured envelope and has none to declare.
+    unmodeled_activation_bytes: Option<u64>,
     decode_quality: DecodeQualityRequestDecision,
 }
 
@@ -2785,6 +2791,7 @@ fn synthesize_estimate_ladder(
                             calibration_fingerprint,
                         ),
                         basis: CandidateBasis::EstimateFittedCurve,
+                        unmodeled_activation_bytes: None,
                         decode_quality: parameter_candidate.decode_quality.clone(),
                     })
                 });
@@ -2806,8 +2813,9 @@ fn synthesize_estimate_ladder(
             if contract.validate_selection(&selection).is_err() {
                 continue;
             }
+            let floor_activation_bytes = plan.generic_headroom_bytes(geometry);
             let predicted_peak_bytes = estimate_floor_weights_bytes(contract, &engaged)
-                .saturating_add(plan.generic_headroom_bytes(geometry));
+                .saturating_add(floor_activation_bytes);
             tracing::info!(
                 route = contract.provider_id,
                 backend = "mlx",
@@ -2829,6 +2837,8 @@ fn synthesize_estimate_ladder(
                     calibration_fingerprint,
                 ),
                 basis: CandidateBasis::EstimateFloor,
+                // Declared where the split is CONSTRUCTED, three lines above.
+                unmodeled_activation_bytes: Some(floor_activation_bytes),
                 decode_quality: parameter_candidate.decode_quality,
             };
             ladder
@@ -3463,6 +3473,14 @@ fn evaluate_request_with_budget_using_bundle(
     // `Measured`. Pushed at the same sites as `evidence` for the same fail-open reason as the
     // digests above.
     let mut candidate_bases: Vec<crate::memory_strategy::CandidateBasis> = Vec::new();
+    // Index-aligned ACTIVATION axis (sc-22508), pushed at the same sites for the same reason: only
+    // the site that CONSTRUCTED a peak knows whether it decomposes into counted weights and a flat
+    // activation term, and what that term is. A blanket declaration here was wrong for two peaks —
+    // a `mage_flow` route, whose peak is `providers::mage::memory::generation_peak_gb` and has no
+    // weights/headroom split at all, and any peak a generator rewrote through
+    // `predicted_memory_peak_from_base`. Both now carry `None` and take the policy's documented
+    // undeclared-floor arm instead of being charged a headroom they do not contain.
+    let mut candidate_activation_bytes: Vec<Option<u64>> = Vec::new();
     if admission.path == AdmissionPath::Evidence {
         // A covered cell is authorized only by its exact verified ladder. Letting the generic
         // resident estimate or caller-supplied evidence run first would turn Evidence telemetry
@@ -3503,6 +3521,8 @@ fn evaluate_request_with_budget_using_bundle(
                 evidence.push(exact);
                 candidate_digests.push(candidate.closure_digest.as_str());
                 candidate_bases.push(crate::memory_strategy::CandidateBasis::Measured);
+                // A measured envelope is one observed number; it does not decompose.
+                candidate_activation_bytes.push(None);
             }
         }
         if evidence.is_empty() {
@@ -3551,6 +3571,7 @@ fn evaluate_request_with_budget_using_bundle(
         evidence.reserve(capacity);
         candidate_digests.reserve(capacity);
         candidate_bases.reserve(capacity);
+        candidate_activation_bytes.reserve(capacity);
         selections.push(resident_selection);
         evidence.push(&resident);
         candidate_digests.push(live_closure_digest.as_str());
@@ -3558,6 +3579,17 @@ fn evaluate_request_with_budget_using_bundle(
         // peak source is unchanged, but it is now graded behind the estimate margin like every
         // other unmeasured candidate instead of at its raw guess.
         candidate_bases.push(CandidateBasis::EstimateFloor);
+        // ...but its PEAK does not decompose here, so it declares no activation term (sc-22508).
+        // This candidate's peak is `predicted_memory_peak_from_base(contract_base_peak_bytes(
+        // request_total_peak_bytes(..)))` minus `attributable_resident_bytes`. Two of those three
+        // steps can destroy the weights+headroom shape: `request_total_peak_bytes` returns the
+        // `mage_flow` provider's own `generation_peak_gb` scalar on that route, and
+        // `predicted_memory_peak_from_base` is a gen-core trait method the loaded provider owns
+        // and may rewrite arbitrarily. Naming `generic_headroom_bytes` here would have declared a
+        // term the peak need not contain — on the mage route, a term the peak DEMONSTRABLY does
+        // not contain. `None` takes the policy's undeclared-floor arm, whose doc says the fix for
+        // a lane that wants better is to declare a real split, not to widen a number.
+        candidate_activation_bytes.push(None);
         selections.extend(additional_evidence.iter().map(|item| MemorySelection {
             strategy: item.key.strategy,
             parameters: item.key.parameters,
@@ -3570,11 +3602,13 @@ fn evaluate_request_with_budget_using_bundle(
                 .map(|_| live_closure_digest.as_str()),
         );
         candidate_bases.extend(additional_evidence.iter().map(|_| CandidateBasis::Measured));
+        candidate_activation_bytes.extend(additional_evidence.iter().map(|_| None));
         for estimate in synthesized_estimates {
             selections.push(estimate.selection);
             evidence.push(&estimate.evidence);
             candidate_digests.push(live_closure_digest.as_str());
             candidate_bases.push(estimate.basis);
+            candidate_activation_bytes.push(estimate.unmodeled_activation_bytes);
         }
     }
     // The digests are carried from the push sites rather than recovered by searching
@@ -3585,26 +3619,23 @@ fn evaluate_request_with_budget_using_bundle(
     // the evidence removes the failure mode instead of arguing it cannot happen.
     debug_assert_eq!(evidence.len(), candidate_digests.len());
     debug_assert_eq!(evidence.len(), candidate_bases.len());
+    debug_assert_eq!(evidence.len(), candidate_activation_bytes.len());
     let candidates = selections
         .iter()
         .zip(evidence)
         .zip(candidate_digests.iter().zip(&candidate_bases))
+        .zip(&candidate_activation_bytes)
         .map(
-            |((selection, evidence), (closure_digest, basis))| Candidate {
+            |(((selection, evidence), (closure_digest, basis)), activation)| Candidate {
                 selection: *selection,
                 evidence,
                 closure_digest,
                 basis: *basis,
-                // sc-22508: every floor on this lane — the resident baseline and each synthesized
-                // rung floor alike — is built as `estimate_floor_weights_bytes +
-                // generic_headroom_bytes`, the SAME headroom convention (fixed reserve + area law).
-                // Declaring it lets the selector charge that flat activation allowance instead of
-                // taxing the counted weights beside it.
-                unmodeled_activation_bytes: matches!(
-                    basis,
-                    crate::memory_strategy::CandidateBasis::EstimateFloor
-                )
-                .then(|| plan.generic_headroom_bytes(geometry)),
+                // sc-22508: carried from the site that BUILT each peak (see
+                // `candidate_activation_bytes`), never inferred from the basis label here. A
+                // `CandidateBasis::EstimateFloor` label says how much evidence stands behind a
+                // number; it does not say the number is `weights + generic_headroom_bytes`.
+                unmodeled_activation_bytes: *activation,
             },
         )
         .collect::<Vec<_>>();
@@ -5046,6 +5077,10 @@ fn generic_mlx_shared_observation(
         parameters: Default::default(),
         tier,
     };
+    let headroom_bytes = (headroom_gb * BYTES_PER_GIB)
+        .max(0.0)
+        .ceil()
+        .clamp(0.0, u64::MAX as f64) as u64;
     let evidence = MemoryEvidence {
         key: MemoryEvidenceKey {
             model_family: "generic_mlx_cold_load".into(),
@@ -5078,7 +5113,17 @@ fn generic_mlx_shared_observation(
         sceneworks_revision: "sc-15449-contract-v1".into(),
         inference_revision: "1c4354b4b22d7f2cf5c4ea5fe17a83ab6c655e82".into(),
         harness_version: String::new(),
-        predicted_peak_bytes: total_bytes,
+        // sc-22508: the peak is the WHOLE floor — resolved-spec weights plus the activation
+        // headroom — because the allowance declared below must be a slice of the peak it grades,
+        // not a second charge sitting outside it (`memory_strategy::Candidate
+        // ::unmodeled_activation_bytes`). Headroom used to live only in the budget's
+        // `reserved_headroom_gb`, which made the declaration an out-of-band charge.
+        //
+        // Moving it is exactly value-preserving, not a policy change: the comparison was
+        // `weights + 0.17*headroom <= total - headroom` and is now
+        // `(weights + headroom) + 0.17*headroom <= total`, the same inequality. `reserved_headroom_gb`
+        // is zeroed below so the term is counted once.
+        predicted_peak_bytes: total_bytes.saturating_add(headroom_bytes),
         observed_peak_bytes: None,
         parity: MemoryParityContract::Exact,
         parity_result: MemoryParityResult::NotRun,
@@ -5111,7 +5156,9 @@ fn generic_mlx_shared_observation(
             available_gb: budget.total_gb,
             reclaimable_gb: 0.0,
             total_gb: budget.total_gb,
-            reserved_headroom_gb: headroom_gb,
+            // Zero, because the headroom is now IN the candidate's peak (see the peak's comment).
+            // Leaving it here as well would charge the term twice.
+            reserved_headroom_gb: 0.0,
         }),
         &[Candidate {
             selection,
@@ -5120,12 +5167,9 @@ fn generic_mlx_shared_observation(
             // The generic cold-load estimate is exactly a weights+headroom floor (sc-18096).
             basis: crate::memory_strategy::CandidateBasis::EstimateFloor,
             // sc-22508: the headroom half of that floor is the only uncertain term; the weights
-            // half is the resolved load spec's counted bytes.
-            unmodeled_activation_bytes: Some(
-                (headroom_gb * BYTES_PER_GIB)
-                    .ceil()
-                    .clamp(0.0, u64::MAX as f64) as u64,
-            ),
+            // half is the resolved load spec's counted bytes. This is a genuine slice of
+            // `predicted_peak_bytes` above, which is what the field's contract requires.
+            unmodeled_activation_bytes: Some(headroom_bytes),
         }],
     )
 }
@@ -8909,17 +8953,76 @@ mod tests {
         generator
     }
 
+    /// sc-22508 (review): the legacy RESIDENT BASELINE declares no weights/activation split, and
+    /// this pins that the selector grades it accordingly.
+    ///
+    /// Its peak is not built here as `weights + generic_headroom_bytes`. It arrives through
+    /// `request_total_peak_bytes` — which returns `providers::mage::memory::generation_peak_gb`, a
+    /// single provider scalar, on the `mage_flow` route — and then through the loaded generator's
+    /// `predicted_memory_peak_from_base`, a gen-core trait method that may rewrite it. Declaring
+    /// `generic_headroom_bytes` for it would charge 17% of a term the peak need not contain.
+    ///
+    /// The two ceilings differ, so the choice is observable: at a host between them, a baseline
+    /// that declared the headroom term would be admitted as Resident, while the undeclared-floor
+    /// arm the policy documents refuses it and the ladder walks down. Both bounds are computed
+    /// from the policy, so this stays a statement about WHICH arm is charged rather than about
+    /// today's fractions.
+    #[test]
+    fn the_legacy_resident_baseline_is_graded_without_a_declared_activation_split() {
+        let generator = full_ladder_generator();
+        let mut plan = fixture_plan();
+        plan.calibration = MlxCalibrationConfig::Absent;
+        let inputs = fixture_inputs(1024, 1024);
+        let baseline_peak_bytes = gib_to_bytes(FIXTURE_SHALLOW_ESTIMATE_FLOOR_GB);
+        let declared_ceiling_gb = widened_estimate_gb(FIXTURE_SHALLOW_ESTIMATE_FLOOR_GB);
+        let undeclared_ceiling_gb = crate::memory_strategy::peak_bytes_to_gb(
+            crate::memory_strategy::floor_admitted_peak_bytes(
+                gen_core::MemoryBackend::Mlx,
+                baseline_peak_bytes,
+                None,
+            ),
+        );
+        assert!(
+            declared_ceiling_gb < undeclared_ceiling_gb,
+            "the two arms must differ for this fixture to discriminate: \
+             declared {declared_ceiling_gb}, undeclared {undeclared_ceiling_gb}"
+        );
+        let host_gb = (declared_ceiling_gb + undeclared_ceiling_gb) / 2.0;
+        let evaluation = evaluate_request_with_budget(
+            &generator,
+            &plan,
+            &inputs,
+            MemoryCacheState::Cold,
+            OffloadPolicy::Resident,
+            fixture_budget(host_gb),
+            baseline_peak_bytes,
+            0,
+            &[],
+        )
+        .expect("the ladder must walk down rather than refuse");
+        assert_ne!(
+            evaluation.context.selection.strategy,
+            MemoryStrategy::Resident,
+            "the resident baseline must be graded on the undeclared-floor arm; declaring the \
+             generic headroom for it admits at {declared_ceiling_gb} GiB and selects Resident here"
+        );
+    }
+
     /// sc-18096 acceptance: an UNMEASURED provider (no calibration opt-in, no evidence bundle)
     /// under a small emulated unified-memory budget — the `SCENEWORKS_MLX_MEMORY_CAP_GB` scenario,
     /// driven through the same pure seam the cap feeds — selects a DEEP rung instead of refusing,
     /// and the selection translates to the right engine knobs.
     ///
-    /// Floor arithmetic (fixture facts: base 3 GiB all transformer, headroom 2 fixed + 4 area):
-    ///   resident        9 GiB modeled -> widened 13.54
-    ///   staged floor    3 + 6 = 9     -> widened 13.54
-    ///   decode floor    3 + 6 = 9     -> widened 13.54  (bounds transients, not weights)
-    ///   attention floor 3 + 6 = 9     -> widened 13.54
-    ///   rung 4 floor    0 + 6 = 6     -> widened  9.02  (windowed transformer leaves residency)
+    /// Floor arithmetic (fixture facts: base 3 GiB all transformer, headroom 2 fixed + 4 area).
+    /// sc-22508 charges each declared floor 17% of its ACTIVATION term (6 GiB) — not a percentage
+    /// of the whole floor — so every ceiling below is `floor + 1.02`, and the numbers here are the
+    /// ones `widened_estimate_gb` computes:
+    ///   staged floor    3 + 6 = 9     -> admitted 10.02
+    ///   decode floor    3 + 6 = 9     -> admitted 10.02  (bounds transients, not weights)
+    ///   attention floor 3 + 6 = 9     -> admitted 10.02
+    ///   rung 4 floor    0 + 6 = 6     -> admitted  7.02  (windowed transformer leaves residency)
+    /// The resident BASELINE declares no split (see the test above) and is graded on the
+    /// undeclared-floor arm instead: 9 * (1 + MLX_RECAPTURE_SPREAD) = 10.13.
     /// A 9.1 GiB budget therefore admits exactly one rung: BoundedTransformerResidency.
     #[test]
     fn unmeasured_provider_under_a_small_budget_selects_a_deep_estimate_rung() {
@@ -13627,12 +13730,19 @@ mod tests {
                 reference_count: 0,
             };
             let raw_incremental_peak = plan.generic_headroom_bytes(geometry);
-            // This peak IS the headroom term (weights are credited as already resident), so the
-            // sc-22508 floor allowance charges all of it — the admitted ceiling is twice the raw.
+            // The counterfactual must be graded on the arm PRODUCTION uses for this candidate, not
+            // on the one the audit can see is true. This peak is the legacy RESIDENT BASELINE's
+            // (weights are credited as already resident, leaving the headroom term), and sc-22508
+            // gives that baseline no weights/activation declaration: its peak reaches the selector
+            // through `predicted_memory_peak_from_base`, and on `mage_flow` through the provider's
+            // own `generation_peak_gb`, neither of which is guaranteed to decompose. So the policy
+            // charges it the undeclared-floor arm — the whole-peak recapture spread — and passing
+            // `Some(raw_incremental_peak)` here would model a 17%-of-activation ceiling production
+            // never applies. That mismatch is what this assertion caught.
             let widened_incremental_peak = crate::memory_strategy::floor_admitted_peak_bytes(
                 gen_core::MemoryBackend::Mlx,
                 raw_incremental_peak,
-                Some(raw_incremental_peak),
+                None,
             );
             // These are precisely the cells for which no optimized product contract applies. Model
             // their legacy Resident fallback with the same compatibility contract production uses
@@ -13731,13 +13841,23 @@ mod tests {
             // have no estimate band left to flip. sc-20799 removed the fourth row the same way:
             // retiring `flux2_dev`'s `exhaustive` reading gave its T2I route a declared
             // `staged_residency` rung across bf16/q4/q8, so the bf16 cell is no longer
-            // Resident-only and has no band to flip. sc-22508 narrowed the band itself: an
-            // estimate floor is no longer widened by a blanket 50.41% of its whole peak but by 17%
-            // of its ACTIVATION term alone, so `flux2_dev` q4 at 64 GiB and `ideogram_4` q8 at
-            // 48 GiB now admit at both host sizes and have no band left to flip. The one that
-            // remains has no ladder yet, which is what keeps this list a live audit rather than a
-            // formality.
-            vec![("ideogram_4_turbo", "ideogram_4_turbo", "q8", 48)],
+            // Resident-only and has no band to flip. sc-22508 narrowed the band itself and emptied
+            // the list.
+            //
+            // The blanket 50.41%-of-the-whole-peak widening is gone. What remains for the legacy
+            // RESIDENT BASELINE audited here is the policy's undeclared-floor arm — the same-cell
+            // recapture spread, 12.6% of the peak — because this candidate's peak reaches the
+            // selector through `predicted_memory_peak_from_base` (and, on `mage_flow`, through the
+            // provider's own `generation_peak_gb`) and is not guaranteed to decompose into counted
+            // weights plus an activation term. `flux2_dev` q4 at 64 GiB and both `ideogram_4` and
+            // `ideogram_4_turbo` q8 at 48 GiB now admit at every audited host size, so no cell has
+            // a band left to flip.
+            //
+            // An EMPTY list is a real audited result here, not a disabled check: the walk above
+            // still asserts coverage of every source-derived cell, and `admitted_now` is still
+            // compared against the production selector for each one. A future manifest or policy
+            // change that reopens a band reds this list rather than passing silently.
+            Vec::<(&str, &str, &str, u64)>::new(),
             "the source-bound resident-only audit changed; update the recorded result, \
              not only this expectation: {flips:?}"
         );
@@ -14121,13 +14241,32 @@ mod tests {
         // sc-18096 (scope addendum from sc-18095's review): the `StaleIdentity` pre-demotion in
         // `evidence_admission_route` is retired. A binding measured under a moved closure still
         // reaches `AdmissionPath::Evidence`; its candidate carries the digest it was MEASURED
-        // under, and `select_strategy` grades it behind `MLX_STALE_MEASURED_MARGIN`. This is the
-        // PRODUCTION-routing proof that the sc-18095 selector arm is reachable on the MLX lane —
-        // not merely a selector unit test.
+        // under, and `select_strategy` grades it at the stale-measured admitted ceiling
+        // (`AdmissionTerm::SameCellRecaptureSpread`). This is the PRODUCTION-routing proof that
+        // the sc-18095 selector arm is reachable on the MLX lane — not merely a selector unit test.
         //
         // Fixture arithmetic: the record's envelope peak is exactly 5 GiB with a 3 GiB captured
-        // foreign reserve, so the widened requirement is ~5 * 1.252 = 6.26 GiB against
-        // `total - reserve` of effective budget.
+        // foreign reserve, so the requirement is `stale_admitted_peak_bytes(Mlx, 5 GiB)` — the
+        // peak plus `MLX_RECAPTURE_SPREAD` of it — against `total - reserve` of effective budget.
+        // The two budgets below are derived from that call rather than restating its value.
+        let stale_requirement_gb = crate::memory_strategy::peak_bytes_to_gb(
+            crate::memory_strategy::stale_admitted_peak_bytes(
+                gen_core::MemoryBackend::Mlx,
+                gib_to_bytes(5.0),
+            ),
+        );
+        // The bracket the two end-to-end arms below depend on, stated where it can red: with the
+        // 3 GiB captured foreign reserve removed, the widened stale requirement must fit the
+        // 9.5 GiB host and must NOT fit the 8.5 GiB one. An allowance change that breaks either
+        // side fails here, naming the reason, instead of silently turning one arm hollow.
+        assert!(
+            stale_requirement_gb <= 9.5 - 3.0,
+            "the 9.5 GiB arm must admit: {stale_requirement_gb}"
+        );
+        assert!(
+            stale_requirement_gb > 8.5 - 3.0,
+            "the 8.5 GiB arm must refuse: {stale_requirement_gb}"
+        );
         let bundle = fixture_bundle();
         let generator = fixture_generator();
         let plan = fixture_plan();
@@ -14168,8 +14307,8 @@ mod tests {
         assert!(stale.lower_alternative.is_none());
 
         // End to end at 9.5 GiB: effective budget is 9.5 - 3 (captured foreign reserve) = 6.5 GiB,
-        // the widened 6.26 GiB fits, and the request keeps the exact verified rung INCLUDING its
-        // request-scoped process ceiling.
+        // the recapture-widened 5.63 GiB fits, and the request keeps the exact verified rung
+        // INCLUDING its request-scoped process ceiling.
         let admitted = evaluate_request_with_budget_using_bundle(
             &generator,
             &plan,
@@ -16895,21 +17034,39 @@ mod tests {
 
     #[test]
     fn generic_mlx_adopts_shared_selector_without_an_optimized_claim() {
+        let weights_bytes = 4 * 1024 * 1024 * 1024;
         let observation = generic_mlx_shared_observation(
-            4 * 1024 * 1024 * 1024,
+            weights_bytes,
             Some(MlxMemoryBudget { total_gb: 32.0 }),
             HEADROOM_GB,
         );
-        assert!(matches!(
-            observation,
-            crate::memory_strategy::Selection::Selected {
-                selection: gen_core::MemorySelection {
-                    strategy: gen_core::MemoryStrategy::Resident,
-                    ..
-                },
-                ..
-            }
-        ));
+        let crate::memory_strategy::Selection::Selected {
+            selection,
+            needed_gb,
+            ..
+        } = observation
+        else {
+            panic!("the generic cold-load floor must reach a selection: {observation:?}");
+        };
+        assert_eq!(selection.strategy, gen_core::MemoryStrategy::Resident);
+        // sc-22508: the declared activation term must be a SLICE OF THE GRADED PEAK, never a
+        // second charge sitting beside it. This route's headroom used to live only in the budget's
+        // `reserved_headroom_gb`, which made `unmodeled_activation_bytes` an out-of-band charge
+        // contradicting the field's contract. Pin that the graded peak now contains it: a peak
+        // rebuilt from the weights alone lands 18 GiB lower and reds here.
+        let headroom_bytes = (HEADROOM_GB * BYTES_PER_GIB).ceil() as u64;
+        assert_eq!(
+            needed_gb,
+            crate::memory_strategy::peak_bytes_to_gb(
+                crate::memory_strategy::floor_admitted_peak_bytes(
+                    gen_core::MemoryBackend::Mlx,
+                    weights_bytes + headroom_bytes,
+                    Some(headroom_bytes),
+                )
+            ),
+            "the floor's peak is weights + headroom, and its allowance is a fraction of the \
+             headroom term inside that peak"
+        );
     }
 
     /// The load-time weights floor (`weights_floor_load_admission`, formerly

--- a/crates/sceneworks-worker/src/mlx_fit_gate.rs
+++ b/crates/sceneworks-worker/src/mlx_fit_gate.rs
@@ -1949,7 +1949,7 @@ fn evidence_admission_route(
                 };
                 let foreign_reserve_bytes =
                     envelope.foreign_reserve_for_host_bytes(budget.total_bytes);
-                let stale_peak_bytes = crate::memory_strategy::stale_widened_peak_bytes(
+                let stale_peak_bytes = crate::memory_strategy::stale_admitted_peak_bytes(
                     gen_core::MemoryBackend::Mlx,
                     envelope.peak_bytes,
                 );
@@ -3486,7 +3486,7 @@ fn evaluate_request_with_budget_using_bundle(
             let graded_peak_bytes = if candidate.closure_digest == live_closure_digest {
                 exact.predicted_peak_bytes
             } else {
-                crate::memory_strategy::stale_widened_peak_bytes(
+                crate::memory_strategy::stale_admitted_peak_bytes(
                     gen_core::MemoryBackend::Mlx,
                     exact.predicted_peak_bytes,
                 )
@@ -3595,6 +3595,16 @@ fn evaluate_request_with_budget_using_bundle(
                 evidence,
                 closure_digest,
                 basis: *basis,
+                // sc-22508: every floor on this lane — the resident baseline and each synthesized
+                // rung floor alike — is built as `estimate_floor_weights_bytes +
+                // generic_headroom_bytes`, the SAME headroom convention (fixed reserve + area law).
+                // Declaring it lets the selector charge that flat activation allowance instead of
+                // taxing the counted weights beside it.
+                unmodeled_activation_bytes: matches!(
+                    basis,
+                    crate::memory_strategy::CandidateBasis::EstimateFloor
+                )
+                .then(|| plan.generic_headroom_bytes(geometry)),
             },
         )
         .collect::<Vec<_>>();
@@ -3806,7 +3816,7 @@ fn evaluate_request_with_budget_using_bundle(
         let graded_peak_bytes = if candidate.closure_digest == live_closure_digest {
             evidence.predicted_peak_bytes
         } else {
-            crate::memory_strategy::stale_widened_peak_bytes(
+            crate::memory_strategy::stale_admitted_peak_bytes(
                 gen_core::MemoryBackend::Mlx,
                 evidence.predicted_peak_bytes,
             )
@@ -5109,6 +5119,13 @@ fn generic_mlx_shared_observation(
             closure_digest: UNCALIBRATED_CLOSURE,
             // The generic cold-load estimate is exactly a weights+headroom floor (sc-18096).
             basis: crate::memory_strategy::CandidateBasis::EstimateFloor,
+            // sc-22508: the headroom half of that floor is the only uncertain term; the weights
+            // half is the resolved load spec's counted bytes.
+            unmodeled_activation_bytes: Some(
+                (headroom_gb * BYTES_PER_GIB)
+                    .ceil()
+                    .clamp(0.0, u64::MAX as f64) as u64,
+            ),
         }],
     )
 }
@@ -8334,16 +8351,22 @@ mod tests {
     const FIXTURE_DEEP_ESTIMATE_FLOOR_GB: f64 = 6.0;
     const FIXTURE_SHALLOW_ESTIMATE_FLOOR_GB: f64 = 9.0;
 
-    /// The production widening an EstimateFloor candidate receives before the fit check.
+    /// The fixture's flat activation-headroom term (2 GiB fixed reserve + 4 GiB area at 1024²) —
+    /// the ONLY uncertain half of every floor above, and the term sc-22508's allowance is charged
+    /// against.
+    const FIXTURE_HEADROOM_GB: f64 = 6.0;
+
+    /// The production allowance an EstimateFloor candidate receives before the fit check.
     ///
-    /// Read from the shipped constant rather than a literal on purpose. `MLX_ESTIMATE_MARGIN` is
-    /// re-derived from the calibration corpus and moved 5% -> 50.4073% when the corpus grew 65 -> 89
-    /// records; every fixture below that had hardcoded a host budget against the 5% term silently
-    /// FLIPPED DIRECTION at that point (a "reaches the deep rung" test became a refusal test, for the
-    /// wrong reason). Sizing budgets through this function instead keeps each test's direction fixed
-    /// across any future re-derivation, so an accepted-floor change stays bookkeeping.
+    /// Computed through the policy rather than a literal on purpose. Before sc-22508 this was
+    /// `floor * (1 + MLX_ESTIMATE_MARGIN)`, and when that corpus-derived margin moved 5% ->
+    /// 50.4073% every fixture that had hardcoded a host budget against the 5% term silently FLIPPED
+    /// DIRECTION (a "reaches the deep rung" test became a refusal test, for the wrong reason).
+    /// Sizing budgets through this function keeps each test's direction fixed across any future
+    /// re-derivation.
     fn widened_estimate_gb(floor_gb: f64) -> f64 {
-        floor_gb * (1.0 + crate::ladder_margin_policy::MLX_ESTIMATE_MARGIN)
+        floor_gb
+            + FIXTURE_HEADROOM_GB * crate::ladder_margin_policy::FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE
     }
 
     /// A host budget that admits EXACTLY the deepest (rung-4) estimate floor and nothing shallower —
@@ -8675,11 +8698,12 @@ mod tests {
             REQUEST_EVIDENCE_REVISION
         );
 
-        // At 76 GiB the staged floor (99.27 widened) no longer fits, and the FITTED bounded-decode
-        // estimate extrapolated from the measured 896² cell (75.76 GiB widened) is selected — with
-        // the measured cell's own sweep parameters, which a floor synthesis (built from the
-        // smallest declared ranges and a 111.30 GiB widened peak) could not produce at this budget.
-        let fitted = evaluate(&generator, 76.0)
+        // At 65 GiB the staged floor no longer fits, and the FITTED bounded-decode estimate
+        // extrapolated from the measured 896² cell (50.37 GiB raw, 56.71 GiB at its same-cell
+        // recapture ceiling) is selected — with the measured cell's own sweep parameters, which a
+        // floor synthesis (built from the smallest declared ranges) could not produce at this
+        // budget.
+        let fitted = evaluate(&generator, 65.0)
             .expect("the fitted-curve estimate must admit where the floors cannot");
         assert_eq!(
             fitted.context.selection.strategy,
@@ -8696,7 +8720,7 @@ mod tests {
             "the fitted estimate must carry the measured basis' parameters"
         );
 
-        // Below every widened estimate the request still refuses — margins are load-bearing. No
+        // Below every admitted estimate the request still refuses — allowances are load-bearing. No
         // verified alternative fits 40 GiB (the 768² cell needs its captured foreign reserve too),
         // so none may be named.
         let message = evaluate(&generator, 40.0)
@@ -8771,7 +8795,7 @@ mod tests {
             "the mutated fingerprint must be conformance-CLEAN so this arm exercises the basis \
              identity gate, not format validation"
         );
-        let message = evaluate(&mismatched_generator, 76.0)
+        let message = evaluate(&mismatched_generator, 65.0)
             .expect_err("a fingerprint-drifted provider loses the measured basis and refuses")
             .to_string();
         assert!(
@@ -8809,7 +8833,7 @@ mod tests {
                 .expect("bounded decode capability")
                 .support = gen_core::MemoryStrategySupport::Missing;
         }
-        let message = evaluate(&unimplemented_generator, 76.0)
+        let message = evaluate(&unimplemented_generator, 65.0)
             .expect_err("an unimplemented rung is never estimate-admissible")
             .to_string();
         assert!(
@@ -8962,25 +8986,26 @@ mod tests {
             REQUEST_EVIDENCE_REVISION
         );
 
-        // Mutation arm: at 9 GiB even the rung-4 widened floor (~9.02 GiB) overflows, and the
-        // refusal is the honest Reject quoting the widened requirement — proving the estimate
-        // margin is applied on this path (a zeroed margin would admit 6.0 <= 6.0).
+        // Mutation arm: at 7 GiB even the rung-4 admitted floor (6 GiB of pure activation headroom
+        // + its 17% allocator-envelope allowance = 7.02 GiB) overflows, and the refusal is the
+        // honest Reject quoting the admitted requirement — proving the per-term allowance is
+        // applied on this path (a zeroed allowance would admit 6.0 <= 7.0).
         let error = evaluate_request_with_budget(
             &generator,
             &plan,
             &inputs,
             MemoryCacheState::Cold,
             OffloadPolicy::Resident,
-            fixture_budget(9.0),
+            fixture_budget(7.0),
             gib_to_bytes(9.0),
             0,
             &[],
         )
-        .expect_err("below every widened estimate the request must refuse")
+        .expect_err("below every admitted estimate the request must refuse")
         .to_string();
         assert!(
-            error.contains("needs 9.02 GiB"),
-            "the refusal must quote the WIDENED rung-4 floor: {error}"
+            error.contains("needs 7.02 GiB"),
+            "the refusal must quote the ADMITTED rung-4 floor: {error}"
         );
     }
 
@@ -13602,10 +13627,13 @@ mod tests {
                 reference_count: 0,
             };
             let raw_incremental_peak = plan.generic_headroom_bytes(geometry);
-            let widened_incremental_peak = (raw_incremental_peak as f64
-                * (1.0 + crate::ladder_margin_policy::MLX_ESTIMATE_MARGIN))
-                .ceil()
-                .clamp(0.0, u64::MAX as f64) as u64;
+            // This peak IS the headroom term (weights are credited as already resident), so the
+            // sc-22508 floor allowance charges all of it — the admitted ceiling is twice the raw.
+            let widened_incremental_peak = crate::memory_strategy::floor_admitted_peak_bytes(
+                gen_core::MemoryBackend::Mlx,
+                raw_incremental_peak,
+                Some(raw_incremental_peak),
+            );
             // These are precisely the cells for which no optimized product contract applies. Model
             // their legacy Resident fallback with the same compatibility contract production uses
             // when a provider has no applicable adopted cell, and bind its aggregate base fact to
@@ -13703,13 +13731,13 @@ mod tests {
             // have no estimate band left to flip. sc-20799 removed the fourth row the same way:
             // retiring `flux2_dev`'s `exhaustive` reading gave its T2I route a declared
             // `staged_residency` rung across bf16/q4/q8, so the bf16 cell is no longer
-            // Resident-only and has no band to flip. The three that remain have no ladder yet,
-            // which is what keeps this list a live audit rather than a formality.
-            vec![
-                ("flux2_dev", "flux2_dev_control", "q4", 64),
-                ("ideogram_4", "ideogram_4", "q8", 48),
-                ("ideogram_4_turbo", "ideogram_4_turbo", "q8", 48),
-            ],
+            // Resident-only and has no band to flip. sc-22508 narrowed the band itself: an
+            // estimate floor is no longer widened by a blanket 50.41% of its whole peak but by 17%
+            // of its ACTIVATION term alone, so `flux2_dev` q4 at 64 GiB and `ideogram_4` q8 at
+            // 48 GiB now admit at both host sizes and have no band left to flip. The one that
+            // remains has no ladder yet, which is what keeps this list a live audit rather than a
+            // formality.
+            vec![("ideogram_4_turbo", "ideogram_4_turbo", "q8", 48)],
             "the source-bound resident-only audit changed; update the recorded result, \
              not only this expectation: {flips:?}"
         );
@@ -14167,11 +14195,11 @@ mod tests {
             "a stale exact cell still derives the request-scoped ceiling"
         );
 
-        // The margin is APPLIED, not just plumbed (production-path mutation check): at 9.1 GiB the
-        // effective budget is 6.1 GiB — the RAW 5 GiB peak fits, the widened 6.26 GiB does not. A
-        // gate that stopped widening stale admission would admit here and flip this arm. The
-        // refusal quotes the graded host requirement: widened 6.26 GiB + the 3 GiB captured
-        // foreign reserve = 9.26 GiB.
+        // The allowance is APPLIED, not just plumbed (production-path mutation check): at 8.5 GiB
+        // the effective budget is 5.5 GiB — the RAW 5 GiB peak fits, the recapture-widened 5.63 GiB
+        // does not. A gate that stopped widening stale admission would admit here and flip this
+        // arm. The refusal quotes the graded host requirement: widened 5.63 GiB + the 3 GiB
+        // captured foreign reserve = 8.63 GiB.
         let error = evaluate_request_with_budget_using_bundle(
             &generator,
             &plan,
@@ -14179,7 +14207,7 @@ mod tests {
             MemoryCacheState::Cold,
             OffloadPolicy::Resident,
             crate::execution_planner::WarmPolicyProposal::inert("fixture"),
-            fixture_budget(9.1),
+            fixture_budget(8.5),
             gib_to_bytes(4.0),
             0,
             &[],
@@ -14189,12 +14217,12 @@ mod tests {
         .expect_err("the raw peak fits 6.1 GiB but the WIDENED stale peak must not")
         .to_string();
         assert!(
-            error.contains("needs at least 9.26 GiB"),
+            error.contains("needs at least 8.63 GiB"),
             "the refusal must quote the widened stale host requirement: {error}"
         );
 
         // The control: the SAME request with the closure unmoved is graded at the raw peak, so the
-        // 9.1 GiB budget that refused above admits — proving the refusal was the stale widening.
+        // 8.5 GiB budget that refused above admits — proving the refusal was the stale widening.
         let current = evaluate_request_with_budget_using_bundle(
             &generator,
             &plan,
@@ -14202,7 +14230,7 @@ mod tests {
             MemoryCacheState::Cold,
             OffloadPolicy::Resident,
             crate::execution_planner::WarmPolicyProposal::inert("fixture"),
-            fixture_budget(9.1),
+            fixture_budget(8.5),
             gib_to_bytes(4.0),
             0,
             &[],
@@ -14582,7 +14610,7 @@ mod tests {
             "the true static boundary must agree that this candidate can fit below 48 GiB"
         );
         let live_reserve = envelope.foreign_reserve_for_host_bytes(live_host);
-        let stale_peak = crate::memory_strategy::stale_widened_peak_bytes(
+        let stale_peak = crate::memory_strategy::stale_admitted_peak_bytes(
             gen_core::MemoryBackend::Mlx,
             envelope.peak_bytes,
         );
@@ -15610,11 +15638,12 @@ mod tests {
         // sc-18096 repin. The mismatched record's 5 GiB raw peak fits the 10 GiB budget easily, so
         // ANY error here proves the record was excluded rather than authorizing the fit — the
         // fail-closed property this test owns. What changed: the bounded-decode rung now also
-        // carries a synthesized floor estimate (weights 6 GiB + headroom 6 GiB, widened to 18.05),
-        // so the refusal is the honest "no rung fits with margins" `Reject` quoting the floor's
-        // widened requirement instead of an `Unverified`/`FingerprintMismatch` refusal.
+        // carries a synthesized floor estimate (weights 6 GiB + headroom 6 GiB, admitted at
+        // 12 + 17% of the 6 GiB activation term = 13.02 under sc-22508), so the refusal is the
+        // honest "no rung fits with its allowance" `Reject` quoting the floor's admitted
+        // requirement instead of an `Unverified`/`FingerprintMismatch` refusal.
         assert!(
-            error.contains("needs 18.05 GiB"),
+            error.contains("needs 13.02 GiB"),
             "the mismatched record must not authorize the fit; the refusal must quote the \
              estimate floor instead: {error}"
         );

--- a/crates/sceneworks-worker/src/video_admission.rs
+++ b/crates/sceneworks-worker/src/video_admission.rs
@@ -910,10 +910,13 @@ pub(crate) struct LadderVideoSelector<'a> {
     /// per-request knobs need the whole `MemorySelection`, and re-deriving it would be a second
     /// selection.
     selections: Vec<VideoSelectedCandidate>,
-    /// Unwidened resident candidate for every geometry core graded. The refusal guard consumes the
-    /// exact binding geometry's value, including any provider profile, instead of recomputing a
-    /// profile-blind weights floor after selection.
-    resident_floors: Vec<(VideoAdmissionGeometry, u64)>,
+    /// Unwidened resident candidate for every geometry core graded, paired with the ACTIVATION
+    /// term that candidate declared (sc-22508). The refusal guard consumes the exact binding
+    /// geometry's values, including any provider profile, instead of recomputing a profile-blind
+    /// weights floor — or a headroom constant — after selection. Carrying the declared term is what
+    /// keeps the guard's admitted ceiling identical to the one the selector graded even when the
+    /// peak came from a decode profile or a warm resident credit.
+    resident_floors: Vec<(VideoAdmissionGeometry, u64, Option<u64>)>,
 }
 
 #[derive(Clone, Debug)]
@@ -1452,8 +1455,34 @@ impl VideoStrategySelector for LadderVideoSelector<'_> {
                 ));
                 return VideoRungSelection::Undecidable;
             };
+            // sc-22508: the activation slice of the peak THIS ITERATION actually constructed, not
+            // the headroom the selector was handed.
+            //
+            // Both floor shapes reaching here decompose, and neither decomposes as `headroom`:
+            // `floor_phase_peaks` builds `estimate_floor_weights_bytes + headroom_bytes`, while
+            // `profiled_floor_phase_peaks` may raise that to the provider's own
+            // `checked_composed_peak`, whose activation slice is `profiled - weights` and can be
+            // multiples of the generic headroom (a 55 GiB profiled peak over 20 GiB of weights
+            // carries 35 GiB of activation, not 18). The peak is then reduced by
+            // `attributable_resident_bytes`, which credits already-resident WEIGHTS — so the
+            // counted-weights term shrinks and the activation term does not.
+            //
+            // Deriving it as `peak - counted_weights` gets both shapes right by construction and
+            // can never exceed the peak it grades, which a declared constant can (warm path, small
+            // floor). Fitted-curve and anchor-derived peaks are phase-resolved and carry no split.
+            let unmodeled_activation_bytes =
+                matches!(basis, CandidateBasis::EstimateFloor).then(|| {
+                    let counted_weights =
+                        crate::mlx_fit_gate::estimate_floor_weights_bytes(self.contract, &engaged)
+                            .saturating_sub(self.attributable_resident_bytes);
+                    predicted_peak_bytes.saturating_sub(counted_weights)
+                });
             if strategy == MemoryStrategy::Resident {
-                self.resident_floors.push((geometry, predicted_peak_bytes));
+                self.resident_floors.push((
+                    geometry,
+                    predicted_peak_bytes,
+                    unmodeled_activation_bytes,
+                ));
             }
             let evidence = crate::mlx_fit_gate::estimate_evidence(
                 self.contract,
@@ -1474,6 +1503,7 @@ impl VideoStrategySelector for LadderVideoSelector<'_> {
                 closure_digest,
                 curve_id,
                 profile_revision,
+                unmodeled_activation_bytes,
             ));
         }
         if synthesized.is_empty() {
@@ -1483,25 +1513,23 @@ impl VideoStrategySelector for LadderVideoSelector<'_> {
         let candidates = synthesized
             .iter()
             .map(
-                |(selection, evidence, _, basis, closure_digest, _, _)| Candidate {
+                |(selection, evidence, _, basis, closure_digest, _, _, activation)| Candidate {
                     selection: *selection,
                     evidence,
                     closure_digest,
                     basis: *basis,
-                    // sc-22508: only the weights+headroom floor decomposes into a counted term and
-                    // a flat activation allowance, and `floor_phase_peaks` built this peak as
-                    // exactly `estimate_floor_weights_bytes + headroom_bytes`. Fitted-curve and
-                    // anchor-derived peaks are phase-resolved and carry no such split.
+                    // sc-22508: derived at the peak's construction site above, for BOTH lanes.
                     //
-                    // MLX ONLY. The headroom term earns a doubling where the modelled allowance is
-                    // a guess AND an overshoot is fatal (the MLX allocator aborts the worker). On
-                    // candle an allocation failure is a recoverable `Err` and the corpus's
-                    // deterministic live-allocation accounting bounds the residual at 2%, so
-                    // charging a whole extra headroom there would be strictly MORE conservative
-                    // than the blanket policy this story retires — which E3 does not license.
-                    unmodeled_activation_bytes: (matches!(basis, CandidateBasis::EstimateFloor)
-                        && backend == MemoryBackend::Mlx)
-                        .then_some(self.headroom_bytes),
+                    // The declaration is not an MLX privilege. A candle floor decomposes exactly as
+                    // an MLX one does — `floor_phase_peaks` is lane-blind — and declaring the split
+                    // is what makes the allowance track the term instead of the peak. What differs
+                    // between the lanes is the FRACTION, and that difference lives where the
+                    // measurement lives: `ladder_margin_policy::floor_envelope_allowance` charges
+                    // MLX's measured allocator envelope (17%) and candle's deterministic accounting
+                    // residual (2%). Withholding the declaration here so candle fell back to a
+                    // whole-peak spread would have been choosing a margin by magnitude, which is
+                    // exactly what E3 retires.
+                    unmodeled_activation_bytes: *activation,
                 },
             )
             .collect::<Vec<_>>();
@@ -1544,7 +1572,7 @@ impl VideoStrategySelector for LadderVideoSelector<'_> {
                     curve_id = synthesized
                         .iter()
                         .find(|(candidate, ..)| candidate.strategy == selection.strategy)
-                        .and_then(|(_, _, _, _, _, curve_id, _)| *curve_id)
+                        .and_then(|(_, _, _, _, _, curve_id, _, _)| *curve_id)
                         .unwrap_or("none"),
                     needed_gb,
                     available_gb,
@@ -1889,9 +1917,11 @@ fn admit_video_generation_with_curves_and_profiles(
             geometry,
             ..
         } => {
-            let Some(resident_floor_bytes) = resident_floors
+            let Some((resident_floor_bytes, resident_floor_activation_bytes)) = resident_floors
                 .iter()
-                .find_map(|(graded, bytes)| (*graded == geometry).then_some(*bytes))
+                .find_map(|(graded, bytes, activation)| {
+                    (*graded == geometry).then_some((*bytes, *activation))
+                })
             else {
                 tracing::error!(
                     event = "video_memory_resident_floor_lost",
@@ -1913,13 +1943,13 @@ fn admit_video_generation_with_curves_and_profiles(
                 crate::memory_strategy::floor_admitted_peak_bytes(
                     contract.backend.backend_kind(),
                     resident_floor_bytes,
-                    // Mirrors the MLX-only headroom declaration on the floor candidates above, so
-                    // this guard compares against the SAME admitted ceiling the selector graded.
-                    if contract.backend.backend_kind() == MemoryBackend::Mlx {
-                        Some(request.headroom_bytes)
-                    } else {
-                        None
-                    },
+                    // The term the resident candidate ITSELF declared, carried out of the selector
+                    // rather than reconstructed here (sc-22508). Reconstructing it from
+                    // `request.headroom_bytes` was wrong for exactly the peaks that matter: a
+                    // provider decode profile raises the peak above weights+headroom, and a warm
+                    // resident credit lowers it, so the mirror and production could disagree on the
+                    // graded ceiling with nothing to catch it.
+                    resident_floor_activation_bytes,
                 ),
                 runtime.selector_budget().and_then(Budget::effective_gb),
             ) {

--- a/crates/sceneworks-worker/src/video_admission.rs
+++ b/crates/sceneworks-worker/src/video_admission.rs
@@ -1488,6 +1488,20 @@ impl VideoStrategySelector for LadderVideoSelector<'_> {
                     evidence,
                     closure_digest,
                     basis: *basis,
+                    // sc-22508: only the weights+headroom floor decomposes into a counted term and
+                    // a flat activation allowance, and `floor_phase_peaks` built this peak as
+                    // exactly `estimate_floor_weights_bytes + headroom_bytes`. Fitted-curve and
+                    // anchor-derived peaks are phase-resolved and carry no such split.
+                    //
+                    // MLX ONLY. The headroom term earns a doubling where the modelled allowance is
+                    // a guess AND an overshoot is fatal (the MLX allocator aborts the worker). On
+                    // candle an allocation failure is a recoverable `Err` and the corpus's
+                    // deterministic live-allocation accounting bounds the residual at 2%, so
+                    // charging a whole extra headroom there would be strictly MORE conservative
+                    // than the blanket policy this story retires — which E3 does not license.
+                    unmodeled_activation_bytes: (matches!(basis, CandidateBasis::EstimateFloor)
+                        && backend == MemoryBackend::Mlx)
+                        .then_some(self.headroom_bytes),
                 },
             )
             .collect::<Vec<_>>();
@@ -1896,7 +1910,17 @@ fn admit_video_generation_with_curves_and_profiles(
             if refusal_is_a_margin_artifact(
                 needed_gb,
                 resident_floor_bytes,
-                crate::memory_strategy::estimate_margin(contract.backend.backend_kind()),
+                crate::memory_strategy::floor_admitted_peak_bytes(
+                    contract.backend.backend_kind(),
+                    resident_floor_bytes,
+                    // Mirrors the MLX-only headroom declaration on the floor candidates above, so
+                    // this guard compares against the SAME admitted ceiling the selector graded.
+                    if contract.backend.backend_kind() == MemoryBackend::Mlx {
+                        Some(request.headroom_bytes)
+                    } else {
+                        None
+                    },
+                ),
                 runtime.selector_budget().and_then(Budget::effective_gb),
             ) {
                 tracing::info!(
@@ -2320,17 +2344,16 @@ fn curve_evidence_covers_request(
 fn refusal_is_a_margin_artifact(
     needed_gb: f64,
     resident_floor_bytes: u64,
-    estimate_margin: f64,
+    admitted_floor_bytes: u64,
     available_gb: Option<f64>,
 ) -> bool {
     let Some(available_gb) = available_gb else {
         return false;
     };
-    // Widen with the SAME integer-byte helper `select_strategy` widened the candidate with, so the
-    // two sides of the comparison are produced by one conversion rather than two roundings.
-    let widened_floor_gb = crate::memory_strategy::peak_bytes_to_gb(
-        crate::memory_strategy::widened_peak_bytes(resident_floor_bytes, estimate_margin),
-    );
+    // The caller produces `admitted_floor_bytes` through the SAME policy function `select_strategy`
+    // graded the floor candidate with (sc-22508), so the two sides of the comparison are produced
+    // by one conversion rather than two roundings.
+    let widened_floor_gb = crate::memory_strategy::peak_bytes_to_gb(admitted_floor_bytes);
     let floor_gb = crate::memory_strategy::peak_bytes_to_gb(resident_floor_bytes);
     needed_gb <= widened_floor_gb && floor_gb <= available_gb
 }

--- a/crates/sceneworks-worker/src/video_admission/tests.rs
+++ b/crates/sceneworks-worker/src/video_admission/tests.rs
@@ -169,15 +169,21 @@ fn budget(total_gb: f64) -> Option<Budget> {
     })
 }
 
-/// A host budget derived FROM the margin policy: `peak_gib` GiB of estimate-backed floor widened
-/// by [`MLX_ESTIMATE_MARGIN`] (in integer bytes, exactly as `select_strategy` widens it), plus
-/// `slack_gb`. Fixtures use this to sit a budget in a window — admit every candidate whose widened
-/// peak is at or under this floor's, refuse every wider one — without hardcoding the margin's
-/// arithmetic into magic floats that rot when the corpus-derived constant moves (sc-18094).
+/// The flat activation-headroom term every fixture below hands the selector (`inputs(.., 18 * GIB)`).
+/// sc-22508 charges a floor's allowance against THIS term alone, so the fixtures state it once.
+const FIXTURE_HEADROOM_GIB: u64 = 18;
+
+/// A host budget derived FROM the per-term policy: `peak_gib` GiB of estimate-backed
+/// weights+headroom FLOOR at the admitted ceiling `select_strategy` grades it at (in integer bytes,
+/// exactly as the selector computes it), plus `slack_gb`. Fixtures use this to sit a budget in a
+/// window — admit every candidate whose admitted peak is at or under this floor's, refuse every
+/// wider one — without hardcoding the policy's arithmetic into magic floats that rot when the
+/// allowance moves (sc-18094, re-termed by sc-22508).
 fn mlx_widened_gb(peak_gib: u64, slack_gb: f64) -> f64 {
-    crate::memory_strategy::peak_bytes_to_gb(crate::memory_strategy::widened_peak_bytes(
+    crate::memory_strategy::peak_bytes_to_gb(crate::memory_strategy::floor_admitted_peak_bytes(
+        gen_core::MemoryBackend::Mlx,
         peak_gib * GIB,
-        crate::ladder_margin_policy::MLX_ESTIMATE_MARGIN,
+        Some(FIXTURE_HEADROOM_GIB * GIB),
     )) + slack_gb
 }
 
@@ -1374,7 +1380,10 @@ fn a_curve_cannot_be_relabelled_to_manufacture_bounded_decode_parameters() {
     let generator = fixture_generator(Some(contract));
     let mut curves = fixture_curve_bundle();
     curves.curves[0].rung = StrategyRung::BoundedDecode;
-    let mut request = inputs(121, budget(40.0), 0);
+    // A 40 GiB host with this fixture's 18 GiB activation headroom: the honest staged fallback is
+    // 40 weights + 18 headroom and the resident one 60 + 18, so no rung fits and the only way to
+    // "admit" would be to mint bounded-decode knobs from the relabelled staged curve.
+    let mut request = inputs(121, budget(40.0), FIXTURE_HEADROOM_GIB * GIB);
     request.expected_closure_digest = FITTED_CURVE_CLOSURE;
 
     let outcome = admit_video_generation_with_curves(&generator, request, Some(&curves));
@@ -1709,72 +1718,95 @@ fn a_refusal_inside_the_estimate_margin_band_is_suppressed() {
 /// both the floor and above-floor outcomes end to end.
 #[test]
 fn a_rejection_whose_peak_exceeds_the_floor_beyond_the_margin_is_not_suppressed() {
-    const MARGIN: f64 = crate::ladder_margin_policy::MLX_ESTIMATE_MARGIN;
-    // ~38 GB weights+headroom resident floor (20 GiB weights + 18 GiB headroom).
+    // ~38 GB weights+headroom resident floor (20 GiB weights + 18 GiB headroom). sc-22508: the
+    // admitted ceiling adds the headroom TERM once, not a percentage of the whole 38 GiB.
     let floor_bytes = 38 * GIB;
+    let admitted_floor_bytes = crate::memory_strategy::floor_admitted_peak_bytes(
+        gen_core::MemoryBackend::Mlx,
+        floor_bytes,
+        Some(FIXTURE_HEADROOM_GIB * GIB),
+    );
     let floor_gb = crate::memory_strategy::peak_bytes_to_gb(floor_bytes);
-    let widened_floor_gb = crate::memory_strategy::peak_bytes_to_gb(
-        crate::memory_strategy::widened_peak_bytes(floor_bytes, MARGIN),
+    let widened_floor_gb = crate::memory_strategy::peak_bytes_to_gb(admitted_floor_bytes);
+    assert_eq!(
+        admitted_floor_bytes,
+        floor_bytes
+            + ((FIXTURE_HEADROOM_GIB * GIB) as f64
+                * crate::ladder_margin_policy::FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE)
+                .ceil() as u64,
+        "the floor's allowance is charged on its activation term, not on its counted weights"
     );
     // A host that comfortably holds the floor but not the fitted decode peak.
     let host_gb = 100.0;
     assert!(floor_gb < host_gb, "{floor_gb} vs {host_gb}");
 
     // The fitted shape: the rejected peak is the DECODE peak, far above the floor.
-    let fitted_decode_reject_gb = 94.3 * (1.0 + MARGIN);
+    let fitted_decode_reject_gb = 120.0;
     assert!(
         fitted_decode_reject_gb > host_gb,
         "the fixture must be a genuine rejection on this host: {fitted_decode_reject_gb} vs \
          {host_gb}"
     );
     assert!(
-        !refusal_is_a_margin_artifact(fitted_decode_reject_gb, floor_bytes, MARGIN, Some(host_gb),),
-        "a rejection whose peak exceeds the weights floor by more than the margin is REAL and \
+        !refusal_is_a_margin_artifact(
+            fitted_decode_reject_gb,
+            floor_bytes,
+            admitted_floor_bytes,
+            Some(host_gb),
+        ),
+        "a rejection whose peak exceeds the weights floor by more than the allowance is REAL and \
          must survive — suppressing it runs the job into an OOM"
     );
 
-    // The fallback shape, on the identical floor/host/margin: the rejected peak IS the widened
+    // The fallback shape, on the identical floor/host/allowance: the rejected peak IS the admitted
     // floor, so the suppression still applies. Without this the assertion above could be satisfied
     // by a guard that never suppresses anything.
     assert!(
-        refusal_is_a_margin_artifact(widened_floor_gb, floor_bytes, MARGIN, Some(host_gb)),
-        "a rejection at exactly the widened floor is the margin artifact this guard exists for"
+        refusal_is_a_margin_artifact(
+            widened_floor_gb,
+            floor_bytes,
+            admitted_floor_bytes,
+            Some(host_gb)
+        ),
+        "a rejection at exactly the admitted floor is the margin artifact this guard exists for"
     );
-    // And the boundary is where the doc says it is: one ULP past the widened floor survives.
+    // And the boundary is where the doc says it is: one ULP past the admitted floor survives.
     assert!(
         !refusal_is_a_margin_artifact(
             widened_floor_gb + f64::EPSILON * widened_floor_gb,
             floor_bytes,
-            MARGIN,
+            admitted_floor_bytes,
             Some(host_gb),
         ),
-        "the scope check is `<= widened floor`, so anything above it is out of scope"
+        "the scope check is `<= admitted floor`, so anything above it is out of scope"
     );
 }
 
 /// The second conjunct — the non-regression condition proper — is independent of the first.
 #[test]
 fn a_floor_that_does_not_fit_is_never_suppressed_and_no_budget_never_suppresses() {
-    const MARGIN: f64 = crate::ladder_margin_policy::MLX_ESTIMATE_MARGIN;
     let floor_bytes = 38 * GIB;
-    let floor_gb = crate::memory_strategy::peak_bytes_to_gb(floor_bytes);
-    let widened_floor_gb = crate::memory_strategy::peak_bytes_to_gb(
-        crate::memory_strategy::widened_peak_bytes(floor_bytes, MARGIN),
+    let admitted_floor_bytes = crate::memory_strategy::floor_admitted_peak_bytes(
+        gen_core::MemoryBackend::Mlx,
+        floor_bytes,
+        Some(FIXTURE_HEADROOM_GIB * GIB),
     );
+    let floor_gb = crate::memory_strategy::peak_bytes_to_gb(floor_bytes);
+    let widened_floor_gb = crate::memory_strategy::peak_bytes_to_gb(admitted_floor_bytes);
 
     // In scope (the peak IS the floor) but the floor itself does not fit: a real refusal the
     // pre-existing load gate would also have made.
     assert!(!refusal_is_a_margin_artifact(
         widened_floor_gb,
         floor_bytes,
-        MARGIN,
+        admitted_floor_bytes,
         Some(floor_gb - 1.0),
     ));
     // Exactly at the floor still fits — the comparison is `<=`, matching `mlx_fit_gate`'s.
     assert!(refusal_is_a_margin_artifact(
         widened_floor_gb,
         floor_bytes,
-        MARGIN,
+        admitted_floor_bytes,
         Some(floor_gb),
     ));
     // No budget signal: never suppress. `select_strategy` cannot even produce a `Reject` without
@@ -1782,7 +1814,7 @@ fn a_floor_that_does_not_fit_is_never_suppressed_and_no_budget_never_suppresses(
     assert!(!refusal_is_a_margin_artifact(
         widened_floor_gb,
         floor_bytes,
-        MARGIN,
+        admitted_floor_bytes,
         None,
     ));
 }
@@ -2276,11 +2308,11 @@ fn the_floor_is_phase_uniform_and_its_peak_is_the_unchanged_scalar() {
 fn fitted_frames_change_the_selected_outcome_inside_the_measured_hull() {
     let contract = fixture_contract(20, 4, &[MemoryStrategy::StagedResidency]);
     let curves = fixture_curve_bundle();
-    // 1 GiB under the widened 38 GiB resident floor: above the f121 fitted staged peak's
-    // MLX_ESTIMATE_MARGIN-widened ceiling (~53.2) and below both f145 rejection thresholds (the
-    // f145 fitted widened peak ~62.9 and the widened resident floor ~57.2), so the frame count is
-    // the only thing that changes between the two verdicts.
-    let host_gb = mlx_widened_gb(38, -1.0);
+    // 0.7 GiB under the admitted 38 GiB resident floor (41.06 = 38 + 17% of its 18 GiB activation
+    // term): above the f121 fitted staged peak's recapture ceiling (~39.8) and below both f145
+    // rejection thresholds (the f145 fitted admitted peak ~47.1 and the admitted resident floor
+    // 41.06), so the frame count is the only thing that changes between the two verdicts.
+    let host_gb = mlx_widened_gb(38, -0.7);
 
     let at_121 = select_once_with_curves(
         &contract,
@@ -2351,14 +2383,16 @@ fn fitted_phase_laws_bind_by_exact_geometry_and_reduce_by_max() {
 
 #[test]
 fn mutating_the_ratified_cross_coefficient_changes_selector_outcome() {
-    let contract = fixture_contract(20, 4, &[MemoryStrategy::StagedResidency]);
+    // A 40 GiB-weights contract, so the two SCALAR floors stay out of reach at the host below and
+    // only the fitted curve can decide: resident floors at 40 + 18 = 58 (admitted 61.06) and
+    // staged at 36 + 18 = 54 (admitted 57.18).
+    let contract = fixture_contract(40, 4, &[MemoryStrategy::StagedResidency]);
     let original = fixture_curve_bundle();
     let geometry = geometry(145, VideoGeometryRole::Requested);
-    // 0.5 GiB under the widened 38 GiB resident floor (~57.2): the f145 fitted peak's
-    // MLX_ESTIMATE_MARGIN-widened ceiling (~62.9) rejects, while zeroing the decode cross term
-    // drops the widened peak to the denoise phase's (~55.9), which admits. Resident never fits, so
-    // the coefficient alone flips the verdict.
-    let host_gb = mlx_widened_gb(38, -0.5);
+    // Between the two fitted verdicts: the f145 fitted peak's recapture ceiling (~47.1) rejects,
+    // while zeroing the decode cross term drops the admitted peak to the denoise phase's (~41.8),
+    // which admits. Neither scalar floor fits, so the coefficient alone flips the verdict.
+    let host_gb = 45.0;
     let original_verdict = select_once_with_curves(&contract, &original, budget(host_gb), geometry);
     assert!(
         matches!(original_verdict, VideoRungSelection::Reject { .. }),
@@ -2385,11 +2419,10 @@ fn mutating_a_phase_residual_changes_the_admission_decision() {
     let contract = fixture_contract(20, 4, &[MemoryStrategy::StagedResidency]);
     let original = fixture_curve_bundle();
     let request = geometry(121, VideoGeometryRole::Requested);
-    // 1 GiB under the widened 38 GiB resident floor (~57.2): the f121 fitted peak's
-    // MLX_ESTIMATE_MARGIN-widened ceiling (~53.2) admits, while growing the decode residual by
-    // 12 GiB pushes it (~71.2) past the budget — and resident never fits, so the residual alone
-    // flips the verdict.
-    let host_gb = mlx_widened_gb(38, -1.0);
+    // 0.7 GiB under the admitted 38 GiB resident floor (41.06): the f121 fitted peak's recapture
+    // ceiling (~39.8) admits, while growing the decode residual by 12 GiB pushes it (~53.3) past
+    // the budget — and resident never fits, so the residual alone flips the verdict.
+    let host_gb = mlx_widened_gb(38, -0.7);
     let original_verdict = select_once_with_curves(&contract, &original, budget(host_gb), request);
     assert!(
         matches!(original_verdict, VideoRungSelection::Selected { .. }),
@@ -2430,10 +2463,11 @@ fn historical_q8_curve_fixture_is_tier_exact_while_q4_and_bf16_keep_an_honest_fl
     }
 
     let generator = fixture_generator(Some(contract));
-    // 1 GiB under the widened 38 GiB resident floor: admits the q8 fitted f121 peak (~53.2
-    // widened by MLX_ESTIMATE_MARGIN) and the q4/bf16 staged floor (~51.1 widened) while resident
-    // stays refused, so every tier lands on the staged rung its basis assertion above describes.
-    let host_gb = mlx_widened_gb(38, -1.0);
+    // 0.7 GiB under the admitted 38 GiB resident floor (41.06): admits the q8 fitted f121 peak
+    // (~39.8 at the recapture ceiling) and the q4/bf16 staged floor (34 + 17% of its 18 GiB
+    // activation term = 37.06) while resident stays refused, so every tier lands on the staged
+    // rung its basis assertion above describes.
+    let host_gb = mlx_widened_gb(38, -0.7);
     for quant in [Some(Quant::Q8), Some(Quant::Q4), None] {
         for cache_state in [MemoryCacheState::Cold, MemoryCacheState::Warm] {
             let mut request = inputs(121, budget(host_gb), 18 * GIB);
@@ -2789,29 +2823,38 @@ fn same_rung_cap_binding_carries_cap_peak_but_actual_request_geometry() {
         decode_pass: VideoDecodePass::SinglePass,
         role: VideoGeometryRole::SinglePassDecodeCap,
     };
-    let expected_peak = {
+    let (expected_peak, expected_basis) = {
         let selector = selector_with_curves(&contract, Some(&curves), budget(95.0));
         let engaged = contract.engaged_composition(MemoryStrategy::StagedResidency);
-        fitted_or_floor_phase_peaks(&selector, cap, MemoryStrategy::StagedResidency, &engaged)
-            .0
-            .peak_bytes()
+        let (peaks, basis, ..) =
+            fitted_or_floor_phase_peaks(&selector, cap, MemoryStrategy::StagedResidency, &engaged);
+        (peaks.peak_bytes(), basis)
     };
 
-    // 0.5 GiB above the cap's fitted peak widened by MLX_ESTIMATE_MARGIN, which is the larger of
-    // the two staged candidates (the requested f305 geometry sits outside the hull and takes the
-    // 45 GiB staged floor, ~67.7 widened) — and below the widened 90 GiB resident floor, so both
-    // geometries select STAGED and the same-rung tie is what is under test.
+    // 0.5 GiB above the cap's admitted staged ceiling, which is the larger of the two staged
+    // candidates — and below the admitted 90 GiB resident floor, so both geometries select STAGED
+    // and the same-rung tie is what is under test. sc-22508: the allowance is named by the cap
+    // candidate's own basis, and this request declares ZERO headroom, so a floor-shaped peak is
+    // admitted at exactly its value.
     let host_gb =
-        crate::memory_strategy::peak_bytes_to_gb(crate::memory_strategy::widened_peak_bytes(
+        crate::memory_strategy::peak_bytes_to_gb(crate::memory_strategy::admitted_peak_bytes(
+            crate::ladder_margin_policy::AdmissionSubject {
+                backend: gen_core::MemoryBackend::Mlx,
+                basis: expected_basis,
+                closure_is_stale: false,
+                unmodeled_activation_bytes: matches!(expected_basis, CandidateBasis::EstimateFloor)
+                    .then_some(0),
+            },
             expected_peak,
-            crate::ladder_margin_policy::MLX_ESTIMATE_MARGIN,
         )) + 0.5;
+    // The resident floor is 90 GiB of weights plus this request's 18 GiB headroom, admitted at
+    // 108 + its 18 GiB headroom allowance = 126.
     assert!(
-        host_gb < mlx_widened_gb(90, 0.0),
+        host_gb < mlx_widened_gb(108, 0.0),
         "the staged-not-resident window must exist: {host_gb}"
     );
 
-    let mut request = inputs(305, budget(host_gb), 0);
+    let mut request = inputs(305, budget(host_gb), FIXTURE_HEADROOM_GIB * GIB);
     request.fps = 30;
     request.expected_closure_digest = FITTED_CURVE_CLOSURE;
     let outcome = admit_video_generation_with_curves(&generator, request, Some(&curves));
@@ -3019,11 +3062,10 @@ fn the_production_funnel_admits_an_unmeasured_ltx25_geometry_from_the_anchor() {
 fn the_anchor_derived_estimate_admits_when_it_fits_and_refuses_when_it_does_not() {
     let contract = ltx25_fixture_contract(&[]);
     let expected = ltx25_expected_derived_peaks();
-    let widened_gb =
-        crate::memory_strategy::peak_bytes_to_gb(crate::memory_strategy::widened_peak_bytes(
-            expected.peak_bytes(),
-            crate::ladder_margin_policy::MLX_ESTIMATE_MARGIN,
-        ));
+    // sc-22508: an anchor-derived peak is FULLY PRICED by the derivation (coefficient uncertainty
+    // inside the coefficients, the allocator envelope in `ANCHOR_ALLOCATOR_ENVELOPE_MARGIN`), so
+    // the selector adds nothing and the admitted ceiling IS the derived peak.
+    let widened_gb = crate::memory_strategy::peak_bytes_to_gb(expected.peak_bytes());
 
     let mut fits = LadderVideoSelector::new(
         ltx25_identity(crate::mlx_fit_gate::UNCALIBRATED_CLOSURE),

--- a/crates/sceneworks-worker/src/video_admission/tests.rs
+++ b/crates/sceneworks-worker/src/video_admission/tests.rs
@@ -173,18 +173,28 @@ fn budget(total_gb: f64) -> Option<Budget> {
 /// sc-22508 charges a floor's allowance against THIS term alone, so the fixtures state it once.
 const FIXTURE_HEADROOM_GIB: u64 = 18;
 
-/// A host budget derived FROM the per-term policy: `peak_gib` GiB of estimate-backed
-/// weights+headroom FLOOR at the admitted ceiling `select_strategy` grades it at (in integer bytes,
-/// exactly as the selector computes it), plus `slack_gb`. Fixtures use this to sit a budget in a
-/// window — admit every candidate whose admitted peak is at or under this floor's, refuse every
-/// wider one — without hardcoding the policy's arithmetic into magic floats that rot when the
-/// allowance moves (sc-18094, re-termed by sc-22508).
-fn mlx_widened_gb(peak_gib: u64, slack_gb: f64) -> f64 {
+/// A host budget derived FROM the per-term policy: a `peak_gib` GiB estimate-backed FLOOR whose
+/// ACTIVATION term is `activation_gib` GiB, at the admitted ceiling `select_strategy` grades it at
+/// (in integer bytes, exactly as the selector computes it), plus `slack_gb`. Fixtures use this to
+/// sit a budget in a window — admit every candidate whose admitted peak is at or under this
+/// floor's, refuse every wider one — without hardcoding the policy's arithmetic into magic floats
+/// that rot when the allowance moves (sc-18094, re-termed by sc-22508).
+///
+/// The activation term is a PARAMETER, not the fixture headroom constant, because production
+/// derives it from the peak it built: a generic floor's activation is the headroom, but a provider
+/// decode profile raises the peak and its activation slice with it (`profiled - weights`).
+fn mlx_widened_floor_gb(peak_gib: u64, activation_gib: u64, slack_gb: f64) -> f64 {
     crate::memory_strategy::peak_bytes_to_gb(crate::memory_strategy::floor_admitted_peak_bytes(
         gen_core::MemoryBackend::Mlx,
         peak_gib * GIB,
-        Some(FIXTURE_HEADROOM_GIB * GIB),
+        Some(activation_gib * GIB),
     )) + slack_gb
+}
+
+/// [`mlx_widened_floor_gb`] for the common case: a GENERIC weights+headroom floor, whose activation
+/// term is exactly the fixture headroom every `inputs(.., 18 * GIB)` hands the selector.
+fn mlx_widened_gb(peak_gib: u64, slack_gb: f64) -> f64 {
+    mlx_widened_floor_gb(peak_gib, FIXTURE_HEADROOM_GIB, slack_gb)
 }
 
 fn geometry(frames: u32, role: VideoGeometryRole) -> VideoAdmissionGeometry {
@@ -554,10 +564,12 @@ fn a_roomy_host_selects_the_resident_rung_through_the_shared_selector() {
 
 #[test]
 fn a_constrained_host_walks_down_the_ladder_instead_of_refusing() {
-    // 20 GiB of weights (4 conditioning + 16 transformer) + 18 GiB headroom = 38 GiB resident,
-    // widened by MLX_ESTIMATE_MARGIN to ~57.2. Staged drops the co-residency to max(4, 16) = 16,
-    // i.e. 34 GiB → ~51.1 widened. A host 0.5 GiB above the widened staged floor therefore
-    // refuses resident and admits staged: the ladder's whole point.
+    // 20 GiB of weights (4 conditioning + 16 transformer) + 18 GiB headroom = 38 GiB resident.
+    // Staged drops the co-residency to max(4, 16) = 16, i.e. a 34 GiB floor. sc-22508 admits each
+    // at its peak plus the allowance on its ACTIVATION term alone (both carry the same 18 GiB
+    // headroom), so the two admitted ceilings stay 4 GiB apart exactly as the raw floors are. A
+    // host 0.5 GiB above the admitted staged floor therefore refuses resident and admits staged:
+    // the ladder's whole point. Both ceilings come from `mlx_widened_gb`, so no number here rots.
     let host_gb = mlx_widened_gb(34, 0.5);
     assert!(host_gb < mlx_widened_gb(38, 0.0), "the window must exist");
     let contract = fixture_contract(20, 4, &[MemoryStrategy::StagedResidency]);
@@ -1198,7 +1210,7 @@ fn a_selected_optimized_rung_reaches_the_generation_request() {
         4,
         &[MemoryStrategy::StagedResidency],
     )));
-    // In the walk-down window: above the widened 34 GiB staged floor, below the widened 38 GiB
+    // In the walk-down window: above the ADMITTED 34 GiB staged floor, below the admitted 38 GiB
     // resident floor (see `a_constrained_host_walks_down_the_ladder_instead_of_refusing`).
     let outcome = admit_video_generation_with_curves(
         &generator,
@@ -1217,12 +1229,18 @@ fn provider_profiles_make_bounded_decode_a_reachable_production_fallback() {
         4,
         &[MemoryStrategy::BoundedDecode],
     )));
-    // The conservative resident profile is 20 + 35 = 55 GiB, which cannot fit (~82.7 widened by
-    // MLX_ESTIMATE_MARGIN). The exact bounded carrier retains the generic 20 + 18 = 38 GiB lower
-    // bound and fits a host 0.5 GiB above that floor's widened ceiling (~57.2). Without consuming
+    // The conservative resident profile is 20 GiB of weights + 35 GiB of profiled activation =
+    // 55 GiB, which cannot fit. The exact bounded carrier retains the generic 20 + 18 = 38 GiB
+    // lower bound and fits a host 0.5 GiB above that floor's admitted ceiling. Without consuming
     // the selected profile, Resident would win first.
+    //
+    // The profiled peak's activation term is `55 - 20`, NOT the 18 GiB generic headroom: sc-22508
+    // derives the term from the peak each candidate actually built.
     let host_gb = mlx_widened_gb(38, 0.5);
-    assert!(host_gb < mlx_widened_gb(55, 0.0), "the window must exist");
+    assert!(
+        host_gb < mlx_widened_floor_gb(55, 35, 0.0),
+        "the window must exist"
+    );
     let outcome = admit_video_generation_with_curves_and_profiles(
         &generator,
         inputs(241, budget(host_gb), 18 * GIB),
@@ -1264,9 +1282,11 @@ fn provider_profile_refusal_is_not_suppressed_by_the_smaller_generic_floor() {
     let refusal = outcome
         .refusal
         .expect("a provider profile that does not fit is a real refusal");
-    // The reported need is the 55 GiB profiled peak widened by MLX_ESTIMATE_MARGIN, exactly as
-    // the selector admits it.
-    let widened_profile = format!("needs about {:.1} GB", mlx_widened_gb(55, 0.0));
+    // The reported need is the 55 GiB profiled peak plus the allowance on ITS activation term —
+    // `55 - 20` GiB of profiled activation over 20 GiB of counted weights, not the 18 GiB generic
+    // headroom — exactly as the selector admits it. A production term derived from the generic
+    // headroom instead would under-report this by 17% of 17 GiB and reds here.
+    let widened_profile = format!("needs about {:.1} GB", mlx_widened_floor_gb(55, 35, 0.0));
     assert!(refusal.contains(&widened_profile), "{refusal}");
     assert!(outcome.memory.is_none());
     assert!(outcome.context.is_none());
@@ -1683,10 +1703,10 @@ fn a_request_above_the_cap_grades_the_cap_geometry_through_the_real_selector() {
 /// NOT manufacture a refusal the pre-existing load gate would not have made.
 #[test]
 fn a_refusal_inside_the_estimate_margin_band_is_suppressed() {
-    // 20 GiB weights + 18 GiB headroom = 38 GiB unwidened resident floor. Every implemented rung
-    // is `Missing` beyond resident, so the ladder has nowhere to go; at 39 GiB the unwidened floor
-    // FITS while its MLX_ESTIMATE_MARGIN-widened ceiling (~57.2) does not, which is exactly the
-    // band.
+    // 20 GiB weights + 18 GiB headroom = 38 GiB raw resident floor. Every implemented rung is
+    // `Missing` beyond resident, so the ladder has nowhere to go; at 39 GiB the raw floor FITS
+    // while its admitted ceiling — 38 plus 17% of the 18 GiB activation term, `mlx_widened_gb(38,
+    // 0.0)` — does not, which is exactly the band.
     let generator = fixture_generator(Some(fixture_contract(20, 4, &[])));
     let banded =
         admit_video_generation_with_curves(&generator, inputs(241, budget(39.0), 18 * GIB), None);
@@ -1740,8 +1760,11 @@ fn a_rejection_whose_peak_exceeds_the_floor_beyond_the_margin_is_not_suppressed(
     let host_gb = 100.0;
     assert!(floor_gb < host_gb, "{floor_gb} vs {host_gb}");
 
-    // The fitted shape: the rejected peak is the DECODE peak, far above the floor.
-    let fitted_decode_reject_gb = 120.0;
+    // The fitted shape: the rejected peak is the DECODE peak, far above the floor. Derived from
+    // the admitted floor plus explicit slack, so the "far above" claim stays true — and stays a
+    // claim about the ALLOWANCE boundary — if the allowance moves.
+    const DECODE_ABOVE_FLOOR_SLACK_GB: f64 = 78.0;
+    let fitted_decode_reject_gb = widened_floor_gb + DECODE_ABOVE_FLOOR_SLACK_GB;
     assert!(
         fitted_decode_reject_gb > host_gb,
         "the fixture must be a genuine rejection on this host: {fitted_decode_reject_gb} vs \
@@ -2152,10 +2175,11 @@ fn a_rung_whose_prerequisite_is_unmet_is_not_offered() {
         fixture_contract(20, 4, &[MemoryStrategy::BoundedTransformerResidency]),
         LoadShape::EagerMaterialization,
     );
-    // 20 GiB weights + 18 GiB headroom = 38 GiB resident (~57.2 widened by MLX_ESTIMATE_MARGIN);
-    // rung 4 sheds the whole 16 GiB transformer, so its floor is 22 GiB (~33.1 widened). A host
-    // 0.5 GiB above rung 4's widened floor can hold ONLY rung 4 — which is exactly why offering
-    // it here would be the harm.
+    // 20 GiB weights + 18 GiB headroom = a 38 GiB resident floor; rung 4 sheds the whole 16 GiB
+    // transformer, so its floor is 22 GiB. Both carry the same 18 GiB activation term, so the
+    // admitted ceilings (`mlx_widened_gb`) stay 16 GiB apart. A host 0.5 GiB above rung 4's
+    // admitted floor can hold ONLY rung 4 — which is exactly why offering it here would be the
+    // harm.
     let host_gb = mlx_widened_gb(22, 0.5);
     assert!(host_gb < mlx_widened_gb(38, 0.0), "the window must exist");
     let (verdict, selections) = select_once(
@@ -2383,24 +2407,68 @@ fn fitted_phase_laws_bind_by_exact_geometry_and_reduce_by_max() {
 
 #[test]
 fn mutating_the_ratified_cross_coefficient_changes_selector_outcome() {
-    // A 40 GiB-weights contract, so the two SCALAR floors stay out of reach at the host below and
-    // only the fitted curve can decide: resident floors at 40 + 18 = 58 (admitted 61.06) and
-    // staged at 36 + 18 = 54 (admitted 57.18).
+    // A 40 GiB-weights contract, NOT the 20 GiB one the neighbouring tests use, and the choice is
+    // load-bearing: at 20 GiB the staged scalar floor is 16 + 18 = 34 GiB, whose admitted ceiling
+    // sits below the host this test needs, so the floor alone would admit and the curve
+    // coefficient could not be what flips the verdict. At 40 GiB the two scalar floors (resident
+    // 40 + 18, staged 36 + 18) are out of reach, leaving the fitted curve as the only decider.
+    // `staged_floor_ceiling_gb` below asserts that rather than assuming it.
     let contract = fixture_contract(40, 4, &[MemoryStrategy::StagedResidency]);
     let original = fixture_curve_bundle();
     let geometry = geometry(145, VideoGeometryRole::Requested);
-    // Between the two fitted verdicts: the f145 fitted peak's recapture ceiling (~47.1) rejects,
-    // while zeroing the decode cross term drops the admitted peak to the denoise phase's (~41.8),
-    // which admits. Neither scalar floor fits, so the coefficient alone flips the verdict.
-    let host_gb = 45.0;
+    let mut mutated = original.clone();
+    mutated.curves[0].phases.decode.per_mpx_frame_gb = 0.0;
+
+    // The window, derived end to end from the policy rather than written down as a float: the host
+    // sits between the two FITTED admitted ceilings (the mutated one admits, the shipped one
+    // rejects) and below the lower of the two SCALAR floor ceilings (so neither floor can decide).
+    // Every bound comes from the same helpers production uses, so an allowance change moves the
+    // window with it instead of silently making one arm vacuous.
+    let fitted_ceiling_gb = |bundle: &VideoMemoryCurveBundle| -> f64 {
+        let selector = selector_with_curves(&contract, Some(bundle), budget(0.0));
+        let engaged = contract.engaged_composition(MemoryStrategy::StagedResidency);
+        let (peaks, basis, ..) = fitted_or_floor_phase_peaks(
+            &selector,
+            geometry,
+            MemoryStrategy::StagedResidency,
+            &engaged,
+        );
+        assert_eq!(
+            basis,
+            CandidateBasis::EstimateFittedCurve,
+            "the window is only meaningful while the curve is what decides"
+        );
+        crate::memory_strategy::peak_bytes_to_gb(crate::memory_strategy::admitted_peak_bytes(
+            crate::ladder_margin_policy::AdmissionSubject {
+                backend: gen_core::MemoryBackend::Mlx,
+                basis,
+                closure_is_stale: false,
+                unmodeled_activation_bytes: None,
+            },
+            peaks.peak_bytes(),
+        ))
+    };
+    let shipped_ceiling_gb = fitted_ceiling_gb(&original);
+    let mutated_ceiling_gb = fitted_ceiling_gb(&mutated);
+    let staged_floor_ceiling_gb = mlx_widened_gb(36 + FIXTURE_HEADROOM_GIB, 0.0);
+    let host_gb = (shipped_ceiling_gb + mutated_ceiling_gb) / 2.0;
+    assert!(
+        mutated_ceiling_gb < host_gb && host_gb < shipped_ceiling_gb,
+        "the coefficient must move the admitted ceiling across the host: \
+         mutated {mutated_ceiling_gb}, host {host_gb}, shipped {shipped_ceiling_gb}"
+    );
+    assert!(
+        host_gb < staged_floor_ceiling_gb,
+        "neither scalar floor may fit, or the curve is not what decides: host {host_gb}, \
+         staged floor ceiling {staged_floor_ceiling_gb}"
+    );
+
     let original_verdict = select_once_with_curves(&contract, &original, budget(host_gb), geometry);
     assert!(
         matches!(original_verdict, VideoRungSelection::Reject { .. }),
         "the generated decode cross coefficient must bind: {original_verdict:?}"
     );
 
-    let mut mutated = original.clone();
-    mutated.curves[0].phases.decode.per_mpx_frame_gb = 0.0;
     let mutated_verdict = select_once_with_curves(&contract, &mutated, budget(host_gb), geometry);
     assert!(
         matches!(
@@ -2531,7 +2599,7 @@ fn checkpoint_bound_ltx_tiers_drive_curve_or_floor_safety_on_cold_and_warm_reque
 
         for cache_state in [MemoryCacheState::Cold, MemoryCacheState::Warm] {
             // Same staged-rung window as the historical-q8 test: admits the q8 fitted f121 peak
-            // and the q4/bf16 staged floor under MLX_ESTIMATE_MARGIN, refuses resident.
+            // and the q4/bf16 staged floor at its admitted ceiling, refuses resident.
             let mut request = inputs(121, budget(mlx_widened_gb(38, -1.0)), 18 * GIB);
             request.fps = 30;
             request.tier = resolved;
@@ -2578,9 +2646,9 @@ fn assert_curve_mismatch_falls_back(
     curves: &VideoMemoryCurveBundle,
     geometry: VideoAdmissionGeometry,
 ) {
-    // In the staged-floor window — above the widened 34 GiB staged floor (~51.1 under
-    // MLX_ESTIMATE_MARGIN), below the widened 38 GiB resident floor (~57.2) — so the floor
-    // decision being preserved is a real staged selection.
+    // In the staged-floor window — above the ADMITTED 34 GiB staged floor, below the admitted
+    // 38 GiB resident floor (both from `mlx_widened_gb`, which adds 17% of the shared 18 GiB
+    // activation term) — so the floor decision being preserved is a real staged selection.
     let host_gb = mlx_widened_gb(34, 0.5);
     let expected = {
         let mut selector = selector_with_curves(contract, None, budget(host_gb));
@@ -2745,9 +2813,9 @@ fn the_single_pass_cap_geometry_can_bind_the_graded_set() {
         },
     ];
 
-    // In the staged-floor window: above the 34 GiB staged floor widened by MLX_ESTIMATE_MARGIN
-    // (~51.1), below the widened 38 GiB resident floor (~57.2) — and far below the fitted f297
-    // cap peak's widened ceiling (~124.7), which is what makes the cap row the binding refusal.
+    // In the staged-floor window: above the ADMITTED 34 GiB staged floor, below the admitted
+    // 38 GiB resident floor (both from `mlx_widened_gb`) — and far below the fitted f297 cap
+    // peak's admitted ceiling, which is what makes the cap row the binding refusal.
     let host_gb = mlx_widened_gb(34, 0.5);
     let requested = VideoAdmissionGeometry {
         decode_pass: VideoDecodePass::Tiled,
@@ -2831,11 +2899,21 @@ fn same_rung_cap_binding_carries_cap_peak_but_actual_request_geometry() {
         (peaks.peak_bytes(), basis)
     };
 
+    // The basis this window is built on. Asserted, not assumed: the whole window below is computed
+    // from the fitted-curve allowance, so a change that demoted this candidate to a floor would
+    // otherwise leave the test passing against arithmetic that no longer describes production.
+    assert_eq!(
+        expected_basis,
+        CandidateBasis::EstimateFittedCurve,
+        "the cap candidate must be the fitted curve for this window to mean anything"
+    );
+
     // 0.5 GiB above the cap's admitted staged ceiling, which is the larger of the two staged
-    // candidates — and below the admitted 90 GiB resident floor, so both geometries select STAGED
-    // and the same-rung tie is what is under test. sc-22508: the allowance is named by the cap
-    // candidate's own basis, and this request declares ZERO headroom, so a floor-shaped peak is
-    // admitted at exactly its value.
+    // candidates — and below the admitted resident floor, so both geometries select STAGED and the
+    // same-rung tie is what is under test. sc-22508: the allowance is named by the cap candidate's
+    // own basis. This mirror declares the term production declares for that basis — `None` for a
+    // fitted curve, and for a floor the activation slice of the peak itself, exactly as
+    // `LadderVideoSelector::select` derives it.
     let host_gb =
         crate::memory_strategy::peak_bytes_to_gb(crate::memory_strategy::admitted_peak_bytes(
             crate::ladder_margin_policy::AdmissionSubject {
@@ -2843,14 +2921,22 @@ fn same_rung_cap_binding_carries_cap_peak_but_actual_request_geometry() {
                 basis: expected_basis,
                 closure_is_stale: false,
                 unmodeled_activation_bytes: matches!(expected_basis, CandidateBasis::EstimateFloor)
-                    .then_some(0),
+                    .then(|| {
+                        expected_peak.saturating_sub(
+                            crate::mlx_fit_gate::estimate_floor_weights_bytes(
+                                &contract,
+                                &contract.engaged_composition(MemoryStrategy::StagedResidency),
+                            ),
+                        )
+                    }),
             },
             expected_peak,
         )) + 0.5;
-    // The resident floor is 90 GiB of weights plus this request's 18 GiB headroom, admitted at
-    // 108 + its 18 GiB headroom allowance = 126.
+    // The resident floor is 90 GiB of weights plus this request's 18 GiB headroom = 108 GiB raw,
+    // admitted at 108 + 17% of the 18 GiB activation term = 111.06 — NOT 108 + 18. The allowance
+    // is a fraction of the activation term, not a second copy of it.
     assert!(
-        host_gb < mlx_widened_gb(108, 0.0),
+        host_gb < mlx_widened_gb(90 + FIXTURE_HEADROOM_GIB, 0.0),
         "the staged-not-resident window must exist: {host_gb}"
     );
 

--- a/crates/sceneworks-worker/src/vram_gate.rs
+++ b/crates/sceneworks-worker/src/vram_gate.rs
@@ -1394,7 +1394,7 @@ pub(crate) fn krea_turbo_fit_with_runtime(
     // per-phase curves ARE the fitted model over this tier's measured cells, so an in-envelope
     // request geometry nobody measured gets an estimate candidate per optimized rung at the
     // curve-predicted peak, graded by the shared selector behind the candle ESTIMATE margin
-    // (`crate::ladder_margin_policy::CANDLE_ESTIMATE_MARGIN`). Where the exact request cell has a
+    // (`crate::ladder_margin_policy::CANDLE_RECAPTURE_SPREAD`). Where the exact request cell has a
     // verified record, the selector's measured-supersedes-estimate rule keeps admission
     // byte-for-byte unchanged.
     //
@@ -1567,6 +1567,7 @@ pub(crate) fn krea_turbo_fit_with_runtime(
             evidence,
             closure_digest: &measured_closure_digest,
             basis: memory_strategy::CandidateBasis::Measured,
+            unmodeled_activation_bytes: None,
         })
         .collect::<Vec<_>>();
     // Synthesized under (and anchored to) the live closure — there is nothing for currency to
@@ -1576,6 +1577,9 @@ pub(crate) fn krea_turbo_fit_with_runtime(
         evidence,
         closure_digest: &live_closure_digest,
         basis: memory_strategy::CandidateBasis::EstimateFittedCurve,
+        // A fitted per-phase curve carries no weights/activation split (sc-22508); its remaining
+        // uncertainty is the same-cell recapture spread the policy charges on the whole peak.
+        unmodeled_activation_bytes: None,
     }));
     let selection = memory_strategy::select_strategy(
         request,
@@ -3913,7 +3917,7 @@ mod tests {
             Some(KreaTurboFit::Reject { needed_gb, .. }) => {
                 let streamed_peak_gb = 9.0 + 2.0 * 0.802816;
                 let expected = streamed_peak_gb
-                    * (1.0 + crate::ladder_margin_policy::CANDLE_ESTIMATE_MARGIN)
+                    * (1.0 + crate::ladder_margin_policy::CANDLE_RECAPTURE_SPREAD)
                     + HEADROOM_GB;
                 assert!(
                     (needed_gb - expected).abs() < 1e-3,

--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -28,9 +28,10 @@ Companions, not prerequisites — you should not need to open either to finish a
 Measuring a lane **improves prediction**. It does not unlock anything.
 
 Since epic 18093 (sc-18095/18096/18097), a lane whose provider compile closure has moved keeps
-serving its measured numbers behind a **widened admission margin**, and unmeasured cells are admitted
-from **fitted estimates** behind a wider margin still
-(`crates/sceneworks-worker/src/ladder_margin_policy.rs`). Nothing in `npm run check`,
+serving its measured numbers behind a **per-term admission allowance**, and unmeasured cells are
+admitted from **fitted, anchor-derived, or floor estimates** behind whichever allowance names their
+remaining uncertainty (`crates/sceneworks-worker/src/ladder_margin_policy.rs`; sc-22508 replaced the
+single per-backend multiplier with one named term per basis). Nothing in `npm run check`,
 `npm run rust:check`, the pre-push hook or CI demands a re-capture — **there are zero staleness gates
 in CI**. So the payoff of a capture is narrower margins and better-grounded admission on that lane,
 not a ladder that was previously refused.

--- a/scripts/derive-ladder-margins.mjs
+++ b/scripts/derive-ladder-margins.mjs
@@ -40,18 +40,21 @@
  *                      capture noise; folding it into a variance estimate would produce a
  *                      nonsense margin, so it is excluded and counted separately.
  *
- * Margin rule (per backend):
+ * Derivation rule (per backend), as of sc-22508:
  *
- *   staleMeasuredMargin = max(hardFloor, VARIANCE_SAFETY_MULTIPLIER x maxBindingSpread)
- *   estimateMargin      = ESTIMATE_WIDENING_MULTIPLIER x staleMeasuredMargin
+ *   recaptureSpread = max(hardFloor, maxBindingSpread)
  *
- * The hard floor applies when variance data is thin — few or no repeat pairs — and, as of the
- * 65-record corpus, it binds for BOTH backends (see the floor rationale on each constant below).
+ * The measured quantity, and nothing on top of it. The epic-18093 rule multiplied this by 2 as a
+ * "safety" term and then by 2 again for estimates; neither multiplier named an uncertainty, and
+ * both were applied to a candidate's WHOLE peak. Epic 22505 E3 replaced that with per-term
+ * allowances in `crates/sceneworks-worker/src/ladder_margin_policy.rs`, where this number is the
+ * SAME-CELL RECAPTURE SPREAD and is charged only where the peak itself is the uncertain quantity.
  *
- * The estimate margin does NOT fold in the max CAN-BIND phase spread. The corpus demonstrates a
- * 17.1369% cross-fingerprint same-key denoise re-capture spread; folding it through the rule
- * shape above (x2 safety, floor, x2 widening) would yield a 68.5% MLX estimate margin —
- * unusable (and even the un-widened variance term alone is 34.3%). Instead
+ * The hard floor applies when variance data is thin — few or no repeat pairs.
+ *
+ * The spread does NOT fold in the max CAN-BIND phase spread (17.1369% on the current corpus). That
+ * belongs to a phase the candidate's own term does not cover, so pricing it as a fraction of the
+ * peak would be exactly the untethered widening E3 retires. Instead
  * ESTIMATE_ADMISSION_REQUIRES_MEASURED_BINDING_PHASE records the constraint that carries that
  * risk: estimate-backed admission (sc-18096/18097) must not admit a candidate whose predicted
  * binding phase differs from the measured cell's without re-deriving per-phase variance for
@@ -61,8 +64,7 @@
  * The constants this script derives are landed in
  * `crates/sceneworks-worker/src/ladder_margin_policy.rs`;
  * `scripts/derive-ladder-margins.test.mjs` pins the two against each other, so re-running this
- * derivation after the evidence grows will red that test the moment the variance term overtakes
- * a floor.
+ * derivation after the evidence grows will red that test the moment the measured spread moves.
  *
  * Run: `node scripts/derive-ladder-margins.mjs [--json]`
  */
@@ -76,8 +78,8 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 export const EVIDENCE_PATH = "docs/generated/memory-calibration-evidence.json";
 
 /**
- * Hard floor for MLX, and the whole MLX margin today (the observed variance term is 2.48%, under
- * the floor). Why 5% and not the observed 1.24% max binding spread:
+ * Hard floor for MLX, used only when repeat coverage is too thin to measure a spread (the current
+ * corpus measures 12.60%, above it). Why a 5% floor rather than zero:
  *
  *   1. FAILURE COST IS ASYMMETRIC AND FATAL. An MLX allocator overshoot aborts the worker
  *      process via the default MLX error handler — there is no recoverable Err on that lane —
@@ -95,9 +97,9 @@ export const EVIDENCE_PATH = "docs/generated/memory-calibration-evidence.json";
 export const MLX_HARD_FLOOR = 0.05;
 
 /**
- * Hard floor for candle, and — by the sc-18094 rule for a backend with ZERO repeat pairs — the
- * whole candle margin: all 15 candle records are unique keys, so there is no variance estimate
- * and none is invented. Why the floor is 2.5x smaller than MLX's:
+ * Hard floor for candle, and — for a backend with ZERO repeat pairs — the whole candle recapture
+ * spread: every candle record is a unique key, so there is no variance estimate and none is
+ * invented. Why the floor is 2.5x smaller than MLX's:
  *
  *   1. FAILURE COST IS RECOVERABLE. A CUDA/candle allocation failure surfaces as an Err the
  *      worker maps to a failed job; the process survives and the job can rerun.
@@ -107,20 +109,13 @@ export const MLX_HARD_FLOOR = 0.05;
  */
 export const CANDLE_HARD_FLOOR = 0.02;
 
-/**
- * Widening applied to the observed max binding spread before comparing with the floor. A max
- * over 39 pairs is an order statistic, not a bound; doubling it is the cheap protection against
- * the next capture landing just outside the sampled range.
- */
-export const VARIANCE_SAFETY_MULTIPLIER = 2;
-
-/**
- * Estimate-backed candidates (sc-18096/18097) carry model extrapolation error ON TOP of capture
- * variance — the estimator is projecting a cell nobody has measured — so their margin is double
- * the stale-measured margin, which only has to absorb re-capture noise on a cell that WAS
- * measured.
- */
-export const ESTIMATE_WIDENING_MULTIPLIER = 2;
+// sc-22508 (epic 22505) retired VARIANCE_SAFETY_MULTIPLIER and ESTIMATE_WIDENING_MULTIPLIER. Both
+// were blanket widenings applied to the whole peak, and neither named a term: the first doubled an
+// order statistic "in case the next capture lands outside the sampled range", the second doubled it
+// again for estimates. What this script derives now is the MEASURED quantity itself — the max
+// same-cell binding-phase spread — which the selector charges only against the term it belongs to
+// (`crates/sceneworks-worker/src/ladder_margin_policy.rs`). Risk outside the sampled range is
+// carried by runtime catching (E6), not by a standing multiple.
 
 /**
  * Constraint inherited by sc-18096/18097, mirrored by the Rust constant of the same name (the
@@ -306,19 +301,19 @@ export function analyzeBackend(records) {
   return analysis;
 }
 
-/** Apply the margin rule (see header) to one backend's analysis. */
+/**
+ * The SAME-CELL RECAPTURE SPREAD for one backend: the observed max binding-phase spread over the
+ * corpus's repeat pairs, floored at the backend's documented accounting residual for a backend with
+ * no repeat pairs. This is the whole derivation now — no safety multiplier, no estimate widening.
+ */
 export function deriveBackendMargins(analysis, hardFloor) {
   const maxBindingSpread = analysis.bindingSpreads[0]?.spread ?? null;
-  const varianceTerm =
-    maxBindingSpread === null ? null : VARIANCE_SAFETY_MULTIPLIER * maxBindingSpread;
-  const staleMeasuredMargin = Math.max(hardFloor, varianceTerm ?? 0);
+  const recaptureSpread = Math.max(hardFloor, maxBindingSpread ?? 0);
   return {
     hardFloor,
     maxBindingSpread,
-    varianceTerm,
-    floorBinds: (varianceTerm ?? 0) <= hardFloor,
-    staleMeasuredMargin,
-    estimateMargin: ESTIMATE_WIDENING_MULTIPLIER * staleMeasuredMargin,
+    floorBinds: (maxBindingSpread ?? 0) <= hardFloor,
+    recaptureSpread,
   };
 }
 
@@ -352,7 +347,7 @@ async function main() {
     return;
   }
 
-  process.stdout.write(`sc-18094 ladder margin derivation — ${EVIDENCE_PATH} (${records.length} records)\n`);
+  process.stdout.write(`sc-18094/sc-22508 recapture-spread derivation — ${EVIDENCE_PATH} (${records.length} records)\n`);
   for (const [backend, { analysis, margins }] of Object.entries(derived)) {
     process.stdout.write(`\n[${backend}] ${analysis.recordCount} records, ${analysis.uniqueKeys} unique keys\n`);
     process.stdout.write(
@@ -374,10 +369,9 @@ async function main() {
     }
     if (analysis.maxCanBindPhaseSpread) {
       const cb = analysis.maxCanBindPhaseSpread;
-      const foldedIn = ESTIMATE_WIDENING_MULTIPLIER * Math.max(margins.hardFloor, VARIANCE_SAFETY_MULTIPLIER * cb.spread);
       process.stdout.write(
         `  max CAN-BIND phase spread (any phase, flips excluded): ${formatPercent(cb.spread)} (${cb.phase}/${cb.metric}, ${cb.recordIds.join(" vs ")})\n` +
-          `    folding it into the estimate margin would yield ${formatPercent(foldedIn)} — carried by the phase-extrapolation constraint instead (see header)\n`,
+          `    it belongs to a phase the candidate's own term does not cover — carried by the phase-extrapolation constraint, not by a wider allowance (see header)\n`,
       );
     }
     if (analysis.envelopeGap) {
@@ -387,10 +381,10 @@ async function main() {
       );
     }
     process.stdout.write(
-      `  variance term (x${VARIANCE_SAFETY_MULTIPLIER}): ${formatPercent(margins.varianceTerm)}   hard floor: ${formatPercent(margins.hardFloor)}   floor binds: ${margins.floorBinds}\n`,
+      `  hard floor: ${formatPercent(margins.hardFloor)}   floor binds: ${margins.floorBinds}\n`,
     );
     process.stdout.write(
-      `  => staleMeasuredMargin = ${formatPercent(margins.staleMeasuredMargin)}   estimateMargin = ${formatPercent(margins.estimateMargin)}\n`,
+      `  => recaptureSpread = ${formatPercent(margins.recaptureSpread)}\n`,
     );
   }
 }

--- a/scripts/derive-ladder-margins.test.mjs
+++ b/scripts/derive-ladder-margins.test.mjs
@@ -9,10 +9,8 @@ import {
   BINDING_PHASE_ENVELOPE_SHARE,
   CANDLE_HARD_FLOOR,
   ESTIMATE_ADMISSION_REQUIRES_MEASURED_BINDING_PHASE,
-  ESTIMATE_WIDENING_MULTIPLIER,
   MLX_HARD_FLOOR,
   RESIDUAL_BOUNDED_MAX_OVER_PHASES_EXEMPT_FROM_BINDING_PHASE_PIN,
-  VARIANCE_SAFETY_MULTIPLIER,
   analyzeBackend,
   deriveBackendMargins,
   deriveMargins,
@@ -78,16 +76,21 @@ test("rust ladder_margin_policy constants match the derivation output", async ()
   const derived = deriveMargins(await loadEvidenceRecords(ROOT));
   const constants = await rustConstants();
 
-  assert.equal(constants.LADDER_MARGIN_HARD_FLOOR_MLX, derived.mlx.margins.hardFloor);
-  assert.equal(constants.LADDER_MARGIN_HARD_FLOOR_CANDLE, derived.candle.margins.hardFloor);
-  assert.equal(constants.MLX_STALE_MEASURED_MARGIN, derived.mlx.margins.staleMeasuredMargin);
-  assert.equal(constants.MLX_ESTIMATE_MARGIN, derived.mlx.margins.estimateMargin);
-  assert.equal(constants.CANDLE_STALE_MEASURED_MARGIN, derived.candle.margins.staleMeasuredMargin);
-  assert.equal(constants.CANDLE_ESTIMATE_MARGIN, derived.candle.margins.estimateMargin);
+  assert.equal(constants.MLX_RECAPTURE_SPREAD, derived.mlx.margins.recaptureSpread);
+  assert.equal(constants.CANDLE_RECAPTURE_SPREAD, derived.candle.margins.recaptureSpread);
 
-  // Exactly the six derivation-coupled constants exist; a seventh margin constant added to the
-  // Rust module without extending this pin would otherwise ship unpinned.
-  assert.equal(Object.keys(constants).length, 6);
+  // The third f64 is NOT corpus-derived and must not pretend to be: sc-22508 charges a floor's
+  // allocator-envelope allowance against its ACTIVATION term, at the same measured 17% bound the
+  // anchor derivation uses (`sceneworks_core::memory_anchor::ANCHOR_ALLOCATOR_ENVELOPE_MARGIN`).
+  assert.equal(constants.FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE, 0.17);
+
+  // Exactly these three f64 constants exist; a fourth margin constant added to the Rust module
+  // without extending this pin would otherwise ship unpinned.
+  assert.deepEqual(Object.keys(constants).sort(), [
+    "CANDLE_RECAPTURE_SPREAD",
+    "FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE",
+    "MLX_RECAPTURE_SPREAD",
+  ]);
 });
 
 // Guards the honesty claims baked into the constants' doc comments. If evidence growth changes
@@ -97,7 +100,7 @@ test("derivation corpus facts backing the doc comments still hold", async () => 
   const derived = deriveMargins(await loadEvidenceRecords(ROOT));
 
   assert.ok(derived.mlx.analysis.repeatPairs > 0, "mlx repeat pairs exist");
-  assert.equal(derived.mlx.margins.floorBinds, false, "mlx variance now exceeds the hard floor");
+  assert.equal(derived.mlx.margins.floorBinds, false, "mlx spread now exceeds the hard floor");
   assert.equal(derived.candle.analysis.repeatPairs, 0, "candle has zero repeat pairs (floor is the whole margin)");
   assert.equal(derived.mlx.analysis.intraRecordRepeatMeasurements, 0);
   assert.equal(derived.candle.analysis.intraRecordRepeatMeasurements, 0);
@@ -168,15 +171,17 @@ test("the estimate-admission binding-phase constraint is pinned on both sides an
     );
   }
 
-  // Load-bearing on the committed corpus: widening the demonstrated per-phase re-capture spread
-  // by the derivation's safety and estimate factors exceeds the shipped MLX estimate margin, so
-  // the constraint is still required for phase extrapolation.
+  // Load-bearing on the committed corpus: the demonstrated per-phase re-capture spread exceeds
+  // the same-cell spread the selector actually charges, so the constraint is still required for
+  // phase extrapolation. sc-22508 removed the x2/x4 widenings, which makes the gap WIDER, not
+  // narrower — the constraint carries more of the risk now, not less.
   const derived = deriveMargins(await loadEvidenceRecords(ROOT));
   const canBind = derived.mlx.analysis.maxCanBindPhaseSpread;
   assert.equal((canBind.spread * 100).toFixed(4), "17.1369", "spread matches the number cited in both doc comments");
-  const fullyWidenedCanBind = Math.max(MLX_HARD_FLOOR, canBind.spread * 2) * 2;
-  assert.equal((fullyWidenedCanBind * 100).toFixed(2), "68.55", "fully widened spread matches the docs");
-  assert.ok(fullyWidenedCanBind > derived.mlx.margins.estimateMargin, "constraint is load-bearing");
+  assert.ok(
+    canBind.spread > derived.mlx.margins.recaptureSpread,
+    "constraint is load-bearing: the can-bind spread exceeds the charged same-cell spread",
+  );
 });
 
 // SC-18829's fitted video curve is the narrow, ratified exception to the measured-binding-phase
@@ -227,24 +232,25 @@ test("the residual-bounded max-over-phases exemption is structural and keeps mar
   }
 
   // SC-18829's claim is NON-REDUCTION: the video ratification may not shrink the image-lane
-  // margins. The exact MLX value is owned by the sc-18094 derivation pin above (0.5040734… on the
-  // merged 89-record corpus) — re-pinning it here would just freeze the corpus twice.
+  // allowances. The exact MLX value is owned by the derivation pin above — re-pinning it here
+  // would just freeze the corpus twice. (sc-22508 re-termed the allowances epic-wide; that is a
+  // policy change, not the video ratification silently reducing anything.)
   assert.ok(
-    derived.mlx.margins.estimateMargin >= 0.10,
-    "ratification does not reduce MLX margin",
+    derived.mlx.margins.recaptureSpread >= 0.10,
+    "ratification does not reduce the MLX recapture spread",
   );
-  assert.equal(derived.candle.margins.estimateMargin, 0.04, "ratification does not reduce candle margin");
+  assert.equal(derived.candle.margins.recaptureSpread, 0.02, "ratification does not reduce the candle spread");
   assert.match(runbook, /Admission-margin verdict \(SC-18829\): keep the ratified constants unchanged/);
   assert.match(runbook, /largest\s+adopted q8 `cross` residual is 0\.4438 GiB/);
   assert.match(runbook, /10% MLX estimate margin/);
   assert.match(runbook, /Candle has no\s+promoted temporal curve yet/);
 });
 
-// Mutation-proofs the VARIANCE path: with a synthetic repeat pair whose doubled spread exceeds
-// the floor, the derived margin must track the variance term, not the floor. Without this, a
-// derivation that always returned the floor would still pass the pin above.
-test("variance term overrides the floor when repeat spread is wide enough", () => {
-  const spread = 0.06; // x2 => 12%, above the 5% mlx floor
+// Mutation-proofs the VARIANCE path: with a synthetic repeat pair whose spread exceeds the floor,
+// the derived spread must track the measurement, not the floor. Without this, a derivation that
+// always returned the floor would still pass the pin above.
+test("the measured spread overrides the floor when repeat spread is wide enough", () => {
+  const spread = 0.06; // above the 5% mlx floor
   const analysis = analyzeBackend([
     syntheticRecord({ id: "syn-a", denoise: 10_000_000_000, decode: 9_000_000_000, overall: 10_500_000_000 }),
     syntheticRecord({
@@ -258,13 +264,13 @@ test("variance term overrides the floor when repeat spread is wide enough", () =
 
   assert.equal(analysis.repeatPairs, 1);
   assert.ok(!margins.floorBinds);
-  assert.ok(Math.abs(margins.staleMeasuredMargin - VARIANCE_SAFETY_MULTIPLIER * spread) < 1e-9);
   assert.ok(
-    Math.abs(margins.estimateMargin - ESTIMATE_WIDENING_MULTIPLIER * margins.staleMeasuredMargin) < 1e-9,
+    Math.abs(margins.recaptureSpread - spread) < 1e-9,
+    "the derivation is the measured spread itself — no safety or estimate multiplier survives",
   );
 });
 
-test("a backend with no repeat pairs falls back to the hard floor as the whole margin", () => {
+test("a backend with no repeat pairs falls back to the hard floor as the whole spread", () => {
   const analysis = analyzeBackend([
     syntheticRecord({ id: "syn-a", backend: "candle", denoise: 4e9, decode: 4e9, overall: 4e9 }),
     syntheticRecord({ id: "syn-b", backend: "candle", tier: "q8", denoise: 8e9, decode: 8e9, overall: 8e9 }),
@@ -274,8 +280,7 @@ test("a backend with no repeat pairs falls back to the hard floor as the whole m
   assert.equal(analysis.repeatPairs, 0);
   assert.equal(margins.maxBindingSpread, null);
   assert.ok(margins.floorBinds);
-  assert.equal(margins.staleMeasuredMargin, CANDLE_HARD_FLOOR);
-  assert.equal(margins.estimateMargin, ESTIMATE_WIDENING_MULTIPLIER * CANDLE_HARD_FLOOR);
+  assert.equal(margins.recaptureSpread, CANDLE_HARD_FLOOR);
 });
 
 // The two exclusion rules that keep the corpus's known artifacts out of the SAME-CELL variance

--- a/scripts/stale-lane-report.mjs
+++ b/scripts/stale-lane-report.mjs
@@ -54,7 +54,7 @@
  *
  * MARGIN: DERIVED, NEVER RESTATED
  *
- * The widening column is `staleMeasuredMargin` from `scripts/derive-ladder-margins.mjs`, computed
+ * The widening column is `recaptureSpread` from `scripts/derive-ladder-margins.mjs`, computed
  * over the same evidence corpus this report reads. That module's constants are pinned against
  * `crates/sceneworks-worker/src/ladder_margin_policy.rs` by `scripts/derive-ladder-margins.test.mjs`,
  * so the number printed here is the number the runtime applies, and a drift on either side reds that
@@ -88,7 +88,7 @@ export const SOURCE_PATHS = Object.freeze({
 
 /** Provenance for the margin column, printed so a reader can check it rather than trust it. */
 export const MARGIN_SOURCE =
-  "scripts/derive-ladder-margins.mjs#staleMeasuredMargin (pinned against " +
+  "scripts/derive-ladder-margins.mjs#recaptureSpread (pinned against " +
   "crates/sceneworks-worker/src/ladder_margin_policy.rs by scripts/derive-ladder-margins.test.mjs)";
 
 /**
@@ -599,8 +599,8 @@ export function buildStaleLaneReport({
     const backendMargins = margins[backend]?.margins ?? null;
     // A lane the derivation does not model gets no invented margin: the impact terms fall back to
     // the raw counts so the lane still ranks, and the null is visible in the output.
-    const staleMeasuredMargin = backendMargins?.staleMeasuredMargin ?? null;
-    const weight = staleMeasuredMargin ?? 1;
+    const recaptureSpread = backendMargins?.recaptureSpread ?? null;
+    const weight = recaptureSpread ?? 1;
     const measured = bindingTally.total + recordTally.total > 0;
     const staleCount = bindingTally.stale + recordTally.stale;
     lanes.push({
@@ -640,8 +640,7 @@ export function buildStaleLaneReport({
       },
       margin: backendMargins
         ? {
-            staleMeasuredMargin: backendMargins.staleMeasuredMargin,
-            estimateMargin: backendMargins.estimateMargin,
+            recaptureSpread: backendMargins.recaptureSpread,
             hardFloor: backendMargins.hardFloor,
             source: MARGIN_SOURCE,
           }
@@ -770,16 +769,15 @@ export function formatReport(report) {
   if (report.staleLanes.length === 0) {
     out.push("No stale lanes. Every captured lane's closure digest matches the live derivation.");
   } else {
-    out.push("STALE LANES, ranked by widened admission surface (stale bindings x margin), then evidence surface:");
+    out.push("STALE LANES, ranked by widened admission surface (stale bindings x recapture spread), then evidence surface:");
     out.push("");
-    const header = ["#", "LANE", "BINDINGS", "RECORDS", "MARGIN", "ESTIMATE", "IMPACT", "CAPTURE", "MODELS"];
+    const header = ["#", "LANE", "BINDINGS", "RECORDS", "RECAPTURE", "IMPACT", "CAPTURE", "MODELS"];
     const rows = report.staleLanes.map((lane) => [
       String(lane.rank),
       lane.lane,
       `${lane.bindings.stale}/${lane.bindings.total}`,
       `${lane.records.stale}/${lane.records.total}`,
-      percent(lane.margin?.staleMeasuredMargin ?? null),
-      percent(lane.margin?.estimateMargin ?? null),
+      percent(lane.margin?.recaptureSpread ?? null),
       lane.impact.widenedAdmissionSurface.toFixed(3),
       lane.capturable ? "yes" : "NO ARM",
       lane.models.join(", ") || "(none)",

--- a/scripts/stale-lane-report.test.mjs
+++ b/scripts/stale-lane-report.test.mjs
@@ -307,8 +307,8 @@ test("ranking weighs the margin, not just the count", () => {
   assert.equal(second.lane, "candle:beta");
   assert.equal(first.rank, 1);
   assert.equal(second.rank, 2);
-  assert.equal(first.impact.widenedAdmissionSurface, 3 * first.margin.staleMeasuredMargin);
-  assert.equal(second.impact.widenedAdmissionSurface, 5 * second.margin.staleMeasuredMargin);
+  assert.equal(first.impact.widenedAdmissionSurface, 3 * first.margin.recaptureSpread);
+  assert.equal(second.impact.widenedAdmissionSurface, 5 * second.margin.recaptureSpread);
   assert.ok(first.impact.widenedAdmissionSurface > second.impact.widenedAdmissionSurface);
 });
 
@@ -366,8 +366,7 @@ test("the margin column is the derivation's, not a literal in this script", asyn
   const report = buildStaleLaneReport(fixture);
   const derived = deriveMargins(fixture.records);
   for (const lane of report.staleLanes) {
-    assert.equal(lane.margin.staleMeasuredMargin, derived[lane.backend].margins.staleMeasuredMargin);
-    assert.equal(lane.margin.estimateMargin, derived[lane.backend].margins.estimateMargin);
+    assert.equal(lane.margin.recaptureSpread, derived[lane.backend].margins.recaptureSpread);
   }
   // No margin literal may be reintroduced here: a hardcoded copy is exactly how this column would
   // drift away from the runtime it claims to describe.
@@ -424,13 +423,12 @@ test("the real corpus reports the margins the worker actually applies", async ()
     rust[match[1]] = Number(match[2]);
   }
   const expected = {
-    mlx: { stale: rust.MLX_STALE_MEASURED_MARGIN, estimate: rust.MLX_ESTIMATE_MARGIN },
-    candle: { stale: rust.CANDLE_STALE_MEASURED_MARGIN, estimate: rust.CANDLE_ESTIMATE_MARGIN },
+    mlx: rust.MLX_RECAPTURE_SPREAD,
+    candle: rust.CANDLE_RECAPTURE_SPREAD,
   };
-  assert.ok(expected.mlx.stale > 0 && expected.candle.stale > 0, "the Rust policy constants parsed");
+  assert.ok(expected.mlx > 0 && expected.candle > 0, "the Rust policy constants parsed");
   for (const lane of [...report.staleLanes, ...report.currentLanes]) {
-    assert.equal(lane.margin.staleMeasuredMargin, expected[lane.backend].stale, lane.lane);
-    assert.equal(lane.margin.estimateMargin, expected[lane.backend].estimate, lane.lane);
+    assert.equal(lane.margin.recaptureSpread, expected[lane.backend], lane.lane);
   }
 });
 


### PR DESCRIPTION
## Scope vs story AC

**AC1 — "No blanket multiplicative margin survives in the selector path; each remaining margin term names its uncertainty and a unit test asserts it is proportionate to that term, not to the whole peak."** — done.

`MLX_ESTIMATE_MARGIN` (0.5041), `MLX_STALE_MEASURED_MARGIN` (0.2520), `CANDLE_ESTIMATE_MARGIN` (0.04) and `CANDLE_STALE_MEASURED_MARGIN` (0.02) are gone, along with `estimate_margin(backend)` / `stale_measured_margin(backend)` and the `widened_peak_bytes(peak, margin)` application in `select_strategy`. `crates/sceneworks-worker/src/ladder_margin_policy.rs` now exposes `admission_allowance(AdmissionSubject) -> AdmissionAllowance`, which names one of three terms:

| term | uncertainty covered | proportionate to | value |
| --- | --- | --- | --- |
| `FullyPriced` | none left | — | 0 bytes |
| `SameCellRecaptureSpread` | re-running one measured cell lands on a different peak | the whole peak (the peak IS what moves between captures) | MLX 12.6018% (measured), candle 2% (accounting residual; zero repeat pairs) |
| `AllocatorEnvelopeOverActivation` | MLX allocator envelope above modelled active bytes | a floor's ACTIVATION (headroom) term only, never its counted weights | 17%, the same measured bound `ANCHOR_ALLOCATOR_ENVELOPE_MARGIN` uses |

Per basis: `Measured`+current → FullyPriced; `Measured`+stale → recapture spread; `EstimateFittedCurve` → recapture spread (the fitted laws already carry per-phase residuals); `EstimateAnchorDerived` → **FullyPriced** (the derivation prices both of its terms); `EstimateFloor` → allocator envelope on its declared headroom, or the whole-peak accounting residual where the lane publishes no split.

The x2 "variance safety" and x2 "estimate widening" multipliers are also removed from `scripts/derive-ladder-margins.mjs`, which now derives `recaptureSpread = max(hardFloor, maxBindingSpread)` — the measurement, nothing on top of it.

The proportionality test: `memory_strategy::tests::a_floors_allowance_tracks_its_headroom_term_not_its_counted_weights` — two floors with identical 6 GiB headroom and a 10x difference in counted weights receive the **same** allowance in bytes, which no fraction-of-the-peak margin can do. Mirrored in `ladder_margin_policy::tests::the_floor_allowance_is_proportionate_to_headroom_not_to_the_peak`.

**AC2 — "A 60 GB derived peak admits at every rung it truly fits on a 128 GB budget (selector test)."** — done.

`memory_strategy::tests::a_sixty_gb_anchor_derived_peak_admits_at_every_rung_it_fits_on_a_128_gb_host` walks all five rungs (60/48/36/24/12 GB derived peaks) on a 128 GB host, giving each rung exactly the bytes its derived peak needs, and asserts that rung is selected at `needed_gb == peak`. It also pins that the retired 90.24 GB blanket ceiling really did sit inside the host's band.

## Behavior deltas worth review

* MLX floors admit earlier: a 38 GiB weights+headroom floor is now graded at 41.06 GiB instead of 57.16.
* MLX stale/fitted candidates: 1.2520x / 1.5041x → 1.1260x.
* Candle: 4% estimate / 2% stale → a single 2% accounting residual.
* `shipped_resident_only_mlx_estimate_band_audit` — the recorded live audit shrinks 3 rows → 1; `flux2_dev` q4@64 and `ideogram_4` q8@48 now admit at both host sizes and have no band left to flip.

## Boundaries respected

* `candle_memory_strategy.rs` touched only for forced plumbing (one `unmodeled_activation_bytes: None` field on the existing `Candidate` construction). Declaring a candle weights/headroom split is left to sc-22509's anchor work and is noted in the code.
* `scripts/inference-closure-digest.mjs` and `memory_calibration.rs` currency logic untouched (sc-22511).
* No inference pin change.

## Verification

* `npm run rust:check` → 0, `npm run rust:check:candle` → 0, `npm run rust:check:neither` → 0.
* `npm run check` → 768 pass / 0 fail.
* `cargo test -p sceneworks-worker --lib` → 2044 pass / 0 fail.

Mutation-checked (each run alone, `touch` between, restored after):

| assertion | mutation | result |
| --- | --- | --- |
| 60 GB anchor-derived admits at every fitting rung | `EstimateAnchorDerived` → recapture spread | RED |
| floor allowance tracks the headroom term | `AllocatorEnvelopeOverActivation` charged on `peak_bytes` | RED |
| recapture spread is the measured value | `MLX_RECAPTURE_SPREAD` → 0.2520 (the retired x2) | RED (Rust pin + node derivation pin) |
| floor allowance is non-zero | `FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE` → 0.0 | RED at compile time |
| selector applies the allowance | `admitted_peak_bytes` returns the raw peak | RED (9 selector tests) |
| video floors declare their split | `unmodeled_activation_bytes: None` on the video lane | RED (8 video tests) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round 2 (sc-22508)

Two blockers, four majors and three minors from review. The two blockers changed graded values, so the affected fixture windows were recomputed from the policy helpers rather than nudged.

### The declared activation term is now DERIVED from the peak that was built, never assumed

**Video lane (`video_admission.rs`).** The declaration was `.then_some(self.headroom_bytes)`, unconditional on the floor basis. But the peak it grades is `profiled_floor_phase_peaks` = `max(weights + headroom, provider decode profile)`, then reduced by `attributable_resident_bytes`. When a decode profile binds, the activation slice is `profiled − weights` (a 55 GiB peak over 20 GiB of weights carries **35 GiB**, not 18), and on a warm path the declared constant could exceed the whole post-subtraction peak. It is now computed at the construction site as `peak − (weights − attributable_resident)`, which is exact for both floor shapes and can never exceed the peak. The refusal-artifact guard no longer reconstructs the term either: the resident candidate's declared value is carried out of the selector on `resident_floors`.

**MLX gate (`mlx_fit_gate.rs`).** The declaration was applied to every `EstimateFloor` candidate including the **resident baseline**, whose peak is `request_total_peak_bytes` — `providers::mage::memory::generation_peak_gb` on `mage_flow` routes, and elsewhere whatever the loaded generator's `predicted_memory_peak_from_base` returns. Neither is guaranteed to decompose. The split is now carried on a new index-aligned `candidate_activation_bytes` axis pushed at each peak's construction site: `Some(generic_headroom_bytes)` for the synthesized floors this file composes itself, `None` for the resident baseline and every measured candidate. The resident baseline therefore takes the policy's documented undeclared-floor arm.

### Candle floors declare their split too

The MLX-only declaration was justified by a "doubling" argument that no longer describes the shipped 17% fraction, and the candle floor **does** decompose (`floor_phase_peaks` is lane-blind). Withholding the declaration because the correct term produced a larger number was picking a margin by magnitude — the E3 pattern being retired. Both lanes now declare; the FRACTION is per-backend, where the measurement lives:

* `FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE` = 17% — the measured MLX allocator retention envelope.
* `CANDLE_FLOOR_ALLOCATOR_ENVELOPE_ALLOWANCE` = 2% — candle has no allocator-pool envelope; what remains above a candle floor's activation is the deterministic accounting residual `CANDLE_RECAPTURE_SPREAD` documents, so the constant is defined as that value rather than inventing a second number. Compile-time invariant added: the fatal lane is never charged less than the recoverable one for this term either.

### `generic_mlx_shared_observation` no longer charges out of band

It graded `predicted_peak_bytes: total_bytes` (weights only) with headroom reserved separately via `Budget.reserved_headroom_gb`, while declaring `unmodeled_activation_bytes: Some(headroom)` — a charge outside the peak, contradicting the field's contract. The headroom is folded into the peak and `reserved_headroom_gb` zeroed. **Exactly value-preserving:** `weights + 0.17·h ≤ total − h` becomes `(weights + h) + 0.17·h ≤ total`.

### Doc/comment corrections

* `ladder_margin_policy.rs` — the equality with `ANCHOR_ALLOCATOR_ENVELOPE_MARGIN` now states that the **base differs**: `memory_anchor::widened` applies 0.17 to a whole phase estimate (weights included), this constant to activation alone. The pin is on the shared measurement, not on a shared base. Anchor-side application deliberately unchanged — that question goes to the feature-end review.
* `memory_strategy.rs` — deleted the dead "estimate margin is strictly wider than the stale margin" claim (both now resolve to `CANDLE_RECAPTURE_SPREAD`), replaced with an assertion on the emitted allowance term key.
* Every remaining comment explaining a fixture window through the deleted `MLX_ESTIMATE_MARGIN` / `MLX_STALE_MEASURED_MARGIN` (numbers stale by ~16 GiB) restated against the per-term allowance; "twice the raw" corrected to "raw + 17% of the activation term"; "108 + 18 = 126" corrected to `mlx_widened_gb(108, 0.0)` = 111.06.

### Test-window repairs

* `mutating_the_ratified_cross_coefficient_changes_selector_outcome` — the bare `host_gb = 45.0` is replaced by a window derived end to end: the host is the midpoint of the shipped and mutated **fitted** admitted ceilings (both computed through `admitted_peak_bytes`), asserted to sit between them and below the staged scalar floor's ceiling. The 20→40 weights change is justified in the comment and now enforced by that last assertion — at 20 GiB the staged floor would decide instead of the curve.
* `same_rung_cap_binding_carries_cap_peak_but_actual_request_geometry` — the mirror now matches production's post-fix derivation instead of `.then_some(0)`, and `expected_basis` is asserted so a basis flip is loud rather than silently invalidating the window.
* `a_rejection_whose_peak_exceeds_the_floor_beyond_the_margin_is_not_suppressed` — `fitted_decode_reject_gb` derived from `admitted_floor_bytes` plus a named slack constant.
* `mlx_widened_gb` split into `mlx_widened_floor_gb(peak, activation, slack)` plus the generic-floor convenience wrapper, so profiled-peak fixtures state their real activation term.
* `shipped_resident_only_mlx_estimate_band_audit` — the counterfactual is graded on the arm production uses for the resident baseline (undeclared), and the recorded flip list is now empty. The coverage assertion and the per-cell production-selector comparison still run, so a reopened band still reds.

### Verification

* `cargo test -p sceneworks-worker` → 2046 pass / 0 fail.
* `npm run rust:check` → 0, `npm run rust:check:candle` → 0, `npm run rust:check:neither` → 0.

Mutation-checked (each run alone, `touch` between, restored after):

| assertion | mutation | result |
| --- | --- | --- |
| `each_backend_prices_its_own_floor_envelope` | candle floor envelope → the MLX 17% | RED |
| `estimate_candidates_are_admitted_at_exactly_the_policy_widened_peak` (term key) | floor arm charges the activation envelope with no declared term | RED |
| `mutating_the_ratified_cross_coefficient_changes_selector_outcome` (derived window) | contract weights 40 → 20 GiB | RED |
| `provider_profile_refusal_is_not_suppressed_by_the_smaller_generic_floor` | video term reverted to `then_some(self.headroom_bytes)` | RED |
| `same_rung_cap_binding_carries_cap_peak_but_actual_request_geometry` (`expected_basis`) | curves dropped so the basis flips to the floor | RED |
| `a_moved_provider_closure_admits_the_stale_ladder_behind_the_widened_margin` (derived bracket) | `stale_admitted_peak_bytes` returns the raw peak | RED |
| `generic_mlx_adopts_shared_selector_without_an_optimized_claim` | peak reverted to weights-only | RED |
| `the_legacy_resident_baseline_is_graded_without_a_declared_activation_split` | resident baseline declares `generic_headroom_bytes` | RED |
| `a_rejection_whose_peak_exceeds_the_floor_beyond_the_margin_is_not_suppressed` | decode-above-floor slack → 0 | RED |
