### PR TITLE
fix(sc-22738): ltx_2_5 rows carry the capture dir their arm requires; failure reasons quote the adapter's last line

### DIFF
--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -866,6 +866,33 @@ SCENEWORKS_LTX_TEXT_ENCODER_ROOT=/abs/path/.../snapshots/<rev>/gemma
 # the manifest pins `01df27d3…`; `hf download --revision 01df27d3… --include 'q8/*' --include 'q4/*'`
 # re-links them at the manifest revision for **zero bytes**, because the blobs are shared (sc-18810).
 
+# memory-mlx-adapter — ltx_2_5 (SC-18783; the arm with NO `SCENEWORKS_LTX25_*` family for you to
+# set). Every artifact variable below is derived and exported by the HARNESS from
+# `--ltx25-snapshot-root` — repository, revision, the `<transformerVariant>/<tier>` root, the shared
+# enhancer's bytes/digest, the dev refinement adapter's bytes/digest — and `ltx25ProviderEnvironment`
+# DELETES any inherited copy first, so exporting them by hand does nothing. What the operator (or, in
+# a catalog walk, `measure-memory-catalog.mjs`) still owes the arm is the RAW-LOG PAIR:
+SCENEWORKS_MEMORY_CAPTURE_DIR=/absolute/path/outside/both/checkouts/raw
+SCENEWORKS_MEMORY_SOURCE_PATH_PREFIX=docs/calibration/<campaign>
+# sc-22738: `mlx_ltx25.rs#prepare_source_capture` `required_env`s BOTH, unconditionally and before
+# the load, because this arm emits a `physical_mlx` sourceCapture on every run — it persists the
+# canonical selected/reference AV pair under `<capture-dir>/<source-prefix>`. It is the SECOND arm
+# that does so; the Qwen MLX arm (`qwen_source_capture`) is the other, and no third arm on either
+# lane does. The three `ltx_2_5:*:mlx` anchors booked on 2026-09-06 all died on
+# `required environment variable SCENEWORKS_MEMORY_CAPTURE_DIR is not set` — bf16 after 883 s,
+# because the harness re-hashes the ~90 GB snapshot before the adapter is ever spawned — since the
+# catalog runner set the pair for `qwen_image` alone. `PROVIDER_FAMILIES.ltx_2_5` now declares
+# `sourceCapture: true` and the runner derives the pair (and `--raw-log-dir` /
+# `--source-path-prefix`, and `ingest --source-root`, and the receipt copy into the campaign
+# directory) from that flag; a test walks the MLX dispatch and reds if the declared set ever stops
+# matching the arms that really emit. This is NOT the Qwen `physical` currency rule: the harness
+# demands a validated physical source session before it calls an anchor current for
+# `modelId === "qwen_image"` only, so LTX-2.5 writes the receipt without owing it for currency.
+#
+# The Candle arm (`ltx_2_5_distilled`) emits NO sourceCapture, so it must be given NEITHER the pair
+# nor `--raw-log-dir`: `capturePlannedCase` refuses a configured raw-log directory whose provider
+# returned no source capture, which is the same failure from the other side.
+
 # memory-mlx-adapter — any lane, optional
 SCENEWORKS_MLX_WIRED_LIMIT_BYTES=<explicit wired-ceiling override>
 
@@ -1112,6 +1139,12 @@ to `$RUNNER_TEMP`. Use a path outside the tree and the question does not arise.
 **One command captures one anchor and writes one record.** There is no campaign to schedule, no
 resume, no reuse assessment and no batch. Capturing a second cell means running the command a second
 time with a different `--anchor`, producing a second file.
+
+The arms that need the raw-log pair are exactly the MLX arms that EMIT a provider `sourceCapture`:
+`qwen_image` (`mlx.rs#qwen_source_capture`) and `ltx_2_5` (`mlx_ltx25.rs#prepare_source_capture`,
+sc-22738). Both `required_env` the capture directory before the load and refuse without it; the
+coupling is enforced from the other side too, so passing `--raw-log-dir` to any OTHER arm makes the
+harness refuse the render. See the LTX-2.5 block under "Adapter environment".
 
 For physical MLX capture, the raw-log directory must also stay outside the checkout. Run
 `scripts/hash-artifact-inventory.mjs --root <exact-tier-root> --github-env <env-file>` once before

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -628,18 +628,32 @@ export const MAGE_COMPONENT_IDS = Object.freeze(["text_encoder", "vae"]);
 /**
  * One row per provider arm an adapter implements, mirroring `match provider` in
  * crates/sceneworks-memory-adapter/src/bin/{mlx,candle}.rs and the env families the runbook lists
- * under "Adapter environment". `physical` marks the one arm that emits a provider `sourceCapture`
- * (the Qwen MLX source capture, mlx.rs `qwen_source_capture`): the harness REQUIRES a sourceCapture
- * whenever `--raw-log-dir` is given, so the raw-log pair and `SCENEWORKS_MEMORY_CAPTURE_DIR` must be
- * passed for that arm and for no other.
+ * under "Adapter environment".
+ *
+ * `sourceCapture` marks an MLX arm that emits a provider `sourceCapture` fragment. The coupling the
+ * harness enforces is BIDIRECTIONAL (`capturePlannedCase`): `--raw-log-dir` without a sourceCapture
+ * fails, and a sourceCapture without the raw-log pair fails too. So exactly these arms get
+ * `SCENEWORKS_MEMORY_CAPTURE_DIR` + `SCENEWORKS_MEMORY_SOURCE_PATH_PREFIX`, the harness's
+ * `--raw-log-dir`/`--source-path-prefix`, `ingest --source-root`, and the receipt copy into the
+ * campaign directory — and no other arm gets any of them.
+ *
+ * sc-22738: this used to be spelled `physical`, which conflated the emission with the CURRENCY rule
+ * below and so bound the pair to `qwen_image` alone. `crates/.../bin/mlx_ltx25.rs` has emitted a
+ * `physical_mlx` sourceCapture since SC-18783 and `required_env`s the capture dir unconditionally
+ * (`prepare_source_capture`), so all three `ltx_2_5:*:mlx` captures died on
+ * `required environment variable SCENEWORKS_MEMORY_CAPTURE_DIR is not set` — for `bf16` after 883s,
+ * because the harness re-hashes the ~90GB LTX-2.5 snapshot before the adapter is ever spawned. The
+ * two facts are now two flags, and `every MLX arm that emits a sourceCapture declares it`
+ * (measure-memory-catalog.test.mjs) derives the expected set from the adapter sources.
+ *
+ * `physical` is the narrower CURRENCY rule: the harness demands a validated physical source session
+ * before it will call an anchor current, and it scopes that demand to `modelId === "qwen_image"`
+ * alone (`requiresPhysicalMlxProvenanceForCurrency`, memory-calibration-harness.mjs), which a test
+ * below binds this table to. `physical` therefore implies `sourceCapture`; the reverse does not
+ * hold, and LTX-2.5 is the arm that proves it. `physical` is NOT inherited by a sibling family.
  *
  * Rows are keyed by PROVIDER by default; sc-22729 adds MODEL-keyed rows (which must declare their
  * `provider`) for the case where several catalog models ride one engine id. See `familyFor`.
- *
- * passed for that arm and for no other. `physical` is NOT inherited by a sibling family: the harness
- * scopes the receipt requirement to `modelId === "qwen_image"` alone
- * (`requiresPhysicalMlxProvenanceForCurrency`, memory-calibration-harness.mjs), and a test below
- * binds this table to that predicate.
  *
  * `sideArtifact` is a second root a family member needs that the MANIFEST does not ship — today only
  * the Qwen edit Lightning distill LoRA, which the worker fetches lazily at a pinned revision. It is
@@ -668,7 +682,10 @@ export const MAGE_COMPONENT_IDS = Object.freeze(["text_encoder", "vae"]);
  * this table's spelling.
  */
 export const PROVIDER_FAMILIES = Object.freeze({
-  qwen_image: { env: "QWEN_IMAGE", repo: "SceneWorks/qwen-image-mlx", arms: ["mlx", "candle"], physical: true },
+  qwen_image: {
+    env: "QWEN_IMAGE", repo: "SceneWorks/qwen-image-mlx", arms: ["mlx", "candle"],
+    sourceCapture: true, physical: true,
+  },
   // `z_image_edit` anchors ride this family too (sc-22724): the catalog id is an alias for the
   // Turbo provider driven in `edit_image` mode (worker engines.rs `z_image_edit → z_image_turbo`),
   // and its manifest entry ships the same Turbo tiers, which `tierDownload` resolves by model id.
@@ -905,8 +922,16 @@ export const PROVIDER_FAMILIES = Object.freeze({
   // the stock enhancer co-requisite `load_artifact` demands of every load. Neither is inside the
   // load root, so the snapshot probe above cannot see them; without these an anchor whose planned
   // cases include the dev variant classified `runnable` and failed after the booked session opened.
+  //
+  // sc-22738: the MLX arm emits a `physical_mlx` sourceCapture on EVERY run (`mlx_ltx25.rs`
+  // `prepare_source_capture` → `source_capture`, which persists the canonical selected/reference AV
+  // pair under `$SCENEWORKS_MEMORY_CAPTURE_DIR/$SCENEWORKS_MEMORY_SOURCE_PATH_PREFIX`), so it needs
+  // exactly the raw-log provenance the Qwen MLX arm needs — but NOT the qwen-only currency receipt
+  // rule, which is why this is `sourceCapture` and not `physical`. The candle row below emits none
+  // (`candle.rs` has no sourceCapture site), so it must NOT be given the pair: the harness refuses a
+  // `--raw-log-dir` whose provider returned no sourceCapture.
   ltx_2_5: {
-    ltx25: true, repo: LTX25_REPOSITORY, arms: ["mlx"],
+    ltx25: true, repo: LTX25_REPOSITORY, arms: ["mlx"], sourceCapture: true,
     requiredSnapshotEntries: [
       { path: LTX25_DEV_REFINEMENT_LORA },
       { path: LTX25_ENHANCER_DIR, dir: true },
@@ -1449,7 +1474,13 @@ async function firstExistingDirectory(candidates) {
  */
 export async function classifyAnchor(key, planned, { models, backend, hubs, current, captured, bounds = new Map(), declaredLanes, declaredProviders, sdxlRoutes = null, families = PROVIDER_FAMILIES }) {
   const parts = anchorParts(key);
-  const row = { key, ...parts, provider: planned.provider, status: "runnable", reason: null, env: {}, roots: [] };
+  const row = {
+    key, ...parts, provider: planned.provider, status: "runnable", reason: null, env: {}, roots: [],
+    // sc-22738: an arm that emits a provider `sourceCapture` is the one that needs the raw-log pair
+    // and the capture-dir environment. Defaulted here so no early-return row can reach
+    // `measureAnchor` with the flag undefined; both terminal paths below set it from the family.
+    sourceCapture: false, physical: false,
+  };
   if (parts.backend !== backend) return { ...row, status: "other_backend", reason: `${parts.backend} lane` };
   const family = familyFor(parts.modelId, planned.provider, families);
   // No shipped family carries `harnessUnsupported` today (sc-22725 gave LTX-2.5's candle engine id
@@ -1533,7 +1564,8 @@ export async function classifyAnchor(key, planned, { models, backend, hubs, curr
       };
     }
     row.ltx25SnapshotRoot = snapshot;
-    row.physical = false;
+    row.sourceCapture = backend === "mlx" && family.sourceCapture === true;
+    row.physical = backend === "mlx" && family.physical === true;
     // sc-22738: the weights identity a footprint hard stop would be bound against. It is the
     // runner's binding of what it set up for the capture, not a provider attestation — a killed
     // run attests nothing — so it names exactly the snapshot the row resolved above. LTX-2.5 rows
@@ -1775,6 +1807,7 @@ export async function classifyAnchor(key, planned, { models, backend, hubs, curr
     row.env[`SCENEWORKS_${side.env}_REVISION`] = side.revision;
     row.env[`SCENEWORKS_${side.env}_ROOT`] = sideRoot;
   }
+  row.sourceCapture = backend === "mlx" && family.sourceCapture === true;
   row.physical = backend === "mlx" && family.physical === true;
   // sc-22738: see the LTX-2.5 branch — the tier root this row resolved, named so a hard stop can
   // state WHICH weights reached the footprint it bounds. `measureAnchor` fills the inventory digest
@@ -2184,11 +2217,43 @@ export async function extractSeedingNewAnchors(exec, root, log, limit = 8) {
   }
 }
 
-/** The first line of a child's stderr that names the failure, not the Node banner after it. */
+/** Longest failure reason a summary row carries. The ONLY bound: never a delimiter, see below. */
+export const FAILURE_REASON_LIMIT = 300;
+
+/**
+ * The LAST line of a child's stderr that names the failure, not the Node banner after it.
+ *
+ * sc-22738: this used to take the FIRST line matching `/^(Error|…Error|fatal|error)\b/`, falling
+ * back to the first non-banner line. Both arms read the wrong end of the message. The harness
+ * rejects a failed provider with `${command} exited ${code}: ${stderr.trim()}` — the adapter's WHOLE
+ * stderr, many lines, terminal error last — and adapters print informational lines before it. Every
+ * Mage anchor in the 09-06 campaign therefore reported `capture_failed` with
+ * `GPU-view coherence retries during this render: mlx_gen=0 mlx_llm=0 (sc-22414)`, the sc-22414
+ * coherence tally the adapter prints on the way out, while the actual refusal —
+ * `a synchronized Mage-Flow lifecycle phase reported a zero active peak` — sat on the next line and
+ * reached no summary row. Reading from the END gets the adapter's terminal error under both
+ * shapes, because Node's own frames and version banner are the only thing that follows it.
+ *
+ * The full stderr is unchanged and still in the anchor log; this only picks what the one-line
+ * summary quotes. It is bounded by LENGTH alone — never truncated at a `;` or a `)`, because both
+ * occur inside real adapter messages (`mlx_gen=0 mlx_llm=0 (sc-22414)`) and cutting there loses the
+ * half that names the cell.
+ */
 export function failureReason(error) {
-  const lines = String(error.stderr ?? error.message ?? "").split("\n").map((line) => line.trim()).filter(Boolean);
-  const named = lines.find((line) => /^(Error|[A-Za-z]*Error|fatal|error)\b/.test(line));
-  return (named ?? lines.find((line) => !/^(at |Node\.js v)/.test(line)) ?? "unknown failure").slice(0, 300);
+  const stderr = String(error.stderr ?? "");
+  // No child stderr means the runner itself refused (`fail`), and those messages are ONE statement
+  // that may wrap — "post-steps changed paths this run does not own:" and then the paths. Keeping
+  // only the last line would drop the sentence and quote a bare path, so join instead.
+  if (!stderr.trim()) {
+    return String(error.message ?? "unknown failure")
+      .split("\n").map((line) => line.trim()).filter(Boolean)
+      .join(" ").slice(0, FAILURE_REASON_LIMIT) || "unknown failure";
+  }
+  const lines = stderr
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !/^(at |Node\.js v)/.test(line));
+  return (lines.at(-1) ?? "unknown failure").slice(0, FAILURE_REASON_LIMIT);
 }
 
 export async function measureAnchor(row, context) {
@@ -2230,7 +2295,7 @@ export async function measureAnchor(row, context) {
     // the guarded render had open rather than a revision that could resolve to several trees.
     if (row.artifact) row.artifact = { ...row.artifact, inventorySha256: inventory.sha256 };
   }
-  if (row.physical) {
+  if (row.sourceCapture) {
     env.SCENEWORKS_MEMORY_CAPTURE_DIR = rawLogDir;
     env.SCENEWORKS_MEMORY_SOURCE_PATH_PREFIX = campaignPrefix;
   }
@@ -2248,7 +2313,7 @@ export async function measureAnchor(row, context) {
       await exec(process.execPath, [
         HARNESS, "ingest", "--input", input, ...sourceRoot, "--output", target,
       ], { log });
-      if (row.physical && status === "committed") {
+      if (row.sourceCapture && status === "committed") {
         const receipts = path.join(rawLogDir, campaignDir);
         try {
           for (const name of await readdir(receipts)) {
@@ -2307,7 +2372,7 @@ export async function measureAnchor(row, context) {
     "--sceneworks-repo", root, "--inference-repo", path.resolve(args.inferenceRepo),
     "--output", captureOutput,
   ];
-  if (row.physical) captureArgs.push("--raw-log-dir", rawLogDir, "--source-path-prefix", campaignPrefix);
+  if (row.sourceCapture) captureArgs.push("--raw-log-dir", rawLogDir, "--source-path-prefix", campaignPrefix);
   if (row.ltx25SnapshotRoot) captureArgs.push("--ltx25-snapshot-root", row.ltx25SnapshotRoot);
   const watchdogEvents = path.join(workDir, "logs", `${slug}-watchdog.jsonl`);
   const providerStderrFile = path.join(workDir, "logs", `${slug}-provider-stderr.txt`);
@@ -2410,7 +2475,7 @@ export async function measureAnchor(row, context) {
   }
 
   // 2. check the raw bundle before touching the tree.
-  const sourceRoot = row.physical ? ["--source-root", rawLogDir] : [];
+  const sourceRoot = row.sourceCapture ? ["--source-root", rawLogDir] : [];
   try {
     await exec(process.execPath, [HARNESS, "check", "--input", captureOutput, ...sourceRoot], { log });
   } catch (error) {
@@ -2522,7 +2587,7 @@ export async function main(argv = process.argv.slice(2)) {
   const runnable = rows.filter((row) => row.status === "runnable");
   if (args.dryRun) {
     for (const row of runnable) {
-      process.stdout.write(`${row.key}\n  physical=${row.physical} ltx25=${Boolean(row.ltx25SnapshotRoot)}\n`);
+      process.stdout.write(`${row.key}\n  sourceCapture=${row.sourceCapture} physical=${row.physical} ltx25=${Boolean(row.ltx25SnapshotRoot)}\n`);
       for (const root of row.roots) process.stdout.write(`  ${root.label}: ${root.path}\n`);
       for (const [name, value] of Object.entries(row.env)) process.stdout.write(`  ${name}=${value}\n`);
     }

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -36,6 +36,7 @@ import {
   familyFor,
   hubRoots,
   failureReason,
+  FAILURE_REASON_LIMIT,
   extractSeedingNewAnchors,
   SEED_DIGEST,
   SENSENOVA_DISTILL_MERGED_MARKER,
@@ -383,6 +384,7 @@ test("classification: runnable anchors carry the adapter env family and the cano
   const qwen = await classifyAnchor("qwen_image:q4:mlx", { provider: "qwen_image" }, context);
   assert.equal(qwen.status, "runnable");
   assert.equal(qwen.physical, true, "the Qwen MLX arm needs the physical receipt session");
+  assert.equal(qwen.sourceCapture, true, "and therefore the raw-log pair the receipt is written into");
   assert.deepEqual(qwen.env, {
     SCENEWORKS_QWEN_IMAGE_REPOSITORY: "SceneWorks/qwen-image-mlx",
     SCENEWORKS_QWEN_IMAGE_REVISION: REVISION,
@@ -391,14 +393,24 @@ test("classification: runnable anchors carry the adapter env family and the cano
 
   const minimax = await classifyAnchor("minimax_h3:q4:mlx", { provider: "minimax_h3" }, context);
   assert.equal(minimax.status, "runnable");
-  assert.equal(minimax.physical, false, "only the Qwen arm emits a sourceCapture; a raw-log pair would make the harness refuse the render");
+  assert.equal(minimax.physical, false);
+  assert.equal(minimax.sourceCapture, false, "the MiniMax arm emits no sourceCapture; a raw-log pair would make the harness refuse the render");
   assert.equal(minimax.env.SCENEWORKS_MINIMAX_H3_UPSTREAM_ROOT, snapshotPath(hub, "MiniMaxAI/MiniMax-H3", UPSTREAM));
   assert.equal(minimax.env.SCENEWORKS_MINIMAX_H3_UPSTREAM_REVISION, UPSTREAM);
 
   const ltx = await classifyAnchor("ltx_2_5:q4:mlx", { provider: "ltx_2_5" }, context);
   assert.equal(ltx.status, "runnable");
   assert.equal(ltx.ltx25SnapshotRoot, snapshotPath(hub, "SceneWorks/ltx-2.5-mlx", REVISION));
-  assert.deepEqual(ltx.env, {}, "the harness binds LTX-2.5 itself");
+  assert.deepEqual(ltx.env, {}, "the harness binds LTX-2.5's artifact roots itself");
+  // sc-22738: NOT `physical` (the harness demands the currency receipt for qwen_image alone) but it
+  // does emit a sourceCapture, so `measureAnchor` owes it the capture-dir pair.
+  assert.equal(ltx.physical, false);
+  assert.equal(ltx.sourceCapture, true, "mlx_ltx25.rs emits a physical_mlx sourceCapture on every run");
+  const ltxCandle = await classifyAnchor("ltx_2_5:q4:candle", { provider: "ltx_2_5_distilled" }, {
+    ...context, backend: "candle",
+  });
+  assert.equal(ltxCandle.status, "runnable", ltxCandle.reason);
+  assert.equal(ltxCandle.sourceCapture, false, "the candle LTX-2.5 arm emits none; a raw-log pair would make the harness refuse it");
 
   const missingTier = await classifyAnchor("qwen_image:q8:mlx", { provider: "qwen_image" }, context);
   assert.equal(missingTier.status, "weights_missing");
@@ -648,7 +660,8 @@ test("the qwen edit family derives the tier root on both lanes, and Lightning al
     const planned = { provider: "qwen_image_edit", mode: "edit_image" };
     const base = await classifyAnchor(`qwen_image_edit_2511:q4:${backend}`, planned, context);
     assert.equal(base.status, "runnable", `${backend}: ${base.reason}`);
-    assert.equal(base.physical, false, "only the qwen_image MLX arm emits a sourceCapture");
+    assert.equal(base.physical, false);
+    assert.equal(base.sourceCapture, false, "the edit arm emits no sourceCapture, whatever it shares with qwen_image");
     assert.deepEqual(base.env, {
       SCENEWORKS_QWEN_IMAGE_EDIT_REPOSITORY: "SceneWorks/qwen-image-edit-2511-mlx",
       SCENEWORKS_QWEN_IMAGE_EDIT_REVISION: REVISION,
@@ -819,6 +832,145 @@ test("only the family the harness demands a physical receipt for is marked physi
     named,
     "a family marked physical that the harness does not demand a receipt for would make every capture of it fail",
   );
+});
+
+// sc-22738. `sourceCapture` is the SECOND half of that rule, and the half the campaign proved was
+// missing: it says the arm emits a provider `sourceCapture`, which is what obliges the runner to
+// pass `SCENEWORKS_MEMORY_CAPTURE_DIR`/`_SOURCE_PATH_PREFIX` and the harness's
+// `--raw-log-dir`/`--source-path-prefix`. The coupling is enforced in BOTH directions
+// (`capturePlannedCase`), so an over-declaration is as fatal as an under-declaration: this is a set
+// equality, never a subset.
+//
+// The expected side is DERIVED from the adapter, not spelled here — the mistake being fixed was a
+// hand-kept flag that said "qwen only" while `mlx_ltx25.rs` had emitted a `physical_mlx`
+// sourceCapture since SC-18783. The walk starts at each `match provider` arm's own entry function
+// and follows calls through the MLX bin and its `#[path]` sibling modules, so an arm that grows an
+// emission (or loses one) moves this case with no edit here.
+function stripRustCommentsForScan(source) {
+  return source.replace(/\/\/[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/** Rust with every `#[cfg(test)] mod …{…}` removed — and nothing else: `#[cfg(test)] const X …;`
+ *  carries no block, and slicing at the attribute would eat the provider-id consts after it. */
+function stripRustTestModules(source) {
+  const marker = "#[cfg(test)]";
+  for (let from = 0; ;) {
+    const at = source.indexOf(marker, from);
+    if (at === -1) return source;
+    if (!/^\s*(?:pub\s+)?mod\s+/.test(source.slice(at + marker.length))) {
+      from = at + marker.length;
+      continue;
+    }
+    const open = source.indexOf("{", at);
+    let depth = 0;
+    let i = open;
+    for (; i < source.length; i += 1) {
+      if (source[i] === "{") depth += 1;
+      else if (source[i] === "}") { depth -= 1; if (!depth) break; }
+    }
+    source = source.slice(0, at) + source.slice(i + 1);
+    from = at;
+  }
+}
+
+/** `name -> body` for every top-level `fn` in one Rust source, keyed as the caller spells it. */
+function rustFunctionBodies(source, qualify = (name) => name) {
+  const bodies = new Map();
+  const declaration = /^(?:pub(?:\([a-z]+\))?\s+)?(?:async\s+)?fn\s+([a-z_][A-Za-z0-9_]*)/gm;
+  for (let match; (match = declaration.exec(source));) {
+    const open = source.indexOf("{", match.index);
+    if (open === -1) continue;
+    let depth = 0;
+    let i = open;
+    for (; i < source.length; i += 1) {
+      if (source[i] === "{") depth += 1;
+      else if (source[i] === "}") { depth -= 1; if (!depth) break; }
+    }
+    bodies.set(qualify(match[1]), source.slice(open, i + 1));
+  }
+  return bodies;
+}
+
+const RUST_CALL = /\b((?:[a-z_][A-Za-z0-9_]*::)?[a-z_][A-Za-z0-9_]*)\s*\(/g;
+
+test("every MLX adapter arm that emits a provider sourceCapture is declared, and no other", async () => {
+  const binDir = path.join(ROOT, "crates/sceneworks-memory-adapter/src/bin");
+  const members = (await readdir(binDir)).filter(
+    (name) => name === "mlx.rs" || name.startsWith("mlx_"),
+  ).sort();
+  assert.ok(members.length >= 2, "expected the mlx bin plus its #[path] arm modules");
+  const sources = new Map();
+  for (const name of members) {
+    sources.set(name, stripRustTestModules(stripRustCommentsForScan(
+      await readFile(path.join(binDir, name), "utf8"),
+    )));
+  }
+  // Every sibling is indexed under the module path the bin calls it by, so a NEW arm module that
+  // emits is walked rather than silently unreachable.
+  const bodies = new Map();
+  for (const [name, source] of sources) {
+    const module = name === "mlx.rs" ? null : name.slice(0, -3);
+    for (const [fn, body] of rustFunctionBodies(source, (id) => (module ? `${module}::${id}` : id))) {
+      bodies.set(fn, body);
+    }
+  }
+  const emitters = [...sources].filter(([, source]) => source.includes('"sourceCapture"')).map(([name]) => name);
+  assert.ok(emitters.length > 0, "no MLX source emits a sourceCapture at all; the scan reads nothing");
+
+  const consts = new Map(
+    [...sources.get("mlx.rs").matchAll(/\bconst\s+([A-Z][A-Z0-9_]*)\s*:\s*&str\s*=\s*"([^"]*)"\s*;/g)]
+      .map((match) => [match[1], match[2]]),
+  );
+  const armsFor = new Map();
+  const dispatch = /(?:^|\n)\s*(?:"([a-z0-9_]+)"|([A-Z][A-Z0-9_]*))\s*=>\s*((?:[a-z_][A-Za-z0-9_]*::)?[a-z_][A-Za-z0-9_]*)\(request\)/g;
+  for (const match of sources.get("mlx.rs").matchAll(dispatch)) {
+    const provider = match[1] ?? consts.get(match[2]);
+    if (!provider || !bodies.has(match[3])) continue;
+    if (!armsFor.has(provider)) armsFor.set(provider, new Set());
+    armsFor.get(provider).add(match[3]);
+  }
+  // Not vacuous: the parse must find the whole shipped dispatch, not a handful of arms.
+  assert.ok(armsFor.size >= 40, `the dispatch parse found only ${armsFor.size} provider arms`);
+
+  const reaches = (entry) => {
+    const seen = new Set();
+    const stack = [entry];
+    while (stack.length > 0) {
+      const name = stack.pop();
+      if (seen.has(name)) continue;
+      seen.add(name);
+      const body = bodies.get(name);
+      if (body === undefined) continue;
+      if (body.includes('"sourceCapture"')) return true;
+      for (const call of body.matchAll(RUST_CALL)) if (bodies.has(call[1])) stack.push(call[1]);
+    }
+    return false;
+  };
+  const emitting = [...armsFor]
+    .filter(([, entries]) => [...entries].some(reaches))
+    .map(([provider]) => provider)
+    .sort();
+
+  const declared = Object.entries(PROVIDER_FAMILIES)
+    .filter(([, family]) => family.sourceCapture)
+    .map(([id, family]) => family.provider ?? id)
+    .sort();
+  assert.deepEqual(
+    declared,
+    emitting,
+    "a declared arm that emits nothing makes the harness refuse the render, and an emitting arm " +
+      "left undeclared dies on `required environment variable SCENEWORKS_MEMORY_CAPTURE_DIR is not set`",
+  );
+
+  // Every emitting arm must also declare the MLX lane, since that is the only lane this walk reads.
+  for (const [id, family] of Object.entries(PROVIDER_FAMILIES)) {
+    if (!family.sourceCapture) continue;
+    assert.ok(family.arms.includes("mlx"), `${id}: sourceCapture is an MLX-arm fact`);
+  }
+  // `physical` is the narrower currency rule and cannot hold without the receipt being emitted.
+  for (const [id, family] of Object.entries(PROVIDER_FAMILIES)) {
+    if (family.physical) assert.equal(family.sourceCapture, true, `${id}: physical implies sourceCapture`);
+  }
 });
 
 // The Lightning distill LoRA is the one artifact in this table the MANIFEST does not ship, so the
@@ -1084,6 +1236,9 @@ test("the LTX-2.5 family derives the same snapshot root on both lanes, under eac
       assert.equal(row.ltx25SnapshotRoot, expected, "the harness is handed the snapshot, not a tier root");
       assert.deepEqual(row.env, {}, "LTX-2.5 carries no adapter env family; the harness binds it");
       assert.equal(row.physical, false);
+      // sc-22738: the MLX arm emits a `physical_mlx` sourceCapture on every run and the Candle arm
+      // emits none, so the raw-log pair is owed to one lane and refused on the other.
+      assert.equal(row.sourceCapture, backend === "mlx", `${backend} ${tier}`);
     }
     // The other lane's engine id must NOT be served here: an arm is per-family, not per-model.
     const crossed = await classifyAnchor(
@@ -3749,6 +3904,36 @@ test("failure reasons name the thrown error, not the Node banner after it", () =
   ].join("\n");
   assert.equal(failureReason({ stderr, message: "node exited 1" }), "Error: memory-strategy calibration: imc-1.hardware.model must be a non-empty string");
   assert.equal(failureReason({ message: "plain" }), "plain");
+
+  // sc-22738. The harness rejects a failed provider with the adapter's WHOLE stderr, terminal error
+  // LAST, and adapters print informational lines on the way out. Reading from the front made every
+  // Mage anchor in the 09-06 campaign report the sc-22414 coherence tally as its failure while the
+  // real refusal never reached a summary row.
+  const mage = [
+    "file:///x/harness.mjs:1962",
+    "        : reject(new Error(msg));",
+    "Error: memory-mlx-adapter exited 1: GPU-view coherence retries during this render: mlx_gen=0 mlx_llm=0 (sc-22414)",
+    "a synchronized Mage-Flow lifecycle phase reported a zero active peak",
+    "    at ChildProcess.<anonymous> (file:///x/harness.mjs:1962:11)",
+    "",
+    "Node.js v24.15.0",
+  ].join("\n");
+  assert.equal(
+    failureReason({ stderr: mage, message: "node exited 1" }),
+    "a synchronized Mage-Flow lifecycle phase reported a zero active peak",
+  );
+
+  // Bounded by LENGTH alone: a `;` or a `)` inside a real adapter message is content, not a cut.
+  const delimited = "Error: adapter refused; the wired ceiling (87044670532 bytes) was already breached";
+  assert.equal(failureReason({ stderr: delimited }), delimited);
+  assert.equal(failureReason({ stderr: "x\n" + "y".repeat(400) }).length, FAILURE_REASON_LIMIT);
+
+  // The runner's OWN refusals arrive with no child stderr and wrap across lines; they stay whole.
+  assert.equal(
+    failureReason({ message: "post-steps changed paths this run does not own:\n?? docs/generated/stray.json" }),
+    "post-steps changed paths this run does not own: ?? docs/generated/stray.json",
+  );
+  assert.equal(failureReason({ stderr: "   \n" }), "unknown failure");
 });
 
 // A hermetic checkout: stub harness + derivation scripts standing in for the real ones, so the
@@ -3773,7 +3958,19 @@ async function stubCheckout() {
         console.error('Error: memory-mlx-adapter exited 1: memory-strategy provider adapter: generate measured render: "[METAL] Command buffer execution failed: Ignored (for causing prior/excessive GPU errors) (00000004:kIOGPUCommandBufferCallbackErrorSubmissionsIgnored). at /out/mlx-c-staged/mlx/c/transforms.cpp:73"');
         process.exit(1);
       }
-      await writeFile(value("--output"), JSON.stringify({ records: [{ backend: "mlx", target: { modelId: "z_image_turbo", tier: "q4" }, env: process.env.SCENEWORKS_Z_IMAGE_ROOT ?? null }] }));
+      // sc-22738: the two MLX arms that emit a provider sourceCapture (mlx.rs qwen_source_capture,
+      // mlx_ltx25.rs prepare_source_capture) required_env the capture dir UNCONDITIONALLY, before
+      // the load -- they do not wait to be asked for a receipt. Both stderr lines below are
+      // verbatim from the 2026-09-06 campaign, in order: the informational sc-22414 tally the
+      // adapter always prints, then the refusal that actually killed all three ltx_2_5 anchors.
+      const captureDir = process.env.SCENEWORKS_MEMORY_CAPTURE_DIR ?? null;
+      const sourcePathPrefix = process.env.SCENEWORKS_MEMORY_SOURCE_PATH_PREFIX ?? null;
+      if (/^(ltx_2_5|qwen_image):/.test(value("--anchor") ?? "") && !captureDir) {
+        console.error("GPU-view coherence retries during this render: mlx_gen=0 mlx_llm=0 (sc-22414)");
+        console.error("memory-strategy provider adapter: required environment variable SCENEWORKS_MEMORY_CAPTURE_DIR is not set");
+        process.exit(1);
+      }
+      await writeFile(value("--output"), JSON.stringify({ records: [{ backend: "mlx", target: { modelId: "z_image_turbo", tier: "q4" }, env: process.env.SCENEWORKS_Z_IMAGE_ROOT ?? null, captureDir, sourcePathPrefix, rawLogDir: value("--raw-log-dir") ?? null }] }));
     } else if (command === "record-exceeded") {
       const events = (await readFile(value("--watchdog-events"), "utf8")).trim().split("\\n").map(JSON.parse);
       const stop = events.find((event) => event.event === "hard_stop");
@@ -4015,9 +4212,9 @@ test("a failed derivation step rolls the tree back to HEAD and keeps the raw cap
   }
 });
 
-test("a physical anchor's gitignored .log receipt is copied beside the evidence and force-added", async () => {
+test("a source-capture anchor's gitignored .log receipt is copied beside the evidence and force-added", async () => {
   const checkout = await stubCheckout();
-  const row = { key: "z_image_turbo:q4:mlx", physical: true, env: {} };
+  const row = { key: "z_image_turbo:q4:mlx", sourceCapture: true, env: {} };
   const context = stubContext(checkout);
   // The harness would write the receipt under <rawLogDir>/<campaignDir>/; emulate that.
   const rawLogDir = path.join(checkout.workDir, "raw", "z-image-turbo-q4-mlx");
@@ -4028,6 +4225,41 @@ test("a physical anchor's gitignored .log receipt is copied beside the evidence 
   const { stdout: shown } = await checkout.git("show", "--stat", "--format=%s", "HEAD");
   assert.ok(shown.includes("docs/calibration/sc-stub/session-1.log"), "the *.log receipt is committed despite the ignore rule");
   assert.equal((await checkout.git("status", "--porcelain")).stdout, "");
+});
+
+// sc-22738. The defect this story fixes, driven end to end: `ltx_2_5:*:mlx` classified runnable,
+// was scheduled, and died inside the adapter on
+// `required environment variable SCENEWORKS_MEMORY_CAPTURE_DIR is not set` — for bf16 after 883
+// seconds, because the harness re-hashes the LTX-2.5 snapshot before the adapter is ever spawned.
+// The row flag is what the runner reads, so drive `measureAnchor` with it set and with it dropped:
+// the second half is the mutation, and it reproduces the exact failure the campaign hit.
+test("an ltx_2_5 mlx anchor's capture carries the capture-dir pair its arm requires", async () => {
+  const checkout = await stubCheckout();
+  const key = "ltx_2_5:q4:mlx";
+  const slug = anchorSlug(key);
+  const context = stubContext(checkout);
+  const rawLogDir = path.join(checkout.workDir, "raw", slug);
+  await mkdir(path.join(rawLogDir, "docs/calibration/sc-stub"), { recursive: true });
+  const result = await measureAnchor(
+    { key, sourceCapture: true, physical: false, ltx25SnapshotRoot: "/snapshot", env: {} },
+    context,
+  );
+  assert.equal(result.status, "committed", result.reason);
+  const evidence = JSON.parse(await readFile(
+    path.join(checkout.root, `docs/calibration/sc-stub/${slug}-evidence.json`),
+    "utf8",
+  ));
+  assert.equal(evidence.records[0].captureDir, rawLogDir, "the arm was handed its raw-log directory");
+  assert.equal(evidence.records[0].sourcePathPrefix, "docs/calibration/sc-stub", "and the campaign prefix it writes under");
+  assert.equal(evidence.records[0].rawLogDir, rawLogDir, "and the harness was told to expect the receipt there");
+
+  // MUTATION: the pre-fix runner, which set the pair for the qwen_image family alone.
+  const dropped = await measureAnchor(
+    { key, sourceCapture: false, physical: false, ltx25SnapshotRoot: "/snapshot", env: {} },
+    stubContext(await stubCheckout()),
+  );
+  assert.equal(dropped.status, "capture_failed");
+  assert.match(dropped.reason, /required environment variable SCENEWORKS_MEMORY_CAPTURE_DIR is not set/);
 });
 
 test("seeding retries extraction only for the new-anchor refusal and never re-seeds an id twice", async () => {


### PR DESCRIPTION
Two defects the 2026-09-06 catalog walk exposed.

## A — `ltx_2_5:*:mlx` refused after a long render

`crates/sceneworks-memory-adapter/src/bin/mlx_ltx25.rs#prepare_source_capture` `required_env`s `SCENEWORKS_MEMORY_CAPTURE_DIR` and `SCENEWORKS_MEMORY_SOURCE_PATH_PREFIX` **unconditionally**: the LTX-2.5 MLX arm emits a `physical_mlx` sourceCapture on every run, persisting the canonical selected/reference AV pair under `<capture-dir>/<source-prefix>`.

`measure-memory-catalog.mjs` set that pair only for rows flagged `physical` — a flag that conflated the *emission* with the harness's `qwen_image`-only **currency** receipt rule (`requiresPhysicalMlxProvenanceForCurrency`). All three `ltx_2_5:*:mlx` anchors therefore died on `memory-strategy provider adapter: required environment variable SCENEWORKS_MEMORY_CAPTURE_DIR is not set` — bf16 after 883 s, because the harness re-hashes the ~90 GB LTX-2.5 snapshot before the adapter is ever spawned.

The two facts are now two declared flags:

* **`sourceCapture`** — the arm emits a provider `sourceCapture`. Drives the env pair, the harness's `--raw-log-dir`/`--source-path-prefix`, `ingest --source-root`, and the receipt copy into the campaign directory. Declared by `qwen_image` and `ltx_2_5`.
* **`physical`** — unchanged: the narrower currency rule, still bound by test to the harness predicate, and now asserted to imply `sourceCapture`.

The coupling is bidirectional in `capturePlannedCase`, so this is a set equality, not a subset: the candle row (`ltx_2_5_distilled`) emits nothing and is given nothing.

`every MLX adapter arm that emits a provider sourceCapture is declared, and no other` **derives** the expected set from the Rust — it walks the `match provider` dispatch in `mlx.rs`, indexes `mlx.rs` plus its `#[path]` arm modules, and follows calls to the emission sites — so the table cannot drift from the arms. It strips `#[cfg(test)] mod …{…}` blocks only, never slicing at a `#[cfg(test)] const`, which would eat the provider-id constants.

## B — the runner quoted the FIRST stderr line

`failureReason` took the first line matching `/^(Error|…Error|fatal|error)\b/`, falling back to the first non-banner line. The harness rejects a failed provider with `${command} exited ${code}: ${stderr.trim()}` — the adapter's whole stderr, terminal error **last** — and adapters print informational lines before it. So every Mage anchor's `capture_failed` reason read `GPU-view coherence retries during this render: mlx_gen=0 mlx_llm=0 (sc-22414)` while the real refusal, `a synchronized Mage-Flow lifecycle phase reported a zero active peak`, reached no summary row.

It now takes the LAST non-banner line, bounded by length alone (`FAILURE_REASON_LIMIT`) — never at a `;` or `)`, both of which occur inside real adapter messages. The full stderr is unchanged in the anchor log. The runner's OWN refusals arrive with no child stderr and wrap across lines (`post-steps changed paths this run does not own:` then the paths), so those are joined rather than trimmed to a bare path.

No delimiter truncation was found anywhere in the runner or harness; `table()` does not truncate.

## Verification

* `node --test scripts/measure-memory-catalog.test.mjs` — 105 tests, 102 pass, 3 skipped (need an inference checkout), 0 fail.
* `node --test scripts/memory-calibration-harness.test.mjs` — 60/60.
* `npm run check` with `INFERENCE_REPO` exported — 856 + 2 pass, 0 fail.
* Real `--list` / `--dry-run` on this host (adapter `campaign-mlx/target/release/memory-mlx-adapter`, both HF roots, read-only):

```
key               status    reason
----------------  --------  ------
ltx_2_5:bf16:mlx  runnable
ltx_2_5:q4:mlx    runnable
ltx_2_5:q8:mlx    runnable

ltx_2_5:bf16:mlx
  sourceCapture=true physical=false ltx25=true
ltx_2_5:q4:mlx
  sourceCapture=true physical=false ltx25=true
ltx_2_5:q8:mlx
  sourceCapture=true physical=false ltx25=true
```

* Mutations, each red then restored:
  * drop `sourceCapture: true` from the `ltx_2_5` family → 3 tests red (classification, the derived-arm binding, the LTX-2.5 both-lanes case).
  * `if (row.sourceCapture)` → `if (false)` on the env assignment → the `measureAnchor` case red on the verbatim campaign message.
  * same on the `--raw-log-dir` push → red.
  * `lines.at(-1)` → `lines.at(0)` → 2 tests red (the unit case and the `measureAnchor` case, whose stub prints the informational line first).

Runbook: an LTX-2.5 block under *Adapter environment* saying that every `SCENEWORKS_LTX25_*` variable is harness-derived (and deleted from an inherited environment) while the raw-log pair is what the arm still needs, plus a pointer in §6 naming the two emitting arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)