### PR TITLE
fix(sc-22738): Wan arms seal a receipt only where the engine publishes the identity from one; TI2V-5B captures unprepared

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/candle_wan_scail2.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/candle_wan_scail2.rs
@@ -464,6 +464,35 @@ fn load_spec(arm: Arm, tier: &str, load_shape: LoadShape) -> Result<Artifact, St
     })
 }
 
+/// Whether this cell's production identity is minted by the SEALED-RECEIPT authority
+/// (`gen_core::wan_i2v_memory`), so the capture must seal a receipt before the load to read it —
+/// or by the provider's own `memory_strategy` module, which the loader publishes only for an
+/// unprepared spec, so sealing one would HIDE it (sc-22738). The MLX arm's helper on this lane's
+/// backend token; `production_calibration_fingerprint` returns `None` for `wan2_2_ti2v_5b` by
+/// design, and a receipt naming any string but the plan's is a table/engine drift refused by name.
+fn receipt_publishes_the_identity(
+    arm: Arm,
+    tier: &str,
+    expected_fingerprint: &str,
+) -> Result<bool, String> {
+    let Some(route) = arm.route else {
+        return Ok(false);
+    };
+    match runtime_cuda::gen_core::wan_i2v_memory::production_calibration_fingerprint(
+        route,
+        runtime_cuda::gen_core::wan_i2v_memory::WanI2vBackend::Candle,
+        numeric_tier(tier)?,
+    ) {
+        None => Ok(false),
+        Some(published) if published == expected_fingerprint => Ok(true),
+        Some(published) => Err(format!(
+            "the pinned receipt authority mints {published} for the {} {tier} cell, not this \
+             arm's {expected_fingerprint}; the table and the engine have drifted",
+            arm.provider
+        )),
+    }
+}
+
 /// A deterministic, non-degenerate RGB8 plane — the same generator the MLX arm uses, so the two
 /// lanes present byte-identical carriers for the same cell.
 fn plane(width: u32, height: u32, salt: u32) -> Image {
@@ -658,7 +687,12 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
     }
 
     let mut resolved = load_spec(arm, tier, load_shape)?;
-    if arm.route.is_some() {
+    // Same split as the MLX arm (sc-22738): the A14B loaders publish a contract only from a sealed
+    // receipt, while TI2V-5B's `sc-19223-…` identity is its own `memory_strategy` module's and
+    // `WanGenerator::memory_strategy_contract` (`candle-gen-wan/src/lib.rs`) returns the receipt's
+    // identity-less contract ahead of it whenever the spec was prepared. Production
+    // (`video_jobs/wan.rs::video_load_spec`) prepares nothing.
+    if receipt_publishes_the_identity(arm, tier, &expected_fingerprint)? {
         candle_gen_wan::i2v_memory_strategy::prepare_load_spec(&mut resolved.spec, arm.provider)
             .map_err(|error| format!("prepare the {} load spec: {error}", arm.provider))?;
     }
@@ -969,6 +1003,33 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Only the A14B routes seal a receipt before the load; TI2V-5B and SCAIL-2 load unprepared,
+    /// exactly as production loads them (sc-22738). Mutation that fails this: guarding the
+    /// pre-pass on `arm.route.is_some()` again.
+    #[test]
+    fn only_the_a14b_routes_seal_a_receipt_before_the_load() {
+        for arm in ARMS {
+            for tier in ["bf16", "q4", "q8"] {
+                let expected = production_fingerprint(arm, tier).unwrap();
+                let seals = receipt_publishes_the_identity(arm, tier, &expected).unwrap();
+                let a14b = matches!(arm.route, Some(WanI2vRoute::T2v14b | WanI2vRoute::I2v14b));
+                assert_eq!(seals, a14b, "{} {tier}", arm.provider);
+            }
+        }
+        let ti2v = receipt_publishes_the_identity(
+            TI2V_5B,
+            "q4",
+            "sc-19223-wan2-2-ti2v-5b-candle-q4-sequential-load-v1",
+        );
+        assert_eq!(ti2v, Ok(false));
+        let drift =
+            receipt_publishes_the_identity(T2V_A14B, "q4", "not-the-engines-string").unwrap_err();
+        assert!(
+            drift.contains("sc-22736-wan2-2-t2v-a14b-candle-q4-v1") && drift.contains("drifted"),
+            "{drift}"
+        );
+    }
 
     #[test]
     fn every_arm_plans_a_geometry_its_own_engine_admits() {

--- a/crates/sceneworks-memory-adapter/src/bin/mlx_wan_scail2.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx_wan_scail2.rs
@@ -2,8 +2,8 @@
 //!
 //! FOUR engine providers, ONE arm, because the four differ only in coordinates a table can hold:
 //! the artifact family, the public request carrier, the rate menu and the production identity. The
-//! measured path is identical — resolve the artifact, seal the receipt the way the worker's
-//! memory-aware load does, load through `runtime_macos::catalog().media()` (the seam
+//! measured path is identical — resolve the artifact, seal a receipt only where the engine publishes
+//! the identity from one, load through `runtime_macos::catalog().media()` (the seam
 //! `crates/sceneworks-worker/src/inference_runtime.rs` wraps), read the LOADED generator's own
 //! contract, drive the four admission probes through the provider's own registered check, and
 //! measure three synchronized phase peaks off the boundaries `generate` already emits.
@@ -468,6 +468,46 @@ fn numeric_quant(arm: Arm, tier: &str) -> Result<Option<Quant>, String> {
     Ok(if arm.route.is_some() { quant } else { None })
 }
 
+/// Whether this cell's production identity is minted by the SEALED-RECEIPT authority
+/// (`gen_core::wan_i2v_memory`), so the capture must seal a receipt before the load to read it —
+/// or by the provider's own `memory_strategy` module, which the loader publishes only for an
+/// unprepared spec, so sealing one would HIDE it (sc-22738).
+///
+/// Asked of the engine rather than spelled per route: `production_calibration_fingerprint`
+/// (`gen-core/src/wan_i2v_memory.rs`) is the receipt authority's own answer, and it returns `None`
+/// for `wan2_2_ti2v_5b` by design — that route's `sc-19236-…` identity belongs to
+/// `mlx-gen-wan/src/memory_strategy.rs`, and `Wan::memory_strategy_contract` (`model.rs`) returns
+/// the receipt's contract, calibration and all, ahead of that one whenever the spec was prepared.
+/// The receipt-published identity must be the plan's: a receipt naming any other string is a drift
+/// between this table and the engine, refused by name before a byte is opened.
+fn receipt_publishes_the_identity(
+    arm: Arm,
+    tier: &str,
+    expected_fingerprint: &str,
+) -> Result<bool, String> {
+    let Some(route) = arm.route else {
+        return Ok(false);
+    };
+    let numeric_tier = MemoryNumericTier {
+        precision: Precision::Bf16,
+        quant: numeric_quant(arm, tier)?,
+        component_precision_floors: &[],
+    };
+    match mlx_gen::gen_core::wan_i2v_memory::production_calibration_fingerprint(
+        route,
+        mlx_gen::gen_core::wan_i2v_memory::WanI2vBackend::Mlx,
+        numeric_tier,
+    ) {
+        None => Ok(false),
+        Some(published) if published == expected_fingerprint => Ok(true),
+        Some(published) => Err(format!(
+            "the pinned receipt authority mints {published} for the {} {tier} cell, not this \
+             arm's {expected_fingerprint}; the table and the engine have drifted",
+            arm.provider
+        )),
+    }
+}
+
 /// A deterministic, non-degenerate RGB8 plane. Every carrier byte a capture presents is generated
 /// here rather than staged, so the record's request identity is reproducible from this source
 /// alone — the same choice the PuLID and LTX arms make for their synthetic carriers.
@@ -765,12 +805,15 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
     }
 
     let mut artifact = load_spec(arm, tier, load_shape)?;
-    // A Wan route's loader prepares a memory receipt only for a spec whose file pins are already
-    // prepared (`model.rs`: `spec.prepared_file_pins().is_prepared()`), so the capture must do what
-    // the worker's memory-aware load does — otherwise the generator loads with no calibration
-    // identity at all. SCAIL-2 seals its own shared-tier pins inside `PreparedMemory::prepare` and
-    // needs no pre-pass.
-    if arm.route.is_some() {
+    // The A14B loaders publish a memory contract ONLY from a sealed receipt (`model.rs`: the
+    // `i2v_memory` prepared for a spec whose file pins are already prepared), so on those routes
+    // the capture seals one before the load — otherwise the generator loads with no contract at
+    // all. TI2V-5B is the opposite (sc-22738): its production identity is its own
+    // `memory_strategy` module's, which `load` publishes only for an UNPREPARED spec — a prepared
+    // one takes the receipt path instead, and the receipt authority mints no identity for that
+    // route. Production (`video_jobs/wan.rs::video_load_spec`) prepares nothing, so neither does
+    // this cell. SCAIL-2 seals its own shared-tier pins inside `PreparedMemory::prepare`.
+    if receipt_publishes_the_identity(arm, tier, &expected_fingerprint)? {
         mlx_gen_wan::i2v_memory_strategy::prepare_load_spec(&mut artifact.spec, arm.provider)
             .map_err(|error| format!("prepare the {} load spec: {error}", arm.provider))?;
     }
@@ -1071,6 +1114,64 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Only the A14B routes seal a receipt before the load (sc-22738).
+    ///
+    /// `wan_2_2:{bf16,q4,q8}:mlx` were refused at e34d7b46a with "published no calibration
+    /// identity": the arm sealed a receipt for every Wan route, and for TI2V-5B the loader then
+    /// published the receipt's identity-less contract ahead of its own `sc-19236-…` one. The
+    /// discriminator is the engine's receipt authority, asked directly, so the A14B cells keep
+    /// their pre-pass and the two unprepared arms match production's own load.
+    ///
+    /// Mutations that fail this: guarding the pre-pass on `arm.route.is_some()` again (the
+    /// TI2V-5B rows flip), or dropping the drift refusal (the last assertion).
+    #[test]
+    fn only_the_a14b_routes_seal_a_receipt_before_the_load() {
+        for arm in ARMS {
+            for tier in ["bf16", "q4", "q8"] {
+                let expected = production_fingerprint(arm, tier).unwrap();
+                let seals = receipt_publishes_the_identity(arm, tier, &expected).unwrap();
+                let a14b = matches!(arm.route, Some(WanI2vRoute::T2v14b | WanI2vRoute::I2v14b));
+                assert_eq!(seals, a14b, "{} {tier}", arm.provider);
+            }
+        }
+        // Not vacuous: the table really carries both kinds of route.
+        assert!(matches!(TI2V_5B.route, Some(WanI2vRoute::Ti2v5b)));
+        assert!(SCAIL2.route.is_none());
+        for tier in ["bf16", "q4", "q8"] {
+            let expected = production_fingerprint(TI2V_5B, tier).unwrap();
+            assert!(expected.starts_with("sc-19236-wan2-2-ti2v-5b-mlx-"));
+            assert_eq!(
+                receipt_publishes_the_identity(TI2V_5B, tier, &expected),
+                Ok(false),
+                "{tier}"
+            );
+        }
+        let drift =
+            receipt_publishes_the_identity(T2V_A14B, "q4", "not-the-engines-string").unwrap_err();
+        assert!(
+            drift.contains("sc-22736-wan2-2-t2v-a14b-mlx-q4-v1") && drift.contains("drifted"),
+            "{drift}"
+        );
+    }
+
+    /// The pre-pass in the arm's body is guarded by the engine-asked discriminator and by nothing
+    /// looser; read as source because the load itself needs real weights (sc-22738).
+    #[test]
+    fn the_receipt_prepass_is_guarded_by_the_receipt_authority() {
+        let body = arm_source_body();
+        let guard = body
+            .find("if receipt_publishes_the_identity(arm, tier, &expected_fingerprint)? {")
+            .expect("the pre-pass is guarded by the receipt authority");
+        let prepass = body
+            .find("mlx_gen_wan::i2v_memory_strategy::prepare_load_spec(&mut artifact.spec")
+            .expect("the pre-pass still exists");
+        assert!(guard < prepass, "the guard precedes the pre-pass");
+        assert!(
+            !body.contains("if arm.route.is_some() {\n        mlx_gen_wan::i2v_memory_strategy"),
+            "the pre-pass must not run for every Wan route"
+        );
+    }
 
     /// `LoadSpec::quantize` follows each route's OWN MLX convention, and the two differ.
     ///


### PR DESCRIPTION
## Summary

`wan_2_2:{bf16,q4,q8}:mlx` were refused before the load at inference e34d7b46a with:

> the loaded wan2_2_ti2v_5b provider … published no calibration identity for the q4 artifact; the production identity for this cell is sc-19236-wan2-2-ti2v-5b-mlx-q4-g64-teq8-v1

**Root cause is SceneWorks-side, not the artifact and not the engine.** The Wan/SCAIL-2 arm (sc-22736) sealed a `wan_i2v_memory` receipt for *every* `route.is_some()` arm, TI2V-5B included. At the pin, `mlx-gen-wan/src/model.rs` (`load`, :465-475) builds both the provider's own `memory_strategy` contract and, for a spec with prepared file pins, the receipt's `i2v_memory`; `Wan::memory_strategy_contract` (:509-514) returns the receipt's contract **ahead of** the provider's. The receipt authority mints no identity for `Ti2v5b` by design (`gen-core/src/wan_i2v_memory.rs:470-473`, `a14b_cell_tokens` :517 → `None`; sealed at :2032), so the loaded generator published a contract with `calibration: None`. Production (`video_jobs/wan.rs::video_load_spec`) prepares no pins for any Wan route, so production's TI2V-5B contract is the `sc-19236-…` one — the capture was loading a shape production never loads.

The A14B routes genuinely need the pre-pass (their loaders publish a contract *only* from the receipt, `model.rs:1425`), so the arm now asks the engine's receipt authority — `production_calibration_fingerprint(route, backend, tier)` — whether it mints this cell's identity, and seals a receipt only then. A receipt naming a string other than the plan's is refused as table/engine drift. The Candle sibling arm had the identical guard (and `candle-gen-wan/src/lib.rs:1125-1130` the identical precedence), so it gets the same fix.

## Evidence

* Artifact layout on disk (`~/.cache/huggingface/hub` and `/Volumes/Models/huggingface/hub`, same snapshot `bb1b0552…`): `<tier>/{config.json, model.safetensors, t5_encoder.safetensors, vae.safetensors, tokenizer.json}` — single-file per component, no shards, no subdirs. Tensor inventories (825 dense / 1425 packed transformer, 242 UMT5, 196 F32 VAE) match the engine's `transformer_bytes`/`conditioning_bytes` predicates exactly; the packed tiers carry a dense BF16 UMT5 that the `teq8` route packs to Q8 at load, and a dense `head.head` (inference #965).
* The engine's own predicate stack accepts all three roots at this pin. Running `mlx_gen_wan::memory_strategy::memory_strategy_contract` (the same `production_contract_and_tier` `load` runs for an unprepared spec — header reads only, no weights loaded) on the arm's `load_spec` for each tier:
  * bf16 → `sc-19236-wan2-2-ti2v-5b-mlx-dense-v1` (base_bytes 22,772,759,992)
  * q4 → `sc-19236-wan2-2-ti2v-5b-mlx-q4-g64-teq8-v1` (11,377,360,312)
  * q8 → `sc-19236-wan2-2-ti2v-5b-mlx-q8-g64-teq8-v1` (13,831,028,152)
* The identity table in the arm already names all three tiers and matches `calibration_fingerprint` (`mlx-gen-wan/src/memory_strategy.rs:667-677`); nothing was missing at the pin.

## Tests

* `only_the_a14b_routes_seal_a_receipt_before_the_load` (both arms): every (arm, tier) seals iff the route is A14B; the three TI2V-5B cells are `Ok(false)` by name; a receipt naming a foreign string is refused as drift.
* `the_receipt_prepass_is_guarded_by_the_receipt_authority` (MLX): source-body assertion that the pre-pass sits under the engine-asked guard and the old `arm.route.is_some()` guard is gone.

Expected after merge: `wan_2_2:{bf16,q4,q8}:mlx` load unprepared, the loaded contract carries the `sc-19236-…` identity the plan names, and the three cells capture. No engine change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
