### PR TITLE
fix(sc-22738): release the catalog processing lease with LOCK_UN, not close(2)

### DIFF
--- a/crates/sceneworks-core/src/catalog_store.rs
+++ b/crates/sceneworks-core/src/catalog_store.rs
@@ -624,7 +624,32 @@ pub struct CatalogFacet {
 /// acquire the same lease before changing registry or disk state.
 #[derive(Debug)]
 pub struct CatalogProcessingLease {
-    _file: File,
+    file: File,
+}
+
+impl Drop for CatalogProcessingLease {
+    /// Releases the advisory lock EXPLICITLY rather than letting `close(2)` do it.
+    ///
+    /// `flock(2)` locks belong to the OPEN FILE DESCRIPTION, not to the descriptor
+    /// or to this process, and `fork(2)` hands a child a reference to that same
+    /// description. Closing our descriptor only drops one reference: while any
+    /// concurrently forked child still holds the inherited one — the window between
+    /// `fork` and `exec` for every `Command` this process spawns (ffmpeg, sips, the
+    /// worker binaries) — the lease keeps reading as HELD to everyone else.
+    ///
+    /// Control routes treat that as "a processor is still running" and refuse
+    /// pause/resume/detach/delete with a 409, so a lease released cleanly by its
+    /// owner could still refuse the very next request (sc-22738: the CI flake in
+    /// `catalog_pause_and_resume_persist_desired_processing_state`, where an
+    /// unrelated concurrent test's child spawn straddled the lease release).
+    ///
+    /// `LOCK_UN` releases the lock on the open file description itself, so it takes
+    /// effect immediately no matter who else references it.
+    fn drop(&mut self) {
+        // Released through the same crate that took the lock, not through std's
+        // inherent `File::unlock`, so acquisition and release cannot drift apart.
+        let _ = fs2::FileExt::unlock(&self.file);
+    }
 }
 
 impl CatalogProcessingLease {
@@ -647,12 +672,21 @@ impl CatalogProcessingLease {
             .open(lock_path)?;
         let contended = fs2::lock_contended_error().raw_os_error();
         match file.try_lock_exclusive() {
-            Ok(()) => Ok(Self { _file: file }),
+            Ok(()) => Ok(Self { file }),
             Err(error) if error.raw_os_error() == contended => Err(CatalogError::Conflict(
                 "Catalog processing is active".to_owned(),
             )),
             Err(error) => Err(CatalogError::Io(error)),
         }
+    }
+
+    /// Reproduces, in-process and deterministically, the descriptor a `fork(2)`
+    /// hands a child: a second file descriptor over the SAME open file
+    /// description, and therefore over the same `flock` lock.
+    #[cfg(test)]
+    fn inherited_descriptor(&self) -> File {
+        use fs2::FileExt as _;
+        self.file.duplicate().expect("descriptor duplicates")
     }
 
     pub fn is_active(catalog: &Catalog) -> CatalogResult<bool> {
@@ -6439,6 +6473,44 @@ mod tests {
             .delete_on_disk(&id)
             .expect("reconciled catalog deletes safely");
         assert!(!detached.path.exists());
+    }
+
+    /// A released lease must be free IMMEDIATELY, even while a descriptor this
+    /// process handed to a child still references the same open file description.
+    ///
+    /// `flock(2)` locks live on the open file description, and `fork(2)` gives the
+    /// child a reference to it, so releasing by `close(2)` alone only takes effect
+    /// once every such reference is gone. `duplicate` reproduces exactly that
+    /// sharing without a child process, so the interleaving is injected rather than
+    /// waited for. Before sc-22738 this asserted `Err(Conflict)`: a pause/resume
+    /// issued while any unrelated `Command` sat between `fork` and `exec` was
+    /// refused with `catalog_processing_conflict` even though the processor had
+    /// stopped.
+    #[test]
+    fn a_released_lease_is_free_even_while_an_inherited_descriptor_survives() {
+        let temporary = tempdir().expect("temp directory");
+        let registry = CatalogRegistry::new(temporary.path().join("state"));
+        let catalog = registry
+            .create_catalog(temporary.path().join("catalog"), "Inherited descriptor")
+            .unwrap();
+
+        let lease = CatalogProcessingLease::try_acquire(&catalog).unwrap();
+        let inherited = lease.inherited_descriptor();
+        drop(lease);
+
+        let reacquired = CatalogProcessingLease::try_acquire(&catalog);
+        assert!(
+            reacquired.is_ok(),
+            "a lease released by its owner must not stay held by an inherited \
+             descriptor: {:?}",
+            reacquired.err()
+        );
+        drop(reacquired);
+        assert!(
+            !CatalogProcessingLease::is_active(&catalog).unwrap(),
+            "an inherited descriptor must not make the catalog read as actively processing"
+        );
+        drop(inherited);
     }
 
     #[test]


### PR DESCRIPTION
## The flake

The hosted-macOS workspace suite intermittently reds on
`tests::dataset_catalogs::catalog_pause_and_resume_persist_desired_processing_state`
at the **resume** assertion, with a 409 `catalog_processing_conflict`. The test is a
correct client: it simulates a running processor by holding a `CatalogProcessingLease`,
pauses, **drops** the lease, publishes `paused` progress, and resumes.

## Which of the three 409s it was

`request_processing_state` can answer 409 from exactly three places, and two are ruled out
by state the test has already read back:

1. **control CAS** (`current.revision != expected`) — the pause response read revision `1`
   back out of the database and nothing else writes the control row, so the resume's
   `expectedRevision: 1` matches;
2. **transition guard** — `current.desired_state` is `Paused` and the test wrote
   `actual.state = Paused`; the only other writer, `reconcile_interrupted`, can only turn
   `Running` into `Failed`, which is also a legal resume source;
3. **lease probe** — `require_active_processor` is false for resume, so a contended
   `try_acquire` answers *"Catalog processor has not stopped yet"*.

It was (3): at the instant of the resume, the lease the test had already released still
read as **held**.

## Why a released lease can still read as held

`flock(2)` locks belong to the **open file description**, not to the descriptor and not to
the process. `fork(2)` gives the child a reference to that same description, so `close(2)`
in the owner only drops one reference — the lock survives until every reference is gone.
Rust opens with `O_CLOEXEC`, so the child sheds it at `exec`, but **between `fork` and
`exec` it holds the lease**, and on a loaded 3-core runner that window is long enough to
straddle an unrelated caller's release. The rust-api test binary forks constantly
(`tests::server` spawns `sleep`, media conversion spawns `sips`/`ffmpeg`), and so does the
product (worker binaries, ffmpeg).

`CatalogProcessingLease` released by dropping its `File` — close only — so any concurrent
spawn anywhere in the process could keep a cleanly-released lease looking active, and every
control route reads that as "a processor is still running": **pause, resume, detach and
delete all refuse with 409**.

## Measured, not guessed

- Instrumenting the lease and sampling `try_acquire` for 200 ms immediately after the test
  releases it showed **real contention with no in-process lease holder in 3 of ~14
  instrumented full-suite runs**, and **none at all in ~950 runs of the catalog module and
  its neighbours alone** — i.e. only where other tests fork.
- `flock` itself was cleared as a suspect: **2,000,000** open/flock/close iterations under
  load produced **zero** spurious `EWOULDBLOCK`.
- A standalone C reproducer showed `close`-only release answering `EWOULDBLOCK` while a
  forked child held the inherited descriptor, and `LOCK_UN` answering OK on the same
  interleaving.

## The fix

`Drop for CatalogProcessingLease` now calls `LOCK_UN` explicitly. `LOCK_UN` releases the
lock on the open file description itself, so it takes effect the moment the owner is done,
no matter who else still references that description.

The regression test **injects** the interleaving instead of waiting for it: `duplicate`
gives a second descriptor over the same open file description — exactly what `fork` hands a
child — the lease is dropped, and the lock must be free. No sleeps, no timing.

**Mutation:** reverting the `LOCK_UN` call fails the new test with
`Conflict("Catalog processing is active")` — the same error the CI run surfaced as
`catalog_processing_conflict`.

## Verification

- new test `a_released_lease_is_free_even_while_an_inherited_descriptor_survives` green;
  fails on mutation
- `catalog_pause_and_resume_persist_desired_processing_state` 20/20 green in a loop
- `cargo test -p sceneworks-rust-api --lib` green at default `--test-threads` (736 passed)
- `cargo fmt --all -- --check` clean; `cargo clippy -p sceneworks-core --all-targets` clean
- `npm run rust:check` exit 0

## Not changed here

`resolved_cache`, `external_library` and `checkpoint_plan_store` release their `fs2` locks
the same close-only way. They are blocking (`lock_exclusive`) or retrying call sites, where
an inherited descriptor costs a delay rather than a user-visible refusal, and none is on the
path that reds this lane — so they stay out of this diff rather than being swept into it
silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)