### PR TITLE
fix(sc-22738): ltx_2_3 rows carry the text-encoder root; Krea Realtime mirrors production admission

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -20509,51 +20509,89 @@ fn krea_realtime_load_spec(tier: &str) -> Result<KreaRealtimeArtifact, String> {
     })
 }
 
-/// The admission context for the Krea Realtime safety scenarios.
+/// The admission SURFACE the plan's target declares.
 ///
-/// `mode` IS AN EVIDENCE KEY, not a label, for the reason spelled out at [`minimax_context`]: the
-/// shipped video funnel asks under `"text_to_video"` and types it with `memory_mode_from_mode_key`,
-/// which maps every non-canonical key to [`MemoryMode::Other`]. This capture carries that spelling
-/// so a probe run here answers the question the runtime actually asks.
-fn krea_realtime_context(
-    selection: MemorySelection,
-    calibration: &MemoryCalibrationIdentity,
-    fingerprint: &str,
-    geometry: KreaRealtimeGeometry,
-    total_bytes: u64,
-    predicted_peak_bytes: u64,
-) -> MemoryRunContext {
-    MemoryRunContext {
-        selection,
-        optimization_authority: MemoryOptimizationAuthority::Calibrated,
-        calibration_abi: calibration.abi,
-        // A parameter only so the stale-evidence probe can pass a deliberate mismatch; every real
-        // call site passes `calibration.fingerprint`.
-        calibration_fingerprint: fingerprint.to_owned(),
-        load_shape: calibration.load_shape,
-        mode: MemoryMode::Other("text_to_video".to_owned()),
-        has_reference: false,
-        use_pid: false,
-        has_phases: true,
-        geometry: MemoryGeometry {
-            width: geometry.width,
-            height: geometry.height,
-            batch: 1,
-            frames: geometry.frames,
-            reference_count: 0,
-        },
-        overlay: None,
-        budget: MemoryBudget {
-            total_bytes,
-            committed_bytes: 0,
-            reclaimable_bytes: 0,
-            reserved_headroom_bytes: 0,
-        },
-        predicted_peak_bytes,
-        cache_state: MemoryCacheState::Cold,
-        evidence_revision: format!("sc-22735@{}", protocol::INFERENCE_PIN),
-    }
+/// Read back off the target rather than inferred from [`validate_krea_realtime_target`]'s refusals,
+/// so [`krea_realtime_probes_admission`] is a decision computed from the request the arm was handed
+/// and not a constant a future reference-carrying anchor could inherit silently.
+struct KreaRealtimeSurface {
+    mode: String,
+    reference_count: u32,
 }
+
+fn krea_realtime_target_surface(request: &Value) -> Result<KreaRealtimeSurface, String> {
+    let target = protocol::planned(request)?
+        .get("target")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "planned.target must be an object".to_owned())?;
+    let mode = target
+        .get("mode")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "planned.target.mode must be a string".to_owned())?
+        .to_owned();
+    let mut reference_count = 0_u32;
+    for field in ["referenceCount", "reference_count"] {
+        if let Some(value) = target.get(field) {
+            let declared = value
+                .as_u64()
+                .and_then(|count| u32::try_from(count).ok())
+                .ok_or_else(|| {
+                    format!("planned.target.{field} must be a non-negative integer when declared")
+                })?;
+            reference_count = reference_count.max(declared);
+        }
+    }
+    Ok(KreaRealtimeSurface {
+        mode,
+        reference_count,
+    })
+}
+
+/// Whether production would ask the Krea Realtime provider's admission gate anything at all about
+/// this request. The twin of [`bernini_probes_admission`], and false for the same reason.
+///
+/// THE ENGINE SIDE. `mlx-gen-krea-realtime`'s registered `safety_check`
+/// (`crates/media/mlx-gen/mlx-gen-krea-realtime/src/memory_strategy.rs:686-694` at inference
+/// `3b922bac`) admits exactly two request modes — `image_to_video` and `video_to_video` — and
+/// refuses every other key BY NAME (`crossed resident request mode`) before it reaches the shared
+/// `default_memory_strategy_safety_check`. It then requires `reference_count == 1` and an
+/// `evidence_revision` sealed under
+/// `provider-resident-video-request-v3:krea_realtime_14b:mode=…:shape=…:`.
+///
+/// THE WORKER SIDE agrees. `video_jobs/krea_realtime.rs` builds its `VideoGenInput` with
+/// `..VideoGenInput::default()` and never sets `memory_context`, so nothing but
+/// `video_admission.rs` can fill it — and the context that path builds carries
+/// `mode = MemoryMode::Other("text_to_video")`, `reference_count = 0` and an `evidence_revision`
+/// that is a curve/anchor id or `video-estimate-floor-v1`
+/// (`video_admission.rs#admit_video_generation_with_curves_and_profiles`), never that sealed
+/// receipt. A reference-free t2v render therefore reaches the engine through
+/// `memory_strategy::generate_with_scope`'s no-context early return; the gate is asked nothing.
+///
+/// sc-22738 probed that surface anyway, and all three `krea_realtime_14b:*:mlx` anchors died on the
+/// FIRST probe — after a full 14B weight load — with "admission rejected a fitting probe budget".
+/// The arm now asks the gate exactly what the worker asks it. It does NOT synthesize a
+/// reference-carrying surface to make the gate answer: that would measure an admission decision the
+/// product never makes for this request, and the anchor would then carry an admission
+/// characterization no shipped path exercises.
+fn krea_realtime_probes_admission(mode: &str, reference_count: u32) -> bool {
+    matches!(mode, "image_to_video" | "video_to_video") || reference_count > 0
+}
+
+/// What the record says about the admission scenarios it did not run, and why. Stated once and
+/// carried into every `not_run` reason, the lifecycle blocker and the diagnostics.
+const KREA_REALTIME_ADMISSION_BLOCKER: &str = concat!(
+    "reference-free Krea Realtime has NO admission surface in production: ",
+    "`mlx-gen-krea-realtime`'s registered safety_check admits only the image_to_video and ",
+    "video_to_video routes carrying exactly one reference under a sealed ",
+    "provider-resident-video-request-v3 receipt, and refuses every other request mode by name; ",
+    "the worker's own t2v path leaves VideoGenInput::memory_context unset, and the context ",
+    "video_admission.rs would build carries text_to_video, reference_count 0 and a curve/anchor ",
+    "evidence id rather than that receipt. This arm therefore asks the admission gate nothing, ",
+    "exactly as the worker asks it nothing: the exact-fit, unknown-budget and stale-evidence ",
+    "scenarios are unexecuted rather than answered on a surface production never presents. This ",
+    "anchor prices the RESIDENT load of the plain reference-free t2v ladder and claims nothing ",
+    "about any optimized rung or admission decision"
+);
 
 fn krea_realtime_request(geometry: KreaRealtimeGeometry, fps: u32, seed: u64) -> GenerationRequest {
     GenerationRequest {
@@ -20601,6 +20639,7 @@ fn krea_realtime_complete_sweep(request: &Value) -> Result<Value, String> {
 /// decides which rungs are capturable, and this provider registers a resident-only witness.
 fn run_krea_realtime(request: &Value) -> Result<Value, String> {
     let geometry = validate_krea_realtime_target(request)?;
+    let surface = krea_realtime_target_surface(request)?;
     protocol::validate_plain_overlay_target(request, KREA_REALTIME_PLAIN_EXECUTION_PATH)?;
     let load_shape = planned_load_shape(request)?;
     if load_shape != LoadShape::EagerMaterialization {
@@ -20697,40 +20736,23 @@ fn run_krea_realtime(request: &Value) -> Result<Value, String> {
         );
     }
 
-    // Admission hygiene on the LOADED provider, through its OWN registered check: it must accept a
-    // fitting probe (so the two rejections below are evidence rather than a blanket refusal), reject
-    // an unknown/zero budget, and reject a mutated calibration fingerprint.
-    let probe = |fingerprint: &str, total_bytes: u64, predicted: u64| {
-        generator.memory_strategy_safety_check(&krea_realtime_context(
-            selection,
-            calibration,
-            fingerprint,
-            geometry,
-            total_bytes,
-            predicted,
-        ))
-    };
-    if !matches!(
-        probe(&calibration.fingerprint, hardware_bytes, 1),
-        MemorySafetyDecision::Accept
-    ) {
-        return Err(
-            "Krea Realtime admission rejected a fitting probe budget; the scenario rejections \
-             below would be a blanket refusal, not evidence"
-                .to_owned(),
-        );
-    }
-    if !matches!(
-        probe(&calibration.fingerprint, 0, 1),
-        MemorySafetyDecision::Reject { .. }
-    ) {
-        return Err("Krea Realtime admission accepted an unknown/zero memory budget".to_owned());
-    }
-    if !matches!(
-        probe("stale-krea-realtime-fingerprint", hardware_bytes, 1),
-        MemorySafetyDecision::Reject { .. }
-    ) {
-        return Err("Krea Realtime admission accepted stale calibration evidence".to_owned());
+    // The arm's admission decision, taken the way the WORKER takes it (sc-22738): see
+    // [`krea_realtime_probes_admission`]. On every cell this arm can plan the answer is `false` —
+    // the reference-free t2v route has no admission surface on either side of the seam — so nothing
+    // is asked of the provider's safety check and the render below runs resident exactly as
+    // production runs it. The record says so rather than claiming an admission result it never got.
+    //
+    // A `true` answer would mean the plan reached this arm with a reference-carrying Krea Realtime
+    // target, which `validate_krea_realtime_target` has already refused BY NAME: i2v warms the
+    // causal KV cache from the encoded still and v2v runs a strength-controlled init, so such a
+    // request seals a different evidence identity and needs its own capture, not a probe
+    // synthesized here. It is refused rather than assumed away.
+    if krea_realtime_probes_admission(&surface.mode, surface.reference_count) {
+        return Err(format!(
+            "{KREA_REALTIME_PROVIDER}: production WOULD build a Krea Realtime memory context for \
+             this surface, but this arm measures only the reference-free t2v ladder; a \
+             reference-carrying anchor seals its own evidence identity and needs its own capture"
+        ));
     }
 
     // Three phase peaks off the boundaries the shipped `generate` already emits, cut exactly the way
@@ -20858,13 +20880,10 @@ fn run_krea_realtime(request: &Value) -> Result<Value, String> {
             overall.active
         ));
     }
-    // The exact-fit probe, on the LOADED generator and against the MEASURED evidence.
-    if !matches!(
-        probe(&calibration.fingerprint, predicted, predicted),
-        MemorySafetyDecision::Accept
-    ) {
-        return Err("Krea Realtime admission rejected an exact-fit calibrated budget".to_owned());
-    }
+    // No exact-fit probe against the MEASURED evidence either, and for the same reason the three
+    // pre-render scenarios are unexecuted: the gate this arm would ask refuses the reference-free
+    // t2v surface by name, so an answer here would characterize a decision production never takes.
+    // See [`KREA_REALTIME_ADMISSION_BLOCKER`].
 
     // Warm repeat determinism + cleanup bounds on this exact loaded provider.
     clear_cache();
@@ -20928,14 +20947,27 @@ fn run_krea_realtime(request: &Value) -> Result<Value, String> {
         );
     }
 
-    let lifecycle_blocker = concat!(
-        "this arm executes the measured render plus two unscoped warm repeats on the loaded ",
-        "provider; it opens no memory-strategy request scope and injects no calibration fault, so ",
-        "the scoped cancellation and authorized-error scenarios and their recovery renders are ",
-        "unexecuted. This record claims nothing about them"
+    let lifecycle_blocker = format!(
+        concat!(
+            "this arm executes the measured render plus two unscoped warm repeats on the loaded ",
+            "provider; it opens no memory-strategy request scope and injects no calibration ",
+            "fault, so the scoped cancellation and authorized-error scenarios and their recovery ",
+            "renders are unexecuted. This record claims nothing about them. ",
+            // sc-22738: stated in the same breath as the lifecycle exclusion because it is the
+            // same kind of claim — what this record deliberately does NOT say.
+            "Additionally: {}"
+        ),
+        KREA_REALTIME_ADMISSION_BLOCKER,
     );
+    let lifecycle_blocker = lifecycle_blocker.as_str();
+    // GATED, not `runtime_complete` (sc-22738). Runtime activation is exactly the claim that the
+    // provider's admission gate accepted an exact-fit budget and rejected the two mutations, and
+    // this capture asked it nothing — because production asks it nothing for this request. The
+    // MEASUREMENT is unaffected and is carried in full: `observedMemory` and `predictedPeakBytes`
+    // are the resident-load prices this anchor exists to publish, and `extract-memory-anchors.mjs`
+    // reads them off this record exactly as it reads them off a runtime-complete one.
     let mut fragment = json!({
-        "status": "runtime_complete",
+        "status": "gated",
         "strategy": strategy,
         // From the CONTRACT's own calibration identity, never copied from the plan: a receipt may
         // only testify to the materialization shape its own run used (sc-16482).
@@ -20947,9 +20979,9 @@ fn run_krea_realtime(request: &Value) -> Result<Value, String> {
         },
         "sweep": krea_realtime_complete_sweep(request)?,
         "scenarios": [
-            { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": predicted },
-            { "name": "unknown_budget", "result": "passed", "reason": "the loaded Krea Realtime generator rejected a zero/unknown budget" },
-            { "name": "stale_evidence", "result": "passed", "reason": "the loaded Krea Realtime generator rejected a mutated calibration fingerprint" },
+            { "name": "exact_fit", "result": "not_run", "reason": KREA_REALTIME_ADMISSION_BLOCKER },
+            { "name": "unknown_budget", "result": "not_run", "reason": KREA_REALTIME_ADMISSION_BLOCKER },
+            { "name": "stale_evidence", "result": "not_run", "reason": KREA_REALTIME_ADMISSION_BLOCKER },
             { "name": "warm_repeat", "result": "passed", "reason": "two warm repeats on the loaded provider reproduced the measured clip frame-for-frame inside the declared envelope, within the clean warm peak and cleanup bounds" },
             { "name": "cancel", "result": "not_run", "reason": lifecycle_blocker },
             { "name": "error", "result": "not_run", "reason": lifecycle_blocker },
@@ -24452,6 +24484,122 @@ mod krea_realtime_tests {
     fn the_realtime_provider_id_is_the_engines_own() {
         assert_eq!(KREA_REALTIME_PROVIDER, mlx_gen_krea_realtime::MODEL_ID);
         assert_eq!(KREA_REALTIME_PROVIDER, "krea_realtime_14b");
+    }
+
+    /// sc-22738. THE decision this fix is about: for every planned `krea_realtime_14b:*:mlx` cell
+    /// the arm's answer to "does this capture ask Krea Realtime's admission gate anything?" must be
+    /// the answer PRODUCTION gives for the same request shape — and today, on every cell this arm
+    /// can plan, that answer is NO.
+    ///
+    /// sc-22735 asked the gate on the anchor's own reference-free t2v surface, which the engine's
+    /// route gate refuses by name, and all three anchors died with "admission rejected a fitting
+    /// probe budget" after a full 14B weight load. The remedy is not a surface that makes the gate
+    /// answer — production never presents one for this request — it is to skip the probe exactly
+    /// where production skips the context.
+    #[test]
+    fn the_arm_asks_the_admission_gate_exactly_what_production_asks_it() {
+        // The plan's own rows, read rather than restated: every one is reference-free t2v, so the
+        // arm's decision on every schedulable cell is the one asserted below.
+        let plan: Value = serde_json::from_str(include_str!(
+            "../../../../config/memory-calibration-plan.json"
+        ))
+        .expect("the anchor plan parses");
+        let mut planned_rows = 0;
+        for (key, row) in plan["anchors"].as_object().expect("anchors object") {
+            if row["provider"].as_str() != Some(KREA_REALTIME_PROVIDER) || !key.ends_with(":mlx") {
+                continue;
+            }
+            let mode = row["mode"].as_str().expect("a plan row declares a mode");
+            let references = row["referenceCount"].as_u64().unwrap_or(0) as u32;
+            assert!(
+                !krea_realtime_probes_admission(mode, references),
+                "{key}: a reference-free Krea Realtime capture must not probe admission"
+            );
+            planned_rows += 1;
+        }
+        assert_eq!(
+            planned_rows, 3,
+            "the plan must still carry the three MLX Krea Realtime rows this case decides for"
+        );
+
+        // The predicate over both of its axes, not just today's rows: the two routes the engine's
+        // gate names probe, every other mode key does not, and a reference count above zero probes
+        // on any mode — so a reference-carrying anchor can never inherit the skip silently.
+        // (The route list itself is bound to the pinned engine's own `safety_check` by
+        // `the Krea Realtime arm's admitted routes are the pinned engine's own` in
+        // scripts/measure-memory-catalog.test.mjs, which reads the engine source.)
+        for mode in [
+            "image_to_video",
+            "video_to_video",
+            "text_to_video",
+            "text_to_image",
+            "edit",
+        ] {
+            for reference_count in [0, 1, 4] {
+                let admitted_route = matches!(mode, "image_to_video" | "video_to_video");
+                assert_eq!(
+                    krea_realtime_probes_admission(mode, reference_count),
+                    admitted_route || reference_count > 0,
+                    "{mode}/refs={reference_count}: the arm's mirror of the engine's route gate \
+                     has drifted"
+                );
+            }
+        }
+
+        // The arm's own target validation refuses every surface the predicate answers `true` for,
+        // so the refusal branch is unreachable from a plan row rather than merely unused: a
+        // reference-carrying Krea Realtime capture is a different anchor, not a mode flag.
+        for (field, value) in [
+            ("mode", json!("image_to_video")),
+            ("referenceCount", json!(1)),
+        ] {
+            let mut request = planned_request();
+            request["planned"]["target"][field] = value;
+            assert!(
+                validate_krea_realtime_target(&request).is_err(),
+                "{field}: a surface the gate would answer for must be refused by name"
+            );
+        }
+
+        // …and the arm ACTS on that decision. The predicate is only the answer; a body that still
+        // called the provider's admission gate, or a record that still claimed the three admission
+        // scenarios passed, would be the sc-22735 defect wearing the sc-22738 predicate. The
+        // measured render needs real weights, so the body is read as source.
+        let source = include_str!("mlx.rs");
+        let start = source
+            .find("\nfn run_krea_realtime(")
+            .expect("the arm still exists");
+        let body = &source[start
+            ..start
+                + source[start..]
+                    .find("\n}\n")
+                    .expect("the arm's body closes")];
+        assert!(
+            !body.contains("safety_check"),
+            "the Krea Realtime arm asks the provider's admission gate something again; production \
+             asks it nothing for a reference-free t2v request"
+        );
+        assert!(
+            body.contains("\"status\": \"gated\""),
+            "a capture that ran no admission probe cannot file a runtime-activating record"
+        );
+        for scenario in ["exact_fit", "unknown_budget", "stale_evidence"] {
+            assert!(
+                body.contains(&format!(
+                    "{{ \"name\": \"{scenario}\", \"result\": \"not_run\", \"reason\": \
+                     KREA_REALTIME_ADMISSION_BLOCKER }}"
+                )),
+                "the {scenario} scenario must be reported unexecuted, with the reason production \
+                 gives for it"
+            );
+        }
+        assert!(
+            KREA_REALTIME_ADMISSION_BLOCKER
+                .contains("reference-free Krea Realtime has NO admission surface")
+                && KREA_REALTIME_ADMISSION_BLOCKER.contains("prices the RESIDENT load"),
+            "the record must state why it ran no probe and what it does price: \
+             {KREA_REALTIME_ADMISSION_BLOCKER}"
+        );
     }
 }
 

--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -1206,11 +1206,34 @@ mod tests {
         for record in evidence.records.iter().filter(|record| {
             record.backend == Backend::Mlx && record.target.mode == "text_to_image"
         }) {
-            image_records += 1;
+            // A record whose ENGINE bounds only some of the three declared phases publishes the
+            // overall-only shape and says so in its diagnostics (sc-22738 — the still Bernini
+            // member: `bernini_requires_bounded_conditioning_peak`). There is no decomposition to
+            // run the counterfactual over, and inventing one is exactly what that arm refuses to
+            // do, so such a record is skipped — but only on its own declaration. An overall-only
+            // record that does NOT declare an unattributed phase is a decomposition that went
+            // missing, and still fails here.
             let observed = match &record.observed_memory {
-                RequiredNullable::Value(observed) => observed.full().expect("full image telemetry"),
+                RequiredNullable::Value(observed) => match observed.full() {
+                    Some(observed) => observed,
+                    None => {
+                        assert!(
+                            record.diagnostics.as_ref().is_some_and(|diagnostics| {
+                                diagnostics.measurements.iter().any(|measurement| {
+                                    measurement.name == "conditioningPhaseUnattributed"
+                                        && measurement.value == 1
+                                })
+                            }),
+                            "{} carries overall-only image telemetry without declaring an \
+                             unattributed phase",
+                            record.id
+                        );
+                        continue;
+                    }
+                },
                 RequiredNullable::Null => panic!("{} has null image telemetry", record.id),
             };
+            image_records += 1;
             let historical = image_predicted_peak_bytes(
                 phase(&observed.conditioning),
                 phase(&observed.denoise),
@@ -3245,6 +3268,19 @@ impl PredictedPhasePeaks {
             "decode": self.decode,
             "overall": self.overall,
         })
+    }
+
+    /// The receipt an arm files when its engine does not bound every declared phase (sc-22738).
+    ///
+    /// `memory_calibration::PredictedPeakBytes` accepts exactly two shapes — the full four-key
+    /// decomposition or an overall-only object — and a partial decomposition deserializes as
+    /// NEITHER (both variants are `deny_unknown_fields`). An arm that measured only some of the
+    /// phases therefore publishes the ceiling and omits the decomposition, rather than filling the
+    /// unmeasured phase with a zero that reads as "this phase cost nothing". The ceiling itself is
+    /// identical: it is taken over the phases that WERE bounded, and on such an engine one of those
+    /// windows contains the unbounded phase.
+    fn overall_only_json(self) -> Value {
+        json!({ "overall": self.overall })
     }
 }
 
@@ -18392,6 +18428,80 @@ fn bernini_request(
     }
 }
 
+/// WHICH LIFECYCLE BOUNDARIES THE PINNED BERNINI ENGINE ACTUALLY EMITS (sc-22738).
+///
+/// `mlx-gen-bernini` at the pinned revision constructs a `Progress` value in exactly three places,
+/// and hands `on_progress` to nothing else:
+///
+/// * `src/bernini.rs:868` — `Progress::Step` for the MAR planning loop (`1..=planning_step`);
+/// * `src/bernini.rs:1052` — `Progress::Step` for the renderer denoise (`planning_step+1..=total`),
+///   the SAME folded bar (F-038);
+/// * `src/bernini.rs:1077` — `Progress::Decoding`, immediately before the z16 VAE decode.
+///
+/// It emits **no `Progress::Loading(_)` at all**, on either route: unlike every other MLX arm in
+/// this file it does not drive `gen_core::residency::run_two_phase`
+/// (`crates/contracts/gen-core/src/residency.rs:622,642`), which is what mints
+/// `Loading(TextEncoder)` / `Loading(Renderer)` for the providers that do.
+///
+/// So the conditioning→denoise EDGE has no boundary. The edge is real — `generate_impl` drops the
+/// Qwen2.5-VL planner and `clear_cache()`s at `bernini.rs:894-901`, encodes the UMT5-XXL prompt and
+/// drops it at `:902-921`, and only then loads the two ~28 GB experts at `:1000-1017` — but no
+/// event is emitted anywhere between the last planner `Step` and the first denoise `Step`, and the
+/// first denoise `Step` fires AFTER both experts are resident. Cutting on it would charge 56 GB of
+/// renderer weights to the conditioning phase; cutting on the first planner `Step` would drop the
+/// UMT5-XXL text encoder, the largest conditioning component, into denoise. Neither is the
+/// conditioning peak, so this arm measures neither and says so.
+///
+/// This is an ENGINE gap, not a route difference: the contract declares the full
+/// `[Conditioning, Denoise, Decode]` envelope for both members
+/// (`mlx-gen-bernini/src/memory_strategy.rs:1121-1135,1148-1153`) while the pipeline bounds only
+/// two of the three. Closing it is an inference-side change (emit the two `Loading` phases at the
+/// stage-2 and stage-3 entries) and therefore a pin bump.
+const BERNINI_ENGINE_BOUNDARIES: &str = concat!(
+    "the pinned mlx-gen-bernini pipeline emits only `Progress::Step` (one folded bar) and a ",
+    "single `Progress::Decoding` (bernini.rs:868, :1052, :1077) — it never emits ",
+    "`Progress::Loading(_)`, so no boundary exists at the conditioning/denoise edge. This record ",
+    "therefore attributes the pre-decode window and the decode window, the two phases the engine ",
+    "does bound, and reports the conditioning phase as UNATTRIBUTED rather than as a zero peak. ",
+    "The pre-decode window strictly contains the conditioning phase, so the overall ceiling this ",
+    "record prices is unaffected and remains conservative."
+);
+
+/// Whether this arm REFUSES a capture that carries no engine-bounded conditioning peak.
+///
+/// The pinned engine bounds no conditioning phase on EITHER route ([`BERNINI_ENGINE_BOUNDARIES`]).
+/// The two members are nonetheless treated differently, deliberately:
+///
+/// * the VIDEO member keeps the strict three-phase requirement it has always had. With no
+///   conditioning boundary that requirement REFUSES rather than files — the conservative
+///   direction, and the state this story leaves it in until the engine emits the boundary;
+/// * the STILL member, whose captures complete on this host, files the two phases the engine does
+///   bound and declares the third unattributed, so nothing downstream can read a false zero.
+fn bernini_requires_bounded_conditioning_peak(arm: BerniniArm) -> bool {
+    arm.model_id == BERNINI_VIDEO_MODEL_ID
+}
+
+/// The zero-active-peak refusal, over the phases this arm requires the engine to have bounded.
+///
+/// Returns `None` when every required phase reported a non-zero active peak.
+fn bernini_zero_phase_error(
+    arm: BerniniArm,
+    conditioning: u64,
+    denoise: u64,
+    decode: u64,
+) -> Option<String> {
+    let collapsed = if bernini_requires_bounded_conditioning_peak(arm) {
+        [conditioning, denoise, decode].contains(&0)
+    } else {
+        [denoise, decode].contains(&0)
+    };
+    collapsed.then(|| {
+        "a synchronized Bernini lifecycle phase reported a zero active peak; the engine stopped \
+         emitting a boundary and the attribution collapsed"
+            .to_owned()
+    })
+}
+
 fn bernini_quality_passes(maximum: f64, mean: f64, rms: f64) -> bool {
     maximum <= BERNINI_MAX_THRESHOLD
         && mean <= BERNINI_MEAN_THRESHOLD
@@ -18608,12 +18718,14 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
     let denoise = denoise.get();
     let conditioning_close = conditioning_close.get();
     let denoise_close = denoise_close.get();
-    if [conditioning.active, denoise.active, decode.active].contains(&0) {
-        return Err(
-            "a synchronized Bernini lifecycle phase reported a zero active peak; the engine \
-             stopped emitting a boundary and the attribution collapsed"
-                .to_owned(),
-        );
+    // Over the phases the PINNED engine actually bounds for this member — see
+    // [`BERNINI_ENGINE_BOUNDARIES`] and [`bernini_requires_bounded_conditioning_peak`]. `denoise`
+    // is the peak over the whole pre-decode window (the capture at `Progress::Decoding` is the
+    // first read since the pre-generate reset), so it strictly contains the conditioning phase.
+    if let Some(error) =
+        bernini_zero_phase_error(arm, conditioning.active, denoise.active, decode.active)
+    {
+        return Err(error);
     }
     // The engine's own decoded depth for this request, NOT the requested count: Bernini's z16
     // decode is NON-causal, so it materializes four output frames per latent frame and a 49-frame
@@ -18649,13 +18761,37 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
     // `every_receipt_builder_is_bound_to_its_lane_prediction_wrapper` reads every `predicted_peaks`
     // binding in this file, and a binding that merely selects between the two wrappers is not one
     // it can tell from a bypass.
-    let (predicted_peaks_json, predicted) = if arm.model_id == BERNINI_IMAGE_MODEL_ID {
-        let predicted_peaks = image_predicted_peak_bytes(conditioning, denoise, decode);
-        (predicted_peaks.json(), predicted_peaks.overall)
-    } else {
-        let predicted_peaks = video_predicted_peak_bytes(conditioning, denoise, decode);
-        (predicted_peaks.json(), predicted_peaks.overall)
-    };
+    //
+    // The still member additionally publishes its receipt in the OVERALL-ONLY shape (sc-22738): a
+    // full `predictedPeakBytes` / `observedMemory` decomposition is a claim that all three declared
+    // phases were measured, and on this engine the conditioning one was not. The overall ceiling is
+    // unchanged — it is taken over the same phases either way, and the pre-decode window contains
+    // the conditioning phase — so nothing about what this record prices is weakened; what changes
+    // is that no consumer can read a conditioning peak of zero off it.
+    let (predicted_peaks_json, observed_memory_json, predicted) =
+        if arm.model_id == BERNINI_IMAGE_MODEL_ID {
+            let predicted_peaks = image_predicted_peak_bytes(conditioning, denoise, decode);
+            (
+                predicted_peaks.overall_only_json(),
+                // `RuntimeObservedMemory` carries the ACTIVE peak and nothing else — the allocator
+                // envelope stays in the diagnostics, where `overallAllocatorEnvelope` already
+                // publishes it.
+                json!({ "overall": { "activeBytes": overall.active } }),
+                predicted_peaks.overall,
+            )
+        } else {
+            let predicted_peaks = video_predicted_peak_bytes(conditioning, denoise, decode);
+            (
+                predicted_peaks.json(),
+                json!({
+                    "conditioning": conditioning.json(),
+                    "denoise": denoise.json(),
+                    "decode": decode.json(),
+                    "overall": overall.json(),
+                }),
+                predicted_peaks.overall,
+            )
+        };
     // The same two ceilings `memory-calibration-harness.mjs#assertResidencyFitsHardware` applies —
     // checked HERE so a capture that cannot be admitted fails loudly during the campaign rather
     // than producing a well-formed record the harness rejects afterwards.
@@ -18749,11 +18885,41 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
             "implementable — they are not run here, and this record claims nothing about them. ",
             // sc-22738: stated in the same breath as the lifecycle exclusion because it is the
             // same kind of claim — what this record deliberately does NOT say.
-            "Additionally: {}"
+            "Additionally: {}{}"
         ),
-        BERNINI_ADMISSION_BLOCKER
+        BERNINI_ADMISSION_BLOCKER,
+        // sc-22738, same kind of claim again: a phase the engine does not bound is named here
+        // rather than left to be inferred from a measurement that is simply absent.
+        if bernini_requires_bounded_conditioning_peak(arm) {
+            String::new()
+        } else {
+            format!(" Additionally: {BERNINI_ENGINE_BOUNDARIES}")
+        }
     );
     let lifecycle_blocker = lifecycle_blocker.as_str();
+    // The conditioning-phase measurements are the keys `extract-memory-anchors.mjs`
+    // (`PHASE_MEASUREMENTS`) and `memory_anchor::validate_anchor` mint an anchor from, so they are
+    // published ONLY when the engine bounded that phase. Withholding them on the still route makes
+    // the record un-anchorable, which is the correct outcome for a decomposition the engine never
+    // gave — and strictly better than an anchor keyed on a fabricated zero. What the window DID
+    // measure is still published, under a name that says what it is.
+    let conditioning_measurements: Vec<(&'static str, &'static str, u64)> =
+        if bernini_requires_bounded_conditioning_peak(arm) {
+            vec![
+                ("conditioningActivePeak", "bytes", conditioning.active),
+                (
+                    "conditioningCloseActive",
+                    "bytes",
+                    conditioning_close.active,
+                ),
+                ("conditioningCloseCache", "bytes", conditioning_close.cache),
+            ]
+        } else {
+            vec![
+                ("conditioningPhaseUnattributed", "count", 1),
+                ("preDecodeWindowActivePeak", "bytes", denoise.active),
+            ]
+        };
     // GATED, not `runtime_complete` (sc-22738). Runtime activation is exactly the claim that the
     // provider's admission gate accepted an exact-fit budget and rejected the two mutations, and
     // this capture asked it nothing — because production asks it nothing for this request. The
@@ -18782,12 +18948,7 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
             { "name": "overlay", "result": "not_applicable", "reason": "settled below from the declared reference-free target" }
         ],
         "predictedPeakBytes": predicted_peaks_json,
-        "observedMemory": {
-            "conditioning": conditioning.json(),
-            "denoise": denoise.json(),
-            "decode": decode.json(),
-            "overall": overall.json(),
-        },
+        "observedMemory": observed_memory_json,
         "quality": {
             "contract": "identical artifact, prompt, seed, geometry, frames, fps, tier and loaded provider contract; cold measured output versus two warm unscoped repeats, compared over every frame",
             "identicalInputs": true,
@@ -18812,9 +18973,6 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
                 ("preRungActiveAfterClear", "bytes", pre_rung_active),
                 ("preRungCacheAfterClear", "bytes", pre_rung_cache),
                 ("preGenerateActivePeak", "bytes", pre_generate.active),
-                ("conditioningActivePeak", "bytes", conditioning.active),
-                ("conditioningCloseActive", "bytes", conditioning_close.active),
-                ("conditioningCloseCache", "bytes", conditioning_close.cache),
                 ("denoiseActivePeak", "bytes", denoise.active),
                 ("denoiseCloseActive", "bytes", denoise_close.active),
                 ("denoiseCloseCache", "bytes", denoise_close.cache),
@@ -18841,7 +18999,9 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
                 ("renderedFrames", "count", u64::from(expected_frames)),
                 ("requestedFrames", "count", u64::from(geometry.frames)),
                 ("outputFps", "count", u64::from(fps)),
-            ],
+            ]
+            .into_iter()
+            .chain(conditioning_measurements),
         ),
         "capturedAt": protocol::captured_at(),
     });
@@ -30318,6 +30478,157 @@ mod exceeded_bound_tests {
             "it states the footprint: {refusal}"
         );
         assert!(refusal.contains("Refusing before the load"), "{refusal}");
+    }
+
+    /// sc-22738 — the still route is graded on the phases the PINNED ENGINE BOUNDS.
+    ///
+    /// All three `bernini_image:*:mlx` anchors rendered for ~8 minutes and were then refused for a
+    /// zero conditioning active peak. The peak was zero because the pinned `mlx-gen-bernini`
+    /// pipeline emits no `Progress::Loading(_)` at all (see [`BERNINI_ENGINE_BOUNDARIES`]), so the
+    /// boundary this arm cut the conditioning phase on was never delivered — the arm was grading a
+    /// route against a phase set copied from a provider that drives the shared residency seam.
+    #[test]
+    fn the_still_route_is_graded_on_the_two_phases_the_engine_bounds() {
+        assert!(
+            !bernini_requires_bounded_conditioning_peak(BERNINI_IMAGE_ARM),
+            "the pinned engine bounds no conditioning phase on the still route; requiring one \
+             refuses every completed still capture"
+        );
+        // The exact shape the campaign hit: a completed render whose only zero is the phase the
+        // engine never bounded.
+        assert_eq!(
+            bernini_zero_phase_error(BERNINI_IMAGE_ARM, 0, 66_000_000_000, 71_000_000_000),
+            None,
+            "a still capture that measured both bounded phases must file"
+        );
+        // The phases the engine DOES bound are still required, so this is not a blanket allowance.
+        for (label, denoise, decode) in [
+            ("the pre-decode window", 0_u64, 71_000_000_000_u64),
+            ("the decode window", 66_000_000_000, 0),
+        ] {
+            assert!(
+                bernini_zero_phase_error(BERNINI_IMAGE_ARM, 12_000_000_000, denoise, decode)
+                    .is_some(),
+                "{label} is bounded by the engine and a zero there is still a collapse"
+            );
+        }
+    }
+
+    /// The VIDEO member's check is untouched: it keeps the strict three-phase requirement, which
+    /// with no conditioning boundary REFUSES rather than files. That is the conservative direction
+    /// and is deliberate — a video record is what the video admission law prices, and it will not
+    /// be minted off an unmeasured phase. Applying the still rule to a 49-frame request reds here.
+    #[test]
+    fn the_video_route_still_refuses_any_zero_phase() {
+        assert!(bernini_requires_bounded_conditioning_peak(
+            BERNINI_VIDEO_ARM
+        ));
+        let refusal =
+            bernini_zero_phase_error(BERNINI_VIDEO_ARM, 0, 66_000_000_000, 71_000_000_000)
+                .expect("the video member refuses a capture with an unmeasured conditioning phase");
+        assert_eq!(
+            refusal,
+            "a synchronized Bernini lifecycle phase reported a zero active peak; the engine \
+             stopped emitting a boundary and the attribution collapsed",
+            "the video member's refusal text is the one the campaign logs already carry"
+        );
+        assert_eq!(
+            bernini_zero_phase_error(
+                BERNINI_VIDEO_ARM,
+                12_000_000_000,
+                66_000_000_000,
+                71_000_000_000
+            ),
+            None
+        );
+    }
+
+    /// WHY the still receipt is published overall-only rather than with one key dropped.
+    ///
+    /// `memory_calibration` accepts exactly two receipt shapes and both `deny_unknown_fields`, so a
+    /// three-of-four decomposition is not a record at all. The choice is therefore between the
+    /// ceiling alone and a fabricated conditioning number, and this pins the first.
+    #[test]
+    fn an_unattributed_phase_is_published_as_a_ceiling_not_as_a_zero() {
+        use sceneworks_core::memory_calibration::{ObservedMemory, PredictedPeakBytes};
+
+        let peaks = PredictedPhasePeaks {
+            conditioning: 1,
+            denoise: 2,
+            decode: 3,
+            overall: 4,
+        };
+        let overall_only: PredictedPeakBytes =
+            serde_json::from_value(peaks.overall_only_json()).expect("overall-only prediction");
+        assert_eq!(overall_only.overall(), 4);
+        assert!(
+            overall_only.full().is_none(),
+            "an overall-only receipt must not read as a decomposition"
+        );
+        assert!(serde_json::from_value::<PredictedPeakBytes>(peaks.json())
+            .expect("full prediction")
+            .full()
+            .is_some());
+        // The shape the arm CANNOT file, and the reason the ceiling is filed instead.
+        assert!(
+            serde_json::from_value::<PredictedPeakBytes>(
+                json!({ "denoise": 2, "decode": 3, "overall": 4 })
+            )
+            .is_err(),
+            "a partial decomposition is not a receipt shape; dropping one key is not an option"
+        );
+
+        let window = PhaseMemory {
+            active: 66_000_000_000,
+            cache: 3,
+        };
+        let observed: ObservedMemory =
+            serde_json::from_value(json!({ "overall": { "activeBytes": window.active } }))
+                .expect("overall-only");
+        assert!(observed.full().is_none());
+        assert_eq!(observed.overall_non_reclaimable_bytes(), window.active);
+        assert!(serde_json::from_value::<ObservedMemory>(json!({
+            "denoise": window.json(),
+            "decode": window.json(),
+            "overall": window.json(),
+        }))
+        .is_err());
+    }
+
+    /// The arm ACTS on the attribution, not merely computes it: the still receipt is the ceiling,
+    /// the anchor-minting conditioning measurements are withheld, and what the window did measure
+    /// is published under a name that says what it is. Read the way the sibling guards in this file
+    /// read `run_bernini` — the measured render needs real weights and cannot run here.
+    #[test]
+    fn the_still_receipt_withholds_the_keys_an_anchor_would_be_minted_from() {
+        let source = include_str!("mlx.rs");
+        let start = source
+            .find("\nfn run_bernini(")
+            .expect("the arm still exists");
+        let body = &source[start
+            ..start
+                + source[start..]
+                    .find("\n}\n")
+                    .expect("the arm's body closes")];
+        assert!(
+            body.contains("predicted_peaks.overall_only_json()"),
+            "the still member must file the ceiling rather than a four-key decomposition"
+        );
+        assert!(
+            body.contains("(\"conditioningPhaseUnattributed\", \"count\", 1)")
+                && body.contains("(\"preDecodeWindowActivePeak\", \"bytes\", denoise.active)"),
+            "the unattributed phase must be declared, and the window that was measured named"
+        );
+        let conditioning_key = "(\"conditioningActivePeak\", \"bytes\", conditioning.active)";
+        let guarded = body
+            .find("if bernini_requires_bounded_conditioning_peak(arm) {")
+            .expect("the measurements are keyed on the engine's boundary set");
+        assert!(
+            body.match_indices(conditioning_key)
+                .all(|(index, _)| index > guarded),
+            "the anchor-minting conditioning measurement must only be emitted where the engine \
+             bounded that phase"
+        );
     }
 
     /// Everything the bound does NOT claim still captures: a bigger host, a shorter clip, another

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -1006,10 +1006,26 @@ export const PROVIDER_FAMILIES = Object.freeze({
   // the root resolves through — stays `ltx_2_3`. Both rows point at the ONE rehost the manifest
   // ships for all three platforms.
   //
-  // The Candle lane additionally binds the DENSE GEMMA text encoder, which is a sibling directory
-  // of the same snapshot rather than a separate repository (`SCENEWORKS_LTX_TEXT_ENCODER_ROOT`,
-  // validated by candle.rs against `<snapshot>/gemma`). That is what `siblingRoots` declares — see
-  // its use in `describeAnchor`. The MLX arm reads no such root, so its row declares none.
+  // BOTH lanes bind the DENSE GEMMA text encoder, which is a sibling directory of the same
+  // snapshot rather than a separate repository (`SCENEWORKS_LTX_TEXT_ENCODER_ROOT`, validated by
+  // BOTH adapters against `<snapshot>/gemma` — `mlx.rs#ltx_load_spec` and the candle twin). That
+  // is what `siblingRoots` declares — see its use in `describeAnchor`.
+  //
+  // sc-22738: the MLX row was declared WITHOUT it, on the belief that only the Candle arm read the
+  // root. `mlx.rs#ltx_load_spec` has required `SCENEWORKS_LTX_TEXT_ENCODER_ROOT` since sc-18808
+  // landed the video arm, so all three booked `ltx_2_3:*:mlx` captures died on
+  // `required environment variable SCENEWORKS_LTX_TEXT_ENCODER_ROOT is not set` — after the tier
+  // root had already been probed and the capture scheduled. `every SCENEWORKS_LTX_* root the
+  // adapters require is bound by the LTX-2.3 rows` (measure-memory-catalog.test.mjs) now derives
+  // the requirement from the adapter sources, so neither row can drift from its arm again.
+  //
+  // The resolution is PRODUCTION's own: `video_jobs/ltx.rs#bundled_ltx_gemma_dir` takes the
+  // selected tier dir's parent snapshot and joins `gemma`, which is exactly
+  // `path.dirname(resolved.root)/gemma` here. Production additionally honors a `$LTX_GEMMA_DIR`
+  // override and, failing that, scans SIBLING snapshot revisions (sc-14377) — neither is mirrored,
+  // and deliberately: both adapters snapshot-validate the text-encoder root against the SAME
+  // repository AND revision as the tier root, so a cross-revision or operator-overridden gemma is
+  // refused by the arm. The mirrored branch is the only one a capture can use.
   //
   // There is no `ltx_2_3:bf16:candle` cell, and its absence is a ROUTING fact rather than an
   // omission: the manifest ships LTX-2.3's `bf16` download as `platforms: ["macos"]`, and the
@@ -1017,7 +1033,10 @@ export const PROVIDER_FAMILIES = Object.freeze({
   // (`video_jobs/candle.rs#candle_ltx_bundle_tier_across_revisions`) returns `None` for
   // `CandleLtxTier::Bf16`. `measure-memory-catalog.test.mjs` asserts that exemption against BOTH
   // of those sources, so it cannot outlive either reason.
-  ltx_2_3: { env: "LTX", repo: LTX_2_3_REPOSITORY, arms: ["mlx"] },
+  ltx_2_3: {
+    env: "LTX", repo: LTX_2_3_REPOSITORY, arms: ["mlx"],
+    siblingRoots: [{ env: "LTX_TEXT_ENCODER", dir: "gemma" }],
+  },
   ltx_2_3_distilled: {
     env: "LTX", repo: LTX_2_3_REPOSITORY, arms: ["candle"],
     siblingRoots: [{ env: "LTX_TEXT_ENCODER", dir: "gemma" }],

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -68,6 +68,7 @@ import {
   requiredFilesFor,
   QWEN_EDIT_LIGHTNING_LORA,
   LTX25_REPOSITORY,
+  LTX_2_3_REPOSITORY,
   LTX25_DEV_REFINEMENT_LORA,
   LTX25_ENHANCER_DIR,
   INSTANTID_IDENTITY_BUNDLE_FILES,
@@ -3138,6 +3139,52 @@ test("every planned bernini, ltx_2_3 and minimax-h3 fingerprint is one its lane'
 // (CI always supplies one — see `skipWithoutRoutes`): the one bare MLX row per family is the tier
 // the engine's `CALIBRATED_TIER` names, so a re-tiered engine reds the plan here as well as in
 // the adapter's own tests.
+// sc-22738. `mlx.rs#krea_realtime_probes_admission` decides whether the Krea Realtime capture asks
+// the provider's admission gate anything, and its answer must be the ENGINE's: production admits
+// only the routes `mlx-gen-krea-realtime`'s registered `safety_check` names, and every other request
+// mode is refused there by name (`crossed resident request mode`) before the shared budget check is
+// ever reached. sc-22735 probed the anchor's own reference-free t2v surface anyway and all three
+// `krea_realtime_14b:*:mlx` cells died on the first probe after a full 14B weight load.
+//
+// The Rust side cannot make this binding: the gate short-circuits on an unresolvable artifact
+// receipt, so a weights-free probe rejects every mode for a reason that says nothing about routing.
+// So both route lists are READ — the engine's out of its `safety_check` match, the arm's out of its
+// `matches!` — and compared. An engine that grows or drops a route reds here rather than leaving the
+// arm quietly skipping a surface production now admits.
+test("the Krea Realtime arm's admitted routes are the pinned engine's own", { skip: skipWithoutRoutes }, async () => {
+  const engine = await readFile(
+    path.join(process.env.INFERENCE_REPO, "crates/media/mlx-gen/mlx-gen-krea-realtime/src/memory_strategy.rs"),
+    "utf8",
+  );
+  const gate = /pub\(crate\) fn safety_check\(([\s\S]*?)\n\}\n/.exec(engine);
+  assert.ok(gate, "the pinned crate still declares a registered safety_check");
+  const routed = /match context\.mode\.as_key\(\) \{([\s\S]*?)\n {4}\};/.exec(gate[1]);
+  assert.ok(routed, "safety_check no longer routes on the request mode; re-read this derivation");
+  const engineRoutes = [...routed[1].matchAll(/^\s*"([a-z_]+)" =>/gm)].map((match) => match[1]).sort();
+  assert.ok(engineRoutes.length > 0, "the engine's route arm list parsed empty");
+  assert.ok(
+    !engineRoutes.includes("text_to_video"),
+    "the engine now admits the reference-free t2v surface; the arm must PROBE admission again "
+      + "rather than record the three scenarios unexecuted",
+  );
+
+  const arm = await readFile(path.join(ROOT, ADAPTER_BIN_PATHS.mlx), "utf8");
+  const predicate = /fn krea_realtime_probes_admission\([\s\S]*?\n\}/.exec(arm);
+  assert.ok(predicate, "the arm still declares krea_realtime_probes_admission");
+  const armRoutes = [...predicate[0].matchAll(/"([a-z_]+)"/g)].map((match) => match[1]).sort();
+  assert.deepEqual(
+    armRoutes,
+    engineRoutes,
+    "the arm's admitted-route mirror has drifted from the pinned engine's own safety_check",
+  );
+  assert.match(
+    predicate[0],
+    /reference_count > 0/,
+    "a reference-carrying request must probe on any mode, so a new reference surface cannot "
+      + "inherit the skip silently",
+  );
+});
+
 test("the bare MLX LTX-2.3 and MiniMax-H3 plan rows are the engines' calibrated tiers", { skip: skipWithoutRoutes }, async () => {
   const bare = await videoFamilyBareTiers();
   for (const [family, crate] of [
@@ -3485,6 +3532,101 @@ test("every declared adapter arm is a provider that lane's adapter really dispat
     [],
     "every plan anchor names a provider its lane's adapter dispatch admits",
   );
+});
+
+/** Every `SCENEWORKS_LTX_*` root `relative`'s LTX-2.3 arm refuses to run without. */
+function requiredLtxEnv(source, relative) {
+  const names = [
+    ...new Set(
+      [...source.matchAll(/required_env\(\s*"(SCENEWORKS_LTX_[A-Z0-9_]+)"\s*,?\s*\)/g)].map(
+        (match) => match[1],
+      ),
+    ),
+  ].sort();
+  assert.ok(
+    names.length > 0,
+    `${relative}: the required_env parse found no SCENEWORKS_LTX_* root at all; the LTX arm's ` +
+      "environment family moved and this derivation has stopped asking its question",
+  );
+  return names;
+}
+
+// sc-22738. The campaign lost ALL THREE `ltx_2_3:*:mlx` captures to
+// `required environment variable SCENEWORKS_LTX_TEXT_ENCODER_ROOT is not set`, ~150 s into each
+// booked run: `PROVIDER_FAMILIES.ltx_2_3` declared no `siblingRoots`, on a comment claiming the MLX
+// arm read no text-encoder root. `mlx.rs#ltx_load_spec` has required it since sc-18808, so `--list`
+// called every cell runnable and the adapter refused before a weight was opened.
+//
+// NOTHING here is a literal env name: the requirement is READ out of each lane's adapter binary, so
+// an arm that grows (or drops) a `SCENEWORKS_LTX_*` root moves this case with no edit, and a row
+// that stops binding one reds. The resolution asserted is PRODUCTION's own —
+// `video_jobs/ltx.rs#bundled_ltx_gemma_dir` joins `gemma` to the selected tier dir's parent
+// snapshot — so the value handed to the arm is the value the worker would resolve.
+test("every SCENEWORKS_LTX_* root the adapters require is bound by the LTX-2.3 rows", async () => {
+  const lanes = [
+    ["mlx", "ltx_2_3"],
+    ["candle", "ltx_2_3_distilled"],
+  ];
+  const required = Object.fromEntries(
+    await Promise.all(
+      lanes.map(async ([backend]) => [
+        backend,
+        requiredLtxEnv(
+          await readFile(path.join(ROOT, ADAPTER_BIN_PATHS[backend]), "utf8"),
+          ADAPTER_BIN_PATHS[backend],
+        ),
+      ]),
+    ),
+  );
+  // Both arms open the same LTX-2.3 identity stack, so a root one lane requires and the other does
+  // not is itself a finding — and it would leave one lane's rows short exactly the way the MLX row
+  // was short.
+  assert.deepEqual(required.mlx, required.candle, "the two LTX arms require the same root family");
+
+  const models = [
+    ...fakeModels(),
+    {
+      id: "ltx_2_3",
+      downloads: [
+        { repo: LTX_2_3_REPOSITORY, revision: REVISION, variant: "q4", files: ["q4/*"] },
+      ],
+    },
+  ];
+  const layout = [[LTX_2_3_REPOSITORY, REVISION, "q4"]];
+
+  const staged = await fakeHub([...layout, [LTX_2_3_REPOSITORY, REVISION, "gemma"]]);
+  const snapshot = snapshotPath(staged, LTX_2_3_REPOSITORY, REVISION);
+  for (const [backend, provider] of lanes) {
+    const row = await classifyAnchor(`ltx_2_3:q4:${backend}`, { provider }, {
+      models, backend, hubs: [staged], current: new Map(), captured: new Map(),
+    });
+    assert.equal(row.status, "runnable", `${backend}: ${row.reason}`);
+    for (const name of required[backend]) {
+      assert.ok(
+        Object.hasOwn(row.env, name),
+        `${backend}: ${ADAPTER_BIN_PATHS[backend]} requires ${name}, but the ltx_2_3 row binds ` +
+          `only ${Object.keys(row.env).sort().join(", ")} — the booked capture dies on it`,
+      );
+    }
+    assert.equal(
+      row.env.SCENEWORKS_LTX_TEXT_ENCODER_ROOT,
+      path.join(snapshot, "gemma"),
+      `${backend}: the text-encoder root must be the gemma sibling of the SELECTED tier's own ` +
+        "snapshot, which is what bundled_ltx_gemma_dir resolves and what both arms snapshot-validate",
+    );
+    assert.equal(row.env.SCENEWORKS_LTX_ROOT, path.join(snapshot, "q4"), backend);
+  }
+
+  // And a host WITHOUT the sibling is `weights_missing` by name rather than runnable: the load
+  // cannot open, so booking a capture there only reproduces the failure this case exists for.
+  const holed = await fakeHub(layout);
+  for (const [backend, provider] of lanes) {
+    const row = await classifyAnchor(`ltx_2_3:q4:${backend}`, { provider }, {
+      models, backend, hubs: [holed], current: new Map(), captured: new Map(),
+    });
+    assert.equal(row.status, "weights_missing", `${backend}: ${row.reason}`);
+    assert.match(row.reason, /gemma\//, backend);
+  }
 });
 
 // sc-22738 (feature-end round 1). The lane-default anchor composition has ONE spelling.


### PR DESCRIPTION
Two campaign refusals from the sc-22738 catalog run, both the same shape: the capture asked for something production does not.

## Defect A — `ltx_2_3` (all three MLX tiers) refused before load

`memory-strategy provider adapter: required environment variable SCENEWORKS_LTX_TEXT_ENCODER_ROOT is not set`, ~150 s in.

**Root cause:** `scripts/measure-memory-catalog.mjs:1020` declared the `ltx_2_3` family with no `siblingRoots`, on a comment asserting that only the Candle arm binds the dense Gemma text encoder. `crates/sceneworks-memory-adapter/src/bin/mlx.rs:13615` (`ltx_load_spec`) has `required_env`'d `SCENEWORKS_LTX_TEXT_ENCODER_ROOT` since sc-18808 landed the video arm, so `--list` classified every cell `runnable` and the adapter refused before opening a weight.

**Fix:** both LTX-2.3 rows bind the gemma sibling. The resolution is production's own — `crates/sceneworks-worker/src/video_jobs/ltx.rs#bundled_ltx_gemma_dir` joins `gemma` to the selected tier dir's parent snapshot, which is `path.dirname(resolved.root)/gemma` in the runner. Production's `$LTX_GEMMA_DIR` override and cross-revision sibling scan (sc-14377) are deliberately not mirrored: both adapters snapshot-validate the text-encoder root against the SAME repository and revision as the tier root, so neither is reachable from a capture. A host without the sibling is `weights_missing`, named, rather than runnable.

The requirement is DERIVED, not spelled: `every SCENEWORKS_LTX_* root the adapters require is bound by the LTX-2.3 rows` reads each lane's adapter binary for its `required_env` names and asserts the classified row binds every one, so an arm that grows or drops a root moves the case with no edit.

## Defect B — `krea_realtime_14b` (all three MLX tiers) refused at admission

`Krea Realtime admission rejected a fitting probe budget; the scenario rejections below would be a blanket refusal, not evidence`, ~112 s in.

**Root cause:** `mlx.rs#run_krea_realtime` probed the loaded provider's registered admission gate on the anchor's own reference-free `text_to_video` surface. `mlx-gen-krea-realtime/src/memory_strategy.rs:686-694` (inference `3b922bac`) admits exactly `image_to_video` and `video_to_video`, requires `reference_count == 1`, and requires an `evidence_revision` sealed under `provider-resident-video-request-v3:krea_realtime_14b:mode=…:shape=…:` — every other request mode is rejected by name before the shared budget check. A t2v probe can only ever be refused.

Production agrees from the other side: `crates/sceneworks-worker/src/video_jobs/krea_realtime.rs` builds its `VideoGenInput` with `..VideoGenInput::default()` and never sets `memory_context`, and the context `video_admission.rs#admit_video_generation_with_curves_and_profiles` would build carries `text_to_video`, `reference_count 0` and a curve/anchor evidence id — never that receipt. A reference-free render reaches the engine through `memory_strategy::generate_with_scope`'s no-context early return; the gate is asked nothing.

**Fix:** the same remedy as the Bernini refusal in #2743. `krea_realtime_probes_admission(mode, reference_count)` decides, computed from the plan's target rather than hard-coded, so a future reference-carrying anchor cannot inherit the skip. On every cell this arm can plan the answer is `false`: no probe runs, the exact-fit / unknown-budget / stale-evidence scenarios record `not_run` with `KREA_REALTIME_ADMISSION_BLOCKER`, and the record files as `gated` rather than `runtime_complete`. The measurement is unaffected and carried in full.

## Tests

- `the arm asks the admission gate exactly what production asks it` (Rust): the plan's own three rows, the predicate over both axes, the arm's target validation refusing every surface the predicate answers `true` for, and the arm body — no `safety_check`, `"status": "gated"`, three `not_run` scenarios.
- `the Krea Realtime arm's admitted routes are the pinned engine's own` (JS): the engine's route list is read out of the pinned `safety_check` match and compared with the arm's `matches!`. It lives here rather than in Rust because the gate short-circuits on an unresolvable artifact receipt, so a weights-free probe rejects every mode for a reason that says nothing about routing.
- `every SCENEWORKS_LTX_* root the adapters require is bound by the LTX-2.3 rows` (JS).

Mutations, each red then restored: dropping `siblingRoots` from the MLX row; resolving the sibling under the tier dir instead of the snapshot; `gated` → `runtime_complete`; the predicate's `||` → `&&`; dropping `video_to_video` from the predicate's route list; reintroducing a `memory_strategy_safety_check` call in the arm.

`cargo test -p sceneworks-memory-adapter --bin memory-mlx-adapter --features mlx` 270 passed. fmt and clippy clean on that crate. `node --test scripts/measure-memory-catalog.test.mjs` 96 tests, 0 fail (3 skipped without an inference checkout).

`npm run check`: 841 tests, 840 pass. The one failure is environmental and pre-existing — `the bare MLX LTX-2.3 and MiniMax-H3 plan rows are the engines' calibrated tiers` reads `$INFERENCE_REPO`'s working tree, which sits at `63056d4e`; `CALIBRATED_TIER` exists at the pin `3b922bac` and not at that revision. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)