### PR TITLE
fix(sc-22738): CUDA campaign walk — empty snapshots are weights_missing, download-missing actually fetches, contaminated GPU fails fast, Illustrious env binding

### DIFF
--- a/.github/workflows/memory-catalog-campaign.yml
+++ b/.github/workflows/memory-catalog-campaign.yml
@@ -388,6 +388,12 @@ jobs:
           if errorlevel 1 exit /b 1
           echo ADAPTER=%GITHUB_WORKSPACE%\target\release\memory-candle-adapter.exe>>%GITHUB_ENV%
 
+      # BEFORE the walk, and it FAILS THE JOB rather than warning (sc-22738). Run 34272596969 spent
+      # 51 guarded renders -- about an hour of GPU time -- refusing every peak as contaminated by
+      # pid 6308, an adapter orphaned by the cancelled run before it. See the script's header.
+      - name: Census the profiled GPU
+        run: bash scripts/ci/memory-catalog/gpu-preflight.sh
+
       - name: Plan the walk
         run: bash scripts/ci/memory-catalog/plan.sh
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6755,6 +6755,7 @@ version = "0.8.7"
 dependencies = [
  "candle-gen",
  "candle-gen-scail2",
+ "candle-gen-sdxl",
  "candle-gen-wan",
  "mlx-gen",
  "mlx-gen-flux2",

--- a/crates/sceneworks-memory-adapter/Cargo.toml
+++ b/crates/sceneworks-memory-adapter/Cargo.toml
@@ -45,6 +45,11 @@ candle-gen = { git = "https://github.com/SceneWorks/inference", rev = "e34d7b46a
 # own `request_evidence_revision`, rather than restating either in the adapter.
 candle-gen-scail2 = { git = "https://github.com/SceneWorks/inference", rev = "e34d7b46a301376676bd8a60419190c7be9aa4f0", features = ["cuda"], optional = true }
 candle-gen-wan = { git = "https://github.com/SceneWorks/inference", rev = "e34d7b46a301376676bd8a60419190c7be9aa4f0", features = ["cuda"], optional = true }
+# sc-22738: the SDXL family's route revisions are READ from the engine's own `SDXL_ROUTES` rather
+# than transcribed into the adapter. The transcription is what broke CUDA run 34272596969 -- the
+# sc-22729 repair moved both Illustrious routes and the copies here did not follow, so six cells
+# were refused for a drift that did not exist at the pin. Same reasoning as the two crates above.
+candle-gen-sdxl = { git = "https://github.com/SceneWorks/inference", rev = "e34d7b46a301376676bd8a60419190c7be9aa4f0", features = ["cuda"], optional = true }
 runtime-cuda = { git = "https://github.com/SceneWorks/inference", rev = "e34d7b46a301376676bd8a60419190c7be9aa4f0", optional = true }
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
@@ -53,7 +58,7 @@ sceneworks-gen-core-testkit = { git = "https://github.com/SceneWorks/inference",
 [features]
 default = []
 mlx = ["dep:mlx-gen", "dep:mlx-gen-flux2", "dep:mlx-gen-instantid", "dep:mlx-gen-krea", "dep:mlx-gen-krea-realtime", "dep:mlx-gen-ltx", "dep:mlx-gen-mage", "dep:mlx-gen-minimax-h3", "dep:mlx-gen-scail2", "dep:mlx-gen-sdxl", "dep:mlx-gen-wan", "dep:mlx-rs", "dep:runtime-macos"]
-candle = ["dep:candle-gen", "dep:candle-gen-scail2", "dep:candle-gen-wan", "dep:runtime-cuda"]
+candle = ["dep:candle-gen", "dep:candle-gen-scail2", "dep:candle-gen-sdxl", "dep:candle-gen-wan", "dep:runtime-cuda"]
 
 [[bin]]
 name = "memory-mlx-adapter"

--- a/crates/sceneworks-memory-adapter/src/bin/candle.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/candle.rs
@@ -113,10 +113,21 @@ const SDXL_COMPONENTS: [(&str, &str); 3] = [
 
 /// One member of the Candle SDXL family.
 ///
-/// `route_revision` is the revision `candle-gen-sdxl`'s own `SDXL_ROUTES` table pins for this
-/// member. It is recorded here — rather than only in the env — because the engine's
-/// `path_has_snapshot` matches the staged root against that literal, so a member whose route
-/// revision has drifted from the shipped manifest cannot seal a contract and cannot load at all.
+/// The revision this member's route pins is NOT a field here. It used to be — transcribed from
+/// `candle-gen-sdxl`'s own `SDXL_ROUTES` table — and sc-22738 is what a transcription costs: the
+/// inference-side sc-22729 repair moved `illustrious_xl_v1` to `778c3f02…` and `illustrious_xl_v2`
+/// to `672e9851…`, the copies here stayed at `c5a92a90…` / `7c5c8b2b…`, and on CUDA run
+/// 34272596969 all six Illustrious cells failed with this adapter's own drift refusal — against a
+/// pin at which the engine and the manifest AGREED. The runner's plan-time check
+/// (`sdxlCandleRouteDrift` in `scripts/measure-memory-catalog.mjs`) derives both sides and had
+/// correctly classified every one of them `runnable`.
+///
+/// So the revision is read from the linked engine crate at the pin, by
+/// [`sdxl_candle_route_revision`]. The check itself stays: the engine's `path_has_snapshot` matches
+/// a staged root against that literal, so a member whose route revision has drifted from the
+/// shipped manifest cannot seal a contract and cannot load at all — and saying which two revisions
+/// disagree is more useful than the engine's own message. It simply can no longer be wrong about
+/// what the engine pins.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct SdxlCandleArm {
     model_id: &'static str,
@@ -126,7 +137,40 @@ struct SdxlCandleArm {
     revision_env: &'static str,
     root_env: &'static str,
     expected_repository: &'static str,
-    route_revision: &'static str,
+}
+
+/// The revision `candle-gen-sdxl` pins for this member, read out of the ENGINE's own
+/// `SDXL_ROUTES` at the compiled pin.
+///
+/// Fail-closed in both directions: a member the engine declares no route for, and a route whose
+/// repository disagrees with the one this adapter stages, are both errors rather than a silently
+/// skipped comparison. `SdxlRoute` is not nameable from outside the crate (only the const is
+/// re-exported), which is why this returns the field rather than the row.
+fn sdxl_candle_route_revision(arm: &SdxlCandleArm) -> Result<&'static str, String> {
+    let route = candle_gen_sdxl::SDXL_ROUTES
+        .iter()
+        .find(|route| route.id == arm.model_id)
+        .ok_or_else(|| {
+            format!(
+                "candle-gen-sdxl's SDXL_ROUTES declares no route {:?} at {}, so this adapter has \
+                 no engine revision to bind {} against",
+                arm.model_id,
+                protocol::INFERENCE_PIN,
+                arm.expected_repository
+            )
+        })?;
+    if route.repository != arm.expected_repository {
+        return Err(format!(
+            "candle-gen-sdxl routes {:?} to {} at {}, but this adapter stages {} through {}; the \
+             two disagree about which repository the route loads",
+            arm.model_id,
+            route.repository,
+            protocol::INFERENCE_PIN,
+            arm.expected_repository,
+            arm.repository_env
+        ));
+    }
+    Ok(route.revision)
 }
 
 const SDXL_CANDLE_BASE_ARM: SdxlCandleArm = SdxlCandleArm {
@@ -137,7 +181,6 @@ const SDXL_CANDLE_BASE_ARM: SdxlCandleArm = SdxlCandleArm {
     revision_env: "SCENEWORKS_SDXL_REVISION",
     root_env: "SCENEWORKS_SDXL_ROOT",
     expected_repository: protocol::SDXL_REPOSITORY,
-    route_revision: "36699bb8a6353e61c920e3bf19f0e6f8e4151c55",
 };
 
 const SDXL_CANDLE_REALVISXL_ARM: SdxlCandleArm = SdxlCandleArm {
@@ -148,7 +191,6 @@ const SDXL_CANDLE_REALVISXL_ARM: SdxlCandleArm = SdxlCandleArm {
     revision_env: "SCENEWORKS_REALVISXL_REVISION",
     root_env: "SCENEWORKS_REALVISXL_ROOT",
     expected_repository: protocol::REALVISXL_REPOSITORY,
-    route_revision: "e40202d63baef826c7df95a639a811698c1178d2",
 };
 
 const SDXL_CANDLE_LIGHTNING_ARM: SdxlCandleArm = SdxlCandleArm {
@@ -159,7 +201,6 @@ const SDXL_CANDLE_LIGHTNING_ARM: SdxlCandleArm = SdxlCandleArm {
     revision_env: "SCENEWORKS_REALVISXL_LIGHTNING_REVISION",
     root_env: "SCENEWORKS_REALVISXL_LIGHTNING_ROOT",
     expected_repository: protocol::REALVISXL_LIGHTNING_REPOSITORY,
-    route_revision: "c09fd586989bdc3c658d4acd03e8ae81677ade8e",
 };
 
 const SDXL_CANDLE_ILLUSTRIOUS_V1_ARM: SdxlCandleArm = SdxlCandleArm {
@@ -170,7 +211,6 @@ const SDXL_CANDLE_ILLUSTRIOUS_V1_ARM: SdxlCandleArm = SdxlCandleArm {
     revision_env: "SCENEWORKS_ILLUSTRIOUS_XL_V1_REVISION",
     root_env: "SCENEWORKS_ILLUSTRIOUS_XL_V1_ROOT",
     expected_repository: protocol::ILLUSTRIOUS_XL_V1_REPOSITORY,
-    route_revision: "c5a92a902dd4e6ee99c2a57981ecf66209905dd1",
 };
 
 const SDXL_CANDLE_ILLUSTRIOUS_V2_ARM: SdxlCandleArm = SdxlCandleArm {
@@ -181,7 +221,6 @@ const SDXL_CANDLE_ILLUSTRIOUS_V2_ARM: SdxlCandleArm = SdxlCandleArm {
     revision_env: "SCENEWORKS_ILLUSTRIOUS_XL_V2_REVISION",
     root_env: "SCENEWORKS_ILLUSTRIOUS_XL_V2_ROOT",
     expected_repository: protocol::ILLUSTRIOUS_XL_V2_REPOSITORY,
-    route_revision: "7c5c8b2bb75a8f38a7365e70bdf84d38d6204473",
 };
 
 const SDXL_CANDLE_FAMILY: [SdxlCandleArm; 5] = [
@@ -1080,13 +1119,14 @@ fn sdxl_candle_route_fingerprint(model_id: &str) -> String {
 fn sdxl_candle_spec(request: &Value, spec: LoadSpec) -> Result<LoadSpec, String> {
     let arm = sdxl_candle_arm(request)?;
     let revision = protocol::required_env(arm.revision_env)?;
-    if revision != arm.route_revision {
+    let route_revision = sdxl_candle_route_revision(&arm)?;
+    if revision != route_revision {
         return Err(format!(
             "candle-gen-sdxl pins route {:?} at {} ({}), but {} names {revision}; the engine's \
              `path_has_snapshot` matches that literal, so no staged root can seal this route at \
              {}. This cell is not capturable until the two revisions agree.",
             arm.model_id,
-            arm.route_revision,
+            route_revision,
             arm.expected_repository,
             arm.revision_env,
             protocol::INFERENCE_PIN
@@ -7680,7 +7720,10 @@ mod sdxl_family_tests {
             let arm = sdxl_candle_arm(&planned(SDXL_ID, model_id)).unwrap();
             assert_eq!(arm.model_id, model_id);
             assert_eq!(arm.expected_repository, repository);
-            assert_eq!(arm.route_revision.len(), 40, "{model_id} route revision");
+            // sc-22738: DERIVED from the linked engine crate, never transcribed here — so this
+            // asserts the lookup resolves, not that a literal in this file is 40 characters long.
+            let route_revision = sdxl_candle_route_revision(&arm).expect(model_id);
+            assert_eq!(route_revision.len(), 40, "{model_id} route revision");
         }
         // Every member's env family and execution path is its own.
         for field in [
@@ -7692,7 +7735,9 @@ mod sdxl_family_tests {
                 .to_vec(),
             SDXL_CANDLE_FAMILY.map(|arm| arm.execution_path).to_vec(),
             SDXL_CANDLE_FAMILY.map(|arm| arm.still_calibration).to_vec(),
-            SDXL_CANDLE_FAMILY.map(|arm| arm.route_revision).to_vec(),
+            SDXL_CANDLE_FAMILY
+                .map(|arm| sdxl_candle_route_revision(&arm).expect(arm.model_id))
+                .to_vec(),
         ] {
             let mut unique = field.clone();
             unique.sort_unstable();

--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -195,6 +195,18 @@ on the SAME `SceneWorks/realvisxl-mlx` backbone, bound through its own
 every routed lane. Two engine-side facts keep some of them from being CAPTURABLE at inference
 `c6d6a4db`, and neither is adapter or plan work:**
 
+> ✅ **RESOLVED at the current pin `e34d7b46` (sc-22738).** The inference-side repair landed:
+> `SDXL_ROUTES` now pins `illustrious_xl_v1` at `778c3f02…` and `illustrious_xl_v2` at `672e9851…`,
+> which is exactly what `config/manifests/builtin.models.jsonc` ships, so the plan classifies all
+> six cells `runnable`. On CUDA run 34272596969 they nonetheless failed — because
+> `memory-candle-adapter` **transcribed** the old revisions into `SdxlCandleArm::route_revision` and
+> refused a drift that no longer existed. That field is gone: `sdxl_candle_route_revision` reads
+> `candle_gen_sdxl::SDXL_ROUTES` out of the linked engine crate at the pin, and additionally refuses
+> a route whose repository disagrees with the one the adapter stages. The check survives; it can no
+> longer be wrong about what the engine pins, and a future route move needs no edit here. **The
+> paragraph below is kept as the description of the CONDITION** — read it if `--list` ever reports
+> these cells `harness_unsupported` again.
+
 - `illustrious_xl_v1` / `illustrious_xl_v2` on **candle**, all three tiers — six cells.
   `candle-gen-sdxl`'s `SDXL_ROUTES`
   (`crates/media/candle-gen/candle-gen-sdxl/src/memory_strategy.rs`) pins those two routes at
@@ -1640,6 +1652,37 @@ on macOS, `E:\huggingface\hub` on the CUDA box). A root that does not exist is a
 error — `hubRoots()` still falls back to the HF env convention and the app cache, and an anchor whose
 snapshot is under none of them plans as `weights_missing` rather than failing the run.
 
+**The candle job censuses the GPU before it walks (sc-22738).** Run 34272596969 spent 51 guarded
+renders — roughly an hour of GPU time — producing 51 copies of one sentence: *"untrustworthy stable
+idle baseline: pure compute processes [6308] are resident on the profiled GPU; the peak is
+contaminated"*. Pid 6308 was a `memory-candle-adapter.exe` orphaned when the previous dispatch
+(34271044903) was cancelled: the harness launches the adapter **detached**, deliberately, so a
+Ctrl-C cannot reach it mid-command-buffer, and the runner's own *"Cleaning up orphan processes"* only
+reaps a step's direct children.
+
+`scripts/ci/memory-catalog/gpu-preflight.sh` now runs between *Build the candle memory adapter* and
+*Plan the walk*:
+
+1. `nvidia-smi -i $CUDA_VISIBLE_DEVICES --query-compute-apps=pid,process_name,used_memory
+   --format=csv,noheader`;
+2. terminates anything matching `*memory-candle-adapter*` / `*memory-mlx-adapter*` — **ours, by
+   name**. Never an arbitrary pid: this box also serves `windows-candle.yml` and
+   `desktop-windows.yml`;
+3. censuses again, and **fails the job** with `::error title=Profiled GPU is not idle` naming the
+   pid, the process and its memory if anything is left. Find out whose it is before killing it.
+
+No `nvidia-smi` on PATH is a warning, not a failure — the engine's stable-idle guard still refuses a
+contaminated peak per anchor; this step is the cheap way to find out early. **The guard itself is
+untouched.** It is measurement validity — a peak sampled beside a foreign process is not this
+model's peak — not a gate on anything shipping (see FEATURE_DEVELOPMENT.md, *Gate teardown*).
+
+The walk carries the other half. A `capture_failed` reason naming pids is annotated with each
+process's **name** (queried once per streak, so the operator gets `[6308 = …\memory-candle-adapter.exe
+(12345 MiB)]` rather than a bare number), and `CONTAMINATION_ABORT_STREAK` (5) consecutive refusals
+naming the *same* process halt the walk with a summary line instead of burning the rest of the
+catalog. That is deliberately a **host**-level abort: a per-cell host condition — an empty snapshot,
+an unstaged component — must never abort the walk, and no longer can.
+
 **Fetching the missing snapshots — `download_missing` / `--download-missing` (sc-22738).** Neither
 box holds the whole catalog. Copying the missing snapshots off the Mac's SSD is slower than fetching
 them from the hub on the Windows box's own link (measured 2026-09-08), so the campaign can fetch
@@ -1675,6 +1718,20 @@ gh workflow run memory-catalog-campaign.yml -R SceneWorks/SceneWorks \
   missing. Each landed snapshot logs `download: <key> <repo>@<rev> <n> files, <bytes> bytes`.
 - **A failed fetch never stops the walk.** That one anchor stays `weights_missing (download failed:
   <reason>)` and the campaign moves on, exactly as an absent snapshot does today.
+- **An EMPTY snapshot directory is fetchable, and is never booked as runnable** (sc-22738, run
+  34272596969). A hub fetch interrupted after the snapshot tree was created and before a blob landed
+  leaves `models--<org>--<name>/snapshots/<rev>/<tier>/` present and empty. That plans as
+  `weights_missing (snapshot present but empty: <path>)`, which makes it eligible here — the CLI
+  resumes an interrupted download — instead of being booked, loaded, and then thrown out of the walk
+  by the artifact inventory. (It was: `artifact inventory is empty:
+  E:\huggingface\hub\models--SceneWorks--Mage-Flow-Base\snapshots\d642341926…\q4` aborted that run at
+  cell 61 of 132 and discarded the remaining 71.)
+- **No hub CLI on PATH is stated ONCE, loudly.** Before it fetches anything the walk probes
+  `hf --version`, then `huggingface-cli --version`. When neither runs, it writes a
+  `::warning title=Hugging Face CLI missing` at the top of the step and every cell it silenced
+  carries `weights_missing (… download unavailable: no Hugging Face CLI on PATH …)` — rather than N
+  identical `ENOENT` lines buried in a multi-hour log. A CLI that is present but exits non-zero
+  counts as installed: its own download error describes a broken install better.
 - **`$HF_TOKEN`** is exported into the job from the repository/org secret of that name and is read
   by the CLI, not by this script. Every artifact the campaign fetches today is public, so an unset
   token only matters for a gated repository; set the secret (or export `HF_TOKEN` /

--- a/scripts/ci/memory-catalog/gpu-preflight.sh
+++ b/scripts/ci/memory-catalog/gpu-preflight.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Refuse to start a candle walk on a contaminated GPU, and reap our OWN orphans first (sc-22738).
+#
+# THE INCIDENT. Run 34272596969 spent 51 guarded renders — roughly an hour of GPU time — producing
+# 51 copies of one sentence: "pure compute processes [6308] are resident on the profiled GPU; the
+# peak is contaminated". Pid 6308 was a `memory-candle-adapter.exe` orphaned when the PREVIOUS
+# dispatch (34271044903) was cancelled. The runner's own "Cleaning up orphan processes" reaps the
+# step's direct children; the harness launches the adapter DETACHED (deliberately — so a Ctrl-C
+# cannot reach it mid-command-buffer), so a cancelled walk can leave one holding VRAM.
+#
+# WHAT THIS DOES, IN ORDER.
+#   1. Census the compute processes on the profiled GPU.
+#   2. Kill the ones that are OURS BY NAME — `memory-candle-adapter*` / `memory-mlx-adapter*`. Only
+#      those, and only by name: this box is shared with other self-hosted lanes and killing a pid
+#      merely because it is inconvenient would take a colleague's build down with it.
+#   3. Census again. Anything left is somebody else's, so FAIL FAST with a `::error` naming the pid,
+#      the process and its memory — before the walk spends 60 cells learning the same thing.
+#
+# WHY THIS IS NOT A GATE. It gates no code, no merge and no measurement: it is the same claim the
+# engine's stable-idle guard makes (a peak sampled beside a foreign process is not this model's
+# peak), made once at the top instead of once per anchor. Read `FEATURE_DEVELOPMENT.md`'s "Gate
+# teardown" before reading anything else into it.
+#
+# WHY IT RUNS UNDER GIT BASH BUT SHELLS OUT TO POWERSHELL TO KILL. `nvidia-smi` is a plain console
+# executable and reads fine from bash. Terminating a Windows process is not: Git Bash's `kill`
+# addresses MSYS pids, not Windows ones, so it cannot signal a native process the runner never
+# started. `Stop-Process` is the spelling that works, and it is invoked per pid, by pid, only after
+# THIS script has matched the process by name.
+# shellcheck source=scripts/ci/memory-catalog/common.sh
+source "$(dirname "$0")/common.sh"
+
+# `pid, process_name, used_memory` for every compute process on the profiled GPU, or empty when
+# nvidia-smi cannot be reached. `-i $CUDA_VISIBLE_DEVICES` keeps the census on the ONE device the
+# capture profiles; without it a second card's renders would read as contamination here.
+census() {
+  local device_args=()
+  if [[ -n "${CUDA_VISIBLE_DEVICES:-}" ]]; then
+    device_args=(-i "$CUDA_VISIBLE_DEVICES")
+  fi
+  nvidia-smi "${device_args[@]}" \
+    --query-compute-apps=pid,process_name,used_memory --format=csv,noheader 2>/dev/null || true
+}
+
+# Indent a census for the job log, dropping the blank line an empty census leaves behind.
+indent() {
+  while IFS= read -r line; do
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    printf '  %s\n' "$line"
+  done
+}
+
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+  # NOT fatal. The walk's own preflight refuses an unset CUDA_VISIBLE_DEVICES and the engine's
+  # stable-idle guard still refuses a contaminated peak per anchor; this step is the cheap way to
+  # find out early, not the thing that makes the measurement valid.
+  echo "::warning title=nvidia-smi unavailable::cannot census the profiled GPU before the walk; a contaminated device will only be caught per-anchor by the engine's stable-idle guard"
+  exit 0
+fi
+
+# ONE census, printed and then reaped from. Two calls would let the log show a process the reaping
+# loop never saw (or the reverse) whenever one exits between them.
+before="$(census)"
+echo "compute processes on GPU ${CUDA_VISIBLE_DEVICES:-<all>} before the walk:"
+indent <<< "$before"
+
+reaped=0
+while IFS=, read -r pid name memory; do
+  pid="$(echo "$pid" | tr -d '[:space:]')"
+  name="$(echo "$name" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  memory="$(echo "$memory" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  [[ -z "$pid" ]] && continue
+  # The binaries this campaign itself launches, matched on the process-name field `nvidia-smi`
+  # prints (a full path on Windows, hence the `*` on both ends). Spelled as literal `case`
+  # alternatives rather than held in a variable: bash parses `|` as case syntax BEFORE expanding
+  # the pattern, so a variable carrying alternatives would match a literal pipe and reap nothing.
+  case "$name" in
+    *memory-candle-adapter* | *memory-mlx-adapter*)
+      echo "::warning title=Reaping an orphaned adapter::pid ${pid} (${name}, ${memory}) is one of this campaign's own binaries left over from an earlier run; terminating it before the walk"
+      if command -v powershell >/dev/null 2>&1; then
+        powershell -NoProfile -Command "Stop-Process -Id ${pid} -Force -ErrorAction SilentlyContinue" || true
+      else
+        kill -9 "$pid" 2>/dev/null || true
+      fi
+      reaped=$(( reaped + 1 ))
+      ;;
+    *)
+      ;;
+  esac
+done <<< "$before"
+
+if (( reaped > 0 )); then
+  # Stop-Process returns before the driver has released the context; give it a moment so the
+  # re-census does not report a process that is already on its way out.
+  sleep 10
+  echo "reaped ${reaped} orphaned adapter process(es)"
+fi
+
+remaining="$(census)"
+if [[ -n "$(echo "$remaining" | tr -d '[:space:]')" ]]; then
+  echo "compute processes still on GPU ${CUDA_VISIBLE_DEVICES:-<all>}:"
+  indent <<< "$remaining"
+  while IFS= read -r line; do
+    [[ -z "$(echo "$line" | tr -d '[:space:]')" ]] && continue
+    echo "::error title=Profiled GPU is not idle::${line} is resident on GPU ${CUDA_VISIBLE_DEVICES:-<all>}. Every capture's stable-idle baseline would be contaminated and every anchor would be refused, so the walk is not started. This process is not one of this campaign's binaries -- find out whose it is before killing it."
+  done <<< "$remaining"
+  exit 1
+fi
+
+echo "profiled GPU is idle; starting the walk"

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -1587,6 +1587,11 @@ export async function resolveArtifactRoot(models, modelId, tier, artifact, hubs)
     const root = await firstExistingDirectory(
       hubs.map((hub) => snapshotPath(hub, artifact.repo, revision, ...suffix)),
     );
+    // sc-22738: present-but-empty is `weights_missing`, not a runnable root — see
+    // `EMPTY_SNAPSHOT_PREFIX`.
+    if (root && !(await directoryHasFiles(root))) {
+      return { root: null, revision, expected: root, reason: `${EMPTY_SNAPSHOT_PREFIX}${root}` };
+    }
     return {
       root,
       revision,
@@ -1594,11 +1599,20 @@ export async function resolveArtifactRoot(models, modelId, tier, artifact, hubs)
       reason: `no ${artifact.repo}@${revision.slice(0, 8)}${label} on this host`,
     };
   }
+  // An unpinned repository is probed by whatever revision is staged here, so an empty tree is
+  // SKIPPED rather than reported: a second staged revision of the same repository may well hold the
+  // weights. Only when no candidate holds a file does the empty one become the answer.
+  let empty = null;
   for (const hub of hubs) {
     for (const candidate of await hostSnapshotRevisions(hub, artifact.repo)) {
       const root = snapshotPath(hub, artifact.repo, candidate, ...suffix);
-      if (await firstExistingDirectory([root])) return { root, revision: candidate, expected: root, reason: null };
+      if (!(await firstExistingDirectory([root]))) continue;
+      if (await directoryHasFiles(root)) return { root, revision: candidate, expected: root, reason: null };
+      empty ??= root;
     }
+  }
+  if (empty) {
+    return { root: null, revision: null, expected: empty, reason: `${EMPTY_SNAPSHOT_PREFIX}${empty}` };
   }
   return {
     root: null,
@@ -1657,6 +1671,53 @@ async function firstExistingDirectory(candidates) {
     } catch { /* absent */ }
   }
   return null;
+}
+
+/**
+ * sc-22738 (CUDA run 34272596969). The ONE spelling of "the directory is there and holds nothing".
+ *
+ * The Windows box's `E:\huggingface\hub` carried
+ * `models--SceneWorks--Mage-Flow-Base\snapshots\d642341926…\q4` as an EMPTY directory — a hub fetch
+ * that was interrupted after the snapshot tree was created and before a blob landed. Every probe in
+ * this file asked only "is it a directory", so the cell planned `runnable`, the walk booked it, and
+ * `hashArtifactInventory` then threw `artifact inventory is empty: …` out of `measureAnchor` and
+ * killed the remaining 71 cells of a multi-hour walk.
+ *
+ * An empty (or otherwise unusable) staged root is a HOST CONDITION about one cell, exactly like an
+ * absent one, so it classifies `weights_missing` with this prefix and — because the hub CLI resumes
+ * an interrupted download — is eligible for `--download-missing` on the same pass.
+ */
+export const EMPTY_SNAPSHOT_PREFIX = "snapshot present but empty: ";
+
+/**
+ * Why `tierRoot` cannot be inventoried, as the per-cell `weights_missing` reason.
+ *
+ * `hashArtifactInventory`'s own "is empty" message is rewritten into this file's one spelling so an
+ * operator reads the same phrase whether the classifier or the capture found the empty tree.
+ */
+export function inventoryUnusableReason(tierRoot, error) {
+  const message = String(error?.message ?? error ?? "unknown failure");
+  if (message.startsWith("artifact inventory is empty:")) return `${EMPTY_SNAPSHOT_PREFIX}${tierRoot}`;
+  return `artifact inventory unusable at ${tierRoot}: ${message}`.slice(0, FAILURE_REASON_LIMIT);
+}
+
+/** Whether `directory` holds at least one file at any depth. A dangling symlink counts as a file
+ *  here on purpose: it is a staging defect the inventory hash reports precisely, not an empty tree. */
+export async function directoryHasFiles(directory) {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch {
+    return false;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (await directoryHasFiles(path.join(directory, entry.name))) return true;
+    } else {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**
@@ -2047,6 +2108,37 @@ export async function classifyAnchor(key, planned, { models, backend, hubs, curr
 /** The Hugging Face CLI, newest spelling first. `hf` superseded `huggingface-cli`; both take the
  *  same `download <repo> --revision … --include … --cache-dir …` form the runbook documents. */
 export const HF_CLI_CANDIDATES = Object.freeze(["hf", "huggingface-cli"]);
+
+/**
+ * Which of [`HF_CLI_CANDIDATES`] this host can run, or `null` when it can run none (sc-22738).
+ *
+ * WHY IT IS PROBED ONCE, UP FRONT. Without this, a box with no Hugging Face CLI answered
+ * `--download-missing` with N identical per-cell `download failed: … ENOENT` lines buried in a
+ * multi-hour walk log, and the operator's only summary was a wall of `weights_missing` rows that
+ * look exactly like the ones a box legitimately does not hold. The condition is not per-cell — it
+ * is one fact about the runner — so it is stated once, loudly, and then quoted on every cell it
+ * silences.
+ *
+ * A CLI that exists but exits non-zero on `--version` still counts as present: that is a broken
+ * install, and the real download's own error is a better description of it than anything guessed
+ * here. Only ENOENT — nothing of that name on PATH — moves on to the next spelling.
+ */
+export async function firstAvailableHfCli({ clis = HF_CLI_CANDIDATES, runCommand = run, env = process.env } = {}) {
+  for (const cli of clis) {
+    try {
+      await runCommand(cli, ["--version"], { env });
+      return cli;
+    } catch (error) {
+      if (error?.code !== "ENOENT") return cli;
+    }
+  }
+  return null;
+}
+
+/** The one reason a cell carries when the runner cannot fetch at all. */
+export const DOWNLOAD_UNAVAILABLE_REASON =
+  `no Hugging Face CLI on PATH (tried ${HF_CLI_CANDIDATES.join(", ")}), so --download-missing `
+  + "fetched nothing on this runner";
 
 /** This host in the manifest's own platform vocabulary. */
 export function manifestPlatform(platform = process.platform) {
@@ -2902,6 +2994,92 @@ export async function extractSeedingNewAnchors(exec, root, log, limit = 8) {
 /** Longest failure reason a summary row carries. The ONLY bound: never a delimiter, see below. */
 export const FAILURE_REASON_LIMIT = 300;
 
+// ---------------------------------------------------------------------------------------------
+// A CONTAMINATED GPU IS A HOST CONDITION, NOT A CATALOG OF PER-CELL FAILURES (sc-22738)
+// ---------------------------------------------------------------------------------------------
+//
+// CUDA run 34272596969: pid 6308 — an orphaned `memory-candle-adapter.exe` left behind when the
+// PREVIOUS dispatch (34271044903) was cancelled; the runner's own "Cleaning up orphan processes"
+// does not reach a detached grandchild — was resident on GPU 1 from the very first cell. The
+// engine's stable-idle guard did its job and refused every peak as contaminated, so the walk spent
+// FIFTY-ONE guarded renders, roughly an hour of GPU time, producing fifty-one copies of one fact
+// about the host.
+//
+// Two separate fixes, in two places, because these are two different problems:
+//
+//   * `.github/workflows/memory-catalog-campaign.yml` → `scripts/ci/memory-catalog/gpu-preflight.sh`
+//     stops the walk from STARTING on a dirty GPU, and reaps our own orphans first.
+//   * this file stops a walk that has ALREADY started once the host proves it is contaminated.
+//
+// The guard itself is untouched: it is measurement validity — a peak sampled beside a foreign
+// process is not this model's peak — not a gate on anything shipping.
+//
+// This abort is deliberately NOT the shape of the empty-snapshot fix above. A host condition that
+// invalidates EVERY remaining cell is worth stopping for; a per-cell condition never is.
+
+/** How many consecutive contaminated captures naming the SAME process prove a contaminated HOST. */
+export const CONTAMINATION_ABORT_STREAK = 5;
+
+const CONTAMINATION_PIDS_RE = /pure compute processes \[([\d,\s]*)\]/;
+
+/** The pids an "untrustworthy stable idle baseline" reason names, or `null` for any other reason. */
+export function contaminationPids(reason) {
+  const match = CONTAMINATION_PIDS_RE.exec(String(reason ?? ""));
+  if (!match) return null;
+  const pids = match[1].split(",").map((pid) => pid.trim()).filter(Boolean).map(Number);
+  return pids.length > 0 && pids.every(Number.isInteger) ? pids : null;
+}
+
+/**
+ * The compute processes `nvidia-smi` reports on the profiled GPU, as `pid → "<name> (<memory>)"`.
+ *
+ * Queried by the RUNNER rather than named by the engine on purpose: the guard's message is
+ * `candle-gen`'s, at the pinned inference revision, and a bare pid there is useless to whoever has
+ * to go and kill it. An unavailable or unparsable `nvidia-smi` yields an empty map — the reason
+ * then reads exactly as it does today, with the pid alone.
+ */
+export async function gpuComputeProcesses({ runCommand = run, env = process.env } = {}) {
+  const byPid = new Map();
+  const device = env.CUDA_VISIBLE_DEVICES;
+  const argv = ["--query-compute-apps=pid,process_name,used_memory", "--format=csv,noheader"];
+  if (device) argv.unshift("-i", device);
+  let stdout;
+  try {
+    ({ stdout } = await runCommand("nvidia-smi", argv, { env }));
+  } catch {
+    return byPid;
+  }
+  for (const line of String(stdout).split("\n")) {
+    const [pid, name, memory] = line.split(",").map((field) => field.trim());
+    if (!/^\d+$/.test(pid ?? "")) continue;
+    byPid.set(Number(pid), memory ? `${name} (${memory})` : name);
+  }
+  return byPid;
+}
+
+/** `reason` with every pid it names annotated with that process's name, where one is known. */
+export function nameContaminatingProcesses(reason, pids, byPid) {
+  const named = pids.filter((pid) => byPid.has(pid));
+  if (named.length === 0) return reason;
+  const describe = named.map((pid) => `${pid} = ${byPid.get(pid)}`).join("; ");
+  return `${reason} [${describe}]`;
+}
+
+/** The walk-level halt a contaminated host earns once the streak is proven. */
+export function contaminatedHostHalt(pids, byPid, streak = CONTAMINATION_ABORT_STREAK) {
+  const described = pids
+    .map((pid) => (byPid.has(pid) ? `${pid} (${byPid.get(pid)})` : String(pid)))
+    .join(", ");
+  return (
+    `${streak} consecutive captures were refused for the SAME foreign compute process on the `
+    + `profiled GPU: ${described}. That is a contaminated HOST, not ${streak} model failures — `
+    + "every remaining anchor would be refused the same way and burn a guarded render doing it. "
+    + "Kill the process (a leftover memory-*-adapter from a cancelled run is the usual cause; the "
+    + "runner's orphan cleanup does not reach a detached grandchild), then re-run the walk. No "
+    + "measurement was recorded for any of the refused cells."
+  );
+}
+
 /**
  * A line the adapter wrote as INFORMATION rather than as its outcome.
  *
@@ -2989,7 +3167,18 @@ export async function measureAnchor(row, context) {
 
   const env = { ...process.env, ...row.env };
   if (row.tierRoot) {
-    const inventory = await hashArtifactInventory(row.tierRoot);
+    // sc-22738 (CUDA run 34272596969). EVERY way the inventory can refuse this root is a per-cell
+    // status. The classifier now rejects an empty tree before booking the cell, so reaching this
+    // arm means the tree changed under the walk or the inventory found something else it cannot
+    // hash (a symlink escaping the hub, an entry that resolves to a non-file). Whatever the cause,
+    // it says one thing about ONE cell — it must never be allowed to abort the walk and throw away
+    // every anchor the run has not reached yet, which is exactly what it did at cell 61 of 132.
+    let inventory;
+    try {
+      inventory = await hashArtifactInventory(row.tierRoot);
+    } catch (error) {
+      return finish("weights_missing", inventoryUnusableReason(row.tierRoot, error));
+    }
     env.SCENEWORKS_MEMORY_MODEL_BYTES = String(inventory.bytes);
     env.SCENEWORKS_MEMORY_MODEL_INVENTORY_SHA256 = inventory.sha256;
     // The same digest a hard stop's artifact binding cites, so a bound names the exact weight files
@@ -3308,8 +3497,20 @@ export async function planRun(args, root = ROOT) {
     // HF env convention and the same place the CLI would write on its own.
     const cacheRoot = hubs[0];
     process.stdout.write(`download-missing: destination hub root ${cacheRoot}\n`);
+    // sc-22738: one probe, one warning, before any cell is silenced by it. `--dry-run` prints what
+    // it WOULD fetch without running the CLI, so it is not gated on one being installed.
+    const cli = args.dryRun ? null : await firstAvailableHfCli();
+    if (!args.dryRun && !cli) {
+      process.stdout.write(
+        `::warning title=Hugging Face CLI missing::${DOWNLOAD_UNAVAILABLE_REASON}\n`,
+      );
+    }
     for (const [index, row] of rows.entries()) {
       if (row.status !== "weights_missing") continue;
+      if (!args.dryRun && !cli) {
+        row.reason = `${row.reason} (download unavailable: ${DOWNLOAD_UNAVAILABLE_REASON})`;
+        continue;
+      }
       const missingReason = row.reason;
       const outcome = await fetchAnchorSnapshots(row, models, { cacheRoot, dryRun: args.dryRun });
       if (outcome.failed) {
@@ -3396,6 +3597,8 @@ export async function main(argv = process.argv.slice(2)) {
   process.on("SIGTERM", onInterrupt);
 
   const results = [];
+  // sc-22738: the consecutive-contamination discriminator, over ATTEMPTS rather than over the run.
+  const contamination = { streak: 0, signature: null, processes: null };
   const summaryPath = path.join(args.workDir, `summary-${stamp()}.json`);
   const writeSummary = () => writeFile(summaryPath, JSON.stringify({ campaign, backend: args.backend, inferencePin, results, commits: state.commits, rows }, null, 2));
   for (const row of runnable) {
@@ -3403,6 +3606,24 @@ export async function main(argv = process.argv.slice(2)) {
     if (state.stopRequested) { results.push({ key: row.key, status: "not_started", reason: "interrupted" }); continue; }
     process.stdout.write(`\n=== ${row.key} (${results.length + 1}/${runnable.length}) ${new Date().toISOString()}\n`);
     const result = await measureAnchor(row, { args, inferencePin, campaignDir, campaignPrefix, workDir: args.workDir, state });
+    // sc-22738: name the foreign process, and stop once the host has proved itself contaminated.
+    const contaminating = contaminationPids(result.reason);
+    if (contaminating) {
+      // Queried once per contaminated STREAK, not once per cell: the process set does not change
+      // between two refusals four seconds apart, and this runs while the GPU is otherwise idle.
+      contamination.processes ??= await gpuComputeProcesses();
+      result.reason = nameContaminatingProcesses(result.reason, contaminating, contamination.processes);
+      const signature = contaminating.join(",");
+      contamination.streak = signature === contamination.signature ? contamination.streak + 1 : 1;
+      contamination.signature = signature;
+      if (contamination.streak >= CONTAMINATION_ABORT_STREAK) {
+        state.halt = contaminatedHostHalt(contaminating, contamination.processes);
+      }
+    } else {
+      contamination.streak = 0;
+      contamination.signature = null;
+      contamination.processes = null;
+    }
     results.push(result);
     process.stdout.write(`--- ${row.key}: ${result.status}${result.reason ? ` (${result.reason})` : ""} in ${result.seconds}s\n`);
     await writeSummary();

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -110,6 +110,16 @@ import {
   tierDownloadRows,
   manifestPlatform,
   HF_CLI_CANDIDATES,
+  EMPTY_SNAPSHOT_PREFIX,
+  directoryHasFiles,
+  inventoryUnusableReason,
+  firstAvailableHfCli,
+  DOWNLOAD_UNAVAILABLE_REASON,
+  CONTAMINATION_ABORT_STREAK,
+  contaminationPids,
+  gpuComputeProcesses,
+  nameContaminatingProcesses,
+  contaminatedHostHalt,
 } from "./measure-memory-catalog.mjs";
 import {
   ANCHOR_LANE_DEFAULT_STRATEGY_PATH,
@@ -272,10 +282,20 @@ async function stageQwenLightningLora(hub, file = QWEN_EDIT_LIGHTNING_LORA.file)
   await writeFile(path.join(root, file), "lora");
 }
 
-async function fakeHub(layout) {
+/**
+ * A hub whose listed roots are STAGED, not merely present.
+ *
+ * sc-22738: every root gets a weight file in it. An empty directory is now a distinct host
+ * condition (`EMPTY_SNAPSHOT_PREFIX` — the interrupted `Mage-Flow-Base/…/q4` fetch that aborted
+ * CUDA run 34272596969 at cell 61), so a fixture that models a staged snapshot has to look like
+ * one. `{ empty: true }` is how a test asks for the OTHER condition on purpose.
+ */
+async function fakeHub(layout, { empty = false } = {}) {
   const hub = await mkdtemp(path.join(tmpdir(), "catalog-hub-"));
   for (const [repo, revision, ...rest] of layout) {
-    await mkdir(snapshotPath(hub, repo, revision, ...rest), { recursive: true });
+    const root = snapshotPath(hub, repo, revision, ...rest);
+    await mkdir(root, { recursive: true });
+    if (!empty) await writeFile(path.join(root, "weights.safetensors"), "w");
   }
   return hub;
 }
@@ -5387,6 +5407,10 @@ async function stubHuggingFaceCli({ fail = false } = {}) {
       'for (const glob of includes.length > 0 ? includes : ["."]) {',
       '  const directory = glob.includes("/") ? glob.slice(0, glob.lastIndexOf("/")) : ".";',
       '  fs.mkdirSync(path.join(snapshot, directory), { recursive: true });',
+      // sc-22738: and a FILE in it. `hf download --include q4/*` materialises weights, and an
+      // empty `q4/` is now its own host condition (`EMPTY_SNAPSHOT_PREFIX`) rather than a staged
+      // root — a stub that created only the directory was asserting the wrong outcome.
+      '  fs.writeFileSync(path.join(snapshot, directory, "weights.safetensors"), "w");',
       '}',
       'fs.writeFileSync(path.join(snapshot, "config.json"), "{}");',
       // `refs/` is written exactly as the hub CLI writes it: not at all for a 40-hex revision.
@@ -5397,6 +5421,11 @@ async function stubHuggingFaceCli({ fail = false } = {}) {
     'const fs = require("node:fs");',
     'const path = require("node:path");',
     "const argv = process.argv.slice(2);",
+    // sc-22738: `firstAvailableHfCli` probes with `--version` before any fetch, so the runner can
+    // say ONCE and loudly that this box has no hub CLI instead of leaving N identical ENOENTs in a
+    // multi-hour log. A probe is not a download: it answers and is deliberately NOT logged, so the
+    // invocation assertions below still count fetches.
+    'if (argv[0] === "--version") { process.stdout.write("stub 1.0\\n"); process.exit(0); }',
     'fs.appendFileSync(process.env.STUB_HF_LOG, JSON.stringify(argv) + "\\n");',
     body,
     "",
@@ -5615,4 +5644,225 @@ test("download rows are narrowed to this host's platform, and fall back rather t
   );
   assert.deepEqual(tierDownloadRows(models, "minimax_h3", "MiniMaxAI/MiniMax-H3", "bf16", "plan9"), unfiltered);
   assert.ok(unfiltered.length > macos.length, "the fallback is wider than one platform's rows");
+});
+
+// ---------------------------------------------------------------------------------------------
+// sc-22738: the four defects CUDA campaign run 34272596969 surfaced
+// ---------------------------------------------------------------------------------------------
+
+test("an EMPTY staged snapshot is weights_missing by name, never a runnable root", async () => {
+  const models = fakeModels();
+  // The same LOCAL family literal the per-(lane, tier) test owns — a per-lane rehost with packed
+  // tiers on the candle side and the unpinned upstream Diffusers checkpoint as its bf16 leg.
+  const family = {
+    env: "WAN_TI2V_5B",
+    repo: "SceneWorks/wan2.2-ti2v-5b-mlx",
+    arms: ["mlx", "candle"],
+    artifacts: {
+      candle: {
+        q4: { repo: "SceneWorks/wan2.2-ti2v-5b-candle" },
+        q8: { repo: "SceneWorks/wan2.2-ti2v-5b-candle" },
+        bf16: { repo: "Wan-AI/Wan2.2-TI2V-5B-Diffusers", layout: "flat" },
+      },
+    },
+  };
+  const artifact = familyArtifact(family, "candle", "q4");
+
+  const staged = await fakeHub([["SceneWorks/wan2.2-ti2v-5b-candle", UPSTREAM, "q4"]]);
+  const empty = await fakeHub([["SceneWorks/wan2.2-ti2v-5b-candle", UPSTREAM, "q4"]], { empty: true });
+
+  const refused = await resolveArtifactRoot(models, "wan_2_2", "q4", artifact, [empty, staged]);
+  assert.equal(refused.root, null, "an empty tier root is never handed back as a load root");
+  assert.equal(
+    refused.reason,
+    `${EMPTY_SNAPSHOT_PREFIX}${snapshotPath(empty, "SceneWorks/wan2.2-ti2v-5b-candle", UPSTREAM, "q4")}`,
+  );
+
+  // The run that produced the defect: `…\Mage-Flow-Base\snapshots\d642…\q4` existed and held
+  // nothing, so the cell planned `runnable`, the walk booked it, and the artifact inventory threw
+  // out of `measureAnchor` and killed the remaining 71 of 132 cells.
+  assert.equal(await directoryHasFiles(snapshotPath(empty, "SceneWorks/wan2.2-ti2v-5b-candle", UPSTREAM, "q4")), false);
+  assert.equal(await directoryHasFiles(snapshotPath(staged, "SceneWorks/wan2.2-ti2v-5b-candle", UPSTREAM, "q4")), true);
+  assert.equal(await directoryHasFiles(path.join(staged, "no-such-directory")), false);
+
+  // A file at ANY depth is staged, not empty.
+  const nested = await mkdtemp(path.join(tmpdir(), "catalog-nested-"));
+  await mkdir(path.join(nested, "a", "b"), { recursive: true });
+  assert.equal(await directoryHasFiles(nested), false, "directories alone are not files");
+  await writeFile(path.join(nested, "a", "b", "w.safetensors"), "w");
+  assert.equal(await directoryHasFiles(nested), true);
+});
+
+test("an unpinned repository skips an empty staged revision, and reports one only when no other holds weights", async () => {
+  const models = fakeModels();
+  // The same LOCAL family literal the per-(lane, tier) test owns — a per-lane rehost with packed
+  // tiers on the candle side and the unpinned upstream Diffusers checkpoint as its bf16 leg.
+  const family = {
+    env: "WAN_TI2V_5B",
+    repo: "SceneWorks/wan2.2-ti2v-5b-mlx",
+    arms: ["mlx", "candle"],
+    artifacts: {
+      candle: {
+        q4: { repo: "SceneWorks/wan2.2-ti2v-5b-candle" },
+        q8: { repo: "SceneWorks/wan2.2-ti2v-5b-candle" },
+        bf16: { repo: "Wan-AI/Wan2.2-TI2V-5B-Diffusers", layout: "flat" },
+      },
+    },
+  };
+  const artifact = familyArtifact(family, "candle", "bf16");
+  assert.equal(artifact.layout, "flat", "the unpinned upstream leg is the flat one");
+
+  const both = await fakeHub([["Wan-AI/Wan2.2-TI2V-5B-Diffusers", REVISION]]);
+  await mkdir(snapshotPath(both, "Wan-AI/Wan2.2-TI2V-5B-Diffusers", UPSTREAM), { recursive: true });
+  const resolved = await resolveArtifactRoot(models, "wan_2_2", "bf16", artifact, [both]);
+  assert.equal(
+    resolved.root,
+    snapshotPath(both, "Wan-AI/Wan2.2-TI2V-5B-Diffusers", REVISION),
+    "the STAGED revision wins over the empty one, whichever order the hub lists them in",
+  );
+
+  const onlyEmpty = await fakeHub([["Wan-AI/Wan2.2-TI2V-5B-Diffusers", REVISION]], { empty: true });
+  const refused = await resolveArtifactRoot(models, "wan_2_2", "bf16", artifact, [onlyEmpty]);
+  assert.equal(refused.root, null);
+  assert.match(refused.reason, new RegExp(`^${EMPTY_SNAPSHOT_PREFIX}`));
+});
+
+test("an inventory the capture cannot hash is a per-cell weights_missing, not a thrown walk", () => {
+  // The exact message `hash-artifact-inventory.mjs` threw at cell 61 of 132, rewritten into this
+  // file's one spelling for the condition.
+  assert.equal(
+    inventoryUnusableReason("/hub/q4", new Error("artifact inventory is empty: /hub/q4")),
+    `${EMPTY_SNAPSHOT_PREFIX}/hub/q4`,
+  );
+  // Anything else the inventory refuses is still a per-cell status, quoted rather than guessed at.
+  const escaped = inventoryUnusableReason("/hub/q4", new Error("artifact inventory file escaped its trusted root: x"));
+  assert.match(escaped, /^artifact inventory unusable at \/hub\/q4: artifact inventory file escaped/);
+  assert.ok(inventoryUnusableReason("/hub/q4", new Error("x".repeat(999))).length <= FAILURE_REASON_LIMIT);
+});
+
+test("--download-missing fetches an EMPTY snapshot too: the hub CLI resumes an interrupted fetch", { skip: skipWithoutShebang }, async () => {
+  const { anchors, models } = downloadFixture();
+  const root = await fakePlanRoot(anchors, models);
+  // Both anchors' roots EXIST; z-image-turbo's holds weights, qwen's is the interrupted fetch.
+  const hub = await fakeHub([[PROVIDER_FAMILIES.z_image_turbo.repo, DOWNLOAD_REVISION, "q4"]]);
+  await mkdir(snapshotPath(hub, PROVIDER_FAMILIES.qwen_image.repo, DOWNLOAD_REVISION, "q4"), { recursive: true });
+  const stub = await stubHuggingFaceCli();
+  const args = {
+    ...parseArgs(["--backend", "mlx", "--list", "--download-missing"]),
+    campaign: "sc-dl-empty", hfCache: [hub],
+  };
+
+  const before = await planRun({ ...args, downloadMissing: false }, root);
+  const planned = before.rows.find((row) => row.key === "qwen_image:q4:mlx");
+  assert.equal(planned.status, "weights_missing", "an empty tier root is never booked as runnable");
+  assert.match(planned.reason, new RegExp(`^${EMPTY_SNAPSHOT_PREFIX}`));
+
+  const { rows } = await withStubCli(stub, () => planRun(args, root));
+  const fetched = rows.find((row) => row.key === "qwen_image:q4:mlx");
+  assert.equal(fetched.status, "runnable", fetched.reason);
+  assert.equal((await stub.invocations()).length, 1, "the already-staged anchor is never re-fetched");
+});
+
+test("with no Hugging Face CLI on PATH, --download-missing says so ONCE and on every cell it silenced", { skip: skipWithoutShebang }, async () => {
+  const { anchors, models } = downloadFixture();
+  const root = await fakePlanRoot(anchors, models);
+  const hub = await fakeHub([[PROVIDER_FAMILIES.z_image_turbo.repo, DOWNLOAD_REVISION, "q4"]]);
+  const args = {
+    ...parseArgs(["--backend", "mlx", "--list", "--download-missing"]),
+    campaign: "sc-dl-nocli", hfCache: [hub],
+  };
+
+  const emptyPath = await mkdtemp(path.join(tmpdir(), "catalog-no-cli-"));
+  const originalPath = process.env.PATH;
+  const written = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (chunk, ...rest) => { written.push(String(chunk)); return true; };
+  let rows;
+  try {
+    process.env.PATH = emptyPath;
+    assert.equal(await firstAvailableHfCli(), null);
+    ({ rows } = await planRun(args, root));
+  } finally {
+    process.env.PATH = originalPath;
+    process.stdout.write = originalWrite;
+  }
+
+  const warnings = written.filter((line) => line.includes("::warning title=Hugging Face CLI missing"));
+  assert.equal(warnings.length, 1, "stated once for the run, not once per cell");
+  assert.match(warnings[0], new RegExp(HF_CLI_CANDIDATES.join(", ")));
+
+  const silenced = rows.find((row) => row.key === "qwen_image:q4:mlx");
+  assert.equal(silenced.status, "weights_missing");
+  assert.ok(silenced.reason.includes(`(download unavailable: ${DOWNLOAD_UNAVAILABLE_REASON})`), silenced.reason);
+  assert.equal(rows.find((row) => row.key === "z_image_turbo:q4:mlx").status, "runnable");
+});
+
+test("a broken-but-present hub CLI is used anyway: only ENOENT falls through to the next spelling", async () => {
+  const tried = [];
+  const enoent = (command) => { tried.push(command); return Promise.reject(Object.assign(new Error("nope"), { code: "ENOENT" })); };
+  assert.equal(await firstAvailableHfCli({ runCommand: enoent }), null);
+  assert.deepEqual(tried, [...HF_CLI_CANDIDATES]);
+
+  // Present but exiting non-zero: its own download error describes the broken install better than
+  // anything guessed here, so it counts as available.
+  assert.equal(
+    await firstAvailableHfCli({ runCommand: () => Promise.reject(Object.assign(new Error("bad install"), { code: 1 })) }),
+    HF_CLI_CANDIDATES[0],
+  );
+  assert.equal(await firstAvailableHfCli({ runCommand: () => Promise.resolve({ stdout: "", stderr: "" }) }), HF_CLI_CANDIDATES[0]);
+});
+
+test("a contaminated GPU is named by process and aborts the walk after a streak, not cell by cell", async () => {
+  // The literal reason `candle-gen`'s stable-idle guard produced 51 times on run 34272596969.
+  const reason = "untrustworthy stable idle baseline: pure compute processes [6308] are resident on the profiled GPU; the peak is contaminated";
+  assert.deepEqual(contaminationPids(reason), [6308]);
+  assert.deepEqual(contaminationPids("pure compute processes [6308, 42] are resident"), [6308, 42]);
+  // Every OTHER failure is not this host condition and must never feed the streak.
+  assert.equal(contaminationPids("sampled GPU was not idle (baseline 1.2 GB, required < 1.0 GB); the peak is contaminated"), null);
+  assert.equal(contaminationPids("pure compute processes [] are resident"), null);
+  assert.equal(contaminationPids(null), null);
+
+  const csv = "6308, D:\\actions-runner-2\\_work\\SceneWorks\\SceneWorks\\target\\release\\memory-candle-adapter.exe, 12345 MiB\n";
+  const processes = await gpuComputeProcesses({
+    runCommand: (command, argv) => {
+      assert.equal(command, "nvidia-smi");
+      assert.ok(argv.includes("--query-compute-apps=pid,process_name,used_memory"));
+      assert.deepEqual(argv.slice(0, 2), ["-i", "1"], "the census stays on the PROFILED device");
+      return Promise.resolve({ stdout: csv, stderr: "" });
+    },
+    env: { CUDA_VISIBLE_DEVICES: "1" },
+  });
+  assert.match(processes.get(6308), /memory-candle-adapter\.exe \(12345 MiB\)/);
+
+  // A pid alone is useless to whoever has to go and kill it; the name is what makes it actionable.
+  assert.match(nameContaminatingProcesses(reason, [6308], processes), /\[6308 = .*memory-candle-adapter\.exe \(12345 MiB\)\]$/);
+  assert.equal(nameContaminatingProcesses(reason, [6308], new Map()), reason, "an unavailable census changes nothing");
+  // An unreachable nvidia-smi is not an error here — the reason simply keeps the bare pid.
+  assert.equal((await gpuComputeProcesses({ runCommand: () => Promise.reject(new Error("no nvidia-smi")) })).size, 0);
+
+  assert.ok(CONTAMINATION_ABORT_STREAK >= 2 && CONTAMINATION_ABORT_STREAK <= 10);
+  const halt = contaminatedHostHalt([6308], processes);
+  assert.match(halt, /memory-candle-adapter\.exe/);
+  assert.match(halt, new RegExp(`${CONTAMINATION_ABORT_STREAK} consecutive captures`));
+  assert.match(halt, /contaminated HOST/);
+});
+
+test("the campaign's GPU preflight step runs before the walk and only ever reaps our own binaries", async () => {
+  const workflow = await readFile(path.join(ROOT, ".github/workflows/memory-catalog-campaign.yml"), "utf8");
+  // Scoped to the CANDLE job: the mlx job above it walks with `run.sh` too, and there is no
+  // nvidia-smi on a Mac to census with.
+  const candle = workflow.slice(workflow.indexOf("\n  candle:"));
+  assert.ok(candle.includes("self-hosted, Windows, X64, cuda"), "the candle job was located");
+  const preflight = candle.indexOf("scripts/ci/memory-catalog/gpu-preflight.sh");
+  const walk = candle.indexOf("scripts/ci/memory-catalog/run.sh");
+  assert.ok(preflight > -1, "the candle job censuses the GPU before it spends an hour on a dirty one");
+  assert.ok(preflight < walk, "and it does so BEFORE the walk");
+  assert.ok(!workflow.slice(0, workflow.indexOf("\n  candle:")).includes("gpu-preflight.sh"));
+
+  const script = await readFile(path.join(ROOT, "scripts/ci/memory-catalog/gpu-preflight.sh"), "utf8");
+  assert.match(script, /--query-compute-apps=pid,process_name,used_memory/);
+  assert.match(script, /-i "\$CUDA_VISIBLE_DEVICES"/, "the census stays on the profiled device");
+  // Ours BY NAME. Never an arbitrary pid: this box serves other self-hosted lanes.
+  assert.match(script, /\*memory-candle-adapter\* \| \*memory-mlx-adapter\*/);
+  assert.match(script, /::error title=Profiled GPU is not idle/);
 });


### PR DESCRIPTION
Fixes the four defects that made CUDA campaign run
[34272596969](https://github.com/SceneWorks/SceneWorks/actions/runs/34272596969) measure **zero of
132 cells**.

## 1. An empty snapshot aborted the walk

`E:\huggingface\hub\models--SceneWorks--Mage-Flow-Base\snapshots\d642341926…\q4` existed and held
nothing — a hub fetch interrupted after the snapshot tree was created and before a blob landed.
Every probe in the runner asked only *"is it a directory"*, so the cell planned `runnable`, the walk
booked it, and `hashArtifactInventory` threw out of `measureAnchor`:

```
=== mage_flow_base:q4:candle (61/132) 2026-09-08T22:49:15.861Z
artifact inventory is empty: E:\huggingface\hub\models--SceneWorks--Mage-Flow-Base\snapshots\d642341926fcdb450c17c8fbda03759e8f731c9b\q4
walk exited with status 1
```

The remaining 71 cells were discarded.

- `resolveArtifactRoot` classifies a present-but-empty root
  `weights_missing (snapshot present but empty: <path>)`, which also makes it eligible for
  `--download-missing` — the hub CLI resumes an interrupted download.
- An **unpinned** repository *skips* an empty staged revision rather than reporting it: a second
  staged revision of the same repository may well hold the weights.
- `measureAnchor` catches **every** inventory refusal as a per-cell status. A host condition about
  one cell must never be able to end the walk.

## 2. `--download-missing` did fetch — the plumbing was sound

Reported as "never fetched", but the walk step's own 74 `download: … <n> files, <bytes> bytes` lines
are in the same log (`E:\huggingface\hub`, `DOWNLOAD_MISSING: true` in the job env, `run.sh` appends
`download_missing_args`). The 74 `would fetch` lines were the *plan* step's dry run, which is
supposed to fetch nothing. The cells still `weights_missing` afterwards are genuinely unfetchable —
hand-staged `$SCENEWORKS_INSTANTID_*` / `$SCENEWORKS_PULID_WEIGHTS` bundles, and subtrees the
upstream repository does not ship (`gemma/` beside LTX-2.3, `<tier>/text_encoder` in
Mage-Flow-Components, `transformer_ref/config.json` in MiniMax-H3) — and each already says
`(after --download-missing fetched N snapshot(s))`. `$HF_TOKEN` was empty and irrelevant: every
artifact fetched is public.

The real gap was **silence**. A box with no hub CLI answered with N identical per-cell `ENOENT`s
buried in a multi-hour log. The runner now probes `hf --version` then `huggingface-cli --version`
**once**, writes a `::warning title=Hugging Face CLI missing`, and marks each cell it silenced
`weights_missing (… download unavailable: no Hugging Face CLI on PATH …)`. A CLI that exists but
exits non-zero counts as installed — its own download error describes a broken install better.

## 3. A foreign GPU process contaminated the whole walk

51 cells `capture_failed (untrustworthy stable idle baseline: pure compute processes [6308] are
resident on the profiled GPU…)`, plus 3 `sampled GPU was not idle (baseline 1.2 GB…)`. Pid 6308 was
resident from the very first cell: an orphaned `memory-candle-adapter.exe` from the cancelled run
34271044903. The harness launches the adapter **detached** (so a Ctrl-C cannot reach it
mid-command-buffer) and the runner's *"Cleaning up orphan processes"* only reaps a step's direct
children — so an hour of GPU time produced 51 copies of one fact about the host.

**New `scripts/ci/memory-catalog/gpu-preflight.sh`**, wired into the candle job between *Build the
candle memory adapter* and *Plan the walk*:

1. `nvidia-smi -i $CUDA_VISIBLE_DEVICES --query-compute-apps=pid,process_name,used_memory --format=csv,noheader`
2. terminate anything matching `*memory-candle-adapter*` / `*memory-mlx-adapter*` — **ours, by
   name**; never an arbitrary pid, because this box also serves `windows-candle.yml` and
   `desktop-windows.yml`
3. re-census, and **fail the job** with `::error title=Profiled GPU is not idle` naming
   pid/process/memory if anything foreign remains — before 60 cells learn the same thing.

No `nvidia-smi` on PATH is a warning, not a failure.

The walk carries the other half: a contaminated reason is annotated with the process **name**
(`[6308 = …\memory-candle-adapter.exe (12345 MiB)]`, queried once per streak), and
`CONTAMINATION_ABORT_STREAK` (5) consecutive refusals naming the *same* process halt the walk with a
summary line. That is a **host**-level abort — deliberately the opposite of defect 1, where a
per-cell condition must not abort anything.

**The stable-idle guard itself is untouched.** It is measurement validity — a peak sampled beside a
foreign process is not this model's peak — not a gate on anything shipping. No new gate is
introduced here.

## 4. Illustrious env binding — a stale transcription in the adapter

Six cells failed with

```
candle-gen-sdxl pins route "illustrious_xl_v1" at c5a92a902dd4e6ee99c2a57981ecf66209905dd1
(SceneWorks/illustrious-xl-v1-mlx), but SCENEWORKS_ILLUSTRIOUS_XL_V1_REVISION names 778c3f02…
```

At pin `e34d7b46` the engine's `SDXL_ROUTES` pins `illustrious_xl_v1` at **`778c3f02…`** and
`illustrious_xl_v2` at **`672e9851…`** — exactly what `builtin.models.jsonc` ships and exactly what
the runner exported. The inference-side sc-22729 repair had landed; what had not moved was
`SdxlCandleArm::route_revision`, a **transcription** of that table into
`crates/sceneworks-memory-adapter/src/bin/candle.rs`, still holding `c5a92a90…` / `7c5c8b2b…`. The
adapter refused a drift that no longer existed, against a plan-time check
(`sdxlCandleRouteDrift`, which derives both sides) that had correctly said `runnable`.

The field is **removed**. `sdxl_candle_route_revision` reads `candle_gen_sdxl::SDXL_ROUTES` out of
the linked engine crate at the pin, and additionally refuses a route whose repository disagrees with
the one the adapter stages. Same reasoning as the sc-22736 Wan/SCAIL-2 crates: read the engine's own
envelope rather than restating it. The refusal survives, can no longer be wrong about what the
engine pins, and a future route move needs no edit here. The operator exports nothing new — the env
values were already derived from the resolved snapshot.

## Verification

| check | result |
| --- | --- |
| `node --test scripts/measure-memory-catalog.test.mjs` | 130 tests, 126 pass, 4 skipped (win32-only), 0 fail |
| `npm run check` | 896 + 2 pass, 0 fail |
| `npm run rust:check` | exit 0 |
| `npm run rust:check:candle` | exit 0 — the only configuration that compiles the candle adapter bin |
| `cargo clippy --target x86_64-unknown-linux-gnu -p sceneworks-memory-adapter --features candle --all-targets` | exit 0, no new lint |
| `shellcheck -x scripts/ci/memory-catalog/*.sh` | exit 0 |
| `actionlint` | clean apart from the pre-existing unknown `cuda` runner label |
| `gpu-preflight.sh` against a fake `nvidia-smi` | idle → 0; our orphan → reaped, 0; foreign process → `::error`, 1; no `nvidia-smi` → warning, 0 |

Eight new tests cover the empty-snapshot classification and download eligibility, the inventory
refusal, the missing-CLI warning and per-cell reason, the CLI-availability probe, the contamination
pid parse / census / naming / halt, and the workflow step ordering.

Two test fixtures changed shape: `fakeHub` and the stub `hf` now **stage a weight file** rather than
creating a bare directory. An empty tree is now a distinct host condition, so a fixture modelling a
staged snapshot has to look like one; `fakeHub(layout, { empty: true })` asks for the other
condition on purpose.

## Not fixed, pre-existing

`cargo clippy --all-targets -D warnings` on the adapter reports three `never used` dead-code
warnings — `sdxl_candle_route_fingerprint`, `candle_wan_scail2::{implements, providers}` — all
test-only helpers, all present at the base commit, none touched here. No shipped lane runs clippy
with `--all-targets` on this crate (`check-candle-build.mjs` uses `cargo check`), so this is the
designed state rather than a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
