### PR TITLE
fix(sc-22738): watchdog census failures are tolerated telemetry faults, never monitor_failure

### DIFF
--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -838,16 +838,22 @@ SCENEWORKS_FLUX2_ROOT=/abs/path/.../snapshots/<rev>/<tier>   # q4 | q8 — tier 
 # and sampler faults that persist for `--telemetry-fault-window` (60 s) of WALL CLOCK with no good
 # sample, which stops as `telemetry_lost` carrying its `telemetryFaultHistory`. Every sampler
 # failure path — a `/usr/bin/footprint` timeout or non-zero exit, a parse failure, the aggregate
-# telemetry deadline, the host free-memory probe — shares that one window, and NONE of them
-# escalates on its own: a tolerated tick emits `telemetry_fault` and keeps the previous good sample
-# as the current reading. A false hard stop is a process-group SIGKILL through a live Metal command
-# buffer, which has wedged this host's GPU; a late stop is the cheaper failure. The cadence is one
-# tick per `--sample-interval` (2 s) and each probe inside a tick — census, footprint, host
-# pressure — gets its own full `--telemetry-timeout` (10 s), with the aggregate staleness deadline
-# derived as three of those, never shorter than one full sample. Both defaults matter: at 0.25 s /
-# 1 s shared across the probes, `footprint` on a 38 GB process received 0.31 s of budget and
-# `bernini:q4:mlx` was SIGKILLed 56.8 minutes in, at 87% memory free, by three unlucky ticks inside
-# 1.2 s.
+# telemetry deadline, the host free-memory probe, the `/bin/ps` process-group census — shares that
+# one window, and NONE of them escalates on its own: a tolerated tick emits `telemetry_fault` and
+# keeps the previous good sample as the current reading. A false hard stop is a process-group
+# SIGKILL through a live Metal command buffer, which has wedged this host's GPU; a late stop is the
+# cheaper failure. The cadence is one tick per `--sample-interval` (2 s) and each probe inside a
+# tick — census, footprint, host pressure — gets its own full `--telemetry-timeout` (10 s), with
+# the aggregate staleness deadline derived as three of those, never shorter than one full sample.
+# The census carries that same budget (`CENSUS_TIMEOUT_SECONDS`, adopted from
+# `--telemetry-timeout`), not the 1 s it used to hard-code, and a census that FAILS is an UNKNOWN
+# view in which the previous census stands: only a SUCCESSFUL census that lacks the root, or the
+# guarded child reporting its exit, is root loss. `monitor_failure` is reserved for an exception
+# that is not a telemetry source failing at all. Every default matters: at 0.25 s / 1 s shared
+# across the probes, `footprint` on a 38 GB process received 0.31 s of budget and `bernini:q4:mlx`
+# was SIGKILLed 56.8 minutes in, at 87% memory free, by three unlucky ticks inside 1.2 s; with the
+# census still on 1 s, `bernini:q8:mlx` was SIGKILLed 85 minutes in at a steady 52 GB by a single
+# `ps` that took longer than a second (`monitor_failure:TimeoutExpired`).
 SCENEWORKS_LTX_REPOSITORY=SceneWorks/ltx-2.3-mlx             # fixed; validated against LTX_REPOSITORY
 SCENEWORKS_LTX_REVISION=<exact artifact revision>
 SCENEWORKS_LTX_ROOT=/abs/path/.../snapshots/<rev>/<tier>     # bf16 | q4 | q8, derived from the plan target

--- a/scripts/memory-calibration-watchdog.py
+++ b/scripts/memory-calibration-watchdog.py
@@ -17,10 +17,17 @@ A hard stop therefore has exactly THREE triggers:
   c. sampler faults that persist for `--telemetry-fault-window` of WALL CLOCK with no good sample.
 
 Every sampler failure path — a per-PID `footprint` timeout, a `footprint` non-zero exit, a parse
-failure, the aggregate telemetry deadline, and the host free-memory/swap probe — is routed through
-that one window (`tolerate_telemetry_fault`). None of them may escalate on its own: a false hard
-stop is a process-group SIGKILL through a live Metal command buffer, which is strictly worse for
-this host than a late stop.
+failure, the aggregate telemetry deadline, the host free-memory/swap probe, and the `/bin/ps`
+process-group census — is routed through that one window (`tolerate_telemetry_fault`). None of them
+may escalate on its own: a false hard stop is a process-group SIGKILL through a live Metal command
+buffer, which is strictly worse for this host than a late stop.
+
+The census is telemetry, not bookkeeping. `/bin/ps` is a source that can be slow or hang exactly
+like `/usr/bin/footprint`, so it carries the same per-probe budget and the same tolerance: a census
+that FAILS is an UNKNOWN view (the previous census stands), never evidence that the guarded root is
+gone. Only a SUCCESSFUL census that lacks the root, or `child.poll()` reporting the sentinel's exit,
+is loss of the guarded process. `monitor_failure` is reserved for an exception that is not a
+telemetry source failing at all — a genuine bug in this monitor.
 """
 
 from __future__ import annotations
@@ -71,6 +78,32 @@ TELEMETRY_TIMEOUT_SECONDS = 10.0
 # must comfortably exceed one full telemetry tick (`TELEMETRY_PROBE_BUDGETS` x the per-probe
 # budget) so a single slow tick can never consume the whole startup allowance.
 CHILD_ATTESTATION_TIMEOUT_SECONDS = 60.0
+# Per-probe budget for the `/bin/ps` process-group census. WHY it is the telemetry budget and not
+# the 1 s it used to hard-code: the census is a whole-system `ps` walk, and on this host under a
+# 100 GB Metal render it measured past a second — `bernini:q8:mlx` was SIGKILLed 85 minutes into a
+# steady 52 GB render, against a 94.8 GB ceiling, by a census that took longer than 1 s (sc-22738).
+# A census is a telemetry source exactly like `/usr/bin/footprint`, so it gets the same budget; the
+# budget exists to bound a HUNG probe, not a slow one. `guard` adopts the run's `--telemetry-timeout`
+# through `set_census_timeout`; the module default is what the sentinel subprocess and direct
+# callers use.
+CENSUS_TIMEOUT_SECONDS = TELEMETRY_TIMEOUT_SECONDS
+# Exceptions a telemetry SOURCE raises: the `ps` census, `/usr/bin/footprint`, `memory_pressure`,
+# `sysctl`, their parsers, and the aggregate staleness deadline. Enumerated so that anything else —
+# an AttributeError, a TypeError, a NameError — remains a monitor BUG and still fails closed through
+# `monitor_failure` instead of being absorbed by the telemetry tolerance.
+TELEMETRY_SOURCE_ERRORS = (
+    # `subprocess.TimeoutExpired` (a probe exceeded its budget) and every other failed probe launch
+    # or reap.
+    subprocess.SubprocessError,
+    # `/bin/ps` or `/usr/bin/footprint` could not be executed; `TimeoutError` (the aggregate
+    # staleness deadline) is an `OSError` subclass.
+    OSError,
+    # Non-zero probe exit or malformed payload, raised by the probes themselves. `RootTelemetryLost`
+    # is a subclass and is refused before this test is reached.
+    RuntimeError,
+    # `int()` and `json` parse failures over probe output; `json.JSONDecodeError` is a `ValueError`.
+    ValueError,
+)
 PROVIDER_PHASE_PROTOCOL = "sceneworks-provider-phase-v1"
 CAMPAIGN_ENTRY_PROVIDER_PHASES = (
     "common_load",
@@ -113,10 +146,27 @@ class Identity:
     started: str
 
 
-def process_identity(pid: int) -> Identity | None:
+def set_census_timeout(seconds: float) -> None:
+    """Adopt this run's per-probe telemetry budget as the census budget.
+
+    Called once by `guard`. The census functions read the module value at call time, so this
+    reaches `identity_is_live`, `OwnedGroup.refresh` and `root_pids` without threading a budget
+    through every signature.
+    """
+    global CENSUS_TIMEOUT_SECONDS
+    if seconds <= 0:
+        raise RuntimeError("census timeout must be positive")
+    CENSUS_TIMEOUT_SECONDS = seconds
+
+
+def census_budget(timeout: float | None) -> float:
+    return CENSUS_TIMEOUT_SECONDS if timeout is None else timeout
+
+
+def process_identity(pid: int, timeout: float | None = None) -> Identity | None:
     result = subprocess.run(
         ["/bin/ps", "-ww", "-p", str(pid), "-o", "pgid=,state=,lstart="],
-        capture_output=True, text=True, timeout=1, check=False,
+        capture_output=True, text=True, timeout=census_budget(timeout), check=False,
     )
     fields = result.stdout.strip().split(None, 2)
     if result.returncode != 0 or len(fields) != 3 or fields[1].startswith("Z"):
@@ -124,12 +174,12 @@ def process_identity(pid: int) -> Identity | None:
     return Identity(pid, int(fields[0]), fields[1], fields[2])
 
 
-def group_identities(pgid: int) -> list[Identity]:
+def group_identities(pgid: int, timeout: float | None = None) -> list[Identity]:
     probe = subprocess.Popen(
         ["/bin/ps", "-ww", "-axo", "pid=,pgid=,state=,lstart="],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
     )
-    stdout, stderr = probe.communicate(timeout=1)
+    stdout, stderr = probe.communicate(timeout=census_budget(timeout))
     if probe.returncode != 0:
         raise RuntimeError(f"ps group census failed: {stderr.strip()}")
     members = []
@@ -146,7 +196,7 @@ def identity_is_live(identity: Identity) -> bool:
     return bool(current and current.pgid == identity.pgid and current.started == identity.started)
 
 
-def parent_pids(timeout: float = 1.0) -> dict[int, int]:
+def parent_pids(timeout: float | None = None) -> dict[int, int]:
     """pid → ppid for every live process, or `{}` when the census is unavailable.
 
     Used only to resolve the guarded ROOT process (the sentinel's one non-anchor child). An
@@ -156,7 +206,7 @@ def parent_pids(timeout: float = 1.0) -> dict[int, int]:
     try:
         result = subprocess.run(
             ["/bin/ps", "-axo", "pid=,ppid="], capture_output=True, text=True,
-            timeout=timeout, check=False,
+            timeout=census_budget(timeout), check=False,
         )
     except (OSError, subprocess.SubprocessError):
         return {}
@@ -497,6 +547,10 @@ class OwnedGroup:
         self.released = True
 
     def refresh(self) -> list[Identity]:
+        # This runs `/bin/ps` twice over, so it can time out like any other telemetry probe. Every
+        # caller inside the guard loop routes that failure through `tolerate_telemetry_fault`; a
+        # raised census is never an empty group.
+        #
         # Numeric PGID census is safe only while an exact launch-owned anchor proves the original
         # group still exists. The auxiliary anchor outlives a killed sentinel and cannot exit on
         # TERM/INT, closing the between-censuses descendant race without permitting PGID reuse.
@@ -642,6 +696,9 @@ def observe_group(
 
 
 def guard(args: argparse.Namespace) -> int:
+    # The census is a telemetry probe and takes this run's per-probe telemetry budget, not the 1 s
+    # that SIGKILLed a healthy 85-minute render (sc-22738).
+    set_census_timeout(args.telemetry_timeout)
     events = EventChain(args.event_file)
     attested_initial_memory_free_bytes = None
     if args.require_child_attestation:
@@ -880,19 +937,25 @@ def guard(args: argparse.Namespace) -> int:
 
         THE single escalation decision for every sampler failure path — a per-PID `footprint`
         timeout, a `footprint` non-zero exit, a parse failure, the aggregate telemetry deadline,
-        and the host free-memory/swap probe all arrive here. None of them may escalate on its own,
-        and no one of them may spend a budget the others share: only losing the guarded root
-        (`RootTelemetryLost`, which is not a sampling fault but the loss of the thing being
-        guarded) or a fault run that occupies `--telemetry-fault-window` of WALL CLOCK with no good
-        sample is telemetry loss.
+        the `/bin/ps` process-group census, and the host free-memory/swap probe all arrive here.
+        None of them may escalate on its own, and no one of them may spend a budget the others
+        share: only losing the guarded root (`RootTelemetryLost`, which is not a sampling fault but
+        the loss of the thing being guarded) or a fault run that occupies
+        `--telemetry-fault-window` of WALL CLOCK with no good sample is telemetry loss.
 
         A tolerated fault leaves the last good sample standing as the current reading, so the
         ceiling test never sees an unknown footprint.
+
+        An exception that is NOT a telemetry source failing is a bug in this monitor, not a fault
+        to absorb: it is re-raised here so it reaches the `monitor_failure` handler and still fails
+        closed.
         """
         nonlocal telemetry_faults, telemetry_fault_reason
         nonlocal telemetry_fault_since, telemetry_fault_history
         if isinstance(error, RootTelemetryLost):
             return False
+        if not isinstance(error, TELEMETRY_SOURCE_ERRORS):
+            raise error
         now = time.monotonic()
         telemetry_faults += 1
         if telemetry_fault_since is None:
@@ -930,6 +993,36 @@ def guard(args: argparse.Namespace) -> int:
         telemetry_fault_reason = None
         last_good_footprint = footprint
         last_good_pressure = pressure
+
+    # The most recent SUCCESSFUL census. A census that FAILS leaves this view standing: the guard's
+    # picture of the group is the last one it actually took, never an empty group.
+    last_live: list[Identity] = sorted(group.retained, key=lambda item: item.pid)
+
+    def observe_census(phase: str) -> tuple[list[Identity], bool, str | None]:
+        """The guard loop's group census, routed through the one telemetry tolerance.
+
+        Returns `(view, known, telemetry-loss reason)`. `known` is False when the census failed and
+        the fault was tolerated: the previous view is returned, and NO caller may read it as the
+        guarded root being gone. Root loss is only ever a SUCCESSFUL census that lacks it, or
+        `child.poll()` reporting an exit.
+        """
+        nonlocal last_live
+        try:
+            last_live = group.refresh()
+        except MonitorSignal:
+            raise
+        except Exception as error:
+            if tolerate_telemetry_fault(error, phase):
+                return last_live, False, None
+            return last_live, False, f"telemetry_lost:{type(error).__name__}:{error}"
+        return last_live, True, None
+
+    def pause_runtime() -> None:
+        sleep_seconds = args.sample_interval
+        if runtime_deadline is not None:
+            sleep_seconds = min(sleep_seconds, max(0.0, runtime_deadline - time.monotonic()))
+        if sleep_seconds > 0:
+            time.sleep(sleep_seconds)
 
     def bounded_telemetry_timeout() -> float:
         if runtime_deadline is None:
@@ -1158,11 +1251,16 @@ def guard(args: argparse.Namespace) -> int:
                     or f"runtime_at_or_above_{args.max_runtime_seconds}s"
                 )
                 break
-            live = group.refresh()
+            live, _, census_lost = observe_census("runtime")
+            if census_lost is not None:
+                hard_stop = census_lost
+                break
             status = group.child.poll()
             if status is not None and status < 0:
                 hard_stop = f"launch_sentinel_lost:status_{status}"
                 break
+            # An empty view can only come from a census that SUCCEEDED: a tolerated census failure
+            # returns the previous view, which is never empty while the group exists.
             if not live:
                 if attestation_stream is not None and not child_reported_done:
                     hard_stop = "child_exited_without_completion_attestation"
@@ -1170,8 +1268,16 @@ def guard(args: argparse.Namespace) -> int:
                 return status if status is not None else 0
             if status is not None:
                 # The census preceded poll; normal sentinel cleanup may have completed between
-                # those observations. Refresh before treating a positive status as a failure.
-                if not group.refresh():
+                # those observations. Refresh before treating a positive status as a failure — and
+                # decide nothing at all on a census that failed, which is an unknown view.
+                view, view_known, census_lost = observe_census("runtime")
+                if census_lost is not None:
+                    hard_stop = census_lost
+                    break
+                if not view_known:
+                    pause_runtime()
+                    continue
+                if not view:
                     if attestation_stream is not None and not child_reported_done:
                         hard_stop = "child_exited_without_completion_attestation"
                         break
@@ -1218,7 +1324,11 @@ def guard(args: argparse.Namespace) -> int:
                 failed_at_or_after_deadline = (
                     runtime_deadline is not None and time.monotonic() >= runtime_deadline
                 )
-                if not group.refresh() and group.child.poll() is not None:
+                # The exit check needs its own census, and that census is telemetry too: a failed one
+                # is an unknown view, never proof the group is gone — and never `monitor_failure`,
+                # which is what a bare `refresh()` raising inside this handler used to produce.
+                view, view_known, census_lost = observe_census("runtime")
+                if view_known and not view and group.child.poll() is not None:
                     return group.child.returncode
                 if failed_at_or_after_deadline:
                     hard_stop = (
@@ -1226,13 +1336,11 @@ def guard(args: argparse.Namespace) -> int:
                         or f"runtime_at_or_above_{args.max_runtime_seconds}s"
                     )
                     break
+                if census_lost is not None:
+                    hard_stop = census_lost
+                    break
                 if tolerate_telemetry_fault(error, "runtime"):
-                    sleep_seconds = args.sample_interval
-                    if runtime_deadline is not None:
-                        sleep_seconds = min(
-                            sleep_seconds, max(0.0, runtime_deadline - time.monotonic()))
-                    if sleep_seconds > 0:
-                        time.sleep(sleep_seconds)
+                    pause_runtime()
                     continue
                 hard_stop = f"telemetry_lost:{type(error).__name__}:{error}"
                 break
@@ -1280,11 +1388,7 @@ def guard(args: argparse.Namespace) -> int:
                         "event": "child_completed", "providerPhase": provider_phase,
                     })
                     attestation_stream.setblocking(False)
-            sleep_seconds = args.sample_interval
-            if runtime_deadline is not None:
-                sleep_seconds = min(sleep_seconds, max(0.0, runtime_deadline - time.monotonic()))
-            if sleep_seconds > 0:
-                time.sleep(sleep_seconds)
+            pause_runtime()
     except MonitorSignal as caught:
         hard_stop = f"monitor_signal_{signal.Signals(caught.signum).name}"
         exit_status = 128 + caught.signum

--- a/scripts/memory-calibration-watchdog.test.mjs
+++ b/scripts/memory-calibration-watchdog.test.mjs
@@ -1435,6 +1435,265 @@ def outcome(n):
   pids.forEach(assertGone);
 });
 
+/**
+ * Drive the guard with a scripted `/bin/ps` process-group census. `censusOutcome` is the body of a
+ * Python `def census_outcome(n, state)` called with the 1-based census number: it returns to let the
+ * REAL census run, or raises. `footprintOutcome` is the same contract as `runWithScriptedFootprint`
+ * plus the shared `state`, so a test can make the census fail only at a chosen point in the tick.
+ * Everything else is production code — the real group, the real loop, the real escalation rule.
+ */
+async function runWithScriptedCensus(files, name, censusOutcome, options = {}) {
+  const {
+    mode = "hold", ceiling = 100, maxRuntimeSeconds = "1.5", timeoutMs = 20_000,
+    footprintOutcome = "def footprint_outcome(n, state): return 1",
+  } = options;
+  const launcher = `${files.program}.${name}.py`;
+  await writeFile(launcher, String.raw`import importlib.util, subprocess, sys, time
+spec = importlib.util.spec_from_file_location("watchdog", ${JSON.stringify(WATCHDOG)})
+module = importlib.util.module_from_spec(spec); sys.modules[spec.name] = module; spec.loader.exec_module(module)
+def census_timeout():
+    return subprocess.TimeoutExpired(
+        cmd=["/bin/ps", "-ww", "-axo", "pid=,pgid=,state=,lstart="], timeout=10.0)
+def footprint_timeout():
+    return subprocess.TimeoutExpired(cmd=["/usr/bin/footprint", "-p", "1"], timeout=10.0)
+state = {"census": 0, "samples": 0, "censusFaults": 0, "inFault": False}
+${censusOutcome}
+${footprintOutcome}
+real_group_identities = module.group_identities
+real_process_identity = module.process_identity
+# A slow or hung /bin/ps fails BOTH census probes: the whole-system group walk and the per-PID
+# identity check that OwnedGroup.refresh runs over its anchors first.
+def scripted_census(pgid, timeout=None):
+    state["census"] += 1
+    census_outcome(state["census"], state)
+    return real_group_identities(pgid, timeout)
+def scripted_identity(pid, timeout=None):
+    state["census"] += 1
+    census_outcome(state["census"], state)
+    return real_process_identity(pid, timeout)
+module.group_identities = scripted_census
+module.process_identity = scripted_identity
+class Footprint:
+    def sample(self, pids, timeout, required=()):
+        state["samples"] += 1
+        return footprint_outcome(state["samples"], state)
+module.DarwinFootprintSampler = Footprint
+sys.argv = [${JSON.stringify(WATCHDOG)},
+    "--max-footprint-bytes", ${JSON.stringify(String(ceiling))},
+    "--max-runtime-seconds", ${JSON.stringify(String(maxRuntimeSeconds))},
+    "--sample-interval", "0.02", "--telemetry-timeout", "0.2",
+    "--term-grace", "0.1", "--event-file", ${JSON.stringify(files.events)},
+    "--", "python3", ${JSON.stringify(files.program)}, ${JSON.stringify(mode)},
+    ${JSON.stringify(files.pids)}, ${JSON.stringify(files.telemetry)},
+    ${JSON.stringify(files.events)}]
+raise SystemExit(module.guard(module.parse_args()))
+`);
+  let status = 0;
+  try {
+    await execFileAsync("python3", [launcher], { timeout: timeoutMs });
+  } catch (error) {
+    status = error.code;
+  }
+  const events = (await readFile(files.events, "utf8")).trim().split("\n").map(JSON.parse);
+  return {
+    status,
+    events,
+    faults: events.filter((event) => event.event === "telemetry_fault"),
+    stopped: events.find((event) => event.event === "hard_stop") ?? null,
+  };
+}
+
+test("a census timeout during the runtime tick is a tolerated telemetry fault", async () => {
+  // sc-22738, measured 2026-09-06: `bernini:q8:mlx` rendered 85 minutes at a steady 52 GB against a
+  // 94.8 GB ceiling and was SIGKILLed by `monitor_failure:TimeoutExpired` from the whole-system
+  // `/bin/ps` census on a hard-coded 1 s budget. `ps` is a telemetry SOURCE like `/usr/bin/
+  // footprint`: a census that fails is an unknown view, never a monitor bug and never an empty
+  // group.
+  const files = await fixture();
+  const result = await runWithScriptedCensus(files, "census-timeout-tolerated", String.raw`
+def census_outcome(n, state):
+    # Well inside the runtime loop: the pre-release observation takes only the first sample.
+    if state["samples"] >= 3 and state["censusFaults"] < 3:
+        state["censusFaults"] += 1
+        raise census_timeout()
+`);
+  assert.equal(result.status, 97);
+  // The guard rode the census outage out to its own wall-time ceiling — it neither failed as a
+  // monitor bug nor read the unknown view as a finished render.
+  assert.equal(result.stopped.reason, "runtime_at_or_above_1.5s");
+  assert.equal(result.faults.length, 3);
+  assert.ok(result.faults.every((event) => event.phase === "runtime"));
+  assert.ok(result.faults.every((event) => event.reason.startsWith("TimeoutExpired:/bin/ps")
+    || event.reason.startsWith("TimeoutExpired:Command '['/bin/ps'")),
+  `census fault reason was ${result.faults[0].reason}`);
+  assert.ok(result.faults.every((event) => event.lastGoodPhysicalFootprintBytes === 1),
+    "a tolerated census must keep the previous good sample as the current reading");
+  const samplesAfter = result.events.filter((event) =>
+    event.event === "sample" && event.eventSequence > result.faults.at(-1).eventSequence);
+  assert.ok(samplesAfter.length > 0, "the guard stopped sampling after the tolerated census fault");
+  const pids = (await readFile(files.pids, "utf8")).trim().split("\n").map(Number);
+  pids.forEach(assertGone);
+});
+
+test("a census timeout raised from the post-tick refresh paths is tolerated", async () => {
+  // The census inside `observe_group` was already covered by the tolerance; the `refresh()` calls
+  // around it were not — and the one inside the sampler-fault handler raised THROUGH that handler
+  // straight to `monitor_failure`. Fail the census only while a footprint fault is being handled,
+  // which is exactly that call.
+  const files = await fixture();
+  const result = await runWithScriptedCensus(files, "census-timeout-post-tick", String.raw`
+def census_outcome(n, state):
+    if state["inFault"]:
+        state["inFault"] = False
+        state["censusFaults"] += 1
+        raise census_timeout()
+`, {
+    footprintOutcome: String.raw`
+def footprint_outcome(n, state):
+    if n == 4:
+        state["inFault"] = True
+        raise footprint_timeout()
+    return 1
+`,
+  });
+  assert.equal(result.status, 97);
+  assert.equal(result.stopped.reason, "runtime_at_or_above_1.5s");
+  assert.equal(result.faults.length, 2, "one census fault and one footprint fault, both tolerated");
+  // The census fault is recorded FIRST even though the footprint failed first: it can only have
+  // come from the census the sampler-fault handler itself runs.
+  assert.deepEqual(result.faults.map((event) => event.consecutiveFaults), [1, 2]);
+  assert.match(result.faults[0].reason, /^TimeoutExpired:.*\/bin\/ps/);
+  assert.match(result.faults[1].reason, /^TimeoutExpired:.*footprint/);
+});
+
+test("a successful census that lacks the root stops at once, after tolerated census faults", async () => {
+  // Root-loss detection must survive the tolerance: a census that FAILS is unknown, but the first
+  // SUCCESSFUL one that no longer enumerates the group ends the guard immediately with the child's
+  // own status rather than riding the wall-time ceiling out.
+  const files = await fixture();
+  const result = await runWithScriptedCensus(files, "census-fault-then-root-gone", String.raw`
+def census_outcome(n, state):
+    if state["samples"] >= 2 and state["censusFaults"] < 2:
+        state["censusFaults"] += 1
+        raise census_timeout()
+`, { mode: "complete", maxRuntimeSeconds: "10" });
+  assert.equal(result.status, 0, "the completed group was reported through the child's own status");
+  assert.equal(result.stopped, null, "a completed group is not a hard stop");
+  assert.equal(result.faults.length, 2, "the census faults were tolerated, not escalated");
+});
+
+test("a census outage across the sentinel's exit defers instead of declaring a live group", async () => {
+  // The other half of "a failed census is unknown": once the sentinel reports a status, the guard
+  // re-censuses to tell normal cleanup from a failure. Reading a FAILED census there as the
+  // previous view would call the group live and hard-stop a run that simply finished — so the
+  // guard defers until a census succeeds. The outage here spans the sentinel's exit and then
+  // clears.
+  const files = await fixture();
+  const result = await runWithScriptedCensus(files, "census-outage-over-exit", String.raw`
+start = time.monotonic()
+def census_outcome(n, state):
+    if 0.15 < time.monotonic() - start < 1.2:
+        state["censusFaults"] += 1
+        raise census_timeout()
+`, { mode: "complete", maxRuntimeSeconds: "10" });
+  assert.equal(result.status, 0, "the completed group was reported through the child's own status");
+  assert.equal(result.stopped, null,
+    "an unknown census while the sentinel exits must not become launch_sentinel_failed_with_live_group");
+  assert.ok(result.faults.length > 0, "the census outage was never recorded");
+});
+
+test("an exception that is not a telemetry source stays a monitor failure", async () => {
+  // The tolerance absorbs telemetry SOURCES, enumerated in TELEMETRY_SOURCE_ERRORS. A bug in the
+  // monitor itself must still fail closed as `monitor_failure`, never be ridden out as a fault.
+  const files = await fixture();
+  const result = await runWithScriptedFootprint(files, "monitor-bug", String.raw`
+def outcome(n):
+    if n == 2: raise AttributeError("monitor bug")
+    return 1
+`, { maxRuntimeSeconds: "1.5" });
+  assert.equal(result.status, 97);
+  assert.equal(result.stopped.reason, "monitor_failure:AttributeError:monitor bug");
+  assert.equal(result.faults.length, 0, "a monitor bug must not be recorded as a telemetry fault");
+  const pids = (await readFile(files.pids, "utf8")).trim().split("\n").map(Number);
+  pids.forEach(assertGone);
+});
+
+test("the process-group census carries the per-probe telemetry budget, not a hard-coded second", async () => {
+  const probe = await execFileAsync("python3", ["-c", String.raw`
+import importlib.util, subprocess, sys
+spec = importlib.util.spec_from_file_location("watchdog", ${JSON.stringify(WATCHDOG)})
+module = importlib.util.module_from_spec(spec); sys.modules[spec.name] = module; spec.loader.exec_module(module)
+# The census is a telemetry probe: it takes the telemetry budget, never the 1 s that SIGKILLed a
+# healthy 85-minute render.
+assert module.CENSUS_TIMEOUT_SECONDS == module.TELEMETRY_TIMEOUT_SECONDS, module.CENSUS_TIMEOUT_SECONDS
+assert module.CENSUS_TIMEOUT_SECONDS >= 10.0, module.CENSUS_TIMEOUT_SECONDS
+budgets = []
+class Recorder:
+    TimeoutExpired = subprocess.TimeoutExpired
+    SubprocessError = subprocess.SubprocessError
+    PIPE = subprocess.PIPE
+    class Completed:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+    @staticmethod
+    def run(command, **kwargs):
+        budgets.append(kwargs["timeout"])
+        return Recorder.Completed()
+    class Popen:
+        pid = -1
+        returncode = 0
+        def __init__(self, command, **kwargs): pass
+        def communicate(self, timeout=None):
+            budgets.append(timeout)
+            return ("", "")
+module.subprocess = Recorder
+def census_budgets():
+    budgets.clear()
+    module.process_identity(1)
+    module.group_identities(1)
+    module.parent_pids()
+    return list(budgets)
+assert census_budgets() == [10.0, 10.0, 10.0], budgets
+# Every census reads the run's adopted budget, so --telemetry-timeout reaches identity_is_live,
+# OwnedGroup.refresh and root_pids without a per-call argument.
+module.set_census_timeout(0.75)
+assert census_budgets() == [0.75, 0.75, 0.75], budgets
+# The enumerated telemetry sources are the ones the probes actually raise.
+for error in [subprocess.TimeoutExpired(cmd=["/bin/ps"], timeout=1.0), OSError("ps"),
+              TimeoutError("aggregate"), RuntimeError("ps group census failed"),
+              ValueError("malformed")]:
+    assert isinstance(error, module.TELEMETRY_SOURCE_ERRORS), error
+for error in [AttributeError("bug"), TypeError("bug"), NameError("bug"), KeyError("bug")]:
+    assert not isinstance(error, module.TELEMETRY_SOURCE_ERRORS), error
+print("census budget is the telemetry budget")
+`]);
+  assert.match(probe.stdout, /census budget is the telemetry budget/);
+});
+
+test("a guard run adopts its --telemetry-timeout as the census budget", async () => {
+  const files = await fixture();
+  await writeFile(files.telemetry, "1\n");
+  const probe = await execFileAsync("python3", ["-c", String.raw`
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("watchdog", ${JSON.stringify(WATCHDOG)})
+module = importlib.util.module_from_spec(spec); sys.modules[spec.name] = module; spec.loader.exec_module(module)
+assert module.CENSUS_TIMEOUT_SECONDS == 10.0, module.CENSUS_TIMEOUT_SECONDS
+sys.argv = [${JSON.stringify(WATCHDOG)},
+    "--max-footprint-bytes", "100", "--max-runtime-seconds", "0.5",
+    "--sample-interval", "0.02", "--telemetry-timeout", "0.37",
+    "--term-grace", "0.1", "--event-file", ${JSON.stringify(files.events)},
+    "--telemetry-file", ${JSON.stringify(files.telemetry)}, "--allow-synthetic-telemetry",
+    "--", "python3", ${JSON.stringify(files.program)}, "hold",
+    ${JSON.stringify(files.pids)}, ${JSON.stringify(files.telemetry)},
+    ${JSON.stringify(files.events)}]
+module.guard(module.parse_args())
+assert module.CENSUS_TIMEOUT_SECONDS == 0.37, module.CENSUS_TIMEOUT_SECONDS
+print("census budget adopted from the run")
+`], { timeout: 20_000 });
+  assert.match(probe.stdout, /census budget adopted from the run/);
+});
+
 test("the ceiling still stops on the first good sample that breaches it after tolerated faults", async () => {
   const files = await fixture();
   const result = await runWithScriptedFootprint(files, "breach-after-faults", String.raw`


### PR DESCRIPTION
## The measured false positive

`bernini:q8:mlx` rendered 85 minutes at a steady 52 GB footprint against a 94.8 GB ceiling on this 128 GB Mac and was SIGKILLed with:

```
watchdog hard stop: monitor_failure:TimeoutExpired:Command '['/bin/ps', '-ww', '-p', '39053', '-o', 'pgid=,state=,lstart=']' timed out after 1 seconds
```

Two holes, both still present at the feature head after #2758:

1. The `/bin/ps` census ran on a hard-coded 1 s budget (`process_identity`, `group_identities`, `parent_pids`) while every other telemetry probe received a full `--telemetry-timeout`. Under a 100 GB Metal render the whole-system census exceeds a second.
2. Only the census inside `observe_group` was covered by `tolerate_telemetry_fault`. The `refresh()` calls at the loop top, in the positive-status recheck, and **inside the sampler-fault handler itself** were bare — the last one raising *through* the handler to the outer `except BaseException`, i.e. `monitor_failure` and a process-group SIGKILL through a live Metal command buffer.

## The fix

- `CENSUS_TIMEOUT_SECONDS` (defaults to `TELEMETRY_TIMEOUT_SECONDS`, adopted from `--telemetry-timeout` by `guard`) is the census budget. It reaches `identity_is_live`, `OwnedGroup.refresh` and `root_pids` without threading an argument through every signature.
- `observe_census()` routes every guard-loop census through the one `tolerate_telemetry_fault` wall-clock window. A census that **fails** is an UNKNOWN view: the previous census stands, and no caller may read it as the group being gone. Root loss remains a **successful** census that lacks the group, or `child.poll()` reporting the exit.
- `TELEMETRY_SOURCE_ERRORS` enumerates what a telemetry source can raise (`subprocess.SubprocessError`, `OSError`/`TimeoutError`, `RuntimeError`, `ValueError`). Anything else is re-raised out of the tolerance and still fails closed as `monitor_failure`.

## Tests

7 new tests (50 total in the file, up from 43; `run-ltx-safety-canary.test.mjs` unchanged and green). Every one is mutation-proven red/green:

| mutation | red |
| --- | --- |
| `CENSUS_TIMEOUT_SECONDS = 1.0` | census-budget test, budget-adoption test |
| loop-top `observe_census` → bare `refresh()` | runtime-tick, root-gone, outage-over-exit |
| handler `observe_census` → bare `refresh()` | runtime-tick, post-tick-refresh |
| drop the `TELEMETRY_SOURCE_ERRORS` guard | monitor-failure test |
| tolerated census returns `[]` instead of the previous view | runtime-tick, root-gone |
| drop the unknown-census deferral in the status branch | outage-over-exit |

`npm run check` with `INFERENCE_REPO` exported: 832/833. The one failure is the pre-existing environmental `CALIBRATED_TIER` assertion in `measure-memory-catalog.test.mjs` (it reads the inference worktree), untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)