### PR TITLE
ci(sc-22738): campaign fetches inference once, shallow, into a persistent per-runner clone

### DIFF
--- a/.github/workflows/memory-catalog-campaign.yml
+++ b/.github/workflows/memory-catalog-campaign.yml
@@ -129,6 +129,9 @@ jobs:
       CARGO_NET_OFFLINE: "true"
       BACKEND: mlx
       DEFAULT_HF_CACHE: /Volumes/Models/huggingface/hub
+      # No INFERENCE_CLONE_DIR here: a job-level `env:` cannot expand $HOME, and the Macs want
+      # exactly the script's default, `$HOME/memory-catalog-inference`. The candle lane sets it
+      # because its clone belongs on D: rather than in the runner user's profile.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -172,6 +175,13 @@ jobs:
             exit "$rc"
           fi
 
+      # BEFORE `cargo fetch`, ON PURPOSE. This is the ONE network fetch of the ~650 MB inference repo
+      # the job makes: it lands a persistent, shallow clone and exports the GIT_CONFIG_* rewrite that
+      # makes cargo's git transport read from THAT clone instead of pulling the repo a second time.
+      # See the header of scripts/ci/memory-catalog/inference.sh.
+      - name: Clone the pinned inference revision
+        run: bash scripts/ci/memory-catalog/inference.sh
+
       - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
@@ -182,9 +192,6 @@ jobs:
           cargo build --release --locked -p sceneworks-memory-adapter \
             --features mlx --bin memory-mlx-adapter
           echo "ADAPTER=$CARGO_TARGET_DIR/release/memory-mlx-adapter" >> "$GITHUB_ENV"
-
-      - name: Clone the pinned inference revision
-        run: bash scripts/ci/memory-catalog/inference.sh
 
       - name: Plan the walk
         run: bash scripts/ci/memory-catalog/plan.sh
@@ -235,6 +242,10 @@ jobs:
       CARGO_NET_OFFLINE: "true"
       BACKEND: candle
       DEFAULT_HF_CACHE: 'E:\huggingface\hub'
+      # The persistent inference clone, on the drive this runner already keeps its per-runner caches
+      # on. Deliberately NOT under $GITHUB_WORKSPACE or $RUNNER_TEMP: both are wiped between jobs,
+      # which is what made every dispatch re-pull ~650 MB over this box's slow link.
+      INFERENCE_CLONE_DIR: 'D:\memory-catalog-inference'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -327,6 +338,14 @@ jobs:
       - name: Prepare the Rust toolchain
         uses: ./.github/actions/prepare-rust-runner
 
+      # BEFORE `cargo fetch`, ON PURPOSE -- and this lane is why. Run 34044786385 spent 70 minutes at
+      # ~150 KB/s in cargo's git fetch of the inference repo, died with `fetch-pack: unexpected
+      # disconnect`, and started over. This step does the ONE fetch, shallow, into a clone on D: that
+      # outlives the job, and exports the GIT_CONFIG_* rewrite pointing cargo at it. See the header
+      # of scripts/ci/memory-catalog/inference.sh.
+      - name: Clone the pinned inference revision
+        run: bash scripts/ci/memory-catalog/inference.sh
+
       - name: Fetch the pinned inference release
         env:
           CARGO_NET_OFFLINE: "false"
@@ -342,9 +361,6 @@ jobs:
           cargo build --release --locked -p sceneworks-memory-adapter --features candle --bin memory-candle-adapter
           if errorlevel 1 exit /b 1
           echo ADAPTER=%GITHUB_WORKSPACE%\target\release\memory-candle-adapter.exe>>%GITHUB_ENV%
-
-      - name: Clone the pinned inference revision
-        run: bash scripts/ci/memory-catalog/inference.sh
 
       - name: Plan the walk
         run: bash scripts/ci/memory-catalog/plan.sh

--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -769,17 +769,58 @@ only way to check (`gh api /orgs/SceneWorks/actions/runners` 403s without `admin
 before assuming `rw-krea` is still the second Mac, and remember that a label no runner carries does
 not fail the dispatch: the job queues silently until the run is cancelled.
 
-**What the job does.** Checks out `ref` at full depth, cuts a NEW branch
-`story/<campaign>-<backend>-campaign-<run_id>` (the walk commits on the current branch and refuses a
-detached HEAD, and this keeps it off `feature/*` and `main`), builds the release adapter
-(`--features mlx --bin memory-mlx-adapter`, or `--features candle --bin memory-candle-adapter` under
-`vcvars64`), clones inference at the pin into a sibling of the workspace, prints the `--list` table
-as the job summary, runs `--dry-run`, then walks for real with `--work-dir` under `$RUNNER_TEMP`.
+**What the job does.** Checks out `ref` shallowly (`fetch-depth: 1` — nothing in the campaign reads
+history beyond HEAD, and a full clone of this repo's 2+ GiB pack was costing 27+ minutes on the
+Windows box), cuts a NEW branch `story/<campaign>-<backend>-campaign-<run_id>` (the walk commits on
+the current branch and refuses a detached HEAD, and this keeps it off `feature/*` and `main`),
+prepares the inference clone, builds the release adapter (`--features mlx --bin memory-mlx-adapter`,
+or `--features candle --bin memory-candle-adapter` under `vcvars64`), prints the `--list` table as
+the job summary, runs `--dry-run`, then walks for real with `--work-dir` under `$RUNNER_TEMP`.
+
+**Inference is fetched ONCE, shallow, into a clone that outlives the job.** The campaign used to
+download the ~650 MB inference repo twice per dispatch — once by `cargo fetch --locked` (the
+workspace pins `candle-kernels` at a `SceneWorks/inference` rev and `.cargo/config.toml` sets
+`git-fetch-with-cli = true`) and once by `scripts/ci/memory-catalog/inference.sh`. On the Windows
+CUDA box that was fatal rather than merely slow: run 34044786385 sat 70 minutes at ~150 KB/s inside
+cargo's fetch, died with `fetch-pack: unexpected disconnect`, and started over.
+
+So `inference.sh` now runs **before** `cargo fetch` and does the only network fetch of that repo the
+job makes:
+
+- **Persistent.** The clone lives at `$INFERENCE_CLONE_DIR` — `D:\memory-catalog-inference` on the
+  CUDA box (set in the job env; `D:` is where that runner already keeps its per-runner caches),
+  `$HOME/memory-catalog-inference` on the Macs (the script's default, because a job-level `env:`
+  cannot expand `$HOME`). Not under `$GITHUB_WORKSPACE` or `$RUNNER_TEMP`: both are wiped between
+  jobs, which is what made every dispatch re-pull the repo. A directory that is not a clone of
+  `SceneWorks/inference` is discarded and re-initialised rather than fetched into.
+- **Shallow, and only the revisions this walk needs.** `git fetch --depth 1` for the pin **plus**
+  every revision `node scripts/anchor-loader-closure.mjs --anchor-revisions` prints — the harness
+  runs `--stamp-anchors` per anchor, which digests each packaged anchor's loader closure at *its
+  own* record's (or attested) inference revision, generally older than the pin and not necessarily
+  on any branch tip. That flag exists to be this fetch list, derived from the same store the
+  stamping walks, so the two cannot drift. All the missing revisions go in ONE fetch, so the server
+  deltas their trees against each other instead of sending one full tree apiece; the fetch retries
+  five times with backoff, because the observed failure is a dropped transfer, not a bad revision.
+- **Cargo reads the clone, not github.com.** The step exports `GIT_CONFIG_COUNT=1` /
+  `GIT_CONFIG_KEY_0=url.file://<clone>.insteadOf` / `GIT_CONFIG_VALUE_0=https://github.com/SceneWorks/inference`
+  into `$GITHUB_ENV`, git's own env-config channel (git ≥ 2.31). It has to be the environment and
+  not `git config --global`: the `git-fetch-with-cli` path spawns git with an empty `HOME` and
+  `GIT_CONFIG_NOSYSTEM=1` for this public repo (sc-17879), so no config *file* is read at all. The
+  rewrite is git-level, so `Cargo.lock` and the cargo db name still key on the github.com URL —
+  only the bytes' origin changes. `cargo fetch` emits one benign warning, `rejected
+  refs/commit/<pin> because shallow roots are not allowed to be updated`; the commit still lands.
+
+Measured on a Mac against the live remote: 11 revisions, 35 s and a 513 MB `.git` on a cold clone,
+0 s and no fetch on the second run, `cargo fetch --locked` exit 0 both times with the pin present in
+`$CARGO_HOME/git/db/inference-*`. The other git dependencies (mlx-rs, mlx-c, candle) are untouched
+by the single rewrite and still fetch from their own remotes.
 
 **The inference pin is derived, never typed.** The job reads `pub const INFERENCE_PIN` out of
 `crates/sceneworks-memory-adapter/src/lib.rs` — the same constant `compiledInferencePin()` reads —
 and hard-fails unless the clone's HEAD equals it and the tree is clean. `npm run bump:inference`
-moves both at once; this workflow needs no edit on a pin bump and writes to no pin site.
+moves both at once; this workflow needs no edit on a pin bump and writes to no pin site. A pin bump
+simply adds one revision to the next run's fetch list; everything already in the persistent clone is
+reused.
 
 **Partial results survive.** The walk runs in the background while a poller pushes the branch every
 `push_every` landed anchor commits, and a further `if: always()` push runs after success, failure,

--- a/scripts/ci/memory-catalog/common.sh
+++ b/scripts/ci/memory-catalog/common.sh
@@ -28,6 +28,21 @@ unix_path() {
   fi
 }
 
+# `file://` URL of a local directory, in the ONE spelling Git for Windows accepts.
+#
+# Git parses a `file://` URL itself rather than handing it to the OS, and on Windows it only
+# recognises a drive path in the MIXED form with a leading slash -- `file:///D:/dir`. Neither the
+# unix form (`file:///d/dir`, no such path to Windows) nor the native form (`file://D:\dir`, the
+# backslashes read as a host) resolves. `cygpath -m` is exactly that mixed spelling; on macOS the
+# unix path is already absolute, so `file://` + the path is the whole answer.
+file_url() {
+  if command -v cygpath >/dev/null 2>&1; then
+    printf 'file:///%s' "$(cygpath -m "$1")"
+  else
+    printf 'file://%s' "$1"
+  fi
+}
+
 # One path segment, exactly the shape `measure-memory-catalog.mjs --campaign` accepts. Validated
 # here as well because it is interpolated into a branch name and a directory name.
 require_campaign() {

--- a/scripts/ci/memory-catalog/inference.sh
+++ b/scripts/ci/memory-catalog/inference.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Put a CLEAN inference checkout at the pinned revision beside (never inside) the SceneWorks tree.
+# Put a CLEAN inference checkout at the pinned revision in a PERSISTENT per-runner clone (sc-22738).
 #
 # PIN RESOLUTION IS DERIVED, NEVER TYPED. `measure-memory-catalog.mjs` reads the pin out of
 # `crates/sceneworks-memory-adapter/src/lib.rs` (`compiledInferencePin()` -> `pub const
@@ -8,10 +8,40 @@
 # disagree: bumping the pin with `npm run bump:inference` moves both at once and this workflow needs
 # no edit. Nothing here writes to any pin site.
 #
-# The clone lives OUTSIDE the checkout (a sibling of $GITHUB_WORKSPACE), because the harness asserts
-# the SceneWorks tree stays clean for the whole walk and counts untracked paths.
+# WHY THIS RUNS BEFORE `cargo fetch`, AND WHY THE CLONE OUTLIVES THE JOB.
+# ---------------------------------------------------------------------------------------------
+# The inference repo is ~650 MB packed and the campaign used to pull it TWICE per dispatch: once by
+# `cargo fetch --locked` (the workspace pins candle-kernels at a `SceneWorks/inference` rev, and
+# `.cargo/config.toml` sets `git-fetch-with-cli = true`) and once here. On the Windows CUDA box that
+# is a link, not a repo, problem: run 34044786385 spent 70 minutes at ~150 KB/s inside cargo's git
+# fetch before dying with `fetch-pack: unexpected disconnect / early EOF`, then started a second
+# 70-minute attempt. Nothing was reused, because the workspace and `$RUNNER_TEMP` are both wiped
+# between jobs.
+#
+# So this step now runs FIRST and does the ONE network fetch the job needs, and the workflow points
+# cargo's git transport at the result with a `url.<file://clone>.insteadOf` rewrite (see the
+# GIT_CONFIG_* exports at the bottom). Two things make that cheap:
+#
+#   * PERSISTENT. The clone lives at $INFERENCE_CLONE_DIR, a fixed per-runner path OUTSIDE the
+#     workspace, so the next dispatch fetches only what it is missing -- normally nothing at all.
+#   * SHALLOW. `--depth 1` for each wanted commit, never a full history clone. The 2+ GiB of history
+#     buys this job nothing: every consumer reads TREES at named revisions, never a log, a
+#     merge-base or a describe.
+#
+# WHICH REVISIONS. Not just the pin. `anchor-loader-closure.mjs --stamp-anchors`, which the harness
+# runs per anchor, digests each packaged anchor's loader closure AT ITS OWN record's inference
+# revision (or an attested one), which is generally older than the pin and need not sit on any
+# branch tip. `--anchor-revisions` prints exactly that set, derived from the same store the stamping
+# walks, and needs no clone -- it IS the fetch list for a shallow clone, and deriving it from the
+# store is what stops the two drifting apart. A revision missing here surfaces as a stamping failure
+# hours into the walk, so the fetch of the list is a hard failure, not a warning.
+#
+# The clone must sit OUTSIDE the checkout: the harness asserts the SceneWorks tree stays clean for
+# the whole walk and counts untracked paths.
 # shellcheck source=scripts/ci/memory-catalog/common.sh
 source "$(dirname "$0")/common.sh"
+
+INFERENCE_URL="https://github.com/SceneWorks/inference"
 
 PIN="$(sed -n 's/^pub const INFERENCE_PIN: &str = "\([0-9a-f]\{40\}\)";.*/\1/p' \
   crates/sceneworks-memory-adapter/src/lib.rs | head -n 1)"
@@ -21,25 +51,84 @@ if [[ ! "$PIN" =~ ^[0-9a-f]{40}$ ]]; then
 fi
 echo "pinned inference revision: $PIN"
 
-WORKSPACE_U="$(unix_path "$GITHUB_WORKSPACE")"
-REPO_U="${WORKSPACE_U}/../memory-catalog-inference"
+# WHERE THE PERSISTENT CLONE LIVES. $INFERENCE_CLONE_DIR wins (the workflow sets it per lane); the
+# fallbacks are the same paths, chosen so a runner that never sets it still gets a persistent dir
+# rather than a per-job one. On the Windows box that is D:, where the runner already keeps its other
+# per-runner caches and where there is room for a 500 MB clone; if D: is somehow absent, $HOME is a
+# correct if less conventional home for it.
+if [[ -z "${INFERENCE_CLONE_DIR:-}" ]]; then
+  if command -v cygpath >/dev/null 2>&1 && [[ -d /d ]]; then
+    INFERENCE_CLONE_DIR="/d/memory-catalog-inference"
+  else
+    INFERENCE_CLONE_DIR="${HOME}/memory-catalog-inference"
+  fi
+fi
+REPO_U="$(unix_path "$INFERENCE_CLONE_DIR")"
+echo "persistent inference clone: $REPO_U"
 
-if [[ ! -d "$REPO_U/.git" ]]; then
+# REUSE ONLY A CLONE THAT IS ACTUALLY THIS REPO. Anything else -- a half-written directory from a
+# killed job, a clone of some other remote -- is discarded rather than fetched into, which would
+# otherwise fail much later with a confusing "revision not found".
+if [[ -d "$REPO_U/.git" ]] \
+  && [[ "$(git -C "$REPO_U" remote get-url origin 2>/dev/null || true)" == "$INFERENCE_URL" ]]; then
+  echo "reusing the existing clone"
+else
+  echo "no usable clone at $REPO_U; initialising one"
   rm -rf "$REPO_U"
-  git clone --no-checkout https://github.com/SceneWorks/inference "$REPO_U"
+  mkdir -p "$REPO_U"
+  git init --quiet "$REPO_U"
+  git -C "$REPO_U" remote add origin "$INFERENCE_URL"
 fi
 
-# Fetch every ref, not just the default branch: `anchor-loader-closure.mjs --stamp-anchors` digests
-# each packaged anchor at ITS OWN record's inference revision, which is generally older than the
-# pin and need not sit on any branch tip.
-git -C "$REPO_U" fetch --all --tags --prune --force
-if ! git -C "$REPO_U" cat-file -e "${PIN}^{commit}" 2>/dev/null; then
-  git -C "$REPO_U" fetch origin "$PIN"
+# The pin first, then every revision the packaged anchors cite. `--anchor-revisions` reads only
+# checked-in JSON, so it runs against THIS checkout and needs no clone of its own.
+WANTED=("$PIN")
+while IFS= read -r rev; do
+  [[ "$rev" =~ ^[0-9a-f]{40}$ ]] || continue
+  [[ "$rev" == "$PIN" ]] && continue
+  WANTED+=("$rev")
+done < <(node scripts/anchor-loader-closure.mjs --anchor-revisions)
+echo "revisions this walk needs: ${#WANTED[@]} (pin + $(( ${#WANTED[@]} - 1 )) anchor revisions)"
+
+# A space-separated string, not an array: the macOS runners' `bash` is 3.2, where `${#arr[@]}` on an
+# EMPTY array is an unbound-variable error under `set -u` -- and "nothing is missing" is the case
+# this step exists to make normal. A 40-hex SHA needs no quoting, so word splitting is exact here.
+MISSING=""
+MISSING_COUNT=0
+for rev in "${WANTED[@]}"; do
+  if ! git -C "$REPO_U" cat-file -e "${rev}^{commit}" 2>/dev/null; then
+    MISSING="${MISSING}${rev} "
+    MISSING_COUNT=$(( MISSING_COUNT + 1 ))
+  fi
+done
+
+if (( MISSING_COUNT == 0 )); then
+  echo "every needed revision is already in the persistent clone; no fetch"
+else
+  # ONE fetch for all of them, not one per revision: a single pack lets the server delta the ~500 MB
+  # tree of each revision against its siblings, where N separate fetches would send N full trees.
+  echo "fetching ${MISSING_COUNT} missing revision(s) shallowly"
+  fetched=0
+  for attempt in 1 2 3 4 5; do
+    # shellcheck disable=SC2086  # deliberate word splitting of the SHA list
+    if git -C "$REPO_U" fetch --depth 1 --no-tags origin $MISSING; then
+      fetched=1
+      break
+    fi
+    # The observed failure mode is a slow transfer the server drops mid-pack ("early EOF"), which
+    # retries fine; a wrong revision would fail identically fast five times and then say so.
+    echo "::warning title=inference fetch failed::attempt ${attempt}/5 did not complete; retrying"
+    sleep "$(( attempt * 15 ))"
+  done
+  if (( fetched == 0 )); then
+    echo "::error title=Could not fetch the inference revisions::5 shallow fetch attempts of ${MISSING}from $INFERENCE_URL all failed"
+    exit 1
+  fi
 fi
 
 # A reused clone can carry leftovers from an interrupted earlier run. Reset it hard: the harness
 # refuses a dirty inference checkout, and a "dirty" verdict here would look like a code problem.
-git -C "$REPO_U" checkout --force "$PIN"
+git -C "$REPO_U" checkout --force --detach "$PIN"
 git -C "$REPO_U" reset --hard "$PIN"
 git -C "$REPO_U" clean -ffdx
 
@@ -53,12 +142,36 @@ if [[ -n "$(git -C "$REPO_U" status --porcelain)" ]]; then
   exit 1
 fi
 
+CLONE_URL="$(file_url "$REPO_U")"
+
 {
   echo "INFERENCE_PIN=$PIN"
   echo "INFERENCE_REPO=$(native_path "$REPO_U")"
+  echo "INFERENCE_CLONE_DIR=$REPO_U"
+  echo "INFERENCE_CLONE_URL=$CLONE_URL"
+  # POINT CARGO'S GIT TRANSPORT AT THE CLONE WE JUST FETCHED, for every later step in the job.
+  #
+  # These are git's own env-config channel (git >= 2.31): GIT_CONFIG_COUNT=N makes git read N
+  # KEY/VALUE pairs out of the environment as if they were config. It has to be the environment
+  # rather than `git config --global`, because `.cargo/config.toml`'s `git-fetch-with-cli = true`
+  # path spawns git with an EMPTY HOME and GIT_CONFIG_NOSYSTEM=1 for this public repo (sc-17879) --
+  # so neither the global nor the system config file is read at all, while GIT_CONFIG_COUNT still
+  # is. It is exported job-wide rather than per-step so it applies identically to the bash steps and
+  # to the candle lane's `shell: cmd` build.
+  #
+  # The rewrite is git-level, so Cargo.lock and the cargo db name still key on the github.com URL:
+  # nothing about the resolved dependency changes, only where the bytes come from. Cargo warns
+  # "rejected refs/commit/<pin> because shallow roots are not allowed to be updated" when it copies
+  # a ref out of a shallow source; the commit itself still lands, which is why that is a warning
+  # here and not a failure.
+  echo "GIT_CONFIG_COUNT=1"
+  echo "GIT_CONFIG_KEY_0=url.${CLONE_URL}.insteadOf"
+  echo "GIT_CONFIG_VALUE_0=${INFERENCE_URL}"
 } >> "$GITHUB_ENV"
 
 {
   echo "Pinned inference revision \`$PIN\`, derived from \`crates/sceneworks-memory-adapter/src/lib.rs\`."
+  echo
+  echo "Persistent shallow clone \`$REPO_U\`; ${MISSING_COUNT} of ${#WANTED[@]} needed revision(s) fetched this run."
   echo
 } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The memory-catalog campaign downloaded the ~650 MB `SceneWorks/inference` repo **twice per dispatch** — once by `cargo fetch --locked` (the workspace pins `candle-kernels` at an inference rev and `.cargo/config.toml` sets `git-fetch-with-cli = true`) and once by `scripts/ci/memory-catalog/inference.sh` — into directories that are wiped between jobs. On the Windows CUDA box that is fatal rather than merely slow: run 34044786385 spent 70 minutes at ~150 KB/s inside cargo's git fetch, died with `fetch-pack: unexpected disconnect / early EOF`, then started a second 70-minute attempt.

## What changed

- **`inference.sh` runs before `cargo fetch`** in both lanes and does the only network fetch of that repo the job makes.
- **Persistent clone.** `$INFERENCE_CLONE_DIR` — `D:\memory-catalog-inference` on the CUDA box (job env; that runner already keeps its per-runner caches on `D:`), `$HOME/memory-catalog-inference` on the Macs (the script default, since a job-level `env:` cannot expand `$HOME`). A directory that is not a clone of `SceneWorks/inference` is discarded and re-initialised.
- **Shallow, and only what is missing.** `git fetch --depth 1` for the pin **plus** every revision `node scripts/anchor-loader-closure.mjs --anchor-revisions` prints. That list is not optional: the harness runs `--stamp-anchors` per anchor, which digests each packaged anchor's loader closure at *its own* record's (or attested) inference revision — generally older than the pin and not on any branch tip. `--anchor-revisions` exists to be exactly this fetch list, derived from the same store the stamping walks. All missing revisions go in **one** fetch so the server deltas their trees against each other; five retries with backoff, because the observed failure is a dropped transfer, not a bad revision.
- **Cargo reads the clone.** The step exports `GIT_CONFIG_COUNT=1` / `GIT_CONFIG_KEY_0=url.file://<clone>.insteadOf` / `GIT_CONFIG_VALUE_0=https://github.com/SceneWorks/inference` into `$GITHUB_ENV`. It has to be git's env-config channel and not `git config --global`: the `git-fetch-with-cli` path spawns git with an empty `HOME` and `GIT_CONFIG_NOSYSTEM=1` for this public repo (sc-17879), so no config *file* is read at all. The rewrite is git-level, so `Cargo.lock` and the cargo db name still key on the github.com URL — only the bytes' origin changes.
- `common.sh` gains `file_url()`, the one `file:///D:/dir` spelling Git for Windows accepts (`cygpath -m`); `native_path`/`unix_path` are unchanged and `INFERENCE_REPO` still exports native.
- Runbook §6a-bis rewritten where it described the fetch/clone (and the stale "checks out `ref` at full depth").

## Local proof (this Mac, live remote, throwaway `HOME`-independent `CARGO_HOME`)

| run | `inference.sh` | fetch | `cargo fetch --locked` |
|---|---|---|---|
| cold (no clone) | exit 0, **35 s**, 11 revisions fetched, `.git` **513 MB**, 11 shallow roots, `rev-list --count HEAD` = 1 | one pack | exit 0, 21 s |
| second run | exit 0, **0 s**, "every needed revision is already in the persistent clone; no fetch" | none | exit 0, 0 s |

Both runs: the pin is present in `$CARGO_HOME/git/db/inference-*` and `git/checkouts/inference-*` is created. `cargo fetch` emits one benign `warning: rejected refs/commit/<pin> because shallow roots are not allowed to be updated`; the commit still lands. mlx-rs, mlx-c and candle are untouched by the single rewrite and still fetch from their own remotes.

`shellcheck -x` clean on both scripts, `bash -n` clean, `actionlint` clean apart from the pre-existing `self-hosted`-label warning. No test covers `scripts/ci/memory-catalog/*.sh`.

## Not verifiable on macOS

The Windows specifics — `cygpath -m` output, Git for Windows accepting `file:///D:/memory-catalog-inference`, and `D:` existing on that runner — are reasoned from the existing native/unix path split and cannot be exercised here. The first candle dispatch after this merges is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
