### PR TITLE
fix(training): join the LTX-2.5 training tier as path segments

### DIFF
--- a/apps/rust-api/src/training.rs
+++ b/apps/rust-api/src/training.rs
@@ -2147,13 +2147,15 @@ fn ltx25_q4_training_tier_present(snapshot: &FsPath) -> bool {
     .all(|file| q4.join(file).is_file())
 }
 
-fn training_tier_name(target: &TrainingTarget) -> &'static str {
+/// The tier subdirectory training reads, as path segments so the caller joins them with the
+/// platform separator (a `"dev/q4"` literal would embed a forward slash on Windows).
+fn training_tier_segments(target: &TrainingTarget) -> &'static [&'static str] {
     if target.base_model == "ltx_2_5" {
-        "dev/q4"
+        &["dev", "q4"]
     } else if target.kernel == "ltx_mlx_lora" {
-        "q4"
+        &["q4"]
     } else {
-        "bf16"
+        &["bf16"]
     }
 }
 
@@ -2179,7 +2181,9 @@ fn tiered_turnkey_train_dir(
     // LTX-2.5 nests two transformer identities before the quant tier, so it does not match the
     // root-level `bf16/q8/q4` turnkey shape tested below.
     if target.base_model == "ltx_2_5" || snapshot_is_tiered_turnkey(&snapshot) {
-        return snapshot.join(training_tier_name(target));
+        return training_tier_segments(target)
+            .iter()
+            .fold(snapshot, |dir, segment| dir.join(segment));
     }
     snapshot
 }


### PR DESCRIPTION
## What does this PR do?

`training_tier_name` in `apps/rust-api/src/training.rs` returned the literal
`"dev/q4"` for the `ltx_2_5` base model, and its caller in
`tiered_turnkey_train_dir` folded that into the snapshot path with a single
`join`. On Windows that embeds a forward slash in the resolved base path, so
`ltx25_training_resolves_and_requires_the_nested_dev_q4_tier` fails comparing
`...\snapshots\ltx25-q4-training\dev/q4` against `...\dev\q4`.

The helper is now `training_tier_segments`, returning the tier as
`&'static [&'static str]` (`["dev","q4"]`, `["q4"]`, `["bf16"]`), and the caller
folds the segments with successive joins so the path uses the platform
separator. Behavior on Linux and macOS is unchanged, and the user-facing message
that mentions "packed q4" is untouched.

Introduced by 76baed2ef (sc-18787). It was invisible to CI because no lane runs
`cargo test` for rust-api on Windows, and elsewhere the separator already
matched.

## Related issue

Closes #

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

`npm run rust:check` from Git Bash on Windows is green: format, clippy, and every
test binary, including the 707 rust-api lib tests and the previously failing
`ltx25_training_resolves_and_requires_the_nested_dev_q4_tier`.

- [ ] macOS (Apple Silicon / MLX)
- [x] Windows (NVIDIA / candle)
- [ ] Docker server (candle / CPU)
- [ ] Not platform-specific (web UI, docs, shared crate)

Two environment-specific notes for the reviewer, neither caused by this change:

- `real_training_job_rejected_when_base_model_missing` fails locally when
  `HF_HOME` is set, because the test then sees a genuinely installed base model
  and gets 201 instead of 400. It passes with `env -u HF_HOME`.
- `npm run check` fails in the LTX safety canary suite on Windows only, on
  `spawn /bin/sh ENOENT` and POSIX file-mode assertions. Those script files are
  byte-identical to `main`; this branch's only diff is the one Rust file.

## Checklist

- [x] I ran `npm run rust:check` (if I touched Rust) and it passed
- [ ] I ran `npm --prefix apps/web run lint && npm --prefix apps/web run test && npm --prefix apps/web run build` (if I touched the web app)
- [x] I ran `npm run check` (scaffold checks) — see the canary note above
- [ ] I updated documentation where relevant
- [ ] All my commits are signed off (`git commit -s` — see the DCO section in CONTRIBUTING.md)
- [x] My PR is focused on a single logical change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
