### PR TITLE
fix(sc-22738): SDXL co-requisites are required only on the lane whose engine opens them

### DIFF
--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -147,16 +147,63 @@ export const LTX25_REPOSITORY = "SceneWorks/ltx-2.5-mlx";
 export const LTX_2_3_REPOSITORY = "SceneWorks/ltx-2.3-mlx";
 
 /**
- * The three caller-staged SDXL components, as `{ env, repo }` pairs. Declared once: every SDXL-family
- * model — and InstantID, which composes the same SDXL base — stages exactly these, and the Rust side
- * declares the same three ids in `candle.rs` `SDXL_COMPONENTS`. `sdxl_component_env_matches_the_catalog`
- * proves the two lists agree.
+ * The three caller-staged SDXL components, as `{ env, repo, arms }` triples. Declared once: every
+ * SDXL-family model — and InstantID, which composes the same SDXL base — stages exactly these, and
+ * the Rust side declares the same three ids in `candle.rs` `SDXL_COMPONENTS`. `the staged SDXL
+ * component env vars agree between the catalog and the candle adapter` proves the two lists agree.
+ *
+ * sc-22738: `arms` is the LANE the co-requisite is a co-requisite OF, and it is `candle` only.
+ * A component is a load requirement of the ENGINE that opens it, not of the model id, so a cell
+ * may only be held `weights_missing` on a component its own lane's engine actually reads:
+ *
+ *   - `candle-gen-sdxl` declares all three on the ordinary snapshot route —
+ *     `plain_descriptor()` sets `required_components: pipeline::REQUIRED_COMPONENTS`
+ *     (candle-gen-sdxl/src/lib.rs:593), and that table is the three ids
+ *     (candle-gen-sdxl/src/pipeline.rs:186-190). `SdxlComponents::from_spec` then `require_component`s
+ *     each one at load, so a candle load without them cannot open.
+ *   - `mlx-gen-sdxl` declares NONE: `descriptor()` sets `required_components: &[]`
+ *     (mlx-gen-sdxl/src/model.rs:167). Its snapshot load (`load` → `load_concrete`,
+ *     mlx-gen-sdxl/src/model.rs:345/377) reads the tokenizer and VAE from INSIDE the tier root —
+ *     `<root>/tokenizer/`, `<root>/tokenizer_2/`, `<root>/vae/…` (mlx-gen-sdxl/src/loader.rs:8,12,29-30,277,293).
+ *     The MLX turnkey rehost is self-contained; it never opens either upstream repo.
+ *
+ * The one MLX route that DOES require a component is the imported fused LDM checkpoint
+ * (`WeightsSource::File`), which requires the caller-staged `ldm_tokenizer` directory
+ * (mlx-gen-sdxl/src/model.rs:354-368, registered at mlx-gen-sdxl/src/lib.rs:164/172). That is a
+ * community-checkpoint import, not a manifest-shipped tiered rehost, so no anchor this runner
+ * measures takes it — and `ldm_tokenizer` is an operator-staged directory, never one of these
+ * three hub repos, so it would not be satisfied by them either.
+ *
+ * The worker's own plan agrees and is derived from exactly those declarations:
+ * `attach_required_components` reads the descriptor's `required_components` and takes an early
+ * no-op path when it is empty (crates/sceneworks-worker/src/image_jobs/base.rs:6146-6156).
+ * Downstream of this runner the split is visible in-repo: the three
+ * `SCENEWORKS_SDXL_COMPONENT_*` env vars this table binds are read by the CANDLE adapter binary
+ * alone (`crates/sceneworks-memory-adapter/src/bin/candle.rs:102-111`) and by no arm of
+ * `bin/mlx.rs`. `the staged SDXL component env vars agree between the catalog and the candle
+ * adapter` reads both binaries and reds if that ever stops being true, so an MLX arm that starts
+ * binding a component forces this `arms` list to be widened rather than silently diverging.
  */
 export const SDXL_COMPONENTS = Object.freeze([
-  { env: "SCENEWORKS_SDXL_COMPONENT_TOKENIZER_CLIP_L", repo: "openai/clip-vit-large-patch14" },
-  { env: "SCENEWORKS_SDXL_COMPONENT_TOKENIZER_CLIP_BIGG", repo: "laion/CLIP-ViT-bigG-14-laion2B-39B-b160k" },
-  { env: "SCENEWORKS_SDXL_COMPONENT_VAE_FP16_FIX", repo: "madebyollin/sdxl-vae-fp16-fix" },
+  { env: "SCENEWORKS_SDXL_COMPONENT_TOKENIZER_CLIP_L", repo: "openai/clip-vit-large-patch14", arms: ["candle"] },
+  { env: "SCENEWORKS_SDXL_COMPONENT_TOKENIZER_CLIP_BIGG", repo: "laion/CLIP-ViT-bigG-14-laion2B-39B-b160k", arms: ["candle"] },
+  { env: "SCENEWORKS_SDXL_COMPONENT_VAE_FP16_FIX", repo: "madebyollin/sdxl-vae-fp16-fix", arms: ["candle"] },
 ]);
+
+/**
+ * The array-shape caller-staged components a `backend` cell must actually resolve — the co-requisites
+ * whose own lane engine opens them. A component with no `arms` is required on every lane the family
+ * declares (the historical behaviour, and still the right default: a co-requisite is lane-blind
+ * unless something is known to make it otherwise).
+ *
+ * Both sites that walk these components go through here, so `anchorDownloadTargets` keeps naming
+ * exactly the repositories `classifyAnchor` probes for the same cell — a component this lane never
+ * opens is neither a `weights_missing` reason nor a `--download-missing` fetch.
+ */
+export function requiredComponentsFor(family, backend) {
+  if (!Array.isArray(family?.components)) return [];
+  return family.components.filter((component) => (component.arms ?? [backend]).includes(backend));
+}
 
 /**
  * sc-22729. `candle-gen-sdxl`'s `SDXL_ROUTES` pins each route's repository AND revision, and its
@@ -886,7 +933,9 @@ export const PROVIDER_FAMILIES = Object.freeze({
   // `tokenizer_clip_bigg`, `vae_fp16_fix`). `candle-gen-sdxl`'s `validate_shared_component_revisions`
   // REQUIRES all three at exact upstream revisions, so a candle capture stages the same corequisite
   // snapshots the worker's `attach_required_components` stages. The MLX turnkey is self-contained
-  // and ignores them, so they are bound on both lanes and simply unused on one.
+  // and ignores them, which is why each carries `arms: ["candle"]` (see `SDXL_COMPONENTS`): they are
+  // a co-requisite of the CANDLE cell only. Binding them on both lanes was not merely redundant —
+  // it made an MLX cell `weights_missing` on a snapshot its engine never opens (sc-22738).
   //
   // `sdxlRoute` marks the members `candle-gen-sdxl` seals through `SDXL_ROUTES`. It is carried by
   // ALL FIVE, not only the two that disagree today: the check is over the engine's declaration, so
@@ -2031,7 +2080,10 @@ export async function classifyAnchor(key, planned, { models, backend, hubs, curr
   }
   // sc-22729: the caller-staged SDXL components. Their revisions come from the model's own
   // corequisite downloads, which are exactly the revisions `candle-gen-sdxl` validates against.
-  for (const component of Array.isArray(family.components) ? family.components : []) {
+  // sc-22738: only on the lane whose engine opens them (`requiredComponentsFor`). An MLX SDXL cell
+  // was reported `weights_missing` for a CLIP-bigG / fp16-fix-VAE snapshot that `mlx-gen-sdxl`
+  // never reads — it declares `required_components: &[]` and loads both out of its own tier root.
+  for (const component of requiredComponentsFor(family, backend)) {
     const download = tierDownload(models, parts.modelId, component.repo, parts.tier);
     const root = await firstExistingDirectory(hubs.map((hub) => snapshotPath(hub, component.repo, download.revision)));
     row.roots.push({ label: `component ${component.env}`, path: root ?? snapshotPath(hubs[0], component.repo, download.revision) });
@@ -2240,9 +2292,10 @@ export function tierDownloadRows(models, modelId, repo, tier, platform = manifes
  * The repositories are exactly the ones `classifyAnchor` probes for this cell — the LTX-2.5
  * snapshot the harness binds through `--ltx25-snapshot-root`, or else the per-(lane, tier) artifact
  * `familyArtifact` resolves; the `upstream` root; the caller-staged `components` in both their array
- * (SDXL) and object (Mage-Flow) shapes; and the member's `sideArtifact`. `siblingRoots` need no
- * entry: a sibling lives INSIDE the artifact's own snapshot at the same revision, so the tier root's
- * co-requisite rows already carry its globs.
+ * (SDXL — lane-filtered by `requiredComponentsFor`, so a lane whose engine never opens a co-requisite
+ * is never asked to fetch it) and object (Mage-Flow) shapes; and the member's `sideArtifact`.
+ * `siblingRoots` need no entry: a sibling lives INSIDE the artifact's own snapshot at the same
+ * revision, so the tier root's co-requisite rows already carry its globs.
  *
  * Two things are deliberately NOT fetchable, and are reported rather than guessed at:
  *
@@ -2263,7 +2316,7 @@ export function anchorDownloadTargets(row, models, { families = PROVIDER_FAMILIE
   if (family.ltx25) repositories.push({ label: "ltx25 snapshot", repo: family.repo });
   else repositories.push({ label: "tier root", repo: familyArtifact(family, row.backend, row.tier).repo });
   if (family.upstream) repositories.push({ label: "upstream root", repo: family.upstream.repo });
-  for (const component of Array.isArray(family.components) ? family.components : []) {
+  for (const component of requiredComponentsFor(family, row.backend)) {
     repositories.push({ label: `component ${component.env}`, repo: component.repo });
   }
   if (family.components && !Array.isArray(family.components)) {

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -874,6 +874,112 @@ test("an InstantID cell whose staged identity stack is missing a file is weights
   }
 });
 
+/**
+ * sc-22738. One SDXL-family model in the fixture manifest's shape: a tiered rehost plus the three
+ * caller-staged components as co-requisites, exactly as the shipped manifest declares them.
+ */
+const SDXL_FIXTURE_MODEL = {
+  id: "sdxl",
+  downloads: [
+    { repo: "SceneWorks/sdxl-base-mlx", revision: REVISION, variant: "q4", files: ["q4/*"] },
+    ...SDXL_COMPONENTS.map(({ repo }) => ({ repo, revision: UPSTREAM, coRequisite: true, files: ["*"] })),
+  ],
+};
+
+// sc-22738: a co-requisite is a co-requisite of the ENGINE that opens it, not of the model id. The
+// two upstream SDXL components were bound on BOTH lanes, so an MLX `sdxl`/`realvisxl`/`illustrious`
+// cell was booked `weights_missing` for a `laion/CLIP-ViT-bigG-14…` (or fp16-fix VAE) snapshot that
+// `mlx-gen-sdxl` never opens: it declares `required_components: &[]` (mlx-gen-sdxl/src/model.rs:167)
+// and loads `tokenizer/`, `tokenizer_2/` and `vae/` out of its own tier root
+// (mlx-gen-sdxl/src/loader.rs:29-30,277,293). Only `candle-gen-sdxl` declares them
+// (candle-gen-sdxl/src/lib.rs:593 → pipeline.rs:186-190), and only the candle adapter binary binds
+// their env vars. The row must reflect what THIS lane's engine requires.
+test("an SDXL co-requisite is required only on the lane whose engine opens it", async () => {
+  const models = [...fakeModels(), SDXL_FIXTURE_MODEL];
+  // Everything staged EXCEPT the CLIP-bigG tokenizer — the snapshot the MLX cells were blocked on.
+  const bigG = "laion/CLIP-ViT-bigG-14-laion2B-39B-b160k";
+  const hub = await fakeHub([
+    ["SceneWorks/sdxl-base-mlx", REVISION, "q4"],
+    ...SDXL_COMPONENTS.filter(({ repo }) => repo !== bigG).map(({ repo }) => [repo, UPSTREAM]),
+  ]);
+  const context = (backend) => ({ models, backend, hubs: [hub], current: new Map(), captured: new Map() });
+
+  const mlx = await classifyAnchor("sdxl:q4:mlx", { provider: "sdxl" }, context("mlx"));
+  assert.equal(mlx.status, "runnable", `the MLX engine never opens ${bigG}: ${mlx.reason}`);
+  // Not merely "not the reason" — the lane binds no component env at all, because it reads none.
+  for (const component of SDXL_COMPONENTS) {
+    assert.equal(mlx.env[component.env], undefined, `${component.env} must not be bound on the MLX lane`);
+  }
+  assert.ok(
+    !mlx.roots.some((root) => root.label.startsWith("component ")),
+    "an MLX SDXL row must not even report a component root it will never read",
+  );
+  // …and it is not a fetch either: `--download-missing` must never book the component snapshots for
+  // a lane that does not need them. `anchorDownloadTargets` names exactly what `classifyAnchor` probes.
+  const mlxTargets = anchorDownloadTargets(mlx, models, { platform: "macos" });
+  assert.deepEqual(
+    mlxTargets.targets.map((target) => target.repo),
+    ["SceneWorks/sdxl-base-mlx"],
+    "the MLX SDXL cell fetches its tier root and nothing else",
+  );
+
+  // The same cell on candle is unchanged: the engine requires all three, so an absent one is
+  // `weights_missing`, named.
+  const candle = await classifyAnchor("sdxl:q4:candle", { provider: "sdxl" }, context("candle"));
+  assert.equal(candle.status, "weights_missing", "candle-gen-sdxl require_components all three");
+  assert.match(candle.reason, new RegExp(bigG.replaceAll(".", "\\.")));
+  const candleTargets = anchorDownloadTargets(candle, models, { platform: "macos" });
+  assert.deepEqual(
+    candleTargets.targets.map((target) => target.repo).sort(),
+    ["SceneWorks/sdxl-base-mlx", ...SDXL_COMPONENTS.map(({ repo }) => repo)].sort(),
+    "the candle SDXL cell fetches its tier root AND all three co-requisites",
+  );
+});
+
+// The lane split is DATA, not a hard-coded `backend === "candle"`: widen a component's `arms` and
+// the requirement comes back on that lane. This is the test that reds if the MLX engine ever
+// declares a required component and the table is not widened to match — and the mutation guard on
+// the gate itself: drop the `arms` filter in `requiredComponentsFor` and the case above goes red
+// while this one stays green, so the two together pin the behaviour in both directions.
+test("a component the MLX engine declares is still required of the MLX lane", async () => {
+  const models = [...fakeModels(), SDXL_FIXTURE_MODEL];
+  const bigG = "laion/CLIP-ViT-bigG-14-laion2B-39B-b160k";
+  const hub = await fakeHub([
+    ["SceneWorks/sdxl-base-mlx", REVISION, "q4"],
+    ...SDXL_COMPONENTS.filter(({ repo }) => repo !== bigG).map(({ repo }) => [repo, UPSTREAM]),
+  ]);
+  // A fixture engine that DOES open the components on both lanes.
+  const families = {
+    ...PROVIDER_FAMILIES,
+    sdxl: {
+      ...PROVIDER_FAMILIES.sdxl,
+      components: SDXL_COMPONENTS.map((component) => ({ ...component, arms: ["mlx", "candle"] })),
+    },
+  };
+  const row = await classifyAnchor(
+    "sdxl:q4:mlx",
+    { provider: "sdxl" },
+    { models, backend: "mlx", hubs: [hub], current: new Map(), captured: new Map(), families },
+  );
+  assert.equal(row.status, "weights_missing", "a component the lane's engine opens is still a hard requirement");
+  assert.match(row.reason, new RegExp(bigG.replaceAll(".", "\\.")));
+  // And a component with no `arms` at all stays lane-blind — the default is unchanged for every
+  // other family, which is why nothing but SDXL moves.
+  const laneBlind = {
+    ...PROVIDER_FAMILIES,
+    sdxl: {
+      ...PROVIDER_FAMILIES.sdxl,
+      components: SDXL_COMPONENTS.map(({ env, repo }) => ({ env, repo })),
+    },
+  };
+  const blind = await classifyAnchor(
+    "sdxl:q4:mlx",
+    { provider: "sdxl" },
+    { models, backend: "mlx", hubs: [hub], current: new Map(), captured: new Map(), families: laneBlind },
+  );
+  assert.equal(blind.status, "weights_missing", "an undeclared `arms` requires the component on every lane");
+});
+
 // The three declarations above are the ADAPTER's own constants, not this script's opinion of them.
 // A drift on either side would send a capture at an artifact the arm does not open (or refuse one it
 // does), so each is read out of the Rust source and compared.
@@ -2702,13 +2808,33 @@ pub fn load_i2v_14b(spec: &LoadSpec) -> Result<Box<dyn Generator>> {
 // validates all three at exact upstream revisions. A rename on one side would leave a capture
 // binding a component the engine never sees, so the two lists are proven equal here.
 test("the staged SDXL component env vars agree between the catalog and the candle adapter", async () => {
-  const source = await readFile(path.join(ROOT, "crates/sceneworks-memory-adapter/src/bin/candle.rs"), "utf8");
-  const declared = [...source.matchAll(/"(SCENEWORKS_SDXL_COMPONENT_[A-Z0-9_]+)"/g)].map((match) => match[1]);
+  const adapterEnvs = async (binary) => {
+    const source = await readFile(path.join(ROOT, `crates/sceneworks-memory-adapter/src/bin/${binary}.rs`), "utf8");
+    return [...new Set([...source.matchAll(/"(SCENEWORKS_SDXL_COMPONENT_[A-Z0-9_]+)"/g)].map((match) => match[1]))];
+  };
+  const declared = await adapterEnvs("candle");
   assert.deepEqual(
-    [...new Set(declared)].sort(),
+    [...declared].sort(),
     SDXL_COMPONENTS.map((component) => component.env).sort(),
     "candle.rs SDXL_COMPONENTS and the catalog's SDXL_COMPONENTS must name the same env vars",
   );
+  // sc-22738: and the LANE split is derived from the same source rather than asserted. A component
+  // is bound for the arm whose adapter binary reads its env var — `candle.rs` reads all three,
+  // `mlx.rs` reads none, because `mlx-gen-sdxl` declares `required_components: &[]`
+  // (mlx-gen-sdxl/src/model.rs:167) and opens `tokenizer/`/`tokenizer_2/`/`vae/` inside its own
+  // tier root instead. If an MLX arm ever starts binding one, this reds and `SDXL_COMPONENTS`
+  // must widen its `arms` — the requirement can never silently come back on a lane, nor silently
+  // vanish from one.
+  const mlxDeclared = await adapterEnvs("mlx");
+  for (const component of SDXL_COMPONENTS) {
+    const arms = ["candle", "mlx"].filter((backend) =>
+      (backend === "candle" ? declared : mlxDeclared).includes(component.env));
+    assert.deepEqual(
+      [...(component.arms ?? [])].sort(),
+      arms.sort(),
+      `${component.env} must declare arms exactly matching the adapter binaries that bind it`,
+    );
+  }
   // Every component repo is a real corequisite of every SDXL-family model, so `tierDownload`
   // resolves a revision for it rather than falling back to an unrelated download.
   const models = await readManifestModels();


### PR DESCRIPTION
## The defect

`SDXL_COMPONENTS` was applied to SDXL-family anchors on **both** backends by the component loop in `classifyAnchor`, so an MLX cell was booked `weights_missing` on a `laion/CLIP-ViT-bigG-14-laion2B-39B-b160k` (or `madebyollin/sdxl-vae-fp16-fix`) snapshot that the MLX engine never opens. A `weights_missing` row must reflect what the **lane's** engine actually requires.

## Engine evidence, at the pinned inference revision `e34d7b46a`

A component is a load requirement of the ENGINE that opens it, not of the model id.

| | declaration | what the loader actually reads |
|---|---|---|
| `mlx-gen-sdxl` | `descriptor()` sets `required_components: &[]` — `mlx-gen-sdxl/src/model.rs:167` | `<root>/tokenizer/`, `<root>/tokenizer_2/`, `<root>/vae/…` — all **inside the tier root** (`mlx-gen-sdxl/src/loader.rs:8,12,29-30,277,293`), via `load` → `load_concrete` (`model.rs:345/377`) |
| `candle-gen-sdxl` | `plain_descriptor()` sets `required_components: pipeline::REQUIRED_COMPONENTS` — `candle-gen-sdxl/src/lib.rs:593`; the table is the three ids — `candle-gen-sdxl/src/pipeline.rs:186-190` | `SdxlComponents::from_spec` `require_component`s each one at load, so a candle load without them cannot open |

**The requirement is narrowed, not weakened.** The one MLX route that *does* require a component is the imported fused LDM checkpoint (`WeightsSource::File` → the caller-staged `ldm_tokenizer` directory, `mlx-gen-sdxl/src/model.rs:354-368`, registered at `lib.rs:164/172`). That is a community-checkpoint import rather than a manifest-shipped tiered rehost, so no anchor this runner measures takes it — and `ldm_tokenizer` is an operator-staged directory, never one of these three hub repos, so these components could not satisfy it anyway.

The worker's own plan agrees, and derives from exactly those declarations: `attach_required_components` reads the descriptor's `required_components` and takes an **early no-op path when it is empty** (`crates/sceneworks-worker/src/image_jobs/base.rs:6146-6156`). Its doc comment already names "Mage-Flow and Candle SDXL" as the providers that advertise component ids.

## The fix

Each component carries `arms`, and both sites that walk them — `classifyAnchor` and `anchorDownloadTargets` — go through a single `requiredComponentsFor(family, backend)`, so the download plan keeps naming exactly the repositories the classifier probes. A component with **no** `arms` stays lane-blind, so no other family moves.

The lane split is **derived, not asserted**: the extended adapter test reads *both* `bin/candle.rs` and `bin/mlx.rs` and requires each component's `arms` to equal the set of adapter binaries that bind its env var. `SCENEWORKS_SDXL_COMPONENT_*` is read by `candle.rs:102-111` and by no arm of `mlx.rs`. If an MLX arm ever starts binding one, that test reds until `arms` is widened — the requirement can neither silently come back on a lane nor silently vanish from one. No new gate: this is a unit test, not a CI check on code changes.

## Before / after — real `--list` on this Mac

`--backend mlx --campaign sc-22738 --inference-repo <inf@e34d7b46a>`, two `--hf-cache` roots:

```
BEFORE                                                          AFTER
sdxl:bf16:mlx                weights_missing  no laion/CLIP…    sdxl:bf16:mlx                runnable
sdxl:q4:mlx                  weights_missing  no laion/CLIP…    sdxl:q4:mlx                  runnable
sdxl:q8:mlx                  weights_missing  no laion/CLIP…    sdxl:q8:mlx                  runnable
realvisxl:bf16:mlx           weights_missing  no laion/CLIP…    realvisxl:bf16:mlx           runnable
realvisxl:q4:mlx             weights_missing  no laion/CLIP…    realvisxl:q4:mlx             runnable
realvisxl:q8:mlx             weights_missing  no laion/CLIP…    realvisxl:q8:mlx             runnable
realvisxl_lightning:bf16:mlx weights_missing  no laion/CLIP…    realvisxl_lightning:bf16:mlx runnable
realvisxl_lightning:q4:mlx   weights_missing  no laion/CLIP…    realvisxl_lightning:q4:mlx   runnable
realvisxl_lightning:q8:mlx   weights_missing  no laion/CLIP…    realvisxl_lightning:q8:mlx   runnable
illustrious_xl_v1:q4:mlx     weights_missing  no laion/CLIP…    illustrious_xl_v1:q4:mlx     runnable
illustrious_xl_v2:q4:mlx     weights_missing  no laion/CLIP…    illustrious_xl_v2:q4:mlx     runnable
```

11 cells flip `weights_missing` → `runnable` **with no download** — the weights were already on the host.

Correctly unchanged:

```
illustrious_xl_v1:bf16:mlx   weights_missing  no SceneWorks/illustrious-xl-v1-mlx@778c3f02/bf16 on this host
illustrious_xl_v1:q8:mlx     weights_missing  no SceneWorks/illustrious-xl-v1-mlx@778c3f02/q8 on this host
illustrious_xl_v2:bf16:mlx   weights_missing  no SceneWorks/illustrious-xl-v2-mlx@672e9851/bf16 on this host
illustrious_xl_v2:q8:mlx     weights_missing  no SceneWorks/illustrious-xl-v2-mlx@672e9851/q8 on this host
```

Those four tier roots are genuinely absent (~25 GB), and they still refuse on that.

`instantid_realvisxl` ×3 stay `weights_missing`, but now on their **own** reason rather than a borrowed one:

```
BEFORE  instantid_realvisxl:{bf16,q4,q8}:mlx  weights_missing  no laion/CLIP-ViT-bigG-14…@743c27bd snapshot on this host
AFTER   instantid_realvisxl:{bf16,q4,q8}:mlx  weights_missing  SCENEWORKS_INSTANTID_WEIGHTS is unset or names no directory on this host
```

The full MLX `--list` diff is confined to those SDXL-family rows; nothing else moved. The **candle** listing is byte-identical before and after (`diff` reports no change), and candle SDXL rows still refuse on the CLIP-bigG component exactly as before.

## Verification

- `node --test scripts/measure-memory-catalog.test.mjs` — **139 tests, 135 pass, 0 fail, 4 skipped** (pre-existing skips).
- `INFERENCE_REPO=<inf@e34d7b46a> npm run check` — **exit 0**, 906 tests pass, 0 fail. Both new tests run inside it.

New/extended coverage (fixture-based, weights-free):

1. *an SDXL co-requisite is required only on the lane whose engine opens it* — an MLX SDXL row with no CLIP-bigG snapshot classifies `runnable`, binds no component env, reports no component root, and its `anchorDownloadTargets` fetches the tier root **only**; the same row on candle stays `weights_missing` naming CLIP-bigG and plans all four fetches.
2. *a component the MLX engine declares is still required of the MLX lane* — a fixture whose components carry `arms: ["mlx","candle"]` keeps the MLX cell `weights_missing`; a fixture with no `arms` at all stays lane-blind.
3. *the staged SDXL component env vars agree between the catalog and the candle adapter* — extended to read `bin/mlx.rs` too and bind `arms` to the adapter binaries that actually consume each env var.

**Mutation:** reverting the lane gate (`requiredComponentsFor` returns `family.components` unfiltered) reds test 1 with exactly the production symptom, while test 2 stays green — the pair pins the behaviour in both directions:

```
✖ an SDXL co-requisite is required only on the lane whose engine opens it
  AssertionError: the MLX engine never opens laion/CLIP-ViT-bigG-14-laion2B-39B-b160k:
    no laion/CLIP-ViT-bigG-14-laion2B-39B-b160k@fedcba98 snapshot on this host
  + actual 'weights_missing'   - expected 'runnable'
✔ a component the MLX engine declares is still required of the MLX lane
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
