### PR TITLE
fix(sc-22738): catalog requests for LTX-2.5 MLX rows carry the attentionChunkSize the arm requires

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx_ltx25.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx_ltx25.rs
@@ -279,49 +279,87 @@ fn validate_target(request: &Value) -> Result<Target, String> {
     })
 }
 
+/// The bounded-control law, mirrored from the pinned engine rather than re-spelled (sc-22738).
+///
+/// `mlx-gen-ltx/src/memory_strategy_2_5.rs::validate_request_memory` makes every bounded control
+/// **conditional on its rung engaging**, in both directions: `chunk_attention` *requires*
+/// `attention_chunk_size` and its absence *forbids* the parameter ("attention_chunk_size requires
+/// chunk_attention=true"); the decode tile pair and the transformer window are governed the same
+/// way. `begin_with_cleanup` only forwards a control at all when
+/// `contract.engages_selection(selection, rung)`, so a selection that carries a control its rung
+/// does not engage is refused by the engine before a weight is read.
+///
+/// This function used to demand the DEEPEST composition unconditionally — `attentionChunkSize`
+/// always, `bounded_transformer_residency` for distilled, `bounded_attention` for dev. That was
+/// correct while epic 18755 swept the whole ladder per plan row and the fixture named the rung.
+/// sc-22505 replaced that with ONE anchor per (model, tier, lane) planned at the lane's default
+/// composition — `resident` with no parameters on MLX, declared once in
+/// `config/anchor-lane-default-strategy.json` — which left this arm demanding a shape no anchor row
+/// can lawfully carry: the ltx_2_5 MLX rows were the only cells in the catalog whose capture could
+/// not start. The demands themselves are unchanged; only their guard is now the engine's.
+///
+/// `MemoryStrategy::engages` is the contract's own cost-order rule, so the rung a row plans decides
+/// which controls it must carry, and the deep ladder compositions this arm accepted before are
+/// still accepted with exactly the same parameter values.
 fn validate_selection_shape(selection: &MemorySelection, target: Target) -> Result<(), String> {
     let parameters = selection.parameters;
-    if parameters.attention_chunk_size != Some(ATTENTION_CHUNK_SIZE) {
+    let engages = |rung: MemoryStrategy| selection.strategy.engages(rung);
+
+    let expected_chunk = engages(MemoryStrategy::BoundedAttention).then_some(ATTENTION_CHUNK_SIZE);
+    if parameters.attention_chunk_size != expected_chunk {
+        return Err(match expected_chunk {
+            Some(size) => format!("{LABEL} requires attentionChunkSize={size}"),
+            None => format!(
+                "{LABEL} must omit attentionChunkSize unless the selection engages bounded_attention"
+            ),
+        });
+    }
+
+    // `bounded_decode` is `Missing` on the diffusion decoder — it has no tiled path to bound — so
+    // the tile pair is expected only where the conv decoder is loaded AND the rung engages it.
+    let tiled = engages(MemoryStrategy::BoundedDecode) && target.decoder == Decoder::Conv;
+    let expected_tile = tiled.then_some(DECODE_TILE_EDGE);
+    let expected_overlap = tiled.then_some(DECODE_OVERLAP);
+    if parameters.decode_tile_edge != expected_tile || parameters.decode_overlap != expected_overlap
+    {
+        return Err(if tiled {
+            format!("{LABEL} conv requires decode tile {DECODE_TILE_EDGE}/{DECODE_OVERLAP}")
+        } else if target.decoder == Decoder::DiffVae {
+            format!("{LABEL} diffvae must omit conv-only decode tile parameters")
+        } else {
+            format!(
+                "{LABEL} must omit decode tile parameters unless the selection engages bounded_decode"
+            )
+        });
+    }
+
+    // Rung 4 declares `LoadShape::DeferredMaterialization` as a prerequisite, and only the
+    // distilled variant loads deferred; the dev variant additionally installs its refinement
+    // adapter, which the engine's `streamable()` refuses outright. So dev can never plan it.
+    if target.variant == TransformerVariant::Dev
+        && (engages(MemoryStrategy::BoundedTransformerResidency)
+            || parameters.transformer_window_size.is_some()
+            || parameters.transformer_window_component.is_some())
+    {
         return Err(format!(
-            "{LABEL} requires attentionChunkSize={ATTENTION_CHUNK_SIZE}"
+            "{LABEL} dev must not claim transformer streaming while its refinement adapter is installed"
         ));
     }
-    match target.decoder {
-        Decoder::Conv
-            if parameters.decode_tile_edge == Some(DECODE_TILE_EDGE)
-                && parameters.decode_overlap == Some(DECODE_OVERLAP) => {}
-        Decoder::Conv => {
-            return Err(format!(
-                "{LABEL} conv requires decode tile {DECODE_TILE_EDGE}/{DECODE_OVERLAP}"
-            ));
-        }
-        Decoder::DiffVae
-            if parameters.decode_tile_edge.is_none() && parameters.decode_overlap.is_none() => {}
-        Decoder::DiffVae => {
-            return Err(format!(
-                "{LABEL} diffvae must omit conv-only decode tile parameters"
-            ));
-        }
-    }
-    match target.variant {
-        TransformerVariant::Distilled
-            if selection.strategy == MemoryStrategy::BoundedTransformerResidency
-                && parameters.transformer_window_size == Some(TRANSFORMER_WINDOW_SIZE)
-                && parameters.transformer_window_component == Some(TransformerComponent::Dit) => {}
-        TransformerVariant::Distilled => {
-            return Err(format!(
+    let streaming = engages(MemoryStrategy::BoundedTransformerResidency);
+    let expected_window = streaming.then_some(TRANSFORMER_WINDOW_SIZE);
+    let expected_component = streaming.then_some(TransformerComponent::Dit);
+    if parameters.transformer_window_size != expected_window
+        || parameters.transformer_window_component != expected_component
+    {
+        return Err(if streaming {
+            format!(
                 "{LABEL} distilled requires bounded_transformer_residency with DiT window {TRANSFORMER_WINDOW_SIZE}"
-            ));
-        }
-        TransformerVariant::Dev
-            if selection.strategy == MemoryStrategy::BoundedAttention
-                && parameters.transformer_window_size.is_none()
-                && parameters.transformer_window_component.is_none() => {}
-        TransformerVariant::Dev => {
-            return Err(format!(
-                "{LABEL} dev requires bounded_attention and must not claim transformer streaming while its refinement adapter is installed"
-            ));
-        }
+            )
+        } else {
+            format!(
+                "{LABEL} must omit the transformer window unless the selection engages bounded_transformer_residency"
+            )
+        });
     }
     Ok(())
 }
@@ -1456,6 +1494,139 @@ mod tests {
                 "modelLoadGroup": null,
             }
         })
+    }
+
+    /// sc-22738. The capture-time agreement the campaign actually needs: the request
+    /// `scripts/memory-calibration-harness.mjs#planAnchor` builds for every checked-in
+    /// `ltx_2_5:*:mlx` plan row must satisfy this arm's real validators — no hand-written sample,
+    /// and no re-spelling of the composition the harness applies.
+    ///
+    /// Both halves are read from the files that own them: the row's target, geometry, load shape,
+    /// fingerprint and fixture from `config/memory-calibration-plan.json`, and the composition from
+    /// `config/anchor-lane-default-strategy.json` — the ONE declaration of the per-lane default
+    /// that `planAnchor` applies to any row carrying no `strategy` override, and that
+    /// `sceneworks-worker`'s lane walk reads through the same `include_str!`. A row's own override
+    /// wins where it has one, exactly as `planAnchor` does. `parameters` is what `planAnchor`
+    /// emits, which is why the whole campaign refused these three cells: the arm demanded the
+    /// ladder-era deepest composition, and no anchor row can carry it.
+    #[test]
+    fn every_planned_ltx25_mlx_row_satisfies_the_arm_at_the_composition_the_harness_plans() {
+        let plan: Value = serde_json::from_str(include_str!(
+            "../../../../config/memory-calibration-plan.json"
+        ))
+        .expect("the anchor plan parses");
+        let lanes: Value = serde_json::from_str(include_str!(
+            "../../../../config/anchor-lane-default-strategy.json"
+        ))
+        .expect("the lane default composition parses");
+        let default = &lanes["lanes"]["mlx"];
+        assert!(
+            default["rung"].is_string(),
+            "config/anchor-lane-default-strategy.json declares no mlx rung"
+        );
+        let mut seen = std::collections::BTreeSet::new();
+        for (key, entry) in plan["anchors"].as_object().expect("anchors object") {
+            if !key.ends_with(":mlx") || entry["provider"].as_str() != Some(LTX25_PROVIDER) {
+                continue;
+            }
+            seen.insert(key.clone());
+            let (_, rest) = key.split_once(':').unwrap();
+            let tier = rest.split_once(':').unwrap().0;
+            let strategy = entry.get("strategy").unwrap_or(default);
+            let request = json!({ "planned": {
+                "target": {
+                    "provider": entry["provider"].clone(),
+                    "modelId": "ltx_2_5",
+                    "tier": tier,
+                    "mode": entry["mode"].clone(),
+                    "overlay": entry["overlay"].clone(),
+                    "transformerVariant": entry["transformerVariant"].clone(),
+                    "decoder": entry["decoder"].clone(),
+                    "geometry": entry["geometry"].clone(),
+                },
+                "loadShape": entry["loadShape"].clone(),
+                "strategy": {
+                    "rung": strategy["rung"].clone(),
+                    "engagedRungs": strategy["engagedRungs"].clone(),
+                    // `planAnchor` emits no parameters for a row that declares none.
+                    "parameters": strategy.get("parameters").cloned().unwrap_or_else(|| json!({})),
+                },
+                "calibrationFingerprint": entry["calibrationFingerprint"].clone(),
+                "fixture": entry["fixture"].clone(),
+                "expectedResult": "passed",
+                "negative": false,
+                "modelLoadPolicy": "fresh_per_case",
+                "modelLoadGroup": null,
+            }});
+            let target = validate_target(&request).unwrap_or_else(|error| panic!("{key}: {error}"));
+            let selection =
+                planned_selection(&request).unwrap_or_else(|error| panic!("{key}: {error}"));
+            validate_selection_shape(&selection, target)
+                .unwrap_or_else(|error| panic!("{key}: {error}"));
+        }
+        // The exact cell set, not a count: the three shipped tiers, each named once.
+        let expected: std::collections::BTreeSet<String> = ["bf16", "q4", "q8"]
+            .iter()
+            .map(|tier| format!("ltx_2_5:{tier}:mlx"))
+            .collect();
+        assert_eq!(seen, expected);
+    }
+
+    /// The other direction of the same law: a control the planned rung does not engage is refused,
+    /// so widening the harness to volunteer parameters is not a way past this arm either. The
+    /// engine says the same thing — `attention_chunk_size requires chunk_attention=true`.
+    #[test]
+    fn a_resident_row_that_volunteers_a_bounded_control_is_refused() {
+        let mut dev = request("bf16", "dev", "conv", 768, 512, BASE_FRAMES);
+        dev["planned"]["strategy"]["rung"] = json!("resident");
+        dev["planned"]["strategy"]["engagedRungs"] = json!(["resident"]);
+        dev["planned"]["strategy"]["parameters"] = json!({});
+        let target = validate_target(&dev).unwrap();
+        validate_selection_shape(&planned_selection(&dev).unwrap(), target)
+            .expect("the lane default composition is accepted");
+
+        for (parameter, value, expected) in [
+            (
+                "attentionChunkSize",
+                json!(ATTENTION_CHUNK_SIZE),
+                "must omit attentionChunkSize",
+            ),
+            (
+                "decodeTileEdge",
+                json!(DECODE_TILE_EDGE),
+                "must omit decode tile parameters",
+            ),
+            (
+                // Dev keeps its own refusal: its refinement adapter makes the rung unreachable at
+                // any composition, so the arm names that rather than the generic omission.
+                "transformerWindowSize",
+                json!(TRANSFORMER_WINDOW_SIZE),
+                "must not claim transformer streaming",
+            ),
+        ] {
+            let mut volunteered = dev.clone();
+            volunteered["planned"]["strategy"]["parameters"][parameter] = value;
+            let selection = planned_selection(&volunteered).unwrap();
+            let error = validate_selection_shape(&selection, target)
+                .expect_err("a control no engaged rung authorizes must be refused");
+            assert!(error.contains(expected), "{parameter}: {error}");
+        }
+
+        // …and the generic omission refusal is the one a distilled row gets, where the rung is
+        // reachable but this composition does not engage it.
+        let mut distilled = request("bf16", "distilled", "conv", 768, 512, BASE_FRAMES);
+        distilled["planned"]["strategy"]["rung"] = json!("resident");
+        distilled["planned"]["strategy"]["engagedRungs"] = json!(["resident"]);
+        distilled["planned"]["strategy"]["parameters"] =
+            json!({ "transformerWindowSize": TRANSFORMER_WINDOW_SIZE });
+        let distilled_target = validate_target(&distilled).unwrap();
+        let error =
+            validate_selection_shape(&planned_selection(&distilled).unwrap(), distilled_target)
+                .expect_err("a window no engaged rung authorizes must be refused");
+        assert!(
+            error.contains("must omit the transformer window"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -59,6 +59,7 @@ import {
   ANCHOR_LANE_DEFAULT_STRATEGY_PATH,
   ANCHOR_STRATEGY,
   LTX25_LANE_PROVIDERS,
+  planAnchor,
 } from "./memory-calibration-harness.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -2130,6 +2131,52 @@ test("an anchor row plans the lane's default rung unless the manifest exempts it
         "dump surface, delete readDeclaredStrategySupport rather than leaving an unexercised source",
     );
   }
+});
+
+/**
+ * sc-22738. The composition a row plans and the CONTROLS it carries are one claim, and the
+ * campaign's first full MLX walk proved they were never checked together: `planAnchor` emits
+ * `strategy.parameters: {}` for every row, while `crates/…/bin/mlx_ltx25.rs` demanded
+ * `attentionChunkSize` unconditionally, so all three `ltx_2_5:*:mlx` cells refused before a weight
+ * was read — the arm still spoke epic 18755's ladder sweep, which sc-22505 replaced with one anchor
+ * at the lane default rung.
+ *
+ * The law, both directions, derived from the manifest rather than a list: the request the harness
+ * builds must carry EXACTLY the parameters the model's own lane block declares for the rungs its
+ * planned composition engages, and nothing for a rung it does not engage. `resident` and
+ * `staged_residency` declare no controls, so today every row is `{}` — and a row that ever plans a
+ * parameterized rung must ship those parameters or this reds. The engine enforces the same
+ * symmetry (`attention_chunk_size requires chunk_attention=true`), which is why volunteering a
+ * control is as wrong as omitting one.
+ */
+test("a planned anchor carries exactly the controls its engaged rungs declare", async () => {
+  const plan = await readPlan();
+  const models = new Map((await readManifestModels()).map((model) => [model.id, model]));
+  // The wire spells the component lowercase; the manifest spells the engine's enum variant.
+  const wire = (parameter, value) =>
+    parameter === "transformerWindowComponent" ? String(value).toLowerCase() : value;
+  let checked = 0;
+  for (const key of Object.keys(plan.anchors)) {
+    const { modelId, backend } = anchorParts(key);
+    const model = models.get(modelId);
+    if (!model) continue;
+    const declared = model[backend]?.memoryStrategyCapabilities ?? {};
+    const planned = planAnchor(plan, key);
+    const expected = {};
+    for (const rung of planned.strategy.engagedRungs) {
+      for (const [parameter, value] of Object.entries(declared[rung]?.parameters ?? {})) {
+        expected[parameter] = wire(parameter, value);
+      }
+    }
+    assert.deepEqual(
+      planned.strategy.parameters,
+      expected,
+      `${key}: plans rung ${planned.strategy.rung} engaging ${JSON.stringify(planned.strategy.engagedRungs)}, ` +
+        `so the manifest's ${backend}.memoryStrategyCapabilities requires exactly ${JSON.stringify(expected)}`,
+    );
+    checked += 1;
+  }
+  assert.ok(checked > 0, "no plan row was judged against the manifest's declared controls");
 });
 
 // sc-22736. The third source read three ways: the shipped shape yields per-rung support, a file


### PR DESCRIPTION
## Symptom

Live MLX catalog campaign (SceneWorks `1cd23a0e6`, inference pin `563c44e16`) — all three `ltx_2_5:*:mlx` anchors fail before any weight is read:

```
memory-strategy provider adapter: MLX LTX-2.5 requires attentionChunkSize=16777216
```

## Diagnosis — candidate (d)

`crates/sceneworks-memory-adapter/src/bin/mlx_ltx25.rs:282` `validate_selection_shape` demanded the **ladder-era deepest composition unconditionally**: `attentionChunkSize == Some(16777216)` always, plus `bounded_transformer_residency` for the distilled variant and `bounded_attention` for dev.

The other candidates were checked and ruled out:

- **(a)/(b)** — `planAnchor` (`scripts/memory-calibration-harness.mjs:1559-1563`) emits `strategy.parameters: {}` for every anchor, and does so **identically on `origin/main` (3320a95b8)**. sc-22736's per-anchor `strategy` override only widened `rung`/`engagedRungs`; it did not change what the MLX rows plan.
- **(c)** — the `ltx_2_5:*:mlx` plan rows are **byte-identical** between `3320a95b8` and the feature head. They carry no `strategy` override, so they plan the MLX lane default: `resident`, `engagedRungs: ["resident"]`, `parameters: {}` (`config/anchor-lane-default-strategy.json`).
- `mlx_ltx25.rs` and the `LTX25_PROVIDER =>` dispatch arm are **also byte-identical** to main.

So the arm's requirement is unsatisfiable by any lawful anchor row. It was correct while epic 18755/18797 swept the whole ladder per plan row and the fixture named the rung; **sc-22505** replaced that with ONE anchor per `(model, tier, lane)` at the lane's default composition, and this arm was never converted. This epic's MLX catalog campaign is the first thing to drive it, which is why it surfaced now.

### Why the fix is not "add `attentionChunkSize` to the request"

Volunteering the parameter would have moved the refusal downstream into the engine. At the pin, `crates/media/mlx-gen/mlx-gen-ltx/src/memory_strategy_2_5.rs::validate_request_memory` (563c44e16, ~L705) is conditional in **both** directions:

```rust
let attention_chunk_size = if memory.chunk_attention {
    require_implemented(contract, MemoryStrategy::BoundedAttention)?;
    …
} else {
    if memory.attention_chunk_size.is_some() {
        return Err(… "ltx_2_5: attention_chunk_size requires chunk_attention=true" …);
    }
    None
};
```

and `begin_with_cleanup` forwards a control only when `contract.engages_selection(&selection, rung)`. A `resident` selection carrying `attentionChunkSize` is refused by the engine.

The engine also **implements** `Resident` for `ltx_2_5` on MLX — `config/engine-capabilities/capabilities.mlx.json` records `resident` in `implementedRungs` for all six `(tier, loadShape)` surfaces — and `builtin_manifests.rs` asserts LTX-2.5 declares no `memoryStrategyStructuralExemptions` on either lane. A rung override to `bounded_attention` would also have red-ed the derived override-legitimacy test ("an anchor row plans the lane's default rung unless the manifest exempts it"), which requires the effective rung to be the lane default on MLX.

## Fix

`validate_selection_shape` now mirrors the engine's law instead of re-spelling it, guarding each demand with the contract's own `MemoryStrategy::engages`:

- `attentionChunkSize` is required **iff** the selection engages `bounded_attention`, and forbidden otherwise.
- the decode tile pair is required **iff** it engages `bounded_decode` **and** the conv decoder is loaded (`bounded_decode` is `Missing` on the diffusion decoder), forbidden otherwise.
- the transformer window is required **iff** it engages `bounded_transformer_residency`, forbidden otherwise; the dev variant keeps its own refusal, since its refinement adapter makes the rung unreachable at any composition (`streamable()` refuses a spec with adapters).

**No value changed** — every constant and every demand is the same one. Only the guard moved, from unconditional to the engine's. The deep ladder compositions the arm accepted before are still accepted with the same parameters.

## Tests

- `every_planned_ltx25_mlx_row_satisfies_the_arm_at_the_composition_the_harness_plans` — drives the **real** `validate_target` / `planned_selection` / `validate_selection_shape` over the checked-in plan rows, with the composition read from `config/anchor-lane-default-strategy.json` exactly as `planAnchor` applies it (row override wins where present). Asserts the exact cell set, not a count.
- `a_resident_row_that_volunteers_a_bounded_control_is_refused` — the other direction, for all three controls.
- `a planned anchor carries exactly the controls its engaged rungs declare` (`scripts/measure-memory-catalog.test.mjs`) — drives the **real** `planAnchor` over every plan row on both lanes and requires exactly the parameters the model's `<lane>.memoryStrategyCapabilities` declares for its engaged rungs, and nothing for a rung it does not engage. Derived from the manifest; no model list.

### Mutations

| assertion | mutation | result |
|---|---|---|
| `every_planned_ltx25_mlx_row_satisfies_the_arm_…` | `expected_chunk = Some(ATTENTION_CHUNK_SIZE)` (restore the unconditional demand) | **RED** — `ltx_2_5:bf16:mlx: MLX LTX-2.5 requires attentionChunkSize=16777216`, the campaign error verbatim |
| `a planned anchor carries exactly the controls…` | `planAnchor` emits `parameters: { attentionChunkSize: 16777216 }` | **RED** |

`touch` between runs; both files restored and re-verified clean. Touched files grepped for `if true` / `if false` / `&& false` / `|| true` — none.

## Verification

| check | exit |
|---|---|
| `cargo test -p sceneworks-memory-adapter --features mlx --bin memory-mlx-adapter` | 0 (248 passed) |
| `cargo clippy -p sceneworks-memory-adapter --features mlx --all-targets -- -D warnings` | 0 |
| `node --test scripts/{measure-memory-catalog,memory-calibration-harness,anchor-loader-closure}.test.mjs` | 0 (155 passed) |
| `npm run check` | 0 (803 + 2 passed) |

**Real-weight verification = a campaign re-run of the three `ltx_2_5:*:mlx` anchors.** The MLX GPU was held by the running campaign, so no adapter run, MLX device test or render was performed here.

## Other rows

Only `ltx_2_5` hits this root cause. Campaign failure classes so far:

- `ltx_2_3:{bf16,q4,q8}:mlx` — **different root**, not this one: `SC-18946 row is missing required _measurementSafety` (`mlx.rs:12635`). That arm deliberately refuses every LTX-2.3 MLX row unless the plan supplies a safety attestation whose disposition is `safety_refused_open`; it is a designed host-safety refusal from the q4 f305 incident, not a regression, and not something to paper over here.
- Bernini / Krea Realtime probe-budget rejections, GPU-view coherence retries, two FLUX.2 warm-repeat failures — all unrelated.
- The candle lane plans the same empty parameters and will be exercised by the candle campaign; the new JS test covers both lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
