### PR TITLE
fix(sc-22738): a Mage-Flow peak above the engine's model is recorded, not refused

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -11390,6 +11390,80 @@ fn mage_admission_budget(
     (required_total_peak_bytes, contract.total_resident_bytes())
 }
 
+/// The FINDING a measured Mage-Flow peak above the engine's own modelled total files (sc-22738).
+///
+/// WHY THIS IS NOT A REFUSAL. It used to be one, and every `mage_flow*:*:mlx` anchor died on it
+/// after a complete 11–38 s render: `measured Mage-Flow peak … exceeds the pinned provider's own
+/// modelled total …`. That inverted the epic's premise. `mlx_gen_mage::memory::generation_peak_gb`
+/// is a MODEL, not an observation — `generation_resident_gb(tier) + vae_peak_gb(w, h)`, where
+/// `generation_resident_gb` is a single 512² anchor per tier with that anchor's VAE term subtracted
+/// out and the ONLY geometry-dependent term in the whole estimator is the linear VAE **decode**
+/// fit. So the model asserts that everything except the VAE decode is resolution-independent, and
+/// it carries no term whatsoever for a reference image: the six family members share one scalar per
+/// tier, edit routes included. Both assertions are false against measurement, which is precisely
+/// what this capture exists to establish. Refusing here discards the only evidence that says so.
+///
+/// WHAT THE EXCEEDANCE MEANS FOR PRODUCTION. The worker admits a Mage request on that same model
+/// (`mlx_fit_gate.rs` `request_total_peak_bytes`, whose `mage_flow` branch IS
+/// `providers::mage::memory::generation_peak_gb`, against a budget from
+/// `production_safe_budget_gb`). An under-prediction is therefore a live production hazard, not a
+/// capture artifact, and the measured peak recorded here is the evidence admission should anchor
+/// on instead (E5: measurement never gates; E4: the production path is what is measured).
+///
+/// The blocker states the pair AND the delta, plus the geometry, tier and route the pair belongs
+/// to, because a bare "exceeded" sentence would not let a reader size the hazard or tell the
+/// resolution-independence gap (`mage_flow` 768² bf16: ~0.6 GB) from the missing reference-image
+/// term (`mage_flow_edit` 768² bf16: ~7.3 GB on the same tier and geometry).
+fn mage_model_shortfall_blocker(
+    arm: MageArm,
+    tier: &str,
+    width: u32,
+    height: u32,
+    measured_peak_bytes: u64,
+    modelled_total_bytes: u64,
+) -> Option<String> {
+    let delta = measured_peak_bytes.checked_sub(modelled_total_bytes)?;
+    if delta == 0 {
+        return None;
+    }
+    Some(format!(
+        "the pinned {} provider's own fit model UNDER-PREDICTS this cell: measured peak \
+         {measured_peak_bytes} bytes exceeds its modelled total {modelled_total_bytes} bytes by \
+         {delta} bytes at {width}x{height} on the {} route at {tier}. Recorded as measured \
+         evidence rather than discarding the capture: `mlx_gen_mage::memory::generation_peak_gb` \
+         scales only its linear VAE decode term with geometry and carries no reference-image term \
+         at all, and the worker admits this route on that same model \
+         (`mlx_fit_gate.rs::request_total_peak_bytes`), so the measured peak is what production \
+         admission should anchor on.",
+        arm.provider,
+        mage_mode(arm),
+    ))
+}
+
+/// The peak-below-weights REFUSAL, which is a different claim from the shortfall finding above.
+///
+/// A render cannot peak below the weights it is holding: MLX active memory is absolute, and the
+/// provider declares those weights itself as the resident credit half of
+/// [`mage_admission_budget`]. A measured peak underneath them is not evidence about the engine's
+/// fit model — it is proof this capture did not measure a loaded render (a drained or
+/// mis-scoped peak counter, a generator that never materialized), and a record built from it would
+/// publish an anchor far below the real floor. That stays a refusal.
+fn mage_peak_below_weights_error(
+    arm: MageArm,
+    tier: &str,
+    measured_peak_bytes: u64,
+    resident_weight_bytes: u64,
+) -> Option<String> {
+    (measured_peak_bytes < resident_weight_bytes).then(|| {
+        format!(
+            "measured {} {tier} peak {measured_peak_bytes} is BELOW the {resident_weight_bytes} \
+             resident weight bytes the loaded provider declares; the capture did not measure a \
+             loaded render",
+            arm.provider
+        )
+    })
+}
+
 /// The plan row must name the production identity this cell's loaded generator publishes —
 /// checked against the weights-free table BEFORE the load, so a row still carrying the retired
 /// single string (or a conformance string) fails in milliseconds rather than after a
@@ -11949,15 +12023,21 @@ fn run_mage_provider(request: &Value) -> Result<Value, String> {
     let predicted_peaks = image_predicted_peak_bytes(conditioning, denoise, decode);
     let predicted = predicted_peaks.overall;
 
-    // What was just measured must fit inside the total this provider modelled for the request; a
-    // measured peak ABOVE it means the engine's own fit model under-predicts this cell, and the
-    // capture says so instead of recording the number under an admission that never covered it.
-    if predicted > required_total_peak_bytes {
-        return Err(format!(
-            "measured Mage-Flow peak {predicted} exceeds the pinned provider's own modelled total \
-             {required_total_peak_bytes} for {width}x{height} at {tier}"
-        ));
+    // A peak below the declared weights proves the capture is invalid, so it still refuses; a peak
+    // ABOVE the engine's modelled total is a finding ABOUT that model and is recorded, never
+    // refused (see [`mage_peak_below_weights_error`] and [`mage_model_shortfall_blocker`]).
+    if let Some(error) = mage_peak_below_weights_error(arm, tier, predicted, resident_credit_bytes)
+    {
+        return Err(error);
     }
+    let model_shortfall_blocker = mage_model_shortfall_blocker(
+        arm,
+        tier,
+        width,
+        height,
+        predicted,
+        required_total_peak_bytes,
+    );
     // Exact fit in the provider's own currency: capacity for exactly the committed snapshot plus
     // the admitted incremental demand, and not one byte less. Restating the measured peak as the
     // demand here would be a different claim from the one the request was admitted under — Mage
@@ -12168,6 +12248,23 @@ fn run_mage_provider(request: &Value) -> Result<Value, String> {
                 vec![MAGE_ENGINE_BOUNDARIES.to_owned()],
             )
         };
+    // The finding rides on the SAME record the measurement does, so a reader of this cell cannot
+    // see the peak without seeing that the engine's model did not cover it.
+    let mut lifecycle_blockers = lifecycle_blockers;
+    lifecycle_blockers.extend(model_shortfall_blocker);
+    // ...and the same pair machine-readably, so a consumer can size the gap without parsing prose.
+    let model_measurements = [
+        (
+            "engineModelledTotalBytes",
+            "bytes",
+            required_total_peak_bytes,
+        ),
+        (
+            "engineModelShortfallBytes",
+            "bytes",
+            predicted.saturating_sub(required_total_peak_bytes),
+        ),
+    ];
 
     let mut fragment = json!({
         "status": "complete",
@@ -12230,6 +12327,7 @@ fn run_mage_provider(request: &Value) -> Result<Value, String> {
                 ("stagedComponents", "count", 2),
             ]
             .into_iter()
+            .chain(model_measurements)
             .chain(lifecycle_measurements),
         ),
         "capturedAt": protocol::captured_at(),
@@ -12288,6 +12386,150 @@ mod mage_tests {
                 format!("MLX five-rung calibration does not implement provider {provider:?}")
             );
         }
+    }
+
+    /// sc-22738. A measured peak ABOVE the engine's own modelled total is a FINDING, never a
+    /// refusal, and the finding states the delta.
+    ///
+    /// The numbers are tonight's measured MLX re-capture on this Mac at 768x768 bf16, where the
+    /// old refusal killed every one of the 18 `mage_flow*:*:mlx` anchors after a complete render:
+    /// the plain route peaked 0.6 GB above the model and the edit route 7.3 GB above the SAME
+    /// modelled total, because `generation_peak_gb` scales only its VAE decode term with geometry
+    /// and has no reference-image term at all.
+    ///
+    /// MUTATIONS THIS PINS. Dropping the delta from the blocker string reds the third and sixth
+    /// assertions. Dropping the measured peak, the modelled total, the geometry, the tier or the
+    /// route reds one of the others. Widening the helper to fire on an equal or under-measured
+    /// peak reds the last two. Restoring the refusal at the CALL SITE is pinned separately, by
+    /// [`the_model_shortfall_reaches_the_record_and_never_refuses`] — this test alone could not
+    /// see it, because the render it happens after needs real weights.
+    #[test]
+    fn a_peak_above_the_engines_model_is_recorded_as_a_finding_with_its_delta() {
+        let arm = MAGE_ARMS
+            .into_iter()
+            .find(|arm| arm.provider == "mage_flow_edit")
+            .expect("the edit route is a registered Mage arm");
+        let measured = 25_635_586_048_u64;
+        let modelled = 18_328_139_520_u64;
+        let finding = mage_model_shortfall_blocker(arm, "bf16", 768, 768, measured, modelled)
+            .expect("a peak above the modelled total is a finding");
+        assert!(
+            finding.contains(&measured.to_string()),
+            "the finding must state the measured peak: {finding}"
+        );
+        assert!(
+            finding.contains(&modelled.to_string()),
+            "the finding must state the modelled total: {finding}"
+        );
+        assert!(
+            finding.contains(&(measured - modelled).to_string()),
+            "the finding must state the delta: {finding}"
+        );
+        assert!(
+            finding.contains("768x768"),
+            "the finding must state the geometry: {finding}"
+        );
+        assert!(
+            finding.contains("bf16") && finding.contains("mage_flow_edit"),
+            "the finding must state the tier and the route: {finding}"
+        );
+        // The plain route's much smaller shortfall at the same geometry and tier is a DIFFERENT
+        // number in the record, not a shared "exceeded" sentence.
+        let plain = MAGE_ARMS
+            .into_iter()
+            .find(|arm| arm.provider == "mage_flow")
+            .expect("the plain route is a registered Mage arm");
+        let plain_finding =
+            mage_model_shortfall_blocker(plain, "bf16", 768, 768, 18_924_699_648, modelled)
+                .expect("a peak above the modelled total is a finding");
+        assert!(
+            plain_finding.contains(&(18_924_699_648_u64 - modelled).to_string())
+                && plain_finding != finding,
+            "each route files its own delta: {plain_finding}"
+        );
+        // A peak the model DID cover files nothing.
+        assert_eq!(
+            mage_model_shortfall_blocker(arm, "bf16", 768, 768, modelled, modelled),
+            None
+        );
+        assert_eq!(
+            mage_model_shortfall_blocker(arm, "bf16", 768, 768, modelled - 1, modelled),
+            None
+        );
+    }
+
+    /// sc-22738. The shortfall FINDING reaches the record, and the arm has no exceedance refusal.
+    ///
+    /// Read the way the sibling receipt guard in this file reads the arm — the exceedance only
+    /// happens after a measured render, which needs real weights, so the property is pinned over
+    /// the arm's source. What it pins is exactly the mutation the fix reverses: restoring
+    /// `if predicted > required_total_peak_bytes { return Err(…) }` reds the second assertion, and
+    /// computing the finding but never extending it into `lifecycle_blockers` (so the record
+    /// carries the peak with no statement that the model missed it) reds the first and third.
+    #[test]
+    fn the_model_shortfall_reaches_the_record_and_never_refuses() {
+        let source = include_str!("mlx.rs");
+        let start = source
+            .find("\nfn run_mage_provider(")
+            .expect("the arm still exists");
+        let body = &source[start
+            ..start
+                + source[start..]
+                    .find("\n}\n")
+                    .expect("the arm's body closes")];
+        assert!(
+            body.contains("let model_shortfall_blocker = mage_model_shortfall_blocker("),
+            "the arm must compute the shortfall finding"
+        );
+        assert!(
+            body.contains("lifecycle_blockers.extend(model_shortfall_blocker);"),
+            "the shortfall finding must be recorded on the record's blockers, not dropped"
+        );
+        assert!(
+            body.contains("\"engineModelledTotalBytes\"")
+                && body.contains("\"engineModelShortfallBytes\""),
+            "the record must carry the modelled total and the shortfall machine-readably"
+        );
+        assert!(
+            !body.contains("exceeds the pinned provider's own modelled total"),
+            "a measured peak above the engine's model is a finding, never a refusal"
+        );
+        // The `>` comparison against the modelled total must not reappear as a control-flow gate.
+        assert!(
+            !body.contains("if predicted > required_total_peak_bytes"),
+            "the exceedance must not gate the capture"
+        );
+    }
+
+    /// sc-22738. The one peak check that survives as a REFUSAL, because it proves the capture is
+    /// invalid rather than saying something about the engine's model: MLX active memory is
+    /// absolute, so a render cannot peak below the weights the provider itself declares resident.
+    ///
+    /// MUTATIONS THIS PINS. Deleting the check, or narrowing it so an under-weight capture stops
+    /// refusing, reds the first assertion; dropping either figure or the route from the refusal
+    /// reds the second; relaxing the comparison to `<=` reds the third. The last pins that this
+    /// check does NOT reclassify the shortfall case — every measured Mage peak tonight is far
+    /// above the declared weights.
+    #[test]
+    fn a_peak_below_the_declared_weights_is_still_a_refusal() {
+        let arm = MAGE_ARMS
+            .into_iter()
+            .find(|arm| arm.provider == "mage_flow")
+            .expect("the plain route is a registered Mage arm");
+        let error = mage_peak_below_weights_error(arm, "bf16", 1_000, 16_000_000_000)
+            .expect("a peak below the declared weights is a refusal");
+        assert!(
+            error.contains("1000") && error.contains("16000000000") && error.contains("mage_flow"),
+            "the refusal must state both figures and the route: {error}"
+        );
+        assert_eq!(
+            mage_peak_below_weights_error(arm, "bf16", 16_000_000_000, 16_000_000_000),
+            None
+        );
+        assert_eq!(
+            mage_peak_below_weights_error(arm, "bf16", 18_924_699_648, 16_000_000_000),
+            None
+        );
     }
 
     /// The six checkpoints are architecturally identical, so a plan whose `modelId` names a

--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -14933,6 +14933,43 @@ fn ltx_ordinary_admission(
     }
 }
 
+/// The exact-fit admission budget, expressed in the currency production's gate actually spends
+/// (sc-22738).
+///
+/// THE DEFECT THIS REPLACES. This probe used to set `budget.total_bytes = predicted` and then file
+/// `effectiveBudgetBytes: predicted`. Those were the same number only while the arm handed the
+/// gate a bare budget. `a1c855ad5` routed this arm through the worker's real presentation
+/// (`ltx_ordinary_admission`, which sets `reserved_headroom_bytes` from
+/// `mlx_fit_gate::live_request_budget`'s non-Mage branch and the live committed/reclaimable pair),
+/// and from that point the budget the gate weighed was
+/// `MemoryBudget::effective_bytes` = `total − committed + reclaimable − reserved`, i.e. the
+/// unified reserve BELOW the predicted need. `standard_memory_strategy_safety_check`'s only
+/// budget clause is `budget.fits(predicted_peak_bytes)`, so the gate refused every LTX-2.3 tier
+/// after a full load — correctly. The record's `effectiveBudgetBytes` was the field that was
+/// wrong, not the gate.
+///
+/// THE FIX IS A UNITS FIX, not a retired scenario. `memory_calibration.rs`'s
+/// `validate_runtime_complete` requires `exact_fit` to pass with
+/// `predictedBytes == effectiveBudgetBytes`, so the scenario the schema asks for is precisely
+/// "a budget whose EFFECTIVE bytes equal the predicted need" — the boundary host, not a host whose
+/// nameplate total equals the need. Solving `effective_bytes() == predicted` for `total_bytes`
+/// with production's own reserve and live snapshot held fixed gives
+/// `total = predicted + reserved + committed − reclaimable`; `fits` accepts exact boundaries, and
+/// the ceiling term `total − reserved = predicted + committed − reclaimable` cannot bind because
+/// the same gate already rejects `reclaimable > committed`. Nothing here is synthesized that
+/// production would not present: the reserve, the committed snapshot and the reclaim credit are
+/// carried through untouched from the live context, and only the host nameplate moves to the
+/// boundary the scenario is defined at.
+fn ltx_exact_fit_budget(live: MemoryBudget, predicted: u64) -> MemoryBudget {
+    MemoryBudget {
+        total_bytes: predicted
+            .saturating_add(live.reserved_headroom_bytes)
+            .saturating_add(live.committed_bytes)
+            .saturating_sub(live.reclaimable_bytes),
+        ..live
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 struct LtxLifecycleMetrics {
     clean_warm_peak: u64,
@@ -16303,14 +16340,26 @@ fn run_ltx_with_admission(
 
     let predicted_peaks = video_predicted_peak_bytes(conditioning, denoise, decode);
     let predicted = predicted_peaks.overall;
+    // The exact-fit scenario, posed the way the gate weighs it: see [`ltx_exact_fit_budget`]. The
+    // effective figure is READ BACK off the budget rather than assumed, so the record's
+    // `effectiveBudgetBytes` is what the predicate actually spent and the schema's
+    // `predictedBytes == effectiveBudgetBytes` clause is a statement about this run.
     let mut exact = context.clone();
     exact.predicted_peak_bytes = predicted;
-    exact.budget.total_bytes = predicted;
-    if !matches!(
-        generator.memory_strategy_safety_check(&exact),
-        MemorySafetyDecision::Accept
-    ) {
-        return Err("LTX-2.3 admission rejected an exact-fit calibrated budget".to_owned());
+    exact.budget = ltx_exact_fit_budget(context.budget, predicted);
+    let exact_effective_bytes = exact.budget.effective_bytes();
+    if exact_effective_bytes != predicted {
+        return Err(format!(
+            "LTX-2.3 exact-fit budget resolved {exact_effective_bytes} effective bytes for a \
+             {predicted} byte predicted peak; the probe must present the boundary host, not a \
+             nameplate total"
+        ));
+    }
+    if let MemorySafetyDecision::Reject { reason } = generator.memory_strategy_safety_check(&exact)
+    {
+        return Err(format!(
+            "LTX-2.3 admission rejected an exact-fit calibrated budget: {reason}"
+        ));
     }
 
     let lifecycle_input = LtxLifecycleInput {
@@ -16378,7 +16427,7 @@ fn run_ltx_with_admission(
     let scenarios = if admission == LtxRunAdmission::BoundedCampaignEntry {
         let blocker = "SC-20318 executes only selected plus warm-repeat parity; cancellation, authorized-error, and recovery renders remain unexecuted";
         json!([
-            { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": predicted },
+            { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": exact_effective_bytes },
             { "name": "unknown_budget", "result": "passed", "reason": "the loaded provider contract rejected a zero/unknown budget" },
             { "name": "stale_evidence", "result": "passed", "reason": "the loaded provider contract rejected a mutated calibration fingerprint" },
             { "name": "warm_repeat", "result": "passed", "reason": "the selected request scope repeated deterministically within the declared clip-wide envelope" },
@@ -16389,7 +16438,7 @@ fn run_ltx_with_admission(
         ])
     } else {
         json!([
-            { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": predicted },
+            { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": exact_effective_bytes },
             { "name": "unknown_budget", "result": "passed", "reason": "the loaded provider contract rejected a zero/unknown budget" },
             { "name": "stale_evidence", "result": "passed", "reason": "the loaded provider contract rejected a mutated calibration fingerprint" },
             { "name": "warm_repeat", "result": "passed", "reason": "the selected request scope repeated deterministically within the declared clip-wide envelope" },
@@ -27628,6 +27677,95 @@ mod ltx_tests {
                 "{key}"
             );
             assert!(!context.has_phases, "{key}");
+        }
+        assert_eq!(
+            rows,
+            LTX_TIERS.len(),
+            "every shipped tier has one planned MLX row"
+        );
+    }
+
+    /// sc-22738. The post-render exact-fit probe is posed in the currency the gate spends.
+    ///
+    /// The regression this pins is the one that killed every `ltx_2_3:*:mlx` anchor after a full
+    /// load: with the worker's real presentation carrying a 2 GiB reserve, a budget whose
+    /// NAMEPLATE total equals the predicted peak has an EFFECTIVE budget a whole reserve below it,
+    /// so `standard_memory_strategy_safety_check`'s `budget.fits` clause refuses it — by design.
+    /// The first assertion below is that refusal, stated as a fact about the old shape rather than
+    /// left implicit; the second is that [`ltx_exact_fit_budget`] restores the boundary the
+    /// scenario is defined at, `effective_bytes() == predicted`, and is admitted there.
+    /// Reverting the helper to `total_bytes = predicted` reds the second on every shipped tier.
+    #[test]
+    fn the_exact_fit_probe_presents_the_boundary_host_not_a_nameplate_total() {
+        let plan: Value = serde_json::from_str(include_str!(
+            "../../../../config/memory-calibration-plan.json"
+        ))
+        .expect("the anchor plan is valid JSON");
+        let mut rows = 0;
+        for (key, row) in plan["anchors"].as_object().expect("anchors is an object") {
+            let parts: Vec<&str> = key.split(':').collect();
+            if parts.len() != 3 || parts[0] != LTX_PROVIDER || parts[2] != "mlx" {
+                continue;
+            }
+            rows += 1;
+            let request = ltx_plan_row_request(key, row);
+            let geometry =
+                ltx_target_geometry(&request).unwrap_or_else(|error| panic!("{key}: {error}"));
+            let selection =
+                planned_selection(&request).unwrap_or_else(|error| panic!("{key}: {error}"));
+            let contract = ltx_fixture_contract(ltx_tier_quant(parts[1]));
+            let calibration = contract.calibration.as_ref().expect("fixture calibration");
+            let (context, projection) = ltx_ordinary_admission(
+                &contract,
+                calibration,
+                selection,
+                geometry,
+                LTX_TEST_HOST_BYTES,
+            )
+            .unwrap_or_else(|error| panic!("{key}: {error}"));
+            // Stands in for the measured overall peak the live arm probes with.
+            let predicted = projection.predicted_peak_bytes;
+
+            let mut nameplate = context.clone();
+            nameplate.predicted_peak_bytes = predicted;
+            nameplate.budget.total_bytes = predicted;
+            assert!(
+                nameplate.budget.effective_bytes() < predicted,
+                "{key}: a nameplate-total budget must sit below the need once production's \
+                 reserve is presented"
+            );
+            assert!(
+                matches!(
+                    mlx_gen::gen_core::default_memory_strategy_safety_check(&contract, &nameplate),
+                    MemorySafetyDecision::Reject { .. }
+                ),
+                "{key}: the pre-sc-22738 exact-fit shape must still be refused; if it is admitted \
+                 the reserve has silently left the production presentation"
+            );
+
+            let mut exact = context.clone();
+            exact.predicted_peak_bytes = predicted;
+            exact.budget = ltx_exact_fit_budget(context.budget, predicted);
+            assert_eq!(
+                exact.budget.effective_bytes(),
+                predicted,
+                "{key}: the exact-fit budget must spend exactly the predicted peak"
+            );
+            assert_eq!(
+                exact.budget.reserved_headroom_bytes, context.budget.reserved_headroom_bytes,
+                "{key}: the probe must carry production's reserve through untouched"
+            );
+            assert_eq!(
+                exact.budget.committed_bytes, context.budget.committed_bytes,
+                "{key}: the probe must carry the live committed snapshot through untouched"
+            );
+            assert!(
+                matches!(
+                    mlx_gen::gen_core::default_memory_strategy_safety_check(&contract, &exact),
+                    MemorySafetyDecision::Accept
+                ),
+                "{key}: the boundary host must be admitted"
+            );
         }
         assert_eq!(
             rows,

--- a/crates/sceneworks-memory-adapter/src/lib.rs
+++ b/crates/sceneworks-memory-adapter/src/lib.rs
@@ -1508,11 +1508,16 @@ fn gated_fragment_body(parts: PlainGatedFragment<'_>) -> Value {
 }
 
 pub fn fail(message: impl AsRef<str>) -> ! {
-    // The failure line FIRST, informational notes after it. `measure-memory-catalog.mjs` names a
-    // failed capture by the FIRST line the adapter wrote to stderr, so a per-render note printed the
-    // moment the render returned would be the line the runner quotes for a capture that failed after
-    // it — which is how eighteen sc-22738 Mage refusals were reported as a GPU-view coherence
-    // statistic rather than as the lifecycle refusal that actually stopped them.
+    // The failure line FIRST, informational notes after it — which is how eighteen sc-22738 Mage
+    // refusals came to be reported as a GPU-view coherence statistic rather than as the lifecycle
+    // refusal that actually stopped them: a per-render note printed the moment the render returned
+    // sat where the outcome belonged.
+    //
+    // The runner reads the OTHER end (`measure-memory-catalog.mjs#failureReason` quotes the last
+    // non-banner line), so this ordering alone would have put the same tally back in every summary
+    // row. `failureReason` therefore skips the `note:` prefix `flush_deferred_notes` writes below;
+    // that prefix is the contract between the two, and renaming it here without teaching the
+    // runner reinstates the defect (sc-22738).
     eprintln!("memory-strategy provider adapter: {}", message.as_ref());
     flush_deferred_notes();
     std::process::exit(1);

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -2372,6 +2372,19 @@ export async function extractSeedingNewAnchors(exec, root, log, limit = 8) {
 export const FAILURE_REASON_LIMIT = 300;
 
 /**
+ * A line the adapter wrote as INFORMATION rather than as its outcome.
+ *
+ * The adapter's `protocol` module documents exactly one such prefix: `flush_deferred_notes` emits
+ * every deferred note as `memory-strategy provider adapter: note: <text>`, and `protocol::fail`
+ * calls it AFTER writing the failure line, so on a failed capture the note lines are the LAST
+ * things on stderr. The banner is optional here because a note can also reach the runner already
+ * unwrapped, and the whole prefix is anchored so a real failure message that merely CONTAINS the
+ * word "note" is never skipped.
+ */
+export const INFORMATIONAL_LINE_PATTERN =
+  /^(?:memory-strategy provider adapter: )?note:/;
+
+/**
  * The LAST line of a child's stderr that names the failure, not the Node banner after it.
  *
  * sc-22738: this used to take the FIRST line matching `/^(Error|…Error|fatal|error)\b/`, falling
@@ -2404,7 +2417,13 @@ export function failureReason(error) {
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line && !/^(at |Node\.js v)/.test(line));
-  return (lines.at(-1) ?? "unknown failure").slice(0, FAILURE_REASON_LIMIT);
+  // sc-22738, the SECOND half of the same defect. Reading from the end fixed the ordering, and
+  // then `protocol::fail` was taught to defer its informational notes until AFTER the failure
+  // line — so the last line became the sc-22414 coherence tally again, this time by construction.
+  // Informational lines are not outcomes: skip them and quote the last line that is one. Falling
+  // back to the last line overall keeps a stderr that is ONLY notes from reporting nothing.
+  const outcome = lines.filter((line) => !INFORMATIONAL_LINE_PATTERN.test(line));
+  return ((outcome.at(-1) ?? lines.at(-1)) ?? "unknown failure").slice(0, FAILURE_REASON_LIMIT);
 }
 
 export async function measureAnchor(row, context) {

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -4037,6 +4037,33 @@ test("failure reasons name the thrown error, not the Node banner after it", () =
     "a synchronized Mage-Flow lifecycle phase reported a zero active peak",
   );
 
+  // sc-22738, the other half. `protocol::fail` now writes the failure line FIRST and flushes its
+  // deferred notes after it, so reading from the end put the sc-22414 coherence tally back in
+  // every summary row — by construction this time. A `note:` line is information, not an outcome.
+  const deferred = [
+    "file:///x/harness.mjs:1962",
+    "Error: memory-mlx-adapter exited 1: memory-strategy provider adapter: LTX-2.3 admission rejected an exact-fit calibrated budget",
+    "memory-strategy provider adapter: note: GPU-view coherence retries during this render: mlx_gen=0 mlx_llm=0 (sc-22414)",
+    "    at ChildProcess.<anonymous> (file:///x/harness.mjs:1962:11)",
+    "Node.js v24.15.0",
+  ].join("\n");
+  assert.equal(
+    failureReason({ stderr: deferred, message: "node exited 1" }),
+    "Error: memory-mlx-adapter exited 1: memory-strategy provider adapter: LTX-2.3 admission rejected an exact-fit calibrated budget",
+  );
+  // The same note without the adapter banner, and several of them, still skipped.
+  assert.equal(
+    failureReason({ stderr: ["the real refusal", "note: first tally", "note: second tally"].join("\n") }),
+    "the real refusal",
+  );
+  // A real failure that merely CONTAINS the word is an outcome and must still be quoted.
+  assert.equal(
+    failureReason({ stderr: "adapter refused: take note: the ceiling was breached" }),
+    "adapter refused: take note: the ceiling was breached",
+  );
+  // Notes alone leave the runner with nothing better to say than the note.
+  assert.equal(failureReason({ stderr: "note: only a tally" }), "note: only a tally");
+
   // Bounded by LENGTH alone: a `;` or a `)` inside a real adapter message is content, not a cut.
   const delimited = "Error: adapter refused; the wired ceiling (87044670532 bytes) was already breached";
   assert.equal(failureReason({ stderr: delimited }), delimited);
@@ -4066,6 +4093,14 @@ async function stubCheckout() {
     const value = (flag) => args[args.indexOf(flag) + 1];
     if (command === "capture") {
       if (process.env.STUB_CAPTURE_FAILS) { console.error("Error: stub capture refused"); process.exit(1); }
+      // sc-22738: the adapter's exit-1 stderr AFTER protocol::fail was taught to defer its
+      // informational notes -- outcome first, flush_deferred_notes after it. The last line on
+      // stderr is therefore a note on every failed capture, by construction.
+      if (process.env.STUB_CAPTURE_DEFERRED_NOTE) {
+        console.error("memory-strategy provider adapter: LTX-2.3 admission rejected an exact-fit calibrated budget: ltx_2_3: incremental live demand 9 exceeds effective budget 7");
+        console.error("memory-strategy provider adapter: note: GPU-view coherence retries during this render: mlx_gen=0 mlx_llm=0 (sc-22414)");
+        process.exit(1);
+      }
       // sc-22738: the adapter's exit-1 stderr on a process-scoped Metal refusal, verbatim from the
       // flux2_dev:bf16:mlx run of 2026-09-06 (paths shortened).
       // sc-22738: the adapter's exit-1 stderr when the PINNED ENGINE's production loader refuses
@@ -4331,6 +4366,18 @@ test("a failed derivation step rolls the tree back to HEAD and keeps the raw cap
     assert.equal((await checkout.git("status", "--porcelain")).stdout, "");
   } finally {
     delete process.env.STUB_CAPTURE_FAILS;
+  }
+  // sc-22738: end to end, through the real child process, with the adapter's deferred note LAST.
+  // Dropping the informational skip in `failureReason` reds this on the note line.
+  process.env.STUB_CAPTURE_DEFERRED_NOTE = "1";
+  try {
+    const result = await measureAnchor(row, stubContext(checkout));
+    assert.equal(result.status, "capture_failed");
+    assert.match(result.reason, /rejected an exact-fit calibrated budget/);
+    assert.doesNotMatch(result.reason, /coherence retries/, "the deferred note is not the outcome");
+    assert.equal((await checkout.git("status", "--porcelain")).stdout, "");
+  } finally {
+    delete process.env.STUB_CAPTURE_DEFERRED_NOTE;
   }
 });
 


### PR DESCRIPTION
## The defect

After #2767 every one of the 18 `mage_flow*:{bf16,q4,q8}:mlx` anchors renders (11-38 s) and then dies in the adapter:

```
measured Mage-Flow peak 25635586048 exceeds the pinned provider's own modelled total 18328139520 for 768x768 at bf16   (mage_flow_edit)
measured Mage-Flow peak 18924699648 exceeds the pinned provider's own modelled total 18328139520 for 768x768 at bf16   (mage_flow)
```

That inverted the epic's premise. The number being exceeded is a **model**, not an observation, and the capture that proves it wrong was the thing being thrown away.

## What the model covers, and why the measurement exceeds it

`mlx_gen_mage::memory::generation_peak_gb` — inference `crates/media/mlx-gen/mlx-gen-mage/src/memory.rs:49` at pin `3b922bac6`:

```
generation_peak_gb(tier, w, h, count) = generation_resident_gb(tier) + vae_peak_gb(w, h) * count
generation_resident_gb(tier)          = calibration_peak_gb(tier) - vae_peak_gb(512, 512)     (:39)
calibration_peak_gb(tier)             = 17.660 | 10.012 | 7.868                               (:27)
vae_peak_gb(w, h)                     = 0.267 + 2.039 * megapixels                            (:43)
```

Two properties fall out, and both are false against measurement:

1. **The only geometry-dependent term in the entire estimator is the linear VAE _decode_ fit** (`:43`). Everything else is `calibration_peak_gb`, three scalars measured once at **512²**, with that anchor's own VAE term subtracted out. The model therefore asserts the DiT/TE/activation working set is resolution-independent. At 768² (2.25× the latent tokens of 512²) it is not — `mage_flow` measured **+0.60 GB** over the model.
2. **There is no reference-image term anywhere.** One scalar per tier is shared by all six family members, the three instruction editors included. The edit routes VAE-encode a reference and carry its latents and conditioning through the whole denoise, entirely unmodelled — `mage_flow_edit` measured **+7.31 GB** over the *same* modelled total, at the same geometry and tier.

The TE and decode are not the gap: the anchor's own doc (`:1-6`, `:20-26`) says it is the complete generation including the encode/decode acceptance path, and the Q8 text-encoder floor is already inside the q4 scalar. The measured overall-only peak after #2767 spans the same span the anchor did. What is missing is the **resolution scaling of the non-VAE portion** and the **reference-image cost**.

Adapter side: `crates/sceneworks-memory-adapter/src/bin/mlx.rs`, `mage_admission_budget` (the modelled total, `generation_peak_gb` + `contract.auxiliary_resident_bytes()`), and the refusal this PR replaces.

## Production-hazard verdict: **yes, this is a live production hazard**

Production admission for this route runs on the **same model**:

- `crates/sceneworks-worker/src/mlx_fit_gate.rs:4432` — `request_total_peak_bytes`'s `mage_flow` branch *is* `runtime_macos::providers::mage::memory::generation_peak_gb`.
- `crates/sceneworks-worker/src/mlx_fit_gate.rs:4405-4408` — the Mage branch of `live_request_budget` takes its total from `mage::memory::production_safe_budget_gb()` (85% of the MLX limit) with **zero reserved headroom**.
- The `AdmissionPath::Evidence` arm admits on a covered cell's measured anchor instead — but **no Mage cell is covered today**, because these captures are what would mint those anchors. Every Mage request falls through to the model.

So a 768² bf16 `mage_flow_edit` request is admitted at 18.33 GB and then peaks at **25.64 GB — 7.31 GB above what admission reserved**, against a budget with no reserve, into an allocator whose default handler calls `exit(-1)` rather than returning a catchable error (`memory.rs:74-78`, `:93-98` document exactly this). The plain route's 0.60 GB is smaller but the same class. The hazard grows with resolution and is worst on the edit routes.

**The fix for the hazard is the measurement, not the refusal.** These anchors are what lets admission stop guessing.

## What changed

One file, `crates/sceneworks-memory-adapter/src/bin/mlx.rs`.

- **`mage_model_shortfall_blocker`** — an exceedance is now a **finding recorded on the record**, never a refusal, mirroring how #2772 recorded klein's retention. `diagnostics.blockers` carries measured peak, modelled total, delta, geometry, tier and route; `diagnostics.measurements` carries `engineModelledTotalBytes` and `engineModelShortfallBytes` so a consumer can size the gap without parsing prose. (E5: measurement never gates. E4: the production path is what is measured.)
- **`mage_peak_below_weights_error`** — the one peak check that genuinely proves the *capture* invalid stays a **refusal**. MLX active memory is absolute, so a render cannot peak below the weights the provider itself declares resident (the credit half of `mage_admission_budget`); a record built from such a peak would publish an anchor below the real floor. `mage_zero_phase_error` is untouched.

## Mutation proof

All four red before green, run individually:

| mutation | red test |
| --- | --- |
| restore the call-site `if predicted > required_total_peak_bytes { return Err(…) }` | `the_model_shortfall_reaches_the_record_and_never_refuses` |
| compute the finding but drop `lifecycle_blockers.extend(...)` | `the_model_shortfall_reaches_the_record_and_never_refuses` |
| drop `{delta}` from the finding string | `a_peak_above_the_engines_model_is_recorded_as_a_finding_with_its_delta` |
| relax the weights floor to `<=` | `a_peak_below_the_declared_weights_is_still_a_refusal` |

## Verification

- `cargo test -p sceneworks-memory-adapter --bin memory-mlx-adapter --features mlx` — **286 passed, 0 failed** (283 before, +3).
- `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean (exit 0).
- `npm run check` with `INFERENCE_REPO=/Users/michael/Repos/inference` — **860/861**. The single failure is the known **environmental** `CALIBRATED_TIER` assertion: that checkout is at `63056d4e9`, not the pinned `3b922bac6`. The pinned revision's `crates/media/mlx-gen/mlx-gen-ltx/src/memory_strategy.rs` declares the constant twice; the working checkout's declares it zero times. Not related to this change.

CPU-only throughout — no GPU renders and no release build, since a measurement run is live on this host.

This branch also carries the still-unmerged `fix/sc-22738-ltx23-exact-fit-admission` commit (`c069b533f`), merged in because it touches the same file.

Epic sc-22723, terminal story sc-22738.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
