### PR TITLE
fix(sc-22738): a historical revision that does not name an alias narrows the closure unit instead of throwing

### DIFF
--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -2209,6 +2209,31 @@ its own measurement revision — and it must never be bent into a stamp at the p
 the measurement's own provenance and mark every anchor current again. A pin bump is *supposed* to
 leave the moved models' anchors stale.
 
+**A historical revision that cannot key a model NARROWS the unit — it is not an error (sc-22738).**
+The walk stands in each anchor's own measurement revision, which can predate the declaration it is
+reading. Two ways that shows up, and they are the same fact:
+
+- an entry point **does not exist yet** (`mlx-gen-ltx/src/memory_strategy.rs` postdates the LTX-2.3
+  capture), or
+- an entry point exists but **does not carry the model's literal yet** — for a catalog alias, the
+  `engineId` literal. `z_image_edit:mlx` resolves to `z_image_turbo`, which both Z-Image entry
+  points spell at the pin and neither spells at `bb2bc989`.
+
+Either way the entry point is dropped from that revision's unit and the reason is printed under the
+anchor's `--stamp-anchors` row (`narrowed: <file> (<reason>)`). The entry-point list is part of the
+hashed text, so a key derived over a narrower list can never equal the pin's and the anchor simply
+reads **not current** — which is the truth about a measurement the current declaration cannot
+describe. A revision that narrows to *nothing* still derives a real, reproducible digest; it does
+not abort the stamp.
+
+The literal rule itself is unchanged and still throws **at the pin**, where a declaration naming no
+loader is a bug (`assertModelIsNamedByEntryPoints`; `anchorLoaderDigests` takes `assertNamed`, true
+by default and false only on the historical walk that already applied the rule as a narrowing). And
+it stays a **whole-list `some()`** rule: one entry point naming the id vouches for the list. Do not
+"tighten" it to per-file — five shipped units (`flux2_dev:mlx`, `krea_2_raw:mlx`, `z_image:mlx`,
+`z_image_turbo:candle`, `bernini:mlx`) keep an entry point that does not itself carry the literal at
+the pin, and narrowing per file silently re-keys anchors that are not stale.
+
 **Currency attestations — the second gate, written down (sc-22667).** A staled key says the
 loader's *source* moved. This runbook's invalidation doctrine is two-gated: only a load-or-device-path
 change with no behaviour witness says the *memory behaviour* moved, and a differing digest alone is

--- a/scripts/anchor-loader-closure.mjs
+++ b/scripts/anchor-loader-closure.mjs
@@ -668,6 +668,51 @@ export function assertModelIsNamedByEntryPoints({ model, engineId, entryPoints, 
 }
 
 /**
+ * The declared entry points a HISTORICAL tree can still key this model by, and why the rest were
+ * dropped (sc-22738).
+ *
+ * The literal rule above is a statement about the CURRENT declaration against the CURRENT pin: it
+ * catches an entry point that would digest the wrong loader today. It is NOT a statement about the
+ * past. Walking back to an anchor's own measurement revision reaches trees that predate the
+ * declaration — a file the declaration names may not exist yet, and a file that does exist may not
+ * name the model yet, because the id it now carries was introduced later. `z_image_edit:mlx`
+ * resolves to engine id `z_image_turbo`, which both Z-Image entry points spell at the pin and
+ * neither spells at `bb2bc989`, where the files do not exist at all.
+ *
+ * Neither of those is a broken declaration, so neither may throw. Both are the same fact — the
+ * historical tree does not carry this model's loader as the declaration describes it — and the key
+ * already knows how to say that: the entry-point list is part of the hashed text, so a unit derived
+ * over a narrower list cannot equal the pin's digest and the anchor reads NOT CURRENT. That is the
+ * truth about it.
+ *
+ * THE LITERAL RULE NARROWS AT THE GRANULARITY IT IS ASKED AT, which is the WHOLE LIST. It has
+ * always been `some()` — one entry point naming the id vouches for the list — and per-file
+ * narrowing would therefore be a different rule, not the same rule applied historically: at the pin
+ * itself five declared units (`flux2_dev:mlx`, `krea_2_raw:mlx`, `z_image:mlx`,
+ * `z_image_turbo:candle`, `bernini:mlx`) keep an entry point that does not itself carry the literal,
+ * and dropping those would silently re-key anchors that are not stale. So the surviving list is
+ * narrowed only when NO survivor names the id, and an unchanged rule leaves every current digest
+ * exactly where it was.
+ */
+export function narrowEntryPointsAtRevision({ model, engineId, entryPoints, tree }) {
+  const id = engineId ?? model.split(":")[0];
+  const present = entryPoints.filter((file) => tree.has(file));
+  const narrowed = entryPoints
+    .filter((file) => !present.includes(file))
+    .map((file) => ({ file, reason: "absent" }));
+  const bodies = tree.read(present);
+  const named = present.some((file) => (bodies.get(file) ?? "").includes(`"${id}"`));
+  if (named) return { entryPoints: present, narrowed };
+  return {
+    entryPoints: [],
+    narrowed: [
+      ...narrowed,
+      ...present.map((file) => ({ file, reason: `does not carry the literal "${id}"` })),
+    ],
+  };
+}
+
+/**
  * `engineId` redirects the literal rule above at a DIFFERENT model's loader, so it cannot be taken
  * on the declaration's own word: `krea_2_turbo:mlx` declaring `engineId: "z_image_turbo"` with the
  * Z-Image entry points would otherwise pass every shape check and key Krea's currency to the
@@ -702,15 +747,25 @@ export function assertEngineIdMatchesPlan({ model, engineId, planAnchors }) {
   );
 }
 
-/** Every declared model's digest at one revision, sharing the per-revision tree read. */
-export function anchorLoaderDigests({ repo, revision, declared, tree, planAnchors }) {
+/**
+ * Every declared model's digest at one revision, sharing the per-revision tree read.
+ *
+ * `assertNamed` is the literal rule, and it is on by default because the default caller is the
+ * CURRENT pin, where a declaration that names no loader is a bug to be shouted about. A caller
+ * walking HISTORICAL revisions has already applied the same rule as a narrowing
+ * (`narrowEntryPointsAtRevision`) and passes `false`, so a past tree that does not yet name the
+ * model narrows the unit instead of aborting the walk (sc-22738). `assertEngineIdMatchesPlan` is
+ * asked in both: it checks the declaration against the anchor plan, not against any tree, so it is
+ * as true of a historical walk as of the pin.
+ */
+export function anchorLoaderDigests({ repo, revision, declared, tree, planAnchors, assertNamed = true }) {
   const resolved = tree ?? gitTree(repo, revision);
   const plan = planAnchors ?? calibrationPlanAnchors();
   const crates = firstPartyCrates(resolved, resolved.paths());
   const out = new Map();
   for (const [model, entry] of Object.entries(declared)) {
     const { entryPoints, engineId } = entry;
-    assertModelIsNamedByEntryPoints({ model, engineId, entryPoints, tree: resolved });
+    if (assertNamed) assertModelIsNamedByEntryPoints({ model, engineId, entryPoints, tree: resolved });
     assertEngineIdMatchesPlan({ model, engineId, planAnchors: plan });
     out.set(model, loaderClosureDigest({ model, engineId, entryPoints, tree: resolved, crates }));
   }
@@ -920,31 +975,41 @@ export function stampAnchorStore({ repo, store, declared, corpora, attestations 
   }
   // One tree read per revision, shared by every model measured at it.
   const digests = new Map();
+  /** `revision|model` -> the declared entry points that revision could not be keyed by, and why. */
+  const narrowedAt = new Map();
   for (const [revision, models] of byRevision) {
     const tree = gitTree(repo, revision);
-    // AN ENTRY POINT THAT DID NOT EXIST YET IS DROPPED, NOT AN ERROR. A historical revision can
-    // predate a file today's declaration names — `mlx-gen-ltx/src/memory_strategy.rs` postdates the
-    // LTX-2.3 capture — and that IS the difference the key should report: the entry-point list is
-    // part of the hashed text, so a closure derived over a smaller list cannot equal the pin's, and
-    // the anchor reads not-current. Which is the truth about it.
-    const historical = Object.fromEntries(
-      [...models].map((model) => [
-        model,
-        {
-          ...(declared[model].engineId ? { engineId: declared[model].engineId } : {}),
-          entryPoints: declared[model].entryPoints.filter((file) => tree.has(file)),
-        },
-      ]),
-    );
-    for (const [model, entry] of Object.entries(historical)) {
-      if (entry.entryPoints.length === 0) {
-        throw new Error(
-          `no declared entry point of ${model} exists at ${revision.slice(0, 8)} — its anchors ` +
-            "cannot be keyed to that measurement at all",
-        );
-      }
+    // AN ENTRY POINT THE HISTORICAL TREE CANNOT KEY THIS MODEL BY IS DROPPED, NOT AN ERROR. A
+    // historical revision can predate a file today's declaration names
+    // (`mlx-gen-ltx/src/memory_strategy.rs` postdates the LTX-2.3 capture), and it can carry files
+    // that do not yet name the model — the same fact, reached two ways, and that IS the difference
+    // the key should report: the entry-point list is part of the hashed text, so a closure derived
+    // over a narrower list cannot equal the pin's, and the anchor reads not-current. Which is the
+    // truth about it. The narrowing and its reason are carried into the report, so a key derived
+    // over less than the declaration says never has to be guessed at.
+    const historical = {};
+    for (const model of models) {
+      const { engineId, entryPoints } = declared[model];
+      const narrowing = narrowEntryPointsAtRevision({ model, engineId, entryPoints, tree });
+      narrowedAt.set(`${revision}|${model}`, narrowing.narrowed);
+      historical[model] = {
+        ...(engineId ? { engineId } : {}),
+        entryPoints: narrowing.entryPoints,
+      };
     }
-    const perModel = anchorLoaderDigests({ repo, revision, declared: historical, tree });
+    // The literal rule was just applied AS THE NARROWING, so it is not asked again as an assertion:
+    // a tree that names the model keeps its full surviving list, and one that does not has already
+    // narrowed to nothing. An empty unit is a legal derivation, not an error — it hashes the model
+    // and an empty file list, which is reproducible, distinct per model, and can never equal a pin
+    // digest derived over at least one entry point. So the anchor reads NOT CURRENT, which is
+    // exactly what a measurement the current declaration cannot describe should say.
+    const perModel = anchorLoaderDigests({
+      repo,
+      revision,
+      declared: historical,
+      tree,
+      assertNamed: false,
+    });
     for (const [model, entry] of perModel) digests.set(`${revision}|${model}`, entry.digest);
   }
   const report = [];
@@ -964,6 +1029,9 @@ export function stampAnchorStore({ repo, store, declared, corpora, attestations 
       revision,
       digest,
       attested: Boolean(attestation),
+      // Every declared entry point this revision could not be keyed by, with its reason. Empty for
+      // the ordinary anchor whose measurement revision carries the whole declaration.
+      narrowed: narrowedAt.get(`${revision}|${anchor.modelId}:${anchor.backend}`) ?? [],
       changed: JSON.stringify(stamped) !== JSON.stringify(anchor.source),
     });
     return { ...anchor, source: stamped };
@@ -1094,6 +1162,11 @@ export async function main(argv = process.argv.slice(2)) {
         `${row.changed ? "*" : " "} ${row.revision.slice(0, 8)} ${row.digest.slice(0, 16)} ` +
           `${row.attested ? "attested " : ""}${row.id}`,
       );
+      // A key derived over less than the declaration names says so, rather than leaving a
+      // not-current anchor looking like an unexplained digest mismatch.
+      for (const { file, reason } of row.narrowed) {
+        console.log(`    narrowed: ${file} (${reason})`);
+      }
     }
     const body = `${JSON.stringify(stamped, null, 2)}\n`;
     if (argv.includes("--check")) {

--- a/scripts/anchor-loader-closure.test.mjs
+++ b/scripts/anchor-loader-closure.test.mjs
@@ -31,6 +31,7 @@ import {
   anchorMeasurementRevision,
   assertEngineIdMatchesPlan,
   assertModelIsNamedByEntryPoints,
+  narrowEntryPointsAtRevision,
   buildAnchorLoaderConfig,
   calibrationPlanAnchors,
   indexCurrencyAttestations,
@@ -488,10 +489,15 @@ function packagedStore() {
       corpora.set(cited, JSON.parse(readFileSync(path.join(root, cited), "utf8")));
     }
   }
+  // sc-22738: `engineId` travels with the entry points, exactly as the CLI passes it. Dropping it
+  // here made every catalog alias look like a declaration naming its own id, so the literal rule
+  // was asked for "z_image_edit" — a string the inference tree never spells at any revision — and
+  // the stamp threw on data the shipped CLI stamps cleanly. A helper that does not reproduce the
+  // declaration faithfully tests a configuration nothing runs.
   const declared = Object.fromEntries(
     Object.entries(config.models).map(([model, entry]) => [
       model,
-      { entryPoints: entry.entryPoints },
+      { ...(entry.engineId ? { engineId: entry.engineId } : {}), entryPoints: entry.entryPoints },
     ]),
   );
   const attestations = indexCurrencyAttestations(
@@ -543,15 +549,30 @@ test("every packaged anchor's key is the derivation at ITS OWN measurement revis
   );
   // And no UNATTESTED anchor reads current unless its measurement revision's closure really equals
   // the pin's: currency by attestation is the only other way to be current, and it is declared.
+  //
+  // sc-22738: AN ANCHOR MEASURED AT THE PIN ITSELF SATISFIES THAT, it does not violate it. Its
+  // measurement revision's closure IS the pin's, so reading current is trivially true rather than
+  // tautological — and a re-measure at the current pin is the normal product of a rerun campaign,
+  // not a defect. This loop used to refuse one outright, which made the suite red the moment a
+  // campaign captured fresh evidence at the pin. The tautology it was reaching for — every anchor
+  // stamped with the pin's digest regardless of when it was measured — is caught by `stale` above,
+  // which requires the store to still carry an anchor whose loader has genuinely moved.
   for (const anchor of store.anchors) {
     if (anchor.source.currencyAttestation) continue;
     const declaredAtPin = config.models[`${anchor.modelId}:${anchor.backend}`].digest;
     if (anchor.source.loaderClosureDigest === declaredAtPin) {
       const measured = anchorMeasurementRevision(anchor, corpora.get(anchor.source.path));
-      assert.notEqual(
-        measured,
-        PIN,
-        `${anchor.id}: measured at the pin itself, so currency is a value against itself here`,
+      assert.equal(
+        measured === PIN ||
+          stampAnchorStore({
+            repo,
+            store: { ...store, anchors: [anchor], exceededBounds: [] },
+            declared,
+            corpora,
+          }).report[0].digest === declaredAtPin,
+        true,
+        `${anchor.id}: reads current, but its own measurement revision does not derive the pin's ` +
+          "digest — the recorded key is not the derivation at the measurement",
       );
     }
   }
@@ -721,6 +742,77 @@ test("a catalog alias declares the engine id it resolves to, and that id must be
   const aliased = loaderClosureText({ model: "z_image_edit:mlx", engineId: "z_image_turbo", entryPoints, files });
   assert.ok(aliased.includes("\n# engine: z_image_turbo\n"));
   assert.notEqual(aliased.replace("z_image_edit", "z_image_turbo"), plain, "the alias line keeps the two closures distinct even over identical files");
+});
+
+// sc-22738. The literal rule is a property of the CURRENT declaration at the CURRENT pin. Walking
+// back to an anchor's own measurement revision reaches trees that predate it, where the alias's
+// engine id may not be spelled anywhere yet — `z_image_turbo` is carried by both Z-Image entry
+// points at the pin and by neither at `bb2bc989`. Asserting the pinned rule while standing in that
+// tree threw and took the whole stamp down with it.
+test("a historical revision that does not name an alias narrows the unit, it does not throw", () => {
+  const entryPoints = ["crates/x/src/model.rs", "crates/x/src/memory_strategy.rs"];
+  const treeOf = (bodies) => ({
+    paths: () => [],
+    contentId: (file) => `c:${file}`,
+    has: (file) => Object.hasOwn(bodies, file),
+    read: (files) => new Map(files.map((file) => [file, bodies[file] ?? ""])),
+  });
+  const alias = { model: "z_image_edit:mlx", engineId: "z_image_turbo", entryPoints };
+  const named = treeOf({
+    "crates/x/src/model.rs": 'pub const MODEL_ID: &str = "z_image_turbo";',
+    "crates/x/src/memory_strategy.rs": "// nothing named here",
+  });
+  const historical = treeOf({
+    "crates/x/src/model.rs": "// this id does not exist yet",
+    "crates/x/src/memory_strategy.rs": "// nothing named here",
+  });
+
+  // AT THE PIN THE RULE STILL BITES. Dropping the assertion from the derivation must red this.
+  assert.throws(
+    () => anchorLoaderDigests({ ...alias, declared: { [alias.model]: alias }, tree: historical, planAnchors: {} }),
+    /never carry the literal "z_image_turbo"/,
+    "the pinned-revision assertion is what catches an entry point that digests the wrong loader",
+  );
+
+  // AT A HISTORICAL REVISION THE SAME RULE NARROWS. Both entry points exist, neither names the
+  // engine id, so neither can key this model there — reported exactly like an absent one.
+  const narrowed = narrowEntryPointsAtRevision({ ...alias, tree: historical });
+  assert.deepEqual(narrowed.entryPoints, []);
+  assert.deepEqual(narrowed.narrowed, [
+    { file: "crates/x/src/model.rs", reason: 'does not carry the literal "z_image_turbo"' },
+    { file: "crates/x/src/memory_strategy.rs", reason: 'does not carry the literal "z_image_turbo"' },
+  ]);
+  // A file that is absent narrows for the other reason, and the two compose.
+  const partial = narrowEntryPointsAtRevision({
+    ...alias,
+    tree: treeOf({ "crates/x/src/model.rs": "// not named yet" }),
+  });
+  assert.deepEqual(partial.entryPoints, []);
+  assert.deepEqual(partial.narrowed.map((entry) => entry.reason), [
+    "absent",
+    'does not carry the literal "z_image_turbo"',
+  ]);
+
+  // THE NARROWED UNIT IS DERIVABLE AND REPRODUCIBLE, not an error: same files, same rule, same
+  // digest twice — and never equal to the digest over a list the tree can key, so the anchor reads
+  // NOT CURRENT rather than blowing the walk up.
+  const derive = (tree, points) =>
+    anchorLoaderDigests({
+      declared: { [alias.model]: { engineId: alias.engineId, entryPoints: points } },
+      tree,
+      planAnchors: {},
+      assertNamed: false,
+    }).get(alias.model).digest;
+  const degenerate = derive(historical, narrowed.entryPoints);
+  assert.equal(degenerate, derive(historical, narrowed.entryPoints), "the narrowed key is reproducible");
+  assert.notEqual(degenerate, derive(named, narrowEntryPointsAtRevision({ ...alias, tree: named }).entryPoints));
+
+  // AND THE RULE IS STILL `some()`, NOT PER-FILE. One entry point naming the id vouches for the
+  // list, so a survivor that does not itself carry the literal is KEPT — five shipped units
+  // (flux2_dev:mlx, krea_2_raw:mlx, z_image:mlx, z_image_turbo:candle, bernini:mlx) depend on this
+  // at the pin itself, and narrowing per file would silently re-key anchors that are not stale.
+  assert.deepEqual(narrowEntryPointsAtRevision({ ...alias, tree: named }).entryPoints, entryPoints);
+  assert.deepEqual(narrowEntryPointsAtRevision({ ...alias, tree: named }).narrowed, []);
 });
 
 // The alias is a REDIRECT of the literal rule at another model's loader, so the shape checks above


### PR DESCRIPTION
## The defect

The anchor currency walk (`stampAnchorStore`) derives each anchor's key at **its own measurement revision**, which can predate the declaration it is reading. `assertModelIsNamedByEntryPoints` was being asserted inside that walk (`anchorLoaderDigests`), but it is a property of the **current** declaration against the **current** pin: it catches an entry point that would digest the wrong loader *today*.

`z_image_edit:mlx` is a catalog alias declaring `engineId: "z_image_turbo"`. Both Z-Image entry points carry that literal at the pin `3b922bac6` (5 and 2 occurrences); at `bb2bc9893b3c…` — cited by three `z_image_edit` corpora on the MLX campaign branch — neither file exists at all. Asserting the pinned rule while standing in that tree threw and aborted the whole stamp.

## Semantics chosen

The literal rule is asked at two different times and must behave differently at each:

- **At the pin** it throws, unchanged (`assertModelIsNamedByEntryPoints`, `scripts/anchor-loader-closure.mjs:662`). `anchorLoaderDigests` now takes `assertNamed`, **true by default**.
- **At a historical revision** the same rule is applied as a **narrowing** (`narrowEntryPointsAtRevision`), exactly as an absent entry point already was. The reason travels into the `--stamp-anchors` report and is printed as `narrowed: <file> (<reason>)`.

Two properties that are load-bearing:

- **It stays a whole-list `some()` rule.** Measured, not assumed: at the pin itself five shipped units (`flux2_dev:mlx`, `krea_2_raw:mlx`, `z_image:mlx`, `z_image_turbo:candle`, `bernini:mlx`) keep an entry point that does not itself carry the literal. Per-file narrowing would silently re-key anchors that are not stale — and it reds the packaged round-trip test (mutation M3 below).
- **An empty historical unit is a legal derivation, not an error.** It hashes the model plus an empty file list: reproducible, distinct per model, and never equal to a pin digest derived over ≥1 entry point. So the anchor reads **not current**, which is the truth about a measurement the current declaration cannot describe.

## Two test-side defects the same evidence surfaced

- `packagedStore()` **dropped `engineId`**, so every catalog alias was checked against its own id — `"z_image_edit"`, which the inference tree never spells at any revision. The shipped CLI passes `engineId` (`:1052`); the helper now does too. This was the live red.
- The tautology guard refused any unattested anchor measured **at the pin**. That is the normal product of a rerun campaign and is *trivially* current, not tautological — its measurement revision's closure **is** the pin's, satisfying the guard's own stated comment. The real tautology detector (`stale.length > 0`) is untouched. This was masked by the alias throw and would have blocked the campaign merge.

## Proof

**Campaign branch** `origin/story/sc-22738-mlx-rerun` @ `9df4e7c6b`, throwaway worktree, `INFERENCE_REPO` = clone at the pin:

| | tests | pass | fail |
|---|---|---|---|
| before | 27 | 24 | **3** |
| + `engineId` in the helper | 27 | 26 | **1** |
| + full fix | 28 | **28** | 0 |

The three original reds (`:509`, `:560`, `:655`) all threw `never carry the literal "z_image_edit"`. The residual `1` was the `krea_2_raw` "measured at the pin itself" guard.

**Feature branch:** 28/28 (was 27/27; +1 regression test). `--stamp-anchors --check` clean — `config/memory-anchors.json` is byte-identical, so no packaged digest moved.

**Mutations** (each applied alone, suite re-run):

| # | mutation | result |
|---|---|---|
| M1 | assert unconditionally in `anchorLoaderDigests` (revert to throwing) | 🔴 the new regression test |
| M2 | drop the pinned assertion entirely | 🔴 `an entry point that never names the model is refused` + the new test |
| M3 | narrow per-file instead of whole-list | 🔴 `every packaged anchor's key is the derivation at ITS OWN measurement revision` + the new test |

**`npm run check`:** exit 0, 861 tests, green at the pin.

Runbook note added under §7c-bis (the anchor currency key section) covering both narrowing reasons, the `narrowed:` report line, and an explicit "do not tighten this to per-file" with the five units that depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
