### PR TITLE
SC-22261: detach terminal product service logs

### DIFF
--- a/.github/workflows/starvector-terminal.yml
+++ b/.github/workflows/starvector-terminal.yml
@@ -72,6 +72,9 @@ jobs:
           node scripts/starvector-terminal-assets.mjs "$STARVECTOR_TERMINAL_CORPUS_ASSETS_ROOT" "$STARVECTOR_TERMINAL_API_URL" mlx:1b "$RUNNER_TEMP/starvector-terminal/mlx-1b/imported-assets.json"
           node scripts/starvector-terminal-case-bundle.mjs "$STARVECTOR_TERMINAL_INFERENCE_ROOT/release/starvector-terminal-corpus-v1.json" "$STARVECTOR_TERMINAL_CORPUS_ASSETS_ROOT" "$STARVECTOR_TERMINAL_CASE_BUNDLE" "${{ inputs.permanent_pin }}" "$RUNNER_TEMP/starvector-terminal/mlx-1b/imported-assets.json"
           node scripts/starvector-terminal-producer.mjs run "$GITHUB_WORKSPACE" release/starvector-terminal-campaign-v1.json "$STARVECTOR_TERMINAL_INFERENCE_ROOT" "$STARVECTOR_TERMINAL_WEIGHTS_ROOT" "$STARVECTOR_TERMINAL_METRICS_ROOT" "$STARVECTOR_TERMINAL_LEASE_ROOT" "$STARVECTOR_TERMINAL_LEASE_HELPER" "$RUNNER_TEMP/starvector-terminal/mlx-1b" mlx:1b "${{ inputs.campaign_run_id }}" "${{ inputs.permanent_pin }}" "$STARVECTOR_TERMINAL_PRODUCT_ROUTE_COMMAND"
+      - name: Stop MLX 1B source-built service
+        if: ${{ always() }}
+        run: node scripts/starvector-terminal-product-service.mjs stop "$RUNNER_TEMP/starvector-terminal/mlx-1b"
       - name: Upload MLX 1B raw evidence even on failure
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -79,9 +82,6 @@ jobs:
           name: starvector-terminal-mlx-1b-${{ inputs.campaign_run_id }}
           path: ${{ runner.temp }}/starvector-terminal/mlx-1b
           if-no-files-found: warn
-      - name: Stop MLX 1B source-built service
-        if: ${{ always() }}
-        run: node scripts/starvector-terminal-product-service.mjs stop "$RUNNER_TEMP/starvector-terminal/mlx-1b"
 
   mlx-8b:
     needs: mlx-1b
@@ -97,6 +97,9 @@ jobs:
           node scripts/starvector-terminal-assets.mjs "$STARVECTOR_TERMINAL_CORPUS_ASSETS_ROOT" "$STARVECTOR_TERMINAL_API_URL" mlx:8b "$RUNNER_TEMP/starvector-terminal/mlx-8b/imported-assets.json"
           node scripts/starvector-terminal-case-bundle.mjs "$STARVECTOR_TERMINAL_INFERENCE_ROOT/release/starvector-terminal-corpus-v1.json" "$STARVECTOR_TERMINAL_CORPUS_ASSETS_ROOT" "$STARVECTOR_TERMINAL_CASE_BUNDLE" "${{ inputs.permanent_pin }}" "$RUNNER_TEMP/starvector-terminal/mlx-8b/imported-assets.json"
           node scripts/starvector-terminal-producer.mjs run "$GITHUB_WORKSPACE" release/starvector-terminal-campaign-v1.json "$STARVECTOR_TERMINAL_INFERENCE_ROOT" "$STARVECTOR_TERMINAL_WEIGHTS_ROOT" "$STARVECTOR_TERMINAL_METRICS_ROOT" "$STARVECTOR_TERMINAL_LEASE_ROOT" "$STARVECTOR_TERMINAL_LEASE_HELPER" "$RUNNER_TEMP/starvector-terminal/mlx-8b" mlx:8b "${{ inputs.campaign_run_id }}" "${{ inputs.permanent_pin }}" "$STARVECTOR_TERMINAL_PRODUCT_ROUTE_COMMAND"
+      - name: Stop MLX 8B source-built service
+        if: ${{ always() }}
+        run: node scripts/starvector-terminal-product-service.mjs stop "$RUNNER_TEMP/starvector-terminal/mlx-8b"
       - name: Upload MLX 8B raw evidence even on failure
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -104,9 +107,6 @@ jobs:
           name: starvector-terminal-mlx-8b-${{ inputs.campaign_run_id }}
           path: ${{ runner.temp }}/starvector-terminal/mlx-8b
           if-no-files-found: warn
-      - name: Stop MLX 8B source-built service
-        if: ${{ always() }}
-        run: node scripts/starvector-terminal-product-service.mjs stop "$RUNNER_TEMP/starvector-terminal/mlx-8b"
 
   cuda-1b:
     needs: mlx-8b
@@ -136,6 +136,10 @@ jobs:
           node scripts/starvector-terminal-assets.mjs $env:STARVECTOR_TERMINAL_CORPUS_ASSETS_ROOT $env:STARVECTOR_TERMINAL_API_URL candle-cuda:1b "$env:RUNNER_TEMP\\starvector-terminal\\cuda-1b\\imported-assets.json"
           node scripts/starvector-terminal-case-bundle.mjs "$env:STARVECTOR_TERMINAL_INFERENCE_ROOT\\release\\starvector-terminal-corpus-v1.json" $env:STARVECTOR_TERMINAL_CORPUS_ASSETS_ROOT $env:STARVECTOR_TERMINAL_CASE_BUNDLE "${{ inputs.permanent_pin }}" "$env:RUNNER_TEMP\\starvector-terminal\\cuda-1b\\imported-assets.json"
           node scripts/starvector-terminal-producer.mjs run $env:GITHUB_WORKSPACE release/starvector-terminal-campaign-v1.json $env:STARVECTOR_TERMINAL_INFERENCE_ROOT $env:STARVECTOR_TERMINAL_WEIGHTS_ROOT $env:STARVECTOR_TERMINAL_METRICS_ROOT $env:STARVECTOR_TERMINAL_LEASE_ROOT $env:STARVECTOR_TERMINAL_LEASE_HELPER "$env:RUNNER_TEMP\\starvector-terminal\\cuda-1b" candle-cuda:1b "${{ inputs.campaign_run_id }}" "${{ inputs.permanent_pin }}" $env:STARVECTOR_TERMINAL_PRODUCT_ROUTE_COMMAND
+      - name: Stop CUDA 1B source-built service
+        if: ${{ always() }}
+        shell: powershell
+        run: node scripts/starvector-terminal-product-service.mjs stop "$env:RUNNER_TEMP\starvector-terminal\cuda-1b"
       - name: Upload CUDA 1B raw evidence even on failure
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -143,10 +147,6 @@ jobs:
           name: starvector-terminal-cuda-1b-${{ inputs.campaign_run_id }}
           path: ${{ runner.temp }}\starvector-terminal\cuda-1b
           if-no-files-found: warn
-      - name: Stop CUDA 1B source-built service
-        if: ${{ always() }}
-        shell: powershell
-        run: node scripts/starvector-terminal-product-service.mjs stop "$env:RUNNER_TEMP\starvector-terminal\cuda-1b"
 
   cuda-8b:
     needs: cuda-1b
@@ -176,6 +176,10 @@ jobs:
           node scripts/starvector-terminal-assets.mjs $env:STARVECTOR_TERMINAL_CORPUS_ASSETS_ROOT $env:STARVECTOR_TERMINAL_API_URL candle-cuda:8b "$env:RUNNER_TEMP\\starvector-terminal\\cuda-8b\\imported-assets.json"
           node scripts/starvector-terminal-case-bundle.mjs "$env:STARVECTOR_TERMINAL_INFERENCE_ROOT\\release\\starvector-terminal-corpus-v1.json" $env:STARVECTOR_TERMINAL_CORPUS_ASSETS_ROOT $env:STARVECTOR_TERMINAL_CASE_BUNDLE "${{ inputs.permanent_pin }}" "$env:RUNNER_TEMP\\starvector-terminal\\cuda-8b\\imported-assets.json"
           node scripts/starvector-terminal-producer.mjs run $env:GITHUB_WORKSPACE release/starvector-terminal-campaign-v1.json $env:STARVECTOR_TERMINAL_INFERENCE_ROOT $env:STARVECTOR_TERMINAL_WEIGHTS_ROOT $env:STARVECTOR_TERMINAL_METRICS_ROOT $env:STARVECTOR_TERMINAL_LEASE_ROOT $env:STARVECTOR_TERMINAL_LEASE_HELPER "$env:RUNNER_TEMP\\starvector-terminal\\cuda-8b" candle-cuda:8b "${{ inputs.campaign_run_id }}" "${{ inputs.permanent_pin }}" $env:STARVECTOR_TERMINAL_PRODUCT_ROUTE_COMMAND
+      - name: Stop CUDA 8B source-built service
+        if: ${{ always() }}
+        shell: powershell
+        run: node scripts/starvector-terminal-product-service.mjs stop "$env:RUNNER_TEMP\starvector-terminal\cuda-8b"
       - name: Upload CUDA 8B raw evidence and terminal suites even on failure
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -183,10 +187,6 @@ jobs:
           name: starvector-terminal-cuda-8b-${{ inputs.campaign_run_id }}
           path: ${{ runner.temp }}\starvector-terminal\cuda-8b
           if-no-files-found: warn
-      - name: Stop CUDA 8B source-built service
-        if: ${{ always() }}
-        shell: powershell
-        run: node scripts/starvector-terminal-product-service.mjs stop "$env:RUNNER_TEMP\starvector-terminal\cuda-8b"
 
   seal-receipt:
     if: ${{ always() }}

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -867,7 +867,7 @@ fn builtin_starvector_manifests_are_exact_native_image_to_svg_closures() {
             );
             assert_eq!(
                 candidate["productionClosure"]["sha256"],
-                "cd7b7124fb4e04c58caa739d7292187199515fb9dc8ec575bf885334f3a4e115"
+                "6356a087c1a4c9add808631d898184a66717c6e4a34ea66162140cc35098c273"
             );
             assert_eq!(
                 candidate["productionClosure"]["entries"]

--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -867,7 +867,7 @@ fn builtin_starvector_manifests_are_exact_native_image_to_svg_closures() {
             );
             assert_eq!(
                 candidate["productionClosure"]["sha256"],
-                "6c300cd26bdd7cc6fee60dc11a47188802a3b52eec1389ab789e082d71e958d3"
+                "cd7b7124fb4e04c58caa739d7292187199515fb9dc8ec575bf885334f3a4e115"
             );
             assert_eq!(
                 candidate["productionClosure"]["entries"]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -25612,7 +25612,7 @@
             },
             "productionClosure": {
               "schemaVersion": 1,
-              "sha256": "6c300cd26bdd7cc6fee60dc11a47188802a3b52eec1389ab789e082d71e958d3",
+              "sha256": "cd7b7124fb4e04c58caa739d7292187199515fb9dc8ec575bf885334f3a4e115",
               "entries": [
                 {
                   "path": ".github/workflows/starvector-terminal.yml",
@@ -25756,8 +25756,8 @@
                 },
                 {
                   "path": "scripts/starvector-terminal-product-service.mjs",
-                  "byteSize": 11393,
-                  "sha256": "0551e1c6dbed65979144b610fcea9df89c54c14489a2aa17c7aa1b571ca9b2ca"
+                  "byteSize": 15246,
+                  "sha256": "5aca99456597c267bf565aa3b14f9e8efc73d983e1c7208c027a6ac4180098f4"
                 },
                 {
                   "path": "scripts/starvector-terminal-route.mjs",

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -25612,12 +25612,12 @@
             },
             "productionClosure": {
               "schemaVersion": 1,
-              "sha256": "cd7b7124fb4e04c58caa739d7292187199515fb9dc8ec575bf885334f3a4e115",
+              "sha256": "6356a087c1a4c9add808631d898184a66717c6e4a34ea66162140cc35098c273",
               "entries": [
                 {
                   "path": ".github/workflows/starvector-terminal.yml",
                   "byteSize": 16053,
-                  "sha256": "36a59f5032557b9a60baabb38c85f6aa9d9d3a623001e6cd881f95419b4a4547"
+                  "sha256": "75f9ee8e7b8a6d032e5dc485377d15c23a07120e2db95d6af23bb28d56bdfa2b"
                 },
                 {
                   "path": "Cargo.lock",
@@ -25756,8 +25756,8 @@
                 },
                 {
                   "path": "scripts/starvector-terminal-product-service.mjs",
-                  "byteSize": 15246,
-                  "sha256": "5aca99456597c267bf565aa3b14f9e8efc73d983e1c7208c027a6ac4180098f4"
+                  "byteSize": 22607,
+                  "sha256": "a00734747db8996678308ddcd444aba2d0d0fc48d919eab4a19059e1c004c5b4"
                 },
                 {
                   "path": "scripts/starvector-terminal-route.mjs",

--- a/scripts/starvector-production-closure.test.mjs
+++ b/scripts/starvector-production-closure.test.mjs
@@ -65,7 +65,7 @@ test("shape and tree checks detect every closure mutation", async () => {
 
 test("live manifest seals the exact frozen-tree production closure", async () => {
   const closure = await checkManifestProductionClosure();
-  assert.equal(closure.sha256, "cd7b7124fb4e04c58caa739d7292187199515fb9dc8ec575bf885334f3a4e115");
+  assert.equal(closure.sha256, "6356a087c1a4c9add808631d898184a66717c6e4a34ea66162140cc35098c273");
   assert.equal(closure.entries.length, 30);
 });
 

--- a/scripts/starvector-production-closure.test.mjs
+++ b/scripts/starvector-production-closure.test.mjs
@@ -65,7 +65,7 @@ test("shape and tree checks detect every closure mutation", async () => {
 
 test("live manifest seals the exact frozen-tree production closure", async () => {
   const closure = await checkManifestProductionClosure();
-  assert.equal(closure.sha256, "6c300cd26bdd7cc6fee60dc11a47188802a3b52eec1389ab789e082d71e958d3");
+  assert.equal(closure.sha256, "cd7b7124fb4e04c58caa739d7292187199515fb9dc8ec575bf885334f3a4e115");
   assert.equal(closure.entries.length, 30);
 });
 

--- a/scripts/starvector-terminal-product-service.mjs
+++ b/scripts/starvector-terminal-product-service.mjs
@@ -2,9 +2,11 @@
 // Start the actual current-tree Rust API and worker for the terminal campaign.
 // This is intentionally not an arbitrary service command: its source revision,
 // Cargo inference pin, binaries and health response are all recorded together.
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { execFile as execFileCallback, spawn } from "node:child_process";
+import { createReadStream } from "node:fs";
 import { copyFile, lstat, mkdir, open, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
 import { promisify } from "node:util";
 import path from "node:path";
 import { isExecutedModule } from "./starvector-terminal-cli.mjs";
@@ -25,6 +27,9 @@ export function productServiceBackendEnv(platform = process.platform) {
 export function productServiceStateRoot(output) {
   return path.join(path.dirname(output), `${path.basename(output)}-product-service-state`);
 }
+export function productServiceActiveStatePath(output) {
+  return path.join(productServiceStateRoot(output), "product-service-active.json");
+}
 const PRODUCT_SERVICE_LOG_FILES = Object.freeze({
   api_stdout: "product-service-api.stdout.log",
   api_stderr: "product-service-api.stderr.log",
@@ -44,9 +49,33 @@ async function openProductServiceLogs(output) {
     throw error;
   }
 }
-export async function productServiceLogsSha256(output) {
-  const chunks = await Promise.all(Object.values(productServiceLogPaths(output)).map((file) => readFile(file)));
-  return sha(Buffer.concat(chunks));
+async function fixedPrefixSha256(file, byteSize) {
+  if (byteSize === 0) return sha("");
+  return fileSha256(file, { openReadStream: (input, options) => createReadStream(input, { ...options, start: 0, end: byteSize - 1 }) });
+}
+export async function productServiceLogsIdentity(output, { requireAll = true } = {}) {
+  const entries = [];
+  for (const file of Object.values(productServiceLogPaths(output))) {
+    const info = await lstat(file).catch((error) => error.code === "ENOENT" ? null : Promise.reject(error));
+    if (!info) {
+      if (requireAll) die(`product service log is missing: ${file}`);
+      continue;
+    }
+    if (info.isSymbolicLink() || !info.isFile()) {
+      if (requireAll) die(`product service log is not a regular file: ${file}`);
+      continue;
+    }
+    const relative = path.relative(output, file).split(path.sep).join("/");
+    entries.push(terminalTreeEntry(relative, info.size, await fixedPrefixSha256(file, info.size)));
+  }
+  const canonicalEntries = sortTerminalTreeEntries(entries);
+  return { schema_version: 1, entries: canonicalEntries, sha256: terminalTreeSha256(canonicalEntries) };
+}
+async function writeProductServiceLogsIdentity(output, options) {
+  const identity = await productServiceLogsIdentity(output, options);
+  await writeFile(path.join(output, "product-service-logs.json"), JSON.stringify(identity, null, 2) + "\n");
+  await writeFile(path.join(output, "product-service-logs.sha256"), `${identity.sha256}\n`);
+  return identity;
 }
 async function git(root, args) { return (await execFile("git", ["-C", root, ...args])).stdout.trim(); }
 async function serviceIdentity(root, permanentPin) {
@@ -59,24 +88,71 @@ async function serviceIdentity(root, permanentPin) {
 async function waitHealthy(url, assertRunning = () => {}) {
   for (let attempt = 0; attempt < 120; attempt += 1) {
     assertRunning();
-    try { const response = await fetch(new URL("/api/v1/health", url)); const body = await response.json(); if (response.ok && body?.status === "ok" && body?.readiness?.status === "ready") { assertRunning(); return body; } } catch { /* booting */ }
+    try { const response = await fetch(new URL("/api/v1/health", url), { signal: AbortSignal.timeout(1000) }); const body = await response.json(); if (response.ok && body?.status === "ok" && body?.readiness?.status === "ready") { assertRunning(); return body; } } catch { /* booting */ }
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
   die("source-built API did not become ready");
 }
-async function terminateProductServicePids(pids, { requireAll = true } = {}) {
+export async function assertProductServicePortFree(url, { serverFactory = createServer } = {}) {
+  const parsed = new URL(url), port = Number(parsed.port);
+  if (parsed.hostname !== "127.0.0.1" || !Number.isInteger(port) || port < 1 || port > 65535) die("product service must bind an explicit loopback host/port");
+  await new Promise((resolve, reject) => {
+    const server = serverFactory();
+    server.unref();
+    server.once("error", (error) => reject(new Error(`starvector terminal service: API port is already occupied: ${error.message}`)));
+    server.listen({ host: parsed.hostname, port, exclusive: true }, () => server.close((error) => error ? reject(error) : resolve()));
+  });
+  return { host: parsed.hostname, port };
+}
+export function productServiceTaskkillArguments(pid) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) die("invalid product service PID");
+  return ["/PID", String(pid), "/T", "/F"];
+}
+async function runProductServiceTaskkill(pid, timeoutMs) {
+  await execFile("taskkill.exe", productServiceTaskkillArguments(pid), { timeout: timeoutMs, windowsHide: true });
+}
+async function pidIsRunning(pid, kill) {
+  try { kill(pid, 0); return true; } catch (error) { if (error.code === "ESRCH") return false; if (error.code === "EPERM") return true; throw error; }
+}
+export async function terminateProductServicePids(pids, {
+  requireAll = true,
+  platform = process.platform,
+  kill = process.kill,
+  taskkill = runProductServiceTaskkill,
+  wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
+  timeoutMs = 5000,
+  pollMs = 100,
+} = {}) {
   const validPids = pids.filter((pid) => Number.isInteger(pid) && pid > 0);
   if (requireAll && validPids.length !== pids.length) die("invalid product service PID");
-  for (const pid of validPids) { try { process.kill(pid, "SIGTERM"); } catch (error) { if (error.code !== "ESRCH") throw error; } }
-  for (let attempt = 0; attempt < 50; attempt += 1) {
-    let alive = false;
-    for (const pid of validPids) {
-      try { process.kill(pid, 0); alive = true; } catch (error) { if (error.code !== "ESRCH") throw error; }
+  const live = async () => {
+    const result = [];
+    for (const pid of validPids) if (await pidIsRunning(pid, kill)) result.push(pid);
+    return result;
+  };
+  let remaining = await live();
+  if (platform === "win32") {
+    for (const pid of remaining) {
+      try { await taskkill(pid, timeoutMs); } catch (error) { if (await pidIsRunning(pid, kill)) throw error; }
     }
-    if (!alive) return;
-    await new Promise((resolve) => setTimeout(resolve, 100));
+  } else {
+    for (const pid of remaining) { try { kill(pid, "SIGTERM"); } catch (error) { if (error.code !== "ESRCH") throw error; } }
   }
-  die("product service did not stop after SIGTERM");
+  const attempts = Math.max(1, Math.ceil(timeoutMs / pollMs));
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    remaining = await live();
+    if (remaining.length === 0) return;
+    await wait(pollMs);
+  }
+  if (platform !== "win32") {
+    for (const pid of remaining) { try { kill(pid, "SIGKILL"); } catch (error) { if (error.code !== "ESRCH") throw error; } }
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      remaining = await live();
+      if (remaining.length === 0) return;
+      await wait(pollMs);
+    }
+  }
+  die(`product service did not stop (pids: ${remaining.join(", ")})`);
 }
 export async function copyRegularTree(source, destination, digestFile = fileSha256) {
   const info = await lstat(source);
@@ -125,30 +201,61 @@ async function materializeOfflineWeights(weightsRoot, stateRoot) {
   return { app_data_sha256: closure.app_data_sha256, hf_home_sha256: closure.hf_home_sha256, models };
 }
 
+const ACTIVE_STATE_KEYS = [
+  "api_binary_sha256",
+  "api_pid",
+  "api_url",
+  "inference_revision",
+  "instance_token",
+  "kind",
+  "schema_version",
+  "sceneworks_revision",
+  "started_at",
+  "state_root",
+  "worker_pid",
+].sort();
+const ACTIVE_BINDING_KEYS = ACTIVE_STATE_KEYS.filter((key) => !["kind", "schema_version"].includes(key));
+
+export function validateProductServiceActiveState(active, record, output) {
+  if (!active || typeof active !== "object" || Array.isArray(active) || JSON.stringify(Object.keys(active).sort()) !== JSON.stringify(ACTIVE_STATE_KEYS)) die("active product service state shape is invalid");
+  if (active.schema_version !== 1 || active.kind !== "starvector_terminal_product_service_active" || !/^[a-f0-9]{64}$/.test(active.instance_token)) die("active product service sentinel is invalid");
+  if (!/^[a-f0-9]{40}$/.test(active.sceneworks_revision) || !/^[a-f0-9]{40}$/.test(active.inference_revision) || !/^[a-f0-9]{64}$/.test(active.api_binary_sha256)) die("active product service identity is invalid");
+  if (!Number.isSafeInteger(active.api_pid) || active.api_pid <= 0 || !Number.isSafeInteger(active.worker_pid) || active.worker_pid <= 0 || active.api_pid === active.worker_pid) die("active product service PIDs are invalid");
+  if (active.state_root !== path.relative(output, productServiceStateRoot(output)) || !active.api_url?.startsWith("http://127.0.0.1:")) die("active product service location is invalid");
+  for (const key of ACTIVE_BINDING_KEYS) if (active[key] !== record?.[key]) die(`active product service state mismatches provenance field ${key}`);
+  return active;
+}
+
 export async function startProductService({ root, output, permanentPin, url, weightsRoot }) {
   if (!root || !output || !weightsRoot || !permanentPin || !url || !url.startsWith("http://127.0.0.1:")) die("local current-tree root/output/offline weights/pin/API URL required");
-  const identity = await serviceIdentity(root, permanentPin); await mkdir(output, { recursive: true });
+  const identity = await serviceIdentity(root, permanentPin);
+  const endpoint = await assertProductServicePortFree(url);
+  await mkdir(output, { recursive: true });
   // `cargo build` is source ownership: no prebuilt or /opt sidecar can satisfy
   // this contract.  It never downloads model weights; the controller separately
   // rejects any model acquisition at job time.
   await execFile("cargo", productServiceBuildArgs(), { cwd: root });
   const binary = path.join(root, "target", "debug", process.platform === "win32" ? "sceneworks-rust-api.exe" : "sceneworks-rust-api");
-  const common = { cwd: root, detached: true }, parsed = new URL(url), apiPort = parsed.port, stateRoot = productServiceStateRoot(output);
-  if (parsed.hostname !== "127.0.0.1" || !apiPort) die("product service must bind an explicit loopback host/port");
+  const common = { cwd: root, detached: true }, stateRoot = productServiceStateRoot(output);
   if (await lstat(stateRoot).catch((error) => error.code === "ENOENT" ? null : Promise.reject(error))) die("temporary product service state already exists");
-  await mkdir(path.join(stateRoot, "data"), { recursive: true }); await mkdir(path.join(stateRoot, "config"), { recursive: true });
-  const weights = await materializeOfflineWeights(weightsRoot, stateRoot);
-  const hfHome = path.join(stateRoot, "hf");
-  const serviceEnv = { ...process.env, ...productServiceBackendEnv(), SCENEWORKS_TERMINAL_CAMPAIGN: "1", SCENEWORKS_API_HOST: "127.0.0.1", SCENEWORKS_API_PORT: apiPort, SCENEWORKS_API_URL: url, SCENEWORKS_DATA_DIR: path.join(stateRoot, "data"), SCENEWORKS_CONFIG_DIR: path.join(stateRoot, "config"), SCENEWORKS_JOBS_DB_PATH: path.join(stateRoot, "data", "cache", "jobs.db"), SCENEWORKS_GPU_ID: process.env.STARVECTOR_TERMINAL_GPU_ID ?? "auto", HF_HOME: hfHome, HUGGINGFACE_HUB_CACHE: path.join(hfHome, "hub"), HF_HUB_OFFLINE: "1", TRANSFORMERS_OFFLINE: "1" };
-  for (const inherited of ["TRANSFORMERS_CACHE", "HF_DATASETS_CACHE", "HF_ENDPOINT"]) delete serviceEnv[inherited];
-  // Piped readable streams keep this CLI referenced after child.unref(). Give
-  // each service durable files instead; the children retain their inherited
-  // descriptors after these parent FileHandles close and after this CLI exits.
-  const logPaths = productServiceLogPaths(output), logHandles = await openProductServiceLogs(output);
+  const logPaths = productServiceLogPaths(output), instanceToken = randomBytes(32).toString("hex");
+  let stateCreated = false;
+  let logHandles = {};
   let api;
   let worker;
+  let activeState;
   const spawnErrors = [];
   try {
+    await mkdir(stateRoot);
+    stateCreated = true;
+    await mkdir(path.join(stateRoot, "data"), { recursive: true }); await mkdir(path.join(stateRoot, "config"), { recursive: true });
+    const weights = await materializeOfflineWeights(weightsRoot, stateRoot), hfHome = path.join(stateRoot, "hf"), binarySha256 = await fileSha256(binary);
+    const serviceEnv = { ...process.env, ...productServiceBackendEnv(), SCENEWORKS_TERMINAL_CAMPAIGN: "1", SCENEWORKS_TERMINAL_SERVICE_INSTANCE_TOKEN: instanceToken, SCENEWORKS_API_HOST: endpoint.host, SCENEWORKS_API_PORT: String(endpoint.port), SCENEWORKS_API_URL: url, SCENEWORKS_DATA_DIR: path.join(stateRoot, "data"), SCENEWORKS_CONFIG_DIR: path.join(stateRoot, "config"), SCENEWORKS_JOBS_DB_PATH: path.join(stateRoot, "data", "cache", "jobs.db"), SCENEWORKS_GPU_ID: process.env.STARVECTOR_TERMINAL_GPU_ID ?? "auto", HF_HOME: hfHome, HUGGINGFACE_HUB_CACHE: path.join(hfHome, "hub"), HF_HUB_OFFLINE: "1", TRANSFORMERS_OFFLINE: "1" };
+    for (const inherited of ["TRANSFORMERS_CACHE", "HF_DATASETS_CACHE", "HF_ENDPOINT"]) delete serviceEnv[inherited];
+    // Piped readable streams keep this CLI referenced after child.unref(). Give
+    // each service durable files instead; the children retain their inherited
+    // descriptors after these parent FileHandles close and after this CLI exits.
+    logHandles = await openProductServiceLogs(output);
     try {
       api = spawn(binary, [], { ...common, env: serviceEnv, stdio: ["ignore", logHandles.api_stdout.fd, logHandles.api_stderr.fd] });
       api.once("error", (error) => spawnErrors.push(`API: ${error.message}`));
@@ -156,50 +263,67 @@ export async function startProductService({ root, output, permanentPin, url, wei
       worker.once("error", (error) => spawnErrors.push(`worker: ${error.message}`));
     } finally {
       await Promise.allSettled(Object.values(logHandles).map((handle) => handle.close()));
+      logHandles = {};
     }
+    if (api.pid === undefined || worker.pid === undefined) die("source-built API or worker has no process identity");
+    const startedAt = new Date().toISOString();
+    activeState = { api_binary_sha256: binarySha256, api_pid: api.pid, api_url: url, inference_revision: identity.inference_revision, instance_token: instanceToken, kind: "starvector_terminal_product_service_active", schema_version: 1, sceneworks_revision: identity.sceneworks_revision, started_at: startedAt, state_root: path.relative(output, stateRoot), worker_pid: worker.pid };
+    await writeFile(productServiceActiveStatePath(output), JSON.stringify(activeState, null, 2) + "\n", { flag: "wx", mode: 0o600 });
     for (const child of [api, worker]) child.unref();
     const assertRunning = () => {
       if (spawnErrors.length || api.pid === undefined || worker.pid === undefined || api.exitCode !== null || worker.exitCode !== null || api.signalCode !== null || worker.signalCode !== null) die(`source-built API or worker exited during readiness${spawnErrors.length ? `: ${spawnErrors.join("; ")}` : ""}`);
     };
     const health = await waitHealthy(url, assertRunning);
-    const record = { ...identity, ...weights, api_url: url, api_host: "127.0.0.1", api_port: Number(apiPort), state_root: path.relative(output, stateRoot), api_binary: path.relative(root, binary), worker_binary: path.relative(root, binary), api_binary_sha256: sha(await readFile(binary)), api_pid: api.pid, worker_pid: worker.pid, logs: Object.fromEntries(Object.entries(logPaths).map(([name, file]) => [name, path.relative(output, file)])), health, offline: { hf_home: path.relative(output, hfHome), hf_hub_offline: serviceEnv.HF_HUB_OFFLINE, transformers_offline: serviceEnv.TRANSFORMERS_OFFLINE }, started_at: new Date().toISOString() };
+    const record = { ...identity, ...weights, instance_token: instanceToken, api_url: url, api_host: endpoint.host, api_port: endpoint.port, state_root: path.relative(output, stateRoot), api_binary: path.relative(root, binary), worker_binary: path.relative(root, binary), api_binary_sha256: binarySha256, api_pid: api.pid, worker_pid: worker.pid, logs: Object.fromEntries(Object.entries(logPaths).map(([name, file]) => [name, path.relative(output, file)])), health, offline: { hf_home: path.relative(output, hfHome), hf_hub_offline: serviceEnv.HF_HUB_OFFLINE, transformers_offline: serviceEnv.TRANSFORMERS_OFFLINE }, started_at: startedAt };
     await writeFile(path.join(output, "product-service-provenance.json"), JSON.stringify(record, null, 2) + "\n");
-    await writeFile(path.join(output, "product-service-logs.sha256"), `${await productServiceLogsSha256(output)}\n`);
     return record;
   } catch (error) {
-    await terminateProductServicePids([worker?.pid, api?.pid], { requireAll: false }).catch((cleanupError) => { error.message += `; service cleanup failed: ${cleanupError.message}`; });
-    await writeFile(path.join(output, "product-service-start-failed.json"), JSON.stringify({ api_pid: api?.pid, worker_pid: worker?.pid, logs: Object.fromEntries(Object.entries(logPaths).map(([name, file]) => [name, path.relative(output, file)])), error: error.message, failed_at: new Date().toISOString() }, null, 2) + "\n");
-    await writeFile(path.join(output, "product-service-logs.sha256"), `${await productServiceLogsSha256(output)}\n`);
-    await rm(stateRoot, { recursive: true, force: true });
+    await Promise.allSettled(Object.values(logHandles).map((handle) => handle.close()));
+    const knownPids = [worker?.pid, api?.pid].filter((pid) => Number.isSafeInteger(pid) && pid > 0);
+    const cleanup = { status: knownPids.length ? "terminated" : "not_needed", error: null, state_retained: false };
+    try { await terminateProductServicePids(knownPids, { requireAll: false }); } catch (cleanupError) { cleanup.status = "failed"; cleanup.error = cleanupError.message; cleanup.state_retained = true; error.message += `; service cleanup failed: ${cleanupError.message}`; }
+    let recorded = false;
+    try {
+      const logs = await writeProductServiceLogsIdentity(output, { requireAll: false });
+      await writeFile(path.join(output, "product-service-start-failed.json"), JSON.stringify({ schema_version: 1, status: "failed", api_pid: api?.pid, worker_pid: worker?.pid, active_state: activeState ?? null, cleanup, logs, error: error.message, failed_at: new Date().toISOString() }, null, 2) + "\n");
+      recorded = true;
+    } catch (recordError) {
+      cleanup.state_retained = true;
+      error.message += `; failure record could not be written: ${recordError.message}`;
+    }
+    if (stateCreated && cleanup.status !== "failed" && recorded) await rm(stateRoot, { recursive: true, force: true });
     throw error;
   }
 }
-export async function stopProductService(output) {
+export async function stopProductService(output, { terminate = terminateProductServicePids } = {}) {
+  if (await lstat(path.join(output, "product-service-stopped.json")).catch((error) => error.code === "ENOENT" ? null : Promise.reject(error))) die("product service is already stopped");
   let record;
   try {
     record = JSON.parse(await readFile(path.join(output, "product-service-provenance.json"), "utf8"));
   } catch (error) {
     if (error.code !== "ENOENT") throw error;
     const failure = JSON.parse(await readFile(path.join(output, "product-service-start-failed.json"), "utf8"));
-    await terminateProductServicePids([failure.worker_pid, failure.api_pid], { requireAll: false });
-    const logsSha256 = await productServiceLogsSha256(output);
-    await writeFile(path.join(output, "product-service-logs.sha256"), `${logsSha256}\n`);
-    await writeFile(path.join(output, "product-service-stopped.json"), JSON.stringify({ api_pid: failure.api_pid, worker_pid: failure.worker_pid, status: "start_failed", logs_sha256: logsSha256, stopped_at: new Date().toISOString() }, null, 2) + "\n");
-    return;
+    if (failure.cleanup?.status !== "failed" || !failure.active_state) die("failed product service start has no active instance to stop");
+    record = failure.active_state;
   }
   const stateRoot = path.resolve(output, record.state_root);
   if (stateRoot !== path.resolve(productServiceStateRoot(output))) die("product service state path escaped its tuple temporary root");
-  await terminateProductServicePids([record.worker_pid, record.api_pid]);
+  const stateInfo = await lstat(stateRoot);
+  if (stateInfo.isSymbolicLink() || !stateInfo.isDirectory()) die("product service state root is not an owned directory");
+  const activePath = productServiceActiveStatePath(output), activeInfo = await lstat(activePath);
+  if (activeInfo.isSymbolicLink() || !activeInfo.isFile()) die("active product service sentinel is not a regular file");
+  const active = validateProductServiceActiveState(JSON.parse(await readFile(activePath, "utf8")), record, output);
   try {
-    const response = await fetch(new URL("/api/v1/health", record.api_url));
-    if (response.ok) die("product service port remains occupied after shutdown");
+    await terminate([active.worker_pid, active.api_pid]);
+    await assertProductServicePortFree(active.api_url);
+    const logs = await writeProductServiceLogsIdentity(output);
+    await writeFile(path.join(output, "product-service-stopped.json"), JSON.stringify({ schema_version: 1, status: "stopped", instance_token: active.instance_token, api_pid: active.api_pid, worker_pid: active.worker_pid, logs, stopped_at: new Date().toISOString() }, null, 2) + "\n");
+    await rm(stateRoot, { recursive: true });
   } catch (error) {
-    if (String(error.message).includes("port remains occupied")) throw error;
+    const logs = await writeProductServiceLogsIdentity(output, { requireAll: false });
+    await writeFile(path.join(output, "product-service-stop-failed.json"), JSON.stringify({ schema_version: 1, status: "failed", instance_token: active.instance_token, api_pid: active.api_pid, worker_pid: active.worker_pid, cleanup: { status: "failed", error: error.message, state_retained: true }, logs, error: error.message, failed_at: new Date().toISOString() }, null, 2) + "\n");
+    throw error;
   }
-  const logsSha256 = await productServiceLogsSha256(output);
-  await writeFile(path.join(output, "product-service-logs.sha256"), `${logsSha256}\n`);
-  await writeFile(path.join(output, "product-service-stopped.json"), JSON.stringify({ api_pid: record.api_pid, worker_pid: record.worker_pid, status: "stopped", logs_sha256: logsSha256, stopped_at: new Date().toISOString() }, null, 2) + "\n");
-  await rm(stateRoot, { recursive: true, force: true });
 }
 if (isExecutedModule(import.meta.url)) {
   const [command, ...args] = process.argv.slice(2); const run = command === "start" ? startProductService({ root: args[0], output: args[1], permanentPin: args[2], url: args[3], weightsRoot: args[4] }) : command === "stop" ? stopProductService(args[0]) : Promise.reject(new Error("usage: start <root> <output> <pin> <url> <weights-root> | stop <output>")); run.catch((error) => { console.error(error.message); process.exitCode = 1; });

--- a/scripts/starvector-terminal-product-service.mjs
+++ b/scripts/starvector-terminal-product-service.mjs
@@ -4,7 +4,7 @@
 // Cargo inference pin, binaries and health response are all recorded together.
 import { createHash } from "node:crypto";
 import { execFile as execFileCallback, spawn } from "node:child_process";
-import { copyFile, lstat, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { copyFile, lstat, mkdir, open, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { promisify } from "node:util";
 import path from "node:path";
 import { isExecutedModule } from "./starvector-terminal-cli.mjs";
@@ -25,6 +25,29 @@ export function productServiceBackendEnv(platform = process.platform) {
 export function productServiceStateRoot(output) {
   return path.join(path.dirname(output), `${path.basename(output)}-product-service-state`);
 }
+const PRODUCT_SERVICE_LOG_FILES = Object.freeze({
+  api_stdout: "product-service-api.stdout.log",
+  api_stderr: "product-service-api.stderr.log",
+  worker_stdout: "product-service-worker.stdout.log",
+  worker_stderr: "product-service-worker.stderr.log",
+});
+export function productServiceLogPaths(output) {
+  return Object.fromEntries(Object.entries(PRODUCT_SERVICE_LOG_FILES).map(([name, file]) => [name, path.join(output, file)]));
+}
+async function openProductServiceLogs(output) {
+  const handles = {};
+  try {
+    for (const [name, file] of Object.entries(productServiceLogPaths(output))) handles[name] = await open(file, "wx", 0o600);
+    return handles;
+  } catch (error) {
+    await Promise.allSettled(Object.values(handles).map((handle) => handle.close()));
+    throw error;
+  }
+}
+export async function productServiceLogsSha256(output) {
+  const chunks = await Promise.all(Object.values(productServiceLogPaths(output)).map((file) => readFile(file)));
+  return sha(Buffer.concat(chunks));
+}
 async function git(root, args) { return (await execFile("git", ["-C", root, ...args])).stdout.trim(); }
 async function serviceIdentity(root, permanentPin) {
   if (await git(root, ["status", "--porcelain"])) die("current-tree product service checkout must be clean");
@@ -33,12 +56,27 @@ async function serviceIdentity(root, permanentPin) {
   if (!pin || pin !== permanentPin) die("current-tree product service Cargo inference pin mismatches permanent pin");
   return { sceneworks_revision: revision, inference_revision: pin };
 }
-async function waitHealthy(url) {
+async function waitHealthy(url, assertRunning = () => {}) {
   for (let attempt = 0; attempt < 120; attempt += 1) {
-    try { const response = await fetch(new URL("/api/v1/health", url)); const body = await response.json(); if (response.ok && body?.status === "ok" && body?.readiness?.status === "ready") return body; } catch { /* booting */ }
+    assertRunning();
+    try { const response = await fetch(new URL("/api/v1/health", url)); const body = await response.json(); if (response.ok && body?.status === "ok" && body?.readiness?.status === "ready") { assertRunning(); return body; } } catch { /* booting */ }
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
   die("source-built API did not become ready");
+}
+async function terminateProductServicePids(pids, { requireAll = true } = {}) {
+  const validPids = pids.filter((pid) => Number.isInteger(pid) && pid > 0);
+  if (requireAll && validPids.length !== pids.length) die("invalid product service PID");
+  for (const pid of validPids) { try { process.kill(pid, "SIGTERM"); } catch (error) { if (error.code !== "ESRCH") throw error; } }
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    let alive = false;
+    for (const pid of validPids) {
+      try { process.kill(pid, 0); alive = true; } catch (error) { if (error.code !== "ESRCH") throw error; }
+    }
+    if (!alive) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  die("product service did not stop after SIGTERM");
 }
 export async function copyRegularTree(source, destination, digestFile = fileSha256) {
   const info = await lstat(source);
@@ -95,7 +133,7 @@ export async function startProductService({ root, output, permanentPin, url, wei
   // rejects any model acquisition at job time.
   await execFile("cargo", productServiceBuildArgs(), { cwd: root });
   const binary = path.join(root, "target", "debug", process.platform === "win32" ? "sceneworks-rust-api.exe" : "sceneworks-rust-api");
-  const common = { cwd: root, detached: true, stdio: ["ignore", "pipe", "pipe"] }, parsed = new URL(url), apiPort = parsed.port, stateRoot = productServiceStateRoot(output);
+  const common = { cwd: root, detached: true }, parsed = new URL(url), apiPort = parsed.port, stateRoot = productServiceStateRoot(output);
   if (parsed.hostname !== "127.0.0.1" || !apiPort) die("product service must bind an explicit loopback host/port");
   if (await lstat(stateRoot).catch((error) => error.code === "ENOENT" ? null : Promise.reject(error))) die("temporary product service state already exists");
   await mkdir(path.join(stateRoot, "data"), { recursive: true }); await mkdir(path.join(stateRoot, "config"), { recursive: true });
@@ -103,35 +141,64 @@ export async function startProductService({ root, output, permanentPin, url, wei
   const hfHome = path.join(stateRoot, "hf");
   const serviceEnv = { ...process.env, ...productServiceBackendEnv(), SCENEWORKS_TERMINAL_CAMPAIGN: "1", SCENEWORKS_API_HOST: "127.0.0.1", SCENEWORKS_API_PORT: apiPort, SCENEWORKS_API_URL: url, SCENEWORKS_DATA_DIR: path.join(stateRoot, "data"), SCENEWORKS_CONFIG_DIR: path.join(stateRoot, "config"), SCENEWORKS_JOBS_DB_PATH: path.join(stateRoot, "data", "cache", "jobs.db"), SCENEWORKS_GPU_ID: process.env.STARVECTOR_TERMINAL_GPU_ID ?? "auto", HF_HOME: hfHome, HUGGINGFACE_HUB_CACHE: path.join(hfHome, "hub"), HF_HUB_OFFLINE: "1", TRANSFORMERS_OFFLINE: "1" };
   for (const inherited of ["TRANSFORMERS_CACHE", "HF_DATASETS_CACHE", "HF_ENDPOINT"]) delete serviceEnv[inherited];
-  const api = spawn(binary, [], { ...common, env: serviceEnv });
-  const worker = spawn(binary, [], { ...common, env: { ...serviceEnv, SCENEWORKS_WORKER_ONLY: "1" } });
-  const stdout = [], stderr = []; for (const child of [api, worker]) { child.stdout.on("data", (chunk) => stdout.push(chunk)); child.stderr.on("data", (chunk) => stderr.push(chunk)); child.unref(); }
-  const health = await waitHealthy(url); if (api.exitCode !== null || worker.exitCode !== null || api.pid === undefined || worker.pid === undefined) die("source-built API or worker exited during readiness"); const record = { ...identity, ...weights, api_url: url, api_host: "127.0.0.1", api_port: Number(apiPort), state_root: path.relative(output, stateRoot), api_binary: path.relative(root, binary), worker_binary: path.relative(root, binary), api_binary_sha256: sha(await readFile(binary)), api_pid: api.pid, worker_pid: worker.pid, health, offline: { hf_home: path.relative(output, hfHome), hf_hub_offline: serviceEnv.HF_HUB_OFFLINE, transformers_offline: serviceEnv.TRANSFORMERS_OFFLINE }, started_at: new Date().toISOString() };
-  await writeFile(path.join(output, "product-service-provenance.json"), JSON.stringify(record, null, 2) + "\n");
-  await writeFile(path.join(output, "product-service-logs.sha256"), sha(Buffer.concat([...stdout, ...stderr])) + "\n");
-  return record;
+  // Piped readable streams keep this CLI referenced after child.unref(). Give
+  // each service durable files instead; the children retain their inherited
+  // descriptors after these parent FileHandles close and after this CLI exits.
+  const logPaths = productServiceLogPaths(output), logHandles = await openProductServiceLogs(output);
+  let api;
+  let worker;
+  const spawnErrors = [];
+  try {
+    try {
+      api = spawn(binary, [], { ...common, env: serviceEnv, stdio: ["ignore", logHandles.api_stdout.fd, logHandles.api_stderr.fd] });
+      api.once("error", (error) => spawnErrors.push(`API: ${error.message}`));
+      worker = spawn(binary, [], { ...common, env: { ...serviceEnv, SCENEWORKS_WORKER_ONLY: "1" }, stdio: ["ignore", logHandles.worker_stdout.fd, logHandles.worker_stderr.fd] });
+      worker.once("error", (error) => spawnErrors.push(`worker: ${error.message}`));
+    } finally {
+      await Promise.allSettled(Object.values(logHandles).map((handle) => handle.close()));
+    }
+    for (const child of [api, worker]) child.unref();
+    const assertRunning = () => {
+      if (spawnErrors.length || api.pid === undefined || worker.pid === undefined || api.exitCode !== null || worker.exitCode !== null || api.signalCode !== null || worker.signalCode !== null) die(`source-built API or worker exited during readiness${spawnErrors.length ? `: ${spawnErrors.join("; ")}` : ""}`);
+    };
+    const health = await waitHealthy(url, assertRunning);
+    const record = { ...identity, ...weights, api_url: url, api_host: "127.0.0.1", api_port: Number(apiPort), state_root: path.relative(output, stateRoot), api_binary: path.relative(root, binary), worker_binary: path.relative(root, binary), api_binary_sha256: sha(await readFile(binary)), api_pid: api.pid, worker_pid: worker.pid, logs: Object.fromEntries(Object.entries(logPaths).map(([name, file]) => [name, path.relative(output, file)])), health, offline: { hf_home: path.relative(output, hfHome), hf_hub_offline: serviceEnv.HF_HUB_OFFLINE, transformers_offline: serviceEnv.TRANSFORMERS_OFFLINE }, started_at: new Date().toISOString() };
+    await writeFile(path.join(output, "product-service-provenance.json"), JSON.stringify(record, null, 2) + "\n");
+    await writeFile(path.join(output, "product-service-logs.sha256"), `${await productServiceLogsSha256(output)}\n`);
+    return record;
+  } catch (error) {
+    await terminateProductServicePids([worker?.pid, api?.pid], { requireAll: false }).catch((cleanupError) => { error.message += `; service cleanup failed: ${cleanupError.message}`; });
+    await writeFile(path.join(output, "product-service-start-failed.json"), JSON.stringify({ api_pid: api?.pid, worker_pid: worker?.pid, logs: Object.fromEntries(Object.entries(logPaths).map(([name, file]) => [name, path.relative(output, file)])), error: error.message, failed_at: new Date().toISOString() }, null, 2) + "\n");
+    await writeFile(path.join(output, "product-service-logs.sha256"), `${await productServiceLogsSha256(output)}\n`);
+    await rm(stateRoot, { recursive: true, force: true });
+    throw error;
+  }
 }
 export async function stopProductService(output) {
-  const record = JSON.parse(await readFile(path.join(output, "product-service-provenance.json"), "utf8"));
+  let record;
+  try {
+    record = JSON.parse(await readFile(path.join(output, "product-service-provenance.json"), "utf8"));
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+    const failure = JSON.parse(await readFile(path.join(output, "product-service-start-failed.json"), "utf8"));
+    await terminateProductServicePids([failure.worker_pid, failure.api_pid], { requireAll: false });
+    const logsSha256 = await productServiceLogsSha256(output);
+    await writeFile(path.join(output, "product-service-logs.sha256"), `${logsSha256}\n`);
+    await writeFile(path.join(output, "product-service-stopped.json"), JSON.stringify({ api_pid: failure.api_pid, worker_pid: failure.worker_pid, status: "start_failed", logs_sha256: logsSha256, stopped_at: new Date().toISOString() }, null, 2) + "\n");
+    return;
+  }
   const stateRoot = path.resolve(output, record.state_root);
   if (stateRoot !== path.resolve(productServiceStateRoot(output))) die("product service state path escaped its tuple temporary root");
-  for (const pid of [record.worker_pid, record.api_pid]) { if (!Number.isInteger(pid) || pid < 1) die("invalid product service PID"); try { process.kill(pid, "SIGTERM"); } catch (error) { if (error.code !== "ESRCH") throw error; } }
-  for (let attempt = 0; attempt < 50; attempt += 1) {
-    let alive = false;
-    for (const pid of [record.worker_pid, record.api_pid]) {
-      try { process.kill(pid, 0); alive = true; } catch (error) { if (error.code !== "ESRCH") throw error; }
-    }
-    if (!alive) break;
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    if (attempt === 49) die("product service did not stop after SIGTERM");
-  }
+  await terminateProductServicePids([record.worker_pid, record.api_pid]);
   try {
     const response = await fetch(new URL("/api/v1/health", record.api_url));
     if (response.ok) die("product service port remains occupied after shutdown");
   } catch (error) {
     if (String(error.message).includes("port remains occupied")) throw error;
   }
-  await writeFile(path.join(output, "product-service-stopped.json"), JSON.stringify({ api_pid: record.api_pid, worker_pid: record.worker_pid, stopped_at: new Date().toISOString() }, null, 2) + "\n");
+  const logsSha256 = await productServiceLogsSha256(output);
+  await writeFile(path.join(output, "product-service-logs.sha256"), `${logsSha256}\n`);
+  await writeFile(path.join(output, "product-service-stopped.json"), JSON.stringify({ api_pid: record.api_pid, worker_pid: record.worker_pid, status: "stopped", logs_sha256: logsSha256, stopped_at: new Date().toISOString() }, null, 2) + "\n");
   await rm(stateRoot, { recursive: true, force: true });
 }
 if (isExecutedModule(import.meta.url)) {

--- a/scripts/starvector-terminal-workflow.test.mjs
+++ b/scripts/starvector-terminal-workflow.test.mjs
@@ -1,14 +1,15 @@
 import assert from "node:assert/strict";
 import { execFile as execFileCallback } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 import { treeIdentity, validateCorpusAssets, validateTerminalServiceClosure } from "./starvector-terminal-readiness.mjs";
 import { terminalTreeEntry, terminalTreeSha256 } from "./lib/terminal-tree-identity.mjs";
-import { closureTreeHash, copyRegularTree, productServiceBackendEnv, productServiceBuildArgs, productServiceStateRoot } from "./starvector-terminal-product-service.mjs";
+import { closureTreeHash, copyRegularTree, productServiceBackendEnv, productServiceBuildArgs, productServiceLogPaths, productServiceLogsSha256, productServiceStateRoot } from "./starvector-terminal-product-service.mjs";
 
 const workflow = await readFile(".github/workflows/starvector-terminal.yml", "utf8");
 const readiness = await readFile(".github/workflows/starvector-terminal-readiness.yml", "utf8");
@@ -75,6 +76,94 @@ test("product service streams copied closure identity and preserves portable ord
   await assert.rejects(() => copyRegularTree(source, path.join(root, "rejected")), /weights closure rejects symlink/);
   await symlink(path.join(destination, "z.bin"), path.join(destination, "link"));
   await assert.rejects(() => closureTreeHash(destination), /weights closure copy contains symlink/);
+});
+
+test("product service start CLI exits while durable-log services remain alive and can later be stopped", { timeout: 20_000 }, async (context) => {
+  if (process.platform === "win32") { context.skip("the executable fixture is a POSIX script; Windows lifecycle uses the same file-backed stdio contract"); return; }
+  const sandbox = await mkdtemp(path.join(tmpdir(), "starvector-service-detach-"));
+  const root = path.join(sandbox, "repo"), output = path.join(sandbox, "tuple"), weightsRoot = path.join(sandbox, "weights"), shimRoot = path.join(sandbox, "bin");
+  const serviceScript = path.resolve("scripts/starvector-terminal-product-service.mjs");
+  let record;
+  try {
+    await mkdir(root); await mkdir(shimRoot); await mkdir(path.join(weightsRoot, "app"), { recursive: true }); await mkdir(path.join(weightsRoot, "hf"), { recursive: true });
+    await writeFile(path.join(root, ".gitignore"), "target/\n");
+    await writeFile(path.join(root, "Cargo.toml"), `[dependencies]\ncandle-core = { git = "https://github.com/SceneWorks/inference", rev = "${pin}" }\n`);
+    await execFile("git", ["init", "-q", root]);
+    await execFile("git", ["-C", root, "add", "."]);
+    await execFile("git", ["-C", root, "-c", "user.name=SceneWorks Test", "-c", "user.email=test@sceneworks.invalid", "commit", "-qm", "fixture"]);
+
+    const cargo = path.join(shimRoot, "cargo");
+    await writeFile(cargo, "#!/bin/sh\nexit 0\n"); await chmod(cargo, 0o755);
+    const binary = path.join(root, "target", "debug", "sceneworks-rust-api");
+    await mkdir(path.dirname(binary), { recursive: true });
+    await writeFile(binary, `#!/usr/bin/env node
+const http = require("node:http");
+const worker = process.env.SCENEWORKS_WORKER_ONLY === "1";
+let server;
+const timer = setInterval(() => {
+  process.stdout.write((worker ? "worker" : "api") + " stdout " + process.pid + "\\n");
+  process.stderr.write((worker ? "worker" : "api") + " stderr " + process.pid + "\\n");
+}, 25);
+if (!worker) {
+  server = http.createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ status: "ok", readiness: { status: "ready" } }));
+  });
+  server.listen(Number(process.env.SCENEWORKS_API_PORT), "127.0.0.1");
+}
+const stop = () => {
+  clearInterval(timer);
+  if (server) server.close(() => process.exit(0)); else process.exit(0);
+};
+process.on("SIGTERM", stop);
+process.on("SIGINT", stop);
+`);
+    await chmod(binary, 0o755);
+
+    await writeFile(path.join(weightsRoot, "app", "receipt.json"), "receipt");
+    await writeFile(path.join(weightsRoot, "hf", "weights.bin"), "weights");
+    const manifest = {
+      terminal_service_closure: {
+        app_data_relative_path: "app",
+        app_data_sha256: await closureTreeHash(path.join(weightsRoot, "app")),
+        hf_home_relative_path: "hf",
+        hf_home_sha256: await closureTreeHash(path.join(weightsRoot, "hf")),
+      },
+      models: {
+        "starvector-1b": { relative_path: "models/1b", revision: "1".repeat(40), inventory_sha256: "a".repeat(64) },
+        "starvector-8b": { relative_path: "models/8b", revision: "2".repeat(40), inventory_sha256: "b".repeat(64) },
+      },
+    };
+    await writeFile(path.join(weightsRoot, "starvector-terminal-weights-v1.json"), JSON.stringify(manifest));
+
+    const reservation = createServer();
+    await new Promise((resolve, reject) => { reservation.once("error", reject); reservation.listen(0, "127.0.0.1", resolve); });
+    const port = reservation.address().port;
+    await new Promise((resolve, reject) => reservation.close((error) => error ? reject(error) : resolve()));
+    const cliEnv = { ...process.env, PATH: `${shimRoot}${path.delimiter}${process.env.PATH ?? ""}` };
+    await execFile(process.execPath, [serviceScript, "start", root, output, pin, `http://127.0.0.1:${port}`, weightsRoot], { env: cliEnv, timeout: 8_000 });
+
+    record = JSON.parse(await readFile(path.join(output, "product-service-provenance.json"), "utf8"));
+    for (const pid of [record.api_pid, record.worker_pid]) assert.doesNotThrow(() => process.kill(pid, 0));
+    const logPaths = productServiceLogPaths(output);
+    assert.deepEqual(record.logs, Object.fromEntries(Object.entries(logPaths).map(([name, file]) => [name, path.relative(output, file)])));
+    const initialSizes = await Promise.all(Object.values(logPaths).map(async (file) => (await stat(file)).size));
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    const laterSizes = await Promise.all(Object.values(logPaths).map(async (file) => (await stat(file)).size));
+    for (let index = 0; index < initialSizes.length; index += 1) assert.ok(laterSizes[index] > initialSizes[index], `service log ${index} stopped after the start CLI exited`);
+
+    await execFile(process.execPath, [serviceScript, "stop", output], { env: cliEnv, timeout: 8_000 });
+    const stopped = JSON.parse(await readFile(path.join(output, "product-service-stopped.json"), "utf8"));
+    assert.equal(stopped.status, "stopped");
+    assert.equal(stopped.logs_sha256, await productServiceLogsSha256(output));
+    assert.equal((await readFile(path.join(output, "product-service-logs.sha256"), "utf8")).trim(), stopped.logs_sha256);
+    for (const pid of [record.api_pid, record.worker_pid]) assert.throws(() => process.kill(pid, 0), { code: "ESRCH" });
+    assert.equal(await lstat(productServiceStateRoot(output)).catch((error) => error.code === "ENOENT" ? null : Promise.reject(error)), null);
+    record = null;
+  } finally {
+    if (record) await execFile(process.execPath, [serviceScript, "stop", output], { timeout: 8_000 }).catch(() => {});
+    await rm(sandbox, { recursive: true, force: true });
+  }
 });
 
 test("readiness workflow is an identity-only dispatch on both campaign hosts", () => {

--- a/scripts/starvector-terminal-workflow.test.mjs
+++ b/scripts/starvector-terminal-workflow.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile as execFileCallback } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmod, lstat, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { chmod, copyFile, link, lstat, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -9,13 +9,110 @@ import test from "node:test";
 import { promisify } from "node:util";
 import { treeIdentity, validateCorpusAssets, validateTerminalServiceClosure } from "./starvector-terminal-readiness.mjs";
 import { terminalTreeEntry, terminalTreeSha256 } from "./lib/terminal-tree-identity.mjs";
-import { closureTreeHash, copyRegularTree, productServiceBackendEnv, productServiceBuildArgs, productServiceLogPaths, productServiceLogsSha256, productServiceStateRoot } from "./starvector-terminal-product-service.mjs";
+import { closureTreeHash, copyRegularTree, productServiceActiveStatePath, productServiceBackendEnv, productServiceBuildArgs, productServiceLogPaths, productServiceLogsIdentity, productServiceStateRoot, productServiceTaskkillArguments, stopProductService } from "./starvector-terminal-product-service.mjs";
 
 const workflow = await readFile(".github/workflows/starvector-terminal.yml", "utf8");
 const readiness = await readFile(".github/workflows/starvector-terminal-readiness.yml", "utf8");
 const hash = (value) => createHash("sha256").update(value).digest("hex");
 const pin = "b2d9e0917499517cf8c1518e0d360cac8693b0c0";
 const execFile = promisify(execFileCallback);
+
+async function availableLoopbackPort() {
+  const reservation = createServer();
+  await new Promise((resolve, reject) => { reservation.once("error", reject); reservation.listen(0, "127.0.0.1", resolve); });
+  const port = reservation.address().port;
+  await new Promise((resolve, reject) => reservation.close((error) => error ? reject(error) : resolve()));
+  return port;
+}
+
+async function executableAlias(destination) {
+  await mkdir(path.dirname(destination), { recursive: true });
+  let copied = false;
+  try { await link(process.execPath, destination); } catch (error) {
+    if (!["EXDEV", "EPERM", "EACCES"].includes(error.code)) throw error;
+    await copyFile(process.execPath, destination);
+    copied = true;
+  }
+  if (copied && process.platform !== "win32") await chmod(destination, 0o755);
+}
+
+async function productServiceFixture() {
+  const sandbox = await mkdtemp(path.join(tmpdir(), "starvector-service-detach-"));
+  const root = path.join(sandbox, "repo"), output = path.join(sandbox, "tuple"), weightsRoot = path.join(sandbox, "weights"), shimRoot = path.join(sandbox, "bin");
+  await mkdir(root); await mkdir(shimRoot); await mkdir(path.join(weightsRoot, "app"), { recursive: true }); await mkdir(path.join(weightsRoot, "hf"), { recursive: true });
+  await writeFile(path.join(root, ".gitignore"), "target/\n");
+  await writeFile(path.join(root, "Cargo.toml"), `[dependencies]\ncandle-core = { git = "https://github.com/SceneWorks/inference", rev = "${pin}" }\n`);
+  await execFile("git", ["init", "-q", root]);
+  await execFile("git", ["-C", root, "add", "."]);
+  await execFile("git", ["-C", root, "-c", "user.name=SceneWorks Test", "-c", "user.email=test@sceneworks.invalid", "commit", "-qm", "fixture"]);
+
+  const runtime = path.join(sandbox, "fake-service.cjs");
+  await writeFile(runtime, `const http = require("node:http");
+const path = require("node:path");
+if (path.basename(process.argv[1] ?? "") === "build") process.exit(0);
+if (process.argv.length === 1) {
+  const worker = process.env.SCENEWORKS_WORKER_ONLY === "1";
+  let server;
+  const timer = setInterval(() => {
+    process.stdout.write((worker ? "worker" : "api") + " stdout " + process.pid + "\\n");
+    process.stderr.write((worker ? "worker" : "api") + " stderr " + process.pid + "\\n");
+  }, 25);
+  if (!worker) {
+    server = http.createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ status: "ok", readiness: { status: "ready" } }));
+    });
+    server.listen(Number(process.env.SCENEWORKS_API_PORT), "127.0.0.1");
+  }
+  const stop = () => {
+    clearInterval(timer);
+    if (server) server.close(() => process.exit(0)); else process.exit(0);
+  };
+  process.on("SIGTERM", stop);
+  process.on("SIGINT", stop);
+}
+`);
+  await executableAlias(path.join(shimRoot, process.platform === "win32" ? "cargo.exe" : "cargo"));
+  await executableAlias(path.join(root, "target", "debug", process.platform === "win32" ? "sceneworks-rust-api.exe" : "sceneworks-rust-api"));
+  await writeFile(path.join(weightsRoot, "app", "receipt.json"), "receipt");
+  await writeFile(path.join(weightsRoot, "hf", "weights.bin"), "weights");
+  const manifest = {
+    terminal_service_closure: {
+      app_data_relative_path: "app",
+      app_data_sha256: await closureTreeHash(path.join(weightsRoot, "app")),
+      hf_home_relative_path: "hf",
+      hf_home_sha256: await closureTreeHash(path.join(weightsRoot, "hf")),
+    },
+    models: {
+      "starvector-1b": { relative_path: "models/1b", revision: "1".repeat(40), inventory_sha256: "a".repeat(64) },
+      "starvector-8b": { relative_path: "models/8b", revision: "2".repeat(40), inventory_sha256: "b".repeat(64) },
+    },
+  };
+  const manifestPath = path.join(weightsRoot, "starvector-terminal-weights-v1.json");
+  await writeFile(manifestPath, JSON.stringify(manifest));
+  const cliEnv = { ...process.env, NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require="${runtime}"`.trim(), PATH: `${shimRoot}${path.delimiter}${process.env.PATH ?? ""}` };
+  const serviceScript = path.resolve("scripts/starvector-terminal-product-service.mjs");
+  return { sandbox, root, output, weightsRoot, manifest, manifestPath, cliEnv, serviceScript };
+}
+
+async function runProductServiceCli(fixture, command, port, timeout = 8_000) {
+  const args = command === "start"
+    ? [fixture.serviceScript, "start", fixture.root, fixture.output, pin, `http://127.0.0.1:${port}`, fixture.weightsRoot]
+    : [fixture.serviceScript, "stop", fixture.output];
+  return execFile(process.execPath, args, { env: fixture.cliEnv, timeout });
+}
+
+function assertPidsRunning(record) {
+  for (const pid of [record.api_pid, record.worker_pid]) assert.doesNotThrow(() => process.kill(pid, 0));
+}
+
+async function forceFixtureCleanup(fixture, record) {
+  if (record) {
+    await runProductServiceCli(fixture, "stop", 0).catch(() => {});
+    for (const pid of [record.worker_pid, record.api_pid]) { try { process.kill(pid, "SIGKILL"); } catch { /* already stopped */ } }
+  }
+  await rm(fixture.sandbox, { recursive: true, force: true });
+}
 
 test("terminal workflow is dispatch-only, serial, and seals raw evidence", () => {
   assert.match(workflow, /^\s+workflow_dispatch:/m);
@@ -36,6 +133,16 @@ test("terminal workflow is dispatch-only, serial, and seals raw evidence", () =>
   assert.doesNotMatch(workflow, /RUNNER_TEMP[^\n]*\.lease/);
   assert.match(workflow, /Upload combined evidence even on failure/);
   assert.equal((workflow.match(/timeout-minutes: 720/g) ?? []).length, 4);
+});
+
+test("every tuple stops its service before uploading final logs and stop provenance", () => {
+  const jobs = ["mlx-1b", "mlx-8b", "cuda-1b", "cuda-8b"];
+  for (let index = 0; index < jobs.length; index += 1) {
+    const start = workflow.indexOf(`  ${jobs[index]}:`), end = index + 1 < jobs.length ? workflow.indexOf(`  ${jobs[index + 1]}:`) : workflow.indexOf("  seal-receipt:");
+    const job = workflow.slice(start, end), stop = job.indexOf("starvector-terminal-product-service.mjs stop"), upload = job.indexOf("uses: actions/upload-artifact@");
+    assert.ok(stop >= 0 && upload >= 0 && stop < upload, `${jobs[index]} must stop and seal logs before artifact upload`);
+    assert.match(job.slice(job.lastIndexOf("- name:", stop), upload), /if: \$\{\{ always\(\) \}\}/);
+  }
 });
 
 test("terminal workflow has no install or model download step", () => {
@@ -78,92 +185,140 @@ test("product service streams copied closure identity and preserves portable ord
   await assert.rejects(() => closureTreeHash(destination), /weights closure copy contains symlink/);
 });
 
-test("product service start CLI exits while durable-log services remain alive and can later be stopped", { timeout: 20_000 }, async (context) => {
-  if (process.platform === "win32") { context.skip("the executable fixture is a POSIX script; Windows lifecycle uses the same file-backed stdio contract"); return; }
-  const sandbox = await mkdtemp(path.join(tmpdir(), "starvector-service-detach-"));
-  const root = path.join(sandbox, "repo"), output = path.join(sandbox, "tuple"), weightsRoot = path.join(sandbox, "weights"), shimRoot = path.join(sandbox, "bin");
-  const serviceScript = path.resolve("scripts/starvector-terminal-product-service.mjs");
+test("product service start CLI exits while durable-log services remain alive and can later be stopped", { timeout: 30_000 }, async () => {
+  const fixture = await productServiceFixture(), port = await availableLoopbackPort();
   let record;
   try {
-    await mkdir(root); await mkdir(shimRoot); await mkdir(path.join(weightsRoot, "app"), { recursive: true }); await mkdir(path.join(weightsRoot, "hf"), { recursive: true });
-    await writeFile(path.join(root, ".gitignore"), "target/\n");
-    await writeFile(path.join(root, "Cargo.toml"), `[dependencies]\ncandle-core = { git = "https://github.com/SceneWorks/inference", rev = "${pin}" }\n`);
-    await execFile("git", ["init", "-q", root]);
-    await execFile("git", ["-C", root, "add", "."]);
-    await execFile("git", ["-C", root, "-c", "user.name=SceneWorks Test", "-c", "user.email=test@sceneworks.invalid", "commit", "-qm", "fixture"]);
-
-    const cargo = path.join(shimRoot, "cargo");
-    await writeFile(cargo, "#!/bin/sh\nexit 0\n"); await chmod(cargo, 0o755);
-    const binary = path.join(root, "target", "debug", "sceneworks-rust-api");
-    await mkdir(path.dirname(binary), { recursive: true });
-    await writeFile(binary, `#!/usr/bin/env node
-const http = require("node:http");
-const worker = process.env.SCENEWORKS_WORKER_ONLY === "1";
-let server;
-const timer = setInterval(() => {
-  process.stdout.write((worker ? "worker" : "api") + " stdout " + process.pid + "\\n");
-  process.stderr.write((worker ? "worker" : "api") + " stderr " + process.pid + "\\n");
-}, 25);
-if (!worker) {
-  server = http.createServer((_request, response) => {
-    response.writeHead(200, { "content-type": "application/json" });
-    response.end(JSON.stringify({ status: "ok", readiness: { status: "ready" } }));
-  });
-  server.listen(Number(process.env.SCENEWORKS_API_PORT), "127.0.0.1");
-}
-const stop = () => {
-  clearInterval(timer);
-  if (server) server.close(() => process.exit(0)); else process.exit(0);
-};
-process.on("SIGTERM", stop);
-process.on("SIGINT", stop);
-`);
-    await chmod(binary, 0o755);
-
-    await writeFile(path.join(weightsRoot, "app", "receipt.json"), "receipt");
-    await writeFile(path.join(weightsRoot, "hf", "weights.bin"), "weights");
-    const manifest = {
-      terminal_service_closure: {
-        app_data_relative_path: "app",
-        app_data_sha256: await closureTreeHash(path.join(weightsRoot, "app")),
-        hf_home_relative_path: "hf",
-        hf_home_sha256: await closureTreeHash(path.join(weightsRoot, "hf")),
-      },
-      models: {
-        "starvector-1b": { relative_path: "models/1b", revision: "1".repeat(40), inventory_sha256: "a".repeat(64) },
-        "starvector-8b": { relative_path: "models/8b", revision: "2".repeat(40), inventory_sha256: "b".repeat(64) },
-      },
-    };
-    await writeFile(path.join(weightsRoot, "starvector-terminal-weights-v1.json"), JSON.stringify(manifest));
-
-    const reservation = createServer();
-    await new Promise((resolve, reject) => { reservation.once("error", reject); reservation.listen(0, "127.0.0.1", resolve); });
-    const port = reservation.address().port;
-    await new Promise((resolve, reject) => reservation.close((error) => error ? reject(error) : resolve()));
-    const cliEnv = { ...process.env, PATH: `${shimRoot}${path.delimiter}${process.env.PATH ?? ""}` };
-    await execFile(process.execPath, [serviceScript, "start", root, output, pin, `http://127.0.0.1:${port}`, weightsRoot], { env: cliEnv, timeout: 8_000 });
-
-    record = JSON.parse(await readFile(path.join(output, "product-service-provenance.json"), "utf8"));
-    for (const pid of [record.api_pid, record.worker_pid]) assert.doesNotThrow(() => process.kill(pid, 0));
-    const logPaths = productServiceLogPaths(output);
-    assert.deepEqual(record.logs, Object.fromEntries(Object.entries(logPaths).map(([name, file]) => [name, path.relative(output, file)])));
+    await runProductServiceCli(fixture, "start", port);
+    record = JSON.parse(await readFile(path.join(fixture.output, "product-service-provenance.json"), "utf8"));
+    assertPidsRunning(record);
+    const logPaths = productServiceLogPaths(fixture.output);
+    assert.deepEqual(record.logs, Object.fromEntries(Object.entries(logPaths).map(([name, file]) => [name, path.relative(fixture.output, file)])));
     const initialSizes = await Promise.all(Object.values(logPaths).map(async (file) => (await stat(file)).size));
     await new Promise((resolve) => setTimeout(resolve, 150));
     const laterSizes = await Promise.all(Object.values(logPaths).map(async (file) => (await stat(file)).size));
-    for (let index = 0; index < initialSizes.length; index += 1) assert.ok(laterSizes[index] > initialSizes[index], `service log ${index} stopped after the start CLI exited`);
+    for (let index = 0; index < initialSizes.length; index += 1) assert.ok(laterSizes[index] > initialSizes[index], "service log stopped after the start CLI exited");
 
-    await execFile(process.execPath, [serviceScript, "stop", output], { env: cliEnv, timeout: 8_000 });
-    const stopped = JSON.parse(await readFile(path.join(output, "product-service-stopped.json"), "utf8"));
+    await runProductServiceCli(fixture, "stop", 0);
+    const stopped = JSON.parse(await readFile(path.join(fixture.output, "product-service-stopped.json"), "utf8"));
+    const logs = await productServiceLogsIdentity(fixture.output);
     assert.equal(stopped.status, "stopped");
-    assert.equal(stopped.logs_sha256, await productServiceLogsSha256(output));
-    assert.equal((await readFile(path.join(output, "product-service-logs.sha256"), "utf8")).trim(), stopped.logs_sha256);
+    assert.deepEqual(stopped.logs, logs);
+    assert.equal(logs.entries.length, 4);
+    assert.equal(logs.sha256, terminalTreeSha256(logs.entries));
+    for (const entry of logs.entries) {
+      const file = path.join(fixture.output, entry.path);
+      assert.deepEqual(Object.keys(entry), ["path", "byte_size", "sha256"]);
+      assert.equal(entry.byte_size, (await stat(file)).size);
+      assert.equal(entry.sha256, hash(await readFile(file)));
+    }
+    assert.deepEqual(JSON.parse(await readFile(path.join(fixture.output, "product-service-logs.json"), "utf8")), logs);
+    assert.equal((await readFile(path.join(fixture.output, "product-service-logs.sha256"), "utf8")).trim(), logs.sha256);
     for (const pid of [record.api_pid, record.worker_pid]) assert.throws(() => process.kill(pid, 0), { code: "ESRCH" });
-    assert.equal(await lstat(productServiceStateRoot(output)).catch((error) => error.code === "ENOENT" ? null : Promise.reject(error)), null);
+    assert.equal(await lstat(productServiceStateRoot(fixture.output)).catch((error) => error.code === "ENOENT" ? null : Promise.reject(error)), null);
     record = null;
   } finally {
-    if (record) await execFile(process.execPath, [serviceScript, "stop", output], { timeout: 8_000 }).catch(() => {});
-    await rm(sandbox, { recursive: true, force: true });
+    await forceFixtureCleanup(fixture, record);
   }
+});
+
+test("product service stop requires an exact active sentinel before signaling", { timeout: 25_000 }, async () => {
+  const fixture = await productServiceFixture(), port = await availableLoopbackPort();
+  let record;
+  try {
+    await runProductServiceCli(fixture, "start", port);
+    record = JSON.parse(await readFile(path.join(fixture.output, "product-service-provenance.json"), "utf8"));
+    const activePath = productServiceActiveStatePath(fixture.output), activeText = await readFile(activePath, "utf8"), active = JSON.parse(activeText);
+    assert.equal(active.instance_token, record.instance_token);
+    assert.match(record.instance_token, /^[a-f0-9]{64}$/);
+
+    await rm(activePath);
+    await assert.rejects(() => runProductServiceCli(fixture, "stop", 0), /product-service-active\.json|ENOENT/);
+    assertPidsRunning(record);
+    await writeFile(activePath, activeText, { flag: "wx", mode: 0o600 });
+
+    await writeFile(activePath, JSON.stringify({ ...active, instance_token: "0".repeat(64) }));
+    await assert.rejects(() => runProductServiceCli(fixture, "stop", 0), /mismatches provenance field instance_token/);
+    assertPidsRunning(record);
+
+    await writeFile(activePath, JSON.stringify({ ...active, api_pid: process.pid }));
+    await assert.rejects(() => runProductServiceCli(fixture, "stop", 0), /mismatches provenance field api_pid/);
+    assertPidsRunning(record);
+
+    await writeFile(activePath, JSON.stringify({ ...active, status: "stopped" }));
+    await assert.rejects(() => runProductServiceCli(fixture, "stop", 0), /active product service state shape is invalid/);
+    assertPidsRunning(record);
+
+    await writeFile(activePath, activeText);
+    await runProductServiceCli(fixture, "stop", 0);
+    await assert.rejects(
+      () => stopProductService(fixture.output, { terminate: async () => assert.fail("double-stop must reject before termination") }),
+      /already stopped/,
+    );
+    record = null;
+  } finally {
+    await forceFixtureCleanup(fixture, record);
+  }
+});
+
+test("product service rejects a pre-existing healthy listener before provenance", { timeout: 15_000 }, async () => {
+  const fixture = await productServiceFixture(), listener = createServer((_request, response) => response.end(JSON.stringify({ status: "ok", readiness: { status: "ready" } })));
+  try {
+    await new Promise((resolve, reject) => { listener.once("error", reject); listener.listen(0, "127.0.0.1", resolve); });
+    const port = listener.address().port;
+    await assert.rejects(() => runProductServiceCli(fixture, "start", port), /API port is already occupied/);
+    assert.equal(listener.listening, true);
+    assert.equal(await lstat(path.join(fixture.output, "product-service-provenance.json")).catch((error) => error.code === "ENOENT" ? null : Promise.reject(error)), null);
+  } finally {
+    await new Promise((resolve) => listener.close(resolve));
+    await forceFixtureCleanup(fixture);
+  }
+});
+
+test("product service records setup and log-open failures before removing child-free state", { timeout: 20_000 }, async () => {
+  for (const failure of ["setup", "open"]) {
+    const fixture = await productServiceFixture(), port = await availableLoopbackPort();
+    try {
+      if (failure === "setup") await writeFile(fixture.manifestPath, JSON.stringify({ ...fixture.manifest, terminal_service_closure: { ...fixture.manifest.terminal_service_closure, app_data_sha256: "0".repeat(64) } }));
+      else { await mkdir(fixture.output); await writeFile(productServiceLogPaths(fixture.output).api_stdout, "stale log"); }
+      await assert.rejects(() => runProductServiceCli(fixture, "start", port));
+      const report = JSON.parse(await readFile(path.join(fixture.output, "product-service-start-failed.json"), "utf8"));
+      assert.equal(report.status, "failed");
+      assert.equal(report.cleanup.status, "not_needed");
+      assert.equal(report.cleanup.state_retained, false);
+      assert.match(report.logs.sha256, /^[a-f0-9]{64}$/);
+      assert.equal((await readFile(path.join(fixture.output, "product-service-logs.sha256"), "utf8")).trim(), report.logs.sha256);
+      assert.equal(await lstat(productServiceStateRoot(fixture.output)).catch((error) => error.code === "ENOENT" ? null : Promise.reject(error)), null);
+    } finally {
+      await forceFixtureCleanup(fixture);
+    }
+  }
+});
+
+test("failed termination records diagnostics and retains authenticated state for safe retry", { timeout: 20_000 }, async () => {
+  const fixture = await productServiceFixture(), port = await availableLoopbackPort();
+  let record;
+  try {
+    await runProductServiceCli(fixture, "start", port);
+    record = JSON.parse(await readFile(path.join(fixture.output, "product-service-provenance.json"), "utf8"));
+    await assert.rejects(() => stopProductService(fixture.output, { terminate: async () => { throw new Error("injected termination failure"); } }), /injected termination failure/);
+    assertPidsRunning(record);
+    assert.equal((await lstat(productServiceStateRoot(fixture.output))).isDirectory(), true);
+    const report = JSON.parse(await readFile(path.join(fixture.output, "product-service-stop-failed.json"), "utf8"));
+    assert.equal(report.status, "failed");
+    assert.deepEqual(report.cleanup, { status: "failed", error: "injected termination failure", state_retained: true });
+    assert.match(report.logs.sha256, /^[a-f0-9]{64}$/);
+    assert.equal((await readFile(path.join(fixture.output, "product-service-logs.sha256"), "utf8")).trim(), report.logs.sha256);
+    await runProductServiceCli(fixture, "stop", 0);
+    record = null;
+  } finally {
+    await forceFixtureCleanup(fixture, record);
+  }
+});
+
+test("product service Windows termination uses bounded process-tree taskkill", () => {
+  assert.deepEqual(productServiceTaskkillArguments(4242), ["/PID", "4242", "/T", "/F"]);
+  assert.throws(() => productServiceTaskkillArguments(0), /invalid product service PID/);
 });
 
 test("readiness workflow is an identity-only dispatch on both campaign hosts", () => {

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -896,7 +896,7 @@ def test_starvector_terminal_candidate_schema_is_closed_and_mutation_resistant()
     candidate = model["vector"]["deviceAdmission"]["terminalCandidate"]
     assert candidate["inferenceRevision"] == "b2d9e0917499517cf8c1518e0d360cac8693b0c0"
     assert candidate["corpusSha256"] == "757370c4eed38a52a29ac80c258fdedd7e437ab891637bcb1c916aa608bf32b5"
-    assert candidate["productionClosure"]["sha256"] == "6c300cd26bdd7cc6fee60dc11a47188802a3b52eec1389ab789e082d71e958d3"
+    assert candidate["productionClosure"]["sha256"] == "cd7b7124fb4e04c58caa739d7292187199515fb9dc8ec575bf885334f3a4e115"
     assert len(candidate["productionClosure"]["entries"]) == 30
     assert model["vector"]["providers"] == {
         "mlx": {"id": "mlx-starvector-8b", "available": True},

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -896,7 +896,7 @@ def test_starvector_terminal_candidate_schema_is_closed_and_mutation_resistant()
     candidate = model["vector"]["deviceAdmission"]["terminalCandidate"]
     assert candidate["inferenceRevision"] == "b2d9e0917499517cf8c1518e0d360cac8693b0c0"
     assert candidate["corpusSha256"] == "757370c4eed38a52a29ac80c258fdedd7e437ab891637bcb1c916aa608bf32b5"
-    assert candidate["productionClosure"]["sha256"] == "cd7b7124fb4e04c58caa739d7292187199515fb9dc8ec575bf885334f3a4e115"
+    assert candidate["productionClosure"]["sha256"] == "6356a087c1a4c9add808631d898184a66717c6e4a34ea66162140cc35098c273"
     assert len(candidate["productionClosure"]["entries"]) == 30
     assert model["vector"]["providers"] == {
         "mlx": {"id": "mlx-starvector-8b", "available": True},


### PR DESCRIPTION
## Summary

- fixes the terminal product-service start hang observed in cancelled campaign run 33835733182
- writes API and worker stdout/stderr directly to four durable files inherited by the detached children, closes the parent file handles, and then unreferences the child processes
- authenticates each active instance with a random 256-bit token bound to both PIDs, the API URL, binary hash, SceneWorks revision, inference revision, state root, and start time before any later stop may signal a PID
- rejects an already occupied API port before spawn/provenance, uses bounded platform-aware termination, and retains active state whenever termination cannot be verified
- stops each of the four tuple services before its always-run artifact upload, so final logs, canonical log identity, digest, and stopped provenance are uploaded
- updates the sealed production closure to 6356a087c1a4c9add808631d898184a66717c6e4a34ea66162140cc35098c273

## Terminal evidence

Run 33835733182 launched a healthy source-built API and worker and wrote exact service provenance, but the start CLI never returned. Both detached children used piped stdout/stderr with data listeners. child.unref() removed the ChildProcess reference, but the readable pipe handles remained referenced and kept the Node event loop alive. The later asset import, case-bundle, producer, and stop commands therefore never ran. The cancelled run did not create the persistent campaign marker and did not cross a model-execution boundary.

The retired campaign identity and its old SceneWorks head must not be reused. A future campaign must use a new identity from the merged replacement head.

## Lifecycle and evidence contract

The start CLI now gives each child inherited numeric file descriptors for separate durable stdout/stderr logs. The parent closes its file handles after spawn, records an exact active-state sentinel, verifies readiness, writes provenance, and exits while the services continue writing.

Stop rejects missing, stopped, malformed, stale, or provenance-mismatched active state before any kill. Windows uses bounded taskkill process-tree termination; POSIX uses bounded TERM/KILL escalation. Setup, log-open, startup cleanup, and stop failures retain diagnostic status plus a canonical log snapshot. State is removed only after process termination and port release are verified.

Final log evidence is a sorted terminal-tree identity with one path, byte size, and streaming SHA-256 entry per log plus the canonical aggregate SHA-256. It no longer hashes an unbounded in-memory concatenation.

## Regression coverage

The cross-platform lifecycle fixture invokes the real start CLI as a separate process and proves that it exits within a bound while both services remain alive and all four durable log files continue growing. A second real CLI invocation stops both services, verifies their PIDs are gone, validates the per-file and aggregate log identities and stop record, and confirms the exact temporary state root is removed. The same fixture runs on hosted Windows with executable Node aliases and exercises taskkill rather than skipping Windows.

Additional regressions prove tuple stop-before-upload ordering; occupied-port rejection before provenance; missing, stale-token, tampered-PID, stopped-shape, and double-stop rejection before termination; diagnosable setup and log-open failures; and retained authenticated state after an injected termination failure.

Validation:

- focused JavaScript closure, route, evidence-path, and lifecycle tests: 29/29
- targeted Python manifest/schema tests: 2/2
- targeted Rust builtin-manifest test: 1/1
- action pin check: 16 workflows
- shell portability check: 7 scripts
- full npm check: 728/731

The three full-suite failures are local environment fixtures only: ajv is not installed in this isolated worktree, and two producer tests require the intentionally absent sibling sc-22261-inference-integration checkout. All focused changed contracts pass.

The protected quartet is unchanged:

- config/memory-anchors.json: b156e9db050373afa86dfbb812e0ae7802f802e14da741373dbe9aab898de7d5
- docs/generated/memory-matrix.json: 2408b7de390e847824c95aa449991638a1892b5fbfc4e12cba9c74fc60c99d8d
- docs/generated/memory-matrix.md: 44177f6a54a15bbd0dbb401204082c9839bd111aaae5293b544935342f178a2f
- release/starvector-terminal-metrics-lock-v1.json: 8ab96cf63a6846aadd351d43cd50c91de747b694cc5b450a29a699a2c843f115

Evidence: https://github.com/SceneWorks/SceneWorks/actions/runs/33835733182