### PR TITLE
fix(models): show Fix for incomplete MiniMax-H3 tiers

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -6455,9 +6455,12 @@ fn install_state_for(
         // even a non-default one — must never surface as an incomplete/repairable cache (sc-9907),
         // because that rendered a false "Cached files are incomplete" warning + Fix button on a
         // perfectly good install. Single-variant models keep the default-tier contract below.
+        let mut tier_dependencies_missing = false;
         let (cache_installed, cache_incomplete, mut missing_required_files) =
             if model_has_variant_matrix(model) {
                 let variants = model_variant_states(model, data_dir);
+                tier_dependencies_missing =
+                    variants.iter().any(|variant| variant.dependencies_missing);
                 let any_installed = variants.iter().any(|variant| variant.installed);
                 // A TORN tier — some of its files present but not all — is a genuine repair candidate:
                 // it will fail to load, and re-downloading that tier fixes it. A never-fetched tier is
@@ -6562,7 +6565,10 @@ fn install_state_for(
                             .and_then(Value::as_bool)
                             .unwrap_or(false)
                 });
-        let usable_stale = stale_files_present && !breaking_update;
+        // A receipt proves the primary files exist, not that their dependencies still do.
+        // Do not let it override missing dependencies. A partial nonbreaking primary update
+        // may still use its complete older receipt.
+        let usable_stale = stale_files_present && !breaking_update && !tier_dependencies_missing;
         let primary_installed = managed_installed || cache_installed || usable_stale;
         let installed_path = if cache_installed || cache_incomplete || usable_stale {
             cache_path.clone()
@@ -6586,8 +6592,11 @@ fn install_state_for(
         let tier_scoped: Vec<Value> = model_co_requisite_downloads(model)
             .into_iter()
             .filter(|download| co_requisite_variant(download).is_some())
+            .filter(|download| download.get("required").and_then(Value::as_str) != Some("soft"))
             .collect();
-        if !tier_scoped.is_empty() {
+        // Current matrix variants already check their matching dependency sets with the primary.
+        // Retain the dependency floor when a receipt is supplying an older primary instead.
+        if (!model_has_variant_matrix(model) || usable_stale) && !tier_scoped.is_empty() {
             let tiers: std::collections::BTreeSet<String> = tier_scoped
                 .iter()
                 .filter_map(co_requisite_variant)
@@ -6789,6 +6798,8 @@ struct ModelVariantState {
     installed_path: Option<String>,
     /// This tier's incomplete-cache signal (some but not all `files` present).
     cache_incomplete: bool,
+    /// A present primary is missing required companions; primary-only receipts cannot repair this.
+    dependencies_missing: bool,
     /// Files this tier is missing from the cache (empty when complete or absent).
     missing_required_files: Vec<String>,
     /// This tier's estimated download size (from `downloads[].estimatedSizeBytes` /
@@ -6847,13 +6858,11 @@ fn no_model_index_family_predicate(family: &str, model_id: &str) -> Option<fn(&F
         // not the family — picks the predicate. Dispatched through the SHARED id list the worker's tier
         // resolver uses, so an id the worker would not tighten is not tightened here either.
         "sensenova-u1" => tc::sensenova_tier_predicate(model_id),
-        // sc-19078: the MiniMax-H3 tiers ship two DiT partition dirs (`{tier}/transformer` and
-        // `{tier}/transformer_ref`) and NO `model_index.json` at either level, so the coarse
-        // `q4/transformer/*` glob is satisfied by a single landed file out of fourteen shards. Like
-        // SenseNova the id — not the family — picks the predicate: the two catalog entries share the
-        // `minimax-h3` family but own DIFFERENT partitions of one repo, so a family-only predicate
-        // would have to demand both and report a reference-only install as torn forever.
-        "minimax-h3" => tc::minimax_h3_tier_predicate(model_id),
+        // Both MiniMax-H3 entries load both DiT partitions. Each partition's glob can match
+        // an interrupted download, so require both indexed shard sets before advertising a tier.
+        "minimax-h3" if tc::minimax_h3_tier_predicate(model_id).is_some() => {
+            Some(|dir| tc::minimax_h3_tier_complete(dir) && tc::minimax_h3_ref_tier_complete(dir))
+        }
         _ => None,
     }
 }
@@ -6989,6 +6998,42 @@ fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantSta
                 }
             }
 
+            // A tier is usable only with its own required companions. Checking these only at
+            // model level let a complete q4 encoder certify bf16 and hid its repair action.
+            // An absent primary remains absent even if shared files from another tier exist.
+            let mut dependencies_missing = false;
+            if installed || cache_incomplete {
+                for download in model_co_requisite_downloads_for_variant(
+                    model,
+                    entry.get("variant").and_then(Value::as_str),
+                )
+                .into_iter()
+                .filter(|download| download.get("required").and_then(Value::as_str) != Some("soft"))
+                {
+                    let health = co_requisite_cache_health(data_dir, &download);
+                    if health.as_ref().is_some_and(|health| health.installed) {
+                        continue;
+                    }
+                    installed = false;
+                    cache_incomplete = true;
+                    dependencies_missing = true;
+                    let repo = download
+                        .get("repo")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    let missing = health
+                        .map(|health| health.missing_files)
+                        .filter(|files| !files.is_empty())
+                        .unwrap_or_else(|| string_array_field(&download, "files"));
+                    if missing.is_empty() {
+                        missing_required_files.push(repo.to_owned());
+                    } else {
+                        missing_required_files
+                            .extend(missing.iter().map(|file| format!("{repo}/{file}")));
+                    }
+                }
+            }
+
             let installed_path = if cache_installed || cache_incomplete {
                 cache_path
             } else if managed_installed {
@@ -7006,6 +7051,7 @@ fn model_variant_states(model: &Value, data_dir: &FsPath) -> Vec<ModelVariantSta
                 installed,
                 installed_path: installed_path.map(|path| path.display().to_string()),
                 cache_incomplete,
+                dependencies_missing,
                 missing_required_files,
                 download_size_bytes: manifest_download_size_bytes(model, entry)
                     .or_else(|| variant_footprint_disk_bytes(entry)),
@@ -10362,6 +10408,78 @@ mod variant_install_tests {
                 }
             ]
         })
+    }
+
+    #[test]
+    fn tier_dependencies_cannot_be_borrowed_from_a_sibling_or_a_receipt() {
+        let _env = isolate_hf_cache();
+        let data = tempfile::tempdir().unwrap();
+        let repo = "SceneWorks/matrix";
+        let components = "SceneWorks/encoders";
+        let mut model = quant_matrix_model(repo);
+        for tier in ["q4", "q8", "bf16"] {
+            model["downloads"].as_array_mut().unwrap().push(json!({
+                "provider": "huggingface", "repo": components, "coRequisite": true,
+                "variant": tier, "files": [format!("{tier}/encoder.bin")]
+            }));
+        }
+        seed_cache(data.path(), repo, &["bf16/model.safetensors"]);
+        seed_cache(
+            data.path(),
+            components,
+            &["q4/encoder.bin", "bf16/encoder.bin"],
+        );
+        let state =
+            || install_state_for(model_download_context(&model).unwrap(), &model, data.path());
+        assert!(state().installed); // Also backfills the primary receipt.
+        let receipt = data.path().join("models").join(safe_download_dir(repo));
+        assert!(!receipt_file_sets(&receipt, repo, Some("matrix_model")).is_empty());
+
+        std::fs::remove_file(
+            huggingface_repo_cache_path(data.path(), components)
+                .unwrap()
+                .join("snapshots/abc123/bf16/encoder.bin"),
+        )
+        .unwrap();
+        let broken = state();
+        assert!(
+            !broken.installed,
+            "q4's encoder and the bf16 primary receipt cannot certify bf16"
+        );
+        assert!(broken.cache_incomplete);
+        assert!(broken
+            .missing_required_files
+            .contains(&format!("{components}/bf16/encoder.bin")));
+        let variants = model_variant_states(&model, data.path());
+        for tier in ["q4", "q8"] {
+            let variant = variants.iter().find(|v| v.variant == tier).unwrap();
+            assert!(
+                !variant.installed && !variant.cache_incomplete,
+                "absent primary {tier}"
+            );
+        }
+
+        seed_cache(data.path(), components, &["bf16/encoder.bin"]);
+        assert!(state().installed);
+        assert!(!state().cache_incomplete);
+    }
+
+    #[test]
+    fn optional_tier_dependencies_do_not_block_an_installed_primary() {
+        let _env = isolate_hf_cache();
+        let data = tempfile::tempdir().unwrap();
+        let repo = "SceneWorks/matrix";
+        let mut model = quant_matrix_model(repo);
+        model["downloads"].as_array_mut().unwrap().push(json!({
+            "provider": "huggingface", "repo": "SceneWorks/optional", "coRequisite": true,
+            "variant": "q4", "required": "soft", "files": ["optional.bin"]
+        }));
+        seed_cache(data.path(), repo, &["q4/model.safetensors"]);
+        let variants = model_variant_states(&model, data.path());
+        let q4 = variants.iter().find(|v| v.variant == "q4").unwrap();
+        assert!(q4.installed && !q4.cache_incomplete);
+        let state = install_state_for(model_download_context(&model).unwrap(), &model, data.path());
+        assert!(state.installed && !state.cache_incomplete);
     }
 
     #[test]

--- a/apps/rust-api/src/tests/catalog.rs
+++ b/apps/rust-api/src/tests/catalog.rs
@@ -3534,9 +3534,8 @@ async fn minimax_h3_tier_download_fetches_one_partition_plus_the_whole_shared_fl
 async fn minimax_h3_tier_state_gates_on_every_shard_the_partition_index_names() {
     // sc-19078: `SceneWorks/minimax-h3-mlx` ships no `model_index.json`, so the coarse
     // `q4/transformer/*` glob is satisfied by a SINGLE landed file out of fourteen shards. Without the
-    // family predicate a torn tier read `installed` and then died at load — the "complete but
-    // unloadable" class. The two entries own disjoint partitions of one repo, so each must be judged
-    // on its OWN partition: here `minimax_h3`'s q4 is complete while `minimax_h3_ref`'s q4 is torn.
+    // family predicate a torn tier read `installed` and then died at load. Both entries require
+    // both partitions, so a torn reference partition must make both entries repairable.
     let _env = isolate_hf_cache();
     std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
     let temp_dir = tempfile::tempdir().expect("temp dir creates");
@@ -3583,8 +3582,9 @@ async fn minimax_h3_tier_state_gates_on_every_shard_the_partition_index_names() 
 
     let base = entry("minimax_h3");
     assert_eq!(base["hasVariantMatrix"], true);
-    assert_eq!(base["installState"], "installed");
-    assert_eq!(tier_state(&base, "q4")["installState"], "installed");
+    assert_eq!(base["installState"], "missing");
+    assert_eq!(base["repairAvailable"], true);
+    assert_eq!(tier_state(&base, "q4")["cacheState"], "incomplete");
     for absent in ["q8", "bf16"] {
         assert_eq!(
             tier_state(&base, absent)["installState"],
@@ -3609,6 +3609,110 @@ async fn minimax_h3_tier_state_gates_on_every_shard_the_partition_index_names() 
             .any(|file| file.as_str() == Some("q4/ (incomplete: missing model components)")),
         "the torn tier must name itself: {torn:?}"
     );
+}
+
+#[tokio::test]
+async fn minimax_h3_missing_bf16_encoder_is_repairable_beside_complete_q4() {
+    let _env = isolate_hf_cache();
+    std::env::set_var("SCENEWORKS_DISABLE_MODEL_SIZE_ESTIMATE", "1");
+    let temp_dir = tempfile::tempdir().unwrap();
+    let config_dir = temp_dir.path().join("config/manifests");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("builtin.models.jsonc"),
+        minimax_h3_manifest(),
+    )
+    .unwrap();
+    write_empty_sibling_manifests(&config_dir);
+    let data_dir = temp_dir.path().join("data");
+    let snapshot = data_dir
+        .join("cache/huggingface/hub/models--SceneWorks--minimax-h3-mlx/snapshots/f22bc294");
+    for tier in ["q4", "bf16"] {
+        for partition in ["transformer", "transformer_ref"] {
+            seed_minimax_partition(&snapshot, tier, partition, &MINIMAX_SHARDS);
+        }
+    }
+    seed_minimax_shared_floor(&data_dir);
+    seed_minimax_packed_text_encoder(&data_dir, "q4");
+    let encoder = data_dir.join(
+        "cache/huggingface/hub/models--MiniMaxAI--MiniMax-H3/snapshots/939557dc/text_encoder",
+    );
+    std::fs::remove_dir_all(&encoder).unwrap();
+    for repaired in [false, true] {
+        if repaired {
+            seed_minimax_shared_floor(&data_dir);
+        }
+        // A fresh catalog scan after the filesystem changes, without reusing its short-lived cache.
+        let app = create_app(test_settings(&temp_dir)).unwrap();
+        let (status, models) = request(app.clone(), "GET", "/api/v1/models", Value::Null).await;
+        assert_eq!(status, StatusCode::OK);
+        for id in ["minimax_h3", "minimax_h3_ref"] {
+            let model = models
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|m| m["id"] == id)
+                .unwrap();
+            assert_eq!(model["installState"], "installed", "q4 remains usable");
+            assert_eq!(model["repairAvailable"], !repaired, "{id}: {model}");
+            let tiers = model["variants"].as_array().unwrap();
+            let tier = |name: &str| tiers.iter().find(|t| t["variant"] == name).unwrap();
+            assert_eq!(tier("q4")["installed"], true);
+            assert_eq!(tier("q8")["cacheState"], "missing", "never downloaded");
+            assert_eq!(tier("bf16")["installed"], repaired);
+            assert_eq!(
+                tier("bf16")["cacheState"],
+                if repaired { "complete" } else { "incomplete" }
+            );
+            if !repaired {
+                for path in [
+                    "text_encoder/config.json",
+                    "text_encoder/model.safetensors.index.json",
+                ] {
+                    let missing = json!(format!("MiniMaxAI/MiniMax-H3/{path}"));
+                    assert!(tier("bf16")["missingRequiredFiles"]
+                        .as_array()
+                        .unwrap()
+                        .contains(&missing));
+                    assert!(model["missingRequiredFiles"]
+                        .as_array()
+                        .unwrap()
+                        .contains(&missing));
+                }
+            }
+        }
+        if !repaired {
+            let (status, primary) = request(
+                app.clone(),
+                "POST",
+                "/api/v1/models/minimax_h3/download",
+                json!({"variant": "bf16"}),
+            )
+            .await;
+            assert_eq!(status, StatusCode::CREATED, "{primary}");
+            assert_eq!(primary["payload"]["files"], json!(["bf16/transformer/*"]));
+            let (_, jobs) = request(app, "GET", "/api/v1/jobs", Value::Null).await;
+            let downloads = jobs.as_array().unwrap();
+            assert_eq!(
+                downloads.len(),
+                7,
+                "primary, sibling, encoder, and four shared components"
+            );
+            assert!(downloads
+                .iter()
+                .any(|job| job["payload"]["repo"] == "MiniMaxAI/MiniMax-H3"
+                    && job["payload"]["revision"] == "939557dc319dd91227e30195a763f272ba7f8765"
+                    && job["payload"]["files"]
+                        == json!([
+                            "text_encoder/config.json",
+                            "text_encoder/model.safetensors.index.json"
+                        ])));
+            assert!(downloads.iter().all(|job| {
+                let files = job["payload"]["files"].to_string();
+                !files.contains("q4/") && !files.contains("q8/")
+            }));
+        }
+    }
 }
 
 #[tokio::test]
@@ -3652,7 +3756,7 @@ async fn minimax_h3_is_not_installed_without_its_shared_component_floor() {
         .expect("minimax_h3 present")
         .clone();
 
-    // The q4 DiT tier itself is complete — this is specifically the co-requisite gate, not a torn tier.
+    // The q4 primary landed, but the tier needs its required companions before it can load.
     let q4 = base["variants"]
         .as_array()
         .expect("variants array")
@@ -3661,9 +3765,10 @@ async fn minimax_h3_is_not_installed_without_its_shared_component_floor() {
         .expect("q4 present")
         .clone();
     assert_eq!(
-        q4["installState"], "installed",
-        "the DiT tier itself landed"
+        q4["installState"], "missing",
+        "a primary alone does not make a usable tier"
     );
+    assert_eq!(q4["cacheState"], "incomplete");
     // …yet the entry is not installed, and names the component repo it is still waiting on.
     assert_eq!(base["installState"], "missing");
     assert_eq!(base["repairAvailable"], true);

--- a/apps/web/src/screens/ModelManagerScreen.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.jsx
@@ -1260,6 +1260,7 @@ export function ModelManagerScreen() {
     const installed = model.installState === "installed";
     const cleanupOnly = model.platformCleanupOnly === true;
     const incomplete = model.cacheState === "incomplete" || model.repairAvailable;
+    const repairVariant = model.variants?.find((variant) => !variant.installed && variant.cacheState === "incomplete");
     const missingRequiredFiles = Array.isArray(model.missingRequiredFiles) ? model.missingRequiredFiles : [];
     const localDownloadJob = cleanupOnly || installed ? null : downloadJobs.find((job) => job.status !== "completed");
     const failedDownload = localDownloadJob && terminalStatuses.has(localDownloadJob.status);
@@ -1667,7 +1668,7 @@ export function ModelManagerScreen() {
             {cleanupOnly ? null : hasTierMatrix ? (
               // A quant-matrix model installs its tiers from the panel above. Keep only a Fix
               // affordance here for an incomplete cache or soft co-requisite update; otherwise
-              // there's no single-tier button. The default-tier job fetches every co-requisite.
+              // there's no single-tier button. Repair the torn tier, including its companions.
               incomplete || model.updateAvailable ? (
                 <button
                   className="model-card-primary"
@@ -1676,7 +1677,9 @@ export function ModelManagerScreen() {
                   onClick={() =>
                     failedDownload
                       ? onResumeDownloadJob(localDownloadJob, { payloadChanges: { downloadAction: "resume" } })
-                      : onDownloadModel(model)
+                      : repairVariant
+                        ? onDownloadVariant(model, repairVariant.variant)
+                        : onDownloadModel(model)
                   }
                   type="button"
                 >

--- a/apps/web/src/screens/ModelManagerScreen.test.jsx
+++ b/apps/web/src/screens/ModelManagerScreen.test.jsx
@@ -759,6 +759,44 @@ describe("ModelManagerScreen gated-model notice", () => {
       { variant: "q8" },
     );
   });
+
+  it("repairs MiniMax-H3 bf16's missing encoder while q4 remains installed", async () => {
+    const model = {
+      ...TORN_TIER_MODEL,
+      id: "minimax_h3",
+      name: "MiniMax-H3",
+      family: "minimax-h3",
+      cacheState: "incomplete",
+      repairAvailable: true,
+      variants: [
+        {
+          variant: "bf16",
+          installed: false,
+          installState: "missing",
+          cacheState: "incomplete",
+          missingRequiredFiles: ["MiniMaxAI/MiniMax-H3/text_encoder/config.json"],
+        },
+        { variant: "q8", installed: false, installState: "missing", cacheState: "missing" },
+        { variant: "q4", installed: true, installState: "installed", cacheState: "complete" },
+      ],
+    };
+    await render([model]);
+    const rows = [...container.querySelectorAll(".model-tier-row")];
+    const bf16 = rows[0]; // Tier order is bf16, q8, q4.
+    expect(bf16.querySelector(".status-badge").textContent).toBe("incomplete");
+    const fix = [...bf16.querySelectorAll("button")].find((button) => button.textContent === "Fix");
+    expect(fix.title).toContain("text_encoder/config.json");
+    expect(fix.disabled).toBe(false);
+    await click(fix);
+    expect(createModelDownloadJob).toHaveBeenCalledWith(expect.objectContaining({ id: "minimax_h3" }), { variant: "bf16" });
+    createModelDownloadJob.mockClear();
+    await click(container.querySelector(".model-card-primary"));
+    expect(createModelDownloadJob).toHaveBeenCalledWith(expect.objectContaining({ id: "minimax_h3" }), { variant: "bf16" });
+    for (const tier of ["Q4", "Q8"]) {
+      const row = rows.find((candidate) => candidate.textContent.includes(tier));
+      expect([...row.querySelectorAll("button")].some((button) => button.textContent === "Fix")).toBe(false);
+    }
+  });
 });
 
 const WAN_MOE_MODEL = {


### PR DESCRIPTION
MiniMax-H3 bf16 could appear installed with no repair action when its dense text encoder was absent: variant status checked only primary weights, while the model-wide dependency check accepted another tier's encoder. This was reproduced against the running desktop API and with a failing regression test.

Each present tier now checks its own required companions, reports missing paths, and remains repairable alongside a usable sibling. MiniMax-H3 checks both required DiT partitions. Both the tier and card Fix actions request the affected tier, and primary-only receipts cannot override missing dependencies. Optional components and valid older installations retain their existing behavior.

Validation: 740 API library tests passed (4 existing ignored); 74 Model Manager tests passed; API Clippy with warnings denied, web lint, and production build passed. Regression coverage includes bf16 encoder removal/restoration, selected-tier download queue contents, untouched absent tiers, stale receipts, optional components, and both Fix buttons. Independent adversarial review passed after correcting the stale-receipt guard.

Tracks [SC-23020](https://app.shortcut.com/trefry/story/23020). This changes application behavior; it does not download the missing model files or replace an installed desktop build.
