### PR TITLE
fix(sc-22738): the catalog campaign stops spending captures on the LTX-2.3 MLX cells it cannot drive

### DIFF
--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -821,6 +821,17 @@ SCENEWORKS_FLUX2_REVISION=<exact artifact revision>
 SCENEWORKS_FLUX2_ROOT=/abs/path/.../snapshots/<rev>/<tier>   # q4 | q8 — tier DERIVED from the plan target
 
 # memory-mlx-adapter — ltx_2_3   (sc-18808; the only VIDEO arm. FOUR vars, not three)
+# 🔴 The catalog campaign CANNOT capture ltx_2_3:*:mlx (sc-22738). The harness's only action is
+# `run`, the arm routes `run` to `LtxRunAdmission::Ordinary`, and that admission is
+# `refuse_unsafe_ltx_capture` — an SC-19642 pre-load refusal with no Ok return on any geometry
+# (at 768x512xf121 its own incident-calibrated projection is 97.9 GB, above the 96.97 GB the q4
+# f305 incident reached before the host watchdog panicked). No plan row can satisfy it: the
+# anchor-plan schema is additionalProperties:false, so it cannot carry `_measurementSafety`, and
+# that block is only the refusal's first field. These three cells are measured by
+# `scripts/run-ltx-safety-canary.mjs --profile bounded-campaign-entry{,-q8,-bf16}` — same
+# geometry, bounded decode 192/64, inside the external 53.35 GB footprint watchdog on its own
+# contained volume — which is a host-exclusive night run, never part of a catalog sweep.
+# `measure-memory-catalog.mjs --list` reports them `harness_unsupported` for exactly that reason.
 SCENEWORKS_LTX_REPOSITORY=SceneWorks/ltx-2.3-mlx             # fixed; validated against LTX_REPOSITORY
 SCENEWORKS_LTX_REVISION=<exact artifact revision>
 SCENEWORKS_LTX_ROOT=/abs/path/.../snapshots/<rev>/<tier>     # bf16 | q4 | q8, derived from the plan target

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -32,6 +32,7 @@ import { readFile, writeFile, mkdir, cp, rm, realpath, stat, readdir } from "nod
 
 import { stripJsoncComments } from "./lib/jsonc.mjs";
 import { hashArtifactInventory } from "./hash-artifact-inventory.mjs";
+import { BOUNDED_CAMPAIGN_ENTRY_SPECS } from "./run-ltx-safety-canary.mjs";
 
 export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 export const PLAN_PATH = "config/memory-calibration-plan.json";
@@ -1239,6 +1240,39 @@ async function firstExistingDirectory(candidates) {
 }
 
 /**
+ * sc-22738. The MLX LTX-2.3 cells this generic runner may NOT drive, and the driver that owns them.
+ *
+ * `memory-calibration-harness.mjs capture` sends exactly one action — `run` — and the adapter's
+ * LTX-2.3 arm routes `run` to `LtxRunAdmission::Ordinary`, whose whole body is
+ * `refuse_unsafe_ltx_capture`: an SC-19642 pre-load refusal with no `Ok` return on any geometry.
+ * The catalog campaign therefore never reached a model load for these three anchors — it reached
+ * the first field of that refusal (`SC-18946 row is missing required _measurementSafety`) and burnt
+ * one failed capture per tier. Supplying that block cannot help, twice over: the anchor plan schema
+ * is `additionalProperties: false` so a plan row cannot carry it at all, and the block is only the
+ * refusal's FIRST field — a row that satisfies it still terminates in the refusal itself.
+ *
+ * The refusal is not a defect. At the anchor geometry (768x512, f121) the arm's own
+ * incident-calibrated projection for the lane-default composition is 97_906_593_920 B, ABOVE the
+ * 96_970_084_480 B physical footprint the q4 f305 incident reached before the host watchdog
+ * panicked, and this runner offers no containment: the footprint watchdog is an external,
+ * nonce-authenticated socket that only `scripts/run-ltx-safety-canary.mjs` provides.
+ *
+ * That driver is what measures these cells, per tier, through the private `bounded_campaign_entry`
+ * action — same geometry, bounded decode 192/64, inside a 53_347_146_863 B footprint ceiling on its
+ * own contained volume. The delegated set is DERIVED from that driver's own per-tier declarations,
+ * so a tier it stops declaring becomes an ordinary measurability gap here rather than a silent one.
+ */
+export const CANARY_DRIVEN_CELLS = Object.freeze(new Map(
+  Object.values(BOUNDED_CAMPAIGN_ENTRY_SPECS).map((spec) => [
+    `ltx_2_3:${spec.tier}:mlx`,
+    `the MLX LTX-2.3 arm refuses every ordinary harness run before model load (SC-19642); ` +
+      `${spec.story} measures this cell through scripts/run-ltx-safety-canary.mjs --profile ` +
+      `${spec.profile} (${spec.identity}), which is the only path carrying the external footprint ` +
+      `watchdog this runner cannot provide`,
+  ]),
+));
+
+/**
  * Decide what the run can do with one plan anchor: which adapter arm serves it, which weights
  * root it loads, and why it would be skipped. Pure apart from the directory probes.
  */
@@ -1258,6 +1292,13 @@ export async function classifyAnchor(key, planned, { models, backend, hubs, curr
   // deleting the branch and the parameter together; that would make the next unbindable provider
   // report as `no_adapter_arm`, which is the wrong diagnosis and sends the reader to adapter work.
   if (family?.harnessUnsupported) return { ...row, status: "harness_unsupported", reason: family.harnessUnsupported };
+  // sc-22738: the same refusal for a cell whose CAPTURE belongs to another driver — see
+  // `CANARY_DRIVEN_CELLS`. Keyed on the cell, not the family, because the `ltx_2_3` family's Candle
+  // sibling is driven here normally; and asserted against the plan's provider so a future row that
+  // reuses the key for some other engine cannot inherit the delegation.
+  if (planned.provider === "ltx_2_3" && CANARY_DRIVEN_CELLS.has(key)) {
+    return { ...row, status: "harness_unsupported", reason: CANARY_DRIVEN_CELLS.get(key) };
+  }
   // sc-22729: the same refusal, scoped to ONE lane and DERIVED. A model whose engine cannot seal an
   // artifact identity for it on a lane is not a missing arm and not a missing declaration — the arm
   // exists and the plan declares the cell — so it reports the engine-side reason rather than

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -54,7 +54,9 @@ import {
   readDeclaredStrategySupport,
   SDXL_ROUTES_PATH,
   SDXL_ROUTES_UNCHECKED,
+  CANARY_DRIVEN_CELLS,
 } from "./measure-memory-catalog.mjs";
+import { BOUNDED_CAMPAIGN_ENTRY_SPECS } from "./run-ltx-safety-canary.mjs";
 import {
   ANCHOR_LANE_DEFAULT_STRATEGY_PATH,
   ANCHOR_STRATEGY,
@@ -1220,6 +1222,11 @@ async function computeMeasurabilityGaps() {
   for (const cell of await shippedTieredCells()) {
     const row = rows.get(cell.key);
     const status = row?.status ?? (plan.anchors[cell.key] ? "unclassified" : "no_plan_anchor");
+    // sc-22738: a cell whose CAPTURE is delegated to another declared driver is measured, not
+    // missing — but only through that exact refusal. Any other status for the same key is still a
+    // gap, and `the canary-driven LTX-2.3 MLX cells are refused for the adapter's own reason`
+    // re-derives the delegation from the adapter and the driver so this cannot become a register.
+    if (status === "harness_unsupported" && CANARY_DRIVEN_CELLS.has(cell.key)) continue;
     if (!["runnable", "weights_missing"].includes(status)) {
       gaps.push({ ...cell, status, reason: row?.reason ?? `${PLAN_PATH} declares no anchor ${cell.key}` });
     }
@@ -2494,6 +2501,76 @@ test("the bernini family is measurable on every shipped tier of every routed lan
 // `ltx_2_3 claims q4 and q8 on candle, and bf16 only on mlx` derives the five-cell key set from the
 // manifest and the worker's Candle tier resolver; this is the other half of the claim — every one
 // of those five cells is planned, armed and closed over.
+// sc-22738. The campaign found this the expensive way: three anchors, three model-load-free
+// failures, one per tier — `SC-18946 row is missing required _measurementSafety; refusing before
+// model load`. The plan row cannot fix that. `packages/schemas/memory-anchor-plan.schema.json` is
+// `additionalProperties: false`, so no anchor can carry a `_measurementSafety` block at all, and
+// the block is only the FIRST field the refusal reads: the arm routes the harness's one action
+// (`run` — `memory-calibration-harness.mjs` sends no other) to `LtxRunAdmission::Ordinary`, whose
+// entire body is `refuse_unsafe_ltx_capture`, and that function has no `Ok` return on any geometry.
+//
+// So the classification must say so BEFORE the campaign spends a capture on it, and the delegation
+// must be re-derived from both ends every run: the adapter's unconditional refusal, and the driver
+// that does measure these cells. Neither half alone is enough — an adapter that starts admitting
+// ordinary runs must red this, and a driver that stops declaring a tier must red it too.
+test("the canary-driven LTX-2.3 MLX cells are refused for the adapter's own reason, not spent on", async () => {
+  const adapter = await readFile(path.join(ROOT, ADAPTER_BIN_PATHS.mlx), "utf8");
+  const harness = await readFile(path.join(ROOT, "scripts/memory-calibration-harness.mjs"), "utf8");
+  // 1. The generic runner sends exactly one provider action for a capture.
+  assert.deepEqual(
+    [...harness.matchAll(/action: "(\w+)",\n\s*planned/g)].map((match) => match[1]),
+    ["run"],
+    "the harness's capture action moved; the delegation below reads the wrong dispatch arm",
+  );
+  // 2. `run` reaches the ordinary admission, and the ordinary admission is a refusal with no exit.
+  assert.match(
+    adapter,
+    /LtxRunAdmission::Ordinary => \{\s*refuse_unsafe_ltx_capture\(request, tier, geometry, &selection\)\?/,
+    "the MLX LTX-2.3 ordinary admission no longer routes to refuse_unsafe_ltx_capture",
+  );
+  const refusal = adapter.slice(adapter.indexOf("fn refuse_unsafe_ltx_capture("));
+  assert.ok(refusal.startsWith("fn refuse_unsafe_ltx_capture("), "the refusal function was renamed");
+  const body = refusal.slice(0, refusal.indexOf("\n}\n") + 3);
+  assert.doesNotMatch(
+    body,
+    /\bOk\(/,
+    "refuse_unsafe_ltx_capture can now succeed; these cells belong to the harness again and this " +
+      "delegation must be deleted rather than kept",
+  );
+  // 3. Both directions against the PLAN, because either alone is a false green: a delegated cell
+  //    that is not planned delegates nothing, and a planned MLX LTX-2.3 cell the driver does not
+  //    declare would be spent on a capture that cannot succeed. The driver's per-tier declarations
+  //    are the delegated set's only source, so dropping a tier there reds HERE — mutation-checked —
+  //    rather than quietly returning that cell to a runner whose every run of it fails.
+  const plan = await readPlan();
+  assert.deepEqual(
+    Object.keys(plan.anchors).filter((key) => key.startsWith("ltx_2_3:") && key.endsWith(":mlx")).sort(),
+    [...CANARY_DRIVEN_CELLS.keys()].sort(),
+    "a planned MLX LTX-2.3 cell that scripts/run-ltx-safety-canary.mjs does not declare, or vice versa",
+  );
+  assert.equal(
+    CANARY_DRIVEN_CELLS.size,
+    Object.keys(BOUNDED_CAMPAIGN_ENTRY_SPECS).length,
+    "the delegated set lost a tier the driver still declares",
+  );
+  // 4. …and every one of them is a real plan anchor that `--list` refuses by that name.
+  const { rows } = await planRun({ backend: "mlx", anchors: null, campaign: "sc-catalog-test", hfCache: [], skipCurrent: false });
+  const byKey = new Map(rows.map((row) => [row.key, row]));
+  for (const key of CANARY_DRIVEN_CELLS.keys()) {
+    assert.ok(plan.anchors[key], `${key} is delegated but not planned`);
+    const row = byKey.get(key);
+    assert.equal(row.status, "harness_unsupported", `${key}: ${row.reason}`);
+    assert.match(row.reason, /SC-19642/, key);
+    assert.match(row.reason, /run-ltx-safety-canary\.mjs/, key);
+  }
+  // The Candle sibling rides the same family name and is NOT delegated: the refusal is per cell.
+  assert.equal(byKey.has("ltx_2_3:q4:candle"), false, "the mlx run lists no candle row");
+  const candle = await planRun({ backend: "candle", anchors: null, campaign: "sc-catalog-test", hfCache: [], skipCurrent: false });
+  for (const row of candle.rows.filter((entry) => entry.modelId === "ltx_2_3")) {
+    assert.notEqual(row.status, "harness_unsupported", `${row.key} inherited the mlx delegation`);
+  }
+});
+
 test("ltx_2_3 is measurable on every shipped tier of every routed lane", async () => {
   const cells = (await shippedTieredCells()).filter((cell) => cell.modelId === "ltx_2_3");
   assert.equal(cells.length, 5, "the five-cell set the sibling case derives");


### PR DESCRIPTION
## Diagnosis

The live MLX catalog campaign (SceneWorks `1cd23a0e6`, inference pin `563c44e16`) failed
`ltx_2_3:{bf16,q4,q8}:mlx` with the adapter exiting before any model load:

```
memory-strategy provider adapter: SC-18946 row is missing required _measurementSafety; refusing before model load
```

**The plan row cannot carry that block, and supplying it would not help.**

1. `packages/schemas/memory-anchor-plan.schema.json` sets `additionalProperties: false` on
   `$defs/anchor`. A `_measurementSafety` key on a plan anchor is not merely un-derived — it is
   *inexpressible*. The blocks that do exist live in `docs/calibration/sc-18946/*.json` and are
   synthesised at request time by `scripts/run-ltx-safety-canary.mjs`, not by the plan.
2. It is only the **first field** the refusal reads.
   `scripts/memory-calibration-harness.mjs` sends exactly one provider action for a capture
   (`action: "run"`). `run_ltx_with_admission` routes that to `LtxRunAdmission::Ordinary`
   (`crates/sceneworks-memory-adapter/src/bin/mlx.rs:15158`), whose entire body is
   `refuse_unsafe_ltx_capture` (`mlx.rs:12715`) — `validate_ltx_safety_evidence` (`mlx.rs:12633`,
   where the quoted message lives) followed by an unconditional `Err`. There is **no `Ok` return on
   any geometry or tier.** A row that satisfied every field of the block would fail one line later
   with `SC-19642 pre-load safety refusal` instead.

**The refusal is the designed state, not a defect.** At the anchor's own geometry
(768×512, f121) the arm's incident-calibrated projection for the lane-default composition is
`97_906_593_920` B — above the `96_970_084_480` B physical footprint the q4 f305 incident reached
before the host watchdog panicked (`LTX_Q4_F305_CRASH_FOOTPRINT_BYTES`). The identical number is
recorded for this exact cell in `docs/calibration/sc-18946/ltx-mlx-single-pass-sweep.json`
(`mlx-ltx-2-3-q4-768x512-f121-fps30-staged_residency` → `disposition: safety_refused_open`). And
the generic runner offers no containment: the footprint watchdog is an external,
nonce-authenticated unix socket that only `scripts/run-ltx-safety-canary.mjs` provides
(`mlx.rs:14702`).

## What actually measures these cells

`scripts/run-ltx-safety-canary.mjs`, through the private `bounded_campaign_entry` action, per tier
— `BOUNDED_CAMPAIGN_ENTRY_SPECS` declares q4 (sc-20318), q8 and bf16 (sc-20430). Same geometry,
**bounded decode 192/64**, which moves the projection to ≈84.7 GB, run inside a
`53_347_146_863` B footprint ceiling on its own contained volume
(`/Volumes/Data/sceneworks-safety-canary`). That is a host-exclusive night run, never part of a
catalog sweep.

## Derivation of the values (why no numbers were invented)

Nothing new is asserted. Every constant quoted above is read from a checked-in source
(`mlx.rs` constants, the sc-18946 sweep record, the canary driver's own specs). **No
`_measurementSafety` block was written into the plan**, because the correct value of that block for
these rows is the one already computed *inside the adapter* from `LTX_{Q4,Q8,BF16}_INVENTORY_BYTES`
and the pinned provider decode cost — and its correct outcome is a refusal.

## The change

`--list` classifies the three cells `harness_unsupported` — the status that already exists for
"the adapter arm is there, the harness cannot drive it" — with the engine-side reason, so the
campaign skips them instead of spending three failed captures per sweep. `CANARY_DRIVEN_CELLS` is
**derived** from the driver's own `BOUNDED_CAMPAIGN_ENTRY_SPECS`, never hand-kept. The gate
`every shipped tiered model is measurable` accepts these cells only through that exact refusal; any
other status for the same key is still counted a gap.

## Tests

New: `the canary-driven LTX-2.3 MLX cells are refused for the adapter's own reason, not spent on`.
It re-derives the delegation from both ends every run — the harness's single capture action, the
adapter's `Ordinary → refuse_unsafe_ltx_capture` dispatch, that function having no `Ok` exit, and
the plan/driver tier sets agreeing in both directions — and asserts the Candle sibling of the same
family is untouched.

Mutations, one guard at a time, `touch` between runs:

| assertion | mutation | result |
| --- | --- | --- |
| classification delegates the cell | `if (planned.provider === "ltx_2_3" && …)` → `if (false)` | **RED** |
| the arm's ordinary run cannot succeed | `refuse_unsafe_ltx_capture` gains `if geometry.frames == 7 { return Ok(()); }` | **RED** |
| the driver declares every planned tier | delete the `bf16` entry from `BOUNDED_CAMPAIGN_ENTRY_SPECS` | **RED** |

`node --test scripts/measure-memory-catalog.test.mjs scripts/anchor-loader-closure.test.mjs
scripts/memory-calibration-harness.test.mjs` → 0 (155 pass, 2 skip).
`npm run check` → 0. `check:memory-anchors` → 0, `check:memory-matrix` → 0 (the plan file is
unchanged, so no fingerprint moved). No Rust was modified, so no cargo run was needed; the MLX GPU
was never touched.

## Verification still owed

Real-weight verification is a **campaign re-run of the three `ltx_2_3:*:mlx` anchors**, which will
now report `harness_unsupported` and skip rather than fail. The *capture* of those cells remains
owed to a host-exclusive `run-ltx-safety-canary.mjs --profile bounded-campaign-entry{,-q8,-bf16}`
night run; `config/memory-anchors.json` today carries only the historical sc-18808 q8 MLX anchor
for this model.
