### PR TITLE
SC-22261 Pin StarVector metrics to CPython 3.12 wheels

### DIFF
--- a/.github/workflows/starvector-metrics-windows.yml
+++ b/.github/workflows/starvector-metrics-windows.yml
@@ -9,6 +9,7 @@ on:
       - "scripts/select-starvector-windows-python.ps1"
       - "scripts/select-starvector-windows-python.test.ps1"
       - "scripts/starvector-terminal-provision.test.mjs"
+      - "scripts/starvector-terminal-metrics.py"
       - "scripts/verify-starvector-windows-metric-wheels.ps1"
   workflow_dispatch:
 

--- a/.github/workflows/starvector-metrics-windows.yml
+++ b/.github/workflows/starvector-metrics-windows.yml
@@ -1,0 +1,43 @@
+name: StarVector metrics wheels (Windows)
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/starvector-metrics-windows.yml"
+      - ".github/workflows/starvector-terminal-provision.yml"
+      - "release/starvector-terminal-metrics-lock-v1.json"
+      - "scripts/select-starvector-windows-python.ps1"
+      - "scripts/select-starvector-windows-python.test.ps1"
+      - "scripts/starvector-terminal-provision.test.mjs"
+      - "scripts/verify-starvector-windows-metric-wheels.ps1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: starvector-metrics-windows-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  wheel-contract:
+    runs-on: windows-2022
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up supported CPython 3.12 x64
+        id: metrics-python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          architecture: x64
+          check-latest: false
+          update-environment: false
+      - name: Reject unsupported Windows Python identities under PowerShell 5.1
+        shell: powershell
+        run: .\scripts\select-starvector-windows-python.test.ps1
+      - name: Resolve and install the pinned metric closure from wheels
+        shell: powershell
+        env:
+          STARVECTOR_METRICS_BOOTSTRAP_PYTHON: ${{ steps.metrics-python.outputs.python-path }}
+        run: .\scripts\verify-starvector-windows-metric-wheels.ps1

--- a/.github/workflows/starvector-terminal-provision.yml
+++ b/.github/workflows/starvector-terminal-provision.yml
@@ -207,7 +207,6 @@ jobs:
           $bootstrapIdentity = $bootstrap.Identity
           $metricsRoot = Join-Path $env:STARVECTOR_TERMINAL_ROOT 'metrics'
           $metricsPython = Join-Path $metricsRoot 'Scripts\python.exe'
-          if (-not [StringComparer]::OrdinalIgnoreCase.Equals([IO.Path]::GetFullPath($metricsRoot), 'D:\sceneworks-terminal\metrics')) { throw 'refusing to replace a metrics venv outside the workflow-owned terminal root' }
           $rebuildMetricsVenv = -not (Test-Path $metricsPython -PathType Leaf)
           if (-not $rebuildMetricsVenv) {
             $existingProbe = Invoke-StarVectorPythonIdentityProbe -Executable $metricsPython -IncludeBaseExecutable
@@ -216,7 +215,7 @@ jobs:
             $rebuildMetricsVenv = $existingProbe.ExitCode -ne 0 -or -not $existingIdentity -or -not $existingBasePython -or -not [StringComparer]::OrdinalIgnoreCase.Equals($bootstrapPython, $existingBasePython) -or $existingIdentity.version.Count -ne 3 -or [int]$existingIdentity.version[0] -ne [int]$bootstrapIdentity.version[0] -or [int]$existingIdentity.version[1] -ne [int]$bootstrapIdentity.version[1] -or [int]$existingIdentity.version[2] -ne [int]$bootstrapIdentity.version[2] -or [string]$existingIdentity.implementation -cne 'CPython' -or [string]$existingIdentity.architecture -cne 'AMD64' -or [int]$existingIdentity.pointer_bits -ne 64
           }
           if ($rebuildMetricsVenv) {
-            if (Test-Path $metricsRoot) { Remove-Item -LiteralPath $metricsRoot -Recurse -Force }
+            Remove-StarVectorWindowsDirectoryTree -TargetRoot $metricsRoot -AllowedRoot 'D:\sceneworks-terminal\metrics'
             & $bootstrapPython -m venv $metricsRoot
             if ($LASTEXITCODE -ne 0) { throw 'failed to create the terminal metrics venv with the selected Python interpreter' }
           }

--- a/.github/workflows/starvector-terminal-provision.yml
+++ b/.github/workflows/starvector-terminal-provision.yml
@@ -110,10 +110,22 @@ jobs:
       - name: Assemble durable model and product-service closure
         run: |
           node scripts/starvector-terminal-provision.mjs weights "$STARVECTOR_TERMINAL_ROOT" "$STARVECTOR_APP_DATA_SOURCE" "$STARVECTOR_HF_HOME_SOURCE" "$STARVECTOR_PROMPT_PROVIDER" "$STARVECTOR_PROMPT_MODEL" "$STARVECTOR_PROMPT_REVISION"
+      - name: Set up supported CPython 3.12 arm64 for terminal metrics
+        id: metrics-python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          architecture: arm64
+          check-latest: false
+          update-environment: false
       - name: Provision pinned metric runtime and official checkpoints
+        env:
+          STARVECTOR_METRICS_BOOTSTRAP_PYTHON: ${{ steps.metrics-python.outputs.python-path }}
         run: |
-          test -x "$STARVECTOR_TERMINAL_ROOT/metrics/bin/python" || python3 -m venv "$STARVECTOR_TERMINAL_ROOT/metrics"
-          "$STARVECTOR_TERMINAL_ROOT/metrics/bin/python" -m pip install --disable-pip-version-check numpy==2.2.6 scikit-image==0.25.2 lpips==0.1.4 torch==2.7.0 torchvision==0.22.0 Pillow==11.3.0 open-clip-torch==3.1.0
+          "$STARVECTOR_METRICS_BOOTSTRAP_PYTHON" -c 'import platform,struct,sys; assert sys.version_info[:2] == (3, 12) and platform.python_implementation() == "CPython" and platform.machine().lower() in {"arm64", "aarch64"} and struct.calcsize("P") * 8 == 64'
+          test -x "$STARVECTOR_TERMINAL_ROOT/metrics/bin/python" || "$STARVECTOR_METRICS_BOOTSTRAP_PYTHON" -m venv "$STARVECTOR_TERMINAL_ROOT/metrics"
+          "$STARVECTOR_TERMINAL_ROOT/metrics/bin/python" -c 'import platform,struct,sys; assert sys.version_info[:2] == (3, 12) and platform.python_implementation() == "CPython" and platform.machine().lower() in {"arm64", "aarch64"} and struct.calcsize("P") * 8 == 64'
+          "$STARVECTOR_TERMINAL_ROOT/metrics/bin/python" -m pip install --disable-pip-version-check --only-binary=:all: --retries 5 --timeout 60 numpy==2.2.6 scikit-image==0.25.2 lpips==0.1.4 torch==2.7.0 torchvision==0.22.0 Pillow==11.3.0 open-clip-torch==3.1.0
           node scripts/starvector-terminal-provision.mjs download https://raw.githubusercontent.com/richzhang/PerceptualSimilarity/master/lpips/weights/v0.1/alex.pth "$STARVECTOR_TERMINAL_ROOT/metrics/checkpoints/lpips-v0.1-alex.pth" df73285e35b22355a2df87cdb6b70b343713b667eddbda73e1977e0c860835c0
           node scripts/starvector-terminal-provision.mjs download https://download.pytorch.org/models/alexnet-owt-7be5be79.pth "$STARVECTOR_TERMINAL_ROOT/metrics/checkpoints/alexnet-owt-7be5be79.pth" 7be5be791159472b1fbf3c69796f7cb30dca7ad8466c2df70058c37116cdee02
           node scripts/starvector-terminal-provision.mjs download https://huggingface.co/laion/CLIP-ViT-B-32-laion2B-s34B-b79K/resolve/1a25a446712ba5ee05982a381eed697ef9b435cf/open_clip_pytorch_model.bin "$STARVECTOR_TERMINAL_ROOT/metrics/checkpoints/open_clip_pytorch_model.bin" 1bd3c7172de5b207ceac554f5ab5266166f3b9baccc9af5989bc801016d080ad
@@ -176,16 +188,35 @@ jobs:
           node scripts/starvector-terminal-provision.mjs checkout "$env:GITHUB_WORKSPACE\inference-source" "$env:STARVECTOR_TERMINAL_ROOT\inference" $env:STARVECTOR_INFERENCE_REVISION
           node scripts/starvector-terminal-provision.mjs preflight "$env:RUNNER_TEMP\starvector-preflight" "$env:STARVECTOR_TERMINAL_ROOT\inference-preflight" $env:STARVECTOR_INFERENCE_REVISION
           node scripts/starvector-terminal-provision.mjs weights $env:STARVECTOR_TERMINAL_ROOT $env:STARVECTOR_APP_DATA_SOURCE $env:STARVECTOR_HF_HOME_SOURCE $env:STARVECTOR_PROMPT_PROVIDER $env:STARVECTOR_PROMPT_MODEL $env:STARVECTOR_PROMPT_REVISION
+      - name: Set up supported CPython 3.12 x64 for terminal metrics
+        id: metrics-python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          architecture: x64
+          check-latest: false
+          update-environment: false
       - name: Provision pinned metric runtime and official checkpoints
         shell: powershell
+        env:
+          STARVECTOR_METRICS_BOOTSTRAP_PYTHON: ${{ steps.metrics-python.outputs.python-path }}
         run: |
           . (Join-Path $PWD 'scripts\select-starvector-windows-python.ps1')
-          $bootstrap = Select-StarVectorBootstrapPython
+          $bootstrap = Select-StarVectorBootstrapPython -CandidatePaths @($env:STARVECTOR_METRICS_BOOTSTRAP_PYTHON)
           $bootstrapPython = $bootstrap.Executable
           $bootstrapIdentity = $bootstrap.Identity
           $metricsRoot = Join-Path $env:STARVECTOR_TERMINAL_ROOT 'metrics'
           $metricsPython = Join-Path $metricsRoot 'Scripts\python.exe'
-          if (-not (Test-Path $metricsPython -PathType Leaf)) {
+          if (-not [StringComparer]::OrdinalIgnoreCase.Equals([IO.Path]::GetFullPath($metricsRoot), 'D:\sceneworks-terminal\metrics')) { throw 'refusing to replace a metrics venv outside the workflow-owned terminal root' }
+          $rebuildMetricsVenv = -not (Test-Path $metricsPython -PathType Leaf)
+          if (-not $rebuildMetricsVenv) {
+            $existingProbe = Invoke-StarVectorPythonIdentityProbe -Executable $metricsPython -IncludeBaseExecutable
+            try { $existingIdentity = $existingProbe.StdOut | ConvertFrom-Json -ErrorAction Stop } catch { $existingIdentity = $null }
+            $existingBasePython = if ($existingIdentity) { Resolve-StarVectorWindowsExecutable $existingIdentity.base_executable } else { $null }
+            $rebuildMetricsVenv = $existingProbe.ExitCode -ne 0 -or -not $existingIdentity -or -not $existingBasePython -or -not [StringComparer]::OrdinalIgnoreCase.Equals($bootstrapPython, $existingBasePython) -or $existingIdentity.version.Count -ne 3 -or [int]$existingIdentity.version[0] -ne [int]$bootstrapIdentity.version[0] -or [int]$existingIdentity.version[1] -ne [int]$bootstrapIdentity.version[1] -or [int]$existingIdentity.version[2] -ne [int]$bootstrapIdentity.version[2] -or [string]$existingIdentity.implementation -cne 'CPython' -or [string]$existingIdentity.architecture -cne 'AMD64' -or [int]$existingIdentity.pointer_bits -ne 64
+          }
+          if ($rebuildMetricsVenv) {
+            if (Test-Path $metricsRoot) { Remove-Item -LiteralPath $metricsRoot -Recurse -Force }
             & $bootstrapPython -m venv $metricsRoot
             if ($LASTEXITCODE -ne 0) { throw 'failed to create the terminal metrics venv with the selected Python interpreter' }
           }
@@ -196,8 +227,8 @@ jobs:
           $expectedMetricsPython = Resolve-StarVectorWindowsExecutable $metricsPython
           $observedMetricsPython = Resolve-StarVectorWindowsExecutable $venvIdentity.executable
           $observedBasePython = Resolve-StarVectorWindowsExecutable $venvIdentity.base_executable
-          if (-not $expectedMetricsPython -or -not $observedMetricsPython -or -not $observedBasePython -or -not [StringComparer]::OrdinalIgnoreCase.Equals($expectedMetricsPython, $observedMetricsPython) -or -not [StringComparer]::OrdinalIgnoreCase.Equals($bootstrapPython, $observedBasePython) -or $venvIdentity.version.Count -ne 3 -or [int]$venvIdentity.version[0] -ne [int]$bootstrapIdentity.version[0] -or [int]$venvIdentity.version[1] -ne [int]$bootstrapIdentity.version[1] -or [int]$venvIdentity.version[2] -ne [int]$bootstrapIdentity.version[2]) { throw 'terminal metrics venv is not bound to the selected exact Python interpreter' }
-          & $metricsPython -m pip install --disable-pip-version-check numpy==2.2.6 scikit-image==0.25.2 lpips==0.1.4 torch==2.7.0 torchvision==0.22.0 Pillow==11.3.0 open-clip-torch==3.1.0
+          if (-not $expectedMetricsPython -or -not $observedMetricsPython -or -not $observedBasePython -or -not [StringComparer]::OrdinalIgnoreCase.Equals($expectedMetricsPython, $observedMetricsPython) -or -not [StringComparer]::OrdinalIgnoreCase.Equals($bootstrapPython, $observedBasePython) -or $venvIdentity.version.Count -ne 3 -or [int]$venvIdentity.version[0] -ne [int]$bootstrapIdentity.version[0] -or [int]$venvIdentity.version[1] -ne [int]$bootstrapIdentity.version[1] -or [int]$venvIdentity.version[2] -ne [int]$bootstrapIdentity.version[2] -or [string]$venvIdentity.implementation -cne 'CPython' -or [string]$venvIdentity.architecture -cne 'AMD64' -or [int]$venvIdentity.pointer_bits -ne 64) { throw 'terminal metrics venv is not bound to the selected exact CPython 3.12 x64 interpreter' }
+          & $metricsPython -m pip install --disable-pip-version-check --only-binary=:all: --retries 5 --timeout 60 numpy==2.2.6 scikit-image==0.25.2 lpips==0.1.4 torch==2.7.0 torchvision==0.22.0 Pillow==11.3.0 open-clip-torch==3.1.0
           if ($LASTEXITCODE -ne 0) { throw 'failed to install the pinned terminal metrics package closure' }
           node scripts/starvector-terminal-provision.mjs download https://raw.githubusercontent.com/richzhang/PerceptualSimilarity/master/lpips/weights/v0.1/alex.pth "$env:STARVECTOR_TERMINAL_ROOT\metrics\checkpoints\lpips-v0.1-alex.pth" df73285e35b22355a2df87cdb6b70b343713b667eddbda73e1977e0c860835c0
           node scripts/starvector-terminal-provision.mjs download https://download.pytorch.org/models/alexnet-owt-7be5be79.pth "$env:STARVECTOR_TERMINAL_ROOT\metrics\checkpoints\alexnet-owt-7be5be79.pth" 7be5be791159472b1fbf3c69796f7cb30dca7ad8466c2df70058c37116cdee02

--- a/scripts/select-starvector-windows-python.ps1
+++ b/scripts/select-starvector-windows-python.ps1
@@ -16,6 +16,75 @@ function Resolve-StarVectorWindowsExecutable {
   return $full
 }
 
+function ConvertTo-StarVectorPythonDistributionName {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  $canonical = [regex]::Replace($Name.Trim().ToLowerInvariant(), '[-_.]+', '-')
+  if ($canonical -notmatch '^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$') {
+    throw "invalid Python distribution name: $Name"
+  }
+  return $canonical
+}
+
+function Remove-StarVectorWindowsDirectoryTree {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$TargetRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$AllowedRoot
+  )
+
+  foreach ($value in @($TargetRoot, $AllowedRoot)) {
+    if ([string]::IsNullOrWhiteSpace($value) -or $value -match '[\r\n"]' -or $value -notmatch '^[A-Za-z]:\\') {
+      throw 'refusing to remove a metrics venv outside the exact workflow-owned terminal root'
+    }
+  }
+  try {
+    $canonicalTarget = [IO.Path]::GetFullPath($TargetRoot)
+    $canonicalAllowed = [IO.Path]::GetFullPath($AllowedRoot)
+  } catch {
+    throw 'refusing to remove a metrics venv outside the exact workflow-owned terminal root'
+  }
+  if (-not [StringComparer]::OrdinalIgnoreCase.Equals($canonicalTarget, $canonicalAllowed)) {
+    throw 'refusing to remove a metrics venv outside the exact workflow-owned terminal root'
+  }
+  if (-not (Test-Path -LiteralPath $canonicalTarget)) { return }
+
+  $pending = New-Object System.Collections.Stack
+  $pending.Push([pscustomobject]@{ Path = $canonicalTarget; Expanded = $false })
+  while ($pending.Count -gt 0) {
+    $frame = $pending.Pop()
+    $item = Get-Item -LiteralPath $frame.Path -Force -ErrorAction Stop
+    if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+      throw "refusing to remove a metrics venv containing a reparse point: $($item.FullName)"
+    }
+    if (-not $item.PSIsContainer) {
+      Remove-Item -LiteralPath $item.FullName -Force -ErrorAction Stop
+      continue
+    }
+    if (-not $frame.Expanded) {
+      $children = @(Get-ChildItem -LiteralPath $item.FullName -Force -ErrorAction Stop)
+      foreach ($child in $children) {
+        if (($child.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+          throw "refusing to remove a metrics venv containing a reparse point: $($child.FullName)"
+        }
+      }
+      $pending.Push([pscustomobject]@{ Path = $item.FullName; Expanded = $true })
+      for ($index = $children.Count - 1; $index -ge 0; $index--) {
+        $pending.Push([pscustomobject]@{ Path = $children[$index].FullName; Expanded = $false })
+      }
+      continue
+    }
+    if (@(Get-ChildItem -LiteralPath $item.FullName -Force -ErrorAction Stop).Count -ne 0) {
+      throw "refusing to remove a metrics venv that changed during validation: $($item.FullName)"
+    }
+    Remove-Item -LiteralPath $item.FullName -Force -ErrorAction Stop
+  }
+}
+
 function Invoke-StarVectorPythonIdentityProbe {
   param(
     [Parameter(Mandatory = $true)]

--- a/scripts/select-starvector-windows-python.ps1
+++ b/scripts/select-starvector-windows-python.ps1
@@ -26,9 +26,9 @@ function Invoke-StarVectorPythonIdentityProbe {
   $startInfo = New-Object System.Diagnostics.ProcessStartInfo
   $startInfo.FileName = $Executable
   if ($IncludeBaseExecutable) {
-    $startInfo.Arguments = '-c "import json,sys;print(json.dumps({''executable'':sys.executable,''base_executable'':getattr(sys,''_base_executable'',None),''version'':[sys.version_info.major,sys.version_info.minor,sys.version_info.micro]}))"'
+    $startInfo.Arguments = '-c "import json,platform,struct,sys;print(json.dumps({''executable'':sys.executable,''base_executable'':getattr(sys,''_base_executable'',None),''version'':[sys.version_info.major,sys.version_info.minor,sys.version_info.micro],''implementation'':platform.python_implementation(),''architecture'':platform.machine(),''pointer_bits'':struct.calcsize(''P'')*8}))"'
   } else {
-    $startInfo.Arguments = '-c "import json,sys;print(json.dumps({''executable'':sys.executable,''version'':[sys.version_info.major,sys.version_info.minor,sys.version_info.micro]}))"'
+    $startInfo.Arguments = '-c "import json,platform,struct,sys;print(json.dumps({''executable'':sys.executable,''version'':[sys.version_info.major,sys.version_info.minor,sys.version_info.micro],''implementation'':platform.python_implementation(),''architecture'':platform.machine(),''pointer_bits'':struct.calcsize(''P'')*8}))"'
   }
   $startInfo.UseShellExecute = $false
   $startInfo.RedirectStandardOutput = $true
@@ -57,11 +57,10 @@ function Invoke-StarVectorPythonIdentityProbe {
 }
 
 function Select-StarVectorBootstrapPython {
-  param([string[]]$CandidatePaths)
-
-  if ($null -eq $CandidatePaths) {
-    $CandidatePaths = @(Get-Command python.exe -All -CommandType Application -ErrorAction SilentlyContinue | ForEach-Object Source | Where-Object { $_ } | Select-Object -Unique)
-  }
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]]$CandidatePaths
+  )
 
   foreach ($candidate in $CandidatePaths) {
     $canonicalCandidate = Resolve-StarVectorWindowsExecutable $candidate
@@ -74,10 +73,17 @@ function Select-StarVectorBootstrapPython {
       continue
     }
     $canonicalExecutable = Resolve-StarVectorWindowsExecutable $identity.executable
-    if ($identity.version.Count -eq 3 -and [int]$identity.version[0] -eq 3 -and [int]$identity.version[1] -ge 12 -and $canonicalExecutable) {
+    if ($identity.version.Count -eq 3 -and
+        [int]$identity.version[0] -eq 3 -and
+        [int]$identity.version[1] -eq 12 -and
+        [string]$identity.implementation -ceq 'CPython' -and
+        [string]$identity.architecture -ceq 'AMD64' -and
+        [int]$identity.pointer_bits -eq 64 -and
+        $canonicalExecutable -and
+        [StringComparer]::OrdinalIgnoreCase.Equals($canonicalCandidate, $canonicalExecutable)) {
       return [pscustomobject]@{ Executable = $canonicalExecutable; Identity = $identity }
     }
   }
 
-  throw 'the self-hosted CUDA runner requires a directly executable Python 3.12 or newer on PATH'
+  throw 'StarVector terminal metrics require the explicitly provisioned CPython 3.12 x64 interpreter'
 }

--- a/scripts/select-starvector-windows-python.test.ps1
+++ b/scripts/select-starvector-windows-python.test.ps1
@@ -33,8 +33,10 @@ public static class FakePython {
             Console.Out.WriteLine("{not-json");
             return 0;
         }
+        int minor = name.StartsWith("03-") ? 11 : (name.StartsWith("04-") ? 14 : 12);
+        string architecture = name.StartsWith("05-") ? "ARM64" : "AMD64";
         string escaped = executable.Replace("\\", "\\\\").Replace("\"", "\\\"");
-        Console.Out.WriteLine("{\"executable\":\"" + escaped + "\",\"version\":[3,12,7]}");
+        Console.Out.WriteLine("{\"executable\":\"" + escaped + "\",\"version\":[3," + minor + ",7],\"implementation\":\"CPython\",\"architecture\":\"" + architecture + "\",\"pointer_bits\":64}");
         return 0;
     }
 }
@@ -43,27 +45,36 @@ public static class FakePython {
   Add-Type -TypeDefinition $source -Language CSharp -OutputAssembly $template -OutputType ConsoleApplication
   $bad = Join-Path $root '01-bad python.exe'
   $malformed = Join-Path $root '02-malformed python.exe'
-  $valid = Join-Path $root '03-valid python.exe'
+  $belowMinimum = Join-Path $root '03-python311.exe'
+  $newerUnsupported = Join-Path $root '04-python314.exe'
+  $wrongArchitecture = Join-Path $root '05-python312-arm64.exe'
+  $valid = Join-Path $root '06-python312-amd64.exe'
   Copy-Item -LiteralPath $template -Destination $bad
   Copy-Item -LiteralPath $template -Destination $malformed
+  Copy-Item -LiteralPath $template -Destination $belowMinimum
+  Copy-Item -LiteralPath $template -Destination $newerUnsupported
+  Copy-Item -LiteralPath $template -Destination $wrongArchitecture
   Copy-Item -LiteralPath $template -Destination $valid
 
   $badProbe = Invoke-StarVectorPythonIdentityProbe -Executable $bad
   Assert-Equal 7 $badProbe.ExitCode 'stderr-writing candidate exit code was not captured'
   Assert-True ($badProbe.StdErr -match 'Traceback') 'stderr-writing candidate stderr was not captured'
 
-  $selection = Select-StarVectorBootstrapPython -CandidatePaths @($bad, $malformed, "$valid`"", $valid)
+  $selection = Select-StarVectorBootstrapPython -CandidatePaths @($bad, $malformed, $belowMinimum, $newerUnsupported, $wrongArchitecture, "$valid`"", $valid)
   Assert-Equal ([IO.Path]::GetFullPath($valid)) $selection.Executable 'selection did not continue to the valid Python candidate'
   Assert-Equal 3 $selection.Identity.version[0] 'selected Python major version changed'
   Assert-Equal 12 $selection.Identity.version[1] 'selected Python minor version changed'
   Assert-Equal 7 $selection.Identity.version[2] 'selected Python micro version changed'
+  Assert-Equal 'CPython' $selection.Identity.implementation 'selected Python implementation changed'
+  Assert-Equal 'AMD64' $selection.Identity.architecture 'selected Python architecture changed'
+  Assert-Equal 64 $selection.Identity.pointer_bits 'selected Python pointer width changed'
   Assert-True ($null -eq (Resolve-StarVectorWindowsExecutable "$valid`"")) 'quoted executable path must fail closed'
 
   $allFailed = $false
   try {
-    Select-StarVectorBootstrapPython -CandidatePaths @($bad, $malformed, "$valid`"") | Out-Null
+    Select-StarVectorBootstrapPython -CandidatePaths @($bad, $malformed, $belowMinimum, $newerUnsupported, $wrongArchitecture, "$valid`"") | Out-Null
   } catch {
-    $allFailed = $_.Exception.Message -eq 'the self-hosted CUDA runner requires a directly executable Python 3.12 or newer on PATH'
+    $allFailed = $_.Exception.Message -eq 'StarVector terminal metrics require the explicitly provisioned CPython 3.12 x64 interpreter'
   }
   Assert-True $allFailed 'all invalid candidates must fail closed with the expected error'
 } finally {

--- a/scripts/select-starvector-windows-python.test.ps1
+++ b/scripts/select-starvector-windows-python.test.ps1
@@ -77,6 +77,54 @@ public static class FakePython {
     $allFailed = $_.Exception.Message -eq 'StarVector terminal metrics require the explicitly provisioned CPython 3.12 x64 interpreter'
   }
   Assert-True $allFailed 'all invalid candidates must fail closed with the expected error'
+
+  Assert-Equal 'open-clip-torch' (ConvertTo-StarVectorPythonDistributionName 'Open.CLIP_Torch') 'distribution-name normalization must fold case, dots, underscores, and hyphens'
+  Assert-Equal 'scikit-image' (ConvertTo-StarVectorPythonDistributionName 'scikit---image') 'distribution-name normalization must collapse repeated separators'
+
+  $outside = Join-Path $root 'outside-sentinel'
+  $safeTree = Join-Path $root 'metrics-tree'
+  $wrongAllowedRoot = Join-Path $root 'wrong-metrics-tree'
+  $junction = Join-Path $safeTree 'escape-junction'
+  New-Item -ItemType Directory -Path $outside | Out-Null
+  New-Item -ItemType Directory -Path (Join-Path $safeTree 'nested') | Out-Null
+  [IO.File]::WriteAllText((Join-Path $outside 'sentinel.txt'), 'outside must survive')
+  [IO.File]::WriteAllText((Join-Path $safeTree 'nested\inside.txt'), 'safe tree file')
+
+  $wrongRootBlocked = $false
+  try {
+    Remove-StarVectorWindowsDirectoryTree -TargetRoot $safeTree -AllowedRoot $wrongAllowedRoot
+  } catch {
+    $wrongRootBlocked = $_.Exception.Message -eq 'refusing to remove a metrics venv outside the exact workflow-owned terminal root'
+  }
+  Assert-True $wrongRootBlocked 'directory deletion must require the exact allowed root'
+  Assert-True (Test-Path -LiteralPath (Join-Path $safeTree 'nested\inside.txt') -PathType Leaf) 'exact-root refusal must preserve the target tree'
+
+  New-Item -ItemType Junction -Path $junction -Target $outside | Out-Null
+  $reparseBlocked = $false
+  try {
+    Remove-StarVectorWindowsDirectoryTree -TargetRoot $safeTree -AllowedRoot $safeTree
+  } catch {
+    $reparseBlocked = $_.Exception.Message -like 'refusing to remove a metrics venv containing a reparse point:*'
+  }
+  Assert-True $reparseBlocked 'directory deletion must refuse a descendant junction'
+  Assert-True (Test-Path -LiteralPath (Join-Path $outside 'sentinel.txt') -PathType Leaf) 'junction refusal must preserve the outside sentinel'
+
+  [IO.Directory]::Delete($junction)
+  Remove-StarVectorWindowsDirectoryTree -TargetRoot $safeTree -AllowedRoot $safeTree
+  Assert-True (-not (Test-Path -LiteralPath $safeTree)) 'a normal metrics tree must be removed after validation'
+  Assert-True (Test-Path -LiteralPath (Join-Path $outside 'sentinel.txt') -PathType Leaf) 'normal tree deletion must not affect the outside sentinel'
+
+  $rootJunction = Join-Path $root 'metrics-root-junction'
+  New-Item -ItemType Junction -Path $rootJunction -Target $outside | Out-Null
+  $rootReparseBlocked = $false
+  try {
+    Remove-StarVectorWindowsDirectoryTree -TargetRoot $rootJunction -AllowedRoot $rootJunction
+  } catch {
+    $rootReparseBlocked = $_.Exception.Message -like 'refusing to remove a metrics venv containing a reparse point:*'
+  }
+  Assert-True $rootReparseBlocked 'directory deletion must refuse a root junction'
+  Assert-True (Test-Path -LiteralPath (Join-Path $outside 'sentinel.txt') -PathType Leaf) 'root-junction refusal must preserve the outside sentinel'
+  [IO.Directory]::Delete($rootJunction)
 } finally {
   Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
 }

--- a/scripts/starvector-terminal-provision.test.mjs
+++ b/scripts/starvector-terminal-provision.test.mjs
@@ -260,10 +260,12 @@ function assertHostedWindowsWheelContract(hostedWorkflow, verification) {
   assert.match(verification, /Where-Object \{ \$_\.Extension -cne '\.whl' \}/);
   assert.match(verification, /'pip', 'install'[\s\S]*?'--no-index'[\s\S]*?'--find-links'[\s\S]*?'--only-binary=:all:'/);
   assert.match(verification, /\$seen\.ContainsKey\(\$canonicalName\)/);
-  assert.match(verification, /importlib\.metadata\.distribution\(sys\.argv\[1\]\)/);
+  assert.match(verification, /importlib\.metadata\.distribution\(sys\.argv\[1\]\);print\(d\.name\);print\(d\.version\)/);
+  assert.doesNotMatch(verification, /json\.dumps/);
+  assert.match(verification, /\$observedIdentity\.Count -ne 2/);
   assert.match(verification, /\$observedCanonicalName = ConvertTo-StarVectorPythonDistributionName/);
   assert.match(verification, /\$observedCanonicalName -cne \[string\]\$package\.canonical_name/);
-  assert.match(verification, /\[string\]\$observed\.version -cne \[string\]\$package\.version/);
+  assert.match(verification, /\[string\]\$observedIdentity\[1\] -cne \[string\]\$package\.version/);
   assert.match(verification, /import PIL,lpips,numpy,open_clip,skimage,torch,torchvision/);
 }
 
@@ -280,6 +282,8 @@ test("hosted Windows wheel contract rejects source-distribution and ambient-inte
     ["online install", (value) => value, (value) => value.replace("'--no-index', '--find-links'", "'--index-url', 'https://pypi.org/simple', '--find-links'")],
     ["source archive acceptance", (value) => value, (value) => value.replace("$_.Extension -cne '.whl'", "$false")],
     ["canonical duplicate detection", (value) => value, (value) => value.replace("$seen.ContainsKey($canonicalName)", "$seen.ContainsKey($name)")],
+    ["JSON native-argument quoting", (value) => value, (value) => value.replace("print(d.name);print(d.version)", 'print(json.dumps({"name":d.name,"version":d.version}))')],
+    ["metadata line count", (value) => value, (value) => value.replace("$observedIdentity.Count -ne 2", "$false")],
     ["observed canonical identity", (value) => value, (value) => value.replace("$observedCanonicalName -cne [string]$package.canonical_name", "$false")],
     ["lpips import", (value) => value, (value) => value.replace(",lpips", "")],
     ["open_clip import", (value) => value, (value) => value.replace(",open_clip", "")],

--- a/scripts/starvector-terminal-provision.test.mjs
+++ b/scripts/starvector-terminal-provision.test.mjs
@@ -16,8 +16,10 @@ const execFile = promisify(execFileCallback);
 const digest = (value) => createHash("sha256").update(value).digest("hex");
 const workflow = await readFile(".github/workflows/starvector-terminal-provision.yml", "utf8");
 const windowsWorkflow = await readFile(".github/workflows/desktop-windows.yml", "utf8");
+const windowsWheelWorkflow = await readFile(".github/workflows/starvector-metrics-windows.yml", "utf8");
 const windowsPythonProbe = await readFile("scripts/select-starvector-windows-python.ps1", "utf8");
 const windowsPythonProbeTest = await readFile("scripts/select-starvector-windows-python.test.ps1", "utf8");
+const windowsWheelVerification = await readFile("scripts/verify-starvector-windows-metric-wheels.ps1", "utf8");
 
 test("file and tree identities stream exact bytes with bounded reads and portable ordering", async () => {
   const chunks = [Buffer.from("large-file-"), Buffer.from("identity")];
@@ -79,25 +81,33 @@ test("provision workflow is dispatch-only and never runs a model, service, campa
 function assertWindowsMetricsPythonContract(step) {
   assert.doesNotMatch(step, /\bpy\s+-3\.11\b/);
   assert.match(step, /select-starvector-windows-python\.ps1/);
-  assert.match(step, /\$bootstrap = Select-StarVectorBootstrapPython/);
+  assert.match(step, /\$bootstrap = Select-StarVectorBootstrapPython -CandidatePaths @\(\$env:STARVECTOR_METRICS_BOOTSTRAP_PYTHON\)/);
   assert.match(step, /\$bootstrapPython = \$bootstrap\.Executable/);
   assert.match(step, /\$bootstrapIdentity = \$bootstrap\.Identity/);
+  assert.doesNotMatch(step, /Get-Command python\.exe/);
   assert.doesNotMatch(step, /& \$candidate/);
+  assert.match(step, /refusing to replace a metrics venv outside the workflow-owned terminal root/);
+  assert.match(step, /\$rebuildMetricsVenv = \$existingProbe\.ExitCode -ne 0/);
+  assert.match(step, /Remove-Item -LiteralPath \$metricsRoot -Recurse -Force/);
   assert.match(step, /& \$bootstrapPython -m venv \$metricsRoot/);
   assert.match(step, /if \(\$LASTEXITCODE -ne 0\) \{ throw 'failed to create the terminal metrics venv/);
   assert.match(step, /Test-Path \$metricsPython -PathType Leaf/);
-  assert.match(step, /Invoke-StarVectorPythonIdentityProbe -Executable \$metricsPython -IncludeBaseExecutable/);
+  assert.match(step, /\$venvProbe = Invoke-StarVectorPythonIdentityProbe -Executable \$metricsPython -IncludeBaseExecutable/);
   assert.match(step, /if \(\$venvProbe\.ExitCode -ne 0\) \{ throw 'terminal metrics venv Python identity probe failed/);
   assert.match(step, /\$venvProbe\.StdOut \| ConvertFrom-Json -ErrorAction Stop/);
   assert.match(step, /\$observedBasePython = Resolve-StarVectorWindowsExecutable \$venvIdentity\.base_executable/);
   assert.match(step, /OrdinalIgnoreCase\.Equals\(\$bootstrapPython, \$observedBasePython\)/);
   assert.match(step, /\[int\]\$venvIdentity\.version\[2\] -ne \[int\]\$bootstrapIdentity\.version\[2\]/);
-  assert.match(step, /& \$metricsPython -m pip install/);
+  assert.match(step, /\[string\]\$venvIdentity\.implementation -cne 'CPython'/);
+  assert.match(step, /\[string\]\$venvIdentity\.architecture -cne 'AMD64'/);
+  assert.match(step, /\[int\]\$venvIdentity\.pointer_bits -ne 64/);
+  assert.match(step, /& \$metricsPython -m pip install --disable-pip-version-check --only-binary=:all: --retries 5 --timeout 60/);
   assert.match(step, /starvector-terminal-provision\.mjs metrics[^\n]*\$metricsRoot \$metricsPython/);
 }
 
 function assertWindowsPythonProbeContract(source) {
-  assert.match(source, /Get-Command python\.exe -All -CommandType Application/);
+  assert.doesNotMatch(source, /Get-Command python\.exe/);
+  assert.match(source, /\[Parameter\(Mandatory = \$true\)\]/);
   assert.match(source, /\$text -match '\[\\r\\n"\]'/);
   assert.match(source, /\$text -notmatch '\^\[A-Za-z\]:\\\\'/);
   assert.match(source, /\[IO\.Path\]::GetFullPath\(\$text\)/);
@@ -115,13 +125,30 @@ function assertWindowsPythonProbeContract(source) {
   assert.match(source, /StdOut = \$stdoutTask\.Result/);
   assert.match(source, /StdErr = \$stderrTask\.Result/);
   assert.match(source, /base_executable'':getattr\(sys,''_base_executable'',None\)/);
+  assert.match(source, /platform\.python_implementation\(\)/);
+  assert.match(source, /platform\.machine\(\)/);
+  assert.match(source, /struct\.calcsize\(''P''\)\*8/);
   assert.match(source, /if \(\$probe\.ExitCode -ne 0\) \{ continue \}/);
   assert.match(source, /\$probe\.StdOut \| ConvertFrom-Json -ErrorAction Stop/);
-  assert.match(source, /\[int\]\$identity\.version\[1\] -ge 12/);
+  assert.match(source, /\[int\]\$identity\.version\[1\] -eq 12/);
+  assert.doesNotMatch(source, /\[int\]\$identity\.version\[1\] -ge 12/);
+  assert.match(source, /\[string\]\$identity\.implementation -ceq 'CPython'/);
+  assert.match(source, /\[string\]\$identity\.architecture -ceq 'AMD64'/);
+  assert.match(source, /\[int\]\$identity\.pointer_bits -eq 64/);
+  assert.match(source, /OrdinalIgnoreCase\.Equals\(\$canonicalCandidate, \$canonicalExecutable\)/);
   assert.doesNotMatch(source, /& \$candidate|Invoke-Expression|Start-Process/);
 }
 
-test("Windows metrics provisioning selects, uses, and verifies one explicit Python 3.12+ executable", () => {
+test("terminal metrics provisioning fixes CPython 3.12 and wheel-only installation on both hosts", () => {
+  assert.equal((workflow.match(/uses: actions\/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97/g) ?? []).length, 2);
+  assert.equal((workflow.match(/python-version: "3\.12"/g) ?? []).length, 2);
+  assert.equal((workflow.match(/update-environment: false/g) ?? []).length, 2);
+  assert.match(workflow, /Set up supported CPython 3\.12 arm64 for terminal metrics[\s\S]*?architecture: arm64/);
+  assert.match(workflow, /Set up supported CPython 3\.12 x64 for terminal metrics[\s\S]*?architecture: x64/);
+  assert.equal((workflow.match(/pip install --disable-pip-version-check --only-binary=:all: --retries 5 --timeout 60/g) ?? []).length, 2);
+  assert.doesNotMatch(workflow, /pip install --disable-pip-version-check (?!.*--only-binary=:all:)/);
+  assert.match(workflow, /sys\.version_info\[:2\] == \(3, 12\)[^\n]*platform\.machine\(\)\.lower\(\) in \{"arm64", "aarch64"\}/);
+
   const start = workflow.indexOf("- name: Provision pinned metric runtime and official checkpoints", workflow.indexOf("  provision-windows:"));
   const end = workflow.indexOf("- name: Materialize the exact pinned 120-row corpus", start);
   const step = workflow.slice(start, end);
@@ -139,9 +166,12 @@ test("Windows Python probes capture native stderr without invoking through Power
   assert.match(windowsPythonProbeTest, /\$ErrorActionPreference = 'Stop'/);
   assert.match(windowsPythonProbeTest, /01-bad python\.exe/);
   assert.match(windowsPythonProbeTest, /02-malformed python\.exe/);
-  assert.match(windowsPythonProbeTest, /03-valid python\.exe/);
+  assert.match(windowsPythonProbeTest, /03-python311\.exe/);
+  assert.match(windowsPythonProbeTest, /04-python314\.exe/);
+  assert.match(windowsPythonProbeTest, /05-python312-arm64\.exe/);
+  assert.match(windowsPythonProbeTest, /06-python312-amd64\.exe/);
   assert.match(windowsPythonProbeTest, /Traceback from the first fake Python candidate/);
-  assert.match(windowsPythonProbeTest, /Select-StarVectorBootstrapPython -CandidatePaths @\(\$bad, \$malformed,/);
+  assert.match(windowsPythonProbeTest, /Select-StarVectorBootstrapPython -CandidatePaths @\(\$bad, \$malformed, \$belowMinimum, \$newerUnsupported, \$wrongArchitecture,/);
   assert.match(windowsPythonProbeTest, /all invalid candidates must fail closed/);
   assert.match(windowsWorkflow, /"scripts\/select-starvector-windows-python\.ps1"/);
   assert.match(windowsWorkflow, /"scripts\/select-starvector-windows-python\.test\.ps1"/);
@@ -157,6 +187,11 @@ test("Windows Python probe contract rejects native-process safety mutations", ()
     ["exit status", (value) => value.replace("ExitCode = $process.ExitCode", "ExitCode = 0")],
     ["bad-candidate continuation", (value) => value.replace("if ($probe.ExitCode -ne 0) { continue }", "if ($probe.ExitCode -ne 0) { break }")],
     ["PowerShell invocation", (value) => value.replace("$probe = Invoke-StarVectorPythonIdentityProbe -Executable $canonicalCandidate", "$probe = & $candidate -c $code")],
+    ["permissive Python minor", (value) => value.replace("[int]$identity.version[1] -eq 12", "[int]$identity.version[1] -ge 12")],
+    ["implementation identity", (value) => value.replace("[string]$identity.implementation -ceq 'CPython'", "$true")],
+    ["architecture identity", (value) => value.replace("[string]$identity.architecture -ceq 'AMD64'", "$true")],
+    ["pointer width", (value) => value.replace("[int]$identity.pointer_bits -eq 64", "$true")],
+    ["reported executable equality", (value) => value.replace("[StringComparer]::OrdinalIgnoreCase.Equals($canonicalCandidate, $canonicalExecutable)", "$true")],
   ]) {
     const changed = mutation(windowsPythonProbe);
     assert.notEqual(changed, windowsPythonProbe, `${label} mutation must alter the helper fixture`);
@@ -169,14 +204,52 @@ test("Windows metrics Python contract rejects path, base-interpreter, and patch-
   const end = workflow.indexOf("- name: Materialize the exact pinned 120-row corpus", start);
   const step = workflow.slice(start, end);
   for (const [label, mutation] of [
-    ["selection helper", (value) => value.replace("$bootstrap = Select-StarVectorBootstrapPython", "$bootstrap = Get-Command python.exe")],
+    ["selection helper", (value) => value.replace("$bootstrap = Select-StarVectorBootstrapPython -CandidatePaths @($env:STARVECTOR_METRICS_BOOTSTRAP_PYTHON)", "$bootstrap = Get-Command python.exe")],
     ["venv captured probe", (value) => value.replace("$venvProbe = Invoke-StarVectorPythonIdentityProbe -Executable $metricsPython -IncludeBaseExecutable", "$venvProbe = & $metricsPython -c $code")],
     ["base path equality", (value) => value.replace("OrdinalIgnoreCase.Equals($bootstrapPython, $observedBasePython)", "OrdinalIgnoreCase.Equals($bootstrapPython, $bootstrapPython)")],
     ["patch version equality", (value) => value.replace("[int]$venvIdentity.version[2] -ne [int]$bootstrapIdentity.version[2]", "[int]$venvIdentity.version[2] -ne [int]$venvIdentity.version[2]")],
+    ["wheel-only install", (value) => value.replace("--only-binary=:all:", "--prefer-binary")],
+    ["stale venv replacement", (value) => value.replace("Remove-Item -LiteralPath $metricsRoot -Recurse -Force", "Write-Host $metricsRoot")],
   ]) {
     const changed = mutation(step);
     assert.notEqual(changed, step, `${label} mutation must alter the workflow fixture`);
     assert.throws(() => assertWindowsMetricsPythonContract(changed), { name: "AssertionError" }, label);
+  }
+});
+
+function assertHostedWindowsWheelContract(hostedWorkflow, verification) {
+  assert.match(hostedWorkflow, /runs-on: windows-2022/);
+  assert.match(hostedWorkflow, /timeout-minutes: 25/);
+  assert.match(hostedWorkflow, /uses: actions\/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97/);
+  assert.match(hostedWorkflow, /python-version: "3\.12"[\s\S]*?architecture: x64[\s\S]*?update-environment: false/);
+  assert.equal((hostedWorkflow.match(/shell: powershell/g) ?? []).length, 2);
+  assert.match(hostedWorkflow, /select-starvector-windows-python\.test\.ps1/);
+  assert.match(hostedWorkflow, /STARVECTOR_METRICS_BOOTSTRAP_PYTHON: \$\{\{ steps\.metrics-python\.outputs\.python-path \}\}/);
+  assert.match(hostedWorkflow, /verify-starvector-windows-metric-wheels\.ps1/);
+  assert.match(verification, /Select-StarVectorBootstrapPython -CandidatePaths @\(\$BootstrapPython\)/);
+  assert.match(verification, /'pip', 'download'[\s\S]*?'--only-binary=:all:'[\s\S]*?'--retries', '5'/);
+  assert.match(verification, /Where-Object \{ \$_\.Extension -cne '\.whl' \}/);
+  assert.match(verification, /'pip', 'install'[\s\S]*?'--no-index'[\s\S]*?'--find-links'[\s\S]*?'--only-binary=:all:'/);
+  assert.match(verification, /\$installed\[\[string\]\$package\.name\] -cne \[string\]\$package\.version/);
+  assert.match(verification, /import PIL,numpy,skimage,torch,torchvision/);
+}
+
+test("hosted Windows resolves and installs the metric lock exclusively from wheels under PowerShell 5.1", () => {
+  assertHostedWindowsWheelContract(windowsWheelWorkflow, windowsWheelVerification);
+});
+
+test("hosted Windows wheel contract rejects source-distribution and ambient-interpreter mutations", () => {
+  for (const [label, workflowMutation, scriptMutation] of [
+    ["ambient interpreter", (value) => value.replace("${{ steps.metrics-python.outputs.python-path }}", "python.exe"), (value) => value],
+    ["floating minor", (value) => value.replace('python-version: "3.12"', 'python-version: ">=3.12"'), (value) => value],
+    ["source download", (value) => value, (value) => value.replace("'--only-binary=:all:', '--retries'", "'--prefer-binary', '--retries'")],
+    ["online install", (value) => value, (value) => value.replace("'--no-index', '--find-links'", "'--index-url', 'https://pypi.org/simple', '--find-links'")],
+    ["source archive acceptance", (value) => value, (value) => value.replace("$_.Extension -cne '.whl'", "$false")],
+  ]) {
+    const changedWorkflow = workflowMutation(windowsWheelWorkflow);
+    const changedScript = scriptMutation(windowsWheelVerification);
+    assert.ok(changedWorkflow !== windowsWheelWorkflow || changedScript !== windowsWheelVerification, `${label} mutation must alter a fixture`);
+    assert.throws(() => assertHostedWindowsWheelContract(changedWorkflow, changedScript), { name: "AssertionError" }, label);
   }
 });
 

--- a/scripts/starvector-terminal-provision.test.mjs
+++ b/scripts/starvector-terminal-provision.test.mjs
@@ -86,9 +86,13 @@ function assertWindowsMetricsPythonContract(step) {
   assert.match(step, /\$bootstrapIdentity = \$bootstrap\.Identity/);
   assert.doesNotMatch(step, /Get-Command python\.exe/);
   assert.doesNotMatch(step, /& \$candidate/);
-  assert.match(step, /refusing to replace a metrics venv outside the workflow-owned terminal root/);
   assert.match(step, /\$rebuildMetricsVenv = \$existingProbe\.ExitCode -ne 0/);
-  assert.match(step, /Remove-Item -LiteralPath \$metricsRoot -Recurse -Force/);
+  assert.match(step, /OrdinalIgnoreCase\.Equals\(\$bootstrapPython, \$existingBasePython\)/);
+  assert.match(step, /\[int\]\$existingIdentity\.version\[0\] -ne \[int\]\$bootstrapIdentity\.version\[0\]/);
+  assert.match(step, /\[int\]\$existingIdentity\.version\[1\] -ne \[int\]\$bootstrapIdentity\.version\[1\]/);
+  assert.match(step, /\[int\]\$existingIdentity\.version\[2\] -ne \[int\]\$bootstrapIdentity\.version\[2\]/);
+  assert.match(step, /if \(\$rebuildMetricsVenv\) \{\s+Remove-StarVectorWindowsDirectoryTree -TargetRoot \$metricsRoot -AllowedRoot 'D:\\sceneworks-terminal\\metrics'/);
+  assert.doesNotMatch(step, /Remove-Item[^\n]*-Recurse/);
   assert.match(step, /& \$bootstrapPython -m venv \$metricsRoot/);
   assert.match(step, /if \(\$LASTEXITCODE -ne 0\) \{ throw 'failed to create the terminal metrics venv/);
   assert.match(step, /Test-Path \$metricsPython -PathType Leaf/);
@@ -108,6 +112,15 @@ function assertWindowsMetricsPythonContract(step) {
 function assertWindowsPythonProbeContract(source) {
   assert.doesNotMatch(source, /Get-Command python\.exe/);
   assert.match(source, /\[Parameter\(Mandatory = \$true\)\]/);
+  assert.ok(source.includes("[regex]::Replace($Name.Trim().ToLowerInvariant(), '[-_.]+', '-')"));
+  assert.match(source, /function Remove-StarVectorWindowsDirectoryTree/);
+  assert.match(source, /OrdinalIgnoreCase\.Equals\(\$canonicalTarget, \$canonicalAllowed\)/);
+  assert.match(source, /New-Object System\.Collections\.Stack/);
+  assert.equal((source.match(/Attributes -band \[IO\.FileAttributes\]::ReparsePoint/g) ?? []).length, 2);
+  assert.match(source, /Get-ChildItem -LiteralPath \$item\.FullName -Force -ErrorAction Stop/);
+  assert.match(source, /Remove-Item -LiteralPath \$item\.FullName -Force -ErrorAction Stop/);
+  assert.doesNotMatch(source, /Remove-Item[^\n]*-Recurse/);
+  assert.match(source, /refusing to remove a metrics venv outside the exact workflow-owned terminal root/);
   assert.match(source, /\$text -match '\[\\r\\n"\]'/);
   assert.match(source, /\$text -notmatch '\^\[A-Za-z\]:\\\\'/);
   assert.match(source, /\[IO\.Path\]::GetFullPath\(\$text\)/);
@@ -173,6 +186,11 @@ test("Windows Python probes capture native stderr without invoking through Power
   assert.match(windowsPythonProbeTest, /Traceback from the first fake Python candidate/);
   assert.match(windowsPythonProbeTest, /Select-StarVectorBootstrapPython -CandidatePaths @\(\$bad, \$malformed, \$belowMinimum, \$newerUnsupported, \$wrongArchitecture,/);
   assert.match(windowsPythonProbeTest, /all invalid candidates must fail closed/);
+  assert.match(windowsPythonProbeTest, /ConvertTo-StarVectorPythonDistributionName 'Open\.CLIP_Torch'/);
+  assert.match(windowsPythonProbeTest, /New-Item -ItemType Junction -Path \$junction -Target \$outside/);
+  assert.match(windowsPythonProbeTest, /junction refusal must preserve the outside sentinel/);
+  assert.match(windowsPythonProbeTest, /directory deletion must refuse a root junction/);
+  assert.match(windowsPythonProbeTest, /a normal metrics tree must be removed after validation/);
   assert.match(windowsWorkflow, /"scripts\/select-starvector-windows-python\.ps1"/);
   assert.match(windowsWorkflow, /"scripts\/select-starvector-windows-python\.test\.ps1"/);
   assert.match(windowsWorkflow, /shell: powershell\s+run: \.\\scripts\\select-starvector-windows-python\.test\.ps1/);
@@ -192,6 +210,10 @@ test("Windows Python probe contract rejects native-process safety mutations", ()
     ["architecture identity", (value) => value.replace("[string]$identity.architecture -ceq 'AMD64'", "$true")],
     ["pointer width", (value) => value.replace("[int]$identity.pointer_bits -eq 64", "$true")],
     ["reported executable equality", (value) => value.replace("[StringComparer]::OrdinalIgnoreCase.Equals($canonicalCandidate, $canonicalExecutable)", "$true")],
+    ["distribution name separator folding", (value) => value.replace("'[-_.]+'", "'[-_]+'")],
+    ["exact deletion root", (value) => value.replace("[StringComparer]::OrdinalIgnoreCase.Equals($canonicalTarget, $canonicalAllowed)", "$true")],
+    ["reparse-point refusal", (value) => value.replace("($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0", "$false")],
+    ["non-recursive removal", (value) => value.replace("Remove-Item -LiteralPath $item.FullName -Force -ErrorAction Stop", "Remove-Item -LiteralPath $item.FullName -Recurse -Force -ErrorAction Stop")],
   ]) {
     const changed = mutation(windowsPythonProbe);
     assert.notEqual(changed, windowsPythonProbe, `${label} mutation must alter the helper fixture`);
@@ -208,8 +230,14 @@ test("Windows metrics Python contract rejects path, base-interpreter, and patch-
     ["venv captured probe", (value) => value.replace("$venvProbe = Invoke-StarVectorPythonIdentityProbe -Executable $metricsPython -IncludeBaseExecutable", "$venvProbe = & $metricsPython -c $code")],
     ["base path equality", (value) => value.replace("OrdinalIgnoreCase.Equals($bootstrapPython, $observedBasePython)", "OrdinalIgnoreCase.Equals($bootstrapPython, $bootstrapPython)")],
     ["patch version equality", (value) => value.replace("[int]$venvIdentity.version[2] -ne [int]$bootstrapIdentity.version[2]", "[int]$venvIdentity.version[2] -ne [int]$venvIdentity.version[2]")],
+    ["stale rebuild gate", (value) => value.replace("if ($rebuildMetricsVenv)", "if ($false)")],
+    ["stale exact root", (value) => value.replace("-AllowedRoot 'D:\\sceneworks-terminal\\metrics'", "-AllowedRoot $metricsRoot")],
+    ["stale base mismatch", (value) => value.replace("OrdinalIgnoreCase.Equals($bootstrapPython, $existingBasePython)", "OrdinalIgnoreCase.Equals($bootstrapPython, $bootstrapPython)")],
+    ["stale major mismatch", (value) => value.replace("[int]$existingIdentity.version[0] -ne [int]$bootstrapIdentity.version[0]", "$false")],
+    ["stale minor mismatch", (value) => value.replace("[int]$existingIdentity.version[1] -ne [int]$bootstrapIdentity.version[1]", "$false")],
+    ["stale micro mismatch", (value) => value.replace("[int]$existingIdentity.version[2] -ne [int]$bootstrapIdentity.version[2]", "$false")],
     ["wheel-only install", (value) => value.replace("--only-binary=:all:", "--prefer-binary")],
-    ["stale venv replacement", (value) => value.replace("Remove-Item -LiteralPath $metricsRoot -Recurse -Force", "Write-Host $metricsRoot")],
+    ["stale venv replacement", (value) => value.replace("Remove-StarVectorWindowsDirectoryTree -TargetRoot $metricsRoot", "Write-Host $metricsRoot")],
   ]) {
     const changed = mutation(step);
     assert.notEqual(changed, step, `${label} mutation must alter the workflow fixture`);
@@ -224,14 +252,19 @@ function assertHostedWindowsWheelContract(hostedWorkflow, verification) {
   assert.match(hostedWorkflow, /python-version: "3\.12"[\s\S]*?architecture: x64[\s\S]*?update-environment: false/);
   assert.equal((hostedWorkflow.match(/shell: powershell/g) ?? []).length, 2);
   assert.match(hostedWorkflow, /select-starvector-windows-python\.test\.ps1/);
+  assert.match(hostedWorkflow, /"scripts\/starvector-terminal-metrics\.py"/);
   assert.match(hostedWorkflow, /STARVECTOR_METRICS_BOOTSTRAP_PYTHON: \$\{\{ steps\.metrics-python\.outputs\.python-path \}\}/);
   assert.match(hostedWorkflow, /verify-starvector-windows-metric-wheels\.ps1/);
   assert.match(verification, /Select-StarVectorBootstrapPython -CandidatePaths @\(\$BootstrapPython\)/);
   assert.match(verification, /'pip', 'download'[\s\S]*?'--only-binary=:all:'[\s\S]*?'--retries', '5'/);
   assert.match(verification, /Where-Object \{ \$_\.Extension -cne '\.whl' \}/);
   assert.match(verification, /'pip', 'install'[\s\S]*?'--no-index'[\s\S]*?'--find-links'[\s\S]*?'--only-binary=:all:'/);
-  assert.match(verification, /\$installed\[\[string\]\$package\.name\] -cne \[string\]\$package\.version/);
-  assert.match(verification, /import PIL,numpy,skimage,torch,torchvision/);
+  assert.match(verification, /\$seen\.ContainsKey\(\$canonicalName\)/);
+  assert.match(verification, /importlib\.metadata\.distribution\(sys\.argv\[1\]\)/);
+  assert.match(verification, /\$observedCanonicalName = ConvertTo-StarVectorPythonDistributionName/);
+  assert.match(verification, /\$observedCanonicalName -cne \[string\]\$package\.canonical_name/);
+  assert.match(verification, /\[string\]\$observed\.version -cne \[string\]\$package\.version/);
+  assert.match(verification, /import PIL,lpips,numpy,open_clip,skimage,torch,torchvision/);
 }
 
 test("hosted Windows resolves and installs the metric lock exclusively from wheels under PowerShell 5.1", () => {
@@ -242,9 +275,14 @@ test("hosted Windows wheel contract rejects source-distribution and ambient-inte
   for (const [label, workflowMutation, scriptMutation] of [
     ["ambient interpreter", (value) => value.replace("${{ steps.metrics-python.outputs.python-path }}", "python.exe"), (value) => value],
     ["floating minor", (value) => value.replace('python-version: "3.12"', 'python-version: ">=3.12"'), (value) => value],
+    ["import surface trigger", (value) => value.replace('      - "scripts/starvector-terminal-metrics.py"\n', ''), (value) => value],
     ["source download", (value) => value, (value) => value.replace("'--only-binary=:all:', '--retries'", "'--prefer-binary', '--retries'")],
     ["online install", (value) => value, (value) => value.replace("'--no-index', '--find-links'", "'--index-url', 'https://pypi.org/simple', '--find-links'")],
     ["source archive acceptance", (value) => value, (value) => value.replace("$_.Extension -cne '.whl'", "$false")],
+    ["canonical duplicate detection", (value) => value, (value) => value.replace("$seen.ContainsKey($canonicalName)", "$seen.ContainsKey($name)")],
+    ["observed canonical identity", (value) => value, (value) => value.replace("$observedCanonicalName -cne [string]$package.canonical_name", "$false")],
+    ["lpips import", (value) => value, (value) => value.replace(",lpips", "")],
+    ["open_clip import", (value) => value, (value) => value.replace(",open_clip", "")],
   ]) {
     const changedWorkflow = workflowMutation(windowsWheelWorkflow);
     const changedScript = scriptMutation(windowsWheelVerification);

--- a/scripts/verify-starvector-windows-metric-wheels.ps1
+++ b/scripts/verify-starvector-windows-metric-wheels.ps1
@@ -1,0 +1,62 @@
+param(
+  [string]$BootstrapPython = $env:STARVECTOR_METRICS_BOOTSTRAP_PYTHON,
+  [string]$MetricsLock = (Join-Path $PSScriptRoot '..\release\starvector-terminal-metrics-lock-v1.json')
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+. (Join-Path $PSScriptRoot 'select-starvector-windows-python.ps1')
+
+$bootstrap = Select-StarVectorBootstrapPython -CandidatePaths @($BootstrapPython)
+$bootstrapPython = $bootstrap.Executable
+$packages = @((Get-Content -LiteralPath $MetricsLock -Raw | ConvertFrom-Json -ErrorAction Stop).required_packages)
+if ($packages.Count -ne 7) { throw 'the StarVector metric lock must contain exactly seven direct packages' }
+
+$specs = @()
+$seen = @{}
+foreach ($package in $packages) {
+  $name = [string]$package.name
+  $version = [string]$package.version
+  if ([string]::IsNullOrWhiteSpace($name) -or [string]::IsNullOrWhiteSpace($version) -or $seen.ContainsKey($name)) {
+    throw 'the StarVector metric lock contains an invalid or duplicate package identity'
+  }
+  $seen[$name] = $true
+  $specs += "$name==$version"
+}
+
+$root = Join-Path $env:RUNNER_TEMP ("starvector-metric-wheel-contract-{0}" -f [Guid]::NewGuid().ToString('N'))
+$wheelhouse = Join-Path $root 'wheelhouse'
+$venv = Join-Path $root 'venv'
+New-Item -ItemType Directory -Path $wheelhouse -Force | Out-Null
+
+$downloadArgs = @('-m', 'pip', 'download', '--disable-pip-version-check', '--only-binary=:all:', '--retries', '5', '--timeout', '60', '--dest', $wheelhouse) + $specs
+& $bootstrapPython @downloadArgs
+if ($LASTEXITCODE -ne 0) { throw 'the pinned StarVector metric closure did not resolve entirely to wheels' }
+
+$downloads = @(Get-ChildItem -LiteralPath $wheelhouse -File)
+if ($downloads.Count -eq 0 -or @($downloads | Where-Object { $_.Extension -cne '.whl' }).Count -ne 0) {
+  throw 'the pinned StarVector metric closure produced a non-wheel distribution'
+}
+
+& $bootstrapPython -m venv $venv
+if ($LASTEXITCODE -ne 0) { throw 'failed to create the hosted StarVector metric verification venv' }
+$venvPython = Join-Path $venv 'Scripts\python.exe'
+$installArgs = @('-m', 'pip', 'install', '--disable-pip-version-check', '--no-index', '--find-links', $wheelhouse, '--only-binary=:all:') + $specs
+& $venvPython @installArgs
+if ($LASTEXITCODE -ne 0) { throw 'the wheel-only StarVector metric closure did not install offline' }
+
+$installed = @{}
+@((& $venvPython -m pip list --format json | ConvertFrom-Json -ErrorAction Stop)) | ForEach-Object {
+  $installed[[string]$_.name] = [string]$_.version
+}
+foreach ($package in $packages) {
+  if (-not $installed.ContainsKey([string]$package.name) -or $installed[[string]$package.name] -cne [string]$package.version) {
+    throw "the installed StarVector metric package identity drifted: $($package.name)"
+  }
+}
+
+& $venvPython -c 'import PIL,numpy,skimage,torch,torchvision'
+if ($LASTEXITCODE -ne 0) { throw 'the compiled StarVector metric packages did not import after wheel-only installation' }
+
+Write-Host ("verified {0} wheel files for CPython {1} {2}" -f $downloads.Count, ($bootstrap.Identity.version -join '.'), $bootstrap.Identity.architecture)

--- a/scripts/verify-starvector-windows-metric-wheels.ps1
+++ b/scripts/verify-starvector-windows-metric-wheels.ps1
@@ -50,11 +50,10 @@ $installArgs = @('-m', 'pip', 'install', '--disable-pip-version-check', '--no-in
 if ($LASTEXITCODE -ne 0) { throw 'the wheel-only StarVector metric closure did not install offline' }
 
 foreach ($package in $lockedPackages) {
-  $observedJson = & $venvPython -c 'import importlib.metadata,json,sys;d=importlib.metadata.distribution(sys.argv[1]);print(json.dumps({"name":d.metadata["Name"],"version":d.version}))' ([string]$package.name)
-  if ($LASTEXITCODE -ne 0) { throw "the installed StarVector metric package identity was unreadable: $($package.name)" }
-  try { $observed = ([string]$observedJson).Trim() | ConvertFrom-Json -ErrorAction Stop } catch { throw "the installed StarVector metric package identity was invalid: $($package.name)" }
-  $observedCanonicalName = ConvertTo-StarVectorPythonDistributionName ([string]$observed.name)
-  if ($observedCanonicalName -cne [string]$package.canonical_name -or [string]$observed.version -cne [string]$package.version) {
+  $observedIdentity = @(& $venvPython -c 'import importlib.metadata,sys;d=importlib.metadata.distribution(sys.argv[1]);print(d.name);print(d.version)' ([string]$package.name))
+  if ($LASTEXITCODE -ne 0 -or $observedIdentity.Count -ne 2) { throw "the installed StarVector metric package identity was unreadable: $($package.name)" }
+  $observedCanonicalName = ConvertTo-StarVectorPythonDistributionName ([string]$observedIdentity[0])
+  if ($observedCanonicalName -cne [string]$package.canonical_name -or [string]$observedIdentity[1] -cne [string]$package.version) {
     throw "the installed StarVector metric package identity drifted: $($package.name)"
   }
 }

--- a/scripts/verify-starvector-windows-metric-wheels.ps1
+++ b/scripts/verify-starvector-windows-metric-wheels.ps1
@@ -14,15 +14,18 @@ $packages = @((Get-Content -LiteralPath $MetricsLock -Raw | ConvertFrom-Json -Er
 if ($packages.Count -ne 7) { throw 'the StarVector metric lock must contain exactly seven direct packages' }
 
 $specs = @()
+$lockedPackages = @()
 $seen = @{}
 foreach ($package in $packages) {
   $name = [string]$package.name
   $version = [string]$package.version
-  if ([string]::IsNullOrWhiteSpace($name) -or [string]::IsNullOrWhiteSpace($version) -or $seen.ContainsKey($name)) {
+  $canonicalName = ConvertTo-StarVectorPythonDistributionName $name
+  if ([string]::IsNullOrWhiteSpace($version) -or $seen.ContainsKey($canonicalName)) {
     throw 'the StarVector metric lock contains an invalid or duplicate package identity'
   }
-  $seen[$name] = $true
+  $seen[$canonicalName] = $true
   $specs += "$name==$version"
+  $lockedPackages += [pscustomobject]@{ name = $name; canonical_name = $canonicalName; version = $version }
 }
 
 $root = Join-Path $env:RUNNER_TEMP ("starvector-metric-wheel-contract-{0}" -f [Guid]::NewGuid().ToString('N'))
@@ -46,17 +49,17 @@ $installArgs = @('-m', 'pip', 'install', '--disable-pip-version-check', '--no-in
 & $venvPython @installArgs
 if ($LASTEXITCODE -ne 0) { throw 'the wheel-only StarVector metric closure did not install offline' }
 
-$installed = @{}
-@((& $venvPython -m pip list --format json | ConvertFrom-Json -ErrorAction Stop)) | ForEach-Object {
-  $installed[[string]$_.name] = [string]$_.version
-}
-foreach ($package in $packages) {
-  if (-not $installed.ContainsKey([string]$package.name) -or $installed[[string]$package.name] -cne [string]$package.version) {
+foreach ($package in $lockedPackages) {
+  $observedJson = & $venvPython -c 'import importlib.metadata,json,sys;d=importlib.metadata.distribution(sys.argv[1]);print(json.dumps({"name":d.metadata["Name"],"version":d.version}))' ([string]$package.name)
+  if ($LASTEXITCODE -ne 0) { throw "the installed StarVector metric package identity was unreadable: $($package.name)" }
+  try { $observed = ([string]$observedJson).Trim() | ConvertFrom-Json -ErrorAction Stop } catch { throw "the installed StarVector metric package identity was invalid: $($package.name)" }
+  $observedCanonicalName = ConvertTo-StarVectorPythonDistributionName ([string]$observed.name)
+  if ($observedCanonicalName -cne [string]$package.canonical_name -or [string]$observed.version -cne [string]$package.version) {
     throw "the installed StarVector metric package identity drifted: $($package.name)"
   }
 }
 
-& $venvPython -c 'import PIL,numpy,skimage,torch,torchvision'
+& $venvPython -c 'import PIL,lpips,numpy,open_clip,skimage,torch,torchvision'
 if ($LASTEXITCODE -ne 0) { throw 'the compiled StarVector metric packages did not import after wheel-only installation' }
 
 Write-Host ("verified {0} wheel files for CPython {1} {2}" -f $downloads.Count, ($bootstrap.Identity.version -join '.'), $bootstrap.Identity.architecture)


### PR DESCRIPTION
## Summary

- provision terminal metrics with pinned actions/setup-python CPython 3.12 on both hosts (Windows x64, macOS arm64)
- require the Windows selector and durable venv to match the exact provisioned interpreter identity, including micro version, architecture, and pointer width
- make metric dependency installation wheel-only and add a hosted windows-2022 PowerShell 5.1 regression that downloads the lock closure as wheels, installs it offline, and imports the compiled packages

## Evidence

PyPI publishes CPython 3.12 Windows x64 and macOS arm64 wheels for every compiled direct dependency in the checked-in seven-package lock. In particular, scikit-image 0.25.2 publishes cp312-win_amd64 but no cp314-win_amd64 wheel. The prior successful macOS provision used Python 3.12, which also matches the repository setup-python convention.

## Validation

- node --test scripts/starvector-terminal-provision.test.mjs (13 passed)
- npm run check with paired inference test root (749 passed)
- pytest CI subset (169 passed, 19 deselected)
- npm run rust:check with isolated HF_HOME (passed integrity, fmt, clippy, tests, and build)
- actionlint: new hosted workflow clean; existing provision workflow reports only its pre-existing unconfigured self-hosted labels
- action pin check passed for 16 workflows
- git diff --check clean
- measurement quartet unchanged

The hosted Windows wheel job is intentionally the authoritative platform proof; it is path-scoped and bounded to 25 minutes.

Shortcut: SC-22261