### PR TITLE
fix(sc-22738): minimax MLX capture record matches the harness schema; --list fails closed on a missing upstream file

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -15635,7 +15635,34 @@ fn run_ltx_with_admission(
             "result": "passed",
             "resolvedPathFingerprint": format!("{repository}@{revision}:{tier}+gemma"),
         },
-        "output": {
+        "diagnostics": protocol::diagnostics(
+            "memory-mlx-adapter:ltx-2-3-provider-contract-video",
+            "executed",
+            [],
+            diagnostic_measurements,
+        ),
+        "capturedAt": protocol::captured_at(),
+    });
+    // sc-22738. The `output` descriptor belongs to the CAMPAIGN CARRIERS and to nothing else.
+    //
+    // A calibration fragment becomes a `records[]` member verbatim (the harness spreads it —
+    // `capturePlannedCase`'s `{ ...fragment }`), and `memory-calibration.schema.json`'s record is
+    // `additionalProperties: false` with no `output` property: every committed video record —
+    // `docs/generated/ltx-mlx-video-sc-18808.json` included — publishes the same four facts as
+    // `renderedFrames` / `outputFps` / `audioTrackDecoded` / `latentTemporalDepth` diagnostic
+    // measurements, which is where the harness and the derivations read them from. Emitting the
+    // block on an ordinary capture therefore does not enrich the record, it makes the bundle
+    // unschedulable — `schema validation failed: $.records[0].output: unexpected property`, AFTER
+    // the render, which is the most expensive place in the system to fail.
+    //
+    // The campaign entries are not calibration records: `run_ltx_campaign_entry` and
+    // `run_ltx_bounded_campaign_entry` stamp their own `_campaignEntry` / `_boundedCampaignEntry`
+    // keys (which the record schema would reject just as flatly) and their fragments are consumed
+    // by `validate_ltx_campaign_entry_fragment` / `validate_ltx_bounded_campaign_fragment`, which
+    // cross-check `/output/*` AGAINST the diagnostics of the same run. That redundancy is the whole
+    // point of the carrier check, so it is kept exactly where it is read.
+    if !matches!(admission, LtxRunAdmission::Ordinary) {
+        fragment["output"] = json!({
             "frames": geometry.frames,
             "fps": fps,
             "audio": {
@@ -15645,15 +15672,8 @@ fn run_ltx_with_admission(
                 "channels": audio.channels,
             },
             "firstFrameNondegenerate": true,
-        },
-        "diagnostics": protocol::diagnostics(
-            "memory-mlx-adapter:ltx-2-3-provider-contract-video",
-            "executed",
-            [],
-            diagnostic_measurements,
-        ),
-        "capturedAt": protocol::captured_at(),
-    });
+        });
+    }
     protocol::settle_plain_overlay_scenario(request, &mut fragment, LTX_PLAIN_EXECUTION_PATH)?;
     Ok(fragment)
 }
@@ -17249,19 +17269,6 @@ fn run_minimax_h3(request: &Value) -> Result<Value, String> {
             "result": "passed",
             "resolvedPathFingerprint": artifact.resolved_path_fingerprint(member, tier),
         },
-        "output": {
-            "frames": geometry.frames,
-            "fps": fps,
-            "videoLatentFrames": geometry.video_latent_frames,
-            "audioLatentFrames": geometry.audio_latent_frames,
-            "audio": {
-                "present": true,
-                "samples": audio.samples,
-                "sampleRate": audio.sample_rate,
-                "channels": audio.channels,
-            },
-            "firstFrameNondegenerate": true,
-        },
         "diagnostics": protocol::diagnostics(
             "memory-mlx-adapter:minimax-h3-joint-av",
             "executed",
@@ -17293,6 +17300,17 @@ fn run_minimax_h3(request: &Value) -> Result<Value, String> {
                 ("negativeMutationRootMeanSquareErrorPer255", "count", (mutated_rms * 255.0).round() as u64),
                 ("videoLatentFrames", "count", u64::from(geometry.video_latent_frames)),
                 ("audioLatentFrames", "count", u64::from(geometry.audio_latent_frames)),
+                // sc-22738. The render receipts, in the ONE place the record schema has for them.
+                // They were a top-level `output` object until the catalog campaign proved the
+                // record is `additionalProperties: false` and rejected the whole bundle after the
+                // render; `docs/generated/ltx-mlx-video-sc-18808.json` is the committed precedent
+                // for publishing them here, under these names.
+                ("renderedFrames", "count", u64::from(geometry.frames)),
+                ("outputFps", "count", u64::from(fps)),
+                ("audioTrackDecoded", "count", 1),
+                ("audioSamples", "count", audio.samples),
+                ("audioSampleRate", "count", u64::from(audio.sample_rate)),
+                ("audioChannels", "count", u64::from(audio.channels)),
                 ("loadShapeDeferred", "count", u64::from(load_shape == LoadShape::DeferredMaterialization)),
                 ("textEncoderFromTierTree", "count", u64::from(artifact.text_encoder_source == MINIMAX_TIERED_TEXT_ENCODER)),
                 ("stagedDitBytes", "bytes", staged_dit_bytes),
@@ -18221,12 +18239,6 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
             "result": "passed",
             "resolvedPathFingerprint": artifact.resolved_path_fingerprint(arm, tier),
         },
-        "output": {
-            "modelId": arm.model_id,
-            "frames": geometry.frames,
-            "fps": fps,
-            "firstFrameNondegenerate": true,
-        },
         "diagnostics": protocol::diagnostics(
             "memory-mlx-adapter:bernini-dual-expert",
             "executed",
@@ -18258,6 +18270,11 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
                 ("negativeMutationRootMeanSquareErrorPer255", "count", (mutated_rms * 255.0).round() as u64),
                 ("loadShapeDeferred", "count", u64::from(load_shape == LoadShape::DeferredMaterialization)),
                 ("stagedTierBytes", "bytes", staged_tier_bytes),
+                // sc-22738: the render receipts, published as measurements rather than as a
+                // top-level `output` object the record schema rejects. The member this record is
+                // filed under is `target.modelId`, so the dropped `output.modelId` is not lost.
+                ("renderedFrames", "count", u64::from(geometry.frames)),
+                ("outputFps", "count", u64::from(fps)),
             ],
         ),
         "capturedAt": protocol::captured_at(),
@@ -20230,14 +20247,6 @@ fn run_krea_realtime(request: &Value) -> Result<Value, String> {
             "result": "passed",
             "resolvedPathFingerprint": artifact.resolved_path_fingerprint(tier),
         },
-        "output": {
-            "frames": geometry.frames,
-            "fps": fps,
-            "latentFrames": geometry.latent_frames,
-            "autoregressiveBlocks": geometry.autoregressive_blocks,
-            "audio": { "present": false },
-            "firstFrameNondegenerate": true,
-        },
         "diagnostics": protocol::diagnostics(
             &format!("memory-mlx-adapter:krea-realtime-{}", tier),
             "executed",
@@ -20269,6 +20278,12 @@ fn run_krea_realtime(request: &Value) -> Result<Value, String> {
                 ("negativeMutationRootMeanSquareErrorPer255", "count", (mutated_rms * 255.0).round() as u64),
                 ("latentFrames", "count", u64::from(geometry.latent_frames)),
                 ("autoregressiveBlocks", "count", u64::from(geometry.autoregressive_blocks)),
+                // sc-22738: the render receipts, published as measurements rather than as a
+                // top-level `output` object the record schema rejects. This route decodes no audio
+                // track, so `audioTrackDecoded` is a measured 0 rather than an absent claim.
+                ("renderedFrames", "count", u64::from(geometry.frames)),
+                ("outputFps", "count", u64::from(fps)),
+                ("audioTrackDecoded", "count", 0),
                 ("loadSpecCarriesQuant", "count", u64::from(spec.quantize.is_some())),
                 ("stagedTierBytes", "bytes", staged_tier_bytes),
             ],

--- a/crates/sceneworks-memory-adapter/src/bin/mlx_wan_scail2.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx_wan_scail2.rs
@@ -957,12 +957,6 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
             "result": "passed",
             "resolvedPathFingerprint": artifact.loadability_fingerprint(tier),
         },
-        "output": {
-            "frames": geometry.frames,
-            "fps": output_fps,
-            "referenceCount": arm.carrier.reference_count(),
-            "firstFrameNondegenerate": true,
-        },
         "diagnostics": protocol::diagnostics(
             &format!("memory-mlx-adapter:{}-video", arm.slug),
             "executed",
@@ -988,6 +982,11 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
                 ("negativeMutationRootMeanSquareErrorPer255", "count", (mutated_rms * 255.0).round() as u64),
                 ("renderedFrames", "count", u64::from(geometry.frames)),
                 ("renderedFps", "count", u64::from(output_fps)),
+                // sc-22738. The carrier's reference count was the one fact the dropped top-level
+                // `output` object published that these measurements did not: the record schema is
+                // `additionalProperties: false`, so the object made the whole bundle unschedulable
+                // after the render. It is a measurement now, beside the frames and fps receipts.
+                ("referenceCount", "count", u64::from(arm.carrier.reference_count())),
             ],
         ),
         "capturedAt": protocol::captured_at(),

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -507,6 +507,66 @@ export const QWEN_EDIT_LIGHTNING_LORA = Object.freeze({
 export const SENSENOVA_DISTILL_MERGED_MARKER = "distill_merged.json";
 
 /**
+ * What `mlx_gen_minimax_h3::model::load` opens in the UPSTREAM snapshot root, at the pinned
+ * revision (`crates/media/mlx-gen/mlx-gen-minimax-h3/src/model.rs`), read off the loader rather
+ * than guessed from the manifest's download globs.
+ *
+ * `spec.weights` for BOTH MiniMax entries is the dense `MiniMaxAI/MiniMax-H3` snapshot — only the
+ * DiT and (at q4/q8) the text encoder are redirected onto the rehost — and the loader probes these
+ * six documents under it before it will build the generator. `FL2VA/audio_vae` carries the audio
+ * VAE's constructor arguments, which the repackaged root config does not.
+ *
+ * sc-22738 declares them because the campaign found the hard way what an undeclared read costs:
+ * this host holds a `MiniMaxAI/MiniMax-H3` snapshot with `FL2VA/`, `audio_vae/`, `tokenizer/` and
+ * `vae/` and NO `text_encoder/`, `--list` called `minimax_h3:bf16:mlx` runnable, and the booked
+ * capture died on `read …/text_encoder: No such file or directory` before it rendered anything.
+ */
+export const MINIMAX_UPSTREAM_ROOT_FILES = Object.freeze([
+  "vae/config.json",
+  "audio_vae/config.json",
+  "tokenizer/tokenizer.json",
+  "FL2VA/audio_vae/config.json",
+  "FL2VA/audio_vae/config.yaml",
+  "FL2VA/audio_vae/metadata.json",
+]);
+
+/**
+ * The text encoder's config, wherever the tier puts it.
+ *
+ * The TE's tier is DERIVED from the DiT's rather than being a free axis (`mlx.rs`
+ * `minimax_text_encoder_source`, and the manifest's three `componentId: "text_encoder"`
+ * co-requisite rows): `q4`/`q8` stage `<tier>/text_encoder` from the rehost, `bf16` takes the dense
+ * `text_encoder/` from the upstream root. So the SAME probe is declared against two different roots
+ * depending on the tier — which is exactly what the per-tier form of a required-file declaration is
+ * for, and why one flat list could not express it.
+ */
+export const MINIMAX_TEXT_ENCODER_CONFIG = "text_encoder/config.json";
+
+/**
+ * The two DiT partitions the loader probes inside the resolved tier root: the base one, and
+ * `transformer_ref/` — which is probed as the base partition's SIBLING at load time for EVERY
+ * entry, not only for `minimax_h3_ref`, because `ref2va` is a first-class task of the engine.
+ */
+export const MINIMAX_TIER_DIT_FILES = Object.freeze([
+  "transformer/config.json",
+  "transformer_ref/config.json",
+]);
+
+/**
+ * The files a required-file declaration demands for `tier`.
+ *
+ * A declaration is either a flat list (every tier needs the same files — the SenseNova `_fast`
+ * marker) or a per-tier object `{ all, q4, q8, bf16 }` whose `all` entry applies to every tier and
+ * whose tier entry is added on top. Absent is the empty list: a family that declares nothing keeps
+ * classifying exactly as it did.
+ */
+export function requiredFilesFor(declaration, tier) {
+  if (!declaration) return [];
+  if (Array.isArray(declaration)) return declaration;
+  return [...(declaration.all ?? []), ...(declaration[tier] ?? [])];
+}
+
+/**
  * The shared Mage-Flow text-encoder + VAE rehost (sc-22733). Declared once and referenced by all six
  * Mage family rows: it is the SAME repository and the SAME revision for every variant and both
  * lanes, and both adapters read it through one `SCENEWORKS_MAGE_FLOW_COMPONENTS_*` family. The
@@ -760,10 +820,29 @@ export const PROVIDER_FAMILIES = Object.freeze({
   // fact stageable from the upstream snapshot alone — wrong in the direction that hides work.
   minimax_h3: {
     env: "MINIMAX_H3", repo: "SceneWorks/minimax-h3-mlx", arms: ["mlx", "candle"],
-    upstream: { env: "MINIMAX_H3_UPSTREAM", repo: "MiniMaxAI/MiniMax-H3" },
+    upstream: {
+      env: "MINIMAX_H3_UPSTREAM", repo: "MiniMaxAI/MiniMax-H3",
+      // sc-22738: what the load READS in this root, per tier. `bf16` adds the dense text encoder,
+      // which is the file this host does not hold and which the classifier called runnable.
+      requiredFiles: { all: MINIMAX_UPSTREAM_ROOT_FILES, bf16: [MINIMAX_TEXT_ENCODER_CONFIG] },
+    },
+    // The two DiT partitions live in the tier root on every rehost-backed cell, and `q4`/`q8` take
+    // the packed text encoder from it as well (`bf16` takes the dense one from upstream above).
+    requiredTierFiles: {
+      all: MINIMAX_TIER_DIT_FILES,
+      q4: [MINIMAX_TEXT_ENCODER_CONFIG],
+      q8: [MINIMAX_TEXT_ENCODER_CONFIG],
+    },
     artifacts: {
       candle: {
-        bf16: { env: "MINIMAX_H3_UPSTREAM", repo: "MiniMaxAI/MiniMax-H3", layout: "flat" },
+        // The one cell whose tier root IS the upstream snapshot root: everything the load opens is
+        // in that flat tree, so the DiT partitions are required THERE. The text encoder and the
+        // root documents are already covered by the `upstream` declaration above, which probes the
+        // same directory — declaring them twice would only duplicate the reason string.
+        bf16: {
+          env: "MINIMAX_H3_UPSTREAM", repo: "MiniMaxAI/MiniMax-H3", layout: "flat",
+          requiredTierFiles: MINIMAX_TIER_DIT_FILES,
+        },
       },
     },
     // The reference entry stages the tier tree at EVERY tier, on both lanes, because
@@ -1327,7 +1406,10 @@ export async function classifyAnchor(key, planned, { models, backend, hubs, curr
   // LoRA at load and the resident shape is not the one the anchor prices. Nine `_fast` MLX cells
   // would therefore hard-fail at capture with an identity mismatch, hours into a booked session,
   // over a fact this probe can read in a millisecond. Classified by name instead.
-  const requiredTierFiles = artifact.requiredTierFiles ?? family.requiredTierFiles ?? [];
+  // sc-22738 generalized the declaration from a flat list to a per-tier one: MiniMax-H3's text
+  // encoder is packed inside the tier root at q4/q8 and taken from the dense upstream root at bf16,
+  // so which file a root must carry depends on the tier being classified.
+  const requiredTierFiles = requiredFilesFor(artifact.requiredTierFiles ?? family.requiredTierFiles, parts.tier);
   const missingTierFiles = [];
   for (const file of requiredTierFiles) {
     try {
@@ -1392,6 +1474,24 @@ export async function classifyAnchor(key, planned, { models, backend, hubs, curr
     row.roots.push({ label: "upstream root", path: upstreamRoot ?? snapshotPath(hubs[0], family.upstream.repo, upstream.revision) });
     if (!upstreamRoot) {
       return { ...row, status: "weights_missing", reason: `no ${family.upstream.repo}@${upstream.revision.slice(0, 8)} snapshot on this host` };
+    }
+    // sc-22738. A PRESENT snapshot is not a complete one. The dense MiniMax-H3 tree staged on the
+    // capture host carried `vae/`, `audio_vae/`, `tokenizer/` and `FL2VA/` but no `text_encoder/`,
+    // and because this branch only asked whether the snapshot directory existed, `--list` reported
+    // `minimax_h3:bf16:mlx` runnable and the booked capture died on the missing directory instead.
+    // The declared files are the ones the pinned loader opens under this root, so an incomplete
+    // mirror is `weights_missing` — named file by file — exactly like an absent one.
+    const missingUpstream = [];
+    for (const file of requiredFilesFor(family.upstream.requiredFiles, parts.tier)) {
+      try {
+        if (!(await stat(path.join(upstreamRoot, file))).isFile()) missingUpstream.push(file);
+      } catch { missingUpstream.push(file); }
+    }
+    if (missingUpstream.length > 0) {
+      return {
+        ...row, status: "weights_missing",
+        reason: `${family.upstream.repo} snapshot ${upstreamRoot} is missing ${missingUpstream.join(", ")}, which the pinned loader opens under the snapshot root`,
+      };
     }
     row.env[`SCENEWORKS_${family.upstream.env}_REPOSITORY`] = family.upstream.repo;
     row.env[`SCENEWORKS_${family.upstream.env}_REVISION`] = upstream.revision;

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -54,6 +54,10 @@ import {
   readDeclaredStrategySupport,
   SDXL_ROUTES_PATH,
   SDXL_ROUTES_UNCHECKED,
+  MINIMAX_UPSTREAM_ROOT_FILES,
+  MINIMAX_TEXT_ENCODER_CONFIG,
+  MINIMAX_TIER_DIT_FILES,
+  requiredFilesFor,
 } from "./measure-memory-catalog.mjs";
 import {
   ANCHOR_LANE_DEFAULT_STRATEGY_PATH,
@@ -79,6 +83,16 @@ function fakeModels() {
       id: "minimax_h3",
       downloads: [
         { repo: "SceneWorks/minimax-h3-mlx", revision: REVISION, variant: "q4", files: ["q4/transformer/*"] },
+        { repo: "MiniMaxAI/MiniMax-H3", revision: UPSTREAM, coRequisite: true, files: ["vae/*"] },
+      ],
+    },
+    // The reference entry is its own catalog model on the same engine id, and it stages the tier
+    // tree at every tier (`transformer_ref/` ships only in the rehost) while still loading the
+    // dense upstream root — so it resolves through its OWN manifest downloads.
+    {
+      id: "minimax_h3_ref",
+      downloads: [
+        { repo: "SceneWorks/minimax-h3-mlx", revision: REVISION, variant: "bf16", files: ["bf16/transformer_ref/*"] },
         { repo: "MiniMaxAI/MiniMax-H3", revision: UPSTREAM, coRequisite: true, files: ["vae/*"] },
       ],
     },
@@ -152,6 +166,28 @@ function fakeModels() {
       ],
     },
   ];
+}
+
+/**
+ * Stage everything the pinned MiniMax-H3 loader opens for `tier`, in the two roots it opens them
+ * in. Written from the same declarations `classifyAnchor` probes, so a file added to either
+ * declaration is staged here with no edit — the tests that want a COMPLETE install say so by
+ * calling this, and the one that wants a specific hole omits exactly that file.
+ */
+async function stageMinimaxFiles(hub, tier, { omit = [] } = {}) {
+  const roots = [
+    [snapshotPath(hub, "SceneWorks/minimax-h3-mlx", REVISION, tier),
+      requiredFilesFor({ all: MINIMAX_TIER_DIT_FILES, q4: [MINIMAX_TEXT_ENCODER_CONFIG], q8: [MINIMAX_TEXT_ENCODER_CONFIG] }, tier)],
+    [snapshotPath(hub, "MiniMaxAI/MiniMax-H3", UPSTREAM),
+      requiredFilesFor({ all: MINIMAX_UPSTREAM_ROOT_FILES, bf16: [MINIMAX_TEXT_ENCODER_CONFIG] }, tier)],
+  ];
+  for (const [root, files] of roots) {
+    for (const file of files) {
+      if (omit.includes(file)) continue;
+      await mkdir(path.join(root, path.dirname(file)), { recursive: true });
+      await writeFile(path.join(root, file), "{}\n");
+    }
+  }
 }
 
 async function fakeHub(layout) {
@@ -283,6 +319,11 @@ test("classification: runnable anchors carry the adapter env family and the cano
     ["MiniMaxAI/MiniMax-H3", UPSTREAM],
     ["SceneWorks/ltx-2.5-mlx", REVISION],
   ]);
+  // sc-22738: a MiniMax cell is runnable only when the files the pinned loader opens are actually
+  // there — the two DiT partitions and the packed text encoder in the tier root, and the six dense
+  // documents in the upstream one. A bare directory tree is what this host really had, and what
+  // `--list` used to call runnable.
+  await stageMinimaxFiles(hub, "q4");
   const context = { models: fakeModels(), backend: "mlx", hubs: [hub], current: new Map(), captured: new Map() };
   const qwen = await classifyAnchor("qwen_image:q4:mlx", { provider: "qwen_image" }, context);
   assert.equal(qwen.status, "runnable");
@@ -307,6 +348,71 @@ test("classification: runnable anchors carry the adapter env family and the cano
   const missingTier = await classifyAnchor("qwen_image:q8:mlx", { provider: "qwen_image" }, context);
   assert.equal(missingTier.status, "weights_missing");
   assert.match(missingTier.reason, /q8 on this host/);
+});
+
+// sc-22738. The campaign lost a booked `minimax_h3:bf16:mlx` capture to
+// `read …/models--MiniMaxAI--MiniMax-H3/snapshots/<rev>/text_encoder: No such file or directory`.
+// `--list` had called the cell runnable because the upstream probe asked only whether the snapshot
+// DIRECTORY existed — and the dense tree staged on that host holds `vae/`, `audio_vae/`,
+// `tokenizer/` and `FL2VA/` but no `text_encoder/`. The loader's reads are declared now, per tier,
+// in both roots, so an incomplete mirror is refused by name before anything is scheduled.
+test("a minimax cell whose snapshot is missing a file the loader opens is weights_missing, by name", async () => {
+  const layout = [
+    ["SceneWorks/minimax-h3-mlx", REVISION, "q4"],
+    ["SceneWorks/minimax-h3-mlx", REVISION, "bf16"],
+    ["MiniMaxAI/MiniMax-H3", UPSTREAM],
+  ];
+  const planned = { provider: "minimax_h3" };
+
+  // The exact host condition: everything but the dense text encoder. bf16 takes its TE from the
+  // upstream root, so bf16 is refused — and q4 takes its own from the tier root, so q4 is NOT.
+  const holed = await fakeHub(layout);
+  await stageMinimaxFiles(holed, "q4");
+  await stageMinimaxFiles(holed, "bf16", { omit: [MINIMAX_TEXT_ENCODER_CONFIG] });
+  const context = (hub) => ({ models: fakeModels(), backend: "mlx", hubs: [hub], current: new Map(), captured: new Map() });
+  const refused = await classifyAnchor("minimax_h3:bf16:mlx", planned, context(holed));
+  assert.equal(refused.status, "weights_missing", refused.reason);
+  assert.match(refused.reason, /text_encoder\/config\.json/);
+  assert.ok(
+    refused.reason.includes(snapshotPath(holed, "MiniMaxAI/MiniMax-H3", UPSTREAM)),
+    `the refusal names the root it probed: ${refused.reason}`,
+  );
+  const unaffected = await classifyAnchor("minimax_h3:q4:mlx", planned, context(holed));
+  assert.equal(unaffected.status, "runnable", unaffected.reason);
+
+  // The reference entry rides the same declarations — it stages the tier tree at every tier and
+  // still loads the dense root — so its bf16 cell is refused for the same missing file.
+  const ref = await classifyAnchor("minimax_h3_ref:bf16:mlx", planned, context(holed));
+  assert.equal(ref.status, "weights_missing", ref.reason);
+  assert.match(ref.reason, /text_encoder\/config\.json/);
+
+  // Each declared file, one at a time: dropping ANY of them refuses the cell, and no single one of
+  // them is load-bearing for the others. A blanket "the snapshot is there" probe passes all of these.
+  for (const file of [...MINIMAX_UPSTREAM_ROOT_FILES, MINIMAX_TEXT_ENCODER_CONFIG]) {
+    const hub = await fakeHub(layout);
+    await stageMinimaxFiles(hub, "bf16", { omit: [file] });
+    const row = await classifyAnchor("minimax_h3:bf16:mlx", planned, context(hub));
+    assert.equal(row.status, "weights_missing", `${file}: ${row.reason}`);
+    assert.ok(row.reason.includes(file), `${file}: ${row.reason}`);
+  }
+  for (const file of [...MINIMAX_TIER_DIT_FILES, MINIMAX_TEXT_ENCODER_CONFIG]) {
+    const hub = await fakeHub(layout);
+    await stageMinimaxFiles(hub, "q4", { omit: [file] });
+    const row = await classifyAnchor("minimax_h3:q4:mlx", planned, context(hub));
+    assert.equal(row.status, "weights_missing", `${file}: ${row.reason}`);
+    assert.ok(row.reason.includes(file), `${file}: ${row.reason}`);
+  }
+
+  // And a COMPLETE install is still runnable on both tiers, with the same env family as before.
+  const whole = await fakeHub(layout);
+  await stageMinimaxFiles(whole, "q4");
+  await stageMinimaxFiles(whole, "bf16");
+  for (const tier of ["q4", "bf16"]) {
+    const row = await classifyAnchor(`minimax_h3:${tier}:mlx`, planned, context(whole));
+    assert.equal(row.status, "runnable", `${tier}: ${row.reason}`);
+    assert.equal(row.env.SCENEWORKS_MINIMAX_H3_UPSTREAM_ROOT, snapshotPath(whole, "MiniMaxAI/MiniMax-H3", UPSTREAM));
+    assert.equal(row.env.SCENEWORKS_MINIMAX_H3_ROOT, snapshotPath(whole, "SceneWorks/minimax-h3-mlx", REVISION, tier));
+  }
 });
 
 test("the z-image family: the base model has its own env family, and the edit alias loads the Turbo artifact", async () => {

--- a/scripts/memory-calibration-harness.test.mjs
+++ b/scripts/memory-calibration-harness.test.mjs
@@ -2746,3 +2746,114 @@ test("every checked-in capture invocation names a declared anchor", async () => 
     );
   }
 });
+
+// sc-22738. The MLX catalog campaign lost a MiniMax-H3 q4 render to
+// `schema validation failed: $.records[0].output: unexpected property`: the adapter's video arms
+// had grown a top-level `output` descriptor, and `capturePlannedCase` spreads the provider fragment
+// into the record VERBATIM (`{ ...fragment }`), so every key an arm invents is a record property.
+// `$defs.record` is `additionalProperties: false`, and the render is already paid for by the time
+// the bundle is validated — the most expensive place in the system to learn the shape is wrong.
+//
+// Two tests, because there are two claims. This one drives the REAL validator over a REAL record
+// and proves the schema forbids the property rather than that some transcription of it does.
+test("the real validator refuses a record that carries an output descriptor", () => {
+  const record = runtimeComplete();
+  validateBundle({ schemaVersion: SCHEMA_VERSION, harnessVersion: HARNESS_VERSION, records: [record] });
+
+  const withOutput = structuredClone(record);
+  withOutput.output = { frames: 121, fps: 24, firstFrameNondegenerate: true };
+  assert.throws(
+    () => validateBundle({ schemaVersion: SCHEMA_VERSION, harnessVersion: HARNESS_VERSION, records: [withOutput] }),
+    /\$\.records\[0\]\.output: unexpected property/,
+  );
+});
+
+/**
+ * Every calibration record fragment the adapters build, keyed by `<bin>:<enclosing fn>`.
+ *
+ * The idiom is uniform across both adapters and is what makes this readable without a Rust parser:
+ * a record arm opens `let mut fragment = json!({` at four spaces, closes at `});` at four spaces,
+ * and its top-level keys are the eight-space `"name":` lines between. A payload that is NOT a
+ * calibration record — the LTX safety/product canaries, the campaign entries and the bounded
+ * carrier proof, which `main()` dispatches under their own actions and which legitimately carry
+ * `output` and `_campaignEntry` — is returned as `Ok(json!({…}))` and never binds `fragment`, so
+ * the idiom excludes them. The signature filter below is the belt to that suspenders: a fragment
+ * is only judged against the record schema if it carries the four keys every capture record has.
+ */
+async function adapterRecordFragments() {
+  const bins = ["mlx.rs", "mlx_ltx25.rs", "mlx_wan_scail2.rs", "candle.rs", "candle_wan_scail2.rs"];
+  const fragments = new Map();
+  for (const bin of bins) {
+    const lines = (await readFile(
+      fileURLToPath(new URL(`../crates/sceneworks-memory-adapter/src/bin/${bin}`, import.meta.url)),
+      "utf8",
+    )).split("\n");
+    let fn = null;
+    for (let i = 0; i < lines.length; i += 1) {
+      const declaration = /^(?:pub(?:\([a-z]+\))? )?fn ([a-z0-9_]+)/.exec(lines[i]);
+      if (declaration) fn = declaration[1];
+      if (!/^ {4}let (?:mut )?fragment = json!\(\{$/.test(lines[i])) continue;
+      const keys = [];
+      for (let j = i + 1; j < lines.length; j += 1) {
+        if (/^ {4}\}\);$/.test(lines[j])) break;
+        const key = /^ {8}"([A-Za-z_]+)":/.exec(lines[j]);
+        if (key) keys.push(key[1]);
+      }
+      fragments.set(`${bin}:${fn}`, keys);
+    }
+  }
+  return fragments;
+}
+
+// The second claim: no shipped arm emits such a property today, MiniMax-H3 and the four other video
+// arms included. Universally quantified over the arms the sources actually contain — a new arm is
+// covered with no edit here — with the five video arms named so the check cannot go quietly vacuous.
+test("every adapter calibration record fragment carries only properties the record schema allows", async () => {
+  const schema = JSON.parse(await readFile(
+    fileURLToPath(new URL("../packages/schemas/memory-calibration.schema.json", import.meta.url)),
+    "utf8",
+  ));
+  const record = schema.$defs.record;
+  assert.equal(record.additionalProperties, false, "an open record would make this test prove nothing");
+  // `sourceCapture` is the one fragment key that is NOT a record property by design: the harness
+  // lifts it into `sourceSessions` and deletes it before the record is assembled.
+  const allowed = new Set([...Object.keys(record.properties), "sourceCapture"]);
+  // The keys every capture record carries. A `fragment` without all four is a different payload
+  // (the InstantID arms' legacy `memory` shape), and judging it against this schema would be wrong.
+  const signature = ["status", "artifact", "observedMemory", "scenarios"];
+
+  const fragments = await adapterRecordFragments();
+  const judged = [];
+  for (const [arm, keys] of fragments) {
+    if (!signature.every((key) => keys.includes(key))) continue;
+    judged.push(arm);
+    const forbidden = keys.filter((key) => !allowed.has(key));
+    assert.deepEqual(forbidden, [], `${arm} emits record properties the schema rejects: ${forbidden}`);
+    assert.equal(new Set(keys).size, keys.length, `${arm} repeats a record property`);
+  }
+
+  for (const arm of [
+    "mlx.rs:run_minimax_h3",
+    "mlx.rs:run_bernini",
+    "mlx.rs:run_krea_realtime",
+    "mlx.rs:run_ltx_with_admission",
+    "mlx_wan_scail2.rs:run",
+    "mlx_ltx25.rs:run",
+  ]) {
+    assert.ok(judged.includes(arm), `${arm} is a video record arm this check must cover`);
+  }
+  assert.ok(judged.length >= 18, `too few record arms recognized (${judged.length}) — the idiom moved`);
+
+  // The other half of the same decision: the LTX CAMPAIGN carriers keep their `output` descriptor,
+  // because `validate_ltx_campaign_entry_fragment` cross-checks `/output/*` against the diagnostics
+  // of the same run. It is published for the campaign admissions and for nothing else.
+  const mlx = await readFile(
+    fileURLToPath(new URL("../crates/sceneworks-memory-adapter/src/bin/mlx.rs", import.meta.url)),
+    "utf8",
+  );
+  assert.match(
+    mlx,
+    /if !matches!\(admission, LtxRunAdmission::Ordinary\) \{\n\s+fragment\["output"\] = json!\(\{/,
+    "the LTX campaign carrier must still publish the output descriptor its own validator reads",
+  );
+});


### PR DESCRIPTION
Two capture-time failures the MLX catalog campaign (sc-22738) hit on the MiniMax-H3 arm added by sc-22737, at SceneWorks `1cd23a0e6` / inference pin `563c44e16`.

## 1. `schema validation failed: $.records[0].output: unexpected property`

`capturePlannedCase` spreads the provider fragment into the record **verbatim** (`{ ...fragment }`), and `packages/schemas/memory-calibration.schema.json`'s `$defs.record` is `additionalProperties: false` with no `output` property. So the top-level `output` descriptor the MLX video arms had grown is not an enrichment — it makes the whole bundle unschedulable, **after** the render, which is the most expensive place in the system to fail.

The record shape for video is already settled and does not include it: every committed record carries the same facts as `diagnostics.measurements` — `renderedFrames`, `outputFps`, `audioTrackDecoded`, `latentTemporalDepth` — which is where the harness and the derivations read them from (`docs/generated/ltx-mlx-video-sc-18808.json` is the canonical video record; not one committed record in the repo, and not one of the 37 image records already committed on `origin/story/sc-22738-mlx-campaign`, carries `output`). So the property is **dropped**, not admitted to the schema.

Dropped from **all five** MLX calibration record builders, not only MiniMax: `run_ltx_with_admission` (LTX-2.3), `run_minimax_h3`, `run_bernini`, `run_krea_realtime` and `mlx_wan_scail2::run` all emitted it and would each have red the same campaign within hours, with the same message. Anything the block published that was not already a measurement is now one (`audioSamples` / `audioSampleRate` / `audioChannels` and `audioTrackDecoded` on MiniMax, `renderedFrames` / `outputFps` on Bernini and Krea Realtime, `referenceCount` on Wan/SCAIL-2). `output.modelId` on Bernini is `target.modelId` on the record; `firstFrameNondegenerate` was a hardcoded `true` behind an arm that already hard-errors on a degenerate first frame.

The LTX **campaign carriers** keep `output`: `validate_ltx_campaign_entry_fragment` / `validate_ltx_bounded_campaign_fragment` cross-check `/output/*` against the same run's diagnostics, and those payloads are dispatched under their own actions (they also carry `_campaignEntry`, which the record schema rejects just as flatly). The descriptor is now published only when `admission != Ordinary`.

## 2. `read …/models--MiniMaxAI--MiniMax-H3/snapshots/<rev>/text_encoder: No such file or directory`

`--list` had classified `minimax_h3:bf16:mlx` **runnable**, because the `upstream` probe in `classifyAnchor` asked only whether the snapshot *directory* existed. The dense tree staged on this host holds `FL2VA/`, `audio_vae/`, `tokenizer/` and `vae/` — and **no `text_encoder/`**, which is exactly what the bf16 tier takes from that root (`minimax_text_encoder_source`: q4/q8 stage the packed TE from the rehost tier, bf16 takes the dense one from upstream).

The files the pinned loader opens are declared now, read off `563c44e16:crates/media/mlx-gen/mlx-gen-minimax-h3/src/model.rs` rather than guessed from the manifest globs: `vae/config.json`, `audio_vae/config.json`, `tokenizer/tokenizer.json` and the three `FL2VA/audio_vae/` documents under the upstream root, `transformer/config.json` + `transformer_ref/config.json` in the tier root, and `text_encoder/config.json` in whichever of the two roots the tier's TE comes from. `requiredTierFiles` is generalized from a flat list to an optional per-tier form (`{ all, q4, q8, bf16 }`) so a probe can be declared against different roots per tier; the SenseNova `_fast` rows keep the flat form unchanged.

On this host the classification is now:

```
minimax_h3:bf16:mlx      weights_missing  … is missing text_encoder/config.json, which the pinned loader opens under the snapshot root
minimax_h3:q4:mlx        runnable
minimax_h3:q8:mlx        runnable
minimax_h3_ref:bf16:mlx  weights_missing  (same file)
minimax_h3_ref:q4:mlx    runnable
minimax_h3_ref:q8:mlx    runnable
```

The absent `text_encoder/` is a **host condition to record, not to fix here**: the two bf16 cells are unmeasurable until the dense snapshot is completed.

## Tests

* `the real validator refuses a record that carries an output descriptor` — drives the real `validateBundle` over a real record; adding `output` throws `$.records[0].output: unexpected property`.
* `every adapter calibration record fragment carries only properties the record schema allows` — extracts every `let mut fragment = json!({` record fragment from both adapters' bins, judges its top-level keys against the **real schema file**'s `$defs.record.properties`, and names the five video arms so it cannot go vacuous. Also pins that the LTX campaign carrier still publishes its descriptor.
* `a minimax cell whose snapshot is missing a file the loader opens is weights_missing, by name` — synthetic hub, one declared file omitted at a time, in both roots, on both catalog entries; a complete install is still runnable.

Mutations run (each restored, `touch`ed, re-run green):

| assertion | mutation | result |
| --- | --- | --- |
| record fragment keys ⊆ schema | re-add `"output"` to `run_minimax_h3` | RED — `mlx.rs:run_minimax_h3 emits record properties the schema rejects: output` |
| campaign carrier keeps `output` | `if !matches!(admission, …)` → `if false` | RED |
| bf16 cell refused | drop `upstream.requiredFiles` | RED — reports `runnable` |
| q4/q8 cell refused | drop `requiredTierFiles` | RED |

Gates: `cargo test -p sceneworks-memory-adapter --features mlx --bin memory-mlx-adapter` 246 passed / exit 0; `cargo clippy … -D warnings` exit 0; `node --test` over the three affected script suites 166 passed / exit 0; `npm run check` exit 0. No MLX render was run — the GPU is held by the campaign, so **real-weight verification is a campaign re-run of the `minimax_h3*:*:mlx` anchors** (and of the LTX-2.3 / Bernini / Krea Realtime / Wan / SCAIL-2 MLX anchors, whose record shape this also changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
