### PR TITLE
fix(sc-22738): GPU preflight refuses only pure-compute contexts, matching the engine's idle guard

### DIFF
--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -1663,16 +1663,32 @@ reaps a step's direct children.
 `scripts/ci/memory-catalog/gpu-preflight.sh` now runs between *Build the candle memory adapter* and
 *Plan the walk*:
 
-1. `nvidia-smi -i $CUDA_VISIBLE_DEVICES --query-compute-apps=pid,process_name,used_memory
-   --format=csv,noheader`;
+1. censuses by **process type**: `nvidia-smi pmon -i $CUDA_VISIBLE_DEVICES -c 1 -s um` for the
+   `C` / `C+G` / `G` column, joined by pid to `nvidia-smi -i $CUDA_VISIBLE_DEVICES
+   --query-compute-apps=pid,process_name,used_memory --format=csv,noheader` for the full process
+   path and memory that `pmon` truncates. The whole census — graphics rows included — is printed;
 2. terminates anything matching `*memory-candle-adapter*` / `*memory-mlx-adapter*` — **ours, by
    name**. Never an arbitrary pid: this box also serves `windows-candle.yml` and
    `desktop-windows.yml`;
 3. censuses again, and **fails the job** with `::error title=Profiled GPU is not idle` naming the
-   pid, the process and its memory if anything is left. Find out whose it is before killing it.
+   pid, the process and its memory if a **pure-compute (`C`)** row is left. Find out whose it is
+   before killing it.
 
-No `nvidia-smi` on PATH is a warning, not a failure — the engine's stable-idle guard still refuses a
-contaminated peak per anchor; this step is the cheap way to find out early. **The guard itself is
+**Type, not presence (the run-34297841666 false positive).** The first spelling of this step
+censused with `--query-compute-apps` alone, which on Windows WDDM returns every process holding a
+device context. It refused twenty desktop graphics contexts — `explorer.exe`,
+`WindowsTerminal.exe`, `StartMenuExperienceHost.exe`, three pids reading `[Insufficient
+Permissions]`, all with `[N/A]` memory — on a host where the engine's own guard had flagged exactly
+one pid. The engine discriminates by type: `candle-gen/src/testkit.rs::pure_compute_pids` counts
+`C` and explicitly passes over `C+G` and `G` because *"WDDM desktop processes are reported as C+G
+even with zero SM/memory activity"*. This step asks the same question with the same command, so a
+preflight refusal and an engine refusal cannot disagree. An unreadable process name is classified by
+its type like any other row; an *unrecognised* type is warned about, never refused.
+
+No `nvidia-smi` on PATH is a warning, not a failure — and so is an `nvidia-smi` whose `pmon` will
+not run, because without the type column every desktop context reads as compute again. The engine's
+stable-idle guard still refuses a contaminated peak per anchor; this step is the cheap way to find
+out early. **The guard itself is
 untouched.** It is measurement validity — a peak sampled beside a foreign process is not this
 model's peak — not a gate on anything shipping (see FEATURE_DEVELOPMENT.md, *Gate teardown*).
 

--- a/scripts/ci/memory-catalog/gpu-preflight.sh
+++ b/scripts/ci/memory-catalog/gpu-preflight.sh
@@ -8,13 +8,28 @@
 # step's direct children; the harness launches the adapter DETACHED (deliberately — so a Ctrl-C
 # cannot reach it mid-command-buffer), so a cancelled walk can leave one holding VRAM.
 #
+# THE FALSE POSITIVE THAT FOLLOWED. The first spelling of this script censused with
+# `nvidia-smi --query-compute-apps`, which on Windows WDDM returns EVERY process holding a device
+# context — `explorer.exe`, `WindowsTerminal.exe`, `StartMenuExperienceHost.exe`, three pids whose
+# names read `[Insufficient Permissions]` — all with `[N/A]` memory. Run 34297841666 refused twenty
+# desktop graphics contexts as "foreign compute processes" and never started the walk, while the
+# engine's own guard on the very same host had flagged exactly ONE pid. The engine discriminates by
+# PROCESS TYPE, not by presence: `candle-gen/src/testkit.rs::pure_compute_pids` reads
+# `nvidia-smi pmon -i <gpu> -c 1 -s um` and refuses only rows of type `C`, explicitly passing over
+# `G` and `C+G` because "WDDM desktop processes are reported as C+G even with zero SM/memory
+# activity". This script now asks the SAME question, with the SAME command, so a preflight refusal
+# and an engine refusal cannot disagree.
+#
 # WHAT THIS DOES, IN ORDER.
-#   1. Census the compute processes on the profiled GPU.
+#   1. Census the processes on the profiled GPU by type — `pmon` for the type,
+#      `--query-compute-apps` for the full process path and memory that `pmon` truncates — and
+#      print the whole thing, graphics rows included, so a refusal is diagnosable from the log.
 #   2. Kill the ones that are OURS BY NAME — `memory-candle-adapter*` / `memory-mlx-adapter*`. Only
 #      those, and only by name: this box is shared with other self-hosted lanes and killing a pid
 #      merely because it is inconvenient would take a colleague's build down with it.
-#   3. Census again. Anything left is somebody else's, so FAIL FAST with a `::error` naming the pid,
-#      the process and its memory — before the walk spends 60 cells learning the same thing.
+#   3. Census again. Any PURE-COMPUTE (`C`) row left is somebody else's, so FAIL FAST with a
+#      `::error` naming the pid, the process and its memory — before the walk spends 60 cells
+#      learning the same thing. Graphics and `C+G` desktop contexts are reported and ignored.
 #
 # WHY THIS IS NOT A GATE. It gates no code, no merge and no measurement: it is the same claim the
 # engine's stable-idle guard makes (a peak sampled beside a foreign process is not this model's
@@ -29,23 +44,106 @@
 # shellcheck source=scripts/ci/memory-catalog/common.sh
 source "$(dirname "$0")/common.sh"
 
-# `pid, process_name, used_memory` for every compute process on the profiled GPU, or empty when
-# nvidia-smi cannot be reached. `-i $CUDA_VISIBLE_DEVICES` keeps the census on the ONE device the
-# capture profiles; without it a second card's renders would read as contamination here.
-census() {
-  local device_args=()
-  if [[ -n "${CUDA_VISIBLE_DEVICES:-}" ]]; then
-    device_args=(-i "$CUDA_VISIBLE_DEVICES")
-  fi
+# The one device the capture profiles. Without `-i` a second card's renders would read as
+# contamination here.
+device_args=()
+if [[ -n "${CUDA_VISIBLE_DEVICES:-}" ]]; then
+  device_args=(-i "$CUDA_VISIBLE_DEVICES")
+fi
+# Only a single ordinal can be matched against `pmon`'s GPU column; a list (or an unset value)
+# leaves the cross-device check to `-i` alone.
+expected_gpu=""
+if [[ "${CUDA_VISIBLE_DEVICES:-}" =~ ^[0-9]+$ ]]; then
+  expected_gpu="$CUDA_VISIBLE_DEVICES"
+fi
+
+is_windows() {
+  case "$(uname -s 2>/dev/null || echo unknown)" in
+    MINGW* | MSYS* | CYGWIN* | Windows_NT) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# `pid, process_name, used_memory` for every process nvidia-smi will name. On Linux this is
+# compute-only; on Windows WDDM it is every GPU-attached process, which is why it supplies NAMES
+# here and never the classification.
+apps_census() {
   nvidia-smi "${device_args[@]}" \
     --query-compute-apps=pid,process_name,used_memory --format=csv,noheader 2>/dev/null || true
 }
 
-# Indent a census for the job log, dropping the blank line an empty census leaves behind.
-indent() {
-  while IFS= read -r line; do
-    [[ -z "${line//[[:space:]]/}" ]] && continue
-    printf '  %s\n' "$line"
+# `pid<TAB>type<TAB>memory` per process, from the same `pmon` invocation the engine's stable-idle
+# guard uses. Column positions come from pmon's own `# gpu pid type fb ...` header rather than
+# being assumed: driver versions differ on whether `ccpm` sits between `fb` and `sm`.
+pmon_census() {
+  nvidia-smi pmon "${device_args[@]}" -c 1 -s um 2>/dev/null |
+    awk -v want="$expected_gpu" '
+      /^#/ {
+        if ($2 == "gpu") { for (i = 2; i <= NF; i++) { col[$i] = i - 1 } }
+        next
+      }
+      {
+        gi = ("gpu" in col) ? col["gpu"] : 1
+        pi = ("pid" in col) ? col["pid"] : 2
+        ti = ("type" in col) ? col["type"] : 3
+        fi = ("fb" in col) ? col["fb"] : 0
+        if ($pi !~ /^[0-9]+$/) { next }
+        if (want != "" && $gi != want) {
+          printf "MISMATCH\t%s\t%s\n", $gi, $pi
+          next
+        }
+        mem = (fi > 0 && fi <= NF && $fi ~ /^[0-9]+$/) ? ($fi " MiB") : "[N/A]"
+        printf "%s\t%s\t%s\n", $pi, $ti, mem
+      }
+    ' || true
+}
+
+# Full name and memory for a pid, from the apps census; empty when nvidia-smi would not name it.
+apps_row() {
+  local pid="$1" apps="$2"
+  printf '%s\n' "$apps" | awk -F',' -v p="$pid" '
+    {
+      gsub(/^[ \t]+|[ \t]+$/, "", $1)
+      if ($1 != p) { next }
+      name = $2; mem = $3
+      gsub(/^[ \t]+|[ \t]+$/, "", name)
+      gsub(/^[ \t]+|[ \t]+$/, "", mem)
+      printf "%s\t%s\n", name, mem
+      exit
+    }
+  '
+}
+
+# One census: `pid<TAB>type<TAB>name<TAB>memory` per row, types straight from pmon and names from
+# the apps census wherever it has one (pmon truncates `command` to a bare, clipped basename).
+census() {
+  local apps pmon pid type mem name enriched
+  apps="$(apps_census)"
+  pmon="$(pmon_census)"
+  while IFS=$'\t' read -r pid type mem; do
+    [[ -z "$pid" ]] && continue
+    if [[ "$pid" == "MISMATCH" ]]; then
+      echo "::warning title=Census returned another GPU::nvidia-smi pmon reported physical GPU ${type} (pid ${mem}) for a census scoped to GPU ${expected_gpu}; that row is ignored" >&2
+      continue
+    fi
+    name="[unnamed]"
+    enriched="$(apps_row "$pid" "$apps")"
+    if [[ -n "$enriched" ]]; then
+      name="${enriched%%$'\t'*}"
+      # The apps census is authoritative on memory too, except where it has none to give.
+      local apps_mem="${enriched#*$'\t'}"
+      [[ -n "$apps_mem" && "$apps_mem" != "[N/A]" ]] && mem="$apps_mem"
+    fi
+    printf '%s\t%s\t%s\t%s\n' "$pid" "$type" "$name" "$mem"
+  done <<< "$pmon"
+}
+
+# The census as a job-log block, dropping the blank line an empty census leaves behind.
+report() {
+  local pid type name mem
+  while IFS=$'\t' read -r pid type name mem; do
+    [[ -z "$pid" ]] && continue
+    printf '  pid %s, type %s, %s, %s\n' "$pid" "$type" "$name" "$mem"
   done
 }
 
@@ -57,17 +155,22 @@ if ! command -v nvidia-smi >/dev/null 2>&1; then
   exit 0
 fi
 
+if ! nvidia-smi pmon "${device_args[@]}" -c 1 -s um >/dev/null 2>&1; then
+  # Without pmon there is no type column, and without a type column every desktop graphics context
+  # reads as compute — the exact false positive that stopped run 34297841666. Refusing to guess is
+  # the only honest option: the engine's per-anchor guard still holds the line.
+  echo "::warning title=nvidia-smi pmon unavailable::cannot classify GPU processes by type before the walk; a contaminated device will only be caught per-anchor by the engine's stable-idle guard"
+  exit 0
+fi
+
 # ONE census, printed and then reaped from. Two calls would let the log show a process the reaping
 # loop never saw (or the reverse) whenever one exits between them.
 before="$(census)"
-echo "compute processes on GPU ${CUDA_VISIBLE_DEVICES:-<all>} before the walk:"
-indent <<< "$before"
+echo "processes on GPU ${CUDA_VISIBLE_DEVICES:-<all>} before the walk (type C is compute; C+G and G are desktop contexts the engine ignores):"
+report <<< "$before"
 
 reaped=0
-while IFS=, read -r pid name memory; do
-  pid="$(echo "$pid" | tr -d '[:space:]')"
-  name="$(echo "$name" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-  memory="$(echo "$memory" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+while IFS=$'\t' read -r pid type name memory; do
   [[ -z "$pid" ]] && continue
   # The binaries this campaign itself launches, matched on the process-name field `nvidia-smi`
   # prints (a full path on Windows, hence the `*` on both ends). Spelled as literal `case`
@@ -75,7 +178,7 @@ while IFS=, read -r pid name memory; do
   # the pattern, so a variable carrying alternatives would match a literal pipe and reap nothing.
   case "$name" in
     *memory-candle-adapter* | *memory-mlx-adapter*)
-      echo "::warning title=Reaping an orphaned adapter::pid ${pid} (${name}, ${memory}) is one of this campaign's own binaries left over from an earlier run; terminating it before the walk"
+      echo "::warning title=Reaping an orphaned adapter::pid ${pid} (type ${type}, ${name}, ${memory}) is one of this campaign's own binaries left over from an earlier run; terminating it before the walk"
       if command -v powershell >/dev/null 2>&1; then
         powershell -NoProfile -Command "Stop-Process -Id ${pid} -Force -ErrorAction SilentlyContinue" || true
       else
@@ -97,13 +200,41 @@ fi
 
 remaining="$(census)"
 if [[ -n "$(echo "$remaining" | tr -d '[:space:]')" ]]; then
-  echo "compute processes still on GPU ${CUDA_VISIBLE_DEVICES:-<all>}:"
-  indent <<< "$remaining"
-  while IFS= read -r line; do
-    [[ -z "$(echo "$line" | tr -d '[:space:]')" ]] && continue
-    echo "::error title=Profiled GPU is not idle::${line} is resident on GPU ${CUDA_VISIBLE_DEVICES:-<all>}. Every capture's stable-idle baseline would be contaminated and every anchor would be refused, so the walk is not started. This process is not one of this campaign's binaries -- find out whose it is before killing it."
-  done <<< "$remaining"
+  echo "processes still on GPU ${CUDA_VISIBLE_DEVICES:-<all>}:"
+  report <<< "$remaining"
+fi
+
+# Only what the engine would refuse. `pure_compute_pids` counts type `C`, passes over `C+G` and
+# `G`, and errors on anything else; an unrecognised type is warned about here rather than refused,
+# because a census oddity is not evidence of a busy GPU and stopping the walk on one would be the
+# false positive this script exists to stop making.
+foreign=0
+while IFS=$'\t' read -r pid type name memory; do
+  [[ -z "$pid" ]] && continue
+  case "$type" in
+    C)
+      case "$name" in
+        *memory-candle-adapter* | *memory-mlx-adapter*)
+          echo "::error title=Our own adapter survived the reap::pid ${pid} (${name}, ${memory}) is one of this campaign's binaries and is STILL resident after the reap; the walk is not started."
+          ;;
+        *)
+          echo "::error title=Profiled GPU is not idle::pid ${pid} (${name}, ${memory}) is a pure-compute process on GPU ${CUDA_VISIBLE_DEVICES:-<all>}. Every capture's stable-idle baseline would be contaminated and every anchor would be refused, so the walk is not started. This process is not one of this campaign's binaries -- find out whose it is before killing it."
+          ;;
+      esac
+      foreign=$(( foreign + 1 ))
+      ;;
+    "C+G" | G)
+      # A WDDM desktop context. It holds a device context and no compute work; the engine's stable
+      # baseline absorbs its fixed residency.
+      ;;
+    *)
+      echo "::warning title=Unrecognised GPU process type::pid ${pid} (${name}, ${memory}) has nvidia-smi process type '${type}', which the engine's stable-idle guard does not recognise; it is not counted as contamination here"
+      ;;
+  esac
+done <<< "$remaining"
+
+if (( foreign > 0 )); then
   exit 1
 fi
 
-echo "profiled GPU is idle; starting the walk"
+echo "profiled GPU carries no foreign compute process; starting the walk"

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -5865,4 +5865,130 @@ test("the campaign's GPU preflight step runs before the walk and only ever reaps
   // Ours BY NAME. Never an arbitrary pid: this box serves other self-hosted lanes.
   assert.match(script, /\*memory-candle-adapter\* \| \*memory-mlx-adapter\*/);
   assert.match(script, /::error title=Profiled GPU is not idle/);
+  // The classification the engine makes: type C is contamination, C+G and G are desktop contexts.
+  assert.match(script, /nvidia-smi pmon "\$\{device_args\[@\]\}" -c 1 -s um/);
+});
+
+// A fake `nvidia-smi` on PATH, plus the two externals the reap path shells out to. `sleep` and
+// `powershell` are real executables (not builtins), so PATH shadowing reaches them; that is what
+// lets a reap be observed here without waiting out the driver-settle sleep or killing anything.
+async function fakeGpuHost({ pmon, apps, pmonAfterReap, appsAfterReap }) {
+  const bin = await mkdtemp(path.join(tmpdir(), "catalog-gpu-preflight-"));
+  const reaped = path.join(bin, "reaped");
+  const emit = (text) => `cat <<'CENSUS'\n${text}\nCENSUS\nexit 0\n`;
+  // `before` until the fake `powershell` records a kill, `after` from then on — that is how a reap
+  // becomes observable without signalling any real process.
+  const stage = (before, after) =>
+    after === undefined ? emit(before) : `if [ -e ${JSON.stringify(reaped)} ]; then\n${emit(after)}fi\n${emit(before)}`;
+  await writeFile(
+    path.join(bin, "nvidia-smi"),
+    `#!/usr/bin/env bash\nif [ "$1" = "pmon" ]; then\n${stage(pmon, pmonAfterReap)}fi\n${stage(apps, appsAfterReap)}`,
+    { mode: 0o755 },
+  );
+  await writeFile(path.join(bin, "sleep"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+  await writeFile(
+    path.join(bin, "powershell"),
+    `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> ${JSON.stringify(path.join(bin, "killed"))}\ntouch ${JSON.stringify(reaped)}\nexit 0\n`,
+    { mode: 0o755 },
+  );
+  return { bin, killedLog: path.join(bin, "killed") };
+}
+
+async function runGpuPreflight(host) {
+  const env = { ...process.env, PATH: `${host.bin}:${process.env.PATH}`, CUDA_VISIBLE_DEVICES: "1" };
+  try {
+    const { stdout } = await execFileAsync("bash", ["scripts/ci/memory-catalog/gpu-preflight.sh"], { cwd: ROOT, env });
+    return { code: 0, stdout };
+  } catch (error) {
+    return { code: error.code ?? 1, stdout: error.stdout ?? "" };
+  }
+}
+
+const PMON_HEADER = [
+  "# gpu        pid  type     fb   ccpm    sm   mem   enc   dec   command",
+  "# Idx          #   C/G     MB     MB     %     %     %     %   name",
+].join("\n");
+
+// The literal desktop census run 34297841666 refused: WDDM reports explorer and friends as C+G
+// with `[N/A]` memory, and `--query-compute-apps` lists every one of them.
+const WDDM_DESKTOP_PMON = [
+  PMON_HEADER,
+  "    1      13116   C+G      -      -     -     -     -     -   explorer.exe",
+  "    1      13608   C+G      -      -     -     -     -     -   WindowsTerminal",
+  "    1      24484     G      -      -     -     -     -     -   ShellExperienceH",
+].join("\n");
+const WDDM_DESKTOP_APPS = [
+  "13116, C:\\Windows\\explorer.exe, [N/A]",
+  "13608, C:\\Program Files\\WindowsApps\\WindowsTerminal.exe, [N/A]",
+  "24484, C:\\Windows\\SystemApps\\ShellExperienceHost.exe, [N/A]",
+].join("\n");
+
+test("the GPU preflight passes a WDDM desktop census: graphics contexts are not compute", async () => {
+  const host = await fakeGpuHost({ pmon: WDDM_DESKTOP_PMON, apps: WDDM_DESKTOP_APPS });
+  const { code, stdout } = await runGpuPreflight(host);
+  assert.equal(code, 0, stdout);
+  // Every row is still printed, so a refusal that DOES happen is diagnosable from the log.
+  assert.match(stdout, /pid 13116, type C\+G, C:\\Windows\\explorer\.exe/);
+  assert.match(stdout, /pid 24484, type G, /);
+  assert.doesNotMatch(stdout, /::error/);
+  assert.match(stdout, /no foreign compute process/);
+});
+
+test("the GPU preflight refuses a foreign PURE-COMPUTE process, naming only that one", async () => {
+  const host = await fakeGpuHost({
+    pmon: [WDDM_DESKTOP_PMON, "    1       6308     C   1024      -     0     0     -     -   sceneworks-api."].join("\n"),
+    apps: [WDDM_DESKTOP_APPS, "6308, C:\\Users\\Michael\\AppData\\Local\\Programs\\SceneWorks\\sceneworks-api.exe, [N/A]"].join("\n"),
+  });
+  const { code, stdout } = await runGpuPreflight(host);
+  assert.equal(code, 1);
+  assert.match(stdout, /::error title=Profiled GPU is not idle::pid 6308 \(C:\\Users\\Michael.*sceneworks-api\.exe, 1024 MiB\)/);
+  // The twenty desktop contexts beside it are NOT errors — that was the false positive.
+  assert.equal(stdout.match(/::error/g).length, 1);
+});
+
+test("the GPU preflight reaps OUR orphaned adapter and then starts the walk", async () => {
+  const orphan = "D:\\actions-runner\\_work\\SceneWorks\\SceneWorks\\target\\release\\memory-candle-adapter.exe";
+  const host = await fakeGpuHost({
+    pmon: [WDDM_DESKTOP_PMON, "    1       6308     C  12345      -    97    41     -     -   memory-candle-a"].join("\n"),
+    apps: [WDDM_DESKTOP_APPS, `6308, ${orphan}, 12345 MiB`].join("\n"),
+    pmonAfterReap: WDDM_DESKTOP_PMON,
+    appsAfterReap: WDDM_DESKTOP_APPS,
+  });
+  const { code, stdout } = await runGpuPreflight(host);
+  assert.equal(code, 0, stdout);
+  assert.match(stdout, /::warning title=Reaping an orphaned adapter::pid 6308 \(type C, .*memory-candle-adapter\.exe, 12345 MiB\)/);
+  assert.match(await readFile(host.killedLog, "utf8"), /Stop-Process -Id 6308 -Force/);
+  assert.match(stdout, /no foreign compute process/);
+});
+
+test("the GPU preflight classifies [Insufficient Permissions] rows by TYPE, never by name", async () => {
+  // Three of the pids run 34297841666 refused had no readable name. Two are desktop contexts and
+  // one is compute; only the compute one is contamination.
+  const host = await fakeGpuHost({
+    pmon: [
+      PMON_HEADER,
+      "    1       3168   C+G      -      -     -     -     -     -   -",
+      "    1       3160     G      -      -     -     -     -     -   -",
+      "    1       6732     C    512      -     3     1     -     -   -",
+    ].join("\n"),
+    apps: [
+      "3168, [Insufficient Permissions], [N/A]",
+      "3160, [Insufficient Permissions], [N/A]",
+      "6732, [Insufficient Permissions], [N/A]",
+    ].join("\n"),
+  });
+  const { code, stdout } = await runGpuPreflight(host);
+  assert.equal(code, 1);
+  assert.match(stdout, /pid 3168, type C\+G, \[Insufficient Permissions\]/);
+  assert.match(stdout, /::error title=Profiled GPU is not idle::pid 6732 \(\[Insufficient Permissions\], 512 MiB\)/);
+  assert.equal(stdout.match(/::error/g).length, 1);
+
+  // The same three rows with NO compute row among them pass, unreadable names and all.
+  const graphicsOnly = await fakeGpuHost({
+    pmon: [PMON_HEADER, "    1       3168   C+G      -      -     -     -     -     -   -", "    1       3160     G      -      -     -     -     -     -   -"].join("\n"),
+    apps: ["3168, [Insufficient Permissions], [N/A]", "3160, [Insufficient Permissions], [N/A]"].join("\n"),
+  });
+  const pass = await runGpuPreflight(graphicsOnly);
+  assert.equal(pass.code, 0, pass.stdout);
+  assert.doesNotMatch(pass.stdout, /::error/);
 });


### PR DESCRIPTION
## The false positive

Run [34297841666](https://github.com/SceneWorks/SceneWorks/actions/runs/34297841666) failed at *Census the profiled GPU* and never started the walk. `scripts/ci/memory-catalog/gpu-preflight.sh` (added by #2794) censused with `nvidia-smi --query-compute-apps`, which on Windows WDDM returns **every** process holding a device context. It refused twenty desktop graphics contexts as "foreign compute processes":

```
3168, [Insufficient Permissions], [N/A]
13608, ...WindowsTerminal.exe, [N/A]
13116, C:\Windows\explorer.exe, [N/A]
15144, ...StartMenuExperienceHost.exe, [N/A]
```

On the same host, the engine's own idle-baseline guard had flagged exactly **one** pid (6308) in run 34272596969, because it discriminates by process **type**, not by presence.

## What the engine actually does

`inference/crates/media/candle-gen/candle-gen/src/testkit.rs`:

- **L768** — `nvidia-smi pmon -i <gpu> -c 1 -s um`
- **L626–662** — `pure_compute_pids()` counts rows of type `C` and explicitly passes over `C+G` and `G`: *"WDDM desktop processes are reported as C+G even with zero SM/memory activity. Their fixed device-level residency is handled by the stable baseline below."*
- **L679–684** — only a non-empty pure-compute set produces *"pure compute processes […] are resident on the profiled GPU"*.

## The fix

The preflight now asks the same question with the same command, so a preflight refusal and an engine refusal cannot disagree:

- `pmon` supplies the **type**, with column positions read from pmon's own `# gpu pid type fb …` header rather than assumed (drivers differ on whether `ccpm` sits between `fb` and `sm`);
- `--query-compute-apps` supplies the **full process path and memory** that pmon's `command` column truncates; the two are joined by pid;
- the **whole census is printed** — `pid, type, name, memory`, graphics rows included — so a refusal is diagnosable from the job log without a re-run;
- **only type `C`** rows that are not this campaign's own binaries fail the job. `C+G` and `G` are reported and ignored. `[Insufficient Permissions]` names are classified by type like any other row. An *unrecognised* type warns rather than refuses — a census oddity is not evidence of a busy GPU;
- an `nvidia-smi` whose `pmon` will not run is a **warning and a pass**, like an absent `nvidia-smi`: without the type column every desktop context reads as compute again, and the engine's per-anchor guard still holds the line.

Reap-by-name of our own orphans (`*memory-candle-adapter*` / `*memory-mlx-adapter*`, via `Stop-Process` by pid) and the fail-fast are unchanged in intent — the fail-fast now fires only on what the engine would refuse. Still no gate: same claim as the engine's stable-idle guard, made once at the top instead of once per anchor.

On the run-34297841666 census this leaves exactly one error — pid 6308, `sceneworks-api.exe`, a genuine pure-compute contaminant — instead of twenty.

## Evidence

Four fake-`nvidia-smi` smoke tests in `scripts/measure-memory-catalog.test.mjs` drive the real script end to end (a fake `sleep` and `powershell` on PATH make the reap observable without signalling anything):

| case | expectation |
| --- | --- |
| WDDM desktop census (`C+G` / `G` only) | passes, every row still printed |
| desktop + one foreign type-`C` | fails naming **only** pid 6308 (`::error` count is 1) |
| our own type-`C` orphan | `Stop-Process -Id 6308 -Force`, re-census clean, passes |
| `[Insufficient Permissions]` on graphics rows | passes; the same name on a type-`C` row still fails |

- `node --test scripts/measure-memory-catalog.test.mjs` — 130 pass, 4 skipped, 0 fail.
- Mutation: making the `C+G | G` branch count as contamination reds three of the four new tests.
- `shellcheck -x scripts/ci/memory-catalog/gpu-preflight.sh` — clean.
- `docs/calibration-runbook.md` updated with the type-not-presence rule and the pmon-unavailable fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
