### PR TITLE
Fix Windows Python probing for StarVector terminal

### DIFF
--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -71,6 +71,8 @@ on:
       - "package.json"
       - ".github/actions/prepare-rust-runner/**"
       - ".github/workflows/desktop-windows.yml"
+      - "scripts/select-starvector-windows-python.ps1"
+      - "scripts/select-starvector-windows-python.test.ps1"
   workflow_dispatch:
 
 # Cancel superseded PR runs, but never cancel a main-push run — same reasoning as
@@ -132,6 +134,9 @@ jobs:
         run: npm ci --prefix apps/desktop
       - name: Validate desktop bundle configuration
         run: npm --prefix apps/desktop test
+      - name: Run StarVector Windows Python selection regression
+        shell: powershell
+        run: .\scripts\select-starvector-windows-python.test.ps1
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
         with:
           toolchain: "1.97.1"

--- a/.github/workflows/starvector-terminal-provision.yml
+++ b/.github/workflows/starvector-terminal-provision.yml
@@ -179,29 +179,10 @@ jobs:
       - name: Provision pinned metric runtime and official checkpoints
         shell: powershell
         run: |
-          $bootstrapPython = $null
-          $bootstrapIdentity = $null
-          $canonicalDriveExecutable = {
-            param([object]$Value)
-            $text = [string]$Value
-            if ([string]::IsNullOrWhiteSpace($text) -or $text -match '[\r\n"]' -or $text -notmatch '^[A-Za-z]:\\') { return $null }
-            try { $full = [IO.Path]::GetFullPath($text) } catch { return $null }
-            if ($full -notmatch '^[A-Za-z]:\\' -or -not (Test-Path -LiteralPath $full -PathType Leaf)) { return $null }
-            return $full
-          }
-          $candidates = @(Get-Command python.exe -All -CommandType Application -ErrorAction SilentlyContinue | ForEach-Object Source | Where-Object { $_ } | Select-Object -Unique)
-          foreach ($candidate in $candidates) {
-            $identityJson = & $candidate -c 'import json,sys; print(json.dumps({"executable":sys.executable,"version":[sys.version_info.major,sys.version_info.minor,sys.version_info.micro]}))' 2>$null
-            if ($LASTEXITCODE -ne 0) { continue }
-            try { $identity = $identityJson | ConvertFrom-Json -ErrorAction Stop } catch { continue }
-            $canonicalExecutable = & $canonicalDriveExecutable $identity.executable
-            if ($identity.version.Count -eq 3 -and [int]$identity.version[0] -eq 3 -and [int]$identity.version[1] -ge 12 -and $canonicalExecutable) {
-              $bootstrapPython = $canonicalExecutable
-              $bootstrapIdentity = $identity
-              break
-            }
-          }
-          if (-not $bootstrapPython) { throw 'the self-hosted CUDA runner requires a directly executable Python 3.12 or newer on PATH' }
+          . (Join-Path $PWD 'scripts\select-starvector-windows-python.ps1')
+          $bootstrap = Select-StarVectorBootstrapPython
+          $bootstrapPython = $bootstrap.Executable
+          $bootstrapIdentity = $bootstrap.Identity
           $metricsRoot = Join-Path $env:STARVECTOR_TERMINAL_ROOT 'metrics'
           $metricsPython = Join-Path $metricsRoot 'Scripts\python.exe'
           if (-not (Test-Path $metricsPython -PathType Leaf)) {
@@ -209,12 +190,12 @@ jobs:
             if ($LASTEXITCODE -ne 0) { throw 'failed to create the terminal metrics venv with the selected Python interpreter' }
           }
           if (-not (Test-Path $metricsPython -PathType Leaf)) { throw 'terminal metrics venv did not publish Scripts\python.exe' }
-          $venvIdentityJson = & $metricsPython -c 'import json,sys; print(json.dumps({"executable":sys.executable,"base_executable":getattr(sys,"_base_executable",None),"version":[sys.version_info.major,sys.version_info.minor,sys.version_info.micro]}))'
-          if ($LASTEXITCODE -ne 0) { throw 'terminal metrics venv Python identity probe failed' }
-          try { $venvIdentity = $venvIdentityJson | ConvertFrom-Json -ErrorAction Stop } catch { throw 'terminal metrics venv Python identity is not valid JSON' }
-          $expectedMetricsPython = & $canonicalDriveExecutable $metricsPython
-          $observedMetricsPython = & $canonicalDriveExecutable $venvIdentity.executable
-          $observedBasePython = & $canonicalDriveExecutable $venvIdentity.base_executable
+          $venvProbe = Invoke-StarVectorPythonIdentityProbe -Executable $metricsPython -IncludeBaseExecutable
+          if ($venvProbe.ExitCode -ne 0) { throw 'terminal metrics venv Python identity probe failed' }
+          try { $venvIdentity = $venvProbe.StdOut | ConvertFrom-Json -ErrorAction Stop } catch { throw 'terminal metrics venv Python identity is not valid JSON' }
+          $expectedMetricsPython = Resolve-StarVectorWindowsExecutable $metricsPython
+          $observedMetricsPython = Resolve-StarVectorWindowsExecutable $venvIdentity.executable
+          $observedBasePython = Resolve-StarVectorWindowsExecutable $venvIdentity.base_executable
           if (-not $expectedMetricsPython -or -not $observedMetricsPython -or -not $observedBasePython -or -not [StringComparer]::OrdinalIgnoreCase.Equals($expectedMetricsPython, $observedMetricsPython) -or -not [StringComparer]::OrdinalIgnoreCase.Equals($bootstrapPython, $observedBasePython) -or $venvIdentity.version.Count -ne 3 -or [int]$venvIdentity.version[0] -ne [int]$bootstrapIdentity.version[0] -or [int]$venvIdentity.version[1] -ne [int]$bootstrapIdentity.version[1] -or [int]$venvIdentity.version[2] -ne [int]$bootstrapIdentity.version[2]) { throw 'terminal metrics venv is not bound to the selected exact Python interpreter' }
           & $metricsPython -m pip install --disable-pip-version-check numpy==2.2.6 scikit-image==0.25.2 lpips==0.1.4 torch==2.7.0 torchvision==0.22.0 Pillow==11.3.0 open-clip-torch==3.1.0
           if ($LASTEXITCODE -ne 0) { throw 'failed to install the pinned terminal metrics package closure' }

--- a/scripts/select-starvector-windows-python.ps1
+++ b/scripts/select-starvector-windows-python.ps1
@@ -1,0 +1,83 @@
+function Resolve-StarVectorWindowsExecutable {
+  param([object]$Value)
+
+  $text = [string]$Value
+  if ([string]::IsNullOrWhiteSpace($text) -or $text -match '[\r\n"]' -or $text -notmatch '^[A-Za-z]:\\') {
+    return $null
+  }
+  try {
+    $full = [IO.Path]::GetFullPath($text)
+  } catch {
+    return $null
+  }
+  if ($full -notmatch '^[A-Za-z]:\\' -or -not (Test-Path -LiteralPath $full -PathType Leaf)) {
+    return $null
+  }
+  return $full
+}
+
+function Invoke-StarVectorPythonIdentityProbe {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Executable,
+    [switch]$IncludeBaseExecutable
+  )
+
+  $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+  $startInfo.FileName = $Executable
+  if ($IncludeBaseExecutable) {
+    $startInfo.Arguments = '-c "import json,sys;print(json.dumps({''executable'':sys.executable,''base_executable'':getattr(sys,''_base_executable'',None),''version'':[sys.version_info.major,sys.version_info.minor,sys.version_info.micro]}))"'
+  } else {
+    $startInfo.Arguments = '-c "import json,sys;print(json.dumps({''executable'':sys.executable,''version'':[sys.version_info.major,sys.version_info.minor,sys.version_info.micro]}))"'
+  }
+  $startInfo.UseShellExecute = $false
+  $startInfo.RedirectStandardOutput = $true
+  $startInfo.RedirectStandardError = $true
+  $startInfo.CreateNoWindow = $true
+
+  $process = New-Object System.Diagnostics.Process
+  $process.StartInfo = $startInfo
+  try {
+    if (-not $process.Start()) {
+      return [pscustomobject]@{ ExitCode = -1; StdOut = ''; StdErr = 'process did not start' }
+    }
+    $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+    $stderrTask = $process.StandardError.ReadToEndAsync()
+    $process.WaitForExit()
+    return [pscustomobject]@{
+      ExitCode = $process.ExitCode
+      StdOut = $stdoutTask.Result
+      StdErr = $stderrTask.Result
+    }
+  } catch {
+    return [pscustomobject]@{ ExitCode = -1; StdOut = ''; StdErr = $_.Exception.Message }
+  } finally {
+    $process.Dispose()
+  }
+}
+
+function Select-StarVectorBootstrapPython {
+  param([string[]]$CandidatePaths)
+
+  if ($null -eq $CandidatePaths) {
+    $CandidatePaths = @(Get-Command python.exe -All -CommandType Application -ErrorAction SilentlyContinue | ForEach-Object Source | Where-Object { $_ } | Select-Object -Unique)
+  }
+
+  foreach ($candidate in $CandidatePaths) {
+    $canonicalCandidate = Resolve-StarVectorWindowsExecutable $candidate
+    if (-not $canonicalCandidate) { continue }
+    $probe = Invoke-StarVectorPythonIdentityProbe -Executable $canonicalCandidate
+    if ($probe.ExitCode -ne 0) { continue }
+    try {
+      $identity = $probe.StdOut | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+      continue
+    }
+    $canonicalExecutable = Resolve-StarVectorWindowsExecutable $identity.executable
+    if ($identity.version.Count -eq 3 -and [int]$identity.version[0] -eq 3 -and [int]$identity.version[1] -ge 12 -and $canonicalExecutable) {
+      return [pscustomobject]@{ Executable = $canonicalExecutable; Identity = $identity }
+    }
+  }
+
+  throw 'the self-hosted CUDA runner requires a directly executable Python 3.12 or newer on PATH'
+}

--- a/scripts/select-starvector-windows-python.test.ps1
+++ b/scripts/select-starvector-windows-python.test.ps1
@@ -1,0 +1,71 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+. (Join-Path $PSScriptRoot 'select-starvector-windows-python.ps1')
+
+function Assert-True {
+  param([bool]$Value, [string]$Message)
+  if (-not $Value) { throw $Message }
+}
+
+function Assert-Equal {
+  param([object]$Expected, [object]$Actual, [string]$Message)
+  if ($Expected -ne $Actual) { throw "$Message (expected '$Expected', got '$Actual')" }
+}
+
+$root = Join-Path $env:RUNNER_TEMP ("starvector python probe {0}" -f [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $root | Out-Null
+try {
+  $source = @'
+using System;
+using System.Diagnostics;
+using System.IO;
+
+public static class FakePython {
+    public static int Main() {
+        string executable = Process.GetCurrentProcess().MainModule.FileName;
+        string name = Path.GetFileName(executable);
+        if (name.StartsWith("01-")) {
+            Console.Error.WriteLine("Traceback from the first fake Python candidate");
+            return 7;
+        }
+        if (name.StartsWith("02-")) {
+            Console.Out.WriteLine("{not-json");
+            return 0;
+        }
+        string escaped = executable.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        Console.Out.WriteLine("{\"executable\":\"" + escaped + "\",\"version\":[3,12,7]}");
+        return 0;
+    }
+}
+'@
+  $template = Join-Path $root 'fake-python-template.exe'
+  Add-Type -TypeDefinition $source -Language CSharp -OutputAssembly $template -OutputType ConsoleApplication
+  $bad = Join-Path $root '01-bad python.exe'
+  $malformed = Join-Path $root '02-malformed python.exe'
+  $valid = Join-Path $root '03-valid python.exe'
+  Copy-Item -LiteralPath $template -Destination $bad
+  Copy-Item -LiteralPath $template -Destination $malformed
+  Copy-Item -LiteralPath $template -Destination $valid
+
+  $badProbe = Invoke-StarVectorPythonIdentityProbe -Executable $bad
+  Assert-Equal 7 $badProbe.ExitCode 'stderr-writing candidate exit code was not captured'
+  Assert-True ($badProbe.StdErr -match 'Traceback') 'stderr-writing candidate stderr was not captured'
+
+  $selection = Select-StarVectorBootstrapPython -CandidatePaths @($bad, $malformed, "$valid`"", $valid)
+  Assert-Equal ([IO.Path]::GetFullPath($valid)) $selection.Executable 'selection did not continue to the valid Python candidate'
+  Assert-Equal 3 $selection.Identity.version[0] 'selected Python major version changed'
+  Assert-Equal 12 $selection.Identity.version[1] 'selected Python minor version changed'
+  Assert-Equal 7 $selection.Identity.version[2] 'selected Python micro version changed'
+  Assert-True ($null -eq (Resolve-StarVectorWindowsExecutable "$valid`"")) 'quoted executable path must fail closed'
+
+  $allFailed = $false
+  try {
+    Select-StarVectorBootstrapPython -CandidatePaths @($bad, $malformed, "$valid`"") | Out-Null
+  } catch {
+    $allFailed = $_.Exception.Message -eq 'the self-hosted CUDA runner requires a directly executable Python 3.12 or newer on PATH'
+  }
+  Assert-True $allFailed 'all invalid candidates must fail closed with the expected error'
+} finally {
+  Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/starvector-terminal-provision.test.mjs
+++ b/scripts/starvector-terminal-provision.test.mjs
@@ -15,6 +15,9 @@ import { validateTerminalServiceClosure } from "./starvector-terminal-readiness.
 const execFile = promisify(execFileCallback);
 const digest = (value) => createHash("sha256").update(value).digest("hex");
 const workflow = await readFile(".github/workflows/starvector-terminal-provision.yml", "utf8");
+const windowsWorkflow = await readFile(".github/workflows/desktop-windows.yml", "utf8");
+const windowsPythonProbe = await readFile("scripts/select-starvector-windows-python.ps1", "utf8");
+const windowsPythonProbeTest = await readFile("scripts/select-starvector-windows-python.test.ps1", "utf8");
 
 test("file and tree identities stream exact bytes with bounded reads and portable ordering", async () => {
   const chunks = [Buffer.from("large-file-"), Buffer.from("identity")];
@@ -75,24 +78,47 @@ test("provision workflow is dispatch-only and never runs a model, service, campa
 
 function assertWindowsMetricsPythonContract(step) {
   assert.doesNotMatch(step, /\bpy\s+-3\.11\b/);
-  assert.doesNotMatch(step, /IsPathFullyQualified/);
-  assert.match(step, /Get-Command python\.exe -All -CommandType Application/);
-  assert.match(step, /\$text -match '\[\\r\\n"\]'/);
-  assert.match(step, /\$text -notmatch '\^\[A-Za-z\]:\\\\'/);
-  assert.match(step, /\[IO\.Path\]::GetFullPath\(\$text\)/);
-  assert.match(step, /Test-Path -LiteralPath \$full -PathType Leaf/);
-  assert.match(step, /sys\.executable/);
-  assert.match(step, /version\":\[sys\.version_info\.major,sys\.version_info\.minor,sys\.version_info\.micro\]/);
-  assert.match(step, /\[int\]\$identity\.version\[1\] -ge 12/);
+  assert.match(step, /select-starvector-windows-python\.ps1/);
+  assert.match(step, /\$bootstrap = Select-StarVectorBootstrapPython/);
+  assert.match(step, /\$bootstrapPython = \$bootstrap\.Executable/);
+  assert.match(step, /\$bootstrapIdentity = \$bootstrap\.Identity/);
+  assert.doesNotMatch(step, /& \$candidate/);
   assert.match(step, /& \$bootstrapPython -m venv \$metricsRoot/);
   assert.match(step, /if \(\$LASTEXITCODE -ne 0\) \{ throw 'failed to create the terminal metrics venv/);
   assert.match(step, /Test-Path \$metricsPython -PathType Leaf/);
-  assert.match(step, /base_executable\":getattr\(sys,"_base_executable",None\)/);
-  assert.match(step, /\$observedBasePython = & \$canonicalDriveExecutable \$venvIdentity\.base_executable/);
+  assert.match(step, /Invoke-StarVectorPythonIdentityProbe -Executable \$metricsPython -IncludeBaseExecutable/);
+  assert.match(step, /if \(\$venvProbe\.ExitCode -ne 0\) \{ throw 'terminal metrics venv Python identity probe failed/);
+  assert.match(step, /\$venvProbe\.StdOut \| ConvertFrom-Json -ErrorAction Stop/);
+  assert.match(step, /\$observedBasePython = Resolve-StarVectorWindowsExecutable \$venvIdentity\.base_executable/);
   assert.match(step, /OrdinalIgnoreCase\.Equals\(\$bootstrapPython, \$observedBasePython\)/);
   assert.match(step, /\[int\]\$venvIdentity\.version\[2\] -ne \[int\]\$bootstrapIdentity\.version\[2\]/);
   assert.match(step, /& \$metricsPython -m pip install/);
   assert.match(step, /starvector-terminal-provision\.mjs metrics[^\n]*\$metricsRoot \$metricsPython/);
+}
+
+function assertWindowsPythonProbeContract(source) {
+  assert.match(source, /Get-Command python\.exe -All -CommandType Application/);
+  assert.match(source, /\$text -match '\[\\r\\n"\]'/);
+  assert.match(source, /\$text -notmatch '\^\[A-Za-z\]:\\\\'/);
+  assert.match(source, /\[IO\.Path\]::GetFullPath\(\$text\)/);
+  assert.match(source, /Test-Path -LiteralPath \$full -PathType Leaf/);
+  assert.match(source, /New-Object System\.Diagnostics\.ProcessStartInfo/);
+  assert.match(source, /\$startInfo\.FileName = \$Executable/);
+  assert.match(source, /\$startInfo\.UseShellExecute = \$false/);
+  assert.match(source, /\$startInfo\.RedirectStandardOutput = \$true/);
+  assert.match(source, /\$startInfo\.RedirectStandardError = \$true/);
+  assert.match(source, /\$startInfo\.CreateNoWindow = \$true/);
+  assert.match(source, /\$stdoutTask = \$process\.StandardOutput\.ReadToEndAsync\(\)/);
+  assert.match(source, /\$stderrTask = \$process\.StandardError\.ReadToEndAsync\(\)/);
+  assert.match(source, /\$process\.WaitForExit\(\)/);
+  assert.match(source, /ExitCode = \$process\.ExitCode/);
+  assert.match(source, /StdOut = \$stdoutTask\.Result/);
+  assert.match(source, /StdErr = \$stderrTask\.Result/);
+  assert.match(source, /base_executable'':getattr\(sys,''_base_executable'',None\)/);
+  assert.match(source, /if \(\$probe\.ExitCode -ne 0\) \{ continue \}/);
+  assert.match(source, /\$probe\.StdOut \| ConvertFrom-Json -ErrorAction Stop/);
+  assert.match(source, /\[int\]\$identity\.version\[1\] -ge 12/);
+  assert.doesNotMatch(source, /& \$candidate|Invoke-Expression|Start-Process/);
 }
 
 test("Windows metrics provisioning selects, uses, and verifies one explicit Python 3.12+ executable", () => {
@@ -108,15 +134,43 @@ test("Windows metrics provisioning selects, uses, and verifies one explicit Pyth
   }
 });
 
+test("Windows Python probes capture native stderr without invoking through PowerShell", () => {
+  assertWindowsPythonProbeContract(windowsPythonProbe);
+  assert.match(windowsPythonProbeTest, /\$ErrorActionPreference = 'Stop'/);
+  assert.match(windowsPythonProbeTest, /01-bad python\.exe/);
+  assert.match(windowsPythonProbeTest, /02-malformed python\.exe/);
+  assert.match(windowsPythonProbeTest, /03-valid python\.exe/);
+  assert.match(windowsPythonProbeTest, /Traceback from the first fake Python candidate/);
+  assert.match(windowsPythonProbeTest, /Select-StarVectorBootstrapPython -CandidatePaths @\(\$bad, \$malformed,/);
+  assert.match(windowsPythonProbeTest, /all invalid candidates must fail closed/);
+  assert.match(windowsWorkflow, /"scripts\/select-starvector-windows-python\.ps1"/);
+  assert.match(windowsWorkflow, /"scripts\/select-starvector-windows-python\.test\.ps1"/);
+  assert.match(windowsWorkflow, /shell: powershell\s+run: \.\\scripts\\select-starvector-windows-python\.test\.ps1/);
+});
+
+test("Windows Python probe contract rejects native-process safety mutations", () => {
+  for (const [label, mutation] of [
+    ["shell execution", (value) => value.replace("$startInfo.UseShellExecute = $false", "$startInfo.UseShellExecute = $true")],
+    ["stdout capture", (value) => value.replace("$startInfo.RedirectStandardOutput = $true", "$startInfo.RedirectStandardOutput = $false")],
+    ["stderr capture", (value) => value.replace("$startInfo.RedirectStandardError = $true", "$startInfo.RedirectStandardError = $false")],
+    ["candidate path binding", (value) => value.replace("$startInfo.FileName = $Executable", "$startInfo.FileName = 'python.exe'")],
+    ["exit status", (value) => value.replace("ExitCode = $process.ExitCode", "ExitCode = 0")],
+    ["bad-candidate continuation", (value) => value.replace("if ($probe.ExitCode -ne 0) { continue }", "if ($probe.ExitCode -ne 0) { break }")],
+    ["PowerShell invocation", (value) => value.replace("$probe = Invoke-StarVectorPythonIdentityProbe -Executable $canonicalCandidate", "$probe = & $candidate -c $code")],
+  ]) {
+    const changed = mutation(windowsPythonProbe);
+    assert.notEqual(changed, windowsPythonProbe, `${label} mutation must alter the helper fixture`);
+    assert.throws(() => assertWindowsPythonProbeContract(changed), { name: "AssertionError" }, label);
+  }
+});
+
 test("Windows metrics Python contract rejects path, base-interpreter, and patch-version guard mutations", () => {
   const start = workflow.indexOf("- name: Provision pinned metric runtime and official checkpoints", workflow.indexOf("  provision-windows:"));
   const end = workflow.indexOf("- name: Materialize the exact pinned 120-row corpus", start);
   const step = workflow.slice(start, end);
   for (const [label, mutation] of [
-    ["drive-absolute guard", (value) => value.replace("$text -notmatch '^[A-Za-z]:\\\\'", "$text -notmatch '^\\\\'")],
-    ["unsafe quoting guard", (value) => value.replace("$text -match '[\\r\\n\"]'", "$text -match '[\\r\\n]'")],
-    ["PowerShell 5.1 canonicalization", (value) => value.replace("[IO.Path]::GetFullPath($text)", "$text")],
-    ["venv base executable", (value) => value.replace('"_base_executable",None', '"executable",None')],
+    ["selection helper", (value) => value.replace("$bootstrap = Select-StarVectorBootstrapPython", "$bootstrap = Get-Command python.exe")],
+    ["venv captured probe", (value) => value.replace("$venvProbe = Invoke-StarVectorPythonIdentityProbe -Executable $metricsPython -IncludeBaseExecutable", "$venvProbe = & $metricsPython -c $code")],
     ["base path equality", (value) => value.replace("OrdinalIgnoreCase.Equals($bootstrapPython, $observedBasePython)", "OrdinalIgnoreCase.Equals($bootstrapPython, $bootstrapPython)")],
     ["patch version equality", (value) => value.replace("[int]$venvIdentity.version[2] -ne [int]$bootstrapIdentity.version[2]", "[int]$venvIdentity.version[2] -ne [int]$venvIdentity.version[2]")],
   ]) {


### PR DESCRIPTION
## What does this PR do?

Fixes the SC-22261 terminal-provision failure exposed by run 33815044106. Under Windows PowerShell 5.1 with `ErrorActionPreference=Stop`, stderr from the first unusable `python.exe` candidate was promoted to a terminating `NativeCommandError` before the loop could inspect `$LASTEXITCODE` and continue.

The Python identity probes now use `System.Diagnostics.ProcessStartInfo` with shell execution disabled, separate executable binding, redirected stdout and stderr, and explicit exit-code capture. Nonzero and malformed candidates continue safely while the existing absolute-path, Python 3.12+, exact micro-version, base-interpreter, venv, and fail-closed checks remain enforced. The same capture path now protects the venv identity probe.

A real Windows regression compiles fake executables under a path containing spaces, exercises stderr plus nonzero exit, malformed JSON, quoted-path rejection, successful fallback, and all-fail behavior under PowerShell Stop semantics. It runs on the hosted `windows-2022` PR lane.

## Related issue

SC-22261

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Refactor / chore (no user-facing behavior change)

## How was this tested?

- [x] `node --test scripts/starvector-terminal-provision.test.mjs scripts/starvector-terminal-workflow.test.mjs scripts/starvector-terminal-source-install.test.mjs scripts/platform-review-contracts.test.mjs` (106/106)
- [x] `STARVECTOR_TERMINAL_INFERENCE_TEST_ROOT=/Users/michael/Repos/inference npm run check` (747/747)
- [x] isolated `HF_HOME` `npm run rust:check`
- [x] `actionlint` with the repository standard ignores for custom self-hosted labels and the pre-existing unused anchor
- [x] protected quartet byte-identical
- [x] Hosted Windows 2022 PowerShell 5.1 regression passed in run 33817349076

## Checklist

- [x] I ran `npm run rust:check` and it passed
- [x] I ran `npm run check`
- [x] Documentation was not required for this internal workflow defect
- [ ] All my commits are signed off
- [x] My PR is focused on a single logical change

No GPU or self-hosted runner was claimed or dispatched, and no terminal/campaign workflow was dispatched.