### PR TITLE
fix(sc-22738): LTX-2.3 mirrors production admission; failure reasons skip deferred notes

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -14933,6 +14933,43 @@ fn ltx_ordinary_admission(
     }
 }
 
+/// The exact-fit admission budget, expressed in the currency production's gate actually spends
+/// (sc-22738).
+///
+/// THE DEFECT THIS REPLACES. This probe used to set `budget.total_bytes = predicted` and then file
+/// `effectiveBudgetBytes: predicted`. Those were the same number only while the arm handed the
+/// gate a bare budget. `a1c855ad5` routed this arm through the worker's real presentation
+/// (`ltx_ordinary_admission`, which sets `reserved_headroom_bytes` from
+/// `mlx_fit_gate::live_request_budget`'s non-Mage branch and the live committed/reclaimable pair),
+/// and from that point the budget the gate weighed was
+/// `MemoryBudget::effective_bytes` = `total − committed + reclaimable − reserved`, i.e. the
+/// unified reserve BELOW the predicted need. `standard_memory_strategy_safety_check`'s only
+/// budget clause is `budget.fits(predicted_peak_bytes)`, so the gate refused every LTX-2.3 tier
+/// after a full load — correctly. The record's `effectiveBudgetBytes` was the field that was
+/// wrong, not the gate.
+///
+/// THE FIX IS A UNITS FIX, not a retired scenario. `memory_calibration.rs`'s
+/// `validate_runtime_complete` requires `exact_fit` to pass with
+/// `predictedBytes == effectiveBudgetBytes`, so the scenario the schema asks for is precisely
+/// "a budget whose EFFECTIVE bytes equal the predicted need" — the boundary host, not a host whose
+/// nameplate total equals the need. Solving `effective_bytes() == predicted` for `total_bytes`
+/// with production's own reserve and live snapshot held fixed gives
+/// `total = predicted + reserved + committed − reclaimable`; `fits` accepts exact boundaries, and
+/// the ceiling term `total − reserved = predicted + committed − reclaimable` cannot bind because
+/// the same gate already rejects `reclaimable > committed`. Nothing here is synthesized that
+/// production would not present: the reserve, the committed snapshot and the reclaim credit are
+/// carried through untouched from the live context, and only the host nameplate moves to the
+/// boundary the scenario is defined at.
+fn ltx_exact_fit_budget(live: MemoryBudget, predicted: u64) -> MemoryBudget {
+    MemoryBudget {
+        total_bytes: predicted
+            .saturating_add(live.reserved_headroom_bytes)
+            .saturating_add(live.committed_bytes)
+            .saturating_sub(live.reclaimable_bytes),
+        ..live
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 struct LtxLifecycleMetrics {
     clean_warm_peak: u64,
@@ -16303,14 +16340,26 @@ fn run_ltx_with_admission(
 
     let predicted_peaks = video_predicted_peak_bytes(conditioning, denoise, decode);
     let predicted = predicted_peaks.overall;
+    // The exact-fit scenario, posed the way the gate weighs it: see [`ltx_exact_fit_budget`]. The
+    // effective figure is READ BACK off the budget rather than assumed, so the record's
+    // `effectiveBudgetBytes` is what the predicate actually spent and the schema's
+    // `predictedBytes == effectiveBudgetBytes` clause is a statement about this run.
     let mut exact = context.clone();
     exact.predicted_peak_bytes = predicted;
-    exact.budget.total_bytes = predicted;
-    if !matches!(
-        generator.memory_strategy_safety_check(&exact),
-        MemorySafetyDecision::Accept
-    ) {
-        return Err("LTX-2.3 admission rejected an exact-fit calibrated budget".to_owned());
+    exact.budget = ltx_exact_fit_budget(context.budget, predicted);
+    let exact_effective_bytes = exact.budget.effective_bytes();
+    if exact_effective_bytes != predicted {
+        return Err(format!(
+            "LTX-2.3 exact-fit budget resolved {exact_effective_bytes} effective bytes for a \
+             {predicted} byte predicted peak; the probe must present the boundary host, not a \
+             nameplate total"
+        ));
+    }
+    if let MemorySafetyDecision::Reject { reason } = generator.memory_strategy_safety_check(&exact)
+    {
+        return Err(format!(
+            "LTX-2.3 admission rejected an exact-fit calibrated budget: {reason}"
+        ));
     }
 
     let lifecycle_input = LtxLifecycleInput {
@@ -16378,7 +16427,7 @@ fn run_ltx_with_admission(
     let scenarios = if admission == LtxRunAdmission::BoundedCampaignEntry {
         let blocker = "SC-20318 executes only selected plus warm-repeat parity; cancellation, authorized-error, and recovery renders remain unexecuted";
         json!([
-            { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": predicted },
+            { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": exact_effective_bytes },
             { "name": "unknown_budget", "result": "passed", "reason": "the loaded provider contract rejected a zero/unknown budget" },
             { "name": "stale_evidence", "result": "passed", "reason": "the loaded provider contract rejected a mutated calibration fingerprint" },
             { "name": "warm_repeat", "result": "passed", "reason": "the selected request scope repeated deterministically within the declared clip-wide envelope" },
@@ -16389,7 +16438,7 @@ fn run_ltx_with_admission(
         ])
     } else {
         json!([
-            { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": predicted },
+            { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": exact_effective_bytes },
             { "name": "unknown_budget", "result": "passed", "reason": "the loaded provider contract rejected a zero/unknown budget" },
             { "name": "stale_evidence", "result": "passed", "reason": "the loaded provider contract rejected a mutated calibration fingerprint" },
             { "name": "warm_repeat", "result": "passed", "reason": "the selected request scope repeated deterministically within the declared clip-wide envelope" },
@@ -27628,6 +27677,95 @@ mod ltx_tests {
                 "{key}"
             );
             assert!(!context.has_phases, "{key}");
+        }
+        assert_eq!(
+            rows,
+            LTX_TIERS.len(),
+            "every shipped tier has one planned MLX row"
+        );
+    }
+
+    /// sc-22738. The post-render exact-fit probe is posed in the currency the gate spends.
+    ///
+    /// The regression this pins is the one that killed every `ltx_2_3:*:mlx` anchor after a full
+    /// load: with the worker's real presentation carrying a 2 GiB reserve, a budget whose
+    /// NAMEPLATE total equals the predicted peak has an EFFECTIVE budget a whole reserve below it,
+    /// so `standard_memory_strategy_safety_check`'s `budget.fits` clause refuses it — by design.
+    /// The first assertion below is that refusal, stated as a fact about the old shape rather than
+    /// left implicit; the second is that [`ltx_exact_fit_budget`] restores the boundary the
+    /// scenario is defined at, `effective_bytes() == predicted`, and is admitted there.
+    /// Reverting the helper to `total_bytes = predicted` reds the second on every shipped tier.
+    #[test]
+    fn the_exact_fit_probe_presents_the_boundary_host_not_a_nameplate_total() {
+        let plan: Value = serde_json::from_str(include_str!(
+            "../../../../config/memory-calibration-plan.json"
+        ))
+        .expect("the anchor plan is valid JSON");
+        let mut rows = 0;
+        for (key, row) in plan["anchors"].as_object().expect("anchors is an object") {
+            let parts: Vec<&str> = key.split(':').collect();
+            if parts.len() != 3 || parts[0] != LTX_PROVIDER || parts[2] != "mlx" {
+                continue;
+            }
+            rows += 1;
+            let request = ltx_plan_row_request(key, row);
+            let geometry =
+                ltx_target_geometry(&request).unwrap_or_else(|error| panic!("{key}: {error}"));
+            let selection =
+                planned_selection(&request).unwrap_or_else(|error| panic!("{key}: {error}"));
+            let contract = ltx_fixture_contract(ltx_tier_quant(parts[1]));
+            let calibration = contract.calibration.as_ref().expect("fixture calibration");
+            let (context, projection) = ltx_ordinary_admission(
+                &contract,
+                calibration,
+                selection,
+                geometry,
+                LTX_TEST_HOST_BYTES,
+            )
+            .unwrap_or_else(|error| panic!("{key}: {error}"));
+            // Stands in for the measured overall peak the live arm probes with.
+            let predicted = projection.predicted_peak_bytes;
+
+            let mut nameplate = context.clone();
+            nameplate.predicted_peak_bytes = predicted;
+            nameplate.budget.total_bytes = predicted;
+            assert!(
+                nameplate.budget.effective_bytes() < predicted,
+                "{key}: a nameplate-total budget must sit below the need once production's \
+                 reserve is presented"
+            );
+            assert!(
+                matches!(
+                    mlx_gen::gen_core::default_memory_strategy_safety_check(&contract, &nameplate),
+                    MemorySafetyDecision::Reject { .. }
+                ),
+                "{key}: the pre-sc-22738 exact-fit shape must still be refused; if it is admitted \
+                 the reserve has silently left the production presentation"
+            );
+
+            let mut exact = context.clone();
+            exact.predicted_peak_bytes = predicted;
+            exact.budget = ltx_exact_fit_budget(context.budget, predicted);
+            assert_eq!(
+                exact.budget.effective_bytes(),
+                predicted,
+                "{key}: the exact-fit budget must spend exactly the predicted peak"
+            );
+            assert_eq!(
+                exact.budget.reserved_headroom_bytes, context.budget.reserved_headroom_bytes,
+                "{key}: the probe must carry production's reserve through untouched"
+            );
+            assert_eq!(
+                exact.budget.committed_bytes, context.budget.committed_bytes,
+                "{key}: the probe must carry the live committed snapshot through untouched"
+            );
+            assert!(
+                matches!(
+                    mlx_gen::gen_core::default_memory_strategy_safety_check(&contract, &exact),
+                    MemorySafetyDecision::Accept
+                ),
+                "{key}: the boundary host must be admitted"
+            );
         }
         assert_eq!(
             rows,

--- a/crates/sceneworks-memory-adapter/src/lib.rs
+++ b/crates/sceneworks-memory-adapter/src/lib.rs
@@ -1508,11 +1508,16 @@ fn gated_fragment_body(parts: PlainGatedFragment<'_>) -> Value {
 }
 
 pub fn fail(message: impl AsRef<str>) -> ! {
-    // The failure line FIRST, informational notes after it. `measure-memory-catalog.mjs` names a
-    // failed capture by the FIRST line the adapter wrote to stderr, so a per-render note printed the
-    // moment the render returned would be the line the runner quotes for a capture that failed after
-    // it — which is how eighteen sc-22738 Mage refusals were reported as a GPU-view coherence
-    // statistic rather than as the lifecycle refusal that actually stopped them.
+    // The failure line FIRST, informational notes after it — which is how eighteen sc-22738 Mage
+    // refusals came to be reported as a GPU-view coherence statistic rather than as the lifecycle
+    // refusal that actually stopped them: a per-render note printed the moment the render returned
+    // sat where the outcome belonged.
+    //
+    // The runner reads the OTHER end (`measure-memory-catalog.mjs#failureReason` quotes the last
+    // non-banner line), so this ordering alone would have put the same tally back in every summary
+    // row. `failureReason` therefore skips the `note:` prefix `flush_deferred_notes` writes below;
+    // that prefix is the contract between the two, and renaming it here without teaching the
+    // runner reinstates the defect (sc-22738).
     eprintln!("memory-strategy provider adapter: {}", message.as_ref());
     flush_deferred_notes();
     std::process::exit(1);

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -2372,6 +2372,19 @@ export async function extractSeedingNewAnchors(exec, root, log, limit = 8) {
 export const FAILURE_REASON_LIMIT = 300;
 
 /**
+ * A line the adapter wrote as INFORMATION rather than as its outcome.
+ *
+ * The adapter's `protocol` module documents exactly one such prefix: `flush_deferred_notes` emits
+ * every deferred note as `memory-strategy provider adapter: note: <text>`, and `protocol::fail`
+ * calls it AFTER writing the failure line, so on a failed capture the note lines are the LAST
+ * things on stderr. The banner is optional here because a note can also reach the runner already
+ * unwrapped, and the whole prefix is anchored so a real failure message that merely CONTAINS the
+ * word "note" is never skipped.
+ */
+export const INFORMATIONAL_LINE_PATTERN =
+  /^(?:memory-strategy provider adapter: )?note:/;
+
+/**
  * The LAST line of a child's stderr that names the failure, not the Node banner after it.
  *
  * sc-22738: this used to take the FIRST line matching `/^(Error|…Error|fatal|error)\b/`, falling
@@ -2404,7 +2417,13 @@ export function failureReason(error) {
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line && !/^(at |Node\.js v)/.test(line));
-  return (lines.at(-1) ?? "unknown failure").slice(0, FAILURE_REASON_LIMIT);
+  // sc-22738, the SECOND half of the same defect. Reading from the end fixed the ordering, and
+  // then `protocol::fail` was taught to defer its informational notes until AFTER the failure
+  // line — so the last line became the sc-22414 coherence tally again, this time by construction.
+  // Informational lines are not outcomes: skip them and quote the last line that is one. Falling
+  // back to the last line overall keeps a stderr that is ONLY notes from reporting nothing.
+  const outcome = lines.filter((line) => !INFORMATIONAL_LINE_PATTERN.test(line));
+  return ((outcome.at(-1) ?? lines.at(-1)) ?? "unknown failure").slice(0, FAILURE_REASON_LIMIT);
 }
 
 export async function measureAnchor(row, context) {

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -4037,6 +4037,33 @@ test("failure reasons name the thrown error, not the Node banner after it", () =
     "a synchronized Mage-Flow lifecycle phase reported a zero active peak",
   );
 
+  // sc-22738, the other half. `protocol::fail` now writes the failure line FIRST and flushes its
+  // deferred notes after it, so reading from the end put the sc-22414 coherence tally back in
+  // every summary row — by construction this time. A `note:` line is information, not an outcome.
+  const deferred = [
+    "file:///x/harness.mjs:1962",
+    "Error: memory-mlx-adapter exited 1: memory-strategy provider adapter: LTX-2.3 admission rejected an exact-fit calibrated budget",
+    "memory-strategy provider adapter: note: GPU-view coherence retries during this render: mlx_gen=0 mlx_llm=0 (sc-22414)",
+    "    at ChildProcess.<anonymous> (file:///x/harness.mjs:1962:11)",
+    "Node.js v24.15.0",
+  ].join("\n");
+  assert.equal(
+    failureReason({ stderr: deferred, message: "node exited 1" }),
+    "Error: memory-mlx-adapter exited 1: memory-strategy provider adapter: LTX-2.3 admission rejected an exact-fit calibrated budget",
+  );
+  // The same note without the adapter banner, and several of them, still skipped.
+  assert.equal(
+    failureReason({ stderr: ["the real refusal", "note: first tally", "note: second tally"].join("\n") }),
+    "the real refusal",
+  );
+  // A real failure that merely CONTAINS the word is an outcome and must still be quoted.
+  assert.equal(
+    failureReason({ stderr: "adapter refused: take note: the ceiling was breached" }),
+    "adapter refused: take note: the ceiling was breached",
+  );
+  // Notes alone leave the runner with nothing better to say than the note.
+  assert.equal(failureReason({ stderr: "note: only a tally" }), "note: only a tally");
+
   // Bounded by LENGTH alone: a `;` or a `)` inside a real adapter message is content, not a cut.
   const delimited = "Error: adapter refused; the wired ceiling (87044670532 bytes) was already breached";
   assert.equal(failureReason({ stderr: delimited }), delimited);
@@ -4066,6 +4093,14 @@ async function stubCheckout() {
     const value = (flag) => args[args.indexOf(flag) + 1];
     if (command === "capture") {
       if (process.env.STUB_CAPTURE_FAILS) { console.error("Error: stub capture refused"); process.exit(1); }
+      // sc-22738: the adapter's exit-1 stderr AFTER protocol::fail was taught to defer its
+      // informational notes -- outcome first, flush_deferred_notes after it. The last line on
+      // stderr is therefore a note on every failed capture, by construction.
+      if (process.env.STUB_CAPTURE_DEFERRED_NOTE) {
+        console.error("memory-strategy provider adapter: LTX-2.3 admission rejected an exact-fit calibrated budget: ltx_2_3: incremental live demand 9 exceeds effective budget 7");
+        console.error("memory-strategy provider adapter: note: GPU-view coherence retries during this render: mlx_gen=0 mlx_llm=0 (sc-22414)");
+        process.exit(1);
+      }
       // sc-22738: the adapter's exit-1 stderr on a process-scoped Metal refusal, verbatim from the
       // flux2_dev:bf16:mlx run of 2026-09-06 (paths shortened).
       // sc-22738: the adapter's exit-1 stderr when the PINNED ENGINE's production loader refuses
@@ -4331,6 +4366,18 @@ test("a failed derivation step rolls the tree back to HEAD and keeps the raw cap
     assert.equal((await checkout.git("status", "--porcelain")).stdout, "");
   } finally {
     delete process.env.STUB_CAPTURE_FAILS;
+  }
+  // sc-22738: end to end, through the real child process, with the adapter's deferred note LAST.
+  // Dropping the informational skip in `failureReason` reds this on the note line.
+  process.env.STUB_CAPTURE_DEFERRED_NOTE = "1";
+  try {
+    const result = await measureAnchor(row, stubContext(checkout));
+    assert.equal(result.status, "capture_failed");
+    assert.match(result.reason, /rejected an exact-fit calibrated budget/);
+    assert.doesNotMatch(result.reason, /coherence retries/, "the deferred note is not the outcome");
+    assert.equal((await checkout.git("status", "--porcelain")).stdout, "");
+  } finally {
+    delete process.env.STUB_CAPTURE_DEFERRED_NOTE;
   }
 });
 


### PR DESCRIPTION
Two defects from the 09-06/09-07 catalog campaign.

## Defect A — every `ltx_2_3:*:mlx` anchor refused after a full load

`a1c855ad5` routed the MLX LTX-2.3 arm through the worker's real budget presentation: `ltx_ordinary_admission` sets `reserved_headroom_bytes` from `mlx_fit_gate::live_request_budget`'s non-Mage branch (2 GiB) alongside the live committed/reclaimable pair.

The post-render exact-fit probe still cloned that context and set `budget.total_bytes = predicted`. `MemoryBudget::effective_bytes` is `total − committed + reclaimable − reserved`, so the budget the gate actually weighed sat one whole reserve **below** the predicted need, and `standard_memory_strategy_safety_check`'s only budget clause (`budget.fits(predicted_peak_bytes)`) refused it — correctly. The field that was wrong was the record's `effectiveBudgetBytes`, which claimed `predicted`.

**This is a units fix, not a retired scenario.** `memory_calibration.rs`'s `validate_runtime_complete` requires `exact_fit` to pass with `predictedBytes == effectiveBudgetBytes`, so the scenario the schema defines is *a budget whose EFFECTIVE bytes equal the predicted need* — the boundary host, not a host whose nameplate total equals the need. `ltx_exact_fit_budget` solves `effective_bytes() == predicted` for `total_bytes` with production's reserve and live snapshot carried through untouched; the arm reads the effective figure back off the budget rather than assuming it.

This deviates from the Bernini (#2743) / Krea Realtime (#2765) `gated` + `not_run` shape on purpose: those two arms have **no** production admission surface at all for their request, so any answer would characterize a decision production never takes. LTX-2.3 does have one, `ltx_ordinary_admission` already runs it pre-load and the provider's own check runs post-load, and marking `exact_fit` `not_run` would drop every LTX-2.3 record from `runtime_complete` to `gated` — which `EvidenceBundle::evidence_for` excludes from authoritative evidence entirely.

LTX-2.3 is the only arm affected: every other MLX arm builds a zero-reserve context, where the two figures genuinely coincide.

## Defect B — failure reasons quoted the deferred note

`failureReason` takes the last non-banner stderr line; `protocol::fail` was then taught to defer its informational notes until *after* the failure line. Net: every failure reason read `note: GPU-view coherence retries during this render: mlx_gen=0 mlx_llm=0 (sc-22414)` again, by construction this time. `failureReason` now skips the `note:` prefix `flush_deferred_notes` writes (banner optional), falling back to the last line overall so an all-notes stderr still says something. The prefix is documented on both sides as the contract between them.

## Verification

- `cargo test -p sceneworks-memory-adapter --bin memory-mlx-adapter --features mlx` — 283 passed, 0 failed
- `cargo fmt --all --check`, `cargo clippy … --all-targets` — clean
- `npm run check` at the pin — 861 + 2 passed, 0 failed

Mutation checks (both red on revert):
- reverting `ltx_exact_fit_budget` to `total_bytes: predicted` reds `the_exact_fit_probe_presents_the_boundary_host_not_a_nameplate_total` on every shipped tier, off by exactly 2,147,483,648 bytes
- dropping the informational skip in `failureReason` reds both the unit assertions and the end-to-end stub-adapter test that runs a real child whose stderr ends with a note