### PR TITLE
Fix StarVector terminal closure hashing above 2 GiB (SC-22261)

### DIFF
--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -867,14 +867,14 @@ fn builtin_starvector_manifests_are_exact_native_image_to_svg_closures() {
             );
             assert_eq!(
                 candidate["productionClosure"]["sha256"],
-                "916f16a495b77bf8df818194c0ee09185e34579207f482adf9773bde5ce579e1"
+                "f1aa5a3a056a18c54860fa3e93a38d5319d183fb7c866890a349c01f632c2404"
             );
             assert_eq!(
                 candidate["productionClosure"]["entries"]
                     .as_array()
                     .expect("production closure entries")
                     .len(),
-                28
+                29
             );
             assert_eq!(
                 candidate["supportedDevices"]["mlx"],

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -25612,7 +25612,7 @@
             },
             "productionClosure": {
               "schemaVersion": 1,
-              "sha256": "916f16a495b77bf8df818194c0ee09185e34579207f482adf9773bde5ce579e1",
+              "sha256": "f1aa5a3a056a18c54860fa3e93a38d5319d183fb7c866890a349c01f632c2404",
               "entries": [
                 {
                   "path": ".github/workflows/starvector-terminal.yml",
@@ -25710,9 +25710,14 @@
                   "sha256": "8ab96cf63a6846aadd351d43cd50c91de747b694cc5b450a29a699a2c843f115"
                 },
                 {
+                  "path": "scripts/lib/file-sha256.mjs",
+                  "byteSize": 392,
+                  "sha256": "5ae246ca43f5fb9f6a51bdff01f2e60b73993861e6cb9957292a5c08cefe4aa6"
+                },
+                {
                   "path": "scripts/starvector-production-closure.mjs",
-                  "byteSize": 8197,
-                  "sha256": "f31baa4b9bc4573476198c47c7d4098a7933edfe8ba830cf2e1b04623a981dc6"
+                  "byteSize": 8230,
+                  "sha256": "d9c7fc95d913972825b2e5404dc1bc9e31498747793c5545e2f10cfdd12b045a"
                 },
                 {
                   "path": "scripts/starvector-terminal-assets.mjs",
@@ -25741,13 +25746,13 @@
                 },
                 {
                   "path": "scripts/starvector-terminal-producer.mjs",
-                  "byteSize": 31260,
-                  "sha256": "5024708739d3dc63e22ebe9fa00cfa07c128b586808f929e75fd06170d128344"
+                  "byteSize": 31334,
+                  "sha256": "dd30d0a4bbf7834853f3c1c66640ddf53ea48475feb0766f10920b1ba44b5e7a"
                 },
                 {
                   "path": "scripts/starvector-terminal-product-service.mjs",
-                  "byteSize": 11118,
-                  "sha256": "9fa87bc71386d26d25172af936592abef1aa7b3f2d970ecabee718cb7165e112"
+                  "byteSize": 11261,
+                  "sha256": "55d758c661bb326f5e2598cd05df09d4274247aca49de50b40c4846e44116c74"
                 },
                 {
                   "path": "scripts/starvector-terminal-route.mjs",

--- a/scripts/lib/file-sha256.mjs
+++ b/scripts/lib/file-sha256.mjs
@@ -1,0 +1,10 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+
+const HASH_CHUNK_BYTES = 1024 * 1024;
+
+export async function fileSha256(file, { openReadStream = createReadStream } = {}) {
+  const digest = createHash("sha256");
+  for await (const chunk of openReadStream(file, { highWaterMark: HASH_CHUNK_BYTES })) digest.update(chunk);
+  return digest.digest("hex");
+}

--- a/scripts/starvector-production-closure.mjs
+++ b/scripts/starvector-production-closure.mjs
@@ -30,6 +30,7 @@ export const PRODUCTION_CLOSURE_PATHS = Object.freeze([
   "packages/schemas/model-manifest.schema.json",
   "release/starvector-terminal-campaign-v1.json",
   "release/starvector-terminal-metrics-lock-v1.json",
+  "scripts/lib/file-sha256.mjs",
   "scripts/starvector-production-closure.mjs",
   "scripts/starvector-terminal-assets.mjs",
   "scripts/starvector-terminal-campaign.mjs",

--- a/scripts/starvector-production-closure.test.mjs
+++ b/scripts/starvector-production-closure.test.mjs
@@ -65,8 +65,8 @@ test("shape and tree checks detect every closure mutation", async () => {
 
 test("live manifest seals the exact frozen-tree production closure", async () => {
   const closure = await checkManifestProductionClosure();
-  assert.equal(closure.sha256, "916f16a495b77bf8df818194c0ee09185e34579207f482adf9773bde5ce579e1");
-  assert.equal(closure.entries.length, 28);
+  assert.equal(closure.sha256, "f1aa5a3a056a18c54860fa3e93a38d5319d183fb7c866890a349c01f632c2404");
+  assert.equal(closure.entries.length, 29);
 });
 
 test("the sealed campaign worker and standalone worker keep the large-stack entry seam", async () => {

--- a/scripts/starvector-terminal-producer.mjs
+++ b/scripts/starvector-terminal-producer.mjs
@@ -8,6 +8,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { INFERENCE_REVISION, readPlanAndLock } from "./starvector-terminal-campaign.mjs";
 import { isExecutedModule } from "./starvector-terminal-cli.mjs";
+import { fileSha256 } from "./lib/file-sha256.mjs";
 
 const execFile = promisify(execFileCallback);
 const sha = (bytes) => createHash("sha256").update(bytes).digest("hex");
@@ -22,12 +23,12 @@ const stable = (value) => Array.isArray(value) ? `[${value.map(stable).join(",")
 // materializes the exact validator paths in its canonical evidence tree.
 const portableRelative = (relative) => relative.split("/").map((part) => part.replaceAll(":", "__colon__")).join("/");
 
-export async function inventory(root) {
+export async function inventory(root, digestFile = fileSha256) {
   const entries = [];
   for (const name of (await readdir(root, { recursive: true })).sort()) {
     const file = path.join(root, name); const info = await lstat(file);
     if (info.isSymbolicLink()) die(`inventory rejects symlink ${name}`);
-    if (info.isFile()) entries.push({ path: name.split(path.sep).join("/"), byte_size: info.size, sha256: sha(await readFile(file)) });
+    if (info.isFile()) entries.push({ path: name.split(path.sep).join("/"), byte_size: info.size, sha256: await digestFile(file) });
   }
   // Do not use locale collation here: a receipt produced on a Windows runner must
   // hash identically to one produced on macOS regardless of the host locale.

--- a/scripts/starvector-terminal-producer.test.mjs
+++ b/scripts/starvector-terminal-producer.test.mjs
@@ -100,6 +100,9 @@ test("tuple marker, bytewise inventory, and symlink policy prevent mixed evidenc
   await claimTupleMarker(root, permanentPin, "campaign", "mlx:1b");
   await assert.rejects(() => claimTupleMarker(root, permanentPin, "campaign", "mlx:1b"), /tuple already/);
   await mkdir(path.join(root, "nested")); await writeFile(path.join(root, "nested", "z"), "z"); await writeFile(path.join(root, "A"), "a");
-  const listed = await inventory(root); assert.deepEqual(listed.entries.map((entry) => entry.path), [...listed.entries.map((entry) => entry.path)].sort());
+  const hashed = [];
+  const listed = await inventory(root, async (file) => { hashed.push(file); return sha(await readFile(file)); });
+  assert.deepEqual(listed.entries.map((entry) => entry.path), [...listed.entries.map((entry) => entry.path)].sort());
+  assert.equal(hashed.length, 3);
   await symlink(path.join(root, "A"), path.join(root, "link")); await assert.rejects(() => inventory(root), /rejects symlink/);
 });

--- a/scripts/starvector-terminal-product-service.mjs
+++ b/scripts/starvector-terminal-product-service.mjs
@@ -8,6 +8,7 @@ import { copyFile, lstat, mkdir, readFile, readdir, rm, writeFile } from "node:f
 import { promisify } from "node:util";
 import path from "node:path";
 import { isExecutedModule } from "./starvector-terminal-cli.mjs";
+import { fileSha256 } from "./lib/file-sha256.mjs";
 
 const execFile = promisify(execFileCallback);
 const sha = (value) => createHash("sha256").update(value).digest("hex");
@@ -38,18 +39,29 @@ async function waitHealthy(url) {
   }
   die("source-built API did not become ready");
 }
-async function copyRegularTree(source, destination) {
+export async function copyRegularTree(source, destination, digestFile = fileSha256) {
   const info = await lstat(source);
   if (info.isSymbolicLink()) die(`weights closure rejects symlink ${source}`);
   if (info.isDirectory()) {
     await mkdir(destination, { recursive: true });
-    for (const name of await readdir(source)) await copyRegularTree(path.join(source, name), path.join(destination, name));
+    for (const name of await readdir(source)) await copyRegularTree(path.join(source, name), path.join(destination, name), digestFile);
     return;
   }
   if (!info.isFile()) die(`weights closure rejects non-regular file ${source}`);
   await mkdir(path.dirname(destination), { recursive: true });
   await copyFile(source, destination);
-  if (sha(await readFile(source)) !== sha(await readFile(destination))) die(`weights closure copy hash drifted: ${source}`);
+  if (await digestFile(source) !== await digestFile(destination)) die(`weights closure copy hash drifted: ${source}`);
+}
+
+export async function closureTreeHash(root, digestFile = fileSha256) {
+  const rows = [];
+  for (const name of await readdir(root, { recursive: true })) {
+    const file = path.join(root, name), info = await lstat(file);
+    if (info.isSymbolicLink()) die(`weights closure copy contains symlink ${name}`);
+    if (info.isFile()) rows.push([name.split(path.sep).join("/"), info.size, await digestFile(file)]);
+  }
+  rows.sort((a, b) => a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0);
+  return sha(JSON.stringify(rows));
 }
 
 async function materializeOfflineWeights(weightsRoot, stateRoot) {
@@ -61,12 +73,7 @@ async function materializeOfflineWeights(weightsRoot, stateRoot) {
   const hfSource = path.join(weightsRoot, ...closure.hf_home_relative_path.split(/[\\/]/));
   await copyRegularTree(appSource, path.join(stateRoot, "data"));
   await copyRegularTree(hfSource, path.join(stateRoot, "hf"));
-  const hashTree = async (root) => {
-    const rows = [];
-    for (const name of await readdir(root, { recursive: true })) { const file = path.join(root, name), info = await lstat(file); if (info.isSymbolicLink()) die(`weights closure copy contains symlink ${name}`); if (info.isFile()) rows.push([name.split(path.sep).join("/"), info.size, sha(await readFile(file))]); }
-    rows.sort((a, b) => a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0); return sha(JSON.stringify(rows));
-  };
-  if (await hashTree(path.join(stateRoot, "data")) !== closure.app_data_sha256 || await hashTree(path.join(stateRoot, "hf")) !== closure.hf_home_sha256) die("materialized receipt/HF closure hash mismatch");
+  if (await closureTreeHash(path.join(stateRoot, "data")) !== closure.app_data_sha256 || await closureTreeHash(path.join(stateRoot, "hf")) !== closure.hf_home_sha256) die("materialized receipt/HF closure hash mismatch");
   const models = {};
   for (const [key, model] of Object.entries(manifest.models ?? {})) {
     if (!model?.relative_path || !model?.inventory_sha256) die("weights manifest model inventory is incomplete");

--- a/scripts/starvector-terminal-provision.mjs
+++ b/scripts/starvector-terminal-provision.mjs
@@ -9,6 +9,7 @@ import { promisify } from "node:util";
 import path from "node:path";
 import { inventory } from "./starvector-terminal-producer.mjs";
 import { isExecutedModule } from "./starvector-terminal-cli.mjs";
+import { fileSha256 } from "./lib/file-sha256.mjs";
 
 const execFile = promisify(execFileCallback);
 const SHA256 = /^[a-f0-9]{64}$/;
@@ -28,7 +29,7 @@ async function sourceFile(root, rootReal, file) {
   return targetInfo;
 }
 
-async function tree(root, symlinkBoundary = root) {
+export async function tree(root, symlinkBoundary = root, digestFile = fileSha256) {
   const entries = [];
   const rootInfo = await lstat(root).catch(() => null);
   if (!rootInfo?.isDirectory() || rootInfo.isSymbolicLink()) die(`regular source directory required: ${root}`);
@@ -37,7 +38,7 @@ async function tree(root, symlinkBoundary = root) {
     const file = path.join(root, name), info = await lstat(file);
     if (info.isDirectory()) continue;
     const regular = await sourceFile(symlinkBoundary, boundaryReal, file);
-    entries.push({ path: name.split(path.sep).join("/"), byte_size: regular.size, sha256: sha(await readFile(file)) });
+    entries.push({ path: name.split(path.sep).join("/"), byte_size: regular.size, sha256: await digestFile(file) });
   }
   entries.sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
   if (entries.length === 0) die(`source tree is empty: ${root}`);

--- a/scripts/starvector-terminal-provision.test.mjs
+++ b/scripts/starvector-terminal-provision.test.mjs
@@ -1,16 +1,56 @@
 import assert from "node:assert/strict";
 import { execFile as execFileCallback } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
 import test from "node:test";
 import { promisify } from "node:util";
-import { assemblePreflight, assembleWeights, downloadExact, installCheckout } from "./starvector-terminal-provision.mjs";
+import { fileSha256 } from "./lib/file-sha256.mjs";
+import { assemblePreflight, assembleWeights, downloadExact, installCheckout, tree } from "./starvector-terminal-provision.mjs";
 
 const execFile = promisify(execFileCallback);
 const digest = (value) => createHash("sha256").update(value).digest("hex");
 const workflow = await readFile(".github/workflows/starvector-terminal-provision.yml", "utf8");
+
+test("file and tree identities stream exact bytes with bounded reads and portable ordering", async () => {
+  const chunks = [Buffer.from("large-file-"), Buffer.from("identity")];
+  let opened;
+  const streamed = await fileSha256("virtual-4995740600-byte-shard", {
+    openReadStream(file, options) {
+      opened = { file, highWaterMark: options.highWaterMark };
+      return Readable.from(chunks);
+    },
+  });
+  assert.equal(streamed, digest(Buffer.concat(chunks)));
+  assert.deepEqual(opened, { file: "virtual-4995740600-byte-shard", highWaterMark: 1024 * 1024 });
+
+  const root = await mkdtemp(path.join(tmpdir(), "starvector-provision-tree-"));
+  await mkdir(path.join(root, "nested"));
+  await writeFile(path.join(root, "z.bin"), "z");
+  await writeFile(path.join(root, "nested", "a.bin"), "a");
+  const calls = [];
+  const identity = await tree(root, root, async (file) => {
+    calls.push(file);
+    return digest(await readFile(file));
+  });
+  assert.deepEqual(identity.entries.map((entry) => entry.path), ["nested/a.bin", "z.bin"]);
+  assert.deepEqual(identity.entries.map((entry) => entry.sha256), [digest("a"), digest("z")]);
+  assert.equal(calls.length, 2);
+  assert.equal(identity.aggregate_sha256, digest(JSON.stringify(identity.entries)));
+});
+
+test("streaming file identity propagates read failures", async () => {
+  await assert.rejects(() => fileSha256("virtual-shard", {
+    openReadStream() {
+      return Readable.from((async function* () {
+        yield Buffer.from("partial");
+        throw new Error("stream read failed");
+      })());
+    },
+  }), /stream read failed/);
+});
 
 test("provision workflow is dispatch-only and never runs a model, service, campaign, or lease", () => {
   assert.match(workflow, /^\s+workflow_dispatch:/m);
@@ -41,6 +81,11 @@ test("preflight assembly requires and copies exactly two inventories plus four h
   await writeFile(path.join(source, "starvector-terminal-preflight.json"), JSON.stringify(index));
   await assemblePreflight(source, destination, revision); await assemblePreflight(source, destination, revision);
   assert.deepEqual(JSON.parse(await readFile(path.join(destination, "starvector-terminal-preflight.json"))), index);
+  const recovered = path.join(root, "recovered"), staleStaging = `${recovered}.staging-${process.pid}`;
+  await mkdir(staleStaging, { recursive: true }); await writeFile(path.join(staleStaging, "partial"), "partial");
+  await assemblePreflight(source, recovered, revision);
+  assert.deepEqual(JSON.parse(await readFile(path.join(recovered, "starvector-terminal-preflight.json"))), index);
+  assert.equal(await lstat(staleStaging).catch((error) => error.code === "ENOENT" ? null : Promise.reject(error)), null);
   const incomplete = structuredClone(index); incomplete.hook_logs.pop(); await writeFile(path.join(source, "starvector-terminal-preflight.json"), JSON.stringify(incomplete));
   await assert.rejects(() => assemblePreflight(source, path.join(root, "incomplete"), revision), /cardinality/);
   const duplicate = structuredClone(index); duplicate.hook_logs[3].backend = "mlx"; await writeFile(path.join(source, "starvector-terminal-preflight.json"), JSON.stringify(duplicate));

--- a/scripts/starvector-terminal-readiness.mjs
+++ b/scripts/starvector-terminal-readiness.mjs
@@ -9,6 +9,7 @@ import { promisify } from "node:util";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { INFERENCE_REVISION, TUPLES, readPlanAndLock } from "./starvector-terminal-campaign.mjs";
+import { fileSha256 } from "./lib/file-sha256.mjs";
 import {
   validateInferencePreflight,
   validateMetricsEnvironment,
@@ -40,7 +41,7 @@ async function regularFile(root, relative, expected, label) {
   return { path: relative.split(/[\\/]/).join("/"), byte_size: info.size, sha256: expected };
 }
 
-async function treeIdentity(root, relative, label) {
+export async function treeIdentity(root, relative, label, digestFile = fileSha256) {
   const directory = path.join(root, ...safeRelative(relative, label));
   const rootInfo = await lstat(directory);
   if (!rootInfo.isDirectory() || rootInfo.isSymbolicLink()) die(`${label} must be a regular directory tree`);
@@ -49,7 +50,7 @@ async function treeIdentity(root, relative, label) {
     const file = path.join(directory, name); const info = await lstat(file);
     if (info.isSymbolicLink()) die(`${label} rejects symlink ${name}`);
     if (!info.isFile() && !info.isDirectory()) die(`${label} rejects non-regular entry ${name}`);
-    if (info.isFile()) rows.push([name.split(path.sep).join("/"), info.size, sha(await readFile(file))]);
+    if (info.isFile()) rows.push([name.split(path.sep).join("/"), info.size, await digestFile(file)]);
   }
   rows.sort((left, right) => left[0] < right[0] ? -1 : left[0] > right[0] ? 1 : 0);
   return { file_count: rows.length, sha256: sha(JSON.stringify(rows)) };

--- a/scripts/starvector-terminal-workflow.test.mjs
+++ b/scripts/starvector-terminal-workflow.test.mjs
@@ -1,13 +1,13 @@
 import assert from "node:assert/strict";
 import { execFile as execFileCallback } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
-import { validateCorpusAssets, validateTerminalServiceClosure } from "./starvector-terminal-readiness.mjs";
-import { productServiceBackendEnv, productServiceBuildArgs, productServiceStateRoot } from "./starvector-terminal-product-service.mjs";
+import { treeIdentity, validateCorpusAssets, validateTerminalServiceClosure } from "./starvector-terminal-readiness.mjs";
+import { closureTreeHash, copyRegularTree, productServiceBackendEnv, productServiceBuildArgs, productServiceStateRoot } from "./starvector-terminal-product-service.mjs";
 
 const workflow = await readFile(".github/workflows/starvector-terminal.yml", "utf8");
 const readiness = await readFile(".github/workflows/starvector-terminal-readiness.yml", "utf8");
@@ -57,6 +57,25 @@ test("source-built product service enables the native backend for each campaign 
   assert.notEqual(productServiceStateRoot(path.join("tmp", "tuple")), path.join("tmp", "tuple", "product-service-state"));
 });
 
+test("product service streams copied closure identity and preserves portable ordering", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "starvector-service-copy-")), source = path.join(root, "source"), destination = path.join(root, "destination");
+  await mkdir(path.join(source, "nested"), { recursive: true });
+  await writeFile(path.join(source, "z.bin"), "z"); await writeFile(path.join(source, "nested", "a.bin"), "a");
+  const copied = [];
+  const digestFile = async (file) => { copied.push(path.relative(root, file).split(path.sep).join("/")); return hash(await readFile(file)); };
+  await copyRegularTree(source, destination, digestFile);
+  assert.equal(copied.length, 4);
+  const hashed = [];
+  const identity = await closureTreeHash(destination, async (file) => { hashed.push(file); return hash(await readFile(file)); });
+  const rows = [["nested/a.bin", 1, hash("a")], ["z.bin", 1, hash("z")]];
+  assert.equal(identity, hash(JSON.stringify(rows)));
+  assert.equal(hashed.length, 2);
+  await symlink(path.join(source, "z.bin"), path.join(source, "link"));
+  await assert.rejects(() => copyRegularTree(source, path.join(root, "rejected")), /weights closure rejects symlink/);
+  await symlink(path.join(destination, "z.bin"), path.join(destination, "link"));
+  await assert.rejects(() => closureTreeHash(destination), /weights closure copy contains symlink/);
+});
+
 test("readiness workflow is an identity-only dispatch on both campaign hosts", () => {
   assert.match(readiness, /^\s+workflow_dispatch:/m);
   assert.doesNotMatch(readiness, /^\s+(push|pull_request|schedule):/m);
@@ -96,6 +115,9 @@ test("readiness validates the complete service tree closure without materializin
   const weights = { models: { "starvector-1b": {}, "starvector-8b": {} }, terminal_service_closure: { app_data_relative_path: "app", app_data_sha256: await tree("app"), hf_home_relative_path: "hf", hf_home_sha256: await tree("hf") } };
   const result = await validateTerminalServiceClosure(root, weights);
   assert.equal(result.app_data.file_count, 1); assert.equal(result.hf_home.file_count, 1);
+  const streamed = [];
+  assert.equal((await treeIdentity(root, "hf", "terminal HF closure", async (file) => { streamed.push(file); return hash(await readFile(file)); })).sha256, weights.terminal_service_closure.hf_home_sha256);
+  assert.equal(streamed.length, 1);
   await writeFile(path.join(root, "hf", "weights.bin"), "drift");
   await assert.rejects(() => validateTerminalServiceClosure(root, weights), /service closure tree hash mismatch/);
 });

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -896,8 +896,8 @@ def test_starvector_terminal_candidate_schema_is_closed_and_mutation_resistant()
     candidate = model["vector"]["deviceAdmission"]["terminalCandidate"]
     assert candidate["inferenceRevision"] == "b2d9e0917499517cf8c1518e0d360cac8693b0c0"
     assert candidate["corpusSha256"] == "757370c4eed38a52a29ac80c258fdedd7e437ab891637bcb1c916aa608bf32b5"
-    assert candidate["productionClosure"]["sha256"] == "916f16a495b77bf8df818194c0ee09185e34579207f482adf9773bde5ce579e1"
-    assert len(candidate["productionClosure"]["entries"]) == 28
+    assert candidate["productionClosure"]["sha256"] == "f1aa5a3a056a18c54860fa3e93a38d5319d183fb7c866890a349c01f632c2404"
+    assert len(candidate["productionClosure"]["entries"]) == 29
     assert model["vector"]["providers"] == {
         "mlx": {"id": "mlx-starvector-8b", "available": True},
         "candle": {"id": "candle-starvector-8b", "available": True},


### PR DESCRIPTION
## Summary

- replace whole-file SHA-256 reads on every StarVector model/HF closure tree path with one 1 MiB streaming helper
- cover producer inventory, provisioning trees, product-service copy verification/tree identity, and readiness identity
- preserve deterministic POSIX path identities, symlink refusal, exact byte digests, atomic staging, and partial-run recovery
- include the helper in the sealed production closure and refresh its exact manifest assertions

## Root cause

Run 33802063638 reached a 4,995,740,600-byte StarVector shard through producer inventory before publication. Node readFile refuses files above its 2 GiB buffer limit, so provisioning terminated before the existing atomic copy/publish logic could complete.

## Validation

- npm run check: 743 passed, 0 failed
- focused StarVector terminal suite: 37 passed, 0 failed
- production closure suite: 5 passed, 0 failed
- npm run rust:check with an isolated empty HF_HOME: passed tier-integrity, cargo fmt, clippy -D warnings, all Rust tests, and cargo build
- mutation checks: reverting each of the five streaming call sites to whole-file reads independently fails its injected-digest assertion
- protected measurement quartet SHA-256 values unchanged

The two ambient-cache stub tests were also rechecked separately: 5/7 with the populated host cache and 7/7 with a fresh empty HF_HOME, confirming unrelated environment leakage. No workflow or real-weight campaign was dispatched.