### PR TITLE
fix(ci): rebind copied StarVector model library

### DIFF
--- a/apps/rust-api/src/tests/jobs.rs
+++ b/apps/rust-api/src/tests/jobs.rs
@@ -867,7 +867,7 @@ fn builtin_starvector_manifests_are_exact_native_image_to_svg_closures() {
             );
             assert_eq!(
                 candidate["productionClosure"]["sha256"],
-                "6087efd5b67cf710c0e6c8d0dc81d499bb653a40d257dc7833c61f000a72fd33"
+                "3840690986d8ae5bc7a14f880290e5ba23ee60af25bbdd5f96b2ca6f1bbe6d5d"
             );
             assert_eq!(
                 candidate["productionClosure"]["entries"]

--- a/config/manifests/builtin.models.jsonc
+++ b/config/manifests/builtin.models.jsonc
@@ -25612,7 +25612,7 @@
             },
             "productionClosure": {
               "schemaVersion": 1,
-              "sha256": "6087efd5b67cf710c0e6c8d0dc81d499bb653a40d257dc7833c61f000a72fd33",
+              "sha256": "3840690986d8ae5bc7a14f880290e5ba23ee60af25bbdd5f96b2ca6f1bbe6d5d",
               "entries": [
                 {
                   "path": ".github/workflows/starvector-terminal.yml",
@@ -25756,8 +25756,8 @@
                 },
                 {
                   "path": "scripts/starvector-terminal-product-service.mjs",
-                  "byteSize": 22607,
-                  "sha256": "a00734747db8996678308ddcd444aba2d0d0fc48d919eab4a19059e1c004c5b4"
+                  "byteSize": 25375,
+                  "sha256": "b6912d8074d39e3f92bad4763438010bcdb67c88ff476f1251cfde24673a339a"
                 },
                 {
                   "path": "scripts/starvector-terminal-route.mjs",

--- a/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
@@ -619,6 +619,75 @@ fn write_download_receipt(data_dir: &Path, repo: &str, file: &str) {
     .unwrap();
 }
 
+fn copy_test_tree(source: &Path, destination: &Path) {
+    std::fs::create_dir_all(destination).unwrap();
+    for entry in std::fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        let target = destination.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_test_tree(&entry.path(), &target);
+        } else {
+            std::fs::copy(entry.path(), target).unwrap();
+        }
+    }
+}
+
+/// The terminal campaign copies both app-data and HF_HOME into an isolated tuple root. The copied
+/// receipt and closure ledgers still name the source library's physical directory by design: byte
+/// copying must not silently make a different path/volume trusted. The public relocation producer
+/// is the only transition that can adopt the already-complete copy without weakening that guard.
+#[test]
+fn copied_receipts_require_validated_relocation_before_the_copied_library_is_ready() {
+    let temp = TempDir::new().unwrap();
+    let source_data = temp.path().join("source-data");
+    let source_library = temp.path().join("source-hf").join("hub");
+    seed_snapshot(&source_library, "owner/model", "model.safetensors");
+    write_download_receipt(&source_data, "owner/model", "model.safetensors");
+    let requirements = vec![requirement("owner/model", "model.safetensors")];
+    assert_eq!(
+        resolve_model_availability(&source_data, &source_library, &requirements, true, &[])
+            .availability,
+        ModelAvailability::ExternalReady
+    );
+
+    let copied_data = temp.path().join("tuple-data");
+    let copied_library = temp.path().join("tuple-hf").join("hub");
+    copy_test_tree(&source_data, &copied_data);
+    copy_test_tree(&source_library, &copied_library);
+    let mismatched =
+        resolve_model_availability(&copied_data, &copied_library, &requirements, true, &[]);
+    assert_eq!(
+        mismatched.availability,
+        ModelAvailability::InstalledExternalUnavailable
+    );
+    assert!(
+        mismatched.library_present,
+        "the copied library exists but its path/physical identity is not the receipted source"
+    );
+
+    let copied_store = ExternalLibraryBindingStore::new(&copied_data).unwrap();
+    copied_store.relocate_binding(&copied_library).unwrap();
+    assert_eq!(
+        resolve_model_availability(&copied_data, &copied_library, &requirements, true, &[])
+            .availability,
+        ModelAvailability::ExternalReady
+    );
+
+    let mut tampered = copied_store.load().unwrap().unwrap();
+    tampered.physical_identity.volume_id = "tampered-volume".to_owned();
+    copied_store.write_unlocked(&tampered).unwrap();
+    let refused =
+        resolve_model_availability(&copied_data, &copied_library, &requirements, true, &[]);
+    assert_eq!(
+        refused.availability,
+        ModelAvailability::InstalledExternalUnavailable
+    );
+    assert!(
+        refused.library_present,
+        "a present library with a tampered volume identity must fail closed"
+    );
+}
+
 /// Nothing installed means nothing can be orphaned and nothing to check a candidate against: an
 /// EMPTY directory (no `models--*` layout at all) binds as a fresh cache home, and the recorded
 /// identity is then what every later install is judged against — the Settings "change model

--- a/scripts/starvector-production-closure.test.mjs
+++ b/scripts/starvector-production-closure.test.mjs
@@ -65,7 +65,7 @@ test("shape and tree checks detect every closure mutation", async () => {
 
 test("live manifest seals the exact frozen-tree production closure", async () => {
   const closure = await checkManifestProductionClosure();
-  assert.equal(closure.sha256, "6087efd5b67cf710c0e6c8d0dc81d499bb653a40d257dc7833c61f000a72fd33");
+  assert.equal(closure.sha256, "3840690986d8ae5bc7a14f880290e5ba23ee60af25bbdd5f96b2ca6f1bbe6d5d");
   assert.equal(closure.entries.length, 30);
 });
 

--- a/scripts/starvector-terminal-evidence-paths.test.mjs
+++ b/scripts/starvector-terminal-evidence-paths.test.mjs
@@ -45,4 +45,7 @@ test("source-built service materializes a receipt-backed offline closure", async
   assert.match(service, /TRANSFORMERS_OFFLINE: "1"/);
   assert.match(service, /copyRegularTree/);
   assert.match(service, /isSymbolicLink/);
+  assert.match(service, /\/api\/v1\/model-library\/relocate/);
+  assert.match(service, /\/api\/v1\/model-library/);
+  assert.doesNotMatch(service, /(?:huggingface-cli|\bcurl\b|\bwget\b)/i);
 });

--- a/scripts/starvector-terminal-product-service.mjs
+++ b/scripts/starvector-terminal-product-service.mjs
@@ -93,6 +93,41 @@ async function waitHealthy(url, assertRunning = () => {}) {
   }
   die("source-built API did not become ready");
 }
+export async function relocateProductServiceLibrary(url, hfHome, {
+  fetchImpl = fetch,
+  timeoutMs = 120_000,
+} = {}) {
+  if (typeof hfHome !== "string" || !path.isAbsolute(hfHome)) die("offline HF home must be an absolute path");
+  const expectedHfHome = path.resolve(hfHome), expectedLibraryRoot = path.join(expectedHfHome, "hub");
+  let response;
+  let body;
+  let probeResponse;
+  let probe;
+  try {
+    const signal = AbortSignal.timeout(timeoutMs);
+    response = await fetchImpl(new URL("/api/v1/model-library/relocate", url), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path: expectedHfHome }),
+      signal,
+    });
+    body = await response.json();
+    if (response.ok) {
+      probeResponse = await fetchImpl(new URL("/api/v1/model-library", url), { signal });
+      probe = await probeResponse.json();
+    }
+  } catch (error) {
+    die(`offline model library relocation request failed: ${error.message}`);
+  }
+  if (!response.ok) die(`offline model library relocation HTTP ${response.status}: ${JSON.stringify(body)}`);
+  if (body?.adopted !== true || typeof body.hfHome !== "string" || typeof body.libraryRoot !== "string" || !path.isAbsolute(body.hfHome) || !path.isAbsolute(body.libraryRoot) || path.relative(expectedHfHome, path.resolve(body.hfHome)) !== "" || path.relative(expectedLibraryRoot, path.resolve(body.libraryRoot)) !== "") {
+    die("offline model library relocation returned an inexact binding");
+  }
+  if (!probeResponse.ok || probe?.available !== true || probe.probeStatus !== "available" || typeof probe.configuredLibraryPath !== "string" || path.relative(expectedLibraryRoot, path.resolve(probe.configuredLibraryPath)) !== "" || typeof probe.expectedLibrary?.configuredPath !== "string" || path.relative(expectedLibraryRoot, path.resolve(probe.expectedLibrary.configuredPath)) !== "") {
+    die("offline model library relocation did not read back as the exact available binding");
+  }
+  return { adopted: true, hf_home: expectedHfHome, library_root: expectedLibraryRoot, probe_status: probe.probeStatus };
+}
 export async function assertProductServicePortFree(url, { serverFactory = createServer } = {}) {
   const parsed = new URL(url), port = Number(parsed.port);
   if (parsed.hostname !== "127.0.0.1" || !Number.isInteger(port) || port < 1 || port > 65535) die("product service must bind an explicit loopback host/port");
@@ -274,7 +309,13 @@ export async function startProductService({ root, output, permanentPin, url, wei
       if (spawnErrors.length || api.pid === undefined || worker.pid === undefined || api.exitCode !== null || worker.exitCode !== null || api.signalCode !== null || worker.signalCode !== null) die(`source-built API or worker exited during readiness${spawnErrors.length ? `: ${spawnErrors.join("; ")}` : ""}`);
     };
     const health = await waitHealthy(url, assertRunning);
-    const record = { ...identity, ...weights, instance_token: instanceToken, api_url: url, api_host: endpoint.host, api_port: endpoint.port, state_root: path.relative(output, stateRoot), api_binary: path.relative(root, binary), worker_binary: path.relative(root, binary), api_binary_sha256: binarySha256, api_pid: api.pid, worker_pid: worker.pid, logs: Object.fromEntries(Object.entries(logPaths).map(([name, file]) => [name, path.relative(output, file)])), health, offline: { hf_home: path.relative(output, hfHome), hf_hub_offline: serviceEnv.HF_HUB_OFFLINE, transformers_offline: serviceEnv.TRANSFORMERS_OFFLINE }, started_at: startedAt };
+    // The app-data closure deliberately carries the source machine's physical-library binding.
+    // Rebind the already hash-verified offline copy through the product relocation seam: it proves
+    // every receipted/validated model at the new root and atomically captures its path + volume
+    // identity without rewriting receipts or downloading anything.
+    const relocation = await relocateProductServiceLibrary(url, hfHome);
+    assertRunning();
+    const record = { ...identity, ...weights, instance_token: instanceToken, api_url: url, api_host: endpoint.host, api_port: endpoint.port, state_root: path.relative(output, stateRoot), api_binary: path.relative(root, binary), worker_binary: path.relative(root, binary), api_binary_sha256: binarySha256, api_pid: api.pid, worker_pid: worker.pid, logs: Object.fromEntries(Object.entries(logPaths).map(([name, file]) => [name, path.relative(output, file)])), health, offline: { hf_home: path.relative(output, hfHome), hf_hub_offline: serviceEnv.HF_HUB_OFFLINE, transformers_offline: serviceEnv.TRANSFORMERS_OFFLINE, library_relocation: { adopted: relocation.adopted, hf_home: path.relative(output, relocation.hf_home), library_root: path.relative(output, relocation.library_root), probe_status: relocation.probe_status } }, started_at: startedAt };
     await writeFile(path.join(output, "product-service-provenance.json"), JSON.stringify(record, null, 2) + "\n");
     return record;
   } catch (error) {

--- a/scripts/starvector-terminal-workflow.test.mjs
+++ b/scripts/starvector-terminal-workflow.test.mjs
@@ -9,7 +9,7 @@ import test from "node:test";
 import { promisify } from "node:util";
 import { treeIdentity, validateCorpusAssets, validateTerminalServiceClosure } from "./starvector-terminal-readiness.mjs";
 import { terminalTreeEntry, terminalTreeSha256 } from "./lib/terminal-tree-identity.mjs";
-import { closureTreeHash, copyRegularTree, productServiceActiveStatePath, productServiceBackendEnv, productServiceBuildArgs, productServiceLogPaths, productServiceLogsIdentity, productServiceStateRoot, productServiceTaskkillArguments, stopProductService } from "./starvector-terminal-product-service.mjs";
+import { closureTreeHash, copyRegularTree, productServiceActiveStatePath, productServiceBackendEnv, productServiceBuildArgs, productServiceLogPaths, productServiceLogsIdentity, productServiceStateRoot, productServiceTaskkillArguments, relocateProductServiceLibrary, stopProductService } from "./starvector-terminal-product-service.mjs";
 
 const workflow = await readFile(".github/workflows/starvector-terminal.yml", "utf8");
 const readiness = await readFile(".github/workflows/starvector-terminal-readiness.yml", "utf8");
@@ -36,7 +36,7 @@ async function executableAlias(destination) {
   if (copied && process.platform !== "win32") await chmod(destination, 0o755);
 }
 
-async function productServiceFixture() {
+async function productServiceFixture({ tamperRelocation = false } = {}) {
   const sandbox = await mkdtemp(path.join(tmpdir(), "starvector-service-detach-"));
   const root = path.join(sandbox, "repo"), output = path.join(sandbox, "tuple"), weightsRoot = path.join(sandbox, "weights"), shimRoot = path.join(sandbox, "bin");
   await mkdir(root); await mkdir(shimRoot); await mkdir(path.join(weightsRoot, "app"), { recursive: true }); await mkdir(path.join(weightsRoot, "hf"), { recursive: true });
@@ -52,13 +52,32 @@ const path = require("node:path");
 if (path.basename(process.argv[1] ?? "") === "build") process.exit(0);
 if (process.argv.length === 1) {
   const worker = process.env.SCENEWORKS_WORKER_ONLY === "1";
+  let relocatedLibrary;
   let server;
   const timer = setInterval(() => {
     process.stdout.write((worker ? "worker" : "api") + " stdout " + process.pid + "\\n");
     process.stderr.write((worker ? "worker" : "api") + " stderr " + process.pid + "\\n");
   }, 25);
   if (!worker) {
-    server = http.createServer((_request, response) => {
+    server = http.createServer((request, response) => {
+      if (request.method === "POST" && request.url === "/api/v1/model-library/relocate") {
+        let bytes = "";
+        request.setEncoding("utf8");
+        request.on("data", (chunk) => { bytes += chunk; });
+        request.on("end", () => {
+          const body = JSON.parse(bytes);
+          if (body.path !== process.env.HF_HOME) { response.writeHead(409, { "content-type": "application/json" }); response.end(JSON.stringify({ detail: "wrong library" })); return; }
+          relocatedLibrary = path.join(body.path, "hub");
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end(JSON.stringify({ adopted: true, hfHome: body.path, libraryRoot: process.env.STARVECTOR_TEST_TAMPER_RELOCATION === "1" ? path.join(path.dirname(body.path), "tampered", "hub") : relocatedLibrary }));
+        });
+        return;
+      }
+      if (request.method === "GET" && request.url === "/api/v1/model-library") {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ available: relocatedLibrary !== undefined, probeStatus: relocatedLibrary ? "available" : "identity_mismatch", configuredLibraryPath: path.join(process.env.HF_HOME, "hub"), expectedLibrary: relocatedLibrary ? { configuredPath: relocatedLibrary } : null }));
+        return;
+      }
       response.writeHead(200, { "content-type": "application/json" });
       response.end(JSON.stringify({ status: "ok", readiness: { status: "ready" } }));
     });
@@ -90,7 +109,7 @@ if (process.argv.length === 1) {
   };
   const manifestPath = path.join(weightsRoot, "starvector-terminal-weights-v1.json");
   await writeFile(manifestPath, JSON.stringify(manifest));
-  const cliEnv = { ...process.env, NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require="${runtime}"`.trim(), PATH: `${shimRoot}${path.delimiter}${process.env.PATH ?? ""}` };
+  const cliEnv = { ...process.env, NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --require="${runtime}"`.trim(), PATH: `${shimRoot}${path.delimiter}${process.env.PATH ?? ""}`, STARVECTOR_TEST_TAMPER_RELOCATION: tamperRelocation ? "1" : "0" };
   const serviceScript = path.resolve("scripts/starvector-terminal-product-service.mjs");
   return { sandbox, root, output, weightsRoot, manifest, manifestPath, cliEnv, serviceScript };
 }
@@ -192,6 +211,12 @@ test("product service start CLI exits while durable-log services remain alive an
     await runProductServiceCli(fixture, "start", port);
     record = JSON.parse(await readFile(path.join(fixture.output, "product-service-provenance.json"), "utf8"));
     assertPidsRunning(record);
+    assert.deepEqual(record.offline.library_relocation, {
+      adopted: true,
+      hf_home: path.relative(fixture.output, path.join(productServiceStateRoot(fixture.output), "hf")),
+      library_root: path.relative(fixture.output, path.join(productServiceStateRoot(fixture.output), "hf", "hub")),
+      probe_status: "available",
+    });
     const logPaths = productServiceLogPaths(fixture.output);
     assert.deepEqual(record.logs, Object.fromEntries(Object.entries(logPaths).map(([name, file]) => [name, path.relative(fixture.output, file)])));
     const initialSizes = await Promise.all(Object.values(logPaths).map(async (file) => (await stat(file)).size));
@@ -275,11 +300,63 @@ test("product service rejects a pre-existing healthy listener before provenance"
   }
 });
 
+test("product service relocation requires the exact adopted offline path", async () => {
+  const expected = path.resolve(tmpdir(), "starvector-relocated-hf");
+  const ok = await relocateProductServiceLibrary("http://127.0.0.1:1", expected, {
+    fetchImpl: async (url, init) => {
+      assert.ok(init.signal);
+      if (url.pathname === "/api/v1/model-library/relocate") {
+        assert.deepEqual(JSON.parse(init.body), { path: expected });
+        assert.equal(init.method, "POST");
+        return { ok: true, json: async () => ({ adopted: true, hfHome: expected, libraryRoot: path.join(expected, "hub") }) };
+      }
+      assert.equal(url.pathname, "/api/v1/model-library");
+      return { ok: true, json: async () => ({ available: true, probeStatus: "available", configuredLibraryPath: path.join(expected, "hub"), expectedLibrary: { configuredPath: path.join(expected, "hub") } }) };
+    },
+  });
+  assert.deepEqual(ok, { adopted: true, hf_home: expected, library_root: path.join(expected, "hub"), probe_status: "available" });
+  for (const body of [
+    { adopted: false, hfHome: expected, libraryRoot: path.join(expected, "hub") },
+    { adopted: true, hfHome: path.dirname(expected), libraryRoot: path.join(expected, "hub") },
+    { adopted: true, hfHome: expected, libraryRoot: path.join(path.dirname(expected), "other", "hub") },
+  ]) {
+    await assert.rejects(
+      () => relocateProductServiceLibrary("http://127.0.0.1:1", expected, { fetchImpl: async () => ({ ok: true, json: async () => body }) }),
+      /returned an inexact binding/,
+    );
+  }
+  await assert.rejects(
+    () => relocateProductServiceLibrary("http://127.0.0.1:1", expected, {
+      fetchImpl: async (url) => ({ ok: true, json: async () => url.pathname.endsWith("/relocate")
+        ? { adopted: true, hfHome: expected, libraryRoot: path.join(expected, "hub") }
+        : { available: false, probeStatus: "identity_mismatch", configuredLibraryPath: path.join(expected, "hub"), expectedLibrary: { configuredPath: path.join(expected, "hub") } } }),
+    }),
+    /did not read back as the exact available binding/,
+  );
+});
+
+test("a rejected product relocation terminates both services and records the failure", { timeout: 15_000 }, async () => {
+  const fixture = await productServiceFixture({ tamperRelocation: true }), port = await availableLoopbackPort();
+  try {
+    await assert.rejects(() => runProductServiceCli(fixture, "start", port), /returned an inexact binding/);
+    const failure = JSON.parse(await readFile(path.join(fixture.output, "product-service-start-failed.json"), "utf8"));
+    assert.equal(failure.cleanup.status, "terminated");
+    assert.equal(failure.cleanup.state_retained, false);
+    assert.match(failure.error, /returned an inexact binding/);
+    for (const pid of [failure.api_pid, failure.worker_pid]) assert.throws(() => process.kill(pid, 0), { code: "ESRCH" });
+    assert.equal(await lstat(productServiceStateRoot(fixture.output)).catch((error) => error.code === "ENOENT" ? null : Promise.reject(error)), null);
+    assert.equal(await lstat(path.join(fixture.output, "product-service-provenance.json")).catch((error) => error.code === "ENOENT" ? null : Promise.reject(error)), null);
+  } finally {
+    await forceFixtureCleanup(fixture);
+  }
+});
+
 test("product service records setup and log-open failures before removing child-free state", { timeout: 20_000 }, async () => {
-  for (const failure of ["setup", "open"]) {
+  for (const failure of ["setup", "hf-hash", "open"]) {
     const fixture = await productServiceFixture(), port = await availableLoopbackPort();
     try {
       if (failure === "setup") await writeFile(fixture.manifestPath, JSON.stringify({ ...fixture.manifest, terminal_service_closure: { ...fixture.manifest.terminal_service_closure, app_data_sha256: "0".repeat(64) } }));
+      else if (failure === "hf-hash") await writeFile(path.join(fixture.weightsRoot, "hf", "weights.bin"), "tampered");
       else { await mkdir(fixture.output); await writeFile(productServiceLogPaths(fixture.output).api_stdout, "stale log"); }
       await assert.rejects(() => runProductServiceCli(fixture, "start", port));
       const report = JSON.parse(await readFile(path.join(fixture.output, "product-service-start-failed.json"), "utf8"));

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -896,7 +896,7 @@ def test_starvector_terminal_candidate_schema_is_closed_and_mutation_resistant()
     candidate = model["vector"]["deviceAdmission"]["terminalCandidate"]
     assert candidate["inferenceRevision"] == "b2d9e0917499517cf8c1518e0d360cac8693b0c0"
     assert candidate["corpusSha256"] == "757370c4eed38a52a29ac80c258fdedd7e437ab891637bcb1c916aa608bf32b5"
-    assert candidate["productionClosure"]["sha256"] == "6087efd5b67cf710c0e6c8d0dc81d499bb653a40d257dc7833c61f000a72fd33"
+    assert candidate["productionClosure"]["sha256"] == "3840690986d8ae5bc7a14f880290e5ba23ee60af25bbdd5f96b2ca6f1bbe6d5d"
     assert len(candidate["productionClosure"]["entries"]) == 30
     assert model["vector"]["providers"] == {
         "mlx": {"id": "mlx-starvector-8b", "available": True},


### PR DESCRIPTION
## Summary

- Keep the terminal service's per-tuple app-data and Hugging Face closures isolated and byte-verified.
- Rebind the copied external-library ledger through SceneWorks' canonical local-only relocation API before campaign work begins.
- Read the binding back through the product API and fail closed unless the exact copied hub is available.

## Terminal campaign evidence

[Campaign run 33846071636](https://github.com/SceneWorks/SceneWorks/actions/runs/33846071636) ran from SceneWorks head `a1b911e0ff22af79542981e371d7ecccd5f3b42c` with permanent inference pin `b2d9e0917499517cf8c1518e0d360cac8693b0c0`. The source-built API and worker became healthy, the case bundle passed, and the persistent one-shot campaign marker boundary was crossed. The first `vector_generate` submission then failed admission with HTTP 503 `external_model_library_unavailable`.

The configured library was the tuple's relocated temporary HF hub, while the copied app-data ledger still correctly named the original `/Users/Shared/SceneWorks/starvector-terminal-source/hf-home/hub` path and physical volume identity. The relocated library was present, so the core identity guard rejected it as a different library before any model load or model execution began. That guard is correct and remains unchanged.

The consumed campaign identity for this same SceneWorks head/inference-pin pair remains retired. This PR does not delete the marker or relax one-shot lineage policy.

## Repair

After the harness copies app-data and HF_HOME and verifies both exact closure tree hashes, it starts the product service and waits for readiness. It then:

1. `POST`s the exact absolute copied HF_HOME to the existing loopback-only `/api/v1/model-library/relocate` production route.
2. Requires `adopted: true` and exact returned HF-home and hub paths.
3. `GET`s `/api/v1/model-library` and requires the exact configured and durable hub binding to read back `available` before provenance is written or `start` returns.

The production relocation path holds the binding lock, validates every receipt-backed and ledger-validated installed closure at the candidate, double-checks canonical path and physical identity around that walk, and atomically updates only the copied binding ledger. It does not edit download receipts, weaken the core guard, download weights, or mutate/use the shared source location. Both requests share a bounded 120-second timeout.

If relocation or readback fails, the existing authenticated service lifecycle terminates both child process trees, seals available logs and failure provenance, withholds success provenance, and removes temporary state only after successful termination.

The production closure is resealed as `3840690986d8ae5bc7a14f880290e5ba23ee60af25bbdd5f96b2ca6f1bbe6d5d`.

## Validation

- Product-service/closure/evidence focused Node tests: 27 passed.
- Product-service workflow suite: 18 passed, including detached start/live-log/separate-stop behavior, exact relocation/readback, path-response mutation, HF-closure hash mutation, and relocation-failure cleanup.
- Core external-library identity suite: 33 passed, including the new copied-receipt/relocated-HF reproduction and tampered-volume refusal.
- Full `sceneworks-core`: 1,326 passed, 4 ignored.
- Rust API model-library route suite: 10 passed.
- `sceneworks-core` test-target Clippy with warnings denied: passed.
- Python builtin-manifest audit: 100 passed.
- Cargo formatting, diff check, live production-closure validation, action-pin audit (16 workflows), and shell portability audit (7 scripts): passed.
- Full `npm run check`: 730/733 passed. The same three isolated-worktree environment-fixture failures remain: one missing local `ajv` package fixture and two tests requiring the absent sibling `sc-22261-inference-integration` checkout. All affected StarVector tests pass.

Protected quartet remains byte-identical:

- `config/memory-anchors.json`: `b156e9db050373afa86dfbb812e0ae7802f802e14da741373dbe9aab898de7d5`
- `docs/generated/memory-matrix.json`: `2408b7de390e847824c95aa449991638a1892b5fbfc4e12cba9c74fc60c99d8d`
- `docs/generated/memory-matrix.md`: `44177f6a54a15bbd0dbb401204082c9839bd111aaae5293b544935342f178a2f`
- `release/starvector-terminal-metrics-lock-v1.json`: `8ab96cf63a6846aadd351d43cd50c91de747b694cc5b450a29a699a2c843f115`
