### PR TITLE
fix(sc-22738): candle arms perform the engine handshake, derive Mage tier floors, open the MiniMax scope, read Bernini's contract like the worker

### DIFF
--- a/crates/sceneworks-memory-adapter/src/bin/candle.rs
+++ b/crates/sceneworks-memory-adapter/src/bin/candle.rs
@@ -3,11 +3,12 @@ compile_error!("memory-candle-adapter is supported only on CUDA hosts");
 
 use candle_gen::testkit::{StableIdleConfig, VramProbe};
 use runtime_cuda::gen_core::{
-    adapter_stack_identity, AdapterKind, AdapterSpec, Capabilities, Conditioning, GenerationMemory,
-    GenerationOutput, GenerationRequest, Image, LoadShape, LoadSpec, MemoryBudget,
-    MemoryCacheState, MemoryGeometry, MemoryMode, MemoryNumericTier, MemoryOptimizationAuthority,
-    MemoryPhase, MemoryRunContext, MemoryRunOutcome, MemorySafetyDecision, MemorySelection,
-    MemoryStrategy, MemoryStrategyParameters, OffloadPolicy, Precision, Progress, Quant,
+    adapter_stack_identity, AdapterKind, AdapterSpec, Capabilities, ComponentPrecisionFloor,
+    Conditioning, GenerationMemory, GenerationOutput, GenerationRequest, Generator, Image,
+    LoadShape, LoadSpec, MemoryBudget, MemoryCacheState, MemoryGeometry, MemoryMode,
+    MemoryNumericTier, MemoryOptimizationAuthority, MemoryPhase, MemoryRequestScope,
+    MemoryRunContext, MemoryRunOutcome, MemorySafetyDecision, MemorySelection, MemoryStrategy,
+    MemoryStrategyParameters, ModelDescriptor, OffloadPolicy, Precision, Progress, Quant,
     TransformerComponent, WeightsSource,
 };
 use runtime_cuda::providers::pulid::PulidFluxRequest;
@@ -1938,7 +1939,67 @@ fn numeric_tier(tier: &str) -> Result<MemoryNumericTier, String> {
     })
 }
 
+/// The provider-declared component floors ACTIVE for one selected quant — the worker's
+/// `candle_memory_strategy::active_component_floors`, verbatim: every declared floor must apply
+/// to the selected tier for the table to be active, otherwise none is (sc-22738).
+fn active_component_floors(
+    declared: &'static [ComponentPrecisionFloor],
+    selected: Option<Quant>,
+) -> &'static [ComponentPrecisionFloor] {
+    match selected {
+        Some(selected)
+            if !declared.is_empty() && declared.iter().all(|floor| floor.applies_to(selected)) =>
+        {
+            declared
+        }
+        _ => &[],
+    }
+}
+
+/// The numeric tier the WORKER selects for a loaded Candle provider: the planned quant plus the
+/// floors the provider's own descriptor declares for it (`candle_memory_strategy::numeric_tier`,
+/// which reads `media_descriptor(engine_id).capabilities.component_precision_floors` — the same
+/// descriptor the loaded generator returns).
+///
+/// sc-22738 (CUDA run 34356681566): the six Mage-Flow q4 cells were refused at `begin` with
+/// "selected tier … component_precision_floors: [] does not match loaded tier …": the Mage q4
+/// rehost keeps its text encoder above tier, `candle-gen-mage` derives the loaded tier's floors
+/// from that declaration (`resolved_numeric_tier` → `quant::active_component_precision_floors`),
+/// and [`numeric_tier`] hard-coded an empty table. A tier is a whole-pipeline contract, so the
+/// floors are part of the identity the selection must name.
+fn loaded_numeric_tier(
+    tier: &str,
+    descriptor: &ModelDescriptor,
+) -> Result<MemoryNumericTier, String> {
+    let base = numeric_tier(tier)?;
+    Ok(MemoryNumericTier {
+        component_precision_floors: active_component_floors(
+            descriptor.capabilities.component_precision_floors,
+            base.quant,
+        ),
+        ..base
+    })
+}
+
 fn planned_selection(request: &Value) -> Result<MemorySelection, String> {
+    planned_selection_with_tier(request, numeric_tier(planned_tier(request)?)?)
+}
+
+/// [`planned_selection`] for a LOADED provider, keyed on the tier the worker would select for it.
+fn planned_selection_for(
+    request: &Value,
+    descriptor: &ModelDescriptor,
+) -> Result<MemorySelection, String> {
+    planned_selection_with_tier(
+        request,
+        loaded_numeric_tier(planned_tier(request)?, descriptor)?,
+    )
+}
+
+fn planned_selection_with_tier(
+    request: &Value,
+    tier: MemoryNumericTier,
+) -> Result<MemorySelection, String> {
     let strategy = planned_memory_strategy(request)?;
     let transformer_window_size = protocol::optional_parameter(request, "transformerWindowSize")?;
     Ok(MemorySelection {
@@ -1951,8 +2012,184 @@ fn planned_selection(request: &Value) -> Result<MemorySelection, String> {
             transformer_window_component: transformer_window_size
                 .map(|_| TransformerComponent::Dit),
         },
-        tier: numeric_tier(planned_tier(request)?)?,
+        tier,
     })
+}
+
+/// The request scope one capture renders under, opened exactly the way the worker opens one.
+///
+/// `scope` is `None` when the provider opened none: `Generator::begin_memory_strategy_request`
+/// returns `Ok(None)` for a contract that implements no optimized rung (`candle-gen-minimax-h3`
+/// declares `Resident` alone and overrides neither seam), and the worker's `generate_with_scope`
+/// renders such a request without a scope. The capture then measures its phases off the progress
+/// boundaries alone: the lifecycle calls are no-ops, while a selected parameter that has no scope
+/// to receive it is refused rather than dropped (sc-22738: "minimax_h3 selection did not create a
+/// provider scope" was this arm demanding a scope the production path never asks for).
+struct CaptureScope<'a> {
+    label: String,
+    scope: Option<Box<dyn MemoryRequestScope + 'a>>,
+}
+
+impl CaptureScope<'_> {
+    fn unsupported(&self, what: &str) -> runtime_cuda::gen_core::Error {
+        runtime_cuda::gen_core::Error::Unsupported(format!(
+            "{}: the planned selection carries {what}, but the provider opened no request scope to \
+             receive it",
+            self.label
+        ))
+    }
+
+    fn configure_request(
+        &mut self,
+        request: &mut GenerationRequest,
+    ) -> runtime_cuda::gen_core::Result<()> {
+        match self.scope.as_mut() {
+            Some(scope) => scope.configure_request(request),
+            None => Ok(()),
+        }
+    }
+
+    fn enter_phase(&mut self, phase: MemoryPhase) -> runtime_cuda::gen_core::Result<()> {
+        match self.scope.as_mut() {
+            Some(scope) => scope.enter_phase(phase),
+            None => Ok(()),
+        }
+    }
+
+    fn leave_phase(&mut self, phase: MemoryPhase) -> runtime_cuda::gen_core::Result<()> {
+        match self.scope.as_mut() {
+            Some(scope) => scope.leave_phase(phase),
+            None => Ok(()),
+        }
+    }
+
+    fn configure_decode(
+        &mut self,
+        tile_edge: u32,
+        overlap: u32,
+        geometry: MemoryGeometry,
+    ) -> runtime_cuda::gen_core::Result<()> {
+        match self.scope.as_mut() {
+            Some(scope) => scope.configure_decode(tile_edge, overlap, geometry),
+            None => Err(self.unsupported("a decode tile")),
+        }
+    }
+
+    fn configure_attention(&mut self, chunk_size: u32) -> runtime_cuda::gen_core::Result<()> {
+        match self.scope.as_mut() {
+            Some(scope) => scope.configure_attention(chunk_size),
+            None => Err(self.unsupported("an attention chunk")),
+        }
+    }
+
+    fn materialize_transformer_window(
+        &mut self,
+        first_block: u32,
+        block_count: u32,
+    ) -> runtime_cuda::gen_core::Result<()> {
+        match self.scope.as_mut() {
+            Some(scope) => scope.materialize_transformer_window(first_block, block_count),
+            None => Err(self.unsupported("a transformer window")),
+        }
+    }
+
+    fn finish(&mut self, outcome: MemoryRunOutcome) -> runtime_cuda::gen_core::Result<()> {
+        match self.scope.as_mut() {
+            Some(scope) => scope.finish(outcome),
+            None => Ok(()),
+        }
+    }
+}
+
+/// Admit one planned context through the provider EXACTLY as the worker does
+/// (`sceneworks_worker::memory_strategy::generate_with_scope`): the provider's own
+/// `memory_strategy_safety_check` first, `begin_memory_strategy_request` only on `Accept`, and an
+/// optimized selection that opened no scope refused by name.
+///
+/// The safety check is not advisory on this lane. `candle-gen-chroma`, `candle-gen-flux2` and
+/// `candle-gen-mage` keep an `AdmissionRegistry` whose `approve` runs inside the safety check and
+/// whose `begin` takes that approval back out — a `begin` with no approval on file is
+/// `"<id>: memory request skipped the safety handshake"` (sc-22738, CUDA run 34356681566: every
+/// Chroma1 and FLUX.2 cell). The refusal reason is also where a provider that loaded WITHOUT a
+/// contract says why (`candle-gen-bernini` carries its `memory_refusal` there), which is what the
+/// worker's `engine_declines_advisory_context` surfaces.
+fn open_memory_request_scope<'a>(
+    generator: &'a dyn Generator,
+    context: &MemoryRunContext,
+    label: &str,
+) -> Result<CaptureScope<'a>, String> {
+    if let MemorySafetyDecision::Reject { reason } = generator.memory_strategy_safety_check(context)
+    {
+        return Err(format!(
+            "{label}: the loaded provider refused the planned memory context: {reason}"
+        ));
+    }
+    let scope = generator
+        .begin_memory_strategy_request(context)
+        .map_err(|error| format!("begin {label} scope: {error}"))?;
+    if context.selection.strategy.is_optimized() && scope.is_none() {
+        return Err(format!(
+            "{label}: the provider accepted an optimized memory-strategy selection without opening \
+             a request scope"
+        ));
+    }
+    Ok(CaptureScope {
+        label: label.to_owned(),
+        scope,
+    })
+}
+
+/// Why a loaded provider exposes no memory-strategy contract, from the provider itself.
+///
+/// The worker never sees a bare `None` here: `generate_with_scope` asks
+/// `memory_strategy_safety_check`, and a provider that loaded without a contract answers with its
+/// refusal (`candle-gen-bernini` keeps the `production_assets` error as `memory_refusal` and
+/// returns it from the safety check whatever the context). The probe context is the resident
+/// baseline at the planned tier: the shared default accepts it for any contract-less provider, so
+/// a `Reject` can only be the provider's own reason. sc-22738 (CUDA run 34356681566): five Bernini
+/// cells failed as "loaded bernini has no memory-strategy contract" with the reason discarded.
+fn missing_contract_reason(generator: &dyn Generator, request: &Value) -> String {
+    let probe = MemoryRunContext {
+        selection: MemorySelection {
+            strategy: MemoryStrategy::Resident,
+            parameters: MemoryStrategyParameters::default(),
+            tier: match planned_tier(request).and_then(numeric_tier) {
+                Ok(tier) => tier,
+                Err(error) => return format!("no memory-strategy contract ({error})"),
+            },
+        },
+        optimization_authority: MemoryOptimizationAuthority::Resident,
+        calibration_abi: runtime_cuda::gen_core::MEMORY_CALIBRATION_ABI,
+        calibration_fingerprint: String::new(),
+        load_shape: LoadShape::EagerMaterialization,
+        mode: MemoryMode::TextToImage,
+        has_reference: false,
+        use_pid: false,
+        has_phases: false,
+        geometry: MemoryGeometry {
+            width: 0,
+            height: 0,
+            batch: 1,
+            frames: 1,
+            reference_count: 0,
+        },
+        overlay: None,
+        budget: MemoryBudget {
+            total_bytes: 0,
+            committed_bytes: 0,
+            reclaimable_bytes: 0,
+            reserved_headroom_bytes: 0,
+        },
+        predicted_peak_bytes: 0,
+        cache_state: MemoryCacheState::Cold,
+        evidence_revision: String::new(),
+    };
+    match generator.memory_strategy_safety_check(&probe) {
+        MemorySafetyDecision::Reject { reason } => {
+            format!("no memory-strategy contract; the provider says: {reason}")
+        }
+        MemorySafetyDecision::Accept => "no memory-strategy contract".to_owned(),
+    }
 }
 
 fn reference_phase(phase: MemoryPhase) -> protocol::ReferencePhase {
@@ -2208,6 +2445,15 @@ fn five_rung_load_spec(
         // refuse a quant by name (`"Candle supports only the dense physical tier"`,
         // `"turnkey q4/q8/bf16 all require precision=Bf16 and LoadSpec.quantize=None"`), and
         // Chroma's tier comes from the artifact path plus the transformer's own packed marker.
+        //
+        // sc-22738: the STILL Bernini entry takes the worker's exact still-lane spec — eager, the
+        // packed tier's quant bound, `bernini_image` as the resolved route — see
+        // `bernini_candle_load_spec`. The `Deferred` default above is what refused every
+        // `bernini_image` cell its contract ("Bernini Candle memory contract requires
+        // EagerMaterialization") before the quant was even consulted.
+        (BERNINI_CANDLE_ID, _) => {
+            bernini_candle_load_spec(spec, tier, BERNINI_CANDLE_IMAGE_MODEL_ID)?
+        }
         _ => spec,
     };
     // The catalog model id reaches the engine as `resolved_route` — the same lever the worker
@@ -2664,10 +2910,15 @@ fn run_five_rung_reference_loaded(
 ) -> Result<Value, String> {
     protocol::validate_plain_overlay_target(request, execution_path)?;
     protocol::validate_still_geometry(request, still_calibration_label(request)?)?;
-    let contract = generator
-        .memory_strategy_contract()
-        .ok_or_else(|| format!("loaded {provider_id} has no memory-strategy contract"))?;
-    let selection = planned_selection(request)?;
+    let contract = generator.memory_strategy_contract().ok_or_else(|| {
+        format!(
+            "loaded {provider_id} has {}",
+            missing_contract_reason(generator, request)
+        )
+    })?;
+    // sc-22738: the tier the WORKER selects for this loaded provider — planned quant plus the
+    // provider's declared component floors — not a bare `(precision, quant)`.
+    let selection = planned_selection_for(request, generator.descriptor())?;
     contract.validate_selection(&selection).map_err(|error| {
         format!("pinned {provider_id} provider rejected planned selection: {error}")
     })?;
@@ -2751,12 +3002,13 @@ fn run_five_rung_reference_loaded(
             protocol::INFERENCE_PIN
         ),
     };
-    let mut scope = generator
-        .begin_memory_strategy_request(&context)
-        .map_err(|error| format!("begin {provider_id} fresh-reference scope: {error}"))?
-        .ok_or_else(|| {
-            format!("{provider_id} fresh-reference selection did not create a provider scope")
-        })?;
+    // sc-22738: the worker's admission sequence — safety check, then begin. `candle-gen-chroma`,
+    // `candle-gen-flux2` and `candle-gen-mage` refuse a `begin` with no approval on file.
+    let mut scope = open_memory_request_scope(
+        generator,
+        &context,
+        &format!("{provider_id} fresh-reference"),
+    )?;
     let parameters = context.selection.parameters;
     match (parameters.decode_tile_edge, parameters.decode_overlap) {
         (Some(edge), Some(overlap)) => scope
@@ -5428,14 +5680,46 @@ fn bernini_candle_load_plan(
     Ok(Sc22737LoadPlan {
         artifact: artifact(&repository, &revision, &target.tier),
         resolved_path_fingerprint: loadability_fingerprint(&repository, &revision, &target.tier),
-        // sc-22738: EAGER — `candle-gen-bernini`'s production contract refuses anything else.
-        // Its registry fixture merely mirrors the spec's shape, which is why the weights-free walk
-        // in `inference_runtime.rs` could not see that the `Deferred` this arm shipped with (and
-        // the six plan rows beside it) was uncapturable; the plan rows now say eager too.
-        spec: LoadSpec::new(WeightsSource::Dir(root))
-            .with_offload_policy(OffloadPolicy::Sequential)
-            .with_load_shape(BERNINI_CANDLE_LOAD_SHAPE)
-            .with_resolved_route(BERNINI_CANDLE_VIDEO_MODEL_ID.to_owned()),
+        spec: bernini_candle_load_spec(
+            LoadSpec::new(WeightsSource::Dir(root)).with_offload_policy(OffloadPolicy::Sequential),
+            &target.tier,
+            BERNINI_CANDLE_VIDEO_MODEL_ID,
+        )?,
+    })
+}
+
+/// The `LoadSpec` the worker hands `candle-gen-bernini` for one published tier directory, on
+/// either lane.
+///
+/// * EAGER — `candle-gen-bernini`'s production contract refuses anything else (sc-22738). Its
+///   registry fixture merely mirrors the spec's shape, which is why the weights-free walk in
+///   `inference_runtime.rs` could not see that the `Deferred` the video arm shipped with (and the
+///   six plan rows beside it) was uncapturable; the plan rows say eager too. The still lane's
+///   `LoadSpec::new` default is eager and its registry rule shapes nothing
+///   (`image_jobs/bernini.rs`), so eager is the ONLY shape either lane loads.
+/// * The packed tier's quant, EXPLICITLY. Both worker lanes resolve
+///   `candle_bernini_tier_quant(tier)` — `Some(Q4)`/`Some(Q8)` for the packed subtrees, `None`
+///   for `bf16/` — and bind it (`image_jobs/bernini.rs` `load_spec(weights_dir, quant, …)`,
+///   `video_jobs/wan.rs` `spec.quantize = input.quant`). It is an assertion, not a load-time
+///   pack: `candle-gen-bernini`'s `production_assets` reads the EXPECTED packing off
+///   `spec.quantize` (`expected_packing`) and then proves every component against it
+///   (`component_receipt`), so a packed root loaded with `quantize: None` is checked as DENSE,
+///   the receipt refuses, and the load carries no contract at all. sc-22738 (CUDA run
+///   34356681566): `bernini q4/q8` and `bernini_image q4/q8` were exactly that — "loaded bernini
+///   has no memory-strategy contract" — because neither arm bound the quant.
+/// * The catalog entry as `resolved_route`, the worker's `.with_resolved_route(request.model)`:
+///   `bernini` on the video lane, `bernini_image` on the still lane.
+fn bernini_candle_load_spec(
+    spec: LoadSpec,
+    tier: &str,
+    resolved_route: &str,
+) -> Result<LoadSpec, String> {
+    let spec = spec
+        .with_load_shape(BERNINI_CANDLE_LOAD_SHAPE)
+        .with_resolved_route(resolved_route.to_owned());
+    Ok(match numeric_tier(tier)?.quant {
+        Some(quant) => spec.with_quant(quant),
+        None => spec,
     })
 }
 
@@ -5784,10 +6068,16 @@ fn run_sc22737_video_capture(request: &Value, arm: Sc22737VideoArm) -> Result<Va
             )
         })?;
     vram.end_load(load_sample);
-    let contract = generator
-        .memory_strategy_contract()
-        .ok_or_else(|| format!("loaded {} has no memory-strategy contract", arm.engine_id))?;
-    let selection = planned_selection(request)?;
+    let contract = generator.memory_strategy_contract().ok_or_else(|| {
+        format!(
+            "loaded {} has {}",
+            arm.engine_id,
+            missing_contract_reason(generator.as_ref(), request)
+        )
+    })?;
+    // sc-22738: the tier the WORKER selects for this loaded provider — planned quant plus the
+    // provider's declared component floors.
+    let selection = planned_selection_for(request, generator.descriptor())?;
     contract.validate_selection(&selection).map_err(|error| {
         format!(
             "pinned {} provider rejected planned selection: {error}",
@@ -5854,15 +6144,14 @@ fn run_sc22737_video_capture(request: &Value, arm: Sc22737VideoArm) -> Result<Va
         cache_state: MemoryCacheState::Cold,
         evidence_revision: format!("sc-22737-adapter@{}", protocol::INFERENCE_PIN),
     };
-    let mut scope = generator
-        .begin_memory_strategy_request(&context)
-        .map_err(|error| format!("begin {} capture scope: {error}", arm.engine_id))?
-        .ok_or_else(|| {
-            format!(
-                "{} selection did not create a provider scope",
-                arm.engine_id
-            )
-        })?;
+    // sc-22738: the worker's admission sequence — safety check, then begin — and a provider that
+    // opens no scope for a resident selection (`candle-gen-minimax-h3`) is rendered without one,
+    // exactly as `generate_with_scope` renders it.
+    let mut scope = open_memory_request_scope(
+        generator.as_ref(),
+        &context,
+        &format!("{} capture", arm.engine_id),
+    )?;
     let parameters = context.selection.parameters;
     match (parameters.decode_tile_edge, parameters.decode_overlap) {
         (Some(edge), Some(overlap)) => scope
@@ -11075,6 +11364,391 @@ mod sensenova_candle_tests {
         ] {
             let error = bind(fixture, "q4").expect_err("the fixture must be bound to its cell");
             assert!(error.contains(expected), "{fixture}: {error}");
+        }
+    }
+}
+
+/// sc-22738 (CUDA run 34356681566): the four adapter-arm classes that diverged from the worker's
+/// production path — the safety handshake before `begin`, the loaded provider's component floors
+/// on the selected tier, a resident render with no provider scope, and the Bernini spec the engine
+/// prices its contract from. Each is asserted against a synthetic provider surface or the produced
+/// `LoadSpec`, weights-free.
+#[cfg(test)]
+mod sc22738_arm_tests {
+    use super::*;
+    use runtime_cuda::gen_core::{Error, Modality, PrecisionFloorComponent};
+    use std::cell::Cell;
+
+    /// A text-encoder-above-tier floor, the shape `candle-gen-mage` declares for q4.
+    const Q4_TEXT_ENCODER_FLOOR: &[ComponentPrecisionFloor] = &[ComponentPrecisionFloor {
+        component: PrecisionFloorComponent::TextEncoder,
+        selected_tier: Quant::Q4,
+        resident_tier: Quant::Q8,
+    }];
+
+    fn descriptor(floors: &'static [ComponentPrecisionFloor]) -> ModelDescriptor {
+        ModelDescriptor {
+            encoder_contract: None,
+            denoiser_output_latent_space: None,
+            id: "sc22738-stub",
+            family: "sc22738",
+            backend: "candle",
+            modality: Modality::Image,
+            capabilities: Capabilities {
+                component_precision_floors: floors,
+                ..Capabilities::default()
+            },
+            required_components: &[],
+            control_kinds: None,
+        }
+    }
+
+    fn context(strategy: MemoryStrategy) -> MemoryRunContext {
+        MemoryRunContext {
+            selection: MemorySelection {
+                strategy,
+                parameters: MemoryStrategyParameters::default(),
+                tier: numeric_tier("bf16").unwrap(),
+            },
+            optimization_authority: MemoryOptimizationAuthority::Calibrated,
+            calibration_abi: runtime_cuda::gen_core::MEMORY_CALIBRATION_ABI,
+            calibration_fingerprint: "sc22738-stub-v1".to_owned(),
+            load_shape: LoadShape::EagerMaterialization,
+            mode: MemoryMode::TextToImage,
+            has_reference: false,
+            use_pid: false,
+            has_phases: false,
+            geometry: MemoryGeometry {
+                width: 1024,
+                height: 1024,
+                batch: 1,
+                frames: 1,
+                reference_count: 0,
+            },
+            overlay: None,
+            budget: MemoryBudget {
+                total_bytes: 1 << 34,
+                committed_bytes: 0,
+                reclaimable_bytes: 0,
+                reserved_headroom_bytes: 0,
+            },
+            predicted_peak_bytes: 1,
+            cache_state: MemoryCacheState::Cold,
+            evidence_revision: "sc22738-stub".to_owned(),
+        }
+    }
+
+    /// A request scope that accepts every lifecycle call.
+    struct AcceptingScope;
+
+    impl MemoryRequestScope for AcceptingScope {
+        fn configure_request(
+            &mut self,
+            _: &mut GenerationRequest,
+        ) -> runtime_cuda::gen_core::Result<()> {
+            Ok(())
+        }
+        fn enter_phase(&mut self, _: MemoryPhase) -> runtime_cuda::gen_core::Result<()> {
+            Ok(())
+        }
+        fn leave_phase(&mut self, _: MemoryPhase) -> runtime_cuda::gen_core::Result<()> {
+            Ok(())
+        }
+        fn configure_decode(
+            &mut self,
+            _: u32,
+            _: u32,
+            _: MemoryGeometry,
+        ) -> runtime_cuda::gen_core::Result<()> {
+            Ok(())
+        }
+        fn configure_attention(&mut self, _: u32) -> runtime_cuda::gen_core::Result<()> {
+            Ok(())
+        }
+        fn materialize_transformer_window(
+            &mut self,
+            _: u32,
+            _: u32,
+        ) -> runtime_cuda::gen_core::Result<()> {
+            Ok(())
+        }
+        fn finish(&mut self, _: MemoryRunOutcome) -> runtime_cuda::gen_core::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// The engine-side admission registry in miniature: `candle-gen-chroma`, `-flux2` and `-mage`
+    /// each take an approval INSIDE `memory_strategy_safety_check` and consume it in
+    /// `begin_memory_strategy_request`, refusing a `begin` with none on file by the exact sentence
+    /// the campaign logged.
+    struct HandshakeStub {
+        descriptor: ModelDescriptor,
+        approved: Cell<bool>,
+        /// `false` models `candle-gen-minimax-h3`: no override of either seam, so `begin` yields
+        /// `Ok(None)` for its resident-only contract.
+        opens_scope: bool,
+        /// `Some` models a provider that loaded WITHOUT a contract and carries the reason
+        /// (`candle-gen-bernini`'s `memory_refusal`).
+        refusal: Option<&'static str>,
+        safety_checks: Cell<u32>,
+    }
+
+    impl HandshakeStub {
+        fn new(opens_scope: bool) -> Self {
+            Self {
+                descriptor: descriptor(&[]),
+                approved: Cell::new(false),
+                opens_scope,
+                refusal: None,
+                safety_checks: Cell::new(0),
+            }
+        }
+    }
+
+    impl Generator for HandshakeStub {
+        fn descriptor(&self) -> &ModelDescriptor {
+            &self.descriptor
+        }
+
+        fn validate(&self, _: &GenerationRequest) -> runtime_cuda::gen_core::Result<()> {
+            Ok(())
+        }
+
+        fn generate(
+            &self,
+            _: &GenerationRequest,
+            _: &mut dyn FnMut(Progress),
+        ) -> runtime_cuda::gen_core::Result<GenerationOutput> {
+            Err(Error::Unsupported("the stub renders nothing".to_owned()))
+        }
+
+        fn memory_strategy_safety_check(&self, _: &MemoryRunContext) -> MemorySafetyDecision {
+            self.safety_checks.set(self.safety_checks.get() + 1);
+            if let Some(reason) = self.refusal {
+                return MemorySafetyDecision::Reject {
+                    reason: reason.to_owned(),
+                };
+            }
+            self.approved.set(true);
+            MemorySafetyDecision::Accept
+        }
+
+        fn begin_memory_strategy_request(
+            &self,
+            _: &MemoryRunContext,
+        ) -> runtime_cuda::gen_core::Result<Option<Box<dyn MemoryRequestScope + '_>>> {
+            if !self.approved.replace(false) {
+                return Err(Error::Unsupported(
+                    "sc22738-stub: memory request skipped the safety handshake".to_owned(),
+                ));
+            }
+            Ok(self
+                .opens_scope
+                .then(|| Box::new(AcceptingScope) as Box<dyn MemoryRequestScope>))
+        }
+    }
+
+    /// Class 1 (chroma1_*, flux2_*): the arm performs the provider's safety handshake before
+    /// `begin`, so a registry-guarded provider opens its scope instead of refusing.
+    #[test]
+    fn the_capture_admits_through_the_safety_check_before_begin() {
+        let stub = HandshakeStub::new(true);
+        let mut scope = open_memory_request_scope(
+            &stub,
+            &context(MemoryStrategy::StagedResidency),
+            "sc22738 stub",
+        )
+        .expect("an approved begin opens the scope");
+        assert_eq!(
+            stub.safety_checks.get(),
+            1,
+            "the handshake ran exactly once"
+        );
+        assert!(
+            scope.scope.is_some(),
+            "the provider's scope is the one the capture drives"
+        );
+        scope.finish(MemoryRunOutcome::Complete).unwrap();
+        // Direct proof that the stub's guard is real: a bare `begin` on the same provider — the
+        // sequence the arm ran before this fix — is refused by the campaign's exact sentence.
+        let error = stub
+            .begin_memory_strategy_request(&context(MemoryStrategy::StagedResidency))
+            .err()
+            .expect("no approval on file");
+        assert!(
+            error.to_string().contains("skipped the safety handshake"),
+            "{error}"
+        );
+    }
+
+    /// A provider that refuses the context is refused by ITS reason, before any `begin`.
+    #[test]
+    fn a_rejected_safety_check_names_the_providers_reason() {
+        let mut stub = HandshakeStub::new(true);
+        stub.refusal = Some("bernini: no sealed memory receipt for the loaded artifact (x)");
+        let error =
+            open_memory_request_scope(&stub, &context(MemoryStrategy::Resident), "sc22738 stub")
+                .err()
+                .expect("a rejected context never reaches begin");
+        assert!(error.contains("no sealed memory receipt"), "{error}");
+    }
+
+    /// Class 3 (minimax_h3, minimax_h3_ref): a resident selection on a provider that opens no
+    /// scope renders without one — the worker's `generate_with_scope` — and the lifecycle calls
+    /// the capture makes around the render are no-ops rather than failures.
+    #[test]
+    fn a_resident_selection_without_a_provider_scope_is_rendered_scopeless() {
+        let stub = HandshakeStub::new(false);
+        let mut scope = open_memory_request_scope(
+            &stub,
+            &context(MemoryStrategy::Resident),
+            "minimax_h3 capture",
+        )
+        .expect("a resident selection needs no scope");
+        assert!(scope.scope.is_none());
+        let mut generation = GenerationRequest::default();
+        scope.configure_request(&mut generation).unwrap();
+        scope.enter_phase(MemoryPhase::Conditioning).unwrap();
+        scope.leave_phase(MemoryPhase::Conditioning).unwrap();
+        scope.finish(MemoryRunOutcome::Complete).unwrap();
+        // A parameter with no scope to receive it is refused, not dropped.
+        let error = scope
+            .configure_decode(256, 32, context(MemoryStrategy::Resident).geometry)
+            .expect_err("no scope can take a decode tile");
+        assert!(
+            error.to_string().contains("opened no request scope"),
+            "{error}"
+        );
+    }
+
+    /// …while an OPTIMIZED selection that opened no scope is the state the worker refuses by name.
+    #[test]
+    fn an_optimized_selection_without_a_provider_scope_is_refused() {
+        let stub = HandshakeStub::new(false);
+        let error = open_memory_request_scope(
+            &stub,
+            &context(MemoryStrategy::StagedResidency),
+            "sc22738 stub",
+        )
+        .err()
+        .expect("an optimized rung needs a scope");
+        assert!(error.contains("without opening a request scope"), "{error}");
+    }
+
+    /// Class 4 (bernini q4/q8, bernini_image ×3): a provider that loaded with no contract answers
+    /// the arm's probe with its own refusal, so the record names the cause instead of the symptom.
+    #[test]
+    fn a_missing_contract_carries_the_providers_refusal() {
+        let mut stub = HandshakeStub::new(true);
+        stub.refusal = Some("bernini: no sealed memory receipt for the loaded artifact (dense)");
+        let request = json!({ "planned": { "target": { "tier": "q4" } } });
+        let reason = missing_contract_reason(&stub, &request);
+        assert!(reason.contains("no sealed memory receipt"), "{reason}");
+        let accepting = HandshakeStub::new(true);
+        assert_eq!(
+            missing_contract_reason(&accepting, &request),
+            "no memory-strategy contract"
+        );
+    }
+
+    /// Class 2 (mage_flow* q4): the selected tier carries the floors the loaded provider declares
+    /// for the planned quant — the worker's `active_component_floors` — and none otherwise.
+    #[test]
+    fn the_selected_tier_carries_the_loaded_providers_component_floors() {
+        let mage_like = descriptor(Q4_TEXT_ENCODER_FLOOR);
+        assert_eq!(
+            loaded_numeric_tier("q4", &mage_like).unwrap(),
+            MemoryNumericTier {
+                precision: Precision::Bf16,
+                quant: Some(Quant::Q4),
+                component_precision_floors: Q4_TEXT_ENCODER_FLOOR,
+            }
+        );
+        // The declared table names q4; q8 and the dense base carry no active floor.
+        assert!(loaded_numeric_tier("q8", &mage_like)
+            .unwrap()
+            .component_precision_floors
+            .is_empty());
+        assert!(loaded_numeric_tier("bf16", &mage_like)
+            .unwrap()
+            .component_precision_floors
+            .is_empty());
+        // A provider that declares none selects exactly what `numeric_tier` selects.
+        assert_eq!(
+            loaded_numeric_tier("q4", &descriptor(&[])).unwrap(),
+            numeric_tier("q4").unwrap()
+        );
+        // …and the selection the arms hand the provider is built from that tier.
+        let request = json!({ "planned": {
+            "target": { "tier": "q4" },
+            "strategy": { "rung": "resident", "parameters": {} },
+        }});
+        assert_eq!(
+            planned_selection_for(&request, &mage_like)
+                .unwrap()
+                .tier
+                .component_precision_floors,
+            Q4_TEXT_ENCODER_FLOOR
+        );
+    }
+
+    /// Class 4: both Bernini arms hand `candle-gen-bernini` the worker's spec — eager, the packed
+    /// tier's quant bound, the catalog entry as the resolved route.
+    #[test]
+    fn the_bernini_arms_bind_the_workers_load_spec() {
+        for (tier, quant) in [
+            ("bf16", None),
+            ("q4", Some(Quant::Q4)),
+            ("q8", Some(Quant::Q8)),
+        ] {
+            let root = PathBuf::from("/nonexistent/bernini").join(tier);
+            // Video arm.
+            let video = bernini_candle_load_spec(
+                LoadSpec::new(WeightsSource::Dir(root.clone()))
+                    .with_offload_policy(OffloadPolicy::Sequential),
+                tier,
+                BERNINI_CANDLE_VIDEO_MODEL_ID,
+            )
+            .unwrap();
+            assert_eq!(video.quantize, quant, "video {tier}");
+            assert_eq!(
+                video.load_shape,
+                LoadShape::EagerMaterialization,
+                "video {tier}"
+            );
+            assert_eq!(
+                video.resolved_route.as_deref(),
+                Some(BERNINI_CANDLE_VIDEO_MODEL_ID),
+                "video {tier}"
+            );
+            // Still arm, through the shared five-rung spec builder.
+            let request = json!({ "planned": {
+                "backend": "candle",
+                "target": {
+                    "provider": BERNINI_CANDLE_ID,
+                    "modelId": BERNINI_CANDLE_IMAGE_MODEL_ID,
+                    "tier": tier,
+                    "mode": "text_to_image",
+                    "overlay": "none",
+                    "geometry": { "width": 848, "height": 848, "batch": 1, "frames": 1 },
+                },
+                "loadShape": "eager_materialization",
+                "strategy": { "rung": "resident", "parameters": {} },
+                "calibrationFingerprint": format!("bernini-image-{tier}-candle-dual-expert-ladder-v1"),
+                "fixture": format!("fresh-five-rung-bernini-image-{tier}-848-seed16402-step2"),
+            }});
+            let still = five_rung_load_spec(&request, BERNINI_CANDLE_ID, tier, root).unwrap();
+            assert_eq!(still.quantize, quant, "still {tier}");
+            assert_eq!(
+                still.load_shape,
+                LoadShape::EagerMaterialization,
+                "still {tier}"
+            );
+            assert_eq!(
+                still.resolved_route.as_deref(),
+                Some(BERNINI_CANDLE_IMAGE_MODEL_ID),
+                "still {tier}"
+            );
         }
     }
 }


### PR DESCRIPTION
sc-22738 (epic sc-22723) follow-through on CUDA campaign run 34356681566 (feature afa67a3d8, pin e34d7b46a). Four Candle memory-adapter arm classes failed in seconds on models production renders fine; each was the arm diverging from the worker's path (E4). Fixed in place, weights-free tests + mutation witnesses in Docker. No new gates; runtime untouched.

## Root cause per class

**1. `memory request (begin) skipped the safety handshake` — chroma1_base/flash/hd ×3, flux2_dev ×3, flux2_klein_9b ×3, flux2_klein_9b_kv ×3 (21 cells).**
`candle-gen-chroma`, `-flux2` and `-mage` keep an `AdmissionRegistry`: `approve` runs inside `Generator::memory_strategy_safety_check` (chroma `src/lib.rs:154`, flux2 `src/lib.rs:1321`, mage `src/lib.rs:332`) and `begin` consumes it (chroma `src/memory_strategy.rs:1512-1517`, flux2 `:1107`, mage `:864`). The worker always asks the safety check first (`crates/sceneworks-worker/src/memory_strategy.rs:193-206`, `generate_with_scope`); the fresh-reference arm went straight to `begin`. New `open_memory_request_scope` performs the worker's exact sequence — safety check → `begin` → refuse an optimized selection with no scope — and both arms use it.

**2. `selected tier … component_precision_floors: [] does not match loaded tier` — mage_flow{,_base,_edit,_edit_base,_edit_turbo,_turbo} q4 (6 cells).**
The Mage q4 rehost keeps its text encoder above tier; the engine derives the loaded tier's floors from its descriptor declaration (`candle-gen-mage/src/memory_strategy.rs:718-731` → `quant::active_component_precision_floors`, `src/quant.rs:35-42`). The worker selects the same way (`crates/sceneworks-worker/src/candle_memory_strategy.rs:793-818`: `media_descriptor(engine_id).capabilities.component_precision_floors`, every floor must `applies_to(quant)`). The adapter's `numeric_tier` hard-coded `&[]`. New `loaded_numeric_tier` / `planned_selection_for` derive the floors from the loaded generator's own descriptor (the same object the registry hands the worker) — never hard-coded.

**3. `minimax_h3 selection did not create a provider scope` — minimax_h3 bf16, minimax_h3_ref bf16 (after 300 s / 167 s of loading).**
`candle-gen-minimax-h3` implements only `Resident` and overrides neither seam (`src/model.rs:1781` implements `memory_strategy_contract` alone), so gen-core's default `begin_memory_strategy_request` returns `Ok(None)` (`crates/contracts/gen-core/src/generator.rs:108-121`). The worker renders a resident selection without a scope (`memory_strategy.rs:199-204` only refuses `None` for an optimized rung); the sc-22737 arm demanded one. `CaptureScope` now wraps the optional scope: lifecycle calls are no-ops without one, a selected parameter with no scope to receive it is refused rather than dropped, and the phases are measured off the progress boundaries as before.

**4. Bernini — `no calibration identity` (bf16 video) / `no memory-strategy contract` (bernini q4/q8, bernini_image ×3).** Two arm-side divergences and one engine-side gap:
- *q4/q8 (both lanes):* neither arm bound the packed tier's quant. `candle-gen-bernini` reads the EXPECTED packing off `spec.quantize` (`src/memory_strategy.rs:1077-1086` `expected_packing`) and proves every component against it (`:1422-1452` `production_assets` → `component_receipt`), so a packed root loaded with `quantize: None` is checked as dense, the receipt refuses, and the load carries no contract (`src/bernini.rs:656-660` keeps the reason as `memory_refusal`). The worker binds it on both lanes (`image_jobs/bernini.rs:517-523,567-576,711-713`; `video_jobs/wan.rs:1467-1468`). New `bernini_candle_load_spec` is shared by both arms.
- *bernini_image (still lane):* `five_rung_load_spec` defaulted to `DeferredMaterialization`; `production_assets` refuses anything but eager (`:1432-1436`), and the worker's still lane loads eager (`LoadSpec::new` default, registry rule shapes nothing). The still arm now takes the worker's spec: eager, quant bound, `bernini_image` as `resolved_route`.
- *bf16 video — ENGINE-SIDE, not fixable in this repo:* the production loader builds its contract through `contract_for_loaded` (`candle-gen-bernini/src/memory_strategy.rs:2074-2087`), which passes `calibration: None`. The per-(route, artifact-proven tier) identity sc-22737 added (`production_calibration_fingerprint`, `:1518-1530`) is published only by `memory_strategy_contract` (`:1537-1553`), which is the REGISTRY closure (`:2413`, `:2419`), never the loader's path. The worker sees the same `None` and renders with an empty fingerprint (`video_admission.rs:2194-2201`), so there is no worker-side identity for the arm to obtain. Exact engine change: in `contract_for_loaded`, replace `None` with `production_calibration_fingerprint(provider_id, spec, expected_packing(spec)?).map(|fp| MemoryCalibrationIdentity::new(fp, spec.load_shape))` — the same expression `memory_strategy_contract` already uses. Until that lands at a pin, every Bernini candle cell stops at "no calibration identity" (now AFTER a contract exists on the packed tiers, so the next run confirms the spec fix). The plan rows are correct and stay.
- The arms now also surface the provider's own refusal on a missing contract (`missing_contract_reason`, via the safety check — what the worker's `engine_declines_advisory_context` reads), so a future "no contract" names its cause.

## Tests (weights-free, `cargo test -p sceneworks-memory-adapter --features candle` in the repo's candle Docker image)
`sc22738_arm_tests`: 7 new tests against a synthetic provider surface whose `begin` refuses without an approval on file (the engine registry in miniature) — handshake-before-begin, rejected reason surfaced, resident-without-scope rendered scopeless, optimized-without-scope refused, missing-contract reason, loaded floors on the selected tier, both Bernini specs (quant/eager/route per tier). Adapter suite: 47 lib + 85 bin passing.

Mutation witnesses (each applied alone, restored, touched): M1 skip handshake, M2 empty floors, M3 require scope for resident, M4 Bernini without quant, M5 still Bernini deferred, M6 hide the refusal — every one reds the matching test.

`cargo clippy -p sceneworks-memory-adapter --features candle -- -D warnings` reports exactly four PRE-EXISTING dead-code errors on `main` (`sdxl_candle_route_fingerprint`, `Sc22737VideoArm::load_shape` read only in tests, `implements`, `providers` — present in the prior agent's logs / unchanged from `main`); nothing new from this change.

## Expected on the next CUDA run
- Capture: chroma1_base/flash/hd ×3, flux2_dev ×3, flux2_klein_9b ×3, flux2_klein_9b_kv ×3, mage_flow* q4 ×6, minimax_h3 bf16, minimax_h3_ref bf16 (weights permitting).
- Bernini ×6: still `capture_failed`, now uniformly "no calibration identity" — engine change above required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
