### PR TITLE
fix(ci): harden SC-22261 terminal host provisioning

### DIFF
--- a/.github/workflows/starvector-terminal-provision.yml
+++ b/.github/workflows/starvector-terminal-provision.yml
@@ -242,6 +242,9 @@ jobs:
           node scripts/starvector-terminal-provision.mjs download https://huggingface.co/datasets/starvector/svg-fonts-simple/resolve/453c739ea13ad2685127f721c333f14d99485299/data/test-00000-of-00001.parquet "$env:RUNNER_TEMP\starvector-parquet\source-3.parquet" 86db32ae45896a18b938baba088b69d797ae2d5f6d3d79742753a0e2ea89d86d
           if (-not (Test-Path "$env:STARVECTOR_TERMINAL_ROOT\corpora\starvector-terminal-v1")) {
             $inventory = (Get-FileHash -Algorithm SHA256 "$env:STARVECTOR_TERMINAL_ROOT\weights\inventories\prompt-raster-inventory-v1.json").Hash.ToLowerInvariant()
+            # The persistent runner exports sccache through RUSTC_WRAPPER. Compile this
+            # deterministic provisioning artifact directly so stale daemon state cannot abort it.
+            Remove-Item Env:RUSTC_WRAPPER -ErrorAction SilentlyContinue
             cargo run --release --locked -p sceneworks-worker --bin starvector_terminal_corpus -- "$env:STARVECTOR_TERMINAL_ROOT\inference\release\starvector-terminal-corpus-v1.json" "$env:RUNNER_TEMP\starvector-parquet" "$env:STARVECTOR_TERMINAL_ROOT\corpora\starvector-terminal-v1" $env:STARVECTOR_INFERENCE_REVISION $env:STARVECTOR_PROMPT_PROVIDER $env:STARVECTOR_PROMPT_MODEL $env:STARVECTOR_PROMPT_REVISION $inventory
           }
       - name: Read-only readiness validation

--- a/.github/workflows/starvector-terminal-provision.yml
+++ b/.github/workflows/starvector-terminal-provision.yml
@@ -110,21 +110,20 @@ jobs:
       - name: Assemble durable model and product-service closure
         run: |
           node scripts/starvector-terminal-provision.mjs weights "$STARVECTOR_TERMINAL_ROOT" "$STARVECTOR_APP_DATA_SOURCE" "$STARVECTOR_HF_HOME_SOURCE" "$STARVECTOR_PROMPT_PROVIDER" "$STARVECTOR_PROMPT_MODEL" "$STARVECTOR_PROMPT_REVISION"
-      - name: Set up supported CPython 3.12 arm64 for terminal metrics
+      - name: Select supported existing CPython 3.12 arm64 for terminal metrics
         id: metrics-python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-          architecture: arm64
-          check-latest: false
-          update-environment: false
+        run: |
+          bootstrap_python="$(node scripts/select-starvector-macos-python.mjs select /opt/homebrew/bin/python3.12 /usr/local/bin/python3.12)"
+          printf 'python-path=%s\n' "$bootstrap_python" >> "$GITHUB_OUTPUT"
       - name: Provision pinned metric runtime and official checkpoints
         env:
           STARVECTOR_METRICS_BOOTSTRAP_PYTHON: ${{ steps.metrics-python.outputs.python-path }}
         run: |
-          "$STARVECTOR_METRICS_BOOTSTRAP_PYTHON" -c 'import platform,struct,sys; assert sys.version_info[:2] == (3, 12) and platform.python_implementation() == "CPython" and platform.machine().lower() in {"arm64", "aarch64"} and struct.calcsize("P") * 8 == 64'
-          test -x "$STARVECTOR_TERMINAL_ROOT/metrics/bin/python" || "$STARVECTOR_METRICS_BOOTSTRAP_PYTHON" -m venv "$STARVECTOR_TERMINAL_ROOT/metrics"
-          "$STARVECTOR_TERMINAL_ROOT/metrics/bin/python" -c 'import platform,struct,sys; assert sys.version_info[:2] == (3, 12) and platform.python_implementation() == "CPython" and platform.machine().lower() in {"arm64", "aarch64"} and struct.calcsize("P") * 8 == 64'
+          if ! node scripts/select-starvector-macos-python.mjs verify-venv "$STARVECTOR_METRICS_BOOTSTRAP_PYTHON" "$STARVECTOR_TERMINAL_ROOT/metrics/bin/python"; then
+            node scripts/select-starvector-macos-python.mjs remove-metrics-tree "$STARVECTOR_TERMINAL_ROOT/metrics" /Users/Shared/SceneWorks/starvector-terminal/metrics
+            "$STARVECTOR_METRICS_BOOTSTRAP_PYTHON" -m venv "$STARVECTOR_TERMINAL_ROOT/metrics"
+          fi
+          node scripts/select-starvector-macos-python.mjs verify-venv "$STARVECTOR_METRICS_BOOTSTRAP_PYTHON" "$STARVECTOR_TERMINAL_ROOT/metrics/bin/python"
           "$STARVECTOR_TERMINAL_ROOT/metrics/bin/python" -m pip install --disable-pip-version-check --only-binary=:all: --retries 5 --timeout 60 numpy==2.2.6 scikit-image==0.25.2 lpips==0.1.4 torch==2.7.0 torchvision==0.22.0 Pillow==11.3.0 open-clip-torch==3.1.0
           node scripts/starvector-terminal-provision.mjs download https://raw.githubusercontent.com/richzhang/PerceptualSimilarity/master/lpips/weights/v0.1/alex.pth "$STARVECTOR_TERMINAL_ROOT/metrics/checkpoints/lpips-v0.1-alex.pth" df73285e35b22355a2df87cdb6b70b343713b667eddbda73e1977e0c860835c0
           node scripts/starvector-terminal-provision.mjs download https://download.pytorch.org/models/alexnet-owt-7be5be79.pth "$STARVECTOR_TERMINAL_ROOT/metrics/checkpoints/alexnet-owt-7be5be79.pth" 7be5be791159472b1fbf3c69796f7cb30dca7ad8466c2df70058c37116cdee02

--- a/scripts/select-starvector-macos-python.mjs
+++ b/scripts/select-starvector-macos-python.mjs
@@ -6,7 +6,7 @@ import { pathToFileURL } from "node:url";
 import { spawnSync } from "node:child_process";
 
 const DEFAULT_PROBE_TIMEOUT_MS = 15_000;
-const PROBE = `import json,platform,struct,sys;print(json.dumps({"executable":sys.executable,"base_executable":getattr(sys,"_base_executable",None),"version":[sys.version_info.major,sys.version_info.minor,sys.version_info.micro],"implementation":platform.python_implementation(),"architecture":platform.machine(),"pointer_bits":struct.calcsize("P")*8}))`;
+const PROBE = `import json,platform,struct,sys;print(json.dumps({"executable":sys.executable,"base_executable":getattr(sys,"_base_executable",None),"prefix":sys.prefix,"base_prefix":sys.base_prefix,"version":[sys.version_info.major,sys.version_info.minor,sys.version_info.micro],"implementation":platform.python_implementation(),"architecture":platform.machine(),"pointer_bits":struct.calcsize("P")*8}))`;
 
 function safeAbsolutePath(value) {
   return typeof value === "string" && path.isAbsolute(value) && !/[\0\r\n"]/.test(value);
@@ -40,7 +40,9 @@ function parseIdentity(stdout) {
 export function probeStarVectorMacPython(value, { timeoutMs = DEFAULT_PROBE_TIMEOUT_MS } = {}) {
   const executable = executableRealpath(value);
   if (!executable) return null;
-  const probe = spawnSync(executable, ["-c", PROBE], {
+  // Invoke the supplied path, not its realpath: CPython finds a venv's adjacent
+  // pyvenv.cfg through that path even when bin/python is a symlink to the base interpreter.
+  const probe = spawnSync(path.resolve(value), ["-c", PROBE], {
     encoding: "utf8",
     timeout: timeoutMs,
     maxBuffer: 1024 * 1024,
@@ -80,6 +82,23 @@ export function validateStarVectorMacVenv(bootstrapPath, venvPythonPath, options
   if (!baseExecutable || baseExecutable !== bootstrap.executable || venv.identity.version.some((part, index) => part !== bootstrap.identity.version[index])) {
     throw new Error("StarVector terminal metrics venv is not bound to the selected exact CPython 3.12 arm64 interpreter");
   }
+  const expectedPrefix = path.dirname(path.dirname(path.resolve(venvPythonPath)));
+  if (!safeAbsolutePath(venv.identity.prefix) || !safeAbsolutePath(venv.identity.base_prefix)) {
+    throw new Error("StarVector terminal metrics venv does not report valid prefix identities");
+  }
+  let canonicalExpectedPrefix;
+  let canonicalObservedPrefix;
+  let canonicalBasePrefix;
+  try {
+    canonicalExpectedPrefix = realpathSync(expectedPrefix);
+    canonicalObservedPrefix = realpathSync(venv.identity.prefix);
+    canonicalBasePrefix = realpathSync(venv.identity.base_prefix);
+  } catch {
+    throw new Error("StarVector terminal metrics venv does not report valid prefix identities");
+  }
+  if (canonicalObservedPrefix !== canonicalExpectedPrefix || canonicalObservedPrefix === canonicalBasePrefix) {
+    throw new Error("StarVector terminal metrics Python is not an isolated venv at the expected metrics root");
+  }
   return { bootstrap, venv };
 }
 
@@ -113,7 +132,8 @@ export function removeStarVectorMacMetricsTree(targetRoot, allowedRoot) {
     const frame = pending.pop();
     const item = lstatSync(frame.file);
     if (item.isSymbolicLink()) {
-      throw new Error(`refusing to remove a metrics venv containing a symlink: ${frame.file}`);
+      unlinkSync(frame.file);
+      continue;
     }
     if (!item.isDirectory()) {
       if (!item.isFile()) throw new Error(`refusing to remove a metrics venv containing a special file: ${frame.file}`);
@@ -122,11 +142,6 @@ export function removeStarVectorMacMetricsTree(targetRoot, allowedRoot) {
     }
     if (!frame.expanded) {
       const children = readdirSync(frame.file).map((name) => path.join(frame.file, name));
-      for (const child of children) {
-        if (lstatSync(child).isSymbolicLink()) {
-          throw new Error(`refusing to remove a metrics venv containing a symlink: ${child}`);
-        }
-      }
       pending.push({ file: frame.file, expanded: true });
       for (let index = children.length - 1; index >= 0; index -= 1) {
         pending.push({ file: children[index], expanded: false });

--- a/scripts/select-starvector-macos-python.mjs
+++ b/scripts/select-starvector-macos-python.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+
+import { constants, accessSync, lstatSync, readdirSync, realpathSync, rmdirSync, statSync, unlinkSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const DEFAULT_PROBE_TIMEOUT_MS = 15_000;
+const PROBE = `import json,platform,struct,sys;print(json.dumps({"executable":sys.executable,"base_executable":getattr(sys,"_base_executable",None),"version":[sys.version_info.major,sys.version_info.minor,sys.version_info.micro],"implementation":platform.python_implementation(),"architecture":platform.machine(),"pointer_bits":struct.calcsize("P")*8}))`;
+
+function safeAbsolutePath(value) {
+  return typeof value === "string" && path.isAbsolute(value) && !/[\0\r\n"]/.test(value);
+}
+
+function executableRealpath(value) {
+  if (!safeAbsolutePath(value)) return null;
+  try {
+    const resolved = realpathSync(value);
+    if (!statSync(resolved).isFile()) return null;
+    accessSync(resolved, constants.X_OK);
+    return resolved;
+  } catch {
+    return null;
+  }
+}
+
+function parseIdentity(stdout) {
+  let identity;
+  try {
+    identity = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+  if (!identity || typeof identity !== "object" || !Array.isArray(identity.version) || identity.version.length !== 3 || !identity.version.every(Number.isInteger)) {
+    return null;
+  }
+  return identity;
+}
+
+export function probeStarVectorMacPython(value, { timeoutMs = DEFAULT_PROBE_TIMEOUT_MS } = {}) {
+  const executable = executableRealpath(value);
+  if (!executable) return null;
+  const probe = spawnSync(executable, ["-c", PROBE], {
+    encoding: "utf8",
+    timeout: timeoutMs,
+    maxBuffer: 1024 * 1024,
+    windowsHide: true,
+  });
+  if (probe.error || probe.signal || probe.status !== 0) return null;
+  const identity = parseIdentity(probe.stdout);
+  if (!identity) return null;
+  const reportedExecutable = executableRealpath(identity.executable);
+  if (!reportedExecutable || reportedExecutable !== executable) return null;
+  return { executable, identity };
+}
+
+function isSupportedIdentity(identity) {
+  return identity.version[0] === 3 &&
+    identity.version[1] === 12 &&
+    identity.implementation === "CPython" &&
+    ["arm64", "aarch64"].includes(identity.architecture.toLowerCase()) &&
+    identity.pointer_bits === 64;
+}
+
+export function selectStarVectorMacPython(candidatePaths, options) {
+  for (const candidate of candidatePaths) {
+    const result = probeStarVectorMacPython(candidate, options);
+    if (result && isSupportedIdentity(result.identity)) return result;
+  }
+  throw new Error("StarVector terminal metrics require an existing absolute CPython 3.12 arm64 interpreter");
+}
+
+export function validateStarVectorMacVenv(bootstrapPath, venvPythonPath, options) {
+  const bootstrap = selectStarVectorMacPython([bootstrapPath], options);
+  const venv = probeStarVectorMacPython(venvPythonPath, options);
+  if (!venv || !isSupportedIdentity(venv.identity)) {
+    throw new Error("StarVector terminal metrics venv is not a supported CPython 3.12 arm64 interpreter");
+  }
+  const baseExecutable = executableRealpath(venv.identity.base_executable);
+  if (!baseExecutable || baseExecutable !== bootstrap.executable || venv.identity.version.some((part, index) => part !== bootstrap.identity.version[index])) {
+    throw new Error("StarVector terminal metrics venv is not bound to the selected exact CPython 3.12 arm64 interpreter");
+  }
+  return { bootstrap, venv };
+}
+
+function checkedExactRoot(targetRoot, allowedRoot) {
+  if (!safeAbsolutePath(targetRoot) || !safeAbsolutePath(allowedRoot)) {
+    throw new Error("refusing to remove a metrics venv outside the exact workflow-owned terminal root");
+  }
+  const target = path.resolve(targetRoot);
+  const allowed = path.resolve(allowedRoot);
+  if (target !== allowed || target === path.parse(target).root) {
+    throw new Error("refusing to remove a metrics venv outside the exact workflow-owned terminal root");
+  }
+  return target;
+}
+
+export function removeStarVectorMacMetricsTree(targetRoot, allowedRoot) {
+  const target = checkedExactRoot(targetRoot, allowedRoot);
+  let root;
+  try {
+    root = lstatSync(target);
+  } catch (error) {
+    if (error?.code === "ENOENT") return;
+    throw error;
+  }
+  if (root.isSymbolicLink()) {
+    throw new Error(`refusing to remove a metrics venv containing a symlink: ${target}`);
+  }
+
+  const pending = [{ file: target, expanded: false }];
+  while (pending.length > 0) {
+    const frame = pending.pop();
+    const item = lstatSync(frame.file);
+    if (item.isSymbolicLink()) {
+      throw new Error(`refusing to remove a metrics venv containing a symlink: ${frame.file}`);
+    }
+    if (!item.isDirectory()) {
+      if (!item.isFile()) throw new Error(`refusing to remove a metrics venv containing a special file: ${frame.file}`);
+      unlinkSync(frame.file);
+      continue;
+    }
+    if (!frame.expanded) {
+      const children = readdirSync(frame.file).map((name) => path.join(frame.file, name));
+      for (const child of children) {
+        if (lstatSync(child).isSymbolicLink()) {
+          throw new Error(`refusing to remove a metrics venv containing a symlink: ${child}`);
+        }
+      }
+      pending.push({ file: frame.file, expanded: true });
+      for (let index = children.length - 1; index >= 0; index -= 1) {
+        pending.push({ file: children[index], expanded: false });
+      }
+      continue;
+    }
+    if (readdirSync(frame.file).length !== 0) {
+      throw new Error(`refusing to remove a metrics venv that changed during validation: ${frame.file}`);
+    }
+    rmdirSync(frame.file);
+  }
+}
+
+function usage() {
+  throw new Error("usage: select-starvector-macos-python.mjs select <absolute candidates...> | verify-venv <bootstrap> <venv-python> | remove-metrics-tree <target> <exact-allowed-root>");
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const [command, ...args] = argv;
+  if (command === "select" && args.length > 0) {
+    process.stdout.write(`${selectStarVectorMacPython(args).executable}\n`);
+    return;
+  }
+  if (command === "verify-venv" && args.length === 2) {
+    validateStarVectorMacVenv(args[0], args[1]);
+    return;
+  }
+  if (command === "remove-metrics-tree" && args.length === 2) {
+    removeStarVectorMacMetricsTree(args[0], args[1]);
+    return;
+  }
+  usage();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/starvector-terminal-provision.test.mjs
+++ b/scripts/starvector-terminal-provision.test.mjs
@@ -80,6 +80,30 @@ test("provision workflow is dispatch-only and never runs a model, service, campa
   assert.doesNotMatch(workflow, /STARVECTOR_PROMPT_PROVIDER: flux_diffusers/);
 });
 
+function assertWindowsCorpusCompilesWithoutInheritedRustcWrapper(workflowSource) {
+  const jobStart = workflowSource.indexOf("  provision-windows:");
+  const stepStart = workflowSource.indexOf("- name: Materialize the exact pinned 120-row corpus", jobStart);
+  const stepEnd = workflowSource.indexOf("- name: Read-only readiness validation", stepStart);
+  assert.ok(jobStart >= 0 && stepStart > jobStart && stepEnd > stepStart);
+  const step = workflowSource.slice(stepStart, stepEnd);
+  const clearWrapper = step.indexOf("Remove-Item Env:RUSTC_WRAPPER -ErrorAction SilentlyContinue");
+  const cargo = step.indexOf("cargo run --release --locked -p sceneworks-worker --bin starvector_terminal_corpus");
+  assert.equal((step.match(/Remove-Item Env:RUSTC_WRAPPER -ErrorAction SilentlyContinue/g) ?? []).length, 1);
+  assert.ok(clearWrapper >= 0 && clearWrapper < cargo);
+}
+
+test("Windows corpus compilation cannot inherit the persistent runner's sccache wrapper", () => {
+  assertWindowsCorpusCompilesWithoutInheritedRustcWrapper(workflow);
+  for (const [label, mutation] of [
+    ["missing wrapper clear", (value) => value.replace("Remove-Item Env:RUSTC_WRAPPER -ErrorAction SilentlyContinue", "Write-Host $env:RUSTC_WRAPPER")],
+    ["wrapper cleared after Cargo", (value) => value.replace(/(\s+)(Remove-Item Env:RUSTC_WRAPPER -ErrorAction SilentlyContinue)(\s+)(cargo run --release --locked -p sceneworks-worker --bin starvector_terminal_corpus[^\n]+)/, "$1$4$3$2")],
+  ]) {
+    const changed = mutation(workflow);
+    assert.notEqual(changed, workflow, `${label} mutation must alter the workflow fixture`);
+    assert.throws(() => assertWindowsCorpusCompilesWithoutInheritedRustcWrapper(changed), { name: "AssertionError" }, label);
+  }
+});
+
 function assertWindowsMetricsPythonContract(step) {
   assert.doesNotMatch(step, /\bpy\s+-3\.11\b/);
   assert.match(step, /select-starvector-windows-python\.ps1/);

--- a/scripts/starvector-terminal-provision.test.mjs
+++ b/scripts/starvector-terminal-provision.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile as execFileCallback } from "node:child_process";
 import { createHash } from "node:crypto";
-import { lstat, mkdir, mkdtemp, readFile, rename, symlink, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, readFile, realpath, rename, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { Readable } from "node:stream";
@@ -9,6 +9,7 @@ import test from "node:test";
 import { promisify } from "node:util";
 import { fileSha256 } from "./lib/file-sha256.mjs";
 import { terminalTreeEntry, terminalTreeSha256 } from "./lib/terminal-tree-identity.mjs";
+import { removeStarVectorMacMetricsTree, selectStarVectorMacPython, validateStarVectorMacVenv } from "./select-starvector-macos-python.mjs";
 import { assemblePreflight, assembleWeights, downloadExact, installCheckout, tree } from "./starvector-terminal-provision.mjs";
 import { validateTerminalServiceClosure } from "./starvector-terminal-readiness.mjs";
 
@@ -17,6 +18,7 @@ const digest = (value) => createHash("sha256").update(value).digest("hex");
 const workflow = await readFile(".github/workflows/starvector-terminal-provision.yml", "utf8");
 const windowsWorkflow = await readFile(".github/workflows/desktop-windows.yml", "utf8");
 const windowsWheelWorkflow = await readFile(".github/workflows/starvector-metrics-windows.yml", "utf8");
+const macosPythonSelector = await readFile("scripts/select-starvector-macos-python.mjs", "utf8");
 const windowsPythonProbe = await readFile("scripts/select-starvector-windows-python.ps1", "utf8");
 const windowsPythonProbeTest = await readFile("scripts/select-starvector-windows-python.test.ps1", "utf8");
 const windowsWheelVerification = await readFile("scripts/verify-starvector-windows-metric-wheels.ps1", "utf8");
@@ -153,14 +155,21 @@ function assertWindowsPythonProbeContract(source) {
 }
 
 test("terminal metrics provisioning fixes CPython 3.12 and wheel-only installation on both hosts", () => {
-  assert.equal((workflow.match(/uses: actions\/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97/g) ?? []).length, 2);
-  assert.equal((workflow.match(/python-version: "3\.12"/g) ?? []).length, 2);
-  assert.equal((workflow.match(/update-environment: false/g) ?? []).length, 2);
-  assert.match(workflow, /Set up supported CPython 3\.12 arm64 for terminal metrics[\s\S]*?architecture: arm64/);
+  assert.equal((workflow.match(/uses: actions\/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97/g) ?? []).length, 1);
+  assert.equal((workflow.match(/python-version: "3\.12"/g) ?? []).length, 1);
+  assert.equal((workflow.match(/update-environment: false/g) ?? []).length, 1);
+  assert.match(workflow, /Select supported existing CPython 3\.12 arm64 for terminal metrics/);
+  assert.match(workflow, /select-starvector-macos-python\.mjs select \/opt\/homebrew\/bin\/python3\.12 \/usr\/local\/bin\/python3\.12/);
+  assert.match(workflow, /select-starvector-macos-python\.mjs verify-venv "\$STARVECTOR_METRICS_BOOTSTRAP_PYTHON" "\$STARVECTOR_TERMINAL_ROOT\/metrics\/bin\/python"/);
+  assert.match(workflow, /remove-metrics-tree "\$STARVECTOR_TERMINAL_ROOT\/metrics" \/Users\/Shared\/SceneWorks\/starvector-terminal\/metrics/);
+  assert.doesNotMatch(workflow.slice(workflow.indexOf("  provision-macos:"), workflow.indexOf("  provision-windows:")), /actions\/setup-python|RUNNER_TOOL_CACHE|AGENT_TOOLSDIRECTORY|\/Users\/runner\/hostedtoolcache/);
   assert.match(workflow, /Set up supported CPython 3\.12 x64 for terminal metrics[\s\S]*?architecture: x64/);
   assert.equal((workflow.match(/pip install --disable-pip-version-check --only-binary=:all: --retries 5 --timeout 60/g) ?? []).length, 2);
   assert.doesNotMatch(workflow, /pip install --disable-pip-version-check (?!.*--only-binary=:all:)/);
-  assert.match(workflow, /sys\.version_info\[:2\] == \(3, 12\)[^\n]*platform\.machine\(\)\.lower\(\) in \{"arm64", "aarch64"\}/);
+  assert.match(macosPythonSelector, /identity\.version\[1\] === 12/);
+  assert.match(macosPythonSelector, /identity\.implementation === "CPython"/);
+  assert.match(macosPythonSelector, /\["arm64", "aarch64"\]\.includes\(identity\.architecture\.toLowerCase\(\)\)/);
+  assert.match(macosPythonSelector, /identity\.pointer_bits === 64/);
 
   const start = workflow.indexOf("- name: Provision pinned metric runtime and official checkpoints", workflow.indexOf("  provision-windows:"));
   const end = workflow.indexOf("- name: Materialize the exact pinned 120-row corpus", start);
@@ -172,6 +181,53 @@ test("terminal metrics provisioning fixes CPython 3.12 and wheel-only installati
   for (const rejected of ["python.exe", "C:python.exe", "\\python.exe", "\\\\server\\share\\python.exe", "C:/Python312/python.exe", "C:\\Python312\\py\nthon.exe", 'C:\\Python312\\py"thon.exe']) {
     assert.equal(isSafeDriveAbsolute(rejected), false, rejected);
   }
+});
+
+test("macOS Python selection ignores unwritable action caches and verifies the exact venv base and micro", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "starvector-macos-python-"));
+  const writeFakePython = async (name, identity, exitCode = 0) => {
+    const executable = path.join(root, name);
+    const payload = JSON.stringify({ executable, base_executable: identity.base_executable ?? executable, ...identity });
+    await writeFile(executable, `#!/bin/sh\nprintf '%s\\n' '${payload}'\nexit ${exitCode}\n`);
+    await chmod(executable, 0o755);
+    return executable;
+  };
+  const invalid = await writeFakePython("python-invalid", { version: [3, 14, 1], implementation: "CPython", architecture: "arm64", pointer_bits: 64 });
+  const bootstrap = await writeFakePython("python-valid", { version: [3, 12, 13], implementation: "CPython", architecture: "arm64", pointer_bits: 64 });
+  const venv = await writeFakePython("venv-python", { base_executable: bootstrap, version: [3, 12, 13], implementation: "CPython", architecture: "arm64", pointer_bits: 64 });
+  const previousRunnerCache = process.env.RUNNER_TOOL_CACHE;
+  const previousAgentTools = process.env.AGENT_TOOLSDIRECTORY;
+  process.env.RUNNER_TOOL_CACHE = "/root/unwritable-hostedtoolcache";
+  process.env.AGENT_TOOLSDIRECTORY = "/root/unwritable-agent-tools";
+  try {
+    assert.equal(selectStarVectorMacPython([invalid, bootstrap]).executable, await realpath(bootstrap));
+    assert.equal(validateStarVectorMacVenv(bootstrap, venv).venv.identity.version[2], 13);
+  } finally {
+    if (previousRunnerCache === undefined) delete process.env.RUNNER_TOOL_CACHE; else process.env.RUNNER_TOOL_CACHE = previousRunnerCache;
+    if (previousAgentTools === undefined) delete process.env.AGENT_TOOLSDIRECTORY; else process.env.AGENT_TOOLSDIRECTORY = previousAgentTools;
+  }
+  const wrongMicro = await writeFakePython("venv-wrong-micro", { base_executable: bootstrap, version: [3, 12, 12], implementation: "CPython", architecture: "arm64", pointer_bits: 64 });
+  assert.throws(() => validateStarVectorMacVenv(bootstrap, wrongMicro), /selected exact CPython/);
+  await chmod(bootstrap, 0o644);
+  assert.throws(() => selectStarVectorMacPython([bootstrap]), /existing absolute CPython/);
+});
+
+test("macOS stale metrics cleanup is exact-root bounded and refuses symlink escape", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "starvector-macos-metrics-"));
+  const metrics = path.join(root, "metrics");
+  const outside = path.join(root, "outside");
+  await mkdir(path.join(metrics, "nested"), { recursive: true });
+  await mkdir(outside, { recursive: true });
+  await writeFile(path.join(metrics, "nested", "inside.txt"), "inside");
+  await writeFile(path.join(outside, "sentinel.txt"), "outside");
+  assert.throws(() => removeStarVectorMacMetricsTree(metrics, path.join(root, "wrong")), /exact workflow-owned terminal root/);
+  await symlink(outside, path.join(metrics, "escape"));
+  assert.throws(() => removeStarVectorMacMetricsTree(metrics, metrics), /containing a symlink/);
+  assert.equal(await readFile(path.join(outside, "sentinel.txt"), "utf8"), "outside");
+  await rename(path.join(metrics, "escape"), path.join(root, "detached-symlink"));
+  removeStarVectorMacMetricsTree(metrics, metrics);
+  assert.equal(await lstat(metrics).catch((error) => error.code === "ENOENT" ? null : Promise.reject(error)), null);
+  assert.equal(await readFile(path.join(outside, "sentinel.txt"), "utf8"), "outside");
 });
 
 test("Windows Python probes capture native stderr without invoking through PowerShell", () => {

--- a/scripts/starvector-terminal-provision.test.mjs
+++ b/scripts/starvector-terminal-provision.test.mjs
@@ -194,6 +194,11 @@ test("terminal metrics provisioning fixes CPython 3.12 and wheel-only installati
   assert.match(macosPythonSelector, /identity\.implementation === "CPython"/);
   assert.match(macosPythonSelector, /\["arm64", "aarch64"\]\.includes\(identity\.architecture\.toLowerCase\(\)\)/);
   assert.match(macosPythonSelector, /identity\.pointer_bits === 64/);
+  assert.match(macosPythonSelector, /"prefix":sys\.prefix,"base_prefix":sys\.base_prefix/);
+  assert.match(macosPythonSelector, /spawnSync\(path\.resolve\(value\)/);
+  assert.doesNotMatch(macosPythonSelector, /spawnSync\(executable,/);
+  assert.match(macosPythonSelector, /canonicalObservedPrefix !== canonicalExpectedPrefix \|\| canonicalObservedPrefix === canonicalBasePrefix/);
+  assert.match(macosPythonSelector, /if \(item\.isSymbolicLink\(\)\) \{\s+unlinkSync\(frame\.file\);/);
 
   const start = workflow.indexOf("- name: Provision pinned metric runtime and official checkpoints", workflow.indexOf("  provision-windows:"));
   const end = workflow.indexOf("- name: Materialize the exact pinned 120-row corpus", start);
@@ -211,14 +216,21 @@ test("macOS Python selection ignores unwritable action caches and verifies the e
   const root = await mkdtemp(path.join(tmpdir(), "starvector-macos-python-"));
   const writeFakePython = async (name, identity, exitCode = 0) => {
     const executable = path.join(root, name);
-    const payload = JSON.stringify({ executable, base_executable: identity.base_executable ?? executable, ...identity });
+    await mkdir(path.dirname(executable), { recursive: true });
+    const payload = JSON.stringify({
+      executable,
+      base_executable: identity.base_executable ?? executable,
+      prefix: identity.prefix ?? path.dirname(path.dirname(executable)),
+      base_prefix: identity.base_prefix ?? root,
+      ...identity,
+    });
     await writeFile(executable, `#!/bin/sh\nprintf '%s\\n' '${payload}'\nexit ${exitCode}\n`);
     await chmod(executable, 0o755);
     return executable;
   };
   const invalid = await writeFakePython("python-invalid", { version: [3, 14, 1], implementation: "CPython", architecture: "arm64", pointer_bits: 64 });
-  const bootstrap = await writeFakePython("python-valid", { version: [3, 12, 13], implementation: "CPython", architecture: "arm64", pointer_bits: 64 });
-  const venv = await writeFakePython("venv-python", { base_executable: bootstrap, version: [3, 12, 13], implementation: "CPython", architecture: "arm64", pointer_bits: 64 });
+  const bootstrap = await writeFakePython("python-valid", { prefix: root, base_prefix: root, version: [3, 12, 13], implementation: "CPython", architecture: "arm64", pointer_bits: 64 });
+  const venv = await writeFakePython("metrics/bin/python", { base_executable: bootstrap, version: [3, 12, 13], implementation: "CPython", architecture: "arm64", pointer_bits: 64 });
   const previousRunnerCache = process.env.RUNNER_TOOL_CACHE;
   const previousAgentTools = process.env.AGENT_TOOLSDIRECTORY;
   process.env.RUNNER_TOOL_CACHE = "/root/unwritable-hostedtoolcache";
@@ -230,27 +242,53 @@ test("macOS Python selection ignores unwritable action caches and verifies the e
     if (previousRunnerCache === undefined) delete process.env.RUNNER_TOOL_CACHE; else process.env.RUNNER_TOOL_CACHE = previousRunnerCache;
     if (previousAgentTools === undefined) delete process.env.AGENT_TOOLSDIRECTORY; else process.env.AGENT_TOOLSDIRECTORY = previousAgentTools;
   }
-  const wrongMicro = await writeFakePython("venv-wrong-micro", { base_executable: bootstrap, version: [3, 12, 12], implementation: "CPython", architecture: "arm64", pointer_bits: 64 });
+  assert.throws(() => validateStarVectorMacVenv(bootstrap, bootstrap), /not an isolated venv/);
+  const wrongMicro = await writeFakePython("wrong-metrics/bin/python", { base_executable: bootstrap, version: [3, 12, 12], implementation: "CPython", architecture: "arm64", pointer_bits: 64 });
   assert.throws(() => validateStarVectorMacVenv(bootstrap, wrongMicro), /selected exact CPython/);
   await chmod(bootstrap, 0o644);
   assert.throws(() => selectStarVectorMacPython([bootstrap]), /existing absolute CPython/);
 });
 
-test("macOS stale metrics cleanup is exact-root bounded and refuses symlink escape", async () => {
+function selectLocalMacPythonOrSkip(context) {
+  try {
+    return selectStarVectorMacPython(["/opt/homebrew/bin/python3.12", "/usr/local/bin/python3.12"]);
+  } catch {
+    context.skip("requires a local CPython 3.12 arm64 interpreter");
+    return null;
+  }
+}
+
+test("macOS venv validation executes the supplied venv path and rejects the bootstrap itself", async (context) => {
+  const bootstrap = selectLocalMacPythonOrSkip(context);
+  if (!bootstrap) return;
+  const root = await mkdtemp(path.join(tmpdir(), "starvector-real-macos-venv-"));
+  const metrics = path.join(root, "metrics");
+  await execFile(bootstrap.executable, ["-m", "venv", metrics]);
+  const validated = validateStarVectorMacVenv(bootstrap.executable, path.join(metrics, "bin", "python"));
+  assert.equal(await realpath(validated.venv.identity.prefix), await realpath(metrics));
+  assert.notEqual(await realpath(validated.venv.identity.prefix), await realpath(validated.venv.identity.base_prefix));
+  assert.throws(() => validateStarVectorMacVenv(bootstrap.executable, bootstrap.executable), /not an isolated venv/);
+  removeStarVectorMacMetricsTree(metrics, metrics);
+});
+
+test("macOS stale metrics cleanup removes real venv symlinks without traversing external targets", async (context) => {
+  const bootstrap = selectLocalMacPythonOrSkip(context);
+  if (!bootstrap) return;
   const root = await mkdtemp(path.join(tmpdir(), "starvector-macos-metrics-"));
   const metrics = path.join(root, "metrics");
   const outside = path.join(root, "outside");
-  await mkdir(path.join(metrics, "nested"), { recursive: true });
+  await execFile(bootstrap.executable, ["-m", "venv", metrics]);
   await mkdir(outside, { recursive: true });
-  await writeFile(path.join(metrics, "nested", "inside.txt"), "inside");
   await writeFile(path.join(outside, "sentinel.txt"), "outside");
   assert.throws(() => removeStarVectorMacMetricsTree(metrics, path.join(root, "wrong")), /exact workflow-owned terminal root/);
-  await symlink(outside, path.join(metrics, "escape"));
-  assert.throws(() => removeStarVectorMacMetricsTree(metrics, metrics), /containing a symlink/);
-  assert.equal(await readFile(path.join(outside, "sentinel.txt"), "utf8"), "outside");
-  await rename(path.join(metrics, "escape"), path.join(root, "detached-symlink"));
+  await symlink(outside, path.join(metrics, "external-link"));
   removeStarVectorMacMetricsTree(metrics, metrics);
   assert.equal(await lstat(metrics).catch((error) => error.code === "ENOENT" ? null : Promise.reject(error)), null);
+  assert.equal(await readFile(path.join(outside, "sentinel.txt"), "utf8"), "outside");
+
+  const rootSymlink = path.join(root, "metrics-root-link");
+  await symlink(outside, rootSymlink);
+  assert.throws(() => removeStarVectorMacMetricsTree(rootSymlink, rootSymlink), /root is a symlink|containing a symlink/);
   assert.equal(await readFile(path.join(outside, "sentinel.txt"), "utf8"), "outside");
 });
 


### PR DESCRIPTION
## Summary

- Replace setup-python on the self-hosted Apple Silicon runner with selection of an existing absolute CPython 3.12 arm64 interpreter, including exact interpreter, micro-version, venv-base, and deletion-boundary validation.
- Keep Windows setup-python unchanged because run 33823364052 ultimately installed exact CPython 3.12.10 x64 and the wheel-only metric closure successfully.
- Clear inherited RUSTC_WRAPPER immediately before the Windows starvector_terminal_corpus Cargo invocation so persistent sccache daemon state cannot abort deterministic corpus publication.

## Terminal-run evidence

Provision run 33823364052 exposed two distinct host defects:

1. macOS setup-python downloaded its package, then attempted to create /Users/runner and failed with permission denied. The replacement uses only supported absolute Homebrew CPython 3.12 candidates and fails closed on version, architecture, implementation, executable identity, or venv-base drift.
2. Windows setup-python completed after 53m04s. The later corpus build inherited D:\tools\bin\sccache.exe through RUSTC_WRAPPER; its persistent connection reset with Windows error 10054 while compiling candle-nn and sceneworks-core, so the corpus index was never published. The wrapper is now removed only inside that provisioning step, immediately before Cargo.

## Validation

- node --test scripts/starvector-terminal-provision.test.mjs: 16/16 passed, including missing and reordered wrapper-clear mutations.
- npm run rust:check: passed tier integrity, rustfmt, Clippy with warnings denied, all Rust tests, and cargo build.
- npm run check: 718/721 passed. The three failures are environment-fixture-only: missing ajv in the CUDA harness fixture and two tests requiring the absent sibling inference integration checkout.
- actionlint: workflow syntax passed; only the existing custom self-hosted runner-label warnings remain.
- git diff --check: passed.

The sealed quartet remains byte-identical:

- config/memory-anchors.json: b156e9db050373afa86dfbb812e0ae7802f802e14da741373dbe9aab898de7d5
- docs/generated/memory-matrix.json: 2408b7de390e847824c95aa449991638a1892b5fbfc4e12cba9c74fc60c99d8d
- docs/generated/memory-matrix.md: 44177f6a54a15bbd0dbb401204082c9839bd111aaae5293b544935342f178a2f
- release/starvector-terminal-metrics-lock-v1.json: 8ab96cf63a6846aadd351d43cd50c91de747b694cc5b450a29a699a2c843f115