### PR TITLE
fix(sc-22738): bound every probe's process tree, and stop pr.sh reding a salvaged job

### DIFF
--- a/.github/workflows/memory-catalog-campaign.yml
+++ b/.github/workflows/memory-catalog-campaign.yml
@@ -122,6 +122,18 @@ on:
         required: false
         type: string
         default: "1"
+      probe_budget_minutes:
+        description: >-
+          Per-probe wall-clock budget (--probe-budget-minutes). Empty uses the lane defaults, 165
+          minutes for a video anchor and 60 for an image one. `240` sets both lanes;
+          `video=240` (or `video=240,image=90`) raises ONE lane and leaves the other's tighter
+          backstop alone. Raise the video lane when a cell reports runtime_budget_exceeded and its
+          reason says no completed render on that backend is on file -- the heavy candle video cells
+          have none, so their budget is extrapolated from the MLX witnesses and a re-run at the
+          default would die at the same second.
+        required: false
+        type: string
+        default: ""
       instantid_weights:
         description: >-
           Absolute path on the runner to the InstantID identity bundle DIRECTORY holding
@@ -168,6 +180,10 @@ env:
   SKIP_CURRENT: ${{ inputs.skip_current }}
   HF_CACHE_INPUT: ${{ inputs.hf_cache_roots }}
   DOWNLOAD_MISSING: ${{ inputs.download_missing }}
+  # The per-lane wall-clock budget, straight through to `--probe-budget-minutes` (sc-22738 review).
+  # It is a dispatch input rather than a constant so raising the budget for a cell whose backend has
+  # no completed witness never needs a source edit.
+  PROBE_BUDGET_INPUT: ${{ inputs.probe_budget_minutes }}
   # The three operator-staged identity stacks (sc-22738). Carried as INPUT_-prefixed names on
   # purpose: `stage-identity-bundles.sh` copies each into $GITHUB_ENV under the name the worker
   # actually reads ONLY when it is non-empty, so an unused input can never blank a runner that

--- a/.github/workflows/memory-catalog-campaign.yml
+++ b/.github/workflows/memory-catalog-campaign.yml
@@ -127,10 +127,12 @@ on:
           Per-probe wall-clock budget (--probe-budget-minutes). Empty uses the lane defaults, 165
           minutes for a video anchor and 60 for an image one. `240` sets both lanes;
           `video=240` (or `video=240,image=90`) raises ONE lane and leaves the other's tighter
-          backstop alone. Raise the video lane when a cell reports runtime_budget_exceeded and its
-          reason says no completed render on that backend is on file -- the heavy candle video cells
-          have none, so their budget is extrapolated from the MLX witnesses and a re-run at the
-          default would die at the same second.
+          backstop alone. Raise a lane when a cell reported runtime_budget_exceeded and you believe
+          it was still rendering: the reason names that lane's longest completed capture on the
+          cell's own backend and the cell it was read from, and a re-run at the same budget stops at
+          the same second. The heavy candle video cells (scail2_14b, wan_2_2_i2v_14b,
+          wan_2_2_t2v_14b -- 14B DiTs at 480p/720p) have no completed candle render on file at all,
+          so their 165 minutes is the figure to raise if one of them stops.
         required: false
         type: string
         default: ""
@@ -181,8 +183,8 @@ env:
   HF_CACHE_INPUT: ${{ inputs.hf_cache_roots }}
   DOWNLOAD_MISSING: ${{ inputs.download_missing }}
   # The per-lane wall-clock budget, straight through to `--probe-budget-minutes` (sc-22738 review).
-  # It is a dispatch input rather than a constant so raising the budget for a cell whose backend has
-  # no completed witness never needs a source edit.
+  # It is a dispatch input rather than a constant so a cell that needs longer than its lane's
+  # default can be re-measured without a source edit and a PR.
   PROBE_BUDGET_INPUT: ${{ inputs.probe_budget_minutes }}
   # The three operator-staged identity stacks (sc-22738). Carried as INPUT_-prefixed names on
   # purpose: `stage-identity-bundles.sh` copies each into $GITHUB_ENV under the name the worker

--- a/.github/workflows/memory-catalog-campaign.yml
+++ b/.github/workflows/memory-catalog-campaign.yml
@@ -192,10 +192,10 @@ jobs:
     concurrency:
       group: memory-catalog-campaign-mlx-${{ startsWith(inputs.runner_label, 'nax') && 'nax' || 'rw-krea' }}
       cancel-in-progress: false
-    # The full MLX walk is ~147 anchors of real GPU renders and the harness imposes no per-anchor
-    # timeout, so this is deliberately a two-day ceiling rather than a measured budget: the ceiling
-    # exists to stop a WEDGED job holding the box forever, and every anchor that finished before a
-    # timeout has already been committed and pushed.
+    # The full MLX walk is ~147 anchors of real GPU renders, so this is deliberately a two-day
+    # ceiling rather than a measured budget. Each anchor is bounded on its own by the harness
+    # (`PROBE_BUDGET_MINUTES`, sc-22738), so this ceiling now only catches a wedge OUTSIDE a probe;
+    # every anchor that finished before a timeout has already been committed and pushed.
     timeout-minutes: 2880
     env:
       # Survives actions/checkout's `clean: true` between jobs on this persistent box, and keeps the

--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -1284,7 +1284,7 @@ first five:
 | `captured` | `--no-commit`: the bundle was written and schema-checked, nothing ingested | clean |
 | `exceeded` | `--no-commit`: the render hit a ceiling (either kind); it is named on the row but there is nowhere to put it | clean |
 | `artifact_unsupported` | the pinned engine's production loader refused the shipped artifact (sc-22738) — the row carries the loader's own `unsupported:` sentence verbatim; **no evidence, no bound, no commit** | clean |
-| `runtime_budget_exceeded` | the probe ran out of its WALL-CLOCK budget and was stopped (below). Its own outcome since sc-22738's run 34356681566, not folded in with `capture_failed`: **nothing was measured**, so no bound is recorded and the cell classifies `runnable` again. It is still a walk failure (exit 2) | clean |
+| `runtime_budget_exceeded` | the probe ran out of its WALL-CLOCK budget and was stopped (below), **having measured nothing** — so no bound is recorded and the cell classifies `runnable` again. Its own outcome since sc-22738's run 34356681566, not folded in with `capture_failed`; still a walk failure (exit 2). The reason names the budget in its own seconds, the backstop's later deadline as itself, this backend's longest completed capture and the cell it was read from, and the `--probe-budget-minutes <lane>=N` re-run that raises this lane alone | clean |
 | `capture_failed` | the capture died for a reason that is NEITHER a footprint stop, a wall-clock stop, a wired-limit refusal nor a pinned-artifact refusal (or is a ceiling the row cannot bind an artifact for), **or** it is the second consecutive Metal refusal, which halts the walk | clean |
 | `check_failed` | the bundle failed `harness check` | clean |
 | `ingest_failed` | a post-capture step failed; the tree was rolled back to HEAD | clean |
@@ -1311,8 +1311,12 @@ guard's ceilings bound a probe that CLIMBS; they say nothing about one that stop
 adapter parked in `mlx::core::eval`. So `measure-memory-catalog.mjs` passes the guard a
 `--max-runtime-seconds` on every capture, defaulted per lane by `PROBE_BUDGET_MINUTES` — **165
 minutes for a video anchor, 60 for an image one** (the lane is derived from the plan: a video anchor
-renders more than one frame), overridable for a run with `--probe-budget-minutes N`, which
-`--dry-run` prints per row. Each default rests on the longest COMPLETED figure its lane has
+renders more than one frame), overridable for a run with `--probe-budget-minutes N` — or **per
+lane**, `--probe-budget-minutes video=240[,image=90]`, so raising the budget for one wedged 14B
+video cell does not also hand every image cell four hours to hang in (sc-22738 review). The campaign
+workflow carries it as the `probe_budget_minutes` dispatch input, so raising a lane needs no source
+edit; the value is passed verbatim and an unknown lane name is refused by the walk rather than
+ignored. `--dry-run` prints the resulting budget per row. Each default rests on the longest COMPLETED figure its lane has
 witnessed (`WITNESSED_CAPTURE_SECONDS`), cleared by the 1.8× margin policy: 4,470 s PER RENDER
 for video and 847 s per capture cycle for image. That flat 93.5 GB line was a render in progress,
 not a wedge: a video arm USED TO render its clip THREE times per capture (measured, clean warm
@@ -1349,12 +1353,42 @@ WITH warm passes (`docs/calibration/sc-22738/*`, `sc-18791/*`): a record without
 keeps every previous requirement. So the video budget is now per render: 165 minutes = 9,900 s is
 2.2× the 4,470 s witness and 1.83× the 5,400 s packed-tier lower bound.
 
+**The CANDLE lane's own witnesses (sc-22738 review, 2026-09-10).** Every figure above is `:mlx`,
+which cost nothing while the budget reached no candle probe — and everything once the runner's
+backstop made it a hard kill at exactly 9,900 s on the CUDA lane. Run 34356681566's own committed
+anchors supply the missing evidence (branch `story/sc-22738-candle-evidence-34356681566`, the 20 it
+landed before it wedged): the three `ltx_2_5:*:candle` video cells completed in 300 s, 285 s and
+446 s of capture→capture cycle on 2026-09-09, and `qwen_image_edit_2511:q8:candle` in 239 s on the
+image lane — read as consecutive `capturedAt` deltas, the same way the 847 s image witness is, and
+therefore UPPER bounds on the captures inside them. The candle video lane is an order of magnitude
+faster than the MLX one, 165 minutes clears its longest completed cycle by 22×, and the 19h43m
+`scail2_14b:bf16:candle` cell was a WEDGE rather than a slow render. Both lane defaults therefore
+stand where they are, now with a completed capture of each backend behind them
+(`VIDEO_RENDER_WITNESSES_SECONDS`, `IMAGE_CAPTURE_WITNESSES_SECONDS`) — the kill line is set by the
+slower backend, and the faster one runs far inside it. What is still unwitnessed is the heavy end of
+the candle video lane (`scail2_14b`, `wan_2_2_i2v_14b`, `wan_2_2_t2v_14b`: 14B DiTs at 480p/720p),
+which is why a stop names its witness cell and the flag that raises the lane rather than leaving an
+operator to re-run into the same second.
+
 A probe that reaches its budget is stopped and reported on its own outcome,
-`runtime_budget_exceeded`, naming the budget, the peak footprint sampled where one was (so you can
-tell a probe wedged at the ceiling from one wedged at 3 GB) and the lane's longest completed render
-(video) or capture (image); a run
+`runtime_budget_exceeded`, naming the budget in its own seconds, the peak footprint sampled where
+one was (so you can tell a probe wedged at the ceiling from one wedged at 3 GB), the lane's longest
+completed render (video) or capture (image) **and the longest one on this cell's own backend, with
+the cell it was read from**; a run
 launched with `--probe-budget-minutes` below its lane's default is told, in the reason, that the
-stop is a budget shortfall and not evidence of a stall.
+stop is a budget shortfall and not evidence of a stall, and one at or above the default is told the
+exact `--probe-budget-minutes <lane>=N` that would raise it.
+
+**WHY THE ROW NAMES THE WITNESS CELL (sc-22738 review, 2026-09-10).** The budget is a hard kill on
+every lane now, so a cell it stops either wedged or could not finish inside it, and only the
+operator can tell which. The candle video witnesses are all `ltx_2_5` (300 s, 285 s and 446 s per
+cycle in run 34356681566) while the heavy candle video cells are 14B DiTs at 480p/720p that have
+never completed a candle render, so "the candle lane finishes video in five minutes" must never be
+read as evidence about `scail2_14b:bf16:candle`. The row therefore states the figure, the cell it
+belongs to, and the flag — it claims nothing about what else has or has not completed, because
+`VIDEO_RENDER_WITNESSES_SECONDS` / `IMAGE_CAPTURE_WITNESSES_SECONDS` hold each backend's LONGEST
+capture rather than a record of every one. And a re-run at the same budget dies at the same second:
+if the render was still making progress, raise that lane and re-run, rather than re-running into it.
 
 **TWO things impose that budget, and they are not alternatives (sc-22738, run 34356681566).** On a
 Mac the footprint guard does it, via `--max-runtime-seconds`, on its ONE stop path — the same
@@ -1368,14 +1402,24 @@ budget reached NO probe on the Windows CUDA lane: run 34356681566 sat on `scail2
 165-minute budget, and the remaining 47 cells were never reached. On a Mac the runner's bound sits
 two minutes BEHIND the guard's deadline (`RUNNER_BACKSTOP_GRACE_SECONDS`), so the guard keeps owning
 every stop it can make and the runner fires only when the guard did not. A runner stop says so in
-its reason, and claims no ceiling and no sampled peak where no guard ran.
+its reason — naming its own later deadline as itself, never as the budget — and claims no ceiling
+and no sampled peak where no guard ran.
 
-**It is not an exceedance:** the run never
+**A STOPPED PROBE STILL KEEPS WHAT IT MEASURED (sc-22738 review).** The guard writes
+`physical_footprint_at_or_above_<ceiling>:observed_<footprint>` at the instant it fires, and its
+post-stop reap can then wedge past the two-minute grace — so the runner reads the event log BEFORE
+its backstop reports, and a bound already in it is committed as `committed_exceeded` rather than
+thrown away. Narrow on purpose: only a FOOTPRINT stop (or the Metal wired-limit refusal) counts,
+because `stopProcessTree` SIGTERMs the guard and the guard writes `monitor_signal_SIGTERM` on its
+way out — the runner's own kill must never be filed as a fact about the model.
+
+**Otherwise it is not an exceedance:** the run never
 crossed a line, so no bound is written (the harness's `record-exceeded` refuses a wall-clock stop
 outright), the store keeps no trace, the watchdog stream and per-anchor log stay in the work dir,
 and the cell classifies `runnable` again on the next `--list`. Re-run it, or re-run it with a larger
-`--probe-budget-minutes` if you believe the render was still making progress — and never below the
-lane default for a cell whose witnessed capture is longer than the budget you are about to give it.
+`--probe-budget-minutes <lane>=N` if you believe the render was still making progress — and never
+below the lane default for a cell whose witnessed capture is longer than the budget you are about to
+give it.
 
 **`committed_exceeded` is the one that changed (sc-22738).** A footprint hard stop used to be a
 `capture_failed` that stamped nothing at all: the store kept no trace, and production went on

--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -1284,7 +1284,8 @@ first five:
 | `captured` | `--no-commit`: the bundle was written and schema-checked, nothing ingested | clean |
 | `exceeded` | `--no-commit`: the render hit a ceiling (either kind); it is named on the row but there is nowhere to put it | clean |
 | `artifact_unsupported` | the pinned engine's production loader refused the shipped artifact (sc-22738) — the row carries the loader's own `unsupported:` sentence verbatim; **no evidence, no bound, no commit** | clean |
-| `capture_failed` | the capture died for a reason that is NEITHER a footprint stop, a wired-limit refusal nor a pinned-artifact refusal (or is a ceiling the row cannot bind an artifact for), **or** it ran out of its wall-clock budget (`runtime_budget_exceeded`, below), **or** it is the second consecutive Metal refusal, which halts the walk | clean |
+| `runtime_budget_exceeded` | the probe ran out of its WALL-CLOCK budget and was stopped (below). Its own outcome since sc-22738's run 34356681566, not folded in with `capture_failed`: **nothing was measured**, so no bound is recorded and the cell classifies `runnable` again. It is still a walk failure (exit 2) | clean |
+| `capture_failed` | the capture died for a reason that is NEITHER a footprint stop, a wall-clock stop, a wired-limit refusal nor a pinned-artifact refusal (or is a ceiling the row cannot bind an artifact for), **or** it is the second consecutive Metal refusal, which halts the walk | clean |
 | `check_failed` | the bundle failed `harness check` | clean |
 | `ingest_failed` | a post-capture step failed; the tree was rolled back to HEAD | clean |
 
@@ -1348,14 +1349,28 @@ WITH warm passes (`docs/calibration/sc-22738/*`, `sc-18791/*`): a record without
 keeps every previous requirement. So the video budget is now per render: 165 minutes = 9,900 s is
 2.2× the 4,470 s witness and 1.83× the 5,400 s packed-tier lower bound.
 
-A probe that reaches its
-budget is stopped on the guard's ONE stop path — the same SIGTERM→SIGKILL escalation and post-stop
-census a footprint stop takes — and is reported as `capture_failed` with reason
-`runtime_budget_exceeded`, naming the budget, the peak footprint sampled (so you can tell a probe
-wedged at the ceiling from one wedged at 3 GB) and the lane's longest completed render (video) or
-capture (image); a run
+A probe that reaches its budget is stopped and reported on its own outcome,
+`runtime_budget_exceeded`, naming the budget, the peak footprint sampled where one was (so you can
+tell a probe wedged at the ceiling from one wedged at 3 GB) and the lane's longest completed render
+(video) or capture (image); a run
 launched with `--probe-budget-minutes` below its lane's default is told, in the reason, that the
-stop is a budget shortfall and not evidence of a stall. **It is not an exceedance:** the run never
+stop is a budget shortfall and not evidence of a stall.
+
+**TWO things impose that budget, and they are not alternatives (sc-22738, run 34356681566).** On a
+Mac the footprint guard does it, via `--max-runtime-seconds`, on its ONE stop path — the same
+SIGTERM→SIGKILL escalation and post-stop census a footprint stop takes. Everywhere else the RUNNER
+does it: `measure-memory-catalog.mjs` bounds each capture's whole process TREE
+(`probeTimeoutMs` → `stopProcessTree`; `taskkill /T /F` on Windows, where node's `kill()` reaches
+only the immediate child and would leave `memory-candle-adapter.exe` running). The guard is
+Darwin-only by construction — its sampler is `/usr/bin/footprint` — so until this was added the
+budget reached NO probe on the Windows CUDA lane: run 34356681566 sat on `scail2_14b:bf16:candle`
+(85/132) from 15:15:45Z to the job's cancellation at 10:59:16Z the next day, 19h43m against a
+165-minute budget, and the remaining 47 cells were never reached. On a Mac the runner's bound sits
+two minutes BEHIND the guard's deadline (`RUNNER_BACKSTOP_GRACE_SECONDS`), so the guard keeps owning
+every stop it can make and the runner fires only when the guard did not. A runner stop says so in
+its reason, and claims no ceiling and no sampled peak where no guard ran.
+
+**It is not an exceedance:** the run never
 crossed a line, so no bound is written (the harness's `record-exceeded` refuses a wall-clock stop
 outright), the store keeps no trace, the watchdog stream and per-anchor log stay in the work dir,
 and the cell classifies `runnable` again on the next `--list`. Re-run it, or re-run it with a larger
@@ -1645,9 +1660,27 @@ work dir (summary JSON, per-anchor logs, retained raw bundles) is uploaded as a 
 every outcome, and a final step opens `chore(<campaign>): <backend> catalog campaign results` into
 `ref` when the branch has commits. Nothing is merged automatically.
 
+🔴 **If the repository forbids Actions from opening PRs, that final step WARNS rather than failing
+(sc-22738, run 34356681566).** `gh pr create` returns
+
+```
+pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve
+pull requests (createPullRequest)
+```
+
+when the repository/organization setting *"Allow GitHub Actions to create and approve pull
+requests"* is off. No `permissions:` block overrides it — `pull-requests: write` is already granted
+— so the step emits a `::warning` with a ready-to-click
+`compare/<ref>...<campaign branch>?expand=1` URL, writes the same link into the job summary, and
+exits 0. The branch and the artifact are already safe at that point; only the click is missing.
+That single message is the ONLY failure treated this way: any other `gh pr create` failure (a bad
+token, a base ref that does not exist, a rejected body) still reds the step, because there the PR is
+genuinely lost and nothing else would say so.
+
 Each job takes a `concurrency` group keyed on (backend, runner) with `cancel-in-progress: false`, so
 two campaigns queue rather than share a GPU. `timeout-minutes` is a wedge ceiling (2880 mlx / 1440
-candle), not a measured budget.
+candle), not a measured budget — and since sc-22738 each anchor is separately bounded by the harness
+(`PROBE_BUDGET_MINUTES`), so the job ceiling only catches a wedge OUTSIDE a probe.
 
 **Hugging Face roots.** `hf_cache_roots` (newline- or `;`-separated) wins; otherwise the runner-level
 `$SCENEWORKS_MEMORY_CAMPAIGN_HF_CACHE`; otherwise the lane default (`/Volumes/Models/huggingface/hub`

--- a/scripts/ci/memory-catalog/common.sh
+++ b/scripts/ci/memory-catalog/common.sh
@@ -98,6 +98,14 @@ build_catalog_args() {
   if [[ -n "${ANCHORS_INPUT:-}" ]]; then
     CATALOG_ARGS+=(--anchors "$ANCHORS_INPUT")
   fi
+  # The per-lane probe budget (sc-22738 review). Passed VERBATIM -- `240`, `video=240` and
+  # `video=240,image=90` are all the walk's own spelling, and it refuses anything else by name, so
+  # a typo reds the dispatch instead of silently leaving the budget at its default. It belongs in
+  # the shared args because `--dry-run`/`--list` print each row's budget: the operator raising one
+  # lane can see the new figure before spending a day of GPU on it.
+  if [[ -n "${PROBE_BUDGET_INPUT:-}" ]]; then
+    CATALOG_ARGS+=(--probe-budget-minutes "$PROBE_BUDGET_INPUT")
+  fi
   # `--model` is repeatable; the input is a space-separated list.
   if [[ -n "${MODELS_INPUT:-}" ]]; then
     local model

--- a/scripts/ci/memory-catalog/pr.sh
+++ b/scripts/ci/memory-catalog/pr.sh
@@ -3,8 +3,25 @@
 #
 # Never merges, never enables auto-merge. `feature/*` has no required checks and is merge-commit
 # only; whether these measurements are accepted is a review decision, not a CI one.
+#
+# THIS STEP MUST NOT RED A SALVAGED JOB (sc-22738, run 34356681566). It runs under `if: always()`
+# precisely so a cancelled or timed-out walk's evidence is never stranded, and the campaign branch
+# with its 20 anchor commits had already been pushed when this step turned the whole job red with
+#
+#   pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve
+#   pull requests (createPullRequest)
+#
+# That is the repository/organization "Allow GitHub Actions to create and approve pull requests"
+# setting. No `permissions:` block can override it -- `pull-requests: write` is already granted --
+# and the workflow token cannot ask for it. The branch is pushed either way, so the only thing
+# missing is a click. `PR_CREATION_FORBIDDEN` below is the one failure that degrades to a warning
+# plus a ready-to-click compare URL; every OTHER failure still fails the step, because a `gh` that
+# cannot authenticate, a base ref that does not exist or a rejected body is a real defect and
+# swallowing it would hide the loss of the PR entirely.
 # shellcheck source=scripts/ci/memory-catalog/common.sh
 source "$(dirname "$0")/common.sh"
+
+PR_CREATION_FORBIDDEN="GitHub Actions is not permitted to create or approve pull requests"
 
 if [[ -z "${CAMPAIGN_BRANCH:-}" ]]; then
   echo "no campaign branch was cut; no PR to open"
@@ -47,16 +64,51 @@ BODY_FILE="${WORK_DIR}/pr-body.md"
 # body file rather than the `/d/a/_temp/...` form bash writes it under. Git Bash's argv mangling
 # usually converts an absolute POSIX path on the way to a non-MSYS program, but that is a heuristic
 # on the argument's shape -- not a guarantee -- and `native_path` is a no-op everywhere else.
-URL="$(gh pr create \
+#
+# stderr is MERGED into stdout and captured rather than left to stream: the policy refusal above is
+# only recognisable by its message, and `set -e` would otherwise end the step before it is read.
+set +e
+OUTPUT="$(gh pr create \
   --base "$BASE_REF" \
   --head "$CAMPAIGN_BRANCH" \
   --title "chore(${CAMPAIGN}): ${BACKEND} catalog campaign results" \
-  --body-file "$(native_path "$BODY_FILE")")"
+  --body-file "$(native_path "$BODY_FILE")" 2>&1)"
+STATUS=$?
+set -e
 
-echo "opened $URL"
+if [[ "$STATUS" -eq 0 ]]; then
+  echo "opened $OUTPUT"
+  {
+    echo "#### Pull request"
+    echo
+    echo "$OUTPUT"
+    echo
+  } >> "$GITHUB_STEP_SUMMARY"
+  exit 0
+fi
+
+echo "$OUTPUT" >&2
+
+if [[ "$OUTPUT" != *"$PR_CREATION_FORBIDDEN"* ]]; then
+  echo "::error title=Results PR was not opened::gh pr create failed for ${CAMPAIGN_BRANCH} -> ${BASE_REF}; see the step log"
+  exit "$STATUS"
+fi
+
+# GitHub renders `compare/<base>...<head>` with a "Create pull request" button already filled in,
+# and slashes in either branch name need no escaping there.
+COMPARE_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/${BASE_REF}...${CAMPAIGN_BRANCH}?expand=1"
+echo "::warning title=Results PR must be opened by hand::this repository does not let GitHub Actions create pull requests, so the ${CAMPAIGN_BRANCH} branch was pushed but no PR was opened. Open it here: ${COMPARE_URL}"
 {
   echo "#### Pull request"
   echo
-  echo "$URL"
+  echo "The measurements are pushed to \`${CAMPAIGN_BRANCH}\`, but this repository does not permit"
+  echo "GitHub Actions to create pull requests, so **the PR must be opened by hand**:"
+  echo
+  echo "[Open the PR: \`${BASE_REF}\` <- \`${CAMPAIGN_BRANCH}\`](${COMPARE_URL})"
+  echo
+  echo "The body this step would have used is attached to the run as \`pr-body.md\` in the campaign"
+  echo "work-dir artifact."
   echo
 } >> "$GITHUB_STEP_SUMMARY"
+# EXIT 0 ON PURPOSE: the branch is safe, the evidence is uploaded, and only a click is missing.
+exit 0

--- a/scripts/ci/memory-catalog/run.sh
+++ b/scripts/ci/memory-catalog/run.sh
@@ -2,12 +2,18 @@
 # Walk every planned anchor for this backend, pushing the branch as measurements land (sc-22738).
 #
 # WHY A BACKGROUND PUSHER. The walk is a single long-lived node process that commits one anchor at
-# a time and can run for many hours; the harness has no per-anchor timeout and no push of its own.
-# If the only push happened after the process returned, a cancel, a job timeout or a wedged render
-# would throw away every anchor already measured -- hours of GPU time that cannot be re-derived
-# cheaply. So the walk runs in the background and a poller pushes the branch every time
+# a time and can run for many hours, and it has no push of its own. If the only push happened after
+# the process returned, a cancel, a job timeout or a wedged render would throw away every anchor
+# already measured -- hours of GPU time that cannot be re-derived cheaply. So the walk runs in the
+# background and a poller pushes the branch every time
 # $PUSH_EVERY new commits have appeared. `push.sh` then runs under `if: always()` and pushes the
 # remainder on success, failure, timeout and cancellation alike.
+#
+# WHY THERE IS NO PER-ANCHOR TIMEOUT HERE. There is one, and it belongs to the harness rather than
+# to this script (sc-22738, run 34356681566): `measure-memory-catalog.mjs` bounds each capture's
+# process tree by that anchor's own `PROBE_BUDGET_MINUTES` and reports the cell
+# `runtime_budget_exceeded` before moving to the NEXT anchor. A timeout here could only kill the
+# whole walk, which is precisely the outcome -- 47 unreached cells -- the bound exists to prevent.
 #
 # The poller only ever runs `git push` -- it never commits, never checks out and never touches the
 # worktree -- so it cannot make the tree dirty underneath the harness's stability assertion.

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -1473,7 +1473,11 @@ export function parseProbeBudgetMinutes(raw, current = null) {
   const entries = String(raw).split(",").map((entry) => entry.trim()).filter(Boolean);
   if (entries.length === 0) fail("--probe-budget-minutes must be a positive number of minutes");
   for (const entry of entries) {
-    const [name, minutes] = entry.includes("=") ? entry.split("=", 2) : [null, entry];
+    // Split at the FIRST `=` and keep the whole remainder: `split("=", 2)` would drop everything
+    // after the second one, so `video=240=99` would quietly book 240 — the silent acceptance this
+    // flag exists to rule out. The remainder goes to `Number`, which refuses it.
+    const equals = entry.indexOf("=");
+    const [name, minutes] = equals === -1 ? [null, entry] : [entry.slice(0, equals), entry.slice(equals + 1)];
     if (name === null) {
       const both = positive(minutes, "");
       for (const lane of PROBE_BUDGET_LANES) budget[lane] = both;

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -16,7 +16,7 @@
 //   node scripts/measure-memory-catalog.mjs --backend mlx \
 //     --adapter target/release/memory-mlx-adapter --inference-repo ../inference \
 //     --work-dir /abs/OUTSIDE/the/repo/calib --campaign sc-NNNN [--model sdxl ...] [--anchors a,b]
-//     [--skip-current] [--probe-budget-minutes N]
+//     [--skip-current] [--probe-budget-minutes N | video=N[,image=N]]
 //     [--dry-run] [--no-commit] [--hf-cache DIR ...]   (--hf-cache is repeatable)
 //     [--download-missing]
 //
@@ -30,11 +30,18 @@
 // fetches nothing.
 //
 // EVERY probe carries a WALL-CLOCK budget (`--probe-budget-minutes`, defaulted per lane by
-// `PROBE_BUDGET_MINUTES`) and is stopped when it reaches it, on the terminal status
-// `runtime_budget_exceeded`. It is NOT an exceedance: a run that thrashed below the ceiling
-// measured nothing, so no bound is written, the store keeps no trace, and the cell classifies
-// `runnable` again on the next `--list` (sc-22738). The walk then moves to the NEXT cell — one
-// wedged probe can no longer consume the whole job.
+// `PROBE_BUDGET_MINUTES`, and raisable per lane — `video=240` — for a run) and is stopped when it
+// reaches it, on the terminal status `runtime_budget_exceeded`. It is NOT an exceedance: a run that
+// thrashed below the ceiling measured nothing, so no bound is written, the store keeps no trace,
+// and the cell classifies `runnable` again on the next `--list` (sc-22738). The walk then moves to
+// the NEXT cell — one wedged probe can no longer consume the whole job. A stop names the longest
+// completed capture on the stopped cell's OWN backend, the cell that figure was read from, and the
+// per-lane flag that raises the budget, because a re-run at the same budget dies at the same second
+// and only the operator can tell a wedge from a render that needed longer.
+//
+// A stopped probe that nevertheless MEASURED a bound keeps it: the guard's footprint hard stop is
+// read out of the event log BEFORE the runner's backstop reports, so a bound written at minute 100
+// of a 165-minute budget survives a reap that then wedged past the backstop (sc-22738 review).
 //
 // TWO things can impose that budget, and they are not alternatives:
 //   * the footprint guard, on Darwin, via `--max-runtime-seconds` — one more trigger on its ONE
@@ -1444,6 +1451,43 @@ export function anchorSlug(key) {
   return key.replaceAll(":", "-").replaceAll("_", "-");
 }
 
+/** The lanes `--probe-budget-minutes` can name, one entry per `PROBE_BUDGET_MINUTES` key. */
+export const PROBE_BUDGET_LANES = Object.freeze(["video", "image"]);
+
+/**
+ * One `--probe-budget-minutes` value, merged onto whatever earlier occurrences of the flag set
+ * (sc-22738 review). Returns `{ video, image }` with `null` for a lane the operator did not name,
+ * which `probeBudgetMinutes` reads as "keep that lane's default".
+ *
+ * `240` sets both lanes; `video=240` or `video=240,image=90` sets only what it names. An unknown
+ * lane is refused rather than ignored: a typo that silently left the budget at 165 is exactly the
+ * failure the flag exists to rescue an operator from.
+ */
+export function parseProbeBudgetMinutes(raw, current = null) {
+  const budget = { video: null, image: null, ...(current ?? {}) };
+  const positive = (text, what) => {
+    const minutes = Number(text);
+    if (!Number.isFinite(minutes) || minutes <= 0) fail(`--probe-budget-minutes must be a positive number of minutes${what}`);
+    return minutes;
+  };
+  const entries = String(raw).split(",").map((entry) => entry.trim()).filter(Boolean);
+  if (entries.length === 0) fail("--probe-budget-minutes must be a positive number of minutes");
+  for (const entry of entries) {
+    const [name, minutes] = entry.includes("=") ? entry.split("=", 2) : [null, entry];
+    if (name === null) {
+      const both = positive(minutes, "");
+      for (const lane of PROBE_BUDGET_LANES) budget[lane] = both;
+      continue;
+    }
+    const lane = name.trim();
+    if (!PROBE_BUDGET_LANES.includes(lane)) {
+      fail(`--probe-budget-minutes names lane ${JSON.stringify(lane)}; the lanes are ${PROBE_BUDGET_LANES.join(", ")}`);
+    }
+    budget[lane] = positive(minutes, ` for ${lane}`);
+  }
+  return budget;
+}
+
 export function parseArgs(argv) {
   const args = {
     backend: null, adapter: null, inferenceRepo: null, workDir: null, campaign: null,
@@ -1469,10 +1513,11 @@ export function parseArgs(argv) {
       case "--skip-current": args.skipCurrent = true; break;
       // Minutes, and fractional minutes are accepted: the budget is one number in one unit, and a
       // test (or a deliberately tight re-run) needs to express seconds without a second flag.
+      // PER LANE too (sc-22738 review): `240` sets both lanes, `video=240,image=90` sets each on
+      // its own, and the flag is repeatable — so the operator who has to give one wedged 14B video
+      // cell more room can do it without also handing every image cell four hours to hang in.
       case "--probe-budget-minutes": {
-        const minutes = Number(value(flag, index));
-        if (!Number.isFinite(minutes) || minutes <= 0) fail("--probe-budget-minutes must be a positive number of minutes");
-        args.probeBudgetMinutes = minutes;
+        args.probeBudgetMinutes = parseProbeBudgetMinutes(value(flag, index), args.probeBudgetMinutes);
         index += 1;
         break;
       }
@@ -3051,21 +3096,92 @@ export async function probeAdapter(command, { cwd = ROOT, env = process.env, wir
  *
  * The cost of being wrong is bounded BY DESIGN and asymmetric on purpose: a runtime stop records no
  * bound and leaves the cell `runnable`, so too tight a budget costs a re-run, while too loose a one
- * costs only operator time. `--probe-budget-minutes` overrides both entries for a run and is
- * honored as given; a run launched below its lane's default is told so in the stop reason
- * (`runtimeBudgetExceededReason`), because a stop under such a budget is not evidence of a stall.
+ * costs only operator time. `--probe-budget-minutes` overrides the table for a run — `N` for both
+ * lanes, or `video=N` / `image=N` to raise ONE of them — and is honored as given; a run launched
+ * below its lane's default is told so in the stop reason (`runtimeBudgetExceededReason`), because a
+ * stop under such a budget is not evidence of a stall.
+ *
+ * THE BOUND IS NOW A HARD KILL ON EVERY LANE, AND THE WITNESS SET HAD TO CATCH UP (sc-22738 review,
+ * 2026-09-10). Before the runner's own backstop the budget reached no candle probe at all, so it
+ * cost nothing that all three video witnesses were `:mlx`. It does now: `probeTimeoutMs` kills a
+ * candle video probe at exactly 9,900 s. A kill line extrapolated from one backend onto a lane with
+ * no witness of its own is not a safe default, so the CANDLE video renders run 34356681566 did
+ * complete are recorded below beside the MLX ones (branch
+ * `story/sc-22738-candle-evidence-34356681566`, the 20 anchors that campaign committed before it
+ * wedged): consecutive `capturedAt` deltas of 300 s, 285 s and 446 s for the three
+ * `ltx_2_5:*:candle` cells on 2026-09-09 — the same reading the image witness is taken from, and an
+ * UPPER bound on the render, since a cycle also carries that cell's ingest → extract → stamp →
+ * matrix → commit. The candle video lane is therefore an order of magnitude faster than the MLX
+ * one, 165 minutes clears its longest completed cycle by 22x, and the 19h43m
+ * `scail2_14b:bf16:candle` cell that the backstop was written for was a WEDGE, not a slow render.
+ *
+ * The figures stay at 165/60 for both lanes on that evidence. What is NOT witnessed on the candle
+ * lane is the heavy end — `scail2_14b`, `wan_2_2_i2v_14b`, `wan_2_2_t2v_14b` are 14B DiTs at
+ * 480p/720p and no candle render of one has ever completed. So every stop names the longest
+ * completed capture on the STOPPED CELL'S OWN backend and the cell it was read from — 446 s from an
+ * `ltx_2_5` capture is visibly not evidence about a 14B DiT — and every stop at or above the lane
+ * default names the exact `--probe-budget-minutes <lane>=N` that raises that lane
+ * (`runtimeBudgetExceededReason`). Raising it needs no source edit: the campaign workflow carries a
+ * `probe_budget_minutes` dispatch input straight through to the flag.
  */
 export const WITNESSED_CAPTURE_SECONDS = { video: 4_470, image: 847 };
 /**
- * The per-render witnesses the video figure above is read from (sc-22738, 2026-09-08). Every one
- * was a THREE-render capture; `perRenderSeconds` is the capture's wall clock over three.
- * `completed: false` marks a lower bound — the capture hit its budget with the render unfinished.
+ * The per-render witnesses the video figure above is read from (sc-22738, 2026-09-08; candle cells
+ * added 2026-09-10). `perRenderSeconds` is the capture's wall clock over its renders — three for
+ * the MLX cells, which predate the one-render video contract, one for the candle cells, which
+ * already captured a single render. `completed: false` marks a lower bound: the capture hit its
+ * budget with the render unfinished.
+ *
+ * `basis` says how each figure was read, because they are not the same measurement: `campaign log`
+ * is a capture's own wall clock, `capture→capture cycle` is the delta between consecutive
+ * `capturedAt` stamps and therefore an UPPER bound on the render inside it.
  */
 export const VIDEO_RENDER_WITNESSES_SECONDS = Object.freeze([
-  { cell: "scail2_14b:bf16:mlx", captureSeconds: 8_709, renders: 3, perRenderSeconds: 2_903, completed: true },
-  { cell: "wan_2_2_t2v_14b:bf16:mlx", captureSeconds: 13_411, renders: 3, perRenderSeconds: 4_470, completed: true },
-  { cell: "wan_2_2_t2v_14b:q4:mlx", captureSeconds: 16_200, renders: 3, perRenderSeconds: 5_400, completed: false },
+  { cell: "scail2_14b:bf16:mlx", captureSeconds: 8_709, renders: 3, perRenderSeconds: 2_903, completed: true, basis: "campaign log" },
+  { cell: "wan_2_2_t2v_14b:bf16:mlx", captureSeconds: 13_411, renders: 3, perRenderSeconds: 4_470, completed: true, basis: "campaign log" },
+  { cell: "wan_2_2_t2v_14b:q4:mlx", captureSeconds: 16_200, renders: 3, perRenderSeconds: 5_400, completed: false, basis: "campaign log" },
+  // Run 34356681566, 2026-09-09 (UTC): lens_turbo:q4:candle 14:34:15 → 14:39:15 → 14:44:00 →
+  // 14:51:26. The first delta also covers whatever the walk refused between those two cells; the
+  // other two bracket one cell each.
+  { cell: "ltx_2_5:bf16:candle", captureSeconds: 300, renders: 1, perRenderSeconds: 300, completed: true, basis: "capture→capture cycle" },
+  { cell: "ltx_2_5:q4:candle", captureSeconds: 285, renders: 1, perRenderSeconds: 285, completed: true, basis: "capture→capture cycle" },
+  { cell: "ltx_2_5:q8:candle", captureSeconds: 446, renders: 1, perRenderSeconds: 446, completed: true, basis: "capture→capture cycle" },
 ]);
+/**
+ * The capture→capture cycles the image figure above is read from (sc-22738; candle cell added
+ * 2026-09-10). Same reading as the video candle rows: the delta between two consecutive
+ * `capturedAt` stamps, an UPPER bound on the capture inside it.
+ */
+export const IMAGE_CAPTURE_WITNESSES_SECONDS = Object.freeze([
+  // 06:59:19 → 07:13:26 on 2026-09-07 (`bernini_image:q4:mlx` → `:q8:mlx`).
+  { cell: "bernini_image:q8:mlx", cycleSeconds: 847, completed: true, basis: "capture→capture cycle" },
+  // Run 34356681566: 15:07:06 → 15:11:05 on 2026-09-09 (`qwen_image_edit_2511:q4:candle` → `:q8:`).
+  { cell: "qwen_image_edit_2511:q8:candle", cycleSeconds: 239, completed: true, basis: "capture→capture cycle" },
+]);
+
+/**
+ * The backends that have a COMPLETED capture behind this lane's budget (sc-22738 review), and that
+ * lane's longest completed figure for each of them.
+ *
+ * A backend with no entry here is running under a kill line extrapolated from someone else's
+ * hardware — which is what every candle cell was until run 34356681566's own committed anchors were
+ * read back into the tables above. `runtimeBudgetExceededReason` puts this figure, and the cell it
+ * was read from, on every stop, so an operator can see at a glance whether the budget that killed
+ * their cell has anything behind it that resembles the cell.
+ */
+export function laneWitnessesByBackend(lane) {
+  const witnesses = lane === "video"
+    ? VIDEO_RENDER_WITNESSES_SECONDS.map((witness) => ({ ...witness, seconds: witness.perRenderSeconds }))
+    : IMAGE_CAPTURE_WITNESSES_SECONDS.map((witness) => ({ ...witness, seconds: witness.cycleSeconds }));
+  const longest = new Map();
+  for (const witness of witnesses) {
+    if (!witness.completed) continue;
+    const { backend } = anchorParts(witness.cell);
+    const held = longest.get(backend);
+    if (!held || witness.seconds > held.seconds) longest.set(backend, { cell: witness.cell, seconds: witness.seconds });
+  }
+  return new Map([...longest.entries()].sort(([left], [right]) => left.localeCompare(right)));
+}
 /** The packed-tier per-render LOWER BOUND the video budget must clear by the margin policy too. */
 export const VIDEO_RENDER_LOWER_BOUND_SECONDS = 5_400;
 /** The margin every lane default clears its witness by (see the basis above). */
@@ -3077,13 +3193,22 @@ export function probeLane(row) {
   return row.videoLane ? "video" : "image";
 }
 
-/** This row's wall-clock budget in minutes: the runner's `--probe-budget-minutes`, else its lane's. */
+/**
+ * This row's wall-clock budget in minutes: the runner's `--probe-budget-minutes`, else its lane's.
+ *
+ * The override is PER LANE (sc-22738 review). A bare `--probe-budget-minutes 240` still sets both,
+ * because that is what it always meant; `video=240` raises the video lane and leaves the image
+ * lane's tighter backstop where it is. Raising one lane by loosening both is how a knob meant to
+ * rescue one wedged 14B video cell would have given every image cell four hours to hang in.
+ */
 export function probeBudgetMinutes(row, override = null) {
-  if (override !== null && override !== undefined) {
-    if (!Number.isFinite(override) || override <= 0) fail("--probe-budget-minutes must be a positive number of minutes");
-    return override;
+  const lane = probeLane(row);
+  const minutes = override !== null && typeof override === "object" ? override[lane] : override;
+  if (minutes !== null && minutes !== undefined) {
+    if (!Number.isFinite(minutes) || minutes <= 0) fail("--probe-budget-minutes must be a positive number of minutes");
+    return minutes;
   }
-  return PROBE_BUDGET_MINUTES[probeLane(row)];
+  return PROBE_BUDGET_MINUTES[lane];
 }
 
 /**
@@ -3134,26 +3259,73 @@ export function probeTimeoutMs(budgetMinutes, guarded) {
  * ended the probe on its own stop path and `"runner"` when the runner's backstop did
  * (`probeTimeoutMs`); the two are read differently, because a runner stop also means the guard was
  * absent or failed.
+ *
+ * SELF-CONSISTENT SECONDS (sc-22738 review). The `(…s)` beside the budget is DERIVED from
+ * `budgetMinutes` and can no longer be handed a different quantity: the guarded runner arm used to
+ * pass `error.timeoutMs`, its own deadline, and rendered "the 165-minute probe budget (10020s)" —
+ * 165 minutes is 9,900 s. `stoppedAtSeconds` is that other deadline, the one that actually fired,
+ * and it is named as ITSELF rather than as the budget.
+ *
+ * WHAT MAKES IT ACTIONABLE (sc-22738 review). A budget is a kill line, so a cell whose own backend
+ * has no completed capture behind that line — every heavy candle video cell — is told exactly that,
+ * with the per-lane flag that raises it. Otherwise a re-run is just the same kill at the same
+ * point, which is what "permanently unmeasurable at the default budget" means.
  */
-export function runtimeBudgetExceededReason({ row, budgetMinutes, budgetSeconds, peak, ceiling, stoppedBy = "guard" }) {
+export function runtimeBudgetExceededReason({
+  row, budgetMinutes, peak, ceiling, stoppedBy = "guard", stoppedAtSeconds = null,
+}) {
   const lane = probeLane(row);
   const laneDefault = PROBE_BUDGET_MINUTES[lane];
   const witnessed = WITNESSED_CAPTURE_SECONDS[lane];
+  const unit = lane === "video" ? "render" : "capture";
+  const { backend } = anchorParts(row.key);
+  const budgetElapsed = Math.round(budgetMinutes * 60);
   const footprint = ceiling === null || ceiling === undefined
     ? "peak physical footprint not sampled: the footprint guard is Darwin-only, so nothing sampled this probe"
     : `peak physical footprint ${peak ? `${peak.peakBytes} bytes over ${peak.samples} sample(s)` : "not sampled"} against the ${ceiling}`;
+  // The deadline that fired, when it is not the budget itself: the runner's backstop sits
+  // `RUNNER_BACKSTOP_GRACE_SECONDS` behind the guard on a guarded lane, and saying so is the whole
+  // difference between "the guard was absent" and "the guard was there and failed to stop it".
+  const fired = stoppedAtSeconds === null || stoppedAtSeconds === undefined ? budgetElapsed : Math.round(stoppedAtSeconds);
+  let stop = "";
+  if (stoppedBy === "runner") {
+    stop = fired > budgetElapsed
+      ? `The runner's own wall-clock backstop stopped the probe's process tree at ${fired}s, `
+        + `${fired - budgetElapsed}s past the guard's own deadline: the guard did not stop the group. `
+      : "The runner's own wall-clock backstop stopped the probe's process tree at that budget. ";
+  } else if (fired !== budgetElapsed) {
+    // The guard's `--max-runtime-seconds` is this same budget, so the two agreeing is the norm and
+    // a disagreement is a defect worth reading on the row rather than swallowing.
+    stop = `The guard's own stop fired at ${fired}s, not at the ${budgetElapsed}s it was given. `;
+  }
+  // sc-22738: the lane figure is PER RENDER on video (a video capture is one render) and a whole
+  // capture cycle on image. sc-22738 review: and THIS BACKEND's own longest completed capture is
+  // named beside it, with the cell it was read from — the candle video witnesses are all `ltx_2_5`,
+  // and reading 446 s as evidence about `scail2_14b:bf16:candle`, a 14B DiT under CFG, is exactly
+  // the extrapolation an operator must not make silently. The row states the figure, whose cell it
+  // belongs to, and the flag; it claims NOTHING about what else has or has not completed, because
+  // this table holds each backend's LONGEST capture rather than a record of every one.
+  const own = laneWitnessesByBackend(lane).get(backend) ?? null;
+  const witness = own === null ? "" : ` (longest on ${backend}: ${own.seconds}s, ${own.cell})`;
   let reason =
-    `runtime_budget_exceeded: the ${budgetMinutes}-minute probe budget (${budgetSeconds}s) elapsed; `
+    `runtime_budget_exceeded: the ${budgetMinutes}-minute probe budget (${budgetElapsed}s) elapsed; `
     + `${footprint}. `
-    + (stoppedBy === "runner" ? "The runner's own wall-clock backstop stopped the probe's process tree. " : "")
+    + stop
     + `Nothing was measured, so no bound was recorded and this cell stays runnable. `
-    // sc-22738: the video figure is PER RENDER (a video capture is one render); the image figure
-    // is a whole capture cycle.
-    + `The longest completed ${lane} ${lane === "video" ? "render" : "capture"} on record ran ${witnessed}s`;
+    + `The longest completed ${lane} ${unit} on record ran ${witnessed}s`
+    + witness;
   if (budgetMinutes < laneDefault) {
     reason += `, and this run was launched with --probe-budget-minutes ${budgetMinutes}, below the ${lane} `
       + `lane's ${laneDefault}-minute default: this stop is a budget shortfall, not evidence of a stall. `
       + `Re-run it at the default budget or larger before reading anything into the flat footprint`;
+  } else {
+    // sc-22738 review: EVERY stop at or above the lane default poses the same question — a wedge,
+    // or a budget this cell cannot finish inside? — and an operator who cannot raise the budget can
+    // only re-run into the identical kill at the identical second. So the knob is named on the row,
+    // in the exact spelling that raises THIS lane alone, whatever the witnesses say.
+    reason += `. A re-run at this budget would stop at the same second: if the render was still `
+      + `making progress, re-run the cell with --probe-budget-minutes ${lane}=${Math.round(budgetMinutes * 2)} `
+      + `(the campaign's probe_budget_minutes input), which raises the ${lane} lane alone`;
   }
   return `${reason}.`;
 }
@@ -3246,6 +3418,28 @@ export const RUNTIME_BUDGET_STOP_PATTERN = /^watchdog hard stop: runtime_at_or_a
 export function runtimeBudgetStopSeconds(hardStop) {
   const match = RUNTIME_BUDGET_STOP_PATTERN.exec(String(hardStop ?? ""));
   return match ? Number(match[1]) : null;
+}
+
+/**
+ * The guard's spelling of the one hard stop that MEASURED something (sc-22738 review).
+ *
+ * `memory-calibration-watchdog.py` writes `physical_footprint_at_or_above_<ceiling>:observed_<n>`
+ * when the sampled footprint reaches the kill line, and the harness's own `parseWatchdogHardStop`
+ * accepts exactly that spelling and refuses every other reason for the same reason: only a
+ * footprint stop states a lower bound on the render's peak. This predicate is the runner's copy of
+ * that rule, and a test drives the harness's parser with both a matching and a non-matching reason
+ * so the two cannot drift apart silently.
+ *
+ * It exists because the runner's stopped-probe path has to tell "the guard measured a bound and
+ * then the reap wedged" from every other way an event log can carry a `hard_stop` — including
+ * `monitor_signal_SIGTERM`, which the guard writes in response to the runner's OWN kill.
+ */
+export const FOOTPRINT_BOUND_STOP_PATTERN =
+  /^watchdog hard stop: physical_footprint_at_or_above_\d+:observed_\d+$/;
+
+/** Whether this `watchdogHardStop` reading is a footprint stop, i.e. a measured lower bound. */
+export function measuredFootprintBound(hardStop) {
+  return FOOTPRINT_BOUND_STOP_PATTERN.test(String(hardStop ?? ""));
 }
 
 /**
@@ -3705,28 +3899,48 @@ export async function measureAnchor(row, context) {
       await exec(process.execPath, captureArgs, { env, log, detached: true, timeoutMs });
     }
   } catch (error) {
-    // sc-22738 (run 34356681566): the RUNNER's own wall-clock backstop fired. Checked FIRST, and
-    // before the guard's event log is even read: on the unguarded lanes there is no event log at
-    // all, and on the guarded one this arm is reached only when the guard did not stop the group
-    // within its own deadline plus the whole escalation — in both cases what the runner knows is
-    // that it killed the tree, not anything about memory. Same claim as the guard's runtime stop,
-    // so it is the SAME terminal status and the same reason sentence: nothing measured, nothing
-    // recorded, cell stays `runnable`, walk continues with the next cell.
-    if (error.timedOut) {
+    // A hard stop is recorded in the guard's event log, not on stderr: name it on the row.
+    const hardStop = await watchdogHardStop(watchdogEvents);
+    // sc-22738 review: WHAT THIS STOPPED RUN NEVERTHELESS MEASURED, read BEFORE the runner's own
+    // backstop gets to speak. The guard writes its footprint bound —
+    // `physical_footprint_at_or_above_<ceiling>:observed_<footprint>`, the line that becomes
+    // `committed_exceeded` — the instant it fires, and the reap that follows can then wedge past
+    // `RUNNER_BACKSTOP_GRACE_SECONDS`. Returning on `timedOut` before reading the log threw that
+    // measured bound away and reported a cell that had recorded NOTHING.
+    //
+    // Narrow ON PURPOSE, to a FOOTPRINT stop and to the Metal refusal, the only two things a
+    // stopped run can have measured. Anything else in the log is a stop, not a measurement — and
+    // one of them is the runner's OWN doing: `stopProcessTree` SIGTERMs the guard, which writes
+    // `monitor_signal_SIGTERM` on its way out, so a looser predicate would feed the runner's own
+    // kill into `record-exceeded` as if it were a bound.
+    const measuredBound = measuredFootprintBound(hardStop);
+    // `!hardStop` is the pre-existing rule and stays: a refusal is the terminal event only when the
+    // guard stopped nothing. On a runner stop that means a refusal whose adapter then WEDGED — the
+    // guard's `monitor_signal_SIGTERM` is in the log by then — reports `runtime_budget_exceeded`
+    // and leaves the cell runnable, which costs a re-run and states nothing false. The one witnessed
+    // refusal (`flux2_dev:bf16:mlx`) exited 1 rather than wedging, so this pairing has never
+    // occurred; widening the rule would change the arms below, which are about a guard that fired.
+    const refused = !hardStop && guarded && metalSubmissionsIgnored(error.stderr ?? error.message);
+    // sc-22738 (run 34356681566): the RUNNER's own wall-clock backstop fired, having measured
+    // nothing. On the unguarded lanes there is no event log at all, and on the guarded one this arm
+    // is reached only when the guard did not stop the group within its own deadline plus the whole
+    // escalation — in both cases what the runner knows is that it killed the tree, not anything
+    // about memory. Same claim as the guard's runtime stop, so it is the SAME terminal status and
+    // the same reason sentence: nothing measured, nothing recorded, cell stays `runnable`, walk
+    // continues with the next cell.
+    if (error.timedOut && !measuredBound && !refused) {
       return finish(
         "runtime_budget_exceeded",
         runtimeBudgetExceededReason({
           row,
           budgetMinutes,
-          budgetSeconds: Math.round(error.timeoutMs / 1000),
           peak: guarded ? await watchdogPeakFootprint(watchdogEvents) : null,
           ceiling: probedHardware ? `${watchdogCeilings(probedHardware).maxFootprintBytes}-byte ceiling` : null,
           stoppedBy: "runner",
+          stoppedAtSeconds: Math.round(error.timeoutMs / 1000),
         }),
       );
     }
-    // A hard stop is recorded in the guard's event log, not on stderr: name it on the row.
-    const hardStop = await watchdogHardStop(watchdogEvents);
     // sc-22738 (2026-09-07): a WALL-CLOCK stop, and the one hard stop that is NOT a measurement.
     //
     // The guard killed this group on exactly the path a footprint stop takes — same escalation,
@@ -3740,15 +3954,15 @@ export async function measureAnchor(row, context) {
     // bundle means no `records` and no bound for the classifier to read. The peak is reported for
     // the operator's judgment only — a probe that wedged at the ceiling is a different problem from
     // one that wedged at 3 GB — and is deliberately not written anywhere.
-    const budgetSeconds = runtimeBudgetStopSeconds(hardStop);
-    if (budgetSeconds !== null) {
+    const guardStopSeconds = runtimeBudgetStopSeconds(hardStop);
+    if (guardStopSeconds !== null) {
       const peak = await watchdogPeakFootprint(watchdogEvents);
       const ceiling = probedHardware
         ? `${watchdogCeilings(probedHardware).maxFootprintBytes}-byte ceiling`
         : "the guard's ceiling";
       return finish(
         "runtime_budget_exceeded",
-        runtimeBudgetExceededReason({ row, budgetMinutes, budgetSeconds, peak, ceiling }),
+        runtimeBudgetExceededReason({ row, budgetMinutes, peak, ceiling, stoppedAtSeconds: guardStopSeconds }),
       );
     }
     // sc-22738 (measured 2026-09-06): the SECOND way a run ends having measured a bound. Metal
@@ -3766,7 +3980,6 @@ export async function measureAnchor(row, context) {
     if (artifact) {
       return finish("artifact_unsupported", `${artifact.provider} ${artifact.tier}: ${artifact.reason}`.slice(0, FAILURE_REASON_LIMIT));
     }
-    const refused = !hardStop && guarded && metalSubmissionsIgnored(error.stderr ?? error.message);
     // Whether the PREVIOUS anchor of this run refused the same way; cleared for every anchor at the
     // top of its own attempt, so the count is over consecutive attempts rather than over the run.
     const refusedBefore = previousMetalRefusal;

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -29,13 +29,22 @@
 // --download-missing` prints what it would fetch, with the manifest's own byte estimate, and
 // fetches nothing.
 //
-// Every guarded probe also carries a WALL-CLOCK budget (`--probe-budget-minutes`, defaulted per
-// lane by `PROBE_BUDGET_MINUTES`), passed to the guard as `--max-runtime-seconds`. A probe that
-// reaches it is stopped on the guard's ONE stop path — the same SIGTERM→SIGKILL escalation and the
-// same post-stop census a footprint stop takes — and reported as `capture_failed` with reason
+// EVERY probe carries a WALL-CLOCK budget (`--probe-budget-minutes`, defaulted per lane by
+// `PROBE_BUDGET_MINUTES`) and is stopped when it reaches it, on the terminal status
 // `runtime_budget_exceeded`. It is NOT an exceedance: a run that thrashed below the ceiling
 // measured nothing, so no bound is written, the store keeps no trace, and the cell classifies
-// `runnable` again on the next `--list` (sc-22738).
+// `runnable` again on the next `--list` (sc-22738). The walk then moves to the NEXT cell — one
+// wedged probe can no longer consume the whole job.
+//
+// TWO things can impose that budget, and they are not alternatives:
+//   * the footprint guard, on Darwin, via `--max-runtime-seconds` — one more trigger on its ONE
+//     stop path, so a runtime stop escalates and censuses exactly as a footprint stop does; and
+//   * the RUNNER itself, on every platform, via `probeTimeoutMs` → `run({ timeoutMs })`, which
+//     stops the probe's whole process TREE (`stopProcessTree`).
+// The guard is Darwin-only by construction (`guardsCapture`; the sampler is `/usr/bin/footprint`),
+// so until sc-22738's run 34356681566 the budget reached NO probe on the Windows CUDA lane and one
+// cell there ran 19h43m against a 165-minute budget. The runner's bound sits behind the guard's on
+// Darwin (`RUNNER_BACKSTOP_GRACE_SECONDS`) so the guard keeps owning the stop it can make.
 //
 // A cell the store already carries a CURRENT measured lower bound for classifies `exceeded_current`
 // and is never scheduled, with or without `--skip-current` (sc-22738): the host has proved it cannot
@@ -2786,17 +2795,90 @@ export async function capturedInCampaign(root, campaignDir) {
 // Process plumbing
 // ---------------------------------------------------------------------------------------------
 
-function run(command, args, { cwd = ROOT, env = process.env, log = null, detached = false, input = null } = {}) {
+/**
+ * How long the runner waits after its own SIGTERM before escalating to SIGKILL (sc-22738).
+ *
+ * The same shape the guard's `--term-grace` has, and for the same reason: a capture that is
+ * shutting down cleanly gets a moment to do it, one that is wedged does not get to keep the box.
+ * On Windows there is only one step — see `stopProcessTree`.
+ */
+export const RUNNER_STOP_GRACE_SECONDS = 15;
+
+/**
+ * Stop a spawned probe AND EVERYTHING IT SPAWNED (sc-22738, run 34356681566).
+ *
+ * `child.kill()` signals the immediate child alone. That is not enough here: the child is the
+ * capture harness, and the process actually holding the GPU is the memory adapter IT spawned. When
+ * run 34356681566 was finally cancelled after 19h43m on one cell, the runner's own cleanup had to
+ * reap `node`, `memory-candle-adapter`, `conhost` and `nvidia-smi` as orphans — and an adapter left
+ * alive poisons every following cell's peak (see `contaminatedHostHalt`).
+ *
+ * POSIX: the capture is spawned `detached`, which makes it a process-GROUP leader, so the negative
+ * pid reaches the adapter too, and TERM→KILL escalates.
+ *
+ * Windows: there is no process group to signal — `os.kill` supports only `CTRL_C_EVENT` and
+ * `CTRL_BREAK_EVENT` for another process, and node's `kill()` is `TerminateProcess` on the child
+ * alone, which is exactly how an adapter survives its parent. `taskkill /T` walks the tree; `/F` is
+ * unconditional because a console-less child honours no graceful signal from another process
+ * there. So on Windows BOTH steps of the escalation are the same unconditional tree kill, and the
+ * grace period buys nothing — stated here rather than discovered on a wedged runner.
+ */
+export function stopProcessTree(child, signal, { detached = false, platform = process.platform, spawnProcess = spawn } = {}) {
+  if (!child?.pid || child.exitCode !== null || child.signalCode !== null) return false;
+  try {
+    if (platform === "win32") {
+      spawnProcess("taskkill", ["/PID", String(child.pid), "/T", "/F"], { stdio: "ignore" })
+        .on("error", () => {});
+    } else {
+      process.kill(detached ? -child.pid : child.pid, signal);
+    }
+    return true;
+  } catch {
+    // ESRCH (already gone) and EPERM (not ours) are both "nothing left to stop here": the caller's
+    // job is to stop waiting, not to succeed at signalling.
+    return false;
+  }
+}
+
+/**
+ * @param {object} [options]
+ * @param {number|null} [options.timeoutMs] wall-clock bound on the child, or null for none. On
+ *   expiry the whole process TREE is stopped (`stopProcessTree`) and the promise rejects with an
+ *   error carrying `timedOut: true` and `timeoutMs`, so a caller can tell a bound it imposed from
+ *   a failure the child reported.
+ */
+function run(command, args, { cwd = ROOT, env = process.env, log = null, detached = false, input = null, timeoutMs = null } = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, { cwd, env, stdio: [input === null ? "ignore" : "pipe", "pipe", "pipe"], detached });
     if (input !== null) child.stdin.end(input);
     let stdout = "";
     let stderr = "";
+    let timedOut = false;
+    const timers = [];
+    const clearTimers = () => { for (const timer of timers) clearTimeout(timer); timers.length = 0; };
+    const timeoutError = () => Object.assign(
+      new Error(`${[command, ...args].join(" ")} exceeded its ${Math.round(timeoutMs / 1000)}s wall-clock budget and was stopped`),
+      { stdout, stderr, timedOut: true, timeoutMs },
+    );
+    if (timeoutMs !== null) {
+      timers.push(setTimeout(() => {
+        timedOut = true;
+        log?.write(`\nRUNNER STOP: ${Math.round(timeoutMs / 1000)}s wall-clock budget elapsed; stopping the probe's process tree\n`);
+        stopProcessTree(child, "SIGTERM", { detached });
+        timers.push(setTimeout(() => stopProcessTree(child, "SIGKILL", { detached }), RUNNER_STOP_GRACE_SECONDS * 1000));
+        // Last resort: a grandchild that survived BOTH steps can hold the stdio pipes open, and
+        // `close` would then never fire — which is the very hang this bound exists to end. Settle
+        // anyway, so the walk moves to the next cell instead of waiting on a process it cannot kill.
+        timers.push(setTimeout(() => reject(timeoutError()), RUNNER_STOP_GRACE_SECONDS * 2 * 1000));
+      }, timeoutMs));
+    }
     child.stdout.on("data", (chunk) => { stdout += chunk; log?.write(chunk); });
     child.stderr.on("data", (chunk) => { stderr += chunk; log?.write(chunk); });
-    child.on("error", reject);
+    child.on("error", (error) => { clearTimers(); reject(error); });
     child.on("close", (code, signal) => {
-      if (code === 0) resolve({ stdout, stderr });
+      clearTimers();
+      if (timedOut) reject(timeoutError());
+      else if (code === 0) resolve({ stdout, stderr });
       else reject(Object.assign(new Error(`${[command, ...args].join(" ")} exited ${code ?? signal}\n${stderr.slice(-4000)}`), { stdout, stderr, code }));
     });
   });
@@ -2851,14 +2933,36 @@ export const LTX_Q4_F305_CRASH_FOOTPRINT_BYTES = 96_970_084_480;
 export const UNIFIED_RESERVE_BYTES = 2 * 1024 * 1024 * 1024;
 
 /**
+ * How long the adapter gets to answer a `probe` before the runner stops it (sc-22738).
+ *
+ * A probe reads host memory and prints one JSON line; it takes seconds. Five minutes is not a
+ * budget, it is a wedge ceiling — generous enough that a cold GPU-runtime init on a loaded box is
+ * never mistaken for a hang, finite so that one cannot hold the walk open indefinitely.
+ */
+export const ADAPTER_PROBE_TIMEOUT_SECONDS = 300;
+
+/**
  * The adapter's own host probe — the same `probe` action the harness runs first inside every
  * capture — so the ceilings below come from the figures the record will carry, not from a second
  * reading of the host. `memoryBytes` is required of every adapter; `wiredLimitBytes` is what the
  * MLX adapter resolves from host policy and is required when the anchor is an MLX one — the candle
  * adapter reports none, and on Darwin its capture is guarded from the host figure alone.
  */
-export async function probeAdapter(command, { cwd = ROOT, env = process.env, wiredLimitRequired = true } = {}) {
-  const { stdout } = await run(command[0], command.slice(1), { cwd, env, input: `${JSON.stringify({ action: "probe" })}\n` });
+export async function probeAdapter(command, { cwd = ROOT, env = process.env, wiredLimitRequired = true, timeoutSeconds = ADAPTER_PROBE_TIMEOUT_SECONDS } = {}) {
+  let stdout;
+  try {
+    // sc-22738: bounded for the same reason the capture is. This is the OTHER adapter process a
+    // cell starts, it runs BEFORE the guard exists (its answer is what derives the guard's
+    // ceilings), and an adapter that wedged in GPU-runtime init here would hang the walk on cell 1
+    // with nothing to stop it. Named as a probe failure rather than a wall-clock stop: nothing was
+    // rendered, and `runtime_budget_exceeded` would state a render budget that never applied.
+    ({ stdout } = await run(command[0], command.slice(1), {
+      cwd, env, input: `${JSON.stringify({ action: "probe" })}\n`, timeoutMs: Math.ceil(timeoutSeconds * 1000),
+    }));
+  } catch (error) {
+    if (error.timedOut) fail(`adapter probe did not answer within ${timeoutSeconds}s; the probe was stopped`);
+    throw error;
+  }
   const hardware = JSON.parse(stdout).hardware;
   const positive = (field) => Number.isSafeInteger(hardware?.[field]) && hardware[field] > 0;
   if (!positive("memoryBytes")) fail("adapter probe reported no positive hardware.memoryBytes");
@@ -2983,6 +3087,39 @@ export function probeBudgetMinutes(row, override = null) {
 }
 
 /**
+ * How far BEHIND the guard the runner's own backstop sits on a guarded capture (sc-22738).
+ *
+ * On Darwin the guard owns the stop path and must keep owning it: it alone can tell a wall-clock
+ * stop from a footprint stop, and only a footprint stop states a bound. The runner's backstop is
+ * therefore parked behind the guard's own deadline by more than the guard's whole escalation
+ * (`--term-grace 1` plus its post-stop census), so it can only ever fire when the guard FAILED to
+ * stop the group — the one case that used to have no bound at all.
+ */
+export const RUNNER_BACKSTOP_GRACE_SECONDS = 120;
+
+/**
+ * The wall-clock bound the RUNNER puts on one capture's process tree, in ms (sc-22738,
+ * run 34356681566).
+ *
+ * THE DEFECT THIS CLOSES. The budget above only ever reached a probe through `watchdogGuard`, and
+ * `guardsCapture` is `platform === "darwin"` — the footprint sampler is `/usr/bin/footprint`. So on
+ * the Windows CUDA lane the capture was spawned with no bound of any kind: run 34356681566 sat on
+ * `scail2_14b:bf16:candle` (85/132) from 15:15:45Z to the job's cancellation at 10:59:16Z the next
+ * day — 19h43m against a 165-minute budget, 7.2x — and the remaining 47 cells were never reached.
+ * Nothing was wrong with the budget; nothing was passing it.
+ *
+ * So the runner now bounds the capture itself, on every platform:
+ *
+ *   * UNGUARDED (win32, linux): exactly the budget. The runner IS the stop path.
+ *   * GUARDED (darwin): the budget plus `RUNNER_BACKSTOP_GRACE_SECONDS`, so the guard always wins
+ *     and the runner only fires when the guard did not.
+ */
+export function probeTimeoutMs(budgetMinutes, guarded) {
+  if (!Number.isFinite(budgetMinutes) || budgetMinutes <= 0) fail("probeTimeoutMs needs a positive budgetMinutes");
+  return Math.ceil((budgetMinutes * 60 + (guarded ? RUNNER_BACKSTOP_GRACE_SECONDS : 0)) * 1000);
+}
+
+/**
  * The `runtime_budget_exceeded` reason a wall-clock stop reports (sc-22738).
  *
  * Names the budget, the peak sampled (so a probe wedged at the ceiling reads differently from one
@@ -2992,16 +3129,24 @@ export function probeBudgetMinutes(row, override = null) {
  * the 90-minute campaign of 2026-09-07 were read as a hung engine for want of this sentence.
  *
  * Pure: `peak` is `watchdogPeakFootprint`'s reading or `null`, `ceiling` the guard's kill line as
- * a phrase, and nothing here touches the store.
+ * a phrase — or `null` on a platform the guard does not run on, where saying "against the guard's
+ * ceiling" would name a ceiling nothing enforced. `stoppedBy` is `"guard"` when the footprint guard
+ * ended the probe on its own stop path and `"runner"` when the runner's backstop did
+ * (`probeTimeoutMs`); the two are read differently, because a runner stop also means the guard was
+ * absent or failed.
  */
-export function runtimeBudgetExceededReason({ row, budgetMinutes, budgetSeconds, peak, ceiling }) {
+export function runtimeBudgetExceededReason({ row, budgetMinutes, budgetSeconds, peak, ceiling, stoppedBy = "guard" }) {
   const lane = probeLane(row);
   const laneDefault = PROBE_BUDGET_MINUTES[lane];
   const witnessed = WITNESSED_CAPTURE_SECONDS[lane];
+  const footprint = ceiling === null || ceiling === undefined
+    ? "peak physical footprint not sampled: the footprint guard is Darwin-only, so nothing sampled this probe"
+    : `peak physical footprint ${peak ? `${peak.peakBytes} bytes over ${peak.samples} sample(s)` : "not sampled"} against the ${ceiling}`;
   let reason =
     `runtime_budget_exceeded: the ${budgetMinutes}-minute probe budget (${budgetSeconds}s) elapsed; `
-    + `peak physical footprint ${peak ? `${peak.peakBytes} bytes over ${peak.samples} sample(s)` : "not sampled"} `
-    + `against the ${ceiling}. Nothing was measured, so no bound was recorded and this cell stays runnable. `
+    + `${footprint}. `
+    + (stoppedBy === "runner" ? "The runner's own wall-clock backstop stopped the probe's process tree. " : "")
+    + `Nothing was measured, so no bound was recorded and this cell stays runnable. `
     // sc-22738: the video figure is PER RENDER (a video capture is one render); the image figure
     // is a whole capture cycle.
     + `The longest completed ${lane} ${lane === "video" ? "render" : "capture"} on record ran ${witnessed}s`;
@@ -3386,7 +3531,12 @@ export function failureReason(error) {
 }
 
 export async function measureAnchor(row, context) {
-  const { args, inferencePin, campaignDir, campaignPrefix, workDir, state, root = ROOT } = context;
+  // `platform` decides ONLY whether this capture runs under the footprint guard (`guardsCapture`),
+  // and defaults to the host's. It is overridable for the same reason `guardsCapture` takes the
+  // parameter at all: the candle campaign runs on Windows and the MLX one on a Mac, so the
+  // UNGUARDED branch below is a branch no developer machine and no macOS lane ever takes — which
+  // is exactly how it shipped for months with no wall-clock bound on it (sc-22738).
+  const { args, inferencePin, campaignDir, campaignPrefix, workDir, state, root = ROOT, platform = process.platform } = context;
   const slug = anchorSlug(row.key);
   const log = new Log(path.join(workDir, "logs", `${slug}.log`));
   const captureOutput = path.join(workDir, "captures", `${slug}.json`);
@@ -3532,8 +3682,13 @@ export async function measureAnchor(row, context) {
   // sc-22738: this probe's wall-clock budget, resolved once so the guard, the failure arm and the
   // log all name the same figure.
   const budgetMinutes = probeBudgetMinutes(row, args.probeBudgetMinutes);
+  const guarded = guardsCapture(row.key, platform);
+  // sc-22738: the runner's OWN bound on this probe's process tree. On the guarded lane it sits
+  // behind the guard's deadline; everywhere else it is the only thing that can end a wedge. See
+  // `probeTimeoutMs` for the run it was written for.
+  const timeoutMs = probeTimeoutMs(budgetMinutes, guarded);
   try {
-    if (guardsCapture(row.key)) {
+    if (guarded) {
       // sc-22738: every Darwin capture runs inside the footprint hard stop, with ceilings derived
       // from the adapter's own probe for this host and the incident — see `watchdogGuard`.
       const hardware = await probeAdapter(providerCommand(args.adapter), {
@@ -3544,12 +3699,32 @@ export async function measureAnchor(row, context) {
       // The guard APPENDS to its event log; this capture's verdict must not read an earlier one's.
       await rm(watchdogEvents, { force: true });
       log.write(`$ /usr/bin/python3 ${guard.join(" ")} -- node ${captureArgs.join(" ")}\n`);
-      await exec("/usr/bin/python3", [...guard, "--", process.execPath, ...captureArgs], { env, log, detached: true });
+      await exec("/usr/bin/python3", [...guard, "--", process.execPath, ...captureArgs], { env, log, detached: true, timeoutMs });
     } else {
       log.write(`$ node ${captureArgs.join(" ")}\n`);
-      await exec(process.execPath, captureArgs, { env, log, detached: true });
+      await exec(process.execPath, captureArgs, { env, log, detached: true, timeoutMs });
     }
   } catch (error) {
+    // sc-22738 (run 34356681566): the RUNNER's own wall-clock backstop fired. Checked FIRST, and
+    // before the guard's event log is even read: on the unguarded lanes there is no event log at
+    // all, and on the guarded one this arm is reached only when the guard did not stop the group
+    // within its own deadline plus the whole escalation — in both cases what the runner knows is
+    // that it killed the tree, not anything about memory. Same claim as the guard's runtime stop,
+    // so it is the SAME terminal status and the same reason sentence: nothing measured, nothing
+    // recorded, cell stays `runnable`, walk continues with the next cell.
+    if (error.timedOut) {
+      return finish(
+        "runtime_budget_exceeded",
+        runtimeBudgetExceededReason({
+          row,
+          budgetMinutes,
+          budgetSeconds: Math.round(error.timeoutMs / 1000),
+          peak: guarded ? await watchdogPeakFootprint(watchdogEvents) : null,
+          ceiling: probedHardware ? `${watchdogCeilings(probedHardware).maxFootprintBytes}-byte ceiling` : null,
+          stoppedBy: "runner",
+        }),
+      );
+    }
     // A hard stop is recorded in the guard's event log, not on stderr: name it on the row.
     const hardStop = await watchdogHardStop(watchdogEvents);
     // sc-22738 (2026-09-07): a WALL-CLOCK stop, and the one hard stop that is NOT a measurement.
@@ -3572,7 +3747,7 @@ export async function measureAnchor(row, context) {
         ? `${watchdogCeilings(probedHardware).maxFootprintBytes}-byte ceiling`
         : "the guard's ceiling";
       return finish(
-        "capture_failed",
+        "runtime_budget_exceeded",
         runtimeBudgetExceededReason({ row, budgetMinutes, budgetSeconds, peak, ceiling }),
       );
     }
@@ -3591,7 +3766,7 @@ export async function measureAnchor(row, context) {
     if (artifact) {
       return finish("artifact_unsupported", `${artifact.provider} ${artifact.tier}: ${artifact.reason}`.slice(0, FAILURE_REASON_LIMIT));
     }
-    const refused = !hardStop && guardsCapture(row.key) && metalSubmissionsIgnored(error.stderr ?? error.message);
+    const refused = !hardStop && guarded && metalSubmissionsIgnored(error.stderr ?? error.message);
     // Whether the PREVIOUS anchor of this run refused the same way; cleared for every anchor at the
     // top of its own attempt, so the count is over consecutive attempts rather than over the run.
     const refusedBefore = previousMetalRefusal;

--- a/scripts/measure-memory-catalog.mjs
+++ b/scripts/measure-memory-catalog.mjs
@@ -3270,10 +3270,11 @@ export function probeTimeoutMs(budgetMinutes, guarded) {
  * 165 minutes is 9,900 s. `stoppedAtSeconds` is that other deadline, the one that actually fired,
  * and it is named as ITSELF rather than as the budget.
  *
- * WHAT MAKES IT ACTIONABLE (sc-22738 review). A budget is a kill line, so a cell whose own backend
- * has no completed capture behind that line — every heavy candle video cell — is told exactly that,
- * with the per-lane flag that raises it. Otherwise a re-run is just the same kill at the same
- * point, which is what "permanently unmeasurable at the default budget" means.
+ * WHAT MAKES IT ACTIONABLE (sc-22738 review). A budget is a kill line, so every stop names the
+ * longest completed capture on the stopped cell's OWN backend and the cell that figure was read
+ * from — enough to see that the candle video figure is an `ltx_2_5` capture and this cell is a 14B
+ * DiT — plus the per-lane flag that raises the budget. Otherwise a re-run is just the same kill at
+ * the same second, which is what "permanently unmeasurable at the default budget" means.
  */
 export function runtimeBudgetExceededReason({
   row, budgetMinutes, peak, ceiling, stoppedBy = "guard", stoppedAtSeconds = null,

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -83,6 +83,11 @@ import {
   WITNESSED_CAPTURE_SECONDS,
   probeBudgetMinutes,
   probeLane,
+  probeTimeoutMs,
+  stopProcessTree,
+  ADAPTER_PROBE_TIMEOUT_SECONDS,
+  RUNNER_BACKSTOP_GRACE_SECONDS,
+  RUNNER_STOP_GRACE_SECONDS,
   runtimeBudgetExceededReason,
   METAL_REFUSAL,
   ARTIFACT_UNSUPPORTED,
@@ -4689,7 +4694,20 @@ async function stubCheckout() {
       // sc-22738: the wedge. A probe that stops climbing and never finishes — the shape
       // \`scail2_14b:bf16:mlx\` held for 90 minutes at a flat 93.5 GB — so the only thing that can
       // end it is the guard's wall-clock budget.
-      if (process.env.STUB_CAPTURE_HANGS) { await new Promise((resolve) => { setTimeout(resolve, 600_000); }); }
+      if (process.env.STUB_CAPTURE_HANGS) {
+        // sc-22738 (run 34356681566): the process actually holding the GPU is not this one, it is
+        // the ADAPTER this one spawns — and when the run was finally cancelled the runner had to
+        // reap \`memory-candle-adapter\` as an orphan of its own. Stand one in, so a stop that only
+        // reached the immediate child is visible as a surviving pid rather than as nothing.
+        if (process.env.STUB_CAPTURE_ADAPTER_PID_FILE) {
+          const { spawn } = await import("node:child_process");
+          const adapter = spawn(process.execPath, ["-e", "setTimeout(() => {}, 600_000)"], { stdio: "ignore" });
+          // Own pid first, adapter's second. The suite reaps BOTH if the bound under test is
+          // broken, so a regression fails in seconds instead of holding the job open.
+          await writeFile(process.env.STUB_CAPTURE_ADAPTER_PID_FILE, \`\${process.pid}\\n\${adapter.pid}\\n\`);
+        }
+        await new Promise((resolve) => { setTimeout(resolve, 600_000); });
+      }
       // sc-22738: the adapter's exit-1 stderr AFTER protocol::fail was taught to defer its
       // informational notes -- outcome first, flush_deferred_notes after it. The last line on
       // stderr is therefore a note on every failed capture, by construction.
@@ -4802,6 +4820,12 @@ async function stubCheckout() {
     const request = JSON.parse(input);
     if (request.action !== "probe") { console.error("Error: stub adapter only probes"); process.exit(2); }
     if (process.env.STUB_PROBE_FAILS) { console.error("Error: stub probe refused"); process.exit(1); }
+    // sc-22738: an adapter that wedges before it answers. This runs BEFORE the guard exists -- its
+    // answer is what derives the guard's ceilings -- so only the runner's own bound can end it.
+    // 20 s rather than the capture stub's 600: two orders of magnitude past the fractional-second
+    // bound the suite drives, and short enough that a run with the bound REMOVED reds by resolving
+    // instead of by holding the suite open.
+    if (process.env.STUB_PROBE_HANGS) { await new Promise((resolve) => { setTimeout(resolve, 20_000); }); }
     const hardware = { memoryBytes: Number(process.env.STUB_PROBE_MEMORY_BYTES ?? 137438953472) };
     if (!process.env.STUB_PROBE_NO_WIRED_LIMIT) hardware.wiredLimitBytes = Number(process.env.STUB_PROBE_WIRED_LIMIT_BYTES ?? Math.min(87044670532, hardware.memoryBytes));
     process.stdout.write(JSON.stringify({ hardware }));
@@ -5557,9 +5581,25 @@ test("a runtime stop's reason names the lane's longest completed render (video) 
   const imageAtDefault = runtimeBudgetExceededReason({ row: { key: "sdxl:q4:mlx", videoLane: false }, budgetMinutes: 60, budgetSeconds: 3600, peak: null, ceiling: "guard's ceiling" });
   assert.match(imageAtDefault, /ran 847s\.$/, imageAtDefault);
   assert.doesNotMatch(imageAtDefault, /shortfall/, imageAtDefault);
+  // sc-22738 (run 34356681566): on a lane the guard does not run on there is no ceiling and no
+  // sampler, and the reason must not borrow the guard's vocabulary to say so — "not sampled
+  // against the guard's ceiling" would name a ceiling nothing enforced. It also names WHO stopped
+  // the probe, because a runner stop additionally means the guard was absent or failed.
+  const unguarded = runtimeBudgetExceededReason({
+    row: { key: "scail2_14b:bf16:candle", videoLane: true }, budgetMinutes: 165, budgetSeconds: 9900,
+    peak: null, ceiling: null, stoppedBy: "runner",
+  });
+  assert.match(unguarded, /^runtime_budget_exceeded: the 165-minute probe budget \(9900s\) elapsed; /, unguarded);
+  assert.match(unguarded, /peak physical footprint not sampled: the footprint guard is Darwin-only, so nothing sampled this probe\./, unguarded);
+  assert.match(unguarded, /The runner's own wall-clock backstop stopped the probe's process tree\./, unguarded);
+  assert.match(unguarded, /no bound was recorded and this cell stays runnable/, unguarded);
+  assert.doesNotMatch(unguarded, /against the/, "no ceiling is claimed where none was enforced");
+  assert.doesNotMatch(unguarded, /shortfall/, "165 is the video lane default, not a shortfall");
+  // The guard's own stop keeps the sentence it had: no backstop clause, ceiling named.
+  assert.doesNotMatch(imageAtDefault, /wall-clock backstop/, imageAtDefault);
 });
 
-test("a probe that reaches its wall-clock budget is a capture_failed, never a memory bound, and the cell stays runnable", { skip: process.platform !== "darwin" && "the footprint sampler is Darwin-only" }, async () => {
+test("a probe that reaches its wall-clock budget is `runtime_budget_exceeded`, never a memory bound, and the cell stays runnable", { skip: process.platform !== "darwin" && "the footprint sampler is Darwin-only" }, async () => {
   const checkout = await stubCheckout();
   const tierRoot = await mkdtemp(path.join(tmpdir(), "catalog-tier-"));
   await writeFile(path.join(tierRoot, "w.safetensors"), "weights");
@@ -5579,10 +5619,11 @@ test("a probe that reaches its wall-clock budget is a capture_failed, never a me
       // the "no artifact binding" refusal is not the guard under test here.
       artifact: { repository: "SceneWorks/z-image-turbo-mlx", resolvedRevision: REVISION, variant: "q4" },
     }, context);
-    // A runtime stop measured NOTHING. It is a failed capture, not an exceedance: recording the
-    // footprint the probe happened to be sitting at would state a lower bound the run never
-    // established, and production would refuse hosts on it.
-    assert.equal(stopped.status, "capture_failed", stopped.reason);
+    // A runtime stop measured NOTHING. It is its OWN terminal status — not an exceedance, and no
+    // longer folded in with ordinary breakage as `capture_failed` (sc-22738, run 34356681566):
+    // recording the footprint the probe happened to be sitting at would state a lower bound the run
+    // never established, and production would refuse hosts on it.
+    assert.equal(stopped.status, "runtime_budget_exceeded", stopped.reason);
     assert.match(stopped.reason, /^runtime_budget_exceeded: the 0\.05-minute probe budget \(3s\) elapsed;/);
     // The line an operator reads has to carry both figures, or there is nothing to judge with.
     assert.match(stopped.reason, /peak physical footprint \d+ bytes over \d+ sample\(s\) against the 94822600832-byte ceiling/);
@@ -5622,6 +5663,173 @@ test("a probe that reaches its wall-clock budget is a capture_failed, never a me
     delete process.env.STUB_CAPTURE_HANGS;
   }
 });
+
+// ---------------------------------------------------------------------------------------------
+// sc-22738 (run 34356681566): THE RUNNER'S OWN WALL-CLOCK BACKSTOP.
+//
+// The budget above only ever reached a probe through `watchdogGuard`, and `guardsCapture` is
+// `platform === "darwin"` because the footprint sampler is `/usr/bin/footprint`. So on the Windows
+// CUDA lane every probe ran unbounded in time: `scail2_14b:bf16:candle` (85/132) started at
+// 15:15:45Z, printed nothing more, and the job was cancelled 19h43m later with 47 cells unreached.
+// ---------------------------------------------------------------------------------------------
+
+test("the runner's bound is exactly the budget where no guard runs, and sits BEHIND the guard where one does", () => {
+  // Unguarded: the runner IS the stop path, so the bound is the budget itself.
+  assert.equal(probeTimeoutMs(165, false), 165 * 60 * 1000);
+  assert.equal(probeTimeoutMs(60, false), 60 * 60 * 1000);
+  // Guarded: strictly LATER than the guard's own deadline, so the guard keeps owning every stop it
+  // can make — it alone can tell a wall-clock stop from a footprint stop, and only a footprint stop
+  // states a bound. The margin has to clear the guard's whole escalation, not just its deadline.
+  assert.equal(probeTimeoutMs(165, true), (165 * 60 + RUNNER_BACKSTOP_GRACE_SECONDS) * 1000);
+  assert.ok(RUNNER_BACKSTOP_GRACE_SECONDS >= 60, "the guard's escalation and post-stop census fit inside the margin");
+  for (const budgetMinutes of [0.05, 1, 60, 165]) {
+    assert.ok(
+      probeTimeoutMs(budgetMinutes, true) > budgetMinutes * 60 * 1000,
+      `the guard's ${budgetMinutes}-minute deadline is strictly inside the runner's backstop`,
+    );
+    assert.ok(Number.isSafeInteger(probeTimeoutMs(budgetMinutes, false)), "a fractional budget still yields whole ms");
+  }
+  assert.equal(probeTimeoutMs(0.05, false), 3000);
+  // A missing or non-positive budget is a defect, never an unbounded probe by omission.
+  for (const bad of [0, -1, NaN, null, undefined]) {
+    assert.throws(() => probeTimeoutMs(bad, false), /positive budgetMinutes/, String(bad));
+  }
+  assert.ok(RUNNER_STOP_GRACE_SECONDS > 0);
+});
+
+test(
+  "an adapter that never answers the hardware probe is stopped too, not left to hang the walk on cell 1",
+  { timeout: 60_000 },
+  async () => {
+    const checkout = await stubCheckout();
+    // The probe runs BEFORE the guard exists -- its answer is what derives the guard's ceilings --
+    // so it is the one adapter process on a cell that no guard could ever bound. Five minutes in
+    // production; a fraction of a second here.
+    assert.equal(ADAPTER_PROBE_TIMEOUT_SECONDS, 300);
+    assert.ok(ADAPTER_PROBE_TIMEOUT_SECONDS > 0 && Number.isFinite(ADAPTER_PROBE_TIMEOUT_SECONDS));
+    process.env.STUB_PROBE_HANGS = "1";
+    try {
+      const started = Date.now();
+      await assert.rejects(
+        probeAdapter([process.execPath, "stub-adapter.mjs"], { cwd: checkout.root, timeoutSeconds: 0.2 }),
+        // Named as a PROBE failure, never as `runtime_budget_exceeded`: nothing was rendered, and a
+        // render budget the run never reached would be the wrong sentence entirely.
+        /^Error: adapter probe did not answer within 0\.2s; the probe was stopped$/,
+      );
+      assert.ok(Date.now() - started < 30_000, "the probe was bounded, not waited out");
+    } finally {
+      delete process.env.STUB_PROBE_HANGS;
+    }
+    // An adapter that answers normally is untouched by the bound.
+    assert.deepEqual(
+      await probeAdapter([process.execPath, "stub-adapter.mjs"], { cwd: checkout.root }),
+      { memoryBytes: 137438953472, wiredLimitBytes: 87044670532 },
+    );
+  },
+);
+
+test("a stop on Windows walks the process TREE, because node's kill() would leave the adapter running", () => {
+  const calls = [];
+  const spawnProcess = (command, args) => { calls.push([command, ...args]); return { on: () => {} }; };
+  const alive = { pid: 4242, exitCode: null, signalCode: null };
+  assert.equal(stopProcessTree(alive, "SIGTERM", { platform: "win32", spawnProcess }), true);
+  // /T walks the tree, /F is unconditional: a console-less child honours no graceful signal from
+  // another process there, which is how `memory-candle-adapter.exe` outlived its parent.
+  assert.deepEqual(calls, [["taskkill", "/PID", "4242", "/T", "/F"]]);
+  stopProcessTree(alive, "SIGKILL", { platform: "win32", spawnProcess });
+  assert.equal(calls.length, 2, "the escalation is the same unconditional tree kill on Windows");
+  // A child that has already exited is not signalled at all — on either platform.
+  for (const done of [{ pid: 1, exitCode: 0, signalCode: null }, { pid: 1, exitCode: null, signalCode: "SIGKILL" }, { pid: null }, null]) {
+    assert.equal(stopProcessTree(done, "SIGTERM", { platform: "win32", spawnProcess }), false, JSON.stringify(done));
+  }
+  assert.equal(calls.length, 2, "nothing further was spawned");
+  // POSIX: a pid that no longer exists is "nothing left to stop", not a throw on the failure path.
+  assert.equal(stopProcessTree({ pid: 2 ** 30, exitCode: null, signalCode: null }, "SIGTERM", { platform: "linux" }), false);
+});
+
+test(
+  "an UNGUARDED probe that outruns its budget is stopped by the runner with its whole process tree, and the walk moves to the next cell",
+  // A generous ceiling on a 3-second budget: if the bound is not enforced the stub capture sleeps
+  // for 600 s, and this timeout is what turns that hang into a RED test rather than a hung suite.
+  { timeout: 90_000 },
+  async (t) => {
+    const checkout = await stubCheckout();
+    const adapterPidFile = path.join(checkout.workDir, "adapter.pid");
+    process.env.STUB_CAPTURE_HANGS = "1";
+    process.env.STUB_CAPTURE_ADAPTER_PID_FILE = adapterPidFile;
+    // If the bound is BROKEN this test times out with a 600-second capture and its adapter still
+    // running, and those two would hold the whole suite open. An `after` hook runs even on a
+    // timed-out test, where a `finally` does not: the abandoned async function is never unwound.
+    t.after(async () => {
+      for (const line of (await readFile(adapterPidFile, "utf8").catch(() => "")).split("\n")) {
+        const pid = Number(line.trim());
+        if (!Number.isSafeInteger(pid) || pid <= 0) continue;
+        try { process.kill(pid, "SIGKILL"); } catch { /* already gone: nothing to reap */ }
+      }
+    });
+    try {
+      // `platform: "linux"` is the branch `guardsCapture` excludes — the one the candle campaign
+      // takes on its Windows runner and that no Mac ever reached. The KILL mechanics stay this
+      // host's real ones; only the guard/no-guard choice is overridden.
+      const context = stubContext(checkout, {
+        platform: "linux",
+        args: { ...stubContext(checkout).args, commit: false, probeBudgetMinutes: 0.05 },
+      });
+      const row = {
+        key: "z_image_turbo:q4:candle", physical: false, env: {},
+        // Fully bound, so nothing but the runtime arm itself can be what stops a bound being
+        // written: this is the arm under test, not the "no artifact binding" refusal.
+        artifact: { repository: "SceneWorks/z-image-turbo-mlx", resolvedRevision: REVISION, variant: "q4" },
+      };
+      const started = Date.now();
+      const stopped = await measureAnchor(row, context);
+      const elapsed = Date.now() - started;
+
+      assert.equal(stopped.status, "runtime_budget_exceeded", stopped.reason);
+      assert.match(stopped.reason, /^runtime_budget_exceeded: the 0\.05-minute probe budget \(3s\) elapsed;/);
+      assert.match(stopped.reason, /The runner's own wall-clock backstop stopped the probe's process tree\./);
+      // No guard ran here, so no ceiling and no sampled peak may be claimed.
+      assert.match(stopped.reason, /not sampled: the footprint guard is Darwin-only/);
+      assert.doesNotMatch(stopped.reason, /-byte ceiling/);
+      await assert.rejects(
+        stat(path.join(checkout.workDir, "logs", "z-image-turbo-q4-candle-watchdog.jsonl")),
+        "the Darwin-only guard did not run on this lane",
+      );
+      assert.doesNotMatch(await readFile(stopped.log, "utf8"), /memory-calibration-watchdog/);
+      // 3 s of budget, not 600 s of stub: the bound is what ended this, with room for spawn cost.
+      assert.ok(elapsed < 60_000, `the probe was stopped at its budget, not left to run (took ${elapsed}ms)`);
+
+      // THE PART THAT MATTERS FOR THE NEXT CELL. Stopping the immediate child is not enough: the
+      // process holding the GPU is the ADAPTER it spawned, and one left alive contaminates every
+      // following capture's peak (`contaminatedHostHalt`). Run 34356681566's own cleanup had to
+      // reap `memory-candle-adapter` as an orphan.
+      const adapterPid = Number((await readFile(adapterPidFile, "utf8")).trim().split("\n")[1]);
+      assert.ok(Number.isSafeInteger(adapterPid) && adapterPid > 0, "the stub adapter recorded its pid");
+      let adapterAlive = true;
+      for (let attempt = 0; attempt < 100 && adapterAlive; attempt += 1) {
+        try { process.kill(adapterPid, 0); await new Promise((resolve) => { setTimeout(resolve, 100); }); }
+        catch { adapterAlive = false; }
+      }
+      assert.equal(adapterAlive, false, `the adapter the probe spawned (pid ${adapterPid}) outlived the stop`);
+
+      // ...and the walk CONTINUES. Nothing was committed, the tree is clean, no halt was raised, and
+      // the very next anchor on the same context still captures — the 47 cells run 34356681566
+      // never reached are the whole point.
+      assert.equal(context.state.commits.length, 0, "nothing was committed");
+      assert.equal(context.state.halt ?? null, null, "a stopped cell is not a stopped walk");
+      assert.equal((await checkout.git("status", "--porcelain")).stdout, "", "the tree is clean for the next anchor");
+      delete process.env.STUB_CAPTURE_HANGS;
+      const next = await measureAnchor(
+        { key: "z_image_turbo:q4:mlx", physical: false, env: {} },
+        stubContext(checkout, { platform: "linux", args: { ...stubContext(checkout).args, commit: false } }),
+      );
+      assert.equal(next.status, "captured", next.reason);
+    } finally {
+      delete process.env.STUB_CAPTURE_HANGS;
+      delete process.env.STUB_CAPTURE_ADAPTER_PID_FILE;
+    }
+  },
+);
 
 // ---------------------------------------------------------------------------------------------
 // sc-22738: a PROCESS-SCOPED Metal refusal, the second way a run ends having measured a bound.
@@ -6578,4 +6786,125 @@ test("the GPU preflight classifies [Insufficient Permissions] rows by TYPE, neve
   const pass = await runGpuPreflight(graphicsOnly);
   assert.equal(pass.code, 0, pass.stdout);
   assert.doesNotMatch(pass.stdout, /::error/);
+});
+
+// ---------------------------------------------------------------------------------------------
+// sc-22738 (run 34356681566): the results PR step must never red a SALVAGED job.
+//
+// `pr.sh` runs under `if: always()` precisely so a cancelled or timed-out walk's evidence is not
+// stranded. Run 34356681566's campaign branch was pushed with 20 anchor commits and this step then
+// failed the whole job with
+//   pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve
+//   pull requests (createPullRequest)
+// which is a repository/organization setting no `permissions:` block can override.
+// ---------------------------------------------------------------------------------------------
+
+// `gh` and `git` faked on PATH, the same way `fakeGpuHost` fakes `nvidia-smi`: `pr.sh` must be
+// driven as the shell script the runner really executes, and neither of the two commands it shells
+// out to may reach the real GitHub or the real remote.
+async function runResultsPr({ createStdout = "", createStderr = "", createStatus = 0, existingUrl = "", branchOnRemote = true } = {}) {
+  const bin = await mkdtemp(path.join(tmpdir(), "catalog-pr-"));
+  const ghLog = path.join(bin, "gh-argv");
+  await writeFile(
+    path.join(bin, "gh"),
+    [
+      "#!/usr/bin/env bash",
+      `printf '%s\\n' "$*" >> ${JSON.stringify(ghLog)}`,
+      'if [ "$1" = "pr" ] && [ "$2" = "list" ]; then',
+      `  printf '%s' ${JSON.stringify(existingUrl)}`,
+      "  exit 0",
+      "fi",
+      'if [ "$1" = "pr" ] && [ "$2" = "create" ]; then',
+      `  printf '%s' ${JSON.stringify(createStdout)}`,
+      `  printf '%s' ${JSON.stringify(createStderr)} >&2`,
+      `  exit ${createStatus}`,
+      "fi",
+      "exit 99",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  // Only `git ls-remote` is reached, and only its exit code is read.
+  await writeFile(path.join(bin, "git"), `#!/usr/bin/env bash\nexit ${branchOnRemote ? 0 : 2}\n`, { mode: 0o755 });
+  const workDir = await mkdtemp(path.join(tmpdir(), "catalog-pr-work-"));
+  const summary = path.join(workDir, "step-summary.md");
+  await writeFile(summary, "");
+  const env = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH}`,
+    CAMPAIGN: "sc-22738",
+    BACKEND: "candle",
+    BASE_REF: "feature/sc-22723-memory-anchor-measurability",
+    BASE_SHA: "afa67a3d86333436089938c1252a6ef7f35bcacd",
+    CAMPAIGN_BRANCH: "story/sc-22738-candle-campaign-34356681566",
+    WORK_DIR: workDir,
+    INFERENCE_PIN: REVISION,
+    RUNNER_NAME: "cuda-windows-2",
+    GITHUB_SERVER_URL: "https://github.com",
+    GITHUB_REPOSITORY: "SceneWorks/SceneWorks",
+    GITHUB_RUN_ID: "34356681566",
+    GITHUB_STEP_SUMMARY: summary,
+  };
+  let code = 0;
+  let stdout = "";
+  let stderr = "";
+  try {
+    const result = await execFileAsync("bash", ["scripts/ci/memory-catalog/pr.sh"], { cwd: ROOT, env });
+    ({ stdout, stderr } = result);
+  } catch (error) {
+    code = error.code ?? 1;
+    stdout = error.stdout ?? "";
+    stderr = error.stderr ?? "";
+  }
+  return { code, stdout, stderr, summary: await readFile(summary, "utf8"), ghArgv: await readFile(ghLog, "utf8").catch(() => "") };
+}
+
+const PR_POLICY_REFUSAL =
+  "pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)";
+
+test("the results PR step degrades to a warning and a compare URL when the repository forbids Actions from opening PRs", async () => {
+  const forbidden = await runResultsPr({ createStatus: 1, createStderr: `${PR_POLICY_REFUSAL}\n` });
+  // THE DEFECT: this exited 1 and turned a job that had already pushed 20 anchor commits red.
+  assert.equal(forbidden.code, 0, `${forbidden.stdout}\n${forbidden.stderr}`);
+  assert.match(forbidden.stdout, /::warning title=Results PR must be opened by hand::/);
+  const compare = "https://github.com/SceneWorks/SceneWorks/compare/"
+    + "feature/sc-22723-memory-anchor-measurability...story/sc-22738-candle-campaign-34356681566?expand=1";
+  // The URL is ready to CLICK, in the annotation and in the summary: the branch is safe and the
+  // only thing missing is the click.
+  assert.ok(forbidden.stdout.includes(compare), forbidden.stdout);
+  assert.ok(forbidden.summary.includes(compare), forbidden.summary);
+  assert.match(forbidden.summary, /the PR must be opened by hand/);
+  // The refusal itself is still on the step log; degrading is not hiding.
+  assert.ok(forbidden.stderr.includes(PR_POLICY_REFUSAL), forbidden.stderr);
+  assert.doesNotMatch(forbidden.stdout, /::error/);
+  // It really did try, with the base and head the campaign cut.
+  assert.match(forbidden.ghArgv, /pr create --base feature\/sc-22723-memory-anchor-measurability --head story\/sc-22738-candle-campaign-34356681566/);
+});
+
+test("every OTHER `gh pr create` failure still fails the step, and a created PR is still reported as one", async () => {
+  // A genuine failure -- a bad token, a missing base ref, a rejected body -- must not be papered
+  // over: the PR is really lost, and only the step's own red says so.
+  const broken = await runResultsPr({ createStatus: 1, createStderr: "gh: HTTP 401: Bad credentials\n" });
+  assert.equal(broken.code, 1);
+  assert.match(broken.stdout, /::error title=Results PR was not opened::/);
+  assert.ok(broken.stderr.includes("Bad credentials"), broken.stderr);
+  assert.doesNotMatch(broken.stdout, /::warning title=Results PR must be opened by hand/);
+  assert.doesNotMatch(broken.summary, /must be opened by hand/);
+
+  // The success path is unchanged by any of this.
+  const opened = await runResultsPr({ createStdout: "https://github.com/SceneWorks/SceneWorks/pull/2810\n" });
+  assert.equal(opened.code, 0, opened.stderr);
+  assert.match(opened.stdout, /opened https:\/\/github\.com\/SceneWorks\/SceneWorks\/pull\/2810/);
+  assert.match(opened.summary, /#### Pull request/);
+  assert.ok(opened.summary.includes("https://github.com/SceneWorks/SceneWorks/pull/2810"));
+  assert.doesNotMatch(opened.stdout, /::warning|::error/);
+
+  // ...as are the two arms that never reach `gh pr create` at all.
+  const already = await runResultsPr({ existingUrl: "https://github.com/SceneWorks/SceneWorks/pull/2799" });
+  assert.equal(already.code, 0, already.stderr);
+  assert.match(already.stdout, /PR already open/);
+  assert.doesNotMatch(already.ghArgv, /pr create/);
+  const nothingPushed = await runResultsPr({ branchOnRemote: false, createStatus: 1, createStderr: `${PR_POLICY_REFUSAL}\n` });
+  assert.equal(nothingPushed.code, 0, nothingPushed.stderr);
+  assert.match(nothingPushed.stdout, /was never pushed \(no anchor landed\); no PR to open/);
+  assert.doesNotMatch(nothingPushed.stdout, /::warning/);
 });

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -5565,7 +5565,9 @@ test("every probe carries a wall-clock budget: per lane by default, derived from
     parseArgs(["--backend", "mlx", "--list", "--probe-budget-minutes", "video=240", "--probe-budget-minutes", "image=90"]).probeBudgetMinutes,
     { video: 240, image: 90 },
   );
-  for (const bad of ["0", "-3", "abc", "video=0", "video=abc", ""]) {
+  // `video=240=99` is a typo, not a budget of 240: everything after the FIRST `=` is the value, so
+  // it reaches `Number` and is refused rather than quietly booking the leading figure.
+  for (const bad of ["0", "-3", "abc", "video=0", "video=abc", "", "video=240=99", "video="]) {
     assert.throws(() => parseArgs(["--backend", "mlx", "--list", "--probe-budget-minutes", bad]), /positive number of minutes/, bad);
   }
   // A typo is REFUSED by name rather than silently leaving the budget at its default — the whole

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -80,7 +80,12 @@ import {
   PROBE_BUDGET_MINUTES,
   VIDEO_RENDER_LOWER_BOUND_SECONDS,
   VIDEO_RENDER_WITNESSES_SECONDS,
+  IMAGE_CAPTURE_WITNESSES_SECONDS,
   WITNESSED_CAPTURE_SECONDS,
+  laneWitnessesByBackend,
+  measuredFootprintBound,
+  FOOTPRINT_BOUND_STOP_PATTERN,
+  parseProbeBudgetMinutes,
   probeBudgetMinutes,
   probeLane,
   probeTimeoutMs,
@@ -137,6 +142,7 @@ import {
   ANCHOR_LANE_DEFAULT_STRATEGY_PATH,
   ANCHOR_STRATEGY,
   LTX25_LANE_PROVIDERS,
+  parseWatchdogHardStop,
   planAnchor,
 } from "./memory-calibration-harness.mjs";
 
@@ -4691,6 +4697,18 @@ async function stubCheckout() {
     const value = (flag) => args[args.indexOf(flag) + 1];
     if (command === "capture") {
       if (process.env.STUB_CAPTURE_FAILS) { console.error("Error: stub capture refused"); process.exit(1); }
+      // sc-22738 review: the guard MEASURED a bound and wrote it down, and the post-stop reap then
+      // wedged. The runner's backstop is what ends such a probe, minutes later, with the bound
+      // already in the event log — so the stub writes exactly what the guard writes at the instant
+      // it fires (its own \`monitor_signal_SIGTERM\` lands AFTER, when the runner kills the tree).
+      if (process.env.STUB_CAPTURE_WATCHDOG_HARD_STOP) {
+        const { appendFile } = await import("node:fs/promises");
+        await appendFile(process.env.STUB_CAPTURE_WATCHDOG_HARD_STOP, [
+          JSON.stringify({ event: "sample", physicalFootprintBytes: 94822600833 }),
+          JSON.stringify({ event: "hard_stop", reason: "physical_footprint_at_or_above_94822600832:observed_94822600833" }),
+          "",
+        ].join("\\n"));
+      }
       // sc-22738: the wedge. A probe that stops climbing and never finishes — the shape
       // \`scail2_14b:bf16:mlx\` held for 90 minutes at a flat 93.5 GB — so the only thing that can
       // end it is the guard's wall-clock budget.
@@ -5478,30 +5496,82 @@ test("every probe carries a wall-clock budget: per lane by default, derived from
   // margin is the defect this pins, whichever entry drifts.
   assert.deepEqual(WITNESSED_CAPTURE_SECONDS, { video: 4_470, image: 847 });
   assert.equal(PROBE_BUDGET_MARGIN, 1.8);
+  // sc-22738 review (2026-09-10): the CANDLE cells run 34356681566 did complete, added because the
+  // budget became a hard kill on that lane and every witness behind it was `:mlx`. Read from that
+  // campaign's own committed anchors (`story/sc-22738-candle-evidence-34356681566`) as consecutive
+  // `capturedAt` deltas, the same reading the image witness is taken from, and therefore an UPPER
+  // bound on the render inside the cycle. One render each: the candle video arms already captured
+  // one render, where the three MLX cells predate that contract.
   assert.deepEqual(
     VIDEO_RENDER_WITNESSES_SECONDS.map(({ cell, perRenderSeconds, completed }) => [cell, perRenderSeconds, completed]),
-    [["scail2_14b:bf16:mlx", 2_903, true], ["wan_2_2_t2v_14b:bf16:mlx", 4_470, true], ["wan_2_2_t2v_14b:q4:mlx", 5_400, false]],
+    [
+      ["scail2_14b:bf16:mlx", 2_903, true], ["wan_2_2_t2v_14b:bf16:mlx", 4_470, true], ["wan_2_2_t2v_14b:q4:mlx", 5_400, false],
+      ["ltx_2_5:bf16:candle", 300, true], ["ltx_2_5:q4:candle", 285, true], ["ltx_2_5:q8:candle", 446, true],
+    ],
   );
   for (const witness of VIDEO_RENDER_WITNESSES_SECONDS) {
-    assert.equal(witness.renders, 3, `${witness.cell} was a three-render capture`);
+    const { backend } = anchorParts(witness.cell);
+    assert.equal(witness.renders, backend === "mlx" ? 3 : 1, `${witness.cell} render count matches its lane's contract`);
     assert.equal(witness.perRenderSeconds, Math.round(witness.captureSeconds / witness.renders), `${witness.cell} per-render figure is the capture over its renders`);
+    assert.ok(["campaign log", "capture→capture cycle"].includes(witness.basis), `${witness.cell} says how it was read`);
   }
+  assert.deepEqual(
+    IMAGE_CAPTURE_WITNESSES_SECONDS.map(({ cell, cycleSeconds, completed }) => [cell, cycleSeconds, completed]),
+    [["bernini_image:q8:mlx", 847, true], ["qwen_image_edit_2511:q8:candle", 239, true]],
+  );
   const longestCompleted = Math.max(...VIDEO_RENDER_WITNESSES_SECONDS.filter((w) => w.completed).map((w) => w.perRenderSeconds));
   assert.equal(WITNESSED_CAPTURE_SECONDS.video, longestCompleted, "the video witness is the longest COMPLETED per-render figure");
+  assert.equal(
+    WITNESSED_CAPTURE_SECONDS.image,
+    Math.max(...IMAGE_CAPTURE_WITNESSES_SECONDS.filter((w) => w.completed).map((w) => w.cycleSeconds)),
+    "the image witness is the longest COMPLETED cycle",
+  );
   assert.equal(VIDEO_RENDER_LOWER_BOUND_SECONDS, Math.max(...VIDEO_RENDER_WITNESSES_SECONDS.filter((w) => !w.completed).map((w) => w.perRenderSeconds)));
   assert.ok(PROBE_BUDGET_MINUTES.video * 60 >= WITNESSED_CAPTURE_SECONDS.video * PROBE_BUDGET_MARGIN, "video budget clears its witness by 1.8x");
   assert.ok(PROBE_BUDGET_MINUTES.video * 60 >= VIDEO_RENDER_LOWER_BOUND_SECONDS * PROBE_BUDGET_MARGIN, "video budget clears the unfinished packed-tier render's lower bound by 1.8x");
   assert.ok(PROBE_BUDGET_MINUTES.video * 60 < WITNESSED_CAPTURE_SECONDS.video * 3, "the video budget is a per-render figure, not a three-render cycle");
   assert.ok(PROBE_BUDGET_MINUTES.image * 60 >= WITNESSED_CAPTURE_SECONDS.image * 4, "image budget clears its witness by 4x");
+  // EVERY lane the budget is enforced on now has a completed capture of its own behind it — the
+  // gap this closes is a kill line derived from one backend and applied to another. The figures are
+  // per backend so the stop reason can name the one that belongs to the cell it stopped.
+  for (const lane of ["video", "image"]) {
+    const byBackend = laneWitnessesByBackend(lane);
+    assert.deepEqual([...byBackend.keys()], ["candle", "mlx"], `the ${lane} lane has a completed witness on BOTH backends`);
+    for (const [backend, witness] of byBackend) {
+      assert.equal(anchorParts(witness.cell).backend, backend, `${lane}/${backend} names the cell it was read from`);
+      assert.ok(PROBE_BUDGET_MINUTES[lane] * 60 >= witness.seconds * PROBE_BUDGET_MARGIN, `${lane} budget clears its ${backend} witness`);
+    }
+    assert.ok(byBackend.get("mlx").seconds > byBackend.get("candle").seconds, `the ${lane} kill line is set by the slower backend`);
+  }
   assert.equal(probeLane({ videoLane: true }), "video");
   assert.equal(probeLane({ videoLane: false }), "image");
-  assert.equal(probeBudgetMinutes({ videoLane: true }, 12), 12, "the flag overrides both lanes");
+  assert.equal(probeBudgetMinutes({ videoLane: true }, 12), 12, "a bare number overrides both lanes");
   assert.equal(probeBudgetMinutes({ videoLane: false }, 0.5), 0.5);
   assert.throws(() => probeBudgetMinutes({ videoLane: false }, 0), /positive number of minutes/);
+  // sc-22738 review: PER LANE. Raising the video lane for a wedged 14B cell must not also hand
+  // every image cell the same hours to hang in, so the flag names the lane and the lane it does not
+  // name keeps its default.
+  assert.equal(probeBudgetMinutes({ videoLane: true }, { video: 240, image: null }), 240);
+  assert.equal(probeBudgetMinutes({ videoLane: false }, { video: 240, image: null }), 60, "the unnamed lane keeps its default");
+  assert.equal(probeBudgetMinutes({ videoLane: false }, { video: 240, image: 90 }), 90);
+  assert.deepEqual(parseProbeBudgetMinutes("240"), { video: 240, image: 240 });
+  assert.deepEqual(parseProbeBudgetMinutes("video=240"), { video: 240, image: null });
+  assert.deepEqual(parseProbeBudgetMinutes("video=240,image=90"), { video: 240, image: 90 });
+  assert.deepEqual(parseProbeBudgetMinutes(" image = 90 "), { video: null, image: 90 }, "spacing is tolerated");
+  assert.deepEqual(parseProbeBudgetMinutes("image=90", { video: 240, image: null }), { video: 240, image: 90 }, "the flag is repeatable");
   assert.equal(parseArgs(["--backend", "mlx", "--list"]).probeBudgetMinutes, null, "unset means the lane default");
-  assert.equal(parseArgs(["--backend", "mlx", "--list", "--probe-budget-minutes", "45"]).probeBudgetMinutes, 45);
-  for (const bad of ["0", "-3", "abc"]) {
+  assert.deepEqual(parseArgs(["--backend", "mlx", "--list", "--probe-budget-minutes", "45"]).probeBudgetMinutes, { video: 45, image: 45 });
+  assert.deepEqual(
+    parseArgs(["--backend", "mlx", "--list", "--probe-budget-minutes", "video=240", "--probe-budget-minutes", "image=90"]).probeBudgetMinutes,
+    { video: 240, image: 90 },
+  );
+  for (const bad of ["0", "-3", "abc", "video=0", "video=abc", ""]) {
     assert.throws(() => parseArgs(["--backend", "mlx", "--list", "--probe-budget-minutes", bad]), /positive number of minutes/, bad);
+  }
+  // A typo is REFUSED by name rather than silently leaving the budget at its default — the whole
+  // point of the knob is that an operator can trust the figure they typed reached the walk.
+  for (const bad of ["vidoe=240", "both=240", "=240"]) {
+    assert.throws(() => parseArgs(["--backend", "mlx", "--list", "--probe-budget-minutes", bad]), /the lanes are video, image/, bad);
   }
   // The LANE is derived from the plan, never listed here: a video anchor is one whose planned
   // geometry renders more than one frame. Both video and image rows must exist for the check to
@@ -5520,6 +5590,46 @@ test("every probe carries a wall-clock budget: per lane by default, derived from
   const byKey = new Map(rows.map((row) => [row.key, row]));
   assert.equal(byKey.get("bernini:q8:mlx").videoLane, true);
   assert.equal(byKey.get("bernini_image:q8:mlx").videoLane, false);
+});
+
+test("the campaign can raise one lane's budget from the dispatch, with no source edit", async () => {
+  // sc-22738 review: the budget is a hard kill on every lane now, so an operator who reads
+  // "re-run it with --probe-budget-minutes video=330" on a stopped cell has to be able to DO that.
+  // Before this the flag existed and nothing on the campaign path passed it: raising the budget
+  // meant editing `PROBE_BUDGET_MINUTES` and landing a PR.
+  const argsFor = async (env) => {
+    const { stdout } = await execFileAsync(
+      "bash",
+      ["-c", 'source scripts/ci/memory-catalog/common.sh; build_catalog_args; printf "%s\\n" "${CATALOG_ARGS[@]}"'],
+      { cwd: ROOT, env: { PATH: process.env.PATH, BACKEND: "candle", CAMPAIGN: "sc-22738", INFERENCE_REPO: "/tmp/inf", WORK_DIR_NATIVE: "/tmp/wd", ...env } },
+    );
+    return stdout.trim().split("\n");
+  };
+  const raised = await argsFor({ PROBE_BUDGET_INPUT: "video=240" });
+  assert.equal(raised.at(-2), "--probe-budget-minutes", raised.join(" "));
+  assert.equal(raised.at(-1), "video=240", raised.join(" "));
+  // The spelling the shell passes is the spelling the walk parses — the two agree by string.
+  assert.deepEqual(parseProbeBudgetMinutes(raised.at(-1)), { video: 240, image: null });
+  assert.deepEqual(parseArgs(["--backend", "candle", "--list", raised.at(-2), raised.at(-1)]).probeBudgetMinutes, { video: 240, image: null });
+  // Unset is the lane defaults, and passes NO flag: an empty dispatch input must not become
+  // `--probe-budget-minutes ''`, which the walk refuses outright.
+  for (const env of [{}, { PROBE_BUDGET_INPUT: "" }]) {
+    assert.ok(!(await argsFor(env)).includes("--probe-budget-minutes"), JSON.stringify(env));
+  }
+
+  const workflow = await readFile(path.join(ROOT, ".github/workflows/memory-catalog-campaign.yml"), "utf8");
+  assert.match(workflow, /^ {6}probe_budget_minutes:$/m, "the dispatch offers the knob");
+  assert.match(workflow, /^ {2}PROBE_BUDGET_INPUT: \$\{\{ inputs\.probe_budget_minutes \}\}$/m, "and carries it to the steps");
+  // Workflow-level env reaches BOTH lanes' walks; the flag is in the shared arg builder, so the
+  // `--dry-run`/`--list` passes print the raised figure per row before a day of GPU is spent on it.
+  const candleAt = workflow.indexOf("\n  candle:");
+  assert.ok(candleAt > workflow.indexOf("\n  mlx:") && workflow.indexOf("\n  mlx:") > -1, "both lane jobs were located");
+  for (const [job, body] of [["mlx", workflow.slice(0, candleAt)], ["candle", workflow.slice(candleAt)]]) {
+    assert.ok(body.includes("scripts/ci/memory-catalog/run.sh"), `the ${job} job walks with run.sh`);
+    assert.ok(body.includes("scripts/ci/memory-catalog/plan.sh"), `the ${job} job plans with plan.sh`);
+  }
+  assert.match(await readFile(path.join(ROOT, "scripts/ci/memory-catalog/plan.sh"), "utf8"), /build_catalog_args/);
+  assert.match(await readFile(path.join(ROOT, "scripts/ci/memory-catalog/run.sh"), "utf8"), /build_catalog_args/);
 });
 
 test("a runtime stop is recognised by its spelling and reports the guard's sampled peak", async () => {
@@ -5557,46 +5667,104 @@ test("a runtime stop's reason names the lane's longest completed render (video) 
   const ceiling = "94822600832-byte ceiling";
   // The campaign of 2026-09-07: `scail2_14b:q4:mlx` under `--probe-budget-minutes 90`, flat at
   // 68.56 GB for 2,354 samples. This is the sentence that was missing when it was read as a hang.
-  const shortfall = runtimeBudgetExceededReason({ row: { key: "scail2_14b:q4:mlx", videoLane: true }, budgetMinutes: 90, budgetSeconds: 5400, peak, ceiling });
+  const shortfall = runtimeBudgetExceededReason({ row: { key: "scail2_14b:q4:mlx", videoLane: true }, budgetMinutes: 90, peak, ceiling, stoppedAtSeconds: 5400 });
   assert.equal(
     shortfall,
     "runtime_budget_exceeded: the 90-minute probe budget (5400s) elapsed; peak physical footprint 68564154584 bytes "
       + "over 2354 sample(s) against the 94822600832-byte ceiling. Nothing was measured, so no bound was recorded and "
-      + "this cell stays runnable. The longest completed video render on record ran 4470s, and this run was launched "
+      + "this cell stays runnable. The longest completed video render on record ran 4470s (longest on mlx: 4470s, "
+      + "wan_2_2_t2v_14b:bf16:mlx), and this run was launched "
       + "with --probe-budget-minutes 90, below the video lane's 165-minute default: this stop is a budget shortfall, "
       + "not evidence of a stall. Re-run it at the default budget or larger before reading anything into the flat footprint.",
   );
-  // At the lane default (or above it) the stop stands on its own: the witness is still named, the
-  // shortfall sentence is not.
+  // At the lane default (or above it) the shortfall sentence is not said — but the knob still is
+  // (sc-22738 review): a stop at the default poses exactly the question an operator cannot answer
+  // by re-running into the same kill at the same second.
   for (const budgetMinutes of [165, 300]) {
-    const reason = runtimeBudgetExceededReason({ row: { key: "scail2_14b:q4:mlx", videoLane: true }, budgetMinutes, budgetSeconds: budgetMinutes * 60, peak, ceiling });
+    const reason = runtimeBudgetExceededReason({ row: { key: "scail2_14b:q4:mlx", videoLane: true }, budgetMinutes, peak, ceiling, stoppedAtSeconds: budgetMinutes * 60 });
     assert.match(reason, new RegExp(`^runtime_budget_exceeded: the ${budgetMinutes}-minute probe budget \\(${budgetMinutes * 60}s\\) elapsed; `), reason);
-    assert.match(reason, /stays runnable\. The longest completed video render on record ran 4470s\.$/, reason);
+    assert.match(reason, /stays runnable\. The longest completed video render on record ran 4470s \(longest on mlx: 4470s, wan_2_2_t2v_14b:bf16:mlx\)\. A re-run at this budget would stop at the same second/, reason);
+    assert.match(reason, new RegExp(`--probe-budget-minutes video=${budgetMinutes * 2} \\(the campaign's probe_budget_minutes input\\), which raises the video lane alone\\.$`), reason);
     assert.doesNotMatch(reason, /shortfall|not evidence of a stall/, reason);
   }
   // The image lane reads its own witness and its own default, and an unsampled peak is said so.
-  const image = runtimeBudgetExceededReason({ row: { key: "sdxl:q4:mlx", videoLane: false }, budgetMinutes: 30, budgetSeconds: 1800, peak: null, ceiling: "guard's ceiling" });
+  const image = runtimeBudgetExceededReason({ row: { key: "sdxl:q4:mlx", videoLane: false }, budgetMinutes: 30, peak: null, ceiling: "guard's ceiling", stoppedAtSeconds: 1800 });
   assert.match(image, /peak physical footprint not sampled against the guard's ceiling\./, image);
-  assert.match(image, /The longest completed image capture on record ran 847s, and this run was launched with --probe-budget-minutes 30, below the image lane's 60-minute default/, image);
-  const imageAtDefault = runtimeBudgetExceededReason({ row: { key: "sdxl:q4:mlx", videoLane: false }, budgetMinutes: 60, budgetSeconds: 3600, peak: null, ceiling: "guard's ceiling" });
-  assert.match(imageAtDefault, /ran 847s\.$/, imageAtDefault);
+  assert.match(image, /The longest completed image capture on record ran 847s \(longest on mlx: 847s, bernini_image:q8:mlx\), and this run was launched with --probe-budget-minutes 30, below the image lane's 60-minute default/, image);
+  const imageAtDefault = runtimeBudgetExceededReason({ row: { key: "sdxl:q4:mlx", videoLane: false }, budgetMinutes: 60, peak: null, ceiling: "guard's ceiling", stoppedAtSeconds: 3600 });
+  assert.match(imageAtDefault, /ran 847s \(longest on mlx: 847s, bernini_image:q8:mlx\)\./, imageAtDefault);
+  assert.match(imageAtDefault, /--probe-budget-minutes image=120 \(the campaign's probe_budget_minutes input\), which raises the image lane alone\.$/, imageAtDefault);
   assert.doesNotMatch(imageAtDefault, /shortfall/, imageAtDefault);
   // sc-22738 (run 34356681566): on a lane the guard does not run on there is no ceiling and no
   // sampler, and the reason must not borrow the guard's vocabulary to say so — "not sampled
   // against the guard's ceiling" would name a ceiling nothing enforced. It also names WHO stopped
   // the probe, because a runner stop additionally means the guard was absent or failed.
   const unguarded = runtimeBudgetExceededReason({
-    row: { key: "scail2_14b:bf16:candle", videoLane: true }, budgetMinutes: 165, budgetSeconds: 9900,
-    peak: null, ceiling: null, stoppedBy: "runner",
+    row: { key: "scail2_14b:bf16:candle", videoLane: true }, budgetMinutes: 165,
+    peak: null, ceiling: null, stoppedBy: "runner", stoppedAtSeconds: 9900,
   });
   assert.match(unguarded, /^runtime_budget_exceeded: the 165-minute probe budget \(9900s\) elapsed; /, unguarded);
   assert.match(unguarded, /peak physical footprint not sampled: the footprint guard is Darwin-only, so nothing sampled this probe\./, unguarded);
-  assert.match(unguarded, /The runner's own wall-clock backstop stopped the probe's process tree\./, unguarded);
+  assert.match(unguarded, /The runner's own wall-clock backstop stopped the probe's process tree at that budget\./, unguarded);
   assert.match(unguarded, /no bound was recorded and this cell stays runnable/, unguarded);
   assert.doesNotMatch(unguarded, /against the/, "no ceiling is claimed where none was enforced");
   assert.doesNotMatch(unguarded, /shortfall/, "165 is the video lane default, not a shortfall");
   // The guard's own stop keeps the sentence it had: no backstop clause, ceiling named.
   assert.doesNotMatch(imageAtDefault, /wall-clock backstop/, imageAtDefault);
+
+  // sc-22738 review, THE SENTENCE THAT CONTRADICTED ITSELF. On the GUARDED lane the runner's own
+  // deadline is the budget plus `RUNNER_BACKSTOP_GRACE_SECONDS`, and it used to be rendered as the
+  // budget's own elapsed figure: "the 165-minute probe budget (10020s) elapsed" — 165 minutes is
+  // 9,900 s. The budget's seconds are now DERIVED from its minutes on both lanes, and the
+  // backstop's later deadline is named as itself.
+  for (const [budgetMinutes, key, videoLane] of [[165, "scail2_14b:bf16:candle", true], [60, "sdxl:q4:mlx", false]]) {
+    for (const guarded of [false, true]) {
+      const reason = runtimeBudgetExceededReason({
+        row: { key, videoLane }, budgetMinutes, peak: null, ceiling: guarded ? "guard's ceiling" : null,
+        stoppedBy: "runner", stoppedAtSeconds: probeTimeoutMs(budgetMinutes, guarded) / 1000,
+      });
+      assert.match(reason, new RegExp(`^runtime_budget_exceeded: the ${budgetMinutes}-minute probe budget \\(${budgetMinutes * 60}s\\) elapsed; `), reason);
+      // The ONE figure that may be quoted as "the budget" is the budget. A grace-inflated one is
+      // the defect, whichever lane it appears on.
+      assert.doesNotMatch(reason, new RegExp(`budget \\(${budgetMinutes * 60 + RUNNER_BACKSTOP_GRACE_SECONDS}s\\)`), reason);
+      assert.match(
+        reason,
+        guarded
+          ? new RegExp(`backstop stopped the probe's process tree at ${budgetMinutes * 60 + RUNNER_BACKSTOP_GRACE_SECONDS}s, ${RUNNER_BACKSTOP_GRACE_SECONDS}s past the guard's own deadline: the guard did not stop the group\\.`)
+          : /backstop stopped the probe's process tree at that budget\./,
+        reason,
+      );
+    }
+  }
+  // A guard whose own deadline disagrees with the budget it was handed is a defect, and the row
+  // says so rather than quietly reporting the budget as the thing that fired.
+  assert.match(
+    runtimeBudgetExceededReason({ row: { key: "sdxl:q4:mlx", videoLane: false }, budgetMinutes: 60, peak: null, ceiling: "guard's ceiling", stoppedAtSeconds: 4200 }),
+    /The guard's own stop fired at 4200s, not at the 3600s it was given\./,
+  );
+
+  // sc-22738 review, THE EXTRAPOLATION AN OPERATOR MUST NOT MAKE SILENTLY. The budget is a hard
+  // kill on every lane now, and `scail2_14b:bf16:candle` — the 19h43m cell run 34356681566 died on
+  // — is a 14B DiT under CFG whose lane's only completed video witnesses are `ltx_2_5`. So the row
+  // states the CANDLE figure and the cell it belongs to: 446 s from an `ltx_2_5` capture is not
+  // evidence about a 14B DiT, and the difference has to be visible on the line an operator reads.
+  const heavy = runtimeBudgetExceededReason({
+    row: { key: "scail2_14b:bf16:candle", videoLane: true }, budgetMinutes: 165, peak: null, ceiling: null,
+    stoppedBy: "runner", stoppedAtSeconds: 9900,
+  });
+  assert.match(heavy, /The longest completed video render on record ran 4470s \(longest on candle: 446s, ltx_2_5:q8:candle\)\./, heavy);
+  assert.match(heavy, /--probe-budget-minutes video=330 \(the campaign's probe_budget_minutes input\), which raises the video lane alone\.$/, heavy);
+  // The row claims nothing about what else did or did not complete: this table holds each backend's
+  // LONGEST capture, not a record of every one, and `z_image_turbo:q4:mlx` (which has an anchor in
+  // the store) would make any "nothing else completed" phrasing a falsehood.
+  assert.doesNotMatch(heavy, /never|no other|has ever completed/, heavy);
+  // And the mlx lane names its own witness, not the candle one.
+  const witnessed = runtimeBudgetExceededReason({
+    row: { key: "wan_2_2_t2v_14b:q8:mlx", videoLane: true }, budgetMinutes: 165, peak: null, ceiling: null,
+    stoppedBy: "runner", stoppedAtSeconds: 9900,
+  });
+  assert.match(witnessed, /\(longest on mlx: 4470s, wan_2_2_t2v_14b:bf16:mlx\)\./, witnessed);
+  assert.doesNotMatch(witnessed, /candle/, witnessed);
 });
 
 test("a probe that reaches its wall-clock budget is `runtime_budget_exceeded`, never a memory bound, and the cell stays runnable", { skip: process.platform !== "darwin" && "the footprint sampler is Darwin-only" }, async () => {
@@ -5630,7 +5798,7 @@ test("a probe that reaches its wall-clock budget is `runtime_budget_exceeded`, n
     assert.match(stopped.reason, /no bound was recorded and this cell stays runnable/);
     // sc-22738 (2026-09-08): 0.05 minutes is below the image lane's default, and the reason says
     // so — a stop under a shortened budget must not read as a wedged engine.
-    assert.match(stopped.reason, /The longest completed image capture on record ran 847s, and this run was launched with --probe-budget-minutes 0\.05, below the image lane's 60-minute default: this stop is a budget shortfall, not evidence of a stall\./);
+    assert.match(stopped.reason, /The longest completed image capture on record ran 847s \(longest on mlx: 847s, bernini_image:q8:mlx\), and this run was launched with --probe-budget-minutes 0\.05, below the image lane's 60-minute default: this stop is a budget shortfall, not evidence of a stall\./);
     assert.equal(context.state.commits.length, 0, "nothing was committed");
     const { stdout: status } = await checkout.git("status", "--porcelain");
     assert.equal(status, "", "the tree is clean for the next anchor");
@@ -5787,7 +5955,10 @@ test(
 
       assert.equal(stopped.status, "runtime_budget_exceeded", stopped.reason);
       assert.match(stopped.reason, /^runtime_budget_exceeded: the 0\.05-minute probe budget \(3s\) elapsed;/);
-      assert.match(stopped.reason, /The runner's own wall-clock backstop stopped the probe's process tree\./);
+      // UNGUARDED: the runner's bound IS the budget, so the tree was stopped at that budget and no
+      // grace-inflated figure appears anywhere in the sentence.
+      assert.match(stopped.reason, /The runner's own wall-clock backstop stopped the probe's process tree at that budget\./);
+      assert.doesNotMatch(stopped.reason, new RegExp(`${3 + RUNNER_BACKSTOP_GRACE_SECONDS}s`), stopped.reason);
       // No guard ran here, so no ceiling and no sampled peak may be claimed.
       assert.match(stopped.reason, /not sampled: the footprint guard is Darwin-only/);
       assert.doesNotMatch(stopped.reason, /-byte ceiling/);
@@ -5828,6 +5999,257 @@ test(
       delete process.env.STUB_CAPTURE_HANGS;
       delete process.env.STUB_CAPTURE_ADAPTER_PID_FILE;
     }
+  },
+);
+
+// ---------------------------------------------------------------------------------------------
+// sc-22738 review: THE GUARDED HALF OF THE SAME BACKSTOP.
+//
+// The test above drives the lane with no guard on it. The Darwin lane HAS one, and there the
+// runner's bound is the budget plus `RUNNER_BACKSTOP_GRACE_SECONDS` — so it can only ever fire when
+// the guard FAILED to stop the group, which no working guard does. Nothing therefore exercised the
+// guarded spawn's own `timeoutMs`: dropping it from that call site left the whole suite green.
+//
+// HOW THIS DRIVES IT WITHOUT WAITING OUT THE GRACE. The node side runs on `t.mock.timers`, the
+// same idea as the watchdog's `QuantizedClock` (#2798): real processes, real signals, real event
+// log, virtual READINGS of the clock the runner schedules against. The guard is real and is given a
+// 60-second deadline it never reaches, so it cannot be what ends this probe — a guard that
+// swallows its own stop — and the runner's 180-second bound is ticked to one millisecond short (it
+// must NOT fire: that pins the grace, since the unguarded value would already have fired) and then
+// over.
+// ---------------------------------------------------------------------------------------------
+
+/** Poll `condition` on the REAL clock — captured before `mock.timers` replaces the global. */
+async function untilReal(condition, { realSetTimeout, timeoutMs = 20_000, what }) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await condition()) return;
+    if (Date.now() > deadline) assert.fail(`timed out after ${timeoutMs}ms waiting for ${what}`);
+    await new Promise((resolve) => { realSetTimeout(resolve, 100); });
+  }
+}
+
+test(
+  "the runner's backstop is wired into the GUARDED spawn too, and stops the tree when the guard does not",
+  { skip: process.platform !== "darwin" && "the footprint guard is Darwin-only", timeout: 90_000 },
+  async (t) => {
+    const checkout = await stubCheckout();
+    const adapterPidFile = path.join(checkout.workDir, "guarded-adapter.pid");
+    const eventFile = path.join(checkout.workDir, "logs", "z-image-turbo-q4-mlx-watchdog.jsonl");
+    // The REAL setTimeout, captured before the mock replaces the global: every wait below is real
+    // wall clock, and only the runner's own scheduling is virtual.
+    const realSetTimeout = globalThis.setTimeout;
+    process.env.STUB_CAPTURE_HANGS = "1";
+    process.env.STUB_CAPTURE_ADAPTER_PID_FILE = adapterPidFile;
+    // Runs even when the test times out, where a `finally` would not: a broken bound leaves a
+    // 600-second stub and its adapter holding the suite open.
+    t.after(async () => {
+      t.mock.timers.reset();
+      delete process.env.STUB_CAPTURE_HANGS;
+      delete process.env.STUB_CAPTURE_ADAPTER_PID_FILE;
+      for (const line of (await readFile(adapterPidFile, "utf8").catch(() => "")).split("\n")) {
+        const pid = Number(line.trim());
+        if (!Number.isSafeInteger(pid) || pid <= 0) continue;
+        try { process.kill(pid, "SIGKILL"); } catch { /* already reaped */ }
+      }
+    });
+
+    const budgetMinutes = 1;
+    const bound = probeTimeoutMs(budgetMinutes, true);
+    assert.equal(bound, (60 + RUNNER_BACKSTOP_GRACE_SECONDS) * 1000, "the guarded bound is the budget plus the grace");
+    const context = stubContext(checkout, {
+      platform: "darwin",
+      // Through the flag's own parser, so the per-lane spelling reaches a real spawn rather than
+      // only a unit test of the parser.
+      args: { ...stubContext(checkout).args, commit: false, probeBudgetMinutes: parseProbeBudgetMinutes("image=1") },
+    });
+    const row = {
+      key: "z_image_turbo:q4:mlx", physical: false, env: {},
+      // Fully bound, so the "no artifact binding" refusal is not what this test is really watching.
+      artifact: { repository: "SceneWorks/z-image-turbo-mlx", resolvedRevision: REVISION, variant: "q4" },
+    };
+
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const pending = measureAnchor(row, context);
+    let settled = null;
+    pending.then((value) => { settled = value; }, (error) => { settled = error; });
+
+    // The guard is REAL and is sampling: this is the Darwin branch, not a stand-in for it.
+    await untilReal(
+      async () => (await readFile(eventFile, "utf8").catch(() => "")).includes('"event": "sample"')
+        || (await readFile(eventFile, "utf8").catch(() => "")).includes('"event":"sample"'),
+      { realSetTimeout, what: "the footprint guard's first sample" },
+    );
+
+    // ONE MILLISECOND SHORT. The unguarded bound (60,000 ms) and the guard's own deadline are both
+    // long past at this point, so anything but the guarded value would have ended the probe here.
+    t.mock.timers.tick(bound - 1);
+    await new Promise((resolve) => { realSetTimeout(resolve, 250); });
+    assert.equal(settled, null, `the guarded bound fired before ${bound}ms: ${JSON.stringify(settled)}`);
+    t.mock.timers.tick(1);
+
+    const stopped = await pending;
+    t.mock.timers.reset();
+
+    assert.equal(stopped.status, "runtime_budget_exceeded", stopped.reason);
+    // sc-22738 review, THE SENTENCE THAT CONTRADICTED ITSELF: the budget's seconds are the budget's,
+    // and the backstop's own later deadline is named as itself.
+    assert.match(stopped.reason, /^runtime_budget_exceeded: the 1-minute probe budget \(60s\) elapsed;/, stopped.reason);
+    assert.match(
+      stopped.reason,
+      new RegExp(`backstop stopped the probe's process tree at ${bound / 1000}s, ${RUNNER_BACKSTOP_GRACE_SECONDS}s past the guard's own deadline: the guard did not stop the group\\.`),
+      stopped.reason,
+    );
+    // The `guarded: true` arm of the stop handler: the guard's sampled peak, and the ceiling its
+    // ceilings were derived from — neither of which the unguarded lane may claim.
+    assert.match(stopped.reason, /peak physical footprint \d+ bytes over \d+ sample\(s\) against the 94822600832-byte ceiling/, stopped.reason);
+    assert.match(stopped.reason, /no bound was recorded and this cell stays runnable/, stopped.reason);
+
+    // The guard really ran, on this probe's own budget: minutes on the runner, seconds on the guard.
+    const log = await readFile(stopped.log, "utf8");
+    assert.match(log, /memory-calibration-watchdog\.py .*--max-runtime-seconds 60 /);
+    assert.match(log, /RUNNER STOP: 180s wall-clock budget elapsed; stopping the probe's process tree/);
+
+    // WHAT THE EVENT LOG SAYS, AND WHAT IT MUST NOT BE TURNED INTO. The guard never reached its own
+    // deadline, so there is no footprint stop and no runtime stop in it — the only `hard_stop` is
+    // the one the RUNNER's own SIGTERM caused, and reading that as a measured bound would file the
+    // runner's kill in the store as a fact about the model.
+    const events = (await readFile(eventFile, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+    assert.ok(events.some((event) => event.event === "sample"), "the guard sampled this probe");
+    const stops = events.filter((event) => event.event === "hard_stop").map((event) => event.reason);
+    assert.deepEqual(stops, ["monitor_signal_SIGTERM"], JSON.stringify(stops));
+    assert.equal(measuredFootprintBound(await watchdogHardStop(eventFile)), false, "the runner's own kill is not a bound");
+    assert.equal(runtimeBudgetStopSeconds(await watchdogHardStop(eventFile)), null, "and it is not the guard's runtime stop either");
+
+    // The TREE, on the guarded lane as well: the adapter the capture spawned is dead.
+    const adapterPid = Number((await readFile(adapterPidFile, "utf8")).trim().split("\n")[1]);
+    assert.ok(Number.isSafeInteger(adapterPid) && adapterPid > 0, "the stub adapter recorded its pid");
+    await untilReal(
+      async () => { try { process.kill(adapterPid, 0); return false; } catch { return true; } },
+      { realSetTimeout, what: `the adapter (pid ${adapterPid}) to be reaped` },
+    );
+
+    assert.equal(context.state.commits.length, 0, "nothing was committed");
+    assert.equal(context.state.halt ?? null, null, "a stopped cell is not a stopped walk");
+    assert.equal((await checkout.git("status", "--porcelain")).stdout, "", "the tree is clean for the next anchor");
+  },
+);
+
+test("the runner's own kill and the guard's measured bound are told apart by the SPELLING the harness accepts", async () => {
+  const stream = (reason) => [
+    JSON.stringify({ event: "sample", physicalFootprintBytes: 94_822_600_833 }),
+    JSON.stringify({ event: "hard_stop", reason }),
+    "",
+  ].join("\n");
+  const footprint = "physical_footprint_at_or_above_94822600832:observed_94822600833";
+  // The runner's predicate and the harness's parser are two copies of one rule — only a footprint
+  // stop states a lower bound — in two files that agree by STRING and nothing else. Drive both.
+  assert.equal(measuredFootprintBound(`watchdog hard stop: ${footprint}`), true);
+  assert.equal(parseWatchdogHardStop(stream(footprint)).ceilingBytes, 94_822_600_832);
+  for (const other of [
+    // The one the runner CAUSES: `stopProcessTree` SIGTERMs the guard, and the guard writes this on
+    // its way out. A looser predicate would feed the runner's own kill to `record-exceeded`.
+    "monitor_signal_SIGTERM",
+    "runtime_at_or_above_9900.0s",
+    "telemetry_lost:TimeoutError:x",
+    "monitor_failure:RuntimeError:x",
+    "memory_free_at_or_below_2147483648",
+  ]) {
+    assert.equal(measuredFootprintBound(`watchdog hard stop: ${other}`), false, other);
+    assert.throws(() => parseWatchdogHardStop(stream(other)), /is not a physical-footprint stop/, other);
+  }
+  for (const nothing of [null, undefined, "", "watchdog hard stop: physical_footprint_at_or_above_1", "physical_footprint_at_or_above_1:observed_2"]) {
+    assert.equal(measuredFootprintBound(nothing), false, String(nothing));
+  }
+  assert.ok(FOOTPRINT_BOUND_STOP_PATTERN.test("watchdog hard stop: physical_footprint_at_or_above_1:observed_2"));
+
+  // The harness's note about what the RUNNER does with a wall-clock stop is a cross-file claim, and
+  // it went stale the moment `runtime_budget_exceeded` replaced `capture_failed` (sc-22738 review).
+  // Bind it to the status this file really returns, so the next rename cannot leave it lying.
+  const harness = await readFile(path.join(ROOT, "scripts/memory-calibration-harness.mjs"), "utf8");
+  const at = harness.indexOf("the SECOND guard against a false lower bound");
+  assert.ok(at > -1, "the harness's note about the runner was located");
+  const note = harness.slice(at, harness.indexOf("*/", at));
+  assert.match(note, /returns `runtime_budget_exceeded` for a wall-clock stop/, note);
+  assert.doesNotMatch(note, /capture_failed/, "the runner has not reported a wall-clock stop that way since sc-22738");
+});
+
+test(
+  "a bound the guard MEASURED before the reap wedged survives the runner's backstop and is committed",
+  { skip: process.platform !== "darwin" && "the footprint guard is Darwin-only", timeout: 90_000 },
+  async (t) => {
+    // sc-22738 review. The runner used to return on `error.timedOut` BEFORE reading the guard's
+    // event log, so a `physical_footprint_at_or_above_…:observed_…` written at minute 100 of a
+    // 165-minute budget — the line that becomes `committed_exceeded` — was thrown away and the cell
+    // reported `runtime_budget_exceeded`, recording NOTHING. The guard here has written its bound
+    // and then wedged; the runner's backstop is what ends the probe.
+    const checkout = await stubCheckout();
+    const tierRoot = await mkdtemp(path.join(tmpdir(), "catalog-tier-"));
+    await writeFile(path.join(tierRoot, "w.safetensors"), "weights");
+    process.env.GIT_AUTHOR_NAME = process.env.GIT_COMMITTER_NAME = "t";
+    process.env.GIT_AUTHOR_EMAIL = process.env.GIT_COMMITTER_EMAIL = "t@t";
+    const eventFile = path.join(checkout.workDir, "logs", "z-image-turbo-q4-mlx-watchdog.jsonl");
+    const adapterPidFile = path.join(checkout.workDir, "wedged-adapter.pid");
+    const realSetTimeout = globalThis.setTimeout;
+    process.env.STUB_CAPTURE_HANGS = "1";
+    process.env.STUB_CAPTURE_ADAPTER_PID_FILE = adapterPidFile;
+    process.env.STUB_CAPTURE_WATCHDOG_HARD_STOP = eventFile;
+    t.after(async () => {
+      t.mock.timers.reset();
+      delete process.env.STUB_CAPTURE_HANGS;
+      delete process.env.STUB_CAPTURE_ADAPTER_PID_FILE;
+      delete process.env.STUB_CAPTURE_WATCHDOG_HARD_STOP;
+      for (const line of (await readFile(adapterPidFile, "utf8").catch(() => "")).split("\n")) {
+        const pid = Number(line.trim());
+        if (!Number.isSafeInteger(pid) || pid <= 0) continue;
+        try { process.kill(pid, "SIGKILL"); } catch { /* already reaped */ }
+      }
+    });
+
+    const context = stubContext(checkout, {
+      platform: "darwin",
+      args: { ...stubContext(checkout).args, probeBudgetMinutes: parseProbeBudgetMinutes("image=1") },
+    });
+    const row = {
+      key: "z_image_turbo:q4:mlx", physical: false, tierRoot,
+      env: { SCENEWORKS_Z_IMAGE_ROOT: tierRoot },
+      artifact: { repository: "SceneWorks/z-image-turbo-mlx", resolvedRevision: REVISION, variant: "q4" },
+    };
+
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const pending = measureAnchor(row, context);
+    await untilReal(
+      async () => (await readFile(eventFile, "utf8").catch(() => "")).includes("physical_footprint_at_or_above_94822600832"),
+      { realSetTimeout, what: "the guard's measured bound to reach its event log" },
+    );
+    t.mock.timers.tick(probeTimeoutMs(1, true));
+    const stopped = await pending;
+    t.mock.timers.reset();
+
+    // THE POINT: the bound is recorded, not discarded, and the runner's stop is not what the cell
+    // reports — a `runtime_budget_exceeded` here would leave the cell `runnable` with the store
+    // carrying no trace of a footprint the host could not hold.
+    assert.equal(stopped.status, "committed_exceeded", stopped.reason);
+    assert.equal(stopped.reason, null, stopped.reason);
+    assert.equal(context.state.commits.length, 1, "the measured bound is one commit, like an anchor");
+    assert.equal(context.state.halt ?? null, null);
+    const { stdout: shown } = await checkout.git("show", "--stat", "--format=%s%n%b", "HEAD");
+    assert.match(shown, /chore\(sc-stub\): record the z_image_turbo:q4:mlx footprint hard stop as a measured bound/);
+    assert.match(shown, /watchdog hard stop: physical_footprint_at_or_above_94822600832:observed_94822600833/);
+    const bundle = JSON.parse(await readFile(
+      path.join(checkout.root, "docs/calibration/sc-stub/z-image-turbo-q4-mlx-exceeded-evidence.json"), "utf8",
+    ));
+    assert.equal(bundle.exceededBounds[0].ceilingBytes, 94_822_600_832);
+    assert.equal(bundle.exceededBounds[0].observedFootprintBytes, 94_822_600_833);
+    assert.equal((await checkout.git("status", "--porcelain")).stdout, "", "the tree is clean for the next anchor");
+
+    // The runner's OWN kill is in the same log, AFTER the bound — and the first hard stop is the one
+    // that speaks, so the SIGTERM the backstop sent can never overwrite the measurement.
+    const stops = (await readFile(eventFile, "utf8")).trim().split("\n")
+      .map((line) => JSON.parse(line)).filter((event) => event.event === "hard_stop").map((event) => event.reason);
+    assert.equal(stops[0], "physical_footprint_at_or_above_94822600832:observed_94822600833", JSON.stringify(stops));
+    assert.ok(stops.includes("monitor_signal_SIGTERM"), `the runner stopped the tree: ${JSON.stringify(stops)}`);
+    assert.equal(await watchdogHardStop(eventFile), "watchdog hard stop: physical_footprint_at_or_above_94822600832:observed_94822600833");
   },
 );
 

--- a/scripts/memory-calibration-harness.mjs
+++ b/scripts/memory-calibration-harness.mjs
@@ -2117,8 +2117,9 @@ export function parseWatchdogHardStop(body) {
   const match = /^physical_footprint_at_or_above_(\d+):observed_(\d+)$/.exec(String(stop.reason));
   if (!match) {
     // sc-22738: the SECOND guard against a false lower bound, behind the runner's own
-    // (`measure-memory-catalog.mjs` returns `capture_failed` for a runtime stop before it ever
-    // calls `record-exceeded`). A wall-clock stop is the case this is now most likely to see: the
+    // (`measure-memory-catalog.mjs` returns `runtime_budget_exceeded` for a wall-clock stop —
+    // whether the guard made it or the runner's backstop did — before it ever calls
+    // `record-exceeded`). A wall-clock stop is the case this is now most likely to see: the
     // probe ran out of its `--max-runtime-seconds` budget wherever its footprint happened to be,
     // which is not a line it was witnessed to cross. Anything that is not a footprint stop is
     // refused here for the same reason, whatever put it in the log.


### PR DESCRIPTION
Two defects from memory-catalog campaign run
[34356681566](https://github.com/SceneWorks/SceneWorks/actions/runs/34356681566), fixed together.

## 1. A probe outran its budget by 7x and nothing stopped it

```
=== scail2_14b:bf16:candle (85/132) 2026-09-09T15:15:45Z
   ...nothing...
2026-09-10T10:59:16Z ##[error]The operation was canceled.
```

19h43m on one cell against a 165-minute video budget. The remaining 47 cells were never reached.

### Root cause (confirmed, single mechanism)

The wall-clock budget only ever reached a probe through the footprint guard, and the guard is
Darwin-only:

- `scripts/measure-memory-catalog.mjs:3202` — `guardsCapture()` is `return platform === "darwin"`
  (the sampler is `/usr/bin/footprint`).
- `scripts/measure-memory-catalog.mjs:3536-3551` — `--max-runtime-seconds` is passed only inside
  `if (guardsCapture(row.key))`. The `else` branch was
  `await exec(process.execPath, captureArgs, { env, log, detached: true })` — no bound of any kind.
- `scripts/measure-memory-catalog.mjs:3534` — `budgetMinutes` was resolved for every row and then
  simply unused on the unguarded path.

The job ran on `cuda-windows-2` / `MICHAEL-TRX50`, so `process.platform === "win32"` and the probe
was spawned unbounded. Nothing was wrong with `PROBE_BUDGET_MINUTES`; nothing was passing it.

### Hypotheses eliminated

- **The runner host died (would make any in-process guard useless).** No. `Push whatever landed`
  ran and succeeded at 10:59:17Z, and `Complete job` at 10:59:25Z reaped `node (16476)`,
  `memory-candle-adapter (8716)`, `conhost` and `nvidia-smi` as orphans — the agent was alive and
  both the walk and the adapter were still running.
- **The guard's stop path fails on Windows.** Not exercised: the guard was never spawned on this
  platform. (It is a real hazard for the new stop path, and is handled — see below.)
- **`probeBudgetMinutes()` returned null.** No — it returned 165; the value never reached a flag.
- **The timer is only checked between probes.** No — there was no timer.
- **Job `timeout-minutes`.** Did not fire: 21h36m elapsed against `timeout-minutes: 1440`.

### The fix

The bound now belongs to the runner, on every platform. `probeTimeoutMs()` → `run({ timeoutMs })`
stops the capture's whole process tree and the cell finishes on its own terminal status,
`runtime_budget_exceeded`, before the walk continues to the **next** cell.

It is in the harness, not `run.sh`: a timeout there could only kill the whole walk, which is exactly
the outcome (47 unreached cells) the bound exists to prevent. The harness is where the budget, the
per-cell status and the continue-to-next-cell loop already live.

- **The tree, not the child.** Node's `kill()` is `TerminateProcess` on the immediate child on
  Windows — that is how `memory-candle-adapter.exe` outlives its parent, and a surviving adapter
  contaminates every following cell's peak (`contaminatedHostHalt`). `stopProcessTree()` uses
  `taskkill /PID <pid> /T /F` on Windows and a process-group signal with TERM→KILL escalation on
  POSIX.
- **The guard keeps owning the stop it can make.** On Darwin the runner's bound sits
  `RUNNER_BACKSTOP_GRACE_SECONDS` (120 s) behind the guard's deadline, past its whole escalation, so
  it fires only when the guard did not. The guard alone can tell a wall-clock stop from a footprint
  stop, and only a footprint stop states a bound.
- **One event, one status.** `runtime_budget_exceeded` replaces `capture_failed` for the guard's
  runtime stop too. Still a walk failure (exit 2); still records nothing, so the cell classifies
  `runnable` again on the next `--list`.
- **No borrowed vocabulary.** A runner stop names itself in the reason and claims no ceiling and no
  sampled peak where no guard ran.
- `measureAnchor` takes `context.platform` (defaulting to the host's) purely to choose
  guarded/unguarded. The unguarded branch is one no developer machine and no macOS lane ever takes,
  which is how this shipped for months; now a Mac can exercise it.

### The other unbounded spawn on the same path

`probeAdapter` ran the adapter with no bound either — and it runs *before* the guard exists, since
its answer is what derives the guard's ceilings. An adapter wedged in GPU-runtime init would have
hung the walk on cell 1 with nothing at all to stop it. It now carries
`ADAPTER_PROBE_TIMEOUT_SECONDS` (300 — a wedge ceiling, not a budget) and reports a probe failure
rather than `runtime_budget_exceeded`, which would state a render budget the run never reached.

## 2. `pr.sh` turned a successful salvage into a red job

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve
pull requests (createPullRequest)
```

That is the repository/org *"Allow GitHub Actions to create and approve pull requests"* setting.
`pull-requests: write` is already granted; no `permissions:` block overrides it. The step runs under
`if: always()` so evidence is never stranded, and the campaign branch with its 20 anchor commits was
already pushed — only a click was missing.

That **one** message now emits a `::warning` plus a ready-to-click
`compare/<base>...<head>?expand=1` URL into the job summary and exits 0. Every other `gh pr create`
failure (bad token, missing base ref, rejected body) still fails the step, because there the PR is
genuinely lost and nothing else would say so.

## Tests

All new and touched assertions were mutation-checked (each guard individually; broken, confirmed
RED, restored, re-run GREEN).

| mutation | assertion that went red |
|---|---|
| disable the `run()` timeout | unguarded probe test times out at 90 s (was 3.1 s) |
| POSIX kill the child, not the group | *"the adapter the probe spawned (pid 38737) outlived the stop"* |
| drop the guarded backstop margin | `9900000 !== 10020000` |
| Windows uses `child.kill()` | taskkill argv assertion |
| drop the already-exited guard | a dead child is signalled |
| runner arm returns `capture_failed` | status assertion |
| guard arm returns `capture_failed` | Darwin status assertion |
| reason always claims a ceiling | *"against the null"* |
| drop the `stoppedBy` clause | backstop sentence missing |
| remove the probe's bound | `Missing expected rejection` after 20 s |
| `pr.sh` policy path exits `$STATUS` | `code !== 0` |
| `pr.sh` degrades every failure | genuine-failure test goes green→red |

The unguarded-probe test uses a `t.after` reap of the stub capture and its stub adapter, so a future
regression fails in ~90 s instead of holding the job open for the stub's 600 s sleep.

## Gates

- `npm run check` — 915 pass, 0 fail, 5 pre-existing skips (+2 in the second invocation)
- `npm run check:shell` — 16 scripts, pass
- `node --test scripts/measure-memory-catalog.test.mjs scripts/memory-calibration-watchdog.test.mjs`
  — 198 pass, 0 fail, 5 pre-existing skips (no inference checkout). The watchdog suite's virtual
  clock is untouched and still deterministic.

Docs: `docs/calibration-runbook.md` gains the `runtime_budget_exceeded` outcome row, the two-imposers
account of the budget, and the PR-policy degradation; the workflow's *"the harness imposes no
per-anchor timeout"* comments are now false and were corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
