### PR TITLE
fix(sc-22738): qwen_image candle cells plan the pinned v2 fingerprint; a partial shard mirror is weights_missing, not runnable

### DIFF
--- a/config/memory-calibration-plan.json
+++ b/config/memory-calibration-plan.json
@@ -1934,7 +1934,7 @@
       },
       "evidenceScope": "authoritative",
       "loadShape": "deferred_materialization",
-      "calibrationFingerprint": "qwen-image-cuda-staged-tiled-decode-bounded-attention-device-format-blocks-v1",
+      "calibrationFingerprint": "qwen-image-cuda-staged-tiled-decode-bounded-attention-device-format-blocks-v2",
       "fixture": "qwen-image-candle-bf16-seed15817-step2"
     },
     "qwen_image:bf16:mlx": {
@@ -1965,7 +1965,7 @@
       },
       "evidenceScope": "authoritative",
       "loadShape": "deferred_materialization",
-      "calibrationFingerprint": "qwen-image-cuda-staged-tiled-decode-bounded-attention-device-format-blocks-v1",
+      "calibrationFingerprint": "qwen-image-cuda-staged-tiled-decode-bounded-attention-device-format-blocks-v2",
       "fixture": "qwen-image-candle-q4-seed15817-step2"
     },
     "qwen_image:q4:mlx": {
@@ -1996,7 +1996,7 @@
       },
       "evidenceScope": "authoritative",
       "loadShape": "deferred_materialization",
-      "calibrationFingerprint": "qwen-image-cuda-staged-tiled-decode-bounded-attention-device-format-blocks-v1",
+      "calibrationFingerprint": "qwen-image-cuda-staged-tiled-decode-bounded-attention-device-format-blocks-v2",
       "fixture": "qwen-image-candle-q8-seed15817-step2"
     },
     "qwen_image:q8:mlx": {

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -1720,6 +1720,63 @@ export async function directoryHasFiles(directory) {
   return false;
 }
 
+/** A sharded safetensors component's index (`model.safetensors.index.json`, or Kolors' upstream
+ *  `model.safetensors.index.fp16.json`): its `weight_map` names every shard the loader opens. */
+export const SAFETENSORS_INDEX_PATTERN = /\.safetensors\.index(?:\.[^.]+)?\.json$/;
+
+/**
+ * The shards a tier root's own safetensors indexes name but the root does not hold, as paths
+ * relative to `tierRoot` (sc-22738).
+ *
+ * A PRESENT tier root is not a complete one, and [`directoryHasFiles`] cannot tell them apart. CUDA
+ * campaign run 34356681566 lost `qwen_image:bf16:candle` to `text encoder contract mismatch …
+ * field architecture_header expected qwen2_5_vl_text` against a `bf16/text_encoder` whose pinned
+ * revision is byte-identical to the q4/q8 one that the same contract accepted for
+ * `qwen_image_edit_2511` on the same box — the only artifact that fails that signature is one with
+ * no `model.layers.0.*` tensors, i.e. a partial shard set. Every sharded component ships the
+ * inventory the engine will open, so an index naming an absent shard is `weights_missing` — named
+ * shard by shard, like every other incomplete mirror this file classifies — and, because the hub CLI
+ * resumes a partial download, `--download-missing` repairs it on the same pass instead of booking a
+ * capture that dies inside the engine's contract. An unreadable index is reported the same way: a
+ * truncated JSON is itself the incomplete mirror. Dot-directories are skipped as the engine's own
+ * walkers skip them (`gen_core::weightsmeta::is_hidden_file`).
+ */
+export async function missingIndexedShards(tierRoot) {
+  const missing = [];
+  const visit = async (dir) => {
+    let entries;
+    try { entries = await readdir(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      if (entry.name.startsWith(".")) continue;
+      const child = path.join(dir, entry.name);
+      if (entry.isDirectory()) { await visit(child); continue; }
+      if (!SAFETENSORS_INDEX_PATTERN.test(entry.name)) continue;
+      const relativeIndex = path.relative(tierRoot, child);
+      let weightMap;
+      try {
+        weightMap = JSON.parse(await readFile(child, "utf8")).weight_map;
+      } catch (error) {
+        missing.push(`${relativeIndex} (unreadable: ${String(error?.message ?? error)})`);
+        continue;
+      }
+      if (!weightMap || typeof weightMap !== "object") {
+        missing.push(`${relativeIndex} (no weight_map)`);
+        continue;
+      }
+      for (const shard of [...new Set(Object.values(weightMap))].sort()) {
+        if (typeof shard !== "string") continue;
+        const candidate = path.join(dir, shard);
+        try {
+          if ((await stat(candidate)).isFile()) continue;
+        } catch { /* absent or a dangling blob symlink: named below */ }
+        missing.push(path.relative(tierRoot, candidate));
+      }
+    }
+  };
+  await visit(tierRoot);
+  return missing;
+}
+
 /**
  * Decide what the run can do with one plan anchor: which adapter arm serves it, which weights
  * root it loads, and why it would be skipped. Pure apart from the directory probes.
@@ -1886,6 +1943,15 @@ export async function classifyAnchor(key, planned, { models, backend, hubs, curr
     return {
       ...row, status: "weights_missing",
       reason: `tier root ${resolved.root} is missing ${missingTierFiles.join(", ")}, which the engine requires before it will publish this cell's calibration identity`,
+    };
+  }
+  // sc-22738: a sharded component whose own index names a shard the root does not hold is a partial
+  // mirror the engine's contract will refuse hours later (see `missingIndexedShards`).
+  const missingShards = await missingIndexedShards(tierRoot);
+  if (missingShards.length > 0) {
+    return {
+      ...row, status: "weights_missing",
+      reason: `tier root ${tierRoot} is missing ${missingShards.join(", ")}, which its own safetensors shard index names beside it; the mirror is partial and --download-missing resumes it`,
     };
   }
   if (family.bundle) {

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -113,6 +113,8 @@ import {
   HF_CLI_CANDIDATES,
   EMPTY_SNAPSHOT_PREFIX,
   directoryHasFiles,
+  missingIndexedShards,
+  SAFETENSORS_INDEX_PATTERN,
   inventoryUnusableReason,
   firstAvailableHfCli,
   DOWNLOAD_UNAVAILABLE_REASON,
@@ -463,6 +465,56 @@ test("classification: runnable anchors carry the adapter env family and the cano
   const missingTier = await classifyAnchor("qwen_image:q8:mlx", { provider: "qwen_image" }, context);
   assert.equal(missingTier.status, "weights_missing");
   assert.match(missingTier.reason, /q8 on this host/);
+});
+
+// sc-22738. CUDA campaign run 34356681566 lost `qwen_image:bf16:candle` to `text encoder contract
+// mismatch … field architecture_header expected qwen2_5_vl_text` against a `bf16/text_encoder`
+// whose pinned revision is byte-identical to the one the same contract accepted for
+// `qwen_image_edit_2511` on the same box: a partial shard set (no `model-00001-of-00004`, so no
+// `model.layers.0.*`) is the only artifact that fails that signature, and `--list` had called the
+// cell runnable because the tier-root probe asks only whether the directory holds a file. A sharded
+// component's own index names the shards the engine will open, so an index naming an absent shard
+// is `weights_missing` — named shard by shard — and eligible for the resuming `--download-missing`.
+test("classification: a tier root whose safetensors index names an absent shard is weights_missing, not runnable", async () => {
+  const hub = await fakeHub([["SceneWorks/qwen-image-mlx", REVISION, "q4"]]);
+  const tierRoot = snapshotPath(hub, "SceneWorks/qwen-image-mlx", REVISION, "q4");
+  const textEncoder = path.join(tierRoot, "text_encoder");
+  await mkdir(textEncoder, { recursive: true });
+  await writeFile(path.join(textEncoder, "model.safetensors.index.json"), JSON.stringify({
+    metadata: { total_size: 2 },
+    weight_map: {
+      "model.embed_tokens.weight": "model-00001-of-00002.safetensors",
+      "model.layers.0.self_attn.q_proj.bias": "model-00001-of-00002.safetensors",
+      "model.norm.weight": "model-00002-of-00002.safetensors",
+    },
+  }));
+  await writeFile(path.join(textEncoder, "model-00002-of-00002.safetensors"), "w");
+  // Kolors' upstream index spelling is a shard index too; a derived dot-directory is not walked.
+  await writeFile(path.join(tierRoot, "model.safetensors.index.fp16.json"), "");
+  assert.equal(SAFETENSORS_INDEX_PATTERN.test("model.safetensors.index.fp16.json"), true);
+  assert.equal(SAFETENSORS_INDEX_PATTERN.test("model.safetensors"), false);
+  assert.equal(SAFETENSORS_INDEX_PATTERN.test("config.json"), false);
+  const cache = path.join(textEncoder, ".candle-device-format-v1");
+  await mkdir(cache, { recursive: true });
+  await writeFile(path.join(cache, "model.safetensors.index.json"), JSON.stringify({ weight_map: { x: "gone.safetensors" } }));
+
+  assert.deepEqual(await missingIndexedShards(tierRoot), [
+    "model.safetensors.index.fp16.json (unreadable: Unexpected end of JSON input)",
+    path.join("text_encoder", "model-00001-of-00002.safetensors"),
+  ]);
+
+  const context = { models: fakeModels(), backend: "mlx", hubs: [hub], current: new Map(), captured: new Map() };
+  const partial = await classifyAnchor("qwen_image:q4:mlx", { provider: "qwen_image" }, context);
+  assert.equal(partial.status, "weights_missing");
+  assert.match(partial.reason, /is missing model\.safetensors\.index\.fp16\.json \(unreadable: .*\), text_encoder[\\/]model-00001-of-00002\.safetensors, which its own safetensors shard index names beside it; the mirror is partial and --download-missing resumes it$/);
+
+  // Complete the mirror and the same root is runnable again: the probe is derived from the
+  // artifact's own inventory, not a per-family declaration.
+  await writeFile(path.join(textEncoder, "model-00001-of-00002.safetensors"), "w");
+  await writeFile(path.join(tierRoot, "model.safetensors.index.fp16.json"), JSON.stringify({ weight_map: {} }));
+  assert.deepEqual(await missingIndexedShards(tierRoot), []);
+  const complete = await classifyAnchor("qwen_image:q4:mlx", { provider: "qwen_image" }, context);
+  assert.equal(complete.status, "runnable", complete.reason);
 });
 
 // sc-22738. The campaign lost a booked `minimax_h3:bf16:mlx` capture to


### PR DESCRIPTION
## Summary

Epic sc-22723 / sc-22738 follow-through on CUDA campaign run 34356681566 (feature afa67a3d8, pin e34d7b46a). Two SceneWorks-side defects behind the `qwen_image` candle refusals; the kolors / ideogram refusals in the same run are inference-side and are written up in the diagnosis below (no SceneWorks change can fix them).

### 1. `qwen_image:{bf16,q4,q8}:candle` planned a stale calibration fingerprint

`config/memory-calibration-plan.json` carried `…-device-format-blocks-v1` for the three txt2img candle cells while the pinned `candle-gen-qwen-image` publishes `-v2` (`crates/media/candle-gen/candle-gen-qwen-image/src/memory_strategy.rs:31-32`). sc-22728 (d8fc4523d) moved the six edit cells to v2 and left these three behind, so `candle.rs` refused each with `plan/provider calibration mismatch: plan=…-v1, pinned provider=…-v2` before any load. Three-line plan fix.

### 2. `qwen_image:bf16:candle` — a partial shard mirror classified as runnable

The engine refused `…\qwen-image-mlx\snapshots\8080a417…\bf16\text_encoder` with `field architecture_header expected qwen2_5_vl_text`. That artifact is provably correct: at HF revision 8080a417 `bf16/text_encoder` and `q4/text_encoder` are the same four LFS blobs (d725335e…, b1830db6…, 09c1807c…, 5dd06833…), the TE has been untouched since the 2026-06-30 folder uploads, its index names `model.layers.0.self_attn.{q,k,v}_proj.bias` (qk_bias, no qk_norm) under prefix `model` — exactly the `qwen2_5_vl_text` signature `encoder_contract.rs:3048-3078` checks — and the byte-identical TE in `qwen-image-edit-2511-mlx` passed the same contract on the same box (edit_2511 ×3 committed). The only artifact that fails that signature is one with no `model.layers.0.*` headers, i.e. `model-00001-of-00004.safetensors` absent from the box's mirror (quantization evidence is vacuous on an empty layer-0 set, so the signature check is the first to notice). `resolveArtifactRoot` called the cell runnable because `directoryHasFiles` asks only whether the tier root holds a file, and `--download-missing` touches only `weights_missing` rows.

`missingIndexedShards` now reads every sharded component's own `*.safetensors.index*.json` under the tier root (Kolors' upstream `model.safetensors.index.fp16.json` spelling included; dot-directories skipped like `gen_core::weightsmeta::is_hidden_file`) and classifies an index naming an absent or unreadable shard as `weights_missing`, named shard by shard, so the resuming `--download-missing` repairs the mirror on the same pass. Test covers the partial → missing → complete → runnable round trip through `classifyAnchor`.

## Diagnosis of the inference-side classes (no SceneWorks change possible)

**kolors ×3 — shipped production defect on the candle lane.** `SceneWorks/kolors-mlx@aadbd49f` (the manifest's only kolors download and `engines.rs:382` `default_repo`) ships the upstream Kwai fp16 shards as its `bf16` tier: `bf16/text_encoder/model.fp16-0000{1,2,3}-of-00003.safetensors` are 200/200 F16 tensors, `bf16/unet` is 1682/1682 F16, and the packed q4/q8 `text_encoder/model.safetensors` keep 88 non-packed tensors (`embedding.word_embeddings.weight`, norms) in F16. `candle-gen-kolors/src/memory_strategy.rs:1121-1126` refuses any dense tensor that is not BF16 and `:1194-1199` refuses any non-packed tensor that is not BF16; `physical_tier` (`:1206`) is called from `KolorsLoadSeal::capture` (`:102`) and `sealed_contract` (`:635`), which `lib.rs:300` `load()` invokes unconditionally whenever the root exists, and the IP/control providers go through the same `capture` (`:166`, `:186`). The pipeline itself loads every component at F32 through `mmap_var_builder`/`load_sorted_mmap` (`pipeline.rs:293,379`), so F16 storage was never a loader problem — the predicate is stricter than the loader, and its fixtures (`:2092` writes BF16 only) never saw the real artifact. **Every candle Kolors route (base, IP-Adapter, control) is refused on CUDA at pin e34d7b46a; the manifest's `candle.measured: true` numbers predate the predicate (landed via inference PR #934, feature/sc-22657, 2026-09-03).** Fix (inference): in `inspect_component_tier` accept `Dtype::F16 | Dtype::BF16` for the dense-tier check and for non-packed tensors of a packed tier (the packed triple's `.scales/.biases` stay BF16 as the converter writes them); the numeric identity stays `Precision::Bf16` as the comment at `:1213-1216` already argues; add a fixture writing F16 shards named `model.fp16-*`.

**ideogram_4 ×3 — shipped production defect on the candle lane.** `bf16/vae/model.safetensors` (SceneWorks/ideogram-4@2e8fb610) holds 250 BF16 tensors plus `bn.num_batches_tracked` I64 `[]`; the packed rehost's `vae` holds the same counter as I32. `candle-gen-ideogram/src/memory_strategy.rs:855-865` `f32_projection` rejects any non-floating header, and `IdeogramLoadReceipt::capture` (`:228-231`) maps every VAE file through it; `lib.rs:353-370` makes a capture error fatal outside `cfg(test)`. The counter is a PyTorch BatchNorm buffer the shared `Flux2Vae` never loads (`candle-gen-flux2/tests/preview_real_weights.rs:98-100` documents `VAE_UNUSED_COUNTER`), and `candle-gen-flux2/src/memory_strategy.rs:415-427` already accepts I32/I64 in its projection. Fix (inference): `f32_projection` should skip or zero-price integer scalars (`I32 | I64` with rank 0), or accept the same dtype set flux2 does; the fixture at `:2281` should carry the counter.

**ideogram_4_turbo ×3 — loader expectation drift, production affected.** `memory_strategy.rs:186-192` refuses a turbo root that contains `unconditional_transformer/`, but the loader's own pinned revisions (`:29-32`, `a3095855`/`2e8fb610`) ship `turbo_lora.safetensors` AND `unconditional_transformer/` side by side in every tier (HF tree verified; local mirror identical), the manifest downloads `<tier>/*` for both ids, and the worker resolves both ids to the same tier root (`image_jobs/base.rs:2048-2053`). The fixture at `:2253-2290` invents a disjoint layout (turbo root without `unconditional_transformer/`) that no shipped revision ever had. Fix (inference): drop the `:188-192` refusal; keep `uncond_paths` empty for turbo so the receipt prices nothing for it (the turbo route never loads it), and update `fixture_root` to write both artifacts under one root.

## Verification

- `node --test scripts/measure-memory-catalog.test.mjs` — 137 tests, 0 fail (new test included)
- `node scripts/extract-memory-anchors.mjs --check` — exit 0
- `node scripts/generate-memory-matrix.mjs --check` — exit 0, no rewrite
- `npm run check > f; echo $?` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
