### PR TITLE
fix(sc-21691): same-size replacement detection does not depend on an mtime tick

### DIFF
--- a/crates/sceneworks-core/src/checkpoint_plan_store.rs
+++ b/crates/sceneworks-core/src/checkpoint_plan_store.rs
@@ -262,12 +262,12 @@ pub struct SourceBindingsV1 {
 /// Deterministic fault-injection boundary for the verification-to-publication seam.
 ///
 /// This is not an execution hook. It exists so the plan-store regression fixture can replace a
-/// same-size source after its bytes have been hashed but before the stamp that could be persisted
-/// is sampled.
+/// same-size source inside the verification window: after the stamp that could be persisted has
+/// been sampled, and before the bytes that stamp will stand for are hashed.
 #[doc(hidden)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CheckpointPlanVerificationEventV1 {
-    LayerHashComplete,
+    LayerStampCaptured,
 }
 
 /// A freshly compiled and persisted checkpoint.
@@ -1051,37 +1051,37 @@ fn layer_relative_path(layer: &ImportLayerV1) -> &str {
 
 /// Hash one source while pinning the stamp that can later skip a hash to those bytes.
 ///
-/// A source replaced after hashing but before the final stamp sample must be rejected: persisting
-/// the replacement's stamp would make a later resolve trust bytes never checked against the plan.
-/// The pre-hash stamp is safe to persist only when the post-hash stamp is identical.
+/// `stamp` must have been sampled from `path` *before* this call, and the bytes are hashed after
+/// it. That ordering is what binds the two: any replacement landing before the hash completes is
+/// read by the hash itself and refused on the digest, so the surviving stamp always describes a
+/// file whose contents were verified no earlier than the stamp.
+///
+/// The stamp is deliberately not re-sampled and compared afterwards. A second stamp only detects a
+/// replacement on filesystems whose change key has finer resolution than the replacement is fast:
+/// on Unix `changed_nanos` carries `ctime`'s nanoseconds and discriminates, while every Windows
+/// field (`size_bytes`, `creation_time`, `last_write_time`, `modified_nanos`) is unchanged by a
+/// same-size in-place rewrite inside one ~15.6 ms system clock tick. Hashing after the stamp needs
+/// no such discrimination and therefore holds identically on every platform.
 fn verify_source_and_capture_stamp(
     checkpoint_id: &str,
     relative_path: &str,
     path: &Path,
     expected_sha256: &str,
-    before: SourceStampV1,
-    after_hash: impl FnOnce(),
+    stamp: SourceStampV1,
+    before_hash: impl FnOnce(),
 ) -> Result<SourceStampV1, CheckpointPlanError> {
+    before_hash();
     let hashed = sha256_file(path).map_err(|error| io_error(path, error))?;
-    after_hash();
-    let after = SourceStampV1::of(path).map_err(|error| io_error(path, error))?;
-    if before == after && hashed == expected_sha256 {
-        return Ok(before);
+    if hashed == expected_sha256 {
+        return Ok(stamp);
     }
 
-    // If the stamp changed after an otherwise matching hash, report the bytes now named by the
-    // path. This second hash is diagnostic only; no observation from a rejected verification is
-    // ever persisted or refreshed.
-    let actual_sha256 = if hashed == expected_sha256 {
-        sha256_file(path).map_err(|error| io_error(path, error))?
-    } else {
-        hashed
-    };
+    // No observation from a rejected verification is ever persisted or refreshed.
     Err(CheckpointPlanError::SourceDrifted {
         checkpoint_id: checkpoint_id.to_owned(),
         relative_path: relative_path.to_owned(),
         expected_sha256: expected_sha256.to_owned(),
-        actual_sha256,
+        actual_sha256: hashed,
     })
 }
 
@@ -1712,7 +1712,7 @@ impl CheckpointPlanStore {
     }
 
     /// Test-only equivalent of [`Self::compile_linked`] with a deterministic boundary after a
-    /// layer has been hashed and before its persisted source stamp is sampled.
+    /// layer's persisted source stamp has been sampled and before its bytes are hashed.
     #[doc(hidden)]
     pub fn compile_linked_with_hook(
         &self,
@@ -1838,9 +1838,9 @@ impl CheckpointPlanStore {
         record.validate_loaded_plan(&plan)?;
 
         // A persisted stamp is a cache key for a later resolve, so it must be bound to the bytes
-        // the plan names. Sampling a new stamp after inspection would let a same-size replacement
-        // between those operations bypass the next resolve's hash. Re-hash under a stable
-        // before/after stamp and persist that stable stamp instead.
+        // the plan names. Sampling a stamp and trusting the inspector's earlier hash would let a
+        // same-size replacement between those operations bypass the next resolve's hash. Sample
+        // the stamp first, then re-hash under it, and persist the stamp only if that hash matched.
         let mut stamps = BTreeMap::new();
         for layer in &plan.layers {
             if locator_kind(&layer.source) != expected_kind {
@@ -1851,7 +1851,7 @@ impl CheckpointPlanStore {
                 });
             }
             let path = self.layer_path(&checkpoint_id, root_path, layer)?;
-            let before = SourceStampV1::of(&path).map_err(|error| io_error(&path, error))?;
+            let sampled = SourceStampV1::of(&path).map_err(|error| io_error(&path, error))?;
             let fingerprint = layer_fingerprint(layer);
             let relative_path = layer_relative_path(layer);
             let stamp = verify_source_and_capture_stamp(
@@ -1859,8 +1859,8 @@ impl CheckpointPlanStore {
                 relative_path,
                 &path,
                 fingerprint,
-                before,
-                || hook(CheckpointPlanVerificationEventV1::LayerHashComplete),
+                sampled,
+                || hook(CheckpointPlanVerificationEventV1::LayerStampCaptured),
             )?;
             stamps.insert(layer.layer_id.clone(), stamp);
         }
@@ -2116,9 +2116,9 @@ impl CheckpointPlanStore {
             let rehashed = !stamp_matches;
             if rehashed {
                 // Same bytes, new entry (touched, re-copied, relinked): refresh the stamp so the
-                // next resolve is cheap again. The refreshed stamp is retained only if it stayed
-                // stable around the exact-byte verification; otherwise it could bless a source
-                // replacement that happened between the hash and stamp sampling.
+                // next resolve is cheap again. `current` was sampled above, before the hash below
+                // reads the bytes, so the refreshed stamp cannot bless a replacement that landed
+                // between the two — the hash reads the replacement and refuses on the digest.
                 let verified_stamp = verify_source_and_capture_stamp(
                     checkpoint_id,
                     relative_path,

--- a/crates/sceneworks-core/src/checkpoint_plan_store.rs
+++ b/crates/sceneworks-core/src/checkpoint_plan_store.rs
@@ -46,6 +46,28 @@ pub const PLANS_DIR: &str = "plans";
 /// The prefix every inspector-emitted `plan_id` carries; see [`validate_plan_id`].
 pub const PLAN_ID_PREFIX: &str = "checkpoint-plan-";
 pub const BINDINGS_DIR: &str = "bindings";
+/// Schema version of the per-plan `bindings/<planId>.json` document.
+///
+/// Versioned independently of [`CHECKPOINT_IMPORT_CONTRACT_VERSION`], which is the *wire* version
+/// shared by the plan, record and inventory contracts: bindings are a private store cache whose
+/// shape may move without moving anything a UI or an export reads. v1 stamps carry no observation
+/// time and therefore cannot be dated against [`SOURCE_STAMP_GRANULARITY_NANOS`]; v2 adds
+/// `observedNanos`. Bindings at any other version are read but never trusted — every stamp in them
+/// is re-hashed once and rewritten at the current version.
+pub const SOURCE_BINDINGS_SCHEMA_VERSION: u32 = 2;
+/// The coarsest timestamp granularity this store may be asked to reason about, in nanoseconds.
+///
+/// Windows FILETIME as observed through `last_write_time` advances on the ~15.625 ms system clock
+/// tick, so two writes inside one tick are indistinguishable in every field a stamp carries. The
+/// bound is applied on EVERY platform rather than per-`cfg`: a bindings document is portable (a
+/// library on a shared or synced volume is stamped by whichever host resolved it last), so a
+/// Unix-only relaxation would trust a Windows-written stamp on exactly the platform that cannot
+/// discriminate. 20 ms is that tick rounded up, and it also clears exFAT's 10 ms mtime
+/// quantization, so it holds on every filesystem an approved library root is supported on (NTFS,
+/// APFS, ext4, exFAT). It does NOT cover FAT/FAT32, whose mtime quantizes to 2 s: a root on one of
+/// those cannot date its own stamps finely enough for any fixed bound short of 2 s, and FAT32's
+/// 4 GiB file cap keeps checkpoint weights off it in practice.
+pub const SOURCE_STAMP_GRANULARITY_NANOS: i64 = 20_000_000;
 /// The advisory file every read-modify-write of the store's SHARED documents serialises on.
 ///
 /// `approved-roots.json` and `inventory.json` are each written atomically, but atomic write is not
@@ -199,11 +221,49 @@ fn validate_root_label(label: &str) -> Result<(), CheckpointPlanError> {
     Ok(())
 }
 
+/// The store's clock, read once per stamp capture.
+///
+/// Production always reads the system clock. The skewed constructor exists so a test can place a
+/// stamp's observation outside [`SOURCE_STAMP_GRANULARITY_NANOS`] of the file it names — the
+/// window is otherwise only reachable by sleeping through it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StoreClockV1 {
+    skew_nanos: i64,
+}
+
+impl StoreClockV1 {
+    /// The real clock: what [`CheckpointPlanStore::open`] installs.
+    pub const SYSTEM: Self = Self { skew_nanos: 0 };
+
+    /// Test-only clock offset from the system clock by `skew_nanos`.
+    #[doc(hidden)]
+    pub const fn skewed(skew_nanos: i64) -> Self {
+        Self { skew_nanos }
+    }
+
+    /// Nanoseconds since the Unix epoch, in the same unit and on the same timeline as a stamp's
+    /// `modified_nanos`. `None` only if the clock is before the epoch or beyond `i64`, in which
+    /// case no stamp can be dated and every stamp stays untrusted.
+    fn now_nanos(self) -> Option<i64> {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .ok()
+            .and_then(|elapsed| i64::try_from(elapsed.as_nanos()).ok())
+            .map(|now| now.saturating_add(self.skew_nanos))
+    }
+}
+
 /// Filesystem stamp of one layer's source entry, captured at compile time. Cheap to re-take; any
 /// difference forces a full re-hash before the source may be used.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SourceStampV1 {
+    /// The store's clock reading at the instant this stamp was sampled, on the same timeline as
+    /// `modified_nanos`. Not part of the file's identity — it dates the OBSERVATION, and is what
+    /// [`Self::is_racy`] measures the file's mtime against. `None` on a v1 stamp read back from
+    /// disk, which is therefore never trustworthy.
+    #[serde(default)]
+    pub observed_nanos: Option<i64>,
     pub size_bytes: u64,
     pub modified_nanos: Option<i64>,
     #[cfg(unix)]
@@ -219,13 +279,17 @@ pub struct SourceStampV1 {
 }
 
 impl SourceStampV1 {
-    fn of(path: &Path) -> std::io::Result<Self> {
+    fn of(path: &Path, clock: StoreClockV1) -> std::io::Result<Self> {
         #[cfg(unix)]
         use std::os::unix::fs::MetadataExt as _;
         #[cfg(windows)]
         use std::os::windows::fs::MetadataExt as _;
+        // Read the clock BEFORE the metadata: an observation must never be later than the state it
+        // claims to describe, or a write racing this call could look older than it is.
+        let observed_nanos = clock.now_nanos();
         let metadata = fs::metadata(path)?;
         Ok(Self {
+            observed_nanos,
             size_bytes: metadata.len(),
             modified_nanos: metadata.modified().ok().and_then(|modified| {
                 modified
@@ -248,9 +312,44 @@ impl SourceStampV1 {
             last_write_time: metadata.last_write_time(),
         })
     }
+
+    /// Whether `other` describes the same filesystem entry as this stamp — every field except
+    /// `observed_nanos`, which dates the observation rather than the file.
+    fn identifies_same_entry(&self, other: &Self) -> bool {
+        let mut compared = self.clone();
+        compared.observed_nanos = other.observed_nanos;
+        compared == *other
+    }
+
+    /// Git's racy-index rule. A stamp may stand in for a hash only when the file it names was last
+    /// modified at least one timestamp tick BEFORE the stamp was taken.
+    ///
+    /// Without this, a same-size in-place rewrite landing within the tick after a stamp was
+    /// captured leaves every field of the stamp unchanged on a platform whose change key is no
+    /// finer than the clock (Windows: `size_bytes`, `creation_time`, `last_write_time` and
+    /// `modified_nanos` are all identical across such a rewrite). The next resolve would match the
+    /// stamp, skip the hash, and hand a loader bytes nothing verified. A younger stamp is simply
+    /// not evidence, so it is re-hashed and re-observed instead; the fresh observation is dated
+    /// later, so one tick later the same file takes the fast path again.
+    ///
+    /// An undated stamp (v1 bindings) and an undated mtime are both untrusted for the same reason:
+    /// there is nothing to measure.
+    fn is_racy(&self) -> bool {
+        match (self.observed_nanos, self.modified_nanos) {
+            (Some(observed), Some(modified)) => {
+                observed.saturating_sub(modified) < SOURCE_STAMP_GRANULARITY_NANOS
+            }
+            _ => true,
+        }
+    }
 }
 
 /// The persisted per-plan binding: one stamp per layer id.
+///
+/// `schema_version` is [`SOURCE_BINDINGS_SCHEMA_VERSION`], not the shared wire version: it moves
+/// when the stamp shape moves. A document at any other version is read, treated as untrusted for
+/// every layer (one re-hash each), and rewritten at the current version — a bindings file is a
+/// cache, so the only cost of not understanding one is the hash it would have saved.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SourceBindingsV1 {
@@ -1062,6 +1161,11 @@ fn layer_relative_path(layer: &ImportLayerV1) -> &str {
 /// field (`size_bytes`, `creation_time`, `last_write_time`, `modified_nanos`) is unchanged by a
 /// same-size in-place rewrite inside one ~15.6 ms system clock tick. Hashing after the stamp needs
 /// no such discrimination and therefore holds identically on every platform.
+///
+/// That ordering closes the BINDING window only. The stamp is also a cache key a later resolve may
+/// skip a hash on, and a replacement landing inside the tick AFTER this call still leaves it
+/// matching. Nothing here can see that; [`SourceStampV1::is_racy`] is what refuses to trust the
+/// stamp until it is old enough to be evidence.
 fn verify_source_and_capture_stamp(
     checkpoint_id: &str,
     relative_path: &str,
@@ -1107,6 +1211,8 @@ pub struct CheckpointPlanStore {
     /// `remove_managed` may delete from cannot be steered by any argument.
     installs_root: PathBuf,
     staging_root: PathBuf,
+    /// Dates every stamp this store captures. Always [`StoreClockV1::SYSTEM`] outside tests.
+    clock: StoreClockV1,
 }
 
 impl CheckpointPlanStore {
@@ -1115,7 +1221,50 @@ impl CheckpointPlanStore {
             root: data_dir.join(CHECKPOINTS_DIR),
             installs_root: data_dir.join(MANAGED_INSTALLS_RELATIVE_DIR),
             staging_root: data_dir.join(MANAGED_STAGING_RELATIVE_DIR),
+            clock: StoreClockV1::SYSTEM,
         }
+    }
+
+    /// The same store, reading a clock offset by `skew_nanos`. Test-only: it is how a fixture
+    /// captures a stamp outside the racy window, or observes one from beyond it, without sleeping.
+    #[doc(hidden)]
+    pub fn with_clock_skew_nanos(&self, skew_nanos: i64) -> Self {
+        Self {
+            clock: StoreClockV1::skewed(skew_nanos),
+            ..self.clone()
+        }
+    }
+
+    /// Test-only: rebind the persisted stamp for `layer_id` under `plan_id` to `path` as it stands
+    /// on disk right now, dating the observation `observed_after_mtime_nanos` after the file's own
+    /// mtime.
+    ///
+    /// It exists to reproduce, on any platform, the state only a coarse-timestamp platform reaches
+    /// on its own: a persisted stamp that MATCHES a file whose bytes were replaced after the stamp
+    /// was captured. Every field of a Unix stamp discriminates such a replacement through `ctime`,
+    /// so without this seam the racy-index rule could never be shown to be the thing standing
+    /// between that replacement and a loader.
+    #[doc(hidden)]
+    pub fn rebind_stamp_for_tests(
+        &self,
+        plan_id: &str,
+        layer_id: &str,
+        path: &Path,
+        observed_after_mtime_nanos: i64,
+    ) -> Result<(), CheckpointPlanError> {
+        let mut bindings = self
+            .read_json::<SourceBindingsV1>(&self.bindings_path(plan_id)?, "source bindings")?
+            .ok_or_else(|| CheckpointPlanError::Corrupt {
+                what: "source bindings".to_owned(),
+                message: format!("no bindings persisted for plan {plan_id:?}"),
+            })?;
+        let mut stamp =
+            SourceStampV1::of(path, StoreClockV1::SYSTEM).map_err(|error| io_error(path, error))?;
+        stamp.observed_nanos = stamp
+            .modified_nanos
+            .map(|modified| modified.saturating_add(observed_after_mtime_nanos));
+        bindings.stamps.insert(layer_id.to_owned(), stamp);
+        self.persist_bindings(&bindings)
     }
 
     /// The document root: `<data_dir>/checkpoints`.
@@ -1851,7 +2000,8 @@ impl CheckpointPlanStore {
                 });
             }
             let path = self.layer_path(&checkpoint_id, root_path, layer)?;
-            let sampled = SourceStampV1::of(&path).map_err(|error| io_error(&path, error))?;
+            let sampled =
+                SourceStampV1::of(&path, self.clock).map_err(|error| io_error(&path, error))?;
             let fingerprint = layer_fingerprint(layer);
             let relative_path = layer_relative_path(layer);
             let stamp = verify_source_and_capture_stamp(
@@ -1865,7 +2015,7 @@ impl CheckpointPlanStore {
             stamps.insert(layer.layer_id.clone(), stamp);
         }
         let bindings = SourceBindingsV1 {
-            schema_version: CHECKPOINT_IMPORT_CONTRACT_VERSION,
+            schema_version: SOURCE_BINDINGS_SCHEMA_VERSION,
             plan_id: plan.plan_id.clone(),
             stamps,
         };
@@ -2048,7 +2198,7 @@ impl CheckpointPlanStore {
         let mut bindings = self
             .read_json::<SourceBindingsV1>(&self.bindings_path(&plan.plan_id)?, "source bindings")?
             .unwrap_or_else(|| SourceBindingsV1 {
-                schema_version: CHECKPOINT_IMPORT_CONTRACT_VERSION,
+                schema_version: SOURCE_BINDINGS_SCHEMA_VERSION,
                 plan_id: plan.plan_id.clone(),
                 stamps: BTreeMap::new(),
             });
@@ -2062,8 +2212,13 @@ impl CheckpointPlanStore {
             });
         }
 
+        // A bindings document written by a different stamp shape cannot be reasoned about: v1
+        // stamps carry no observation time at all, so nothing in them can be dated against the
+        // racy-index rule. Read it, trust none of it, and rewrite it at the current version.
+        let bindings_are_current = bindings.schema_version == SOURCE_BINDINGS_SCHEMA_VERSION;
         let mut layers = Vec::with_capacity(plan.layers.len());
-        let mut refreshed = false;
+        let mut refreshed = !bindings_are_current;
+        bindings.schema_version = SOURCE_BINDINGS_SCHEMA_VERSION;
         for layer in &plan.layers {
             // The root a layer's relative path is joined onto is chosen by the LOCATOR, never by
             // the caller: a linked layer resolves under its approved library root, a managed layer
@@ -2094,7 +2249,7 @@ impl CheckpointPlanStore {
                 }
             };
             let path = confined_root_join(checkpoint_id, &root_path, relative_path)?;
-            let current = match SourceStampV1::of(&path) {
+            let current = match SourceStampV1::of(&path, self.clock) {
                 Ok(stamp) => stamp,
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                     return Err(CheckpointPlanError::SourceMissing {
@@ -2112,13 +2267,24 @@ impl CheckpointPlanStore {
                     path,
                 });
             }
-            let stamp_matches = bindings.stamps.get(&layer.layer_id) == Some(&current);
-            let rehashed = !stamp_matches;
+            // A persisted stamp skips the hash only when it names this same entry AND is old
+            // enough to be evidence about it. A stamp captured within one timestamp tick of the
+            // file's mtime is not: on a platform whose change key is no finer than the clock, a
+            // same-size rewrite inside that tick leaves the stamp identical, and trusting it here
+            // would hand a loader bytes nothing ever hashed.
+            let trusted = bindings_are_current
+                && bindings
+                    .stamps
+                    .get(&layer.layer_id)
+                    .is_some_and(|stamp| stamp.identifies_same_entry(&current) && !stamp.is_racy());
+            let rehashed = !trusted;
             if rehashed {
-                // Same bytes, new entry (touched, re-copied, relinked): refresh the stamp so the
-                // next resolve is cheap again. `current` was sampled above, before the hash below
-                // reads the bytes, so the refreshed stamp cannot bless a replacement that landed
-                // between the two — the hash reads the replacement and refuses on the digest.
+                // A new entry (touched, re-copied, relinked) or a stamp still inside its racy
+                // window: hash the bytes and re-observe. `current` was sampled above, before the
+                // hash below reads the bytes, so the refreshed stamp cannot bless a replacement
+                // that landed between the two — the hash reads the replacement and refuses on the
+                // digest. The refreshed observation is later than the one it replaces, so a file
+                // that stops changing leaves the racy window after one tick and stays cheap.
                 let verified_stamp = verify_source_and_capture_stamp(
                     checkpoint_id,
                     relative_path,

--- a/crates/sceneworks-core/tests/checkpoint_plan_store.rs
+++ b/crates/sceneworks-core/tests/checkpoint_plan_store.rs
@@ -7,6 +7,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
 use tempfile::TempDir;
 
 use sceneworks_core::checkpoint_import::{
@@ -20,6 +21,17 @@ use sceneworks_core::checkpoint_plan_store::{
     CheckpointPlanVerificationEventV1, APPROVED_ROOTS_FILE, BINDINGS_DIR, CHECKPOINTS_DIR,
     INVENTORY_FILE, PLANS_DIR, PLAN_ID_PREFIX, STORE_LOCK_FILE,
 };
+
+/// Lowercase hex sha256, matching the digest form the plan store persists and reports.
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
 
 fn fixture_dir(label: &str) -> TempDir {
     tempfile::Builder::new()
@@ -329,11 +341,19 @@ fn semantic_digest_is_locator_independent_but_source_binding_is_not() {
     );
 }
 
-/// A same-size source replacement after verification hashing but before the binding stamp is
-/// sampled must not persist the replacement's stamp: otherwise the next resolve would skip the
-/// hash and trust bytes that were never compared to this plan's digest.
+/// A same-size source replacement inside the verification window — after the binding stamp is
+/// sampled, before the bytes that stamp will stand for are hashed — must not persist that stamp:
+/// otherwise the next resolve would skip the hash and trust bytes that were never compared to this
+/// plan's digest.
+///
+/// The refusal is proven by the digest, never by a stamp difference, so it does not depend on the
+/// host filesystem's change-key resolution. The fixture asserts only the two properties the store
+/// is required to discriminate on: the replacement is the same length and a different digest. It
+/// deliberately does NOT assert that the two files' stamps differ — a same-size in-place rewrite
+/// inside one Windows system clock tick leaves every Windows stamp field identical, and a store
+/// that needed them to differ would be the defect this test exists to catch.
 #[test]
-fn same_size_replacement_between_verification_hash_and_stamp_refuses_without_persistence() {
+fn same_size_replacement_inside_verification_window_refuses_without_persistence() {
     let fx = fixture("stamp-toctou");
     let file = fx.library_dir.join("kreamania.safetensors");
     write_krea_native_file(&file, 0x5a);
@@ -355,17 +375,33 @@ fn same_size_replacement_between_verification_hash_and_stamp_refuses_without_per
     let mut replacement = original.clone();
     let last = replacement.len() - 1;
     replacement[last] ^= 0xff;
-    assert_eq!(replacement.len(), original.len());
+
+    // Preconditions the store is required to discriminate on, stated before it is exercised: the
+    // replacement occupies exactly as many bytes as the original, and hashes to something else.
+    assert_eq!(
+        replacement.len(),
+        original.len(),
+        "the fixture must be a same-size replacement or it proves nothing about the stamp"
+    );
+    let replacement_sha256 = sha256_hex(&replacement);
+    assert_ne!(
+        replacement_sha256, expected_sha256,
+        "the fixture must change the bytes the plan names"
+    );
+
     let mut hook_ran = false;
     let error = fx
         .store
         .compile_linked_with_hook(&root.root_id, "kreamania.safetensors", |event| {
-            assert_eq!(event, CheckpointPlanVerificationEventV1::LayerHashComplete);
+            assert_eq!(event, CheckpointPlanVerificationEventV1::LayerStampCaptured);
             hook_ran = true;
             fs::write(&file, &replacement).unwrap();
         })
-        .expect_err("replacement after hash must not publish an unchecked stamp");
-    assert!(hook_ran, "fixture must replace the source after hashing");
+        .expect_err("replacement inside the verification window must not publish a stamp");
+    assert!(
+        hook_ran,
+        "fixture must replace the source inside the verification window"
+    );
     assert_eq!(
         fs::metadata(&file).unwrap().len(),
         u64::try_from(original.len()).unwrap()
@@ -380,7 +416,10 @@ fn same_size_replacement_between_verification_hash_and_stamp_refuses_without_per
             assert_eq!(actual_checkpoint_id, checkpoint_id);
             assert_eq!(relative_path, "kreamania.safetensors");
             assert_eq!(actual_expected, expected_sha256);
-            assert_ne!(actual_sha256, expected_sha256);
+            assert_eq!(
+                actual_sha256, replacement_sha256,
+                "the refusal must name the bytes actually read, not a stale observation"
+            );
         }
         other => panic!("TOCTOU replacement must refuse as source drift, got {other:?}"),
     }

--- a/crates/sceneworks-core/tests/checkpoint_plan_store.rs
+++ b/crates/sceneworks-core/tests/checkpoint_plan_store.rs
@@ -19,8 +19,31 @@ use sceneworks_core::checkpoint_inspector::{
 use sceneworks_core::checkpoint_plan_store::{
     linked_checkpoint_id, managed_checkpoint_id, CheckpointPlanError, CheckpointPlanStore,
     CheckpointPlanVerificationEventV1, APPROVED_ROOTS_FILE, BINDINGS_DIR, CHECKPOINTS_DIR,
-    INVENTORY_FILE, PLANS_DIR, PLAN_ID_PREFIX, STORE_LOCK_FILE,
+    INVENTORY_FILE, PLANS_DIR, PLAN_ID_PREFIX, SOURCE_BINDINGS_SCHEMA_VERSION,
+    SOURCE_STAMP_GRANULARITY_NANOS, STORE_LOCK_FILE,
 };
+
+/// A clock offset far past [`SOURCE_STAMP_GRANULARITY_NANOS`]. A stamp captured through a store
+/// skewed by this is dated well after the mtime of the file it names, so it is outside the racy
+/// window on capture; a resolve through such a store re-dates whatever it refreshes the same way.
+/// Five seconds, not five milliseconds: the point is to be unambiguously outside the bound.
+const SETTLED_SKEW_NANOS: i64 = 5_000_000_000;
+
+/// A view of `store` whose stamps are dated outside the racy window — the fast path, reached
+/// without sleeping through [`SOURCE_STAMP_GRANULARITY_NANOS`].
+fn settled(store: &CheckpointPlanStore) -> CheckpointPlanStore {
+    store.with_clock_skew_nanos(SETTLED_SKEW_NANOS)
+}
+
+/// A view of `store` whose stamps are dated inside the racy window by construction.
+///
+/// A real compile spends tens of milliseconds inspecting and hashing before it samples its stamp,
+/// so on this host it usually lands outside the window on its own — "usually" being precisely the
+/// timing dependence this regression must not be built on. Skewing the clock backwards puts every
+/// stamp it captures unambiguously inside the window on every host.
+fn racy(store: &CheckpointPlanStore) -> CheckpointPlanStore {
+    store.with_clock_skew_nanos(-SETTLED_SKEW_NANOS)
+}
 
 /// Lowercase hex sha256, matching the digest form the plan store persists and reports.
 fn sha256_hex(bytes: &[u8]) -> String {
@@ -432,8 +455,10 @@ fn same_size_replacement_inside_verification_window_refuses_without_persistence(
     // A stationary original source still compiles and resolves with its original digest and linked
     // provenance; the guard rejects only an unbound stamp, not a valid checkpoint.
     fs::write(&file, &original).unwrap();
-    let compiled = fx
-        .store
+    // Compiled through a settled clock so the stamp is dated clear of the racy window rather than
+    // relying on the compile happening to outrun a timestamp tick; the window has its own test.
+    let settled_store = settled(&fx.store);
+    let compiled = settled_store
         .compile_linked(&root.root_id, "kreamania.safetensors")
         .unwrap();
     match &compiled.plan.layers[0].source {
@@ -449,7 +474,7 @@ fn same_size_replacement_inside_verification_window_refuses_without_persistence(
         }
         other => panic!("linked compile must retain linked provenance, got {other:?}"),
     }
-    let resolved = fx.store.resolve(&checkpoint_id).unwrap();
+    let resolved = settled_store.resolve(&checkpoint_id).unwrap();
     assert!(!resolved.layers[0].rehashed);
 }
 
@@ -459,8 +484,11 @@ fn resolve_verifies_stamps_and_refuses_drifted_or_missing_sources() {
     let file = fx.library_dir.join("kreamania.safetensors");
     write_krea_native_file(&file, 0x5a);
     let root = fx.store.approve_root(&fx.library_dir).unwrap();
-    let compiled = fx
-        .store
+    // Compiled through a settled clock so the persisted stamp is dated clear of the racy window
+    // from the start; this test is about stamp CONTENT, and the window itself is exercised by
+    // `resolve_reverifies_a_stamp_inside_the_racy_window` below.
+    let settled_store = settled(&fx.store);
+    let compiled = settled_store
         .compile_linked(&root.root_id, "kreamania.safetensors")
         .unwrap();
 
@@ -489,9 +517,9 @@ fn resolve_verifies_stamps_and_refuses_drifted_or_missing_sources() {
     let staging = fx.library_dir.join("kreamania.safetensors.staging");
     fs::write(&staging, &bytes).unwrap();
     fs::rename(&staging, &file).unwrap();
-    let rehashed = fx.store.resolve(&compiled.checkpoint_id).unwrap();
+    let rehashed = settled_store.resolve(&compiled.checkpoint_id).unwrap();
     assert!(rehashed.layers[0].rehashed, "a new entry must be re-hashed");
-    let again = fx.store.resolve(&compiled.checkpoint_id).unwrap();
+    let again = settled_store.resolve(&compiled.checkpoint_id).unwrap();
     assert!(!again.layers[0].rehashed, "the stamp was refreshed");
 
     // Same size, different bytes with a changed stamp (an in-place edit or a retargeted root):
@@ -558,6 +586,280 @@ fn resolve_verifies_stamps_and_refuses_drifted_or_missing_sources() {
         fx.store.resolve(&compiled.checkpoint_id),
         Err(CheckpointPlanError::RootUnavailable { .. })
     ));
+}
+
+/// The persisted `bindings/<planId>.json` for `plan_id`.
+fn bindings_path(fx: &Fixture, plan_id: &str) -> PathBuf {
+    fx.data_dir
+        .join(CHECKPOINTS_DIR)
+        .join(BINDINGS_DIR)
+        .join(format!("{plan_id}.json"))
+}
+
+fn bindings_json(fx: &Fixture, plan_id: &str) -> Value {
+    serde_json::from_str(&fs::read_to_string(bindings_path(fx, plan_id)).unwrap()).unwrap()
+}
+
+/// A stamp is only a cache key once it is old enough to be evidence: a resolve inside one timestamp
+/// tick of the source's mtime re-hashes and re-observes, and the refreshed observation is what
+/// makes the next resolve cheap (sc-21691, git's racy-index rule).
+#[test]
+fn resolve_reverifies_a_stamp_inside_the_racy_window() {
+    let fx = fixture("racy-window");
+    let file = fx.library_dir.join("kreamania.safetensors");
+    write_krea_native_file(&file, 0x5a);
+    let root = fx.store.approve_root(&fx.library_dir).unwrap();
+
+    // A stamp captured inside the window: exactly the state a same-size rewrite can hide inside.
+    let racy_store = racy(&fx.store);
+    let compiled = racy_store
+        .compile_linked(&root.root_id, "kreamania.safetensors")
+        .unwrap();
+    let layer_id = compiled.plan.layers[0].layer_id.clone();
+
+    let persisted = bindings_json(&fx, &compiled.plan.plan_id);
+    assert_eq!(
+        persisted["schemaVersion"],
+        json!(SOURCE_BINDINGS_SCHEMA_VERSION),
+        "a compile persists bindings at the current stamp schema"
+    );
+    let observed = persisted["stamps"][&layer_id]["observedNanos"]
+        .as_i64()
+        .expect("every persisted stamp is dated");
+    let modified = persisted["stamps"][&layer_id]["modifiedNanos"]
+        .as_i64()
+        .expect("the fixture filesystem reports an mtime");
+    assert!(
+        observed - modified < SOURCE_STAMP_GRANULARITY_NANOS,
+        "the fixture must land inside the racy window or it proves nothing: \
+         observed {observed} is already {} ns past mtime {modified}",
+        observed - modified
+    );
+
+    assert!(
+        racy_store.resolve(&compiled.checkpoint_id).unwrap().layers[0].rehashed,
+        "a stamp younger than the timestamp granularity is re-verified"
+    );
+    assert!(
+        racy_store.resolve(&compiled.checkpoint_id).unwrap().layers[0].rehashed,
+        "a re-observation that is itself inside the window does not become a cache key"
+    );
+
+    // Re-verifying re-observes: once an observation is dated clear of the file's mtime the same
+    // unchanged file takes the fast path, so the rule costs one extra hash, not one per resolve.
+    let settled_store = settled(&fx.store);
+    assert!(
+        settled_store
+            .resolve(&compiled.checkpoint_id)
+            .unwrap()
+            .layers[0]
+            .rehashed,
+        "the last observation persisted was still inside the window"
+    );
+    let refreshed = bindings_json(&fx, &compiled.plan.plan_id);
+    let refreshed_observed = refreshed["stamps"][&layer_id]["observedNanos"]
+        .as_i64()
+        .unwrap();
+    assert!(
+        refreshed_observed > observed,
+        "a re-verified stamp must be re-observed, or it can never leave the window"
+    );
+    assert!(
+        !settled_store
+            .resolve(&compiled.checkpoint_id)
+            .unwrap()
+            .layers[0]
+            .rehashed,
+        "outside the window the stamp is trusted and the hash is skipped"
+    );
+    assert!(
+        !settled_store
+            .resolve(&compiled.checkpoint_id)
+            .unwrap()
+            .layers[0]
+            .rehashed,
+        "the fast path is stable, not alternating"
+    );
+}
+
+/// The hole the rule closes: a stamp that MATCHES the file yet was captured inside the window is
+/// not evidence about its bytes. Reproduced through the store's rebind seam because a Unix `ctime`
+/// discriminates the replacement on its own — the seam puts every platform in the position
+/// Windows reaches unaided, where the racy-index rule is the only thing left standing.
+#[test]
+fn a_matching_stamp_inside_the_racy_window_refuses_replaced_bytes() {
+    let fx = fixture("racy-drift");
+    let file = fx.library_dir.join("kreamania.safetensors");
+    write_krea_native_file(&file, 0x5a);
+    let root = fx.store.approve_root(&fx.library_dir).unwrap();
+    let settled_store = settled(&fx.store);
+    let compiled = settled_store
+        .compile_linked(&root.root_id, "kreamania.safetensors")
+        .unwrap();
+    let layer_id = compiled.plan.layers[0].layer_id.clone();
+    let expected_sha256 = match &compiled.plan.layers[0].source {
+        SourceLocatorV1::Linked { fingerprint, .. } => fingerprint.clone(),
+        other => panic!("linked compile must carry a linked locator, got {other:?}"),
+    };
+    assert!(
+        !settled_store
+            .resolve(&compiled.checkpoint_id)
+            .unwrap()
+            .layers[0]
+            .rehashed,
+        "precondition: the compiled stamp is outside the window and would be trusted"
+    );
+
+    let original = fs::read(&file).unwrap();
+    let mut replacement = original.clone();
+    let last = replacement.len() - 1;
+    replacement[last] ^= 0xff;
+    assert_eq!(
+        replacement.len(),
+        original.len(),
+        "the fixture must be a same-size replacement or the stamp discriminates it on size"
+    );
+    let replacement_sha256 = sha256_hex(&replacement);
+    assert_ne!(replacement_sha256, expected_sha256);
+    fs::write(&file, &replacement).unwrap();
+
+    // The state a coarse-timestamp platform reaches by itself: the persisted stamp describes the
+    // file as it now stands (replaced), and was observed no later than the file's own mtime.
+    fx.store
+        .rebind_stamp_for_tests(&compiled.plan.plan_id, &layer_id, &file, 0)
+        .unwrap();
+
+    match settled_store.resolve(&compiled.checkpoint_id) {
+        Err(CheckpointPlanError::SourceDrifted {
+            checkpoint_id,
+            relative_path,
+            expected_sha256: refused_expected,
+            actual_sha256,
+        }) => {
+            assert_eq!(checkpoint_id, compiled.checkpoint_id);
+            assert_eq!(relative_path, "kreamania.safetensors");
+            assert_eq!(refused_expected, expected_sha256);
+            assert_eq!(
+                actual_sha256, replacement_sha256,
+                "the refusal must name the bytes on disk, not the stamp's claim about them"
+            );
+        }
+        other => panic!(
+            "a matching stamp inside the racy window must not stand in for a hash, got {other:?}"
+        ),
+    }
+
+    // Refused, and nothing about the refusal is persisted: the next resolve refuses identically
+    // rather than blessing the replacement through a refreshed stamp.
+    assert!(matches!(
+        settled_store.resolve(&compiled.checkpoint_id),
+        Err(CheckpointPlanError::SourceDrifted { .. })
+    ));
+}
+
+/// A bindings document from before stamps were dated cannot be reasoned about, so it is trusted for
+/// nothing: every layer is re-hashed once, and the document is rewritten at the current version.
+#[test]
+fn legacy_undated_bindings_are_reverified_once_then_rewritten() {
+    let fx = fixture("legacy-bindings");
+    let file = fx.library_dir.join("kreamania.safetensors");
+    write_krea_native_file(&file, 0x5a);
+    let root = fx.store.approve_root(&fx.library_dir).unwrap();
+    let settled_store = settled(&fx.store);
+    let compiled = settled_store
+        .compile_linked(&root.root_id, "kreamania.safetensors")
+        .unwrap();
+    let layer_id = compiled.plan.layers[0].layer_id.clone();
+
+    // Rewrite the persisted document as a v1 store would have left it: version 1, no observation.
+    let path = bindings_path(&fx, &compiled.plan.plan_id);
+    let mut legacy = bindings_json(&fx, &compiled.plan.plan_id);
+    legacy["schemaVersion"] = json!(1);
+    legacy["stamps"][&layer_id]
+        .as_object_mut()
+        .unwrap()
+        .remove("observedNanos")
+        .expect("the fixture must actually strip the field a v1 document never had");
+    fs::write(&path, serde_json::to_vec_pretty(&legacy).unwrap()).unwrap();
+
+    assert!(
+        settled_store
+            .resolve(&compiled.checkpoint_id)
+            .unwrap()
+            .layers[0]
+            .rehashed,
+        "an undated stamp is evidence of nothing and must be re-hashed"
+    );
+    let rewritten = bindings_json(&fx, &compiled.plan.plan_id);
+    assert_eq!(
+        rewritten["schemaVersion"],
+        json!(SOURCE_BINDINGS_SCHEMA_VERSION),
+        "the re-verified document is rewritten at the current version"
+    );
+    assert!(rewritten["stamps"][&layer_id]["observedNanos"].is_i64());
+    assert!(
+        !settled_store
+            .resolve(&compiled.checkpoint_id)
+            .unwrap()
+            .layers[0]
+            .rehashed,
+        "once, not on every resolve"
+    );
+}
+
+/// The version gate stands on its own, independently of whether the stamps inside happen to be
+/// datable: a document whose schema this build does not know may carry fields that mean something
+/// else, so nothing in it is a cache key — even a stamp that reads as dated and settled.
+#[test]
+fn bindings_at_an_unknown_schema_version_are_trusted_for_nothing() {
+    let fx = fixture("unknown-bindings-schema");
+    let file = fx.library_dir.join("kreamania.safetensors");
+    write_krea_native_file(&file, 0x5a);
+    let root = fx.store.approve_root(&fx.library_dir).unwrap();
+    let settled_store = settled(&fx.store);
+    let compiled = settled_store
+        .compile_linked(&root.root_id, "kreamania.safetensors")
+        .unwrap();
+    let layer_id = compiled.plan.layers[0].layer_id.clone();
+    assert!(
+        !settled_store
+            .resolve(&compiled.checkpoint_id)
+            .unwrap()
+            .layers[0]
+            .rehashed,
+        "precondition: at the current version this stamp is trusted"
+    );
+
+    let path = bindings_path(&fx, &compiled.plan.plan_id);
+    let mut future = bindings_json(&fx, &compiled.plan.plan_id);
+    future["schemaVersion"] = json!(SOURCE_BINDINGS_SCHEMA_VERSION + 1);
+    assert!(
+        future["stamps"][&layer_id]["observedNanos"].is_i64(),
+        "the fixture must leave a dated stamp, or the version gate is not what is under test"
+    );
+    fs::write(&path, serde_json::to_vec_pretty(&future).unwrap()).unwrap();
+
+    assert!(
+        settled_store
+            .resolve(&compiled.checkpoint_id)
+            .unwrap()
+            .layers[0]
+            .rehashed,
+        "a stamp from an unknown schema is re-verified however well dated it looks"
+    );
+    assert_eq!(
+        bindings_json(&fx, &compiled.plan.plan_id)["schemaVersion"],
+        json!(SOURCE_BINDINGS_SCHEMA_VERSION),
+        "and the document is rewritten at the version this build does understand"
+    );
+    assert!(
+        !settled_store
+            .resolve(&compiled.checkpoint_id)
+            .unwrap()
+            .layers[0]
+            .rehashed,
+        "once, not on every resolve"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## The colliding key

`SourceStampV1::of` (`crates/sceneworks-core/src/checkpoint_plan_store.rs:221`) builds a
platform-dependent change key:

- **Unix**: `size_bytes`, `modified_nanos`, `device`, `inode`, **`changed_nanos`** (`ctime * 1e9 + ctime_nsec`).
- **Windows**: `size_bytes`, `modified_nanos`, `creation_time`, `last_write_time`.

`verify_source_and_capture_stamp` (old `checkpoint_plan_store.rs:1057`) sampled a stamp before the
verification hash and a second one after it, and accepted iff the two were equal and the hash
matched. The only field that discriminates a **same-size, in-place rewrite** is Unix's
`changed_nanos`, which carries nanosecond `ctime`. Windows has no `ctime` analogue on stable
`std::fs::Metadata`; `creation_time` is birth time (preserved by an in-place rewrite, and preserved
across delete+recreate by NTFS file tunneling), and `last_write_time`/`modified()` are both FILETIME
values stamped from the system clock, whose update granularity is ~15.6 ms. A `fs::write` that lands
microseconds after the stamp sample therefore leaves **all four Windows fields identical**, `before
== after` holds, and the store published the replacement's stamp.

That is exactly the reported flake: `crates/sceneworks-core/tests/checkpoint_plan_store.rs`
`same_size_replacement_between_verification_hash_and_stamp_refuses_without_persistence`, red on the
Windows self-hosted lane only (#2754, #2762), green on macOS/Linux and green on Windows rerun.

## Verdict: the defect is in the store, not the test

The test does not rely on a timestamp tick it never guarantees — it never touches timestamps at all.
It asserts a real invariant, and on Windows the store genuinely fails it. A same-size, same-mtime
replacement was a real TOCTOU hole in production on any filesystem with coarse mtime: the store
would persist a stamp describing bytes it never verified, and the next `resolve` would match that
stamp, skip the re-hash, and hand a loader bytes never compared to the plan's digest.

Note that a "strengthen the stamp" fix (bounded prefix/suffix digest, or a Windows change-time) does
**not** close it: a prefix/suffix sample misses a middle-byte replacement, and Windows `ChangeTime`
is stamped from the same coarse clock, so it collides in the same tick.

## What changed

Removed the dependency on stamp discrimination entirely. `verify_source_and_capture_stamp` now
takes the stamp that was **already sampled by the caller**, hashes the bytes **after** it, and
persists that stamp only if the hash matched the plan's fingerprint:

- Any replacement landing between the stamp sample and the end of the hash is read *by the hash*
  and refused as `SourceDrifted` on the digest. No timestamp resolution is involved, so the
  guarantee holds identically on Windows, macOS and Linux.
- Both call sites already sampled their stamp before hashing (`compile_with_hook`'s `sampled`,
  `resolve`'s `current`), so the ordering required no restructuring.
- The diagnostic second full hash on the rejected path is gone — the hash that produced the refusal
  is now the one reported, so `actual_sha256` names the bytes actually read rather than a re-read.
- The fault-injection variant is renamed `LayerHashComplete` -> `LayerStampCaptured` and fires at
  the new window boundary (after the stamp, before the hash). It stays `#[doc(hidden)]`.

Test: renamed to `same_size_replacement_inside_verification_window_refuses_without_persistence`, and
its **preconditions are now explicit** — it asserts the replacement is the same length and hashes to
a different digest before the store is exercised, and asserts the refusal reports that exact digest.
It deliberately does *not* assert that the two files' stamps differ: on Windows they legitimately do
not, and a store that needed them to differ is the defect this test exists to catch. The comment
says so, so a future platform cannot silently pass the wrong way.

## Mutation proof (macOS)

Each guard mutated alone, binary rebuilt, restored + `touch`ed after:

| Mutation | Result |
| --- | --- |
| `if hashed == expected_sha256` -> `if true` (accept regardless of digest) | **RED** |
| hook moved back after the hash (old ordering, stamp no longer brackets the read) | **RED** — reproduces the Windows failure signature verbatim on macOS |
| restored | **GREEN** |

## Gates

- `cargo test -p sceneworks-core --test checkpoint_plan_store` — **31 passed, 0 failed**
- `cargo fmt --all` — clean, no diff
- `cargo clippy -p sceneworks-core --all-targets` — exit 0, no warnings

No disabled check script was re-enabled.

## Residual, surfaced not buried

This PR closes the compile/refresh **binding** window on every platform. A separate, narrower
property is untouched and I did not expand scope into it without your call: the persisted stamp is
also a *cache key* at `resolve`, and on Windows a same-size replacement occurring within ~15.6 ms
*after* a successful compile still produces a matching stamp, so that resolve skips the hash. Unix
closes it via `changed_nanos`. The standard fix is git's racy-index rule — persist the stamp's
observation time and treat a stamp whose mtime is not provably older than it as untrustworthy,
forcing one re-hash. That is a persisted-schema change (`SourceStampV1` gains a field excluded from
`PartialEq`) and it makes the first `resolve` after every compile re-hash the full source, which
flips two existing assertions (`checkpoint_plan_store.rs:414`, `:435`) and costs a full multi-GB
hash on first use. Worth doing, but it is a behaviour/perf decision rather than a flake fix — say
the word and I will file it or do it now.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)