### PR TITLE
feat(sc-22738): video memory captures are one measured render; warm passes stay on the image lane

### DIFF
--- a/crates/sceneworks-core/src/memory_calibration.rs
+++ b/crates/sceneworks-core/src/memory_calibration.rs
@@ -648,6 +648,12 @@ pub struct Quality {
     pub contract: Option<String>,
     pub identical_inputs: Option<bool>,
     pub identical_latents: Option<bool>,
+    /// How many warm passes the capture ran after its measured render (sc-22738). `Some(0)` is a
+    /// video-lane receipt whose determinism comparison was NOT run: `result` is `not_run` and the
+    /// comparison figures are absent, and the runtime-complete validator accepts exactly that
+    /// shape rather than refusing the record or reading a synthetic zero. Absent on every record
+    /// captured before the declaration existed, which keeps the previous requirements.
+    pub warm_passes: Option<u32>,
     pub result: Option<QualityResult>,
     pub maximum_error: Option<f64>,
     pub mean_error: Option<f64>,
@@ -1430,15 +1436,27 @@ fn validate_physical_mlx_outputs_against_record(
     record: &EvidenceRecord,
     session: &SourceSession,
 ) -> Result<(), String> {
-    let has_av = session.outputs.iter().any(|output| {
-        matches!(
-            output.role,
-            Some(SourceOutputRole::SelectedAv | SourceOutputRole::ReferenceAv)
-        )
-    });
-    if has_av != record.quality.audio.is_some() {
+    // A typed audio comparison is selected-versus-REFERENCE PCM, so it is coupled to the
+    // `reference_av` receipt, not to the A/V kind as such: a single-render video session
+    // (sc-22738) carries a `selected_av` receipt and no audio comparison, and a session may not
+    // carry a reference without a selected render to compare it against.
+    let has_selected_av = session
+        .outputs
+        .iter()
+        .any(|output| output.role == Some(SourceOutputRole::SelectedAv));
+    let has_reference_av = session
+        .outputs
+        .iter()
+        .any(|output| output.role == Some(SourceOutputRole::ReferenceAv));
+    if has_reference_av && !has_selected_av {
         return Err(format!(
-            "{} physical MLX A/V receipts and typed audio quality must be present together",
+            "{} physical MLX reference_av receipt has no selected_av render to compare against",
+            record.id
+        ));
+    }
+    if has_reference_av != record.quality.audio.is_some() {
+        return Err(format!(
+            "{} physical MLX reference A/V receipt and typed audio quality must be present together",
             record.id
         ));
     }
@@ -2118,6 +2136,30 @@ fn validate_runtime_complete(record: &EvidenceRecord) -> Result<(), String> {
         ));
     }
     let quality = &record.quality;
+    // sc-22738: a receipt declaring `warmPasses: 0` ran no comparison render, so its quality is
+    // `not_run` by construction and carries no figure to check — the thresholds it WOULD have been
+    // judged by still travel. Degrades to "not measured"; never a refusal, never a synthetic 0.
+    if quality.warm_passes == Some(0) {
+        if quality.result != Some(QualityResult::NotRun) {
+            return Err(format!(
+                "{} declares quality.warmPasses 0, so its quality must be not_run",
+                record.id
+            ));
+        }
+        if quality.maximum_error.is_some()
+            || quality.mean_error.is_some()
+            || quality.root_mean_square_error.is_some()
+            || quality.audio.is_some()
+        {
+            return Err(format!(
+                "{} declares quality.warmPasses 0 but carries a comparison figure it cannot have \
+                 measured",
+                record.id
+            ));
+        }
+        require_quality_thresholds(quality, &record.id)?;
+        return require_runtime_complete_loadability(record);
+    }
     if quality.identical_inputs != Some(true) || quality.result != Some(QualityResult::Passed) {
         return Err(format!(
             "{} runtime-complete quality evidence did not pass",
@@ -2141,6 +2183,10 @@ fn validate_runtime_complete(record: &EvidenceRecord) -> Result<(), String> {
     if rmse > rmse_threshold {
         return Err(format!("{} RMSE threshold was exceeded", record.id));
     }
+    require_runtime_complete_loadability(record)
+}
+
+fn require_runtime_complete_loadability(record: &EvidenceRecord) -> Result<(), String> {
     if record.loadability.result != LoadabilityResult::Passed
         || !matches!(
             &record.loadability.resolved_path_fingerprint,
@@ -2685,10 +2731,11 @@ mod tests {
     use serde_json::{json, Map, Value};
 
     use super::{
-        load_bundle, load_packaged_bundle, Backend, BundleLoadError, CalibrationBinding,
-        EvidenceBundle, EvidenceMismatchReason, EvidenceQuery, EvidenceVerdict, Geometry,
-        LoadShapeKey, Ltx25Decoder, Ltx25TransformerVariant, MlxAdmissionEnvelope, ObservedMemory,
-        PredictedPeakBytes, RecordStatus, RequiredNullable, SourceSessionKind, StrategyRung,
+        load_bundle, load_packaged_bundle, validate_physical_mlx_outputs_against_record, Backend,
+        BundleLoadError, CalibrationBinding, EvidenceBundle, EvidenceMismatchReason, EvidenceQuery,
+        EvidenceRecord, EvidenceVerdict, Geometry, LoadShapeKey, Ltx25Decoder,
+        Ltx25TransformerVariant, MlxAdmissionEnvelope, ObservedMemory, PredictedPeakBytes,
+        RecordStatus, RequiredNullable, SourceSession, SourceSessionKind, StrategyRung,
         MEMORY_CALIBRATION_ABI, MEMORY_CALIBRATION_SCHEMA_VERSION,
         PACKAGED_MEMORY_CALIBRATION_EVIDENCE,
     };
@@ -4360,5 +4407,131 @@ mod tests {
             bundle.evidence_for(&unexecuted),
             EvidenceVerdict::OutOfEnvelope
         );
+    }
+
+    /// sc-22738: a runtime-complete record declaring `quality.warmPasses: 0` — a single-render
+    /// video capture — is accepted with `result: not_run` and no comparison figure, and refused
+    /// the moment it carries a figure it could not have measured or claims a pass it did not run.
+    /// Records without the declaration keep every previous requirement.
+    #[test]
+    fn runtime_complete_accepts_a_declared_zero_warm_pass_quality_as_not_measured() {
+        fn runtime_record(raw: &mut Value) -> &mut Value {
+            raw["records"]
+                .as_array_mut()
+                .expect("records array")
+                .iter_mut()
+                .find(|record| record["status"] == "runtime_complete")
+                .expect("packaged runtime-complete record")
+        }
+        let mut single: Value = serde_json::from_str(PACKAGED_MEMORY_CALIBRATION_EVIDENCE)
+            .expect("packaged evidence JSON");
+        let thresholds = runtime_record(&mut single)["quality"].clone();
+        runtime_record(&mut single)["quality"] = json!({
+            "contract": "one measured render; NOT MEASURED: no warm pass",
+            "result": "not_run",
+            "warmPasses": 0,
+            "maximumErrorThreshold": thresholds["maximumErrorThreshold"],
+            "meanErrorThreshold": thresholds["meanErrorThreshold"],
+            "rootMeanSquareErrorThreshold": thresholds["rootMeanSquareErrorThreshold"],
+        });
+        load_bundle(&single.to_string()).expect("a declared unrun comparison is not a refusal");
+
+        type Doctoring = (fn(&mut Value), &'static str);
+        let doctorings: [Doctoring; 4] = [
+            (
+                |quality| quality["result"] = json!("passed"),
+                "must be not_run",
+            ),
+            (
+                |quality| quality["maximumError"] = json!(0.0),
+                "cannot have measured",
+            ),
+            (
+                |quality| {
+                    quality
+                        .as_object_mut()
+                        .unwrap()
+                        .remove("maximumErrorThreshold");
+                },
+                "threshold evidence is incomplete",
+            ),
+            // Without the declaration the previous requirement stands: not_run is refused.
+            (
+                |quality| {
+                    quality.as_object_mut().unwrap().remove("warmPasses");
+                },
+                "did not pass",
+            ),
+        ];
+        for (mutate, expected) in doctorings {
+            let mut doctored = single.clone();
+            mutate(&mut runtime_record(&mut doctored)["quality"]);
+            assert!(
+                matches!(
+                    load_bundle(&doctored.to_string()),
+                    Err(BundleLoadError::Invalid(message)) if message.contains(expected)
+                ),
+                "{expected}"
+            );
+        }
+    }
+
+    /// sc-22738: a physical A/V session of ONE render carries `selected_av` alone, and the typed
+    /// audio comparison is coupled to the `reference_av` receipt rather than to the A/V kind.
+    #[test]
+    fn a_single_render_av_session_needs_no_audio_comparison_and_a_reference_needs_one() {
+        let mut raw: Value = serde_json::from_str(PACKAGED_MEMORY_CALIBRATION_EVIDENCE)
+            .expect("packaged evidence JSON");
+        let repositories = raw["records"][0]["repositories"].clone();
+        let record: EvidenceRecord =
+            serde_json::from_value(raw["records"][0].take()).expect("packaged record parses");
+        let session = |roles: &[&str]| -> SourceSession {
+            serde_json::from_value(json!({
+                "id": "ims-0123456789abcdefabcd",
+                "kind": "physical_mlx",
+                "command": "[]",
+                "sourcePath": "docs/calibration/x/ims-0123456789abcdefabcd.log",
+                "capturedAt": record.captured_at,
+                "repositories": repositories,
+                "hardware": { "probe": "p", "memoryBytes": 1 },
+                "stdoutSha256": "a".repeat(64),
+                "inputs": [],
+                "outputs": roles.iter().map(|role| json!({
+                    "role": role,
+                    "path": format!(
+                        "docs/calibration/x/{}-{role}-{}x{}-f{}-{}.avbin",
+                        record.logical_case_id,
+                        record.target.geometry.width,
+                        record.target.geometry.height,
+                        record.target.geometry.frames,
+                        "b".repeat(64)
+                    ),
+                    "sha256": "b".repeat(64),
+                    "bytes": 1,
+                })).collect::<Vec<_>>(),
+                "claims": ["memory"],
+                "result": "passed",
+            }))
+            .expect("session parses")
+        };
+        assert!(
+            record.quality.audio.is_none(),
+            "the packaged record carries no audio"
+        );
+        validate_physical_mlx_outputs_against_record(&record, &session(&["selected_av"]))
+            .expect("one selected render, no comparison, no audio block");
+        let error = validate_physical_mlx_outputs_against_record(
+            &record,
+            &session(&["selected_av", "reference_av"]),
+        )
+        .unwrap_err();
+        assert!(
+            error.contains("reference A/V receipt and typed audio quality"),
+            "{error}"
+        );
+        let error =
+            validate_physical_mlx_outputs_against_record(&record, &session(&["reference_av"]))
+                .unwrap_err();
+        assert!(error.contains("no selected_av render"), "{error}");
     }
 }

--- a/crates/sceneworks-memory-adapter/src/bin/mlx.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx.rs
@@ -16534,6 +16534,10 @@ fn run_ltx_with_admission(
     phase_sink: &mut dyn LtxCampaignPhaseSink,
 ) -> Result<Value, String> {
     let geometry = validate_ltx_target(request)?;
+    // The lane's render plan (sc-22738): a video capture is ONE measured render, no warm pass.
+    // The SC-20318 campaign entries below are lifecycle PROOFS, not catalog captures, and keep
+    // their own render counts; the ordinary capture honours this.
+    let capture = protocol::capture_policy(request)?.require_video(LTX_VIDEO_LABEL)?;
     protocol::validate_plain_overlay_target(request, LTX_PLAIN_EXECUTION_PATH)?;
     let load_shape = planned_load_shape(request)?;
     if load_shape != LoadShape::EagerMaterialization {
@@ -16828,50 +16832,43 @@ fn run_ltx_with_admission(
         seed,
         fault_phase: decode_plan.lifecycle_fault_phase(),
     };
-    let (lifecycle, bounded_warm) = match admission {
-        LtxRunAdmission::CampaignEntry => (
-            verify_ltx_lifecycle(
-                generator.as_ref(),
-                &context,
-                &measured,
-                lifecycle_input,
-                phase_sink,
-            )?,
-            None,
-        ),
-        LtxRunAdmission::BoundedCampaignEntry => {
-            let warm = verify_ltx_bounded_warm_repeat(
-                generator.as_ref(),
-                &context,
-                &measured,
-                lifecycle_input,
-            )?;
-            (
-                LtxLifecycleMetrics {
-                    maximum_error: warm.maximum_error,
-                    mean_error: warm.mean_error,
-                    rms_error: warm.rms_error,
-                    ..Default::default()
-                },
-                Some(warm),
-            )
-        }
-        // The ordinary capture executes the same runtime-complete lifecycle the supervised entry
-        // does; only the phase sink differs (the catalog runner's watchdog needs no phase channel).
-        LtxRunAdmission::Ordinary => (
-            verify_ltx_lifecycle(
-                generator.as_ref(),
-                &context,
-                &measured,
-                lifecycle_input,
-                phase_sink,
-            )?,
-            None,
-        ),
-    };
-    let maximum_error = lifecycle.maximum_error;
-    let mean_error = lifecycle.mean_error;
-    let rms_error = lifecycle.rms_error;
+    // `lifecycle` is `Some` only when a warm control was rendered: the SC-20318 campaign entries,
+    // which exist to prove the request-scope lifecycle. The ORDINARY capture — the catalog anchor —
+    // is one measured render on the video lane (sc-22738, `capture` above): no clean warm control,
+    // no warm repeat, no fault injection, no recovery render. The 2026-09-07 corpus
+    // (`docs/calibration/sc-22738/ltx-2-3-*-mlx-evidence.json`) was captured under the previous
+    // six-render lifecycle and stays valid as it is.
+    let (lifecycle, bounded_warm): (Option<LtxLifecycleMetrics>, Option<LtxBoundedWarmMetrics>) =
+        match admission {
+            LtxRunAdmission::CampaignEntry => (
+                Some(verify_ltx_lifecycle(
+                    generator.as_ref(),
+                    &context,
+                    &measured,
+                    lifecycle_input,
+                    phase_sink,
+                )?),
+                None,
+            ),
+            LtxRunAdmission::BoundedCampaignEntry => {
+                let warm = verify_ltx_bounded_warm_repeat(
+                    generator.as_ref(),
+                    &context,
+                    &measured,
+                    lifecycle_input,
+                )?;
+                (
+                    Some(LtxLifecycleMetrics {
+                        maximum_error: warm.maximum_error,
+                        mean_error: warm.mean_error,
+                        rms_error: warm.rms_error,
+                        ..Default::default()
+                    }),
+                    Some(warm),
+                )
+            }
+            LtxRunAdmission::Ordinary => (None, None),
+        };
 
     // Runtime-complete keeps the schema's unexecuted mutation slot null. The adapter still proves
     // falsifiability and records the breach in diagnostics.
@@ -16884,7 +16881,25 @@ fn run_ltx_with_admission(
         return Err("LTX-2.3 output mutation did not breach the determinism envelope".to_owned());
     }
 
-    let scenarios = if admission == LtxRunAdmission::BoundedCampaignEntry {
+    let single_render_blocker = format!(
+        "this capture executes ONE measured render inside the selected request scope and no \
+         warm pass ({}); it injects no calibration fault, so the cancellation and \
+         authorized-error scenarios and their recovery renders are unexecuted and this record \
+         claims nothing about them",
+        protocol::VIDEO_WARM_PASSES_NOT_RUN
+    );
+    let scenarios = if lifecycle.is_none() {
+        json!([
+            { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": exact_effective_bytes },
+            { "name": "unknown_budget", "result": "passed", "reason": "the loaded provider contract rejected a zero/unknown budget" },
+            { "name": "stale_evidence", "result": "passed", "reason": "the loaded provider contract rejected a mutated calibration fingerprint" },
+            capture.not_run_warm_repeat_scenario()?,
+            { "name": "cancel", "result": "not_run", "reason": single_render_blocker },
+            { "name": "error", "result": "not_run", "reason": single_render_blocker },
+            { "name": "loadability", "result": "passed" },
+            { "name": "overlay", "result": "not_applicable", "reason": "settled below from the declared reference-free target" }
+        ])
+    } else if admission == LtxRunAdmission::BoundedCampaignEntry {
         let blocker = "SC-20318 executes only selected plus warm-repeat parity; cancellation, authorized-error, and recovery renders remain unexecuted";
         json!([
             { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": exact_effective_bytes },
@@ -17019,7 +17034,7 @@ fn run_ltx_with_admission(
             ),
             ("providerRequestScopeRenders", "count", 2),
         ]);
-    } else {
+    } else if let Some(lifecycle) = &lifecycle {
         diagnostic_measurements.extend([
             ("warmRepeatPeak", "bytes", lifecycle.clean_warm_peak),
             (
@@ -17065,7 +17080,38 @@ fn run_ltx_with_admission(
             lifecycle.error_recovery,
             lifecycle.measured_clip,
         ));
+    } else {
+        // sc-22738: no `warmRepeat*` / `lifecycleMax*` figure — the warm passes were not run
+        // (`quality.warmPasses`), and an unmeasured figure is omitted, never written as 0.
+        diagnostic_measurements.push(("warmPasses", "count", u64::from(capture.warm_passes)));
     }
+    const LTX_QUALITY_CONTRACT: &str = "identical artifact, prompt, seed, geometry, frames, fps, tier, provider contract and selected request scope; measured clip versus a clean warm repeat, compared over every frame";
+    let quality = match &lifecycle {
+        Some(lifecycle) => json!({
+            "contract": LTX_QUALITY_CONTRACT,
+            "identicalInputs": true,
+            "result": "passed",
+            "maximumError": lifecycle.maximum_error,
+            "meanError": lifecycle.mean_error,
+            "rootMeanSquareError": lifecycle.rms_error,
+            "maximumErrorThreshold": LTX_MAX_THRESHOLD,
+            "meanErrorThreshold": LTX_MEAN_THRESHOLD,
+            "rootMeanSquareErrorThreshold": LTX_RMS_THRESHOLD,
+        }),
+        None => capture.not_run_quality(
+            LTX_QUALITY_CONTRACT,
+            (LTX_MAX_THRESHOLD, LTX_MEAN_THRESHOLD, LTX_RMS_THRESHOLD),
+        )?,
+    };
+    let blockers = match &lifecycle {
+        Some(lifecycle) => ltx_lifecycle_blockers(
+            tier,
+            lifecycle_input.fault_phase,
+            lifecycle.cancel_recovery,
+            lifecycle.error_recovery,
+        ),
+        None => vec![single_render_blocker.clone()],
+    };
 
     let mut fragment = json!({
         "status": "runtime_complete",
@@ -17085,17 +17131,7 @@ fn run_ltx_with_admission(
             "decode": decode.json(),
             "overall": overall.json(),
         },
-        "quality": {
-            "contract": "identical artifact, prompt, seed, geometry, frames, fps, tier, provider contract and selected request scope; measured clip versus a clean warm repeat, compared over every frame",
-            "identicalInputs": true,
-            "result": "passed",
-            "maximumError": maximum_error,
-            "meanError": mean_error,
-            "rootMeanSquareError": rms_error,
-            "maximumErrorThreshold": LTX_MAX_THRESHOLD,
-            "meanErrorThreshold": LTX_MEAN_THRESHOLD,
-            "rootMeanSquareErrorThreshold": LTX_RMS_THRESHOLD,
-        },
+        "quality": quality,
         "negativeMutation": null,
         "loadability": {
             "result": "passed",
@@ -17104,12 +17140,7 @@ fn run_ltx_with_admission(
         "diagnostics": protocol::diagnostics(
             "memory-mlx-adapter:ltx-2-3-provider-contract-video",
             "executed",
-            ltx_lifecycle_blockers(
-                tier,
-                lifecycle_input.fault_phase,
-                lifecycle.cancel_recovery,
-                lifecycle.error_recovery,
-            ),
+            blockers,
             diagnostic_measurements,
         ),
         "capturedAt": protocol::captured_at(),
@@ -18328,6 +18359,8 @@ fn minimax_complete_sweep(request: &Value) -> Result<Value, String> {
 /// load shapes (rung 4 is `Implemented` only under `deferred_materialization`).
 fn run_minimax_h3(request: &Value) -> Result<Value, String> {
     let (member, geometry) = validate_minimax_target(request)?;
+    // The lane's render plan (sc-22738): a video capture is ONE measured render, no warm pass.
+    let capture = protocol::capture_policy(request)?.require_video(MINIMAX_LABEL)?;
     protocol::validate_plain_overlay_target(request, MINIMAX_PLAIN_EXECUTION_PATH)?;
     let load_shape = planned_load_shape(request)?;
     let selection = planned_selection(request)?;
@@ -18633,76 +18666,35 @@ fn run_minimax_h3(request: &Value) -> Result<Value, String> {
         );
     }
 
-    // Warm repeat determinism + cleanup bounds on this exact loaded provider.
-    clear_cache();
-    reset_peak_memory();
-    let (baseline, _, _) = diagnostic_video_frames(
-        generator
-            .generate(&minimax_request(member, geometry, fps, seed), &mut |_| {})
-            .map_err(|error| format!("generate warm MiniMax-H3 control: {error}"))?,
-        MINIMAX_VIDEO_LABEL,
-    )?;
-    let clean_warm_peak = get_peak_memory() as u64;
-    clear_cache();
-    let clean_post_cleanup = AllocatorState::capture_current();
-    let cleanup_bounds =
-        LifecycleMemoryBounds::from_clean_warm(clean_warm_peak, clean_post_cleanup);
-    let (maximum_error, mean_error, rms_error) = video_max_mean_rms_abs(&measured, &baseline)?;
-    if !minimax_quality_passes(maximum_error, mean_error, rms_error) {
-        return Err(format!(
-            "MiniMax-H3 warm repeat exceeded the determinism envelope: max={maximum_error:.6}, \
-             mean={mean_error:.6}, rms={rms_error:.6}"
-        ));
-    }
-    reset_peak_memory();
-    let (warm, _, _) = diagnostic_video_frames(
-        generator
-            .generate(&minimax_request(member, geometry, fps, seed), &mut |_| {})
-            .map_err(|error| format!("generate warm MiniMax-H3 repeat: {error}"))?,
-        MINIMAX_VIDEO_LABEL,
-    )?;
-    let warm_peak = get_peak_memory() as u64;
-    if !cleanup_bounds.allows_warm_peak(warm_peak) {
-        return Err(format!(
-            "MiniMax-H3 warm repeat peaked at {warm_peak} bytes, above the clean warm control \
-             {clean_warm_peak} bytes plus 2%"
-        ));
-    }
-    clear_cache();
-    let warm_post_cleanup = AllocatorState::capture_current();
-    if !cleanup_bounds.allows_retained(warm_post_cleanup) {
-        return Err(format!(
-            "MiniMax-H3 warm repeat retained active/cache bytes {warm_post_cleanup:?} above the \
-             clean warm cleanup {clean_post_cleanup:?} plus {} bytes",
-            cleanup_bounds.tolerance_bytes,
-        ));
-    }
-    let (warm_maximum, warm_mean, warm_rms) = video_max_mean_rms_abs(&measured, &warm)?;
-    if !minimax_quality_passes(warm_maximum, warm_mean, warm_rms) {
-        return Err("MiniMax-H3 second warm repeat changed the deterministic output".to_owned());
-    }
+    // No warm pass: the video lane captures ONE measured render (sc-22738, `capture` above), so
+    // there is no clean warm control to judge determinism against and no warm repeat to bound;
+    // the receipt says so (`warm_repeat` not_run, `quality.warmPasses: 0`) instead of writing
+    // zeros where `lifecycleClean*` / `lifecycleWarmRepeat*` used to be.
 
     // Arm-internal negative-mutation falsifiability check. A runtime_complete record must keep
     // `negativeMutation` null, so the breach is verified here — the capture FAILS if the envelope
     // cannot be breached — and the measured numbers land in diagnostics rather than in the field.
+    // Against the measured clip itself: the mutation must breach the envelope the arm declares.
     let mutated = measured
         .iter()
         .map(qwen_negative_mutation)
         .collect::<Vec<_>>();
-    let (mutated_maximum, mutated_mean, mutated_rms) = video_max_mean_rms_abs(&mutated, &baseline)?;
+    let (mutated_maximum, mutated_mean, mutated_rms) = video_max_mean_rms_abs(&mutated, &measured)?;
     if minimax_quality_passes(mutated_maximum, mutated_mean, mutated_rms) {
         return Err(
             "MiniMax-H3 output mutation did not breach the determinism envelope".to_owned(),
         );
     }
 
-    let lifecycle_blocker = concat!(
-        "this arm executes the measured render plus two unscoped warm repeats on the loaded ",
-        "provider; it opens no memory-strategy request scope and injects no calibration fault, so ",
-        "the scoped cancellation and authorized-error scenarios and their recovery renders are ",
-        "unexecuted. The pinned provider does register begin_request, so they are implementable — ",
-        "they are not run here, and this record claims nothing about them"
+    let lifecycle_blocker = format!(
+        "this arm executes ONE measured render on the loaded provider and no warm pass ({}); it \
+         opens no memory-strategy request scope and injects no calibration fault, so the scoped \
+         cancellation and authorized-error scenarios and their recovery renders are unexecuted. \
+         The pinned provider does register begin_request, so they are implementable — they are \
+         not run here, and this record claims nothing about them",
+        protocol::VIDEO_WARM_PASSES_NOT_RUN
     );
+    let lifecycle_blocker = lifecycle_blocker.as_str();
     let mut fragment = json!({
         "status": "runtime_complete",
         "strategy": strategy,
@@ -18719,7 +18711,7 @@ fn run_minimax_h3(request: &Value) -> Result<Value, String> {
             { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": predicted },
             { "name": "unknown_budget", "result": "passed", "reason": "the registered MiniMax-H3 admission check rejected a zero/unknown budget before load" },
             { "name": "stale_evidence", "result": "passed", "reason": "the registered MiniMax-H3 admission check rejected a mutated calibration fingerprint before load" },
-            { "name": "warm_repeat", "result": "passed", "reason": "two warm repeats on the loaded provider reproduced the measured clip frame-for-frame inside the declared envelope, within the clean warm peak and cleanup bounds" },
+            capture.not_run_warm_repeat_scenario()?,
             { "name": "cancel", "result": "not_run", "reason": lifecycle_blocker },
             { "name": "error", "result": "not_run", "reason": lifecycle_blocker },
             { "name": "loadability", "result": "passed" },
@@ -18732,17 +18724,10 @@ fn run_minimax_h3(request: &Value) -> Result<Value, String> {
             "decode": decode.json(),
             "overall": overall.json(),
         },
-        "quality": {
-            "contract": "identical artifact, prompt, seed, geometry, frames, fps, steps, tier, staged components and loaded provider contract; cold measured clip versus two warm unscoped repeats, compared over every frame",
-            "identicalInputs": true,
-            "result": "passed",
-            "maximumError": maximum_error,
-            "meanError": mean_error,
-            "rootMeanSquareError": rms_error,
-            "maximumErrorThreshold": MINIMAX_MAX_THRESHOLD,
-            "meanErrorThreshold": MINIMAX_MEAN_THRESHOLD,
-            "rootMeanSquareErrorThreshold": MINIMAX_RMS_THRESHOLD,
-        },
+        "quality": capture.not_run_quality(
+            "identical artifact, prompt, seed, geometry, frames, fps, steps, tier, staged components and loaded provider contract; the cold measured clip versus a warm repeat, compared over every frame",
+            (MINIMAX_MAX_THRESHOLD, MINIMAX_MEAN_THRESHOLD, MINIMAX_RMS_THRESHOLD),
+        )?,
         "negativeMutation": null,
         "loadability": {
             "result": "passed",
@@ -18767,13 +18752,10 @@ fn run_minimax_h3(request: &Value) -> Result<Value, String> {
                 ("decodeCloseCache", "bytes", decode_close.cache),
                 ("overallAllocatorEnvelope", "bytes", overall.allocator_bytes()),
                 ("predictedOverallCeiling", "bytes", predicted),
-                ("lifecycleCleanWarmPeak", "bytes", clean_warm_peak),
-                ("lifecycleCleanPostCleanupActive", "bytes", clean_post_cleanup.active),
-                ("lifecycleCleanPostCleanupCache", "bytes", clean_post_cleanup.cache),
-                ("lifecycleCleanupTolerance", "bytes", cleanup_bounds.tolerance_bytes),
-                ("lifecycleWarmRepeatPeak", "bytes", warm_peak),
-                ("lifecycleWarmRepeatPostCleanupActive", "bytes", warm_post_cleanup.active),
-                ("lifecycleWarmRepeatPostCleanupCache", "bytes", warm_post_cleanup.cache),
+                // sc-22738: no `lifecycleClean*` / `lifecycleWarmRepeat*` figure — the warm
+                // passes were not run (`quality.warmPasses`), and an unmeasured figure is omitted,
+                // never written as 0.
+                ("warmPasses", "count", u64::from(capture.warm_passes)),
                 ("negativeMutationMaximumErrorPer255", "count", (mutated_maximum * 255.0).round() as u64),
                 ("negativeMutationMeanErrorPer255", "count", (mutated_mean * 255.0).round() as u64),
                 ("negativeMutationRootMeanSquareErrorPer255", "count", (mutated_rms * 255.0).round() as u64),
@@ -19409,6 +19391,17 @@ fn bernini_output_frames(
 /// cut on the boundaries the shipped `generate` already emits.
 fn run_bernini(request: &Value) -> Result<Value, String> {
     let (arm, geometry) = bernini_target(request)?;
+    // The lane's render plan (sc-22738). This ONE arm serves both catalog members: the still
+    // `bernini_image` entry (frames == 1) is an IMAGE capture and keeps its clean warm control and
+    // warm repeat exactly as before; the video entry is ONE measured render. The branch below is
+    // the lane's — derived from the plan's frame count — never the member's.
+    let capture = protocol::capture_policy(request)?;
+    if (capture.lane == protocol::CaptureLane::Video) != (arm.frames > 1) {
+        return Err(format!(
+            "the {} member renders {} frame(s) but the plan's geometry puts it on the {:?} lane",
+            arm.model_id, arm.frames, capture.lane
+        ));
+    }
     protocol::validate_plain_overlay_target(request, arm.execution_path)?;
     let load_shape = planned_load_shape(request)?;
     let selection = planned_selection(request)?;
@@ -19642,82 +19635,241 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
     // generator to admit a synthetic reference-carrying budget here would price an admission
     // decision this request never triggers, and the receipt would carry it as though it did.
 
-    // Warm repeat determinism + cleanup bounds on this exact loaded provider.
-    clear_cache();
-    reset_peak_memory();
-    let baseline = bernini_output_frames(
-        arm,
-        generator
-            .generate(&bernini_request(arm, geometry, fps, seed), &mut |_| {})
-            .map_err(|error| format!("generate warm Bernini control: {error}"))?,
-        fps,
-    )?;
-    let clean_warm_peak = get_peak_memory() as u64;
-    clear_cache();
-    let clean_post_cleanup = AllocatorState::capture_current();
-    let cleanup_bounds =
-        LifecycleMemoryBounds::from_clean_warm(clean_warm_peak, clean_post_cleanup);
-    let (maximum_error, mean_error, rms_error) = video_max_mean_rms_abs(&measured, &baseline)?;
-    if !bernini_quality_passes(maximum_error, mean_error, rms_error) {
-        return Err(format!(
-            "Bernini warm repeat exceeded the determinism envelope: max={maximum_error:.6}, \
-             mean={mean_error:.6}, rms={rms_error:.6}"
-        ));
+    /// The image lane's two warm passes and what they measured (sc-22738): `Some` only when the
+    /// lane runs them. On the video lane there is no clean warm control to judge determinism
+    /// against and no warm repeat to bound, and the receipt says so (`warm_repeat` not_run,
+    /// `quality.warmPasses: 0`) instead of writing zeros where these figures would be.
+    struct BerniniWarmPasses {
+        baseline: Vec<Image>,
+        clean_warm_peak: u64,
+        clean_post_cleanup: AllocatorState,
+        cleanup_bounds: LifecycleMemoryBounds,
+        warm_peak: u64,
+        warm_post_cleanup: AllocatorState,
+        maximum_error: f64,
+        mean_error: f64,
+        rms_error: f64,
     }
-    reset_peak_memory();
-    let warm = bernini_output_frames(
-        arm,
-        generator
-            .generate(&bernini_request(arm, geometry, fps, seed), &mut |_| {})
-            .map_err(|error| format!("generate warm Bernini repeat: {error}"))?,
-        fps,
-    )?;
-    let warm_peak = get_peak_memory() as u64;
-    if !cleanup_bounds.allows_warm_peak(warm_peak) {
-        return Err(format!(
-            "Bernini warm repeat peaked at {warm_peak} bytes, above the clean warm control \
-             {clean_warm_peak} bytes plus 2%"
-        ));
-    }
-    clear_cache();
-    let warm_post_cleanup = AllocatorState::capture_current();
-    if !cleanup_bounds.allows_retained(warm_post_cleanup) {
-        return Err(format!(
-            "Bernini warm repeat retained active/cache bytes {warm_post_cleanup:?} above the \
-             clean warm cleanup {clean_post_cleanup:?} plus {} bytes",
-            cleanup_bounds.tolerance_bytes,
-        ));
-    }
-    let (warm_maximum, warm_mean, warm_rms) = video_max_mean_rms_abs(&measured, &warm)?;
-    if !bernini_quality_passes(warm_maximum, warm_mean, warm_rms) {
-        return Err("Bernini second warm repeat changed the deterministic output".to_owned());
-    }
+    let warm = if capture.warm_passes == 0 {
+        None
+    } else {
+        // Warm repeat determinism + cleanup bounds on this exact loaded provider.
+        clear_cache();
+        reset_peak_memory();
+        let baseline = bernini_output_frames(
+            arm,
+            generator
+                .generate(&bernini_request(arm, geometry, fps, seed), &mut |_| {})
+                .map_err(|error| format!("generate warm Bernini control: {error}"))?,
+            fps,
+        )?;
+        let clean_warm_peak = get_peak_memory() as u64;
+        clear_cache();
+        let clean_post_cleanup = AllocatorState::capture_current();
+        let cleanup_bounds =
+            LifecycleMemoryBounds::from_clean_warm(clean_warm_peak, clean_post_cleanup);
+        let (maximum_error, mean_error, rms_error) = video_max_mean_rms_abs(&measured, &baseline)?;
+        if !bernini_quality_passes(maximum_error, mean_error, rms_error) {
+            return Err(format!(
+                "Bernini warm repeat exceeded the determinism envelope: max={maximum_error:.6}, \
+                 mean={mean_error:.6}, rms={rms_error:.6}"
+            ));
+        }
+        reset_peak_memory();
+        let repeat = bernini_output_frames(
+            arm,
+            generator
+                .generate(&bernini_request(arm, geometry, fps, seed), &mut |_| {})
+                .map_err(|error| format!("generate warm Bernini repeat: {error}"))?,
+            fps,
+        )?;
+        let warm_peak = get_peak_memory() as u64;
+        if !cleanup_bounds.allows_warm_peak(warm_peak) {
+            return Err(format!(
+                "Bernini warm repeat peaked at {warm_peak} bytes, above the clean warm control \
+                 {clean_warm_peak} bytes plus 2%"
+            ));
+        }
+        clear_cache();
+        let warm_post_cleanup = AllocatorState::capture_current();
+        if !cleanup_bounds.allows_retained(warm_post_cleanup) {
+            return Err(format!(
+                "Bernini warm repeat retained active/cache bytes {warm_post_cleanup:?} above the \
+                 clean warm cleanup {clean_post_cleanup:?} plus {} bytes",
+                cleanup_bounds.tolerance_bytes,
+            ));
+        }
+        let (warm_maximum, warm_mean, warm_rms) = video_max_mean_rms_abs(&measured, &repeat)?;
+        if !bernini_quality_passes(warm_maximum, warm_mean, warm_rms) {
+            return Err("Bernini second warm repeat changed the deterministic output".to_owned());
+        }
+        Some(BerniniWarmPasses {
+            baseline,
+            clean_warm_peak,
+            clean_post_cleanup,
+            cleanup_bounds,
+            warm_peak,
+            warm_post_cleanup,
+            maximum_error,
+            mean_error,
+            rms_error,
+        })
+    };
 
     // Arm-internal negative-mutation falsifiability check: a runtime_complete record keeps
     // `negativeMutation` null, so the breach is verified here and the numbers land in diagnostics.
+    // Against the clean warm control where one was rendered, else against the measured output
+    // itself: either way the mutation must breach the envelope the arm declares.
     let mutated = measured
         .iter()
         .map(qwen_negative_mutation)
         .collect::<Vec<_>>();
-    let (mutated_maximum, mutated_mean, mutated_rms) = video_max_mean_rms_abs(&mutated, &baseline)?;
+    let mutation_reference = warm.as_ref().map_or(&measured, |warm| &warm.baseline);
+    let (mutated_maximum, mutated_mean, mutated_rms) =
+        video_max_mean_rms_abs(&mutated, mutation_reference)?;
     if bernini_quality_passes(mutated_maximum, mutated_mean, mutated_rms) {
         return Err("Bernini output mutation did not breach the determinism envelope".to_owned());
     }
 
+    let renders_executed = match &warm {
+        Some(_) => {
+            "the measured render plus two unscoped warm repeats on the loaded provider".to_owned()
+        }
+        None => format!(
+            "ONE measured render on the loaded provider and no warm pass ({})",
+            protocol::VIDEO_WARM_PASSES_NOT_RUN
+        ),
+    };
     let lifecycle_blocker = format!(
         concat!(
-            "this arm executes the measured render plus two unscoped warm repeats on the loaded ",
-            "provider; it opens no memory-strategy request scope and injects no calibration ",
-            "fault, so the scoped cancellation and authorized-error scenarios and their recovery ",
-            "renders are unexecuted. The pinned provider does register begin_request, so they are ",
-            "implementable — they are not run here, and this record claims nothing about them. ",
+            "this arm executes {}; it opens no memory-strategy request scope and injects no ",
+            "calibration fault, so the scoped cancellation and authorized-error scenarios and ",
+            "their recovery renders are unexecuted. The pinned provider does register ",
+            "begin_request, so they are implementable — they are not run here, and this record ",
+            "claims nothing about them. ",
             // sc-22738: stated in the same breath as the lifecycle exclusion because it is the
             // same kind of claim — what this record deliberately does NOT say.
             "Additionally: {}"
         ),
-        BERNINI_ADMISSION_BLOCKER
+        renders_executed, BERNINI_ADMISSION_BLOCKER
     );
     let lifecycle_blocker = lifecycle_blocker.as_str();
+    const BERNINI_QUALITY_CONTRACT: &str = "identical artifact, prompt, seed, geometry, frames, fps, tier and loaded provider contract; cold measured output versus two warm unscoped repeats, compared over every frame";
+    let warm_repeat_scenario = match &warm {
+        Some(_) => {
+            json!({ "name": "warm_repeat", "result": "passed", "reason": "two warm repeats on the loaded provider reproduced the measured output frame-for-frame inside the declared envelope, within the clean warm peak and cleanup bounds" })
+        }
+        None => capture.not_run_warm_repeat_scenario()?,
+    };
+    let quality = match &warm {
+        Some(warm) => json!({
+            "contract": BERNINI_QUALITY_CONTRACT,
+            "identicalInputs": true,
+            "result": "passed",
+            "maximumError": warm.maximum_error,
+            "meanError": warm.mean_error,
+            "rootMeanSquareError": warm.rms_error,
+            "maximumErrorThreshold": BERNINI_MAX_THRESHOLD,
+            "meanErrorThreshold": BERNINI_MEAN_THRESHOLD,
+            "rootMeanSquareErrorThreshold": BERNINI_RMS_THRESHOLD,
+        }),
+        None => capture.not_run_quality(
+            BERNINI_QUALITY_CONTRACT,
+            (
+                BERNINI_MAX_THRESHOLD,
+                BERNINI_MEAN_THRESHOLD,
+                BERNINI_RMS_THRESHOLD,
+            ),
+        )?,
+    };
+    let mut measurements = vec![
+        ("preRungActiveAfterClear", "bytes", pre_rung_active),
+        ("preRungCacheAfterClear", "bytes", pre_rung_cache),
+        ("preGenerateActivePeak", "bytes", pre_generate.active),
+        ("conditioningActivePeak", "bytes", conditioning.active),
+        (
+            "conditioningCloseActive",
+            "bytes",
+            conditioning_close.active,
+        ),
+        ("conditioningCloseCache", "bytes", conditioning_close.cache),
+        ("denoiseActivePeak", "bytes", denoise.active),
+        ("denoiseCloseActive", "bytes", denoise_close.active),
+        ("denoiseCloseCache", "bytes", denoise_close.cache),
+        ("decodeActivePeak", "bytes", decode.active),
+        ("decodeCloseActive", "bytes", decode_close.active),
+        ("decodeCloseCache", "bytes", decode_close.cache),
+        (
+            "overallAllocatorEnvelope",
+            "bytes",
+            overall.allocator_bytes(),
+        ),
+        ("predictedOverallCeiling", "bytes", predicted),
+        ("warmPasses", "count", u64::from(capture.warm_passes)),
+    ];
+    // sc-22738: on the video lane no `lifecycleClean*` / `lifecycleWarmRepeat*` figure is emitted —
+    // the warm passes were not run (`quality.warmPasses`), and an unmeasured figure is omitted,
+    // never written as 0.
+    if let Some(warm) = &warm {
+        measurements.extend([
+            ("lifecycleCleanWarmPeak", "bytes", warm.clean_warm_peak),
+            (
+                "lifecycleCleanPostCleanupActive",
+                "bytes",
+                warm.clean_post_cleanup.active,
+            ),
+            (
+                "lifecycleCleanPostCleanupCache",
+                "bytes",
+                warm.clean_post_cleanup.cache,
+            ),
+            (
+                "lifecycleCleanupTolerance",
+                "bytes",
+                warm.cleanup_bounds.tolerance_bytes,
+            ),
+            ("lifecycleWarmRepeatPeak", "bytes", warm.warm_peak),
+            (
+                "lifecycleWarmRepeatPostCleanupActive",
+                "bytes",
+                warm.warm_post_cleanup.active,
+            ),
+            (
+                "lifecycleWarmRepeatPostCleanupCache",
+                "bytes",
+                warm.warm_post_cleanup.cache,
+            ),
+        ]);
+    }
+    measurements.extend([
+        (
+            "negativeMutationMaximumErrorPer255",
+            "count",
+            (mutated_maximum * 255.0).round() as u64,
+        ),
+        (
+            "negativeMutationMeanErrorPer255",
+            "count",
+            (mutated_mean * 255.0).round() as u64,
+        ),
+        (
+            "negativeMutationRootMeanSquareErrorPer255",
+            "count",
+            (mutated_rms * 255.0).round() as u64,
+        ),
+        (
+            "loadShapeDeferred",
+            "count",
+            u64::from(load_shape == LoadShape::DeferredMaterialization),
+        ),
+        ("stagedTierBytes", "bytes", staged_tier_bytes),
+        // sc-22738: the render receipts, published as measurements rather than as a top-level
+        // `output` object the record schema rejects. The member this record is filed under is
+        // `target.modelId`, so the dropped `output.modelId` is not lost.
+        ("renderedFrames", "count", u64::from(expected_frames)),
+        ("requestedFrames", "count", u64::from(geometry.frames)),
+        ("outputFps", "count", u64::from(fps)),
+    ]);
     // GATED, not `runtime_complete` (sc-22738). Runtime activation is exactly the claim that the
     // provider's admission gate accepted an exact-fit budget and rejected the two mutations, and
     // this capture asked it nothing — because production asks it nothing for this request. The
@@ -19739,7 +19891,7 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
             { "name": "exact_fit", "result": "not_run", "reason": BERNINI_ADMISSION_BLOCKER },
             { "name": "unknown_budget", "result": "not_run", "reason": BERNINI_ADMISSION_BLOCKER },
             { "name": "stale_evidence", "result": "not_run", "reason": BERNINI_ADMISSION_BLOCKER },
-            { "name": "warm_repeat", "result": "passed", "reason": "two warm repeats on the loaded provider reproduced the measured output frame-for-frame inside the declared envelope, within the clean warm peak and cleanup bounds" },
+            warm_repeat_scenario,
             { "name": "cancel", "result": "not_run", "reason": lifecycle_blocker },
             { "name": "error", "result": "not_run", "reason": lifecycle_blocker },
             { "name": "loadability", "result": "passed" },
@@ -19752,17 +19904,7 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
             "decode": decode.json(),
             "overall": overall.json(),
         },
-        "quality": {
-            "contract": "identical artifact, prompt, seed, geometry, frames, fps, tier and loaded provider contract; cold measured output versus two warm unscoped repeats, compared over every frame",
-            "identicalInputs": true,
-            "result": "passed",
-            "maximumError": maximum_error,
-            "meanError": mean_error,
-            "rootMeanSquareError": rms_error,
-            "maximumErrorThreshold": BERNINI_MAX_THRESHOLD,
-            "meanErrorThreshold": BERNINI_MEAN_THRESHOLD,
-            "rootMeanSquareErrorThreshold": BERNINI_RMS_THRESHOLD,
-        },
+        "quality": quality,
         "negativeMutation": null,
         "loadability": {
             "result": "passed",
@@ -19772,40 +19914,7 @@ fn run_bernini(request: &Value) -> Result<Value, String> {
             "memory-mlx-adapter:bernini-dual-expert",
             "executed",
             [lifecycle_blocker.to_owned()],
-            [
-                ("preRungActiveAfterClear", "bytes", pre_rung_active),
-                ("preRungCacheAfterClear", "bytes", pre_rung_cache),
-                ("preGenerateActivePeak", "bytes", pre_generate.active),
-                ("conditioningActivePeak", "bytes", conditioning.active),
-                ("conditioningCloseActive", "bytes", conditioning_close.active),
-                ("conditioningCloseCache", "bytes", conditioning_close.cache),
-                ("denoiseActivePeak", "bytes", denoise.active),
-                ("denoiseCloseActive", "bytes", denoise_close.active),
-                ("denoiseCloseCache", "bytes", denoise_close.cache),
-                ("decodeActivePeak", "bytes", decode.active),
-                ("decodeCloseActive", "bytes", decode_close.active),
-                ("decodeCloseCache", "bytes", decode_close.cache),
-                ("overallAllocatorEnvelope", "bytes", overall.allocator_bytes()),
-                ("predictedOverallCeiling", "bytes", predicted),
-                ("lifecycleCleanWarmPeak", "bytes", clean_warm_peak),
-                ("lifecycleCleanPostCleanupActive", "bytes", clean_post_cleanup.active),
-                ("lifecycleCleanPostCleanupCache", "bytes", clean_post_cleanup.cache),
-                ("lifecycleCleanupTolerance", "bytes", cleanup_bounds.tolerance_bytes),
-                ("lifecycleWarmRepeatPeak", "bytes", warm_peak),
-                ("lifecycleWarmRepeatPostCleanupActive", "bytes", warm_post_cleanup.active),
-                ("lifecycleWarmRepeatPostCleanupCache", "bytes", warm_post_cleanup.cache),
-                ("negativeMutationMaximumErrorPer255", "count", (mutated_maximum * 255.0).round() as u64),
-                ("negativeMutationMeanErrorPer255", "count", (mutated_mean * 255.0).round() as u64),
-                ("negativeMutationRootMeanSquareErrorPer255", "count", (mutated_rms * 255.0).round() as u64),
-                ("loadShapeDeferred", "count", u64::from(load_shape == LoadShape::DeferredMaterialization)),
-                ("stagedTierBytes", "bytes", staged_tier_bytes),
-                // sc-22738: the render receipts, published as measurements rather than as a
-                // top-level `output` object the record schema rejects. The member this record is
-                // filed under is `target.modelId`, so the dropped `output.modelId` is not lost.
-                ("renderedFrames", "count", u64::from(expected_frames)),
-                ("requestedFrames", "count", u64::from(geometry.frames)),
-                ("outputFps", "count", u64::from(fps)),
-            ],
+            measurements,
         ),
         "capturedAt": protocol::captured_at(),
     });
@@ -21697,6 +21806,8 @@ fn krea_realtime_complete_sweep(request: &Value) -> Result<Value, String> {
 /// decides which rungs are capturable, and this provider registers a resident-only witness.
 fn run_krea_realtime(request: &Value) -> Result<Value, String> {
     let geometry = validate_krea_realtime_target(request)?;
+    // The lane's render plan (sc-22738): a video capture is ONE measured render, no warm pass.
+    let capture = protocol::capture_policy(request)?.require_video(KREA_REALTIME_LABEL)?;
     let surface = krea_realtime_target_surface(request)?;
     protocol::validate_plain_overlay_target(request, KREA_REALTIME_PLAIN_EXECUTION_PATH)?;
     let load_shape = planned_load_shape(request)?;
@@ -21943,62 +22054,19 @@ fn run_krea_realtime(request: &Value) -> Result<Value, String> {
     // t2v surface by name, so an answer here would characterize a decision production never takes.
     // See [`KREA_REALTIME_ADMISSION_BLOCKER`].
 
-    // Warm repeat determinism + cleanup bounds on this exact loaded provider.
-    clear_cache();
-    reset_peak_memory();
-    let (baseline, _, _) = diagnostic_video_frames(
-        generator
-            .generate(&krea_realtime_request(geometry, fps, seed), &mut |_| {})
-            .map_err(|error| format!("generate warm Krea Realtime control: {error}"))?,
-        KREA_REALTIME_VIDEO_LABEL,
-    )?;
-    let clean_warm_peak = get_peak_memory() as u64;
-    clear_cache();
-    let clean_post_cleanup = AllocatorState::capture_current();
-    let cleanup_bounds =
-        LifecycleMemoryBounds::from_clean_warm(clean_warm_peak, clean_post_cleanup);
-    let (maximum_error, mean_error, rms_error) = video_max_mean_rms_abs(&measured, &baseline)?;
-    if !krea_realtime_quality_passes(maximum_error, mean_error, rms_error) {
-        return Err(format!(
-            "Krea Realtime warm repeat exceeded the determinism envelope: max={maximum_error:.6}, \
-             mean={mean_error:.6}, rms={rms_error:.6}"
-        ));
-    }
-    reset_peak_memory();
-    let (warm, _, _) = diagnostic_video_frames(
-        generator
-            .generate(&krea_realtime_request(geometry, fps, seed), &mut |_| {})
-            .map_err(|error| format!("generate warm Krea Realtime repeat: {error}"))?,
-        KREA_REALTIME_VIDEO_LABEL,
-    )?;
-    let warm_peak = get_peak_memory() as u64;
-    if !cleanup_bounds.allows_warm_peak(warm_peak) {
-        return Err(format!(
-            "Krea Realtime warm repeat peaked at {warm_peak} bytes, above the clean warm control \
-             {clean_warm_peak} bytes plus 2%"
-        ));
-    }
-    clear_cache();
-    let warm_post_cleanup = AllocatorState::capture_current();
-    if !cleanup_bounds.allows_retained(warm_post_cleanup) {
-        return Err(format!(
-            "Krea Realtime warm repeat retained active/cache bytes {warm_post_cleanup:?} above the \
-             clean warm cleanup {clean_post_cleanup:?} plus {} bytes",
-            cleanup_bounds.tolerance_bytes,
-        ));
-    }
-    let (warm_maximum, warm_mean, warm_rms) = video_max_mean_rms_abs(&measured, &warm)?;
-    if !krea_realtime_quality_passes(warm_maximum, warm_mean, warm_rms) {
-        return Err("Krea Realtime second warm repeat changed the deterministic output".to_owned());
-    }
+    // No warm pass: the video lane captures ONE measured render (sc-22738, `capture` above), so
+    // there is no clean warm control to judge determinism against and no warm repeat to bound;
+    // the receipt says so (`warm_repeat` not_run, `quality.warmPasses: 0`) instead of writing
+    // zeros where `lifecycleClean*` / `lifecycleWarmRepeat*` used to be.
 
     // Arm-internal negative-mutation falsifiability check: the capture FAILS if the envelope cannot
-    // be breached, and the measured numbers land in diagnostics rather than in the field.
+    // be breached, and the measured numbers land in diagnostics rather than in the field. Against
+    // the measured clip itself: the mutation must breach the envelope the arm declares.
     let mutated = measured
         .iter()
         .map(qwen_negative_mutation)
         .collect::<Vec<_>>();
-    let (mutated_maximum, mutated_mean, mutated_rms) = video_max_mean_rms_abs(&mutated, &baseline)?;
+    let (mutated_maximum, mutated_mean, mutated_rms) = video_max_mean_rms_abs(&mutated, &measured)?;
     if krea_realtime_quality_passes(mutated_maximum, mutated_mean, mutated_rms) {
         return Err(
             "Krea Realtime output mutation did not breach the determinism envelope".to_owned(),
@@ -22007,14 +22075,15 @@ fn run_krea_realtime(request: &Value) -> Result<Value, String> {
 
     let lifecycle_blocker = format!(
         concat!(
-            "this arm executes the measured render plus two unscoped warm repeats on the loaded ",
-            "provider; it opens no memory-strategy request scope and injects no calibration ",
-            "fault, so the scoped cancellation and authorized-error scenarios and their recovery ",
-            "renders are unexecuted. This record claims nothing about them. ",
+            "this arm executes ONE measured render on the loaded provider and no warm pass ({}); ",
+            "it opens no memory-strategy request scope and injects no calibration fault, so the ",
+            "scoped cancellation and authorized-error scenarios and their recovery renders are ",
+            "unexecuted. This record claims nothing about them. ",
             // sc-22738: stated in the same breath as the lifecycle exclusion because it is the
             // same kind of claim — what this record deliberately does NOT say.
             "Additionally: {}"
         ),
+        protocol::VIDEO_WARM_PASSES_NOT_RUN,
         KREA_REALTIME_ADMISSION_BLOCKER,
     );
     let lifecycle_blocker = lifecycle_blocker.as_str();
@@ -22040,7 +22109,7 @@ fn run_krea_realtime(request: &Value) -> Result<Value, String> {
             { "name": "exact_fit", "result": "not_run", "reason": KREA_REALTIME_ADMISSION_BLOCKER },
             { "name": "unknown_budget", "result": "not_run", "reason": KREA_REALTIME_ADMISSION_BLOCKER },
             { "name": "stale_evidence", "result": "not_run", "reason": KREA_REALTIME_ADMISSION_BLOCKER },
-            { "name": "warm_repeat", "result": "passed", "reason": "two warm repeats on the loaded provider reproduced the measured clip frame-for-frame inside the declared envelope, within the clean warm peak and cleanup bounds" },
+            capture.not_run_warm_repeat_scenario()?,
             { "name": "cancel", "result": "not_run", "reason": lifecycle_blocker },
             { "name": "error", "result": "not_run", "reason": lifecycle_blocker },
             { "name": "loadability", "result": "passed" },
@@ -22053,17 +22122,10 @@ fn run_krea_realtime(request: &Value) -> Result<Value, String> {
             "decode": decode.json(),
             "overall": overall.json(),
         },
-        "quality": {
-            "contract": "identical artifact, prompt, seed, geometry, frames, fps, steps, tier and loaded provider contract; cold measured clip versus two warm unscoped repeats, compared over every frame",
-            "identicalInputs": true,
-            "result": "passed",
-            "maximumError": maximum_error,
-            "meanError": mean_error,
-            "rootMeanSquareError": rms_error,
-            "maximumErrorThreshold": KREA_REALTIME_MAX_THRESHOLD,
-            "meanErrorThreshold": KREA_REALTIME_MEAN_THRESHOLD,
-            "rootMeanSquareErrorThreshold": KREA_REALTIME_RMS_THRESHOLD,
-        },
+        "quality": capture.not_run_quality(
+            "identical artifact, prompt, seed, geometry, frames, fps, steps, tier and loaded provider contract; the cold measured clip versus a warm repeat, compared over every frame",
+            (KREA_REALTIME_MAX_THRESHOLD, KREA_REALTIME_MEAN_THRESHOLD, KREA_REALTIME_RMS_THRESHOLD),
+        )?,
         "negativeMutation": null,
         "loadability": {
             "result": "passed",
@@ -22088,13 +22150,10 @@ fn run_krea_realtime(request: &Value) -> Result<Value, String> {
                 ("decodeCloseCache", "bytes", decode_close.cache),
                 ("overallAllocatorEnvelope", "bytes", overall.allocator_bytes()),
                 ("predictedOverallCeiling", "bytes", predicted),
-                ("lifecycleCleanWarmPeak", "bytes", clean_warm_peak),
-                ("lifecycleCleanPostCleanupActive", "bytes", clean_post_cleanup.active),
-                ("lifecycleCleanPostCleanupCache", "bytes", clean_post_cleanup.cache),
-                ("lifecycleCleanupTolerance", "bytes", cleanup_bounds.tolerance_bytes),
-                ("lifecycleWarmRepeatPeak", "bytes", warm_peak),
-                ("lifecycleWarmRepeatPostCleanupActive", "bytes", warm_post_cleanup.active),
-                ("lifecycleWarmRepeatPostCleanupCache", "bytes", warm_post_cleanup.cache),
+                // sc-22738: no `lifecycleClean*` / `lifecycleWarmRepeat*` figure — the warm
+                // passes were not run (`quality.warmPasses`), and an unmeasured figure is omitted,
+                // never written as 0.
+                ("warmPasses", "count", u64::from(capture.warm_passes)),
                 ("negativeMutationMaximumErrorPer255", "count", (mutated_maximum * 255.0).round() as u64),
                 ("negativeMutationMeanErrorPer255", "count", (mutated_mean * 255.0).round() as u64),
                 ("negativeMutationRootMeanSquareErrorPer255", "count", (mutated_rms * 255.0).round() as u64),
@@ -28685,8 +28744,8 @@ mod ltx_tests {
         );
         let post_load = &body[load_at..];
         let lifecycle = &post_load[..post_load
-            .find("let maximum_error = lifecycle.maximum_error;")
-            .expect("the lifecycle match precedes the quality figures")];
+            .find("// Runtime-complete keeps the schema's unexecuted mutation slot null.")
+            .expect("the lifecycle match precedes the falsifiability mutation")];
         let ordinary = &lifecycle[lifecycle
             .rfind("LtxRunAdmission::Ordinary =>")
             .expect("the lifecycle match has an Ordinary arm")..];
@@ -28694,9 +28753,24 @@ mod ltx_tests {
             !ordinary.contains("Err(") && !ordinary.contains("return"),
             "the Ordinary lifecycle arm refuses or exits: {ordinary}"
         );
+        // sc-22738: the ordinary capture is ONE measured render on the video lane. Its lifecycle
+        // arm renders nothing — no clean warm control, no fault, no recovery — and files the
+        // `not_run` receipt instead; only the SC-20318 campaign entries execute a lifecycle.
         assert!(
-            ordinary.contains("verify_ltx_lifecycle("),
-            "the Ordinary lifecycle arm must execute the runtime-complete lifecycle"
+            !ordinary.contains("verify_ltx_lifecycle(")
+                && !ordinary.contains("verify_ltx_bounded_warm_repeat("),
+            "the Ordinary lifecycle arm must not render a warm pass: {ordinary}"
+        );
+        assert!(
+            ordinary.contains("(None, None)"),
+            "the Ordinary lifecycle arm files no lifecycle metrics: {ordinary}"
+        );
+        let campaign = &lifecycle[lifecycle
+            .find("LtxRunAdmission::CampaignEntry =>")
+            .expect("the lifecycle match has a CampaignEntry arm")..];
+        assert!(
+            campaign.contains("verify_ltx_lifecycle("),
+            "the campaign entry keeps its runtime-complete lifecycle proof"
         );
     }
 
@@ -33208,5 +33282,158 @@ mod exceeded_bound_tests {
         assert_eq!(bound.observed_footprint_bytes, 97_147_294_328);
         assert_eq!(bound.host_memory_bytes, 137_438_953_472);
         assert!(bound.observed_footprint_bytes >= bound.ceiling_bytes);
+    }
+}
+
+/// sc-22738 (2026-09-08): a video capture is ONE measured render; the image lane keeps its two
+/// warm passes. The lane is the PLAN's — derived from the row's frame count, exactly as
+/// `measure-memory-catalog.mjs` derives the budget lane — never a per-model choice, and every
+/// changed arm reads it through `protocol::capture_policy` before it renders.
+#[cfg(test)]
+mod single_render_video_lane_tests {
+    use super::*;
+
+    /// The catalog plan, one request per MLX row, in the shape every arm reads (`planned.target`).
+    fn planned_mlx_rows() -> Vec<(String, Value, Value)> {
+        let plan: Value = serde_json::from_str(include_str!(
+            "../../../../config/memory-calibration-plan.json"
+        ))
+        .expect("the anchor plan is valid JSON");
+        plan["anchors"]
+            .as_object()
+            .expect("anchors is an object")
+            .iter()
+            .filter(|(key, _)| key.ends_with(":mlx"))
+            .map(|(key, row)| {
+                let parts: Vec<&str> = key.split(':').collect();
+                let request = json!({
+                    "planned": {
+                        "target": {
+                            "provider": row["provider"],
+                            "modelId": parts[0],
+                            "tier": parts[1],
+                            "mode": row["mode"],
+                            "overlay": row["overlay"],
+                            "geometry": row["geometry"],
+                        },
+                    }
+                });
+                (key.clone(), row.clone(), request)
+            })
+            .collect()
+    }
+
+    /// Every changed arm, by the provider id its plan rows carry, and the video members each one
+    /// captures. The still `bernini_image` member is served by the SAME `run_bernini` and is the
+    /// one row that proves the branch is the lane's and not the arm's.
+    const SINGLE_RENDER_VIDEO_ARMS: [(&str, &str); 8] = [
+        ("run_ltx_with_admission (Ordinary)", LTX_PROVIDER),
+        ("run_minimax_h3", MINIMAX_PROVIDER),
+        ("run_bernini (video member)", BERNINI_PROVIDER),
+        ("run_krea_realtime", KREA_REALTIME_PROVIDER),
+        ("mlx_ltx25::run", "ltx_2_5"),
+        ("mlx_wan_scail2::run (ti2v 5b)", "wan2_2_ti2v_5b"),
+        ("mlx_wan_scail2::run (t2v a14b)", "wan2_2_t2v_14b"),
+        ("mlx_wan_scail2::run (scail2)", "scail2_14b"),
+    ];
+
+    /// Per changed arm: every planned video row resolves to exactly ONE `generate` (no warm pass),
+    /// and every planned image row — the still Bernini member included — to THREE. Mutations that
+    /// fail this: restoring the warm passes on the video lane (`VIDEO_WARM_PASSES = 2`), deriving
+    /// the lane from the provider instead of the frame count, or dropping the image lane's two.
+    #[test]
+    fn every_changed_video_arm_captures_one_render_and_the_image_lane_keeps_three() {
+        let rows = planned_mlx_rows();
+        for (arm, provider) in SINGLE_RENDER_VIDEO_ARMS {
+            let video_rows: Vec<_> = rows
+                .iter()
+                .filter(|(_, row, _)| {
+                    row["provider"] == provider && row["geometry"]["frames"].as_u64() > Some(1)
+                })
+                .collect();
+            assert!(
+                !video_rows.is_empty(),
+                "{arm}: no planned video row for {provider}"
+            );
+            for (key, _, request) in video_rows {
+                let policy = protocol::capture_policy(request)
+                    .unwrap_or_else(|error| panic!("{key}: {error}"));
+                assert_eq!(policy.lane, protocol::CaptureLane::Video, "{arm}: {key}");
+                assert_eq!(policy.warm_passes, 0, "{arm}: {key} must run no warm pass");
+                assert_eq!(policy.renders(), 1, "{arm}: {key} is one measured render");
+                assert!(policy.require_video(arm).is_ok(), "{arm}: {key}");
+                let scenario = policy.not_run_warm_repeat_scenario().unwrap();
+                assert_eq!(scenario["result"], "not_run", "{arm}: {key}");
+                let quality = policy.not_run_quality("c", (1.0, 1.0, 1.0)).unwrap();
+                assert_eq!(
+                    (quality["warmPasses"].as_u64(), quality["result"].as_str()),
+                    (Some(0), Some("not_run")),
+                    "{arm}: {key}"
+                );
+            }
+        }
+        // The image lane, unchanged: three renders, and no `not_run` receipt may be filed for it.
+        let mut image_rows = 0;
+        let mut still_bernini = 0;
+        for (key, row, request) in &rows {
+            if row["geometry"]["frames"].as_u64() != Some(1) {
+                continue;
+            }
+            image_rows += 1;
+            let policy =
+                protocol::capture_policy(request).unwrap_or_else(|error| panic!("{key}: {error}"));
+            assert_eq!(policy.lane, protocol::CaptureLane::Image, "{key}");
+            assert_eq!(
+                policy.renders(),
+                3,
+                "{key}: an image capture is measured + two warm passes"
+            );
+            assert!(
+                policy.not_run_quality("c", (1.0, 1.0, 1.0)).is_err(),
+                "{key}"
+            );
+            assert!(policy.require_video("image arm").is_err(), "{key}");
+            if row["provider"] == BERNINI_PROVIDER {
+                still_bernini += 1;
+                assert_eq!(key.split(':').next(), Some(BERNINI_IMAGE_MODEL_ID), "{key}");
+            }
+        }
+        assert!(
+            image_rows > 100,
+            "{image_rows} image rows: the plan changed shape"
+        );
+        assert_eq!(
+            still_bernini,
+            BERNINI_TIERS.len(),
+            "one still Bernini row per tier keeps three renders"
+        );
+    }
+
+    /// The Bernini arm's lane is the plan's frame count checked against the member it names: the
+    /// still member on one frame is the image lane (three renders), the video member is one.
+    #[test]
+    fn the_bernini_lane_check_is_the_plans_frame_count_against_the_members() {
+        for arm in BERNINI_ARMS {
+            let policy = protocol::capture_policy(&json!({
+                "planned": {
+                    "target": {
+                        "geometry": { "width": 848, "height": 480, "batch": 1, "frames": arm.frames }
+                    }
+                }
+            }))
+            .unwrap();
+            assert_eq!(
+                policy.lane == protocol::CaptureLane::Video,
+                arm.frames > 1,
+                "{}",
+                arm.model_id
+            );
+            assert_eq!(
+                policy.renders(),
+                if arm.frames > 1 { 1 } else { 3 },
+                "{}",
+                arm.model_id
+            );
+        }
     }
 }

--- a/crates/sceneworks-memory-adapter/src/bin/mlx_ltx25.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx_ltx25.rs
@@ -870,6 +870,9 @@ fn mutate_audio_pcm(audio: &AudioTrack) -> AudioTrack {
     mutated
 }
 
+/// The PCM digest a typed `quality.audio` comparison keys on. Only the tests' selected-versus-
+/// reference fixtures still compare two tracks: the capture renders one (sc-22738).
+#[cfg(test)]
 fn pcm_sha256(audio: &AudioTrack) -> String {
     let mut hasher = Sha256::new();
     for samples in audio.samples.chunks(16_384) {
@@ -1020,12 +1023,15 @@ fn persist_canonical_av(
     }))
 }
 
+/// The physical source-session receipt of ONE measured render (sc-22738): the `selected_av`
+/// output only. The `reference_av` role belongs to a warm repeat, which the video lane does not
+/// run; the retained `sc-18791` / `sc-22738` LTX-2.5 sessions that carry both roles were captured
+/// under the previous two-render arm and remain valid as they are.
 fn source_capture(
     plan: &SourceCapturePlan,
     artifact: &Artifact,
     tier: &str,
     selected: &RenderedClip,
-    reference: &RenderedClip,
 ) -> Result<Value, String> {
     let mut inputs = vec![
         json!({
@@ -1063,7 +1069,6 @@ fn source_capture(
         "inputs": inputs,
         "outputs": [
             persist_canonical_av(plan, "selected_av", selected)?,
-            persist_canonical_av(plan, "reference_av", reference)?,
         ],
         "claims": [
             "memory", "quality", "negative_mutation", "lifecycle", "loadability", "overlay"
@@ -1089,6 +1094,8 @@ fn complete_sweep(request: &Value) -> Result<Value, String> {
 
 pub(super) fn run(request: &Value) -> Result<Value, String> {
     let target = validate_target(request)?;
+    // The lane's render plan (sc-22738): a video capture is ONE measured render, no warm pass.
+    let capture = protocol::capture_policy(request)?.require_video(LABEL)?;
     let tier = planned_qwen_tier(request)?;
     let selection = planned_selection(request)?;
     validate_selection_shape(&selection, target)?;
@@ -1245,37 +1252,21 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
         );
     }
 
-    let mut warm_context = probe_context.clone();
-    warm_context.cache_state = MemoryCacheState::Warm;
-    let repeat = render(generator.as_ref(), target, &warm_context, false)?;
-    if selected.fps != repeat.fps {
-        return Err("LTX-2.5 identical-input repeat changed A/V identity".to_owned());
-    }
-    let (maximum_error, mean_error, rms_error) =
-        video_max_mean_rms_abs(&selected.frames, &repeat.frames)?;
-    if !quality_passes(maximum_error, mean_error, rms_error) {
-        return Err(format!(
-            "LTX-2.5 warm repeat exceeded determinism envelope: max={maximum_error:.6}, mean={mean_error:.6}, rms={rms_error:.6}"
-        ));
-    }
-    let (audio_maximum_error, audio_mean_error, audio_rms_error) =
-        audio_max_mean_rms_abs(&selected.audio, &repeat.audio)?;
-    if !audio_quality_passes(audio_maximum_error, audio_mean_error, audio_rms_error) {
-        return Err(format!(
-            "LTX-2.5 warm repeat exceeded PCM determinism envelope: max={audio_maximum_error:.6}, mean={audio_mean_error:.6}, rms={audio_rms_error:.6}"
-        ));
-    }
-    let selected_pcm_sha256 = pcm_sha256(&selected.audio);
-    let reference_pcm_sha256 = pcm_sha256(&repeat.audio);
+    // No warm pass: the video lane captures ONE measured render (sc-22738, `capture` above). There
+    // is no identical-input repeat to judge the video and PCM determinism envelopes against, so
+    // the receipt carries `quality.warmPasses: 0` with `result: not_run` and NO typed `audio`
+    // block (a typed audio comparison needs a `reference_av` render this capture did not make),
+    // instead of writing zeros. The falsifiability mutations below are judged against the
+    // measured render itself.
     let mutated = qwen_negative_mutation(&selected.frames[0]);
     let (mutated_maximum, mutated_mean, mutated_rms) =
-        image_max_mean_rms_abs(&mutated, &repeat.frames[0])?;
+        image_max_mean_rms_abs(&mutated, &selected.frames[0])?;
     if quality_passes(mutated_maximum, mutated_mean, mutated_rms) {
         return Err("LTX-2.5 output mutation did not breach determinism envelope".to_owned());
     }
     let mutated_audio = mutate_audio_pcm(&selected.audio);
     let (mutated_audio_maximum, mutated_audio_mean, mutated_audio_rms) =
-        audio_max_mean_rms_abs(&mutated_audio, &repeat.audio)?;
+        audio_max_mean_rms_abs(&mutated_audio, &selected.audio)?;
     if audio_quality_passes(mutated_audio_maximum, mutated_audio_mean, mutated_audio_rms) {
         return Err(
             "LTX-2.5 same-shape PCM mutation did not breach determinism envelope".to_owned(),
@@ -1289,12 +1280,13 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
     }
     let sample_count = u64::try_from(selected.audio.samples.len())
         .map_err(|_| "LTX-2.5 PCM sample count must fit u64".to_owned())?;
-    let source_capture = source_capture(&capture_plan, &artifact, tier, &selected, &repeat)?;
+    let source_capture = source_capture(&capture_plan, &artifact, tier, &selected)?;
 
-    let lifecycle_reason = concat!(
-        "SC-18783 executes the measured full-pipeline render plus one identical-input warm parity ",
-        "render per fresh process; cancellation and injected-error lifecycle cases remain explicitly ",
-        "unexecuted here and are not used as calibration currency"
+    let lifecycle_reason = format!(
+        "SC-18783 executes ONE measured full-pipeline render per fresh process and no warm pass \
+         ({}); cancellation and injected-error lifecycle cases remain explicitly unexecuted here \
+         and are not used as calibration currency",
+        protocol::VIDEO_WARM_PASSES_NOT_RUN
     );
     let fragment = json!({
         "status": "runtime_complete",
@@ -1310,7 +1302,7 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
             { "name": "exact_fit", "result": "passed", "predictedBytes": predicted, "effectiveBudgetBytes": predicted },
             { "name": "unknown_budget", "result": "passed", "reason": "the loaded provider rejected a zero/unknown budget" },
             { "name": "stale_evidence", "result": "passed", "reason": "the loaded provider rejected a mutated calibration fingerprint" },
-            { "name": "warm_repeat", "result": "passed", "reason": "an identical-input full-pipeline request completed on the same loaded provider" },
+            capture.not_run_warm_repeat_scenario()?,
             { "name": "cancel", "result": "not_run", "reason": lifecycle_reason },
             { "name": "error", "result": "not_run", "reason": lifecycle_reason },
             { "name": "loadability", "result": "passed" },
@@ -1323,31 +1315,13 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
             "decode": decode.json(),
             "overall": overall.json(),
         },
-        "quality": {
-            "contract": "identical public artifact revision, transformer variant, decoder, prompt, seed, geometry, cadence, tier, required adapter recipe, and loaded provider; every video pixel and interleaved PCM sample in the measured render versus warm full-pipeline repeat",
-            "identicalInputs": true,
-            "result": "passed",
-            "maximumError": maximum_error,
-            "meanError": mean_error,
-            "rootMeanSquareError": rms_error,
-            "maximumErrorThreshold": LTX_MAX_THRESHOLD,
-            "meanErrorThreshold": LTX_MEAN_THRESHOLD,
-            "rootMeanSquareErrorThreshold": LTX_RMS_THRESHOLD,
-            "audio": {
-                "result": "passed",
-                "sampleRateHz": selected.audio.sample_rate,
-                "channels": selected.audio.channels,
-                "sampleCount": sample_count,
-                "selectedPcmSha256": selected_pcm_sha256,
-                "referencePcmSha256": reference_pcm_sha256,
-                "maximumAbsoluteError": audio_maximum_error,
-                "meanAbsoluteError": audio_mean_error,
-                "rootMeanSquareError": audio_rms_error,
-                "maximumAbsoluteErrorThreshold": AUDIO_MAX_THRESHOLD,
-                "meanAbsoluteErrorThreshold": AUDIO_MEAN_THRESHOLD,
-                "rootMeanSquareErrorThreshold": AUDIO_RMS_THRESHOLD,
-            },
-        },
+        // No typed `audio` block: it is a selected-versus-reference PCM comparison, and there is no
+        // reference render. The measured track's identity travels as measurements below and in the
+        // content-addressed `selected_av` receipt.
+        "quality": capture.not_run_quality(
+            "identical public artifact revision, transformer variant, decoder, prompt, seed, geometry, cadence, tier, required adapter recipe, and loaded provider; every video pixel and interleaved PCM sample in the measured render versus a warm full-pipeline repeat",
+            (LTX_MAX_THRESHOLD, LTX_MEAN_THRESHOLD, LTX_RMS_THRESHOLD),
+        )?,
         "negativeMutation": null,
         "loadability": {
             "result": "passed",
@@ -1367,6 +1341,13 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
                 output_fps_diagnostic(target),
                 ("devVariant", "count", u64::from(target.variant == TransformerVariant::Dev)),
                 ("diffusionDecoder", "count", u64::from(target.decoder == Decoder::DiffVae)),
+                // sc-22738: the measured track's identity, where the typed `quality.audio`
+                // comparison block used to carry it; no warm pass ran (`quality.warmPasses`).
+                ("warmPasses", "count", u64::from(capture.warm_passes)),
+                ("audioTrackDecoded", "count", 1),
+                ("audioSamples", "count", sample_count),
+                ("audioSampleRate", "count", u64::from(selected.audio.sample_rate)),
+                ("audioChannels", "count", u64::from(selected.audio.channels)),
                 ("negativeMutationMaximumErrorPer255", "count", (mutated_maximum * 255.0).round() as u64),
                 ("negativeMutationMeanErrorPer255", "count", (mutated_mean * 255.0).round() as u64),
                 ("negativeMutationRootMeanSquareErrorPer255", "count", (mutated_rms * 255.0).round() as u64),
@@ -1986,7 +1967,18 @@ mod tests {
             }),
         };
         let clip = tiny_clip(vec![0.0, 0.25, -0.5, 0.75]);
-        let receipt = source_capture(&plan, &artifact, "q4", &clip, &clip).unwrap();
+        let receipt = source_capture(&plan, &artifact, "q4", &clip).unwrap();
+        // sc-22738: ONE measured render files ONE rendered receipt. A `reference_av` here would
+        // claim a warm repeat this capture did not make.
+        assert_eq!(
+            receipt["outputs"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|output| output["role"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            ["selected_av"]
+        );
         let inputs = receipt["inputs"].as_array().unwrap();
         assert_eq!(
             inputs
@@ -2006,7 +1998,7 @@ mod tests {
         );
         assert_eq!(inputs[2]["sha256"], "c".repeat(64));
         plan.dev_adapter_inventory = None;
-        let distilled_receipt = source_capture(&plan, &artifact, "q4", &clip, &clip).unwrap();
+        let distilled_receipt = source_capture(&plan, &artifact, "q4", &clip).unwrap();
         assert_eq!(
             distilled_receipt["inputs"]
                 .as_array()

--- a/crates/sceneworks-memory-adapter/src/bin/mlx_wan_scail2.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/mlx_wan_scail2.rs
@@ -26,11 +26,14 @@ use mlx_gen::gen_core::ReplacementMode;
 const SEED: u64 = 22_736;
 const LABEL: &str = "MLX Wan2.2/SCAIL-2";
 
-/// Determinism envelope for a warm repeat of one of these clips.
+/// Determinism envelope these clips are judged by.
 ///
 /// The same claim the other video arms make — repeat determinism on ONE loaded provider with an
 /// identical request — so the same published FLUX.2 envelope applies rather than a looser bound
 /// invented here. The mandatory `+64` negative mutation is more than eight times the maximum.
+/// Since sc-22738 (2026-09-08) a video capture is ONE measured render, so no warm repeat is
+/// compared against it here: the thresholds travel in the receipt (`quality.warmPasses: 0`,
+/// `result: not_run`) and bound only the falsifiability mutation.
 const MAX_THRESHOLD: f64 = FLUX2_MAX_THRESHOLD;
 const MEAN_THRESHOLD: f64 = FLUX2_MEAN_THRESHOLD;
 const RMS_THRESHOLD: f64 = FLUX2_RMS_THRESHOLD;
@@ -734,13 +737,13 @@ fn complete_sweep(request: &Value) -> Result<Value, String> {
 /// `wan_lightning_on`, sc-10047): the record names that exclusion so it cannot be read as the
 /// default composition's evidence.
 fn lifecycle_blocker(arm: Arm) -> String {
-    let mut blocker = concat!(
-        "this arm executes the measured render plus two unscoped warm repeats on the loaded ",
-        "provider; it opens no memory-strategy request scope and injects no calibration fault, so ",
-        "the scoped cancellation and authorized-error scenarios and their recovery renders are ",
-        "unexecuted. This record claims nothing about them"
-    )
-    .to_owned();
+    let mut blocker = format!(
+        "this arm executes ONE measured render on the loaded provider and no warm pass ({}); it \
+         opens no memory-strategy request scope and injects no calibration fault, so the scoped \
+         cancellation and authorized-error scenarios and their recovery renders are unexecuted. \
+         This record claims nothing about them",
+        protocol::VIDEO_WARM_PASSES_NOT_RUN
+    );
     if matches!(arm.route, Some(WanI2vRoute::T2v14b | WanI2vRoute::I2v14b)) {
         blocker.push_str(&format!(
             ". The A14B render is measured with NO adapters at the native multi-step recipe \
@@ -760,6 +763,8 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
     // multi-gigabyte load: the member, the mode, the geometry against the ENGINE's own menus, the
     // fixture, the tier, and the plan's identity against this arm's table.
     let arm = arm(request)?;
+    // The lane's render plan (sc-22738): a video capture is ONE measured render, no warm pass.
+    let capture = protocol::capture_policy(request)?.require_video(arm.provider)?;
     protocol::validate_plain_overlay_target(request, arm.execution_path)?;
     validate_mode(request, arm)?;
     let geometry = target_geometry(request, arm)?;
@@ -955,67 +960,19 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
     // identity SceneWorks mints, so an answer here would characterize a decision production never
     // takes. See [`ADMISSION_BLOCKER`].
 
-    // Warm-repeat determinism and allocator cleanup bounds on this exact loaded provider.
-    clear_cache();
-    reset_peak_memory();
-    let (baseline, _, _) = diagnostic_video_frames(
-        generator
-            .generate(&planned_render, &mut |_| {})
-            .map_err(|error| format!("generate warm {} control: {error}", arm.provider))?,
-        LABEL,
-    )?;
-    let clean_warm_peak = get_peak_memory() as u64;
-    clear_cache();
-    let clean_post_cleanup = AllocatorState::capture_current();
-    let cleanup_bounds =
-        LifecycleMemoryBounds::from_clean_warm(clean_warm_peak, clean_post_cleanup);
-    let (maximum_error, mean_error, rms_error) = video_max_mean_rms_abs(&measured, &baseline)?;
-    if !quality_passes(maximum_error, mean_error, rms_error) {
-        return Err(format!(
-            "{} warm repeat exceeded the determinism envelope: max={maximum_error:.6}, \
-             mean={mean_error:.6}, rms={rms_error:.6}",
-            arm.provider
-        ));
-    }
-    reset_peak_memory();
-    let (warm, _, _) = diagnostic_video_frames(
-        generator
-            .generate(&planned_render, &mut |_| {})
-            .map_err(|error| format!("generate warm {} repeat: {error}", arm.provider))?,
-        LABEL,
-    )?;
-    let warm_peak = get_peak_memory() as u64;
-    if !cleanup_bounds.allows_warm_peak(warm_peak) {
-        return Err(format!(
-            "{} warm repeat peaked at {warm_peak} bytes, above the clean warm control \
-             {clean_warm_peak} bytes plus 2%",
-            arm.provider
-        ));
-    }
-    clear_cache();
-    let warm_post_cleanup = AllocatorState::capture_current();
-    if !cleanup_bounds.allows_retained(warm_post_cleanup) {
-        return Err(format!(
-            "{} warm repeat retained active/cache bytes {warm_post_cleanup:?} above the clean warm \
-             cleanup {clean_post_cleanup:?} plus {} bytes",
-            arm.provider, cleanup_bounds.tolerance_bytes,
-        ));
-    }
-    let (warm_maximum, warm_mean, warm_rms) = video_max_mean_rms_abs(&measured, &warm)?;
-    if !quality_passes(warm_maximum, warm_mean, warm_rms) {
-        return Err(format!(
-            "{} second warm repeat changed the deterministic output",
-            arm.provider
-        ));
-    }
+    // No warm pass: the video lane captures ONE measured render (sc-22738, `capture` above), so
+    // there is no clean warm control to judge determinism against and no warm repeat to bound;
+    // the receipt says so (`warm_repeat` not_run, `quality.warmPasses: 0`) instead of writing
+    // zeros where `lifecycleClean*` / `lifecycleWarmRepeat*` used to be.
 
     // Arm-internal negative-mutation falsifiability check: a runtime_complete record must keep
     // `negativeMutation` null, so the breach is verified here and the numbers land in diagnostics.
+    // Against the measured clip itself: the mutation must breach the envelope the arm declares.
     let mutated = measured
         .iter()
         .map(qwen_negative_mutation)
         .collect::<Vec<_>>();
-    let (mutated_maximum, mutated_mean, mutated_rms) = video_max_mean_rms_abs(&mutated, &baseline)?;
+    let (mutated_maximum, mutated_mean, mutated_rms) = video_max_mean_rms_abs(&mutated, &measured)?;
     if quality_passes(mutated_maximum, mutated_mean, mutated_rms) {
         return Err(format!(
             "{} output mutation did not breach the determinism envelope",
@@ -1043,7 +1000,7 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
             { "name": "exact_fit", "result": "not_run", "reason": ADMISSION_BLOCKER },
             { "name": "unknown_budget", "result": "not_run", "reason": ADMISSION_BLOCKER },
             { "name": "stale_evidence", "result": "not_run", "reason": ADMISSION_BLOCKER },
-            { "name": "warm_repeat", "result": "passed", "reason": "two warm repeats on the loaded provider reproduced the measured clip frame-for-frame inside the declared envelope, within the clean warm peak and cleanup bounds" },
+            capture.not_run_warm_repeat_scenario()?,
             { "name": "cancel", "result": "not_run", "reason": lifecycle_blocker },
             { "name": "error", "result": "not_run", "reason": lifecycle_blocker },
             { "name": "loadability", "result": "passed" },
@@ -1056,17 +1013,10 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
             "decode": decode.json(),
             "overall": overall.json(),
         },
-        "quality": {
-            "contract": "identical artifact, prompt, seed, geometry, frames, fps, steps, carrier, tier and loaded provider contract; cold measured clip versus two warm unscoped repeats, compared over every frame",
-            "identicalInputs": true,
-            "result": "passed",
-            "maximumError": maximum_error,
-            "meanError": mean_error,
-            "rootMeanSquareError": rms_error,
-            "maximumErrorThreshold": MAX_THRESHOLD,
-            "meanErrorThreshold": MEAN_THRESHOLD,
-            "rootMeanSquareErrorThreshold": RMS_THRESHOLD,
-        },
+        "quality": capture.not_run_quality(
+            "identical artifact, prompt, seed, geometry, frames, fps, steps, carrier, tier and loaded provider contract; the cold measured clip versus a warm repeat, compared over every frame",
+            (MAX_THRESHOLD, MEAN_THRESHOLD, RMS_THRESHOLD),
+        )?,
         "negativeMutation": null,
         "loadability": {
             "result": "passed",
@@ -1085,13 +1035,10 @@ pub(super) fn run(request: &Value) -> Result<Value, String> {
                 ("overallAllocatorEnvelope", "bytes", overall.allocator_bytes()),
                 ("predictedOverallCeiling", "bytes", predicted),
                 ("stagedArtifactBytes", "bytes", staged_bytes),
-                ("lifecycleCleanWarmPeak", "bytes", clean_warm_peak),
-                ("lifecycleCleanPostCleanupActive", "bytes", clean_post_cleanup.active),
-                ("lifecycleCleanPostCleanupCache", "bytes", clean_post_cleanup.cache),
-                ("lifecycleCleanupTolerance", "bytes", cleanup_bounds.tolerance_bytes),
-                ("lifecycleWarmRepeatPeak", "bytes", warm_peak),
-                ("lifecycleWarmRepeatPostCleanupActive", "bytes", warm_post_cleanup.active),
-                ("lifecycleWarmRepeatPostCleanupCache", "bytes", warm_post_cleanup.cache),
+                // sc-22738: no `lifecycleClean*` / `lifecycleWarmRepeat*` figure — the warm
+                // passes were not run (`quality.warmPasses`), and an unmeasured figure is omitted,
+                // never written as 0.
+                ("warmPasses", "count", u64::from(capture.warm_passes)),
                 ("negativeMutationMaximumErrorPer255", "count", (mutated_maximum * 255.0).round() as u64),
                 ("negativeMutationMeanErrorPer255", "count", (mutated_mean * 255.0).round() as u64),
                 ("negativeMutationRootMeanSquareErrorPer255", "count", (mutated_rms * 255.0).round() as u64),

--- a/crates/sceneworks-memory-adapter/src/lib.rs
+++ b/crates/sceneworks-memory-adapter/src/lib.rs
@@ -664,7 +664,15 @@ pub fn validate_quality_metrics(response: &Value) -> Result<(), String> {
         .get("status")
         .and_then(Value::as_str)
         .unwrap_or_default();
-    let required = required_quality_metrics(status);
+    // sc-22738: a receipt declaring `warmPasses: 0` ran no comparison render, so it carries no
+    // comparison figure to require — the harness, the schema and `sceneworks-core` read the same
+    // declaration and accept `result: not_run` in its place. Any figure it DOES carry is still
+    // held to finiteness below.
+    let required = if quality.get("warmPasses").and_then(Value::as_u64) == Some(0) {
+        &[][..]
+    } else {
+        required_quality_metrics(status)
+    };
     for metric in QUALITY_METRICS {
         let Some(value) = quality.get(metric) else {
             if required.contains(&metric) {
@@ -926,6 +934,170 @@ pub fn validate_still_geometry(request: &Value, calibration_label: &str) -> Resu
         }
     }
     Ok(())
+}
+
+// ==== capture lane: how many renders one capture runs (sc-22738, 2026-09-08) ====================
+
+/// The lane a plan row is captured under — the SAME derivation `scripts/measure-memory-catalog.mjs`
+/// budgets a probe by (`videoLane`, #2784): a video anchor renders more than one frame.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CaptureLane {
+    Image,
+    Video,
+}
+
+/// Warm passes an IMAGE capture runs after its measured render: a clean warm control and a warm
+/// repeat, which feed the determinism envelope (`quality`), the clean-warm allocator bounds
+/// (`lifecycleClean*` / `lifecycleWarmRepeat*`) and the `warm_repeat` scenario. Unchanged.
+pub const IMAGE_WARM_PASSES: u32 = 2;
+
+/// Warm passes a VIDEO capture runs after its measured render: NONE (sc-22738, decided 2026-09-08).
+///
+/// The anchor's peaks come from the FIRST render — `extract-memory-anchors.mjs` and
+/// `sceneworks-core::memory_anchor` read only the three phase peaks, the overall allocator
+/// envelope and `outputFps` off a record — while the two warm passes existed for the
+/// residency-retention and allocator-envelope checks and cost 2x the render on video. Witnessed:
+/// `scail2_14b:bf16:mlx` ~8,500 s per three-render capture (8,709 s, 2026-09-06);
+/// `wan_2_2_t2v_14b:bf16:mlx` 13,411 s; `wan_2_2_t2v_14b:q4:mlx` exceeded a 16,200 s budget without
+/// finishing (the packed tier dequantizes per step, so it is SLOWER than dense). A video capture is
+/// therefore one measured render, and its receipt says so instead of writing zeros: the
+/// `warm_repeat` scenario is `not_run`, `quality` carries `warmPasses: 0` with `result: not_run` and
+/// no comparison figures, and no `lifecycleClean*` / `lifecycleWarmRepeat*` measurement is emitted.
+pub const VIDEO_WARM_PASSES: u32 = 0;
+
+/// Why a single-render video receipt runs no warm pass — the `warm_repeat` scenario's reason and
+/// the head of every video arm's lifecycle blocker, so the record states it once in its own words.
+pub const VIDEO_WARM_PASSES_NOT_RUN: &str = "sc-22738 (2026-09-08): a video capture is ONE \
+    measured render; the clean warm control and warm repeat are not run on the video lane. The \
+    anchor's phase peaks come from the first render, and the two warm passes cost 2x the render on \
+    video (witnessed: scail2_14b:bf16:mlx 8,709 s per three-render capture, wan_2_2_t2v_14b:bf16:mlx \
+    13,411 s, wan_2_2_t2v_14b:q4:mlx unfinished at 16,200 s). Output determinism, the warm-peak \
+    bound and post-cleanup retention are therefore NOT MEASURED for this record; nothing here is a \
+    zero";
+
+/// One capture's render plan, derived from the plan row's lane and nothing else: a lane property,
+/// never a per-model choice. Every arm asks this before it renders, and a receipt's `warmPasses`
+/// declaration is read back from it rather than restated.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CapturePolicy {
+    pub lane: CaptureLane,
+    /// Warm passes after the measured render: [`IMAGE_WARM_PASSES`] or [`VIDEO_WARM_PASSES`].
+    pub warm_passes: u32,
+}
+
+impl CapturePolicy {
+    pub const fn for_lane(lane: CaptureLane) -> Self {
+        Self {
+            lane,
+            warm_passes: match lane {
+                CaptureLane::Image => IMAGE_WARM_PASSES,
+                CaptureLane::Video => VIDEO_WARM_PASSES,
+            },
+        }
+    }
+
+    /// Total `generate` calls one capture makes: the measured render plus the lane's warm passes.
+    pub const fn renders(self) -> u32 {
+        1 + self.warm_passes
+    }
+
+    /// A video arm's declaration that its plan row IS on the video lane and that this capture runs
+    /// the video lane's warm passes — the one place a video arm's single render is decided.
+    pub fn require_video(self, arm_label: &str) -> Result<Self, String> {
+        if self.lane != CaptureLane::Video {
+            return Err(format!(
+                "{arm_label} is a video arm; the plan declares a single-frame geometry, which is \
+                 the image lane"
+            ));
+        }
+        Ok(self)
+    }
+
+    /// The `quality` block of a receipt whose warm passes were NOT run: the contract and the
+    /// thresholds the comparison WOULD be judged by travel so the record is self-describing, the
+    /// result is `not_run`, and no comparison figure is written (`warmPasses: 0` is the schema's
+    /// permission for a `runtime_complete` record to carry exactly this shape).
+    pub fn not_run_quality(
+        self,
+        contract: &str,
+        thresholds: (f64, f64, f64),
+    ) -> Result<Value, String> {
+        if self.warm_passes != 0 {
+            return Err(format!(
+                "a {:?} capture runs {} warm passes and measures its quality; only a zero-warm-pass \
+                 capture may file quality as not_run",
+                self.lane, self.warm_passes
+            ));
+        }
+        let (maximum, mean, rms) = thresholds;
+        Ok(json!({
+            "contract": format!("{contract}; NOT MEASURED: {VIDEO_WARM_PASSES_NOT_RUN}"),
+            "result": "not_run",
+            "warmPasses": self.warm_passes,
+            "maximumErrorThreshold": maximum,
+            "meanErrorThreshold": mean,
+            "rootMeanSquareErrorThreshold": rms,
+        }))
+    }
+
+    /// The `warm_repeat` scenario of a receipt whose warm passes were NOT run.
+    pub fn not_run_warm_repeat_scenario(self) -> Result<Value, String> {
+        if self.warm_passes != 0 {
+            return Err(format!(
+                "a {:?} capture runs {} warm passes; its warm_repeat scenario is measured, not \
+                 not_run",
+                self.lane, self.warm_passes
+            ));
+        }
+        Ok(
+            json!({ "name": "warm_repeat", "result": "not_run", "reason": VIDEO_WARM_PASSES_NOT_RUN }),
+        )
+    }
+}
+
+/// The lane of a plan row (`planned.target.geometry.frames > 1` is video), as
+/// `measure-memory-catalog.mjs` derives the budget lane.
+pub fn capture_lane(request: &Value) -> Result<CaptureLane, String> {
+    let frames = planned(request)?
+        .pointer("/target/geometry/frames")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| "planned.target.geometry.frames must be an integer".to_owned())?;
+    if frames == 0 {
+        return Err("planned.target.geometry.frames must be positive".to_owned());
+    }
+    Ok(if frames > 1 {
+        CaptureLane::Video
+    } else {
+        CaptureLane::Image
+    })
+}
+
+/// The capture policy of a plan row: see [`CapturePolicy`].
+pub fn capture_policy(request: &Value) -> Result<CapturePolicy, String> {
+    Ok(CapturePolicy::for_lane(capture_lane(request)?))
+}
+
+/// Which render of a capture a `generate` call is: the measured one, or the n-th warm pass.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RenderRole {
+    Measured,
+    /// Warm pass `n` (1-based), only ever issued when the lane's `warm_passes >= n`.
+    Warm(u32),
+}
+
+/// Drive the renders one capture makes under `policy`: the measured render, then exactly
+/// `policy.warm_passes` warm passes, in order. Returns the measured output and the warm outputs.
+/// A video policy calls `render` ONCE; an image policy calls it three times.
+pub fn drive_renders<T, E>(
+    policy: CapturePolicy,
+    mut render: impl FnMut(RenderRole) -> Result<T, E>,
+) -> Result<(T, Vec<T>), E> {
+    let measured = render(RenderRole::Measured)?;
+    let mut warm = Vec::with_capacity(policy.warm_passes as usize);
+    for pass in 1..=policy.warm_passes {
+        warm.push(render(RenderRole::Warm(pass))?);
+    }
+    Ok((measured, warm))
 }
 
 /// The overlay this calibration target declares (`planned.target.overlay`) — `"none"`, `"lora"`,
@@ -2857,5 +3029,150 @@ mod tests {
             3,
             "a degenerate geometry still yields one pixel"
         );
+    }
+
+    // ==== capture lane (sc-22738) ==============================================================
+
+    fn plan_with_frames(frames: u64) -> Value {
+        json!({
+            "planned": {
+                "target": { "geometry": { "width": 832, "height": 480, "batch": 1, "frames": frames } }
+            }
+        })
+    }
+
+    /// The lane is the plan's, derived exactly as `measure-memory-catalog.mjs` derives the budget
+    /// lane: more than one frame is video. Mutation that fails this: deriving the lane from the
+    /// provider id, or reading `frames >= 1` as video.
+    #[test]
+    fn the_capture_lane_is_the_plans_frame_count_and_nothing_else() {
+        assert_eq!(
+            capture_lane(&plan_with_frames(1)).unwrap(),
+            CaptureLane::Image
+        );
+        assert_eq!(
+            capture_lane(&plan_with_frames(2)).unwrap(),
+            CaptureLane::Video
+        );
+        assert_eq!(
+            capture_lane(&plan_with_frames(77)).unwrap(),
+            CaptureLane::Video
+        );
+        assert!(capture_lane(&plan_with_frames(0)).is_err());
+        assert!(capture_lane(&json!({ "planned": { "target": {} } })).is_err());
+    }
+
+    /// The decision itself: a video capture is ONE render, an image capture is three. Restoring the
+    /// warm passes on the video lane (`VIDEO_WARM_PASSES = 2`) turns this red; so does touching
+    /// the image lane's two.
+    #[test]
+    fn a_video_capture_is_one_render_and_an_image_capture_is_three() {
+        assert_eq!(VIDEO_WARM_PASSES, 0);
+        assert_eq!(IMAGE_WARM_PASSES, 2);
+        let video = capture_policy(&plan_with_frames(49)).unwrap();
+        let image = capture_policy(&plan_with_frames(1)).unwrap();
+        assert_eq!(video.renders(), 1);
+        assert_eq!(image.renders(), 3);
+        assert_eq!(video.require_video("MLX Wan2.2/SCAIL-2").unwrap(), video);
+        assert!(image
+            .require_video("MLX Wan2.2/SCAIL-2")
+            .unwrap_err()
+            .contains("video arm"));
+    }
+
+    /// The driver issues exactly the lane's `generate` calls, in order: measured first, then the
+    /// warm passes. A stub render counts them, so the number and order are asserted rather than
+    /// inferred — one call for a video plan, three for an image plan.
+    #[test]
+    fn the_render_driver_issues_one_generate_for_video_and_three_for_image() {
+        for (frames, expected) in [
+            (49, vec![RenderRole::Measured]),
+            (
+                1,
+                vec![
+                    RenderRole::Measured,
+                    RenderRole::Warm(1),
+                    RenderRole::Warm(2),
+                ],
+            ),
+        ] {
+            let policy = capture_policy(&plan_with_frames(frames)).unwrap();
+            let mut calls = Vec::new();
+            let (measured, warm) = drive_renders::<_, String>(policy, |role| {
+                calls.push(role);
+                Ok(calls.len())
+            })
+            .unwrap();
+            assert_eq!(calls, expected, "{frames} frame(s)");
+            assert_eq!(measured, 1);
+            assert_eq!(warm.len(), policy.warm_passes as usize);
+            assert_eq!(calls.len() as u32, policy.renders());
+        }
+        // A failing measured render stops the capture before any warm pass is attempted.
+        let image = capture_policy(&plan_with_frames(1)).unwrap();
+        let mut calls = 0;
+        let error = drive_renders::<(), _>(image, |_| {
+            calls += 1;
+            Err("render failed".to_owned())
+        })
+        .unwrap_err();
+        assert_eq!((calls, error.as_str()), (1, "render failed"));
+    }
+
+    /// The receipt of a zero-warm-pass capture states what was not measured and writes no zero:
+    /// `warm_repeat` is `not_run` with the lane's reason, `quality` is `not_run` with `warmPasses: 0`
+    /// and the thresholds, and NO comparison figure or `identicalInputs` claim is present. An image
+    /// policy may not file its quality this way — it measured one.
+    #[test]
+    fn a_single_render_receipt_declares_its_unrun_warm_passes_instead_of_writing_zeros() {
+        let video = capture_policy(&plan_with_frames(25)).unwrap();
+        let scenario = video.not_run_warm_repeat_scenario().unwrap();
+        assert_eq!(scenario["name"], "warm_repeat");
+        assert_eq!(scenario["result"], "not_run");
+        assert_eq!(scenario["reason"], VIDEO_WARM_PASSES_NOT_RUN);
+        assert!(VIDEO_WARM_PASSES_NOT_RUN.contains("8,709 s"));
+        assert!(VIDEO_WARM_PASSES_NOT_RUN.contains("13,411 s"));
+        assert!(VIDEO_WARM_PASSES_NOT_RUN.contains("16,200 s"));
+
+        let quality = video
+            .not_run_quality("identical inputs; cold versus warm", (0.05, 0.01, 0.02))
+            .unwrap();
+        assert_eq!(quality["result"], "not_run");
+        assert_eq!(quality["warmPasses"], 0);
+        assert_eq!(quality["maximumErrorThreshold"], 0.05);
+        assert_eq!(quality["meanErrorThreshold"], 0.01);
+        assert_eq!(quality["rootMeanSquareErrorThreshold"], 0.02);
+        assert!(quality["contract"]
+            .as_str()
+            .unwrap()
+            .starts_with("identical inputs; cold versus warm; NOT MEASURED:"));
+        for absent in [
+            "maximumError",
+            "meanError",
+            "rootMeanSquareError",
+            "identicalInputs",
+            "audio",
+        ] {
+            assert!(
+                quality.get(absent).is_none(),
+                "{absent} must not be written"
+            );
+        }
+        // Files through the same response validator every adapter binary writes through.
+        validate_quality_metrics(&json!({ "status": "runtime_complete", "quality": quality }))
+            .unwrap();
+        // A measured-quality runtime_complete record still needs every figure.
+        assert!(validate_quality_metrics(&json!({
+            "status": "runtime_complete",
+            "quality": { "result": "passed", "maximumErrorThreshold": 0.05 }
+        }))
+        .is_err());
+
+        let image = capture_policy(&plan_with_frames(1)).unwrap();
+        assert!(image
+            .not_run_quality("identical inputs", (0.05, 0.01, 0.02))
+            .unwrap_err()
+            .contains("runs 2 warm passes"));
+        assert!(image.not_run_warm_repeat_scenario().is_err());
     }
 }

--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -1296,22 +1296,52 @@ finish is the failure the bound exists to prevent.
 guard's ceilings bound a probe that CLIMBS; they say nothing about one that stops climbing, and
 `scail2_14b:bf16:mlx` sat flat at 93.5 GB under the 94.82 GB kill line for 90 minutes with the
 adapter parked in `mlx::core::eval`. So `measure-memory-catalog.mjs` passes the guard a
-`--max-runtime-seconds` on every capture, defaulted per lane by `PROBE_BUDGET_MINUTES` — **270
+`--max-runtime-seconds` on every capture, defaulted per lane by `PROBE_BUDGET_MINUTES` — **165
 minutes for a video anchor, 60 for an image one** (the lane is derived from the plan: a video anchor
 renders more than one frame), overridable for a run with `--probe-budget-minutes N`, which
-`--dry-run` prints per row. Each default rests on the longest COMPLETED capture its lane has
-witnessed (`WITNESSED_CAPTURE_SECONDS`): 8,709 s for video — the one unbudgeted
-`scail2_14b:bf16:mlx` capture on record, which rendered all 80 decoded frames — and 847 s for
-image. That flat 93.5 GB line was a render in progress, not a wedge: a video arm renders its clip
-THREE times per capture (measured, clean warm control, warm repeat), a SCAIL-2 render is a 14B DiT
-under CFG whose main thread waits on the GPU at every step by design, and the same cell stopped at
-every tier under a 90-minute budget with the GPU at 99–100% utilization and no GPU fault in the
-system log. (The watchdog stream's `providerPhase` is `null` for every anchor — the runner passes
-no `--provider-phase-profile` — so its absence is not a progress signal.) A probe that reaches its
+`--dry-run` prints per row. Each default rests on the longest COMPLETED figure its lane has
+witnessed (`WITNESSED_CAPTURE_SECONDS`), cleared by the 1.8× margin policy: 4,470 s PER RENDER
+for video and 847 s per capture cycle for image. That flat 93.5 GB line was a render in progress,
+not a wedge: a video arm USED TO render its clip THREE times per capture (measured, clean warm
+control, warm repeat), a SCAIL-2 render is a 14B DiT under CFG whose main thread waits on the GPU
+at every step by design, and the same cell stopped at every tier under a 90-minute budget with the
+GPU at 99–100% utilization and no GPU fault in the system log. (The watchdog stream's
+`providerPhase` is `null` for every anchor — the runner passes no `--provider-phase-profile` — so
+its absence is not a progress signal.)
+
+**A video capture is ONE measured render (sc-22738, decided 2026-09-08).** The three-render
+contract — measured render, clean warm control, warm repeat — stays on the IMAGE lane, where it is
+cheap; on the video lane it cost 2× the render for checks the anchor never reads. The anchor's phase
+peaks come from the FIRST render (`extract-memory-anchors.mjs` and `memory_anchor.rs` read only the
+three phase peaks, the overall allocator envelope and `outputFps`), while the warm passes fed the
+determinism envelope (`quality`), the clean-warm allocator bounds (`lifecycleClean*` /
+`lifecycleWarmRepeat*`) and the `warm_repeat` scenario. Witnessed under the three-render contract:
+`scail2_14b:bf16:mlx` 8,709 s per capture (~2,903 s per render); `wan_2_2_t2v_14b:bf16:mlx`
+13,411 s (4,470 s per render, the longest completed dense render on file);
+`wan_2_2_t2v_14b:q4:mlx` exceeded a 16,200 s budget WITHOUT finishing (>5,400 s per render — the
+packed tier dequantizes per step and is slower than dense). The lane is a property of the plan row
+(`sceneworks_memory_adapter::capture_policy`: `geometry.frames > 1` is video, the same derivation
+the runner budgets by), never a per-model choice: every MLX video arm — LTX-2.3 (ordinary capture;
+the SC-20318 campaign entries keep their lifecycle proofs), LTX-2.5, MiniMax-H3, Bernini's video
+member, Krea Realtime, Wan 2.2 / SCAIL-2 — reads it before it renders, and the still `bernini_image`
+member served by the same arm keeps its three renders. The candle video arms already captured one
+render. The receipt states what was NOT measured instead of writing zeros: `warm_repeat` is
+`not_run` with the reason, `quality` carries `warmPasses: 0` with `result: not_run` and the
+thresholds only (no comparison figure, no `identicalInputs`, no typed `audio` block — an LTX-2.5
+session files `selected_av` alone), and no `lifecycleClean*` / `lifecycleWarmRepeat*` measurement
+is emitted. Every consumer degrades to "not measured" for such a record — the JSON schema, the
+harness's `validateRuntimeComplete`, `sceneworks-core::memory_calibration` and the adapter's own
+response validator accept the declared shape — and nothing invalidates the video cells captured
+WITH warm passes (`docs/calibration/sc-22738/*`, `sc-18791/*`): a record without the declaration
+keeps every previous requirement. So the video budget is now per render: 165 minutes = 9,900 s is
+2.2× the 4,470 s witness and 1.83× the 5,400 s packed-tier lower bound.
+
+A probe that reaches its
 budget is stopped on the guard's ONE stop path — the same SIGTERM→SIGKILL escalation and post-stop
 census a footprint stop takes — and is reported as `capture_failed` with reason
 `runtime_budget_exceeded`, naming the budget, the peak footprint sampled (so you can tell a probe
-wedged at the ceiling from one wedged at 3 GB) and the lane's longest completed capture; a run
+wedged at the ceiling from one wedged at 3 GB) and the lane's longest completed render (video) or
+capture (image); a run
 launched with `--probe-budget-minutes` below its lane's default is told, in the reason, that the
 stop is a budget shortfall and not evidence of a stall. **It is not an exceedance:** the run never
 crossed a line, so no bound is written (the harness's `record-exceeded` refuses a wall-clock stop

--- a/packages/schemas/memory-calibration.schema.json
+++ b/packages/schemas/memory-calibration.schema.json
@@ -680,6 +680,10 @@
             "contract": { "type": "string", "minLength": 1 },
             "identicalInputs": { "type": "boolean" },
             "identicalLatents": { "type": "boolean" },
+            "warmPasses": {
+              "$comment": "sc-22738: how many warm passes the capture ran after its measured render. 0 is a video-lane receipt (one measured render, no clean warm control, no warm repeat): its determinism comparison was NOT run, so `result` is `not_run` and no comparison figure is carried — the thresholds it would have been judged by still travel. A runtime_complete record with warmPasses 0 is accepted in exactly that shape (see the status branch below). Absent on every record captured before the declaration existed, which keeps the previous requirements for those records.",
+              "type": "integer", "minimum": 0
+            },
             "result": { "enum": ["passed", "failed", "not_run"] },
             "maximumError": { "type": "number", "minimum": 0 },
             "meanError": { "type": "number", "minimum": 0 },
@@ -940,14 +944,31 @@
                 ]
               },
               "quality": {
-                "required": [
-                  "contract", "result", "maximumError", "meanError",
-                  "rootMeanSquareError", "maximumErrorThreshold", "meanErrorThreshold",
-                  "rootMeanSquareErrorThreshold", "identicalInputs"
-                ],
-                "properties": {
-                  "identicalInputs": { "const": true },
-                  "result": { "const": "passed" }
+                "if": { "properties": { "warmPasses": { "const": 0 } }, "required": ["warmPasses"] },
+                "then": {
+                  "$comment": "sc-22738: a single-render video receipt. The comparison was not run; nothing here is a zero.",
+                  "required": [
+                    "contract", "result", "warmPasses",
+                    "maximumErrorThreshold", "meanErrorThreshold", "rootMeanSquareErrorThreshold"
+                  ],
+                  "not": { "anyOf": [
+                    { "required": ["maximumError"] }, { "required": ["meanError"] },
+                    { "required": ["rootMeanSquareError"] }, { "required": ["audio"] }
+                  ] },
+                  "properties": {
+                    "result": { "const": "not_run" }
+                  }
+                },
+                "else": {
+                  "required": [
+                    "contract", "result", "maximumError", "meanError",
+                    "rootMeanSquareError", "maximumErrorThreshold", "meanErrorThreshold",
+                    "rootMeanSquareErrorThreshold", "identicalInputs"
+                  ],
+                  "properties": {
+                    "identicalInputs": { "const": true },
+                    "result": { "const": "passed" }
+                  }
                 }
               },
               "negativeMutation": { "type": "null" },

--- a/scripts/extract-memory-anchors.test.mjs
+++ b/scripts/extract-memory-anchors.test.mjs
@@ -1730,3 +1730,65 @@ test("the LTX-2.5 component deltas are priced from the committed weights invento
   const packagedStore = JSON.parse(await readFile(path.join(ROOT, STORE_PATH), "utf8"));
   assert.deepEqual(packagedStore.componentDeltas, rows);
 });
+
+// ---------------------------------------------------------------------------------------------
+// sc-22738: a single-render VIDEO record carries no warm-pass figure, and anchors all the same.
+// ---------------------------------------------------------------------------------------------
+
+test("a video record with quality not_run, warmPasses 0 and no lifecycleWarm*/lifecycleClean* measurement anchors exactly like one that ran its warm passes", () => {
+  const video = (overrides = {}) => record({
+    id: "imc-single-render-video",
+    target: {
+      modelId: "minimax_h3", tier: "q4", mode: "text_to_video", provider: "minimax_h3",
+      geometry: { width: 1024, height: 576, frames: 124 },
+    },
+    status: "runtime_complete",
+    quality: {
+      contract: "identical inputs; NOT MEASURED: no warm pass",
+      result: "not_run", warmPasses: 0,
+      maximumErrorThreshold: 0.03, meanErrorThreshold: 0.003, rootMeanSquareErrorThreshold: 0.003,
+    },
+    scenarios: [{ name: "warm_repeat", result: "not_run", reason: "sc-22738: one measured render" }],
+    diagnostics: {
+      measurements: [
+        { name: "conditioningActivePeak", value: 1 },
+        { name: "denoiseActivePeak", value: 2 },
+        { name: "decodeActivePeak", value: 3 },
+        { name: "overallAllocatorEnvelope", value: 10 },
+        { name: "warmPasses", value: 0 },
+        { name: "outputFps", value: 24 },
+      ],
+    },
+    ...overrides,
+  });
+  const single = anchorCandidate(video(), corpus);
+  assert.ok(single !== null, "one measured render is an anchor");
+  assert.deepEqual(single.phaseActivePeakBytes, { conditioning: 1, denoise: 2, decode: 3 });
+  assert.equal(single.overallAllocatorEnvelopeBytes, 10);
+  // The same cell captured under the previous three-render contract prices identically: the
+  // warm-pass figures were never an input to the anchor.
+  const threeRender = anchorCandidate(video({
+    quality: {
+      contract: "identical inputs", identicalInputs: true, result: "passed",
+      maximumError: 0, meanError: 0, rootMeanSquareError: 0,
+      maximumErrorThreshold: 0.03, meanErrorThreshold: 0.003, rootMeanSquareErrorThreshold: 0.003,
+    },
+    scenarios: [{ name: "warm_repeat", result: "passed", reason: "two warm repeats reproduced the clip" }],
+    diagnostics: {
+      measurements: [
+        { name: "conditioningActivePeak", value: 1 },
+        { name: "denoiseActivePeak", value: 2 },
+        { name: "decodeActivePeak", value: 3 },
+        { name: "overallAllocatorEnvelope", value: 10 },
+        { name: "lifecycleCleanWarmPeak", value: 9 },
+        { name: "lifecycleWarmRepeatPeak", value: 9 },
+        { name: "lifecycleWarmRepeatPostCleanupActive", value: 1 },
+        { name: "outputFps", value: 24 },
+      ],
+    },
+  }), corpus);
+  assert.ok(threeRender !== null);
+  const priced = ({ phaseActivePeakBytes, phaseAllocatorEnvelopeBytes, overallAllocatorEnvelopeBytes }) =>
+    ({ phaseActivePeakBytes, phaseAllocatorEnvelopeBytes, overallAllocatorEnvelopeBytes });
+  assert.deepEqual(priced(single), priced(threeRender), "the extractor reads no warm-pass figure");
+});

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -2312,12 +2312,14 @@ export async function probeAdapter(command, { cwd = ROOT, env = process.env, wir
  * unbounded in time.
  *
  * WHAT THAT FLAT LINE ACTUALLY WAS (sc-22738, diagnosed 2026-09-08). Not a wedge. A video arm
- * renders its clip THREE times per capture — the measured render, a clean warm control and a warm
- * repeat (`crates/sceneworks-memory-adapter/src/bin/mlx_wan_scail2.rs`, the determinism envelope
- * every video arm carries) — and a SCAIL-2 render is a 14B DiT at 832x480x77 under CFG (two DiT
- * forwards per step) whose main thread waits on the GPU at the per-step `eval` by design
- * (`mlx-gen-scail2/src/generate.rs`). The ONE unbudgeted `scail2_14b:bf16:mlx` capture on record
- * COMPLETED, rendering all 80 decoded frames, in 8,709 s (2026-09-06, `calib-mlx/campaign.log`).
+ * USED TO render its clip THREE times per capture — the measured render, a clean warm control and
+ * a warm repeat (the determinism envelope every video arm carried) — and a SCAIL-2 render is a 14B
+ * DiT at 832x480x77 under CFG (two DiT forwards per step) whose main thread waits on the GPU at
+ * the per-step `eval` by design (`mlx-gen-scail2/src/generate.rs`). The ONE unbudgeted
+ * `scail2_14b:bf16:mlx` capture on record COMPLETED, rendering all 80 decoded frames, in 8,709 s
+ * (2026-09-06, `calib-mlx/campaign.log`). Since 2026-09-08 a video capture is ONE measured render
+ * (`crates/sceneworks-memory-adapter/src/lib.rs`, `VIDEO_WARM_PASSES`): the anchor's peaks come
+ * from the first render, and the warm passes cost 2x the render on video.
  * A 90-minute budget then stopped the same cell at every tier with the GPU at 99–100% device
  * utilization, the footprint oscillating ±90 MB on a 4–6 s cadence and no GPU fault in the system
  * log: the budget, not the render, was what ended those probes. The `providerPhase` field of the
@@ -2328,18 +2330,31 @@ export async function probeAdapter(command, { cwd = ROOT, env = process.env, wir
  * duration/elapsed field are ABSENT from `docs/calibration/sc-22738/*.json`), so the budgets rest
  * on the longest COMPLETED capture each lane has witnessed, `WITNESSED_CAPTURE_SECONDS`:
  *
- *   * video: 8,709 s — the completed `scail2_14b:bf16:mlx` capture above, the one direct witness
- *     of a whole three-render video capture cycle. (The earlier basis, 4,161 s for `ltx_2_3:q4:mlx`
- *     from consecutive `capturedAt` deltas, was a cycle bound for a lighter model; it under-read
- *     SCAIL-2 by 2.1x and the 150-minute budget it produced cleared the witness by 3%.)
+ *   * video: 4,470 s PER RENDER (sc-22738, re-based 2026-09-08). A video capture is now ONE
+ *     measured render (`sceneworks_memory_adapter::VIDEO_WARM_PASSES`): the three-render cycle
+ *     that produced the earlier 8,709 s witness — measured render, clean warm control, warm repeat
+ *     — no longer runs on the video lane, so the witnesses are read per render. Three witnesses,
+ *     all three-render captures, recorded in `VIDEO_RENDER_WITNESSES_SECONDS`:
+ *       - `scail2_14b:bf16:mlx` completed in 8,709 s → 2,903 s per render (2026-09-06);
+ *       - `wan_2_2_t2v_14b:bf16:mlx` completed in 13,411 s → 4,470 s per render, the longest
+ *         COMPLETED dense render on file and this lane's witness;
+ *       - `wan_2_2_t2v_14b:q4:mlx` exceeded a 16,200 s budget WITHOUT finishing → more than
+ *         5,400 s per render, a lower bound, not a completion: the packed tier dequantizes per
+ *         step and is slower than dense (`VIDEO_RENDER_LOWER_BOUND_SECONDS`).
+ *     (The earlier basis, 4,161 s for `ltx_2_3:q4:mlx` from consecutive `capturedAt` deltas, was a
+ *     cycle bound for a lighter model; it under-read SCAIL-2 by 2.1x and the 150-minute budget it
+ *     produced cleared the witness by 3%.)
  *   * image: 847 s — the `bernini_image:q8:mlx` capture→commit cycle (07:13:26 after q4's
- *     06:59:19 on 2026-09-07), read the same way.
+ *     06:59:19 on 2026-09-07), read the same way. Unchanged: the image lane still runs its two
+ *     warm passes.
  *
- * So: 270 minutes for video is 1.86x the witnessed 8,709 s cycle, which is the same margin policy
- * the earlier figure claimed (1.8x) applied to the right witness; 60 minutes for image is 4.2x the
- * longest image cycle on file. Both are backstops against a wedge, not schedule targets — a budget
- * tight enough to argue about is converting slow renders into re-runs, which is exactly what the
- * 90-minute campaign did three times over.
+ * So: 165 minutes (9,900 s) for video is 2.2x the witnessed 4,470 s dense render and 1.83x the
+ * 5,400 s packed-tier lower bound — the same 1.8x margin policy as before, applied to the longest
+ * per-render figure on file rather than to a completed one alone, because the one render that did
+ * NOT complete is the one the budget exists for; 60 minutes for image is 4.2x the longest image
+ * cycle on file. Both are backstops against a wedge, not schedule targets — a budget tight enough
+ * to argue about is converting slow renders into re-runs, which is exactly what the 90-minute
+ * campaign did three times over.
  *
  * The cost of being wrong is bounded BY DESIGN and asymmetric on purpose: a runtime stop records no
  * bound and leaves the cell `runnable`, so too tight a budget costs a re-run, while too loose a one
@@ -2347,8 +2362,22 @@ export async function probeAdapter(command, { cwd = ROOT, env = process.env, wir
  * honored as given; a run launched below its lane's default is told so in the stop reason
  * (`runtimeBudgetExceededReason`), because a stop under such a budget is not evidence of a stall.
  */
-export const WITNESSED_CAPTURE_SECONDS = { video: 8_709, image: 847 };
-export const PROBE_BUDGET_MINUTES = { video: 270, image: 60 };
+export const WITNESSED_CAPTURE_SECONDS = { video: 4_470, image: 847 };
+/**
+ * The per-render witnesses the video figure above is read from (sc-22738, 2026-09-08). Every one
+ * was a THREE-render capture; `perRenderSeconds` is the capture's wall clock over three.
+ * `completed: false` marks a lower bound — the capture hit its budget with the render unfinished.
+ */
+export const VIDEO_RENDER_WITNESSES_SECONDS = Object.freeze([
+  { cell: "scail2_14b:bf16:mlx", captureSeconds: 8_709, renders: 3, perRenderSeconds: 2_903, completed: true },
+  { cell: "wan_2_2_t2v_14b:bf16:mlx", captureSeconds: 13_411, renders: 3, perRenderSeconds: 4_470, completed: true },
+  { cell: "wan_2_2_t2v_14b:q4:mlx", captureSeconds: 16_200, renders: 3, perRenderSeconds: 5_400, completed: false },
+]);
+/** The packed-tier per-render LOWER BOUND the video budget must clear by the margin policy too. */
+export const VIDEO_RENDER_LOWER_BOUND_SECONDS = 5_400;
+/** The margin every lane default clears its witness by (see the basis above). */
+export const PROBE_BUDGET_MARGIN = 1.8;
+export const PROBE_BUDGET_MINUTES = { video: 165, image: 60 };
 
 /** The lane a plan row is budgeted under: a video anchor renders more than one frame. */
 export function probeLane(row) {
@@ -2384,7 +2413,9 @@ export function runtimeBudgetExceededReason({ row, budgetMinutes, budgetSeconds,
     `runtime_budget_exceeded: the ${budgetMinutes}-minute probe budget (${budgetSeconds}s) elapsed; `
     + `peak physical footprint ${peak ? `${peak.peakBytes} bytes over ${peak.samples} sample(s)` : "not sampled"} `
     + `against the ${ceiling}. Nothing was measured, so no bound was recorded and this cell stays runnable. `
-    + `The longest completed ${lane} capture on record ran ${witnessed}s`;
+    // sc-22738: the video figure is PER RENDER (a video capture is one render); the image figure
+    // is a whole capture cycle.
+    + `The longest completed ${lane} ${lane === "video" ? "render" : "capture"} on record ran ${witnessed}s`;
   if (budgetMinutes < laneDefault) {
     reason += `, and this run was launched with --probe-budget-minutes ${budgetMinutes}, below the ${lane} `
       + `lane's ${laneDefault}-minute default: this stop is a budget shortfall, not evidence of a stall. `

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -73,7 +73,10 @@ import {
   watchdogPeakFootprint,
   runtimeBudgetStopSeconds,
   RUNTIME_BUDGET_STOP_PATTERN,
+  PROBE_BUDGET_MARGIN,
   PROBE_BUDGET_MINUTES,
+  VIDEO_RENDER_LOWER_BOUND_SECONDS,
+  VIDEO_RENDER_WITNESSES_SECONDS,
   WITNESSED_CAPTURE_SECONDS,
   probeBudgetMinutes,
   probeLane,
@@ -4967,16 +4970,33 @@ test("a footprint hard stop on a no-commit run surfaces as `exceeded` naming the
 
 test("every probe carries a wall-clock budget: per lane by default, derived from the plan, overridable", async () => {
   // The table, and the flag that overrides it.
-  assert.deepEqual(PROBE_BUDGET_MINUTES, { video: 270, image: 60 });
-  assert.equal(probeBudgetMinutes({ videoLane: true }), 270);
+  assert.deepEqual(PROBE_BUDGET_MINUTES, { video: 165, image: 60 });
+  assert.equal(probeBudgetMinutes({ videoLane: true }), 165);
   assert.equal(probeBudgetMinutes({ videoLane: false }), 60);
   // sc-22738 (2026-09-08): each lane's budget rests on the longest COMPLETED capture it has
-  // witnessed, with the margin the table's own doc comment states. The video witness is the
-  // 8,709 s `scail2_14b:bf16:mlx` capture that a 150-minute budget cleared by 3% and a 90-minute
-  // campaign then stopped three times over; a budget that no longer clears its witness by that
+  // witnessed, with the margin the table's own doc comment states. The video witness is read PER
+  // RENDER since a video capture became one measured render: the three three-render witnesses on
+  // file are the completed 8,709 s `scail2_14b:bf16:mlx` (2,903 s per render), the completed
+  // 13,411 s `wan_2_2_t2v_14b:bf16:mlx` (4,470 s per render — the witness) and the UNFINISHED
+  // `wan_2_2_t2v_14b:q4:mlx` that exceeded 16,200 s (>5,400 s per render, a lower bound the
+  // budget must clear by the same margin). A budget that no longer clears its witness by that
   // margin is the defect this pins, whichever entry drifts.
-  assert.deepEqual(WITNESSED_CAPTURE_SECONDS, { video: 8_709, image: 847 });
-  assert.ok(PROBE_BUDGET_MINUTES.video * 60 >= WITNESSED_CAPTURE_SECONDS.video * 1.8, "video budget clears its witness by 1.8x");
+  assert.deepEqual(WITNESSED_CAPTURE_SECONDS, { video: 4_470, image: 847 });
+  assert.equal(PROBE_BUDGET_MARGIN, 1.8);
+  assert.deepEqual(
+    VIDEO_RENDER_WITNESSES_SECONDS.map(({ cell, perRenderSeconds, completed }) => [cell, perRenderSeconds, completed]),
+    [["scail2_14b:bf16:mlx", 2_903, true], ["wan_2_2_t2v_14b:bf16:mlx", 4_470, true], ["wan_2_2_t2v_14b:q4:mlx", 5_400, false]],
+  );
+  for (const witness of VIDEO_RENDER_WITNESSES_SECONDS) {
+    assert.equal(witness.renders, 3, `${witness.cell} was a three-render capture`);
+    assert.equal(witness.perRenderSeconds, Math.round(witness.captureSeconds / witness.renders), `${witness.cell} per-render figure is the capture over its renders`);
+  }
+  const longestCompleted = Math.max(...VIDEO_RENDER_WITNESSES_SECONDS.filter((w) => w.completed).map((w) => w.perRenderSeconds));
+  assert.equal(WITNESSED_CAPTURE_SECONDS.video, longestCompleted, "the video witness is the longest COMPLETED per-render figure");
+  assert.equal(VIDEO_RENDER_LOWER_BOUND_SECONDS, Math.max(...VIDEO_RENDER_WITNESSES_SECONDS.filter((w) => !w.completed).map((w) => w.perRenderSeconds)));
+  assert.ok(PROBE_BUDGET_MINUTES.video * 60 >= WITNESSED_CAPTURE_SECONDS.video * PROBE_BUDGET_MARGIN, "video budget clears its witness by 1.8x");
+  assert.ok(PROBE_BUDGET_MINUTES.video * 60 >= VIDEO_RENDER_LOWER_BOUND_SECONDS * PROBE_BUDGET_MARGIN, "video budget clears the unfinished packed-tier render's lower bound by 1.8x");
+  assert.ok(PROBE_BUDGET_MINUTES.video * 60 < WITNESSED_CAPTURE_SECONDS.video * 3, "the video budget is a per-render figure, not a three-render cycle");
   assert.ok(PROBE_BUDGET_MINUTES.image * 60 >= WITNESSED_CAPTURE_SECONDS.image * 4, "image budget clears its witness by 4x");
   assert.equal(probeLane({ videoLane: true }), "video");
   assert.equal(probeLane({ videoLane: false }), "image");
@@ -4998,7 +5018,7 @@ test("every probe carries a wall-clock budget: per lane by default, derived from
   for (const row of rows) {
     const frames = plan.anchors[row.key].geometry?.frames ?? 1;
     assert.equal(row.videoLane, frames > 1, `${row.key} renders ${frames} frame(s)`);
-    assert.equal(probeBudgetMinutes(row), frames > 1 ? 270 : 60, row.key);
+    assert.equal(probeBudgetMinutes(row), frames > 1 ? 165 : 60, row.key);
     if (frames > 1) video += 1;
   }
   assert.ok(video > 0 && video < rows.length, `${video} of ${rows.length} mlx rows are video anchors`);
@@ -5037,7 +5057,7 @@ test("a runtime stop is recognised by its spelling and reports the guard's sampl
   assert.equal(await watchdogPeakFootprint(path.join(dir, "absent.jsonl")), null);
 });
 
-test("a runtime stop's reason names the lane's longest completed capture, and a budget below the lane default as a shortfall rather than a stall", () => {
+test("a runtime stop's reason names the lane's longest completed render (video) or capture (image), and a budget below the lane default as a shortfall rather than a stall", () => {
   const peak = { peakBytes: 68_564_154_584, samples: 2354 };
   const ceiling = "94822600832-byte ceiling";
   // The campaign of 2026-09-07: `scail2_14b:q4:mlx` under `--probe-budget-minutes 90`, flat at
@@ -5047,16 +5067,16 @@ test("a runtime stop's reason names the lane's longest completed capture, and a 
     shortfall,
     "runtime_budget_exceeded: the 90-minute probe budget (5400s) elapsed; peak physical footprint 68564154584 bytes "
       + "over 2354 sample(s) against the 94822600832-byte ceiling. Nothing was measured, so no bound was recorded and "
-      + "this cell stays runnable. The longest completed video capture on record ran 8709s, and this run was launched "
-      + "with --probe-budget-minutes 90, below the video lane's 270-minute default: this stop is a budget shortfall, "
+      + "this cell stays runnable. The longest completed video render on record ran 4470s, and this run was launched "
+      + "with --probe-budget-minutes 90, below the video lane's 165-minute default: this stop is a budget shortfall, "
       + "not evidence of a stall. Re-run it at the default budget or larger before reading anything into the flat footprint.",
   );
   // At the lane default (or above it) the stop stands on its own: the witness is still named, the
   // shortfall sentence is not.
-  for (const budgetMinutes of [270, 300]) {
+  for (const budgetMinutes of [165, 300]) {
     const reason = runtimeBudgetExceededReason({ row: { key: "scail2_14b:q4:mlx", videoLane: true }, budgetMinutes, budgetSeconds: budgetMinutes * 60, peak, ceiling });
     assert.match(reason, new RegExp(`^runtime_budget_exceeded: the ${budgetMinutes}-minute probe budget \\(${budgetMinutes * 60}s\\) elapsed; `), reason);
-    assert.match(reason, /stays runnable\. The longest completed video capture on record ran 8709s\.$/, reason);
+    assert.match(reason, /stays runnable\. The longest completed video render on record ran 4470s\.$/, reason);
     assert.doesNotMatch(reason, /shortfall|not evidence of a stall/, reason);
   }
   // The image lane reads its own witness and its own default, and an unsampled peak is said so.

--- a/scripts/memory-calibration-harness.mjs
+++ b/scripts/memory-calibration-harness.mjs
@@ -63,14 +63,22 @@ const PHYSICAL_MLX_PROVIDER_OUTPUT_ROLES = Object.freeze([
 const PHYSICAL_MLX_AV_PROVIDER_OUTPUT_ROLES = Object.freeze([
   "selected_av", "reference_av",
 ]);
+// sc-22738: a video capture is ONE measured render, so a single-render A/V session carries the
+// `selected_av` receipt alone — there is no warm repeat to file as `reference_av`. Sessions that
+// carry both roles were captured under the previous two-render arm and stay valid as they are.
+const PHYSICAL_MLX_SINGLE_AV_SESSION_OUTPUT_ROLES = Object.freeze(["request", "selected_av"]);
+const PHYSICAL_MLX_SINGLE_AV_PROVIDER_OUTPUT_ROLES = Object.freeze(["selected_av"]);
 const PHYSICAL_MLX_RGB_BASENAME = /^(implan-[0-9a-f]{20})-(selected_rgb|reference_rgb)-([1-9][0-9]*)x([1-9][0-9]*)-([0-9a-f]{64})\.rgb$/;
 const PHYSICAL_MLX_AV_BASENAME = /^(implan-[0-9a-f]{20})-(selected_av|reference_av)-([1-9][0-9]*)x([1-9][0-9]*)-f([1-9][0-9]*)-([0-9a-f]{64})\.avbin$/;
 
 function physicalMlxExpectedRoles(outputs, includeRequest) {
   const hasAv = outputs?.some((output) => output?.role === "selected_av" || output?.role === "reference_av");
-  return hasAv
-    ? (includeRequest ? PHYSICAL_MLX_AV_SESSION_OUTPUT_ROLES : PHYSICAL_MLX_AV_PROVIDER_OUTPUT_ROLES)
-    : (includeRequest ? PHYSICAL_MLX_SESSION_OUTPUT_ROLES : PHYSICAL_MLX_PROVIDER_OUTPUT_ROLES);
+  if (!hasAv) return includeRequest ? PHYSICAL_MLX_SESSION_OUTPUT_ROLES : PHYSICAL_MLX_PROVIDER_OUTPUT_ROLES;
+  const hasReferenceAv = outputs.some((output) => output?.role === "reference_av");
+  if (!hasReferenceAv) {
+    return includeRequest ? PHYSICAL_MLX_SINGLE_AV_SESSION_OUTPUT_ROLES : PHYSICAL_MLX_SINGLE_AV_PROVIDER_OUTPUT_ROLES;
+  }
+  return includeRequest ? PHYSICAL_MLX_AV_SESSION_OUTPUT_ROLES : PHYSICAL_MLX_AV_PROVIDER_OUTPUT_ROLES;
 }
 
 function stable(value) {
@@ -213,11 +221,14 @@ function validatePhysicalMlxOutputsAgainstRecord(record, session) {
       fail(`${record.id}: physical MLX output receipt does not match the measured logical case geometry`);
     }
   }
-  const hasAv = session.outputs.some((output) => output.role === "selected_av");
-  if (hasAv !== (record.quality.audio !== undefined)) {
-    fail(`${record.id}: physical MLX A/V receipts and typed audio quality must be present together`);
+  // A typed audio comparison is selected-versus-REFERENCE PCM, so it is coupled to the
+  // `reference_av` receipt, not to the A/V kind as such: a single-render video session (sc-22738)
+  // carries `selected_av` and no audio comparison.
+  const hasReferenceAv = session.outputs.some((output) => output.role === "reference_av");
+  if (hasReferenceAv !== (record.quality.audio !== undefined)) {
+    fail(`${record.id}: physical MLX reference A/V receipt and typed audio quality must be present together`);
   }
-  if (hasAv) validateAudioQuality(record);
+  if (hasReferenceAv) validateAudioQuality(record);
 }
 
 function validateAudioQuality(record) {
@@ -248,13 +259,32 @@ function validateAudioQuality(record) {
 
 export function validatePhysicalMlxAvContentsAgainstRecord(record, avContents, label) {
   if (avContents.size === 0) return;
-  validateAudioQuality(record);
   const selected = avContents.get("selected_av");
   const reference = avContents.get("reference_av");
-  const audio = record.quality.audio;
   const outputFps = record.diagnostics?.measurements?.find(
     (measurement) => measurement.name === "outputFps",
   )?.value;
+  const measurement = (name) => record.diagnostics?.measurements?.find((entry) => entry.name === name)?.value;
+  if (!selected) fail(`${label}: an A/V session must carry the selected_av render`);
+  if (!reference) {
+    // sc-22738: one measured render, no reference. The track's identity is bound to the record's
+    // own `audio*` measurements instead of a selected-versus-reference `quality.audio` block.
+    if (record.quality.audio !== undefined) {
+      fail(`${label}: typed audio quality needs a reference_av render this session did not make`);
+    }
+    if (selected.width !== record.target.geometry.width
+        || selected.height !== record.target.geometry.height
+        || selected.frames !== record.target.geometry.frames
+        || selected.fps !== outputFps
+        || selected.sampleRateHz !== measurement("audioSampleRate")
+        || selected.channels !== measurement("audioChannels")
+        || selected.sampleCount !== measurement("audioSamples")) {
+      fail(`${label}: canonical A/V header differs from measured video/audio identity`);
+    }
+    return;
+  }
+  validateAudioQuality(record);
+  const audio = record.quality.audio;
   for (const content of [selected, reference]) {
     if (!content
         || content.width !== record.target.geometry.width
@@ -855,22 +885,40 @@ function validateRuntimeComplete(record) {
   if (overlay?.result !== "not_applicable") fail(`${record.id}: runtime-complete evidence must be base-only`);
   text(overlay.reason, `${record.id}.overlay.reason`);
   if (record.negativeMutation !== null) fail(`${record.id}: unexecuted negative mutation must remain null`);
-  if (
-    record.quality.result !== "passed" ||
-    record.quality.identicalInputs !== true
-  ) fail(`${record.id}: runtime-complete quality evidence must pass with identical inputs`);
   text(record.quality.contract, `${record.id}.quality.contract`);
-  for (const metric of [
-    "maximumError", "meanError", "rootMeanSquareError",
-    "maximumErrorThreshold", "meanErrorThreshold", "rootMeanSquareErrorThreshold",
-  ]) {
-    number(record.quality[metric], `${record.id}.quality.${metric}`);
+  if (record.quality.warmPasses === 0) {
+    // sc-22738: a single-render video receipt. The determinism comparison was NOT run, so the
+    // record says `not_run` and carries no figure; it degrades to "not measured", never to a
+    // refusal and never to a synthetic number. The thresholds it would be judged by still travel.
+    if (record.quality.result !== "not_run") {
+      fail(`${record.id}: quality.warmPasses 0 declares an unrun comparison, so quality.result must be not_run`);
+    }
+    for (const metric of ["maximumError", "meanError", "rootMeanSquareError"]) {
+      if (record.quality[metric] !== undefined) {
+        fail(`${record.id}: quality.warmPasses 0 cannot carry quality.${metric}`);
+      }
+    }
+    if (record.quality.audio !== undefined) fail(`${record.id}: quality.warmPasses 0 cannot carry typed audio quality`);
+    for (const metric of ["maximumErrorThreshold", "meanErrorThreshold", "rootMeanSquareErrorThreshold"]) {
+      number(record.quality[metric], `${record.id}.quality.${metric}`);
+    }
+  } else {
+    if (
+      record.quality.result !== "passed" ||
+      record.quality.identicalInputs !== true
+    ) fail(`${record.id}: runtime-complete quality evidence must pass with identical inputs`);
+    for (const metric of [
+      "maximumError", "meanError", "rootMeanSquareError",
+      "maximumErrorThreshold", "meanErrorThreshold", "rootMeanSquareErrorThreshold",
+    ]) {
+      number(record.quality[metric], `${record.id}.quality.${metric}`);
+    }
+    if (
+      record.quality.maximumError > record.quality.maximumErrorThreshold ||
+      record.quality.meanError > record.quality.meanErrorThreshold ||
+      record.quality.rootMeanSquareError > record.quality.rootMeanSquareErrorThreshold
+    ) fail(`${record.id}: runtime-complete quality threshold exceeded`);
   }
-  if (
-    record.quality.maximumError > record.quality.maximumErrorThreshold ||
-    record.quality.meanError > record.quality.meanErrorThreshold ||
-    record.quality.rootMeanSquareError > record.quality.rootMeanSquareErrorThreshold
-  ) fail(`${record.id}: runtime-complete quality threshold exceeded`);
   if (record.loadability.result !== "passed") fail(`${record.id}: runtime-complete loadability did not pass`);
   text(record.loadability.resolvedPathFingerprint, `${record.id}.loadability.resolvedPathFingerprint`);
   // The wired ceiling was checked only on `complete` before sc-18864, which is exactly how three

--- a/scripts/memory-calibration-harness.test.mjs
+++ b/scripts/memory-calibration-harness.test.mjs
@@ -3121,3 +3121,127 @@ test("a bound's reason is one of the two enumerated causes, never free text", as
   hardStopReason.exceededBounds[0].id = "exc-0000000000000000dead";
   assert.throws(() => validateBundle(hardStopReason), /id is not the digest of its own identity/);
 });
+
+// ---------------------------------------------------------------------------------------------
+// sc-22738: a VIDEO capture is one measured render — the receipt declares its unrun warm passes.
+// ---------------------------------------------------------------------------------------------
+
+/** A single-render video receipt: `warmPasses: 0`, `result: not_run`, thresholds only. */
+function singleRenderVideoRuntimeComplete() {
+  const record = runtimeComplete();
+  record.backend = "mlx";
+  record.evidenceScope = "authoritative";
+  record.hardware = {
+    probe: "fixture Apple hardware probe",
+    memoryBytes: 128 * 1024 ** 3,
+    model: "Mac16,5",
+    chip: "Apple M4 Max",
+    osVersion: "15.7",
+    metalDevice: "Apple M4 Max",
+    mlxMemoryLimitBytes: 96 * 1024 ** 3,
+    wiredLimitBytes: 80 * 1024 ** 3,
+  };
+  record.target = {
+    modelId: "minimax_h3", provider: "minimax_h3", tier: "q4", mode: "text_to_video", overlay: "none",
+    geometry: { width: 1024, height: 576, batch: 1, frames: 124 },
+  };
+  record.scenarios.find((entry) => entry.name === "warm_repeat").reason =
+    "sc-22738: a video capture is ONE measured render; no warm pass was run";
+  record.quality = {
+    contract: "identical inputs; the cold measured clip versus a warm repeat; NOT MEASURED: no warm pass",
+    result: "not_run",
+    warmPasses: 0,
+    maximumErrorThreshold: 0.03, meanErrorThreshold: 0.003, rootMeanSquareErrorThreshold: 0.003,
+  };
+  record.diagnostics = {
+    adapter: "memory-mlx-adapter:minimax-h3-joint-av", execution: "executed", blockers: [],
+    measurements: [
+      { name: "conditioningActivePeak", unit: "bytes", value: 100 },
+      { name: "denoiseActivePeak", unit: "bytes", value: 200 },
+      { name: "decodeActivePeak", unit: "bytes", value: 150 },
+      { name: "overallAllocatorEnvelope", unit: "bytes", value: 200 },
+      { name: "warmPasses", unit: "count", value: 0 },
+      { name: "outputFps", unit: "count", value: 24 },
+    ],
+  };
+  record.logicalCaseId = logicalCaseId(record);
+  record.id = recordId(record);
+  return record;
+}
+
+test("a single-render video receipt with warmPasses 0 degrades quality to not measured — never a refusal, never a synthetic figure (sc-22738)", () => {
+  const record = singleRenderVideoRuntimeComplete();
+  assert.equal(validateRecord(record), record);
+  validateBundle({ schemaVersion: SCHEMA_VERSION, harnessVersion: HARNESS_VERSION, sourceSessions: [], records: [record] });
+  assert.equal(evidenceSemantics(record, {
+    sceneWorks: record.repositories.sceneWorks.matrixSourceRevision,
+    inference: record.repositories.inference.revision,
+    inferenceClosureDigests: { "mlx:minimax_h3": record.repositories.inference.closureDigest },
+  }), "current", "the measurement stays valid evidence");
+
+  // What the declaration does NOT permit: a pass it did not run, a figure it could not have
+  // measured, a typed audio comparison with no reference render, or missing thresholds.
+  for (const [mutate, message] of [
+    [(quality) => { quality.result = "passed"; }, /must be not_run/],
+    [(quality) => { quality.maximumError = 0; }, /cannot carry quality\.maximumError/],
+    [(quality) => { quality.rootMeanSquareError = 0; }, /cannot carry quality\.rootMeanSquareError/],
+    [(quality) => { quality.audio = audioQuality(); }, /cannot carry typed audio quality/],
+    [(quality) => { delete quality.meanErrorThreshold; }, /quality\.meanErrorThreshold must be a nonnegative finite number/],
+  ]) {
+    const doctored = structuredClone(record);
+    mutate(doctored.quality);
+    doctored.id = recordId(doctored);
+    assert.throws(() => validateRecord(doctored), message);
+    assert.throws(() => validateBundle({
+      schemaVersion: SCHEMA_VERSION, harnessVersion: HARNESS_VERSION, sourceSessions: [], records: [doctored],
+    }), /schema validation failed|must be not_run|cannot carry|nonnegative finite/);
+  }
+  // Without the declaration the previous contract stands: a runtime-complete record measures its
+  // quality, and `not_run` is refused.
+  const undeclared = structuredClone(record);
+  delete undeclared.quality.warmPasses;
+  undeclared.id = recordId(undeclared);
+  assert.throws(() => validateRecord(undeclared), /must pass with identical inputs/);
+  // And an image-lane record that DID run its warm passes is untouched by the declaration.
+  const measured = runtimeComplete();
+  measured.quality.warmPasses = 2;
+  measured.id = recordId(measured);
+  assert.equal(validateRecord(measured), measured);
+});
+
+test("a single-render physical A/V session carries selected_av alone; the audio comparison is coupled to reference_av (sc-22738)", () => {
+  const { bytes } = canonicalAvFixture();
+  const content = parsePhysicalMlxAvContent(bytes);
+  const record = {
+    id: "imc-single-render-av",
+    target: { geometry: { width: 2, height: 1, frames: 1 } },
+    diagnostics: { measurements: [
+      { name: "outputFps", value: 24 },
+      { name: "audioSampleRate", value: 24000 },
+      { name: "audioChannels", value: 2 },
+      { name: "audioSamples", value: 4 },
+    ] },
+    quality: { result: "not_run", warmPasses: 0 },
+  };
+  const selectedOnly = new Map([["selected_av", content]]);
+  validatePhysicalMlxAvContentsAgainstRecord(record, selectedOnly, record.id);
+  // The measured track's identity is still bound — to the record's own audio measurements.
+  const wrongRate = structuredClone(record);
+  wrongRate.diagnostics.measurements.find((entry) => entry.name === "audioSampleRate").value = 48000;
+  assert.throws(
+    () => validatePhysicalMlxAvContentsAgainstRecord(wrongRate, selectedOnly, record.id),
+    /A\/V header differs from measured video\/audio identity/,
+  );
+  // A typed audio comparison needs the reference render this session did not make.
+  const claimsAudio = structuredClone(record);
+  claimsAudio.quality.audio = audioQuality({ sampleCount: 4, selectedPcmSha256: content.pcmSha256, referencePcmSha256: content.pcmSha256 });
+  assert.throws(
+    () => validatePhysicalMlxAvContentsAgainstRecord(claimsAudio, selectedOnly, record.id),
+    /needs a reference_av render this session did not make/,
+  );
+  // A reference without a selected render is not a session of anything.
+  assert.throws(
+    () => validatePhysicalMlxAvContentsAgainstRecord(record, new Map([["reference_av", content]]), record.id),
+    /must carry the selected_av render/,
+  );
+});


### PR DESCRIPTION
## Decision (sc-22738, 2026-09-08)

The memory-capture arms for **video** providers run **one** measured render per capture, not three. The Wan/SCAIL-2 arm rendered a 14B clip three times per capture — measured render, clean warm control, warm repeat. Witnessed: `scail2_14b:bf16:mlx` 8,709 s per capture; `wan_2_2_t2v_14b:bf16:mlx` 13,411 s; `wan_2_2_t2v_14b:q4:mlx` exceeded a 16,200 s budget without finishing (packed-tier dequant is slower than dense). The anchor's phase peaks come from the FIRST render — `extract-memory-anchors.mjs` and `memory_anchor.rs` read only the three phase peaks, the overall allocator envelope and `outputFps` — while the two warm passes fed residency-retention / allocator-envelope checks that cost 2x the render on video.

## What changed

**Lane property, not a per-model case.** `sceneworks_memory_adapter::{CaptureLane, CapturePolicy, capture_policy, drive_renders}` (lib.rs): the lane is the plan row's `geometry.frames > 1`, the same derivation #2784 budgets a probe by. `IMAGE_WARM_PASSES = 2` (unchanged), `VIDEO_WARM_PASSES = 0`. Every MLX video arm reads it before it renders.

**Arms changed (MLX lane):**
- `mlx_wan_scail2.rs` `run` — 3 → 1 render.
- `mlx.rs` `run_minimax_h3` — 3 → 1.
- `mlx.rs` `run_krea_realtime` — 3 → 1.
- `mlx.rs` `run_bernini` — this ONE arm serves both catalog members: the video member (`bernini`, 49 frames) is 3 → 1; the still member (`bernini_image`, frames == 1) is the image lane and keeps its clean warm control + warm repeat, branch decided by the plan's frame count against the member (mismatch is refused).
- `mlx.rs` `run_ltx_with_admission` (`LtxRunAdmission::Ordinary`, the catalog capture) — 6 → 1 (measured + clean warm + cancel/error faults + two recoveries no longer run). The SC-20318 campaign entries (`CampaignEntry`, `BoundedCampaignEntry`) are lifecycle PROOFS with their own carrier validators and keep their render counts.
- `mlx_ltx25.rs` `run` — 2 → 1; the physical source session files `selected_av` only (no `reference_av`), and no typed `quality.audio` block (that is a selected-vs-reference PCM comparison).

**Candle lane:** `candle_wan_scail2.rs`, `candle.rs` `run_ltx25_capture` / `run_sc22737_video_capture` already captured ONE render with `quality: { result: not_run }` — no change.

**Image arms:** untouched.

## What the receipt now says

Honest about what was not run, no zeros:
- `scenarios.warm_repeat` = `not_run` with reason `VIDEO_WARM_PASSES_NOT_RUN` (names the witnessed durations).
- `quality` = `{ contract: "<contract>; NOT MEASURED: …", result: "not_run", warmPasses: 0, maximumErrorThreshold, meanErrorThreshold, rootMeanSquareErrorThreshold }` — no `maximumError`/`meanError`/`rootMeanSquareError`, no `identicalInputs`, no `audio`.
- No `lifecycleCleanWarmPeak` / `lifecycleClean*` / `lifecycleWarmRepeat*` / `warmRepeat*` / `lifecycleMax*` measurement; a `warmPasses: 0` count measurement instead. LTX-2.5 carries the measured track's identity as `audioSamples`/`audioSampleRate`/`audioChannels`.
- The falsifiability mutation check is judged against the measured render itself (as LTX-2.3 already did).
- Lifecycle blockers state "ONE measured render … and no warm pass".

## Downstream consumers checked

Everything that REQUIRED a warm-repeat/retention figure now degrades to "not measured" on a `warmPasses: 0` record — never a refusal, never a synthetic number — and records WITHOUT the declaration keep every previous requirement, so the retained video cells captured WITH warm passes (`docs/calibration/sc-22738/{ltx-2-3,ltx-2-5,minimax-h3*}-*`, `sc-18791/ltx25-mlx-evidence.seed.json`, the `docs/generated` LTX sweeps) stay valid as they are:
- `packages/schemas/memory-calibration.schema.json`: `quality.warmPasses` (integer ≥ 0); the `runtime_complete` quality clause is now `if warmPasses == 0 → result not_run, thresholds required, no comparison figure / audio` else the previous requirement.
- `scripts/memory-calibration-harness.mjs`: `validateRuntimeComplete` degrade branch; single-AV physical sessions (`selected_av` alone) via `physicalMlxExpectedRoles`; the typed audio comparison is coupled to `reference_av` (not to the A/V kind) in `validatePhysicalMlxOutputsAgainstRecord` / `validatePhysicalMlxAvContentsAgainstRecord`; a single-render A/V header is bound to the record's own `audio*` measurements.
- `crates/sceneworks-core/src/memory_calibration.rs`: `Quality.warm_passes`; `validate_runtime_complete` degrade branch; `validate_physical_mlx_outputs_against_record` couples audio to `reference_av` and refuses a reference without a selected render.
- `sceneworks_memory_adapter::validate_quality_metrics` (the response validator every adapter binary writes through): no figure required when `warmPasses == 0`.
- `scripts/extract-memory-anchors.mjs`, `generate-memory-matrix.mjs`, `crates/sceneworks-core/src/memory_anchor.rs`, worker admission: read no warm key (only phase peaks / envelope / `outputFps`) — verified by grep and by the new extractor test; no change needed.

## Budget basis (`scripts/measure-memory-catalog.mjs`)

`WITNESSED_CAPTURE_SECONDS.video` 8,709 → **4,470 s per render** (`wan_2_2_t2v_14b:bf16:mlx` 13,411/3, the longest COMPLETED dense render); `VIDEO_RENDER_WITNESSES_SECONDS` records all three witnesses (SCAIL-2 8,709/3 ≈ 2,903 s; wan bf16 4,470 s; wan q4 > 16,200/3 = 5,400 s UNFINISHED, `VIDEO_RENDER_LOWER_BOUND_SECONDS`). `PROBE_BUDGET_MINUTES.video` 270 → **165** = 9,900 s: 2.2x the completed witness and 1.83x the packed-tier lower bound, the same 1.8x margin policy (`PROBE_BUDGET_MARGIN`). Image budget untouched (60 min, 847 s). The runtime-stop reason says "longest completed video render" (per render) vs "image capture". `docs/calibration-runbook.md` updated with the decision, the witnesses and the new figures.

## Tests

- `cargo test -p sceneworks-memory-adapter --features mlx --bin memory-mlx-adapter`: 301 passed (new: `single_render_video_lane_tests` ×2 walking every planned MLX row — every changed arm's video rows resolve to 1 render, every image row incl. `bernini_image` to 3; the LTX ordinary-path source test now asserts the Ordinary lifecycle arm renders nothing and the campaign entry keeps its proof; `source_capture` files `selected_av` alone).
- `cargo test -p sceneworks-memory-adapter --lib`: 47 passed incl. 4 new (lane derivation, 1 vs 3 renders, `drive_renders` stub counting 1 call for a video plan / 3 for an image plan and stopping on a failed measured render, the not_run receipt shape through `validate_quality_metrics`).
- `cargo test -p sceneworks-core --lib memory_calibration`: 22 passed (new: warmPasses-0 runtime_complete accepted / doctored variants refused / undeclared keeps the old rule; single-render A/V session coupling).
- `node --test scripts/measure-memory-catalog.test.mjs scripts/extract-memory-anchors.test.mjs`: 152 passed, 4 skipped (Darwin-only guard cases), 0 failed; `scripts/memory-calibration-harness.test.mjs`: 103 passed (new: warmPasses-0 record through `validateRecord`/`validateBundle`/schema and `evidenceSemantics` = current; single-AV session contents).
- **Mutation evidence:** `VIDEO_WARM_PASSES = 2` reds `a_video_capture_is_one_render_and_an_image_capture_is_three`, `the_render_driver_issues_one_generate_for_video_and_three_for_image`, `a_single_render_receipt_declares_its_unrun_warm_passes_instead_of_writing_zeros` `every_changed_video_arm_captures_one_render_and_the_image_lane_keeps_three` and `the_bernini_lane_check_is_the_plans_frame_count_against_the_members`: lib 44 passed / 3 FAILED, bin 0 passed / 2 FAILED; restored to 0, lib green again (47 passed).
- `cargo clippy -p sceneworks-memory-adapter --features mlx --all-targets -- -D warnings`: exit 0; `cargo clippy -p sceneworks-core --all-targets -- -D warnings`: exit 0; `cargo fmt --all -- --check`: exit 0; `npm run rust:check`: exit 0 (covers the candle / neither feature configurations on macOS); `INFERENCE_REPO=<pinned e34d7b46a checkout> npm run check`: exit 0. The candle adapter binary itself cannot compile on macOS (its inference deps are `cfg(not(target_os = "macos"))`); it is unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
