### PR TITLE
fix(starvector): align terminal provisioning contracts (SC-22261)

### DIFF
--- a/.github/workflows/starvector-terminal-provision.yml
+++ b/.github/workflows/starvector-terminal-provision.yml
@@ -179,12 +179,39 @@ jobs:
       - name: Provision pinned metric runtime and official checkpoints
         shell: powershell
         run: |
-          if (-not (Test-Path "$env:STARVECTOR_TERMINAL_ROOT\metrics\Scripts\python.exe")) { py -3.11 -m venv "$env:STARVECTOR_TERMINAL_ROOT\metrics" }
-          & "$env:STARVECTOR_TERMINAL_ROOT\metrics\Scripts\python.exe" -m pip install --disable-pip-version-check numpy==2.2.6 scikit-image==0.25.2 lpips==0.1.4 torch==2.7.0 torchvision==0.22.0 Pillow==11.3.0 open-clip-torch==3.1.0
+          $bootstrapPython = $null
+          $bootstrapIdentity = $null
+          $candidates = @(Get-Command python.exe -All -CommandType Application -ErrorAction SilentlyContinue | ForEach-Object Source | Where-Object { $_ } | Select-Object -Unique)
+          foreach ($candidate in $candidates) {
+            $identityJson = & $candidate -c 'import json,sys; print(json.dumps({"executable":sys.executable,"version":[sys.version_info.major,sys.version_info.minor,sys.version_info.micro]}))' 2>$null
+            if ($LASTEXITCODE -ne 0) { continue }
+            try { $identity = $identityJson | ConvertFrom-Json -ErrorAction Stop } catch { continue }
+            if ($identity.version.Count -eq 3 -and [int]$identity.version[0] -eq 3 -and [int]$identity.version[1] -ge 12 -and [IO.Path]::IsPathFullyQualified([string]$identity.executable)) {
+              $bootstrapPython = [IO.Path]::GetFullPath([string]$identity.executable)
+              $bootstrapIdentity = $identity
+              break
+            }
+          }
+          if (-not $bootstrapPython) { throw 'the self-hosted CUDA runner requires a directly executable Python 3.12 or newer on PATH' }
+          $metricsRoot = Join-Path $env:STARVECTOR_TERMINAL_ROOT 'metrics'
+          $metricsPython = Join-Path $metricsRoot 'Scripts\python.exe'
+          if (-not (Test-Path $metricsPython -PathType Leaf)) {
+            & $bootstrapPython -m venv $metricsRoot
+            if ($LASTEXITCODE -ne 0) { throw 'failed to create the terminal metrics venv with the selected Python interpreter' }
+          }
+          if (-not (Test-Path $metricsPython -PathType Leaf)) { throw 'terminal metrics venv did not publish Scripts\python.exe' }
+          $venvIdentityJson = & $metricsPython -c 'import json,sys; print(json.dumps({"executable":sys.executable,"version":[sys.version_info.major,sys.version_info.minor,sys.version_info.micro]}))'
+          if ($LASTEXITCODE -ne 0) { throw 'terminal metrics venv Python identity probe failed' }
+          try { $venvIdentity = $venvIdentityJson | ConvertFrom-Json -ErrorAction Stop } catch { throw 'terminal metrics venv Python identity is not valid JSON' }
+          $expectedMetricsPython = [IO.Path]::GetFullPath($metricsPython)
+          $observedMetricsPython = [IO.Path]::GetFullPath([string]$venvIdentity.executable)
+          if (-not [StringComparer]::OrdinalIgnoreCase.Equals($expectedMetricsPython, $observedMetricsPython) -or [int]$venvIdentity.version[0] -ne 3 -or [int]$venvIdentity.version[1] -lt 12 -or [int]$venvIdentity.version[0] -ne [int]$bootstrapIdentity.version[0] -or [int]$venvIdentity.version[1] -ne [int]$bootstrapIdentity.version[1]) { throw 'terminal metrics venv is not bound to the selected Python 3.12+ interpreter' }
+          & $metricsPython -m pip install --disable-pip-version-check numpy==2.2.6 scikit-image==0.25.2 lpips==0.1.4 torch==2.7.0 torchvision==0.22.0 Pillow==11.3.0 open-clip-torch==3.1.0
+          if ($LASTEXITCODE -ne 0) { throw 'failed to install the pinned terminal metrics package closure' }
           node scripts/starvector-terminal-provision.mjs download https://raw.githubusercontent.com/richzhang/PerceptualSimilarity/master/lpips/weights/v0.1/alex.pth "$env:STARVECTOR_TERMINAL_ROOT\metrics\checkpoints\lpips-v0.1-alex.pth" df73285e35b22355a2df87cdb6b70b343713b667eddbda73e1977e0c860835c0
           node scripts/starvector-terminal-provision.mjs download https://download.pytorch.org/models/alexnet-owt-7be5be79.pth "$env:STARVECTOR_TERMINAL_ROOT\metrics\checkpoints\alexnet-owt-7be5be79.pth" 7be5be791159472b1fbf3c69796f7cb30dca7ad8466c2df70058c37116cdee02
           node scripts/starvector-terminal-provision.mjs download https://huggingface.co/laion/CLIP-ViT-B-32-laion2B-s34B-b79K/resolve/1a25a446712ba5ee05982a381eed697ef9b435cf/open_clip_pytorch_model.bin "$env:STARVECTOR_TERMINAL_ROOT\metrics\checkpoints\open_clip_pytorch_model.bin" 1bd3c7172de5b207ceac554f5ab5266166f3b9baccc9af5989bc801016d080ad
-          node scripts/starvector-terminal-provision.mjs metrics "$env:GITHUB_WORKSPACE\sceneworks" "$env:STARVECTOR_TERMINAL_ROOT\metrics" "$env:STARVECTOR_TERMINAL_ROOT\metrics\Scripts\python.exe" $env:STARVECTOR_CLIP_REVISION
+          node scripts/starvector-terminal-provision.mjs metrics "$env:GITHUB_WORKSPACE\sceneworks" $metricsRoot $metricsPython $env:STARVECTOR_CLIP_REVISION
       - name: Materialize the exact pinned 120-row corpus
         shell: powershell
         run: |

--- a/.github/workflows/starvector-terminal-provision.yml
+++ b/.github/workflows/starvector-terminal-provision.yml
@@ -181,13 +181,22 @@ jobs:
         run: |
           $bootstrapPython = $null
           $bootstrapIdentity = $null
+          $canonicalDriveExecutable = {
+            param([object]$Value)
+            $text = [string]$Value
+            if ([string]::IsNullOrWhiteSpace($text) -or $text -match '[\r\n"]' -or $text -notmatch '^[A-Za-z]:\\') { return $null }
+            try { $full = [IO.Path]::GetFullPath($text) } catch { return $null }
+            if ($full -notmatch '^[A-Za-z]:\\' -or -not (Test-Path -LiteralPath $full -PathType Leaf)) { return $null }
+            return $full
+          }
           $candidates = @(Get-Command python.exe -All -CommandType Application -ErrorAction SilentlyContinue | ForEach-Object Source | Where-Object { $_ } | Select-Object -Unique)
           foreach ($candidate in $candidates) {
             $identityJson = & $candidate -c 'import json,sys; print(json.dumps({"executable":sys.executable,"version":[sys.version_info.major,sys.version_info.minor,sys.version_info.micro]}))' 2>$null
             if ($LASTEXITCODE -ne 0) { continue }
             try { $identity = $identityJson | ConvertFrom-Json -ErrorAction Stop } catch { continue }
-            if ($identity.version.Count -eq 3 -and [int]$identity.version[0] -eq 3 -and [int]$identity.version[1] -ge 12 -and [IO.Path]::IsPathFullyQualified([string]$identity.executable)) {
-              $bootstrapPython = [IO.Path]::GetFullPath([string]$identity.executable)
+            $canonicalExecutable = & $canonicalDriveExecutable $identity.executable
+            if ($identity.version.Count -eq 3 -and [int]$identity.version[0] -eq 3 -and [int]$identity.version[1] -ge 12 -and $canonicalExecutable) {
+              $bootstrapPython = $canonicalExecutable
               $bootstrapIdentity = $identity
               break
             }
@@ -200,12 +209,13 @@ jobs:
             if ($LASTEXITCODE -ne 0) { throw 'failed to create the terminal metrics venv with the selected Python interpreter' }
           }
           if (-not (Test-Path $metricsPython -PathType Leaf)) { throw 'terminal metrics venv did not publish Scripts\python.exe' }
-          $venvIdentityJson = & $metricsPython -c 'import json,sys; print(json.dumps({"executable":sys.executable,"version":[sys.version_info.major,sys.version_info.minor,sys.version_info.micro]}))'
+          $venvIdentityJson = & $metricsPython -c 'import json,sys; print(json.dumps({"executable":sys.executable,"base_executable":getattr(sys,"_base_executable",None),"version":[sys.version_info.major,sys.version_info.minor,sys.version_info.micro]}))'
           if ($LASTEXITCODE -ne 0) { throw 'terminal metrics venv Python identity probe failed' }
           try { $venvIdentity = $venvIdentityJson | ConvertFrom-Json -ErrorAction Stop } catch { throw 'terminal metrics venv Python identity is not valid JSON' }
-          $expectedMetricsPython = [IO.Path]::GetFullPath($metricsPython)
-          $observedMetricsPython = [IO.Path]::GetFullPath([string]$venvIdentity.executable)
-          if (-not [StringComparer]::OrdinalIgnoreCase.Equals($expectedMetricsPython, $observedMetricsPython) -or [int]$venvIdentity.version[0] -ne 3 -or [int]$venvIdentity.version[1] -lt 12 -or [int]$venvIdentity.version[0] -ne [int]$bootstrapIdentity.version[0] -or [int]$venvIdentity.version[1] -ne [int]$bootstrapIdentity.version[1]) { throw 'terminal metrics venv is not bound to the selected Python 3.12+ interpreter' }
+          $expectedMetricsPython = & $canonicalDriveExecutable $metricsPython
+          $observedMetricsPython = & $canonicalDriveExecutable $venvIdentity.executable
+          $observedBasePython = & $canonicalDriveExecutable $venvIdentity.base_executable
+          if (-not $expectedMetricsPython -or -not $observedMetricsPython -or -not $observedBasePython -or -not [StringComparer]::OrdinalIgnoreCase.Equals($expectedMetricsPython, $observedMetricsPython) -or -not [StringComparer]::OrdinalIgnoreCase.Equals($bootstrapPython, $observedBasePython) -or $venvIdentity.version.Count -ne 3 -or [int]$venvIdentity.version[0] -ne [int]$bootstrapIdentity.version[0] -or [int]$venvIdentity.version[1] -ne [int]$bootstrapIdentity.version[1] -or [int]$venvIdentity.version[2] -ne [int]$bootstrapIdentity.version[2]) { throw 'terminal metrics venv is not bound to the selected exact Python interpreter' }
           & $metricsPython -m pip install --disable-pip-version-check numpy==2.2.6 scikit-image==0.25.2 lpips==0.1.4 torch==2.7.0 torchvision==0.22.0 Pillow==11.3.0 open-clip-torch==3.1.0
           if ($LASTEXITCODE -ne 0) { throw 'failed to install the pinned terminal metrics package closure' }
           node scripts/starvector-terminal-provision.mjs download https://raw.githubusercontent.com/richzhang/PerceptualSimilarity/master/lpips/weights/v0.1/alex.pth "$env:STARVECTOR_TERMINAL_ROOT\metrics\checkpoints\lpips-v0.1-alex.pth" df73285e35b22355a2df87cdb6b70b343713b667eddbda73e1977e0c860835c0

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -867,14 +867,14 @@ fn builtin_starvector_manifests_are_exact_native_image_to_svg_closures() {
             );
             assert_eq!(
                 candidate["productionClosure"]["sha256"],
-                "f1aa5a3a056a18c54860fa3e93a38d5319d183fb7c866890a349c01f632c2404"
+                "6c300cd26bdd7cc6fee60dc11a47188802a3b52eec1389ab789e082d71e958d3"
             );
             assert_eq!(
                 candidate["productionClosure"]["entries"]
                     .as_array()
                     .expect("production closure entries")
                     .len(),
-                29
+                30
             );
             assert_eq!(
                 candidate["supportedDevices"]["mlx"],

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -25612,7 +25612,7 @@
             },
             "productionClosure": {
               "schemaVersion": 1,
-              "sha256": "f1aa5a3a056a18c54860fa3e93a38d5319d183fb7c866890a349c01f632c2404",
+              "sha256": "6c300cd26bdd7cc6fee60dc11a47188802a3b52eec1389ab789e082d71e958d3",
               "entries": [
                 {
                   "path": ".github/workflows/starvector-terminal.yml",
@@ -25715,9 +25715,14 @@
                   "sha256": "5ae246ca43f5fb9f6a51bdff01f2e60b73993861e6cb9957292a5c08cefe4aa6"
                 },
                 {
+                  "path": "scripts/lib/terminal-tree-identity.mjs",
+                  "byteSize": 1885,
+                  "sha256": "ce519e709c290428e15b7480104d89b5771a01f395f8a93bf1ab35f5ad35af3a"
+                },
+                {
                   "path": "scripts/starvector-production-closure.mjs",
-                  "byteSize": 8230,
-                  "sha256": "d9c7fc95d913972825b2e5404dc1bc9e31498747793c5545e2f10cfdd12b045a"
+                  "byteSize": 8274,
+                  "sha256": "5435236f1f7805be550a6495f22a1cd79752ceb90f5f408c0ac9e8be6ed618cf"
                 },
                 {
                   "path": "scripts/starvector-terminal-assets.mjs",
@@ -25751,8 +25756,8 @@
                 },
                 {
                   "path": "scripts/starvector-terminal-product-service.mjs",
-                  "byteSize": 11261,
-                  "sha256": "55d758c661bb326f5e2598cd05df09d4274247aca49de50b40c4846e44116c74"
+                  "byteSize": 11393,
+                  "sha256": "0551e1c6dbed65979144b610fcea9df89c54c14489a2aa17c7aa1b571ca9b2ca"
                 },
                 {
                   "path": "scripts/starvector-terminal-route.mjs",

--- a/scripts/lib/terminal-tree-identity.mjs
+++ b/scripts/lib/terminal-tree-identity.mjs
@@ -1,0 +1,41 @@
+import { createHash } from "node:crypto";
+
+const SHA256 = /^[a-f0-9]{64}$/;
+const ENTRY_KEYS = ["path", "byte_size", "sha256"];
+
+function invalid(message) {
+  throw new Error(`terminal tree identity: ${message}`);
+}
+
+export function terminalTreeEntry(relativePath, byteSize, sha256) {
+  const entry = { path: relativePath, byte_size: byteSize, sha256 };
+  validateTerminalTreeEntry(entry);
+  return entry;
+}
+
+export function sortTerminalTreeEntries(entries) {
+  if (!Array.isArray(entries)) invalid("entries must use the object-array representation");
+  return [...entries].sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
+}
+
+export function terminalTreeSha256(entries) {
+  if (!Array.isArray(entries)) invalid("entries must use the object-array representation");
+  let previous;
+  for (const entry of entries) {
+    validateTerminalTreeEntry(entry);
+    if (previous !== undefined && previous >= entry.path) invalid("entries must be uniquely sorted by portable path");
+    previous = entry.path;
+  }
+  return createHash("sha256").update(JSON.stringify(entries)).digest("hex");
+}
+
+function validateTerminalTreeEntry(entry) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry) || JSON.stringify(Object.keys(entry)) !== JSON.stringify(ENTRY_KEYS)) {
+    invalid("entry must be exactly {path, byte_size, sha256}");
+  }
+  if (typeof entry.path !== "string" || !entry.path || entry.path.includes("\\") || entry.path.includes("\0") || entry.path.startsWith("/") || entry.path.split("/").some((part) => !part || part === "." || part === "..")) {
+    invalid("entry path must be a safe portable relative path");
+  }
+  if (!Number.isSafeInteger(entry.byte_size) || entry.byte_size < 0) invalid("entry byte_size must be a non-negative safe integer");
+  if (!SHA256.test(entry.sha256 ?? "")) invalid("entry sha256 must be lowercase SHA-256");
+}

--- a/scripts/starvector-production-closure.mjs
+++ b/scripts/starvector-production-closure.mjs
@@ -31,6 +31,7 @@ export const PRODUCTION_CLOSURE_PATHS = Object.freeze([
   "release/starvector-terminal-campaign-v1.json",
   "release/starvector-terminal-metrics-lock-v1.json",
   "scripts/lib/file-sha256.mjs",
+  "scripts/lib/terminal-tree-identity.mjs",
   "scripts/starvector-production-closure.mjs",
   "scripts/starvector-terminal-assets.mjs",
   "scripts/starvector-terminal-campaign.mjs",

--- a/scripts/starvector-production-closure.test.mjs
+++ b/scripts/starvector-production-closure.test.mjs
@@ -65,8 +65,8 @@ test("shape and tree checks detect every closure mutation", async () => {
 
 test("live manifest seals the exact frozen-tree production closure", async () => {
   const closure = await checkManifestProductionClosure();
-  assert.equal(closure.sha256, "f1aa5a3a056a18c54860fa3e93a38d5319d183fb7c866890a349c01f632c2404");
-  assert.equal(closure.entries.length, 29);
+  assert.equal(closure.sha256, "6c300cd26bdd7cc6fee60dc11a47188802a3b52eec1389ab789e082d71e958d3");
+  assert.equal(closure.entries.length, 30);
 });
 
 test("the sealed campaign worker and standalone worker keep the large-stack entry seam", async () => {

--- a/scripts/starvector-terminal-product-service.mjs
+++ b/scripts/starvector-terminal-product-service.mjs
@@ -9,6 +9,7 @@ import { promisify } from "node:util";
 import path from "node:path";
 import { isExecutedModule } from "./starvector-terminal-cli.mjs";
 import { fileSha256 } from "./lib/file-sha256.mjs";
+import { sortTerminalTreeEntries, terminalTreeEntry, terminalTreeSha256 } from "./lib/terminal-tree-identity.mjs";
 
 const execFile = promisify(execFileCallback);
 const sha = (value) => createHash("sha256").update(value).digest("hex");
@@ -58,10 +59,10 @@ export async function closureTreeHash(root, digestFile = fileSha256) {
   for (const name of await readdir(root, { recursive: true })) {
     const file = path.join(root, name), info = await lstat(file);
     if (info.isSymbolicLink()) die(`weights closure copy contains symlink ${name}`);
-    if (info.isFile()) rows.push([name.split(path.sep).join("/"), info.size, await digestFile(file)]);
+    if (info.isFile()) rows.push(terminalTreeEntry(name.split(path.sep).join("/"), info.size, await digestFile(file)));
   }
-  rows.sort((a, b) => a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0);
-  return sha(JSON.stringify(rows));
+  const canonicalRows = sortTerminalTreeEntries(rows);
+  return terminalTreeSha256(canonicalRows);
 }
 
 async function materializeOfflineWeights(weightsRoot, stateRoot) {

--- a/scripts/starvector-terminal-provision.mjs
+++ b/scripts/starvector-terminal-provision.mjs
@@ -10,6 +10,7 @@ import path from "node:path";
 import { inventory } from "./starvector-terminal-producer.mjs";
 import { isExecutedModule } from "./starvector-terminal-cli.mjs";
 import { fileSha256 } from "./lib/file-sha256.mjs";
+import { sortTerminalTreeEntries, terminalTreeEntry, terminalTreeSha256 } from "./lib/terminal-tree-identity.mjs";
 
 const execFile = promisify(execFileCallback);
 const SHA256 = /^[a-f0-9]{64}$/;
@@ -38,11 +39,11 @@ export async function tree(root, symlinkBoundary = root, digestFile = fileSha256
     const file = path.join(root, name), info = await lstat(file);
     if (info.isDirectory()) continue;
     const regular = await sourceFile(symlinkBoundary, boundaryReal, file);
-    entries.push({ path: name.split(path.sep).join("/"), byte_size: regular.size, sha256: await digestFile(file) });
+    entries.push(terminalTreeEntry(name.split(path.sep).join("/"), regular.size, await digestFile(file)));
   }
-  entries.sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
-  if (entries.length === 0) die(`source tree is empty: ${root}`);
-  return { entries, aggregate_sha256: sha(JSON.stringify(entries)) };
+  const canonicalEntries = sortTerminalTreeEntries(entries);
+  if (canonicalEntries.length === 0) die(`source tree is empty: ${root}`);
+  return { entries: canonicalEntries, aggregate_sha256: terminalTreeSha256(canonicalEntries) };
 }
 
 async function copyTree(source, destination, symlinkBoundary = source) {

--- a/scripts/starvector-terminal-provision.test.mjs
+++ b/scripts/starvector-terminal-provision.test.mjs
@@ -1,14 +1,16 @@
 import assert from "node:assert/strict";
 import { execFile as execFileCallback } from "node:child_process";
 import { createHash } from "node:crypto";
-import { lstat, mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, rename, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
 import test from "node:test";
 import { promisify } from "node:util";
 import { fileSha256 } from "./lib/file-sha256.mjs";
+import { terminalTreeEntry, terminalTreeSha256 } from "./lib/terminal-tree-identity.mjs";
 import { assemblePreflight, assembleWeights, downloadExact, installCheckout, tree } from "./starvector-terminal-provision.mjs";
+import { validateTerminalServiceClosure } from "./starvector-terminal-readiness.mjs";
 
 const execFile = promisify(execFileCallback);
 const digest = (value) => createHash("sha256").update(value).digest("hex");
@@ -71,6 +73,26 @@ test("provision workflow is dispatch-only and never runs a model, service, campa
   assert.doesNotMatch(workflow, /STARVECTOR_PROMPT_PROVIDER: flux_diffusers/);
 });
 
+test("Windows metrics provisioning selects, uses, and verifies one explicit Python 3.12+ executable", () => {
+  const start = workflow.indexOf("- name: Provision pinned metric runtime and official checkpoints", workflow.indexOf("  provision-windows:"));
+  const end = workflow.indexOf("- name: Materialize the exact pinned 120-row corpus", start);
+  const step = workflow.slice(start, end);
+  assert.ok(start >= 0 && end > start);
+  assert.doesNotMatch(step, /\bpy\s+-3\.11\b/);
+  assert.match(step, /Get-Command python\.exe -All -CommandType Application/);
+  assert.match(step, /sys\.executable/);
+  assert.match(step, /version\":\[sys\.version_info\.major,sys\.version_info\.minor,sys\.version_info\.micro\]/);
+  assert.match(step, /\[IO\.Path\]::IsPathFullyQualified/);
+  assert.match(step, /\[int\]\$identity\.version\[1\] -ge 12/);
+  assert.match(step, /& \$bootstrapPython -m venv \$metricsRoot/);
+  assert.match(step, /if \(\$LASTEXITCODE -ne 0\) \{ throw 'failed to create the terminal metrics venv/);
+  assert.match(step, /Test-Path \$metricsPython -PathType Leaf/);
+  assert.match(step, /& \$metricsPython -c 'import json,sys/);
+  assert.match(step, /OrdinalIgnoreCase\.Equals\(\$expectedMetricsPython, \$observedMetricsPython\)/);
+  assert.match(step, /& \$metricsPython -m pip install/);
+  assert.match(step, /starvector-terminal-provision\.mjs metrics[^\n]*\$metricsRoot \$metricsPython/);
+});
+
 test("preflight assembly requires and copies exactly two inventories plus four hooks", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "starvector-provision-preflight-")), source = path.join(root, "source"), destination = path.join(root, "destination");
   await mkdir(path.join(source, "inventory"), { recursive: true }); await mkdir(path.join(source, "hooks"), { recursive: true });
@@ -111,6 +133,36 @@ test("weights assembly inventories fixed model roots and copies only source-prod
   assert.deepEqual(Object.keys(manifest.models).sort(), ["starvector-1b", "starvector-8b"]);
   assert.equal(manifest.prompt_raster.provider_id, "candle_flux");
   assert.match(manifest.terminal_service_closure.app_data_sha256, /^[a-f0-9]{64}$/);
+  const weightsRoot = path.join(hostRoot, "weights");
+  const readiness = await validateTerminalServiceClosure(weightsRoot, manifest);
+  assert.equal(readiness.app_data.sha256, manifest.terminal_service_closure.app_data_sha256);
+  assert.equal(readiness.hf_home.sha256, manifest.terminal_service_closure.hf_home_sha256);
+  const assembledHf = await tree(path.join(weightsRoot, "service-closure", "hf-home"));
+  assert.equal(assembledHf.aggregate_sha256, manifest.terminal_service_closure.hf_home_sha256);
+  const first = assembledHf.entries[0];
+  for (const mutation of [
+    { ...first, path: `changed/${first.path}` },
+    { ...first, byte_size: first.byte_size + 1 },
+    { ...first, sha256: digest("changed") },
+  ]) {
+    const entries = assembledHf.entries.map((entry, index) => index === 0 ? mutation : entry);
+    assert.notEqual(terminalTreeSha256(entries), assembledHf.aggregate_sha256);
+  }
+  assert.throws(() => terminalTreeSha256([...assembledHf.entries].reverse()), /uniquely sorted/);
+  assert.throws(() => terminalTreeSha256(assembledHf.entries.map((entry) => [entry.path, entry.byte_size, entry.sha256])), /exactly \{path, byte_size, sha256\}/);
+  assert.deepEqual(terminalTreeEntry(first.path, first.byte_size, first.sha256), first);
+  const assembledFile = path.join(weightsRoot, "service-closure", "hf-home", ...first.path.split("/"));
+  const originalBytes = await readFile(assembledFile), renamedFile = `${assembledFile}.renamed`;
+  await rename(assembledFile, renamedFile);
+  await assert.rejects(() => validateTerminalServiceClosure(weightsRoot, manifest), /service closure tree hash mismatch/);
+  await rename(renamedFile, assembledFile);
+  await writeFile(assembledFile, Buffer.concat([originalBytes, Buffer.from("size-drift")]));
+  await assert.rejects(() => validateTerminalServiceClosure(weightsRoot, manifest), /service closure tree hash mismatch/);
+  const hashDrift = Buffer.from(originalBytes); hashDrift[0] ^= 0xff;
+  await writeFile(assembledFile, hashDrift);
+  await assert.rejects(() => validateTerminalServiceClosure(weightsRoot, manifest), /service closure tree hash mismatch/);
+  await writeFile(assembledFile, originalBytes);
+  await validateTerminalServiceClosure(weightsRoot, manifest);
   await assembleWeights({ hostRoot, serviceAppData: path.join(sources, "app"), serviceHfHome: path.join(sources, "hf"), promptProvider: "candle_flux", promptModel: "flux_schnell", promptRevision: revisions.flux });
   const missing = structuredClone(validReceipts); missing.receipts[2].resolvedFiles = ["q4/missing.bin"]; missing.resolvedFiles = ["q4/missing.bin"];
   await writeFile(path.join(sources, "app", "models", "receipt", ".sceneworks-download-complete.json"), JSON.stringify(missing));

--- a/scripts/starvector-terminal-provision.test.mjs
+++ b/scripts/starvector-terminal-provision.test.mjs
@@ -73,24 +73,57 @@ test("provision workflow is dispatch-only and never runs a model, service, campa
   assert.doesNotMatch(workflow, /STARVECTOR_PROMPT_PROVIDER: flux_diffusers/);
 });
 
+function assertWindowsMetricsPythonContract(step) {
+  assert.doesNotMatch(step, /\bpy\s+-3\.11\b/);
+  assert.doesNotMatch(step, /IsPathFullyQualified/);
+  assert.match(step, /Get-Command python\.exe -All -CommandType Application/);
+  assert.match(step, /\$text -match '\[\\r\\n"\]'/);
+  assert.match(step, /\$text -notmatch '\^\[A-Za-z\]:\\\\'/);
+  assert.match(step, /\[IO\.Path\]::GetFullPath\(\$text\)/);
+  assert.match(step, /Test-Path -LiteralPath \$full -PathType Leaf/);
+  assert.match(step, /sys\.executable/);
+  assert.match(step, /version\":\[sys\.version_info\.major,sys\.version_info\.minor,sys\.version_info\.micro\]/);
+  assert.match(step, /\[int\]\$identity\.version\[1\] -ge 12/);
+  assert.match(step, /& \$bootstrapPython -m venv \$metricsRoot/);
+  assert.match(step, /if \(\$LASTEXITCODE -ne 0\) \{ throw 'failed to create the terminal metrics venv/);
+  assert.match(step, /Test-Path \$metricsPython -PathType Leaf/);
+  assert.match(step, /base_executable\":getattr\(sys,"_base_executable",None\)/);
+  assert.match(step, /\$observedBasePython = & \$canonicalDriveExecutable \$venvIdentity\.base_executable/);
+  assert.match(step, /OrdinalIgnoreCase\.Equals\(\$bootstrapPython, \$observedBasePython\)/);
+  assert.match(step, /\[int\]\$venvIdentity\.version\[2\] -ne \[int\]\$bootstrapIdentity\.version\[2\]/);
+  assert.match(step, /& \$metricsPython -m pip install/);
+  assert.match(step, /starvector-terminal-provision\.mjs metrics[^\n]*\$metricsRoot \$metricsPython/);
+}
+
 test("Windows metrics provisioning selects, uses, and verifies one explicit Python 3.12+ executable", () => {
   const start = workflow.indexOf("- name: Provision pinned metric runtime and official checkpoints", workflow.indexOf("  provision-windows:"));
   const end = workflow.indexOf("- name: Materialize the exact pinned 120-row corpus", start);
   const step = workflow.slice(start, end);
   assert.ok(start >= 0 && end > start);
-  assert.doesNotMatch(step, /\bpy\s+-3\.11\b/);
-  assert.match(step, /Get-Command python\.exe -All -CommandType Application/);
-  assert.match(step, /sys\.executable/);
-  assert.match(step, /version\":\[sys\.version_info\.major,sys\.version_info\.minor,sys\.version_info\.micro\]/);
-  assert.match(step, /\[IO\.Path\]::IsPathFullyQualified/);
-  assert.match(step, /\[int\]\$identity\.version\[1\] -ge 12/);
-  assert.match(step, /& \$bootstrapPython -m venv \$metricsRoot/);
-  assert.match(step, /if \(\$LASTEXITCODE -ne 0\) \{ throw 'failed to create the terminal metrics venv/);
-  assert.match(step, /Test-Path \$metricsPython -PathType Leaf/);
-  assert.match(step, /& \$metricsPython -c 'import json,sys/);
-  assert.match(step, /OrdinalIgnoreCase\.Equals\(\$expectedMetricsPython, \$observedMetricsPython\)/);
-  assert.match(step, /& \$metricsPython -m pip install/);
-  assert.match(step, /starvector-terminal-provision\.mjs metrics[^\n]*\$metricsRoot \$metricsPython/);
+  assertWindowsMetricsPythonContract(step);
+  const isSafeDriveAbsolute = (value) => /^[A-Za-z]:\\/.test(value) && !/[\r\n"]/.test(value);
+  assert.equal(isSafeDriveAbsolute("C:\\Python312\\python.exe"), true);
+  for (const rejected of ["python.exe", "C:python.exe", "\\python.exe", "\\\\server\\share\\python.exe", "C:/Python312/python.exe", "C:\\Python312\\py\nthon.exe", 'C:\\Python312\\py"thon.exe']) {
+    assert.equal(isSafeDriveAbsolute(rejected), false, rejected);
+  }
+});
+
+test("Windows metrics Python contract rejects path, base-interpreter, and patch-version guard mutations", () => {
+  const start = workflow.indexOf("- name: Provision pinned metric runtime and official checkpoints", workflow.indexOf("  provision-windows:"));
+  const end = workflow.indexOf("- name: Materialize the exact pinned 120-row corpus", start);
+  const step = workflow.slice(start, end);
+  for (const [label, mutation] of [
+    ["drive-absolute guard", (value) => value.replace("$text -notmatch '^[A-Za-z]:\\\\'", "$text -notmatch '^\\\\'")],
+    ["unsafe quoting guard", (value) => value.replace("$text -match '[\\r\\n\"]'", "$text -match '[\\r\\n]'")],
+    ["PowerShell 5.1 canonicalization", (value) => value.replace("[IO.Path]::GetFullPath($text)", "$text")],
+    ["venv base executable", (value) => value.replace('"_base_executable",None', '"executable",None')],
+    ["base path equality", (value) => value.replace("OrdinalIgnoreCase.Equals($bootstrapPython, $observedBasePython)", "OrdinalIgnoreCase.Equals($bootstrapPython, $bootstrapPython)")],
+    ["patch version equality", (value) => value.replace("[int]$venvIdentity.version[2] -ne [int]$bootstrapIdentity.version[2]", "[int]$venvIdentity.version[2] -ne [int]$venvIdentity.version[2]")],
+  ]) {
+    const changed = mutation(step);
+    assert.notEqual(changed, step, `${label} mutation must alter the workflow fixture`);
+    assert.throws(() => assertWindowsMetricsPythonContract(changed), { name: "AssertionError" }, label);
+  }
 });
 
 test("preflight assembly requires and copies exactly two inventories plus four hooks", async () => {

--- a/scripts/starvector-terminal-readiness.mjs
+++ b/scripts/starvector-terminal-readiness.mjs
@@ -10,6 +10,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { INFERENCE_REVISION, TUPLES, readPlanAndLock } from "./starvector-terminal-campaign.mjs";
 import { fileSha256 } from "./lib/file-sha256.mjs";
+import { sortTerminalTreeEntries, terminalTreeEntry, terminalTreeSha256 } from "./lib/terminal-tree-identity.mjs";
 import {
   validateInferencePreflight,
   validateMetricsEnvironment,
@@ -50,10 +51,10 @@ export async function treeIdentity(root, relative, label, digestFile = fileSha25
     const file = path.join(directory, name); const info = await lstat(file);
     if (info.isSymbolicLink()) die(`${label} rejects symlink ${name}`);
     if (!info.isFile() && !info.isDirectory()) die(`${label} rejects non-regular entry ${name}`);
-    if (info.isFile()) rows.push([name.split(path.sep).join("/"), info.size, await digestFile(file)]);
+    if (info.isFile()) rows.push(terminalTreeEntry(name.split(path.sep).join("/"), info.size, await digestFile(file)));
   }
-  rows.sort((left, right) => left[0] < right[0] ? -1 : left[0] > right[0] ? 1 : 0);
-  return { file_count: rows.length, sha256: sha(JSON.stringify(rows)) };
+  const canonicalRows = sortTerminalTreeEntries(rows);
+  return { file_count: canonicalRows.length, sha256: terminalTreeSha256(canonicalRows) };
 }
 
 export async function validateTerminalServiceClosure(weightsRoot, weights) {

--- a/scripts/starvector-terminal-workflow.test.mjs
+++ b/scripts/starvector-terminal-workflow.test.mjs
@@ -7,6 +7,7 @@ import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 import { treeIdentity, validateCorpusAssets, validateTerminalServiceClosure } from "./starvector-terminal-readiness.mjs";
+import { terminalTreeEntry, terminalTreeSha256 } from "./lib/terminal-tree-identity.mjs";
 import { closureTreeHash, copyRegularTree, productServiceBackendEnv, productServiceBuildArgs, productServiceStateRoot } from "./starvector-terminal-product-service.mjs";
 
 const workflow = await readFile(".github/workflows/starvector-terminal.yml", "utf8");
@@ -67,8 +68,8 @@ test("product service streams copied closure identity and preserves portable ord
   assert.equal(copied.length, 4);
   const hashed = [];
   const identity = await closureTreeHash(destination, async (file) => { hashed.push(file); return hash(await readFile(file)); });
-  const rows = [["nested/a.bin", 1, hash("a")], ["z.bin", 1, hash("z")]];
-  assert.equal(identity, hash(JSON.stringify(rows)));
+  const rows = [terminalTreeEntry("nested/a.bin", 1, hash("a")), terminalTreeEntry("z.bin", 1, hash("z"))];
+  assert.equal(identity, terminalTreeSha256(rows));
   assert.equal(hashed.length, 2);
   await symlink(path.join(source, "z.bin"), path.join(source, "link"));
   await assert.rejects(() => copyRegularTree(source, path.join(root, "rejected")), /weights closure rejects symlink/);
@@ -110,7 +111,7 @@ test("readiness validates the complete service tree closure without materializin
   await writeFile(path.join(root, "app", "receipts.json"), "receipts"); await writeFile(path.join(root, "hf", "weights.bin"), "weights");
   const tree = async (name) => {
     const file = path.join(root, name, name === "app" ? "receipts.json" : "weights.bin"), bytes = await readFile(file);
-    return hash(JSON.stringify([[path.basename(file), bytes.length, hash(bytes)]]));
+    return terminalTreeSha256([terminalTreeEntry(path.basename(file), bytes.length, hash(bytes))]);
   };
   const weights = { models: { "starvector-1b": {}, "starvector-8b": {} }, terminal_service_closure: { app_data_relative_path: "app", app_data_sha256: await tree("app"), hf_home_relative_path: "hf", hf_home_sha256: await tree("hf") } };
   const result = await validateTerminalServiceClosure(root, weights);

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -896,8 +896,8 @@ def test_starvector_terminal_candidate_schema_is_closed_and_mutation_resistant()
     candidate = model["vector"]["deviceAdmission"]["terminalCandidate"]
     assert candidate["inferenceRevision"] == "b2d9e0917499517cf8c1518e0d360cac8693b0c0"
     assert candidate["corpusSha256"] == "757370c4eed38a52a29ac80c258fdedd7e437ab891637bcb1c916aa608bf32b5"
-    assert candidate["productionClosure"]["sha256"] == "f1aa5a3a056a18c54860fa3e93a38d5319d183fb7c866890a349c01f632c2404"
-    assert len(candidate["productionClosure"]["entries"]) == 29
+    assert candidate["productionClosure"]["sha256"] == "6c300cd26bdd7cc6fee60dc11a47188802a3b52eec1389ab789e082d71e958d3"
+    assert len(candidate["productionClosure"]["entries"]) == 30
     assert model["vector"]["providers"] == {
         "mlx": {"id": "mlx-starvector-8b", "available": True},
         "candle": {"id": "candle-starvector-8b", "available": True},


### PR DESCRIPTION
## Summary

- define one exact portable object-row contract for terminal service-tree identities and use it in provisioning, readiness, and product-service materialization
- exercise the real assembleWeights output end to end and prove path, size, content hash, ordering, and representation mutations fail closed
- replace the unavailable Windows py -3.11 launcher assumption with explicit Python 3.12+ executable discovery, absolute binding, and venv identity verification
- include the new runtime helper in the sealed production closure and refresh its Node, Python, and Rust consumers

## Root cause

Run 33808747302 exposed two deterministic contract defects: provisioning sealed object rows while readiness and the product-service consumer recomputed tuple rows, and the Windows provisioning step requested an unavailable py -3.11 launcher before the metrics venv existed.

## Validation

- focused terminal/provision/readiness/production-closure tests: 50 passed
- npm run check: 744 passed (742 primary plus 2 removed-source matrix)
- Python builtin manifest audit: 100 passed
- npm run rust:check under isolated HF_HOME: tier integrity, fmt, clippy, full Cargo tests, and build passed
- targeted Rust manifest-closure regression: passed
- production-closure manifest check and git diff check: passed
- actionlint: passed after ignoring only the workflow pre-existing custom runner-label diagnostics

No terminal campaign, model execution, workflow dispatch, credential change, or protected measurement artifact mutation was performed.