### PR TITLE
fix(sc-22738): every probe carries a wall-clock budget; a runtime stop is capture_failed, never a memory bound

### DIFF
--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -1272,7 +1272,7 @@ first five:
 | `captured` | `--no-commit`: the bundle was written and schema-checked, nothing ingested | clean |
 | `exceeded` | `--no-commit`: the render hit a ceiling (either kind); it is named on the row but there is nowhere to put it | clean |
 | `artifact_unsupported` | the pinned engine's production loader refused the shipped artifact (sc-22738) — the row carries the loader's own `unsupported:` sentence verbatim; **no evidence, no bound, no commit** | clean |
-| `capture_failed` | the capture died for a reason that is NEITHER a footprint stop, a wired-limit refusal nor a pinned-artifact refusal (or is a ceiling the row cannot bind an artifact for), **or** it is the second consecutive Metal refusal, which halts the walk | clean |
+| `capture_failed` | the capture died for a reason that is NEITHER a footprint stop, a wired-limit refusal nor a pinned-artifact refusal (or is a ceiling the row cannot bind an artifact for), **or** it ran out of its wall-clock budget (`runtime_budget_exceeded`, below), **or** it is the second consecutive Metal refusal, which halts the walk | clean |
 | `check_failed` | the bundle failed `harness check` | clean |
 | `ingest_failed` | a post-capture step failed; the tree was rolled back to HEAD | clean |
 
@@ -1291,6 +1291,22 @@ that stales the bound puts the cell straight back to `runnable`, with no edit to
 that is ALL it does: production keeps refusing exactly what the bound refused when measured
 (sc-22738), because a shared-engine fix silently re-admitting a request a host was already unable to
 finish is the failure the bound exists to prevent.
+
+**Every probe carries a wall-clock budget (sc-22738, 2026-09-07).** The guard's ceilings bound a
+probe that CLIMBS; they say nothing about one that stops climbing, and `scail2_14b:bf16:mlx` sat
+flat at 93.5 GB under the 94.82 GB kill line for 90 minutes with the host swapping and the adapter
+parked in `mlx::core::eval`. So `measure-memory-catalog.mjs` now passes the guard a
+`--max-runtime-seconds` on every capture, defaulted per lane by `PROBE_BUDGET_MINUTES` — **150
+minutes for a video anchor, 60 for an image one** (the lane is derived from the plan: a video anchor
+renders more than one frame), overridable for a run with `--probe-budget-minutes N`, which
+`--dry-run` prints per row. A probe that reaches its budget is stopped on the guard's ONE stop path
+— the same SIGTERM→SIGKILL escalation and post-stop census a footprint stop takes — and is reported
+as `capture_failed` with reason `runtime_budget_exceeded`, naming the budget and the peak footprint
+sampled so you can tell a probe wedged at the ceiling from one wedged at 3 GB. **It is not an
+exceedance:** the run never crossed a line, so no bound is written (the harness's `record-exceeded`
+refuses a wall-clock stop outright), the store keeps no trace, the watchdog stream and per-anchor log
+stay in the work dir, and the cell classifies `runnable` again on the next `--list`. Re-run it, or
+re-run it with a larger `--probe-budget-minutes` if you believe the render was still making progress.
 
 **`committed_exceeded` is the one that changed (sc-22738).** A footprint hard stop used to be a
 `capture_failed` that stamped nothing at all: the store kept no trace, and production went on

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -16,8 +16,16 @@
 //   node scripts/measure-memory-catalog.mjs --backend mlx \
 //     --adapter target/release/memory-mlx-adapter --inference-repo ../inference \
 //     --work-dir /abs/OUTSIDE/the/repo/calib --campaign sc-NNNN [--model sdxl ...] [--anchors a,b]
-//     [--skip-current]
+//     [--skip-current] [--probe-budget-minutes N]
 //     [--dry-run] [--no-commit] [--hf-cache DIR ...]   (--hf-cache is repeatable)
+//
+// Every guarded probe also carries a WALL-CLOCK budget (`--probe-budget-minutes`, defaulted per
+// lane by `PROBE_BUDGET_MINUTES`), passed to the guard as `--max-runtime-seconds`. A probe that
+// reaches it is stopped on the guard's ONE stop path — the same SIGTERM→SIGKILL escalation and the
+// same post-stop census a footprint stop takes — and reported as `capture_failed` with reason
+// `runtime_budget_exceeded`. It is NOT an exceedance: a run that thrashed below the ceiling
+// measured nothing, so no bound is written, the store keeps no trace, and the cell classifies
+// `runnable` again on the next `--list` (sc-22738).
 //
 // A cell the store already carries a CURRENT measured lower bound for classifies `exceeded_current`
 // and is never scheduled, with or without `--skip-current` (sc-22738): the host has proved it cannot
@@ -1326,6 +1334,7 @@ export function parseArgs(argv) {
   const args = {
     backend: null, adapter: null, inferenceRepo: null, workDir: null, campaign: null,
     anchors: null, models: [], skipCurrent: false, dryRun: false, commit: true, hfCache: [], list: false,
+    probeBudgetMinutes: null,
   };
   const value = (flag, index) => {
     const selected = argv[index + 1];
@@ -1344,6 +1353,15 @@ export function parseArgs(argv) {
       case "--anchors": args.anchors = value(flag, index).split(",").filter(Boolean); index += 1; break;
       case "--model": args.models.push(value(flag, index)); index += 1; break;
       case "--skip-current": args.skipCurrent = true; break;
+      // Minutes, and fractional minutes are accepted: the budget is one number in one unit, and a
+      // test (or a deliberately tight re-run) needs to express seconds without a second flag.
+      case "--probe-budget-minutes": {
+        const minutes = Number(value(flag, index));
+        if (!Number.isFinite(minutes) || minutes <= 0) fail("--probe-budget-minutes must be a positive number of minutes");
+        args.probeBudgetMinutes = minutes;
+        index += 1;
+        break;
+      }
       case "--dry-run": args.dryRun = true; break;
       case "--no-commit": args.commit = false; break;
       case "--list": args.list = true; break;
@@ -1640,6 +1658,12 @@ export async function classifyAnchor(key, planned, { models, backend, hubs, curr
     // and the capture-dir environment. Defaulted here so no early-return row can reach
     // `measureAnchor` with the flag undefined; both terminal paths below set it from the family.
     sourceCapture: false, physical: false,
+    // sc-22738: which wall-clock budget this probe carries (`PROBE_BUDGET_MINUTES`). The PLAN is
+    // the authority and it already states it: a video anchor is one whose planned geometry renders
+    // more than one frame. Derived rather than listed so a new video row cannot be given an image
+    // lane's budget by omission — and set on the base row, so every early-return status carries it
+    // too and `--dry-run` can print it for a cell it will not run.
+    videoLane: Number(planned?.geometry?.frames ?? 1) > 1,
   };
   if (parts.backend !== backend) return { ...row, status: "other_backend", reason: `${parts.backend} lane` };
   const family = familyFor(parts.modelId, planned.provider, families);
@@ -2277,6 +2301,51 @@ export async function probeAdapter(command, { cwd = ROOT, env = process.env, wir
  * how the MLX lane's own admission reasons about device memory); it is advisory here, never a kill
  * line (sc-22738, measured 2026-09-06).
  */
+/**
+ * The per-probe WALL-CLOCK budget, in minutes, by lane (sc-22738, 2026-09-07).
+ *
+ * WHY A BUDGET AT ALL. The guard's ceilings bound a probe that CLIMBS. They say nothing about one
+ * that stops climbing: `scail2_14b:bf16:mlx` sat at a flat 93.5 GB against the 94.82 GB kill line
+ * for 90 minutes, the host swapping and the adapter's main thread parked in `mlx::core::eval` →
+ * `waitUntilSignaledValue`, and would have sat there until an operator noticed. The watchdog has
+ * supported `--max-runtime-seconds` since it was written; nothing passed it, so every probe ran
+ * unbounded in time.
+ *
+ * THE BASIS, AND WHAT IT IS NOT. The evidence corpus states no wall clock: `durationSeconds` and
+ * every other duration/elapsed field are ABSENT from `docs/calibration/sc-22738/*.json` (a capture
+ * bundle carries `capturedAt` and nothing about how long the render took). So these are derived
+ * from the two figures the corpus and this tree DO state:
+ *
+ *   * consecutive `capturedAt` deltas inside one uninterrupted walk, each an UPPER bound on that
+ *     anchor's whole capture→commit cycle. Longest for a completed IMAGE anchor: 847 s
+ *     (`bernini_image:q8:mlx`, 07:13:26 after q4's 06:59:19 on 2026-09-07). Longest bounding a
+ *     completed VIDEO anchor: 4,161 s (`ltx_2_3:q4:mlx`), with the clean back-to-back `ltx_2_5`
+ *     pair at 1,132 s and 1,097 s.
+ *   * the longest run this tree WITNESSES a guarded probe making real progress in: the 85-minute
+ *     `bernini:q8:mlx` render (a VIDEO entry — `bernini` is the video row, `bernini_image` the
+ *     still one) that was steady at 52 GB when a census false positive SIGKILLed it, named in
+ *     `scripts/memory-calibration-watchdog.py`'s header.
+ *
+ * So: 150 minutes for video is 1.8x that witnessed 85-minute render and ~2.2x the longest video
+ * capture cycle on file; 60 minutes for image is 4.2x the longest image capture cycle on file. Both
+ * are backstops against a wedge, not schedule targets — a budget tight enough to argue about would
+ * be converting slow renders into re-runs.
+ *
+ * The cost of being wrong is bounded BY DESIGN and asymmetric on purpose: a runtime stop records no
+ * bound and leaves the cell `runnable`, so too tight a budget costs a re-run, while too loose a one
+ * costs only operator time. `--probe-budget-minutes` overrides both entries for a run.
+ */
+export const PROBE_BUDGET_MINUTES = { video: 150, image: 60 };
+
+/** This row's wall-clock budget in minutes: the runner's `--probe-budget-minutes`, else its lane's. */
+export function probeBudgetMinutes(row, override = null) {
+  if (override !== null && override !== undefined) {
+    if (!Number.isFinite(override) || override <= 0) fail("--probe-budget-minutes must be a positive number of minutes");
+    return override;
+  }
+  return PROBE_BUDGET_MINUTES[row.videoLane ? "video" : "image"];
+}
+
 export function watchdogCeilings({ memoryBytes }) {
   const bounds = [LTX_Q4_F305_CRASH_FOOTPRINT_BYTES - UNIFIED_RESERVE_BYTES, memoryBytes - UNIFIED_RESERVE_BYTES];
   return { maxFootprintBytes: Math.min(...bounds), minMemoryFreeBytes: UNIFIED_RESERVE_BYTES };
@@ -2292,17 +2361,25 @@ export function watchdogCeilings({ memoryBytes }) {
  * watchdog can panic.
  *
  * Both ceilings are DERIVED (`watchdogCeilings`) from the adapter's probed host memory and the
- * incident, never chosen here; the probe's wired limit is validated but is not a kill line. No wall-time ceiling: a runtime-complete video anchor runs six renders, and time is
- * not the hazard this guard exists for. Darwin-only by construction — the footprint sampler is
- * `/usr/bin/footprint`.
+ * incident, never chosen here; the probe's wired limit is validated but is not a kill line.
+ *
+ * A WALL-CLOCK ceiling too, since sc-22738 (2026-09-07): `budgetMinutes` — see
+ * `PROBE_BUDGET_MINUTES` for the figures and their basis. It is a REQUIRED argument, not a default
+ * here, so no caller can spawn an unbounded probe by omission; the guard treats it as one more
+ * trigger on its ONE stop path, so a runtime stop escalates and discriminates exactly as a
+ * footprint stop does. What differs is what the RUNNER makes of it: a footprint stop measured a
+ * lower bound, a runtime stop measured nothing at all.
+ *
+ * Darwin-only by construction — the footprint sampler is `/usr/bin/footprint`.
  */
-export function watchdogGuard({ hardware, eventFile }) {
+export function watchdogGuard({ hardware, eventFile, budgetMinutes }) {
   const { memoryBytes, wiredLimitBytes } = hardware;
   if (!Number.isSafeInteger(memoryBytes) || memoryBytes <= 0) fail("watchdog guard needs a positive hardware.memoryBytes");
   if (wiredLimitBytes !== undefined) {
     if (!Number.isSafeInteger(wiredLimitBytes) || wiredLimitBytes <= 0) fail("watchdog guard needs a positive hardware.wiredLimitBytes");
     if (wiredLimitBytes > memoryBytes) fail("watchdog guard: wired ceiling above host memory");
   }
+  if (!Number.isFinite(budgetMinutes) || budgetMinutes <= 0) fail("watchdog guard needs a positive budgetMinutes");
   const { maxFootprintBytes, minMemoryFreeBytes } = watchdogCeilings({ memoryBytes });
   if (maxFootprintBytes <= 0) fail(`watchdog guard: no positive footprint ceiling on a ${memoryBytes}-byte host`);
   return [
@@ -2312,6 +2389,8 @@ export function watchdogGuard({ hardware, eventFile }) {
     "--max-footprint-bytes", String(maxFootprintBytes),
     "--host-memory-bytes", String(memoryBytes),
     "--min-memory-free-bytes", String(minMemoryFreeBytes),
+    // Minutes in, seconds out: the guard speaks seconds, the operator books minutes.
+    "--max-runtime-seconds", String(budgetMinutes * 60),
     "--sample-interval", "2",
     "--telemetry-timeout", "10",
     "--term-grace", "1",
@@ -2338,6 +2417,55 @@ export async function watchdogHardStop(eventFile) {
     if (event.event === "hard_stop") return `watchdog hard stop: ${event.reason}`;
   }
   return null;
+}
+
+/**
+ * The guard's own spelling of a WALL-CLOCK stop, as `watchdogHardStop` returns it (sc-22738).
+ *
+ * `memory-calibration-watchdog.py` writes `runtime_at_or_above_<seconds>s` — the argparse value is
+ * a float, so `9000.0` and `3` both occur — for every path that ends on the runtime deadline: the
+ * startup window, the sampling loop, and a telemetry probe bounded by the deadline. A test in
+ * `memory-calibration-watchdog.test.mjs` binds that spelling to this pattern, because the two
+ * scripts agree on it by string and nothing else would notice it drifting.
+ */
+export const RUNTIME_BUDGET_STOP_PATTERN = /^watchdog hard stop: runtime_at_or_above_(\d+(?:\.\d+)?)s$/;
+
+/** The budget a runtime stop names, in seconds, or `null` when `hardStop` is not a runtime stop. */
+export function runtimeBudgetStopSeconds(hardStop) {
+  const match = RUNTIME_BUDGET_STOP_PATTERN.exec(String(hardStop ?? ""));
+  return match ? Number(match[1]) : null;
+}
+
+/**
+ * The highest `phys_footprint` the guard sampled, `{ peakBytes, samples }`, or `null` when the log
+ * states none (sc-22738).
+ *
+ * Read on the FAILURE path, where the original outcome must still surface, so — unlike the
+ * harness's `parseWatchdogPeak`, whose caller is about to write a bound out of it — nothing here
+ * throws: a missing, truncated or sample-less log yields `null` and the row says "not sampled".
+ * This figure states no bound and is never recorded; it exists so the `--- key: status (reason)`
+ * line tells a human how close the wedged probe was to the ceiling.
+ */
+export async function watchdogPeakFootprint(eventFile) {
+  let body;
+  try {
+    body = await readFile(eventFile, "utf8");
+  } catch {
+    return null;
+  }
+  let peakBytes = null;
+  let samples = 0;
+  for (const line of body.split("\n")) {
+    if (!line.trim()) continue;
+    let event;
+    try { event = JSON.parse(line); } catch { continue; }
+    if (event?.event !== "sample") continue;
+    const footprint = event.physicalFootprintBytes;
+    if (!Number.isSafeInteger(footprint) || footprint <= 0) continue;
+    samples += 1;
+    if (peakBytes === null || footprint > peakBytes) peakBytes = footprint;
+  }
+  return peakBytes === null ? null : { peakBytes, samples };
 }
 
 /**
@@ -2637,6 +2765,9 @@ export async function measureAnchor(row, context) {
   // The host's Metal wired ceiling as THIS anchor's probe read it, kept for the refusal arm below:
   // the bound is keyed on the limit the refused render actually ran under, not on a later reading.
   let probedHardware = null;
+  // sc-22738: this probe's wall-clock budget, resolved once so the guard, the failure arm and the
+  // log all name the same figure.
+  const budgetMinutes = probeBudgetMinutes(row, args.probeBudgetMinutes);
   try {
     if (guardsCapture(row.key)) {
       // sc-22738: every Darwin capture runs inside the footprint hard stop, with ceilings derived
@@ -2645,7 +2776,7 @@ export async function measureAnchor(row, context) {
         cwd: root, env, wiredLimitRequired: anchorParts(row.key).backend === "mlx",
       });
       probedHardware = hardware;
-      const guard = watchdogGuard({ hardware, eventFile: watchdogEvents });
+      const guard = watchdogGuard({ hardware, eventFile: watchdogEvents, budgetMinutes });
       // The guard APPENDS to its event log; this capture's verdict must not read an earlier one's.
       await rm(watchdogEvents, { force: true });
       log.write(`$ /usr/bin/python3 ${guard.join(" ")} -- node ${captureArgs.join(" ")}\n`);
@@ -2657,6 +2788,31 @@ export async function measureAnchor(row, context) {
   } catch (error) {
     // A hard stop is recorded in the guard's event log, not on stderr: name it on the row.
     const hardStop = await watchdogHardStop(watchdogEvents);
+    // sc-22738 (2026-09-07): a WALL-CLOCK stop, and the one hard stop that is NOT a measurement.
+    //
+    // The guard killed this group on exactly the path a footprint stop takes — same escalation,
+    // same post-stop census — but for a different reason: the probe ran out of time, wherever its
+    // footprint happened to be. `scail2_14b:bf16:mlx` sat flat at 93.5 GB under a 94.82 GB ceiling
+    // for 90 minutes; the footprint it was sitting at is not a line it was witnessed to CROSS, and
+    // recording it as `exceededBounds` would state a lower bound the run never established and make
+    // production refuse hosts on it. So this arm returns BEFORE the two bound-recording arms below,
+    // records nothing, commits nothing, and leaves the cell `runnable` for the next `--list`: no
+    // bundle means no `records` and no bound for the classifier to read. The peak is reported for
+    // the operator's judgment only — a probe that wedged at the ceiling is a different problem from
+    // one that wedged at 3 GB — and is deliberately not written anywhere.
+    const budgetSeconds = runtimeBudgetStopSeconds(hardStop);
+    if (budgetSeconds !== null) {
+      const peak = await watchdogPeakFootprint(watchdogEvents);
+      const ceiling = probedHardware
+        ? `${watchdogCeilings(probedHardware).maxFootprintBytes}-byte ceiling`
+        : "the guard's ceiling";
+      return finish(
+        "capture_failed",
+        `runtime_budget_exceeded: the ${budgetMinutes}-minute probe budget (${budgetSeconds}s) elapsed; `
+          + `peak physical footprint ${peak ? `${peak.peakBytes} bytes over ${peak.samples} sample(s)` : "not sampled"} `
+          + `against the ${ceiling}. Nothing was measured, so no bound was recorded and this cell stays runnable.`,
+      );
+    }
     // sc-22738 (measured 2026-09-06): the SECOND way a run ends having measured a bound. Metal
     // refused this process's submissions once its working set reached the host's wired limit —
     // `flux2_dev:bf16:mlx` at 775 s, sampled peak 86,988,010,336 against an 87,044,670,532-byte
@@ -2856,7 +3012,7 @@ export async function main(argv = process.argv.slice(2)) {
   const runnable = rows.filter((row) => row.status === "runnable");
   if (args.dryRun) {
     for (const row of runnable) {
-      process.stdout.write(`${row.key}\n  sourceCapture=${row.sourceCapture} physical=${row.physical} ltx25=${Boolean(row.ltx25SnapshotRoot)}\n`);
+      process.stdout.write(`${row.key}\n  sourceCapture=${row.sourceCapture} physical=${row.physical} ltx25=${Boolean(row.ltx25SnapshotRoot)} budget=${probeBudgetMinutes(row, args.probeBudgetMinutes)}m\n`);
       for (const root of row.roots) process.stdout.write(`  ${root.label}: ${root.path}\n`);
       for (const [name, value] of Object.entries(row.env)) process.stdout.write(`  ${name}=${value}\n`);
     }

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -70,6 +70,11 @@ import {
   watchdogCeilings,
   watchdogGuard,
   watchdogHardStop,
+  watchdogPeakFootprint,
+  runtimeBudgetStopSeconds,
+  RUNTIME_BUDGET_STOP_PATTERN,
+  PROBE_BUDGET_MINUTES,
+  probeBudgetMinutes,
   METAL_REFUSAL,
   ARTIFACT_UNSUPPORTED,
   artifactUnsupported,
@@ -4204,6 +4209,10 @@ async function stubCheckout() {
     const value = (flag) => args[args.indexOf(flag) + 1];
     if (command === "capture") {
       if (process.env.STUB_CAPTURE_FAILS) { console.error("Error: stub capture refused"); process.exit(1); }
+      // sc-22738: the wedge. A probe that stops climbing and never finishes — the shape
+      // \`scail2_14b:bf16:mlx\` held for 90 minutes at a flat 93.5 GB — so the only thing that can
+      // end it is the guard's wall-clock budget.
+      if (process.env.STUB_CAPTURE_HANGS) { await new Promise((resolve) => { setTimeout(resolve, 600_000); }); }
       // sc-22738: the adapter's exit-1 stderr AFTER protocol::fail was taught to defer its
       // informational notes -- outcome first, flush_deferred_notes after it. The last line on
       // stderr is therefore a note on every failed capture, by construction.
@@ -4246,7 +4255,13 @@ async function stubCheckout() {
       let ceiling;
       let reason;
       if (stop) {
-        [, ceiling, observed] = /^physical_footprint_at_or_above_(\\d+):observed_(\\d+)$/.exec(stop.reason);
+        // The real harness refuses any hard stop that is not a footprint stop, because only a
+        // footprint stop states a lower bound (sc-22738). The stub refuses the same way, so a run
+        // that reaches this command with a WALL-CLOCK stop fails loudly here instead of inventing
+        // a bound out of a budget.
+        const footprint = /^physical_footprint_at_or_above_(\\d+):observed_(\\d+)$/.exec(stop.reason);
+        if (!footprint) { console.error("Error: stub record-exceeded: " + stop.reason + " is not a physical-footprint stop"); process.exit(1); }
+        [, ceiling, observed] = footprint;
         reason = stop.reason;
       } else {
         // The refusal arm: no hard stop, so the witnesses the runner must have handed over are the
@@ -4700,7 +4715,7 @@ test("the MLX LTX-2.3 cells are ordinary anchors: admitted by the production bud
 test("the watchdog guard's footprint hard stop is the incident and host RAM, never the wired limit", () => {
   // This Mac's probe: 128 GiB, wired ceiling 87,044,670,532.
   const hardware = { memoryBytes: 137_438_953_472, wiredLimitBytes: 87_044_670_532 };
-  const guard = watchdogGuard({ hardware, eventFile: "/tmp/events.jsonl" });
+  const guard = watchdogGuard({ hardware, eventFile: "/tmp/events.jsonl", budgetMinutes: 60 });
   assert.equal(guard[0], path.join(ROOT, WATCHDOG));
   const flag = (name) => Number(guard[guard.indexOf(name) + 1]);
   // The wired limit caps Metal buffers; the guard samples the kernel `phys_footprint`, which counts
@@ -4719,9 +4734,21 @@ test("the watchdog guard's footprint hard stop is the incident and host RAM, nev
   assert.ok(flag("--max-footprint-bytes") < LTX_Q4_F305_CRASH_FOOTPRINT_BYTES);
   assert.ok(flag("--min-memory-free-bytes") + flag("--max-footprint-bytes") <= hardware.memoryBytes - 32 * 1024 * 1024 * 1024, "≥ 32 GiB of baseline room");
   // The generic guard speaks no attestation or phase protocol — those belong to the frozen canary
-  // profiles — and sets no wall-time ceiling.
-  for (const absent of ["--require-child-attestation", "--require-provider-phases", "--provider-phase-profile", "--max-runtime-seconds"]) {
+  // profiles.
+  for (const absent of ["--require-child-attestation", "--require-provider-phases", "--provider-phase-profile"]) {
     assert.equal(guard.includes(absent), false, absent);
+  }
+  // It DOES set a wall-time ceiling since sc-22738 (2026-09-07): `scail2_14b:bf16:mlx` sat flat at
+  // 93.5 GB under this 94.82 GB kill line for 90 minutes with the host swapping, because nothing
+  // ever passed the `--max-runtime-seconds` the guard has always supported. Minutes in, seconds out.
+  assert.equal(flag("--max-runtime-seconds"), 3_600);
+  assert.equal(Number(watchdogGuard({ hardware, eventFile: "x", budgetMinutes: 150 })[guard.indexOf("--max-runtime-seconds") + 1]), 9_000);
+  assert.equal(Number(watchdogGuard({ hardware, eventFile: "x", budgetMinutes: 0.05 })[guard.indexOf("--max-runtime-seconds") + 1]), 3);
+  // REQUIRED, not defaulted: an omitted budget is refused rather than quietly spawning the
+  // unbounded probe this story exists to make impossible.
+  assert.throws(() => watchdogGuard({ hardware, eventFile: "x" }), /positive budgetMinutes/);
+  for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY, "60"]) {
+    assert.throws(() => watchdogGuard({ hardware, eventFile: "x", budgetMinutes: bad }), /positive budgetMinutes/, String(bad));
   }
   // The ceiling is the SMALLER of the incident less the reserve and host RAM less the reserve, so
   // no host policy can raise the kill line to or above the incident — and the wired limit is inert
@@ -4739,10 +4766,10 @@ test("the watchdog guard's footprint hard stop is the incident and host RAM, nev
     assert.ok(ceilings.maxFootprintBytes < LTX_Q4_F305_CRASH_FOOTPRINT_BYTES);
     assert.ok(ceilings.maxFootprintBytes + ceilings.minMemoryFreeBytes <= 137_438_953_472);
   }
-  assert.throws(() => watchdogGuard({ hardware: { memoryBytes: 1, wiredLimitBytes: 2 }, eventFile: "x" }), /above host memory/);
-  assert.throws(() => watchdogGuard({ hardware: { memoryBytes: 1, wiredLimitBytes: 0 }, eventFile: "x" }), /wiredLimitBytes/);
-  assert.throws(() => watchdogGuard({ hardware: { wiredLimitBytes: 2 }, eventFile: "x" }), /memoryBytes/);
-  assert.throws(() => watchdogGuard({ hardware: { memoryBytes: UNIFIED_RESERVE_BYTES }, eventFile: "x" }), /no positive footprint ceiling/);
+  assert.throws(() => watchdogGuard({ hardware: { memoryBytes: 1, wiredLimitBytes: 2 }, eventFile: "x", budgetMinutes: 60 }), /above host memory/);
+  assert.throws(() => watchdogGuard({ hardware: { memoryBytes: 1, wiredLimitBytes: 0 }, eventFile: "x", budgetMinutes: 60 }), /wiredLimitBytes/);
+  assert.throws(() => watchdogGuard({ hardware: { wiredLimitBytes: 2 }, eventFile: "x", budgetMinutes: 60 }), /memoryBytes/);
+  assert.throws(() => watchdogGuard({ hardware: { memoryBytes: UNIFIED_RESERVE_BYTES }, eventFile: "x", budgetMinutes: 60 }), /no positive footprint ceiling/);
   // Guarded set: EVERY capture on Darwin — a candle capture on a Mac draws from the same unified
   // pool the sampler measures — and none elsewhere, where the footprint sampler does not exist.
   assert.equal(guardsCapture("z_image_turbo:q4:mlx", "darwin"), true);
@@ -4928,6 +4955,133 @@ test("a footprint hard stop on a no-commit run surfaces as `exceeded` naming the
     assert.equal(status, "", "a stopped capture leaves the checkout clean for the next anchor");
   } finally {
     delete process.env.STUB_PROBE_MEMORY_BYTES;
+  }
+});
+
+// ---------------------------------------------------------------------------------------------
+// sc-22738: the per-probe WALL-CLOCK budget, and the one hard stop that measures nothing.
+// ---------------------------------------------------------------------------------------------
+
+test("every probe carries a wall-clock budget: per lane by default, derived from the plan, overridable", async () => {
+  // The table, and the flag that overrides it.
+  assert.deepEqual(PROBE_BUDGET_MINUTES, { video: 150, image: 60 });
+  assert.equal(probeBudgetMinutes({ videoLane: true }), 150);
+  assert.equal(probeBudgetMinutes({ videoLane: false }), 60);
+  assert.equal(probeBudgetMinutes({ videoLane: true }, 12), 12, "the flag overrides both lanes");
+  assert.equal(probeBudgetMinutes({ videoLane: false }, 0.5), 0.5);
+  assert.throws(() => probeBudgetMinutes({ videoLane: false }, 0), /positive number of minutes/);
+  assert.equal(parseArgs(["--backend", "mlx", "--list"]).probeBudgetMinutes, null, "unset means the lane default");
+  assert.equal(parseArgs(["--backend", "mlx", "--list", "--probe-budget-minutes", "45"]).probeBudgetMinutes, 45);
+  for (const bad of ["0", "-3", "abc"]) {
+    assert.throws(() => parseArgs(["--backend", "mlx", "--list", "--probe-budget-minutes", bad]), /positive number of minutes/, bad);
+  }
+  // The LANE is derived from the plan, never listed here: a video anchor is one whose planned
+  // geometry renders more than one frame. Both video and image rows must exist for the check to
+  // mean anything, and `bernini` (the video entry) versus `bernini_image` (the still one) is the
+  // pair that makes the derivation worth having — one family, two lanes, two budgets.
+  const plan = await readPlan();
+  const { rows } = await planRun({ backend: "mlx", anchors: null, campaign: "sc-catalog-test", hfCache: [], skipCurrent: false });
+  let video = 0;
+  for (const row of rows) {
+    const frames = plan.anchors[row.key].geometry?.frames ?? 1;
+    assert.equal(row.videoLane, frames > 1, `${row.key} renders ${frames} frame(s)`);
+    assert.equal(probeBudgetMinutes(row), frames > 1 ? 150 : 60, row.key);
+    if (frames > 1) video += 1;
+  }
+  assert.ok(video > 0 && video < rows.length, `${video} of ${rows.length} mlx rows are video anchors`);
+  const byKey = new Map(rows.map((row) => [row.key, row]));
+  assert.equal(byKey.get("bernini:q8:mlx").videoLane, true);
+  assert.equal(byKey.get("bernini_image:q8:mlx").videoLane, false);
+});
+
+test("a runtime stop is recognised by its spelling and reports the guard's sampled peak", async () => {
+  assert.equal(runtimeBudgetStopSeconds("watchdog hard stop: runtime_at_or_above_9000.0s"), 9000);
+  assert.equal(runtimeBudgetStopSeconds("watchdog hard stop: runtime_at_or_above_3s"), 3);
+  // Everything that is NOT a wall-clock stop keeps its own arm — above all the footprint stop,
+  // which DOES state a bound and must still reach `record-exceeded`.
+  for (const other of [
+    null, "", "watchdog hard stop: physical_footprint_at_or_above_94822600832:observed_94822600833",
+    "watchdog hard stop: telemetry_lost:TimeoutError:x", "watchdog hard stop: monitor_signal_SIGTERM",
+    "watchdog hard stop: runtime_at_or_above_9000",
+  ]) {
+    assert.equal(runtimeBudgetStopSeconds(other), null, String(other));
+  }
+  assert.ok(RUNTIME_BUDGET_STOP_PATTERN.test("watchdog hard stop: runtime_at_or_above_150.5s"));
+  // The peak is read for the operator, so it never throws on the failure path.
+  const dir = await mkdtemp(path.join(tmpdir(), "catalog-peak-"));
+  const file = path.join(dir, "events.jsonl");
+  await writeFile(file, [
+    JSON.stringify({ event: "started" }),
+    JSON.stringify({ event: "sample", physicalFootprintBytes: 3 }),
+    JSON.stringify({ event: "sample", physicalFootprintBytes: 93_500_000_000 }),
+    JSON.stringify({ event: "sample", physicalFootprintBytes: 12 }),
+    "{ truncated",
+    "",
+  ].join("\n"));
+  assert.deepEqual(await watchdogPeakFootprint(file), { peakBytes: 93_500_000_000, samples: 3 }, "the PEAK, not the last sample");
+  await writeFile(path.join(dir, "empty.jsonl"), "");
+  assert.equal(await watchdogPeakFootprint(path.join(dir, "empty.jsonl")), null);
+  assert.equal(await watchdogPeakFootprint(path.join(dir, "absent.jsonl")), null);
+});
+
+test("a probe that reaches its wall-clock budget is a capture_failed, never a memory bound, and the cell stays runnable", { skip: process.platform !== "darwin" && "the footprint sampler is Darwin-only" }, async () => {
+  const checkout = await stubCheckout();
+  const tierRoot = await mkdtemp(path.join(tmpdir(), "catalog-tier-"));
+  await writeFile(path.join(tierRoot, "w.safetensors"), "weights");
+  process.env.GIT_AUTHOR_NAME = process.env.GIT_COMMITTER_NAME = "t";
+  process.env.GIT_AUTHOR_EMAIL = process.env.GIT_COMMITTER_EMAIL = "t@t";
+  // The wedge: the capture never finishes and its footprint never reaches the ceiling (the probe
+  // reports a 128 GiB host, so the kill line is the incident's 94,822,600,832 bytes and a Node
+  // process cannot approach it). Only the budget can end this run — 3 seconds of it.
+  process.env.STUB_CAPTURE_HANGS = "1";
+  try {
+    const context = stubContext(checkout, {
+      args: { ...stubContext(checkout).args, probeBudgetMinutes: 0.05 },
+    });
+    const stopped = await measureAnchor({
+      key: "z_image_turbo:q4:mlx", physical: false, tierRoot, env: { SCENEWORKS_Z_IMAGE_ROOT: tierRoot },
+      // Fully bound, so nothing but the runtime arm itself can be what stops a bound being written:
+      // the "no artifact binding" refusal is not the guard under test here.
+      artifact: { repository: "SceneWorks/z-image-turbo-mlx", resolvedRevision: REVISION, variant: "q4" },
+    }, context);
+    // A runtime stop measured NOTHING. It is a failed capture, not an exceedance: recording the
+    // footprint the probe happened to be sitting at would state a lower bound the run never
+    // established, and production would refuse hosts on it.
+    assert.equal(stopped.status, "capture_failed", stopped.reason);
+    assert.match(stopped.reason, /^runtime_budget_exceeded: the 0\.05-minute probe budget \(3s\) elapsed;/);
+    // The line an operator reads has to carry both figures, or there is nothing to judge with.
+    assert.match(stopped.reason, /peak physical footprint \d+ bytes over \d+ sample\(s\) against the 94822600832-byte ceiling/);
+    assert.match(stopped.reason, /no bound was recorded and this cell stays runnable/);
+    assert.equal(context.state.commits.length, 0, "nothing was committed");
+    const { stdout: status } = await checkout.git("status", "--porcelain");
+    assert.equal(status, "", "the tree is clean for the next anchor");
+    // NO BOUND, by every route one could have arrived through.
+    await assert.rejects(
+      stat(path.join(checkout.root, "docs/calibration/sc-stub/z-image-turbo-q4-mlx-exceeded-evidence.json")),
+      "no bound bundle was written",
+    );
+    const store = JSON.parse(await readFile(path.join(checkout.root, ANCHOR_STORE_PATH), "utf8"));
+    assert.deepEqual(store.exceededBounds ?? [], [], "the anchor store carries no bound for this cell");
+    assert.deepEqual(store.anchors ?? [], [], "and no measurement either");
+    // ...which is exactly why the cell is still schedulable: `--list` reads the store, and the
+    // store never heard about this attempt.
+    assert.equal((await readExceededBounds(checkout.root)).size, 0);
+    // The guard's own evidence is KEPT in the work dir for the operator, on the SAME stop path a
+    // footprint stop takes: samples, the hard stop, the escalation and the terminated group.
+    const eventFile = path.join(checkout.workDir, "logs", "z-image-turbo-q4-mlx-watchdog.jsonl");
+    const events = (await readFile(eventFile, "utf8")).trim().split("\n").map(JSON.parse);
+    const hardStop = events.find((event) => event.event === "hard_stop");
+    assert.ok(hardStop, "the guard recorded the stop");
+    assert.equal(hardStop.reason, "runtime_at_or_above_3.0s");
+    assert.equal(runtimeBudgetStopSeconds(await watchdogHardStop(eventFile)), 3, "the runner reads the guard's own spelling");
+    assert.ok(events.some((event) => event.event === "sample"), "the samples behind the reported peak are kept");
+    assert.ok(events.some((event) => event.event === "terminated"), "the group was terminated, not left running");
+    assert.ok((await stat(stopped.log)).size > 0, "the per-anchor log is kept too");
+    const log = await readFile(stopped.log, "utf8");
+    // The plumbing, end to end: minutes on the runner, seconds on the guard.
+    assert.match(log, /memory-calibration-watchdog\.py .*--max-runtime-seconds 3 /);
+  } finally {
+    delete process.env.STUB_CAPTURE_HANGS;
   }
 });
 

--- a/scripts/memory-calibration-harness.mjs
+++ b/scripts/memory-calibration-harness.mjs
@@ -2068,9 +2068,20 @@ export function parseWatchdogHardStop(body) {
   if (!stop) return null;
   const match = /^physical_footprint_at_or_above_(\d+):observed_(\d+)$/.exec(String(stop.reason));
   if (!match) {
+    // sc-22738: the SECOND guard against a false lower bound, behind the runner's own
+    // (`measure-memory-catalog.mjs` returns `capture_failed` for a runtime stop before it ever
+    // calls `record-exceeded`). A wall-clock stop is the case this is now most likely to see: the
+    // probe ran out of its `--max-runtime-seconds` budget wherever its footprint happened to be,
+    // which is not a line it was witnessed to cross. Anything that is not a footprint stop is
+    // refused here for the same reason, whatever put it in the log.
+    const runtime = /^runtime_at_or_above_(\d+(?:\.\d+)?)s$/.exec(String(stop.reason));
     fail(
       `watchdog hard stop ${JSON.stringify(stop.reason)} is not a physical-footprint stop; only a ` +
-        "footprint stop states a lower bound on the render's peak",
+        "footprint stop states a lower bound on the render's peak" +
+        (runtime
+          ? `. This is a WALL-CLOCK stop: the probe reached its ${runtime[1]}s budget, which measures ` +
+            "no memory at all — the capture is a failure, not an exceedance"
+          : ""),
     );
   }
   const ceilingBytes = Number(match[1]);

--- a/scripts/memory-calibration-harness.test.mjs
+++ b/scripts/memory-calibration-harness.test.mjs
@@ -18,7 +18,7 @@ import {
   validatePhysicalMlxAvContentsAgainstRecord,
   validateSourceSessionFiles,
   METAL_REFUSAL_TOLERANCE, METAL_SUBMISSIONS_IGNORED_CODE, METAL_SUBMISSIONS_IGNORED_PHRASE,
-  metalSubmissionsIgnored, parseWatchdogPeak, recordExceededBound,
+  metalSubmissionsIgnored, parseWatchdogPeak, parseWatchdogHardStop, recordExceededBound,
 } from "./memory-calibration-harness.mjs";
 
 /**
@@ -2982,6 +2982,42 @@ test("the bound's footprint is the sampler's PEAK, never its last reading", () =
     () => parseWatchdogPeak(JSON.stringify({ event: "sample", physicalFootprintBytes: 0 })),
     /non-positive physical footprint/,
   );
+});
+
+test("a WALL-CLOCK stop states no bound: `record-exceeded` refuses it, whichever witness it is handed", async () => {
+  // sc-22738: every guarded probe now carries a `--max-runtime-seconds` budget, so this is the
+  // hard stop this parser is most likely to meet that is not a footprint stop. A probe that ran out
+  // of TIME was never witnessed crossing any line — `scail2_14b:bf16:mlx` sat flat at 93.5 GB under
+  // a 94.82 GB ceiling for 90 minutes — and turning the footprint it happened to be sitting at into
+  // an `exceededBounds` entry would make production refuse hosts on an inequality nothing measured.
+  const stream = (reason) => [
+    JSON.stringify({ event: "started", pid: 1 }),
+    JSON.stringify({ event: "sample", phase: "runtime", physicalFootprintBytes: 93_500_000_000 }),
+    JSON.stringify({ event: "hard_stop", reason }),
+    JSON.stringify({ event: "terminated", reason }),
+  ].join("\n");
+  for (const seconds of ["9000.0", "3600", "150.5"]) {
+    assert.throws(
+      () => parseWatchdogHardStop(stream(`runtime_at_or_above_${seconds}s`)),
+      new RegExp(`WALL-CLOCK stop: the probe reached its ${seconds.replace(".", "\\.")}s budget`),
+      seconds,
+    );
+  }
+  // ...and the refusal survives the whole command, INCLUDING the arm that reads a Metal refusal out
+  // of the adapter's stderr: a stop in the log is consulted first, so a wedged probe whose stderr
+  // happened to carry the refusal string cannot be laundered into a bound through the other door.
+  const fixture = await refusalFixture({ events: stream("runtime_at_or_above_9000.0s") });
+  await assert.rejects(recordRefusal({ fixture }), /WALL-CLOCK stop/);
+  // The control: the SAME stream with a footprint stop is exactly what does state a bound.
+  const footprint = parseWatchdogHardStop([
+    JSON.stringify({ event: "sample", phase: "runtime", physicalFootprintBytes: 94_822_600_833 }),
+    JSON.stringify({ event: "hard_stop", reason: "physical_footprint_at_or_above_94822600832:observed_94822600833" }),
+  ].join("\n"));
+  assert.deepEqual(footprint, {
+    reason: "physical_footprint_at_or_above_94822600832:observed_94822600833",
+    ceilingBytes: 94_822_600_832,
+    observedFootprintBytes: 94_822_600_833,
+  });
 });
 
 test("a process-scoped Metal refusal at the wired limit records a bound whose ceiling is its own witnessed peak", async () => {

--- a/scripts/memory-calibration-watchdog.test.mjs
+++ b/scripts/memory-calibration-watchdog.test.mjs
@@ -259,6 +259,38 @@ test("a wall-time ceiling fails closed and removes the owned group", async () =>
   result.pids.forEach(assertGone);
 });
 
+test("a probe stopped by its wall-clock budget takes the ceiling stop's exact path, and says so in the runner's spelling", async () => {
+  // sc-22738: this is the trigger `scripts/measure-memory-catalog.mjs` now arms on every guarded
+  // probe (`--max-runtime-seconds`, from `--probe-budget-minutes`). Two properties are asserted
+  // together because the runner depends on both:
+  //
+  //   1. the SPELLING. The runner classifies the stop by parsing this reason
+  //      (`RUNTIME_BUDGET_STOP_PATTERN`); the two scripts agree on a string and nothing else would
+  //      notice it drifting. Note the FLOAT: argparse types the budget as a float, so a 3-second
+  //      budget spells `runtime_at_or_above_3.0s`, not `_3s`.
+  //   2. the PATH. A runtime stop is not a second kill path bolted on beside the ceiling's: the
+  //      hard stop is emitted, the group takes the same SIGTERM→SIGKILL escalation, the same
+  //      `terminated` event closes the log, and the same 97 leaves the shell. A wedged probe is
+  //      being killed through a live Metal command buffer, and there is exactly one way to do that.
+  const budget = await run("hold", 100, 1, 0.2, "2");
+  const ceilingStop = await run("high", 99, 98);
+  assert.equal(budget.status, 97);
+  assert.equal(budget.status, ceilingStop.status, "both stops leave the same status");
+  const stopped = budget.events.find((event) => event.event === "hard_stop");
+  assert.equal(stopped.reason, "runtime_at_or_above_0.2s");
+  // The runner's own parser, spelled here so a change to either side reds this test.
+  assert.match(`watchdog hard stop: ${stopped.reason}`, /^watchdog hard stop: runtime_at_or_above_(\d+(?:\.\d+)?)s$/);
+  for (const result of [budget, ceilingStop]) {
+    const events = result.events.map((event) => event.event);
+    assert.equal(events.at(-1), "terminated", "the same terminal event closes both logs");
+    assert.equal(
+      events.indexOf("terminated") - events.indexOf("hard_stop"), 1,
+      "the stop is followed immediately by the escalation, on both",
+    );
+    result.pids.forEach(assertGone);
+  }
+});
+
 test("cleanup crossing the deadline cannot relabel an earlier telemetry failure", async () => {
   const files = await fixture();
   const launcher = `${files.program}.predeadline-failure.py`;


### PR DESCRIPTION
## The gap

The footprint guard bounds a probe that **climbs**. It says nothing about one that stops climbing. Observed 2026-09-07: `scail2_14b:bf16:mlx` rendered for 90 minutes with its physical footprint flat at ~93.5 GB against a 94.82 GB ceiling, the host swapping, the adapter's main thread parked in `mlx::core::eval` → Metal `waitUntilSignaledValue`. `memory-calibration-watchdog.py` has supported `--max-runtime-seconds` since it was written, but neither the harness nor the catalog runner ever passed it, so a probe thrashing below the ceiling ran forever.

## What this does

**A per-probe wall-clock budget.** `measure-memory-catalog.mjs` passes `--max-runtime-seconds` to the guard on every capture. `watchdogGuard` takes `budgetMinutes` as a **required** argument — an omitted budget is refused, so no caller can spawn an unbounded probe by omission.

| lane | default | basis |
|---|---|---|
| video | **150 min** | 1.8x the longest run this tree witnesses a guarded probe making real progress in (the 85-minute `bernini:q8:mlx` render steady at 52 GB when a census false positive killed it, named in the watchdog header); ~2.2x the longest `capturedAt`-delta bounding a completed video capture (4,161 s, `ltx_2_3:q4:mlx`; the clean back-to-back `ltx_2_5` pair is 1,132 s / 1,097 s) |
| image | **60 min** | 4.2x the longest `capturedAt`-delta bounding a completed image capture (847 s, `bernini_image:q8:mlx`) |

The lane is **derived from the plan** (`geometry.frames > 1`), not listed, so a new video row cannot inherit an image budget by omission — `bernini` (video) and `bernini_image` (still) get 150 and 60 from one family. `--probe-budget-minutes N` overrides both; `--dry-run` prints the budget per row.

**Note on the basis:** the task asked me to cite `durationSeconds` from `docs/calibration/sc-22738/*.json`. No such field exists — a capture bundle carries `capturedAt` and nothing about how long the render took (verified by grep across all 124 files). The figures above are the next-best in-repo evidence: consecutive `capturedAt` deltas inside one uninterrupted walk (each an upper bound on that anchor's whole capture→commit cycle) and the durations this tree's own comments record from measured incidents. The full derivation is in the `PROBE_BUDGET_MINUTES` doc comment.

**A runtime stop is not a memory exceedance.** It runs on the guard's **one** stop path — same SIGTERM→SIGKILL escalation, same post-stop host discrimination; no second kill path was invented, and a test asserts both stops produce the identical `hard_stop` → `terminated` → exit-97 shape. But the run crossed no line, so it records nothing:

- `capture_failed`, reason `runtime_budget_exceeded`, naming the budget **and** the peak footprint sampled — so a human can tell a probe wedged at the ceiling from one wedged at 3 GB. Both figures reach the `--- key: status (reason)` line and the summary table/JSON.
- **No `exceededBounds` entry.** Recording the footprint the probe happened to be sitting at would state a lower bound the run never established, and production would refuse hosts on it.
- Watchdog stream and per-anchor log stay in the work dir; nothing is committed; the cell classifies `runnable` again on the next `--list`.
- Second guard: the harness's `record-exceeded` (`parseWatchdogHardStop`) refuses a wall-clock stop outright, naming it as such.

Probe-tooling only — no runtime behaviour changes, no new gates.

## Tests

`node --test scripts/measure-memory-catalog.test.mjs scripts/memory-calibration-harness.test.mjs` → **176 tests, 172 pass, 4 skipped (non-Darwin-only), 0 fail**. `scripts/memory-calibration-watchdog.test.mjs` alone → **51/51**.

New coverage:
- watchdog: budget reached → `runtime_at_or_above_0.2s` (the float spelling argparse produces), bound to the runner's parser, and the same terminal event sequence + status as a ceiling stop.
- runner: end-to-end through the real guard with a hanging capture and a 3-second budget → `capture_failed`, reason carries budget + peak + ceiling, no bound bundle, empty `exceededBounds`, empty `anchors`, clean tree, zero commits, samples/`hard_stop`/`terminated` kept, and `--max-runtime-seconds 3` in the log (minutes×60 plumbing).
- runner: the budget table, the plan-derived lane for **every** mlx row, flag parsing and its refusals; `watchdogGuard` refusing a missing/zero/NaN/string budget.
- harness: `record-exceeded` refuses a wall-clock stop through both doors (hard-stop arm and Metal-stderr arm), with a footprint-stop control that still records.

**Mutation.** With the runner's no-bound guard removed (`if (budgetSeconds !== null)` → `if (false)`), the end-to-end test fails:

```
AssertionError: The input did not match /^runtime_budget_exceeded: the 0\.05-minute probe budget \(3s\) elapsed;/
  actual: 'watchdog hard stop: runtime_at_or_above_3.0s; recording it failed:
           Error: stub record-exceeded: runtime_at_or_above_3.0s is not a physical-footprint stop'
```

— which also shows the harness-side guard catching what the runner's guard would have let through.

`npm run check` → 878 tests, 876 pass. The 2 failures are both wall-clock-sensitive watchdog telemetry-window tests (`a good sample re-anchors the window`, `sentinel loss during child startup`) failing from **host contention** — a real MLX capture is running on this Mac at load ~8. **Confirmed pre-existing:** with `scripts/memory-calibration-watchdog.test.mjs` reverted to HEAD, `a good sample re-anchors the window` fails identically on both runs; this PR does not touch `memory-calibration-watchdog.py` at all.

Runbook updated (`docs/calibration-runbook.md`): a paragraph in the outcome section plus the `capture_failed` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
