### PR TITLE
fix(sc-22738): a current exceeded bound is a captured cell; hard-stop commits carry their Dockerfile embeds

### DIFF
--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -1225,6 +1225,20 @@ are SUCCESS — the walk's exit code is 2 only if some anchor ended outside this
 | `check_failed` | the bundle failed `harness check` | clean |
 | `ingest_failed` | a post-capture step failed; the tree was rolled back to HEAD | clean |
 
+A cell can also end before it starts. `--list` classifies an anchor whose store already carries a
+**current** measured lower bound as `exceeded_current`, and such a row is never in the runnable set —
+with or without `--skip-current`, so it reaches none of the outcomes above and cannot move the exit
+code. That is deliberate: the host has already established the one fact a re-run could establish
+(the peak at this geometry is at or above a footprint it had to stop), so booking it again spends
+another guarded render — 76 minutes for the `bernini:bf16:mlx` stop — to learn nothing. Until
+sc-22738 it classified `runnable`, because a bound's bundle has an EMPTY `records` array and the
+matrix publishes only anchors, so neither index the classifier consulted could see it.
+
+Currency is the SAME rule an anchor's is: the bound's `source.loaderClosureDigest` against the digest
+`config/anchor-loader-closures.json` carries for that `(model, lane)`. A pin bump or a closure edit
+that stales the bound — the same event that stops it refusing anything in production — puts the cell
+straight back to `runnable`, with no edit to the runner.
+
 **`committed_exceeded` is the one that changed (sc-22738).** A footprint hard stop used to be a
 `capture_failed` that stamped nothing at all: the store kept no trace, and production went on
 admitting the very request the host had just been unable to finish. `bernini:bf16:mlx` is the case
@@ -2194,7 +2208,10 @@ affected ones in the same commit.
 > nothing else. What DOES move is `docker/rust.Dockerfile`, which must copy the new corpus into both
 > builder contexts (`platform-review-contracts.test.mjs` reds otherwise), and the compiled-in list
 > in `memory_anchor.rs`, which must stay SORTED — `appendPackagedSource` inserts in place for
-> exactly that reason.
+> exactly that reason. **The runner writes both COPY lines itself** (`insertEvidenceCopy`, added in
+> the same step as the embed and carried in the same commit), on the completed-capture path as much
+> as on the hard-stop one — before that, every anchor commit landed a tree that reds the
+> platform-review suite until someone added the lines by hand.
 
 **Which tests red is lane-dependent and step-dependent.** The table below is the measured result of
 simulating an `mlx:z_image_turbo` capture on `origin/main` before the E5 collapse, both ways (§7d).

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -19,6 +19,12 @@
 //     [--skip-current]
 //     [--dry-run] [--no-commit] [--hf-cache DIR ...]   (--hf-cache is repeatable)
 //
+// A cell the store already carries a CURRENT measured lower bound for classifies `exceeded_current`
+// and is never scheduled, with or without `--skip-current` (sc-22738): the host has proved it cannot
+// finish there under this loader closure, and a re-run could only re-establish the same inequality.
+// A bound that has STALED classifies nothing, so the cell is capturable again the moment its
+// evidence stops speaking for production.
+//
 // `--no-commit` captures and checks each anchor and stops there (status `captured`, raw bundle in
 // <work-dir>/captures): the harness refuses complete evidence from a dirty checkout, so the first
 // anchor's ingest would leave every later anchor in the same run uncapturable (sc-22724). Ingest a
@@ -1192,6 +1198,45 @@ export async function readMatrixCurrency(root = ROOT) {
   return current;
 }
 
+/**
+ * The measured lower bounds the store already holds, keyed like an anchor
+ * (`<modelId>:<tier>:<backend>`), each with whether it is CURRENT (sc-22738).
+ *
+ * A bound is evidence about a cell exactly as a record is — the run established that this cell's
+ * peak is at or above the footprint the guard stopped it at — but it is carried in the store's
+ * `exceededBounds` array and its bundle's `records` array is empty, so neither `capturedInCampaign`
+ * (which indexes `records`) nor the matrix's currency map (which publishes only anchors) could see
+ * it. A cell the host has already proved it cannot finish therefore classified `runnable` and the
+ * next `--skip-current` re-run would book the same 76-minute render again.
+ *
+ * Currency is the SAME rule a record's is (`generate-memory-matrix.mjs`, both `current:` sites):
+ * the row's `source.loaderClosureDigest` against the digest `config/anchor-loader-closures.json`
+ * carries for that `(modelId, backend)` at the pinned inference revision. So a bound stops
+ * classifying its cell the moment a pin bump or a closure edit stales it — the same moment it stops
+ * refusing anything in production — and the cell becomes capturable again with no edit here.
+ */
+export async function readExceededBounds(root = ROOT) {
+  const bounds = new Map();
+  let store;
+  let closures;
+  try {
+    store = JSON.parse(await readFile(path.join(root, ANCHOR_STORE_PATH), "utf8"));
+    closures = JSON.parse(await readFile(path.join(root, ANCHOR_LOADER_CONFIG_PATH), "utf8"));
+  } catch {
+    return bounds;
+  }
+  for (const bound of store.exceededBounds ?? []) {
+    if (!bound.modelId || !bound.tier || !bound.backend) continue;
+    const declared = closures.models?.[`${bound.modelId}:${bound.backend}`]?.digest;
+    bounds.set(`${bound.modelId}:${bound.tier}:${bound.backend}`, {
+      current: declared !== undefined && declared === bound.source?.loaderClosureDigest,
+      source: bound.source?.path ?? ANCHOR_STORE_PATH,
+      observedFootprintBytes: bound.observedFootprintBytes ?? null,
+    });
+  }
+  return bounds;
+}
+
 export async function compiledInferencePin(root = ROOT) {
   const source = await readFile(path.join(root, ADAPTER_LIB_PATH), "utf8");
   const match = /^pub const INFERENCE_PIN: &str = "([0-9a-f]{40})";/m.exec(source);
@@ -1379,7 +1424,7 @@ async function firstExistingDirectory(candidates) {
  * Decide what the run can do with one plan anchor: which adapter arm serves it, which weights
  * root it loads, and why it would be skipped. Pure apart from the directory probes.
  */
-export async function classifyAnchor(key, planned, { models, backend, hubs, current, captured, declaredLanes, declaredProviders, sdxlRoutes = null, families = PROVIDER_FAMILIES }) {
+export async function classifyAnchor(key, planned, { models, backend, hubs, current, captured, bounds = new Map(), declaredLanes, declaredProviders, sdxlRoutes = null, families = PROVIDER_FAMILIES }) {
   const parts = anchorParts(key);
   const row = { key, ...parts, provider: planned.provider, status: "runnable", reason: null, env: {}, roots: [] };
   if (parts.backend !== backend) return { ...row, status: "other_backend", reason: `${parts.backend} lane` };
@@ -1415,6 +1460,22 @@ export async function classifyAnchor(key, planned, { models, backend, hubs, curr
     };
   }
   if (captured.has(key)) return { ...row, status: "already_captured", reason: captured.get(key) };
+  // sc-22738: a CURRENT measured lower bound is a captured cell, not an uncaptured one. The run that
+  // produced it established the one fact a re-run could establish — this cell's peak is at or above
+  // a footprint this host had to stop — so booking it again spends another guarded render (76
+  // minutes for the bernini bf16 stop) to learn the same thing, and the only reason it stayed
+  // `runnable` is that a bound's bundle carries no `records` entry for the classifier to see. A
+  // STALE bound classifies nothing: the cell goes back to `runnable`, because the loader closure it
+  // was measured under is no longer the one production loads.
+  const bound = bounds.get(key);
+  if (bound?.current) {
+    return {
+      ...row, status: "exceeded_current", current: true,
+      reason:
+        `exceeded bound recorded at the pinned inference revision (${bound.source}); the host `
+        + "already proved this cell cannot complete under this loader closure",
+    };
+  }
   if (declaredLanes && !declaredLanes.has(`${parts.modelId}:${backend}`)) {
     return {
       ...row, status: "lane_undeclared",
@@ -1739,6 +1800,65 @@ export function appendPackagedSource(source, relativePath) {
   return `${source.slice(0, at)}${entry}\n${source.slice(at)}`;
 }
 
+/**
+ * The two Rust builder stages' evidence-copy blocks, and the line that opens each of them.
+ *
+ * Every `include_str!` `memory_anchor.rs` compiles in must ALSO be copied into both Docker builder
+ * contexts, or `docker build` breaks while `cargo build` on a checkout stays green — the two see
+ * different trees. `scripts/platform-review-contracts.test.mjs` ("Rust Docker builders copy every
+ * production generated embed from sceneworks-core") asserts exactly that, counting the `COPY <path>
+ * ./<dir>/` line twice. `appendPackagedSource` added the embed and left the Dockerfile alone, so
+ * every anchor commit — a completed capture's as much as a hard stop's — landed a red tree that had
+ * to be repaired by hand afterwards (PR #2759 and the bernini q4 seed both did).
+ */
+export const DOCKERFILE_PATH = "docker/rust.Dockerfile";
+export const DOCKERFILE_EMBED_ANCHOR = "COPY docs/generated/memory-calibration-evidence.json ./docs/generated/";
+
+/**
+ * `dockerfile` with `relativePath` copied into BOTH builder stages, idempotently.
+ *
+ * Placement follows the lines already there rather than inventing an order: inside the same
+ * directory group in sorted position (so `docs/calibration/sc-22738/` stays readable as one block),
+ * else after the last line of the same `docs/<kind>/` family, else at the end of the block. The
+ * block is the contiguous run of `COPY` lines around each occurrence of [`DOCKERFILE_EMBED_ANCHOR`],
+ * which is the one embed both stages have carried since the file was written.
+ *
+ * Fails when the two blocks cannot be found: a Dockerfile this cannot read must red the run rather
+ * than silently commit an embed the image will not carry.
+ */
+export function insertEvidenceCopy(dockerfile, relativePath) {
+  const directory = relativePath.slice(0, relativePath.lastIndexOf("/") + 1);
+  const entry = `COPY ${relativePath} ./${directory}`;
+  const lines = dockerfile.split("\n");
+  const anchors = lines.flatMap((line, index) => (line === DOCKERFILE_EMBED_ANCHOR ? [index] : []));
+  if (anchors.length !== 2) {
+    fail(
+      `${DOCKERFILE_PATH} carries ${anchors.length} "${DOCKERFILE_EMBED_ANCHOR}" lines, not the two `
+        + "builder stages this run must copy the new evidence into",
+    );
+  }
+  const family = `COPY ${directory.split("/").slice(0, 2).join("/")}/`;
+  // Last block first: an insertion shifts every LATER index, never an earlier one.
+  for (const anchor of [...anchors].reverse()) {
+    let start = anchor;
+    while (start > 0 && lines[start - 1].startsWith("COPY ")) start -= 1;
+    let end = anchor;
+    while (end + 1 < lines.length && lines[end + 1].startsWith("COPY ")) end += 1;
+    if (lines.slice(start, end + 1).includes(entry)) continue;
+    let at = null;
+    for (let index = start; index <= end; index += 1) {
+      if (!lines[index].startsWith(`COPY ${directory}`)) continue;
+      if (lines[index] > entry) { at = index; break; }
+      at = index + 1;
+    }
+    if (at === null) {
+      for (let index = start; index <= end; index += 1) if (lines[index].startsWith(family)) at = index + 1;
+    }
+    lines.splice(at ?? end + 1, 0, entry);
+  }
+  return lines.join("\n");
+}
+
 /** Anchors already ingested under the campaign directory, keyed by anchor key. */
 export async function capturedInCampaign(root, campaignDir) {
   const captured = new Map();
@@ -2005,7 +2125,9 @@ export async function measureAnchor(row, context) {
   const exceededOutput = path.join(workDir, "captures", `${slug}-exceeded.json`);
   const exceededEvidenceRelative = `${campaignDir}/${slug}-exceeded-evidence.json`;
   const started = Date.now();
-  const touched = [ANCHOR_STORE_PATH, MATRIX_PATH, MATRIX_MD_PATH, PACKAGED_SOURCES_PATH];
+  // sc-22738: the Dockerfile moves with the packaged-source list, on BOTH commit paths — an embed
+  // the image does not copy is a red `platform-review-contracts` suite on a commit already made.
+  const touched = [ANCHOR_STORE_PATH, MATRIX_PATH, MATRIX_MD_PATH, PACKAGED_SOURCES_PATH, DOCKERFILE_PATH];
   const exec = (command, commandArgs, options = {}) => run(command, commandArgs, { cwd: root, ...options });
   const gitAt = (gitArgs) => git(gitArgs, root);
   const created = [];
@@ -2054,6 +2176,10 @@ export async function measureAnchor(row, context) {
       }
       const rust = await readFile(path.join(root, PACKAGED_SOURCES_PATH), "utf8");
       await writeFile(path.join(root, PACKAGED_SOURCES_PATH), appendPackagedSource(rust, target));
+      // The same corpus, into both Docker builder contexts. Idempotent, so a re-ingest of a bundle
+      // already packaged rewrites nothing.
+      const dockerfile = await readFile(path.join(root, DOCKERFILE_PATH), "utf8");
+      await writeFile(path.join(root, DOCKERFILE_PATH), insertEvidenceCopy(dockerfile, target));
       await extractSeedingNewAnchors(exec, root, log);
       await exec(process.execPath, [
         "scripts/anchor-loader-closure.mjs", "--repo", path.resolve(args.inferenceRepo), "--stamp-anchors",
@@ -2189,6 +2315,10 @@ export async function planRun(args, root = ROOT) {
   const campaign = args.campaign ?? `catalog-${new Date().toISOString().slice(0, 10)}`;
   const campaignDir = `docs/calibration/${campaign}`;
   const captured = await capturedInCampaign(root, campaignDir);
+  // sc-22738: measured lower bounds are campaign-independent — they live in the committed store, not
+  // under one campaign directory — so a bound recorded by an earlier campaign still speaks for the
+  // cell as long as its currency key is the pinned one.
+  const bounds = await readExceededBounds(root);
   const declaredLanes = await readDeclaredLanes(root);
   const declaredProviders = await readDeclaredProviders(root);
   const hubs = hubRoots(args.hfCache);
@@ -2206,7 +2336,7 @@ export async function planRun(args, root = ROOT) {
   for (const key of keys) {
     if (args.anchors && !args.anchors.includes(key)) continue;
     if ((args.models ?? []).length > 0 && !args.models.includes(anchorParts(key).modelId)) continue;
-    const row = await classifyAnchor(key, plan.anchors[key], { models, backend: args.backend, hubs, current, captured, declaredLanes, declaredProviders, sdxlRoutes });
+    const row = await classifyAnchor(key, plan.anchors[key], { models, backend: args.backend, hubs, current, captured, bounds, declaredLanes, declaredProviders, sdxlRoutes });
     if (row.status === "other_backend" && !args.anchors) continue;
     // An unperformed route-revision comparison is reported on the row it did not happen for, so a
     // run without an inference checkout cannot silently look like a run that proved the engine agrees.

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -72,6 +72,12 @@ import {
   LTX25_ENHANCER_DIR,
   INSTANTID_IDENTITY_BUNDLE_FILES,
   INSTANTID_CONTROLNET_WEIGHT_FILE,
+  ANCHOR_STORE_PATH,
+  ANCHOR_LOADER_CONFIG_PATH,
+  DOCKERFILE_PATH,
+  DOCKERFILE_EMBED_ANCHOR,
+  insertEvidenceCopy,
+  readExceededBounds,
 } from "./measure-memory-catalog.mjs";
 import {
   ANCHOR_LANE_DEFAULT_STRATEGY_PATH,
@@ -1260,6 +1266,43 @@ test("appending to PACKAGED_MEMORY_ANCHOR_SOURCES is idempotent and keeps the ru
   );
 });
 
+// sc-22738: the embed and the Docker COPY lines are ONE step. `platform-review-contracts.test.mjs`
+// ("Rust Docker builders copy every production generated embed from sceneworks-core") requires each
+// `include_str!` in `memory_anchor.rs` to be copied into BOTH builder stages, and packaging a corpus
+// without them reds that suite on a commit the runner has already made.
+test("a new evidence corpus is copied into both Rust builder stages, in place and idempotently", async () => {
+  const dockerfile = await readFile(path.join(ROOT, DOCKERFILE_PATH), "utf8");
+  const relative = "docs/calibration/sc-22738/aaa-first-mlx-evidence.json";
+  const line = `COPY ${relative} ./docs/calibration/sc-22738/`;
+  const once = insertEvidenceCopy(dockerfile, relative);
+  assert.equal(once.split(`\n${line}\n`).length - 1, 2, "one line per builder stage");
+  assert.equal(insertEvidenceCopy(once, relative), once, "idempotent");
+  const lines = once.split("\n");
+  for (const index of lines.flatMap((text, at) => (text === line ? [at] : []))) {
+    assert.ok(lines[index - 1].startsWith("COPY "), "inserted inside the stage's COPY run, never after it");
+    assert.ok(lines[index + 1].startsWith("COPY "), "inserted inside the stage's COPY run, never before it");
+  }
+  // Sorted WITHIN its own directory group, which is what keeps a campaign's corpora readable as one
+  // block rather than interleaved with `docs/generated/`.
+  const group = lines.filter((text) => text.startsWith("COPY docs/calibration/sc-22738/"));
+  assert.ok(group.length >= 4, "the campaign group holds the shipped bound plus the new corpus, per stage");
+  assert.deepEqual(group.slice(0, group.length / 2), [...group.slice(0, group.length / 2)].sort());
+  assert.equal(group[0], line, "a corpus that sorts first lands first");
+  // A directory with no lines yet joins the other `docs/calibration/` lines rather than the end.
+  const fresh = "docs/calibration/sc-99999/x-evidence.json";
+  const freshLine = `COPY ${fresh} ./docs/calibration/sc-99999/`;
+  const withFresh = insertEvidenceCopy(dockerfile, fresh).split("\n");
+  assert.equal(withFresh.filter((text) => text === freshLine).length, 2);
+  for (const index of withFresh.flatMap((text, at) => (text === freshLine ? [at] : []))) {
+    assert.ok(withFresh[index - 1].startsWith("COPY docs/calibration/"), "it lands beside the other calibration corpora");
+  }
+  assert.throws(
+    () => insertEvidenceCopy(`FROM rust AS builder\n${DOCKERFILE_EMBED_ANCHOR}\nRUN cargo build\n`, relative),
+    /not the two builder stages/,
+    "a Dockerfile whose two stages cannot be found reds the run instead of committing an uncopied embed",
+  );
+});
+
 test("a campaign directory's ingested bundles mark their anchors as already captured", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "catalog-campaign-"));
   const dir = "docs/calibration/sc-1";
@@ -1273,6 +1316,87 @@ test("a campaign directory's ingested bundles mark their anchors as already capt
   assert.equal((await capturedInCampaign(root, "docs/calibration/absent")).size, 0);
 });
 
+// sc-22738. A bound's bundle has an EMPTY `records` array and the matrix publishes only anchors,
+// so neither of the two indexes `classifyAnchor` consulted could see a cell the host had already
+// proved it cannot finish: `--list` said `runnable`, and the next `--skip-current` re-run would
+// book the same guarded render again (76 minutes for the bernini bf16 stop). Currency is the same
+// rule a record's is, so a bound that stales stops classifying and the cell is capturable again.
+test("a CURRENT exceeded bound is a captured cell; a stale bound leaves the anchor runnable", async () => {
+  const storeRoot = await mkdtemp(path.join(tmpdir(), "catalog-bounds-"));
+  await mkdir(path.join(storeRoot, "config"), { recursive: true });
+  const digest = "b".repeat(64);
+  const bound = {
+    modelId: "bernini", tier: "bf16", backend: "mlx", observedFootprintBytes: 97147294328,
+    source: {
+      path: "docs/calibration/sc-22738/bernini-bf16-mlx-exceeded-evidence.json",
+      loaderClosureDigest: digest,
+    },
+  };
+  const seed = async (rows) => {
+    await writeFile(path.join(storeRoot, ANCHOR_STORE_PATH), JSON.stringify({ anchors: [], exceededBounds: rows }));
+    await writeFile(path.join(storeRoot, ANCHOR_LOADER_CONFIG_PATH), JSON.stringify({ models: { "bernini:mlx": { digest } } }));
+  };
+  await seed([bound]);
+  const currentBounds = await readExceededBounds(storeRoot);
+  assert.deepEqual([...currentBounds.keys()], ["bernini:bf16:mlx"]);
+  assert.equal(currentBounds.get("bernini:bf16:mlx").current, true);
+  assert.equal(currentBounds.get("bernini:bf16:mlx").source, bound.source.path);
+  await seed([{ ...bound, source: { ...bound.source, loaderClosureDigest: "c".repeat(64) } }]);
+  assert.equal((await readExceededBounds(storeRoot)).get("bernini:bf16:mlx").current, false, "a bound measured under another loader closure is stale");
+  await seed([{ ...bound, backend: "candle" }]);
+  assert.equal(
+    (await readExceededBounds(storeRoot)).get("bernini:bf16:candle").current, false,
+    "the closure digest is looked up per (model, LANE); the mlx digest does not keep a candle bound current",
+  );
+  assert.equal((await readExceededBounds(await mkdtemp(path.join(tmpdir(), "catalog-empty-")))).size, 0);
+
+  const hub = await fakeHub([["SceneWorks/z-image-turbo-mlx", REVISION, "q4"]]);
+  const base = { models: fakeModels(), backend: "candle", hubs: [hub], current: new Map(), captured: new Map() };
+  const key = "z_image_turbo:q4:candle";
+  const bounded = await classifyAnchor(key, { provider: "z_image_turbo" }, {
+    ...base,
+    bounds: new Map([[key, { current: true, source: "docs/calibration/sc-1/z-exceeded-evidence.json" }]]),
+  });
+  assert.equal(bounded.status, "exceeded_current");
+  assert.equal(bounded.current, true);
+  assert.match(bounded.reason, /exceeded bound recorded at the pinned inference revision/);
+  assert.match(bounded.reason, /docs\/calibration\/sc-1\/z-exceeded-evidence\.json/);
+  const staleRow = await classifyAnchor(key, { provider: "z_image_turbo" }, {
+    ...base,
+    bounds: new Map([[key, { current: false, source: "docs/calibration/sc-1/z-exceeded-evidence.json" }]]),
+  });
+  assert.equal(staleRow.status, "runnable", "a stale bound classifies nothing");
+  assert.equal(
+    (await classifyAnchor(key, { provider: "z_image_turbo" }, base)).status, "runnable",
+    "a cell with no bound at all is untouched",
+  );
+});
+
+// The same question against the REAL committed store, through the walk that schedules the captures:
+// a cell whose bound is current is never in the runnable set — with or without `--skip-current`,
+// because there is nothing left for a re-run to establish.
+test("the committed exceeded bound keeps its own cell out of the runnable set of a real --list", async () => {
+  const bounds = await readExceededBounds();
+  assert.ok(bounds.size > 0, "the shipped store carries at least one measured lower bound");
+  for (const skipCurrent of [false, true]) {
+    const { rows } = await planRun({ backend: "mlx", anchors: null, campaign: "sc-catalog-test", hfCache: [], skipCurrent, models: [] });
+    for (const [key, bound] of bounds) {
+      const row = rows.find((candidate) => candidate.key === key);
+      if (!row || row.backend !== "mlx") continue;
+      if (bound.current) {
+        assert.equal(row.status, "exceeded_current", `${key} carries a current bound`);
+        assert.equal(row.current, true);
+      } else {
+        assert.notEqual(row.status, "exceeded_current", `${key}'s bound is stale, so the cell is capturable again`);
+      }
+    }
+    assert.ok(
+      !rows.filter((row) => row.status === "runnable").some((row) => bounds.get(row.key)?.current),
+      "no cell with a current bound is scheduled for a capture",
+    );
+  }
+});
+
 test("every provider the committed plan declares is either served by a family row or refused by name", async () => {
   const plan = await readPlan();
   const models = await readManifestModels();
@@ -1281,7 +1405,10 @@ test("every provider the committed plan declares is either served by a family ro
     const keys = Object.keys(plan.anchors).filter((key) => key.endsWith(`:${backend}`));
     assert.deepEqual(rows.map((row) => row.key), keys.sort(), `${backend}: one row per plan anchor`);
     for (const row of rows) {
-      assert.ok(["runnable", "weights_missing", "no_adapter_arm", "harness_unsupported", "lane_undeclared", "provider_undeclared"].includes(row.status), `${row.key}: ${row.status}`);
+      // sc-22738: `exceeded_current` is the seventh — a cell whose measured lower bound is current
+      // is answered by the store rather than by a root, so it resolves none (the branch below
+      // excludes it for the same reason `lane_undeclared` is excluded).
+      assert.ok(["runnable", "weights_missing", "no_adapter_arm", "harness_unsupported", "lane_undeclared", "provider_undeclared", "exceeded_current"].includes(row.status), `${row.key}: ${row.status}`);
       if (row.status === "lane_undeclared") assert.match(row.reason, /anchor-loader-closures\.json/);
       if (row.status === "provider_undeclared") assert.match(row.reason, /inference-provider-closures\.json/);
       // sc-22729/sc-22734: the family is resolved by the SAME rule classification uses — model-keyed when
@@ -1290,7 +1417,7 @@ test("every provider the committed plan declares is either served by a family ro
       const family = familyFor(row.modelId, row.provider);
       if (row.status === "no_adapter_arm") {
         assert.equal(family?.arms.includes(backend) ?? false, false);
-      } else if (!["harness_unsupported", "lane_undeclared", "provider_undeclared"].includes(row.status)) {
+      } else if (!["harness_unsupported", "lane_undeclared", "provider_undeclared", "exceeded_current"].includes(row.status)) {
         // A served provider must resolve a manifest download, or the classification could not name a root.
         tierDownload(models, row.modelId, family.repo, row.tier);
         assert.ok(row.roots.length > 0, `${row.key} names the root it would load`);
@@ -1525,7 +1652,12 @@ async function computeMeasurabilityGaps() {
   for (const cell of await shippedTieredCells()) {
     const row = rows.get(cell.key);
     const status = row?.status ?? (plan.anchors[cell.key] ? "unclassified" : "no_plan_anchor");
-    if (!["runnable", "weights_missing"].includes(status)) {
+    // sc-22738: `exceeded_current` joins the two. The gap set counts cells the campaign cannot
+    // REACH — a missing arm, an undeclared lane, an unbindable artifact — and a cell whose current
+    // measured lower bound is already in the store is the opposite of unreached: it has evidence,
+    // and re-running it could only re-establish the same inequality. A bound that stales puts the
+    // cell straight back into `runnable`, so the gap set still sees it the moment it is capturable.
+    if (!["runnable", "weights_missing", "exceeded_current"].includes(status)) {
       gaps.push({ ...cell, status, reason: row?.reason ?? `${PLAN_PATH} declares no anchor ${cell.key}` });
     }
   }
@@ -3494,6 +3626,30 @@ async function stubCheckout() {
   await writeFile(path.join(root, "docs/generated/memory-matrix.json"), "{}\n");
   await writeFile(path.join(root, "docs/generated/memory-matrix.md"), "# matrix\n");
   await writeFile(path.join(root, ".gitignore"), "*.log\n");
+  // sc-22738: the two Rust builder stages, in the shape `docker/rust.Dockerfile` really has — one
+  // contiguous run of evidence `COPY` lines per stage, opened by the memory-calibration evidence
+  // line. Every `include_str!` the ingest compiles in has to reach BOTH of them.
+  await mkdir(path.join(root, "docker"), { recursive: true });
+  await writeFile(path.join(root, DOCKERFILE_PATH), [
+    "FROM rust:1-bookworm AS builder",
+    "COPY config ./config",
+    "# Generated calibration inputs embedded by sceneworks-core.",
+    "COPY docs/generated/memory-calibration-evidence.json ./docs/generated/",
+    "COPY docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json ./docs/calibration/sc-18791/",
+    "COPY docs/generated/qwen-candle-five-rung-sc-15817.json ./docs/generated/",
+    "",
+    "RUN cargo build --release",
+    "",
+    "FROM nvidia/cuda:12.9.1-devel-ubuntu22.04 AS candle-builder",
+    "COPY config ./config",
+    "# Generated calibration inputs embedded by sceneworks-core (see the ordinary builder above).",
+    "COPY docs/generated/memory-calibration-evidence.json ./docs/generated/",
+    "COPY docs/calibration/sc-18791/ltx25-mlx-evidence.seed.json ./docs/calibration/sc-18791/",
+    "COPY docs/generated/qwen-candle-five-rung-sc-15817.json ./docs/generated/",
+    "",
+    "RUN cargo build --release",
+    "",
+  ].join("\n"));
   await writeFile(path.join(root, PACKAGED_SOURCES_PATH), [
     "const PACKAGED_MEMORY_ANCHOR_SOURCES: &[(&str, &str)] = &[",
     "    (",
@@ -3547,6 +3703,34 @@ test("one anchor lands as one commit carrying the evidence, the packaged-source 
   const evidence = JSON.parse(await readFile(path.join(checkout.root, "docs/calibration/sc-stub/z-image-turbo-q4-mlx-evidence.json"), "utf8"));
   assert.equal(evidence.records[0].env, tierRoot, "the derived adapter environment reached the provider");
   assert.ok((await stat(result.log)).size > 0, "the per-anchor log was written");
+});
+
+// sc-22738: the gap this story closes on the ORDINARY commit path too. Every campaign commit added
+// an `include_str!` and left `docker/rust.Dockerfile` alone, so each one landed a tree that reds
+// `platform-review-contracts.test.mjs`; PR #2759 and the bernini q4 seed both had to add the two
+// COPY lines by hand afterwards. The assertion below is that suite's own predicate, applied to the
+// tree this run produced.
+test("an anchor commit carries the new corpus's COPY line in both Docker builder stages", async () => {
+  const checkout = await stubCheckout();
+  const tierRoot = await mkdtemp(path.join(tmpdir(), "catalog-tier-"));
+  await writeFile(path.join(tierRoot, "w.safetensors"), "weights");
+  process.env.GIT_AUTHOR_NAME = process.env.GIT_COMMITTER_NAME = "t";
+  process.env.GIT_AUTHOR_EMAIL = process.env.GIT_COMMITTER_EMAIL = "t@t";
+  const row = { key: "z_image_turbo:q4:mlx", physical: false, tierRoot, env: { SCENEWORKS_Z_IMAGE_ROOT: tierRoot } };
+  const context = stubContext(checkout);
+  assert.equal((await measureAnchor(row, context)).status, "committed");
+  const dockerfile = await readFile(path.join(checkout.root, DOCKERFILE_PATH), "utf8");
+  const rust = await readFile(path.join(checkout.root, PACKAGED_SOURCES_PATH), "utf8");
+  const embeds = [...rust.matchAll(/include_str!\("\.\.\/\.\.\/\.\.\/(docs\/(?:generated|calibration)\/[^"\n]+)"\)/g)]
+    .map((match) => match[1]);
+  assert.ok(embeds.includes("docs/calibration/sc-stub/z-image-turbo-q4-mlx-evidence.json"));
+  for (const embed of embeds) {
+    const copy = `COPY ${embed} ./${embed.slice(0, embed.lastIndexOf("/") + 1)}`;
+    assert.equal(dockerfile.split(copy).length - 1, 2, `${embed} must reach both builder contexts`);
+  }
+  const { stdout: shown } = await checkout.git("show", "--stat", "--format=%s", "HEAD");
+  assert.ok(shown.includes(DOCKERFILE_PATH), "the Dockerfile moves in the SAME commit as the embed");
+  assert.equal((await checkout.git("status", "--porcelain")).stdout, "", "nothing is left behind for a by-hand repair");
 });
 
 test("a --no-commit run captures and checks, then stops with a clean tree so the next anchor can still be captured", async () => {
@@ -3862,6 +4046,14 @@ test("a footprint hard stop is COMMITTED as a measured lower bound, through the 
       rust.includes('"docs/calibration/sc-stub/z-image-turbo-q4-mlx-exceeded-evidence.json"'),
       "the bound's corpus is compiled into the Rust loader, exactly as an anchor's is",
     );
+    // ...and is copied into both Docker builder stages by the same step (sc-22738), so a hard-stop
+    // commit is not a tree that reds `platform-review-contracts.test.mjs` until someone repairs it.
+    const dockerfile = await readFile(path.join(checkout.root, DOCKERFILE_PATH), "utf8");
+    assert.equal(
+      dockerfile.split("COPY docs/calibration/sc-stub/z-image-turbo-q4-mlx-exceeded-evidence.json ./docs/calibration/sc-stub/").length - 1,
+      2,
+    );
+    assert.ok(shown.includes(DOCKERFILE_PATH), "the Dockerfile is in the bound's commit");
     const bundle = JSON.parse(await readFile(
       path.join(checkout.root, "docs/calibration/sc-stub/z-image-turbo-q4-mlx-exceeded-evidence.json"), "utf8",
     ));


### PR DESCRIPTION
Two gaps the catalog runner still had after #2759 taught it to record a footprint hard stop as a measured bound.

**1. A current exceeded bound now classifies its cell, and is never scheduled.**
`classifyAnchor` consulted two indexes — `capturedInCampaign` (over a bundle's `records`) and the matrix currency map (which publishes only anchors) — and a bound is in neither: its bundle's `records` array is empty and the matrix carries no `exceededBounds`. So `bernini:bf16:mlx` printed `runnable`, and the next `--skip-current` re-run would have booked the same guarded render (76 minutes) for a cell the host already proved it cannot finish.

`readExceededBounds` reads the committed store's `exceededBounds` and grades each row by the SAME currency rule a record's is graded by — `source.loaderClosureDigest` against the digest `config/anchor-loader-closures.json` carries for that `(model, lane)`. A current bound classifies `exceeded_current` (never runnable, with or without `--skip-current`); a STALE bound classifies nothing and the cell is capturable again, with no edit here.

`exceeded_current` reaches none of the run outcomes, so it cannot move the exit code; it joins `runnable` / `weights_missing` in the measurability gap set's allowed statuses, because a cell with current evidence is the opposite of unreached.

**2. The ingest commit now carries its own Dockerfile embeds.**
`appendPackagedSource` added an `include_str!` to `memory_anchor.rs` and left `docker/rust.Dockerfile` alone, but `platform-review-contracts.test.mjs` requires every such embed to be `COPY`-ed into BOTH Rust builder stages. Every campaign commit — a completed capture's as much as a hard stop's — therefore landed a tree that reds that suite until someone added the two lines by hand (#2759 and the bernini q4 seed both did). `insertEvidenceCopy` now writes them in the same step, in place (sorted inside the corpus's own directory group, else beside the other `docs/calibration/` lines), idempotently, and `docker/rust.Dockerfile` is in `touched` so it moves and rolls back with the rest.

## Verification
- `node scripts/measure-memory-catalog.mjs --backend mlx --list`: `bernini:bf16:mlx  exceeded_current  exceeded bound recorded at the pinned inference revision (docs/calibration/sc-22738/bernini-bf16-mlx-exceeded-evidence.json); …`. `bernini:q4:mlx` is `runnable` here only because its bound lives on the unmerged `chore/sc-22738-bernini-q4-exceeded-bound`; replaying that branch's store against this runner classifies it `exceeded_current` too.
- 4 new cases (2 classification incl. the real store through `planRun`, 2 Dockerfile incl. the real `docker/rust.Dockerfile` and the stub-checkout commit), plus assertions added to the existing hard-stop commit case. `scripts/measure-memory-catalog.test.mjs` 94/94.
- Mutations, each red exactly where it should be: currency comparison forced true → the bounds case reds; only the first builder stage inserted → 3 Dockerfile cases red; the bound branch never fires → both classification cases red; `DOCKERFILE_PATH` out of `touched` → 5 commit-path cases red.
- `npm run check` with `INFERENCE_REPO` at the pin: green, 841/841, 0 failures.
- `docs/calibration-runbook.md`: the outcome table gains the `exceeded_current` classification and its currency rule; the sc-22738 note now says the runner writes the COPY lines itself.
