### PR TITLE
feat(sc-22738): campaign fetches missing pinned snapshots on request (--download-missing)

### DIFF
--- a/.github/workflows/memory-catalog-campaign.yml
+++ b/.github/workflows/memory-catalog-campaign.yml
@@ -17,6 +17,17 @@
 # with the summary JSON, the per-anchor logs and the retained raw bundles. The last step opens a PR
 # back into the dispatched `ref` when the branch has commits. Nothing is merged automatically.
 #
+# FETCHING THE WEIGHTS IT NEEDS (`download_missing`, default false, sc-22738). Neither box holds the
+# whole catalog, and an anchor whose pinned snapshot is under none of the hub roots plans as
+# `weights_missing` and is skipped. Downloading the missing snapshots on the Windows box is faster
+# than copying them off the Mac's SSD, so the dispatch can turn on `--download-missing`: for the
+# `weights_missing` anchors AND ONLY THOSE, the walk resolves each repository/pinned-revision/file
+# globs out of the manifest rows the plan already reads, fetches them one at a time through the
+# Hugging Face CLI into the FIRST hub root, and classifies the anchor again. `$HF_TOKEN` (a runner
+# secret) is exported for the CLI and is only needed for a gated repository; a failed fetch leaves
+# that one anchor `weights_missing (download failed: …)` and never stops the walk. The flag reaches
+# the dry run (which fetches nothing) and the walk, never the `--list` pass.
+#
 # THE SCARCE RESOURCE IS THE GPU, NOT THE RUNNER. Each job takes a job-level `concurrency` group
 # keyed on (backend, runner) with `cancel-in-progress: false`, so two campaigns can never share one
 # box's GPU: the second dispatch queues behind the first rather than fighting it for unified memory
@@ -63,6 +74,15 @@ on:
         required: false
         type: string
         default: ""
+      download_missing:
+        description: >-
+          Fetch the pinned snapshots of anchors that would otherwise plan as weights_missing
+          (--download-missing). They land in the FIRST hub root above through the Hugging Face CLI
+          at the manifest's pinned revision, one at a time; a gated repo needs $HF_TOKEN on the
+          runner. Off by default: leave it off when the box already holds its weights.
+        required: false
+        type: boolean
+        default: false
       ref:
         description: "Branch to walk from. The campaign branch is cut from this ref and the PR targets it."
         required: true
@@ -86,8 +106,9 @@ on:
         type: string
         default: "1"
 
-# `gh pr create` and the branch pushes both run as the default GITHUB_TOKEN. No other secret is
-# needed or read by this workflow.
+# `gh pr create` and the branch pushes both run as the default GITHUB_TOKEN. The only other secret
+# this workflow reads is `HF_TOKEN`, and only the Hugging Face CLI sees it, only under
+# `download_missing` against a gated repository.
 permissions:
   contents: write
   pull-requests: write
@@ -104,6 +125,11 @@ env:
   MODELS_INPUT: ${{ inputs.models }}
   SKIP_CURRENT: ${{ inputs.skip_current }}
   HF_CACHE_INPUT: ${{ inputs.hf_cache_roots }}
+  DOWNLOAD_MISSING: ${{ inputs.download_missing }}
+  # Read by the Hugging Face CLI itself when --download-missing fetches a gated repository. Absent
+  # is not an error: every SceneWorks rehost and every upstream this campaign fetches is public, so
+  # an unset token only matters for a gated one. `hf_transfer` is opt-in on the runner, not here.
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
 jobs:
   mlx:

--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -1521,9 +1521,10 @@ measurement runs at epic end or on explicit request, never per code change.
 
 **Inputs.** `backend` (`mlx` | `candle`), `campaign` (one path segment, e.g. `sc-22738`), `anchors`
 (comma-separated keys), `models` (space-separated ids), `skip_current` (default true),
-`hf_cache_roots`, `ref` (the branch to walk from and the PR base), `runner_label` (mlx only),
-`push_every`. `anchors`, `models`, `skip_current` and `hf_cache_roots` map one-for-one onto the
-script's `--anchors` / `--model` / `--skip-current` / `--hf-cache` flags.
+`hf_cache_roots`, `download_missing` (default false), `ref` (the branch to walk from and the PR
+base), `runner_label` (mlx only), `push_every`. `anchors`, `models`, `skip_current`,
+`hf_cache_roots` and `download_missing` map one-for-one onto the script's `--anchors` / `--model` /
+`--skip-current` / `--hf-cache` / `--download-missing` flags.
 
 **Where each lane runs.**
 
@@ -1608,6 +1609,51 @@ candle), not a measured budget.
 on macOS, `E:\huggingface\hub` on the CUDA box). A root that does not exist is a warning, not an
 error — `hubRoots()` still falls back to the HF env convention and the app cache, and an anchor whose
 snapshot is under none of them plans as `weights_missing` rather than failing the run.
+
+**Fetching the missing snapshots — `download_missing` / `--download-missing` (sc-22738).** Neither
+box holds the whole catalog. Copying the missing snapshots off the Mac's SSD is slower than fetching
+them from the hub on the Windows box's own link (measured 2026-09-08), so the campaign can fetch
+what it needs:
+
+```bash
+gh workflow run memory-catalog-campaign.yml -R SceneWorks/SceneWorks \
+  --ref feature/sc-22723-memory-anchor-measurability \
+  -f backend=candle -f campaign=sc-22738 \
+  -f ref=feature/sc-22723-memory-anchor-measurability \
+  -f download_missing=true
+```
+
+- **Only `weights_missing` anchors.** A `runnable` cell is never re-fetched, and a cell refused for
+  any other reason (`no_adapter_arm`, `lane_undeclared`, `exceeded_current`, `harness_unsupported`)
+  is not a weights problem and gets no download. After the fetch the cell is classified **again**,
+  by the same `classifyAnchor` that refused it.
+- **Nothing is invented.** Each anchor's repositories are the ones the classifier probes (the
+  LTX-2.5 snapshot, the per-(lane, tier) artifact, `upstream`, the SDXL and Mage-Flow components,
+  the member's side artifact), and each repository's revision and file globs come from the manifest
+  download rows for that model, tier and platform. `--revision` is **always** the pinned revision —
+  never `main`, which pinning a manifest download removes from the mirror anyway — so a repository
+  the manifest ships unpinned (the upstream Wan 2.2 / SVD Diffusers checkpoints) is reported as not
+  fetchable instead of being resolved off a branch. So are the hand-staged roots (PuLID's identity
+  bundle, the InstantID stack): they are operator env vars, not hub repositories.
+- **Destination: the FIRST `--hf-cache` root**, i.e. the first line of `hf_cache_roots` above —
+  `E:\huggingface\hub` on the CUDA box, `/Volumes/Models/huggingface/hub` on a Mac. Standard hub
+  layout (`models--<org>--<name>/snapshots/<rev>/…`, with `refs/` exactly as the CLI writes them),
+  because it is the CLI that writes it: `hf download <repo> --revision <rev> --include <glob> …
+  --cache-dir <root>` (falling back to `huggingface-cli` when `hf` is not installed).
+- **One at a time, resumable.** These are multi-GB transfers on a link that has already killed a
+  parallel fetch; the CLI resumes a partial download, so a re-dispatch pays only for what is
+  missing. Each landed snapshot logs `download: <key> <repo>@<rev> <n> files, <bytes> bytes`.
+- **A failed fetch never stops the walk.** That one anchor stays `weights_missing (download failed:
+  <reason>)` and the campaign moves on, exactly as an absent snapshot does today.
+- **`$HF_TOKEN`** is exported into the job from the repository/org secret of that name and is read
+  by the CLI, not by this script. Every artifact the campaign fetches today is public, so an unset
+  token only matters for a gated repository; set the secret (or export `HF_TOKEN` /
+  `HUGGING_FACE_HUB_TOKEN` on the runner) before dispatching one. `HF_HUB_ENABLE_HF_TRANSFER` is
+  runner-level opt-in and is not set here.
+- **`--dry-run --download-missing`** prints one line per snapshot it would fetch, with the
+  manifest's own `estimatedSizeBytes` where the rows declare it, and fetches nothing. That is what
+  the workflow's *Plan the walk* step runs; the `--list` table in the same step deliberately does
+  **not** carry the flag, so reading the plan can never start a download.
 
 ### 6b. Through the guarded dispatch
 

--- a/scripts/ci/memory-catalog/common.sh
+++ b/scripts/ci/memory-catalog/common.sh
@@ -114,3 +114,20 @@ build_catalog_args() {
     CATALOG_ARGS+=(--hf-cache "$root")
   done < <(hf_cache_roots)
 }
+
+# `--download-missing`, when the dispatch asked for it (sc-22738).
+#
+# DELIBERATELY NOT part of build_catalog_args: that array is shared with plan.sh's `--list` pass,
+# which is meant to be a millisecond-cheap table, and `--list --download-missing` would start the
+# multi-GB transfers there instead of in the walk. Only the two passes that are allowed to fetch --
+# the dry run (which prints what it would fetch and fetches nothing) and the walk itself -- append
+# it, and each does so explicitly.
+#
+# The destination is the FIRST --hf-cache root, i.e. the first line hf_cache_roots() prints. A gated
+# repository additionally needs $HF_TOKEN in the job env; every artifact this campaign fetches today
+# is public.
+download_missing_args() {
+  if [[ "${DOWNLOAD_MISSING:-false}" == "true" ]]; then
+    printf '%s\n' "--download-missing"
+  fi
+}

--- a/scripts/ci/memory-catalog/plan.sh
+++ b/scripts/ci/memory-catalog/plan.sh
@@ -26,5 +26,14 @@ node scripts/measure-memory-catalog.mjs "${CATALOG_ARGS[@]}" --list | tee "$LIST
 } >> "$GITHUB_STEP_SUMMARY"
 
 echo "--- dry run ---"
-node scripts/measure-memory-catalog.mjs "${CATALOG_ARGS[@]}" --adapter "$ADAPTER" --dry-run \
+# `--download-missing` reaches the DRY RUN (where it only prints what it would fetch) and the walk,
+# never the `--list` pass above -- see download_missing_args in common.sh. So the table above still
+# reports a cell whose weights are absent as `weights_missing`; the dry run below is where an
+# operator reads which snapshots the walk will fetch first.
+DRY_RUN_ARGS=("${CATALOG_ARGS[@]}" --adapter "$ADAPTER" --dry-run)
+while IFS= read -r flag; do
+  [[ -z "$flag" ]] && continue
+  DRY_RUN_ARGS+=("$flag")
+done < <(download_missing_args)
+node scripts/measure-memory-catalog.mjs "${DRY_RUN_ARGS[@]}" \
   | tee "${WORK_DIR}/plan-dry-run.txt"

--- a/scripts/ci/memory-catalog/run.sh
+++ b/scripts/ci/memory-catalog/run.sh
@@ -16,6 +16,10 @@ source "$(dirname "$0")/common.sh"
 
 build_catalog_args
 CATALOG_ARGS+=(--adapter "$ADAPTER")
+while IFS= read -r flag; do
+  [[ -z "$flag" ]] && continue
+  CATALOG_ARGS+=("$flag")
+done < <(download_missing_args)
 
 LOG="${WORK_DIR}/campaign.log"
 : > "$LOG"

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -18,6 +18,16 @@
 //     --work-dir /abs/OUTSIDE/the/repo/calib --campaign sc-NNNN [--model sdxl ...] [--anchors a,b]
 //     [--skip-current] [--probe-budget-minutes N]
 //     [--dry-run] [--no-commit] [--hf-cache DIR ...]   (--hf-cache is repeatable)
+//     [--download-missing]
+//
+// `--download-missing` (default OFF, sc-22738) fetches the pinned snapshots of every anchor the
+// plan would otherwise classify `weights_missing` — and only those — into the FIRST `--hf-cache`
+// root, through the Hugging Face CLI (`hf download <repo> --revision <pinned> --include <globs>
+// --cache-dir <root>`, falling back to `huggingface-cli`), then classifies the anchor again. One
+// download at a time, resumable, `$HF_TOKEN` honoured by the CLI itself; a failed fetch leaves the
+// anchor `weights_missing (download failed: …)` and never aborts the walk. `--dry-run
+// --download-missing` prints what it would fetch, with the manifest's own byte estimate, and
+// fetches nothing.
 //
 // Every guarded probe also carries a WALL-CLOCK budget (`--probe-budget-minutes`, defaulted per
 // lane by `PROBE_BUDGET_MINUTES`), passed to the guard as `--max-runtime-seconds`. A probe that
@@ -1334,7 +1344,7 @@ export function parseArgs(argv) {
   const args = {
     backend: null, adapter: null, inferenceRepo: null, workDir: null, campaign: null,
     anchors: null, models: [], skipCurrent: false, dryRun: false, commit: true, hfCache: [], list: false,
-    probeBudgetMinutes: null,
+    probeBudgetMinutes: null, downloadMissing: false,
   };
   const value = (flag, index) => {
     const selected = argv[index + 1];
@@ -1362,6 +1372,9 @@ export function parseArgs(argv) {
         index += 1;
         break;
       }
+      // sc-22738. Off by default: a campaign that has its weights must never start a multi-GB
+      // transfer, and the flag is the operator's statement that this box is allowed to fetch.
+      case "--download-missing": args.downloadMissing = true; break;
       case "--dry-run": args.dryRun = true; break;
       case "--no-commit": args.commit = false; break;
       case "--list": args.list = true; break;
@@ -2013,6 +2026,240 @@ export async function classifyAnchor(key, planned, { models, backend, hubs, curr
     variant: parts.tier,
   };
   return row;
+}
+
+// ---------------------------------------------------------------------------------------------
+// `--download-missing`: fetch the pinned snapshots a `weights_missing` anchor needs (sc-22738)
+// ---------------------------------------------------------------------------------------------
+//
+// The campaign runs on boxes that do not hold the whole catalog: the Windows CUDA runner's
+// `E:\huggingface\hub` carries a fraction of what the plan declares, and every anchor whose pinned
+// snapshot is under none of the `--hf-cache` roots classifies `weights_missing` and is skipped.
+// Copying the missing snapshots off the Mac's SSD is slower than fetching them from the hub on that
+// box's own link (2026-09-08), so the walk can fetch them itself.
+//
+// Everything below is DERIVED from what the plan already knows — the family row that says which
+// repositories one anchor binds, and the manifest download rows that pin each repository's revision
+// and its file globs. Nothing here decides what an anchor needs; `classifyAnchor` does, and it
+// decides again after the fetch. The flag is opt-in and touches ONLY rows the plan classified
+// `weights_missing`: a runnable anchor is never re-fetched, and no other status is reconsidered.
+
+/** The Hugging Face CLI, newest spelling first. `hf` superseded `huggingface-cli`; both take the
+ *  same `download <repo> --revision … --include … --cache-dir …` form the runbook documents. */
+export const HF_CLI_CANDIDATES = Object.freeze(["hf", "huggingface-cli"]);
+
+/** This host in the manifest's own platform vocabulary. */
+export function manifestPlatform(platform = process.platform) {
+  if (platform === "darwin") return "macos";
+  if (platform === "win32") return "windows";
+  return "linux";
+}
+
+/**
+ * The manifest download rows that ship `tier` of `repo` for `modelId` — the tier's own rows plus
+ * every tier-independent co-requisite of the same repository.
+ *
+ * Narrowed to THIS host's platform, because several families ship a different file set per platform
+ * (MiniMax-H3's dense upstream ships `transformer/*` on windows/linux and only the text encoder on
+ * macOS) and fetching the union would pull tens of GB no lane loads. The narrowing is fail-safe: a
+ * repository whose rows are all scoped to other platforms falls back to the unfiltered set rather
+ * than resolving to "no globs", which downstream would read as "fetch the whole repository".
+ */
+export function tierDownloadRows(models, modelId, repo, tier, platform = manifestPlatform()) {
+  const model = models.find((entry) => entry.id === modelId);
+  if (!model) return [];
+  const rows = (model.downloads ?? []).filter(
+    (download) => download.repo === repo && (download.variant === undefined || download.variant === tier),
+  );
+  const scoped = rows.filter((download) => !download.platforms || download.platforms.includes(platform));
+  return scoped.length > 0 ? scoped : rows;
+}
+
+/**
+ * Every pinned snapshot ONE anchor binds, as `{ label, repo, revision, include, estimatedBytes }`,
+ * plus the roots that cannot be fetched at all and why.
+ *
+ * The repositories are exactly the ones `classifyAnchor` probes for this cell — the LTX-2.5
+ * snapshot the harness binds through `--ltx25-snapshot-root`, or else the per-(lane, tier) artifact
+ * `familyArtifact` resolves; the `upstream` root; the caller-staged `components` in both their array
+ * (SDXL) and object (Mage-Flow) shapes; and the member's `sideArtifact`. `siblingRoots` need no
+ * entry: a sibling lives INSIDE the artifact's own snapshot at the same revision, so the tier root's
+ * co-requisite rows already carry its globs.
+ *
+ * Two things are deliberately NOT fetchable, and are reported rather than guessed at:
+ *
+ *   - a repository the manifest ships with NO pinned revision (the upstream Wan 2.2 / SVD Diffusers
+ *     checkpoints). `--revision` is ALWAYS the pinned revision here; falling back to `main` would
+ *     fetch whatever the branch points at today, which is not the artifact the anchor prices — and
+ *     pinning a manifest download REMOVES `refs/main` from the mirror in the first place;
+ *   - a `bundle` / `stagedEnv` root (PuLID's identity bundle, the InstantID stack), which is a
+ *     pre-staged directory named by an operator env var and not a hub repository at all.
+ */
+export function anchorDownloadTargets(row, models, { families = PROVIDER_FAMILIES, platform = manifestPlatform() } = {}) {
+  const targets = [];
+  const unfetchable = [];
+  const family = familyFor(row.modelId, row.provider, families);
+  if (!family) return { targets, unfetchable: [`no artifact family declares ${row.modelId} on provider ${row.provider}`] };
+
+  const repositories = [];
+  if (family.ltx25) repositories.push({ label: "ltx25 snapshot", repo: family.repo });
+  else repositories.push({ label: "tier root", repo: familyArtifact(family, row.backend, row.tier).repo });
+  if (family.upstream) repositories.push({ label: "upstream root", repo: family.upstream.repo });
+  for (const component of Array.isArray(family.components) ? family.components : []) {
+    repositories.push({ label: `component ${component.env}`, repo: component.repo });
+  }
+  if (family.components && !Array.isArray(family.components)) {
+    repositories.push({ label: "components snapshot", repo: family.components.repo });
+  }
+
+  const seen = new Set();
+  for (const { label, repo } of repositories) {
+    const rows = tierDownloadRows(models, row.modelId, repo, row.tier, platform);
+    if (rows.length === 0) {
+      unfetchable.push(`the manifest declares no ${repo} download for ${row.modelId}:${row.tier}`);
+      continue;
+    }
+    // One target per (repo, revision): a family whose co-requisites sit at a different revision
+    // from its tier weights is two fetches, never one fetch at whichever revision sorted first.
+    const byRevision = new Map();
+    for (const download of rows) {
+      if (!/^[0-9a-f]{40}$/.test(download.revision ?? "")) continue;
+      const entry = byRevision.get(download.revision) ?? { include: [], estimatedBytes: 0, whole: false };
+      if ((download.files ?? []).length === 0) entry.whole = true;
+      for (const glob of download.files ?? []) if (!entry.include.includes(glob)) entry.include.push(glob);
+      entry.estimatedBytes += Number(download.estimatedSizeBytes ?? 0);
+      byRevision.set(download.revision, entry);
+    }
+    if (byRevision.size === 0) {
+      unfetchable.push(
+        `${repo} is shipped without a pinned revision, and this fetch passes --revision with the `
+        + "pinned revision or does not run at all",
+      );
+      continue;
+    }
+    for (const [revision, entry] of byRevision) {
+      if (seen.has(`${repo}@${revision}`)) continue;
+      seen.add(`${repo}@${revision}`);
+      // `whole` means at least one row of this repository ships no `files` predicate, so the
+      // download IS the snapshot; passing the other rows' globs would fetch strictly less.
+      targets.push({ label, repo, revision, include: entry.whole ? [] : entry.include, estimatedBytes: entry.estimatedBytes });
+    }
+  }
+
+  // Not a manifest download: the member's own pinned side artifact (the Qwen edit Lightning distill
+  // LoRA), whose repository, revision and file the family row pins because the worker fetches it
+  // lazily rather than declaring it.
+  const side = family.sideArtifact?.[row.modelId];
+  if (side && !seen.has(`${side.repo}@${side.revision}`)) {
+    seen.add(`${side.repo}@${side.revision}`);
+    targets.push({
+      label: "side artifact", repo: side.repo, revision: side.revision,
+      include: side.file ? [side.file] : [], estimatedBytes: 0,
+    });
+  }
+  if (family.bundle) {
+    unfetchable.push(`$${family.bundle.env} is a pre-staged loose-file bundle, not a Hugging Face repository`);
+  }
+  for (const staging of family.stagedEnv ?? []) {
+    unfetchable.push(`$${staging.env} names a hand-staged directory, not a Hugging Face repository`);
+  }
+  return { targets, unfetchable };
+}
+
+/**
+ * The CLI arguments for one target. `--revision` is ALWAYS the pinned revision: the whole point of
+ * the flag is to land the snapshot the anchor prices, and a fetch that resolved a branch would
+ * quietly measure some other artifact.
+ */
+export function hfDownloadArgv(target, cacheRoot) {
+  const argv = ["download", target.repo, "--revision", target.revision];
+  for (const glob of target.include) argv.push("--include", glob);
+  argv.push("--cache-dir", cacheRoot);
+  return argv;
+}
+
+/** Files and bytes under one staged snapshot, for the per-anchor log line. */
+async function snapshotFileStats(root) {
+  let files = 0;
+  let bytes = 0;
+  const visit = async (dir) => {
+    let entries;
+    try { entries = await readdir(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      const child = path.join(dir, entry.name);
+      if (entry.isDirectory()) { await visit(child); continue; }
+      try {
+        const info = await stat(child);
+        if (info.isFile()) { files += 1; bytes += info.size; }
+      } catch { /* a dangling blob symlink counts as neither */ }
+    }
+  };
+  await visit(root);
+  return { files, bytes };
+}
+
+/**
+ * Fetch every snapshot one `weights_missing` anchor needs into `cacheRoot`, one at a time.
+ *
+ * Serial on purpose: these are multi-GB transfers on a runner whose link is the bottleneck (the
+ * Windows box died at ~150 KB/s inside a single parallel git fetch), and the CLI RESUMES a partial
+ * download, so a killed campaign re-runs the same command and pays only for what is missing.
+ *
+ * A failure NEVER aborts the walk — it comes back as a reason the caller appends to the anchor's
+ * `weights_missing` row, exactly as an absent snapshot does today.
+ */
+export async function fetchAnchorSnapshots(row, models, {
+  cacheRoot,
+  dryRun = false,
+  log = (line) => process.stdout.write(`${line}\n`),
+  families = PROVIDER_FAMILIES,
+  platform = manifestPlatform(),
+  env = process.env,
+  runCommand = run,
+  clis = HF_CLI_CANDIDATES,
+} = {}) {
+  const { targets, unfetchable } = anchorDownloadTargets(row, models, { families, platform });
+  if (targets.length === 0) {
+    return { fetched: [], failed: unfetchable.length > 0 ? unfetchable.join("; ") : "nothing to fetch", unfetchable };
+  }
+  const fetched = [];
+  for (const target of targets) {
+    if (dryRun) {
+      log(
+        `download: ${row.key} ${target.repo}@${target.revision.slice(0, 8)} would fetch `
+        + `${target.include.length > 0 ? `${target.include.length} glob(s): ${target.include.join(" ")}` : "the whole snapshot"}`
+        + `${target.estimatedBytes > 0 ? ` (~${target.estimatedBytes} bytes)` : ""}`,
+      );
+      fetched.push({ ...target, dryRun: true });
+      continue;
+    }
+    let lastError = null;
+    let ran = false;
+    for (const cli of clis) {
+      try {
+        await runCommand(cli, hfDownloadArgv(target, cacheRoot), { env });
+        ran = true;
+        break;
+      } catch (error) {
+        lastError = error;
+        // Only a MISSING cli falls through to the next spelling; a real download failure is the
+        // answer, not a reason to run a second tool.
+        if (error?.code !== "ENOENT") break;
+      }
+    }
+    if (!ran) {
+      return {
+        fetched,
+        failed: `${target.repo}@${target.revision.slice(0, 8)}: ${failureReason(lastError ?? new Error("no Hugging Face CLI on PATH"))}`,
+        unfetchable,
+      };
+    }
+    const staged = snapshotPath(cacheRoot, target.repo, target.revision);
+    const stats = await snapshotFileStats(staged);
+    log(`download: ${row.key} ${target.repo}@${target.revision.slice(0, 8)} ${stats.files} files, ${stats.bytes} bytes`);
+    fetched.push({ ...target, ...stats });
+  }
+  return { fetched, failed: null, unfetchable };
 }
 
 /** Append one evidence corpus to the Rust loader's compiled-in list, idempotently. */
@@ -2997,12 +3244,10 @@ export async function planRun(args, root = ROOT) {
   for (const model of args.models ?? []) {
     if (!keys.some((key) => anchorParts(key).modelId === model)) fail(`--model ${model} matches no plan anchor`);
   }
-  const rows = [];
-  for (const key of keys) {
-    if (args.anchors && !args.anchors.includes(key)) continue;
-    if ((args.models ?? []).length > 0 && !args.models.includes(anchorParts(key).modelId)) continue;
-    const row = await classifyAnchor(key, plan.anchors[key], { models, backend: args.backend, hubs, current, captured, bounds, declaredLanes, declaredProviders, sdxlRoutes, wanMlxSealed });
-    if (row.status === "other_backend" && !args.anchors) continue;
+  const context = { models, backend: args.backend, hubs, current, captured, bounds, declaredLanes, declaredProviders, sdxlRoutes, wanMlxSealed };
+  // Everything the classifier states about one row AFTER `classifyAnchor` returns it, so a
+  // re-classification following a fetch reaches exactly the same status a first pass would have.
+  const settle = (row) => {
     // An unperformed route-revision comparison is reported on the row it did not happen for, so a
     // run without an inference checkout cannot silently look like a run that proved the engine agrees.
     if (row.routeCheck && ["runnable", "weights_missing"].includes(row.status)) {
@@ -3012,7 +3257,44 @@ export async function planRun(args, root = ROOT) {
       row.status = "current";
       row.reason = "anchor is current at the pinned inference revision (--skip-current)";
     }
-    rows.push(row);
+    return row;
+  };
+  const rows = [];
+  for (const key of keys) {
+    if (args.anchors && !args.anchors.includes(key)) continue;
+    if ((args.models ?? []).length > 0 && !args.models.includes(anchorParts(key).modelId)) continue;
+    const row = await classifyAnchor(key, plan.anchors[key], context);
+    if (row.status === "other_backend" && !args.anchors) continue;
+    rows.push(settle(row));
+  }
+  // sc-22738. `--download-missing` fetches the pinned snapshots the ALREADY-CLASSIFIED
+  // `weights_missing` rows need, then asks the classifier again. Nothing else is touched: a
+  // `runnable` row is never re-fetched, and a row refused for any other reason (no adapter arm, an
+  // undeclared lane, an exceeded bound) is not a weights problem and gets no download.
+  if (args.downloadMissing) {
+    // The FIRST --hf-cache root is the destination, because that is the root the operator named
+    // for this box; with no --hf-cache at all it is whatever `hubRoots()` puts first, which is the
+    // HF env convention and the same place the CLI would write on its own.
+    const cacheRoot = hubs[0];
+    process.stdout.write(`download-missing: destination hub root ${cacheRoot}\n`);
+    for (const [index, row] of rows.entries()) {
+      if (row.status !== "weights_missing") continue;
+      const missingReason = row.reason;
+      const outcome = await fetchAnchorSnapshots(row, models, { cacheRoot, dryRun: args.dryRun });
+      if (outcome.failed) {
+        row.reason = `${missingReason} (download failed: ${outcome.failed})`;
+        continue;
+      }
+      for (const note of outcome.unfetchable) process.stdout.write(`download: ${row.key} not fetchable: ${note}\n`);
+      // A dry run states what it WOULD fetch and changes no classification: nothing landed, so
+      // re-classifying could only report the same missing root a second time.
+      if (args.dryRun) continue;
+      const reclassified = settle(await classifyAnchor(row.key, plan.anchors[row.key], context));
+      if (reclassified.status === "weights_missing") {
+        reclassified.reason = `${reclassified.reason} (after --download-missing fetched ${outcome.fetched.length} snapshot(s))`;
+      }
+      rows[index] = reclassified;
+    }
   }
   return { plan, rows, campaign, campaignDir, campaignPrefix: campaignDir, hubs };
 }

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -101,6 +101,12 @@ import {
   assertStageable,
   MAX_STAGED_FILE_BYTES,
   readExceededBounds,
+  anchorDownloadTargets,
+  hfDownloadArgv,
+  fetchAnchorSnapshots,
+  tierDownloadRows,
+  manifestPlatform,
+  HF_CLI_CANDIDATES,
 } from "./measure-memory-catalog.mjs";
 import {
   ANCHOR_LANE_DEFAULT_STRATEGY_PATH,
@@ -5326,4 +5332,267 @@ test("a refusal on a no-commit run surfaces as `exceeded` naming the Metal refus
   } finally {
     delete process.env.STUB_CAPTURE_METAL_REFUSAL;
   }
+});
+
+// ---------------------------------------------------------------------------------------------
+// sc-22738: `--download-missing` fetches the pinned snapshots a weights_missing anchor needs
+// ---------------------------------------------------------------------------------------------
+//
+// The campaign runs on boxes that do not hold the whole catalog, and downloading a missing snapshot
+// on the Windows box beats copying it off the Mac's SSD. These tests drive the fetch through a STUB
+// `hf` on PATH that writes the hub layout the real CLI writes, so they prove the wiring — which
+// anchors are fetched, where they land, what argv the CLI is handed, and what a failure does — with
+// no network and no weights.
+
+// The stub is a shebang script, which the runner resolves off PATH only where a shebang is honoured;
+// spawn() on Windows does no PATHEXT resolution, so the three PATH-driven tests below are macOS/Linux.
+// Nothing lane-specific is being tested in them — the wiring is the same on either box — and the
+// pure functions (`anchorDownloadTargets`, `hfDownloadArgv`, `tierDownloadRows`) run everywhere.
+const skipWithoutShebang = process.platform === "win32" && "the stub CLI is a shebang script on PATH";
+
+/** A stub `hf` on PATH: appends its argv to $STUB_HF_LOG and creates the snapshot it was asked for. */
+async function stubHuggingFaceCli({ fail = false } = {}) {
+  const dir = await mkdtemp(path.join(tmpdir(), "catalog-hf-cli-"));
+  const log = path.join(dir, "invocations.txt");
+  const body = fail
+    ? 'process.stderr.write("stub refusal: 401 Client Error\\n");\nprocess.exit(1);'
+    : [
+      'const repo = argv[1];',
+      'const revision = argv[argv.indexOf("--revision") + 1];',
+      'const cacheDir = argv[argv.indexOf("--cache-dir") + 1];',
+      'const includes = argv.flatMap((a, i) => (a === "--include" ? [argv[i + 1]] : []));',
+      'const snapshot = path.join(cacheDir, "models--" + repo.split("/").join("--"), "snapshots", revision);',
+      // The real CLI materialises whatever the globs select; the stub materialises each glob's own
+      // directory prefix, which is what `classifyAnchor` probes for.
+      'for (const glob of includes.length > 0 ? includes : ["."]) {',
+      '  const directory = glob.includes("/") ? glob.slice(0, glob.lastIndexOf("/")) : ".";',
+      '  fs.mkdirSync(path.join(snapshot, directory), { recursive: true });',
+      '}',
+      'fs.writeFileSync(path.join(snapshot, "config.json"), "{}");',
+      // `refs/` is written exactly as the hub CLI writes it: not at all for a 40-hex revision.
+      'fs.mkdirSync(path.join(cacheDir, "models--" + repo.split("/").join("--"), "blobs"), { recursive: true });',
+    ].join("\n");
+  const script = [
+    "#!/usr/bin/env node",
+    'const fs = require("node:fs");',
+    'const path = require("node:path");',
+    "const argv = process.argv.slice(2);",
+    'fs.appendFileSync(process.env.STUB_HF_LOG, JSON.stringify(argv) + "\\n");',
+    body,
+    "",
+  ].join("\n");
+  const binary = path.join(dir, HF_CLI_CANDIDATES[0]);
+  await writeFile(binary, script, { mode: 0o755 });
+  return {
+    dir,
+    log,
+    invocations: async () => (await readFile(log, "utf8").catch(() => ""))
+      .split("\n").filter(Boolean).map((line) => JSON.parse(line)),
+  };
+}
+
+/** Run `body` with the stub CLI first on PATH and $STUB_HF_LOG pointed at its log. */
+async function withStubCli(stub, body) {
+  const originalPath = process.env.PATH;
+  const originalLog = process.env.STUB_HF_LOG;
+  process.env.PATH = `${stub.dir}${path.delimiter}${originalPath}`;
+  process.env.STUB_HF_LOG = stub.log;
+  try {
+    return await body();
+  } finally {
+    process.env.PATH = originalPath;
+    if (originalLog === undefined) delete process.env.STUB_HF_LOG;
+    else process.env.STUB_HF_LOG = originalLog;
+  }
+}
+
+/**
+ * A checkout-shaped directory `planRun` can read: one plan anchor per key, a manifest carrying the
+ * families' own repositories, and the two closure declarations the classifier consults.
+ */
+async function fakePlanRoot(anchors, models) {
+  const root = await mkdtemp(path.join(tmpdir(), "catalog-root-"));
+  await mkdir(path.join(root, "config", "manifests"), { recursive: true });
+  await writeFile(path.join(root, "config", "memory-calibration-plan.json"), JSON.stringify({ anchors }));
+  await writeFile(path.join(root, "config", "manifests", "builtin.models.jsonc"), JSON.stringify({ models }));
+  const lanes = Object.keys(anchors).map((key) => {
+    const parts = anchorParts(key);
+    return `${parts.modelId}:${parts.backend}`;
+  });
+  const providers = Object.entries(anchors).map(([key, planned]) => `${anchorParts(key).backend}:${planned.provider}`);
+  await writeFile(
+    path.join(root, "config", "anchor-loader-closures.json"),
+    JSON.stringify({ models: Object.fromEntries(lanes.map((lane) => [lane, { digest: "d".repeat(64) }])) }),
+  );
+  await writeFile(
+    path.join(root, "config", "inference-provider-closures.json"),
+    JSON.stringify({ providers: Object.fromEntries(providers.map((provider) => [provider, {}])) }),
+  );
+  return root;
+}
+
+const DOWNLOAD_REVISION = "abcdef0123456789abcdef0123456789abcdef01";
+
+function downloadFixture() {
+  return {
+    anchors: {
+      "qwen_image:q4:mlx": { provider: "qwen_image" },
+      "z_image_turbo:q4:mlx": { provider: "z_image_turbo" },
+    },
+    models: [
+      {
+        id: "qwen_image",
+        downloads: [{
+          repo: PROVIDER_FAMILIES.qwen_image.repo, revision: DOWNLOAD_REVISION, variant: "q4",
+          files: ["q4/*"], estimatedSizeBytes: 4321,
+        }],
+      },
+      {
+        id: "z_image_turbo",
+        downloads: [{
+          repo: PROVIDER_FAMILIES.z_image_turbo.repo, revision: DOWNLOAD_REVISION, variant: "q4",
+          files: ["q4/*"],
+        }],
+      },
+    ],
+  };
+}
+
+test("a download target names the family's repository, the PINNED revision and the manifest's globs", () => {
+  const { models } = downloadFixture();
+  const row = { key: "qwen_image:q4:mlx", modelId: "qwen_image", tier: "q4", backend: "mlx", provider: "qwen_image" };
+  const { targets, unfetchable } = anchorDownloadTargets(row, models, { platform: "macos" });
+  assert.deepEqual(unfetchable, []);
+  assert.equal(targets.length, 1);
+  assert.equal(targets[0].repo, PROVIDER_FAMILIES.qwen_image.repo);
+  assert.equal(targets[0].revision, DOWNLOAD_REVISION);
+  assert.deepEqual(targets[0].include, ["q4/*"]);
+  assert.equal(targets[0].estimatedBytes, 4321);
+
+  // THE MUTATION TARGET. `--revision` is the pinned revision, always: a fetch that resolved `main`
+  // would land whatever the branch points at rather than the artifact the anchor prices — and
+  // pinning a manifest download removes `refs/main` from the mirror in the first place.
+  const argv = hfDownloadArgv(targets[0], "/hub");
+  assert.deepEqual(argv, [
+    "download", PROVIDER_FAMILIES.qwen_image.repo, "--revision", DOWNLOAD_REVISION,
+    "--include", "q4/*", "--cache-dir", "/hub",
+  ]);
+  assert.equal(argv[argv.indexOf("--revision") + 1], DOWNLOAD_REVISION, "the pinned revision is passed, never main");
+  assert.ok(!argv.includes("main"));
+});
+
+test("no anchor can be fetched off a branch: every target the shipped plan produces carries a 40-hex revision", async () => {
+  const models = await readManifestModels();
+  const plan = await readPlan();
+  let unpinned = 0;
+  for (const [key, planned] of Object.entries(plan.anchors)) {
+    const parts = anchorParts(key);
+    const { targets, unfetchable } = anchorDownloadTargets({ key, ...parts, provider: planned.provider }, models);
+    for (const target of targets) {
+      assert.match(target.revision, /^[0-9a-f]{40}$/, `${key} would fetch ${target.repo}@${target.revision}`);
+    }
+    if (unfetchable.some((note) => /shipped without a pinned revision/.test(note))) unpinned += 1;
+  }
+  // The upstream Wan 2.2 / SVD Diffusers checkpoints are the shipped unpinned case; they are
+  // REPORTED rather than resolved off a branch, which is the whole reason the refusal exists.
+  assert.ok(unpinned > 0, "the unpinned-revision refusal is reachable on the shipped plan");
+});
+
+test("--download-missing fetches ONLY the weights_missing anchors, into the first hub root, and re-classifies them", { skip: skipWithoutShebang }, async () => {
+  const { anchors, models } = downloadFixture();
+  const root = await fakePlanRoot(anchors, models);
+  const first = await fakeHub([[PROVIDER_FAMILIES.z_image_turbo.repo, DOWNLOAD_REVISION, "q4"]]);
+  const second = await mkdtemp(path.join(tmpdir(), "catalog-hub-second-"));
+  const stub = await stubHuggingFaceCli();
+  const args = {
+    ...parseArgs(["--backend", "mlx", "--list", "--download-missing"]),
+    campaign: "sc-dl-test", hfCache: [first, second],
+  };
+
+  const before = await planRun({ ...args, downloadMissing: false }, root);
+  assert.equal(before.rows.find((row) => row.key === "qwen_image:q4:mlx").status, "weights_missing");
+  assert.equal(before.rows.find((row) => row.key === "z_image_turbo:q4:mlx").status, "runnable");
+
+  const { rows } = await withStubCli(stub, () => planRun(args, root));
+  const fetched = rows.find((row) => row.key === "qwen_image:q4:mlx");
+  assert.equal(fetched.status, "runnable", fetched.reason);
+  // It landed in the FIRST --hf-cache root, in hub layout, and the tier root is what the row binds.
+  assert.equal(fetched.tierRoot, snapshotPath(first, PROVIDER_FAMILIES.qwen_image.repo, DOWNLOAD_REVISION, "q4"));
+  assert.ok((await stat(snapshotPath(first, PROVIDER_FAMILIES.qwen_image.repo, DOWNLOAD_REVISION, "q4"))).isDirectory());
+  assert.deepEqual(await readdir(second), [], "nothing is written into a later --hf-cache root");
+
+  // The anchor that was ALREADY present was never fetched: exactly one invocation, for the other repo.
+  const invocations = await stub.invocations();
+  assert.equal(invocations.length, 1, JSON.stringify(invocations));
+  assert.equal(invocations[0][1], PROVIDER_FAMILIES.qwen_image.repo);
+  assert.equal(invocations[0][invocations[0].indexOf("--revision") + 1], DOWNLOAD_REVISION);
+  assert.equal(invocations[0][invocations[0].indexOf("--cache-dir") + 1], first);
+  assert.equal(rows.find((row) => row.key === "z_image_turbo:q4:mlx").status, "runnable");
+});
+
+test("a failed fetch leaves the anchor weights_missing naming the reason, and never stops the walk", { skip: skipWithoutShebang }, async () => {
+  const { anchors, models } = downloadFixture();
+  const root = await fakePlanRoot(anchors, models);
+  const hub = await fakeHub([[PROVIDER_FAMILIES.z_image_turbo.repo, DOWNLOAD_REVISION, "q4"]]);
+  const stub = await stubHuggingFaceCli({ fail: true });
+  const args = {
+    ...parseArgs(["--backend", "mlx", "--list", "--download-missing"]),
+    campaign: "sc-dl-test", hfCache: [hub],
+  };
+
+  const { rows } = await withStubCli(stub, () => planRun(args, root));
+  const refused = rows.find((row) => row.key === "qwen_image:q4:mlx");
+  assert.equal(refused.status, "weights_missing");
+  assert.match(refused.reason, /download failed:/);
+  assert.match(refused.reason, new RegExp(`${PROVIDER_FAMILIES.qwen_image.repo}@${DOWNLOAD_REVISION.slice(0, 8)}`));
+  // The walk keeps going: the other anchor is classified exactly as it was.
+  assert.equal(rows.find((row) => row.key === "z_image_turbo:q4:mlx").status, "runnable");
+});
+
+test("--dry-run --download-missing prints what it would fetch and fetches nothing", { skip: skipWithoutShebang }, async () => {
+  const { anchors, models } = downloadFixture();
+  const root = await fakePlanRoot(anchors, models);
+  const hub = await mkdtemp(path.join(tmpdir(), "catalog-hub-dry-"));
+  const stub = await stubHuggingFaceCli();
+  const lines = [];
+  const row = { key: "qwen_image:q4:mlx", modelId: "qwen_image", tier: "q4", backend: "mlx", provider: "qwen_image" };
+  const outcome = await withStubCli(stub, () => fetchAnchorSnapshots(row, models, {
+    cacheRoot: hub, dryRun: true, platform: "macos", log: (line) => lines.push(line),
+  }));
+  assert.equal(outcome.failed, null);
+  assert.equal(outcome.fetched.length, 1);
+  assert.match(lines.join("\n"), /would fetch 1 glob\(s\): q4\/\*.*~4321 bytes/);
+  assert.deepEqual(await stub.invocations(), [], "a dry run runs no CLI at all");
+  assert.deepEqual(await readdir(hub), [], "a dry run writes nothing into the hub root");
+
+  // And through planRun: the dry run leaves the classification alone.
+  const args = {
+    ...parseArgs(["--backend", "mlx", "--list", "--download-missing"]),
+    dryRun: true, campaign: "sc-dl-test", hfCache: [hub],
+  };
+  const { rows } = await withStubCli(stub, () => planRun(args, root));
+  assert.equal(rows.find((entry) => entry.key === "qwen_image:q4:mlx").status, "weights_missing");
+  assert.deepEqual(await stub.invocations(), []);
+});
+
+test("download rows are narrowed to this host's platform, and fall back rather than resolving to no globs", async () => {
+  assert.equal(manifestPlatform("darwin"), "macos");
+  assert.equal(manifestPlatform("win32"), "windows");
+  assert.equal(manifestPlatform("linux"), "linux");
+  const models = await readManifestModels();
+  // MiniMax-H3's dense upstream ships the whole DiT on windows/linux and only the text encoder and
+  // the VAEs on macOS; the narrowing is what keeps an MLX box from fetching the windows leg.
+  const macos = tierDownloadRows(models, "minimax_h3", "MiniMaxAI/MiniMax-H3", "bf16", "macos");
+  const windows = tierDownloadRows(models, "minimax_h3", "MiniMaxAI/MiniMax-H3", "bf16", "windows");
+  assert.ok(macos.length > 0 && windows.length > 0);
+  assert.ok(macos.every((download) => !download.platforms || download.platforms.includes("macos")));
+  assert.ok(windows.some((download) => (download.files ?? []).some((glob) => glob === "transformer/*")));
+  assert.ok(!macos.some((download) => (download.files ?? []).some((glob) => glob === "transformer/*")));
+  // A repository whose rows are all scoped elsewhere falls back to the UNFILTERED set rather than
+  // to "no globs", which downstream would read as "fetch the whole repository".
+  const unfiltered = (models.find((entry) => entry.id === "minimax_h3").downloads ?? []).filter(
+    (download) => download.repo === "MiniMaxAI/MiniMax-H3" && (download.variant === undefined || download.variant === "bf16"),
+  );
+  assert.deepEqual(tierDownloadRows(models, "minimax_h3", "MiniMaxAI/MiniMax-H3", "bf16", "plan9"), unfiltered);
+  assert.ok(unfiltered.length > macos.length, "the fallback is wider than one platform's rows");
 });


### PR DESCRIPTION
## What

`scripts/measure-memory-catalog.mjs` gains `--download-missing` (default **off**): for the anchors the plan already classified `weights_missing` — and only those — the walk fetches the pinned snapshots they need into the **first** `--hf-cache` root, then classifies each anchor again.

Michael's finding (2026-09-08): downloading the missing snapshots on the Windows CUDA box is faster than copying them off the Mac's SSD, so the campaign should fetch what it needs rather than skipping the cell.

## How the fetch is derived, not decided

Nothing here has its own idea of what an anchor needs. `anchorDownloadTargets` walks the same family row `classifyAnchor` walks — the LTX-2.5 snapshot, the per-(lane, tier) artifact `familyArtifact` resolves, `upstream`, the SDXL (array) and Mage-Flow (object) `components`, the member's `sideArtifact` — and reads each repository's revision and file globs out of the manifest download rows for that model, tier and platform (`tierDownloadRows`, tier rows plus tier-independent co-requisites). `siblingRoots` need no entry: a sibling lives inside the artifact's own snapshot at the same revision, so the tier root's co-requisite rows already carry its globs.

`--revision` is **always** the pinned revision. Two things are therefore reported rather than guessed at:

- a repository the manifest ships **unpinned** (the upstream Wan 2.2 / SVD Diffusers checkpoints) — resolving `main` would fetch whatever the branch points at rather than the artifact the anchor prices, and pinning a manifest download removes `refs/main` from the mirror anyway;
- the hand-staged roots (`bundle` — PuLID's identity stack — and `stagedEnv`), which are operator env vars naming a directory, not hub repositories.

The fetch shells out to the CLI the repo already documents: `hf download <repo> --revision <pinned> --include <glob>… --cache-dir <root>`, falling back to `huggingface-cli` when `hf` is not installed. One download at a time (multi-GB transfers on a link that already killed a parallel fetch), resumable by the CLI, one log line per landed snapshot: `download: <key> <repo>@<rev> <n> files, <bytes> bytes`. A failed fetch leaves that one anchor `weights_missing (download failed: <reason>)` and **never** aborts the walk. `--dry-run --download-missing` prints what it would fetch with the manifest's own `estimatedSizeBytes` and fetches nothing.

## Workflow

`download_missing` (boolean, default false) → `--download-missing`, plus `HF_TOKEN: ${{ secrets.HF_TOKEN }}` in the job env for the CLI (only a gated repository needs it; every artifact this campaign fetches today is public). The flag reaches the **dry run** and the **walk** — never `plan.sh`'s `--list` pass, so reading the plan can never start a transfer. Documented in the workflow header and in `docs/calibration-runbook.md` §6a-bis, including the token requirement and that the first hub root is the destination.

## Coverage

Which artifact families the fetch covers: every family whose roots the manifest ships as pinned downloads — the tiered rehosts on both lanes (including `familyArtifact`'s lane/tier overrides, so the Wan candle q4/q8 and SANA per-lane repos resolve), LTX-2.5's snapshot with its `enhancer/` and `distilled_lora/` co-requisites, MiniMax-H3's dense upstream, the SDXL caller-staged components, Mage-Flow's components snapshot, and the Qwen edit Lightning distill LoRA (family-pinned, not a manifest row). What it cannot cover, and says so per anchor: the unpinned upstream Wan 2.2 / SVD Diffusers checkpoints (no pinned revision to pass), and the PuLID / InstantID hand-staged directories (not hub repositories).

## Verification

- `node --test scripts/measure-memory-catalog.test.mjs` — **122 tests, 118 pass, 0 fail, 4 pre-existing skips**. Six new tests, driven by a stub `hf` on PATH that writes the real hub layout: a `weights_missing` anchor is fetched into the first root and re-classifies `runnable` (and nothing lands in the second root); a fetch failure keeps it `weights_missing` naming the reason while the rest of the walk is untouched; an already-present anchor produces **zero** CLI invocations; the argv is asserted whole, including the pinned revision; `--dry-run` runs no CLI and writes nothing; and every target the **shipped** plan can produce carries a 40-hex revision.
- **Mutation:** dropping `--revision target.revision` from `hfDownloadArgv` reds 2 tests (the argv assertion and the end-to-end fetch, which then lands nothing at the pinned snapshot path); restored, green again.
- `INFERENCE_REPO=<pinned inference> npm run check` → **exit 0** (redirected to a file, not piped).
- `actionlint .github/workflows/memory-catalog-campaign.yml` → only the pre-existing "label `cuda` is unknown" self-hosted-runner note on the untouched `runs-on:` line.
- `shellcheck -x scripts/ci/memory-catalog/{run,plan,common}.sh` → exit 0.

No new gates: `--download-missing` is opt-in, gates nothing, and the runbook's rule that runtime treats every measurement as valid is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
