### PR TITLE
fix(ci): provision portable Windows Python

### DIFF
--- a/.github/workflows/starvector-metrics-windows.yml
+++ b/.github/workflows/starvector-metrics-windows.yml
@@ -6,6 +6,8 @@ on:
       - ".github/workflows/starvector-metrics-windows.yml"
       - ".github/workflows/starvector-terminal-provision.yml"
       - "release/starvector-terminal-metrics-lock-v1.json"
+      - "scripts/provision-starvector-windows-python.ps1"
+      - "scripts/provision-starvector-windows-python.test.ps1"
       - "scripts/select-starvector-windows-python.ps1"
       - "scripts/select-starvector-windows-python.test.ps1"
       - "scripts/starvector-terminal-provision.test.mjs"
@@ -37,6 +39,10 @@ jobs:
       - name: Reject unsupported Windows Python identities under PowerShell 5.1
         shell: powershell
         run: .\scripts\select-starvector-windows-python.test.ps1
+      - name: Verify portable CPython provisioning under PowerShell 5.1
+        shell: powershell
+        timeout-minutes: 10
+        run: .\scripts\provision-starvector-windows-python.test.ps1
       - name: Resolve and install the pinned metric closure from wheels
         shell: powershell
         env:

--- a/.github/workflows/starvector-terminal-provision.yml
+++ b/.github/workflows/starvector-terminal-provision.yml
@@ -187,51 +187,47 @@ jobs:
           node scripts/starvector-terminal-provision.mjs checkout "$env:GITHUB_WORKSPACE\inference-source" "$env:STARVECTOR_TERMINAL_ROOT\inference" $env:STARVECTOR_INFERENCE_REVISION
           node scripts/starvector-terminal-provision.mjs preflight "$env:RUNNER_TEMP\starvector-preflight" "$env:STARVECTOR_TERMINAL_ROOT\inference-preflight" $env:STARVECTOR_INFERENCE_REVISION
           node scripts/starvector-terminal-provision.mjs weights $env:STARVECTOR_TERMINAL_ROOT $env:STARVECTOR_APP_DATA_SOURCE $env:STARVECTOR_HF_HOME_SOURCE $env:STARVECTOR_PROMPT_PROVIDER $env:STARVECTOR_PROMPT_MODEL $env:STARVECTOR_PROMPT_REVISION
-      - name: Set up supported CPython 3.12 x64 for terminal metrics
-        id: metrics-python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-          architecture: x64
-          check-latest: false
-          update-environment: false
-      - name: Provision pinned metric runtime and official checkpoints
+      - name: Provision exact portable CPython 3.12.10 x64 and terminal metrics
         shell: powershell
-        env:
-          STARVECTOR_METRICS_BOOTSTRAP_PYTHON: ${{ steps.metrics-python.outputs.python-path }}
+        timeout-minutes: 70
         run: |
-          . (Join-Path $PWD 'scripts\select-starvector-windows-python.ps1')
-          $bootstrap = Select-StarVectorBootstrapPython -CandidatePaths @($env:STARVECTOR_METRICS_BOOTSTRAP_PYTHON)
-          $bootstrapPython = $bootstrap.Executable
-          $bootstrapIdentity = $bootstrap.Identity
-          $metricsRoot = Join-Path $env:STARVECTOR_TERMINAL_ROOT 'metrics'
-          $metricsPython = Join-Path $metricsRoot 'Scripts\python.exe'
-          $rebuildMetricsVenv = -not (Test-Path $metricsPython -PathType Leaf)
-          if (-not $rebuildMetricsVenv) {
-            $existingProbe = Invoke-StarVectorPythonIdentityProbe -Executable $metricsPython -IncludeBaseExecutable
-            try { $existingIdentity = $existingProbe.StdOut | ConvertFrom-Json -ErrorAction Stop } catch { $existingIdentity = $null }
-            $existingBasePython = if ($existingIdentity) { Resolve-StarVectorWindowsExecutable $existingIdentity.base_executable } else { $null }
-            $rebuildMetricsVenv = $existingProbe.ExitCode -ne 0 -or -not $existingIdentity -or -not $existingBasePython -or -not [StringComparer]::OrdinalIgnoreCase.Equals($bootstrapPython, $existingBasePython) -or $existingIdentity.version.Count -ne 3 -or [int]$existingIdentity.version[0] -ne [int]$bootstrapIdentity.version[0] -or [int]$existingIdentity.version[1] -ne [int]$bootstrapIdentity.version[1] -or [int]$existingIdentity.version[2] -ne [int]$bootstrapIdentity.version[2] -or [string]$existingIdentity.implementation -cne 'CPython' -or [string]$existingIdentity.architecture -cne 'AMD64' -or [int]$existingIdentity.pointer_bits -ne 64
+          . (Join-Path $PWD 'scripts\provision-starvector-windows-python.ps1')
+          $pythonRoot = Join-Path $env:STARVECTOR_TERMINAL_ROOT 'python\cpython-3.12.10-x64-nuget'
+          $lockPath = Join-Path $env:STARVECTOR_TERMINAL_ROOT '.locks\cpython-3.12.10-x64-nuget.lock'
+          Invoke-StarVectorWindowsPythonLock -LockPath $lockPath -ScriptBlock {
+            $bootstrapPython = Install-StarVectorWindowsPythonPackage -DestinationRoot $pythonRoot -AllowedRoot $pythonRoot -RunnerTemp $env:RUNNER_TEMP
+            $bootstrap = Select-StarVectorBootstrapPython -CandidatePaths @($bootstrapPython) -ExpectedVersion @(3, 12, 10)
+            $bootstrapPython = $bootstrap.Executable
+            $bootstrapIdentity = $bootstrap.Identity
+            $metricsRoot = Join-Path $env:STARVECTOR_TERMINAL_ROOT 'metrics'
+            $metricsPython = Join-Path $metricsRoot 'Scripts\python.exe'
+            $rebuildMetricsVenv = -not (Test-Path $metricsPython -PathType Leaf)
+            if (-not $rebuildMetricsVenv) {
+              $existingProbe = Invoke-StarVectorPythonIdentityProbe -Executable $metricsPython -IncludeBaseExecutable
+              try { $existingIdentity = $existingProbe.StdOut | ConvertFrom-Json -ErrorAction Stop } catch { $existingIdentity = $null }
+              $existingBasePython = if ($existingIdentity) { Resolve-StarVectorWindowsExecutable $existingIdentity.base_executable } else { $null }
+              $rebuildMetricsVenv = $existingProbe.ExitCode -ne 0 -or -not $existingIdentity -or -not $existingBasePython -or -not [StringComparer]::OrdinalIgnoreCase.Equals($bootstrapPython, $existingBasePython) -or $existingIdentity.version.Count -ne 3 -or [int]$existingIdentity.version[0] -ne [int]$bootstrapIdentity.version[0] -or [int]$existingIdentity.version[1] -ne [int]$bootstrapIdentity.version[1] -or [int]$existingIdentity.version[2] -ne [int]$bootstrapIdentity.version[2] -or [string]$existingIdentity.implementation -cne 'CPython' -or [string]$existingIdentity.architecture -cne 'AMD64' -or [int]$existingIdentity.pointer_bits -ne 64
+            }
+            if ($rebuildMetricsVenv) {
+              Remove-StarVectorWindowsDirectoryTree -TargetRoot $metricsRoot -AllowedRoot 'D:\sceneworks-terminal\metrics'
+              & $bootstrapPython -m venv --copies $metricsRoot
+              if ($LASTEXITCODE -ne 0) { throw 'failed to create the terminal metrics venv with the selected Python interpreter' }
+            }
+            if (-not (Test-Path $metricsPython -PathType Leaf)) { throw 'terminal metrics venv did not publish Scripts\python.exe' }
+            $venvProbe = Invoke-StarVectorPythonIdentityProbe -Executable $metricsPython -IncludeBaseExecutable
+            if ($venvProbe.ExitCode -ne 0) { throw 'terminal metrics venv Python identity probe failed' }
+            try { $venvIdentity = $venvProbe.StdOut | ConvertFrom-Json -ErrorAction Stop } catch { throw 'terminal metrics venv Python identity is not valid JSON' }
+            $expectedMetricsPython = Resolve-StarVectorWindowsExecutable $metricsPython
+            $observedMetricsPython = Resolve-StarVectorWindowsExecutable $venvIdentity.executable
+            $observedBasePython = Resolve-StarVectorWindowsExecutable $venvIdentity.base_executable
+            if (-not $expectedMetricsPython -or -not $observedMetricsPython -or -not $observedBasePython -or -not [StringComparer]::OrdinalIgnoreCase.Equals($expectedMetricsPython, $observedMetricsPython) -or -not [StringComparer]::OrdinalIgnoreCase.Equals($bootstrapPython, $observedBasePython) -or $venvIdentity.version.Count -ne 3 -or [int]$venvIdentity.version[0] -ne [int]$bootstrapIdentity.version[0] -or [int]$venvIdentity.version[1] -ne [int]$bootstrapIdentity.version[1] -or [int]$venvIdentity.version[2] -ne [int]$bootstrapIdentity.version[2] -or [string]$venvIdentity.implementation -cne 'CPython' -or [string]$venvIdentity.architecture -cne 'AMD64' -or [int]$venvIdentity.pointer_bits -ne 64) { throw 'terminal metrics venv is not bound to the selected exact CPython 3.12.10 x64 interpreter' }
+            & $metricsPython -m pip install --disable-pip-version-check --only-binary=:all: --retries 5 --timeout 60 numpy==2.2.6 scikit-image==0.25.2 lpips==0.1.4 torch==2.7.0 torchvision==0.22.0 Pillow==11.3.0 open-clip-torch==3.1.0
+            if ($LASTEXITCODE -ne 0) { throw 'failed to install the pinned terminal metrics package closure' }
+            node scripts/starvector-terminal-provision.mjs download https://raw.githubusercontent.com/richzhang/PerceptualSimilarity/master/lpips/weights/v0.1/alex.pth "$env:STARVECTOR_TERMINAL_ROOT\metrics\checkpoints\lpips-v0.1-alex.pth" df73285e35b22355a2df87cdb6b70b343713b667eddbda73e1977e0c860835c0
+            node scripts/starvector-terminal-provision.mjs download https://download.pytorch.org/models/alexnet-owt-7be5be79.pth "$env:STARVECTOR_TERMINAL_ROOT\metrics\checkpoints\alexnet-owt-7be5be79.pth" 7be5be791159472b1fbf3c69796f7cb30dca7ad8466c2df70058c37116cdee02
+            node scripts/starvector-terminal-provision.mjs download https://huggingface.co/laion/CLIP-ViT-B-32-laion2B-s34B-b79K/resolve/1a25a446712ba5ee05982a381eed697ef9b435cf/open_clip_pytorch_model.bin "$env:STARVECTOR_TERMINAL_ROOT\metrics\checkpoints\open_clip_pytorch_model.bin" 1bd3c7172de5b207ceac554f5ab5266166f3b9baccc9af5989bc801016d080ad
+            node scripts/starvector-terminal-provision.mjs metrics "$env:GITHUB_WORKSPACE\sceneworks" $metricsRoot $metricsPython $env:STARVECTOR_CLIP_REVISION
           }
-          if ($rebuildMetricsVenv) {
-            Remove-StarVectorWindowsDirectoryTree -TargetRoot $metricsRoot -AllowedRoot 'D:\sceneworks-terminal\metrics'
-            & $bootstrapPython -m venv $metricsRoot
-            if ($LASTEXITCODE -ne 0) { throw 'failed to create the terminal metrics venv with the selected Python interpreter' }
-          }
-          if (-not (Test-Path $metricsPython -PathType Leaf)) { throw 'terminal metrics venv did not publish Scripts\python.exe' }
-          $venvProbe = Invoke-StarVectorPythonIdentityProbe -Executable $metricsPython -IncludeBaseExecutable
-          if ($venvProbe.ExitCode -ne 0) { throw 'terminal metrics venv Python identity probe failed' }
-          try { $venvIdentity = $venvProbe.StdOut | ConvertFrom-Json -ErrorAction Stop } catch { throw 'terminal metrics venv Python identity is not valid JSON' }
-          $expectedMetricsPython = Resolve-StarVectorWindowsExecutable $metricsPython
-          $observedMetricsPython = Resolve-StarVectorWindowsExecutable $venvIdentity.executable
-          $observedBasePython = Resolve-StarVectorWindowsExecutable $venvIdentity.base_executable
-          if (-not $expectedMetricsPython -or -not $observedMetricsPython -or -not $observedBasePython -or -not [StringComparer]::OrdinalIgnoreCase.Equals($expectedMetricsPython, $observedMetricsPython) -or -not [StringComparer]::OrdinalIgnoreCase.Equals($bootstrapPython, $observedBasePython) -or $venvIdentity.version.Count -ne 3 -or [int]$venvIdentity.version[0] -ne [int]$bootstrapIdentity.version[0] -or [int]$venvIdentity.version[1] -ne [int]$bootstrapIdentity.version[1] -or [int]$venvIdentity.version[2] -ne [int]$bootstrapIdentity.version[2] -or [string]$venvIdentity.implementation -cne 'CPython' -or [string]$venvIdentity.architecture -cne 'AMD64' -or [int]$venvIdentity.pointer_bits -ne 64) { throw 'terminal metrics venv is not bound to the selected exact CPython 3.12 x64 interpreter' }
-          & $metricsPython -m pip install --disable-pip-version-check --only-binary=:all: --retries 5 --timeout 60 numpy==2.2.6 scikit-image==0.25.2 lpips==0.1.4 torch==2.7.0 torchvision==0.22.0 Pillow==11.3.0 open-clip-torch==3.1.0
-          if ($LASTEXITCODE -ne 0) { throw 'failed to install the pinned terminal metrics package closure' }
-          node scripts/starvector-terminal-provision.mjs download https://raw.githubusercontent.com/richzhang/PerceptualSimilarity/master/lpips/weights/v0.1/alex.pth "$env:STARVECTOR_TERMINAL_ROOT\metrics\checkpoints\lpips-v0.1-alex.pth" df73285e35b22355a2df87cdb6b70b343713b667eddbda73e1977e0c860835c0
-          node scripts/starvector-terminal-provision.mjs download https://download.pytorch.org/models/alexnet-owt-7be5be79.pth "$env:STARVECTOR_TERMINAL_ROOT\metrics\checkpoints\alexnet-owt-7be5be79.pth" 7be5be791159472b1fbf3c69796f7cb30dca7ad8466c2df70058c37116cdee02
-          node scripts/starvector-terminal-provision.mjs download https://huggingface.co/laion/CLIP-ViT-B-32-laion2B-s34B-b79K/resolve/1a25a446712ba5ee05982a381eed697ef9b435cf/open_clip_pytorch_model.bin "$env:STARVECTOR_TERMINAL_ROOT\metrics\checkpoints\open_clip_pytorch_model.bin" 1bd3c7172de5b207ceac554f5ab5266166f3b9baccc9af5989bc801016d080ad
-          node scripts/starvector-terminal-provision.mjs metrics "$env:GITHUB_WORKSPACE\sceneworks" $metricsRoot $metricsPython $env:STARVECTOR_CLIP_REVISION
       - name: Materialize the exact pinned 120-row corpus
         shell: powershell
         run: |

--- a/scripts/provision-starvector-windows-python.ps1
+++ b/scripts/provision-starvector-windows-python.ps1
@@ -1,0 +1,377 @@
+$script:StarVectorWindowsPythonPackageUri = 'https://api.nuget.org/v3-flatcontainer/python/3.12.10/python.3.12.10.nupkg'
+$script:StarVectorWindowsPythonPackageSha256 = '0eb85c2dfccccf1b17352de4c397f69194035b7d37149eacc16f1147d93de3b8'
+$script:StarVectorWindowsPythonPackageSha512 = 'bbda4dcf688a94211b62d50968a91b38f305d0b8d1ecd90269f74a86f8a0a4fcebb7ca162a0753a47691eb3df0c964009bd3d8194c6fd19afae8d5fd01e1cc0f'
+$script:StarVectorWindowsPythonPackageBytes = 14515433
+$script:StarVectorWindowsPythonExeSha256 = '4d6f5f81a4bca11191c4c7c6b43632694d0a4ce74e068619d8fdc161d469859a'
+$script:StarVectorWindowsPythonDllSha256 = '9a0e3435aaa680d868150f87ab3e388ad2eebc22f87e036155c7b4eda8cd2120'
+$script:StarVectorWindowsPythonVersion = @(3, 12, 10)
+$script:StarVectorWindowsPythonMaximumPackageBytes = 20MB
+$script:StarVectorWindowsPythonMaximumExpandedBytes = 80MB
+$script:StarVectorWindowsPythonMaximumArchiveEntries = 1400
+
+. (Join-Path $PSScriptRoot 'select-starvector-windows-python.ps1')
+
+function Invoke-StarVectorWindowsPythonLock {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$LockPath,
+    [Parameter(Mandatory = $true)]
+    [scriptblock]$ScriptBlock,
+    [ValidateRange(1, 1800)]
+    [int]$TimeoutSeconds = 1800
+  )
+
+  $canonicalLock = Assert-StarVectorWindowsPathComponents -Path $LockPath -LeafType File -AllowMissingLeaf
+  $lockParent = Split-Path -Parent $canonicalLock
+  Assert-StarVectorWindowsPathComponents -Path $lockParent -LeafType Directory -AllowMissingLeaf | Out-Null
+  [IO.Directory]::CreateDirectory($lockParent) | Out-Null
+  Assert-StarVectorWindowsPathComponents -Path $lockParent -LeafType Directory | Out-Null
+  Assert-StarVectorWindowsPathComponents -Path $canonicalLock -LeafType File -AllowMissingLeaf | Out-Null
+
+  $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+  $stream = $null
+  while (-not $stream) {
+    try {
+      $stream = [IO.File]::Open($canonicalLock, [IO.FileMode]::OpenOrCreate, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
+    } catch [IO.IOException] {
+      if ([DateTime]::UtcNow -ge $deadline) {
+        throw "timed out waiting for the exclusive portable Python lock: $canonicalLock"
+      }
+      Start-Sleep -Milliseconds 250
+    }
+  }
+  try {
+    return & $ScriptBlock
+  } finally {
+    $stream.Dispose()
+  }
+}
+
+function Get-StarVectorSha512 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  Assert-StarVectorWindowsPathComponents -Path $Path -LeafType File | Out-Null
+  $item = Get-Item -LiteralPath $Path -Force -ErrorAction Stop
+  if ($item.PSIsContainer -or ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+    throw "refusing to hash a non-regular package file: $Path"
+  }
+  return (Get-FileHash -LiteralPath $item.FullName -Algorithm SHA512 -ErrorAction Stop).Hash.ToLowerInvariant()
+}
+
+function Get-StarVectorSha256 {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+  )
+
+  Assert-StarVectorWindowsPathComponents -Path $Path -LeafType File | Out-Null
+  $item = Get-Item -LiteralPath $Path -Force -ErrorAction Stop
+  if ($item.PSIsContainer -or ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+    throw "refusing to hash a non-regular package file: $Path"
+  }
+  return (Get-FileHash -LiteralPath $item.FullName -Algorithm SHA256 -ErrorAction Stop).Hash.ToLowerInvariant()
+}
+
+function Save-StarVectorWindowsPythonPackage {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Uri,
+    [Parameter(Mandatory = $true)]
+    [string]$Destination,
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedSha256,
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedSha512,
+    [Parameter(Mandatory = $true)]
+    [ValidateRange(1, 104857600)]
+    [long]$ExpectedBytes,
+    [ValidateRange(1, 300)]
+    [int]$TimeoutSeconds = 120,
+    [ValidateRange(1, 104857600)]
+    [long]$MaximumBytes = $script:StarVectorWindowsPythonMaximumPackageBytes
+  )
+
+  $parsedUri = $null
+  if (-not [Uri]::TryCreate($Uri, [UriKind]::Absolute, [ref]$parsedUri) -or $parsedUri.Scheme -cne 'https') {
+    throw 'portable Python package download requires an absolute HTTPS URL'
+  }
+  if ($ExpectedSha256 -notmatch '^[a-f0-9]{64}$' -or $ExpectedSha512 -notmatch '^[a-f0-9]{128}$') {
+    throw 'portable Python package download requires exact lowercase SHA-256 and SHA-512 identities'
+  }
+  if ($ExpectedBytes -gt $MaximumBytes) {
+    throw 'portable Python package identity exceeds the configured download limit'
+  }
+  $destinationPath = [IO.Path]::GetFullPath($Destination)
+  if ($destinationPath -notmatch '^[A-Za-z]:\\' -or (Test-Path -LiteralPath $destinationPath)) {
+    throw 'portable Python package destination must be a new absolute Windows file path'
+  }
+  $destinationParent = Split-Path -Parent $destinationPath
+  Assert-StarVectorWindowsPathComponents -Path $destinationParent -LeafType Directory | Out-Null
+
+  Add-Type -AssemblyName System.Net.Http
+  $handler = [Net.Http.HttpClientHandler]::new()
+  $handler.AllowAutoRedirect = $false
+  $client = [Net.Http.HttpClient]::new($handler)
+  $client.Timeout = [TimeSpan]::FromSeconds($TimeoutSeconds)
+  $client.MaxResponseContentBufferSize = $MaximumBytes
+  try {
+    $response = $client.GetAsync($parsedUri).GetAwaiter().GetResult()
+    try {
+      if (-not $response.IsSuccessStatusCode) {
+        throw "portable Python package download returned HTTP $([int]$response.StatusCode)"
+      }
+      if ($response.Content.Headers.ContentLength -and $response.Content.Headers.ContentLength -ne $ExpectedBytes) {
+        throw "portable Python package content length is not the expected $ExpectedBytes bytes"
+      }
+      $bytes = $response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult()
+      if ($bytes.LongLength -ne $ExpectedBytes) {
+        throw "portable Python package is not the expected $ExpectedBytes bytes"
+      }
+      [IO.File]::WriteAllBytes($destinationPath, $bytes)
+    } finally {
+      $response.Dispose()
+    }
+  } finally {
+    $client.Dispose()
+    $handler.Dispose()
+  }
+
+  if ((Get-StarVectorSha256 $destinationPath) -cne $ExpectedSha256 -or (Get-StarVectorSha512 $destinationPath) -cne $ExpectedSha512) {
+    Remove-Item -LiteralPath $destinationPath -Force -ErrorAction SilentlyContinue
+    throw 'portable Python package checksums do not match the pinned PSF NuGet identity'
+  }
+  return $destinationPath
+}
+
+function Expand-StarVectorWindowsPythonPackage {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ArchivePath,
+    [Parameter(Mandatory = $true)]
+    [string]$DestinationRoot,
+    [ValidateRange(1, 268435456)]
+    [long]$MaximumExpandedBytes = $script:StarVectorWindowsPythonMaximumExpandedBytes,
+    [ValidateRange(1, 10000)]
+    [int]$MaximumEntries = $script:StarVectorWindowsPythonMaximumArchiveEntries
+  )
+
+  Assert-StarVectorWindowsPathComponents -Path $ArchivePath -LeafType File | Out-Null
+  $canonicalRoot = Assert-StarVectorWindowsPathComponents -Path $DestinationRoot -LeafType Directory -AllowMissingLeaf
+  if (Test-Path -LiteralPath $canonicalRoot) {
+    throw 'portable Python staging root must not already exist'
+  }
+  $stagingParent = Split-Path -Parent $canonicalRoot
+  Assert-StarVectorWindowsPathComponents -Path $stagingParent -LeafType Directory | Out-Null
+  [IO.Directory]::CreateDirectory($canonicalRoot) | Out-Null
+  Assert-StarVectorWindowsPathComponents -Path $canonicalRoot -LeafType Directory | Out-Null
+  $canonicalRoot = $canonicalRoot.TrimEnd('\')
+  $rootBoundary = "$canonicalRoot\"
+  $expandedBytes = [long]0
+  $entryCount = 0
+
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  $archive = [IO.Compression.ZipFile]::OpenRead($ArchivePath)
+  try {
+    foreach ($entry in $archive.Entries) {
+      $entryCount += 1
+      if ($entryCount -gt $MaximumEntries) {
+        throw "portable Python package exceeds the $MaximumEntries-entry archive limit"
+      }
+      if ([string]::IsNullOrWhiteSpace($entry.FullName) -or $entry.FullName -match '[\\:\0]') {
+        throw "portable Python package contains an unsafe archive path: $($entry.FullName)"
+      }
+      $relativePath = $entry.FullName.Replace('/', [IO.Path]::DirectorySeparatorChar)
+      $targetPath = [IO.Path]::GetFullPath((Join-Path $canonicalRoot $relativePath))
+      if (-not $targetPath.StartsWith($rootBoundary, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "portable Python package path escapes its staging root: $($entry.FullName)"
+      }
+      $expandedBytes += [long]$entry.Length
+      if ($expandedBytes -gt $MaximumExpandedBytes) {
+        throw "portable Python package exceeds the $MaximumExpandedBytes-byte expansion limit"
+      }
+      if ([string]::IsNullOrEmpty($entry.Name)) {
+        [IO.Directory]::CreateDirectory($targetPath) | Out-Null
+        continue
+      }
+      [IO.Directory]::CreateDirectory((Split-Path -Parent $targetPath)) | Out-Null
+      $source = $entry.Open()
+      $destination = $null
+      try {
+        $destination = [IO.File]::Open($targetPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+        $source.CopyTo($destination)
+      } finally {
+        if ($destination) { $destination.Dispose() }
+        $source.Dispose()
+      }
+    }
+  } finally {
+    $archive.Dispose()
+  }
+}
+
+function Assert-StarVectorWindowsPythonPackageMetadata {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$PackageRoot
+  )
+
+  try {
+    [xml]$nuspec = Get-Content -LiteralPath (Join-Path $PackageRoot 'python.nuspec') -Raw -ErrorAction Stop
+    $metadata = $nuspec.SelectSingleNode("/*[local-name()='package']/*[local-name()='metadata']")
+    $id = $metadata.SelectSingleNode("*[local-name()='id']").InnerText
+    $version = $metadata.SelectSingleNode("*[local-name()='version']").InnerText
+    $authors = $metadata.SelectSingleNode("*[local-name()='authors']").InnerText
+    $repository = $metadata.SelectSingleNode("*[local-name()='repository']")
+  } catch {
+    throw 'portable Python package metadata is unreadable'
+  }
+  if ($id -cne 'python' -or $version -cne '3.12.10' -or $authors -cne 'Python Software Foundation' -or
+      $repository.GetAttribute('type') -cne 'git' -or $repository.GetAttribute('url') -cne 'https://github.com/Python/CPython.git' -or
+      $repository.GetAttribute('commit') -cne '0cc8128') {
+    throw 'portable Python package metadata does not match the pinned PSF CPython 3.12.10 release'
+  }
+  if ($metadata.SelectNodes("*[local-name()='dependencies']/*").Count -ne 0) {
+    throw 'portable Python package unexpectedly declares dependencies'
+  }
+}
+
+function Get-StarVectorInstalledWindowsPython {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$DestinationRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedSha256,
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedSha512,
+    [Parameter(Mandatory = $true)]
+    [int[]]$ExpectedVersion,
+    [long]$ExpectedPackageBytes = 0,
+    [string]$ExpectedPythonSha256 = '',
+    [string]$ExpectedDllSha256 = ''
+  )
+
+  $package = Join-Path $DestinationRoot '_provenance\python.3.12.10.nupkg'
+  $python = Join-Path $DestinationRoot 'tools\python.exe'
+  $pythonDll = Join-Path $DestinationRoot 'tools\python312.dll'
+  try {
+    Assert-StarVectorWindowsPathComponents -Path $DestinationRoot -LeafType Directory | Out-Null
+    if ((Get-StarVectorSha256 $package) -cne $ExpectedSha256 -or (Get-StarVectorSha512 $package) -cne $ExpectedSha512) { return $null }
+    if ($ExpectedPackageBytes -gt 0 -and (Get-Item -LiteralPath $package -Force -ErrorAction Stop).Length -ne $ExpectedPackageBytes) { return $null }
+    if (-not [string]::IsNullOrEmpty($ExpectedPythonSha256) -and (Get-StarVectorSha256 $python) -cne $ExpectedPythonSha256) { return $null }
+    if (-not [string]::IsNullOrEmpty($ExpectedDllSha256) -and (Get-StarVectorSha256 $pythonDll) -cne $ExpectedDllSha256) { return $null }
+    return Select-StarVectorBootstrapPython -CandidatePaths @($python) -ExpectedVersion $ExpectedVersion
+  } catch {
+    return $null
+  }
+}
+
+function Install-StarVectorWindowsPythonArchive {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$ArchivePath,
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedSha256,
+    [Parameter(Mandatory = $true)]
+    [string]$ExpectedSha512,
+    [Parameter(Mandatory = $true)]
+    [string]$DestinationRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$AllowedRoot,
+    [int[]]$ExpectedVersion = $script:StarVectorWindowsPythonVersion,
+    [long]$ExpectedPackageBytes = 0,
+    [string]$ExpectedPythonSha256 = '',
+    [string]$ExpectedDllSha256 = ''
+  )
+
+  Assert-StarVectorWindowsPathComponents -Path $ArchivePath -LeafType File | Out-Null
+  $canonicalDestination = Assert-StarVectorWindowsPathComponents -Path $DestinationRoot -LeafType Directory -AllowMissingLeaf
+  $canonicalAllowed = Assert-StarVectorWindowsPathComponents -Path $AllowedRoot -LeafType Directory -AllowMissingLeaf
+  if (-not [StringComparer]::OrdinalIgnoreCase.Equals($canonicalDestination, $canonicalAllowed)) {
+    throw 'portable Python destination must equal its exact allowed root'
+  }
+  if ($ExpectedPackageBytes -gt 0 -and (Get-Item -LiteralPath $ArchivePath -Force -ErrorAction Stop).Length -ne $ExpectedPackageBytes) {
+    throw 'portable Python package size does not match the pinned PSF NuGet identity'
+  }
+  if ((Get-StarVectorSha256 $ArchivePath) -cne $ExpectedSha256 -or (Get-StarVectorSha512 $ArchivePath) -cne $ExpectedSha512) {
+    throw 'portable Python package checksums do not match the pinned PSF NuGet identity'
+  }
+  $existing = Get-StarVectorInstalledWindowsPython -DestinationRoot $DestinationRoot -ExpectedSha256 $ExpectedSha256 -ExpectedSha512 $ExpectedSha512 -ExpectedVersion $ExpectedVersion -ExpectedPackageBytes $ExpectedPackageBytes -ExpectedPythonSha256 $ExpectedPythonSha256 -ExpectedDllSha256 $ExpectedDllSha256
+  if ($existing) { return $existing.Executable }
+
+  $destinationParent = Split-Path -Parent $canonicalDestination
+  Assert-StarVectorWindowsPathComponents -Path $destinationParent -LeafType Directory -AllowMissingLeaf | Out-Null
+  [IO.Directory]::CreateDirectory($destinationParent) | Out-Null
+  Assert-StarVectorWindowsPathComponents -Path $destinationParent -LeafType Directory | Out-Null
+  Assert-StarVectorWindowsPathComponents -Path $canonicalDestination -LeafType Directory -AllowMissingLeaf | Out-Null
+  Remove-StarVectorWindowsDirectoryTree -TargetRoot $DestinationRoot -AllowedRoot $AllowedRoot
+  $stagingRoot = "$DestinationRoot.staging-$([Guid]::NewGuid().ToString('N'))"
+  $published = $false
+  try {
+    Expand-StarVectorWindowsPythonPackage -ArchivePath $ArchivePath -DestinationRoot $stagingRoot
+    foreach ($required in @('python.nuspec', '.signature.p7s', 'tools\python.exe', 'tools\python312.dll', 'tools\Lib\venv\__init__.py', 'tools\Lib\ensurepip\__init__.py')) {
+      if (-not (Test-Path -LiteralPath (Join-Path $stagingRoot $required) -PathType Leaf)) {
+        throw "portable Python package lacks required file: $required"
+      }
+    }
+    Assert-StarVectorWindowsPythonPackageMetadata -PackageRoot $stagingRoot
+    $provenanceRoot = Join-Path $stagingRoot '_provenance'
+    [IO.Directory]::CreateDirectory($provenanceRoot) | Out-Null
+    [IO.File]::Copy($ArchivePath, (Join-Path $provenanceRoot 'python.3.12.10.nupkg'), $false)
+    if (-not (Get-StarVectorInstalledWindowsPython -DestinationRoot $stagingRoot -ExpectedSha256 $ExpectedSha256 -ExpectedSha512 $ExpectedSha512 -ExpectedVersion $ExpectedVersion -ExpectedPackageBytes $ExpectedPackageBytes -ExpectedPythonSha256 $ExpectedPythonSha256 -ExpectedDllSha256 $ExpectedDllSha256)) {
+      throw 'portable Python package did not publish exact CPython 3.12.10 x64'
+    }
+    [IO.Directory]::Move($stagingRoot, $DestinationRoot)
+    $published = $true
+    $installed = Get-StarVectorInstalledWindowsPython -DestinationRoot $DestinationRoot -ExpectedSha256 $ExpectedSha256 -ExpectedSha512 $ExpectedSha512 -ExpectedVersion $ExpectedVersion -ExpectedPackageBytes $ExpectedPackageBytes -ExpectedPythonSha256 $ExpectedPythonSha256 -ExpectedDllSha256 $ExpectedDllSha256
+    if (-not $installed) {
+      throw 'published portable Python root failed exact identity validation'
+    }
+    return $installed.Executable
+  } catch {
+    if ($published -and (Test-Path -LiteralPath $DestinationRoot)) {
+      Remove-StarVectorWindowsDirectoryTree -TargetRoot $DestinationRoot -AllowedRoot $AllowedRoot
+    }
+    throw
+  } finally {
+    if (Test-Path -LiteralPath $stagingRoot) {
+      Remove-StarVectorWindowsDirectoryTree -TargetRoot $stagingRoot -AllowedRoot $stagingRoot
+    }
+  }
+}
+
+function Install-StarVectorWindowsPythonPackage {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$DestinationRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$AllowedRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$RunnerTemp
+  )
+
+  $canonicalDestination = Assert-StarVectorWindowsPathComponents -Path $DestinationRoot -LeafType Directory -AllowMissingLeaf
+  $canonicalAllowed = Assert-StarVectorWindowsPathComponents -Path $AllowedRoot -LeafType Directory -AllowMissingLeaf
+  if (-not [StringComparer]::OrdinalIgnoreCase.Equals($canonicalDestination, $canonicalAllowed)) {
+    throw 'portable Python destination must equal its exact allowed root'
+  }
+  $canonicalRunnerTemp = Assert-StarVectorWindowsPathComponents -Path $RunnerTemp -LeafType Directory
+  $existing = Get-StarVectorInstalledWindowsPython -DestinationRoot $DestinationRoot -ExpectedSha256 $script:StarVectorWindowsPythonPackageSha256 -ExpectedSha512 $script:StarVectorWindowsPythonPackageSha512 -ExpectedVersion $script:StarVectorWindowsPythonVersion -ExpectedPackageBytes $script:StarVectorWindowsPythonPackageBytes -ExpectedPythonSha256 $script:StarVectorWindowsPythonExeSha256 -ExpectedDllSha256 $script:StarVectorWindowsPythonDllSha256
+  if ($existing) { return $existing.Executable }
+
+  $downloadRoot = Join-Path $canonicalRunnerTemp ("starvector-python-{0}" -f [Guid]::NewGuid().ToString('N'))
+  Assert-StarVectorWindowsPathComponents -Path $downloadRoot -LeafType Directory -AllowMissingLeaf | Out-Null
+  [IO.Directory]::CreateDirectory($downloadRoot) | Out-Null
+  Assert-StarVectorWindowsPathComponents -Path $downloadRoot -LeafType Directory | Out-Null
+  try {
+    $archive = Join-Path $downloadRoot 'python.3.12.10.nupkg'
+    Save-StarVectorWindowsPythonPackage -Uri $script:StarVectorWindowsPythonPackageUri -Destination $archive -ExpectedSha256 $script:StarVectorWindowsPythonPackageSha256 -ExpectedSha512 $script:StarVectorWindowsPythonPackageSha512 -ExpectedBytes $script:StarVectorWindowsPythonPackageBytes | Out-Null
+    return Install-StarVectorWindowsPythonArchive -ArchivePath $archive -ExpectedSha256 $script:StarVectorWindowsPythonPackageSha256 -ExpectedSha512 $script:StarVectorWindowsPythonPackageSha512 -DestinationRoot $DestinationRoot -AllowedRoot $AllowedRoot -ExpectedVersion $script:StarVectorWindowsPythonVersion -ExpectedPackageBytes $script:StarVectorWindowsPythonPackageBytes -ExpectedPythonSha256 $script:StarVectorWindowsPythonExeSha256 -ExpectedDllSha256 $script:StarVectorWindowsPythonDllSha256
+  } finally {
+    if (Test-Path -LiteralPath $downloadRoot) {
+      Remove-StarVectorWindowsDirectoryTree -TargetRoot $downloadRoot -AllowedRoot $downloadRoot
+    }
+  }
+}

--- a/scripts/provision-starvector-windows-python.test.ps1
+++ b/scripts/provision-starvector-windows-python.test.ps1
@@ -13,6 +13,37 @@ function Assert-Equal {
   if ($Expected -ne $Actual) { throw "$Message (expected '$Expected', got '$Actual')" }
 }
 
+function New-CanonicalZipFromDirectory {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$SourceRoot,
+    [Parameter(Mandatory = $true)]
+    [string]$DestinationPath
+  )
+
+  $canonicalSourceRoot = [IO.Path]::GetFullPath($SourceRoot).TrimEnd([IO.Path]::DirectorySeparatorChar)
+  $stream = [IO.File]::Open($DestinationPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+  $archive = [IO.Compression.ZipArchive]::new($stream, [IO.Compression.ZipArchiveMode]::Create, $false)
+  try {
+    foreach ($file in Get-ChildItem -LiteralPath $canonicalSourceRoot -File -Recurse | Sort-Object FullName) {
+      $relativePath = $file.FullName.Substring($canonicalSourceRoot.Length).TrimStart([IO.Path]::DirectorySeparatorChar)
+      $entryName = $relativePath.Replace([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+      $entry = $archive.CreateEntry($entryName, [IO.Compression.CompressionLevel]::Optimal)
+      $input = [IO.File]::OpenRead($file.FullName)
+      $output = $entry.Open()
+      try {
+        $input.CopyTo($output)
+      } finally {
+        $output.Dispose()
+        $input.Dispose()
+      }
+    }
+  } finally {
+    $archive.Dispose()
+    $stream.Dispose()
+  }
+}
+
 $root = Join-Path $env:RUNNER_TEMP ("starvector portable python {0}" -f [Guid]::NewGuid().ToString('N'))
 [IO.Directory]::CreateDirectory($root) | Out-Null
 try {
@@ -63,7 +94,7 @@ public static class FakePortablePython {
   $fixtureExeSha256 = Get-StarVectorSha256 (Join-Path $fixtureTools 'python.exe')
   $fixtureDllSha256 = Get-StarVectorSha256 (Join-Path $fixtureTools 'python312.dll')
   $fixtureArchive = Join-Path $root 'python.3.12.10.fixture.nupkg'
-  [IO.Compression.ZipFile]::CreateFromDirectory($fixtureRoot, $fixtureArchive)
+  New-CanonicalZipFromDirectory -SourceRoot $fixtureRoot -DestinationPath $fixtureArchive
   $fixtureSha256 = Get-StarVectorSha256 $fixtureArchive
   $fixtureSha512 = Get-StarVectorSha512 $fixtureArchive
   $fixturePackage = @{
@@ -161,6 +192,26 @@ public static class FakePortablePython {
   }
   Assert-True $traversalRejected 'archive path traversal was not rejected'
   Assert-True (-not (Test-Path -LiteralPath (Join-Path $root 'escape.txt'))) 'archive path traversal wrote outside the staging root'
+
+  $backslashArchive = Join-Path $root 'backslash-name.nupkg'
+  $stream = [IO.File]::Open($backslashArchive, [IO.FileMode]::CreateNew)
+  $zip = [IO.Compression.ZipArchive]::new($stream, [IO.Compression.ZipArchiveMode]::Create, $false)
+  try {
+    $entry = $zip.CreateEntry('tools\python.exe')
+    $writer = [IO.StreamWriter]::new($entry.Open())
+    try { $writer.Write('unsafe noncanonical entry') } finally { $writer.Dispose() }
+  } finally {
+    $zip.Dispose()
+    $stream.Dispose()
+  }
+  $backslashRoot = Join-Path $root 'backslash-root'
+  $backslashRejected = $false
+  try {
+    Expand-StarVectorWindowsPythonPackage -ArchivePath $backslashArchive -DestinationRoot $backslashRoot
+  } catch {
+    $backslashRejected = $_.Exception.Message -like 'portable Python package contains an unsafe archive path:*'
+  }
+  Assert-True $backslashRejected 'archive entry with a backslash name was not rejected'
 
   $entryLimitRoot = Join-Path $root 'entry-limit-root'
   $entryLimitRejected = $false

--- a/scripts/provision-starvector-windows-python.test.ps1
+++ b/scripts/provision-starvector-windows-python.test.ps1
@@ -1,0 +1,204 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+. (Join-Path $PSScriptRoot 'provision-starvector-windows-python.ps1')
+
+function Assert-True {
+  param([bool]$Value, [string]$Message)
+  if (-not $Value) { throw $Message }
+}
+
+function Assert-Equal {
+  param([object]$Expected, [object]$Actual, [string]$Message)
+  if ($Expected -ne $Actual) { throw "$Message (expected '$Expected', got '$Actual')" }
+}
+
+$root = Join-Path $env:RUNNER_TEMP ("starvector portable python {0}" -f [Guid]::NewGuid().ToString('N'))
+[IO.Directory]::CreateDirectory($root) | Out-Null
+try {
+  $lockParent = Join-Path $root 'lock-parent'
+  [IO.Directory]::CreateDirectory($lockParent) | Out-Null
+  $lockPath = Join-Path $lockParent 'portable-python.lock'
+  $heldLock = [IO.File]::Open($lockPath, [IO.FileMode]::OpenOrCreate, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
+  try {
+    $lockTimedOut = $false
+    try {
+      Invoke-StarVectorWindowsPythonLock -LockPath $lockPath -TimeoutSeconds 1 -ScriptBlock { throw 'contended lock ran its protected body' }
+    } catch {
+      $lockTimedOut = $_.Exception.Message -like 'timed out waiting for the exclusive portable Python lock:*'
+    }
+    Assert-True $lockTimedOut 'exclusive lock did not reject a concurrent shared-root provisioner'
+  } finally {
+    $heldLock.Dispose()
+  }
+  Assert-Equal 'lock-acquired' (Invoke-StarVectorWindowsPythonLock -LockPath $lockPath -ScriptBlock { 'lock-acquired' }) 'exclusive lock did not release cleanly'
+
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  $source = @'
+using System;
+using System.Diagnostics;
+using System.IO;
+
+public static class FakePortablePython {
+    public static int Main() {
+        string executable = Process.GetCurrentProcess().MainModule.FileName;
+        string escaped = executable.Replace("\\", "\\\\").Replace("\"", "\\\"");
+        Console.Out.WriteLine("{\"executable\":\"" + escaped + "\",\"version\":[3,12,10],\"implementation\":\"CPython\",\"architecture\":\"AMD64\",\"pointer_bits\":64}");
+        return 0;
+    }
+}
+'@
+  $fixtureRoot = Join-Path $root 'fixture'
+  $fixtureTools = Join-Path $fixtureRoot 'tools'
+  [IO.Directory]::CreateDirectory((Join-Path $fixtureTools 'Lib\venv')) | Out-Null
+  [IO.Directory]::CreateDirectory((Join-Path $fixtureTools 'Lib\ensurepip')) | Out-Null
+  Add-Type -TypeDefinition $source -Language CSharp -OutputAssembly (Join-Path $fixtureTools 'python.exe') -OutputType ConsoleApplication
+  foreach ($relative in @('.signature.p7s', 'tools\python312.dll', 'tools\Lib\venv\__init__.py', 'tools\Lib\ensurepip\__init__.py')) {
+    [IO.File]::WriteAllText((Join-Path $fixtureRoot $relative), $relative)
+  }
+  [IO.File]::WriteAllText((Join-Path $fixtureRoot 'python.nuspec'), @'
+<?xml version="1.0" encoding="utf-8"?>
+<package><metadata><id>python</id><version>3.12.10</version><authors>Python Software Foundation</authors><repository type="git" url="https://github.com/Python/CPython.git" commit="0cc8128" /></metadata></package>
+'@)
+  $fixtureExeSha256 = Get-StarVectorSha256 (Join-Path $fixtureTools 'python.exe')
+  $fixtureDllSha256 = Get-StarVectorSha256 (Join-Path $fixtureTools 'python312.dll')
+  $fixtureArchive = Join-Path $root 'python.3.12.10.fixture.nupkg'
+  [IO.Compression.ZipFile]::CreateFromDirectory($fixtureRoot, $fixtureArchive)
+  $fixtureSha256 = Get-StarVectorSha256 $fixtureArchive
+  $fixtureSha512 = Get-StarVectorSha512 $fixtureArchive
+  $fixturePackage = @{
+    ArchivePath = $fixtureArchive
+    ExpectedSha256 = $fixtureSha256
+    ExpectedSha512 = $fixtureSha512
+    ExpectedPackageBytes = (Get-Item -LiteralPath $fixtureArchive).Length
+    ExpectedPythonSha256 = $fixtureExeSha256
+    ExpectedDllSha256 = $fixtureDllSha256
+  }
+
+  $partialRoot = Join-Path $root 'durable-python'
+  [IO.Directory]::CreateDirectory($partialRoot) | Out-Null
+  [IO.File]::WriteAllText((Join-Path $partialRoot 'python-3.12.10-amd64.exe'), 'partial setup-python installer root')
+  $oldToolCache = $env:RUNNER_TOOL_CACHE
+  $oldAgentTools = $env:AGENT_TOOLSDIRECTORY
+  $env:RUNNER_TOOL_CACHE = 'D:\actions-runner\_work\_tool'
+  $env:AGENT_TOOLSDIRECTORY = 'E:\different-runner\_work\_tool'
+  try {
+    $installed = Install-StarVectorWindowsPythonArchive @fixturePackage -DestinationRoot $partialRoot -AllowedRoot $partialRoot
+  } finally {
+    $env:RUNNER_TOOL_CACHE = $oldToolCache
+    $env:AGENT_TOOLSDIRECTORY = $oldAgentTools
+  }
+  Assert-Equal ([IO.Path]::GetFullPath((Join-Path $partialRoot 'tools\python.exe'))) $installed 'partial root was not replaced by the exact portable interpreter'
+  Assert-True (-not (Test-Path -LiteralPath (Join-Path $partialRoot 'python-3.12.10-amd64.exe'))) 'partial setup-python installer survived repair'
+  Assert-True ($installed -notlike 'D:\actions-runner\*' -and $installed -notlike 'E:\different-runner\*') 'portable interpreter depended on a runner-specific toolcache'
+  Assert-Equal $installed (Install-StarVectorWindowsPythonArchive @fixturePackage -DestinationRoot $partialRoot -AllowedRoot $partialRoot) 'valid portable root was not reused idempotently'
+
+  [IO.File]::WriteAllText((Join-Path $partialRoot 'tools\python312.dll'), 'corrupt extracted runtime')
+  $repaired = Install-StarVectorWindowsPythonArchive @fixturePackage -DestinationRoot $partialRoot -AllowedRoot $partialRoot
+  Assert-Equal $installed $repaired 'corrupt portable root was not deterministically rebuilt'
+  Assert-Equal $fixtureDllSha256 (Get-StarVectorSha256 (Join-Path $partialRoot 'tools\python312.dll')) 'corrupt extracted runtime survived the rebuild'
+
+  $preservedRoot = Join-Path $root 'preserved-partial-root'
+  [IO.Directory]::CreateDirectory($preservedRoot) | Out-Null
+  [IO.File]::WriteAllText((Join-Path $preservedRoot 'sentinel.txt'), 'preserve before checksum validation')
+  $badHashRejected = $false
+  try {
+    Install-StarVectorWindowsPythonArchive -ArchivePath $fixtureArchive -ExpectedSha256 ('0' * 64) -ExpectedSha512 $fixtureSha512 -DestinationRoot $preservedRoot -AllowedRoot $preservedRoot | Out-Null
+  } catch {
+    $badHashRejected = $_.Exception.Message -eq 'portable Python package checksums do not match the pinned PSF NuGet identity'
+  }
+  Assert-True $badHashRejected 'checksum mismatch was not rejected before partial-root cleanup'
+  Assert-True (Test-Path -LiteralPath (Join-Path $preservedRoot 'sentinel.txt') -PathType Leaf) 'checksum mismatch deleted the existing partial root'
+
+  $wrongRootRejected = $false
+  try {
+    Install-StarVectorWindowsPythonArchive -ArchivePath $fixtureArchive -ExpectedSha256 $fixtureSha256 -ExpectedSha512 $fixtureSha512 -DestinationRoot $preservedRoot -AllowedRoot (Join-Path $root 'wrong-root') | Out-Null
+  } catch {
+    $wrongRootRejected = $_.Exception.Message -eq 'portable Python destination must equal its exact allowed root'
+  }
+  Assert-True $wrongRootRejected 'partial-root replacement did not enforce the exact allowed root'
+  Assert-True (Test-Path -LiteralPath (Join-Path $preservedRoot 'sentinel.txt') -PathType Leaf) 'wrong-root refusal deleted the existing partial root'
+
+  $externalRoot = Join-Path $root 'external-target'
+  [IO.Directory]::CreateDirectory($externalRoot) | Out-Null
+  [IO.File]::WriteAllText((Join-Path $externalRoot 'sentinel.txt'), 'must survive junction rejection')
+  foreach ($junctionKind in @('destination', 'parent')) {
+    $junction = Join-Path $root "$junctionKind-junction"
+    cmd /c mklink /J "`"$junction`"" "`"$externalRoot`"" | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "failed to create the $junctionKind junction fixture" }
+    try {
+      $junctionDestination = if ($junctionKind -ceq 'destination') { $junction } else { Join-Path $junction 'nested-python' }
+      $junctionRejected = $false
+      try {
+        Install-StarVectorWindowsPythonArchive -ArchivePath $fixtureArchive -ExpectedSha256 $fixtureSha256 -ExpectedSha512 $fixtureSha512 -DestinationRoot $junctionDestination -AllowedRoot $junctionDestination | Out-Null
+      } catch {
+        $junctionRejected = $_.Exception.Message -like 'path must not traverse a reparse point:*'
+      }
+      Assert-True $junctionRejected "portable Python did not reject a $junctionKind-root junction"
+      Assert-True (Test-Path -LiteralPath (Join-Path $externalRoot 'sentinel.txt') -PathType Leaf) "$junctionKind-root rejection changed its external target"
+    } finally {
+      [IO.Directory]::Delete($junction, $false)
+    }
+  }
+
+  $traversalArchive = Join-Path $root 'traversal.nupkg'
+  $stream = [IO.File]::Open($traversalArchive, [IO.FileMode]::CreateNew)
+  $zip = [IO.Compression.ZipArchive]::new($stream, [IO.Compression.ZipArchiveMode]::Create, $false)
+  try {
+    $entry = $zip.CreateEntry('../escape.txt')
+    $writer = [IO.StreamWriter]::new($entry.Open())
+    try { $writer.Write('escape') } finally { $writer.Dispose() }
+  } finally {
+    $zip.Dispose()
+    $stream.Dispose()
+  }
+  $traversalRoot = Join-Path $root 'traversal-root'
+  $traversalRejected = $false
+  try {
+    Expand-StarVectorWindowsPythonPackage -ArchivePath $traversalArchive -DestinationRoot $traversalRoot
+  } catch {
+    $traversalRejected = $_.Exception.Message -like 'portable Python package path escapes its staging root:*'
+  }
+  Assert-True $traversalRejected 'archive path traversal was not rejected'
+  Assert-True (-not (Test-Path -LiteralPath (Join-Path $root 'escape.txt'))) 'archive path traversal wrote outside the staging root'
+
+  $entryLimitRoot = Join-Path $root 'entry-limit-root'
+  $entryLimitRejected = $false
+  try {
+    Expand-StarVectorWindowsPythonPackage -ArchivePath $fixtureArchive -DestinationRoot $entryLimitRoot -MaximumEntries 1
+  } catch {
+    $entryLimitRejected = $_.Exception.Message -eq 'portable Python package exceeds the 1-entry archive limit'
+  }
+  Assert-True $entryLimitRejected 'archive entry-count limit was not enforced'
+
+  $expansionLimitRoot = Join-Path $root 'expansion-limit-root'
+  $expansionLimitRejected = $false
+  try {
+    Expand-StarVectorWindowsPythonPackage -ArchivePath $fixtureArchive -DestinationRoot $expansionLimitRoot -MaximumExpandedBytes 1
+  } catch {
+    $expansionLimitRejected = $_.Exception.Message -eq 'portable Python package exceeds the 1-byte expansion limit'
+  }
+  Assert-True $expansionLimitRejected 'archive expansion-size limit was not enforced'
+
+  $officialRoot = Join-Path $root 'official-python'
+  $official = Install-StarVectorWindowsPythonPackage -DestinationRoot $officialRoot -AllowedRoot $officialRoot -RunnerTemp $root
+  $officialIdentity = Select-StarVectorBootstrapPython -CandidatePaths @($official) -ExpectedVersion @(3, 12, 10)
+  Assert-Equal ([IO.Path]::GetFullPath((Join-Path $officialRoot 'tools\python.exe'))) $officialIdentity.Executable 'official portable interpreter path changed'
+  Assert-Equal 10 $officialIdentity.Identity.version[2] 'official portable interpreter micro version changed'
+  Assert-Equal $script:StarVectorWindowsPythonExeSha256 (Get-StarVectorSha256 (Join-Path $officialRoot 'tools\python.exe')) 'official portable python.exe hash changed'
+  Assert-Equal $script:StarVectorWindowsPythonDllSha256 (Get-StarVectorSha256 (Join-Path $officialRoot 'tools\python312.dll')) 'official portable python312.dll hash changed'
+
+  $venvRoot = Join-Path $root 'official-venv'
+  & $official -m venv --copies $venvRoot
+  if ($LASTEXITCODE -ne 0) { throw 'official portable CPython failed to create a venv' }
+  $venvPython = Join-Path $venvRoot 'Scripts\python.exe'
+  $venvProbe = Invoke-StarVectorPythonIdentityProbe -Executable $venvPython -IncludeBaseExecutable
+  Assert-Equal 0 $venvProbe.ExitCode 'portable CPython venv identity probe failed'
+  $venvIdentity = $venvProbe.StdOut | ConvertFrom-Json -ErrorAction Stop
+  Assert-Equal 10 $venvIdentity.version[2] 'portable CPython venv micro version changed'
+  Assert-Equal ([IO.Path]::GetFullPath($official)) (Resolve-StarVectorWindowsExecutable $venvIdentity.base_executable) 'portable CPython venv base identity changed'
+} finally {
+  if (Test-Path -LiteralPath $root) {
+    Remove-StarVectorWindowsDirectoryTree -TargetRoot $root -AllowedRoot $root
+  }
+}

--- a/scripts/provision-starvector-windows-python.test.ps1
+++ b/scripts/provision-starvector-windows-python.test.ps1
@@ -3,6 +3,9 @@ Set-StrictMode -Version Latest
 
 . (Join-Path $PSScriptRoot 'provision-starvector-windows-python.ps1')
 
+Add-Type -AssemblyName System.IO.Compression
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
 function Assert-True {
   param([bool]$Value, [string]$Message)
   if (-not $Value) { throw $Message }
@@ -23,23 +26,54 @@ function New-CanonicalZipFromDirectory {
 
   $canonicalSourceRoot = [IO.Path]::GetFullPath($SourceRoot).TrimEnd([IO.Path]::DirectorySeparatorChar)
   $stream = [IO.File]::Open($DestinationPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
-  $archive = [IO.Compression.ZipArchive]::new($stream, [IO.Compression.ZipArchiveMode]::Create, $false)
   try {
-    foreach ($file in Get-ChildItem -LiteralPath $canonicalSourceRoot -File -Recurse | Sort-Object FullName) {
-      $relativePath = $file.FullName.Substring($canonicalSourceRoot.Length).TrimStart([IO.Path]::DirectorySeparatorChar)
-      $entryName = $relativePath.Replace([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
-      $entry = $archive.CreateEntry($entryName, [IO.Compression.CompressionLevel]::Optimal)
-      $input = [IO.File]::OpenRead($file.FullName)
-      $output = $entry.Open()
-      try {
-        $input.CopyTo($output)
-      } finally {
-        $output.Dispose()
-        $input.Dispose()
+    $archive = [IO.Compression.ZipArchive]::new($stream, [IO.Compression.ZipArchiveMode]::Create, $true)
+    try {
+      foreach ($file in Get-ChildItem -LiteralPath $canonicalSourceRoot -File -Recurse | Sort-Object FullName) {
+        $relativePath = $file.FullName.Substring($canonicalSourceRoot.Length).TrimStart([IO.Path]::DirectorySeparatorChar)
+        $entryName = $relativePath.Replace([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+        $entry = $archive.CreateEntry($entryName, [IO.Compression.CompressionLevel]::Optimal)
+        $sourceStream = [IO.File]::OpenRead($file.FullName)
+        try {
+          $entryStream = $entry.Open()
+          try {
+            $sourceStream.CopyTo($entryStream)
+          } finally {
+            $entryStream.Dispose()
+          }
+        } finally {
+          $sourceStream.Dispose()
+        }
       }
+    } finally {
+      $archive.Dispose()
     }
   } finally {
-    $archive.Dispose()
+    $stream.Dispose()
+  }
+}
+
+function New-SingleEntryZip {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$DestinationPath,
+    [Parameter(Mandatory = $true)]
+    [string]$EntryName,
+    [Parameter(Mandatory = $true)]
+    [string]$Content
+  )
+
+  $stream = [IO.File]::Open($DestinationPath, [IO.FileMode]::CreateNew, [IO.FileAccess]::Write, [IO.FileShare]::None)
+  try {
+    $archive = [IO.Compression.ZipArchive]::new($stream, [IO.Compression.ZipArchiveMode]::Create, $true)
+    try {
+      $entry = $archive.CreateEntry($EntryName)
+      $writer = [IO.StreamWriter]::new($entry.Open())
+      try { $writer.Write($Content) } finally { $writer.Dispose() }
+    } finally {
+      $archive.Dispose()
+    }
+  } finally {
     $stream.Dispose()
   }
 }
@@ -64,7 +98,6 @@ try {
   }
   Assert-Equal 'lock-acquired' (Invoke-StarVectorWindowsPythonLock -LockPath $lockPath -ScriptBlock { 'lock-acquired' }) 'exclusive lock did not release cleanly'
 
-  Add-Type -AssemblyName System.IO.Compression.FileSystem
   $source = @'
 using System;
 using System.Diagnostics;
@@ -173,16 +206,7 @@ public static class FakePortablePython {
   }
 
   $traversalArchive = Join-Path $root 'traversal.nupkg'
-  $stream = [IO.File]::Open($traversalArchive, [IO.FileMode]::CreateNew)
-  $zip = [IO.Compression.ZipArchive]::new($stream, [IO.Compression.ZipArchiveMode]::Create, $false)
-  try {
-    $entry = $zip.CreateEntry('../escape.txt')
-    $writer = [IO.StreamWriter]::new($entry.Open())
-    try { $writer.Write('escape') } finally { $writer.Dispose() }
-  } finally {
-    $zip.Dispose()
-    $stream.Dispose()
-  }
+  New-SingleEntryZip -DestinationPath $traversalArchive -EntryName '../escape.txt' -Content 'escape'
   $traversalRoot = Join-Path $root 'traversal-root'
   $traversalRejected = $false
   try {
@@ -194,16 +218,7 @@ public static class FakePortablePython {
   Assert-True (-not (Test-Path -LiteralPath (Join-Path $root 'escape.txt'))) 'archive path traversal wrote outside the staging root'
 
   $backslashArchive = Join-Path $root 'backslash-name.nupkg'
-  $stream = [IO.File]::Open($backslashArchive, [IO.FileMode]::CreateNew)
-  $zip = [IO.Compression.ZipArchive]::new($stream, [IO.Compression.ZipArchiveMode]::Create, $false)
-  try {
-    $entry = $zip.CreateEntry('tools\python.exe')
-    $writer = [IO.StreamWriter]::new($entry.Open())
-    try { $writer.Write('unsafe noncanonical entry') } finally { $writer.Dispose() }
-  } finally {
-    $zip.Dispose()
-    $stream.Dispose()
-  }
+  New-SingleEntryZip -DestinationPath $backslashArchive -EntryName 'tools\python.exe' -Content 'unsafe noncanonical entry'
   $backslashRoot = Join-Path $root 'backslash-root'
   $backslashRejected = $false
   try {

--- a/scripts/select-starvector-windows-python.ps1
+++ b/scripts/select-starvector-windows-python.ps1
@@ -1,3 +1,62 @@
+function Assert-StarVectorWindowsPathComponents {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path,
+    [ValidateSet('Any', 'File', 'Directory')]
+    [string]$LeafType = 'Any',
+    [switch]$AllowMissingLeaf
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Path) -or $Path -match '[\r\n"]' -or $Path -notmatch '^[A-Za-z]:\\') {
+    throw 'expected an absolute Windows path without control characters'
+  }
+  try {
+    $canonical = [IO.Path]::GetFullPath($Path)
+    $pathRoot = [IO.Path]::GetPathRoot($canonical)
+  } catch {
+    throw 'expected a canonical absolute Windows path'
+  }
+  if ($canonical -notmatch '^[A-Za-z]:\\' -or [string]::IsNullOrWhiteSpace($pathRoot)) {
+    throw 'expected a canonical absolute Windows path'
+  }
+
+  $rootItem = Get-Item -LiteralPath $pathRoot -Force -ErrorAction Stop
+  if (-not $rootItem.PSIsContainer -or ($rootItem.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+    throw "path root must be a regular directory: $pathRoot"
+  }
+  $parts = @($canonical.Substring($pathRoot.Length) -split '\\' | Where-Object { -not [string]::IsNullOrEmpty($_) })
+  $current = $pathRoot
+  $missing = $false
+  for ($index = 0; $index -lt $parts.Count; $index++) {
+    $current = Join-Path $current $parts[$index]
+    $isLeaf = $index -eq ($parts.Count - 1)
+    if (-not (Test-Path -LiteralPath $current)) {
+      $missing = $true
+      continue
+    }
+    if ($missing) {
+      throw "path changed while its components were validated: $canonical"
+    }
+    $item = Get-Item -LiteralPath $current -Force -ErrorAction Stop
+    if (($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+      throw "path must not traverse a reparse point: $($item.FullName)"
+    }
+    if (-not $isLeaf -and -not $item.PSIsContainer) {
+      throw "path parent must be a directory: $($item.FullName)"
+    }
+    if ($isLeaf -and $LeafType -ceq 'File' -and $item.PSIsContainer) {
+      throw "path leaf must be a regular file: $($item.FullName)"
+    }
+    if ($isLeaf -and $LeafType -ceq 'Directory' -and -not $item.PSIsContainer) {
+      throw "path leaf must be a regular directory: $($item.FullName)"
+    }
+  }
+  if ($missing -and -not $AllowMissingLeaf) {
+    throw "path does not exist: $canonical"
+  }
+  return $canonical
+}
+
 function Resolve-StarVectorWindowsExecutable {
   param([object]$Value)
 
@@ -11,6 +70,11 @@ function Resolve-StarVectorWindowsExecutable {
     return $null
   }
   if ($full -notmatch '^[A-Za-z]:\\' -or -not (Test-Path -LiteralPath $full -PathType Leaf)) {
+    return $null
+  }
+  try {
+    Assert-StarVectorWindowsPathComponents -Path $full -LeafType File | Out-Null
+  } catch {
     return $null
   }
   return $full
@@ -89,15 +153,17 @@ function Invoke-StarVectorPythonIdentityProbe {
   param(
     [Parameter(Mandatory = $true)]
     [string]$Executable,
-    [switch]$IncludeBaseExecutable
+    [switch]$IncludeBaseExecutable,
+    [ValidateRange(1, 120000)]
+    [int]$TimeoutMilliseconds = 15000
   )
 
   $startInfo = New-Object System.Diagnostics.ProcessStartInfo
   $startInfo.FileName = $Executable
   if ($IncludeBaseExecutable) {
-    $startInfo.Arguments = '-c "import json,platform,struct,sys;print(json.dumps({''executable'':sys.executable,''base_executable'':getattr(sys,''_base_executable'',None),''version'':[sys.version_info.major,sys.version_info.minor,sys.version_info.micro],''implementation'':platform.python_implementation(),''architecture'':platform.machine(),''pointer_bits'':struct.calcsize(''P'')*8}))"'
+    $startInfo.Arguments = '-c "import ensurepip,json,pip,platform,struct,sys,venv;print(json.dumps({''executable'':sys.executable,''base_executable'':getattr(sys,''_base_executable'',None),''version'':[sys.version_info.major,sys.version_info.minor,sys.version_info.micro],''implementation'':platform.python_implementation(),''architecture'':platform.machine(),''pointer_bits'':struct.calcsize(''P'')*8}))"'
   } else {
-    $startInfo.Arguments = '-c "import json,platform,struct,sys;print(json.dumps({''executable'':sys.executable,''version'':[sys.version_info.major,sys.version_info.minor,sys.version_info.micro],''implementation'':platform.python_implementation(),''architecture'':platform.machine(),''pointer_bits'':struct.calcsize(''P'')*8}))"'
+    $startInfo.Arguments = '-c "import ensurepip,json,pip,platform,struct,sys,venv;print(json.dumps({''executable'':sys.executable,''version'':[sys.version_info.major,sys.version_info.minor,sys.version_info.micro],''implementation'':platform.python_implementation(),''architecture'':platform.machine(),''pointer_bits'':struct.calcsize(''P'')*8}))"'
   }
   $startInfo.UseShellExecute = $false
   $startInfo.RedirectStandardOutput = $true
@@ -112,6 +178,11 @@ function Invoke-StarVectorPythonIdentityProbe {
     }
     $stdoutTask = $process.StandardOutput.ReadToEndAsync()
     $stderrTask = $process.StandardError.ReadToEndAsync()
+    if (-not $process.WaitForExit($TimeoutMilliseconds)) {
+      try { $process.Kill() } catch { }
+      try { $process.WaitForExit(5000) | Out-Null } catch { }
+      return [pscustomobject]@{ ExitCode = -1; StdOut = ''; StdErr = "Python identity probe exceeded $TimeoutMilliseconds ms" }
+    }
     $process.WaitForExit()
     return [pscustomobject]@{
       ExitCode = $process.ExitCode
@@ -128,7 +199,9 @@ function Invoke-StarVectorPythonIdentityProbe {
 function Select-StarVectorBootstrapPython {
   param(
     [Parameter(Mandatory = $true)]
-    [string[]]$CandidatePaths
+    [string[]]$CandidatePaths,
+    [ValidateCount(2, 3)]
+    [int[]]$ExpectedVersion = @(3, 12)
   )
 
   foreach ($candidate in $CandidatePaths) {
@@ -142,9 +215,11 @@ function Select-StarVectorBootstrapPython {
       continue
     }
     $canonicalExecutable = Resolve-StarVectorWindowsExecutable $identity.executable
-    if ($identity.version.Count -eq 3 -and
-        [int]$identity.version[0] -eq 3 -and
-        [int]$identity.version[1] -eq 12 -and
+    $versionMatches = $identity.version.Count -eq 3 -and
+      [int]$identity.version[0] -eq $ExpectedVersion[0] -and
+      [int]$identity.version[1] -eq $ExpectedVersion[1] -and
+      ($ExpectedVersion.Count -eq 2 -or [int]$identity.version[2] -eq $ExpectedVersion[2])
+    if ($versionMatches -and
         [string]$identity.implementation -ceq 'CPython' -and
         [string]$identity.architecture -ceq 'AMD64' -and
         [int]$identity.pointer_bits -eq 64 -and

--- a/scripts/select-starvector-windows-python.test.ps1
+++ b/scripts/select-starvector-windows-python.test.ps1
@@ -20,6 +20,7 @@ try {
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
 
 public static class FakePython {
     public static int Main() {
@@ -31,6 +32,10 @@ public static class FakePython {
         }
         if (name.StartsWith("02-")) {
             Console.Out.WriteLine("{not-json");
+            return 0;
+        }
+        if (name.StartsWith("07-")) {
+            Thread.Sleep(30000);
             return 0;
         }
         int minor = name.StartsWith("03-") ? 11 : (name.StartsWith("04-") ? 14 : 12);
@@ -49,16 +54,21 @@ public static class FakePython {
   $newerUnsupported = Join-Path $root '04-python314.exe'
   $wrongArchitecture = Join-Path $root '05-python312-arm64.exe'
   $valid = Join-Path $root '06-python312-amd64.exe'
+  $hanging = Join-Path $root '07-hanging-python.exe'
   Copy-Item -LiteralPath $template -Destination $bad
   Copy-Item -LiteralPath $template -Destination $malformed
   Copy-Item -LiteralPath $template -Destination $belowMinimum
   Copy-Item -LiteralPath $template -Destination $newerUnsupported
   Copy-Item -LiteralPath $template -Destination $wrongArchitecture
   Copy-Item -LiteralPath $template -Destination $valid
+  Copy-Item -LiteralPath $template -Destination $hanging
 
   $badProbe = Invoke-StarVectorPythonIdentityProbe -Executable $bad
   Assert-Equal 7 $badProbe.ExitCode 'stderr-writing candidate exit code was not captured'
   Assert-True ($badProbe.StdErr -match 'Traceback') 'stderr-writing candidate stderr was not captured'
+  $hangingProbe = Invoke-StarVectorPythonIdentityProbe -Executable $hanging -TimeoutMilliseconds 100
+  Assert-Equal -1 $hangingProbe.ExitCode 'hanging identity probe was not terminated'
+  Assert-True ($hangingProbe.StdErr -match 'exceeded 100 ms') 'hanging identity probe did not report its bound'
 
   $selection = Select-StarVectorBootstrapPython -CandidatePaths @($bad, $malformed, $belowMinimum, $newerUnsupported, $wrongArchitecture, "$valid`"", $valid)
   Assert-Equal ([IO.Path]::GetFullPath($valid)) $selection.Executable 'selection did not continue to the valid Python candidate'
@@ -69,6 +79,23 @@ public static class FakePython {
   Assert-Equal 'AMD64' $selection.Identity.architecture 'selected Python architecture changed'
   Assert-Equal 64 $selection.Identity.pointer_bits 'selected Python pointer width changed'
   Assert-True ($null -eq (Resolve-StarVectorWindowsExecutable "$valid`"")) 'quoted executable path must fail closed'
+
+  $wrongMicroFailed = $false
+  try {
+    Select-StarVectorBootstrapPython -CandidatePaths @($valid) -ExpectedVersion @(3, 12, 10) | Out-Null
+  } catch {
+    $wrongMicroFailed = $_.Exception.Message -eq 'StarVector terminal metrics require the explicitly provisioned CPython 3.12 x64 interpreter'
+  }
+  Assert-True $wrongMicroFailed 'exact-micro selection accepted a different CPython 3.12 patch release'
+  Assert-Equal ([IO.Path]::GetFullPath($valid)) (Select-StarVectorBootstrapPython -CandidatePaths @($valid) -ExpectedVersion @(3, 12, 7)).Executable 'exact-micro selection rejected its pinned patch release'
+
+  $candidateJunction = Join-Path $root 'candidate-junction'
+  New-Item -ItemType Junction -Path $candidateJunction -Target $root | Out-Null
+  try {
+    Assert-True ($null -eq (Resolve-StarVectorWindowsExecutable (Join-Path $candidateJunction '06-python312-amd64.exe'))) 'executable selection traversed a junction parent'
+  } finally {
+    [IO.Directory]::Delete($candidateJunction)
+  }
 
   $allFailed = $false
   try {

--- a/scripts/starvector-terminal-provision.test.mjs
+++ b/scripts/starvector-terminal-provision.test.mjs
@@ -207,6 +207,8 @@ function assertWindowsPortablePythonContract(step, source, testSource) {
   assert.match(source, /\$entryCount -gt \$MaximumEntries/);
   assert.match(source, /\$expandedBytes -gt \$MaximumExpandedBytes/);
   assert.match(source, /path escapes its staging root/);
+  assert.match(source, /Add-Type -AssemblyName System\.IO\.Compression\.FileSystem/);
+  assert.match(source, /\[IO\.Compression\.ZipFile\]::OpenRead\(\$ArchivePath\)/);
   assert.match(source, /Python Software Foundation/);
   assert.match(source, /https:\/\/github\.com\/Python\/CPython\.git/);
   assert.match(source, /0cc8128/);
@@ -238,7 +240,7 @@ function assertWindowsPortablePythonContract(step, source, testSource) {
   assert.match(testSource, /portable Python did not reject a \$junctionKind-root junction/);
   assert.doesNotMatch(testSource, /CreateFromDirectory/);
   assert.match(testSource, /Replace\(\[IO\.Path\]::DirectorySeparatorChar, \[IO\.Path\]::AltDirectorySeparatorChar\)/);
-  assert.match(testSource, /CreateEntry\('tools\\python\.exe'\)/);
+  assert.match(testSource, /New-SingleEntryZip -DestinationPath \$backslashArchive -EntryName 'tools\\python\.exe'/);
   assert.match(testSource, /archive entry with a backslash name was not rejected/);
   assert.match(testSource, /archive entry-count limit was not enforced/);
   assert.match(testSource, /archive expansion-size limit was not enforced/);
@@ -246,7 +248,44 @@ function assertWindowsPortablePythonContract(step, source, testSource) {
   assert.match(testSource, /official portable python\.exe hash changed/);
   assert.match(testSource, /official portable python312\.dll hash changed/);
   assert.match(testSource, /& \$official -m venv --copies \$venvRoot/);
+  assertWindowsPortablePythonFixtureArchiveContract(testSource);
 }
+
+function assertWindowsPortablePythonFixtureArchiveContract(testSource) {
+  const compressionLoad = testSource.indexOf("Add-Type -AssemblyName System.IO.Compression\n");
+  const fileSystemLoad = testSource.indexOf("Add-Type -AssemblyName System.IO.Compression.FileSystem\n");
+  const firstArchiveConstruction = testSource.indexOf("[IO.Compression.ZipArchive]::new");
+  assert.ok(compressionLoad >= 0 && fileSystemLoad > compressionLoad && firstArchiveConstruction > fileSystemLoad);
+
+  for (const functionName of ["New-CanonicalZipFromDirectory", "New-SingleEntryZip"]) {
+    const start = testSource.indexOf(`function ${functionName} {`);
+    const nextFunction = testSource.indexOf("\nfunction ", start + 1);
+    const scriptBody = testSource.indexOf("\n$root =", start + 1);
+    const end = nextFunction >= 0 ? nextFunction : scriptBody;
+    const body = testSource.slice(start, end);
+    const streamOpen = body.indexOf("$stream = [IO.File]::Open(");
+    const guardedConstruction = body.indexOf("try {\n    $archive = [IO.Compression.ZipArchive]::new", streamOpen);
+    const archiveDispose = body.indexOf("$archive.Dispose()", guardedConstruction);
+    const streamDispose = body.indexOf("$stream.Dispose()", archiveDispose);
+    assert.ok(start >= 0 && streamOpen >= 0 && guardedConstruction > streamOpen && archiveDispose > guardedConstruction && streamDispose > archiveDispose, functionName);
+    assert.match(body, /ZipArchive\]::new\(\$stream, \[IO\.Compression\.ZipArchiveMode\]::Create, \$true\)/);
+  }
+}
+
+test("PowerShell 5.1 ZIP fixtures load their defining assembly and guard every acquired stream", () => {
+  assertWindowsPortablePythonFixtureArchiveContract(windowsPythonProvisionTest);
+  for (const [label, mutation] of [
+    ["compression assembly", (value) => value.replace("Add-Type -AssemblyName System.IO.Compression\n", "")],
+    ["guard before archive construction", (value) => value.replace("  try {\n    $archive = [IO.Compression.ZipArchive]::new($stream, [IO.Compression.ZipArchiveMode]::Create, $true)", "  $archive = [IO.Compression.ZipArchive]::new($stream, [IO.Compression.ZipArchiveMode]::Create, $true)\n  try {")],
+    ["archive disposal", (value) => value.replace("      $archive.Dispose()", "      Write-Host $archive")],
+    ["stream disposal", (value) => value.replace("    $stream.Dispose()", "    Write-Host $stream")],
+    ["outer stream ownership", (value) => value.replace("[IO.Compression.ZipArchiveMode]::Create, $true", "[IO.Compression.ZipArchiveMode]::Create, $false")],
+  ]) {
+    const changed = mutation(windowsPythonProvisionTest);
+    assert.notEqual(changed, windowsPythonProvisionTest, `${label} mutation must alter the fixture`);
+    assert.throws(() => assertWindowsPortablePythonFixtureArchiveContract(changed), { name: "AssertionError" }, label);
+  }
+});
 
 test("terminal metrics provisioning fixes CPython 3.12 and wheel-only installation on both hosts", () => {
   assert.equal((workflow.match(/uses: actions\/setup-python@/g) ?? []).length, 0);

--- a/scripts/starvector-terminal-provision.test.mjs
+++ b/scripts/starvector-terminal-provision.test.mjs
@@ -236,6 +236,10 @@ function assertWindowsPortablePythonContract(step, source, testSource) {
   assert.match(testSource, /AGENT_TOOLSDIRECTORY = 'E:\\different-runner\\_work\\_tool'/);
   assert.match(testSource, /exclusive lock did not reject a concurrent shared-root provisioner/);
   assert.match(testSource, /portable Python did not reject a \$junctionKind-root junction/);
+  assert.doesNotMatch(testSource, /CreateFromDirectory/);
+  assert.match(testSource, /Replace\(\[IO\.Path\]::DirectorySeparatorChar, \[IO\.Path\]::AltDirectorySeparatorChar\)/);
+  assert.match(testSource, /CreateEntry\('tools\\python\.exe'\)/);
+  assert.match(testSource, /archive entry with a backslash name was not rejected/);
   assert.match(testSource, /archive entry-count limit was not enforced/);
   assert.match(testSource, /archive expansion-size limit was not enforced/);
   assert.match(testSource, /Install-StarVectorWindowsPythonPackage -DestinationRoot \$officialRoot/);

--- a/scripts/starvector-terminal-provision.test.mjs
+++ b/scripts/starvector-terminal-provision.test.mjs
@@ -21,6 +21,8 @@ const windowsWheelWorkflow = await readFile(".github/workflows/starvector-metric
 const macosPythonSelector = await readFile("scripts/select-starvector-macos-python.mjs", "utf8");
 const windowsPythonProbe = await readFile("scripts/select-starvector-windows-python.ps1", "utf8");
 const windowsPythonProbeTest = await readFile("scripts/select-starvector-windows-python.test.ps1", "utf8");
+const windowsPythonProvision = await readFile("scripts/provision-starvector-windows-python.ps1", "utf8");
+const windowsPythonProvisionTest = await readFile("scripts/provision-starvector-windows-python.test.ps1", "utf8");
 const windowsWheelVerification = await readFile("scripts/verify-starvector-windows-metric-wheels.ps1", "utf8");
 
 test("file and tree identities stream exact bytes with bounded reads and portable ordering", async () => {
@@ -106,8 +108,8 @@ test("Windows corpus compilation cannot inherit the persistent runner's sccache 
 
 function assertWindowsMetricsPythonContract(step) {
   assert.doesNotMatch(step, /\bpy\s+-3\.11\b/);
-  assert.match(step, /select-starvector-windows-python\.ps1/);
-  assert.match(step, /\$bootstrap = Select-StarVectorBootstrapPython -CandidatePaths @\(\$env:STARVECTOR_METRICS_BOOTSTRAP_PYTHON\)/);
+  assert.match(step, /provision-starvector-windows-python\.ps1/);
+  assert.match(step, /\$bootstrap = Select-StarVectorBootstrapPython -CandidatePaths @\(\$bootstrapPython\) -ExpectedVersion @\(3, 12, 10\)/);
   assert.match(step, /\$bootstrapPython = \$bootstrap\.Executable/);
   assert.match(step, /\$bootstrapIdentity = \$bootstrap\.Identity/);
   assert.doesNotMatch(step, /Get-Command python\.exe/);
@@ -119,7 +121,7 @@ function assertWindowsMetricsPythonContract(step) {
   assert.match(step, /\[int\]\$existingIdentity\.version\[2\] -ne \[int\]\$bootstrapIdentity\.version\[2\]/);
   assert.match(step, /if \(\$rebuildMetricsVenv\) \{\s+Remove-StarVectorWindowsDirectoryTree -TargetRoot \$metricsRoot -AllowedRoot 'D:\\sceneworks-terminal\\metrics'/);
   assert.doesNotMatch(step, /Remove-Item[^\n]*-Recurse/);
-  assert.match(step, /& \$bootstrapPython -m venv \$metricsRoot/);
+  assert.match(step, /& \$bootstrapPython -m venv --copies \$metricsRoot/);
   assert.match(step, /if \(\$LASTEXITCODE -ne 0\) \{ throw 'failed to create the terminal metrics venv/);
   assert.match(step, /Test-Path \$metricsPython -PathType Leaf/);
   assert.match(step, /\$venvProbe = Invoke-StarVectorPythonIdentityProbe -Executable \$metricsPython -IncludeBaseExecutable/);
@@ -142,7 +144,7 @@ function assertWindowsPythonProbeContract(source) {
   assert.match(source, /function Remove-StarVectorWindowsDirectoryTree/);
   assert.match(source, /OrdinalIgnoreCase\.Equals\(\$canonicalTarget, \$canonicalAllowed\)/);
   assert.match(source, /New-Object System\.Collections\.Stack/);
-  assert.equal((source.match(/Attributes -band \[IO\.FileAttributes\]::ReparsePoint/g) ?? []).length, 2);
+  assert.ok((source.match(/Attributes -band \[IO\.FileAttributes\]::ReparsePoint/g) ?? []).length >= 4);
   assert.match(source, /Get-ChildItem -LiteralPath \$item\.FullName -Force -ErrorAction Stop/);
   assert.match(source, /Remove-Item -LiteralPath \$item\.FullName -Force -ErrorAction Stop/);
   assert.doesNotMatch(source, /Remove-Item[^\n]*-Recurse/);
@@ -151,6 +153,7 @@ function assertWindowsPythonProbeContract(source) {
   assert.match(source, /\$text -notmatch '\^\[A-Za-z\]:\\\\'/);
   assert.match(source, /\[IO\.Path\]::GetFullPath\(\$text\)/);
   assert.match(source, /Test-Path -LiteralPath \$full -PathType Leaf/);
+  assert.match(source, /Assert-StarVectorWindowsPathComponents -Path \$full -LeafType File/);
   assert.match(source, /New-Object System\.Diagnostics\.ProcessStartInfo/);
   assert.match(source, /\$startInfo\.FileName = \$Executable/);
   assert.match(source, /\$startInfo\.UseShellExecute = \$false/);
@@ -159,18 +162,21 @@ function assertWindowsPythonProbeContract(source) {
   assert.match(source, /\$startInfo\.CreateNoWindow = \$true/);
   assert.match(source, /\$stdoutTask = \$process\.StandardOutput\.ReadToEndAsync\(\)/);
   assert.match(source, /\$stderrTask = \$process\.StandardError\.ReadToEndAsync\(\)/);
-  assert.match(source, /\$process\.WaitForExit\(\)/);
+  assert.match(source, /\$process\.WaitForExit\(\$TimeoutMilliseconds\)/);
+  assert.match(source, /\$process\.Kill\(\)/);
   assert.match(source, /ExitCode = \$process\.ExitCode/);
   assert.match(source, /StdOut = \$stdoutTask\.Result/);
   assert.match(source, /StdErr = \$stderrTask\.Result/);
+  assert.match(source, /import ensurepip,json,pip,platform,struct,sys,venv/);
   assert.match(source, /base_executable'':getattr\(sys,''_base_executable'',None\)/);
   assert.match(source, /platform\.python_implementation\(\)/);
   assert.match(source, /platform\.machine\(\)/);
   assert.match(source, /struct\.calcsize\(''P''\)\*8/);
   assert.match(source, /if \(\$probe\.ExitCode -ne 0\) \{ continue \}/);
   assert.match(source, /\$probe\.StdOut \| ConvertFrom-Json -ErrorAction Stop/);
-  assert.match(source, /\[int\]\$identity\.version\[1\] -eq 12/);
-  assert.doesNotMatch(source, /\[int\]\$identity\.version\[1\] -ge 12/);
+  assert.match(source, /\[int\]\$identity\.version\[1\] -eq \$ExpectedVersion\[1\]/);
+  assert.match(source, /\$ExpectedVersion\.Count -eq 2 -or \[int\]\$identity\.version\[2\] -eq \$ExpectedVersion\[2\]/);
+  assert.doesNotMatch(source, /\[int\]\$identity\.version\[1\] -ge \$ExpectedVersion\[1\]/);
   assert.match(source, /\[string\]\$identity\.implementation -ceq 'CPython'/);
   assert.match(source, /\[string\]\$identity\.architecture -ceq 'AMD64'/);
   assert.match(source, /\[int\]\$identity\.pointer_bits -eq 64/);
@@ -178,16 +184,78 @@ function assertWindowsPythonProbeContract(source) {
   assert.doesNotMatch(source, /& \$candidate|Invoke-Expression|Start-Process/);
 }
 
+function assertWindowsPortablePythonContract(step, source, testSource) {
+  assert.match(source, /https:\/\/api\.nuget\.org\/v3-flatcontainer\/python\/3\.12\.10\/python\.3\.12\.10\.nupkg/);
+  assert.match(source, /0eb85c2dfccccf1b17352de4c397f69194035b7d37149eacc16f1147d93de3b8/);
+  assert.match(source, /bbda4dcf688a94211b62d50968a91b38f305d0b8d1ecd90269f74a86f8a0a4fcebb7ca162a0753a47691eb3df0c964009bd3d8194c6fd19afae8d5fd01e1cc0f/);
+  assert.match(source, /StarVectorWindowsPythonPackageBytes = 14515433/);
+  assert.match(source, /4d6f5f81a4bca11191c4c7c6b43632694d0a4ce74e068619d8fdc161d469859a/);
+  assert.match(source, /9a0e3435aaa680d868150f87ab3e388ad2eebc22f87e036155c7b4eda8cd2120/);
+  assert.match(source, /StarVectorWindowsPythonMaximumPackageBytes = 20MB/);
+  assert.match(source, /StarVectorWindowsPythonMaximumExpandedBytes = 80MB/);
+  assert.match(source, /StarVectorWindowsPythonMaximumArchiveEntries = 1400/);
+  assert.match(source, /function Invoke-StarVectorWindowsPythonLock/);
+  assert.match(source, /\$stream = \[IO\.File\]::Open\(\$canonicalLock, \[IO\.FileMode\]::OpenOrCreate, \[IO\.FileAccess\]::ReadWrite, \[IO\.FileShare\]::None\)/);
+  assert.match(source, /timed out waiting for the exclusive portable Python lock/);
+  assert.match(source, /function Save-StarVectorWindowsPythonPackage/);
+  assert.match(source, /\$handler\.AllowAutoRedirect = \$false/);
+  assert.match(source, /\$client\.Timeout = \[TimeSpan\]::FromSeconds\(\$TimeoutSeconds\)/);
+  assert.match(source, /ContentLength -ne \$ExpectedBytes/);
+  assert.match(source, /\$bytes\.LongLength -ne \$ExpectedBytes/);
+  assert.match(source, /Get-StarVectorSha256 \$destinationPath/);
+  assert.match(source, /Get-StarVectorSha512 \$destinationPath/);
+  assert.match(source, /\$entryCount -gt \$MaximumEntries/);
+  assert.match(source, /\$expandedBytes -gt \$MaximumExpandedBytes/);
+  assert.match(source, /path escapes its staging root/);
+  assert.match(source, /Python Software Foundation/);
+  assert.match(source, /https:\/\/github\.com\/Python\/CPython\.git/);
+  assert.match(source, /0cc8128/);
+  assert.match(source, /\.signature\.p7s/);
+  assert.match(source, /Get-StarVectorSha256 \$python\) -cne \$ExpectedPythonSha256/);
+  assert.match(source, /Get-StarVectorSha256 \$pythonDll\) -cne \$ExpectedDllSha256/);
+  assert.match(source, /Assert-StarVectorWindowsPathComponents -Path \$DestinationRoot -LeafType Directory -AllowMissingLeaf/);
+  assert.match(source, /\[IO\.Directory\]::Move\(\$stagingRoot, \$DestinationRoot\)/);
+  assert.doesNotMatch(source, /msiexec|python-3\.12\.10-amd64\.exe|HKLM:|HKCR:|choco install/i);
+
+  assert.match(step, /timeout-minutes: 70/);
+  assert.match(step, /\$pythonRoot = Join-Path \$env:STARVECTOR_TERMINAL_ROOT 'python\\cpython-3\.12\.10-x64-nuget'/);
+  assert.match(step, /\$lockPath = Join-Path \$env:STARVECTOR_TERMINAL_ROOT '\.locks\\cpython-3\.12\.10-x64-nuget\.lock'/);
+  assert.doesNotMatch(step, /\$lockPath[^\n]*python\\/);
+  assert.equal((step.match(/Invoke-StarVectorWindowsPythonLock -LockPath \$lockPath -ScriptBlock \{/g) ?? []).length, 1);
+  const lockedBody = step.match(/Invoke-StarVectorWindowsPythonLock -LockPath \$lockPath -ScriptBlock \{\n([\s\S]*?)\n          \}\s*$/)?.[1];
+  assert.ok(lockedBody, "portable Python and metric setup must remain inside the exclusive lock body");
+  const install = lockedBody.indexOf("Install-StarVectorWindowsPythonPackage");
+  const venv = lockedBody.indexOf("& $bootstrapPython -m venv --copies $metricsRoot", install);
+  const metrics = lockedBody.indexOf("starvector-terminal-provision.mjs metrics", venv);
+  assert.ok(install >= 0 && venv > install && metrics > venv);
+  assert.match(step, /Select-StarVectorBootstrapPython -CandidatePaths @\(\$bootstrapPython\) -ExpectedVersion @\(3, 12, 10\)/);
+  assert.doesNotMatch(step, /actions\/setup-python|RUNNER_TOOL_CACHE|AGENT_TOOLSDIRECTORY|GITHUB_PATH|\$env:Path\s*=|GITHUB_OUTPUT/);
+
+  assert.match(testSource, /partial setup-python installer root/);
+  assert.match(testSource, /RUNNER_TOOL_CACHE = 'D:\\actions-runner\\_work\\_tool'/);
+  assert.match(testSource, /AGENT_TOOLSDIRECTORY = 'E:\\different-runner\\_work\\_tool'/);
+  assert.match(testSource, /exclusive lock did not reject a concurrent shared-root provisioner/);
+  assert.match(testSource, /portable Python did not reject a \$junctionKind-root junction/);
+  assert.match(testSource, /archive entry-count limit was not enforced/);
+  assert.match(testSource, /archive expansion-size limit was not enforced/);
+  assert.match(testSource, /Install-StarVectorWindowsPythonPackage -DestinationRoot \$officialRoot/);
+  assert.match(testSource, /official portable python\.exe hash changed/);
+  assert.match(testSource, /official portable python312\.dll hash changed/);
+  assert.match(testSource, /& \$official -m venv --copies \$venvRoot/);
+}
+
 test("terminal metrics provisioning fixes CPython 3.12 and wheel-only installation on both hosts", () => {
-  assert.equal((workflow.match(/uses: actions\/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97/g) ?? []).length, 1);
-  assert.equal((workflow.match(/python-version: "3\.12"/g) ?? []).length, 1);
-  assert.equal((workflow.match(/update-environment: false/g) ?? []).length, 1);
+  assert.equal((workflow.match(/uses: actions\/setup-python@/g) ?? []).length, 0);
+  assert.equal((workflow.match(/python-version:/g) ?? []).length, 0);
+  assert.equal((workflow.match(/update-environment:/g) ?? []).length, 0);
   assert.match(workflow, /Select supported existing CPython 3\.12 arm64 for terminal metrics/);
   assert.match(workflow, /select-starvector-macos-python\.mjs select \/opt\/homebrew\/bin\/python3\.12 \/usr\/local\/bin\/python3\.12/);
   assert.match(workflow, /select-starvector-macos-python\.mjs verify-venv "\$STARVECTOR_METRICS_BOOTSTRAP_PYTHON" "\$STARVECTOR_TERMINAL_ROOT\/metrics\/bin\/python"/);
   assert.match(workflow, /remove-metrics-tree "\$STARVECTOR_TERMINAL_ROOT\/metrics" \/Users\/Shared\/SceneWorks\/starvector-terminal\/metrics/);
   assert.doesNotMatch(workflow.slice(workflow.indexOf("  provision-macos:"), workflow.indexOf("  provision-windows:")), /actions\/setup-python|RUNNER_TOOL_CACHE|AGENT_TOOLSDIRECTORY|\/Users\/runner\/hostedtoolcache/);
-  assert.match(workflow, /Set up supported CPython 3\.12 x64 for terminal metrics[\s\S]*?architecture: x64/);
+  const windowsJob = workflow.slice(workflow.indexOf("  provision-windows:"));
+  assert.doesNotMatch(windowsJob, /actions\/setup-python|RUNNER_TOOL_CACHE|AGENT_TOOLSDIRECTORY|D:\\actions-runner|cuda-windows-2/);
+  assert.match(windowsJob, /Provision exact portable CPython 3\.12\.10 x64 and terminal metrics/);
   assert.equal((workflow.match(/pip install --disable-pip-version-check --only-binary=:all: --retries 5 --timeout 60/g) ?? []).length, 2);
   assert.doesNotMatch(workflow, /pip install --disable-pip-version-check (?!.*--only-binary=:all:)/);
   assert.match(macosPythonSelector, /identity\.version\[1\] === 12/);
@@ -200,11 +268,12 @@ test("terminal metrics provisioning fixes CPython 3.12 and wheel-only installati
   assert.match(macosPythonSelector, /canonicalObservedPrefix !== canonicalExpectedPrefix \|\| canonicalObservedPrefix === canonicalBasePrefix/);
   assert.match(macosPythonSelector, /if \(item\.isSymbolicLink\(\)\) \{\s+unlinkSync\(frame\.file\);/);
 
-  const start = workflow.indexOf("- name: Provision pinned metric runtime and official checkpoints", workflow.indexOf("  provision-windows:"));
+  const start = workflow.indexOf("- name: Provision exact portable CPython 3.12.10 x64 and terminal metrics", workflow.indexOf("  provision-windows:"));
   const end = workflow.indexOf("- name: Materialize the exact pinned 120-row corpus", start);
   const step = workflow.slice(start, end);
   assert.ok(start >= 0 && end > start);
   assertWindowsMetricsPythonContract(step);
+  assertWindowsPortablePythonContract(step, windowsPythonProvision, windowsPythonProvisionTest);
   const isSafeDriveAbsolute = (value) => /^[A-Za-z]:\\/.test(value) && !/[\r\n"]/.test(value);
   assert.equal(isSafeDriveAbsolute("C:\\Python312\\python.exe"), true);
   for (const rejected of ["python.exe", "C:python.exe", "\\python.exe", "\\\\server\\share\\python.exe", "C:/Python312/python.exe", "C:\\Python312\\py\nthon.exe", 'C:\\Python312\\py"thon.exe']) {
@@ -301,9 +370,12 @@ test("Windows Python probes capture native stderr without invoking through Power
   assert.match(windowsPythonProbeTest, /04-python314\.exe/);
   assert.match(windowsPythonProbeTest, /05-python312-arm64\.exe/);
   assert.match(windowsPythonProbeTest, /06-python312-amd64\.exe/);
+  assert.match(windowsPythonProbeTest, /07-hanging-python\.exe/);
   assert.match(windowsPythonProbeTest, /Traceback from the first fake Python candidate/);
   assert.match(windowsPythonProbeTest, /Select-StarVectorBootstrapPython -CandidatePaths @\(\$bad, \$malformed, \$belowMinimum, \$newerUnsupported, \$wrongArchitecture,/);
   assert.match(windowsPythonProbeTest, /all invalid candidates must fail closed/);
+  assert.match(windowsPythonProbeTest, /exact-micro selection accepted a different CPython 3\.12 patch release/);
+  assert.match(windowsPythonProbeTest, /executable selection traversed a junction parent/);
   assert.match(windowsPythonProbeTest, /ConvertTo-StarVectorPythonDistributionName 'Open\.CLIP_Torch'/);
   assert.match(windowsPythonProbeTest, /New-Item -ItemType Junction -Path \$junction -Target \$outside/);
   assert.match(windowsPythonProbeTest, /junction refusal must preserve the outside sentinel/);
@@ -323,7 +395,9 @@ test("Windows Python probe contract rejects native-process safety mutations", ()
     ["exit status", (value) => value.replace("ExitCode = $process.ExitCode", "ExitCode = 0")],
     ["bad-candidate continuation", (value) => value.replace("if ($probe.ExitCode -ne 0) { continue }", "if ($probe.ExitCode -ne 0) { break }")],
     ["PowerShell invocation", (value) => value.replace("$probe = Invoke-StarVectorPythonIdentityProbe -Executable $canonicalCandidate", "$probe = & $candidate -c $code")],
-    ["permissive Python minor", (value) => value.replace("[int]$identity.version[1] -eq 12", "[int]$identity.version[1] -ge 12")],
+    ["missing probe timeout", (value) => value.replace("$process.WaitForExit($TimeoutMilliseconds)", "$process.WaitForExit()")],
+    ["permissive Python minor", (value) => value.replace("[int]$identity.version[1] -eq $ExpectedVersion[1]", "[int]$identity.version[1] -ge $ExpectedVersion[1]")],
+    ["ignored Python micro", (value) => value.replace("$ExpectedVersion.Count -eq 2 -or [int]$identity.version[2] -eq $ExpectedVersion[2]", "$true")],
     ["implementation identity", (value) => value.replace("[string]$identity.implementation -ceq 'CPython'", "$true")],
     ["architecture identity", (value) => value.replace("[string]$identity.architecture -ceq 'AMD64'", "$true")],
     ["pointer width", (value) => value.replace("[int]$identity.pointer_bits -eq 64", "$true")],
@@ -339,12 +413,39 @@ test("Windows Python probe contract rejects native-process safety mutations", ()
   }
 });
 
+test("portable Windows Python contract rejects provenance, bounds, lock, and path-safety mutations", () => {
+  const start = workflow.indexOf("- name: Provision exact portable CPython 3.12.10 x64 and terminal metrics", workflow.indexOf("  provision-windows:"));
+  const end = workflow.indexOf("- name: Materialize the exact pinned 120-row corpus", start);
+  const step = workflow.slice(start, end);
+  for (const [label, stepMutation, sourceMutation] of [
+    ["floating package", (value) => value, (value) => value.replace("python/3.12.10/python.3.12.10.nupkg", "python/3.12.10/python.nupkg")],
+    ["package sha256", (value) => value, (value) => value.replace("0eb85c2dfccccf1b17352de4c397f69194035b7d37149eacc16f1147d93de3b8", "0".repeat(64))],
+    ["package size", (value) => value, (value) => value.replace("StarVectorWindowsPythonPackageBytes = 14515433", "StarVectorWindowsPythonPackageBytes = 0")],
+    ["python exe hash", (value) => value, (value) => value.replace("4d6f5f81a4bca11191c4c7c6b43632694d0a4ce74e068619d8fdc161d469859a", "0".repeat(64))],
+    ["runtime dll hash", (value) => value, (value) => value.replace("9a0e3435aaa680d868150f87ab3e388ad2eebc22f87e036155c7b4eda8cd2120", "0".repeat(64))],
+    ["archive entry cap", (value) => value, (value) => value.replace("StarVectorWindowsPythonMaximumArchiveEntries = 1400", "StarVectorWindowsPythonMaximumArchiveEntries = 10000")],
+    ["expanded byte cap", (value) => value, (value) => value.replace("StarVectorWindowsPythonMaximumExpandedBytes = 80MB", "StarVectorWindowsPythonMaximumExpandedBytes = 256MB")],
+    ["redirect refusal", (value) => value, (value) => value.replace("$handler.AllowAutoRedirect = $false", "$handler.AllowAutoRedirect = $true")],
+    ["exclusive file lock", (value) => value, (value) => value.replace("[IO.FileShare]::None", "[IO.FileShare]::ReadWrite")],
+    ["destination component validation", (value) => value, (value) => value.replaceAll("Assert-StarVectorWindowsPathComponents -Path $DestinationRoot -LeafType Directory -AllowMissingLeaf", "Write-Host $DestinationRoot")],
+    ["missing workflow lock", (value) => value.replace("Invoke-StarVectorWindowsPythonLock -LockPath $lockPath -ScriptBlock {", "& {"), (value) => value],
+    ["lock inside mutable Python root", (value) => value.replace("'.locks\\cpython-3.12.10-x64-nuget.lock'", "'python\\cpython-3.12.10-x64-nuget.lock'"), (value) => value],
+    ["ambient venv links", (value) => value.replace("-m venv --copies $metricsRoot", "-m venv $metricsRoot"), (value) => value],
+    ["path mutation", (value) => value.replace("$bootstrapPython = $bootstrap.Executable", "$env:Path = \"$bootstrapPython;$env:Path\""), (value) => value],
+  ]) {
+    const changedStep = stepMutation(step);
+    const changedSource = sourceMutation(windowsPythonProvision);
+    assert.ok(changedStep !== step || changedSource !== windowsPythonProvision, `${label} mutation must alter a fixture`);
+    assert.throws(() => assertWindowsPortablePythonContract(changedStep, changedSource, windowsPythonProvisionTest), { name: "AssertionError" }, label);
+  }
+});
+
 test("Windows metrics Python contract rejects path, base-interpreter, and patch-version guard mutations", () => {
-  const start = workflow.indexOf("- name: Provision pinned metric runtime and official checkpoints", workflow.indexOf("  provision-windows:"));
+  const start = workflow.indexOf("- name: Provision exact portable CPython 3.12.10 x64 and terminal metrics", workflow.indexOf("  provision-windows:"));
   const end = workflow.indexOf("- name: Materialize the exact pinned 120-row corpus", start);
   const step = workflow.slice(start, end);
   for (const [label, mutation] of [
-    ["selection helper", (value) => value.replace("$bootstrap = Select-StarVectorBootstrapPython -CandidatePaths @($env:STARVECTOR_METRICS_BOOTSTRAP_PYTHON)", "$bootstrap = Get-Command python.exe")],
+    ["selection helper", (value) => value.replace("$bootstrap = Select-StarVectorBootstrapPython -CandidatePaths @($bootstrapPython) -ExpectedVersion @(3, 12, 10)", "$bootstrap = Get-Command python.exe")],
     ["venv captured probe", (value) => value.replace("$venvProbe = Invoke-StarVectorPythonIdentityProbe -Executable $metricsPython -IncludeBaseExecutable", "$venvProbe = & $metricsPython -c $code")],
     ["base path equality", (value) => value.replace("OrdinalIgnoreCase.Equals($bootstrapPython, $observedBasePython)", "OrdinalIgnoreCase.Equals($bootstrapPython, $bootstrapPython)")],
     ["patch version equality", (value) => value.replace("[int]$venvIdentity.version[2] -ne [int]$bootstrapIdentity.version[2]", "[int]$venvIdentity.version[2] -ne [int]$venvIdentity.version[2]")],
@@ -368,8 +469,11 @@ function assertHostedWindowsWheelContract(hostedWorkflow, verification) {
   assert.match(hostedWorkflow, /timeout-minutes: 25/);
   assert.match(hostedWorkflow, /uses: actions\/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97/);
   assert.match(hostedWorkflow, /python-version: "3\.12"[\s\S]*?architecture: x64[\s\S]*?update-environment: false/);
-  assert.equal((hostedWorkflow.match(/shell: powershell/g) ?? []).length, 2);
+  assert.equal((hostedWorkflow.match(/shell: powershell/g) ?? []).length, 3);
   assert.match(hostedWorkflow, /select-starvector-windows-python\.test\.ps1/);
+  assert.match(hostedWorkflow, /"scripts\/provision-starvector-windows-python\.ps1"/);
+  assert.match(hostedWorkflow, /"scripts\/provision-starvector-windows-python\.test\.ps1"/);
+  assert.match(hostedWorkflow, /timeout-minutes: 10\s+run: \.\\scripts\\provision-starvector-windows-python\.test\.ps1/);
   assert.match(hostedWorkflow, /"scripts\/starvector-terminal-metrics\.py"/);
   assert.match(hostedWorkflow, /STARVECTOR_METRICS_BOOTSTRAP_PYTHON: \$\{\{ steps\.metrics-python\.outputs\.python-path \}\}/);
   assert.match(hostedWorkflow, /verify-starvector-windows-metric-wheels\.ps1/);
@@ -396,6 +500,8 @@ test("hosted Windows wheel contract rejects source-distribution and ambient-inte
     ["ambient interpreter", (value) => value.replace("${{ steps.metrics-python.outputs.python-path }}", "python.exe"), (value) => value],
     ["floating minor", (value) => value.replace('python-version: "3.12"', 'python-version: ">=3.12"'), (value) => value],
     ["import surface trigger", (value) => value.replace('      - "scripts/starvector-terminal-metrics.py"\n', ''), (value) => value],
+    ["portable provision trigger", (value) => value.replace('      - "scripts/provision-starvector-windows-python.ps1"\n', ''), (value) => value],
+    ["portable provision test", (value) => value.replace("run: .\\scripts\\provision-starvector-windows-python.test.ps1", "run: Write-Host skipped"), (value) => value],
     ["source download", (value) => value, (value) => value.replace("'--only-binary=:all:', '--retries'", "'--prefer-binary', '--retries'")],
     ["online install", (value) => value, (value) => value.replace("'--no-index', '--find-links'", "'--index-url', 'https://pypi.org/simple', '--find-links'")],
     ["source archive acceptance", (value) => value, (value) => value.replace("$_.Extension -cne '.whl'", "$false")],


### PR DESCRIPTION
## Summary

- replace the Windows StarVector terminal provisioner's dependency on `actions/setup-python` and its shared runner toolcache/registry repair path with an exact portable CPython 3.12.10 x64 distribution
- keep interpreter selection strict, create the metrics environment with `venv --copies`, retain wheel-only dependency installation, and avoid PATH mutation
- serialize provisioning across the interchangeable Windows runners so validation, repair, publication, venv setup, and metrics preparation cannot race through the shared durable root

## Terminal evidence

Provision run `33830057444` exposed divergent state across the interchangeable runners. `cuda-windows-2` had previously succeeded, while `cuda-windows` found a partial `D:\actions-runner\_work\_tool\Python\3.12.10\x64`. `actions/setup-python` could not remove machine-wide HKLM/HKCR installer registry keys without administrator rights, and its reinstall left the installer but no `python.exe`, terminating the Windows job. The macOS lane was green.

This change does not use the PSF MSI/EXE installer and therefore does not touch the registry or the actions toolcache.

## Portable artifact and safety contract

The provisioner downloads the official PSF NuGet package:

- `python` `3.12.10` x64 from `https://api.nuget.org/v3-flatcontainer/python/3.12.10/python.3.12.10.nupkg`
- exact package size `14,515,433` bytes
- SHA-256 `0eb85c2dfccccf1b17352de4c397f69194035b7d37149eacc16f1147d93de3b8`
- SHA-512 `bbda4dcf688a94211b62d50968a91b38f305d0b8d1ecd90269f74a86f8a0a4fcebb7ca162a0753a47691eb3df0c964009bd3d8194c6fd19afae8d5fd01e1cc0f`
- extracted `tools\python.exe` SHA-256 `4d6f5f81a4bca11191c4c7c6b43632694d0a4ce74e068619d8fdc161d469859a`
- extracted `tools\python312.dll` SHA-256 `9a0e3435aaa680d868150f87ab3e388ad2eebc22f87e036155c7b4eda8cd2120`
- PSF nuspec identity, CPython source commit `0cc81280367df838c4b199f8f0378837165071c2`, zero dependencies, and repository-signature entry are required

Downloads are HTTPS-only, redirect-free, bounded to 120 seconds, exact-sized, and dual-hash verified before extraction. ZIP entry count and expanded bytes are capped; traversal, alternate data stream, duplicate, and rooted paths are rejected. Destination components and the exact mutable root are checked against reparse/junction escape, cleanup is exact-root-only, staging uses a fresh GUID directory, and publication is an atomic directory move. Existing installations are accepted only after provenance, runtime identity, and extracted binary hashes revalidate.

An exclusive file lock at `D:\sceneworks-terminal\.locks\cpython-3.12.10-x64-nuget.lock`, outside the mutable interpreter root, covers validation/removal/download/publish and all downstream venv/package/checkpoint/metrics setup. This prevents `cuda-windows` and `cuda-windows-2` from racing the shared durable root. Runtime validation requires exact CPython 3.12.10, AMD64/64-bit, exact executable/base identities, and the expected `venv`, `ensurepip`, and `pip` modules.

## Validation

- `node --test scripts/starvector-terminal-provision.test.mjs`: 18/18 passed
- `npm run check:ci:action-pins`: passed for all 16 workflows
- `npm run check:shell`: passed
- actionlint: the hosted workflow is clean; the production workflow reports only the existing unknown custom labels `rw-starvector`, `cuda`, and `real-weights`
- `env -u HF_HOME npm run rust:check`: passed tier integrity, rustfmt, clippy, all Rust tests, and build
- the initial Rust run inherited `HF_HOME=/Volumes/Models/huggingface`, which made two unrelated stub tests observe real cached weights; rerunning with that ambient host fixture removed passed in full
- `npm run check`: 720/723 passed; the same three environment-fixture-only failures remain: missing `ajv` for `epic-20738-terminal-cuda-harness.test.mjs`, plus two tests requiring the absent sibling `/tmp/sc22261-selfhosted-python-setup.IW6MUN/sc-22261-inference-integration`
- focused hosted Windows contract coverage includes the real official download and venv, partial-root repair, divergent runner toolcache variables, idempotent reuse and corruption repair, checksum-before-deletion, reparse-safe destination handling, traversal/entry/expanded-size caps, lock contention/release, and exact runtime hashes

The protected quartet is unchanged:

- `config/memory-anchors.json`: `b156e9db050373afa86dfbb812e0ae7802f802e14da741373dbe9aab898de7d5`
- `docs/generated/memory-matrix.json`: `2408b7de390e847824c95aa449991638a1892b5fbfc4e12cba9c74fc60c99d8d`
- `docs/generated/memory-matrix.md`: `44177f6a54a15bbd0dbb401204082c9839bd111aaae5293b544935342f178a2f`
- `release/starvector-terminal-metrics-lock-v1.json`: `8ab96cf63a6846aadd351d43cd50c91de747b694cc5b450a29a699a2c843f115`
