### PR TITLE
chore(sc-22738): feature-end round 1 — derive E1 denominator from routing, bind no_adapter_arm to adapter dispatch, promote the measurability test

### DIFF
--- a/config/anchor-lane-default-strategy.json
+++ b/config/anchor-lane-default-strategy.json
@@ -1,0 +1,13 @@
+{
+  "$comment": "sc-22738. The ONE declaration of the per-lane default anchor composition. Read by scripts/memory-calibration-harness.mjs (ANCHOR_STRATEGY, which planAnchor applies to any plan row carrying no `strategy` override) AND by crates/sceneworks-worker/src/inference_runtime.rs (every_planned_lane_row_resolves_a_weights_free_contract_implementing_its_rung, via include_str!). Both sides used to spell it out independently and nothing bound them; changing a rung here now reds the Rust test unless the contracts follow. This is the LAW's composition, not an operator knob — see the ANCHOR_STRATEGY doc comment for why, and for the single per-row escape.",
+  "lanes": {
+    "mlx": {
+      "rung": "resident",
+      "engagedRungs": ["resident"]
+    },
+    "candle": {
+      "rung": "staged_residency",
+      "engagedRungs": ["resident", "staged_residency"]
+    }
+  }
+}

--- a/crates/sceneworks-worker/src/inference_runtime.rs
+++ b/crates/sceneworks-worker/src/inference_runtime.rs
@@ -469,8 +469,9 @@ pub(crate) fn load_for_model_with(
 /// registrations, whose contract builders are themselves weights-free.
 ///
 /// The planned rung is exactly what `memory-calibration-harness.mjs` `planAnchor` sends: the row's
-/// own `rung` when it states one, else the lane default from `ANCHOR_STRATEGY` (mlx `resident`,
-/// candle `staged_residency`). A change to either side that this does not follow is a red here.
+/// own `rung` when it states one, else the lane default. That default is not respelled here
+/// (sc-22738) — both sides read `config/anchor-lane-default-strategy.json`, so a change to either
+/// side that this does not follow is a red here.
 #[cfg(all(
     test,
     any(
@@ -491,11 +492,22 @@ pub(crate) fn every_planned_lane_row_resolves_a_weights_free_contract_implementi
     // else out of the entry.
     let anchors = plan["anchors"].as_object().expect("plan anchors object");
     let registry = media();
-    let lane_default_rung = match lane {
-        "mlx" => "resident",
-        "candle" => "staged_residency",
-        other => panic!("unknown lane {other}"),
-    };
+    // sc-22738: the lane default is READ, never respelled. `memory-calibration-harness.mjs`'s
+    // `ANCHOR_STRATEGY` — the composition `planAnchor` applies to every row with no `strategy`
+    // override — is built from this same file, so a change to the JS default reaches this walk
+    // instead of leaving it asserting a rung the plan no longer captures at. Fail-closed: an absent
+    // lane or a non-string rung panics rather than falling back to a default nothing declared.
+    let lane_defaults: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../config/anchor-lane-default-strategy.json"
+    ))
+    .expect("anchor lane default strategy parses");
+    let lane_default_rung = lane_defaults["lanes"][lane]["rung"]
+        .as_str()
+        .unwrap_or_else(|| {
+            panic!("config/anchor-lane-default-strategy.json declares no rung for lane {lane}")
+        })
+        .to_owned();
+    let lane_default_rung = lane_default_rung.as_str();
     let mut checked = 0_usize;
     let mut overridden = 0_usize;
     let mut forced = 0_usize;

--- a/docs/generated/memory-matrix.json
+++ b/docs/generated/memory-matrix.json
@@ -154,12 +154,12 @@
       {
         "id": "minimax_h3",
         "epic": 17137,
-        "reason": "the MLX resolver is a PREFIX PREDICATE this generator cannot enumerate, and no Candle video route arm exists at all"
+        "reason": "both lanes ARE routed (VideoModelCaps mlx+candle, resolve_candle_video_route's MiniMaxH3 arm), but this generator's route parsers cannot enumerate either: the MLX resolver is a PREFIX PREDICATE and the Candle arm lives outside candle_video_engine_id. Matrix-only — the E1 measurability burndown reads the routing catalog and DOES claim these cells"
       },
       {
         "id": "minimax_h3_ref",
         "epic": 17137,
-        "reason": "the MLX resolver is a PREFIX PREDICATE this generator cannot enumerate, and no Candle video route arm exists at all"
+        "reason": "both lanes ARE routed (VideoModelCaps mlx+candle, resolve_candle_video_route's MiniMaxH3 arm), but this generator's route parsers cannot enumerate either: the MLX resolver is a PREFIX PREDICATE and the Candle arm lives outside candle_video_engine_id. Matrix-only — the E1 measurability burndown reads the routing catalog and DOES claim these cells"
       }
     ],
     "anchors": 15,

--- a/docs/generated/memory-matrix.md
+++ b/docs/generated/memory-matrix.md
@@ -4,7 +4,7 @@
 
 - SceneWorks revision: `source-tree:942b55e64d4e3cc5c94e46461082f6ca244e25302b45e2a9619c2d669299f430`
 - Catalog entries: 64 (image 53, video 11)
-- Out-of-matrix entries (subtracted from the universe): `minimax_h3` — the MLX resolver is a PREFIX PREDICATE this generator cannot enumerate, and no Candle video route arm exists at all (sc-17137); `minimax_h3_ref` — the MLX resolver is a PREFIX PREDICATE this generator cannot enumerate, and no Candle video route arm exists at all (sc-17137)
+- Out-of-matrix entries (subtracted from the universe): `minimax_h3` — both lanes ARE routed (VideoModelCaps mlx+candle, resolve_candle_video_route's MiniMaxH3 arm), but this generator's route parsers cannot enumerate either: the MLX resolver is a PREFIX PREDICATE and the Candle arm lives outside candle_video_engine_id. Matrix-only — the E1 measurability burndown reads the routing catalog and DOES claim these cells (sc-17137); `minimax_h3_ref` — both lanes ARE routed (VideoModelCaps mlx+candle, resolve_candle_video_route's MiniMaxH3 arm), but this generator's route parsers cannot enumerate either: the MLX resolver is a PREFIX PREDICATE and the Candle arm lives outside candle_video_engine_id. Matrix-only — the E1 measurability burndown reads the routing catalog and DOES claim these cells (sc-17137)
 - Resolved coordinates: 9265
 - Published cells: 762
 - Elided coordinates: 8503 (Implemented 4129, Missing 4374)

--- a/scripts/generate-memory-matrix.mjs
+++ b/scripts/generate-memory-matrix.mjs
@@ -2373,24 +2373,39 @@ export const IMAGE_MLX_DERIVATION_ENTRY_POINTS = Object.freeze([
  *    against the manifest, not merely a `VIDEO_ROUTE_RESOLVERS` row; adding the row alone throws
  *    `minimax_h3_engine_id declared no model -> engine arm`, which is how this was measured.
  *
- * 2. **Candle — the lane is not routed at all.** `video_jobs/candle.rs#candle_video_engine_id` has
- *    no `minimax_h3` arm, so no Candle MiniMax job resolves an engine, and
- *    `memory_route_registry.rs` declares no MiniMax row on either lane. Claiming Candle MiniMax
- *    cells would claim cells no lane can open — the SAME class sc-22737 removed for
- *    `ltx_2_3:bf16:candle`, re-introduced. So the Candle half is an UNROUTED (lane, tier), which is
- *    epic 22723 E1's one exemption, and routing it is a production behaviour change (a missing arm
- *    falls through to `CandleVideoRoute::Stub`, which hands the user a procedural fake video) that
- *    does not belong to a measurability story.
+ * 2. **Candle — the generator's PUBLIC route parser cannot see the arm either.** `parseVideoRoutes`
+ *    reads `video_jobs/candle.rs#candle_video_engine_id`, which has no `minimax_h3` arm; the Candle
+ *    dispatch is deliberately kept OUT of it, in `video_jobs/mod.rs#resolve_candle_video_route`
+ *    (`} else if let Some(engine_id) = minimax_h3_engine_id(&request.model) { CandleVideoRoute::
+ *    MiniMaxH3(engine_id) }`), and is parsed separately by `parseInternalCandleVideoRoutes` for
+ *    exactly that reason. So this half is the SAME parser fact as (1), on the other lane.
  *
- * The `mlx:minimax_h3` and `mlx:minimax_h3_ref` ANCHORS are nonetheless planned, armed and closed
- * over by sc-22737 (`config/memory-calibration-plan.json`,
- * `crates/sceneworks-memory-adapter/src/bin/mlx.rs`), so the cells are measurable through
- * `measure-memory-catalog.mjs` — which is the oracle epic 22723 E2 names — even while this
- * generator still subtracts them from the MATRIX universe.
+ * ## sc-22738: reason 2 used to claim the Candle LANE was unrouted. It is not.
+ *
+ * The previous wording read "Candle — the lane is not routed at all", and cited the absent
+ * `candle_video_engine_id` arm as proof. That confused this generator's parser with the ROUTER:
+ * `resolve_candle_video_route` has selected `CandleVideoRoute::MiniMaxH3` since sc-19508, and the
+ * routing catalog declares `VideoModelCaps::new("minimax_h3", true, true, …)` and the same for
+ * `minimax_h3_ref` (`crates/sceneworks-core/src/jobs_store/routing/catalog.rs`), so BOTH lanes are
+ * routed and neither is epic 22723 E1's unrouted-lane exemption.
+ *
+ * That mattered beyond the comment: `measure-memory-catalog.test.mjs` used to take its routed-lane
+ * axis from this generator's `models[].backends`, so the subtraction below silently removed all
+ * twelve MiniMax-H3 cells from the E1 burndown — deleting their plan rows left the measurability
+ * test green. The burndown now reads the routing catalog directly (`routedCatalogLanes`), so this
+ * subtraction is scoped to the MATRIX and cannot exempt a cell from measurability.
+ *
+ * The `minimax_h3` / `minimax_h3_ref` ANCHORS are planned, armed and closed over on BOTH lanes by
+ * sc-22737 (`config/memory-calibration-plan.json`,
+ * `crates/sceneworks-memory-adapter/src/bin/{mlx,candle}.rs`), so the cells are measurable through
+ * `measure-memory-catalog.mjs` — the oracle epic 22723 E2 names — even while this generator still
+ * subtracts them from the MATRIX universe.
  */
 const MINIMAX_OUT_OF_MATRIX_REASON =
-  "the MLX resolver is a PREFIX PREDICATE this generator cannot enumerate, and no Candle video " +
-  "route arm exists at all";
+  "both lanes ARE routed (VideoModelCaps mlx+candle, resolve_candle_video_route's MiniMaxH3 arm), " +
+  "but this generator's route parsers cannot enumerate either: the MLX resolver is a PREFIX " +
+  "PREDICATE and the Candle arm lives outside candle_video_engine_id. Matrix-only — the E1 " +
+  "measurability burndown reads the routing catalog and DOES claim these cells";
 
 export const OUT_OF_MATRIX_CATALOG_ENTRIES = new Map([
   ["minimax_h3", { epic: 17137, reason: MINIMAX_OUT_OF_MATRIX_REASON }],

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -548,6 +548,24 @@ export const MAGE_COMPONENT_IDS = Object.freeze(["text_encoder", "vae"]);
  * Rows are keyed by PROVIDER by default; sc-22734 adds MODEL-keyed rows (which must declare their
  * `provider`) for the case where several catalog models ride one engine id but ship their own
  * independently pinned artifacts. See `familyFor`.
+ *
+ * ## What is NOT in this table, and why that is not a gap (sc-22738)
+ *
+ * STRICT-CONTROL OVERLAY PROVIDERS — `z_image_control`, `z_image_turbo_control`,
+ * `krea_2_turbo_control` and their siblings in `SHIPPED_CONTROL_WEIGHTS`
+ * (`crates/sceneworks-core/src/control_weights.rs`) — are engine ids for a base catalog entry
+ * loaded WITH a ControlNet attached. They ship no tiered downloads because they are not manifest
+ * models at all, so they can never be one of epic 22723 E1's `<modelId>:<tier>:<backend>` cells and
+ * `--list` has nothing to ask about them. `config/inference-provider-closures.json` declares four
+ * such lanes and those declarations must STAY — production control renders load under the `_control`
+ * provider id and their route currency is graded per (backend, provider) — so the closure table and
+ * this table are DELIBERATELY not in bijection. `scripts/stale-lane-report.mjs` reports them under
+ * their own heading (`shippedControlOverlayProviders`) rather than as "uncapturable".
+ *
+ * `arms` is bound to the Rust dispatch by `every declared adapter arm is a provider that lane's
+ * adapter really dispatches` (scripts/measure-memory-catalog.test.mjs): a declared arm with no
+ * `match provider` arm behind it reds, so `no_adapter_arm` is derived from the adapter and not from
+ * this table's spelling.
  */
 export const PROVIDER_FAMILIES = Object.freeze({
   qwen_image: { env: "QWEN_IMAGE", repo: "SceneWorks/qwen-image-mlx", arms: ["mlx", "candle"], physical: true },

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -12,6 +12,8 @@ import {
   parseInternalCandleVideoRoutes,
   parseRouteRegistryLaneTiers,
 } from "./generate-memory-matrix.mjs";
+import { routedLanes } from "./check-tier-integrity.mjs";
+import { adapterCapturableProviders } from "./stale-lane-report.mjs";
 import {
   ROOT,
   ADAPTER_LIB_PATH,
@@ -53,7 +55,11 @@ import {
   SDXL_ROUTES_PATH,
   SDXL_ROUTES_UNCHECKED,
 } from "./measure-memory-catalog.mjs";
-import { ANCHOR_STRATEGY, LTX25_LANE_PROVIDERS } from "./memory-calibration-harness.mjs";
+import {
+  ANCHOR_LANE_DEFAULT_STRATEGY_PATH,
+  ANCHOR_STRATEGY,
+  LTX25_LANE_PROVIDERS,
+} from "./memory-calibration-harness.mjs";
 
 const execFileAsync = promisify(execFile);
 const REVISION = "0123456789abcdef0123456789abcdef01234567";
@@ -995,11 +1001,22 @@ test("every provider the committed plan declares is either served by a family ro
  * - SHIPPED tier: a non-corequisite manifest download whose `variant` is a numeric tier. The
  *   manifest (`config/manifests/builtin.models.jsonc`) is the only artifact that says what a user
  *   can download, so it is the only source for the tier axis.
- * - ROUTED lane: `models[].backends` in `docs/generated/memory-matrix.json`, which
- *   `generate-memory-matrix.mjs` derives from the worker's route resolvers
- *   (`crates/sceneworks-worker/src/memory_route_registry.rs`, the same `CANDLE_BESPOKE_REQUEST_PROVIDERS`
- *   and per-family engine tables the worker dispatches with). A lane that does not route the
- *   model is the ONLY exemption; a "structurally N/A" matrix cell is not one (epic 22723 E1).
+ * - ROUTED lane: `routedLanes()` (scripts/check-tier-integrity.mjs) over the ROUTING CATALOG
+ *   itself — `crates/sceneworks-core/src/jobs_store/routing/{catalog,candle,mlx}.rs`. A lane that
+ *   does not route the model is the ONLY exemption; a "structurally N/A" matrix cell is not one
+ *   (epic 22723 E1).
+ *
+ *   **Not `models[].backends` from `docs/generated/memory-matrix.json` (sc-22738).** That column is
+ *   the same `routedLanes()` oracle, but restricted to the matrix's own universe, and the matrix
+ *   subtracts `OUT_OF_MATRIX_CATALOG_ENTRIES` (`minimax_h3`, `minimax_h3_ref`) before emitting
+ *   `models` — a SECOND exemption source, which E1 admits exactly one of. Reading the matrix let
+ *   all twelve MiniMax-H3 cells leave the denominator for a fact about the GENERATOR's parser
+ *   (`minimax_h3_engine_id` is a prefix predicate it cannot enumerate) rather than about routing:
+ *   the catalog routes both entries on both lanes (`VideoModelCaps::new("minimax_h3", true, true,
+ *   …)`), so deleting their twelve plan rows left this test green. Reading the routing catalog
+ *   directly removes the second exemption instead of documenting it; `the denominator's routed-lane
+ *   oracle is the routing catalog, not the matrix` asserts the two agree everywhere the matrix has
+ *   an opinion, so this is a widening and never a divergence.
  * - ROUTED tier: the per-lane rule below, narrowed further by `parseBackendTierOverrides` — and
  *   NOTHING else. See `computeShippedTieredCells`.
  *
@@ -1063,6 +1080,42 @@ function laneHasTierBundle(model, backend) {
   );
 }
 
+const ROUTING_SOURCES = Object.freeze({
+  routingCatalog: "crates/sceneworks-core/src/jobs_store/routing/catalog.rs",
+  routingCandle: "crates/sceneworks-core/src/jobs_store/routing/candle.rs",
+  routingMlx: "crates/sceneworks-core/src/jobs_store/routing/mlx.rs",
+});
+
+let routedCatalogLanesPromise;
+/**
+ * `Map<modelId, Set<lane>>` — the lane-existence oracle, read off the ROUTING CATALOG (sc-22738).
+ *
+ * The same `routedLanes()` the matrix generator itself calls, applied to the whole catalog instead
+ * of to the matrix's post-subtraction universe. Fails closed: `routedLanes` throws nothing but
+ * returns no entry for an id nothing routes, and every consumer here treats an absent id as "no
+ * lane", which is E1's one exemption and is asserted to be a routing fact by the case below.
+ */
+function routedCatalogLanes() {
+  routedCatalogLanesPromise ??= (async () =>
+    routedLanes(
+      Object.fromEntries(
+        await Promise.all(
+          Object.entries(ROUTING_SOURCES).map(async ([key, relative]) => [
+            key,
+            await readFile(path.join(ROOT, relative), "utf8"),
+          ]),
+        ),
+      ),
+    ))();
+  return routedCatalogLanesPromise;
+}
+
+/** The lanes the routing catalog serves `modelId` on, in a stable order. */
+function lanesOf(routed, modelId) {
+  const served = routed.get(modelId) ?? new Set();
+  return ["mlx", "candle"].filter((backend) => served.has(backend));
+}
+
 let routeLaneTiersPromise;
 /** The registry's per-lane tier FLOOR, from the generator's own parser — never a second spelling. */
 function routeLaneTiers() {
@@ -1087,8 +1140,7 @@ async function codeDerivedTierOverrides() {
 
 async function computeShippedTieredCells() {
   const models = await readManifestModels();
-  const matrix = JSON.parse(await readFile(path.join(ROOT, MATRIX_PATH), "utf8"));
-  const routed = new Map(matrix.models.map((model) => [model.id, model.backends ?? []]));
+  const routed = await routedCatalogLanes();
   const laneTiers = await routeLaneTiers();
   const overrides = await codeDerivedTierOverrides();
   const cells = [];
@@ -1098,7 +1150,7 @@ async function computeShippedTieredCells() {
       (download) => !download.coRequisite && ["q4", "q8", "bf16"].includes(download.variant),
     );
     if (shipped.length === 0) continue;
-    for (const backend of routed.get(model.id) ?? []) {
+    for (const backend of lanesOf(routed, model.id)) {
       // An untiered NON-co-requisite download this lane's host fetches is a BUNDLE whose tiers live
       // inside it, so it serves every tier the model ships — `SceneWorks/bernini` is that repo. See
       // `laneHasTierBundle` for why a co-requisite is not one.
@@ -1195,6 +1247,68 @@ const MANIFEST_ONLY_DECLARED_CELLS = [
   "sd3_5_large:q8:candle", "sd3_5_large_turbo:q8:candle", "sd3_5_medium:q8:candle",
 ];
 
+// sc-22738 (feature-end round 1). The denominator's LANE axis, and E1's one exemption.
+//
+// Three claims, all mechanical:
+//
+//  1. Everywhere the matrix has an opinion, its `models[].backends` column equals the routing
+//     catalog's answer — so moving the denominator off the matrix (see `computeShippedTieredCells`)
+//     widened the universe and changed nothing else. A drift here means the generator's own
+//     `routedLanes` join has moved and one of the two readers is stale.
+//  2. Every `OUT_OF_MATRIX_CATALOG_ENTRIES` id the catalog still ships is ROUTED on at least one
+//     lane and IS in the denominator. The matrix subtracts them for a fact about its parser, and
+//     that is not an E1 exemption; this is the assertion that makes the subtraction unable to
+//     silence a cell.
+//  3. The general rule: a tiered manifest model is missing from the denominator on EVERY lane only
+//     when the routing catalog routes it nowhere. Nothing else may remove a model.
+test("the denominator's routed-lane oracle is the routing catalog, not the matrix", async () => {
+  const routed = await routedCatalogLanes();
+  const matrix = JSON.parse(await readFile(path.join(ROOT, MATRIX_PATH), "utf8"));
+  assert.ok(matrix.models.length > 0, "the matrix still publishes models");
+  for (const model of matrix.models) {
+    assert.deepEqual(
+      model.backends ?? [],
+      lanesOf(routed, model.id),
+      `${model.id}: the matrix's routed lanes disagree with the routing catalog`,
+    );
+  }
+
+  const models = await readManifestModels();
+  const byId = new Map(models.map((model) => [model.id, model]));
+  const universe = new Set((await shippedTieredCells()).map((cell) => cell.modelId));
+  for (const [id, entry] of OUT_OF_MATRIX_CATALOG_ENTRIES) {
+    if (!byId.has(id)) continue; // `assertOutOfMatrixEntriesAreStillUnroutable` owns the stale case.
+    assert.ok(
+      !matrix.models.some((model) => model.id === id),
+      `${id} is subtracted from the matrix universe (epic ${entry.epic})`,
+    );
+    assert.ok(
+      lanesOf(routed, id).length > 0,
+      `${id} is subtracted from the matrix but the routing catalog routes it nowhere`,
+    );
+    assert.ok(
+      universe.has(id),
+      `${id} is routed and ships tiers, but the burndown denominator does not ask about it`,
+    );
+  }
+
+  // The rule itself, over the whole catalog.
+  const absent = [];
+  for (const model of models) {
+    const tiered = (model.downloads ?? []).some(
+      (download) => !download.coRequisite && ["q4", "q8", "bf16"].includes(download.variant),
+    );
+    if (!tiered) continue;
+    if (!universe.has(model.id) && lanesOf(routed, model.id).length > 0) absent.push(model.id);
+  }
+  assert.deepEqual(
+    absent,
+    [],
+    "a tiered manifest model may leave the denominator on every lane ONLY because the routing " +
+      "catalog routes it nowhere (epic 22723 E1)",
+  );
+});
+
 test("the gap-set denominator is narrowed only by code-derived tier overrides", async () => {
   const { cells, dropped } = await tieredCellUniverse();
   const overrides = await codeDerivedTierOverrides();
@@ -1257,15 +1371,14 @@ test("a lane only claims the tiers whose downloads that lane's host would fetch"
   // something on this lane can open — a download the host fetches, an untiered bundle it fetches,
   // or a route rule that declares the tier — and an unclaimed (routed model, shipped tier) has none
   // of the three.
-  const matrix = JSON.parse(await readFile(path.join(ROOT, MATRIX_PATH), "utf8"));
-  const routed = new Map(matrix.models.map((model) => [model.id, model.backends ?? []]));
+  const routed = await routedCatalogLanes();
   const laneTiers = await routeLaneTiers();
   const overrides = await codeDerivedTierOverrides();
   for (const model of models) {
     const shipped = (model.downloads ?? []).filter(
       (download) => !download.coRequisite && ["q4", "q8", "bf16"].includes(download.variant),
     );
-    for (const backend of routed.get(model.id) ?? []) {
+    for (const backend of lanesOf(routed, model.id)) {
       const bundled = laneHasTierBundle(model, backend);
       const floor = laneTiers.get(`${backend}:${model.id}`) ?? new Set();
       // sc-22729: and the lane's own code must be able to LOAD the tier — see
@@ -2372,21 +2485,29 @@ test("ltx_2_3 is measurable on every shipped tier of every routed lane", async (
   assert.equal(gaps.length, 0, gapReport(gaps));
 });
 
-// sc-22737. MiniMax-H3 is the one family `shippedTieredCells` cannot see: `generate-memory-matrix.mjs`
-// subtracts `minimax_h3` / `minimax_h3_ref` from the matrix universe (`OUT_OF_MATRIX_CATALOG_ENTRIES`
-// — the MLX resolver is a prefix predicate the generator cannot enumerate), and the gap set is keyed
-// off the matrix's routed lanes. Epic 22723 E2 names `--list` as the oracle, so the family is asked
-// there directly. Both lanes are DERIVED from the worker's dispatch, through the same
-// `parseInternalCandleVideoRoutes` read the generator makes — it throws if the Candle
-// `CandleVideoRoute::MiniMaxH3` arm (`video_jobs/mod.rs#resolve_candle_video_route`) or the shared
-// `minimax_h3_engine_id` resolver both lanes consult is gone — the tier axis from the manifest, and
-// every (member, tier, lane) must be planned and classify runnable / weights_missing.
+// sc-22737, re-derived by sc-22738. `generate-memory-matrix.mjs` subtracts `minimax_h3` /
+// `minimax_h3_ref` from the MATRIX universe (`OUT_OF_MATRIX_CATALOG_ENTRIES` — the MLX resolver is a
+// prefix predicate the generator cannot enumerate). That is a fact about the generator's parser, and
+// E1 admits exactly one exemption — an unrouted lane — so the burndown denominator no longer reads
+// the matrix at all and the twelve cells are IN it (`the denominator's routed-lane oracle is the
+// routing catalog, not the matrix`). This case is the second, independent reading: epic 22723 E2
+// names `--list` as the oracle, so the family is asked there directly, with both lanes DERIVED from
+// the worker's dispatch through the same `parseInternalCandleVideoRoutes` read the generator makes
+// — it throws if the Candle `CandleVideoRoute::MiniMaxH3` arm
+// (`video_jobs/mod.rs#resolve_candle_video_route`) or the shared `minimax_h3_engine_id` resolver
+// both lanes consult is gone — the tier axis from the manifest, and every (member, tier, lane) must
+// be planned and classify runnable / weights_missing.
 test("the minimax-h3 family is measurable on every shipped tier of every routed lane, through --list", async () => {
   const family = ["minimax_h3", "minimax_h3_ref"];
-  // The subtraction is recorded, never silent: the family is absent from the gap universe BECAUSE
-  // it is listed there. If the generator ever admits it, the sibling gap cases take over.
+  // The subtraction is recorded, never silent — and it no longer removes the family from the
+  // burndown: every one of the twelve cells is in the gap universe, so the sibling gap cases and
+  // this one now ask the same question through two different derivations.
   assert.deepEqual([...OUT_OF_MATRIX_CATALOG_ENTRIES.keys()].sort(), family);
-  assert.equal((await shippedTieredCells()).filter((cell) => family.includes(cell.modelId)).length, 0);
+  assert.equal(
+    (await shippedTieredCells()).filter((cell) => family.includes(cell.modelId)).length,
+    12,
+    "the routing catalog routes both entries on both lanes, so all six tiers per entry are claimed",
+  );
   const routed = parseInternalCandleVideoRoutes(
     await readFile(path.join(ROOT, "crates/sceneworks-worker/src/video_jobs/mod.rs"), "utf8"),
     await readFile(path.join(ROOT, "crates/sceneworks-worker/src/video_jobs/minimax_h3.rs"), "utf8"),
@@ -2785,11 +2906,128 @@ test("PROVIDER_FAMILIES repos are the adapter's *_REPOSITORY constants", async (
     }
   }
 });
-// The catalog-wide burndown. `todo` until the terminal story of epic 22723 (sc-22738) promotes it:
-// node:test reports a failing todo without failing the run, so the gap set is printed on every
-// `npm run check` while the other families are brought in, and the assertion itself is already
-// the one that will gate. Remove the `todo` option to promote; do not add a count.
-test("every shipped tiered model is measurable", { todo: "epic 22723 burndown; sc-22738 promotes this to a hard assertion" }, async () => {
+const ADAPTER_BIN_PATHS = Object.freeze({
+  mlx: "crates/sceneworks-memory-adapter/src/bin/mlx.rs",
+  candle: "crates/sceneworks-memory-adapter/src/bin/candle.rs",
+});
+
+let adapterArmsPromise;
+/** `{mlx, candle}` -> the provider ids each adapter binary's dispatch admits, parsed from Rust. */
+function adapterArms() {
+  adapterArmsPromise ??= (async () =>
+    Object.fromEntries(
+      await Promise.all(
+        Object.entries(ADAPTER_BIN_PATHS).map(async ([backend, relative]) => [
+          backend,
+          adapterCapturableProviders(
+            await readFile(path.join(ROOT, relative), "utf8"),
+            relative,
+          ),
+        ]),
+      ),
+    ))();
+  return adapterArmsPromise;
+}
+
+// sc-22738 (feature-end round 1). `classifyAnchor`'s `no_adapter_arm` verdict is graded off
+// `PROVIDER_FAMILIES[].arms` — a hand-kept table — and NOTHING tied that table to the Rust the arms
+// live in. Deleting `KOLORS_ID => Ok(KOLORS_PLAIN_EXECUTION_PATH)` from `candle.rs` left this file,
+// `stale-lane-report.test.mjs` and the whole `npm run check` green: the adapter could no longer
+// serve `candle:kolors`, and the measurability oracle went on saying it could.
+//
+// So `arms` is DERIVED here, through `adapterCapturableProviders` — the stale-lane report's own
+// parser, which reads the `match provider` blocks able to refuse with "five-rung calibration does
+// not implement provider" and admits a provider only when EVERY such dispatch does. It throws if
+// the dispatch shape moves, so this cannot degrade to an empty set and pass vacuously.
+//
+// Two directions, because either one alone is a false green:
+//
+//  * every declared `(family, arm)` is a provider that lane's adapter dispatches — a deleted Rust
+//    arm reds instead of becoming a silent `runnable`;
+//  * every PLAN row's `<backend>:<provider>` is dispatched too — a plan row can name a provider no
+//    family row covers, and `--list` would classify it off a family lookup that never happened.
+test("every declared adapter arm is a provider that lane's adapter really dispatches", async () => {
+  const arms = await adapterArms();
+  for (const backend of Object.keys(ADAPTER_BIN_PATHS)) {
+    assert.ok(arms[backend].length > 0, `${backend}: the dispatch parse admits no provider at all`);
+  }
+
+  let checked = 0;
+  for (const [key, family] of Object.entries(PROVIDER_FAMILIES)) {
+    // Model-keyed rows (sc-22729/sc-22734) name the engine provider they ride; provider-keyed rows
+    // ARE the provider id. `familyFor` resolves both the same way.
+    const provider = family.provider ?? key;
+    assert.ok((family.arms ?? []).length > 0, `${key} declares no arm at all`);
+    for (const backend of family.arms) {
+      assert.ok(
+        arms[backend].includes(provider),
+        `${key}: PROVIDER_FAMILIES declares a ${backend} arm, but ${ADAPTER_BIN_PATHS[backend]} ` +
+          `dispatches no ${provider} provider — classifyAnchor would call this cell runnable`,
+      );
+      checked += 1;
+    }
+  }
+  assert.ok(checked > 0, "no family arm was checked; this test guards nothing");
+
+  const plan = await readPlan();
+  const unbacked = [];
+  for (const [key, row] of Object.entries(plan.anchors)) {
+    const { backend } = anchorParts(key);
+    if (!arms[backend].includes(row.provider)) unbacked.push(`${key} -> ${backend}:${row.provider}`);
+  }
+  assert.deepEqual(
+    unbacked,
+    [],
+    "every plan anchor names a provider its lane's adapter dispatch admits",
+  );
+});
+
+// sc-22738 (feature-end round 1). The lane-default anchor composition has ONE spelling.
+//
+// `crates/sceneworks-worker/src/inference_runtime.rs` walks the same plan and asks each row's
+// contract to `validate_selection` the rung it will be captured at. Its `lane_default_rung` used to
+// respell `ANCHOR_STRATEGY` in Rust — mlx -> "resident", candle -> "staged_residency" — with nothing
+// binding the two, so changing a default here left the Rust walk asserting the old rung and green.
+// Both sides now read `config/anchor-lane-default-strategy.json`. This case holds that shape:
+// `ANCHOR_STRATEGY` really is that file, and the Rust really reads it rather than a literal.
+test("the lane default anchor composition is one declaration both lanes' walkers read", async () => {
+  const declared = JSON.parse(
+    await readFile(path.join(ROOT, ANCHOR_LANE_DEFAULT_STRATEGY_PATH), "utf8"),
+  );
+  assert.deepEqual(Object.keys(declared.lanes).sort(), ["candle", "mlx"]);
+  for (const [backend, entry] of Object.entries(declared.lanes)) {
+    assert.equal(ANCHOR_STRATEGY[backend].rung, entry.rung, backend);
+    assert.deepEqual([...ANCHOR_STRATEGY[backend].engagedRungs], entry.engagedRungs, backend);
+    assert.ok(entry.engagedRungs.includes(entry.rung), `${backend}: the default rung is engaged`);
+  }
+
+  const rust = await readFile(
+    path.join(ROOT, "crates/sceneworks-worker/src/inference_runtime.rs"),
+    "utf8",
+  );
+  assert.match(
+    rust,
+    /include_str!\(\s*"\.\.\/\.\.\/\.\.\/config\/anchor-lane-default-strategy\.json"\s*\)/,
+    "inference_runtime.rs no longer reads the shared lane-default declaration",
+  );
+  // …and it does not carry a second spelling of the values. `"mlx" => "resident"` was the defect.
+  const walk = /fn every_planned_lane_row_resolves_a_weights_free_contract_implementing_its_rung[\s\S]*?\n\}\n/.exec(rust);
+  assert.ok(walk, "the planned-rung walk is still where the lane default is applied");
+  assert.doesNotMatch(
+    walk[0],
+    /"(?:mlx|candle)"\s*=>\s*"(?:resident|staged_residency)"/,
+    "the planned-rung walk respells a lane default instead of reading the shared declaration",
+  );
+});
+
+// The catalog-wide burndown, and epic 22723's E1/E2 gate. PROMOTED to a hard assertion by sc-22738
+// (it was `todo` while the families were brought in, so the gap set printed on every `npm run check`
+// without failing it). It is a SHAPE claim and carries no count: `measurabilityGaps()` walks every
+// `<modelId>:<tier>:<backend>` the routing catalog and the manifest between them claim, on BOTH
+// lanes, and demands `--list` classify each one `runnable` or `weights_missing`. `weights_missing`
+// is a host condition, never a gap (E5), so this needs no weights, no GPU and no inference
+// checkout.
+test("every shipped tiered model is measurable", async () => {
   const gaps = await measurabilityGaps();
   assert.equal(gaps.length, 0, gapReport(gaps));
 });

--- a/scripts/memory-calibration-harness.mjs
+++ b/scripts/memory-calibration-harness.mjs
@@ -1402,15 +1402,44 @@ export function evidenceSemantics(record, revisions) {
  * effective rung to be `resident` exactly when the model's manifest lane block declares a
  * `memoryStrategyStructuralExemptions.staged_residency`, so this cannot be used to pick a rung the
  * architecture does not force.
+ *
+ * ## Where the values live (sc-22738)
+ *
+ * NOT here. `crates/sceneworks-worker/src/inference_runtime.rs` walks this same plan and asks each
+ * row's contract to `validate_selection` the rung it will be captured at, and it used to RESPELL
+ * these two defaults in Rust (`lane_default_rung`: mlx -> "resident", candle -> "staged_residency")
+ * with nothing binding the two spellings — a lane default changed here would have left the Rust
+ * walk asserting the OLD rung and still green. Both sides now read
+ * `config/anchor-lane-default-strategy.json`, the Rust one through `include_str!`, so a change to
+ * the composition is a change to one file and reds the walk unless the contracts follow.
+ *
+ * Read synchronously at module load and fail-closed: a missing lane, rung or engaged-rung list
+ * throws here rather than degrading to a default composition no law authorized.
  */
-export const ANCHOR_STRATEGY = Object.freeze({
-  mlx: Object.freeze({ rung: "resident", engagedRungs: Object.freeze(["resident"]), parameters: Object.freeze({}) }),
-  candle: Object.freeze({
-    rung: "staged_residency",
-    engagedRungs: Object.freeze(["resident", "staged_residency"]),
-    parameters: Object.freeze({}),
-  }),
-});
+export const ANCHOR_LANE_DEFAULT_STRATEGY_PATH = "config/anchor-lane-default-strategy.json";
+
+function loadAnchorStrategy() {
+  const declared = JSON.parse(
+    readFileSync(path.join(ROOT, ANCHOR_LANE_DEFAULT_STRATEGY_PATH), "utf8"),
+  ).lanes;
+  const lanes = {};
+  for (const backend of ["mlx", "candle"]) {
+    const entry = declared?.[backend];
+    if (typeof entry?.rung !== "string" || !Array.isArray(entry.engagedRungs) || entry.engagedRungs.length === 0) {
+      fail(
+        `${ANCHOR_LANE_DEFAULT_STRATEGY_PATH} declares no usable default composition for the ${backend} lane`,
+      );
+    }
+    lanes[backend] = Object.freeze({
+      rung: entry.rung,
+      engagedRungs: Object.freeze([...entry.engagedRungs]),
+      parameters: Object.freeze({}),
+    });
+  }
+  return Object.freeze(lanes);
+}
+
+export const ANCHOR_STRATEGY = loadAnchorStrategy();
 
 /** `<modelId>:<tier>:<backend>` — the anchor plan's key, and the cell identity itself. */
 const ANCHOR_KEY = /^([a-z][a-z0-9_]*):(q4|q8|bf16):(mlx|candle)$/;

--- a/scripts/stale-lane-report.mjs
+++ b/scripts/stale-lane-report.mjs
@@ -83,7 +83,53 @@ export const SOURCE_PATHS = Object.freeze({
   plan: "config/memory-calibration-plan.json",
   mlxAdapter: "crates/sceneworks-memory-adapter/src/bin/mlx.rs",
   candleAdapter: "crates/sceneworks-memory-adapter/src/bin/candle.rs",
+  controlWeights: "crates/sceneworks-core/src/control_weights.rs",
 });
+
+/**
+ * Provenance for the OVERLAY-PROVIDER partition (sc-22738), printed like {@link MARGIN_SOURCE}.
+ */
+export const OVERLAY_PROVIDER_SOURCE =
+  "SHIPPED_CONTROL_WEIGHTS[].engine_id in crates/sceneworks-core/src/control_weights.rs that is not" +
+  " a catalog model id — a strict-control overlay of a base entry, so it is a PROVIDER lane and" +
+  " never an epic 22723 E1 (model, tier, lane) cell";
+
+/**
+ * The strict-control OVERLAY provider ids (sc-22738).
+ *
+ * A closure lane like `mlx:z_image_turbo_control` names an engine provider that exists only as the
+ * strict-control overlay of a base catalog entry: `z_image_turbo` is the manifest model, and the
+ * `_control` engine is the same model loaded with a ControlNet attached. It ships no tiered
+ * downloads of its own — it is not a manifest model at all — so it can never be one of epic 22723
+ * E1's `<modelId>:<tier>:<backend>` cells, and `measure-memory-catalog.mjs --list` correctly never
+ * asks about it. Grading such a lane "uncapturable" told the reader an adapter arm was MISSING,
+ * which sent them to adapter work for a lane that is out of scope by construction. The declarations
+ * must nonetheless STAY: production route currency is graded per (backend, provider), and a control
+ * render loads under the `_control` provider id.
+ *
+ * DERIVED, never hand-kept: the ids come from the production allow-list the render path itself
+ * consults (`SHIPPED_CONTROL_WEIGHTS`), minus every id the catalog ships as a model — which is what
+ * keeps `sdxl` (a control engine_id AND a manifest model) out of this set. Fails closed: an
+ * unparseable or empty table throws rather than yielding an empty partition.
+ */
+export function shippedControlOverlayProviders(source, manifest, label) {
+  const table =
+    /pub const SHIPPED_CONTROL_WEIGHTS:\s*&\[ShippedControlWeight\]\s*=\s*&\[([\s\S]*?)\n\];/.exec(
+      typeof source === "string" ? source : "",
+    );
+  if (!table) {
+    throw new Error(
+      `${label}: SHIPPED_CONTROL_WEIGHTS is no longer a parseable table, so the control-overlay ` +
+        "provider partition cannot be derived",
+    );
+  }
+  const engines = new Set([...table[1].matchAll(/engine_id:\s*"([^"]+)"/g)].map((item) => item[1]));
+  if (engines.size === 0) {
+    throw new Error(`${label}: SHIPPED_CONTROL_WEIGHTS names no engine_id at all`);
+  }
+  const catalogIds = new Set((manifest?.models ?? []).map((model) => model.id));
+  return new Set([...engines].filter((id) => !catalogIds.has(id)).sort());
+}
 
 /**
  * The provider closure ledger, validated (sc-17774).
@@ -818,6 +864,7 @@ export function buildStaleLaneReport({
   manifestBody,
   plan,
   adapterSources,
+  controlWeightsSource,
   meta = {},
 }) {
   if (typeof adapterSources?.mlx !== "string" || typeof adapterSources?.candle !== "string") {
@@ -825,6 +872,13 @@ export function buildStaleLaneReport({
       "buildStaleLaneReport needs both adapter sources — capturability cannot be reported without them",
     );
   }
+  // Required, not defaulted: an absent source would silently collapse the overlay partition back
+  // into "uncapturable", which is the mis-grading sc-22738 removed.
+  const overlayProviders = shippedControlOverlayProviders(
+    controlWeightsSource,
+    manifest,
+    SOURCE_PATHS.controlWeights,
+  );
   const arms = {
     mlx: adapterCapturableProviders(adapterSources.mlx, SOURCE_PATHS.mlxAdapter),
     candle: adapterCapturableProviders(adapterSources.candle, SOURCE_PATHS.candleAdapter),
@@ -945,7 +999,16 @@ export function buildStaleLaneReport({
     });
 
   const stale = rankLanes(lanes.filter((lane) => lane.status === "stale" || lane.status === "partially-stale"));
-  const uncapturable = [...lanes, ...undeclaredLanes].filter((lane) => !lane.capturable);
+  // sc-22738: an OVERLAY-provider lane is reported under its own heading and is NOT "uncapturable".
+  // See `shippedControlOverlayProviders` — it is out of the E1 cell universe by construction, not
+  // waiting on adapter work, so booking a capture host for it is not the wasted booking the
+  // uncapturable heading warns about. Its measurement status (stale / current / unmeasured) is
+  // unchanged and it still appears in those partitions, exactly as any other declared lane does.
+  const isOverlayLane = (lane) => overlayProviders.has(lane.provider);
+  const overlayProviderLanes = [...lanes, ...undeclaredLanes].filter(isOverlayLane);
+  const uncapturable = [...lanes, ...undeclaredLanes].filter(
+    (lane) => !lane.capturable && !isOverlayLane(lane),
+  );
   return {
     generatedAgainst: {
       inferenceRevision: meta.inferenceRevision ?? null,
@@ -957,6 +1020,9 @@ export function buildStaleLaneReport({
       source: CAPTURABILITY_SOURCE,
       arms,
       uncapturableLanes: uncapturable.map((lane) => lane.lane),
+      overlayProviderSource: OVERLAY_PROVIDER_SOURCE,
+      overlayProviders: [...overlayProviders],
+      overlayProviderLanes: overlayProviderLanes.map((lane) => lane.lane),
     },
     flagshipApparatusCoverage: {
       source:
@@ -970,6 +1036,7 @@ export function buildStaleLaneReport({
       currentLanes: lanes.filter((lane) => lane.status === "current").length,
       unmeasuredLanes: lanes.filter((lane) => lane.status === "unmeasured").length,
       uncapturableLanes: uncapturable.length,
+      overlayProviderLanes: overlayProviderLanes.length,
       undeclaredLanes: undeclaredLanes.length,
       staleBindings: lanes.reduce((sum, lane) => sum + lane.bindings.stale, 0),
       staleRecords: lanes.reduce((sum, lane) => sum + lane.records.stale, 0),
@@ -978,13 +1045,22 @@ export function buildStaleLaneReport({
     currentLanes: lanes.filter((lane) => lane.status === "current"),
     unmeasuredLanes: lanes.filter((lane) => lane.status === "unmeasured"),
     uncapturableLanes: uncapturable,
+    overlayProviderLanes,
     undeclaredLanes,
   };
 }
 
 export async function loadSources(root = ROOT) {
-  const [closuresBody, evidenceBody, manifestBody, cargoBody, planBody, mlxAdapter, candleAdapter] =
-    await Promise.all(
+  const [
+    closuresBody,
+    evidenceBody,
+    manifestBody,
+    cargoBody,
+    planBody,
+    mlxAdapter,
+    candleAdapter,
+    controlWeightsSource,
+  ] = await Promise.all(
       Object.values(SOURCE_PATHS).map((relative) => readFile(path.join(root, relative), "utf8")),
     );
   const closures = JSON.parse(closuresBody);
@@ -1000,6 +1076,7 @@ export async function loadSources(root = ROOT) {
     manifestBody,
     plan: JSON.parse(planBody),
     adapterSources: { mlx: mlxAdapter, candle: candleAdapter },
+    controlWeightsSource,
     meta: { inferenceRevision: closures.inferenceRevision, digestVersion: closures.digestVersion },
   };
 }
@@ -1028,7 +1105,9 @@ export function formatReport(report) {
   out.push(
     `${totals.declaredLanes} declared lanes: ${totals.staleLanes} stale, ${totals.currentLanes} current, ` +
       `${totals.unmeasuredLanes} pending capture; ${totals.uncapturableLanes} lanes (declared or ` +
-      `planned) have no adapter arm, and ${totals.undeclaredLanes} planned lanes were never declared.`,
+      `planned) have no adapter arm, ${totals.overlayProviderLanes} are strict-control overlay ` +
+      `providers outside the E1 cell universe, and ${totals.undeclaredLanes} planned lanes were ` +
+      "never declared.",
   );
   out.push(
     `${totals.staleBindings} shipped calibration bindings are serving under a widened margin; ` +
@@ -1101,6 +1180,30 @@ export function formatReport(report) {
           `records=${lane.records.total ?? 0} eligible  status=${lane.status}`,
       );
     }
+  }
+  if (report.overlayProviderLanes?.length) {
+    out.push("");
+    out.push(
+      "STRICT-CONTROL OVERLAY PROVIDERS — OUT OF THE E1 CELL UNIVERSE, not uncapturable. These lanes",
+    );
+    out.push(
+      "name a ControlNet overlay of a base catalog entry, not a manifest model with tiered downloads,",
+    );
+    out.push(
+      "so `measure-memory-catalog.mjs --list` has no `<modelId>:<tier>:<backend>` cell to ask about and",
+    );
+    out.push(
+      "epic 22723 E1 never claimed one. The declarations STAY: production control renders load under",
+    );
+    out.push("these provider ids, and their route currency is graded per (backend, provider):");
+    for (const lane of report.overlayProviderLanes) {
+      out.push(
+        `  ${lane.lane}  declared=${lane.declared ? "yes" : "NO"}  adapter=${lane.capturable ? "yes" : "NO ARM"}  ` +
+          `plan=${lane.plan.entries} entries  bindings=${lane.bindings.total ?? 0} shipped  ` +
+          `records=${lane.records.total ?? 0} eligible  status=${lane.status}`,
+      );
+    }
+    out.push(`  source: ${report.capturability.overlayProviderSource}`);
   }
   if (report.undeclaredLanes.some((lane) => lane.capturable)) {
     out.push("");

--- a/scripts/stale-lane-report.test.mjs
+++ b/scripts/stale-lane-report.test.mjs
@@ -7,11 +7,14 @@ import { fileURLToPath } from "node:url";
 
 import { digestOccurrences, recordsNeedingDigest } from "./backfill-closure-digests.mjs";
 import { deriveMargins } from "./derive-ladder-margins.mjs";
+import { PROVIDER_FAMILIES } from "./measure-memory-catalog.mjs";
 import { inferencePinFromCargo } from "./inference-closure-digest.mjs";
 import {
   CAPTURABILITY_SOURCE,
   MARGIN_SOURCE,
+  OVERLAY_PROVIDER_SOURCE,
   SOURCE_PATHS,
+  shippedControlOverlayProviders,
   adapterCapturableProviders,
   buildStaleLaneReport,
   evidenceBindings,
@@ -130,6 +133,10 @@ function fixtureFrom({
   // Every provider the fixtures declare has an arm BY DEFAULT, so pre-sc-18212 expectations (an
   // unmeasured lane is "pending capture") keep holding; capturability tests override these.
   adapterSources = { mlx: adapterSource(["alpha"]), candle: adapterSource(["beta", "gamma"]) },
+  // sc-22738: the strict-control overlay partition is derived from this table. The fixture default
+  // declares one overlay id no fixture lane uses, so the partition is empty here and the pre-sc-22738
+  // expectations (an armless lane is "uncapturable") keep holding; overlay tests override it.
+  controlWeightsSource = controlWeightsSourceFor(["fixture_only_control"]),
 }) {
   return {
     liveDigests: new Map(lanes),
@@ -141,7 +148,20 @@ function fixtureFrom({
     manifestBody: JSON.stringify({ models }, null, 2),
     plan,
     adapterSources,
+    controlWeightsSource,
   };
+}
+
+/** A `SHIPPED_CONTROL_WEIGHTS` table in the exact shape `shippedControlOverlayProviders` parses. */
+function controlWeightsSourceFor(engineIds) {
+  return [
+    "pub const SHIPPED_CONTROL_WEIGHTS: &[ShippedControlWeight] = &[",
+    ...engineIds.map(
+      (id) =>
+        `    ShippedControlWeight { engine_id: "${id}", repo: "org/repo", file: "f.safetensors", revision: "0" },`,
+    ),
+    "];",
+  ].join("\n");
 }
 
 /**
@@ -505,16 +525,25 @@ test("the real corpus report is internally consistent, whatever the corpus curre
   // ABSENT, which E8 forbids CI from failing on. The derivation directly above (missingLanes is
   // exactly the not-covered lanes, computed from the same three gates) is unchanged and still
   // grades the data that IS present.
-  // Declared+unmeasured+armless lanes live ONLY in `uncapturableLanes` (status "uncapturable");
-  // measured armless lanes stay in the staleness partition and appear in `uncapturableLanes` as a
-  // second, cross-cutting membership.
+  // Declared+unmeasured+armless lanes live ONLY in `uncapturableLanes` (status "uncapturable") —
+  // or, since sc-22738, in `overlayProviderLanes` when the provider is a strict-control overlay,
+  // which is a SCOPE partition rather than an adapter-work one. Measured armless lanes stay in the
+  // staleness partition and appear in one of those two lists as a second, cross-cutting membership.
+  const armless = [...report.uncapturableLanes, ...report.overlayProviderLanes].filter(
+    (lane) => lane.status === "uncapturable",
+  );
   const all = [
     ...report.staleLanes,
     ...report.currentLanes,
     ...report.unmeasuredLanes,
-    ...report.uncapturableLanes.filter((lane) => lane.status === "uncapturable"),
+    ...armless,
   ];
   const universe = [...all, ...report.undeclaredLanes];
+  assert.equal(
+    new Set(all.map((lane) => lane.lane)).size,
+    all.length,
+    "the four measurement partitions are disjoint",
+  );
 
   assert.equal(all.length, report.totals.declaredLanes);
   assert.equal(all.length, sources.liveDigests.size);
@@ -523,7 +552,7 @@ test("the real corpus report is internally consistent, whatever the corpus curre
     report.totals.staleLanes +
       report.totals.currentLanes +
       report.totals.unmeasuredLanes +
-      report.uncapturableLanes.filter((lane) => lane.status === "uncapturable").length,
+      armless.length,
   );
   assert.equal(report.totals.staleBindings, all.reduce((sum, lane) => sum + lane.bindings.stale, 0));
   assert.equal(report.totals.staleRecords, all.reduce((sum, lane) => sum + lane.records.stale, 0));
@@ -565,10 +594,32 @@ test("the real corpus report is internally consistent, whatever the corpus curre
       `${lane.lane} capturable flag matches the parsed adapter arms`,
     );
   }
+  // sc-22738: the armless population splits in two. A strict-control overlay provider is reported
+  // as out of the E1 cell universe rather than as adapter work, and the two lists together are
+  // still exactly the lanes with no arm — nothing may fall out of both.
+  const overlayLanes = new Set(report.capturability.overlayProviderLanes);
+  assert.deepEqual(
+    universe
+      .filter((lane) => !lane.capturable && !overlayLanes.has(lane.lane))
+      .map((lane) => lane.lane)
+      .sort(),
+    [...report.capturability.uncapturableLanes].sort(),
+    "the uncapturable list is exactly the armless lanes that are not overlay providers",
+  );
+  assert.deepEqual(
+    report.overlayProviderLanes.map((lane) => lane.lane).sort(),
+    [...overlayLanes].sort(),
+    "the overlay-lane objects and the cross-cutting id list agree",
+  );
   assert.deepEqual(
     universe.filter((lane) => !lane.capturable).map((lane) => lane.lane).sort(),
-    [...report.capturability.uncapturableLanes].sort(),
-    "the uncapturable list is exactly the lanes without an arm",
+    [
+      ...new Set([
+        ...report.capturability.uncapturableLanes,
+        ...universe.filter((lane) => !lane.capturable && overlayLanes.has(lane.lane)).map((lane) => lane.lane),
+      ]),
+    ].sort(),
+    "every armless lane is reported under exactly one of the two headings",
   );
   for (const lane of report.unmeasuredLanes) {
     assert.ok(lane.capturable, `${lane.lane} is pending capture, so an adapter arm must exist`);
@@ -1234,4 +1285,112 @@ test("the human report separates pending capture from uncapturable, and prints t
   assert.match(text, /CAPTURE/);
   assert.match(text, /NO ARM/, "an armless stale lane is flagged in the ranked table");
   assert.ok(text.includes(CAPTURABILITY_SOURCE));
+});
+
+// sc-22738 (feature-end round 1). The strict-control OVERLAY partition.
+//
+// `config/inference-provider-closures.json` declares four lanes whose provider is a ControlNet
+// overlay of a base catalog entry — `candle:krea_2_turbo_control`, `candle:z_image_control`,
+// `mlx:krea_2_turbo_control`, `mlx:z_image_turbo_control`. None of them is a manifest model, so none
+// can ever be an epic 22723 E1 `<modelId>:<tier>:<backend>` cell and `measure-memory-catalog.mjs
+// --list` correctly never asks about them. Three of the four have no adapter arm, and the report
+// used to grade those "uncapturable" — telling the reader adapter work was outstanding for a lane
+// that is out of scope by construction. The declarations must STAY: production control renders load
+// under these provider ids and their route currency is graded per (backend, provider).
+test("strict-control overlay providers are reported as out of scope, not as uncapturable", async () => {
+  const sources = await loadSources();
+  const report = buildStaleLaneReport(sources);
+  const catalogIds = new Set(sources.manifest.models.map((model) => model.id));
+
+  // The partition is derived from the production allow-list, not from a list kept here.
+  assert.deepEqual(
+    report.capturability.overlayProviders,
+    [
+      ...shippedControlOverlayProviders(
+        sources.controlWeightsSource,
+        sources.manifest,
+        SOURCE_PATHS.controlWeights,
+      ),
+    ],
+  );
+  assert.ok(
+    report.capturability.overlayProviders.length > 0,
+    "the control allow-list still names at least one non-catalog overlay engine",
+  );
+  for (const provider of report.capturability.overlayProviders) {
+    assert.ok(!catalogIds.has(provider), `${provider} is a catalog model, not an overlay provider`);
+  }
+  // `sdxl` is an engine_id in the SAME table and IS a catalog model; it must never be partitioned
+  // out, or a real tiered lane could leave the uncapturable grading through this door.
+  assert.ok(catalogIds.has("sdxl"));
+  assert.ok(!report.capturability.overlayProviders.includes("sdxl"));
+
+  // Every declared closure lane whose provider is an overlay lands under the overlay heading, and
+  // none of them is graded uncapturable.
+  const declaredOverlay = [...sources.liveDigests.keys()]
+    .filter((lane) =>
+      report.capturability.overlayProviders.includes(lane.split(":").slice(1).join(":")),
+    )
+    .sort();
+  assert.ok(declaredOverlay.length > 0, "the closure table still declares an overlay-provider lane");
+  assert.deepEqual(report.capturability.overlayProviderLanes.slice().sort(), declaredOverlay);
+
+  // …and the partition is the RIGHT one, judged from three sources the report does not consult
+  // together: a declared closure lane is outside the E1 cell universe exactly when its provider is
+  // neither a manifest model (so `--list` can key no `<modelId>:<tier>:<backend>` cell on it) nor
+  // any `PROVIDER_FAMILIES` engine provider (so no anchor can name it). Without this the case would
+  // only check the derivation against itself: dropping `z_image_control` from
+  // `SHIPPED_CONTROL_WEIGHTS` would move `candle:z_image_control` back under "uncapturable" and
+  // every self-referential assertion above would still hold.
+  const familyProviders = new Set(
+    Object.entries(PROVIDER_FAMILIES).map(([key, family]) => family.provider ?? key),
+  );
+  assert.deepEqual(
+    declaredOverlay,
+    [...sources.liveDigests.keys()]
+      .filter((lane) => {
+        const provider = lane.split(":").slice(1).join(":");
+        return !catalogIds.has(provider) && !familyProviders.has(provider);
+      })
+      .sort(),
+    "the overlay partition must be exactly the declared lanes no E1 cell can ever key on",
+  );
+  for (const lane of declaredOverlay) {
+    assert.ok(
+      !report.capturability.uncapturableLanes.includes(lane),
+      `${lane} is an overlay provider and must not be graded uncapturable`,
+    );
+  }
+  assert.equal(report.totals.overlayProviderLanes, report.overlayProviderLanes.length);
+
+  const text = formatReport(report);
+  assert.match(
+    text,
+    /STRICT-CONTROL OVERLAY PROVIDERS — OUT OF THE E1 CELL UNIVERSE, not uncapturable/,
+  );
+  assert.ok(text.includes(OVERLAY_PROVIDER_SOURCE));
+  for (const lane of declaredOverlay) assert.ok(text.includes(lane), `${lane} is printed`);
+});
+
+// The derivation fails CLOSED: it may never quietly yield an empty partition, which would put the
+// overlay lanes back under "uncapturable" without anything saying so.
+test("the overlay-provider derivation refuses a table it cannot read", () => {
+  const manifest = { models: [{ id: "sdxl" }] };
+  assert.throws(
+    () => shippedControlOverlayProviders("// the table moved", manifest, "x.rs"),
+    /SHIPPED_CONTROL_WEIGHTS is no longer a parseable table/,
+  );
+  assert.throws(
+    () =>
+      shippedControlOverlayProviders(
+        "pub const SHIPPED_CONTROL_WEIGHTS: &[ShippedControlWeight] = &[\n];",
+        manifest,
+        "x.rs",
+      ),
+    /names no engine_id at all/,
+  );
+  assert.throws(
+    () => buildStaleLaneReport({ ...twoLaneFixture(), controlWeightsSource: undefined }),
+    /SHIPPED_CONTROL_WEIGHTS is no longer a parseable table/,
+  );
 });

--- a/tests/test_builtin_manifest_audit.py
+++ b/tests/test_builtin_manifest_audit.py
@@ -909,36 +909,40 @@ def test_only_overlay_bearing_rows_may_omit_their_calibration_identity():
     `crates/media/candle-gen/candle-gen-sd3/src/memory_strategy.rs:876-886`), so the six SD3.5 lora
     rows CANNOT name an identity: the engine never publishes one for that load shape. The schema
     therefore admits an overlay-bearing measured row with no `fingerprint`, and that permission is
-    wider than the truth — no other shipped engine withholds today. This test is the narrow half:
-    it pins the exact committed set, so a fingerprint dropped from any other row reds here.
+    wider than the truth.
+
+    STRUCTURAL HALF ONLY (sc-22738). This test used to pin the exact six-row set
+    `{sd3_5_*:candle[1|3]}`, which is a frozen-corpus gate: it reds on any new overlay-bearing row,
+    including a correct one, and it says nothing about WHY a row may omit its identity. The derived
+    rule — which model/crate pairs actually withhold, read from the engine source when
+    `INFERENCE_REPO` points at a checkout that carries it — already lives in
+    `scripts/manifest-memory-declarations.test.mjs`
+    ("no overlay-bearing manifest row promises an identity its candle engine withholds under
+    adapters"). What survives here is the SHAPE claim that file does not make: an omission implies
+    the row is overlay-bearing, over every measured contract row in the catalog.
 
     The clean-base half is enforced structurally, and asserted below against the real schema.
     """
-    omitted = {
-        (model_id, backend, index)
+    omitted = [
+        (model_id, backend, index, row)
         for model_id, backend, index, row in _measured_contract_rows()
         if "fingerprint" not in row
-    }
-    assert omitted == {
-        ("sd3_5_large", "candle", 1),
-        ("sd3_5_large", "candle", 3),
-        ("sd3_5_large_turbo", "candle", 1),
-        ("sd3_5_large_turbo", "candle", 3),
-        ("sd3_5_medium", "candle", 1),
-        ("sd3_5_medium", "candle", 3),
-    }, (
-        "the set of rows without a production calibration identity changed; a row may omit "
-        "`fingerprint` ONLY because its engine withholds one under adapters: "
-        f"{sorted(omitted)}"
+    ]
+    # Not a count: the claim is only that the population is non-empty, so the loop below is not
+    # vacuous. A catalog in which every measured row named its identity would make this test
+    # meaningless rather than wrong, and that is what this says.
+    assert omitted, (
+        "no measured contract row omits its calibration identity, so the omission rule below "
+        "guards nothing — has the engine started publishing under adapters?"
     )
-    # Every one of them is overlay-bearing, which is what earns the omission.
-    for model_id, backend, index, row in _measured_contract_rows():
-        if (model_id, backend, index) not in omitted:
-            continue
+    # An omission is earned ONLY by being overlay-bearing: a clean base row that drops its
+    # fingerprint is an authoring oversight, and this is what catches it.
+    for model_id, backend, index, row in omitted:
         assert [
             overlay for overlay in row["overlays"] if overlay != "none"
         ] or row.get("providerOverlay", "none") != "none", (
-            f"{model_id}:{backend}[{index}] omits fingerprint but declares no overlay"
+            f"{model_id}:{backend}[{index}] omits fingerprint but declares no overlay; only an "
+            "engine that withholds the identity under adapters may leave it out"
         )
 
 


### PR DESCRIPTION
Feature-end review round 1 for epic 22723, all six findings resolved as one batch. No pin site touched.

| # | Finding | Source of truth now |
|---|---|---|
| 1 | [major] E1 denominator's routed-lane axis came from the matrix, which subtracts `OUT_OF_MATRIX_CATALOG_ENTRIES` — a second exemption source | `routedLanes()` over `crates/sceneworks-core/src/jobs_store/routing/{catalog,candle,mlx}.rs`; the 12 MiniMax-H3 cells are now IN the burndown |
| 2 | [major] `no_adapter_arm` graded off the hand-kept `PROVIDER_FAMILIES[].arms` | `adapterCapturableProviders()` parses the Rust `match provider` dispatch; both families and plan rows checked |
| 3 | [minor] Four overlay-provider closure lanes graded "uncapturable" | `SHIPPED_CONTROL_WEIGHTS[].engine_id` (control_weights.rs) minus catalog model ids; own report heading |
| 4 | [minor] pytest pinned an exact six-row set | structural half only (omission implies overlay-bearing); the derived rule lives in `manifest-memory-declarations.test.mjs` |
| 5 | [minor] `lane_default_rung` respelled `ANCHOR_STRATEGY` | `config/anchor-lane-default-strategy.json`, read by the harness and by Rust via `include_str!` |
| 6 | terminal promotion | `every shipped tiered model is measurable` is no longer `todo` — hard assertion, zero gaps on both lanes |

The generator's stale rationale is corrected too: `resolve_candle_video_route` has had a `CandleVideoRoute::MiniMaxH3` arm since sc-19508 and the routing catalog declares `VideoModelCaps::new("minimax_h3", true, true, ...)`, so both lanes ARE routed — the subtraction is a fact about the generator's parser and is now matrix-only.

## Mutations run

`touch` between runs; touched files grepped for `if true` / `if false` / `&& false` afterwards (clean).

| Assertion | Mutation | Result |
|---|---|---|
| `every shipped tiered model is measurable` | delete all 12 `minimax_h3*` plan rows | RED (`npm run check`, 5 failures) |
| `every shipped tiered model is measurable` | delete `sd3_5_medium:q8:candle` plan row | RED (`npm run check`, `no_plan_anchor`) |
| `every declared adapter arm is a provider that lane's adapter really dispatches` | delete `KOLORS_ID => Ok(KOLORS_PLAIN_EXECUTION_PATH)` from `candle.rs` | RED (`npm run check`) |
| `strict-control overlay providers are reported as out of scope` | drop `z_image_control` from `SHIPPED_CONTROL_WEIGHTS` | RED |
| pytest `test_only_overlay_bearing_rows_may_omit_their_calibration_identity` | drop a clean-base row's `fingerprint` | RED |
| Rust `every_planned_mlx_lane_resolves_a_weights_free_provider_contract` | flip the mlx lane default to `staged_residency` in the shared JSON | RED |

## Verification

- `npm run check` exit 0 without `INFERENCE_REPO` (802 pass, 0 fail, **0 todo**) and with it at pin `8a65db2aa` (804 pass, 0 fail, 0 todo)
- `npm run check:memory-matrix` exit 0 (regenerated: the out-of-matrix reason text changed)
- `node scripts/measure-memory-catalog.mjs --list --backend mlx` — 168 rows, `--backend candle` — 158 rows; **zero** `no_adapter_arm` / `lane_undeclared` / `provider_undeclared` / `harness_unsupported` on either lane
- `node scripts/stale-lane-report.mjs` exit 0 — the "DECLARED/PLANNED BUT UNCAPTURABLE" heading is now empty and the four overlay lanes print under the new heading
- `python3.12 -m pytest tests/test_builtin_manifest_audit.py -q` — 101 passed
- `npm run rust:check`, `npm run rust:check:candle`, `npm run rust:check:neither` — all exit 0

E5 respected: nothing added fails for lack of a measurement; `weights_missing` remains a host condition.

Do not merge — a feature-end re-review follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
