### PR TITLE
fix(sc-22738): SCAIL-2 MLX probes were budget-killed mid-render, not stalled — re-base the video budget on the witnessed capture

### DIFF
--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -1292,21 +1292,33 @@ that is ALL it does: production keeps refusing exactly what the bound refused wh
 (sc-22738), because a shared-engine fix silently re-admitting a request a host was already unable to
 finish is the failure the bound exists to prevent.
 
-**Every probe carries a wall-clock budget (sc-22738, 2026-09-07).** The guard's ceilings bound a
-probe that CLIMBS; they say nothing about one that stops climbing, and `scail2_14b:bf16:mlx` sat
-flat at 93.5 GB under the 94.82 GB kill line for 90 minutes with the host swapping and the adapter
-parked in `mlx::core::eval`. So `measure-memory-catalog.mjs` now passes the guard a
-`--max-runtime-seconds` on every capture, defaulted per lane by `PROBE_BUDGET_MINUTES` — **150
+**Every probe carries a wall-clock budget (sc-22738, 2026-09-07; re-based 2026-09-08).** The
+guard's ceilings bound a probe that CLIMBS; they say nothing about one that stops climbing, and
+`scail2_14b:bf16:mlx` sat flat at 93.5 GB under the 94.82 GB kill line for 90 minutes with the
+adapter parked in `mlx::core::eval`. So `measure-memory-catalog.mjs` passes the guard a
+`--max-runtime-seconds` on every capture, defaulted per lane by `PROBE_BUDGET_MINUTES` — **270
 minutes for a video anchor, 60 for an image one** (the lane is derived from the plan: a video anchor
 renders more than one frame), overridable for a run with `--probe-budget-minutes N`, which
-`--dry-run` prints per row. A probe that reaches its budget is stopped on the guard's ONE stop path
-— the same SIGTERM→SIGKILL escalation and post-stop census a footprint stop takes — and is reported
-as `capture_failed` with reason `runtime_budget_exceeded`, naming the budget and the peak footprint
-sampled so you can tell a probe wedged at the ceiling from one wedged at 3 GB. **It is not an
-exceedance:** the run never crossed a line, so no bound is written (the harness's `record-exceeded`
-refuses a wall-clock stop outright), the store keeps no trace, the watchdog stream and per-anchor log
-stay in the work dir, and the cell classifies `runnable` again on the next `--list`. Re-run it, or
-re-run it with a larger `--probe-budget-minutes` if you believe the render was still making progress.
+`--dry-run` prints per row. Each default rests on the longest COMPLETED capture its lane has
+witnessed (`WITNESSED_CAPTURE_SECONDS`): 8,709 s for video — the one unbudgeted
+`scail2_14b:bf16:mlx` capture on record, which rendered all 80 decoded frames — and 847 s for
+image. That flat 93.5 GB line was a render in progress, not a wedge: a video arm renders its clip
+THREE times per capture (measured, clean warm control, warm repeat), a SCAIL-2 render is a 14B DiT
+under CFG whose main thread waits on the GPU at every step by design, and the same cell stopped at
+every tier under a 90-minute budget with the GPU at 99–100% utilization and no GPU fault in the
+system log. (The watchdog stream's `providerPhase` is `null` for every anchor — the runner passes
+no `--provider-phase-profile` — so its absence is not a progress signal.) A probe that reaches its
+budget is stopped on the guard's ONE stop path — the same SIGTERM→SIGKILL escalation and post-stop
+census a footprint stop takes — and is reported as `capture_failed` with reason
+`runtime_budget_exceeded`, naming the budget, the peak footprint sampled (so you can tell a probe
+wedged at the ceiling from one wedged at 3 GB) and the lane's longest completed capture; a run
+launched with `--probe-budget-minutes` below its lane's default is told, in the reason, that the
+stop is a budget shortfall and not evidence of a stall. **It is not an exceedance:** the run never
+crossed a line, so no bound is written (the harness's `record-exceeded` refuses a wall-clock stop
+outright), the store keeps no trace, the watchdog stream and per-anchor log stay in the work dir,
+and the cell classifies `runnable` again on the next `--list`. Re-run it, or re-run it with a larger
+`--probe-budget-minutes` if you believe the render was still making progress — and never below the
+lane default for a cell whose witnessed capture is longer than the budget you are about to give it.
 
 **`committed_exceeded` is the one that changed (sc-22738).** A footprint hard stop used to be a
 `capture_failed` that stamped nothing at all: the store kept no trace, and production went on

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -2302,40 +2302,58 @@ export async function probeAdapter(command, { cwd = ROOT, env = process.env, wir
  * line (sc-22738, measured 2026-09-06).
  */
 /**
- * The per-probe WALL-CLOCK budget, in minutes, by lane (sc-22738, 2026-09-07).
+ * The per-probe WALL-CLOCK budget, in minutes, by lane (sc-22738, 2026-09-07; re-based 2026-09-08).
  *
  * WHY A BUDGET AT ALL. The guard's ceilings bound a probe that CLIMBS. They say nothing about one
- * that stops climbing: `scail2_14b:bf16:mlx` sat at a flat 93.5 GB against the 94.82 GB kill line
- * for 90 minutes, the host swapping and the adapter's main thread parked in `mlx::core::eval` →
- * `waitUntilSignaledValue`, and would have sat there until an operator noticed. The watchdog has
+ * that stops climbing, and a stopped-climbing probe is indistinguishable from a wedged one from
+ * the outside: `scail2_14b:bf16:mlx` sat at a flat 93.5 GB against the 94.82 GB kill line, the
+ * adapter's main thread parked in `mlx::core::eval` → `waitUntilSignaledValue`. The watchdog has
  * supported `--max-runtime-seconds` since it was written; nothing passed it, so every probe ran
  * unbounded in time.
  *
- * THE BASIS, AND WHAT IT IS NOT. The evidence corpus states no wall clock: `durationSeconds` and
- * every other duration/elapsed field are ABSENT from `docs/calibration/sc-22738/*.json` (a capture
- * bundle carries `capturedAt` and nothing about how long the render took). So these are derived
- * from the two figures the corpus and this tree DO state:
+ * WHAT THAT FLAT LINE ACTUALLY WAS (sc-22738, diagnosed 2026-09-08). Not a wedge. A video arm
+ * renders its clip THREE times per capture — the measured render, a clean warm control and a warm
+ * repeat (`crates/sceneworks-memory-adapter/src/bin/mlx_wan_scail2.rs`, the determinism envelope
+ * every video arm carries) — and a SCAIL-2 render is a 14B DiT at 832x480x77 under CFG (two DiT
+ * forwards per step) whose main thread waits on the GPU at the per-step `eval` by design
+ * (`mlx-gen-scail2/src/generate.rs`). The ONE unbudgeted `scail2_14b:bf16:mlx` capture on record
+ * COMPLETED, rendering all 80 decoded frames, in 8,709 s (2026-09-06, `calib-mlx/campaign.log`).
+ * A 90-minute budget then stopped the same cell at every tier with the GPU at 99–100% device
+ * utilization, the footprint oscillating ±90 MB on a 4–6 s cadence and no GPU fault in the system
+ * log: the budget, not the render, was what ended those probes. The `providerPhase` field of the
+ * watchdog stream is `null` for EVERY anchor because the runner passes no
+ * `--provider-phase-profile`; it is not a progress signal and its absence proves nothing.
  *
- *   * consecutive `capturedAt` deltas inside one uninterrupted walk, each an UPPER bound on that
- *     anchor's whole capture→commit cycle. Longest for a completed IMAGE anchor: 847 s
- *     (`bernini_image:q8:mlx`, 07:13:26 after q4's 06:59:19 on 2026-09-07). Longest bounding a
- *     completed VIDEO anchor: 4,161 s (`ltx_2_3:q4:mlx`), with the clean back-to-back `ltx_2_5`
- *     pair at 1,132 s and 1,097 s.
- *   * the longest run this tree WITNESSES a guarded probe making real progress in: the 85-minute
- *     `bernini:q8:mlx` render (a VIDEO entry — `bernini` is the video row, `bernini_image` the
- *     still one) that was steady at 52 GB when a census false positive SIGKILLed it, named in
- *     `scripts/memory-calibration-watchdog.py`'s header.
+ * THE BASIS. The evidence corpus states no wall clock (`durationSeconds` and every other
+ * duration/elapsed field are ABSENT from `docs/calibration/sc-22738/*.json`), so the budgets rest
+ * on the longest COMPLETED capture each lane has witnessed, `WITNESSED_CAPTURE_SECONDS`:
  *
- * So: 150 minutes for video is 1.8x that witnessed 85-minute render and ~2.2x the longest video
- * capture cycle on file; 60 minutes for image is 4.2x the longest image capture cycle on file. Both
- * are backstops against a wedge, not schedule targets — a budget tight enough to argue about would
- * be converting slow renders into re-runs.
+ *   * video: 8,709 s — the completed `scail2_14b:bf16:mlx` capture above, the one direct witness
+ *     of a whole three-render video capture cycle. (The earlier basis, 4,161 s for `ltx_2_3:q4:mlx`
+ *     from consecutive `capturedAt` deltas, was a cycle bound for a lighter model; it under-read
+ *     SCAIL-2 by 2.1x and the 150-minute budget it produced cleared the witness by 3%.)
+ *   * image: 847 s — the `bernini_image:q8:mlx` capture→commit cycle (07:13:26 after q4's
+ *     06:59:19 on 2026-09-07), read the same way.
+ *
+ * So: 270 minutes for video is 1.86x the witnessed 8,709 s cycle, which is the same margin policy
+ * the earlier figure claimed (1.8x) applied to the right witness; 60 minutes for image is 4.2x the
+ * longest image cycle on file. Both are backstops against a wedge, not schedule targets — a budget
+ * tight enough to argue about is converting slow renders into re-runs, which is exactly what the
+ * 90-minute campaign did three times over.
  *
  * The cost of being wrong is bounded BY DESIGN and asymmetric on purpose: a runtime stop records no
  * bound and leaves the cell `runnable`, so too tight a budget costs a re-run, while too loose a one
- * costs only operator time. `--probe-budget-minutes` overrides both entries for a run.
+ * costs only operator time. `--probe-budget-minutes` overrides both entries for a run and is
+ * honored as given; a run launched below its lane's default is told so in the stop reason
+ * (`runtimeBudgetExceededReason`), because a stop under such a budget is not evidence of a stall.
  */
-export const PROBE_BUDGET_MINUTES = { video: 150, image: 60 };
+export const WITNESSED_CAPTURE_SECONDS = { video: 8_709, image: 847 };
+export const PROBE_BUDGET_MINUTES = { video: 270, image: 60 };
+
+/** The lane a plan row is budgeted under: a video anchor renders more than one frame. */
+export function probeLane(row) {
+  return row.videoLane ? "video" : "image";
+}
 
 /** This row's wall-clock budget in minutes: the runner's `--probe-budget-minutes`, else its lane's. */
 export function probeBudgetMinutes(row, override = null) {
@@ -2343,7 +2361,36 @@ export function probeBudgetMinutes(row, override = null) {
     if (!Number.isFinite(override) || override <= 0) fail("--probe-budget-minutes must be a positive number of minutes");
     return override;
   }
-  return PROBE_BUDGET_MINUTES[row.videoLane ? "video" : "image"];
+  return PROBE_BUDGET_MINUTES[probeLane(row)];
+}
+
+/**
+ * The `runtime_budget_exceeded` reason a wall-clock stop reports (sc-22738).
+ *
+ * Names the budget, the peak sampled (so a probe wedged at the ceiling reads differently from one
+ * wedged at 3 GB), and the longest COMPLETED capture this lane has on record — and, when the run
+ * was launched with `--probe-budget-minutes` below its lane's default, says in as many words that
+ * the stop is a budget shortfall rather than evidence of a stall. The three `scail2_14b` cells of
+ * the 90-minute campaign of 2026-09-07 were read as a hung engine for want of this sentence.
+ *
+ * Pure: `peak` is `watchdogPeakFootprint`'s reading or `null`, `ceiling` the guard's kill line as
+ * a phrase, and nothing here touches the store.
+ */
+export function runtimeBudgetExceededReason({ row, budgetMinutes, budgetSeconds, peak, ceiling }) {
+  const lane = probeLane(row);
+  const laneDefault = PROBE_BUDGET_MINUTES[lane];
+  const witnessed = WITNESSED_CAPTURE_SECONDS[lane];
+  let reason =
+    `runtime_budget_exceeded: the ${budgetMinutes}-minute probe budget (${budgetSeconds}s) elapsed; `
+    + `peak physical footprint ${peak ? `${peak.peakBytes} bytes over ${peak.samples} sample(s)` : "not sampled"} `
+    + `against the ${ceiling}. Nothing was measured, so no bound was recorded and this cell stays runnable. `
+    + `The longest completed ${lane} capture on record ran ${witnessed}s`;
+  if (budgetMinutes < laneDefault) {
+    reason += `, and this run was launched with --probe-budget-minutes ${budgetMinutes}, below the ${lane} `
+      + `lane's ${laneDefault}-minute default: this stop is a budget shortfall, not evidence of a stall. `
+      + `Re-run it at the default budget or larger before reading anything into the flat footprint`;
+  }
+  return `${reason}.`;
 }
 
 export function watchdogCeilings({ memoryBytes }) {
@@ -2793,7 +2840,8 @@ export async function measureAnchor(row, context) {
     // The guard killed this group on exactly the path a footprint stop takes — same escalation,
     // same post-stop census — but for a different reason: the probe ran out of time, wherever its
     // footprint happened to be. `scail2_14b:bf16:mlx` sat flat at 93.5 GB under a 94.82 GB ceiling
-    // for 90 minutes; the footprint it was sitting at is not a line it was witnessed to CROSS, and
+    // for 90 minutes (a render in progress, it turned out — see `PROBE_BUDGET_MINUTES`); the
+    // footprint it was sitting at is not a line it was witnessed to CROSS, and
     // recording it as `exceededBounds` would state a lower bound the run never established and make
     // production refuse hosts on it. So this arm returns BEFORE the two bound-recording arms below,
     // records nothing, commits nothing, and leaves the cell `runnable` for the next `--list`: no
@@ -2808,9 +2856,7 @@ export async function measureAnchor(row, context) {
         : "the guard's ceiling";
       return finish(
         "capture_failed",
-        `runtime_budget_exceeded: the ${budgetMinutes}-minute probe budget (${budgetSeconds}s) elapsed; `
-          + `peak physical footprint ${peak ? `${peak.peakBytes} bytes over ${peak.samples} sample(s)` : "not sampled"} `
-          + `against the ${ceiling}. Nothing was measured, so no bound was recorded and this cell stays runnable.`,
+        runtimeBudgetExceededReason({ row, budgetMinutes, budgetSeconds, peak, ceiling }),
       );
     }
     // sc-22738 (measured 2026-09-06): the SECOND way a run ends having measured a bound. Metal

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -74,7 +74,10 @@ import {
   runtimeBudgetStopSeconds,
   RUNTIME_BUDGET_STOP_PATTERN,
   PROBE_BUDGET_MINUTES,
+  WITNESSED_CAPTURE_SECONDS,
   probeBudgetMinutes,
+  probeLane,
+  runtimeBudgetExceededReason,
   METAL_REFUSAL,
   ARTIFACT_UNSUPPORTED,
   artifactUnsupported,
@@ -4964,9 +4967,19 @@ test("a footprint hard stop on a no-commit run surfaces as `exceeded` naming the
 
 test("every probe carries a wall-clock budget: per lane by default, derived from the plan, overridable", async () => {
   // The table, and the flag that overrides it.
-  assert.deepEqual(PROBE_BUDGET_MINUTES, { video: 150, image: 60 });
-  assert.equal(probeBudgetMinutes({ videoLane: true }), 150);
+  assert.deepEqual(PROBE_BUDGET_MINUTES, { video: 270, image: 60 });
+  assert.equal(probeBudgetMinutes({ videoLane: true }), 270);
   assert.equal(probeBudgetMinutes({ videoLane: false }), 60);
+  // sc-22738 (2026-09-08): each lane's budget rests on the longest COMPLETED capture it has
+  // witnessed, with the margin the table's own doc comment states. The video witness is the
+  // 8,709 s `scail2_14b:bf16:mlx` capture that a 150-minute budget cleared by 3% and a 90-minute
+  // campaign then stopped three times over; a budget that no longer clears its witness by that
+  // margin is the defect this pins, whichever entry drifts.
+  assert.deepEqual(WITNESSED_CAPTURE_SECONDS, { video: 8_709, image: 847 });
+  assert.ok(PROBE_BUDGET_MINUTES.video * 60 >= WITNESSED_CAPTURE_SECONDS.video * 1.8, "video budget clears its witness by 1.8x");
+  assert.ok(PROBE_BUDGET_MINUTES.image * 60 >= WITNESSED_CAPTURE_SECONDS.image * 4, "image budget clears its witness by 4x");
+  assert.equal(probeLane({ videoLane: true }), "video");
+  assert.equal(probeLane({ videoLane: false }), "image");
   assert.equal(probeBudgetMinutes({ videoLane: true }, 12), 12, "the flag overrides both lanes");
   assert.equal(probeBudgetMinutes({ videoLane: false }, 0.5), 0.5);
   assert.throws(() => probeBudgetMinutes({ videoLane: false }, 0), /positive number of minutes/);
@@ -4985,7 +4998,7 @@ test("every probe carries a wall-clock budget: per lane by default, derived from
   for (const row of rows) {
     const frames = plan.anchors[row.key].geometry?.frames ?? 1;
     assert.equal(row.videoLane, frames > 1, `${row.key} renders ${frames} frame(s)`);
-    assert.equal(probeBudgetMinutes(row), frames > 1 ? 150 : 60, row.key);
+    assert.equal(probeBudgetMinutes(row), frames > 1 ? 270 : 60, row.key);
     if (frames > 1) video += 1;
   }
   assert.ok(video > 0 && video < rows.length, `${video} of ${rows.length} mlx rows are video anchors`);
@@ -5024,6 +5037,37 @@ test("a runtime stop is recognised by its spelling and reports the guard's sampl
   assert.equal(await watchdogPeakFootprint(path.join(dir, "absent.jsonl")), null);
 });
 
+test("a runtime stop's reason names the lane's longest completed capture, and a budget below the lane default as a shortfall rather than a stall", () => {
+  const peak = { peakBytes: 68_564_154_584, samples: 2354 };
+  const ceiling = "94822600832-byte ceiling";
+  // The campaign of 2026-09-07: `scail2_14b:q4:mlx` under `--probe-budget-minutes 90`, flat at
+  // 68.56 GB for 2,354 samples. This is the sentence that was missing when it was read as a hang.
+  const shortfall = runtimeBudgetExceededReason({ row: { key: "scail2_14b:q4:mlx", videoLane: true }, budgetMinutes: 90, budgetSeconds: 5400, peak, ceiling });
+  assert.equal(
+    shortfall,
+    "runtime_budget_exceeded: the 90-minute probe budget (5400s) elapsed; peak physical footprint 68564154584 bytes "
+      + "over 2354 sample(s) against the 94822600832-byte ceiling. Nothing was measured, so no bound was recorded and "
+      + "this cell stays runnable. The longest completed video capture on record ran 8709s, and this run was launched "
+      + "with --probe-budget-minutes 90, below the video lane's 270-minute default: this stop is a budget shortfall, "
+      + "not evidence of a stall. Re-run it at the default budget or larger before reading anything into the flat footprint.",
+  );
+  // At the lane default (or above it) the stop stands on its own: the witness is still named, the
+  // shortfall sentence is not.
+  for (const budgetMinutes of [270, 300]) {
+    const reason = runtimeBudgetExceededReason({ row: { key: "scail2_14b:q4:mlx", videoLane: true }, budgetMinutes, budgetSeconds: budgetMinutes * 60, peak, ceiling });
+    assert.match(reason, new RegExp(`^runtime_budget_exceeded: the ${budgetMinutes}-minute probe budget \\(${budgetMinutes * 60}s\\) elapsed; `), reason);
+    assert.match(reason, /stays runnable\. The longest completed video capture on record ran 8709s\.$/, reason);
+    assert.doesNotMatch(reason, /shortfall|not evidence of a stall/, reason);
+  }
+  // The image lane reads its own witness and its own default, and an unsampled peak is said so.
+  const image = runtimeBudgetExceededReason({ row: { key: "sdxl:q4:mlx", videoLane: false }, budgetMinutes: 30, budgetSeconds: 1800, peak: null, ceiling: "guard's ceiling" });
+  assert.match(image, /peak physical footprint not sampled against the guard's ceiling\./, image);
+  assert.match(image, /The longest completed image capture on record ran 847s, and this run was launched with --probe-budget-minutes 30, below the image lane's 60-minute default/, image);
+  const imageAtDefault = runtimeBudgetExceededReason({ row: { key: "sdxl:q4:mlx", videoLane: false }, budgetMinutes: 60, budgetSeconds: 3600, peak: null, ceiling: "guard's ceiling" });
+  assert.match(imageAtDefault, /ran 847s\.$/, imageAtDefault);
+  assert.doesNotMatch(imageAtDefault, /shortfall/, imageAtDefault);
+});
+
 test("a probe that reaches its wall-clock budget is a capture_failed, never a memory bound, and the cell stays runnable", { skip: process.platform !== "darwin" && "the footprint sampler is Darwin-only" }, async () => {
   const checkout = await stubCheckout();
   const tierRoot = await mkdtemp(path.join(tmpdir(), "catalog-tier-"));
@@ -5052,6 +5096,9 @@ test("a probe that reaches its wall-clock budget is a capture_failed, never a me
     // The line an operator reads has to carry both figures, or there is nothing to judge with.
     assert.match(stopped.reason, /peak physical footprint \d+ bytes over \d+ sample\(s\) against the 94822600832-byte ceiling/);
     assert.match(stopped.reason, /no bound was recorded and this cell stays runnable/);
+    // sc-22738 (2026-09-08): 0.05 minutes is below the image lane's default, and the reason says
+    // so — a stop under a shortened budget must not read as a wedged engine.
+    assert.match(stopped.reason, /The longest completed image capture on record ran 847s, and this run was launched with --probe-budget-minutes 0\.05, below the image lane's 60-minute default: this stop is a budget shortfall, not evidence of a stall\./);
     assert.equal(context.state.commits.length, 0, "nothing was committed");
     const { stdout: status } = await checkout.git("status", "--porcelain");
     assert.equal(status, "", "the tree is clean for the next anchor");


### PR DESCRIPTION
## Root cause (sc-22738, `scail2_14b:*:mlx` "no progress")

The SCAIL-2 MLX captures were never stalled. They were **killed by the wall-clock budget while rendering**:

- A video capture arm renders its clip **three times** — measured render, clean warm control, warm repeat (`crates/sceneworks-memory-adapter/src/bin/mlx_wan_scail2.rs`, `run`). A SCAIL-2 render is a 14B DiT at 832x480x77 with CFG on (two DiT forwards per step, `mlx-gen-scail2/src/generate.rs:653-662`), and the main thread waits on the GPU at the per-step `eval` by design — that is the `mlx::core::eval → waitUntilSignaledValue` frame that was read as a hang.
- The one **unbudgeted** `scail2_14b:bf16:mlx` capture on record **completed in 8,709 s** (rendered all 80 decoded frames; `calib-mlx/campaign.log`, 2026-09-06 — it then failed only on the 77≠80 frame equality that #2755 fixed).
- The campaign of 2026-09-07 was launched with `--probe-budget-minutes 90` (5,400 s). The lane default was 150 min (9,000 s), whose stated basis (4,161 s `ltx_2_3:q4:mlx` cycle bound / 85-min bernini render) omitted the 8,709 s witness and cleared it by 3%.
- During the stopped q4 probe the footprint oscillated ±90 MB on a 4–6 s cadence (1,116 value changes over the "flat" 68.5 GB plateau); during the running q8 probe the GPU reads 99–100% device utilization with the adapter's threads idle; `log show` over both windows finds no GPU hang/restart/fault. `providerPhase` is `null` for **every** anchor's watchdog stream because the runner passes no `--provider-phase-profile` — its absence is not a progress signal.
- No admission gate is involved: the arm asks the gate nothing (`probes_admission` is `false`), and `Scail2Pipeline::generate` (`pipeline.rs:206-220`) is synchronous `validate → run → ensure_unchanged`; there is no receipt future to await.

## Fix (SceneWorks-side, `scripts/measure-memory-catalog.mjs`)

- `PROBE_BUDGET_MINUTES.video` re-based from 150 to **270** on the witnessed 8,709 s capture with the doc comment's own 1.8× margin policy; the witness is now a named constant, `WITNESSED_CAPTURE_SECONDS = { video: 8709, image: 847 }`, and the test pins the budget/witness relationship for both lanes.
- The `runtime_budget_exceeded` reason is now built by `runtimeBudgetExceededReason` — it names the lane's longest completed capture, and when the run was launched with `--probe-budget-minutes` below the lane default it says so in as many words ("a budget shortfall, not evidence of a stall"). `--probe-budget-minutes` is still honored as given.
- `docs/calibration-runbook.md` updated to match.

No Rust or inference change: the engine behaves correctly at e16c6a55e, and the scail2 crate is byte-identical at e34d7b46a.

## The in-flight q8 probe

Started 01:10Z under the same 90-minute budget; expect it to stop as `runtime_budget_exceeded` at ~02:40Z having measured nothing. The three scail2 cells need a run at the new default (or `--probe-budget-minutes 270`); bf16 alone needs ~2.5 h.

## Verification

- `node --test scripts/measure-memory-catalog.test.mjs` — all pass (includes the new synthetic reason test and the extended end-to-end runtime-stop test).
- `cargo fmt --all -- --check` clean (no Rust touched; the Rust gates cannot be affected by this diff and were not re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
