### PR TITLE
fix(sc-22980): build the SHA-256 stack optimized in the dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,3 +146,27 @@ all = "warn"
 # candle_kernels_patch_guard.rs fails the build if they skew or the patch is dropped).
 [patch."https://github.com/huggingface/candle"]
 candle-kernels = { git = "https://github.com/SceneWorks/inference", rev = "e11fd9f0fd26a0eee3a0eb1f4ca7f81c32b5aeb8" }
+
+# Build the SHA-256 stack optimized even in the dev/test profile.
+#
+# `cargo test` compiles the whole graph unoptimized, and `sha2` unoptimized is roughly an order of
+# magnitude slower than its NEON path: the profile below is dominated by `core::ub_checks`,
+# `ptr::copy_nonoverlapping::precondition_check` and `is_aligned_to` inside `sha256_compress`, none
+# of which survive `opt-level = 3`.
+#
+# That cost is not hypothetical. `gen_core::runtime::ArtifactSeal::pin` content-pins every weights
+# file a provider contract resolves (`EncoderContract::source_for_load` ->
+# `PinnedEncoderSource::pin`), and since the sc-22667 inference pin the MLX providers register real
+# memory-strategy contracts, so the `mlx_fit_gate` resident-only audits hash their full-size encoder
+# fixtures on every cell. That single change took the macOS MLX workspace-test step from ~9 minutes
+# to ~58.
+#
+# Optimizing three leaf crates costs a few seconds of build time and changes no behavior.
+[profile.dev.package.sha2]
+opt-level = 3
+
+[profile.dev.package.digest]
+opt-level = 3
+
+[profile.dev.package.block-buffer]
+opt-level = 3


### PR DESCRIPTION
Closes [sc-22980](https://app.shortcut.com/trefry/story/22980).

## The problem

`macos-mlx.yml` went from a ~20-minute median to ~70. Daily medians from the GitHub API:

```
09-01  21.8m      09-04  76.5m
09-02  20.3m      09-05  72.6m
09-03  23.4m      09-09  65.4m
```

`main` itself: 18.6m at 09-03 21:16 ([run 33807045337](https://github.com/SceneWorks/SceneWorks/actions/runs/33807045337)) → 75.1m at 09-04 09:38 ([run 33859326026](https://github.com/SceneWorks/SceneWorks/actions/runs/33859326026)).

In [run 34407653608](https://github.com/SceneWorks/SceneWorks/actions/runs/34407653608) (64m51s), one step is 57m54s: `Workspace tests (excluding the NAX guard, which needs M5)`. Everything else totals ~7 min. The `sceneworks-worker` lib binary reports `finished in 2998.17s`, and 2967s of that is three tests in [mlx_fit_gate.rs](crates/sceneworks-worker/src/mlx_fit_gate.rs), while the other 2086 tests finish in ~9 min:

| test | wall |
| --- | --- |
| `resident_only_audit_inventory_rejects_duplicate_and_zero_cell_drop_mutations` | ~49 min |
| `shipped_resident_only_mlx_estimate_band_audit_uses_the_production_budget_path` | ~28 min |
| `resident_only_audit_rejects_impossible_control_routes_and_keeps_real_ones` | ~28 min |

## The cause

PR #2709 (sc-22667) bumped the inference pin `670dc1f4 → c6d6a4dbd` and merged to main on 09-04 04:17 — the commit between the last fast main run and the first slow one. That pin gives many MLX providers a real registered `memory_strategy` contract; before it, `ProviderRegistry::memory_strategy_contract` returned `Ok(None)` immediately and did no work.

`sample` on the running test binary: 100% CPU, RSS 41 MB, 8759 of 9618 samples in one stack.

```
ProviderRegistry::memory_strategy_contract
  → LoadSpec::read_prepared_files_unchanged
    → mlx_gen_flux2::memory_strategy::registered_dev_control_contract
      → build_dev_control_contract → dev_asset_facts_with
        → mlx_gen_flux2::model::dev_control_component_footprint
          → component_footprint_for_with_contracts
            → gen_core::encoder_contract::EncoderContract::source_for_load
              → validate_source_with_policy → PinnedEncoderSource::pin
                → gen_core::runtime::ArtifactSeal::pin
                  → ArtifactSeal::read_unchanged → hash_file_sha256
```

Building the contract resolves the text encoder, which content-pins it with a full SHA-256. **That pin is intended** — this PR does not touch it. What is not intended is paying it unoptimized: `cargo test` compiles the graph at opt-level 0, and the debug `sha256_compress` is dominated by `core::ub_checks`, `ptr::copy_nonoverlapping::precondition_check` and `is_aligned_to`, none of which survive `opt-level = 3`.

The audits are where that lands. Each of the 62 source-derived cells gets a fresh `tempfile::tempdir()`, and `gen_core_testkit::write_encoder_contract_fixture_with_quant` sizes its encoder at the true declared length — so every cell hashes tens of GB of sparse zeros. gen-core memoizes digests (`proven_digest`, keyed on loader path plus inode fingerprints), but a new tempdir has new inodes, so the memo misses every time, and the three audit tests each rebuild the same inventory.

## The change

Root `Cargo.toml`, +24 lines, three leaf crates. No behavior change, no test-semantics change. Rebuild cost: 54s, 64 crates. All three packages are in the graph under `--no-default-features` too, so no lane gets an unmatched-profile-spec warning.

## Measured

Same test binary, same test set, on the dev Mac:

| | before | after |
| --- | --- | --- |
| `resident_only_audit_rejects_impossible_control_routes…` alone | 653.41s | **35.85s** |
| all three audit tests together | 653s+ (long pole still running) | **68.52s** |
| `sceneworks-worker` lib — 2089 passed, 214 ignored | 2998.17s *(CI)* | **84.20s** |
| full `cargo test -- --skip nax_16bit_sdpa_is_correct` | — | **5m13s, green** |

Identical pass and ignore counts before and after, so nothing was skipped. `npm run rust:check` (derived-docs + fmt + lint + test + build) exits 0.

Expect the `Workspace tests` step to land around 8–10 min and the job around 15–17 min. First run after merge takes a one-time `rust-cache` miss, since the action keys on `Cargo.toml`.

## Not fixed here, and not the same problem

`windows-candle.yml` did **not** regress this way. Job execution across its own 08-28 step-up: `candle-worker` 1479s ([run 33016711144](https://github.com/SceneWorks/SceneWorks/actions/runs/33016711144)) → 1499s ([run 33183293421](https://github.com/SceneWorks/SceneWorks/actions/runs/33183293421)) — noise. The jump is `8c644e423` ("test(worker): cover imported NVFP4 end to end") adding a second job, `imported-nvfp4-worker-smoke`, ~15 min, running after `candle-worker` on the two-runner CUDA pool.

Tested directly rather than assumed: the same three shared modules (`external_library_runtime`, `image_jobs`, `snapshot_install`, 424 passed) run 18.37s on the pre-fix binary and 18.99s on the post-fix binary. This change does nothing for that lane.

Also noted, not chased: 73 Windows tests log "running for over 60 seconds" (`external_library_runtime` 36, `vram_gate` 25, `image_jobs` 12) while the binary finishes in 340.87s — a shared-lock signature, not per-test CPU. The same modules take ~10s on macOS. `check.yml` is flat at ~11.5m median throughout and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)