### PR TITLE
Repair missing snapshot revisions in model install receipts

### DIFF
--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -4152,7 +4152,11 @@ fn repair_missing_snapshot_revisions(managed: &FsPath, model: &Value, data_dir: 
         let Some(revision) = download_receipt::recover_revision(entry, &root) else {
             return false;
         };
-        let snapshot = root.join("snapshots").join(&revision);
+        let Ok((_, snapshot)) = sceneworks_core::hf_home::model_source_library(data_dir)
+            .discover_snapshot(repo, Some(&revision))
+        else {
+            return false;
+        };
         let files = string_array_field(entry, "resolvedFiles");
         if !snapshot_tier_is_loadable(&snapshot, &files, family_complete)
             || !listed_shard_indexes_are_complete(&snapshot, &files)

--- a/apps/rust-api/src/models.rs
+++ b/apps/rust-api/src/models.rs
@@ -4096,6 +4096,9 @@ fn repair_torn_backfilled_receipts(managed_path: &FsPath, data_dir: &FsPath) {
     let _write_guard = RECEIPT_BACKFILL_WRITE_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let Ok(_receipt_lock) = sceneworks_core::download_receipt::lock(managed_path) else {
+        return;
+    };
     // Re-read under the lock: a concurrent backfill may have rewritten the file.
     let kept = receipt_entries(managed_path)
         .into_iter()
@@ -4112,9 +4115,66 @@ fn repair_torn_backfilled_receipts(managed_path: &FsPath, data_dir: &FsPath) {
     if let Some(object) = receipt.as_object_mut() {
         object.insert("receipts".to_owned(), Value::Array(kept));
     }
-    let _ = serde_json::to_vec_pretty(&receipt)
-        .ok()
-        .and_then(|bytes| std::fs::write(&receipt_path, bytes).ok());
+    let _ = sceneworks_core::download_receipt::write(&receipt_path, &receipt);
+}
+
+/// Heal legacy install identity before the catalog and local-cache eligibility read it.
+fn repair_missing_snapshot_revisions(managed: &FsPath, model: &Value, data_dir: &FsPath) {
+    use sceneworks_core::download_receipt;
+    let marker = managed.join(".sceneworks-download-complete.json");
+    if !marker.is_file() {
+        return;
+    }
+    let Ok(_lock) = download_receipt::lock(managed) else {
+        return;
+    };
+    let Ok(bytes) = std::fs::read(&marker) else {
+        return;
+    };
+    let Ok(mut receipt) = serde_json::from_slice::<Value>(&bytes) else {
+        return;
+    };
+    let family_complete = model_family_tier_predicate(model);
+    let repair = |entry: &mut Value| {
+        if entry
+            .get("modelId")
+            .and_then(Value::as_str)
+            .is_some_and(|id| Some(id) != model.get("id").and_then(Value::as_str))
+        {
+            return false;
+        }
+        let Some(repo) = entry.get("repo").and_then(Value::as_str) else {
+            return false;
+        };
+        let Some(root) = huggingface_repo_cache_path(data_dir, repo) else {
+            return false;
+        };
+        let Some(revision) = download_receipt::recover_revision(entry, &root) else {
+            return false;
+        };
+        let snapshot = root.join("snapshots").join(&revision);
+        let files = string_array_field(entry, "resolvedFiles");
+        if !snapshot_tier_is_loadable(&snapshot, &files, family_complete)
+            || !listed_shard_indexes_are_complete(&snapshot, &files)
+        {
+            return false;
+        }
+        entry["snapshotRevision"] = Value::String(revision);
+        true
+    };
+    // The newest receipt is mirrored at the top level. Repair both representations without
+    // rebuilding the envelope or dropping unrelated variants and fields.
+    let mut changed = repair(&mut receipt);
+    if let Some(entries) = receipt.get_mut("receipts").and_then(Value::as_array_mut) {
+        for entry in entries {
+            changed |= repair(entry);
+        }
+    }
+    if changed {
+        if let Err(error) = download_receipt::write(&marker, &receipt) {
+            tracing::warn!(%error, path = %marker.display(), "could not repair missing snapshot revisions");
+        }
+    }
 }
 
 fn backfill_current_receipt(
@@ -4188,9 +4248,15 @@ fn backfill_current_receipt(
     if receipts.is_empty() {
         return;
     }
+    if std::fs::create_dir_all(managed_path).is_err() {
+        return;
+    }
     let _write_guard = RECEIPT_BACKFILL_WRITE_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let Ok(_receipt_lock) = sceneworks_core::download_receipt::lock(managed_path) else {
+        return;
+    };
     if !receipt_file_sets(managed_path, &context.repo, Some(model_id)).is_empty() {
         return;
     }
@@ -4218,14 +4284,10 @@ fn backfill_current_receipt(
         .as_object_mut()
         .unwrap()
         .insert("receipts".to_owned(), Value::Array(merged));
-    let _ = std::fs::create_dir_all(managed_path);
-    let _ = serde_json::to_vec_pretty(&receipt).ok().and_then(|bytes| {
-        std::fs::write(
-            managed_path.join(".sceneworks-download-complete.json"),
-            bytes,
-        )
-        .ok()
-    });
+    let _ = sceneworks_core::download_receipt::write(
+        &managed_path.join(".sceneworks-download-complete.json"),
+        &receipt,
+    );
 }
 
 #[cfg(test)]
@@ -4487,6 +4549,88 @@ mod download_receipt_tests {
     // env-first `huggingface_repo_cache_path`, so without this they would resolve into a developer's
     // real HF cache when HF_HOME is set. Serialize on the same `HF_ENV_LOCK`; never add a second lock.
     use crate::tests::support::isolate_hf_cache;
+
+    #[test]
+    fn discovery_repairs_legacy_snapshot_revisions_and_restores_cache_eligibility() {
+        use sceneworks_core::model_artifacts::artifact_selection::{
+            local_cache_eligibility_for_model, LocalCacheCoverage,
+        };
+        let _env = isolate_hf_cache();
+        let temp = tempfile::tempdir().unwrap();
+        let data = temp.path();
+        let repo = "owner/receipt-repair";
+        let rev = "1111111111111111111111111111111111111111";
+        let snapshot = huggingface_repo_cache_path(data, repo)
+            .unwrap()
+            .join("snapshots")
+            .join(rev);
+        std::fs::create_dir_all(snapshot.join("q4")).unwrap();
+        std::fs::write(snapshot.join("q4/model.safetensors"), b"weights").unwrap();
+        let managed = data.join("models").join(safe_download_dir(repo));
+        std::fs::create_dir_all(&managed).unwrap();
+        let marker = managed.join(".sceneworks-download-complete.json");
+        // A newer catalog pin must never be substituted for the snapshot actually installed.
+        let model = json!({"id":"repair", "downloads":[{"provider":"huggingface", "repo":repo,
+            "revision":"2222222222222222222222222222222222222222", "variant":"q4", "default":true, "files":["q4/*"]}]});
+        for revision in [None, Some(Value::Null), Some(json!("")), Some(json!("  "))] {
+            let mut entry = json!({"repo":repo, "modelId":"repair", "variant":"q4", "backfilled":true,
+                "resolvedFiles":["q4/model.safetensors"], "customField":"preserved"});
+            if let Some(revision) = revision {
+                entry["snapshotRevision"] = revision;
+            }
+            let sibling = json!({"repo":repo,"modelId":"other","variant":"q8", "snapshotRevision":rev,
+                "resolvedFiles":["q8/model.safetensors"]});
+            let mut top = entry.clone();
+            top["receipts"] = json!([entry, sibling]);
+            std::fs::write(&marker, serde_json::to_vec(&top).unwrap()).unwrap();
+            assert_eq!(
+                local_cache_eligibility_for_model(&model, "macos", Some("q4"), data).coverage,
+                LocalCacheCoverage::None
+            );
+            install_state_for(model_download_context(&model).unwrap(), &model, data);
+            let bytes = std::fs::read(&marker).unwrap();
+            let after: Value = serde_json::from_slice(&bytes).unwrap();
+            top["snapshotRevision"] = json!(rev);
+            top["receipts"][0]["snapshotRevision"] = json!(rev);
+            assert_eq!(
+                after, top,
+                "only missing revisions change, including the mirrored top-level receipt"
+            );
+            assert_eq!(
+                local_cache_eligibility_for_model(&model, "macos", Some("q4"), data).coverage,
+                LocalCacheCoverage::Full
+            );
+            install_state_for(model_download_context(&model).unwrap(), &model, data);
+            assert_eq!(
+                std::fs::read(&marker).unwrap(),
+                bytes,
+                "repeat discovery is idempotent"
+            );
+        }
+    }
+
+    #[test]
+    fn snapshot_revision_repair_does_not_pin_a_torn_shard_set() {
+        let _env = isolate_hf_cache();
+        let temp = tempfile::tempdir().unwrap();
+        let repo = "owner/torn-repair";
+        let root = huggingface_repo_cache_path(temp.path(), repo).unwrap();
+        let snapshot = root.join("snapshots/1111111111111111111111111111111111111111");
+        std::fs::create_dir_all(&snapshot).unwrap();
+        std::fs::write(
+            snapshot.join("model.safetensors.index.json"),
+            br#"{"weight_map":{"a":"missing.safetensors"}}"#,
+        )
+        .unwrap();
+        let managed = temp.path().join("models").join(safe_download_dir(repo));
+        std::fs::create_dir_all(&managed).unwrap();
+        let marker = managed.join(".sceneworks-download-complete.json");
+        let receipt = json!({"repo":repo,"modelId":"repair", "resolvedFiles":["model.safetensors.index.json"]});
+        let before = serde_json::to_vec(&receipt).unwrap();
+        std::fs::write(&marker, &before).unwrap();
+        repair_missing_snapshot_revisions(&managed, &json!({"id":"repair"}), temp.path());
+        assert_eq!(std::fs::read(&marker).unwrap(), before);
+    }
 
     fn builtin_models_entry(model_id: &str) -> Value {
         let raw = sceneworks_core::builtin_manifests::BUILTIN_MANIFESTS
@@ -6526,6 +6670,7 @@ fn install_state_for(
         // BEFORE it is read, so an affected install self-heals on the next scan instead of needing a
         // manual delete — and so the backfill below can re-record the tier honestly.
         repair_torn_backfilled_receipts(&managed_path, data_dir);
+        repair_missing_snapshot_revisions(&managed_path, model, data_dir);
         let receipt_file_sets = receipt_file_sets(
             &managed_path,
             &download_context.repo,

--- a/crates/sceneworks-core/src/download_receipt.rs
+++ b/crates/sceneworks-core/src/download_receipt.rs
@@ -1,0 +1,261 @@
+//! Shared installation-receipt identity and write coordination.
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::fs::{self, OpenOptions};
+use std::io;
+use std::path::{Component, Path};
+
+/// Serialize receipt read/modify/write across discovery and the download worker.
+pub fn lock(managed: &Path) -> io::Result<crate::file_lock::FileLock> {
+    crate::file_lock::FileLock::exclusive(
+        OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(managed.join(".sceneworks-download-receipt.lock"))?,
+    )
+}
+
+/// Publish a complete receipt while holding [`lock`].
+pub fn write(marker: &Path, receipt: &Value) -> io::Result<()> {
+    crate::store_util::atomic_write(marker, &serde_json::to_vec_pretty(receipt)?)
+        .map_err(io::Error::other)
+}
+
+/// Missing, JSON null, and blank strings all represent an unrecorded revision.
+pub fn revision_missing(receipt: &Value) -> bool {
+    match receipt.get("snapshotRevision") {
+        None | Some(Value::Null) => true,
+        Some(Value::String(value)) => value.trim().is_empty(),
+        _ => false,
+    }
+}
+
+/// Recover identity only from one immutable snapshot holding every recorded file. Existing
+/// tree stamps must still match; this never establishes or replaces an integrity baseline.
+pub fn recover_revision(receipt: &Value, repo_root: &Path) -> Option<String> {
+    if !revision_missing(receipt) {
+        return None;
+    }
+    let files = receipt
+        .get("resolvedFiles")?
+        .as_array()?
+        .iter()
+        .map(Value::as_str)
+        .collect::<Option<Vec<_>>>()?;
+    if files.is_empty()
+        || files.iter().any(|file| {
+            file.is_empty()
+                || file.contains('\\')
+                || Path::new(file)
+                    .components()
+                    .any(|part| !matches!(part, Component::Normal(_)))
+        })
+    {
+        return None;
+    }
+    let entries = fs::read_dir(repo_root.join("snapshots")).ok()?;
+    let mut matching = Vec::new();
+    for entry in entries {
+        let entry = entry.ok()?;
+        let revision = entry.file_name().into_string().ok()?;
+        if crate::model_artifacts::validate_immutable_revision(&revision).is_err()
+            || !entry.file_type().ok()?.is_dir()
+        {
+            continue;
+        }
+        let snapshot = entry.path();
+        if files.iter().all(|file| snapshot.join(file).is_file()) {
+            matching.push((revision, snapshot));
+        }
+    }
+    let [(revision, snapshot)] = matching.as_slice() else {
+        return None;
+    };
+    // Promotion copies only resolvedFiles. A complete external tree is not enough if an older
+    // receipt omitted a shard: pinning that list would advertise a local bundle that cannot load.
+    for name in files
+        .iter()
+        .filter(|name| name.ends_with(crate::safetensors::SAFETENSORS_INDEX_SUFFIX))
+    {
+        let index: Value = serde_json::from_slice(&fs::read(snapshot.join(name)).ok()?).ok()?;
+        let weights = index.get("weight_map")?.as_object()?;
+        if weights.is_empty() {
+            return None;
+        }
+        let parent = Path::new(name).parent()?;
+        for shard in weights.values() {
+            let shard = parent.join(shard.as_str()?);
+            if !files.iter().any(|file| Path::new(file) == shard) {
+                return None;
+            }
+        }
+    }
+    if let Some(expected) = receipt.get("artifactTreeStamp").filter(|v| !v.is_null()) {
+        if expected.as_str()? != resolved_files_tree_stamp(snapshot, &files).ok()? {
+            return None;
+        }
+    }
+    Some(revision.clone())
+}
+
+pub fn update_metadata_stamp(digest: &mut Sha256, metadata: &std::fs::Metadata) {
+    digest.update(metadata.len().to_le_bytes());
+    let modified = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok());
+    digest.update(
+        modified
+            .map_or(0, |duration| duration.as_secs())
+            .to_le_bytes(),
+    );
+    digest.update(
+        modified
+            .map_or(0, |duration| duration.subsec_nanos())
+            .to_le_bytes(),
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        digest.update(metadata.dev().to_le_bytes());
+        digest.update(metadata.ino().to_le_bytes());
+        digest.update(metadata.ctime().to_le_bytes());
+        digest.update(metadata.ctime_nsec().to_le_bytes());
+    }
+}
+
+pub fn resolved_files_tree_stamp(
+    root: &Path,
+    files: &[impl AsRef<str>],
+) -> std::io::Result<String> {
+    let mut names = files.iter().map(AsRef::as_ref).collect::<Vec<_>>();
+    names.sort_unstable();
+    let mut digest = Sha256::new();
+    for name in names {
+        let relative = Path::new(name);
+        if relative.is_absolute()
+            || relative
+                .components()
+                .any(|component| !matches!(component, std::path::Component::Normal(_)))
+        {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("artifact receipt contains unsafe resolved file {name:?}"),
+            ));
+        }
+        let path = root.join(relative);
+        let metadata = std::fs::symlink_metadata(&path)?;
+        digest.update(name.as_bytes());
+        digest.update([0]);
+        update_metadata_stamp(&mut digest, &metadata);
+        if metadata.file_type().is_symlink() {
+            digest.update(std::fs::read_link(&path)?.to_string_lossy().as_bytes());
+            digest.update(b"followed-target");
+            update_metadata_stamp(&mut digest, &std::fs::metadata(&path)?);
+        }
+        digest.update([0xff]);
+    }
+    Ok(format!("sha256:{:x}", digest.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    const REV: &str = "1111111111111111111111111111111111111111";
+    const OTHER: &str = "2222222222222222222222222222222222222222";
+
+    fn seed(root: &Path, revision: &str) -> std::path::PathBuf {
+        let snapshot = root.join("snapshots").join(revision);
+        fs::create_dir_all(&snapshot).unwrap();
+        fs::write(snapshot.join("model.safetensors"), b"weights").unwrap();
+        snapshot
+    }
+
+    #[test]
+    fn recovers_all_missing_forms_but_preserves_recorded_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        seed(temp.path(), REV);
+        for revision in [None, Some(Value::Null), Some(json!("")), Some(json!("  "))] {
+            let mut receipt = json!({"resolvedFiles":["model.safetensors"]});
+            if let Some(revision) = revision {
+                receipt["snapshotRevision"] = revision;
+            }
+            assert_eq!(
+                recover_revision(&receipt, temp.path()).as_deref(),
+                Some(REV)
+            );
+        }
+        for revision in [json!(OTHER), json!("main"), json!(false)] {
+            let receipt =
+                json!({"resolvedFiles":["model.safetensors"], "snapshotRevision":revision});
+            assert_eq!(recover_revision(&receipt, temp.path()), None);
+        }
+    }
+
+    #[test]
+    fn unavailable_incomplete_unsafe_and_ambiguous_snapshots_stay_unresolved() {
+        let temp = tempfile::tempdir().unwrap();
+        let receipt = json!({"resolvedFiles":["model.safetensors"]});
+        assert_eq!(recover_revision(&receipt, temp.path()), None);
+        seed(temp.path(), "main");
+        assert_eq!(recover_revision(&receipt, temp.path()), None);
+        seed(temp.path(), REV);
+        for files in [
+            json!([]),
+            json!(["missing"]),
+            json!(["../model.safetensors"]),
+            json!(["/model.safetensors"]),
+            json!(["..\\model.safetensors"]),
+            json!([null]),
+            json!([""]),
+        ] {
+            assert_eq!(
+                recover_revision(&json!({"resolvedFiles":files}), temp.path()),
+                None
+            );
+        }
+        seed(temp.path(), OTHER);
+        assert_eq!(recover_revision(&receipt, temp.path()), None);
+    }
+
+    #[test]
+    fn every_indexed_shard_must_be_recorded_even_when_all_exist_externally() {
+        let temp = tempfile::tempdir().unwrap();
+        let snapshot = seed(temp.path(), REV);
+        fs::write(snapshot.join("other.safetensors"), b"other weights").unwrap();
+        fs::write(
+            snapshot.join("model.safetensors.index.json"),
+            br#"{"weight_map":{"a":"model.safetensors","b":"other.safetensors"}}"#,
+        )
+        .unwrap();
+        let mut receipt =
+            json!({"resolvedFiles":["model.safetensors.index.json", "model.safetensors"]});
+        assert_eq!(recover_revision(&receipt, temp.path()), None);
+        receipt["resolvedFiles"]
+            .as_array_mut()
+            .unwrap()
+            .push(json!("other.safetensors"));
+        assert_eq!(
+            recover_revision(&receipt, temp.path()).as_deref(),
+            Some(REV)
+        );
+    }
+
+    #[test]
+    fn existing_integrity_stamp_must_match_and_is_not_replaced() {
+        let temp = tempfile::tempdir().unwrap();
+        let snapshot = seed(temp.path(), REV);
+        let stamp = resolved_files_tree_stamp(&snapshot, &["model.safetensors"]).unwrap();
+        let receipt = json!({"resolvedFiles":["model.safetensors"], "artifactTreeStamp":stamp});
+        assert_eq!(
+            recover_revision(&receipt, temp.path()).as_deref(),
+            Some(REV)
+        );
+        fs::write(snapshot.join("model.safetensors"), b"changed weights").unwrap();
+        assert_eq!(recover_revision(&receipt, temp.path()), None);
+        assert_eq!(receipt["artifactTreeStamp"], stamp);
+    }
+}

--- a/crates/sceneworks-core/src/lib.rs
+++ b/crates/sceneworks-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod control_weights;
 pub mod credentials;
 pub mod dataset_quality;
 pub mod decoder_support;
+pub mod download_receipt;
 pub mod external_roots;
 pub mod file_lock;
 pub mod hf_home;

--- a/crates/sceneworks-core/src/model_artifacts/artifact_selection.rs
+++ b/crates/sceneworks-core/src/model_artifacts/artifact_selection.rs
@@ -307,6 +307,7 @@ fn receipt_file_sets(
             let revision = entry
                 .get("snapshotRevision")
                 .and_then(Value::as_str)
+                .filter(|revision| !revision.trim().is_empty())
                 .map(str::to_owned);
             let variant = entry
                 .get("variant")

--- a/crates/sceneworks-core/src/model_artifacts/promotion_tests.rs
+++ b/crates/sceneworks-core/src/model_artifacts/promotion_tests.rs
@@ -475,3 +475,62 @@ fn a_manifest_entry_promotes_and_is_then_recognized_as_the_local_tier() {
     // was opened explicitly by this test, never as a side effect of resolving a candidate.
     assert!(!ResolvedCachePolicy::default().enabled);
 }
+
+#[test]
+fn repaired_legacy_receipt_promotes_and_loads_with_external_library_disconnected() {
+    let temp = tempfile::tempdir().unwrap();
+    let data = temp.path().join("data");
+    let library = temp.path().join("library");
+    install_snapshot_file(
+        &library,
+        "owner/model",
+        PRIMARY_REVISION,
+        "q4/model.safetensors",
+        b"local weights",
+    );
+    let mut receipt = json!({"repo":"owner/model", "modelId":"demo", "variant":"q4",
+        "resolvedFiles":["q4/model.safetensors"], "snapshotRevision":null});
+    let model = json!({"id":"demo", "downloads":[{"provider":"huggingface", "repo":"owner/model",
+        "variant":"q4", "default":true, "files":["q4/*"]}]});
+    write_receipts(&data, "owner/model", json!([receipt]));
+    let before = selected_requirements_for_model(&model, "macos", Some("q4"), &data);
+    assert!(before.requirements[0].revision.is_none());
+    let revision =
+        crate::download_receipt::recover_revision(&receipt, &library.join("models--owner--model"))
+            .unwrap();
+    receipt["snapshotRevision"] = json!(revision);
+    write_receipts(&data, "owner/model", json!([receipt]));
+    let selected = selected_requirements_for_model(&model, "macos", Some("q4"), &data);
+    let candidate =
+        promotion_candidate_for_requirements(&resolver_for(&library), &selected.requirements)
+            .unwrap();
+    let store = ResolvedCacheStore::open(&data).unwrap();
+    let outcome = ResolvedCacheMaterializer::new(store)
+        .materialize(
+            &candidate,
+            &library,
+            "demo",
+            &MaterializationCancellation::default(),
+        )
+        .unwrap();
+    let MaterializationOutcome::Published(metadata) = outcome else {
+        panic!("promotion did not publish");
+    };
+    std::fs::rename(&library, temp.path().join("disconnected-library")).unwrap();
+    let local = local_artifact_for_requirements(
+        std::slice::from_ref(&metadata.artifact),
+        &selected.requirements,
+    )
+    .unwrap();
+    let ArtifactLocation::ResolvedLocal { root } = local.location else {
+        panic!("not local");
+    };
+    let (_, snapshot) = ArtifactSourceLibrary::new(root)
+        .unwrap()
+        .discover_snapshot("owner/model", Some(PRIMARY_REVISION))
+        .unwrap();
+    assert_eq!(
+        std::fs::read(snapshot.join("q4/model.safetensors")).unwrap(),
+        b"local weights"
+    );
+}

--- a/crates/sceneworks-worker/src/external_library_runtime.rs
+++ b/crates/sceneworks-worker/src/external_library_runtime.rs
@@ -1952,6 +1952,54 @@ mod tests {
         });
     }
 
+    #[test]
+    fn repairing_a_legacy_revision_enables_runtime_local_loading_without_the_source() {
+        let temp = TempDir::new().unwrap();
+        let data = temp.path().join("data");
+        let library = temp.path().join("external-hf");
+        let repo = "guardfx/revision-repair";
+        seed_snapshot(&library, repo, REV_A, "model.safetensors");
+        let mut receipt = json!({"repo":repo,"modelId":"repair", "resolvedFiles":["model.safetensors"],"snapshotRevision":null});
+        write_receipts(&data, repo, json!([receipt]));
+        let payload=json!({"modelManifestEntry":{"id":"repair","downloads":[{"provider":"huggingface","repo":repo,"files":["model.safetensors"]}]}}).as_object().unwrap().clone();
+        let settings = settings(data.clone());
+        with_local_cache(&library, || {
+            let artifact = publish_bundle(
+                &data,
+                &library,
+                repo,
+                REV_A,
+                "default",
+                &["model.safetensors"],
+            );
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap();
+            assert!(guard
+                .resolutions()
+                .iter()
+                .all(|r| r.availability != ModelAvailability::LocalReady));
+            drop(guard);
+            receipt["snapshotRevision"] =
+                json!(sceneworks_core::download_receipt::recover_revision(
+                    &receipt,
+                    &library.join("models--guardfx--revision-repair")
+                )
+                .unwrap());
+            write_receipts(&data, repo, json!([receipt]));
+            std::fs::rename(&library, temp.path().join("unplugged")).unwrap();
+            let guard =
+                RuntimeSourceGuard::begin(&JobType::ImageGenerate, &payload, &settings).unwrap();
+            assert_eq!(
+                guard.resolutions()[0].availability,
+                ModelAvailability::LocalReady
+            );
+            let loaded = crate::model_jobs::huggingface_snapshot_dir(&data, repo).unwrap();
+            assert!(loaded.starts_with(artifact.location.root()));
+            assert!(std::fs::File::open(loaded.join("model.safetensors")).is_ok());
+            drop(guard);
+        });
+    }
+
     /// A requirement whose receipt carries NO `snapshotRevision` makes the WHOLE repository
     /// unserveable, not merely that one requirement.
     ///

--- a/crates/sceneworks-worker/src/imports.rs
+++ b/crates/sceneworks-worker/src/imports.rs
@@ -206,27 +206,42 @@ pub(crate) async fn write_model_download_receipt(
         );
         object.insert("loraFileSha256".to_owned(), Value::String(hash.to_owned()));
     }
-    let marker_path = target_dir.join(INSTALL_MARKER);
-    let mut receipts = match tokio::fs::read(&marker_path).await {
-        Ok(bytes) => serde_json::from_slice::<Value>(&bytes)
-            .ok()
-            .and_then(|value| value.get("receipts").and_then(Value::as_array).cloned())
-            .unwrap_or_default(),
-        Err(_) => Vec::new(),
-    };
-    receipts.retain(|existing| {
-        existing.get("repo") != receipt.get("repo")
-            || existing.get("modelId") != receipt.get("modelId")
-            || existing.get("variant") != receipt.get("variant")
-    });
-    receipts.push(receipt.clone());
-    let mut marker = receipt;
-    marker
-        .as_object_mut()
-        .expect("receipt is an object")
-        .insert("receipts".to_owned(), Value::Array(receipts));
-    let bytes = serde_json::to_vec_pretty(&marker)?;
-    tokio::fs::write(marker_path, bytes).await?;
+    let target_dir = target_dir.to_path_buf();
+    tokio::task::spawn_blocking(move || -> WorkerResult<()> {
+        let marker_path = target_dir.join(INSTALL_MARKER);
+        let _lock = sceneworks_core::download_receipt::lock(&target_dir)?;
+        let mut receipts = match std::fs::read(&marker_path) {
+            Ok(bytes) => serde_json::from_slice::<Value>(&bytes)
+                .ok()
+                .map(|value| {
+                    value
+                        .get("receipts")
+                        .and_then(Value::as_array)
+                        .cloned()
+                        .unwrap_or_else(|| vec![value])
+                })
+                .unwrap_or_default(),
+            Err(_) => Vec::new(),
+        };
+        receipts.retain(|existing| {
+            existing.get("repo") != receipt.get("repo")
+                || existing.get("modelId") != receipt.get("modelId")
+                || existing.get("variant") != receipt.get("variant")
+        });
+        receipts.push(receipt.clone());
+        let mut marker = receipt;
+        marker
+            .as_object_mut()
+            .expect("receipt is an object")
+            .insert("receipts".to_owned(), Value::Array(receipts));
+        sceneworks_core::download_receipt::write(&marker_path, &marker)?;
+        Ok(())
+    })
+    .await
+    .map_err(|error| {
+        WorkerError::InvalidPayload(format!("receipt write task failed: {error}"))
+    })??;
+
     Ok(())
 }
 

--- a/crates/sceneworks-worker/src/model_jobs.rs
+++ b/crates/sceneworks-worker/src/model_jobs.rs
@@ -2509,31 +2509,7 @@ fn artifact_files(root: &Path) -> WorkerResult<Vec<PathBuf>> {
     Ok(files)
 }
 
-fn update_metadata_stamp(digest: &mut Sha256, metadata: &std::fs::Metadata) {
-    digest.update(metadata.len().to_le_bytes());
-    let modified = metadata
-        .modified()
-        .ok()
-        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok());
-    digest.update(
-        modified
-            .map_or(0, |duration| duration.as_secs())
-            .to_le_bytes(),
-    );
-    digest.update(
-        modified
-            .map_or(0, |duration| duration.subsec_nanos())
-            .to_le_bytes(),
-    );
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        digest.update(metadata.dev().to_le_bytes());
-        digest.update(metadata.ino().to_le_bytes());
-        digest.update(metadata.ctime().to_le_bytes());
-        digest.update(metadata.ctime_nsec().to_le_bytes());
-    }
-}
+use sceneworks_core::download_receipt::update_metadata_stamp;
 
 fn artifact_tree_stamp(root: &Path) -> WorkerResult<String> {
     let mut digest = Sha256::new();
@@ -2563,33 +2539,7 @@ pub(crate) fn resolved_files_tree_stamp(
     root: &Path,
     files: &[impl AsRef<str>],
 ) -> WorkerResult<String> {
-    let mut names = files.iter().map(AsRef::as_ref).collect::<Vec<_>>();
-    names.sort_unstable();
-    let mut digest = Sha256::new();
-    for name in names {
-        let relative = Path::new(name);
-        if relative.is_absolute()
-            || relative
-                .components()
-                .any(|component| !matches!(component, std::path::Component::Normal(_)))
-        {
-            return Err(WorkerError::InvalidPayload(format!(
-                "artifact receipt contains unsafe resolved file {name:?}"
-            )));
-        }
-        let path = root.join(relative);
-        let metadata = std::fs::symlink_metadata(&path)?;
-        digest.update(name.as_bytes());
-        digest.update([0]);
-        update_metadata_stamp(&mut digest, &metadata);
-        if metadata.file_type().is_symlink() {
-            digest.update(std::fs::read_link(&path)?.to_string_lossy().as_bytes());
-            digest.update(b"followed-target");
-            update_metadata_stamp(&mut digest, &std::fs::metadata(&path)?);
-        }
-        digest.update([0xff]);
-    }
-    Ok(format!("sha256:{:x}", digest.finalize()))
+    Ok(sceneworks_core::download_receipt::resolved_files_tree_stamp(root, files)?)
 }
 
 fn artifact_content_fingerprint(root: &Path) -> WorkerResult<String> {
@@ -2733,6 +2683,30 @@ pub(crate) fn app_managed_artifact_provenance(
 mod artifact_provenance_tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn tree_stamp_repair_fills_null_revision_and_refuses_a_replaced_receipt() {
+        let temp = tempfile::tempdir().unwrap();
+        let rev = "1111111111111111111111111111111111111111";
+        let snapshot = temp.path().join(rev);
+        std::fs::create_dir_all(&snapshot).unwrap();
+        std::fs::write(snapshot.join("model.safetensors"), b"weights").unwrap();
+        let marker = temp.path().join(".sceneworks-download-complete.json");
+        let receipt = json!({"repo":"owner/model","variant":"q4","snapshotRevision":null,"resolvedFiles":["model.safetensors"]});
+        let mut top = receipt.clone();
+        top["receipts"] = json!([receipt]);
+        std::fs::write(&marker, serde_json::to_vec(&top).unwrap()).unwrap();
+        establish_receipt_tree_stamp(&marker, &receipt, &snapshot, &["model.safetensors"]).unwrap();
+        let after: Value = serde_json::from_slice(&std::fs::read(&marker).unwrap()).unwrap();
+        assert_eq!(after["snapshotRevision"], rev);
+        assert_eq!(after["receipts"][0]["snapshotRevision"], rev);
+        let before = std::fs::read(&marker).unwrap();
+        assert!(
+            establish_receipt_tree_stamp(&marker, &receipt, &snapshot, &["model.safetensors"])
+                .is_err()
+        );
+        assert_eq!(std::fs::read(&marker).unwrap(), before);
+    }
 
     #[test]
     fn app_managed_receipt_detects_same_path_mutation_and_rejects_bad_identity() {
@@ -3234,6 +3208,11 @@ fn establish_receipt_tree_stamp(
     snapshot: &Path,
     files: &[&str],
 ) -> WorkerResult<String> {
+    let _receipt_lock = sceneworks_core::download_receipt::lock(
+        marker
+            .parent()
+            .ok_or_else(|| WorkerError::InvalidPayload("receipt has no parent".to_owned()))?,
+    )?;
     let stamp = resolved_files_tree_stamp(snapshot, files)?;
     let revision = snapshot
         .file_name()
@@ -3257,9 +3236,17 @@ fn establish_receipt_tree_stamp(
         );
         // A backfilled receipt carries no revision, so resolution leans on the exact file set
         // identifying exactly one snapshot. Record what we just resolved to remove that ambiguity.
-        object
-            .entry("snapshotRevision".to_owned())
-            .or_insert_with(|| Value::String(revision.to_owned()));
+        if object.get("snapshotRevision").is_none_or(|value| {
+            value.is_null()
+                || value
+                    .as_str()
+                    .is_some_and(|revision| revision.trim().is_empty())
+        }) {
+            object.insert(
+                "snapshotRevision".to_owned(),
+                Value::String(revision.to_owned()),
+            );
+        }
     };
 
     let mut top = serde_json::from_slice::<Value>(&std::fs::read(marker)?).map_err(|error| {
@@ -3268,6 +3255,24 @@ fn establish_receipt_tree_stamp(
             marker.display()
         ))
     })?;
+    // The caller read before acquiring the write lock. A concurrent download or discovery
+    // repair may have replaced that identity; never stamp the replacement with the old tree.
+    let current = top
+        .get("receipts")
+        .and_then(Value::as_array)
+        .map(|entries| entries.iter().collect::<Vec<_>>())
+        .unwrap_or_else(|| vec![&top]);
+    if !current.iter().any(|entry| identity(entry))
+        || current.iter().filter(|entry| identity(entry)).any(|entry| {
+            ["resolvedFiles", "snapshotRevision", "artifactTreeStamp"]
+                .iter()
+                .any(|key| entry.get(*key) != receipt.get(*key))
+        })
+    {
+        return Err(WorkerError::InvalidPayload(
+            "install receipt changed during provenance repair".to_owned(),
+        ));
+    }
     // `write_model_download_receipt` mirrors the newest receipt at the top level AND in `receipts`.
     // Patch both when they name the same artifact, so neither copy contradicts the other.
     if identity(&top) {
@@ -3278,9 +3283,7 @@ fn establish_receipt_tree_stamp(
             patch(entry);
         }
     }
-    let temporary = marker.with_extension("json.tmp");
-    std::fs::write(&temporary, serde_json::to_vec_pretty(&top)?)?;
-    std::fs::rename(temporary, marker)?;
+    sceneworks_core::download_receipt::write(marker, &top)?;
     Ok(stamp)
 }
 

--- a/crates/sceneworks-worker/src/tests/supervisor_lifecycle.rs
+++ b/crates/sceneworks-worker/src/tests/supervisor_lifecycle.rs
@@ -894,3 +894,25 @@ fn database_lock_retry_uses_only_the_machine_readable_api_code() {
         "rendered wording must never be the retry contract"
     );
 }
+
+#[tokio::test]
+async fn concurrent_receipt_writes_preserve_legacy_and_new_sibling_variants() {
+    let temp = tempdir().unwrap();
+    let legacy = json!({"repo":"owner/model","modelId":"model","variant":"q4",
+        "resolvedFiles":["q4/model.safetensors"], "snapshotRevision":"1111111111111111111111111111111111111111"});
+    std::fs::write(temp.path().join(INSTALL_MARKER), serde_json::to_vec(&legacy).unwrap()).unwrap();
+    let q8 = json!({"modelId":"model","variant":"q8"}).as_object().unwrap().clone();
+    let bf16 = json!({"modelId":"model","variant":"bf16"}).as_object().unwrap().clone();
+    let q8_files=vec!["q8/model.safetensors".to_owned()];
+    let bf16_files=vec!["bf16/model.safetensors".to_owned()];
+    let (a,b)=tokio::join!(
+        write_model_download_receipt(temp.path(), &q8, "owner/model", "q8", &q8_files, Some("rev"), Default::default()),
+        write_model_download_receipt(temp.path(), &bf16, "owner/model", "bf16", &bf16_files, Some("rev"), Default::default())
+    );
+    a.unwrap(); b.unwrap();
+    let top:Value=serde_json::from_slice(&std::fs::read(temp.path().join(INSTALL_MARKER)).unwrap()).unwrap();
+    let receipts=top["receipts"].as_array().unwrap();
+    assert_eq!(receipts.len(),3);
+    assert!(receipts.contains(&legacy));
+    for variant in ["q4","q8","bf16"] { assert_eq!(receipts.iter().filter(|r|r["variant"]==variant).count(),1); }
+}


### PR DESCRIPTION
Legacy model-install receipts could lack `snapshotRevision` even when an immutable Hugging Face snapshot was installed, permanently disabling local copies. Discovery now recovers missing, null, or blank revisions from one complete matching snapshot, preserving existing identity and integrity evidence. Ambiguous, incomplete, or changed sources remain unresolved.

Receipt updates use coordinated atomic writes across catalog discovery and download/provenance writers, preserving sibling variants and rejecting stale updates. Recovery also checks that every indexed shard is included in the recorded file set.

Validation includes regression tests for identity recovery and unsafe candidates, catalog eligibility, concurrent receipt writes, and worker local loading with the source disconnected. The three affected local installations were repaired with backups; the application reports local-ready copies for Wan2.2, Qwen Image, and Bernini. Wan q4 transformer, text encoder, and VAE tensors were loaded and evaluated from the internal copy with an unavailable external-library path configured. Qwen retains its existing optional-component exclusion.

Tracks [SC-23031](https://app.shortcut.com/trefry/story/23031). Independent adversarial review completed and findings addressed.

Local validation runs with a private Hugging Face cache and serial tests: the operator machine has real model installations, which unrelated baseline tests otherwise inherit. The baseline deletion tests reproduce the failures against the operator cache and pass in the isolated cache.

Validation: `npm run rust:check` passed with an isolated Hugging Face cache and serial execution (4,952 tests passed; 225 ignored), plus clippy on the final API change and all four model-path inventory checks.
