### PR TITLE
fix(sc-22738): heavy-lane sccache treatment for the campaign's candle build, and a re-run that resumes

### DIFF
--- a/.github/workflows/memory-catalog-campaign.yml
+++ b/.github/workflows/memory-catalog-campaign.yml
@@ -17,6 +17,12 @@
 # with the summary JSON, the per-anchor logs and the retained raw bundles. The last step opens a PR
 # back into the dispatched `ref` when the branch has commits. Nothing is merged automatically.
 #
+# RE-RUNNING A FAILED DISPATCH IS SUPPORTED, AND IS THE RECOVERY FOR A TRANSIENT INFRA FAULT.
+# `gh run rerun --failed` reuses the RUN ID, so the branch name is the same one -- and the new
+# attempt RESUMES that branch rather than colliding with it or re-cutting it. Anchors an earlier
+# attempt already committed stay put, plan as `current`, and are skipped; the walk appends the rest.
+# See the header of `scripts/ci/memory-catalog/branch.sh` for the three arms and why they exist.
+#
 # FETCHING THE WEIGHTS IT NEEDS (`download_missing`, default false, sc-22738). Neither box holds the
 # whole catalog, and an anchor whose pinned snapshot is under none of the hub roots plans as
 # `weights_missing` and is skipped. Downloading the missing snapshots on the Windows box is faster
@@ -433,6 +439,61 @@ jobs:
       # %USERPROFILE%\.cargo\bin proxies (sc-13166). Same composite action every candle lane uses.
       - name: Prepare the Rust toolchain
         uses: ./.github/actions/prepare-rust-runner
+
+      # THE SAME DECISION windows-candle.yml ALREADY MADE, FOR THE SAME REASON (sc-22738).
+      # ------------------------------------------------------------------------------------------
+      # The shared runner exports RUSTC_WRAPPER=sccache. The prep action above correctly clears a
+      # wrapper that is MISSING, but an INSTALLED daemon can still reset its local connection
+      # mid-build -- Windows os error 10054, "an existing connection was forcibly closed by the
+      # remote host". windows-candle.yml records that failure twice (the backend-candle test and the
+      # sidecar check) and disables the wrapper for both. This job hit it a third time: run
+      # 34490358777 died four minutes into "Build the candle memory adapter" with ZERO rustc
+      # diagnostics --
+      #
+      #   sccache: error: failed to execute compile
+      #   sccache: caused by: error reading compile response from server
+      #   sccache: caused by: An existing connection was forcibly closed by the remote host.
+      #                       (os error 10054)
+      #   error: could not compile `candle-transformers` / `candle-gen`
+      #
+      # -- because a wrapper that drops its socket reports no compiler error to attribute the
+      # failure to. That is also why this is a DISABLE and not a retry-with-fallback: a retry would
+      # spend a second cold candle build to learn exactly as little.
+      #
+      # This job compiles candle-core, candle-transformers, the whole vendored inference tree and
+      # the CUDA kernels on that same box, and does it COLD every dispatch (actions/checkout's
+      # `clean: true` runs `git clean -ffdx`, which takes `target/` with it). It is the heavy Candle
+      # lane by every property the sibling comment names, so rustc is made direct and deterministic
+      # FOR THIS JOB ONLY. Cargo's registry/git caches are untouched and every sibling workflow keeps
+      # its sccache.
+      - name: Disable unstable sccache wrapper for the heavy Candle lane
+        shell: powershell
+        run: |
+          Add-Content -Path $env:GITHUB_ENV -Value 'RUSTC_WRAPPER='
+          Remove-Item Env:RUSTC_WRAPPER -ErrorAction SilentlyContinue
+
+      # NO "Isolate Cargo dependency checkout" STEP HERE, AND THAT IS DELIBERATE (sc-22738).
+      # ------------------------------------------------------------------------------------------
+      # windows-candle.yml pairs the step above with one that repoints CARGO_HOME at
+      # $RUNNER_TEMP\cargo-home, because a sibling runner service could replace the SHARED
+      # %USERPROFILE%\.cargo git checkout while rustc was still reading vendored inference sources
+      # (surfacing as an unrelated missing-path / os error 267). That premise does not hold for this
+      # job: sc-17614 established -- and .github/actions/prepare-rust-runner/action.yml documents at
+      # its "CARGO_HOME IS NOT RUSTUP'S HOME HERE" header -- that each runner service pins CARGO_HOME
+      # in its OWN .env to a PER-RUNNER dependency cache (D:\cargo-home-N: registry\, git\,
+      # config.toml, no bin\). A runner service executes one job at a time, so the cargo git checkout
+      # this job reads is already private to it and a second copy would buy nothing.
+      #
+      # It would also cost something measured. windows-candle.yml's own header states the price of
+      # its step: "a job-local CARGO_HOME under RUNNER_TEMP is re-downloaded every run". This is the
+      # lane whose entire fetch design exists because this box's link is slow -- the persistent
+      # shallow inference clone below was cut after a 70-minute 150 KB/s cargo fetch died mid-pack --
+      # so discarding the per-runner crates.io registry on every dispatch is the wrong trade here.
+      #
+      # If a runner service is ever registered WITHOUT that CARGO_HOME pin, the result is a loud
+      # failure in the build step below rather than silent corruption, and re-running the failed job
+      # is now a supported recovery: scripts/ci/memory-catalog/branch.sh resumes the campaign branch
+      # instead of colliding with it.
 
       # BEFORE `cargo fetch`, ON PURPOSE -- and this lane is why. Run 34044786385 spent 70 minutes at
       # ~150 KB/s in cargo's git fetch of the inference repo, died with `fetch-pack: unexpected

--- a/docs/calibration-runbook.md
+++ b/docs/calibration-runbook.md
@@ -1646,7 +1646,8 @@ not fail the dispatch: the job queues silently until the run is cancelled.
 
 **What the job does.** Checks out `ref` shallowly (`fetch-depth: 1` — nothing in the campaign reads
 history beyond HEAD, and a full clone of this repo's 2+ GiB pack was costing 27+ minutes on the
-Windows box), cuts a NEW branch `story/<campaign>-<backend>-campaign-<run_id>` (the walk commits on
+Windows box), cuts (or, on a re-run, RESUMES — see below) the branch
+`story/<campaign>-<backend>-campaign-<run_id>` (the walk commits on
 the current branch and refuses a detached HEAD, and this keeps it off `feature/*` and `main`),
 prepares the inference clone, builds the release adapter (`--features mlx --bin memory-mlx-adapter`,
 or `--features candle --bin memory-candle-adapter` under `vcvars64`), prints the `--list` table as
@@ -1704,6 +1705,19 @@ work dir (summary JSON, per-anchor logs, retained raw bundles) is uploaded as a 
 every outcome, and a final step opens `chore(<campaign>): <backend> catalog campaign results` into
 `ref` when the branch has commits. Nothing is merged automatically.
 
+**Re-running a failed dispatch is the recovery, and it resumes (sc-22738, run 34490358777).**
+`gh run rerun --failed` reuses the RUN ID — `github.run_attempt` is the counter that moves — so the
+new attempt lands on the SAME `story/<campaign>-<backend>-campaign-<run_id>` branch. It continues
+that branch instead of colliding with it: anchors an earlier attempt pushed are fetched back (their
+tree is what `--skip-current` reads, so they plan as `current` and are skipped), the walk appends
+the rest, and the PR that is already open picks up the new commits. Nothing measured is discarded —
+even commits an attempt made but never managed to push are kept and go up with the next push. Before
+this, `git switch -c` hit `fatal: a branch named 'story/…-<run_id>' already exists` twelve seconds
+in, so the documented recovery for a transient infra fault produced a second, different failure that
+looked like the first. The three arms and the reasoning live in
+`scripts/ci/memory-catalog/branch.sh`; a re-run served by a DIFFERENT runner listener is fine, since
+the decision reads the remote rather than the box.
+
 🔴 **If the repository forbids Actions from opening PRs, that final step WARNS rather than failing
 (sc-22738, run 34356681566).** `gh pr create` returns
 
@@ -1731,6 +1745,22 @@ candle), not a measured budget — and since sc-22738 each anchor is separately 
 on macOS, `E:\huggingface\hub` on the CUDA box). A root that does not exist is a warning, not an
 error — `hubRoots()` still falls back to the HF env convention and the app cache, and an anchor whose
 snapshot is under none of them plans as `weights_missing` rather than failing the run.
+
+**The candle job builds with rustc DIRECT, not through sccache (sc-22738, run 34490358777).** The
+shared Windows runner exports `RUSTC_WRAPPER=sccache`, and an installed daemon can reset its own
+local connection mid-build: *"An existing connection was forcibly closed by the remote host. (os
+error 10054)"*, followed by `error: could not compile candle-transformers` and **no rustc diagnostic
+at all** — the wrapper drops the socket, so there is nothing to attribute the failure to. Run
+34490358777 died that way four minutes into *Build the candle memory adapter*.
+`windows-candle.yml` had already met this twice (the backend-candle test and the sidecar check) and
+answered it by clearing the wrapper for those jobs; this lane compiles the same candle + CUDA graph
+on the same box, cold on every dispatch (`actions/checkout`'s `clean` takes `target/` with it), so
+it now carries the identical step in the identical position — after
+`prepare-rust-runner` (which only clears a *missing* wrapper) and before the first `cargo`
+invocation. It does **not** take that block's second step, the job-local `CARGO_HOME`: each runner
+service already pins its own `D:\cargo-home-N` (sc-17614) and serves one job at a time, while a
+`$RUNNER_TEMP` `CARGO_HOME` is re-downloaded every run — the wrong trade on the box whose slow link
+this lane's whole fetch design exists to work around.
 
 **The candle job censuses the GPU before it walks (sc-22738).** Run 34272596969 spent 51 guarded
 renders — roughly an hour of GPU time — producing 51 copies of one sentence: *"untrustworthy stable

--- a/scripts/ci/memory-catalog/branch.sh
+++ b/scripts/ci/memory-catalog/branch.sh
@@ -1,17 +1,66 @@
 #!/usr/bin/env bash
-# Cut the campaign branch the walk will commit onto (sc-22738).
+# Cut -- or RESUME -- the campaign branch the walk will commit onto (sc-22738).
 #
 # `measure-memory-catalog.mjs` commits on the CURRENT branch and refuses a detached HEAD, so the
-# branch has to exist before the first anchor. It is a NEW branch per run -- never the dispatched
-# ref itself -- so a campaign can never write onto `feature/*` or `main` directly, and two runs of
-# the same campaign cannot collide.
+# branch has to exist before the first anchor. It is never the dispatched ref itself, so a campaign
+# can never write onto `feature/*` or `main` directly.
+#
+# WHY A RE-RUN RESUMES THE BRANCH INSTEAD OF CUTTING A SECOND ONE (sc-22738, run 34490358777).
+# ------------------------------------------------------------------------------------------------
+# The branch name is keyed on $GITHUB_RUN_ID, and a re-run REUSES the run id -- `github.run_attempt`
+# is the counter that moves. `git switch -c` met that head-on twelve seconds into
+# `gh run rerun --failed`:
+#
+#   fatal: a branch named 'story/sc-22738-candle-campaign-34490358777' already exists
+#
+# The branch survives in the persistent self-hosted workspace because actions/checkout's `clean`
+# removes FILES, not refs. So the documented recovery for a transient infra fault was itself a trap:
+# the operator re-ran, waited, and got a second failure that looked like the first.
+#
+# Three ways to make a re-run work, and only one of them is right:
+#
+#   * A PER-ATTEMPT BRANCH (`...-<run_id>-<attempt>`) never collides, but it SPLITS the campaign.
+#     Attempt 2 would be cut from `ref` WITHOUT attempt 1's anchors, so `--skip-current` would
+#     re-measure every one of them -- hours of GPU each -- and the two branches would then collide
+#     on the same matrix and anchor-store files at merge time. Rejected.
+#   * DELETING the existing branch discards committed measurements. Rejected outright: the
+#     commit-and-push-per-anchor design exists precisely so an interrupted walk keeps what it
+#     measured.
+#   * RESUMING it is what "re-run the failed job" ought to mean. The walk continues on top of the
+#     anchors the earlier attempt landed, so the history stays linear at one commit per anchor with
+#     nothing duplicated, the anchors already measured plan as `current` and are skipped, and the
+#     pull request that is already open simply picks up the new commits.
+#
+# NOTHING AN EARLIER ATTEMPT MEASURED IS EVER DISCARDED, so there are three arms below rather than
+# two. The remote copy wins when it exists, because a push is the only durable record and a re-run
+# may be served by any of the box's runner listeners; a local branch with commits that never left
+# the box is still measurements, so it is kept and this attempt's push carries them up.
+#
+# The arms are chosen from what EXISTS rather than from $GITHUB_RUN_ATTEMPT: the run id is in the
+# branch name, so a branch under that name -- remote or local -- can only be an earlier attempt of
+# THIS run, and that is a fact about the refs rather than about the counter.
+#
+# THE RESUME FETCH IS `--depth 1` ON PURPOSE. Only the branch TIP is needed: a shallow commit still
+# carries the COMPLETE tree, which is what the plan reads to classify the earlier attempt's anchors
+# as already captured and what the harness commits onto. Deepening far enough to reach the base
+# commit would pull this repo's 2+ GiB history over the box's slow link -- the cost the campaign
+# checkout is shallow to avoid in the first place.
+#
+# THE THREE SHAs THIS EXPORTS, and why they are three:
+#   REF_SHA      the dispatched ref's tip in this checkout. Names the base in the PR body.
+#   RESUMED_FROM the tip an earlier attempt left behind, or empty on a fresh cut. Lets the PR body
+#                say which commits predate this attempt.
+#   BASE_SHA     the newest commit of this branch the REMOTE already has. push.sh counts
+#                `BASE_SHA..HEAD`, so that is exactly "what this branch has that the remote does
+#                not" -- it neither re-counts a previous attempt's pushed anchors nor strands the
+#                commits a previous attempt failed to push.
 # shellcheck source=scripts/ci/memory-catalog/common.sh
 source "$(dirname "$0")/common.sh"
 
 require_campaign
 
 BRANCH="$(campaign_branch)"
-BASE_SHA="$(git rev-parse HEAD)"
+REF_SHA="$(git rev-parse HEAD)"
 WORK_DIR="$(work_dir_unix)"
 WORK_DIR_NATIVE="$(native_path "$WORK_DIR")"
 
@@ -19,13 +68,43 @@ WORK_DIR_NATIVE="$(native_path "$WORK_DIR")"
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-git switch -c "$BRANCH"
+RESUMED_FROM=""
+if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+  # An earlier attempt PUSHED anchors, so the remote holds the authoritative copy of them.
+  echo "${BRANCH} is on the remote: an earlier attempt of run ${GITHUB_RUN_ID} pushed to it"
+  git fetch --no-tags --depth 1 origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+  # --force-create, because a local branch of the same name may also have survived in this
+  # workspace and could be behind what was pushed.
+  git switch --force-create "$BRANCH" "refs/remotes/origin/${BRANCH}"
+  RESUMED_FROM="$(git rev-parse HEAD)"
+  BASE_SHA="$RESUMED_FROM"
+  echo "resumed ${BRANCH} at ${RESUMED_FROM}; this attempt commits on top of it"
+elif git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  # An earlier attempt on THIS listener left the branch behind without pushing it -- which is the
+  # failure the fatal above actually came from, since that attempt died at the build step with
+  # nothing measured. Keep whatever is on it: BASE_SHA stays the ref tip, so anything it does carry
+  # is counted as unpushed and goes up with this attempt's first push.
+  git switch "$BRANCH"
+  BASE_SHA="$REF_SHA"
+  LOCAL_TIP="$(git rev-parse HEAD)"
+  if [[ "$LOCAL_TIP" != "$REF_SHA" ]]; then
+    RESUMED_FROM="$LOCAL_TIP"
+    echo "reusing the local ${BRANCH} at ${LOCAL_TIP}; it carries commits no attempt managed to push"
+  else
+    echo "reusing the local ${BRANCH}, which an earlier attempt left empty at the ref tip"
+  fi
+else
+  git switch --create "$BRANCH" "$REF_SHA"
+  BASE_SHA="$REF_SHA"
+fi
 
 mkdir -p "$WORK_DIR"
 
 {
   echo "CAMPAIGN_BRANCH=$BRANCH"
   echo "BASE_SHA=$BASE_SHA"
+  echo "REF_SHA=$REF_SHA"
+  echo "RESUMED_FROM=$RESUMED_FROM"
   echo "WORK_DIR=$WORK_DIR"
   echo "WORK_DIR_NATIVE=$WORK_DIR_NATIVE"
   echo "PUSHED_COUNT=0"
@@ -37,7 +116,10 @@ mkdir -p "$WORK_DIR"
   echo "| | |"
   echo "|---|---|"
   echo "| branch | \`$BRANCH\` |"
-  echo "| cut from | \`$BASE_REF\` at \`$BASE_SHA\` |"
+  echo "| cut from | \`$BASE_REF\` at \`$REF_SHA\` |"
+  if [[ -n "$RESUMED_FROM" ]]; then
+    echo "| resumed | run attempt \`${GITHUB_RUN_ATTEMPT:-?}\` continues the existing branch at \`$RESUMED_FROM\` |"
+  fi
   echo "| runner | \`$RUNNER_NAME\` |"
   echo "| work dir | \`$WORK_DIR\` |"
   echo

--- a/scripts/ci/memory-catalog/common.sh
+++ b/scripts/ci/memory-catalog/common.sh
@@ -52,6 +52,10 @@ require_campaign() {
   fi
 }
 
+# The campaign branch, keyed on the RUN ID and deliberately NOT on $GITHUB_RUN_ATTEMPT: every
+# attempt of one run must land on ONE branch, so a re-run continues the anchors the previous attempt
+# committed instead of splitting them across two branches and two pull requests. branch.sh is where
+# the collision that keying implies is resolved -- read its header before changing this name.
 campaign_branch() {
   printf 'story/%s-%s-campaign-%s' "$CAMPAIGN" "$BACKEND" "$GITHUB_RUN_ID"
 }

--- a/scripts/ci/memory-catalog/pr.sh
+++ b/scripts/ci/memory-catalog/pr.sh
@@ -47,7 +47,13 @@ BODY_FILE="${WORK_DIR}/pr-body.md"
   echo "- workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
   echo "- runner: \`${RUNNER_NAME}\`"
   echo "- pinned inference revision: \`${INFERENCE_PIN:-unknown}\`"
-  echo "- cut from \`${BASE_REF}\` at \`${BASE_SHA}\`"
+  # REF_SHA is the dispatched ref's tip. On a fresh cut it IS BASE_SHA, which is why the fallback
+  # is exact rather than approximate; on a RESUMED re-run the two differ, and saying "cut from the
+  # ref at the resumed tip" would be a plain untruth. See scripts/ci/memory-catalog/branch.sh.
+  echo "- cut from \`${BASE_REF}\` at \`${REF_SHA:-$BASE_SHA}\`"
+  if [[ -n "${RESUMED_FROM:-}" ]]; then
+    echo "- run attempt \`${GITHUB_RUN_ATTEMPT:-?}\` RESUMED this branch at \`${RESUMED_FROM}\`; every commit up to that point was measured by an earlier attempt of the same run"
+  fi
   echo
   echo "Each commit is one \`capture -> check -> ingest -> extract -> stamp -> matrix\` pass from"
   echo "\`scripts/measure-memory-catalog.mjs\`. The run's summary JSON and per-anchor logs are attached"

--- a/scripts/ci/memory-catalog/push.sh
+++ b/scripts/ci/memory-catalog/push.sh
@@ -21,8 +21,11 @@ if [[ -n "$(git status --porcelain)" ]]; then
   git status --porcelain
 fi
 
+# $BASE_SHA is the newest commit of this branch the REMOTE already has (branch.sh), so this counts
+# what is NOT up there yet. On a resumed re-run that excludes the anchors an earlier attempt pushed
+# and includes any it committed but failed to push.
 COUNT="$(git rev-list --count "${BASE_SHA}..HEAD")"
-echo "${COUNT} anchor commit(s) on ${CAMPAIGN_BRANCH}"
+echo "${COUNT} anchor commit(s) not yet on the remote ${CAMPAIGN_BRANCH}"
 if [[ "$COUNT" == "0" ]]; then
   echo "nothing landed; not pushing an empty branch"
   exit 0
@@ -33,6 +36,6 @@ git push --set-upstream --force-with-lease origin "HEAD:${CAMPAIGN_BRANCH}"
 {
   echo "#### Pushed"
   echo
-  echo "\`${COUNT}\` anchor commit(s) on \`${CAMPAIGN_BRANCH}\`."
+  echo "\`${COUNT}\` new anchor commit(s) pushed to \`${CAMPAIGN_BRANCH}\`."
   echo
 } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/measure-memory-catalog.test.mjs
+++ b/scripts/measure-memory-catalog.test.mjs
@@ -7226,7 +7226,12 @@ test("the GPU preflight classifies [Insufficient Permissions] rows by TYPE, neve
 // `gh` and `git` faked on PATH, the same way `fakeGpuHost` fakes `nvidia-smi`: `pr.sh` must be
 // driven as the shell script the runner really executes, and neither of the two commands it shells
 // out to may reach the real GitHub or the real remote.
-async function runResultsPr({ createStdout = "", createStderr = "", createStatus = 0, existingUrl = "", branchOnRemote = true } = {}) {
+// `baseSha`/`refSha`/`resumedFrom` are exactly what branch.sh exports: on a fresh cut BASE_SHA is
+// the ref tip and the other two are absent/empty, and on a resumed re-run BASE_SHA is the tip the
+// remote already has while REF_SHA still names the dispatched ref (sc-22738).
+const CAMPAIGN_REF_TIP = "afa67a3d86333436089938c1252a6ef7f35bcacd";
+
+async function runResultsPr({ createStdout = "", createStderr = "", createStatus = 0, existingUrl = "", branchOnRemote = true, baseSha = CAMPAIGN_REF_TIP, refSha = "", resumedFrom = "" } = {}) {
   const bin = await mkdtemp(path.join(tmpdir(), "catalog-pr-"));
   const ghLog = path.join(bin, "gh-argv");
   await writeFile(
@@ -7258,7 +7263,7 @@ async function runResultsPr({ createStdout = "", createStderr = "", createStatus
     CAMPAIGN: "sc-22738",
     BACKEND: "candle",
     BASE_REF: "feature/sc-22723-memory-anchor-measurability",
-    BASE_SHA: "afa67a3d86333436089938c1252a6ef7f35bcacd",
+    BASE_SHA: baseSha,
     CAMPAIGN_BRANCH: "story/sc-22738-candle-campaign-34356681566",
     WORK_DIR: workDir,
     INFERENCE_PIN: REVISION,
@@ -7266,7 +7271,12 @@ async function runResultsPr({ createStdout = "", createStderr = "", createStatus
     GITHUB_SERVER_URL: "https://github.com",
     GITHUB_REPOSITORY: "SceneWorks/SceneWorks",
     GITHUB_RUN_ID: "34356681566",
+    GITHUB_RUN_ATTEMPT: "2",
     GITHUB_STEP_SUMMARY: summary,
+    // Empty is the fresh-cut shape branch.sh exports, and pr.sh must read that as "no resume"
+    // rather than as an unset-variable failure under `set -u`.
+    REF_SHA: refSha,
+    RESUMED_FROM: resumedFrom,
   };
   let code = 0;
   let stdout = "";
@@ -7279,7 +7289,14 @@ async function runResultsPr({ createStdout = "", createStderr = "", createStatus
     stdout = error.stdout ?? "";
     stderr = error.stderr ?? "";
   }
-  return { code, stdout, stderr, summary: await readFile(summary, "utf8"), ghArgv: await readFile(ghLog, "utf8").catch(() => "") };
+  return {
+    code,
+    stdout,
+    stderr,
+    summary: await readFile(summary, "utf8"),
+    body: await readFile(path.join(workDir, "pr-body.md"), "utf8").catch(() => ""),
+    ghArgv: await readFile(ghLog, "utf8").catch(() => ""),
+  };
 }
 
 const PR_POLICY_REFUSAL =
@@ -7331,4 +7348,279 @@ test("every OTHER `gh pr create` failure still fails the step, and a created PR 
   assert.equal(nothingPushed.code, 0, nothingPushed.stderr);
   assert.match(nothingPushed.stdout, /was never pushed \(no anchor landed\); no PR to open/);
   assert.doesNotMatch(nothingPushed.stdout, /::warning/);
+});
+
+// ---------------------------------------------------------------------------------------------
+// sc-22738 (run 34490358777): `gh run rerun --failed` must not be a SECOND, different failure.
+//
+// The campaign branch is named after the RUN ID and a re-run reuses it, so `git switch -c` died 12
+// seconds in with `fatal: a branch named 'story/sc-22738-candle-campaign-34490358777' already
+// exists` -- the documented recovery for a transient infra fault turned into a failure that looked
+// like the one it was recovering from.
+//
+// Everything below drives `branch.sh` as the shell script the runner really executes, against a
+// REAL bare remote and a REAL workspace. Nothing is faked, because the entire question is what git
+// does with refs that outlive a job -- and `file://` rather than a bare path, because the local
+// transport ignores `--depth` and the shallow resume fetch is part of what is under test.
+// ---------------------------------------------------------------------------------------------
+
+const CAMPAIGN_RUN_ID = "34490358777";
+const CAMPAIGN_REF = "feature/sc-22723-memory-anchor-measurability";
+const CAMPAIGN_BRANCH_NAME = `story/sc-22738-candle-campaign-${CAMPAIGN_RUN_ID}`;
+
+const GIT_IDENTITY = {
+  GIT_AUTHOR_NAME: "campaign harness",
+  GIT_AUTHOR_EMAIL: "harness@example.invalid",
+  GIT_COMMITTER_NAME: "campaign harness",
+  GIT_COMMITTER_EMAIL: "harness@example.invalid",
+};
+
+async function gitAt(cwd, args) {
+  return execFileAsync("git", args, { cwd, env: { ...process.env, ...GIT_IDENTITY } });
+}
+
+async function anchorCommit(repo, name) {
+  await writeFile(path.join(repo, name), `{"anchor":${JSON.stringify(name)}}\n`);
+  await gitAt(repo, ["add", name]);
+  await gitAt(repo, ["commit", "-m", `measure(${name})`]);
+  return (await gitAt(repo, ["rev-parse", "HEAD"])).stdout.trim();
+}
+
+// `pushedAnchors` land on the remote (an attempt that got its measurements off the box);
+// `strandedAnchors` are committed on top and never pushed (an attempt that did not).
+// `dropLocalBranch` deletes the local ref afterwards, which is what a re-run served by a DIFFERENT
+// runner listener sees. `emptyLocalBranch` is the observed failure: a branch left behind by an
+// attempt that died at the build step with nothing measured at all.
+async function campaignWorkspace({
+  pushedAnchors = 0,
+  strandedAnchors = 0,
+  dropLocalBranch = true,
+  emptyLocalBranch = false,
+} = {}) {
+  const root = await mkdtemp(path.join(tmpdir(), "catalog-branch-"));
+  const remote = path.join(root, "origin.git");
+  const work = path.join(root, "work");
+  await gitAt(root, ["init", "--bare", "-b", "main", remote]);
+  await gitAt(root, ["init", "-b", CAMPAIGN_REF, work]);
+  const refSha = await anchorCommit(work, "ref.txt");
+  await gitAt(work, ["remote", "add", "origin", `file://${remote}`]);
+  await gitAt(work, ["push", "-u", "origin", CAMPAIGN_REF]);
+
+  let pushedTip = null;
+  let strandedTip = null;
+  let anchor = 0;
+  if (pushedAnchors > 0 || strandedAnchors > 0) {
+    await gitAt(work, ["switch", "-c", CAMPAIGN_BRANCH_NAME]);
+    for (let i = 0; i < pushedAnchors; i += 1) {
+      anchor += 1;
+      pushedTip = await anchorCommit(work, `anchor-${anchor}.json`);
+    }
+    if (pushedAnchors > 0) await gitAt(work, ["push", "origin", CAMPAIGN_BRANCH_NAME]);
+    for (let i = 0; i < strandedAnchors; i += 1) {
+      anchor += 1;
+      strandedTip = await anchorCommit(work, `anchor-${anchor}.json`);
+    }
+    await gitAt(work, ["switch", CAMPAIGN_REF]);
+    if (dropLocalBranch) await gitAt(work, ["branch", "-D", CAMPAIGN_BRANCH_NAME]);
+  } else if (emptyLocalBranch) {
+    await gitAt(work, ["branch", CAMPAIGN_BRANCH_NAME]);
+  }
+  return { root, remote, work, refSha, pushedTip, strandedTip };
+}
+
+async function runCampaignBranchScript(workspace, { runAttempt = "2" } = {}) {
+  const envFile = path.join(workspace.root, "github-env");
+  const summaryFile = path.join(workspace.root, "step-summary.md");
+  const runnerTemp = path.join(workspace.root, "runner-temp");
+  await mkdir(runnerTemp, { recursive: true });
+  await writeFile(envFile, "");
+  await writeFile(summaryFile, "");
+  const env = {
+    ...process.env,
+    ...GIT_IDENTITY,
+    CAMPAIGN: "sc-22738",
+    BACKEND: "candle",
+    BASE_REF: CAMPAIGN_REF,
+    RUNNER_NAME: "cuda-windows-2",
+    GITHUB_RUN_ID: CAMPAIGN_RUN_ID,
+    GITHUB_RUN_ATTEMPT: runAttempt,
+    RUNNER_TEMP: runnerTemp,
+    GITHUB_ENV: envFile,
+    GITHUB_STEP_SUMMARY: summaryFile,
+  };
+  let code = 0;
+  let stdout = "";
+  let stderr = "";
+  try {
+    ({ stdout, stderr } = await execFileAsync(
+      "bash",
+      [path.join(ROOT, "scripts/ci/memory-catalog/branch.sh")],
+      { cwd: workspace.work, env },
+    ));
+  } catch (error) {
+    code = error.code ?? 1;
+    stdout = error.stdout ?? "";
+    stderr = error.stderr ?? "";
+  }
+  const exported = {};
+  for (const line of (await readFile(envFile, "utf8")).split("\n")) {
+    const at = line.indexOf("=");
+    if (at > 0) exported[line.slice(0, at)] = line.slice(at + 1);
+  }
+  const read = async (args) => (await gitAt(workspace.work, args)).stdout.trim();
+  return {
+    code,
+    stdout,
+    stderr,
+    exported,
+    env,
+    head: await read(["rev-parse", "HEAD"]),
+    branch: await read(["rev-parse", "--abbrev-ref", "HEAD"]),
+    files: (await read(["ls-files"])).split("\n").filter(Boolean),
+    summary: await readFile(summaryFile, "utf8"),
+  };
+}
+
+test("the campaign branch is cut from the dispatched ref when nothing of it exists yet", async () => {
+  const workspace = await campaignWorkspace();
+  const run = await runCampaignBranchScript(workspace, { runAttempt: "1" });
+  assert.equal(run.code, 0, `${run.stdout}\n${run.stderr}`);
+  assert.equal(run.branch, CAMPAIGN_BRANCH_NAME);
+  assert.equal(run.head, workspace.refSha, "a fresh cut starts at the ref tip");
+  assert.equal(run.exported.CAMPAIGN_BRANCH, CAMPAIGN_BRANCH_NAME);
+  assert.equal(run.exported.BASE_SHA, workspace.refSha);
+  assert.equal(run.exported.REF_SHA, workspace.refSha);
+  assert.equal(run.exported.RESUMED_FROM, "", "nothing was resumed, so the PR body says nothing");
+  assert.doesNotMatch(run.summary, /resumed/);
+  assert.ok(run.summary.includes(`| cut from | \`${CAMPAIGN_REF}\` at \`${workspace.refSha}\` |`));
+});
+
+test("a re-run whose earlier attempt left the branch behind is not a second failure", async () => {
+  // THE DEFECT, exactly: run 34490358777 died in the build step, and `gh run rerun --failed` then
+  // died in 12 seconds at `git switch -c` because the branch name is keyed on the run id and the
+  // local ref outlived the job.
+  const workspace = await campaignWorkspace({ emptyLocalBranch: true });
+  const run = await runCampaignBranchScript(workspace);
+  assert.equal(run.code, 0, `${run.stdout}\n${run.stderr}`);
+  assert.doesNotMatch(run.stderr, /already exists/);
+  assert.equal(run.branch, CAMPAIGN_BRANCH_NAME);
+  assert.equal(run.head, workspace.refSha, "the leftover branch carried no measurements");
+  assert.equal(run.exported.BASE_SHA, workspace.refSha);
+  assert.equal(run.exported.RESUMED_FROM, "", "an empty leftover is not a resume");
+});
+
+test("a re-run resumes the anchors an earlier attempt pushed instead of re-cutting the branch", async () => {
+  const workspace = await campaignWorkspace({ pushedAnchors: 3 });
+  const run = await runCampaignBranchScript(workspace);
+  assert.equal(run.code, 0, `${run.stdout}\n${run.stderr}`);
+  assert.equal(run.branch, CAMPAIGN_BRANCH_NAME);
+  assert.equal(run.head, workspace.pushedTip, "the re-run continues the pushed branch");
+  assert.equal(run.exported.RESUMED_FROM, workspace.pushedTip);
+  // BASE_SHA is what the remote already has, so push.sh counts only what this attempt adds and the
+  // three pushed anchors are neither re-counted nor re-pushed.
+  assert.equal(run.exported.BASE_SHA, workspace.pushedTip);
+  assert.equal(run.exported.REF_SHA, workspace.refSha);
+  // The measurements are IN THE TREE, which is what `--skip-current` reads to classify them as
+  // already captured -- a shallow tip still carries a complete tree.
+  for (const anchor of ["anchor-1.json", "anchor-2.json", "anchor-3.json"]) {
+    assert.ok(run.files.includes(anchor), `${anchor} survived the re-run: ${run.files.join(", ")}`);
+  }
+  assert.match(run.summary, /run attempt `2` continues the existing branch/);
+});
+
+test("a resumed re-run appends to the pushed branch without duplicating its history", async () => {
+  const workspace = await campaignWorkspace({ pushedAnchors: 3 });
+  const run = await runCampaignBranchScript(workspace);
+  assert.equal(run.code, 0, `${run.stdout}\n${run.stderr}`);
+
+  // One more anchor, then the real push step, driven with the environment branch.sh exported.
+  await anchorCommit(workspace.work, "anchor-4.json");
+  const pushed = await execFileAsync(
+    "bash",
+    [path.join(ROOT, "scripts/ci/memory-catalog/push.sh")],
+    { cwd: workspace.work, env: { ...run.env, ...run.exported } },
+  );
+  assert.match(pushed.stdout, /^1 anchor commit\(s\) not yet on the remote/m, pushed.stdout);
+
+  const log = (await gitAt(workspace.remote, ["log", "--format=%s", CAMPAIGN_BRANCH_NAME])).stdout
+    .trim()
+    .split("\n");
+  assert.deepEqual(
+    log,
+    [
+      "measure(anchor-4.json)",
+      "measure(anchor-3.json)",
+      "measure(anchor-2.json)",
+      "measure(anchor-1.json)",
+      "measure(ref.txt)",
+    ],
+    "one commit per anchor, in order, with nothing from the earlier attempt repeated",
+  );
+});
+
+test("a local branch an earlier attempt never managed to push is kept, not reset away", async () => {
+  // The commits are measurements even though no push carried them off the box, and the branch name
+  // holds the run id, so a local ref under it can only be this run's own earlier attempt.
+  const workspace = await campaignWorkspace({ strandedAnchors: 2, dropLocalBranch: false });
+  const run = await runCampaignBranchScript(workspace);
+  assert.equal(run.code, 0, `${run.stdout}\n${run.stderr}`);
+  assert.equal(run.head, workspace.strandedTip, "the stranded anchors are still on HEAD");
+  assert.equal(run.exported.RESUMED_FROM, workspace.strandedTip);
+  // The remote has NONE of them, so they count as unpushed and go up with this attempt's push.
+  assert.equal(run.exported.BASE_SHA, workspace.refSha);
+  assert.ok(run.files.includes("anchor-1.json") && run.files.includes("anchor-2.json"));
+});
+
+test("when a branch exists both on the remote and locally, the remote copy is authoritative", async () => {
+  // A deliberate, stated tradeoff. The remote is the only durable record and a re-run may be served
+  // by any of the box's listeners, so a local ref that runs AHEAD of it loses those commits and
+  // their anchors are measured again -- GPU time, never data, and never a divergent branch.
+  const workspace = await campaignWorkspace({
+    pushedAnchors: 2,
+    strandedAnchors: 1,
+    dropLocalBranch: false,
+  });
+  const run = await runCampaignBranchScript(workspace);
+  assert.equal(run.code, 0, `${run.stdout}\n${run.stderr}`);
+  assert.equal(run.head, workspace.pushedTip);
+  assert.equal(run.exported.BASE_SHA, workspace.pushedTip);
+  assert.ok(run.files.includes("anchor-2.json"));
+  assert.ok(!run.files.includes("anchor-3.json"), "the ahead-of-remote local commit is not carried");
+});
+
+test("the results PR body reports a resume rather than claiming the branch was cut there", async () => {
+  const RESUMED_TIP = "b1c2d3e4f50617283940516273849506a7b8c9d0";
+  const resumed = await runResultsPr({
+    createStdout: "https://github.com/SceneWorks/SceneWorks/pull/2811\n",
+    // The resume shape branch.sh really exports: BASE_SHA has moved to the resumed tip, so a body
+    // that reached for it would name the wrong commit as the base.
+    baseSha: RESUMED_TIP,
+    refSha: CAMPAIGN_REF_TIP,
+    resumedFrom: RESUMED_TIP,
+  });
+  assert.equal(resumed.code, 0, resumed.stderr);
+  assert.ok(
+    resumed.body.includes(
+      `- cut from \`feature/sc-22723-memory-anchor-measurability\` at \`${CAMPAIGN_REF_TIP}\``,
+    ),
+    resumed.body,
+  );
+  assert.match(
+    resumed.body,
+    new RegExp(`run attempt \`2\` RESUMED this branch at \`${RESUMED_TIP}\``),
+    resumed.body,
+  );
+
+  // A fresh cut says nothing about attempts, and with REF_SHA absent the base is still named
+  // correctly, because on a fresh cut BASE_SHA IS the ref tip.
+  const fresh = await runResultsPr({
+    createStdout: "https://github.com/SceneWorks/SceneWorks/pull/2810\n",
+  });
+  assert.ok(
+    fresh.body.includes(
+      `- cut from \`feature/sc-22723-memory-anchor-measurability\` at \`${CAMPAIGN_REF_TIP}\``,
+    ),
+    fresh.body,
+  );
+  assert.doesNotMatch(fresh.body, /RESUMED/);
 });

--- a/scripts/platform-review-contracts.test.mjs
+++ b/scripts/platform-review-contracts.test.mjs
@@ -244,6 +244,134 @@ test("Windows CUDA isolates Cargo dependency checkouts after toolchain discovery
   );
 });
 
+// sc-22738 (run 34490358777). The memory-catalog campaign's candle job builds the SAME dependency
+// graph on the SAME shared box as the lane above -- candle-core, candle-transformers, the vendored
+// inference tree, the CUDA kernels -- and it had simply never been given that lane's treatment. It
+// died four minutes into "Build the candle memory adapter" with no rustc diagnostic at all:
+//
+//   sccache: caused by: An existing connection was forcibly closed by the remote host. (os error 10054)
+//   error: could not compile `candle-transformers`
+//
+// The two lanes must read as ONE decision, so this pins the campaign's step to the sibling's
+// spelling AND to the sibling's position: after the toolchain is resolved (the prep action is what
+// clears a MISSING wrapper) and before the first cargo invocation, so both the `bash` fetch step and
+// the `shell: cmd` vcvars build inherit the cleared variable.
+const CAMPAIGN_WORKFLOW = ".github/workflows/memory-catalog-campaign.yml";
+const CAMPAIGN_WRAPPER_STEP = [
+  "      - name: Disable unstable sccache wrapper for the heavy Candle lane",
+  "        shell: powershell",
+  "        run: |",
+  "          Add-Content -Path $env:GITHUB_ENV -Value 'RUSTC_WRAPPER='",
+  "          Remove-Item Env:RUSTC_WRAPPER -ErrorAction SilentlyContinue",
+  "",
+].join("\n");
+
+function assertCampaignCandleWrapperDisabled(workflow) {
+  const candle = workflowJob(workflow, "candle");
+  const mlx = workflowJob(workflow, "mlx");
+
+  const prepare = candle.indexOf("uses: ./.github/actions/prepare-rust-runner");
+  const disableWrapper = candle.indexOf(
+    "name: Disable unstable sccache wrapper for the heavy Candle lane",
+  );
+  const fetch = candle.indexOf("run: cargo fetch --locked");
+  const build = candle.indexOf("--features candle --bin memory-candle-adapter");
+  assert.ok(prepare >= 0, "the campaign's candle job resolves the toolchain with the shared action");
+  assert.ok(disableWrapper >= 0, "and disables the unstable sccache wrapper");
+  assert.ok(fetch >= 0 && build >= 0, "and then fetches and builds the adapter");
+  assert.ok(prepare < disableWrapper, "the wrapper is cleared AFTER the toolchain is resolved");
+  assert.ok(disableWrapper < fetch && fetch < build, "and BEFORE any cargo invocation");
+
+  // Both halves, individually: GITHUB_ENV clears it for every LATER step (including the
+  // `shell: cmd` build), Remove-Item clears it for this step's own process.
+  const step = workflowStep(candle, "Disable unstable sccache wrapper for the heavy Candle lane");
+  assert.match(step, /^ {8}shell: powershell$/m);
+  assert.match(step, /Add-Content -Path \$env:GITHUB_ENV -Value 'RUSTC_WRAPPER='/);
+  assert.match(step, /Remove-Item Env:RUSTC_WRAPPER -ErrorAction SilentlyContinue/);
+
+  // The mlx lane is deliberately NOT given this: os error 10054 is a Windows socket reset, and no
+  // macOS runner service exports the wrapper -- docs/rust-mlx-build.md offers sccache to a
+  // developer, and scripts/setup-nax-runner.sh only points at that note.
+  assert.doesNotMatch(mlx, /RUSTC_WRAPPER/, "the mlx lane keeps whatever wrapper its Mac has");
+
+  // And NO job-local CARGO_HOME, which is the other half of windows-candle.yml's block and the half
+  // this lane deliberately does not take: each runner service already pins its own dependency cache
+  // (D:\cargo-home-N, sc-17614) and runs one job at a time, while a $RUNNER_TEMP CARGO_HOME is
+  // re-downloaded every run on the box whose slow link this campaign's whole fetch design exists to
+  // work around. Delete this assertion only alongside the rationale in the workflow.
+  assert.doesNotMatch(
+    candle,
+    /CARGO_HOME=/,
+    "the campaign lane relies on the per-runner CARGO_HOME rather than a re-downloaded job-local one",
+  );
+}
+
+test("the campaign's candle build gets the heavy-Candle-lane sccache treatment", async () => {
+  const workflow = await source(CAMPAIGN_WORKFLOW);
+  assertCampaignCandleWrapperDisabled(workflow);
+  assert.ok(
+    workflow.includes(CAMPAIGN_WRAPPER_STEP),
+    "the campaign step is spelled exactly as windows-candle.yml's, so the two read as one decision",
+  );
+});
+
+test("the campaign sccache contract rejects removal, reordering and half-measures", async () => {
+  const workflow = await source(CAMPAIGN_WORKFLOW);
+  for (const [why, mutation] of [
+    ["the step is deleted outright", workflow.replace(CAMPAIGN_WRAPPER_STEP, "")],
+    [
+      "only the process-local half survives",
+      workflow.replace(
+        "          Add-Content -Path $env:GITHUB_ENV -Value 'RUSTC_WRAPPER='\n",
+        "",
+      ),
+    ],
+    [
+      "only the GITHUB_ENV half survives",
+      workflow.replace(
+        "          Remove-Item Env:RUSTC_WRAPPER -ErrorAction SilentlyContinue\n",
+        "",
+      ),
+    ],
+    [
+      "it slips after the first cargo invocation",
+      workflow
+        .replace(CAMPAIGN_WRAPPER_STEP, "")
+        .replace(
+          "      - name: Build the candle memory adapter\n",
+          `${CAMPAIGN_WRAPPER_STEP}      - name: Build the candle memory adapter\n`,
+        ),
+    ],
+    [
+      "it lands before the toolchain is resolved",
+      workflow
+        .replace(CAMPAIGN_WRAPPER_STEP, "")
+        .replace(
+          "      - name: Prepare the Rust toolchain\n",
+          `${CAMPAIGN_WRAPPER_STEP}      - name: Prepare the Rust toolchain\n`,
+        ),
+    ],
+    [
+      "the mlx lane picks it up too",
+      workflow.replace(
+        "      - name: Fetch prebuilt MLX (sc-21382)\n",
+        `${CAMPAIGN_WRAPPER_STEP}      - name: Fetch prebuilt MLX (sc-21382)\n`,
+      ),
+    ],
+    [
+      "a redundant job-local CARGO_HOME is added back",
+      workflow.replace(
+        "      - name: Census the profiled GPU\n",
+        "      - name: Isolate Cargo dependency checkout\n        shell: powershell\n        run: |\n"
+          + '          Add-Content -Path $env:GITHUB_ENV -Value "CARGO_HOME=$jobCargoHome"\n'
+          + "      - name: Census the profiled GPU\n",
+      ),
+    ],
+  ]) {
+    assert.throws(() => assertCampaignCandleWrapperDisabled(mutation), undefined, why);
+  }
+});
+
 test("Windows Krea provisioning accepts supported newer Python 3 runtimes", async () => {
   const workflow = await source(".github/workflows/windows-candle.yml");
   assert.match(workflow, /Python 3\.12 or newer/);


### PR DESCRIPTION
Two campaign-tooling defects from run [34490358777](https://github.com/SceneWorks/SceneWorks/actions/runs/34490358777), which died four minutes into *Build the candle memory adapter* and then died again twelve seconds into the documented recovery.

## Fix 1 — the campaign's candle build never got the heavy-Candle-lane treatment

The shared Windows runner exports `RUSTC_WRAPPER=sccache`. `prepare-rust-runner` clears a **missing** wrapper, but an installed daemon can still reset its own local connection mid-build and leave no rustc diagnostic at all:

```
sccache: error: failed to execute compile
sccache: caused by: error reading compile response from server
sccache: caused by: An existing connection was forcibly closed by the remote host. (os error 10054)
error: could not compile `candle-transformers` / `candle-gen`
```

`windows-candle.yml` had already met and answered this twice — the backend-candle test and the sidecar check — by making rustc direct for those jobs. The campaign's candle job compiles the same graph (candle-core, candle-transformers, the vendored inference tree, the CUDA kernels) on the same box, **cold on every dispatch** because `actions/checkout`'s `clean: true` runs `git clean -ffdx` and takes `target/` with it. It is the heavy Candle lane by every property the sibling comment names, and it simply had never been given the step.

It now carries the byte-identical step in the identical position: after `prepare-rust-runner`, before the first `cargo` invocation, so both the `bash` fetch and the `shell: cmd` vcvars build inherit the cleared variable. Not a retry-with-fallback — a wrapper that drops its socket produces no diagnostic, so a retry would spend a second cold candle build to learn as little.

### Hazards judged individually

| hazard | verdict | why |
|---|---|---|
| (a) disable the sccache wrapper | **applied** | Same failure, same error number, same box, same graph, third occurrence. |
| (b) isolate the Cargo dependency checkout | **rejected** | Its premise ("multiple runner services share `%USERPROFILE%\.cargo`") no longer holds. sc-17614 (`674f9b4de`, verified against the real box) established, and `.github/actions/prepare-rust-runner/action.yml` documents at its *"CARGO_HOME IS NOT RUSTUP'S HOME HERE"* header, that **each runner service pins `CARGO_HOME` in its own `.env` to a per-runner cache `D:\cargo-home-N`**. A runner service runs one job at a time, so the cargo git checkout is already private to this job. It would also cost something the repo has measured: `windows-candle.yml`'s own header states *"a job-local CARGO_HOME under RUNNER_TEMP is re-downloaded every run"* — the wrong trade on the box whose slow link this lane's entire fetch design (persistent shallow `D:` inference clone) exists to work around. Note the dates: the isolation step landed `08cb1d557` on 2026-08-01, three days *before* sc-17614 found the per-runner pin. |
| (c) anything else in that block | **already present** | `prepare-rust-runner`, the separate `cargo fetch --locked` with `CARGO_NET_OFFLINE: "false"`, and the `cmd` + `vcvars64` + `NVCC_CCBIN` build spelling are all already on this job. |
| the **mlx** lane | **rejected** | os error 10054 is a Windows socket reset; no macOS runner service exports the wrapper (`docs/rust-mlx-build.md` offers sccache to a *developer*, and `scripts/setup-nax-runner.sh` only points at that note), and no macOS lane in the repo disables it. A test asserts the mlx job stays free of `RUSTC_WRAPPER`. |

The rejection of (b) is written into the workflow beside the step it declines, so nobody re-litigates it from the sibling lane alone, and a test pins it (`assert.doesNotMatch(candle, /CARGO_HOME=/)`) with the reason in a message.

## Fix 2 — `branch.sh` turned a re-run into a hard failure

The branch name is keyed on `$GITHUB_RUN_ID`, which a re-run **reuses** (`github.run_attempt` is the counter that moves), and the local ref outlives the job because `actions/checkout`'s clean removes files, not refs. So `gh run rerun --failed` died in twelve seconds:

```
fatal: a branch named 'story/sc-22738-candle-campaign-34490358777' already exists
```

### The design, and why

A **per-attempt branch** (`…-<run_id>-<attempt>`) never collides but splits the campaign: attempt 2 would be cut from `ref` without attempt 1's anchors, so `--skip-current` would re-measure every one of them — hours of GPU each — and the two branches would then conflict on the same matrix and anchor-store files at merge time. **Deleting** the branch discards committed measurements outright. So a re-run **resumes**, which is what "re-run the failed job" ought to mean: the walk continues on top of what the earlier attempt landed, history stays linear at one commit per anchor with nothing duplicated, the anchors already measured plan as `current` and are skipped, and the PR that is already open picks up the new commits.

Three arms, chosen from **what exists** rather than from `run_attempt` (the run id is in the branch name, so a ref under it can only be this run's earlier attempt, and the remote is the only durable record — a re-run may be served by any of the box's four listeners):

1. **on the remote** → shallow-fetch it (`--depth 1`; a shallow tip still carries the complete tree, which is all `--skip-current` and the harness read, and deepening would drag the 2+ GiB pack over the slow link) and continue it;
2. **local only** → keep it. Those commits are measurements even though no push carried them off the box, so `BASE_SHA` stays the ref tip and this attempt's push carries them up;
3. **neither** → cut it from the ref, as before.

`BASE_SHA` now means *"the newest commit of this branch the remote already has"*, so `push.sh`'s `BASE_SHA..HEAD` is exactly "what is not up there yet" — it neither re-counts a previous attempt's pushed anchors nor strands the ones it failed to push. `REF_SHA` and `RESUMED_FROM` keep the PR body honest instead of claiming the branch was cut at the resumed tip.

The reasoning lives in `scripts/ci/memory-catalog/branch.sh`'s header, with pointers from `common.sh` (why the name is keyed on the run id and not the attempt), the workflow header, and `docs/calibration-runbook.md`.

## Verification

- **9 new tests.** Seven drive `branch.sh`, `push.sh` and `pr.sh` as the shell scripts the runner really executes, against a **real bare remote** and a real workspace over `file://` (the local transport ignores `--depth`, and the shallow resume fetch is part of what is under test) — fresh cut, the exact observed regression, resume-from-remote, append-without-duplicating (the remote's log is asserted commit-by-commit), stranded-local preservation, remote-wins-when-both-exist, and the PR body's resume line. Two pin the workflow contract, one of them a mutation list in the file's own house style.
- **16 individual-guard mutations, every one RED**, baselines GREEN. Including one that makes `assertCampaignCandleWrapperDisabled` a no-op, so the mutation list cannot go vacuous.
- `npm run check` — 933 tests, 0 fail (5 pre-existing environment-gated skips). `npm run check:shell` — 16 scripts, bash-3.2 parse under `/bin/bash` 3.x. `check-action-pins` — pass. `actionlint` — no new findings (the one `label "cuda" is unknown` line is byte-identical on `origin/main`).
- No Rust changed, so `rust:check` was not run.
- Zero `if true` / `if false` / `&& false` / `|| true` / `.skip(` / commented-out asserts in the shipped diff.

## Risks

- The (b) rejection rests on the repo's own record of the runner `.env` files (sc-17614's commit body says it was verified on the box) rather than on a live probe of all four listeners. If a listener is ever registered without that `CARGO_HOME` pin, the failure is a loud build error, not silent corruption — and re-running the job is now a supported recovery.
- The resume path prefers the remote when a local branch runs **ahead** of it, so those unpushed commits are dropped and their anchors are measured again. GPU time, never data, and never a divergent branch; pinned by a test with the reasoning in it.
- A resumed attempt builds and measures against the branch's tree, which may be behind `ref` if `ref` moved between attempts. That is what resuming a branch means, and the harness's pin check still runs against that tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
