### PR TITLE
fix(sc-22738): Bernini still-image route attributes the phases its engine actually emits

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -1206,11 +1206,34 @@ mod tests {
         for record in evidence.records.iter().filter(|record| {
             record.backend == Backend::Mlx && record.target.mode == "text_to_image"
         }) {
-            image_records += 1;
+            // A record whose ENGINE bounds only some of the three declared phases publishes the
+            // overall-only shape and says so in its diagnostics (sc-22738 — the still Bernini
+            // member: `bernini_requires_bounded_conditioning_peak`). There is no decomposition to
+            // run the counterfactual over, and inventing one is exactly what that arm refuses to
+            // do, so such a record is skipped — but only on its own declaration. An overall-only
+            // record that does NOT declare an unattributed phase is a decomposition that went
+            // missing, and still fails here.
             let observed = match &record.observed_memory {
-                RequiredNullable::Value(observed) => observed.full().expect("full image telemetry"),
+                RequiredNullable::Value(observed) => match observed.full() {
+                    Some(observed) => observed,
+                    None => {
+                        assert!(
+                            record.diagnostics.as_ref().is_some_and(|diagnostics| {
+                                diagnostics.measurements.iter().any(|measurement| {
+                                    measurement.name == "conditioningPhaseUnattributed"
+                                        && measurement.value == 1
+                                })
+                            }),
+                            "{} carries overall-only image telemetry without declaring an \
+                             unattributed phase",
+                            record.id
+                        );
+                        continue;
+                    }
+                },
                 RequiredNullable::Null => panic!("{} has null image telemetry", record.id),
             };
+            image_records += 1;
             let historical = image_predicted_peak_bytes(
                 phase(&observed.conditioning),
                 phase(&observed.denoise),
@@ -3245,6 +3268,19 @@ impl PredictedPhasePeaks {
             "decode": self.decode,
             "overall": self.overall,
         })
+    }
+
+    /// The receipt an arm files when its engine does not bound every declared phase (sc-22738).
+    ///
+    /// `memory_calibration::PredictedPeakBytes` accepts exactly two shapes — the full four-key
+    /// decomposition or an overall-only object — and a partial decomposition deserializes as
+    /// NEITHER (both variants are `deny_unknown_fields`). An arm that measured only some of the
+    /// phases therefore publishes the ceiling and omits the decomposition, rather than filling the
+    /// unmeasured phase with a zero that reads as "this phase cost nothing". The ceiling itself is
+    /// identical: it is taken over the phases that WERE bounded, and on such an engine one of those
+    /// windows contains the unbounded phase.
+    fn overall_only_json(self) -> Value {
+        json!({ "overall": self.overall })
     }
 }
 
@@ -18392,6 +18428,80 @@ fn bernini_request(
     }
 }
 
+/// WHICH LIFECYCLE BOUNDARIES THE PINNED BERNINI ENGINE ACTUALLY EMITS (sc-22738).
+///
+/// `mlx-gen-bernini` at the pinned revision constructs a `Progress` value in exactly three places,
+/// and hands `on_progress` to nothing else:
+///
+/// * `src/bernini.rs:868` — `Progress::Step` for the MAR planning loop (`1..=planning_step`);
+/// * `src/bernini.rs:1052` — `Progress::Step` for the renderer denoise (`planning_step+1..=total`),
+///   the SAME folded bar (F-038);
+/// * `src/bernini.rs:1077` — `Progress::Decoding`, immediately before the z16 VAE decode.
+///
+/// It emits **no `Progress::Loading(_)` at all**, on either route: unlike every other MLX arm in
+/// this file it does not drive `gen_core::residency::run_two_phase`
+/// (`crates/contracts/gen-core/src/residency.rs:622,642`), which is what mints
+/// `Loading(TextEncoder)` / `Loading(Renderer)` for the providers that do.
+///
+/// So the conditioning→denoise EDGE has no boundary. The edge is real — `generate_impl` drops the
+/// Qwen2.5-VL planner and `clear_cache()`s at `bernini.rs:894-901`, encodes the UMT5-XXL prompt and
+/// drops it at `:902-921`, and only then loads the two ~28 GB experts at `:1000-1017` — but no
+/// event is emitted anywhere between the last planner `Step` and the first denoise `Step`, and the
+/// first denoise `Step` fires AFTER both experts are resident. Cutting on it would charge 56 GB of
+/// renderer weights to the conditioning phase; cutting on the first planner `Step` would drop the
+/// UMT5-XXL text encoder, the largest conditioning component, into denoise. Neither is the
+/// conditioning peak, so this arm measures neither and says so.
+///
+/// This is an ENGINE gap, not a route difference: the contract declares the full
+/// `[Conditioning, Denoise, Decode]` envelope for both members
+/// (`mlx-gen-bernini/src/memory_strategy.rs:1121-1135,1148-1153`) while the pipeline bounds only
+/// two of the three. Closing it is an inference-side change (emit the two `Loading` phases at the
+/// stage-2 and stage-3 entries) and therefore a pin bump.
+const BERNINI_ENGINE_BOUNDARIES: &str = concat!(
+    "the pinned mlx-gen-bernini pipeline emits only `Progress::Step` (one folded bar) and a ",
+    "single `Progress::Decoding` (bernini.rs:868, :1052, :1077) — it never emits ",
+    "`Progress::Loading(_)`, so no boundary exists at the conditioning/denoise edge. This record ",
+    "therefore attributes the pre-decode window and the decode window, the two phases the engine ",
+    "does bound, and reports the conditioning phase as UNATTRIBUTED rather than as a zero peak. ",
+    "The pre-decode window strictly contains the conditioning phase, so the overall ceiling this ",
+    "record prices is unaffected and remains conservative."
+);
+
+/// Whether this arm REFUSES a capture that carries no engine-bounded conditioning peak.
+///
+/// The pinned engine bounds no conditioning phase on EITHER route ([`BERNINI_ENGINE_BOUNDARIES`]).
+/// The two members are nonetheless treated differently, deliberately:
+///
+/// * the VIDEO member keeps the strict three-phase requirement it has always had. With no
+///   conditioning boundary that requirement REFUSES rather than files — the conservative
+///   direction, and the state this story leaves it in until the engine emits the boundary;
+/// * the STILL member, whose captures complete on this host, files the two phases the engine does
+///   bound and declares the third unattributed, so nothing downstream can read a false zero.
+fn bernini_requires_bounded_conditioning_peak(arm: BerniniArm) -> bool {
+    arm.model_id == BERNINI_VIDEO_MODEL_ID
+}
+
+/// The zero-active-peak refusal, over the phases this arm requires the engine to have bounded.
+///
+/// Returns `None` when every required phase reported a non-zero active peak.
+fn bernini_zero_phase_error(
+    arm: BerniniArm,
+    conditioning: u64,
+    denoise: u64,
+    decode: u64,
+) -> Option<String> {
+    let collapsed = if bernini_requires_bounded_conditioning_peak(arm) {
+        [conditioning, denoise, decode].contains(&0)
+    } else {
+        [denoise, decode].contains(&0)
+    };
+    collapsed.then(|| {
+        "a synchronized Bernini lifecycle phase reported a zero active peak; the engine stopped \
+         emitting a boundary and the attribution collapsed"
+            .to_owned()
+    })
+}
+
 fn bernini_quality_passes(maximum: f64, mean: f64, rms: f64) -> bool {
     maximum <= BERNINI_MAX_THRESHOLD
         && mean <= BERNINI_MEAN_THRESHOLD
@@ -18608,12 +18718,14 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
     let denoise = denoise.get();
     let conditioning_close = conditioning_close.get();
     let denoise_close = denoise_close.get();
-    if [conditioning.active, denoise.active, decode.active].contains(&0) {
-        return Err(
-            "a synchronized Bernini lifecycle phase reported a zero active peak; the engine \
-             stopped emitting a boundary and the attribution collapsed"
-                .to_owned(),
-        );
+    // Over the phases the PINNED engine actually bounds for this member — see
+    // [`BERNINI_ENGINE_BOUNDARIES`] and [`bernini_requires_bounded_conditioning_peak`]. `denoise`
+    // is the peak over the whole pre-decode window (the capture at `Progress::Decoding` is the
+    // first read since the pre-generate reset), so it strictly contains the conditioning phase.
+    if let Some(error) =
+        bernini_zero_phase_error(arm, conditioning.active, denoise.active, decode.active)
+    {
+        return Err(error);
     }
     // The engine's own decoded depth for this request, NOT the requested count: Bernini's z16
     // decode is NON-causal, so it materializes four output frames per latent frame and a 49-frame
@@ -18649,13 +18761,37 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
     // `every_receipt_builder_is_bound_to_its_lane_prediction_wrapper` reads every `predicted_peaks`
     // binding in this file, and a binding that merely selects between the two wrappers is not one
     // it can tell from a bypass.
-    let (predicted_peaks_json, predicted) = if arm.model_id == BERNINI_IMAGE_MODEL_ID {
-        let predicted_peaks = image_predicted_peak_bytes(conditioning, denoise, decode);
-        (predicted_peaks.json(), predicted_peaks.overall)
-    } else {
-        let predicted_peaks = video_predicted_peak_bytes(conditioning, denoise, decode);
-        (predicted_peaks.json(), predicted_peaks.overall)
-    };
+    //
+    // The still member additionally publishes its receipt in the OVERALL-ONLY shape (sc-22738): a
+    // full `predictedPeakBytes` / `observedMemory` decomposition is a claim that all three declared
+    // phases were measured, and on this engine the conditioning one was not. The overall ceiling is
+    // unchanged — it is taken over the same phases either way, and the pre-decode window contains
+    // the conditioning phase — so nothing about what this record prices is weakened; what changes
+    // is that no consumer can read a conditioning peak of zero off it.
+    let (predicted_peaks_json, observed_memory_json, predicted) =
+        if arm.model_id == BERNINI_IMAGE_MODEL_ID {
+            let predicted_peaks = image_predicted_peak_bytes(conditioning, denoise, decode);
+            (
+                predicted_peaks.overall_only_json(),
+                // `RuntimeObservedMemory` carries the ACTIVE peak and nothing else — the allocator
+                // envelope stays in the diagnostics, where `overallAllocatorEnvelope` already
+                // publishes it.
+                json!({ "overall": { "activeBytes": overall.active } }),
+                predicted_peaks.overall,
+            )
+        } else {
+            let predicted_peaks = video_predicted_peak_bytes(conditioning, denoise, decode);
+            (
+                predicted_peaks.json(),
+                json!({
+                    "conditioning": conditioning.json(),
+                    "denoise": denoise.json(),
+                    "decode": decode.json(),
+                    "overall": overall.json(),
+                }),
+                predicted_peaks.overall,
+            )
+        };
     // The same two ceilings `memory-calibration-harness.mjs#assertResidencyFitsHardware` applies —
     // checked HERE so a capture that cannot be admitted fails loudly during the campaign rather
     // than producing a well-formed record the harness rejects afterwards.
@@ -18749,11 +18885,41 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
             "implementable — they are not run here, and this record claims nothing about them. ",
             // sc-22738: stated in the same breath as the lifecycle exclusion because it is the
             // same kind of claim — what this record deliberately does NOT say.
-            "Additionally: {}"
+            "Additionally: {}{}"
         ),
-        BERNINI_ADMISSION_BLOCKER
+        BERNINI_ADMISSION_BLOCKER,
+        // sc-22738, same kind of claim again: a phase the engine does not bound is named here
+        // rather than left to be inferred from a measurement that is simply absent.
+        if bernini_requires_bounded_conditioning_peak(arm) {
+            String::new()
+        } else {
+            format!(" Additionally: {BERNINI_ENGINE_BOUNDARIES}")
+        }
     );
     let lifecycle_blocker = lifecycle_blocker.as_str();
+    // The conditioning-phase measurements are the keys `extract-memory-anchors.mjs`
+    // (`PHASE_MEASUREMENTS`) and `memory_anchor::validate_anchor` mint an anchor from, so they are
+    // published ONLY when the engine bounded that phase. Withholding them on the still route makes
+    // the record un-anchorable, which is the correct outcome for a decomposition the engine never
+    // gave — and strictly better than an anchor keyed on a fabricated zero. What the window DID
+    // measure is still published, under a name that says what it is.
+    let conditioning_measurements: Vec<(&'static str, &'static str, u64)> =
+        if bernini_requires_bounded_conditioning_peak(arm) {
+            vec![
+                ("conditioningActivePeak", "bytes", conditioning.active),
+                (
+                    "conditioningCloseActive",
+                    "bytes",
+                    conditioning_close.active,
+                ),
+                ("conditioningCloseCache", "bytes", conditioning_close.cache),
+            ]
+        } else {
+            vec![
+                ("conditioningPhaseUnattributed", "count", 1),
+                ("preDecodeWindowActivePeak", "bytes", denoise.active),
+            ]
+        };
     // GATED, not `runtime_complete` (sc-22738). Runtime activation is exactly the claim that the
     // provider's admission gate accepted an exact-fit budget and rejected the two mutations, and
     // this capture asked it nothing — because production asks it nothing for this request. The
@@ -18782,12 +18948,7 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
             { "name": "overlay", "result": "not_applicable", "reason": "settled below from the declared reference-free target" }
         ],
         "predictedPeakBytes": predicted_peaks_json,
-        "observedMemory": {
-            "conditioning": conditioning.json(),
-            "denoise": denoise.json(),
-            "decode": decode.json(),
-            "overall": overall.json(),
-        },
+        "observedMemory": observed_memory_json,
         "quality": {
             "contract": "identical artifact, prompt, seed, geometry, frames, fps, tier and loaded provider contract; cold measured output versus two warm unscoped repeats, compared over every frame",
             "identicalInputs": true,
@@ -18812,9 +18973,6 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
                 ("preRungActiveAfterClear", "bytes", pre_rung_active),
                 ("preRungCacheAfterClear", "bytes", pre_rung_cache),
                 ("preGenerateActivePeak", "bytes", pre_generate.active),
-                ("conditioningActivePeak", "bytes", conditioning.active),
-                ("conditioningCloseActive", "bytes", conditioning_close.active),
-                ("conditioningCloseCache", "bytes", conditioning_close.cache),
                 ("denoiseActivePeak", "bytes", denoise.active),
                 ("denoiseCloseActive", "bytes", denoise_close.active),
                 ("denoiseCloseCache", "bytes", denoise_close.cache),
@@ -18841,7 +18999,9 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
                 ("renderedFrames", "count", u64::from(expected_frames)),
                 ("requestedFrames", "count", u64::from(geometry.frames)),
                 ("outputFps", "count", u64::from(fps)),
-            ],
+            ]
+            .into_iter()
+            .chain(conditioning_measurements),
         ),
         "capturedAt": protocol::captured_at(),
     });
@@ -30318,6 +30478,157 @@ mod exceeded_bound_tests {
             "it states the footprint: {refusal}"
         );
         assert!(refusal.contains("Refusing before the load"), "{refusal}");
+    }
+
+    /// sc-22738 — the still route is graded on the phases the PINNED ENGINE BOUNDS.
+    ///
+    /// All three `bernini_image:*:mlx` anchors rendered for ~8 minutes and were then refused for a
+    /// zero conditioning active peak. The peak was zero because the pinned `mlx-gen-bernini`
+    /// pipeline emits no `Progress::Loading(_)` at all (see [`BERNINI_ENGINE_BOUNDARIES`]), so the
+    /// boundary this arm cut the conditioning phase on was never delivered — the arm was grading a
+    /// route against a phase set copied from a provider that drives the shared residency seam.
+    #[test]
+    fn the_still_route_is_graded_on_the_two_phases_the_engine_bounds() {
+        assert!(
+            !bernini_requires_bounded_conditioning_peak(BERNINI_IMAGE_ARM),
+            "the pinned engine bounds no conditioning phase on the still route; requiring one \
+             refuses every completed still capture"
+        );
+        // The exact shape the campaign hit: a completed render whose only zero is the phase the
+        // engine never bounded.
+        assert_eq!(
+            bernini_zero_phase_error(BERNINI_IMAGE_ARM, 0, 66_000_000_000, 71_000_000_000),
+            None,
+            "a still capture that measured both bounded phases must file"
+        );
+        // The phases the engine DOES bound are still required, so this is not a blanket allowance.
+        for (label, denoise, decode) in [
+            ("the pre-decode window", 0_u64, 71_000_000_000_u64),
+            ("the decode window", 66_000_000_000, 0),
+        ] {
+            assert!(
+                bernini_zero_phase_error(BERNINI_IMAGE_ARM, 12_000_000_000, denoise, decode)
+                    .is_some(),
+                "{label} is bounded by the engine and a zero there is still a collapse"
+            );
+        }
+    }
+
+    /// The VIDEO member's check is untouched: it keeps the strict three-phase requirement, which
+    /// with no conditioning boundary REFUSES rather than files. That is the conservative direction
+    /// and is deliberate — a video record is what the video admission law prices, and it will not
+    /// be minted off an unmeasured phase. Applying the still rule to a 49-frame request reds here.
+    #[test]
+    fn the_video_route_still_refuses_any_zero_phase() {
+        assert!(bernini_requires_bounded_conditioning_peak(
+            BERNINI_VIDEO_ARM
+        ));
+        let refusal =
+            bernini_zero_phase_error(BERNINI_VIDEO_ARM, 0, 66_000_000_000, 71_000_000_000)
+                .expect("the video member refuses a capture with an unmeasured conditioning phase");
+        assert_eq!(
+            refusal,
+            "a synchronized Bernini lifecycle phase reported a zero active peak; the engine \
+             stopped emitting a boundary and the attribution collapsed",
+            "the video member's refusal text is the one the campaign logs already carry"
+        );
+        assert_eq!(
+            bernini_zero_phase_error(
+                BERNINI_VIDEO_ARM,
+                12_000_000_000,
+                66_000_000_000,
+                71_000_000_000
+            ),
+            None
+        );
+    }
+
+    /// WHY the still receipt is published overall-only rather than with one key dropped.
+    ///
+    /// `memory_calibration` accepts exactly two receipt shapes and both `deny_unknown_fields`, so a
+    /// three-of-four decomposition is not a record at all. The choice is therefore between the
+    /// ceiling alone and a fabricated conditioning number, and this pins the first.
+    #[test]
+    fn an_unattributed_phase_is_published_as_a_ceiling_not_as_a_zero() {
+        use sceneworks_core::memory_calibration::{ObservedMemory, PredictedPeakBytes};
+
+        let peaks = PredictedPhasePeaks {
+            conditioning: 1,
+            denoise: 2,
+            decode: 3,
+            overall: 4,
+        };
+        let overall_only: PredictedPeakBytes =
+            serde_json::from_value(peaks.overall_only_json()).expect("overall-only prediction");
+        assert_eq!(overall_only.overall(), 4);
+        assert!(
+            overall_only.full().is_none(),
+            "an overall-only receipt must not read as a decomposition"
+        );
+        assert!(serde_json::from_value::<PredictedPeakBytes>(peaks.json())
+            .expect("full prediction")
+            .full()
+            .is_some());
+        // The shape the arm CANNOT file, and the reason the ceiling is filed instead.
+        assert!(
+            serde_json::from_value::<PredictedPeakBytes>(
+                json!({ "denoise": 2, "decode": 3, "overall": 4 })
+            )
+            .is_err(),
+            "a partial decomposition is not a receipt shape; dropping one key is not an option"
+        );
+
+        let window = PhaseMemory {
+            active: 66_000_000_000,
+            cache: 3,
+        };
+        let observed: ObservedMemory =
+            serde_json::from_value(json!({ "overall": { "activeBytes": window.active } }))
+                .expect("overall-only");
+        assert!(observed.full().is_none());
+        assert_eq!(observed.overall_non_reclaimable_bytes(), window.active);
+        assert!(serde_json::from_value::<ObservedMemory>(json!({
+            "denoise": window.json(),
+            "decode": window.json(),
+            "overall": window.json(),
+        }))
+        .is_err());
+    }
+
+    /// The arm ACTS on the attribution, not merely computes it: the still receipt is the ceiling,
+    /// the anchor-minting conditioning measurements are withheld, and what the window did measure
+    /// is published under a name that says what it is. Read the way the sibling guards in this file
+    /// read `run_bernini` — the measured render needs real weights and cannot run here.
+    #[test]
+    fn the_still_receipt_withholds_the_keys_an_anchor_would_be_minted_from() {
+        let source = include_str!("mlx.rs");
+        let start = source
+            .find("\nfn run_bernini(")
+            .expect("the arm still exists");
+        let body = &source[start
+            ..start
+                + source[start..]
+                    .find("\n}\n")
+                    .expect("the arm's body closes")];
+        assert!(
+            body.contains("predicted_peaks.overall_only_json()"),
+            "the still member must file the ceiling rather than a four-key decomposition"
+        );
+        assert!(
+            body.contains("(\"conditioningPhaseUnattributed\", \"count\", 1)")
+                && body.contains("(\"preDecodeWindowActivePeak\", \"bytes\", denoise.active)"),
+            "the unattributed phase must be declared, and the window that was measured named"
+        );
+        let conditioning_key = "(\"conditioningActivePeak\", \"bytes\", conditioning.active)";
+        let guarded = body
+            .find("if bernini_requires_bounded_conditioning_peak(arm) {")
+            .expect("the measurements are keyed on the engine's boundary set");
+        assert!(
+            body.match_indices(conditioning_key)
+                .all(|(index, _)| index > guarded),
+            "the anchor-minting conditioning measurement must only be emitted where the engine \
+             bounded that phase"
+        );
     }
 
     /// Everything the bound does NOT claim still captures: a bigger host, a shorter clip, another


### PR DESCRIPTION
## The measured defect

All three `bernini_image:{bf16,q4,q8}:mlx` anchors (text_to_image, 848x480, batch 1, frames 1)
rendered for ~8 minutes and then exited 1 with:

> a synchronized Bernini lifecycle phase reported a zero active peak; the engine stopped emitting a
> boundary and the attribution collapsed

## Root cause — the engine bounds two of the three phases it declares

At the pinned revision `3b922bac6`, `mlx-gen-bernini` constructs a `Progress` value in exactly three
places and hands `on_progress` to nothing else:

* `crates/media/mlx-gen/mlx-gen-bernini/src/bernini.rs:868` — `Progress::Step`, MAR planning loop;
* `.../bernini.rs:1052` — `Progress::Step`, renderer denoise (the SAME folded bar, F-038);
* `.../bernini.rs:1077` — `Progress::Decoding`, immediately before the z16 VAE decode.

It emits **no `Progress::Loading(_)` at all, on either route**: unlike every other MLX arm it does
not drive `gen_core::residency::run_two_phase`
(`crates/contracts/gen-core/src/residency.rs:622,642`), which is what mints
`Loading(TextEncoder)` / `Loading(Renderer)` for the providers that do. The adapter arm
(`crates/sceneworks-memory-adapter/src/bin/mlx.rs`, `run_bernini`) cut the conditioning phase on
`Loading(Renderer)` — a phase set copied from the MiniMax-H3 arm — so `conditioning.active` was
structurally `0` on every Bernini capture.

**This is case 2 in the brief: an engine gap, not a legitimate route-specific phase set.** The
contract declares the full `[Conditioning, Denoise, Decode]` envelope for both members
(`mlx-gen-bernini/src/memory_strategy.rs:1121-1135,1148-1153`) while the pipeline bounds only two of
them. The conditioning/denoise edge is real — `generate_impl` drops the Qwen2.5-VL planner and
`clear_cache()`s at `bernini.rs:894-901`, encodes and drops the UMT5-XXL prompt at `:902-921`, and
only then loads the two ~28 GB experts at `:1000-1017` — but no event is emitted between the last
planner `Step` and the first denoise `Step`, and the first denoise `Step` fires **after** both
experts are resident. Cutting on it would charge 56 GB of renderer weights to conditioning; cutting
on the first planner `Step` would drop the UMT5-XXL text encoder — the largest conditioning
component — into denoise. Neither is the conditioning peak, so this arm measures neither.

### Not a still-only defect

The video route emits exactly the same boundaries. The `bernini:bf16:mlx` 49-frame capture did not
"pass" this check earlier — per `b0da57b91` it was killed by the capture guard at 97,147,294,328
bytes mid-VAE-decode, i.e. it never reached the check. The still route is simply the first Bernini
capture small enough to survive to it.

**Inference-side fix needed (pin bump):** emit `Progress::Loading(LoadPhase::TextEncoder)` at the
stage-2 entry (`bernini.rs:902`) and `Progress::Loading(LoadPhase::Renderer)` at the stage-3 entry
(`bernini.rs:~1000`), the same two events `run_two_phase` mints. Until then the video member cannot
file either — see below.

## What changed (E4: production loader path; E5: measurement never gates production)

`run_bernini` now grades and files against the boundaries the engine actually emits:

* `BERNINI_ENGINE_BOUNDARIES` documents the pinned emission set with file:line citations.
* `bernini_requires_bounded_conditioning_peak(arm)` / `bernini_zero_phase_error(..)` — pure,
  testable, keyed on the member.
* **Still member:** the pre-decode window (closed at `Progress::Decoding`; the first read since the
  pre-generate reset, so it strictly *contains* the conditioning phase) and the decode window are
  both required to be non-zero. The conditioning phase is declared **unattributed**, not zero:
  * `predictedPeakBytes` / `observedMemory` are filed in the **overall-only** shape. A
    three-of-four decomposition is not a record shape at all (`memory_calibration`'s two variants
    are both `deny_unknown_fields`), so the choice was the ceiling alone or an invented number.
  * `conditioningActivePeak` — the key `scripts/extract-memory-anchors.mjs#PHASE_MEASUREMENTS` and
    `memory_anchor::validate_anchor` mint an anchor from — is **withheld**, so the cell classifies
    analytically rather than anchoring on a fabricated zero.
  * What *was* measured is still published as `preDecodeWindowActivePeak`, beside
    `conditioningPhaseUnattributed`, and the record's blocker string states the gap.
  * The overall ceiling this record prices is unchanged: it is taken over the same phases either
    way, and the pre-decode window contains the conditioning phase.
* **Video member: untouched.** It keeps the strict three-phase requirement, with the identical
  refusal text. With no conditioning boundary that requirement refuses rather than files — the
  conservative direction, and the right one for the records the video admission law prices. It is
  left that way deliberately until the engine emits the boundary.
* `resident_peak_counterfactual_only_loosens_shipped_image_admission` now skips an overall-only MLX
  image record **only on its own `conditioningPhaseUnattributed` declaration**; an overall-only
  record without it still fails, so a decomposition that goes missing is not laundered.

## Verification

* `cargo test -p sceneworks-memory-adapter --bin memory-mlx-adapter --features mlx` — **269 passed,
  0 failed** (265 before; 4 new).
* `cargo fmt --all`, `cargo clippy -p sceneworks-memory-adapter --features mlx --all-targets` clean.
* `npm run check` with `INFERENCE_REPO=/Users/michael/Repos/inference`: **838/839**. The one failure
  is pre-existing and environmental —
  `measure-memory-catalog.test.mjs:3141 "the bare MLX LTX-2.3 and MiniMax-H3 plan rows are the
  engines' calibrated tiers"` asserts `mlx-gen-ltx/src/memory_strategy.rs` declares
  `CALIBRATED_TIER`; the shared inference checkout is at `63056d4e9`, not the pin `3b922bac6`. It
  was not moved (a GPU campaign is running on this host).

### Mutations (each red on its own)

| mutation | red test |
| --- | --- |
| revert: require a bounded conditioning peak on the still route | `the_still_route_is_graded_on_the_two_phases_the_engine_bounds` |
| apply the still rule to the 49-frame video request | `the_video_route_still_refuses_any_zero_phase` |
| still route files the full four-key decomposition | `the_still_receipt_withholds_the_keys_an_anchor_would_be_minted_from` |
| still route emits `conditioningActivePeak` | `the_still_receipt_withholds_the_keys_an_anchor_would_be_minted_from` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)