### PR TITLE
fix(sc-22738): the SD3.5 MLX arm's quality RMSE is finite or the record is refused

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -19709,6 +19709,11 @@ struct Sd3Arm {
 const SD3_LARGE_PROVIDER: &str = "sd3_5_large";
 const SD3_LARGE_TURBO_PROVIDER: &str = "sd3_5_large_turbo";
 const SD3_MEDIUM_PROVIDER: &str = "sd3_5_medium";
+// The same reasoning as `SDXL_RMS_THRESHOLD`, which this arm's parity comparison is a twin of: RMS
+// is bounded by the same per-pixel envelope as maximum absolute error rather than by a tighter
+// SD3.5-specific tolerance invented ahead of a physical campaign. Both arms compare a selected rung
+// against the unselected request at the shared `MAX_THRESHOLD`/`MEAN_THRESHOLD` pair.
+const SD3_RMS_THRESHOLD: f64 = MAX_THRESHOLD;
 
 const SD3_LARGE_ARM: Sd3Arm = Sd3Arm {
     provider: SD3_LARGE_PROVIDER,
@@ -19953,6 +19958,23 @@ fn sd3_context(
 ///
 /// Loads through the production catalog (`runtime_macos::catalog().media()`) — the same seam the
 /// worker's `inference_runtime::load` uses — never a replica of the engine's loader.
+/// The SD3.5 arm's runtime-complete quality block. Split out of [`run_sd3`] so the shape a record
+/// is filed with can be asserted without real weights and a GPU — the defect this closes (sc-22738)
+/// was a MISSING field in exactly this literal, which only a physical render could reach.
+fn sd3_quality(maximum_error: f64, mean_error: f64, rms_error: f64) -> Value {
+    json!({
+        "contract": "identical artifact, prompt, negative prompt, guidance, seed, geometry, steps and tier; selected SD3.5 rung versus unselected request",
+        "identicalInputs": true,
+        "result": "passed",
+        "maximumError": maximum_error,
+        "meanError": mean_error,
+        "rootMeanSquareError": rms_error,
+        "maximumErrorThreshold": MAX_THRESHOLD,
+        "meanErrorThreshold": MEAN_THRESHOLD,
+        "rootMeanSquareErrorThreshold": SD3_RMS_THRESHOLD,
+    })
+}
+
 fn run_sd3(request: &Value) -> Result<Value, String> {
     // Refuse an unimplemented `(provider, mode)` BEFORE any environment or weight work — the arm
     // itself is taken off the resolved artifact below, once the tier and repository are bound.
@@ -20128,16 +20150,25 @@ fn run_sd3(request: &Value) -> Result<Value, String> {
             .generate(&sd3_request(arm, width, height), &mut |_| {})
             .map_err(|error| format!("generate unselected {} reference: {error}", arm.provider))?,
     )?;
-    let (maximum_error, mean_error) = image_max_mean_abs(&selected, &baseline)?;
-    if maximum_error > MAX_THRESHOLD || mean_error > MEAN_THRESHOLD {
+    // The RMS metric is measured, compared and published alongside max/mean because the
+    // runtime-complete quality shape requires all three
+    // (`memory-calibration-harness.mjs#validateRuntimeComplete`). Before sc-22738 this arm computed
+    // only max/mean through `image_max_mean_abs` and published no `rootMeanSquareError` at all, so
+    // three successfully rendered SD3.5 anchors were refused at record validation.
+    let (maximum_error, mean_error, rms_error) = image_max_mean_rms_abs(&selected, &baseline)?;
+    if maximum_error > MAX_THRESHOLD || mean_error > MEAN_THRESHOLD || rms_error > SD3_RMS_THRESHOLD
+    {
         return Err(format!(
-            "{} selected rung exceeded unselected parity: max={maximum_error:.6}, mean={mean_error:.6}",
+            "{} selected rung exceeded unselected parity: max={maximum_error:.6}, mean={mean_error:.6}, rms={rms_error:.6}",
             arm.provider
         ));
     }
     let mutated = qwen_negative_mutation(&selected);
-    let (mutated_maximum, mutated_mean) = image_max_mean_abs(&mutated, &baseline)?;
-    if mutated_maximum <= MAX_THRESHOLD && mutated_mean <= MEAN_THRESHOLD {
+    let (mutated_maximum, mutated_mean, mutated_rms) = image_max_mean_rms_abs(&mutated, &baseline)?;
+    if mutated_maximum <= MAX_THRESHOLD
+        && mutated_mean <= MEAN_THRESHOLD
+        && mutated_rms <= SD3_RMS_THRESHOLD
+    {
         return Err(format!(
             "{} output mutation did not breach the parity envelope",
             arm.provider
@@ -20176,15 +20207,7 @@ fn run_sd3(request: &Value) -> Result<Value, String> {
             "decode": decode.json(),
             "overall": overall.json(),
         },
-        "quality": {
-            "contract": "identical artifact, prompt, negative prompt, guidance, seed, geometry, steps and tier; selected SD3.5 rung versus unselected request",
-            "identicalInputs": true,
-            "result": "passed",
-            "maximumError": maximum_error,
-            "meanError": mean_error,
-            "maximumErrorThreshold": MAX_THRESHOLD,
-            "meanErrorThreshold": MEAN_THRESHOLD,
-        },
+        "quality": sd3_quality(maximum_error, mean_error, rms_error),
         "negativeMutation": null,
         "loadability": {
             "result": "passed",
@@ -20203,6 +20226,7 @@ fn run_sd3(request: &Value) -> Result<Value, String> {
                 ("overallAllocatorEnvelope", "bytes", overall.allocator_bytes()),
                 ("negativeMutationMaximumErrorPer255", "count", (mutated_maximum * 255.0).round() as u64),
                 ("negativeMutationMeanErrorPer255", "count", (mutated_mean * 255.0).round() as u64),
+                ("negativeMutationRootMeanSquareErrorPer255", "count", (mutated_rms * 255.0).round() as u64),
             ],
         ),
         "capturedAt": protocol::captured_at(),
@@ -22247,6 +22271,87 @@ mod flux_one_tests {
 #[cfg(test)]
 mod sd3_tests {
     use super::*;
+
+    /// sc-22738. `sd3_5_large` at bf16, q4 and q8 rendered, then had their records refused at
+    /// `imc-*.quality.rootMeanSquareError must be a nonnegative finite number` — this arm published
+    /// max/mean only, and the runtime-complete quality contract reads three metrics. The assertion
+    /// is the shared filing guard rather than a hand-listed field set, so this test states the same
+    /// contract the harness does instead of a second copy of it.
+    #[test]
+    fn the_sd3_quality_block_carries_every_runtime_complete_metric() {
+        let quality = sd3_quality(0.004, 0.0005, 0.001);
+        protocol::validate_quality_metrics(&json!({
+            "status": "runtime_complete",
+            "quality": quality.clone(),
+        }))
+        .expect("the SD3.5 quality block must be fileable as a runtime-complete record");
+        assert_eq!(quality["rootMeanSquareError"], json!(0.001));
+        assert_eq!(
+            quality["rootMeanSquareErrorThreshold"],
+            json!(SD3_RMS_THRESHOLD)
+        );
+    }
+
+    /// The SD3.5 thresholds are the shared image envelope, and the RMS bound is the maximum one —
+    /// the same choice `SDXL_RMS_THRESHOLD` makes, and the reason neither arm invents a tolerance
+    /// ahead of a physical campaign.
+    #[test]
+    fn the_sd3_rms_threshold_is_the_shared_maximum_envelope() {
+        assert_eq!(SD3_RMS_THRESHOLD, MAX_THRESHOLD);
+        assert_eq!(SD3_RMS_THRESHOLD, SDXL_RMS_THRESHOLD);
+    }
+
+    /// The metric is measured by the SHARED helper, not by a second implementation: an identical
+    /// pair is zero on all three, and a uniform per-channel bias moves max, mean and RMS together.
+    #[test]
+    fn the_sd3_metric_helper_is_the_shared_max_mean_rms_comparison() {
+        let image = Image {
+            width: 2,
+            height: 2,
+            pixels: vec![0, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176],
+        };
+        let (maximum, mean, rms) = image_max_mean_rms_abs(&image, &image).unwrap();
+        assert_eq!((maximum, mean, rms), (0.0, 0.0, 0.0));
+
+        let mutated = qwen_negative_mutation(&image);
+        let (maximum, mean, rms) = image_max_mean_rms_abs(&mutated, &image).unwrap();
+        for metric in [maximum, mean, rms] {
+            assert!(metric.is_finite(), "{metric}");
+            assert!(metric > SD3_RMS_THRESHOLD, "{metric}");
+        }
+        // A uniform bias makes all three the same number; anything else means the RMS accumulator
+        // is not walking the same pairs.
+        assert!((rms - mean).abs() < 1e-12);
+        assert!((maximum - mean).abs() < 1e-12);
+    }
+
+    /// An unusable comparison is a REFUSAL, not a silent metric: the shared helper refuses a shape
+    /// mismatch and an empty image outright, so no NaN or zero-length division can reach the record.
+    #[test]
+    fn the_sd3_metric_helper_refuses_an_uncomparable_pair() {
+        let left = Image {
+            width: 2,
+            height: 1,
+            pixels: vec![0, 1, 2, 3, 4, 5],
+        };
+        let right = Image {
+            width: 1,
+            height: 1,
+            pixels: vec![0, 1, 2],
+        };
+        assert!(image_max_mean_rms_abs(&left, &right)
+            .unwrap_err()
+            .contains("image shape mismatch"));
+
+        let empty = Image {
+            width: 0,
+            height: 0,
+            pixels: Vec::new(),
+        };
+        assert!(image_max_mean_rms_abs(&empty, &empty)
+            .unwrap_err()
+            .contains("image shape mismatch"));
+    }
 
     fn sd3_snapshot_root(repository: &str, revision: &str, tier: &str) -> PathBuf {
         let nonce = std::time::SystemTime::now()

--- a/crates/sceneworks-memory-adapter/src/lib.rs
+++ b/crates/sceneworks-memory-adapter/src/lib.rs
@@ -611,7 +611,88 @@ pub fn request_from_stdin() -> Result<Value, String> {
     serde_json::from_str(&input).map_err(|error| format!("parse provider request JSON: {error}"))
 }
 
+/// Every scalar quality metric a record can carry, in the order the harness names them.
+const QUALITY_METRICS: [&str; 6] = [
+    "maximumError",
+    "meanError",
+    "rootMeanSquareError",
+    "maximumErrorThreshold",
+    "meanErrorThreshold",
+    "rootMeanSquareErrorThreshold",
+];
+
+/// The metrics `memory-calibration-harness.mjs` requires for a given record status —
+/// `validateComplete` reads four, `validateRuntimeComplete` reads all six. Every other status
+/// (`gated`, `declared`, the bounded-carrier statuses) carries no scalar quality metrics at all,
+/// so nothing is required of it here.
+fn required_quality_metrics(status: &str) -> &'static [&'static str] {
+    /// `validateComplete`'s four: the RMS pair is read only by the runtime-complete validator, so
+    /// requiring it of a `complete` record would refuse records the harness accepts today.
+    const COMPLETE: [&str; 4] = [
+        "maximumError",
+        "meanError",
+        "maximumErrorThreshold",
+        "meanErrorThreshold",
+    ];
+    match status {
+        "runtime_complete" => &QUALITY_METRICS,
+        "complete" => &COMPLETE,
+        _ => &[],
+    }
+}
+
+/// Refuse a record whose quality metrics are absent or non-finite BEFORE it is filed (E4/E5).
+///
+/// This exists because an adapter arm has exactly two ways to publish an unusable metric and both
+/// of them are silent at the source. A metric the arm never emits is simply missing, and — because
+/// `serde_json`'s `From<f64>` maps every non-finite float to `Value::Null` — a NaN or an infinity
+/// computed from an invalid comparison is written as `null` rather than failing to serialize. The
+/// harness sees the same thing in both cases and refuses the record with a message that cannot tell
+/// them apart, hundreds of GPU-seconds after the render that produced it (sc-22738: the SD3.5 arm
+/// emitted no `rootMeanSquareError` at all and three anchors were refused after a successful
+/// render). Checking here — at the ONE point every adapter binary files a record through — turns
+/// both into a refusal naming the metric and the status that requires it.
+///
+/// Only presence and finiteness are checked. Whether a metric is inside its threshold is the arm's
+/// own comparison, which it makes against its own named constants before building the fragment.
+pub fn validate_quality_metrics(response: &Value) -> Result<(), String> {
+    let Some(quality) = response.get("quality").and_then(Value::as_object) else {
+        return Ok(());
+    };
+    let status = response
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let required = required_quality_metrics(status);
+    for metric in QUALITY_METRICS {
+        let Some(value) = quality.get(metric) else {
+            if required.contains(&metric) {
+                return Err(format!(
+                    "a {status} record must carry quality.{metric}; the harness reads it and \
+                     refuses the record without it"
+                ));
+            }
+            continue;
+        };
+        // `null` here is the serialized form of a non-finite f64, not an authored null: `json!`
+        // cannot represent NaN or an infinity any other way.
+        let number = value.as_f64().ok_or_else(|| {
+            format!(
+                "quality.{metric} must be a nonnegative finite number, got {value} \
+                 (a non-finite comparison result serializes to null)"
+            )
+        })?;
+        if !number.is_finite() || number < 0.0 {
+            return Err(format!(
+                "quality.{metric} must be a nonnegative finite number, got {number}"
+            ));
+        }
+    }
+    Ok(())
+}
+
 pub fn write_response(response: &Value) -> Result<(), String> {
+    validate_quality_metrics(response)?;
     serde_json::to_writer(io::stdout(), response)
         .map_err(|error| format!("write provider response JSON: {error}"))
 }
@@ -2151,6 +2232,110 @@ mod tests {
             .unwrap();
         assert_eq!(overlay["result"], "not_applicable");
         assert_ne!(overlay["result"], "not_run");
+    }
+
+    /// A runtime-complete quality block carrying every metric the harness reads.
+    fn runtime_complete_quality() -> Value {
+        json!({
+            "contract": "identical inputs",
+            "identicalInputs": true,
+            "result": "passed",
+            "maximumError": 0.01,
+            "meanError": 0.001,
+            "rootMeanSquareError": 0.002,
+            "maximumErrorThreshold": 3e-2,
+            "meanErrorThreshold": 3e-3,
+            "rootMeanSquareErrorThreshold": 3e-2,
+        })
+    }
+
+    fn record(status: &str, quality: Value) -> Value {
+        json!({ "status": status, "quality": quality })
+    }
+
+    #[test]
+    fn a_complete_quality_block_is_filed() {
+        validate_quality_metrics(&record("runtime_complete", runtime_complete_quality())).unwrap();
+    }
+
+    /// sc-22738's defect exactly: the arm emitted no `rootMeanSquareError`, the fragment serialized
+    /// happily, and three SD3.5 anchors were refused at the harness AFTER a successful render.
+    #[test]
+    fn a_runtime_complete_record_missing_the_rms_metric_is_refused() {
+        let mut quality = runtime_complete_quality();
+        quality
+            .as_object_mut()
+            .unwrap()
+            .remove("rootMeanSquareError");
+        let error = validate_quality_metrics(&record("runtime_complete", quality)).unwrap_err();
+        assert!(error.contains("quality.rootMeanSquareError"), "{error}");
+        assert!(error.contains("runtime_complete"), "{error}");
+    }
+
+    #[test]
+    fn a_runtime_complete_record_missing_the_rms_threshold_is_refused() {
+        let mut quality = runtime_complete_quality();
+        quality
+            .as_object_mut()
+            .unwrap()
+            .remove("rootMeanSquareErrorThreshold");
+        let error = validate_quality_metrics(&record("runtime_complete", quality)).unwrap_err();
+        assert!(
+            error.contains("quality.rootMeanSquareErrorThreshold"),
+            "{error}"
+        );
+    }
+
+    /// `json!` cannot represent NaN or an infinity, so an invalid comparison reaches the record as
+    /// `null` rather than as a serialization failure. That null is what has to be refused.
+    #[test]
+    fn a_non_finite_metric_is_refused_as_the_null_it_serializes_to() {
+        for non_finite in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let mut quality = runtime_complete_quality();
+            quality["rootMeanSquareError"] = json!(non_finite);
+            assert_eq!(
+                quality["rootMeanSquareError"],
+                Value::Null,
+                "a non-finite f64 must serialize to null, which is what the guard sees"
+            );
+            let error = validate_quality_metrics(&record("runtime_complete", quality)).unwrap_err();
+            assert!(error.contains("nonnegative finite number"), "{error}");
+        }
+    }
+
+    #[test]
+    fn a_negative_metric_is_refused() {
+        let mut quality = runtime_complete_quality();
+        quality["meanError"] = json!(-1e-9);
+        let error = validate_quality_metrics(&record("runtime_complete", quality)).unwrap_err();
+        assert!(error.contains("quality.meanError"), "{error}");
+    }
+
+    /// `validateComplete` reads four metrics and never the RMS pair, so requiring it of a
+    /// `complete` record would refuse records the harness accepts today.
+    #[test]
+    fn a_complete_record_may_omit_the_rms_pair() {
+        let mut quality = runtime_complete_quality();
+        let object = quality.as_object_mut().unwrap();
+        object.remove("rootMeanSquareError");
+        object.remove("rootMeanSquareErrorThreshold");
+        validate_quality_metrics(&record("complete", quality.clone())).unwrap();
+        let mut missing_mean = quality;
+        missing_mean.as_object_mut().unwrap().remove("meanError");
+        let error = validate_quality_metrics(&record("complete", missing_mean)).unwrap_err();
+        assert!(error.contains("quality.meanError"), "{error}");
+    }
+
+    /// A gated record's quality block carries no scalar metrics at all.
+    #[test]
+    fn a_gated_record_carries_no_required_metrics() {
+        validate_quality_metrics(&record("gated", json!({ "result": "not_run" }))).unwrap();
+    }
+
+    /// A probe response has no quality block; the guard must not invent one.
+    #[test]
+    fn a_response_without_a_quality_block_is_filed() {
+        validate_quality_metrics(&json!({ "backends": ["mlx"] })).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## The defect

`sd3_5_large` at bf16, q4 and q8 **rendered successfully** in tonight's MLX campaign (119s / 40s / 54s) and were then refused at record validation:

```
memory-strategy calibration: imc-69b4275a1807f1abf271.quality.rootMeanSquareError must be a nonnegative finite number
```

## Root cause

The value was not NaN, not negative, not infinite — it was **absent**.

`run_sd3` (`crates/sceneworks-memory-adapter/src/bin/mlx.rs:20124` pre-change) compared the selected rung against the unselected baseline through `image_max_mean_abs`, which returns max/mean only, and its quality literal (`mlx.rs:20180-20188` pre-change) published four metrics. `validateRuntimeComplete` (`scripts/memory-calibration-harness.mjs:864-867`) reads six.

SD3.5 was the **only** `runtime_complete` arm in the adapter missing it. Every other one already measures RMS through the shared `image_max_mean_rms_abs` (`mlx.rs:6556`); the arms that omit the RMS pair are all `status: "complete"`, whose validator never reads it.

The error message could not have said "absent": `serde_json`'s `From<f64>` maps NaN and the infinities to `Value::Null` rather than failing to serialize, so a missing field and a non-finite one arrive at the harness as the identical complaint.

## What changed

**`bin/mlx.rs`** — the SD3.5 arm
- Both the parity comparison and the negative-mutation breach now go through the shared `image_max_mean_rms_abs`. No second implementation.
- `SD3_RMS_THRESHOLD = MAX_THRESHOLD`, the shared maximum envelope — the same choice `SDXL_RMS_THRESHOLD` makes, and for the stated reason: no SD3.5-specific tolerance invented ahead of a physical campaign.
- Publishes `rootMeanSquareError` / `rootMeanSquareErrorThreshold`, plus the `negativeMutationRootMeanSquareErrorPer255` diagnostic its SDXL twin carries.
- The quality literal moved into `sd3_quality(max, mean, rms)` so the shape a record is filed with is assertable without weights or a GPU — the defect lived in a literal only a physical render could reach.

**`lib.rs`** — the refusal
- `validate_quality_metrics` runs inside `write_response`, the one point every adapter binary files a record through. A metric that is required for the record's status and missing, or present and non-finite/negative (i.e. `null`), is a refusal naming the metric and the status, before stdout.
- Status-scoped to what the harness actually reads: six for `runtime_complete`, four for `complete`, none for `gated` and friends. It cannot refuse a record the harness accepts today.

The determinism check is unaffected — the SD3.5 comparison is valid, it was simply under-reported. The shared helper already refuses a shape mismatch and an empty image outright, so no zero-length division or NaN can reach a record by that route either; `the_sd3_metric_helper_refuses_an_uncomparable_pair` pins it.

## Verification

Mutation-proven, each guard alone, restored with `touch` between runs:

| mutation | result |
|---|---|
| drop the presence requirement (`required = &[]`) | **3 red** |
| drop the finiteness check (`.or(Some(0.0))`) | **1 red** |
| remove the RMS fields from `sd3_quality` | **1 red** (SD3.5 shape test) |

- `cargo test -p sceneworks-memory-adapter --lib` — **43 passed** (8 new)
- `cargo test -p sceneworks-memory-adapter --bin memory-mlx-adapter --features mlx` — **273 passed** (4 new `sd3_tests`)
- `cargo fmt --all`, `cargo clippy ... --all-targets` — clean, zero warnings
- `npm run check` with `INFERENCE_REPO` exported — **838/839**

The single `npm run check` failure is environmental, as anticipated: `measure-memory-catalog.test.mjs:3141` asserts `mlx-gen-ltx/src/memory_strategy.rs` declares `CALIBRATED_TIER`, and the local inference checkout is at `63056d4e` rather than the pin `3b922bac`, where that symbol does not exist. Unrelated to this diff.

No disabled check script was re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)