### PR TITLE
fix(sc-22738): --list fails closed on every extra artifact an arm loads (qwen lightning LoRA and siblings)

### DIFF
--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -507,6 +507,36 @@ export const QWEN_EDIT_LIGHTNING_LORA = Object.freeze({
 export const SENSENOVA_DISTILL_MERGED_MARKER = "distill_merged.json";
 
 /**
+ * The files the InstantID identity stack must carry, per staged directory (sc-22738).
+ *
+ * `SCENEWORKS_INSTANTID_WEIGHTS` is a bundle DIRECTORY and `SCENEWORKS_INSTANTID_CONTROLNET` an
+ * IdentityNet directory, and the adapter refuses each by name when a file is absent
+ * (`lib.rs` `instantid_identity_bundle_at` over `INSTANTID_IDENTITY_BUNDLE_FILES`, and
+ * `instantid_controlnet_dir` over `INSTANTID_CONTROLNET_WEIGHT_FILE`). `--list` asked only whether
+ * the two directories existed, so a half-staged identity stack classified `runnable` and the
+ * capture died on the missing file — the same shape of miss the Qwen Lightning LoRA cost. Bound to
+ * those Rust constants by a test rather than restated, so neither list can drift alone.
+ */
+export const INSTANTID_IDENTITY_BUNDLE_FILES = Object.freeze([
+  "ip-adapter.safetensors",
+  "scrfd_10g.safetensors",
+  "arcface_iresnet100.safetensors",
+]);
+export const INSTANTID_CONTROLNET_WEIGHT_FILE = "diffusion_pytorch_model.safetensors";
+
+/**
+ * The stage-two official refinement LoRA both LTX-2.5 arms attach, relative to the SNAPSHOT root
+ * (sc-22738) — `mlx_ltx25.rs` `DEV_ADAPTER` and `candle.rs` `LTX25_DISTILL_LORA_RELATIVE_PATH`,
+ * which are the same string and are bound to this one by a test. It sits BESIDE the
+ * `<variant>/<tier>` load root rather than inside it, so nothing the tier probe reads can see it.
+ */
+export const LTX25_DEV_REFINEMENT_LORA = "distilled_lora/ltx-2.5-22b-distilled-lora-450-bf16.safetensors";
+
+/** The stock enhancer co-requisite the MLX LTX-2.5 arm requires beside the load root
+ *  (`mlx_ltx25.rs` `load_artifact`); the Candle arm never opens it. */
+export const LTX25_ENHANCER_DIR = "enhancer";
+
+/**
  * What `mlx_gen_minimax_h3::model::load` opens in the UPSTREAM snapshot root, at the pinned
  * revision (`crates/media/mlx-gen/mlx-gen-minimax-h3/src/model.rs`), read off the loader rather
  * than guessed from the manifest's download globs.
@@ -701,7 +731,12 @@ export const PROVIDER_FAMILIES = Object.freeze({
   instantid_realvisxl: {
     provider: "instantid", env: "INSTANTID_REALVISXL", repo: "SceneWorks/realvisxl-mlx", arms: ["mlx", "candle"],
     components: SDXL_COMPONENTS,
-    stagedEnv: ["SCENEWORKS_INSTANTID_WEIGHTS", "SCENEWORKS_INSTANTID_CONTROLNET"],
+    // Each staged directory declares the files the adapter opens INSIDE it (sc-22738): a directory
+    // that exists but is half-staged is exactly as unloadable as an absent one.
+    stagedEnv: [
+      { env: "SCENEWORKS_INSTANTID_WEIGHTS", files: INSTANTID_IDENTITY_BUNDLE_FILES },
+      { env: "SCENEWORKS_INSTANTID_CONTROLNET", files: [INSTANTID_CONTROLNET_WEIGHT_FILE] },
+    ],
   },
   flux2_dev: { env: "FLUX2", repo: "SceneWorks/flux2-dev-mlx", arms: ["mlx", "candle"] },
   // sc-22727. TWO catalog models ride this ONE engine provider id (worker engines.rs:
@@ -855,11 +890,25 @@ export const PROVIDER_FAMILIES = Object.freeze({
   // The harness prepares and binds the LTX-2.5 snapshot itself (`--ltx25-snapshot-root`), for
   // whichever lane the plan routes: BOTH engine ids below are served from the same public snapshot,
   // and both are declared here because the plan row's `provider` is what selects the family.
-  ltx_2_5: { ltx25: true, repo: LTX25_REPOSITORY, arms: ["mlx"] },
+  // `requiredSnapshotEntries` (sc-22738) are what each arm opens BESIDE `<variant>/<tier>`: the
+  // official stage-two refinement LoRA the dev variant attaches on both lanes, and — MLX only —
+  // the stock enhancer co-requisite `load_artifact` demands of every load. Neither is inside the
+  // load root, so the snapshot probe above cannot see them; without these an anchor whose planned
+  // cases include the dev variant classified `runnable` and failed after the booked session opened.
+  ltx_2_5: {
+    ltx25: true, repo: LTX25_REPOSITORY, arms: ["mlx"],
+    requiredSnapshotEntries: [
+      { path: LTX25_DEV_REFINEMENT_LORA },
+      { path: LTX25_ENHANCER_DIR, dir: true },
+    ],
+  },
   // The Candle arm loads LTX-2.5 under its own engine id (candle.rs `LTX25_ID`, `candle-gen-ltx`
   // `MODEL_25_ID`), so the candle plan rows name `ltx_2_5_distilled` while the anchor key — and
   // therefore the manifest download the snapshot root resolves through — stays `ltx_2_5`.
-  ltx_2_5_distilled: { ltx25: true, repo: LTX25_REPOSITORY, arms: ["candle"] },
+  ltx_2_5_distilled: {
+    ltx25: true, repo: LTX25_REPOSITORY, arms: ["candle"],
+    requiredSnapshotEntries: [{ path: LTX25_DEV_REFINEMENT_LORA }],
+  },
   // The turnkey still family (sc-22732). Five catalog models over three engine crates, each a plain
   // reference-free text-to-image route with its text encoder, transformer and decoder packed inside
   // the per-tier snapshot — so one root is the whole load and no `upstream` or `bundle` is needed.
@@ -1308,6 +1357,15 @@ export function snapshotPath(hub, repo, revision, ...rest) {
   return path.join(hub, `models--${repo.replaceAll("/", "--")}`, "snapshots", revision, ...rest);
 }
 
+/** Whether `candidate` is a readable regular file (a symlink into the HF blob store counts). */
+async function isFile(candidate) {
+  try {
+    return (await stat(candidate)).isFile();
+  } catch {
+    return false;
+  }
+}
+
 async function firstExistingDirectory(candidates) {
   for (const candidate of candidates) {
     try {
@@ -1376,6 +1434,20 @@ export async function classifyAnchor(key, planned, { models, backend, hubs, curr
     const snapshot = await firstExistingDirectory(hubs.map((hub) => snapshotPath(hub, family.repo, download.revision)));
     row.roots.push({ label: "ltx25 snapshot", path: snapshot ?? snapshotPath(hubs[0], family.repo, download.revision) });
     if (!snapshot) return { ...row, status: "weights_missing", reason: `no ${family.repo}@${download.revision.slice(0, 8)} snapshot on this host` };
+    const missingSnapshot = [];
+    for (const entry of family.requiredSnapshotEntries ?? []) {
+      const candidate = path.join(snapshot, entry.path);
+      const present = entry.dir
+        ? (await firstExistingDirectory([candidate])) !== null
+        : await isFile(candidate);
+      if (!present) missingSnapshot.push(entry.path);
+    }
+    if (missingSnapshot.length > 0) {
+      return {
+        ...row, status: "weights_missing",
+        reason: `${family.repo} snapshot ${snapshot} is missing ${missingSnapshot.join(", ")}, which the ${backend} arm opens beside the load root`,
+      };
+    }
     row.ltx25SnapshotRoot = snapshot;
     row.physical = false;
     return row;
@@ -1564,12 +1636,23 @@ export async function classifyAnchor(key, planned, { models, backend, hubs, curr
   // An identity stack the worker fetches on first use rather than declaring as a manifest download
   // has nothing for the harness to resolve, so the operator stages it and names it here. An unset
   // or absent path is `weights_missing` — the host simply lacks the artifact — not a gap.
-  for (const name of family.stagedEnv ?? []) {
+  for (const staging of family.stagedEnv ?? []) {
+    const name = staging.env;
     const staged = process.env[name];
     const root = staged ? await firstExistingDirectory([staged]) : null;
     row.roots.push({ label: `staged ${name}`, path: staged ?? `(${name} unset)` });
     if (!root) {
       return { ...row, status: "weights_missing", reason: `${name} is unset or names no directory on this host` };
+    }
+    const missingStaged = [];
+    for (const file of staging.files ?? []) {
+      if (!(await isFile(path.join(root, file)))) missingStaged.push(file);
+    }
+    if (missingStaged.length > 0) {
+      return {
+        ...row, status: "weights_missing",
+        reason: `${name} directory ${root} is missing ${missingStaged.join(", ")}, which the adapter arm opens under it`,
+      };
     }
     row.env[name] = root;
   }
@@ -1581,6 +1664,19 @@ export async function classifyAnchor(key, planned, { models, backend, hubs, curr
     row.roots.push({ label: "side artifact", path: sideRoot ?? snapshotPath(hubs[0], side.repo, side.revision) });
     if (!sideRoot) {
       return { ...row, status: "weights_missing", reason: `no ${side.repo}@${side.revision.slice(0, 8)} snapshot on this host` };
+    }
+    // sc-22738. A PRESENT snapshot is not the pinned FILE. The Lightning snapshot staged on this
+    // capture host holds the 8-step distill and NOT the pinned 4-step one the arm joins
+    // (mlx.rs / candle.rs `qwen_edit_lightning_adapter`, `protocol::QWEN_EDIT_LIGHTNING_FILE`), so
+    // asking only whether the snapshot directory existed reported all three
+    // `qwen_image_edit_2511_lightning` cells runnable and every booked capture died on
+    // `the Lightning distill LoRA is not at …`. The declared file IS the one the arm opens, so an
+    // incomplete mirror is `weights_missing` — named — exactly like an absent one.
+    if (side.file && !(await isFile(path.join(sideRoot, side.file)))) {
+      return {
+        ...row, status: "weights_missing",
+        reason: `${side.repo} snapshot ${sideRoot} is missing ${side.file}, which the adapter arm attaches as this member's distill LoRA`,
+      };
     }
     row.env[`SCENEWORKS_${side.env}_REPOSITORY`] = side.repo;
     row.env[`SCENEWORKS_${side.env}_REVISION`] = side.revision;

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -58,6 +58,12 @@ import {
   MINIMAX_TEXT_ENCODER_CONFIG,
   MINIMAX_TIER_DIT_FILES,
   requiredFilesFor,
+  QWEN_EDIT_LIGHTNING_LORA,
+  LTX25_REPOSITORY,
+  LTX25_DEV_REFINEMENT_LORA,
+  LTX25_ENHANCER_DIR,
+  INSTANTID_IDENTITY_BUNDLE_FILES,
+  INSTANTID_CONTROLNET_WEIGHT_FILE,
 } from "./measure-memory-catalog.mjs";
 import {
   ANCHOR_LANE_DEFAULT_STRATEGY_PATH,
@@ -132,6 +138,15 @@ function fakeModels() {
       ],
     },
     { id: "chroma1_hd", downloads: [{ repo: "SceneWorks/chroma1-hd-mlx", revision: REVISION, variant: "q4", files: ["q4/*"] }] },
+    // sc-22738: the InstantID route — the plain RealVisXL rehost plus the three caller-staged SDXL
+    // components, and an identity stack that is no download at all but two staged directories.
+    {
+      id: "instantid_realvisxl",
+      downloads: [
+        { repo: "SceneWorks/realvisxl-mlx", revision: REVISION, variant: "q4", files: ["q4/*"] },
+        ...SDXL_COMPONENTS.map(({ repo }) => ({ repo, revision: UPSTREAM, coRequisite: true, files: ["*"] })),
+      ],
+    },
     // The turnkey still family (sc-22732). Kolors and the two Lens models each ship every tier from
     // one repository; the two Ideogram models ship q4/q8 from the packed turnkey and bf16 from a
     // SECOND repository at a SECOND revision, which is the case the family's `tiers` override
@@ -189,6 +204,26 @@ async function stageMinimaxFiles(hub, tier, { omit = [] } = {}) {
       await writeFile(path.join(root, file), "{}\n");
     }
   }
+}
+
+/**
+ * The two artifacts the LTX-2.5 arms open BESIDE `<variant>/<tier>` (sc-22738), staged into the
+ * snapshot root. `omit` names the one a test wants absent.
+ */
+async function stageLtx25SnapshotEntries(hub, { omit = [] } = {}) {
+  const snapshot = snapshotPath(hub, LTX25_REPOSITORY, REVISION);
+  if (!omit.includes(LTX25_DEV_REFINEMENT_LORA)) {
+    await mkdir(path.join(snapshot, path.dirname(LTX25_DEV_REFINEMENT_LORA)), { recursive: true });
+    await writeFile(path.join(snapshot, LTX25_DEV_REFINEMENT_LORA), "lora");
+  }
+  if (!omit.includes(LTX25_ENHANCER_DIR)) await mkdir(path.join(snapshot, LTX25_ENHANCER_DIR), { recursive: true });
+}
+
+/** The pinned Lightning distill LoRA file inside its already-staged snapshot (sc-22738). */
+async function stageQwenLightningLora(hub, file = QWEN_EDIT_LIGHTNING_LORA.file) {
+  const root = snapshotPath(hub, QWEN_EDIT_LIGHTNING_LORA.repo, QWEN_EDIT_LIGHTNING_LORA.revision);
+  await mkdir(root, { recursive: true });
+  await writeFile(path.join(root, file), "lora");
 }
 
 async function fakeHub(layout) {
@@ -325,6 +360,7 @@ test("classification: runnable anchors carry the adapter env family and the cano
   // documents in the upstream one. A bare directory tree is what this host really had, and what
   // `--list` used to call runnable.
   await stageMinimaxFiles(hub, "q4");
+  await stageLtx25SnapshotEntries(hub);
   const context = { models: fakeModels(), backend: "mlx", hubs: [hub], current: new Map(), captured: new Map() };
   const qwen = await classifyAnchor("qwen_image:q4:mlx", { provider: "qwen_image" }, context);
   assert.equal(qwen.status, "runnable");
@@ -588,6 +624,7 @@ test("the qwen edit family derives the tier root on both lanes, and Lightning al
     ["SceneWorks/qwen-image-edit-2511-mlx", REVISION, "q4"],
     [lora.repo, lora.revision],
   ]);
+  await stageQwenLightningLora(hub);
   for (const backend of ["mlx", "candle"]) {
     const context = { models: fakeModels(), backend, hubs: [hub], current: new Map(), captured: new Map() };
     const planned = { provider: "qwen_image_edit", mode: "edit_image" };
@@ -620,6 +657,133 @@ test("the qwen edit family derives the tier root on both lanes, and Lightning al
   const missing = await classifyAnchor("qwen_image_edit_2511_lightning:q4:mlx", planned, context);
   assert.equal(missing.status, "weights_missing");
   assert.match(missing.reason, /Qwen-Image-Edit-2511-Lightning@/);
+});
+
+// sc-22738. The campaign lost all three `qwen_image_edit_2511_lightning:*:mlx` captures to
+// `memory-strategy provider adapter: the Lightning distill LoRA is not at …-4steps-V1.0-bf16.safetensors`.
+// `--list` had called them runnable because the side-artifact probe asked only whether the SNAPSHOT
+// existed — and the snapshot staged on that host carries the 8-step distill, not the pinned 4-step
+// one the arm joins. A present snapshot is not the pinned file.
+test("a Lightning cell whose distill snapshot lacks the pinned LoRA file is weights_missing, by name", async () => {
+  const lora = QWEN_EDIT_LIGHTNING_LORA;
+  const planned = { provider: "qwen_image_edit", mode: "edit_image" };
+  const layout = [
+    ["SceneWorks/qwen-image-edit-2511-mlx", REVISION, "q4"],
+    [lora.repo, lora.revision],
+  ];
+  // The exact host condition: the snapshot is there, holding the WRONG step count.
+  const holed = await fakeHub(layout);
+  await stageQwenLightningLora(holed, "Qwen-Image-Edit-2511-Lightning-8steps-V1.0-bf16.safetensors");
+  const context = (hub) => ({ models: fakeModels(), backend: "mlx", hubs: [hub], current: new Map(), captured: new Map() });
+  const refused = await classifyAnchor("qwen_image_edit_2511_lightning:q4:mlx", planned, context(holed));
+  assert.equal(refused.status, "weights_missing", refused.reason);
+  assert.match(refused.reason, new RegExp(lora.file.replaceAll(".", "\\.")), "the reason names the file the arm opens");
+  assert.match(refused.reason, new RegExp(snapshotPath(holed, lora.repo, lora.revision)), "and the root it looked in");
+  // The base id shares the tier root and attaches no LoRA, so it is untouched by the refusal.
+  assert.equal((await classifyAnchor("qwen_image_edit_2511:q4:mlx", planned, context(holed))).status, "runnable");
+  // And with the pinned file staged, the same cell is runnable — the probe is the file, not the name.
+  const complete = await fakeHub(layout);
+  await stageQwenLightningLora(complete);
+  const row = await classifyAnchor("qwen_image_edit_2511_lightning:q4:mlx", planned, context(complete));
+  assert.equal(row.status, "runnable", row.reason);
+});
+
+// sc-22738. The same class of miss on the other two families whose arms open something the tier or
+// snapshot probe never looked at: the LTX-2.5 stage-two refinement LoRA and stock enhancer, and the
+// InstantID identity stack's staged files. A directory that exists but is half-staged is exactly as
+// unloadable as an absent one, and calling either `runnable` books a capture that cannot open.
+test("an LTX-2.5 snapshot missing what the arm opens beside the load root is weights_missing, by name", async () => {
+  const context = (hub, backend) => ({ models: fakeModels(), backend, hubs: [hub], current: new Map(), captured: new Map() });
+  // MLX needs both; Candle attaches the LoRA and never opens the enhancer.
+  const noLora = await fakeHub([[LTX25_REPOSITORY, REVISION, "distilled"]]);
+  await stageLtx25SnapshotEntries(noLora, { omit: [LTX25_DEV_REFINEMENT_LORA] });
+  for (const [backend, provider] of [["mlx", "ltx_2_5"], ["candle", "ltx_2_5_distilled"]]) {
+    const row = await classifyAnchor(`ltx_2_5:q4:${backend}`, { provider }, context(noLora, backend));
+    assert.equal(row.status, "weights_missing", `${backend}: ${row.reason}`);
+    assert.match(row.reason, /distilled_lora\/ltx-2\.5-22b-distilled-lora-450-bf16\.safetensors/);
+  }
+  const noEnhancer = await fakeHub([[LTX25_REPOSITORY, REVISION, "distilled"]]);
+  await stageLtx25SnapshotEntries(noEnhancer, { omit: [LTX25_ENHANCER_DIR] });
+  const mlx = await classifyAnchor("ltx_2_5:q4:mlx", { provider: "ltx_2_5" }, context(noEnhancer, "mlx"));
+  assert.equal(mlx.status, "weights_missing", mlx.reason);
+  assert.match(mlx.reason, /enhancer/);
+  const candle = await classifyAnchor("ltx_2_5:q4:candle", { provider: "ltx_2_5_distilled" }, context(noEnhancer, "candle"));
+  assert.equal(candle.status, "runnable", "the Candle arm never opens the enhancer, so it must not be required of it");
+});
+
+test("an InstantID cell whose staged identity stack is missing a file is weights_missing, by name", async () => {
+  const hub = await fakeHub([
+    ["SceneWorks/realvisxl-mlx", REVISION, "q4"],
+    ...SDXL_COMPONENTS.map(({ repo }) => [repo, UPSTREAM]),
+  ]);
+  const weights = await mkdtemp(path.join(tmpdir(), "instantid-weights-"));
+  const controlnet = await mkdtemp(path.join(tmpdir(), "instantid-controlnet-"));
+  const previous = { ...process.env };
+  process.env.SCENEWORKS_INSTANTID_WEIGHTS = weights;
+  process.env.SCENEWORKS_INSTANTID_CONTROLNET = controlnet;
+  try {
+    const planned = { provider: "instantid" };
+    const context = { models: fakeModels(), backend: "mlx", hubs: [hub], current: new Map(), captured: new Map() };
+    // Two empty directories: what `--list` used to call a staged identity stack.
+    const bare = await classifyAnchor("instantid_realvisxl:q4:mlx", planned, context);
+    assert.equal(bare.status, "weights_missing", bare.reason);
+    assert.match(bare.reason, new RegExp(INSTANTID_IDENTITY_BUNDLE_FILES[0].replaceAll(".", "\\.")));
+    // The bundle complete, the IdentityNet directory still empty: refused on its own file.
+    for (const file of INSTANTID_IDENTITY_BUNDLE_FILES) await writeFile(path.join(weights, file), "weights");
+    const half = await classifyAnchor("instantid_realvisxl:q4:mlx", planned, context);
+    assert.equal(half.status, "weights_missing", half.reason);
+    assert.match(half.reason, new RegExp(INSTANTID_CONTROLNET_WEIGHT_FILE.replaceAll(".", "\\.")));
+    await writeFile(path.join(controlnet, INSTANTID_CONTROLNET_WEIGHT_FILE), "weights");
+    const row = await classifyAnchor("instantid_realvisxl:q4:mlx", planned, context);
+    assert.equal(row.status, "runnable", row.reason);
+    assert.equal(row.env.SCENEWORKS_INSTANTID_WEIGHTS, weights);
+    assert.equal(row.env.SCENEWORKS_INSTANTID_CONTROLNET, controlnet);
+  } finally {
+    process.env = previous;
+  }
+});
+
+// The three declarations above are the ADAPTER's own constants, not this script's opinion of them.
+// A drift on either side would send a capture at an artifact the arm does not open (or refuse one it
+// does), so each is read out of the Rust source and compared.
+test("the extra artifacts declared per family are the ones the adapter source names", async () => {
+  const lib = await readFile(path.join(ROOT, "crates/sceneworks-memory-adapter/src/lib.rs"), "utf8");
+  const bundleFiles = /pub const INSTANTID_IDENTITY_BUNDLE_FILES: \[&str; 3\] = \[([\s\S]*?)\];/.exec(lib);
+  assert.ok(bundleFiles, "lib.rs still declares INSTANTID_IDENTITY_BUNDLE_FILES");
+  const named = [...bundleFiles[1].matchAll(/INSTANTID_([A-Z_]+)_FILE/g)].map(([, stem]) => {
+    const value = new RegExp(`pub const INSTANTID_${stem}_FILE: &str = "([^"]+)"`).exec(lib);
+    assert.ok(value, `lib.rs still declares INSTANTID_${stem}_FILE`);
+    return value[1];
+  });
+  assert.deepEqual([...INSTANTID_IDENTITY_BUNDLE_FILES], named, "the staged bundle list is the adapter's own");
+  assert.equal(
+    /pub const INSTANTID_CONTROLNET_WEIGHT_FILE: &str = "([^"]+)"/.exec(lib)?.[1],
+    INSTANTID_CONTROLNET_WEIGHT_FILE,
+  );
+  const instantid = PROVIDER_FAMILIES.instantid_realvisxl.stagedEnv;
+  assert.deepEqual(instantid.map((entry) => entry.env), [
+    /pub const INSTANTID_IDENTITY_BUNDLE_ENV: &str = "([^"]+)"/.exec(lib)?.[1],
+    /pub const INSTANTID_CONTROLNET_ENV: &str = "([^"]+)"/.exec(lib)?.[1],
+  ], "each staged directory is bound to the env var the adapter reads");
+  assert.ok(instantid.every((entry) => (entry.files ?? []).length > 0), "and each declares what it must carry");
+
+  const mlxLtx25 = await readFile(path.join(ROOT, "crates/sceneworks-memory-adapter/src/bin/mlx_ltx25.rs"), "utf8");
+  const candle = await readFile(path.join(ROOT, "crates/sceneworks-memory-adapter/src/bin/candle.rs"), "utf8");
+  assert.equal(/const DEV_ADAPTER: &str = "([^"]+)"/.exec(mlxLtx25)?.[1], LTX25_DEV_REFINEMENT_LORA);
+  assert.equal(
+    /const LTX25_DISTILL_LORA_RELATIVE_PATH: &str =\s*"([^"]+)"/.exec(candle)?.[1],
+    LTX25_DEV_REFINEMENT_LORA,
+    "both lanes attach the same file, so one declaration serves both families",
+  );
+  assert.match(mlxLtx25, new RegExp(`join\\("${LTX25_ENHANCER_DIR}"\\)`), "the MLX arm still opens the enhancer by that name");
+
+  const mlx = await readFile(path.join(ROOT, "crates/sceneworks-memory-adapter/src/bin/mlx.rs"), "utf8");
+  assert.equal(
+    /pub const QWEN_EDIT_LIGHTNING_FILE: &str =\s*"([^"]+)"/.exec(lib)?.[1],
+    QWEN_EDIT_LIGHTNING_LORA.file,
+    "the declared distill LoRA is the file the arm joins",
+  );
+  assert.match(mlx, /join\(protocol::QWEN_EDIT_LIGHTNING_FILE\)/);
 });
 
 // The catalog's `physical` flag and the harness's receipt predicate are two spellings of one rule,
@@ -892,6 +1056,7 @@ test("every sana/chroma env family and repository is the one the adapter binarie
 // families must therefore derive the same snapshot root, on their own lane and on no other.
 test("the LTX-2.5 family derives the same snapshot root on both lanes, under each lane's engine id", async () => {
   const hub = await fakeHub([["SceneWorks/ltx-2.5-mlx", REVISION, "distilled"]]);
+  await stageLtx25SnapshotEntries(hub);
   const expected = snapshotPath(hub, "SceneWorks/ltx-2.5-mlx", REVISION);
   for (const [backend, provider] of [["mlx", "ltx_2_5"], ["candle", "ltx_2_5_distilled"]]) {
     const context = { models: fakeModels(), backend, hubs: [hub], current: new Map(), captured: new Map() };


### PR DESCRIPTION
## The miss

All three `qwen_image_edit_2511_lightning:{bf16,q4,q8}:mlx` captures died at
`memory-strategy provider adapter: the Lightning distill LoRA is not at /Volumes/Models/huggingface/hub/models--lightx2v--Qwen-Image-Edit-2511-Lightning/snapshots/d74eba14.../Qwen-Image-Edit-2511-Lightning-4steps-V1.0-bf16.safetensors`.

`--list --backend mlx` had called all three `runnable`: the `sideArtifact` probe
asked only whether the LoRA SNAPSHOT DIRECTORY existed. It does — and it holds the
**8-step** distill, not the pinned **4-step** file the arm joins
(`mlx.rs`/`candle.rs` `qwen_edit_lightning_adapter` →
`protocol::QWEN_EDIT_LIGHTNING_FILE`). A present snapshot is not the pinned file,
exactly as #2748 found for MiniMax's dense `text_encoder/`.

**Host condition, not fixed here:** this Mac has only the 8-step LoRA staged. The
three Lightning MLX cells now classify `weights_missing` naming the 4-step file
and the snapshot root, instead of booking a capture that cannot open.

## The sweep

Every family whose arm opens an artifact outside the tier root was checked
against its declaration. Two more had the same gap:

| family | extra artifact | was | now |
| --- | --- | --- | --- |
| `qwen_image_edit` (`_lightning` member) | `<lora snapshot>/…-4steps-V1.0-bf16.safetensors` | snapshot dir only | file probed by name |
| `instantid_realvisxl` | `SCENEWORKS_INSTANTID_WEIGHTS/{ip-adapter,scrfd_10g,arcface_iresnet100}.safetensors`, `SCENEWORKS_INSTANTID_CONTROLNET/diffusion_pytorch_model.safetensors` | both dirs only | files probed per staged dir |
| `ltx_2_5` (mlx) / `ltx_2_5_distilled` (candle) | `distilled_lora/ltx-2.5-22b-distilled-lora-450-bf16.safetensors` (both lanes), `enhancer/` (mlx only) | snapshot dir only | probed beside the load root |

Already correct and left alone: `pulid_flux` (`bundle.files`), the SenseNova
`_fast` marker, MiniMax's two roots (#2748), Mage-Flow's per-tier component dirs,
the SDXL component snapshots (revision-level, no file reads in the arm), and the
LTX-2.3 Gemma `siblingRoots` (the arm validates the directory). The strict-control
overlay providers remain out of the table — they are not manifest models, so
`--list` never asks about them.

Not declared, deliberately: LTX-2.5's `vae_diffusion_decoder.safetensors`. It
lives INSIDE the `<variant>/<tier>` load root and is required only of DiffVAE
targets, and the anchor key (`ltx_2_5:<tier>:<backend>`) carries no variant, so
the `ltx25` branch has no root to probe it under.

## Verification

* Each declaration is bound to the adapter's own Rust constant by
  `the extra artifacts declared per family are the ones the adapter source names`
  (parses `lib.rs`, `mlx_ltx25.rs`, `candle.rs`), so neither side can drift alone.
* Three negative tests reproduce the exact host conditions (the 8-step LoRA in
  place of the 4-step; an empty then half-staged InstantID stack; a snapshot
  missing the refinement LoRA / the enhancer) and assert `weights_missing` naming
  the file AND the root. Each also asserts the neighbouring cell that does NOT
  load the artifact stays `runnable` — the candle LTX-2.5 arm never opens the
  enhancer, and `qwen_image_edit_2511` attaches no LoRA.
* Mutation, one declaration at a time, `touch` between runs: drop the side-artifact
  file probe → Lightning test RED; drop the InstantID `files` → InstantID test +
  the binding test RED; drop `requiredSnapshotEntries` → LTX-2.5 test RED.
* `node --test scripts/measure-memory-catalog.test.mjs scripts/anchor-loader-closure.test.mjs` → exit 0, 108 pass / 0 fail / 2 skipped.
* `npm run check` → red only in the untouched `scripts/memory-calibration-watchdog.test.mjs`,
  a DIFFERENT timing assertion each run, and green 34/34 when that file runs alone —
  host contention from the MLX campaign holding the GPU, not this change.

No Rust touched. No pin site touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)