### PR TITLE
fix(sc-22738): every fs2 lock holder releases with LOCK_UN, not close

### DIFF
--- a/apps/rust-api/src/manifest.rs
+++ b/apps/rust-api/src/manifest.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use fs2::FileExt as _;
+use sceneworks_core::file_lock::FileLock;
 
 const MANIFEST_CACHE_LIMIT: usize = 16;
 /// Max time to block on the cross-process manifest lock before erroring. Mirrors the
@@ -11,10 +11,12 @@ const MANIFEST_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 const MANIFEST_LOCK_POLL: std::time::Duration = std::time::Duration::from_millis(25);
 
 /// RAII holder for the cross-process advisory exclusive lock on a `<manifest>.lock`
-/// sibling. Released when the file handle drops. Acquired on a blocking thread since
-/// flock is synchronous (see [`acquire_manifest_file_lock`]).
+/// sibling. Released with an explicit `LOCK_UN`, not by `close(2)` alone, which leaves the
+/// lock held while any forked child still references the same open file description
+/// (sc-22738). Acquired on a blocking thread since flock is synchronous (see
+/// [`acquire_manifest_file_lock`]).
 pub(crate) struct ManifestFileLock {
-    _file: std::fs::File,
+    _lock: FileLock,
 }
 
 fn manifest_lock_path(manifest_path: &FsPath) -> PathBuf {
@@ -40,7 +42,7 @@ pub(crate) async fn acquire_manifest_file_lock(
     }
     let lock_path = manifest_lock_path(path);
     tokio::task::spawn_blocking(move || {
-        let file = std::fs::OpenOptions::new()
+        let mut file = std::fs::OpenOptions::new()
             .create(true)
             .read(true)
             .write(true)
@@ -61,9 +63,10 @@ pub(crate) async fn acquire_manifest_file_lock(
         // which is correct on every platform.
         let contended = fs2::lock_contended_error().raw_os_error();
         loop {
-            match file.try_lock_exclusive() {
-                Ok(()) => return Ok(ManifestFileLock { _file: file }),
-                Err(error) if error.raw_os_error() == contended => {
+            match FileLock::try_exclusive_retryable(file) {
+                Ok(lock) => return Ok(ManifestFileLock { _lock: lock }),
+                Err((handle, error)) if error.raw_os_error() == contended => {
+                    file = handle;
                     if std::time::Instant::now() >= deadline {
                         return Err(ApiError::internal(format!(
                             "Timed out after {MANIFEST_LOCK_TIMEOUT:?} waiting for manifest lock {}",
@@ -72,7 +75,7 @@ pub(crate) async fn acquire_manifest_file_lock(
                     }
                     std::thread::sleep(MANIFEST_LOCK_POLL);
                 }
-                Err(error) => {
+                Err((_handle, error)) => {
                     return Err(ApiError::internal(format!(
                         "Failed to acquire manifest lock {}: {error}",
                         lock_path.display()
@@ -359,3 +362,44 @@ pub(crate) fn merge_object(base: &mut Value, override_value: Value) {
 // Re-exported `pub(crate)` so the crate-root `use manifest::*` keeps it available
 // to the rest of the api (and tests) under the same path as before.
 pub(crate) use sceneworks_core::jsonc::strip_jsonc_comments;
+
+#[cfg(test)]
+mod file_lock_tests {
+    use super::*;
+    use fs2::FileExt as _;
+
+    /// sc-22738: a released manifest lock must be free IMMEDIATELY, even while a descriptor this
+    /// process handed to a child still references the same open file description. `flock(2)` locks
+    /// live on the open file description, and `fork(2)` gives the child a reference to it, so a
+    /// close-only release only takes effect once every such reference is gone — and this process
+    /// forks constantly (media conversion spawns `sips`/`ffmpeg`, the worker binaries). The
+    /// assertion uses the non-blocking primitive so a regression is an assertion rather than a
+    /// 30-second spin-wait.
+    #[tokio::test]
+    async fn a_released_manifest_lock_is_free_even_while_an_inherited_descriptor_survives() {
+        let directory = tempfile::tempdir().expect("temp directory");
+        let manifest = directory.path().join("user.loras.jsonc");
+
+        let held = acquire_manifest_file_lock(&manifest)
+            .await
+            .expect("manifest lock acquires");
+        let inherited = held
+            ._lock
+            .inherited_descriptor()
+            .expect("descriptor duplicates");
+        drop(held);
+
+        let probe = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(manifest_lock_path(&manifest))
+            .expect("probe opens lock file");
+        assert!(
+            probe.try_lock_exclusive().is_ok(),
+            "a manifest lock released by its owner must not stay held by an inherited descriptor"
+        );
+        drop(inherited);
+    }
+}

--- a/crates/sceneworks-core/src/checkpoint_plan_store.rs
+++ b/crates/sceneworks-core/src/checkpoint_plan_store.rs
@@ -37,6 +37,7 @@ use crate::checkpoint_inspector::{
     discover_library_root, inspect_checkpoint, CheckpointCandidateV1, CheckpointDiagnosticCodeV1,
     CheckpointDiagnosticSeverityV1, CheckpointDiagnosticV1, CheckpointInspectionRequestV1,
 };
+use crate::file_lock::FileLock;
 
 /// Directory under the application data dir that holds every file this store owns.
 pub const CHECKPOINTS_DIR: &str = "checkpoints";
@@ -1309,14 +1310,16 @@ impl CheckpointPlanStore {
 
     /// Take the store's exclusive cross-process lock for one read-modify-write.
     ///
-    /// The returned handle IS the lock: dropping the file releases it.
+    /// The returned handle IS the lock: dropping it releases the lock with `LOCK_UN` (see
+    /// [`FileLock`] — a close-only release stays visibly held while any forked child still
+    /// references the same open file description).
     ///
     /// The lock is NOT reentrant — `fs2` locks an open file description, so a second acquisition on
     /// a fresh descriptor blocks even inside one process. Every mutator therefore takes it exactly
     /// once and never calls another locking mutator underneath it: `remove_root` does its own
     /// inventory rewrite rather than calling `invalidate` in a loop, which is also what collapses
     /// its N document writes into one.
-    fn lock_store(&self) -> Result<fs::File, CheckpointPlanError> {
+    fn lock_store(&self) -> Result<FileLock, CheckpointPlanError> {
         fs::create_dir_all(&self.root).map_err(|error| io_error(&self.root, error))?;
         let path = self.store_lock_path();
         // A lock file that is a symlink would let a planted link move the lock (and the writes it
@@ -1336,8 +1339,7 @@ impl CheckpointPlanStore {
             .truncate(false)
             .open(&path)
             .map_err(|error| io_error(&path, error))?;
-        fs2::FileExt::lock_exclusive(&file).map_err(|error| io_error(&path, error))?;
-        Ok(file)
+        FileLock::exclusive(file).map_err(|error| io_error(&path, error))
     }
 
     fn write_atomic(&self, path: &Path, payload: &[u8]) -> Result<(), CheckpointPlanError> {
@@ -2313,5 +2315,38 @@ impl CheckpointPlanStore {
             plan,
             layers,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A released store lock must be free IMMEDIATELY, even while a descriptor this process handed
+    /// to a child still references the same open file description. `flock(2)` locks live on the
+    /// open file description, so a close-only release only takes effect once every such reference
+    /// is gone; `inherited_descriptor` reproduces that sharing without a child process, so the
+    /// interleaving is injected rather than waited for. Before sc-22738 the next mutator blocked
+    /// behind an already-released lock for as long as an unrelated `Command` sat between `fork`
+    /// and `exec`.
+    #[test]
+    fn a_released_store_lock_is_free_even_while_an_inherited_descriptor_survives() {
+        let temporary = tempfile::tempdir().expect("temp directory");
+        let store = CheckpointPlanStore::open(temporary.path());
+
+        let guard = store.lock_store().expect("store lock acquires");
+        let inherited = guard.inherited_descriptor().expect("descriptor duplicates");
+        drop(guard);
+
+        let lock_file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(store.store_lock_path())
+            .expect("store lock file opens");
+        assert!(
+            FileLock::try_exclusive(lock_file).is_ok(),
+            "a store lock released by its owner must not stay held by an inherited descriptor"
+        );
+        drop(inherited);
     }
 }

--- a/crates/sceneworks-core/src/file_lock.rs
+++ b/crates/sceneworks-core/src/file_lock.rs
@@ -1,0 +1,151 @@
+//! The guard every `fs2` advisory lock holder in this workspace releases through, so no holder
+//! releases by `close(2)` alone.
+//!
+//! (`catalog_store::CatalogProcessingLease` keeps its own equivalent `Drop`, written first when
+//! sc-22738 was diagnosed there; it holds the same `LOCK_UN` invariant and its own regression
+//! test.)
+//!
+//! `flock(2)` locks belong to the OPEN FILE DESCRIPTION, not to the descriptor and not to the
+//! process. `fork(2)` hands a child a reference to that same description, so closing the owner's
+//! descriptor only drops ONE reference: while any concurrently forked child still holds the
+//! inherited one — the window between `fork` and `exec` for every `Command` the process spawns
+//! (ffmpeg, sips, the worker binaries) — the lock keeps reading as HELD to everyone else. Rust
+//! opens with `O_CLOEXEC`, so the child sheds it at `exec`, but on a loaded runner that window is
+//! long enough to straddle an unrelated caller's release.
+//!
+//! sc-22738 measured that on the catalog processing lease, where it surfaced as a user-visible 409
+//! (`catalog_processing_conflict`) from a lease its owner had already dropped. Every other holder
+//! in the workspace released the same close-only way; on blocking or retrying call sites the cost
+//! is a delay rather than a refusal, but it is the same defect.
+//!
+//! [`FileLock`] releases with `LOCK_UN`, which acts on the open file description itself and so
+//! takes effect the moment the owner is done, no matter who else still references it.
+
+use std::fs::File;
+use std::io;
+
+use fs2::FileExt;
+
+/// An acquired `fs2` advisory lock. Dropping it releases the lock explicitly.
+#[derive(Debug)]
+pub struct FileLock {
+    file: File,
+}
+
+impl FileLock {
+    /// Block until the exclusive lock is held.
+    pub fn exclusive(file: File) -> io::Result<Self> {
+        FileExt::lock_exclusive(&file)?;
+        Ok(Self { file })
+    }
+
+    /// Block until the shared lock is held.
+    pub fn shared(file: File) -> io::Result<Self> {
+        FileExt::lock_shared(&file)?;
+        Ok(Self { file })
+    }
+
+    /// Take the exclusive lock or fail; contention is reported as [`fs2::lock_contended_error`].
+    pub fn try_exclusive(file: File) -> io::Result<Self> {
+        FileExt::try_lock_exclusive(&file)?;
+        Ok(Self { file })
+    }
+
+    /// Retry-loop variant of [`Self::try_exclusive`]: hands the handle back on failure so a
+    /// spin-waiting caller (`fs2` has no timed blocking-lock API) can attempt again without
+    /// reopening the lock file.
+    #[allow(clippy::result_large_err)]
+    pub fn try_exclusive_retryable(file: File) -> Result<Self, (File, io::Error)> {
+        match FileExt::try_lock_exclusive(&file) {
+            Ok(()) => Ok(Self { file }),
+            Err(error) => Err((file, error)),
+        }
+    }
+
+    /// Retry-loop variant of [`Self::try_shared`]; see [`Self::try_exclusive_retryable`].
+    #[allow(clippy::result_large_err)]
+    pub fn try_shared_retryable(file: File) -> Result<Self, (File, io::Error)> {
+        match FileExt::try_lock_shared(&file) {
+            Ok(()) => Ok(Self { file }),
+            Err(error) => Err((file, error)),
+        }
+    }
+
+    /// Take the shared lock or fail; contention is reported as [`fs2::lock_contended_error`].
+    pub fn try_shared(file: File) -> io::Result<Self> {
+        FileExt::try_lock_shared(&file)?;
+        Ok(Self { file })
+    }
+
+    /// The locked handle, for holders that also read or write the lock file.
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
+    /// A second descriptor over the SAME open file description — exactly what `fork(2)` hands a
+    /// child, and therefore over the same `flock` lock. Lets a test inject the interleaving that
+    /// makes a close-only release visible, instead of waiting for a real spawn to straddle it.
+    pub fn inherited_descriptor(&self) -> io::Result<File> {
+        self.file.duplicate()
+    }
+}
+
+impl Drop for FileLock {
+    /// Releases the lock EXPLICITLY rather than letting `close(2)` do it. See the module docs:
+    /// `close(2)` only drops one reference to the open file description that owns the lock.
+    fn drop(&mut self) {
+        // Released through the same crate that took the lock, not through std's inherent
+        // `File::unlock`, so acquisition and release cannot drift apart.
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lock_file(path: &std::path::Path) -> File {
+        std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(path)
+            .expect("lock file opens")
+    }
+
+    /// A released lock must be free IMMEDIATELY, even while a descriptor this process handed to a
+    /// child still references the same open file description. Removing the `LOCK_UN` in
+    /// [`FileLock::drop`] fails this: the inherited descriptor keeps the lock held.
+    #[test]
+    fn a_released_lock_is_free_even_while_an_inherited_descriptor_survives() {
+        let directory = tempfile::tempdir().expect("temp directory");
+        let path = directory.path().join("guard.lock");
+
+        let guard = FileLock::try_exclusive(lock_file(&path)).expect("lock acquires");
+        let inherited = guard.inherited_descriptor().expect("descriptor duplicates");
+        drop(guard);
+
+        let reacquired = FileLock::try_exclusive(lock_file(&path));
+        assert!(
+            reacquired.is_ok(),
+            "a lock released by its owner must not stay held by an inherited descriptor: {:?}",
+            reacquired.err()
+        );
+        drop(inherited);
+    }
+
+    /// The guard is still a real lock: a second acquisition is refused while it is alive.
+    #[test]
+    fn a_held_lock_still_refuses_a_second_acquisition() {
+        let directory = tempfile::tempdir().expect("temp directory");
+        let path = directory.path().join("guard.lock");
+
+        let held = FileLock::try_exclusive(lock_file(&path)).expect("lock acquires");
+        assert!(
+            FileLock::try_exclusive(lock_file(&path)).is_err(),
+            "a held exclusive lock must refuse a second acquisition"
+        );
+        drop(held);
+    }
+}

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod credentials;
 pub mod dataset_quality;
 pub mod decoder_support;
 pub mod external_roots;
+pub mod file_lock;
 pub mod hf_home;
 pub mod hf_repo_renames;
 pub mod ideogram_caption;

--- a/crates/sceneworks-core/src/model_artifacts/external_library.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library.rs
@@ -6,9 +6,9 @@
 //! but workers always re-probe its exact path and physical identity before constructing a loader.
 
 use super::{ArtifactLocation, ResolvedModelArtifact};
+use crate::file_lock::FileLock;
 use crate::hf_home::safe_repo_dir_name;
 use crate::store_util::{atomic_write, random_hex};
-use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use std::fs::{File, OpenOptions};
 use std::path::{Component, Path, PathBuf};
@@ -704,16 +704,15 @@ impl ExternalLibraryBindingStore {
             .map_err(|error| ExternalLibraryError(error.to_string()))
     }
 
-    fn lock_shared(&self) -> Result<File, ExternalLibraryError> {
-        let file = self.open_lock()?;
-        FileExt::lock_shared(&file)?;
-        Ok(file)
+    /// The returned guard IS the lock: dropping it releases with `LOCK_UN` rather than by
+    /// `close(2)` alone, which would keep reading as held while any forked child still references
+    /// the same open file description (see [`FileLock`]).
+    fn lock_shared(&self) -> Result<FileLock, ExternalLibraryError> {
+        Ok(FileLock::shared(self.open_lock()?)?)
     }
 
-    fn lock_exclusive(&self) -> Result<File, ExternalLibraryError> {
-        let file = self.open_lock()?;
-        FileExt::lock_exclusive(&file)?;
-        Ok(file)
+    fn lock_exclusive(&self) -> Result<FileLock, ExternalLibraryError> {
+        Ok(FileLock::exclusive(self.open_lock()?)?)
     }
 
     fn open_lock(&self) -> Result<File, ExternalLibraryError> {

--- a/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/external_library_tests.rs
@@ -8,6 +8,30 @@ use tempfile::TempDir;
 
 const REVISION: &str = "0123456789abcdef0123456789abcdef01234567";
 
+/// A released ledger lock must be free IMMEDIATELY, even while a descriptor this process handed to
+/// a child still references the same open file description. `flock(2)` locks live on the open file
+/// description, and `fork(2)` gives the child a reference to it, so releasing by `close(2)` alone
+/// only takes effect once every such reference is gone. `inherited_descriptor` reproduces that
+/// sharing without a child process, so the interleaving is injected rather than waited for. Before
+/// sc-22738 the next ledger read or write blocked behind an already-released lock for as long as
+/// an unrelated `Command` sat between `fork` and `exec`.
+#[test]
+fn a_released_ledger_lock_is_free_even_while_an_inherited_descriptor_survives() {
+    let temp = TempDir::new().unwrap();
+    let store = ExternalLibraryBindingStore::new(&temp.path().join("data")).unwrap();
+
+    let guard = store.lock_exclusive().unwrap();
+    let inherited = guard.inherited_descriptor().expect("descriptor duplicates");
+    drop(guard);
+
+    let probe = crate::file_lock::FileLock::try_exclusive(store.open_lock().unwrap());
+    assert!(
+        probe.is_ok(),
+        "a ledger lock released by its owner must not stay held by an inherited descriptor"
+    );
+    drop(inherited);
+}
+
 #[cfg(target_os = "macos")]
 #[test]
 fn macos_volume_uuid_parser_is_exact_and_fail_closed() {

--- a/crates/sceneworks-core/src/resolved_cache.rs
+++ b/crates/sceneworks-core/src/resolved_cache.rs
@@ -19,13 +19,13 @@ pub use retention::{
     RetentionHold, RetentionReport, SourceLifecycleSelector,
 };
 
+use crate::file_lock::FileLock;
 use crate::model_artifacts::{
     ActiveArtifactLease, ArtifactAvailability, ArtifactCompleteness, ArtifactIdentity,
     ArtifactLocation, ArtifactProvenance, ClosureFileStat, ModelArtifactResolver,
     PromotionCandidate, ResolvedBundleClosure, ResolvedBundleMember, ResolvedModelArtifact,
     MODEL_ARTIFACT_CONTRACT_VERSION,
 };
-use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeSet;
@@ -583,7 +583,7 @@ struct StoreInner {
     session_id: String,
     /// `None` only for the read-only inspection handle created by
     /// [`ResolvedCacheStore::enumerate_existing`]; every runtime session holds its lock.
-    _session_lock: Option<File>,
+    _session_lock: Option<FileLock>,
 }
 
 impl std::fmt::Debug for ResolvedCacheStore {
@@ -613,10 +613,10 @@ impl ResolvedCacheStore {
         })?;
         let session_id = random_id()?;
         let session_lock_path = root.join("sessions").join(format!("{session_id}.lock"));
-        let session_lock = open_lock_file(&session_lock_path)?;
-        FileExt::try_lock_exclusive(&session_lock).map_err(|error| {
-            ResolvedCacheError::new(format!("lock cache session {session_id}: {error}"))
-        })?;
+        let session_lock =
+            FileLock::try_exclusive(open_lock_file(&session_lock_path)?).map_err(|error| {
+                ResolvedCacheError::new(format!("lock cache session {session_id}: {error}"))
+            })?;
         std::fs::create_dir(root.join("sessions").join(&session_id)).map_err(|error| {
             ResolvedCacheError::new(format!("create cache session records: {error}"))
         })?;
@@ -1017,14 +1017,14 @@ impl ResolvedCacheStore {
             return Err(ResolvedCacheError::new("source root is not a directory"));
         }
         let digest = cache_key_digest(cache_key)?;
-        let artifact_lock = open_lock_file(&self.artifact_lock_path(&digest))?;
-        match FileExt::try_lock_exclusive(&artifact_lock) {
-            Ok(()) => {}
-            Err(error) if is_lock_contended(&error) => {
-                return Ok(ReservationOutcome::Contended);
-            }
-            Err(error) => return Err(error.into()),
-        }
+        let artifact_lock =
+            match FileLock::try_exclusive(open_lock_file(&self.artifact_lock_path(&digest))?) {
+                Ok(lock) => lock,
+                Err(error) if is_lock_contended(&error) => {
+                    return Ok(ReservationOutcome::Contended);
+                }
+                Err(error) => return Err(error.into()),
+            };
         let entry = self.entry_path(cache_key)?;
         ensure_managed_entry_dir(&entry)?;
         let _metadata_lock = self.lock_metadata(&digest)?;
@@ -1309,8 +1309,7 @@ impl ResolvedCacheStore {
     ) -> Result<Option<ResolvedCacheLease>, ResolvedCacheError> {
         let logical_model_owner = validate_model_owner(logical_model_owner)?.to_owned();
         let digest = cache_key_digest(cache_key)?;
-        let artifact_lock = open_lock_file(&self.artifact_lock_path(&digest))?;
-        FileExt::lock_shared(&artifact_lock)?;
+        let artifact_lock = FileLock::shared(open_lock_file(&self.artifact_lock_path(&digest))?)?;
         let metadata_lock = self.lock_metadata(&digest)?;
         let mut metadata = match self.read_metadata_unlocked(&digest)? {
             JournalRead::Valid { metadata, .. }
@@ -1367,12 +1366,12 @@ impl ResolvedCacheStore {
         let summaries = self.enumerate()?;
         for summary in &summaries {
             let digest = cache_key_digest(&summary.cache_key)?;
-            let artifact_lock = open_lock_file(&self.artifact_lock_path(&digest))?;
-            match FileExt::try_lock_exclusive(&artifact_lock) {
-                Ok(()) => {}
-                Err(error) if is_lock_contended(&error) => continue,
-                Err(error) => return Err(error.into()),
-            }
+            let _artifact_lock =
+                match FileLock::try_exclusive(open_lock_file(&self.artifact_lock_path(&digest))?) {
+                    Ok(lock) => lock,
+                    Err(error) if is_lock_contended(&error) => continue,
+                    Err(error) => return Err(error.into()),
+                };
             let _metadata_lock = self.lock_metadata(&digest)?;
             match self.read_metadata_unlocked(&digest) {
                 Ok(JournalRead::Valid {
@@ -1510,12 +1509,12 @@ impl ResolvedCacheStore {
             if !metadata.is_dir() || metadata.is_symlink() {
                 continue;
             }
-            let artifact_lock = open_lock_file(&self.artifact_lock_path(digest))?;
-            match FileExt::try_lock_exclusive(&artifact_lock) {
-                Ok(()) => {}
-                Err(error) if is_lock_contended(&error) => continue,
-                Err(error) => return Err(error.into()),
-            }
+            let _artifact_lock =
+                match FileLock::try_exclusive(open_lock_file(&self.artifact_lock_path(digest))?) {
+                    Ok(lock) => lock,
+                    Err(error) if is_lock_contended(&error) => continue,
+                    Err(error) => return Err(error.into()),
+                };
             let _metadata_lock = self.lock_metadata(digest)?;
             let live = match self.read_metadata_unlocked(digest) {
                 Ok(JournalRead::Valid { metadata, .. })
@@ -1566,10 +1565,13 @@ impl ResolvedCacheStore {
             .join(format!("{digest}.metadata.lock"))
     }
 
-    fn lock_metadata(&self, digest: &str) -> Result<File, ResolvedCacheError> {
-        let file = open_lock_file(&self.metadata_lock_path(digest))?;
-        FileExt::lock_exclusive(&file)?;
-        Ok(file)
+    /// The returned guard IS the lock: dropping it releases with `LOCK_UN` rather than by
+    /// `close(2)` alone, which would keep reading as held while any forked child still references
+    /// the same open file description (see [`FileLock`]).
+    fn lock_metadata(&self, digest: &str) -> Result<FileLock, ResolvedCacheError> {
+        Ok(FileLock::exclusive(open_lock_file(
+            &self.metadata_lock_path(digest),
+        )?)?)
     }
 
     fn read_metadata_locked(
@@ -1929,9 +1931,8 @@ impl ResolvedCacheStore {
             .root
             .join("sessions")
             .join(format!("{session}.lock"));
-        let file = open_lock_file(&path)?;
-        match FileExt::try_lock_exclusive(&file) {
-            Ok(()) => Ok(true),
+        match FileLock::try_exclusive(open_lock_file(&path)?) {
+            Ok(_probe) => Ok(true),
             Err(error) if is_lock_contended(&error) => Ok(false),
             Err(error) => Err(error.into()),
         }
@@ -1948,14 +1949,15 @@ impl ResolvedCacheStore {
             if !is_valid_session_id(session) || session == self.inner.session_id {
                 continue;
             }
-            let file = open_lock_file(&item.path())?;
-            match FileExt::try_lock_exclusive(&file) {
-                Ok(()) => {
+            match FileLock::try_exclusive(open_lock_file(&item.path())?) {
+                Ok(lock) => {
                     let records = sessions.join(session);
                     if records.is_dir() {
                         std::fs::remove_dir_all(records)?;
                     }
-                    drop(file);
+                    // Windows will not remove a file with an open handle, and the lock must be
+                    // released before the lock FILE itself is unlinked.
+                    drop(lock);
                     let _ = std::fs::remove_file(item.path());
                 }
                 Err(error) if is_lock_contended(&error) => {}
@@ -1975,7 +1977,7 @@ pub struct ResolvedCacheReservation {
     session_id: String,
     staging_path: PathBuf,
     record_path: PathBuf,
-    artifact_lock: Option<File>,
+    artifact_lock: Option<FileLock>,
     finished: bool,
 }
 
@@ -2244,7 +2246,7 @@ impl ResolvedCacheReservation {
 pub struct ResolvedCacheLease {
     runtime_lease: Option<ActiveArtifactLease>,
     #[allow(dead_code)]
-    artifact_lock: File,
+    artifact_lock: FileLock,
     record_path: PathBuf,
 }
 

--- a/crates/sceneworks-core/src/resolved_cache/retention.rs
+++ b/crates/sceneworks-core/src/resolved_cache/retention.rs
@@ -439,16 +439,16 @@ impl ResolvedCacheStore {
         now: u64,
     ) -> Result<ManualRemovalOutcome, ResolvedCacheError> {
         let digest = cache_key_digest(cache_key)?;
-        let artifact_lock = open_lock_file(&self.artifact_lock_path(&digest))?;
-        match FileExt::try_lock_exclusive(&artifact_lock) {
-            Ok(()) => {}
-            Err(error) if is_lock_contended(&error) => {
-                return Err(ResolvedCacheError::request(
-                    "cannot remove a resolved-cache entry with an active lease or reservation",
-                ));
-            }
-            Err(error) => return Err(error.into()),
-        }
+        let _artifact_lock =
+            match FileLock::try_exclusive(open_lock_file(&self.artifact_lock_path(&digest))?) {
+                Ok(lock) => lock,
+                Err(error) if is_lock_contended(&error) => {
+                    return Err(ResolvedCacheError::request(
+                        "cannot remove a resolved-cache entry with an active lease or reservation",
+                    ));
+                }
+                Err(error) => return Err(error.into()),
+            };
         let _metadata_lock = self.lock_metadata(&digest)?;
         let entry = self.inner.root.join("entries").join(&digest);
         if std::fs::symlink_metadata(&entry).is_err() {
@@ -555,20 +555,20 @@ impl ResolvedCacheStore {
                 continue;
             }
             let entry = self.inner.root.join("entries").join(&digest);
-            let artifact_lock = open_lock_file(&self.artifact_lock_path(&digest))?;
-            match FileExt::try_lock_exclusive(&artifact_lock) {
-                Ok(()) => {}
-                Err(error) if is_lock_contended(&error) => {
-                    report.deferred.push(RetainedRecord {
-                        cache_key: metadata.cache_key.clone(),
-                        bytes: entry_bytes(&entry, &metadata),
-                        hold: RetentionHold::ActiveUse,
-                        detail: None,
-                    });
-                    continue;
-                }
-                Err(error) => return Err(error.into()),
-            }
+            let _artifact_lock =
+                match FileLock::try_exclusive(open_lock_file(&self.artifact_lock_path(&digest))?) {
+                    Ok(lock) => lock,
+                    Err(error) if is_lock_contended(&error) => {
+                        report.deferred.push(RetainedRecord {
+                            cache_key: metadata.cache_key.clone(),
+                            bytes: entry_bytes(&entry, &metadata),
+                            hold: RetentionHold::ActiveUse,
+                            detail: None,
+                        });
+                        continue;
+                    }
+                    Err(error) => return Err(error.into()),
+                };
             let _metadata_lock = self.lock_metadata(&digest)?;
             let metadata = match self.read_metadata_unlocked(&digest) {
                 Ok(JournalRead::Valid { metadata, .. })
@@ -848,14 +848,14 @@ impl ResolvedCacheStore {
         };
 
         // Phase two: exclusive artifact lock, then re-verify everything cheaply.
-        let artifact_lock = open_lock_file(&self.artifact_lock_path(&digest))?;
-        match FileExt::try_lock_exclusive(&artifact_lock) {
-            Ok(()) => {}
-            Err(error) if is_lock_contended(&error) => {
-                return retained(RetentionHold::ActiveUse, None);
-            }
-            Err(error) => return Err(error.into()),
-        }
+        let _artifact_lock =
+            match FileLock::try_exclusive(open_lock_file(&self.artifact_lock_path(&digest))?) {
+                Ok(lock) => lock,
+                Err(error) if is_lock_contended(&error) => {
+                    return retained(RetentionHold::ActiveUse, None);
+                }
+                Err(error) => return Err(error.into()),
+            };
         let _metadata_lock = self.lock_metadata(&digest)?;
         let entry = self.inner.root.join("entries").join(&digest);
         let metadata = match self.read_metadata_unlocked(&digest) {
@@ -966,12 +966,12 @@ impl ResolvedCacheStore {
         &self,
         digest: &str,
     ) -> Result<Option<EvictionMarker>, ResolvedCacheError> {
-        let artifact_lock = open_lock_file(&self.artifact_lock_path(digest))?;
-        match FileExt::try_lock_exclusive(&artifact_lock) {
-            Ok(()) => {}
-            Err(error) if is_lock_contended(&error) => return Ok(None),
-            Err(error) => return Err(error.into()),
-        }
+        let _artifact_lock =
+            match FileLock::try_exclusive(open_lock_file(&self.artifact_lock_path(digest))?) {
+                Ok(lock) => lock,
+                Err(error) if is_lock_contended(&error) => return Ok(None),
+                Err(error) => return Err(error.into()),
+            };
         let _metadata_lock = self.lock_metadata(digest)?;
         match self.read_metadata_unlocked(digest)? {
             JournalRead::Evicted { .. } => Ok(Some(self.finish_pending_eviction(digest)?)),
@@ -980,9 +980,8 @@ impl ResolvedCacheStore {
     }
 
     fn artifact_lock_is_contended(&self, digest: &str) -> Result<bool, ResolvedCacheError> {
-        let artifact_lock = open_lock_file(&self.artifact_lock_path(digest))?;
-        match FileExt::try_lock_exclusive(&artifact_lock) {
-            Ok(()) => Ok(false),
+        match FileLock::try_exclusive(open_lock_file(&self.artifact_lock_path(digest))?) {
+            Ok(_probe) => Ok(false),
             Err(error) if is_lock_contended(&error) => Ok(true),
             Err(error) => Err(error.into()),
         }

--- a/crates/sceneworks-core/src/resolved_cache/retention_tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/retention_tests.rs
@@ -5,6 +5,7 @@ use crate::model_artifacts::{
     ModelArtifactResolver, ResolvedBundleClosure, ResolvedBundleMember,
     MODEL_ARTIFACT_CONTRACT_VERSION,
 };
+use fs2::FileExt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tempfile::TempDir;

--- a/crates/sceneworks-core/src/resolved_cache/tests.rs
+++ b/crates/sceneworks-core/src/resolved_cache/tests.rs
@@ -4,6 +4,7 @@ use crate::model_artifacts::{
     ArtifactIdentity, ArtifactMemberRole, ArtifactProvenance, ArtifactSourceLibrary,
     ResolvedBundleClosure, ResolvedBundleMember, MODEL_ARTIFACT_CONTRACT_VERSION,
 };
+use fs2::FileExt;
 use serde_json::{json, Value};
 use std::collections::BTreeMap;
 use std::process::Command;
@@ -2173,4 +2174,60 @@ fn a_produced_bundle_whose_declared_output_is_a_symlink_is_never_published() {
         outside.is_file(),
         "the refusal never touches what the link pointed at"
     );
+}
+
+/// Released cache locks must be free IMMEDIATELY, even while a descriptor this process handed to a
+/// child still references the same open file description.
+///
+/// `flock(2)` locks live on the open file description, and `fork(2)` gives the child a reference to
+/// it, so releasing by `close(2)` alone only takes effect once every such reference is gone.
+/// `inherited_descriptor` reproduces that sharing without a child process, so the interleaving is
+/// injected rather than waited for. Before sc-22738 a dropped reservation's artifact lock, and a
+/// released metadata lock, both kept reading as HELD for as long as an unrelated `Command` sat
+/// between `fork` and `exec` — costing every contending reservation, lease, recovery and retention
+/// pass a spurious "in active use" verdict or a block.
+#[test]
+fn released_cache_locks_are_free_even_while_an_inherited_descriptor_survives() {
+    let scratch = TempDir::new().unwrap();
+    let source = scratch.path().join("source");
+    std::fs::create_dir(&source).unwrap();
+    let candidate = source_candidate(&source, REVISION_A);
+    let store = ResolvedCacheStore::open(&scratch.path().join("data")).unwrap();
+    let digest = cache_key_digest(&candidate.cache_key).unwrap();
+
+    let reservation = match store.reserve(&candidate, &source, "fixture:model").unwrap() {
+        ReservationOutcome::Acquired(reservation) => reservation,
+        _ => panic!("fixture reservation must acquire"),
+    };
+    let inherited = reservation
+        .artifact_lock
+        .as_ref()
+        .expect("an acquired reservation holds the artifact lock")
+        .inherited_descriptor()
+        .expect("descriptor duplicates");
+    drop(reservation);
+    let probe =
+        FileLock::try_exclusive(open_lock_file(&store.artifact_lock_path(&digest)).unwrap());
+    assert!(
+        probe.is_ok(),
+        "an artifact lock released with the reservation must not stay held by an inherited \
+         descriptor: {:?}",
+        probe.err()
+    );
+    drop(probe);
+    drop(inherited);
+
+    let metadata_lock = store.lock_metadata(&digest).unwrap();
+    let inherited = metadata_lock
+        .inherited_descriptor()
+        .expect("descriptor duplicates");
+    drop(metadata_lock);
+    let probe =
+        FileLock::try_exclusive(open_lock_file(&store.metadata_lock_path(&digest)).unwrap());
+    assert!(
+        probe.is_ok(),
+        "a released metadata lock must not stay held by an inherited descriptor: {:?}",
+        probe.err()
+    );
+    drop(inherited);
 }

--- a/crates/sceneworks-worker/src/catalog_analysis.rs
+++ b/crates/sceneworks-worker/src/catalog_analysis.rs
@@ -11,10 +11,10 @@ use std::fs::{File, OpenOptions};
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 
-use fs2::FileExt;
 use sceneworks_core::catalog_store::{
     Catalog, CatalogError, CatalogProcessingLease, CatalogRecord, CatalogRegistry, NewCatalogRecord,
 };
+use sceneworks_core::file_lock::FileLock;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
@@ -451,7 +451,10 @@ struct StructuredAnalysisCheckpoint {
 
 struct CatalogAnalysisLease {
     _processing: Option<CatalogProcessingLease>,
-    _files: Vec<File>,
+    /// [`FileLock`]s, not bare handles: each releases with an explicit `LOCK_UN`, because
+    /// `close(2)` alone leaves the lock held while any forked child still references the same open
+    /// file description (sc-22738).
+    _files: Vec<FileLock>,
 }
 
 impl CatalogAnalysisLease {
@@ -489,8 +492,8 @@ impl CatalogAnalysisLease {
                 .truncate(false)
                 .open(&path)?;
             let contended = fs2::lock_contended_error().raw_os_error();
-            match file.try_lock_exclusive() {
-                Ok(()) => files.push(file),
+            match FileLock::try_exclusive(file) {
+                Ok(lock) => files.push(lock),
                 Err(error) if error.raw_os_error() == contended => {
                     return Err(CatalogAnalysisError::Busy(format!(
                         "Catalog {} already has active fetch or analysis work.",
@@ -1626,6 +1629,45 @@ mod tests {
                 .find(|record| record.id == id)
                 .expect("record exists")
         }
+    }
+
+    /// sc-22738: released analysis locks must be free IMMEDIATELY, even while a descriptor this
+    /// process handed to a child still references the same open file description. `flock(2)` locks
+    /// live on the open file description, so a close-only release only takes effect once every
+    /// such reference is gone — and analysis forks (converters, model runners) throughout a pass,
+    /// which would leave the next pass refused as "already has active fetch or analysis work".
+    #[test]
+    fn a_released_analysis_lease_is_free_even_while_an_inherited_descriptor_survives() {
+        use fs2::FileExt as _;
+
+        let fixture = Fixture::new("analysis-lock", &["a"]);
+        let catalog = fixture
+            .registry
+            .open_attached(&fixture.catalog_id)
+            .expect("catalog opens");
+
+        let lease = CatalogAnalysisLease::acquire(&catalog).expect("lease acquires");
+        let inherited = lease
+            ._files
+            .iter()
+            .map(|lock| lock.inherited_descriptor().expect("descriptor duplicates"))
+            .collect::<Vec<_>>();
+        drop(lease);
+
+        for name in [FETCH_LOCK_FILE, ANALYSIS_LOCK_FILE] {
+            let probe = OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(fixture.root.join(name))
+                .expect("probe opens lock file");
+            assert!(
+                probe.try_lock_exclusive().is_ok(),
+                "{name} released with the lease must not stay held by an inherited descriptor"
+            );
+        }
+        drop(inherited);
     }
 
     #[derive(Default)]

--- a/crates/sceneworks-worker/src/catalog_image_fetch.rs
+++ b/crates/sceneworks-worker/src/catalog_image_fetch.rs
@@ -6,7 +6,6 @@
 
 use crate::downloads::{fetch_public_source_url_bytes_with_options, PublicSourceUrlFetchOptions};
 use crate::{WorkerError, WorkerResult};
-use fs2::FileExt as _;
 use futures_util::future::join_all;
 use image::codecs::jpeg::JpegEncoder;
 use image::{DynamicImage, ImageFormat, ImageReader};
@@ -14,6 +13,7 @@ use rusqlite::{params, Connection, OptionalExtension};
 use sceneworks_core::catalog_store::{
     Catalog, CatalogError, CatalogProcessingLease, CatalogRecord, CatalogRegistry, NewCatalogRecord,
 };
+use sceneworks_core::file_lock::FileLock;
 use sceneworks_core::time::utc_now;
 use serde::{Deserialize, Serialize};
 #[cfg(test)]
@@ -330,7 +330,8 @@ enum DiscardFaultPoint {
 #[derive(Debug)]
 struct CatalogFetchLease {
     _processing: Option<CatalogProcessingLease>,
-    _file: File,
+    /// A [`FileLock`], not a bare handle: released with an explicit `LOCK_UN` (sc-22738).
+    _file: FileLock,
 }
 
 struct ArtifactBudget {
@@ -634,10 +635,10 @@ impl CatalogFetchLease {
             .truncate(false)
             .open(&path)?;
         let contended = fs2::lock_contended_error().raw_os_error();
-        match file.try_lock_exclusive() {
-            Ok(()) => Ok(Self {
+        match FileLock::try_exclusive(file) {
+            Ok(lock) => Ok(Self {
                 _processing: processing,
-                _file: file,
+                _file: lock,
             }),
             Err(error) if error.raw_os_error() == contended => {
                 Err(CatalogImageFetchError::Busy(format!(
@@ -4189,6 +4190,31 @@ mod tests {
         let _first = CatalogFetchLease::acquire(&first_catalog).expect("first lease");
         let error = CatalogFetchLease::acquire(&second_catalog).expect_err("must contend");
         assert!(matches!(error, CatalogImageFetchError::Busy(_)));
+    }
+
+    /// sc-22738: a released fetch lease must be free IMMEDIATELY, even while a descriptor this
+    /// process handed to a child still references the same open file description. `flock(2)` locks
+    /// live on the open file description, so a close-only release only takes effect once every
+    /// such reference is gone — and image fetch forks throughout a pass, which would leave the next
+    /// fetch refused as `Busy`.
+    #[test]
+    fn a_released_fetch_lease_is_free_even_while_an_inherited_descriptor_survives() {
+        let (_root, registry, id) = catalog_fixture();
+        let catalog = registry.open_attached(&id).expect("catalog opens");
+
+        let lease = CatalogFetchLease::acquire(&catalog).expect("lease acquires");
+        let inherited = lease
+            ._file
+            .inherited_descriptor()
+            .expect("descriptor duplicates");
+        drop(lease);
+
+        let reacquired = CatalogFetchLease::acquire(&catalog);
+        assert!(
+            reacquired.is_ok(),
+            "a fetch lease released by its owner must not stay held by an inherited descriptor"
+        );
+        drop(inherited);
     }
 
     #[tokio::test]

--- a/crates/sceneworks-worker/src/downloads.rs
+++ b/crates/sceneworks-worker/src/downloads.rs
@@ -89,7 +89,7 @@ pub(crate) use download_lock::DownloadLock;
 
 mod download_lock {
     use super::{task_join_error, WorkerError, WorkerResult};
-    use fs2::FileExt as _;
+    use sceneworks_core::file_lock::FileLock;
     use std::path::{Path, PathBuf};
     use std::time::{Duration, Instant};
 
@@ -113,7 +113,10 @@ mod download_lock {
     /// the size check when no sha256 is available. The lock releases when the
     /// underlying handle drops. Mirrors `manifest::ManifestLock`.
     pub(crate) struct DownloadLock {
-        _file: std::fs::File,
+        /// A [`FileLock`], not a bare handle: the release is an explicit `LOCK_UN`, because
+        /// `close(2)` alone leaves the lock held while any forked child still references the same
+        /// open file description (sc-22738).
+        _lock: FileLock,
     }
 
     impl DownloadLock {
@@ -125,7 +128,7 @@ mod download_lock {
             if let Some(parent) = lock_path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            let file = std::fs::OpenOptions::new()
+            let mut file = std::fs::OpenOptions::new()
                 .create(true)
                 .read(true)
                 .write(true)
@@ -138,9 +141,10 @@ mod download_lock {
             // (same posture as `manifest::ManifestLock`, sc-8843).
             let contended = fs2::lock_contended_error().raw_os_error();
             loop {
-                match file.try_lock_exclusive() {
-                    Ok(()) => return Ok(Self { _file: file }),
-                    Err(error) if error.raw_os_error() == contended => {
+                match FileLock::try_exclusive_retryable(file) {
+                    Ok(lock) => return Ok(Self { _lock: lock }),
+                    Err((handle, error)) if error.raw_os_error() == contended => {
+                        file = handle;
                         if Instant::now() >= deadline {
                             return Err(WorkerError::Io(std::io::Error::new(
                                 std::io::ErrorKind::TimedOut,
@@ -152,7 +156,7 @@ mod download_lock {
                         }
                         std::thread::sleep(DOWNLOAD_LOCK_POLL);
                     }
-                    Err(error) => return Err(error.into()),
+                    Err((_handle, error)) => return Err(error.into()),
                 }
             }
         }
@@ -184,6 +188,7 @@ mod download_lock {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use fs2::FileExt as _;
 
         /// sc-8900 / F-098: two holders of the same target's download lock are
         /// mutually exclusive — the second `try_lock_exclusive` sees contention while
@@ -223,6 +228,39 @@ mod download_lock {
             // A DIFFERENT target never contends with the first.
             let other = dir.path().join("weights").join("other.safetensors");
             let _first_other = DownloadLock::acquire(&other).expect("distinct target locks");
+        }
+
+        /// sc-22738: a released download lock must be free IMMEDIATELY, even while a descriptor
+        /// this process handed to a child still references the same open file description.
+        /// `flock(2)` locks live on the open file description, so a close-only release only takes
+        /// effect once every such reference is gone — and this pool forks constantly. The probe is
+        /// the non-blocking primitive, not `acquire`, so the failure is an assertion rather than a
+        /// one-hour spin-wait.
+        #[test]
+        fn a_released_download_lock_is_free_even_while_an_inherited_descriptor_survives() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let target = dir.path().join("weights").join("model.safetensors");
+
+            let held = DownloadLock::acquire(&target).expect("lock acquires");
+            let inherited = held
+                ._lock
+                .inherited_descriptor()
+                .expect("descriptor duplicates");
+            drop(held);
+
+            let probe = std::fs::OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(download_lock_path(&target))
+                .expect("probe opens lock file");
+            assert!(
+                probe.try_lock_exclusive().is_ok(),
+                "a download lock released by its owner must not stay held by an inherited \
+                 descriptor"
+            );
+            drop(inherited);
         }
 
         /// The lock file is a `.download.lock` sibling of the target (per-file scope),

--- a/crates/sceneworks-worker/src/manifest.rs
+++ b/crates/sceneworks-worker/src/manifest.rs
@@ -3,7 +3,7 @@ use super::*;
 
 use std::io::Write as _;
 
-use fs2::FileExt as _;
+use sceneworks_core::file_lock::FileLock;
 
 /// Max time to block waiting for the cross-process manifest lock before giving up
 /// with a clear error. Manifest RMW is a few KB of JSON, so a real hold is sub-ms;
@@ -162,15 +162,17 @@ fn merge_manifest_entry_locked(
 }
 
 /// RAII holder for a cross-process advisory exclusive lock on a `<manifest>.lock`
-/// sibling file. The lock is released when the underlying file handle drops.
+/// sibling file. Released with an explicit `LOCK_UN`, not by `close(2)` alone, which
+/// leaves the lock held while any forked child still references the same open file
+/// description (sc-22738).
 struct ManifestLock {
-    _file: std::fs::File,
+    _lock: FileLock,
 }
 
 impl ManifestLock {
     fn acquire(manifest_path: &Path) -> WorkerResult<Self> {
         let lock_path = manifest_lock_path(manifest_path);
-        let file = std::fs::OpenOptions::new()
+        let mut file = std::fs::OpenOptions::new()
             .create(true)
             .read(true)
             .write(true)
@@ -185,9 +187,10 @@ impl ManifestLock {
         // which is correct on every platform.
         let contended = fs2::lock_contended_error().raw_os_error();
         loop {
-            match file.try_lock_exclusive() {
-                Ok(()) => return Ok(Self { _file: file }),
-                Err(error) if error.raw_os_error() == contended => {
+            match FileLock::try_exclusive_retryable(file) {
+                Ok(lock) => return Ok(Self { _lock: lock }),
+                Err((handle, error)) if error.raw_os_error() == contended => {
+                    file = handle;
                     if std::time::Instant::now() >= deadline {
                         return Err(WorkerError::Io(std::io::Error::new(
                             std::io::ErrorKind::TimedOut,
@@ -200,7 +203,7 @@ impl ManifestLock {
                     }
                     std::thread::sleep(MANIFEST_LOCK_POLL);
                 }
-                Err(error) => return Err(error.into()),
+                Err((_handle, error)) => return Err(error.into()),
             }
         }
     }
@@ -261,6 +264,40 @@ pub(crate) async fn write_json_value(path: &Path, value: &Value) -> WorkerResult
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// sc-22738: a released manifest lock must be free IMMEDIATELY, even while a descriptor this
+    /// process handed to a child still references the same open file description. `flock(2)` locks
+    /// live on the open file description, so a close-only release only takes effect once every
+    /// such reference is gone — and this process forks (ffmpeg, converters) throughout a manifest
+    /// merge. The assertion uses the non-blocking primitive so the failure is an assertion rather
+    /// than a 30-second spin-wait.
+    #[test]
+    fn a_released_manifest_lock_is_free_even_while_an_inherited_descriptor_survives() {
+        use fs2::FileExt as _;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manifest = dir.path().join("user.loras.jsonc");
+
+        let held = ManifestLock::acquire(&manifest).expect("manifest lock acquires");
+        let inherited = held
+            ._lock
+            .inherited_descriptor()
+            .expect("descriptor duplicates");
+        drop(held);
+
+        let probe = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(manifest_lock_path(&manifest))
+            .expect("probe opens lock file");
+        assert!(
+            probe.try_lock_exclusive().is_ok(),
+            "a manifest lock released by its owner must not stay held by an inherited descriptor"
+        );
+        drop(inherited);
+    }
 
     fn entry(id: &str) -> serde_json::Map<String, Value> {
         let mut map = serde_json::Map::new();

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -7,6 +7,7 @@ use sceneworks_core::base_weights::{
 use sceneworks_core::checkpoint_import::ManagedProvenanceV1;
 use sceneworks_core::checkpoint_ingest::ManagedIngest;
 use sceneworks_core::checkpoint_plan_store::CheckpointPlanStore;
+use sceneworks_core::file_lock::FileLock;
 
 /// Post the terminal `Completed` update for a Hugging Face cache download, building the shared
 /// `{<id_key>, repo, path, storage:"huggingface_cache", completedAt}` result object (F-116). Both
@@ -3734,16 +3735,67 @@ where
     Ok(())
 }
 
+/// Cross-platform: the conversion locks are taken on every backend, so this module is NOT gated on
+/// macOS the way the converter tests below are.
+#[cfg(test)]
+mod conversion_lock_tests {
+    use super::*;
+    use fs2::FileExt as _;
+
+    /// sc-22738: released conversion locks must be free IMMEDIATELY, even while a descriptor this
+    /// process handed to a child still references the same open file description. `flock(2)` locks
+    /// live on the open file description, so a close-only release only takes effect once every such
+    /// reference is gone — and conversion forks converter processes throughout, which would park
+    /// the next finalize (and the startup sweep) behind an already-released lock for up to the
+    /// 30-second timeout.
+    #[test]
+    fn released_conversion_locks_are_free_even_while_an_inherited_descriptor_survives() {
+        let temporary = tempfile::tempdir().expect("temp directory");
+        let lock_root = temporary.path().join("locks");
+        std::fs::create_dir_all(&lock_root).expect("lock root");
+        let target = temporary.path().join("models").join("converted");
+
+        let locks = ConversionFinalizeLocks::acquire(&lock_root, &target).expect("locks acquire");
+        let inherited = [
+            locks
+                ._lifecycle
+                .inherited_descriptor()
+                .expect("descriptor duplicates"),
+            locks
+                ._target
+                .inherited_descriptor()
+                .expect("descriptor duplicates"),
+        ];
+        drop(locks);
+
+        // The lifecycle lock is taken SHARED by finalizers and EXCLUSIVE by the startup sweep, so
+        // the sweep's acquisition is what a stuck release blocks; probe it that way.
+        let lifecycle = open_conversion_lock(&lock_root.join(CONVERSION_LIFECYCLE_LOCK))
+            .expect("lifecycle lock opens");
+        assert!(
+            lifecycle.try_lock_exclusive().is_ok(),
+            "a released lifecycle lock must not stay held by an inherited descriptor"
+        );
+        drop(inherited);
+    }
+}
+
 struct ConversionFinalizeLocks {
-    _lifecycle: std::fs::File,
-    _target: std::fs::File,
+    /// [`FileLock`]s, not bare handles: each releases with an explicit `LOCK_UN`, because
+    /// `close(2)` alone leaves the lock held while any forked child still references the same open
+    /// file description (sc-22738), and this process forks converters throughout a conversion.
+    _lifecycle: FileLock,
+    _target: FileLock,
 }
 
 impl ConversionFinalizeLocks {
     fn acquire(lock_root: &Path, final_dir: &Path) -> WorkerResult<Self> {
         let lifecycle_path = lock_root.join(CONVERSION_LIFECYCLE_LOCK);
-        let lifecycle = open_conversion_lock(&lifecycle_path)?;
-        lock_conversion_file(&lifecycle, &lifecycle_path, true)?;
+        let lifecycle = lock_conversion_file(
+            open_conversion_lock(&lifecycle_path)?,
+            &lifecycle_path,
+            true,
+        )?;
 
         // Hash the canonical target path so arbitrary/custom model ids can never alias the
         // lifecycle lock or another model's lock-file pathname.
@@ -3752,8 +3804,8 @@ impl ConversionFinalizeLocks {
             Sha256::digest(final_dir.to_string_lossy().as_bytes())
         );
         let target_path = lock_root.join(format!("target-{target_digest}.lock"));
-        let target = open_conversion_lock(&target_path)?;
-        lock_conversion_file(&target, &target_path, false)?;
+        let target =
+            lock_conversion_file(open_conversion_lock(&target_path)?, &target_path, false)?;
         Ok(Self {
             _lifecycle: lifecycle,
             _target: target,
@@ -3877,18 +3929,20 @@ fn resolve_conversion_managed_roots(data_dir: &Path) -> WorkerResult<ConversionM
     })
 }
 
-fn lock_conversion_file(file: &std::fs::File, path: &Path, shared: bool) -> WorkerResult<()> {
+fn lock_conversion_file(file: std::fs::File, path: &Path, shared: bool) -> WorkerResult<FileLock> {
     let deadline = std::time::Instant::now() + CONVERSION_LOCK_TIMEOUT;
     let contended = fs2::lock_contended_error().raw_os_error();
+    let mut file = file;
     loop {
         let result = if shared {
-            fs2::FileExt::try_lock_shared(file)
+            FileLock::try_shared_retryable(file)
         } else {
-            fs2::FileExt::try_lock_exclusive(file)
+            FileLock::try_exclusive_retryable(file)
         };
         match result {
-            Ok(()) => return Ok(()),
-            Err(error) if error.raw_os_error() == contended => {
+            Ok(lock) => return Ok(lock),
+            Err((handle, error)) if error.raw_os_error() == contended => {
+                file = handle;
                 if std::time::Instant::now() >= deadline {
                     return Err(WorkerError::Io(std::io::Error::new(
                         std::io::ErrorKind::TimedOut,
@@ -3901,7 +3955,7 @@ fn lock_conversion_file(file: &std::fs::File, path: &Path, shared: bool) -> Work
                 }
                 std::thread::sleep(CONVERSION_LOCK_POLL);
             }
-            Err(error) => return Err(error.into()),
+            Err((_handle, error)) => return Err(error.into()),
         }
     }
 }
@@ -3927,8 +3981,11 @@ fn sweep_stranded_conversion_backups_blocking(data_dir: &Path) -> WorkerResult<(
         lock_root,
     } = resolve_conversion_managed_roots(data_dir)?;
     let lifecycle_path = lock_root.join(CONVERSION_LIFECYCLE_LOCK);
-    let lifecycle = open_conversion_lock(&lifecycle_path)?;
-    lock_conversion_file(&lifecycle, &lifecycle_path, false)?;
+    let _lifecycle = lock_conversion_file(
+        open_conversion_lock(&lifecycle_path)?,
+        &lifecycle_path,
+        false,
+    )?;
 
     let mut by_target: HashMap<String, Vec<PathBuf>> = HashMap::new();
     for entry in std::fs::read_dir(&backup_root)? {

--- a/crates/sceneworks-worker/src/training_jobs.rs
+++ b/crates/sceneworks-worker/src/training_jobs.rs
@@ -21,8 +21,8 @@
 //! unsupported combinations remain queued. There is no Python/torch training fallback.
 
 use super::*;
-use fs2::FileExt as _;
 use sceneworks_core::contracts::ExtraFields;
+use sceneworks_core::file_lock::FileLock;
 use sceneworks_core::training::{TrainingPlan, TRAINING_PLAN_VERSION};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
@@ -216,7 +216,7 @@ const PREPARED_BUNDLE_COORDINATOR_LOCK: &str = ".prepared-bundles.lock";
 #[derive(Default)]
 struct PreparedTrainingInputs {
     directory: Option<tempfile::TempDir>,
-    ownership_lock: Option<std::fs::File>,
+    ownership_lock: Option<FileLock>,
     snapshots: BTreeMap<PreparedBundleKey, PathBuf>,
     #[cfg(test)]
     materialization_count: usize,
@@ -319,10 +319,11 @@ fn reclaim_abandoned_prepared_bundle_sets(parent: &Path) -> WorkerResult<()> {
             Err(WorkerError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => continue,
             Err(error) => return Err(error),
         };
-        match lock.try_lock_exclusive() {
-            Ok(()) => {
+        match FileLock::try_exclusive(lock) {
+            Ok(lock) => {
                 // Windows will not remove a directory containing this open handle. Dropping the
-                // acquired stale-set lock before deletion is therefore part of the contract.
+                // acquired stale-set lock before deletion is therefore part of the contract; the
+                // guard also releases with an explicit `LOCK_UN` (sc-22738).
                 drop(lock);
                 std::fs::remove_dir_all(&path).map_err(|error| {
                     WorkerError::Io(std::io::Error::new(
@@ -351,7 +352,7 @@ fn reclaim_abandoned_prepared_bundle_sets(parent: &Path) -> WorkerResult<()> {
 
 fn create_prepared_bundle_directory(
     settings: &Settings,
-) -> WorkerResult<(tempfile::TempDir, std::fs::File)> {
+) -> WorkerResult<(tempfile::TempDir, FileLock)> {
     let parent = settings.data_dir.join("cache").join("training-inputs");
     std::fs::create_dir_all(&parent).map_err(|error| {
         WorkerError::Io(std::io::Error::new(
@@ -365,7 +366,7 @@ fn create_prepared_bundle_directory(
     enforce_owner_only_directory(&parent)?;
 
     let coordinator = owner_only_lock_file(&parent.join(PREPARED_BUNDLE_COORDINATOR_LOCK))?;
-    coordinator.lock_exclusive().map_err(|error| {
+    let coordinator = FileLock::exclusive(coordinator).map_err(|error| {
         WorkerError::Io(std::io::Error::new(
             error.kind(),
             format!(
@@ -403,23 +404,25 @@ fn create_prepared_bundle_directory(
                 );
             }
         };
-    if let Err(error) = ownership_lock.try_lock_exclusive() {
-        let error = WorkerError::Io(std::io::Error::new(
-            error.kind(),
-            format!(
-                "Could not claim training input snapshot {}: {error}",
-                directory.path().display()
-            ),
-        ));
-        return finish_prepared_input_operation(
-            Err(error),
-            PreparedTrainingInputs {
-                directory: Some(directory),
-                ownership_lock: Some(ownership_lock),
-                ..PreparedTrainingInputs::default()
-            },
-        );
-    }
+    let ownership_lock = match FileLock::try_exclusive(ownership_lock) {
+        Ok(lock) => lock,
+        Err(error) => {
+            let error = WorkerError::Io(std::io::Error::new(
+                error.kind(),
+                format!(
+                    "Could not claim training input snapshot {}: {error}",
+                    directory.path().display()
+                ),
+            ));
+            return finish_prepared_input_operation(
+                Err(error),
+                PreparedTrainingInputs {
+                    directory: Some(directory),
+                    ..PreparedTrainingInputs::default()
+                },
+            );
+        }
+    };
     drop(coordinator);
     Ok((directory, ownership_lock))
 }
@@ -507,7 +510,7 @@ impl PreparedTrainingInputs {
                 .join(PREPARED_BUNDLE_COORDINATOR_LOCK),
         )
         .and_then(|lock| {
-            lock.lock_exclusive().map_err(|error| {
+            FileLock::exclusive(lock).map_err(|error| {
                 WorkerError::Io(std::io::Error::new(
                     error.kind(),
                     format!(
@@ -515,8 +518,7 @@ impl PreparedTrainingInputs {
                         path.display()
                     ),
                 ))
-            })?;
-            Ok(lock)
+            })
         });
         // The request/trainer is dropped by the caller; release our own lock handle as well before
         // attempting directory removal so Windows cannot reject deletion because of an open file.
@@ -2740,6 +2742,35 @@ mod tests {
         std::fs::create_dir_all(&bare).unwrap();
         assert!(training_text_encoder("ltx_2_3", &bare).is_none());
         assert!(training_text_encoder("ltx_2_5", &tier).is_none());
+    }
+
+    /// sc-22738: a released snapshot ownership lock must be free IMMEDIATELY, even while a
+    /// descriptor this process handed to a child still references the same open file description.
+    /// `flock(2)` locks live on the open file description, so a close-only release only takes
+    /// effect once every such reference is gone — and training forks trainers and converters
+    /// constantly, which would make reclamation read a finished set as still owned and leave it on
+    /// disk.
+    #[test]
+    fn a_released_ownership_lock_is_free_even_while_an_inherited_descriptor_survives() {
+        use fs2::FileExt as _;
+
+        let data_dir = tempfile::tempdir().expect("data tempdir");
+        let settings = test_settings(data_dir.path());
+        let (directory, ownership_lock) =
+            create_prepared_bundle_directory(&settings).expect("create snapshot set");
+        let lock_path = directory.path().join(PREPARED_BUNDLE_OWNER_LOCK);
+
+        let inherited = ownership_lock
+            .inherited_descriptor()
+            .expect("descriptor duplicates");
+        drop(ownership_lock);
+
+        let probe = owner_only_lock_file(&lock_path).expect("probe opens lock file");
+        assert!(
+            probe.try_lock_exclusive().is_ok(),
+            "an ownership lock released by its owner must not stay held by an inherited descriptor"
+        );
+        drop(inherited);
     }
 
     fn test_settings(data_dir: &Path) -> Settings {


### PR DESCRIPTION
Follow-through on #2785 (same defect class, Michael's "deeper fix lands in the same PR" rule; #2785 merged before this commit could land there).

`flock(2)` locks belong to the open file description; a forked child shares it until `exec`, so a close-only release can leave the lock visibly held to a concurrent `try_*`. New `sceneworks-core::file_lock::FileLock` releases with `LOCK_UN` in `Drop` (plus `try_*_retryable` so spin-waiting sites keep the same descriptor). No locking semantics changed (same kinds, scopes, order, contention handling; `acquire_complete` still hashes once).

Lock holders swept:
- sceneworks-core: `resolved_cache` (session + artifact locks, retention eviction paths, contention probe, `lock_metadata` guards), `model_artifacts/external_library` (ledger shared+exclusive), `checkpoint_plan_store`
- sceneworks-worker: `downloads::DownloadLock`, `manifest::ManifestLock`, `training_jobs` (coordinator, ownership, stale-set reclamation), `catalog_analysis` two-file lease, `catalog_image_fetch` lease, `model_jobs` conversion + finalize locks
- rust-api: `manifest::ManifestFileLock`

Tests: 11 new (dup-shares-the-description shape, no sleeps). Mutation: removing `LOCK_UN` from `FileLock::drop` → 11/11 red (4 core, 6 worker, 1 rust-api); restored → green.
Verification: fmt clean; clippy clean on all three crates; core 1343 / worker 2089 (214 ignored) / rust-api 737 passed; `npm run rust:check` exit 0 (4936 passed, 39 binaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)