### PR TITLE
chore(sc-22738): workflow_dispatch memory-catalog campaign for the mlx and candle lanes

### DIFF
--- a/.github/workflows/memory-catalog-campaign.yml
+++ b/.github/workflows/memory-catalog-campaign.yml
@@ -55,7 +55,11 @@ on:
         type: boolean
         default: true
       hf_cache_roots:
-        description: "Optional extra Hugging Face hub roots, one per line or ';'-separated. Empty falls back to $SCENEWORKS_MEMORY_CAMPAIGN_HF_CACHE on the runner, then this lane's documented default."
+        description: >-
+          Optional extra Hugging Face hub roots, one per line or ';'-separated. Empty falls back
+          to $SCENEWORKS_MEMORY_CAMPAIGN_HF_CACHE on the runner, then this lane's default:
+          /Volumes/Models/huggingface/hub for mlx (either Mac), E:\huggingface\hub for candle
+          (the Windows CUDA box).
         required: false
         type: string
         default: ""

--- a/.github/workflows/memory-catalog-campaign.yml
+++ b/.github/workflows/memory-catalog-campaign.yml
@@ -1,0 +1,290 @@
+# Manually-triggered memory-anchor measurement campaign (sc-22738, epic 22723).
+#
+# `scripts/measure-memory-catalog.mjs` walks every anchor the plan declares for ONE backend on ONE
+# host and COMMITS each measurement as it lands (capture -> check -> ingest -> extract -> stamp ->
+# matrix -> commit). It refuses a detached HEAD and a dirty tree, and it asserts BOTH checkouts stay
+# clean and stable for the whole walk. This workflow is the on-demand way to run that walk on the
+# self-hosted GPU boxes instead of tying up an interactive shell for a day.
+#
+# WHY DISPATCH-ONLY, AND WHY IT GATES NOTHING. Per FEATURE_DEVELOPMENT.md's "Gate teardown"
+# (2026-08-15/16, sc-19758 / sc-19751), measurement runs ONCE at epic end or on explicit request --
+# never per code change. There is deliberately no `push:`, no `pull_request:` and no `schedule:`
+# here, so this workflow can never become a required check and can never be selected as one: a
+# `workflow_dispatch`-only workflow reports no context on any PR.
+#
+# WHAT IT PRODUCES. A NEW branch `story/<campaign>-<backend>-campaign-<run_id>` carrying one commit
+# per measured anchor, pushed as the walk proceeds (never only at the end), plus a work-dir artifact
+# with the summary JSON, the per-anchor logs and the retained raw bundles. The last step opens a PR
+# back into the dispatched `ref` when the branch has commits. Nothing is merged automatically.
+#
+# THE SCARCE RESOURCE IS THE GPU, NOT THE RUNNER. Each job takes a job-level `concurrency` group
+# keyed on (backend, runner) with `cancel-in-progress: false`, so two campaigns can never share one
+# box's GPU: the second dispatch queues behind the first rather than fighting it for unified memory
+# (MLX) or VRAM (CUDA).
+name: Memory catalog campaign
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend:
+        description: "Which lane to walk. mlx runs on a Mac, candle on the Windows CUDA box."
+        required: true
+        type: choice
+        options:
+          - mlx
+          - candle
+        default: mlx
+      campaign:
+        description: "Campaign id -- one path segment, e.g. sc-22738. Names the evidence prefix, the work dir and the branch."
+        required: true
+        type: string
+        default: sc-22738
+      anchors:
+        description: "Optional comma-separated anchor keys (<model>:<tier>:<backend>). Empty walks every planned anchor for the backend."
+        required: false
+        type: string
+        default: ""
+      models:
+        description: "Optional space-separated model ids to restrict the walk to. Empty means every model."
+        required: false
+        type: string
+        default: ""
+      skip_current:
+        description: "Skip anchors already current at the pinned inference revision (--skip-current)."
+        required: false
+        type: boolean
+        default: true
+      hf_cache_roots:
+        description: "Optional extra Hugging Face hub roots, one per line or ';'-separated. Empty falls back to $SCENEWORKS_MEMORY_CAMPAIGN_HF_CACHE on the runner, then this lane's documented default."
+        required: false
+        type: string
+        default: ""
+      ref:
+        description: "Branch to walk from. The campaign branch is cut from this ref and the PR targets it."
+        required: true
+        type: string
+        default: feature/sc-22723-memory-anchor-measurability
+      runner_label:
+        description: >-
+          Which Mac the mlx lane runs on (ignored for candle). `rw-krea` is the SECOND Mac
+          (nax-macos-2); `nax` is Michael's dev Mac (nax-macos), which is also the app repo's
+          ordinary PR runner. Both label sets were verified against the runners that actually served
+          recent jobs -- see the runbook note before changing either.
+        required: true
+        type: choice
+        options:
+          - "rw-krea (nax-macos-2, the second Mac)"
+          - "nax (nax-macos, the dev Mac)"
+        default: "rw-krea (nax-macos-2, the second Mac)"
+      push_every:
+        description: "Push the campaign branch once this many new anchor commits have landed. 1 pushes after every anchor."
+        required: false
+        type: string
+        default: "1"
+
+# `gh pr create` and the branch pushes both run as the default GITHUB_TOKEN. No other secret is
+# needed or read by this workflow.
+permissions:
+  contents: write
+  pull-requests: write
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CAMPAIGN: ${{ inputs.campaign }}
+  BASE_REF: ${{ inputs.ref }}
+  PUSH_EVERY: ${{ inputs.push_every }}
+  ANCHORS_INPUT: ${{ inputs.anchors }}
+  MODELS_INPUT: ${{ inputs.models }}
+  SKIP_CURRENT: ${{ inputs.skip_current }}
+  HF_CACHE_INPUT: ${{ inputs.hf_cache_roots }}
+
+jobs:
+  mlx:
+    if: ${{ inputs.backend == 'mlx' }}
+    name: mlx catalog campaign
+    # `rw-krea` and `nax` are the two macOS label sets verified as carried by a live runner
+    # (nax-macos-2 and nax-macos respectively). A label NO runner carries does not fail the
+    # dispatch -- the job queues silently until the run is cancelled -- so this is a closed choice
+    # rather than a free-text label.
+    runs-on: ${{ startsWith(inputs.runner_label, 'nax') && fromJSON('["self-hosted","macOS","ARM64","nax"]') || fromJSON('["self-hosted","macOS","ARM64","rw-krea"]') }}
+    concurrency:
+      group: memory-catalog-campaign-mlx-${{ startsWith(inputs.runner_label, 'nax') && 'nax' || 'rw-krea' }}
+      cancel-in-progress: false
+    # The full MLX walk is ~147 anchors of real GPU renders and the harness imposes no per-anchor
+    # timeout, so this is deliberately a two-day ceiling rather than a measured budget: the ceiling
+    # exists to stop a WEDGED job holding the box forever, and every anchor that finished before a
+    # timeout has already been committed and pushed.
+    timeout-minutes: 2880
+    env:
+      # Survives actions/checkout's `clean: true` between jobs on this persistent box, and keeps the
+      # ~30-40 GB of build output out of the checkout the harness asserts is clean.
+      CARGO_TARGET_DIR: ${{ github.workspace }}/../cargo-target
+      CARGO_NET_OFFLINE: "true"
+      BACKEND: mlx
+      DEFAULT_HF_CACHE: /Volumes/Models/huggingface/hub
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+          # The campaign pushes a NEW branch. A shallow clone cannot do that ("shallow update not
+          # allowed"), and the harness reads history to decide what is already current.
+          fetch-depth: 0
+
+      - name: Cut the campaign branch
+        id: branch
+        run: bash scripts/ci/memory-catalog/branch.sh
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      # No `npm ci`: every script this campaign runs imports only node built-ins and sibling
+      # scripts/ modules, and an install would be one more thing that can dirty the box.
+
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch
+        with:
+          toolchain: "1.97.1"
+
+      - name: Fetch prebuilt MLX (sc-21382)
+        # Same step as macos-mlx.yml: pmetal-mlx-sys's cmake build of libmlx is ~6 min on every cache
+        # miss. Exit 1 means "no prebuilt published for this mlx-rs rev", which is a slow source
+        # build rather than an error; anything else is fatal.
+        run: |
+          set +e
+          scripts/fetch-prebuilt-mlx.sh --github-env
+          rc=$?
+          set -e
+          if [ "$rc" = 1 ]; then
+            echo "::warning title=prebuilt MLX unavailable::no prebuilt for the pinned mlx-rs rev; building libmlx from source (see step log)"
+          elif [ "$rc" != 0 ]; then
+            exit "$rc"
+          fi
+
+      - name: Fetch the pinned inference release
+        env:
+          CARGO_NET_OFFLINE: "false"
+        run: cargo fetch --locked
+
+      - name: Build the MLX memory adapter
+        run: |
+          cargo build --release --locked -p sceneworks-memory-adapter \
+            --features mlx --bin memory-mlx-adapter
+          echo "ADAPTER=$CARGO_TARGET_DIR/release/memory-mlx-adapter" >> "$GITHUB_ENV"
+
+      - name: Clone the pinned inference revision
+        run: bash scripts/ci/memory-catalog/inference.sh
+
+      - name: Plan the walk
+        run: bash scripts/ci/memory-catalog/plan.sh
+
+      - name: Walk the catalog
+        id: walk
+        run: bash scripts/ci/memory-catalog/run.sh
+
+      - name: Push whatever landed
+        # ALWAYS. A cancelled or timed-out walk has already committed every anchor it finished; this
+        # is the step that makes sure those commits leave the box.
+        if: ${{ always() }}
+        run: bash scripts/ci/memory-catalog/push.sh
+
+      - name: Upload the campaign work dir
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.campaign }}-mlx-campaign-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/memory-catalog-${{ inputs.campaign }}-${{ github.run_id }}/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Open the results PR
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/ci/memory-catalog/pr.sh
+
+  candle:
+    if: ${{ inputs.backend == 'candle' }}
+    name: candle catalog campaign
+    # The one self-hosted CUDA pool, exactly as desktop-windows.yml spells it. There is no runner
+    # choice here: both Windows runners are processes on ONE box.
+    runs-on: [self-hosted, Windows, X64, cuda]
+    concurrency:
+      group: memory-catalog-campaign-candle-cuda
+      cancel-in-progress: false
+    # Shorter than the MLX ceiling because the candle plan is a smaller set of anchors, but still a
+    # day: same reasoning -- a wedge ceiling, not a measured budget.
+    timeout-minutes: 1440
+    env:
+      # Native sm_120 (Blackwell) -- this runner IS the RTX PRO 6000 box, same as windows-candle.yml.
+      CUDA_COMPUTE_CAP: "120"
+      # The runbook keeps exactly one device visible on the CUDA capture host; the harness's own
+      # preflight refuses the walk when this is unset.
+      CUDA_VISIBLE_DEVICES: "1"
+      CARGO_NET_OFFLINE: "true"
+      BACKEND: candle
+      DEFAULT_HF_CACHE: 'E:\huggingface\hub'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Cut the campaign branch
+        id: branch
+        run: bash scripts/ci/memory-catalog/branch.sh
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+
+      # Makes this box build against the REAL rustup toolchain bin rather than the fragile
+      # %USERPROFILE%\.cargo\bin proxies (sc-13166). Same composite action every candle lane uses.
+      - name: Prepare the Rust toolchain
+        uses: ./.github/actions/prepare-rust-runner
+
+      - name: Fetch the pinned inference release
+        env:
+          CARGO_NET_OFFLINE: "false"
+        run: cargo fetch --locked
+
+      - name: Build the candle memory adapter
+        # cmd + vcvars64 + NVCC_CCBIN is how every CUDA compile on this box is spelled; candle-gen's
+        # cuda feature invokes nvcc, which needs the host compiler on PATH.
+        shell: cmd
+        run: |
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+          set NVCC_CCBIN=%VCToolsInstallDir%bin\Hostx64\x64
+          cargo build --release --locked -p sceneworks-memory-adapter --features candle --bin memory-candle-adapter
+          if errorlevel 1 exit /b 1
+          echo ADAPTER=%GITHUB_WORKSPACE%\target\release\memory-candle-adapter.exe>>%GITHUB_ENV%
+
+      - name: Clone the pinned inference revision
+        run: bash scripts/ci/memory-catalog/inference.sh
+
+      - name: Plan the walk
+        run: bash scripts/ci/memory-catalog/plan.sh
+
+      - name: Walk the catalog
+        id: walk
+        run: bash scripts/ci/memory-catalog/run.sh
+
+      - name: Push whatever landed
+        if: ${{ always() }}
+        run: bash scripts/ci/memory-catalog/push.sh
+
+      - name: Upload the campaign work dir
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.campaign }}-candle-campaign-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/memory-catalog-${{ inputs.campaign }}-${{ github.run_id }}/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Open the results PR
+        if: ${{ always() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/ci/memory-catalog/pr.sh

--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -1177,6 +1177,75 @@ Flag notes, all from the `capture` arm of `main`:
   optimized one (`staged_residency`, nothing deeper) on candle, fixed by the harness to match what
   `scripts/extract-memory-anchors.mjs` can actually price.
 
+### 6a-bis. The whole catalog on a runner — `memory-catalog-campaign.yml` (sc-22738)
+
+The same `measure-memory-catalog.mjs` walk as §6a, run on the self-hosted GPU boxes instead of an
+interactive shell, so a multi-hour campaign does not tie up a terminal (and, on the MLX side, does
+not have to run on the dev Mac at all).
+
+**Trigger.** Actions → *Memory catalog campaign* → *Run workflow*, or:
+
+```bash
+gh workflow run memory-catalog-campaign.yml -R SceneWorks/SceneWorks \
+  --ref feature/sc-22723-memory-anchor-measurability \
+  -f backend=mlx -f campaign=sc-22738 \
+  -f ref=feature/sc-22723-memory-anchor-measurability \
+  -f 'runner_label=rw-krea (nax-macos-2, the second Mac)'
+```
+
+It is `workflow_dispatch`-ONLY — no `push`, no `pull_request`, no `schedule`. It gates nothing and
+can never become a required check; per the *Gate teardown* note in FEATURE_DEVELOPMENT.md,
+measurement runs at epic end or on explicit request, never per code change.
+
+**Inputs.** `backend` (`mlx` | `candle`), `campaign` (one path segment, e.g. `sc-22738`), `anchors`
+(comma-separated keys), `models` (space-separated ids), `skip_current` (default true),
+`hf_cache_roots`, `ref` (the branch to walk from and the PR base), `runner_label` (mlx only),
+`push_every`. `anchors`, `models`, `skip_current` and `hf_cache_roots` map one-for-one onto the
+script's `--anchors` / `--model` / `--skip-current` / `--hf-cache` flags.
+
+**Where each lane runs.**
+
+| backend | `runs-on` | box |
+|---|---|---|
+| `mlx` (default) | `[self-hosted, macOS, ARM64, rw-krea]` | `nax-macos-2`, the second Mac |
+| `mlx` (other choice) | `[self-hosted, macOS, ARM64, nax]` | `nax-macos`, the dev Mac |
+| `candle` | `[self-hosted, Windows, X64, cuda]` | the RTX PRO 6000 Windows box |
+
+🔴 Weight-set labels move between the two Macs — they name a weight set, not a machine. Both label
+sets above were confirmed against the `runner_name` of jobs that actually served them, which is the
+only way to check (`gh api /orgs/SceneWorks/actions/runners` 403s without `admin:org`). Re-confirm
+before assuming `rw-krea` is still the second Mac, and remember that a label no runner carries does
+not fail the dispatch: the job queues silently until the run is cancelled.
+
+**What the job does.** Checks out `ref` at full depth, cuts a NEW branch
+`story/<campaign>-<backend>-campaign-<run_id>` (the walk commits on the current branch and refuses a
+detached HEAD, and this keeps it off `feature/*` and `main`), builds the release adapter
+(`--features mlx --bin memory-mlx-adapter`, or `--features candle --bin memory-candle-adapter` under
+`vcvars64`), clones inference at the pin into a sibling of the workspace, prints the `--list` table
+as the job summary, runs `--dry-run`, then walks for real with `--work-dir` under `$RUNNER_TEMP`.
+
+**The inference pin is derived, never typed.** The job reads `pub const INFERENCE_PIN` out of
+`crates/sceneworks-memory-adapter/src/lib.rs` — the same constant `compiledInferencePin()` reads —
+and hard-fails unless the clone's HEAD equals it and the tree is clean. `npm run bump:inference`
+moves both at once; this workflow needs no edit on a pin bump and writes to no pin site.
+
+**Partial results survive.** The walk runs in the background while a poller pushes the branch every
+`push_every` landed anchor commits, and a further `if: always()` push runs after success, failure,
+timeout and cancellation alike — so a cancelled campaign still ships every anchor it finished. The
+work dir (summary JSON, per-anchor logs, retained raw bundles) is uploaded as a run artifact on
+every outcome, and a final step opens `chore(<campaign>): <backend> catalog campaign results` into
+`ref` when the branch has commits. Nothing is merged automatically.
+
+Each job takes a `concurrency` group keyed on (backend, runner) with `cancel-in-progress: false`, so
+two campaigns queue rather than share a GPU. `timeout-minutes` is a wedge ceiling (2880 mlx / 1440
+candle), not a measured budget.
+
+**Hugging Face roots.** `hf_cache_roots` (newline- or `;`-separated) wins; otherwise the runner-level
+`$SCENEWORKS_MEMORY_CAMPAIGN_HF_CACHE`; otherwise the lane default (`/Volumes/Models/huggingface/hub`
+on macOS, `E:\huggingface\hub` on the CUDA box). A root that does not exist is a warning, not an
+error — `hubRoots()` still falls back to the HF env convention and the app cache, and an anchor whose
+snapshot is under none of them plans as `weights_missing` rather than failing the run.
+
 ### 6b. Through the guarded dispatch
 
 > Provenance: transcribed from the workflow files and **not** dispatched while writing this runbook —

--- a/scripts/ci/memory-catalog/branch.sh
+++ b/scripts/ci/memory-catalog/branch.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Cut the campaign branch the walk will commit onto (sc-22738).
+#
+# `measure-memory-catalog.mjs` commits on the CURRENT branch and refuses a detached HEAD, so the
+# branch has to exist before the first anchor. It is a NEW branch per run -- never the dispatched
+# ref itself -- so a campaign can never write onto `feature/*` or `main` directly, and two runs of
+# the same campaign cannot collide.
+# shellcheck source=scripts/ci/memory-catalog/common.sh
+source "$(dirname "$0")/common.sh"
+
+require_campaign
+
+BRANCH="$(campaign_branch)"
+BASE_SHA="$(git rev-parse HEAD)"
+WORK_DIR="$(work_dir_unix)"
+WORK_DIR_NATIVE="$(native_path "$WORK_DIR")"
+
+# The identity every per-anchor commit is authored under. Local to this checkout.
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+git switch -c "$BRANCH"
+
+mkdir -p "$WORK_DIR"
+
+{
+  echo "CAMPAIGN_BRANCH=$BRANCH"
+  echo "BASE_SHA=$BASE_SHA"
+  echo "WORK_DIR=$WORK_DIR"
+  echo "WORK_DIR_NATIVE=$WORK_DIR_NATIVE"
+  echo "PUSHED_COUNT=0"
+} >> "$GITHUB_ENV"
+
+{
+  echo "### ${CAMPAIGN} ${BACKEND} catalog campaign"
+  echo
+  echo "| | |"
+  echo "|---|---|"
+  echo "| branch | \`$BRANCH\` |"
+  echo "| cut from | \`$BASE_REF\` at \`$BASE_SHA\` |"
+  echo "| runner | \`$RUNNER_NAME\` |"
+  echo "| work dir | \`$WORK_DIR\` |"
+  echo
+} >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/ci/memory-catalog/common.sh
+++ b/scripts/ci/memory-catalog/common.sh
@@ -1,0 +1,101 @@
+# shellcheck shell=bash
+# Shared helpers for the sc-22738 memory-catalog campaign workflow
+# (.github/workflows/memory-catalog-campaign.yml). Sourced, never executed.
+#
+# WHY A NATIVE/UNIX PATH SPLIT. The candle lane runs these steps under Git Bash on Windows, where
+# `$RUNNER_TEMP` arrives as `D:\a\_temp`. Bash builtins want a `/d/a/_temp` form; node (and the
+# harness's `assertOutsideRepo`, which realpaths what it is given) wants the native form. Every
+# path this campaign hands to node therefore has a `_N` (native) spelling alongside the `_U` (unix)
+# spelling bash uses.
+
+set -euo pipefail
+
+# Native spelling of a path, for anything handed to node.
+native_path() {
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$1"
+  else
+    printf '%s' "$1"
+  fi
+}
+
+# Unix spelling of a path, for bash itself.
+unix_path() {
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$1"
+  else
+    printf '%s' "$1"
+  fi
+}
+
+# One path segment, exactly the shape `measure-memory-catalog.mjs --campaign` accepts. Validated
+# here as well because it is interpolated into a branch name and a directory name.
+require_campaign() {
+  if [[ ! "${CAMPAIGN:-}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    echo "::error title=Bad campaign id::campaign must be one path segment matching [A-Za-z0-9._-]+, got '${CAMPAIGN:-}'"
+    exit 1
+  fi
+}
+
+campaign_branch() {
+  printf 'story/%s-%s-campaign-%s' "$CAMPAIGN" "$BACKEND" "$GITHUB_RUN_ID"
+}
+
+work_dir_unix() {
+  printf '%s/memory-catalog-%s-%s' "$(unix_path "$RUNNER_TEMP")" "$CAMPAIGN" "$GITHUB_RUN_ID"
+}
+
+# The Hugging Face hub roots to hand the walk, one per line.
+#
+# Precedence: the dispatch input, then a runner-level $SCENEWORKS_MEMORY_CAMPAIGN_HF_CACHE, then
+# this lane's documented default ($DEFAULT_HF_CACHE, set per job). Roots that do not exist are NOT
+# an error -- `hubRoots()` already falls back to the HF env convention and the app cache, and an
+# anchor whose snapshot is under none of them is reported `unavailable` by the plan rather than
+# failing the run -- so a missing root only earns a warning.
+hf_cache_roots() {
+  local raw=""
+  if [[ -n "${HF_CACHE_INPUT:-}" ]]; then
+    raw="$HF_CACHE_INPUT"
+  elif [[ -n "${SCENEWORKS_MEMORY_CAMPAIGN_HF_CACHE:-}" ]]; then
+    raw="$SCENEWORKS_MEMORY_CAMPAIGN_HF_CACHE"
+  else
+    raw="${DEFAULT_HF_CACHE:-}"
+  fi
+  # `;` and newlines both separate; empty entries are dropped.
+  printf '%s' "$raw" | tr ';' '\n' | while IFS= read -r root; do
+    root="$(echo "$root" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [[ -z "$root" ]] && continue
+    printf '%s\n' "$root"
+  done
+}
+
+# Every flag the walk takes except --dry-run / --list, appended to the global array CATALOG_ARGS.
+build_catalog_args() {
+  CATALOG_ARGS=(
+    --backend "$BACKEND"
+    --campaign "$CAMPAIGN"
+    --inference-repo "$INFERENCE_REPO"
+    --work-dir "$WORK_DIR_NATIVE"
+  )
+  if [[ "${SKIP_CURRENT:-false}" == "true" ]]; then
+    CATALOG_ARGS+=(--skip-current)
+  fi
+  if [[ -n "${ANCHORS_INPUT:-}" ]]; then
+    CATALOG_ARGS+=(--anchors "$ANCHORS_INPUT")
+  fi
+  # `--model` is repeatable; the input is a space-separated list.
+  if [[ -n "${MODELS_INPUT:-}" ]]; then
+    local model
+    for model in $MODELS_INPUT; do
+      CATALOG_ARGS+=(--model "$model")
+    done
+  fi
+  local root
+  while IFS= read -r root; do
+    [[ -z "$root" ]] && continue
+    if [[ ! -d "$(unix_path "$root")" ]]; then
+      echo "::warning title=Hugging Face hub root missing::'$root' is not a directory on this runner; anchors whose snapshots live there will plan as unavailable"
+    fi
+    CATALOG_ARGS+=(--hf-cache "$root")
+  done < <(hf_cache_roots)
+}

--- a/scripts/ci/memory-catalog/inference.sh
+++ b/scripts/ci/memory-catalog/inference.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Put a CLEAN inference checkout at the pinned revision beside (never inside) the SceneWorks tree.
+#
+# PIN RESOLUTION IS DERIVED, NEVER TYPED. `measure-memory-catalog.mjs` reads the pin out of
+# `crates/sceneworks-memory-adapter/src/lib.rs` (`compiledInferencePin()` -> `pub const
+# INFERENCE_PIN`) and refuses the walk when the inference checkout's HEAD does not equal it. That
+# constant is the one this script reads too, with the identical regex, so the two can never
+# disagree: bumping the pin with `npm run bump:inference` moves both at once and this workflow needs
+# no edit. Nothing here writes to any pin site.
+#
+# The clone lives OUTSIDE the checkout (a sibling of $GITHUB_WORKSPACE), because the harness asserts
+# the SceneWorks tree stays clean for the whole walk and counts untracked paths.
+# shellcheck source=scripts/ci/memory-catalog/common.sh
+source "$(dirname "$0")/common.sh"
+
+PIN="$(sed -n 's/^pub const INFERENCE_PIN: &str = "\([0-9a-f]\{40\}\)";.*/\1/p' \
+  crates/sceneworks-memory-adapter/src/lib.rs | head -n 1)"
+if [[ ! "$PIN" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "::error title=No INFERENCE_PIN::crates/sceneworks-memory-adapter/src/lib.rs declares no 40-hex INFERENCE_PIN"
+  exit 1
+fi
+echo "pinned inference revision: $PIN"
+
+WORKSPACE_U="$(unix_path "$GITHUB_WORKSPACE")"
+REPO_U="${WORKSPACE_U}/../memory-catalog-inference"
+
+if [[ ! -d "$REPO_U/.git" ]]; then
+  rm -rf "$REPO_U"
+  git clone --no-checkout https://github.com/SceneWorks/inference "$REPO_U"
+fi
+
+# Fetch every ref, not just the default branch: `anchor-loader-closure.mjs --stamp-anchors` digests
+# each packaged anchor at ITS OWN record's inference revision, which is generally older than the
+# pin and need not sit on any branch tip.
+git -C "$REPO_U" fetch --all --tags --prune --force
+if ! git -C "$REPO_U" cat-file -e "${PIN}^{commit}" 2>/dev/null; then
+  git -C "$REPO_U" fetch origin "$PIN"
+fi
+
+# A reused clone can carry leftovers from an interrupted earlier run. Reset it hard: the harness
+# refuses a dirty inference checkout, and a "dirty" verdict here would look like a code problem.
+git -C "$REPO_U" checkout --force "$PIN"
+git -C "$REPO_U" reset --hard "$PIN"
+git -C "$REPO_U" clean -ffdx
+
+HEAD_SHA="$(git -C "$REPO_U" rev-parse HEAD)"
+if [[ "$HEAD_SHA" != "$PIN" ]]; then
+  echo "::error title=Inference checkout is not at the pin::HEAD is $HEAD_SHA, expected $PIN"
+  exit 1
+fi
+if [[ -n "$(git -C "$REPO_U" status --porcelain)" ]]; then
+  echo "::error title=Inference checkout is dirty::the harness refuses a dirty inference tree"
+  exit 1
+fi
+
+{
+  echo "INFERENCE_PIN=$PIN"
+  echo "INFERENCE_REPO=$(native_path "$REPO_U")"
+} >> "$GITHUB_ENV"
+
+{
+  echo "Pinned inference revision \`$PIN\`, derived from \`crates/sceneworks-memory-adapter/src/lib.rs\`."
+  echo
+} >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/ci/memory-catalog/plan.sh
+++ b/scripts/ci/memory-catalog/plan.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Print what the walk WOULD do, before it touches a GPU (sc-22738).
+#
+# Two cheap passes, both of which fail the job before any render if the dispatch is wrong:
+#   * `--list`   -- the per-anchor status/reason table, published as the job summary. This is where
+#                   an operator reads "unavailable" (weights are not on this box) or "current"
+#                   (already anchored at the pin) without waiting for the walk.
+#   * `--dry-run` -- the same planning path the real walk takes, including the preflight that
+#                   compares the inference checkout against the compiled INFERENCE_PIN, checks the
+#                   adapter binary exists, and (candle) refuses an unset CUDA_VISIBLE_DEVICES.
+# shellcheck source=scripts/ci/memory-catalog/common.sh
+source "$(dirname "$0")/common.sh"
+
+build_catalog_args
+
+LIST_OUT="${WORK_DIR}/plan-list.txt"
+node scripts/measure-memory-catalog.mjs "${CATALOG_ARGS[@]}" --list | tee "$LIST_OUT"
+
+{
+  echo "#### Planned anchors"
+  echo
+  echo '```'
+  cat "$LIST_OUT"
+  echo '```'
+  echo
+} >> "$GITHUB_STEP_SUMMARY"
+
+echo "--- dry run ---"
+node scripts/measure-memory-catalog.mjs "${CATALOG_ARGS[@]}" --adapter "$ADAPTER" --dry-run \
+  | tee "${WORK_DIR}/plan-dry-run.txt"

--- a/scripts/ci/memory-catalog/pr.sh
+++ b/scripts/ci/memory-catalog/pr.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Open the results PR into the dispatched ref, if anything landed (sc-22738).
+#
+# Never merges, never enables auto-merge. `feature/*` has no required checks and is merge-commit
+# only; whether these measurements are accepted is a review decision, not a CI one.
+# shellcheck source=scripts/ci/memory-catalog/common.sh
+source "$(dirname "$0")/common.sh"
+
+if [[ -z "${CAMPAIGN_BRANCH:-}" ]]; then
+  echo "no campaign branch was cut; no PR to open"
+  exit 0
+fi
+
+if ! git ls-remote --exit-code --heads origin "$CAMPAIGN_BRANCH" >/dev/null 2>&1; then
+  echo "${CAMPAIGN_BRANCH} was never pushed (no anchor landed); no PR to open"
+  exit 0
+fi
+
+EXISTING="$(gh pr list --head "$CAMPAIGN_BRANCH" --base "$BASE_REF" --state open --json url --jq '.[0].url' || true)"
+if [[ -n "$EXISTING" ]]; then
+  echo "PR already open: $EXISTING"
+  echo "[$CAMPAIGN_BRANCH]($EXISTING)" >> "$GITHUB_STEP_SUMMARY"
+  exit 0
+fi
+
+BODY_FILE="${WORK_DIR}/pr-body.md"
+{
+  echo "Measurements from the \`${BACKEND}\` memory-catalog campaign \`${CAMPAIGN}\`, one commit per anchor."
+  echo
+  echo "- workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+  echo "- runner: \`${RUNNER_NAME}\`"
+  echo "- pinned inference revision: \`${INFERENCE_PIN:-unknown}\`"
+  echo "- cut from \`${BASE_REF}\` at \`${BASE_SHA}\`"
+  echo
+  echo "Each commit is one \`capture -> check -> ingest -> extract -> stamp -> matrix\` pass from"
+  echo "\`scripts/measure-memory-catalog.mjs\`. The run's summary JSON and per-anchor logs are attached"
+  echo "to the workflow run as an artifact."
+  echo
+  echo "Planned anchors:"
+  echo
+  echo '```'
+  cat "${WORK_DIR}/plan-list.txt" 2>/dev/null || echo "(the plan table was not captured)"
+  echo '```'
+} > "$BODY_FILE"
+
+URL="$(gh pr create \
+  --base "$BASE_REF" \
+  --head "$CAMPAIGN_BRANCH" \
+  --title "chore(${CAMPAIGN}): ${BACKEND} catalog campaign results" \
+  --body-file "$BODY_FILE")"
+
+echo "opened $URL"
+{
+  echo "#### Pull request"
+  echo
+  echo "$URL"
+  echo
+} >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/ci/memory-catalog/push.sh
+++ b/scripts/ci/memory-catalog/push.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Push whatever the walk committed, on EVERY outcome (sc-22738).
+#
+# This step is wired with `if: always()`, so it runs after a success, a failure, a job timeout and a
+# cancellation. Anchors are hours of GPU time each and the harness commits them one at a time
+# precisely so a crash loses at most the anchor in flight -- that guarantee is only real if the
+# commits leave the box.
+# shellcheck source=scripts/ci/memory-catalog/common.sh
+source "$(dirname "$0")/common.sh"
+
+if [[ -z "${CAMPAIGN_BRANCH:-}" ]]; then
+  echo "no campaign branch was cut; nothing to push"
+  exit 0
+fi
+
+# The walk can be interrupted mid-anchor and leave the tree dirty. Never commit that residue: the
+# harness rolls a failed post-step back itself, and anything still uncommitted here is by definition
+# not a completed measurement.
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "::warning title=Uncommitted residue::the checkout is dirty after the walk; it is NOT being committed"
+  git status --porcelain
+fi
+
+COUNT="$(git rev-list --count "${BASE_SHA}..HEAD")"
+echo "${COUNT} anchor commit(s) on ${CAMPAIGN_BRANCH}"
+if [[ "$COUNT" == "0" ]]; then
+  echo "nothing landed; not pushing an empty branch"
+  exit 0
+fi
+
+git push --set-upstream --force-with-lease origin "HEAD:${CAMPAIGN_BRANCH}"
+
+{
+  echo "#### Pushed"
+  echo
+  echo "\`${COUNT}\` anchor commit(s) on \`${CAMPAIGN_BRANCH}\`."
+  echo
+} >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/ci/memory-catalog/run.sh
+++ b/scripts/ci/memory-catalog/run.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Walk every planned anchor for this backend, pushing the branch as measurements land (sc-22738).
+#
+# WHY A BACKGROUND PUSHER. The walk is a single long-lived node process that commits one anchor at
+# a time and can run for many hours; the harness has no per-anchor timeout and no push of its own.
+# If the only push happened after the process returned, a cancel, a job timeout or a wedged render
+# would throw away every anchor already measured -- hours of GPU time that cannot be re-derived
+# cheaply. So the walk runs in the background and a poller pushes the branch every time
+# $PUSH_EVERY new commits have appeared. `push.sh` then runs under `if: always()` and pushes the
+# remainder on success, failure, timeout and cancellation alike.
+#
+# The poller only ever runs `git push` -- it never commits, never checks out and never touches the
+# worktree -- so it cannot make the tree dirty underneath the harness's stability assertion.
+# shellcheck source=scripts/ci/memory-catalog/common.sh
+source "$(dirname "$0")/common.sh"
+
+build_catalog_args
+CATALOG_ARGS+=(--adapter "$ADAPTER")
+
+LOG="${WORK_DIR}/campaign.log"
+: > "$LOG"
+
+echo "walking: node scripts/measure-memory-catalog.mjs ${CATALOG_ARGS[*]}"
+
+node scripts/measure-memory-catalog.mjs "${CATALOG_ARGS[@]}" >>"$LOG" 2>&1 &
+WALK_PID=$!
+
+# Stream the walk into the job log so an operator can watch progress live.
+tail -f "$LOG" &
+TAIL_PID=$!
+
+if [[ ! "${PUSH_EVERY:-1}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::warning title=Bad push_every::'${PUSH_EVERY:-}' is not a positive integer; pushing after every anchor"
+  PUSH_EVERY=1
+fi
+
+pushed=0
+base_count="$(git rev-list --count HEAD)"
+
+cleanup() {
+  kill "$TAIL_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+while kill -0 "$WALK_PID" 2>/dev/null; do
+  sleep 60
+  count="$(git rev-list --count HEAD)"
+  landed=$(( count - base_count ))
+  if (( landed - pushed >= PUSH_EVERY )); then
+    if git push --set-upstream origin "HEAD:${CAMPAIGN_BRANCH}"; then
+      pushed=$landed
+      echo "pushed ${pushed} landed anchor commit(s) to ${CAMPAIGN_BRANCH}"
+    else
+      # A transient push failure must not kill a multi-hour walk; the always() push retries.
+      echo "::warning title=Campaign push failed::could not push after ${landed} commits; will retry"
+    fi
+  fi
+done
+
+set +e
+wait "$WALK_PID"
+WALK_STATUS=$?
+set -e
+
+cleanup
+# Give tail a moment to flush the tail of the log before the step ends.
+sleep 2
+
+echo "walk exited with status ${WALK_STATUS}"
+{
+  echo "#### Walk result"
+  echo
+  echo "Exit status \`${WALK_STATUS}\` (2 means at least one anchor did not reach \`committed\`/\`captured\`)."
+  echo
+  echo '```'
+  tail -n 80 "$LOG"
+  echo '```'
+  echo
+} >> "$GITHUB_STEP_SUMMARY"
+
+exit "$WALK_STATUS"


### PR DESCRIPTION
Michael's decision for epic 22723 / sc-22738: run the memory-catalog measurement campaign on the self-hosted runners, one job per backend lane, instead of tying up an interactive shell for a day.

## What lands

- `.github/workflows/memory-catalog-campaign.yml` — `workflow_dispatch` **only** (no `push`, no `pull_request`, no `schedule`), so it gates nothing and can never be selected as a required check. Two jobs, selected by the `backend` input:
  - **mlx** → `[self-hosted, macOS, ARM64, rw-krea]` (nax-macos-2, the second Mac) by default, or `[self-hosted, macOS, ARM64, nax]` (the dev Mac) via the `runner_label` choice.
  - **candle** → `[self-hosted, Windows, X64, cuda]`, as `desktop-windows.yml` spells it, with `vcvars64` + `NVCC_CCBIN` for the CUDA adapter build and `CUDA_VISIBLE_DEVICES=1` (the harness preflight refuses the walk when it is unset).
- `scripts/ci/memory-catalog/*.sh` — the six steps (branch, inference clone, plan, walk, push, PR) plus a shared `common.sh`. They carry a native/unix path split so the same scripts run under Git Bash on the Windows box.
- `docs/calibration-runbook.md` §6a-bis — how to trigger it and what it produces.

## Safety properties

- **Never a detached HEAD, never `feature/*` directly.** The job cuts a NEW branch `story/<campaign>-<backend>-campaign-<run_id>` from the dispatched `ref` before the first anchor.
- **Partial results cannot be lost.** The walk runs in the background while a poller pushes the branch every `push_every` landed anchor commits, and a further `if: always()` push runs after success, failure, job timeout and cancellation alike. The work dir (summary JSON, per-anchor logs, raw bundles) uploads as an artifact on every outcome.
- **Pin is derived, never typed.** The job reads `pub const INFERENCE_PIN` out of `crates/sceneworks-memory-adapter/src/lib.rs` — the same constant `compiledInferencePin()` reads — and hard-fails unless the inference clone's HEAD equals it and the tree is clean. A pin bump needs no edit here, and no pin site is written.
- **Both checkouts stay clean.** The inference clone and the work dir live outside `$GITHUB_WORKSPACE`; no `npm ci` (every script imports only node built-ins and sibling `scripts/` modules).
- Per-`(backend, runner)` `concurrency` with `cancel-in-progress: false`, so two campaigns queue rather than share a GPU. `timeout-minutes` is a wedge ceiling (2880 mlx / 1440 candle), not a measured budget.
- `permissions: contents: write, pull-requests: write`; the default `GITHUB_TOKEN` only. Nothing is merged automatically.

## Runner labels

Both macOS label sets were confirmed against the `runner_name` of jobs that actually served them (`gh api /orgs/SceneWorks/actions/runners` 403s without `admin:org`): `rw-krea` → `nax-macos-2`, `nax` → `nax-macos`. The runbook section records that weight-set labels name a weight set rather than a machine and can move, and that a label no runner carries queues silently instead of failing.

## Verification

- `actionlint` — the only finding is `label "cuda" is unknown`, byte-identical to the pre-existing finding on `desktop-windows.yml:197` (the repo ships no `actionlint.yaml`). No new class of issue.
- `shellcheck -x` on all seven scripts — clean.
- `bash -n` on all seven — clean.
- `npm run check` — 804 tests, 0 fail, exit 0 (rerun after the doc edit).
- Smoke-tested the exact `--list` invocation shape the workflow builds: exit 0, 168 planned mlx anchors.
- **The workflow itself was not executed** — it needs the self-hosted GPU boxes and a multi-hour real-weights walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
