### PR TITLE
fix(sc-22738): a FLUX.2 warm-repeat retention is measured evidence, not a refusal

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -6571,6 +6571,51 @@ fn flux2_quality_passes(maximum: f64, mean: f64, rms: f64) -> bool {
     maximum <= FLUX2_MAX_THRESHOLD && mean <= FLUX2_MEAN_THRESHOLD && rms <= FLUX2_RMS_THRESHOLD
 }
 
+/// The FLUX.2 arm's lifecycle blockers: the standing scope blocker, plus a warm-repeat retention
+/// FINDING when the post-cleanup allocator reading exceeds the clean warm bound.
+///
+/// sc-22738 (measured 2026-09-06): `flux2_klein_9b:q8:mlx` rendered correctly and was then thrown
+/// away, because a retention over this bound used to `return Err` and discard the whole capture.
+/// The reading was real — 30,189,746,856 active against a 24,981,289,616-byte clean warm cleanup
+/// plus a 709,354,919-byte tolerance, so 5,208,457,240 bytes over — but it is EVIDENCE, not a
+/// reason to refuse, for three reasons:
+///
+/// * The measured phase peaks this record ships come from the FIRST render on a freshly loaded
+///   generator — the production cold path. Renders two and three only feed the repeat comparison,
+///   so what they retain cannot corrupt the numbers the record actually claims.
+/// * The record already declares `warm_repeat` (and `cancel`/`error`) `not_run`, and says the
+///   cleanup bounds are "attested in quality and diagnostics instead". Refusing on a bound the
+///   record does not claim discarded the very diagnostics that were supposed to carry it: the one
+///   observation of this event survived only as a truncated line in a campaign log.
+/// * Production would retain it too. A cell whose warm repeat retains 5 GB is a fact about the
+///   engine that admission should see, not a capture to re-roll until it comes out clean.
+///
+/// The bound is NOT weakened — `lifecycleWarmRepeatPostCleanupActive`, its clean twin and the
+/// tolerance are all still measured and emitted, and an overage now lands in `blockers` under the
+/// cell's own name — so a retention is louder in the store than it was as a dropped capture.
+///
+/// Scoped to this arm deliberately: it is the only one that measured a positive retention. Across
+/// the 43 captures the same campaign committed, 42 report the warm and clean readings EQUAL TO THE
+/// BYTE and the 43rd is 50 MB *below* its clean twin, so on every other arm the refusal has never
+/// fired and there is nothing to re-characterize.
+fn flux2_lifecycle_blockers(
+    model_id: &str,
+    lifecycle_blocker: &str,
+    bounds: LifecycleMemoryBounds,
+    warm_post_cleanup: AllocatorState,
+) -> Vec<String> {
+    let mut blockers = vec![lifecycle_blocker.to_owned()];
+    if !bounds.allows_retained(warm_post_cleanup) {
+        blockers.push(format!(
+            "{model_id} warm repeat retained active/cache bytes {warm_post_cleanup:?} above the \
+             clean warm cleanup {:?} plus {} bytes; recorded as measured evidence rather than \
+             discarding the capture, whose peaks come from the cold first render",
+            bounds.clean_post_cleanup, bounds.tolerance_bytes,
+        ));
+    }
+    blockers
+}
+
 /// The LTX-2.3 twin of [`flux2_quality_passes`], over the LTX-named thresholds so an `mlx:ltx_2_3`
 /// receipt's numbers trace to an LTX constant.
 fn ltx_quality_passes(maximum: f64, mean: f64, rms: f64) -> bool {
@@ -7265,14 +7310,8 @@ fn run_flux2(request: &Value) -> Result<Value, String> {
         ));
     }
     clear_cache();
+    // Recorded, not refused — see `flux2_lifecycle_blockers` for why this reading is evidence.
     let warm_post_cleanup = AllocatorState::capture_current();
-    if !cleanup_bounds.allows_retained(warm_post_cleanup) {
-        return Err(format!(
-            "{} warm repeat retained active/cache bytes {warm_post_cleanup:?} above the \
-             clean warm cleanup {clean_post_cleanup:?} plus {} bytes",
-            arm.model_id, cleanup_bounds.tolerance_bytes,
-        ));
-    }
     let (warm_maximum, warm_mean, warm_rms) = image_max_mean_rms_abs(&selected, &warm)?;
     if !flux2_quality_passes(warm_maximum, warm_mean, warm_rms) {
         return Err(format!(
@@ -7346,7 +7385,12 @@ fn run_flux2(request: &Value) -> Result<Value, String> {
         "diagnostics": protocol::diagnostics(
             &format!("memory-mlx-adapter:{}-resident", arm.slug),
             "executed",
-            [lifecycle_blocker.to_owned()],
+            flux2_lifecycle_blockers(
+                arm.model_id,
+                lifecycle_blocker,
+                cleanup_bounds,
+                warm_post_cleanup,
+            ),
             [
                 ("preRungActiveAfterClear", "bytes", pre_rung_active),
                 ("preRungCacheAfterClear", "bytes", pre_rung_cache),
@@ -22935,6 +22979,120 @@ mod sana_chroma_tests {
 mod flux2_tests {
     use super::*;
     use mlx_gen::gen_core::MemoryStrategySupport;
+
+    /// sc-22738: a warm-repeat retention over the clean warm bound is RECORDED, not refused — and
+    /// the recording has to survive into the blocker list, because that list is the only place the
+    /// overage is named. Both halves are asserted here: the bound still discriminates (a reading
+    /// inside it adds nothing, one byte over on either axis adds a finding), and the finding
+    /// actually reaches the blockers the record ships.
+    ///
+    /// The over-bound case is the real `flux2_klein_9b:q8:mlx` reading from the 2026-09-06 MLX
+    /// walk, scaled nowhere: the campaign's own numbers, so a future reader can match the finding
+    /// text against the log line that motivated this.
+    #[test]
+    fn a_flux2_warm_retention_over_the_bound_is_recorded_as_a_blocker_not_refused() {
+        let scope = "scope blocker";
+        let clean = AllocatorState {
+            active: 1_000,
+            cache: 200,
+        };
+        let bounds = LifecycleMemoryBounds::from_clean_warm(10_000, clean);
+        assert_eq!(bounds.tolerance_bytes, 200);
+
+        // Inside the bound on both axes: the standing scope blocker and nothing else.
+        let within = flux2_lifecycle_blockers(
+            "flux2_klein_9b",
+            scope,
+            bounds,
+            AllocatorState {
+                active: 1_200,
+                cache: 400,
+            },
+        );
+        assert_eq!(
+            within,
+            vec![scope.to_owned()],
+            "a retention inside the bound must add no finding"
+        );
+
+        // One byte over on EITHER axis is a finding, so neither axis can be dropped unnoticed.
+        for over in [
+            AllocatorState {
+                active: 1_201,
+                cache: 400,
+            },
+            AllocatorState {
+                active: 1_200,
+                cache: 401,
+            },
+        ] {
+            let blockers = flux2_lifecycle_blockers("flux2_klein_9b", scope, bounds, over);
+            assert_eq!(
+                blockers.len(),
+                2,
+                "a retention above the bound must be recorded beside the scope blocker: {blockers:?}"
+            );
+            assert_eq!(blockers[0], scope, "the scope blocker must stay first");
+            let finding = &blockers[1];
+            assert!(
+                finding.contains("flux2_klein_9b"),
+                "the finding must name the cell: {finding}"
+            );
+            // The tolerance is asserted through its OWN phrase, not a bare "200": the clean
+            // cleanup's cache is also 200, so a loose substring check stayed green when the
+            // tolerance was replaced by a literal zero (caught by mutation M4).
+            assert!(
+                finding.contains("active: 1000") && finding.contains("plus 200 bytes"),
+                "the finding must carry the clean warm cleanup and the tolerance: {finding}"
+            );
+        }
+
+        // The measured klein q8 event itself: 5,208,457,240 bytes over a 709,354,919-byte
+        // tolerance. It is recorded, and the capture is NOT refused — the whole point of sc-22738.
+        let measured = LifecycleMemoryBounds::from_clean_warm(
+            35_467_745_964,
+            AllocatorState {
+                active: 24_981_289_616,
+                cache: 0,
+            },
+        );
+        assert_eq!(measured.tolerance_bytes, 709_354_919);
+        let blockers = flux2_lifecycle_blockers(
+            "flux2_klein_9b",
+            scope,
+            measured,
+            AllocatorState {
+                active: 30_189_746_856,
+                cache: 0,
+            },
+        );
+        assert_eq!(
+            blockers.len(),
+            2,
+            "the measured klein q8 retention is a finding"
+        );
+        assert!(
+            blockers[1].contains("active: 30189746856")
+                && blockers[1].contains("active: 24981289616")
+                && blockers[1].contains("plus 709354919 bytes"),
+            "{:?}",
+            blockers[1]
+        );
+
+        // ...and the clean rerun of that same anchor, which retained nothing, stays quiet.
+        assert_eq!(
+            flux2_lifecycle_blockers(
+                "flux2_klein_9b",
+                scope,
+                measured,
+                AllocatorState {
+                    active: 24_981_289_616,
+                    cache: 0,
+                },
+            ),
+            vec![scope.to_owned()],
+        );
+    }
 
     /// sc-18808 added the still geometry: `validate_flux2_target` now refuses a non-still target
     /// alongside a foreign provider, so a request that omits the axis entirely can no longer reach


### PR DESCRIPTION
## What the walk measured

The 2026-09-06 MLX catalog walk rendered `flux2_klein_9b:q8:mlx` correctly and then threw the
capture away:

```
flux2_klein_9b warm repeat retained active/cache bytes AllocatorState { active: 30189746856, cache: 0 }
above the clean warm cleanup AllocatorState { active: 24981289616, cache: 0 } plus 709354919 bytes
```

5,208,457,240 bytes over a 709,354,919-byte tolerance (7.3x). Its sibling tiers, and both klein-kv
q8 and the flux2-dev cells, passed the same guard.

## Reproduction: it does not reproduce

One targeted capture through the harness directly (same prebuilt adapter, same pin, same weights,
same seed, idle host):

| reading | campaign (2026-09-06) | rerun (2026-09-07) |
| --- | --- | --- |
| `lifecycleCleanWarmPeak` | — | 35,467,745,964 |
| `lifecycleCleanPostCleanupActive` | 24,981,289,616 | **24,981,289,616** |
| `lifecycleCleanupTolerance` | 709,354,919 | **709,354,919** |
| `lifecycleWarmRepeatPostCleanupActive` | 30,189,746,856 | **24,981,289,616** |
| retained over clean | **+5,208,457,240** | **0** |

The clean side reproduces **to the byte**, so the inputs and the code path are identical; only the
warm-repeat reading diverged. The rerun passed and wrote a complete `runtime_complete` record, which
`memory-calibration-harness.mjs check` accepts — so the cell is measurable and it was only the
intermittent retention standing between this anchor and a committed record.

This is not allocator jitter. Across the 43 captures the same campaign committed, **42 report the
warm and clean readings equal to the byte** and the 43rd is 50 MB *below* its clean twin. A positive
retention never occurs otherwise.

## Root cause

**Not the arm's accounting, and not an MLX allocator cache.** `cache` was 0 on both readings, and
the arm's own `clear_cache()` runs before each capture, so nothing reclaimable was being charged.
The three images the arm holds are host-side `Vec<u8>` (`Image` in
`crates/sceneworks-memory-adapter/src/bin/mlx.rs`), not MLX arrays, so they cannot account for GBs.

**It is engine-side, and the mechanism is lazy weight materialization.** At inference
`3b922bac6094e06f98bb2598a6d6fe10dc92739e`, on the klein resident T2I path:

* the text encoder **is** materialized at load — `crates/media/mlx-gen/mlx-gen-flux2/src/loader.rs:126-132`
  (`materialize_accessed()`), and likewise at `:180`, `:243`, `:247`, `:259`, `:397`, `:430`;
* the **DiT and VAE are not** — `loader.rs:302-326` (`load_transformer_with`, ending in
  `Flux2Transformer::from_weights_quant` at `:325`) and `loader.rs:292-295` (`load_vae`) never call
  it, and MLX safetensors loads are lazy by construction
  (`crates/media/mlx-gen/src/weights.rs:50-56`).

The capture's own numbers confirm this exactly: `preRungActiveAfterClear` = 15,136,802,820 — the
dense bf16 text encoder alone — rising to 24,981,289,616 only after the first render, i.e. the DiT
and VAE first allocate *inside* `generate()`.

What is **ruled out** in the engine (all at the pin):

* No accumulating per-request state on the resident path: `Generator::generate` takes `&self`
  (`src/model.rs:973`), and the only interior mutability reachable is
  `Residency::warm: Mutex<Option<ResidentPair<..>>>` (`crates/contracts/gen-core/src/residency.rs:60`),
  which `run_request_scoped` neither replaces nor mutates on the resident branch
  (`residency.rs:404-450`, early return at `:337-339`).
* The KV cache (`src/kv_cache.rs:53-65`) is constructed and dropped inside the per-seed loop and is
  gated off on this route (`src/model.rs:1293`); the block stream requires
  `Sequential + DeferredMaterialization` (`src/memory_strategy.rs:758-765`), not this path.
* **No `impl Drop` anywhere in `mlx-gen-flux2/src`**, and no `set_wired_limit` / `set_cache_limit` /
  `set_memory_limit` in `crates/` at all.
* The premise that klein q4/q8 ship a quantized text encoder is **false at this pin**:
  `src/artifact_inventory.rs:1051-1058` refuses any turnkey whose `text_encoder` or `vae` carries a
  packed marker, so the TE is dense at every tier and is never dequantized per call.
* Base vs `-kv` is string-only in the engine (`artifact_inventory.rs:1250-1268`,
  `memory_strategy.rs:793-857`); nothing branches on tensors or load order.

The residual, stated as the open question it is: the 5,208,457,240-byte step is within 0.5% of one
q8 single-block transformer stack (24 x (36864x4096 + 4096x16384) = 5,234,491,392 q8 codes, from
`Flux2Config::klein_9b()` at `src/config.rs:500-518`), which is consistent with the lazy DiT graph
re-materializing a block stack, plausibly via the per-render retained-compile thread-locals
(`RETAINED_SWIGLU` at `src/transformer.rs:52-66`, `RETAINED_COMPILE_GLUE` at
`crates/media/mlx-gen/src/nn.rs:469-480`, enabled per render at `src/model.rs:1305`). **I could not
find code that duplicates that stack, and it did not recur on the rerun**, so I am not asserting
that as the mechanism.

## What changed

`flux2_lifecycle_blockers` in `crates/sceneworks-memory-adapter/src/bin/mlx.rs`. A warm-repeat
retention over the clean warm bound is now **recorded as a measured finding in the record's
`blockers`** instead of `return Err`-ing and discarding the capture.

The bound is not weakened. `lifecycleWarmRepeatPostCleanupActive`, its clean twin and the tolerance
are all still measured and emitted, and an overage now lands in `blockers` under the cell's own
name — louder in the store than a dropped capture, which survived only as a truncated campaign-log
line. The justification is that the record already declares `warm_repeat`, `cancel` and `error`
`not_run` and says the cleanup bounds are "attested in quality and diagnostics instead", so the
refusal was gating the whole capture on a bound the record does not claim — while the phase peaks it
*does* claim come from the first render on a freshly loaded generator, which nothing renders 2 and 3
retain can corrupt. Production would retain it too.

Scoped to this arm deliberately: it is the only one that has ever measured a positive retention.

## Engine-side fix (NOT taken here, deliberately)

The engine fix is to materialize the DiT and VAE at load, as the text encoder already is — add
`materialize_accessed()` after `Flux2Transformer::from_weights_quant` (`loader.rs:325`) and after
`Flux2Vae::from_weights` (`loader.rs:294`). That would make the resident footprint deterministic and
put those bytes at load time.

**I did not open an inference PR for it.** It moves ~10 GB from first-render to load time on every
FLUX.2 resident cell, which changes the footprint admission is calibrated against — that is a
measurement-campaign change, not a small, clearly-correct patch, and shipping it unmeasured would
invalidate the anchors this epic is capturing. It needs its own story with a re-capture.

## Verification

All of the below were re-run on the merged tree, after merging `origin/feature/sc-22723-memory-anchor-measurability`
(which had moved `mlx.rs` by 426 lines); the definition, the call site in `run_flux2` and the tests
were each re-checked by name after the merge rather than trusting that it applied cleanly.

* `cargo test -p sceneworks-memory-adapter --bin memory-mlx-adapter --features mlx` — **276 passed**,
  0 failed (270 on the base before this change; 271 with this test; 276 after the merge brought in
  five more).
* Mutation-proven, each guard mutated individually, tree restored byte-identical afterwards:
  * M1 invert the bound check — **RED**
  * M2 never record (`if false`) — **RED**
  * M3 drop the cell name from the finding — **RED**
  * M4 drop the tolerance from the finding — **RED** (first pass GREEN; the assertion had been
    satisfied by an unrelated field that also read `200`, so it was tightened to the exact phrase)
* `cargo fmt --all -- --check` — clean. `cargo clippy -p sceneworks-memory-adapter --bin
  memory-mlx-adapter --features mlx --all-targets -- -D warnings` — clean.
* `npm run check` with `INFERENCE_REPO` at the pin — **859 passed**, 0 failed.
* All three configs green: `npm run rust:check`, `npm run rust:check:neither`,
  `npm run rust:check:candle`.
* One targeted MLX capture on this host (the reproduction above); no other renders.

## Follow-up owed

The klein q8 cell still has no committed measured anchor — the rerun's record is a valid
`runtime_complete` capture but was written outside the repo, since ingesting it here would have
dirtied the tree mid-story. With this change the catalog walk will now commit that cell instead of
dropping it, so re-running the anchor is all that is needed.
